### PR TITLE
virsh.capabilities: fix bug for SMP machines

### DIFF
--- a/libvirt/tests/src/virsh_cmd/host/virsh_capabilities.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_capabilities.py
@@ -32,13 +32,14 @@ def run(test, params, env):
             raise error.TestFail("The host arch in capabilities_xml is wrong!")
 
         # check the host cpus num.
-        cpus = dom.getElementsByTagName('cpus')[0]
-        host_cpus_output = cpus.getAttribute('num')
-        logging.info("Host cpus num (capabilities_xml):%s",
-                     host_cpus_output)
+        cpus = dom.getElementsByTagName('cpus')
+        host_cpus = 0
+        for cpu in cpus:
+            host_cpus += int(cpu.getAttribute('num'))
+        logging.info("Host cpus num (capabilities_xml):%s", host_cpus)
         cmd = "less /proc/cpuinfo | grep processor | wc -l"
         cmd_result = utils.run(cmd, ignore_status=True)
-        if cmp(host_cpus_output, cmd_result.stdout.strip()) != 0:
+        if cmp(host_cpus, int(cmd_result.stdout.strip())) != 0:
             raise error.TestFail("Host cpus num (capabilities_xml) is "
                                  "wrong")
 


### PR DESCRIPTION
For machines that have more than one processor we must count all cores
for each processor to get the correct number of cpus.

Signed-off-by: Pavel Hrdina phrdina@redhat.com
