### PR TITLE
libvirt.tests.svirt_install: Correct unattended_install import

### DIFF
--- a/libvirt/tests/src/svirt/svirt_install.py
+++ b/libvirt/tests/src/svirt/svirt_install.py
@@ -1,6 +1,6 @@
 from autotest.client.shared import error
 from virttest import data_dir, storage, utils_selinux, virsh
-from tests import unattended_install
+from virttest.tests import unattended_install
 
 
 def run(test, params, env):


### PR DESCRIPTION
Now key tests, such as unattended_install were moved to
the virttest.tests namespace. Fix the import link.

CC: Feng Yang fyang@redhat.com
Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
