### PR TITLE
sendkey: Check for and install required guest utility

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_sendkey.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_sendkey.cfg
@@ -4,7 +4,6 @@
     take_regular_screendumps = "no"
     variants:
         - params_test:
-            sendkey_params = "yes"
             create_file_name = "/root/abc"
             variants:
                 # All code implement "touch create_file_name" command in guest


### PR DESCRIPTION
The test assumed that 'rsyslog' was installed on the guest as a
way to log whether the running of command resulted in output going
to /var/log/messages.

Since other tests install guest utilities, have this code follow that
same patter to check and install the rsyslog package.  Along the way
fix a couple of other issues...
- The log file checked is /var/log/messages not /var/log/message
- We need to ensure that rsyslog is actually running before using
  NOTE: Using the service command is more "modern" - this test could
        still fail on older OS's that don't use systemd.  I'm not quite
        sure what check would be made there, but this at least works
        for the more modern ones.
- No need to send an "rm -rf None" if "create_file" is None
- Output to /var/log/messages is actually done to a system buffer first,
  then to /var/log/messages.  This can result in test failure if the
  expected text wasn't yet present.  Follow the other example in the
  code and try for 60 seconds before giving up.  I did try to add code
  that would modify the rsyslog config files to change some configuration
  value to require immediate writes, but that got messy - this was just
  simpler.
- Remove 'sendkey_params' / params_test as it really wasn't necessary
  as either this test uses sysrq or not.  Besides the only time the
  create_file_name is used is for the params_test - so use that.
