### PR TITLE
change_media: Check for mkisofs

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_change_media.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_change_media.py
@@ -131,6 +131,12 @@ def run(test, params, env):
     if device_type not in ['cdrom', 'floppy']:
         raise error.TestNAError("Got a invalid device type:/n%s" % device_type)
 
+    try:
+        utils_misc.find_command("mkisofs")
+    except ValueError:
+        raise error.TestNAError("Command 'mkisofs' is missing. You must "
+                                "install it (try 'genisoimage' package.")
+
     # Backup for recovery.
     vmxml_backup = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
 


### PR DESCRIPTION
Since this test uses 'mkisofs' as the basis for it's work, we need to
ensure that the tool is available on the host and SKIP if not; otherwise,
the test will fail with ERROR's
