### PR TITLE
pool_create: Resolve test errors

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/pool/virsh_pool_create.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/pool/virsh_pool_create.cfg
@@ -4,7 +4,7 @@
     vms =
     main_vm =
     start_vm = "no"
-    pool_create_xml_file = "/tmp/virt-test-pool.xml"
+    pool_create_xml_file = "virt-test-pool.xml"
     pool_create_name = "virt-test-pool"
     pool_create_use_exist_pool = "no"
     pool_create_exist_pool_name = ""

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool_create.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool_create.py
@@ -1,7 +1,7 @@
 import os
 import logging
 from autotest.client.shared import error
-from virttest import virsh, xml_utils, libvirt_storage, libvirt_xml
+from virttest import virsh, xml_utils, data_dir, libvirt_storage, libvirt_xml
 
 
 def pool_check(pool_name, pool_ins):
@@ -38,6 +38,7 @@ def run(test, params, env):
         "pool_create_undefine_exist_pool", "no")
     readonly_mode = "yes" == params.get("pool_create_readonly_mode", "no")
     status_error = "yes" == params.get("status_error", "no")
+    exist_active = False
 
     # Deal with each parameters
     # backup the exist pool
@@ -47,6 +48,26 @@ def run(test, params, env):
             raise error.TestFail("Require pool: %s exist", exist_pool_name)
         backup_xml = libvirt_xml.PoolXML.backup_xml(exist_pool_name)
         pool_xml = backup_xml
+        exist_active = pool_ins.is_pool_active(exist_pool_name)
+
+    # backup pool state
+    pool_ins_state = virsh.pool_state_dict()
+    logging.debug("Backed up pool(s): %s", pool_ins_state)
+
+    if "--file" in option:
+        pool_path = os.path.join(data_dir.get_data_dir(), 'images')
+        dir_xml = """
+<pool type='dir'>
+  <name>%s</name>
+  <target>
+    <path>%s</path>
+  </target>
+</pool>
+""" % (pool_name, pool_path)
+        pool_xml = os.path.join(test.tmpdir, pool_xml)
+        xml_object = open(pool_xml, 'w')
+        xml_object.write(dir_xml)
+        xml_object.close()
 
     # Delete the exist pool
     start_pool = False
@@ -92,12 +113,32 @@ def run(test, params, env):
             elif not pool_check(pool_name, pool_ins):
                 raise error.TestFail("Pool check fail")
         elif status_error and status == 0:
-            raise error.TestFail("Expect fail, but run successfully.")
+            # For an inactive 'default' pool, when the test runs to create
+            # an existing pool of 'default', the test will pass because the
+            # 'default' pool will be considered a transient pool when the
+            # 'name' and 'uuid' match (which they do in this case). So
+            # don't fail the test unnecessarily
+            if (pool_name == exist_pool_name and not exist_active):
+                pass
+            else:
+                raise error.TestFail("Expect fail, but run successfully.")
     finally:
         # Recover env
-        if pool_ins.is_pool_active(pool_name):
+        # If we have a different pool name than default OR
+        # we need to undefine this tests created default pool OR
+        # we had a transient, active default pool created above, then
+        # we need to destroy what the test created.
+        # NB: When the active, transient pool is destroyed the
+        # previously defined, but inactive pool will now exist.
+        if pool_name != exist_pool_name or undefine_exist_pool or \
+           (pool_name == exist_pool_name and not exist_active):
             virsh.pool_destroy(pool_name)
-        if undefine_exist_pool and not pool_ins.pool_exists(exist_pool_name):
+
+        # restore the undefined default pool
+        if undefine_exist_pool: # and not pool_ins.pool_exists(exist_pool_name):
             virsh.pool_define(backup_xml)
             if start_pool:
                 pool_ins.start_pool(exist_pool_name)
+            # Recover autostart
+            if pool_ins_state[exist_pool_name]['autostart']:
+                virsh.pool_autostart(exist_pool_name, ignore_status=False)


### PR DESCRIPTION
Originally posted to virt-test before the commit as PR 1236:

https://github.com/autotest/virt-test/pull/1236

This replaces and resolves issues mentioned from review. The main
difference between this version and the last one posted previously
is that the code now handles the transient 'default' storage pool
not being started prior to the test being run in the "error" case.
I also cleaned up and commented more the finally logic.
