### PR TITLE
attach_detach_interface: Check for required utility

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_interface.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_interface.py
@@ -1,7 +1,7 @@
 import logging
 import re
 from autotest.client.shared import error
-from virttest import libvirt_vm, virsh, utils_net
+from virttest import libvirt_vm, virsh, utils_net, utils_misc
 from virttest.libvirt_xml import vm_xml
 
 
@@ -95,6 +95,13 @@ def run(test, params, env):
 
     # Interface specific attributes.
     iface_type = params.get("at_detach_iface_type", "network")
+    if iface_type == "bridge":
+        try:
+            utils_misc.find_command("brctl")
+        except ValueError:
+            raise error.TestNAError("Command 'brctl' is missing. You must "
+                                    "install it.")
+
     iface_source = params.get("at_detach_iface_source", "default")
     iface_mac = params.get("at_detach_iface_mac", "created")
     virsh_dargs = {'ignore_status': True, 'uri': uri}


### PR DESCRIPTION
When running the 'bridge' tests, the code needs to check for the used
'brctl' utility before using it; otherwise, the tests will FAIL.
