### PR TITLE
libvirt.tests: Re-write virsh_pool.py to cover more pool types and commands

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/pool/virsh_pool.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/pool/virsh_pool.cfg
@@ -1,8 +1,29 @@
-- virsh.pool: install setup image_copy unattended_install.cdrom
+- virsh.pool:
     type = virsh_pool
     vms = ''
     main_vm = ''
     pool_name = "temp_pool_1"
-    pool_target = "virsh_pool"
     pool_type = "dir"
     vol_name = "temp_vol_1"
+    variants:
+        - positive_test:
+            status_error = "no"
+            variants:
+                - pool_type_dir:
+                    pool_type = "dir"
+                    pool_target = "dir-pool"
+                - pool_type_disk:
+                    pool_type = "disk"
+                    pool_target = "/dev"
+                - pool_type_fs:
+                    pool_type = "fs"
+                    pool_target = "fs"
+                - pool_type_logical:
+                    pool_type = "logical"
+                    pool_target = "/dev/logical"
+                - pool_type_netfs:
+                    pool_type = "netfs"
+                    pool_target = "/nfs-mount"
+                - pool_type_iscsi:
+                    pool_type = "iscsi"
+                    pool_target = "/dev/disk/by-path"

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool.py
@@ -1,306 +1,305 @@
-import logging
 import re
 import os
-import shutil
+import logging
+from autotest.client import utils
+from autotest.client import lv_utils
 from autotest.client.shared import error
-from virttest import virsh, utils_libvirtd
+from virttest import utils_libvirtd
+from virttest import libvirt_storage
+from virttest import utils_test
+from virttest import virsh
 
 
 def run(test, params, env):
     """
     Test the virsh pool commands
 
-    (1) Define a 'dir' type pool(temp) and check for success
-    (2) Undefine the pool and check for success
-    (3) Repeat Step1
-    (4) Start the pool(temp) and check for success
-    (5) Check on pool list whether the start is active and autostart is 'no'
-    (6) Mark the pool(temp) for autostart and check for the success
-    (7) Check on pool-list whether autostart is 'yes'
-    (7.a) Restart the libvirt service
-    (7.b) Check on pool-list whether autostart is still 'yes'
-    (8) Undefine the pool(temp) and check for the proper error message
-    (9) Create the volume(tmp) on the pool(temp) anc check for success
-    (10) Destroy the pool(temp) and check for success
-    (11) Check volume list on pool(temp) and check for failure
-    (12) Repeat Step4
-    (13) Check volume list on pool(temp) and check for volume(tmp)
-    (14) Delete the volume(tmp) on pool(temp)
-    (15) Check volume list on pool(temp) and check for volume(tmp) not present
-    (16) Destroy the pool(temp) and check for success
-    (17) Undefine the pool(temp) and check for success
-    TODO: To support the tests for multiple pool types
-    TODO: Add more negative cases during libvirt service stopped
-    TODO: Test autostart of the pool after system reboot
+    (1) Define a given type pool
+    (2) List pool with '--inactive --type' options
+    (3) Dumpxml for the pool
+    (4) Undefine the pool
+    (5) Define pool by using the XML file in step (3)
+    (6) Build the pool(except 'disk' type pool
+        For 'fs' type pool, cover --overwrite and --no-overwrite options
+    (7) Start the pool
+    (8) List pool with '--persistent --type' options
+    (9) Mark pool autostart
+    (10) List pool with '--autostart --type' options
+    (11) Restart libvirtd and list pool with '--autostart --persistent' options
+    (12) Destroy the pool
+    (13) Unmark pool autostart
+    (14) Repeat step (11)
+    (15) Start the pool
+    (16) Get pool info
+    (17) Get pool uuid by name
+    (18) Get pool name by uuid
+    (19) Refresh the pool
+         For 'dir' type pool, touch a file under target path and refresh again
+         to make the new file show in vol-list.
+    (20) Destroy the pool
+    (21) Delete pool for 'dir' type pool. After the command, the pool object
+         will still exist but target path will be deleted
+    (22) Undefine the pool
     """
 
-    def check_list_state(pool_name, state="active"):
-        """
-        Check pool from the list
-        """
-
-        found = False
-        # Get the list stored in a variable
-        output = virsh.pool_list(option="--all", ignore_status=True)
-        if output.exit_status != 0:
-            error.TestFail("Virsh pool list command failed:\n%s" %
-                           output.stdout)
-        result = re.findall(r"(\w+)\s+(\w+)\s+(\w+)", str(output.stdout))
-        for item in result:
-            if pool_name in item[0]:
-                found = True
-                if not state == item[1]:
-                    logging.debug("State: %s of a given pool: %s"
-                                  " is not shown in the list", state, pool_name)
-                    return False
-        if found:
-            return True
-        else:
-            logging.debug("Pool: %s is not found in the list", pool_name)
-            return False
-
-    def check_list_autostart(pool_name, autostart="no"):
-        """
-        Check pool from the list
-        """
-
-        found = False
-        # Get the list stored in a variable
-        output = virsh.pool_list(option="--all", ignore_status=True)
-        if output.exit_status != 0:
-            error.TestFail("Virsh pool list command failed:\n%s" %
-                           output.stdout)
-        result = re.findall(r"(\w+)\s+(\w+)\s+(\w+)", str(output))
-        for item in result:
-            if pool_name in item[0]:
-                found = True
-                if not autostart in item[2]:
-                    raise error.TestFail("%s pool shouldn't be marked as "
-                                         "autostart=%s", item[0], item[2])
-        if found:
-            return True
-        else:
-            logging.debug("Pool: %s is not found in the list", pool_name)
-            return False
-
-    def check_vol_list(vol_name, pool_name, pool_target):
-        """
-        Check volume from the list
-        """
-
-        found = False
-        # Get the volume list stored in a variable
-        output = virsh.vol_list(pool_name, ignore_status=True)
-        if output.exit_status != 0:
-            return False
-
-        result = re.findall(r"(\w+)\s+(%s/%s)" % (pool_target, vol_name),
-                            str(output.stdout))
-        for item in result:
-            if vol_name in item[0]:
-                found = True
-        if found:
-            return True
-        else:
-            return False
-
-    def define_pool(pool_name, pool_type, pool_target):
-        """
-        To define a pool
-        """
-        if 'dir' in pool_type:
-            try:
-                os.makedirs(pool_target)
-            except OSError, details:
-                raise error.TestFail("Check the target path:\n%s" % details)
-
-            result = virsh.pool_define_as(pool_name, pool_type, pool_target,
-                                          ignore_status=True)
-            if result.exit_status != 0:
-                raise error.TestFail("Command virsh pool-define-as"
-                                     "failed:\n%s" % result.stdout)
-            else:
-                logging.debug("%s type pool: %s defined successfully",
-                              pool_type, pool_name)
-        else:
-            raise error.TestFail("pool type %s has not yet been"
-                                 "supported in the test" % pool_type)
-
     # Initialize the variables
-    pool_name = params.get("pool_name")
-    pool_type = params.get("pool_type")
-    pool_target = params.get("pool_target")
+    pool_name = params.get("pool_name", "temp_pool_1")
+    pool_type = params.get("pool_type", "dir")
+    pool_target = params.get("pool_target", "")
     if os.path.dirname(pool_target) is "":
         pool_target = os.path.join(test.tmpdir, pool_target)
-    vol_name = params.get("vol_name")
+    vol_name = params.get("vol_name", "temp_vol_1")
+    # Use pool name as VG name
+    vg_name = pool_name
+    status_error = "yes" == params.get("status_error", "no")
+    vol_path = os.path.join(pool_target, vol_name)
+    # Clean up flags:
+    # cleanup_env[0] for nfs, cleanup_env[1] for iscsi, cleanup_env[2] for lvm
+    cleanup_env = [False, False, False]
 
-    logging.info("\n\tPool Name: %s\n\tPool Type: %s\n\tPool Target: %s\n\t"
-                 "Volume Name:%s", pool_name, pool_type,
-                 pool_target, vol_name)
+    def check_exit_status(result, expect_error=False):
+        """
+        Check the exit status of virsh commands.
+
+        :param result: Virsh command result object
+        :param expect_error: Boolean value, expect command success or fail
+        """
+        if not expect_error:
+            if result.exit_status != 0:
+                raise error.TestFail(result.stderr)
+            else:
+                logging.debug("Command output:\n%s", result.stdout.strip())
+        elif expect_error and result.exit_status == 0:
+            raise error.TestFail("Expect fail, but run successfully.")
+
+    def check_pool_list(pool_name, option="--all", expect_error=False):
+        """
+        Check pool by running pool-list command with given option.
+
+        :param pool_name: Name of the pool
+        :param option: option for pool-list command
+        :param expect_error: Boolean value, expect command success or fail
+        """
+        found = False
+        # Get the list stored in a variable
+        result = virsh.pool_list(option, ignore_status=True)
+        check_exit_status(result, False)
+        output = re.findall(r"(\S+)\ +(\S+)\ +(\S+)[\ +\n]",
+                            str(result.stdout))
+        for item in output:
+            if pool_name in item[0]:
+                found = True
+                break
+        if found:
+            logging.debug("Find pool '%s' in pool list.", pool_name)
+        else:
+            logging.debug("Not find pool %s in pool list.", pool_name)
+        if expect_error and found:
+            raise error.TestFail("Unexpect pool '%s' exist." % pool_name)
+        if not expect_error and not found:
+            raise error.TestFail("Expect pool '%s' doesn't exist." % pool_name)
+
+    def check_vol_list(vol_name, pool_name):
+        """
+        Check volume from the list
+
+        :param vol_name: Name of the volume
+        :param pool_name: Name of the pool
+        """
+        found = False
+        # Get the volume list stored in a variable
+        result = virsh.vol_list(pool_name, ignore_status=True)
+        check_exit_status(result)
+
+        output = re.findall(r"(\S+)\ +(\S+)[\ +\n]", str(result.stdout))
+        for item in output:
+            if vol_name in item[0]:
+                found = True
+                break
+        if found:
+            logging.debug(
+                "Find volume '%s' in pool '%s'.", vol_name, pool_name)
+        else:
+            raise error.TestFail(
+                "Not find volume '%s' in pool '%s'." %
+                (vol_name, pool_name))
+
+    def check_pool_info(pool_info, check_point, value):
+        """
+        Check the pool name, uuid, etc.
+
+        :param pool_info: A dict include pool's information
+        :param key: Key of pool info dict, available value: Name, UUID, State
+                    Persistent, Autostart, Capacity, Allocation, Available
+        :param value: Expect value of pool_info[key]
+        """
+        if pool_info is None:
+            raise error.TestFail("Pool info dictionary is needed.")
+        if pool_info[check_point] == value:
+            logging.debug("Pool '%s' is '%s'.", check_point, value)
+        else:
+            raise error.TestFail("Pool '%s' isn't '%s'." % (check_point, value))
+
     # Run Testcase
     try:
+        _pool = libvirt_storage.StoragePool()
         # Step (1)
-        define_pool(pool_name, pool_type, pool_target)
+        # Pool define
+        result = utils_test.libvirt.define_pool(pool_name, pool_type,
+                                                pool_target, cleanup_env)
+        check_exit_status(result, status_error)
 
         # Step (2)
-        result = virsh.pool_undefine(pool_name, ignore_status=True)
-        if result.exit_status != 0:
-            raise error.TestFail("Command virsh pool-undefine failed:\n%s" %
-                                 result.stdout)
-        else:
-            logging.debug("Pool: %s successfully undefined", pool_name)
-            shutil.rmtree(pool_target)
+        # Pool list
+        option = "--inactive --type %s" % pool_type
+        check_pool_list(pool_name, option)
 
         # Step (3)
-        define_pool(pool_name, pool_type, pool_target)
+        # Pool dumpxml
+        pool_xml = os.path.join(test.tmpdir, "pool.xml.tmp")
+        xml = virsh.pool_dumpxml(pool_name, to_file=pool_xml)
+        logging.debug("Pool '%s' XML:\n%s", pool_name, xml)
 
         # Step (4)
-        result = virsh.pool_start(pool_name, ignore_status=True)
-        if result.exit_status != 0:
-            raise error.TestFail("Command virsh pool-start failed:\n%s" %
-                                 result.stdout)
-        else:
-            logging.debug("Pool: %s successfully started", pool_name)
+        # Undefine pool
+        result = virsh.pool_undefine(pool_name, ignore_status=True)
+        check_exit_status(result)
+        check_pool_list(pool_name, "--all", True)
 
         # Step (5)
-
-        if not check_list_state(pool_name, "active"):
-            raise error.TestFail("State of the pool: %s is marked inactive"
-                                 "instead of active" % pool_name)
-        if not check_list_autostart(pool_name, "no"):
-            raise error.TestFail("Autostart of the pool: %s marked as yes"
-                                 "instead of no" % pool_name)
+        # Define pool from XML file
+        result = virsh.pool_define(pool_xml)
+        check_exit_status(result, status_error)
 
         # Step (6)
-        result = virsh.pool_autostart(pool_name, ignore_status=True)
-        if result.exit_status != 0:
-            raise error.TestFail("Command virsh autostart is failed:\n%s" %
-                                 result.stdout)
-        else:
-            logging.debug("Pool: %s marked for autostart successfully",
-                          pool_name)
+        # Buid pool, this step may fail for 'disk' and 'logical' types pool
+        if pool_type not in ["disk", "logical"]:
+            option = ""
+        # Options --overwrite and --no-overwrite can only be used to
+        # build a filesystem pool, but it will fail for now
+            # if pool_type == "fs":
+            #    option = '--overwrite'
+            result = virsh.pool_build(pool_name, option, ignore_status=True)
+            check_exit_status(result)
 
         # Step (7)
-        if not check_list_state(pool_name, "active"):
-            raise error.TestFail("State of pool: %s marked as inactive"
-                                 "instead of active" % pool_name)
-        if not check_list_autostart(pool_name, "yes"):
-            raise error.TestFail("Autostart of pool: %s marked as no"
-                                 "instead of yes" % pool_name)
-
-        # Step (7.a)
-        utils_libvirtd.libvirtd_stop()
-        # TODO: Add more negative cases after libvirtd stopped
-        utils_libvirtd.libvirtd_start()
-
-        # Step (7.b)
-        if not check_list_state(pool_name, "active"):
-            raise error.TestFail("State of pool: %s marked as inactive"
-                                 "instead of active" % pool_name)
-        if not check_list_autostart(pool_name, "yes"):
-            raise error.TestFail("Autostart of pool: %s marked as no"
-                                 "instead of yes" % pool_name)
+        # Pool start
+        result = virsh.pool_start(pool_name, ignore_status=True)
+        check_exit_status(result)
 
         # Step (8)
-        result = virsh.pool_undefine(pool_name, ignore_status=True)
-        if result.exit_status == 0:
-            raise error.TestFail("Command virsh pool-undefine succeeded"
-                                 " with pool still active and running")
-        else:
-            logging.debug("Active pool: %s undefine failed as expected",
-                          pool_name)
+        # Pool list
+        option = "--persistent --type %s" % pool_type
+        check_pool_list(pool_name, option)
 
         # Step (9)
-        result = virsh.vol_create_as(vol_name, pool_name, "1048576",
-                                     "1048576", "raw", ignore_status=True)
-        if result.exit_status != 0:
-            raise error.TestFail("Command virsh vol-create-as failed:\n%s" %
-                                 result.stdout)
-        else:
-            logging.debug("Volume: %s successfully created on pool: %s",
-                          vol_name, pool_name)
-
-        if not check_vol_list(vol_name, pool_name, pool_target):
-            raise error.TestFail("Volume %s is not found in the "
-                                 "output of virsh vol-list" % vol_name)
+        # Pool autostart
+        result = virsh.pool_autostart(pool_name, ignore_status=True)
+        check_exit_status(result)
 
         # Step (10)
-        if not virsh.pool_destroy(pool_name):
-            raise error.TestFail("Command virsh pool-destroy failed")
-        else:
-            logging.debug("Pool: %s destroyed successfully", pool_name)
-
-        if not check_list_state(pool_name, "inactive"):
-            raise error.TestFail("State of pool: %s marked as active"
-                                 "instead of inactive" % pool_name)
-        if not check_list_autostart(pool_name, "yes"):
-            raise error.TestFail("Autostart of pool: %s marked as no"
-                                 "instead of yes" % pool_name)
+        # Pool list
+        option = "--autostart --type %s" % pool_type
+        check_pool_list(pool_name, option)
 
         # Step (11)
-        if check_vol_list(vol_name, pool_name, pool_target):
-            raise error.TestFail("Command virsh vol-list succeeded"
-                                 " on an inactive pool")
+        # Restart libvirtd and check the autostart pool
+        utils_libvirtd.libvirtd_restart()
+        option = "--autostart --persistent"
+        check_pool_list(pool_name, option)
+
         # Step (12)
-        result = virsh.pool_start(pool_name, ignore_status=True)
-        if result.exit_status != 0:
-            raise error.TestFail("Command virsh pool-start failed:\n%s" %
-                                 result.stdout)
+        # Pool destroy
+        if virsh.pool_destroy(pool_name):
+            logging.debug("Pool %s destroyed.", pool_name)
         else:
-            logging.debug("Pool: %s started successfully", pool_name)
+            raise error.TestFail("Destroy pool % failed." % pool_name)
 
         # Step (13)
-        if not check_vol_list(vol_name, pool_name, pool_target):
-            raise error.TestFail("Volume %s is not found in the "
-                                 "output of virsh vol-list" % vol_name)
+        # Pool autostart disable
+        result = virsh.pool_autostart(pool_name, "--disable",
+                                      ignore_status=True)
+        check_exit_status(result)
 
         # Step (14)
-        result = virsh.vol_delete(vol_name, pool_name)
-        if result.exit_status != 0:
-            raise error.TestFail("Command virsh vol-delete failed:\n%s" %
-                                 result.stdout)
-        else:
-            logging.debug("Volume: %s deleted successfully", vol_name)
+        # Repeat step (11)
+        utils_libvirtd.libvirtd_restart()
+        option = "--autostart"
+        check_pool_list(pool_name, option, True)
 
         # Step (15)
-        if check_vol_list(vol_name, pool_name, pool_target):
-            raise error.TestFail("Command virsh vol-list shows deleted volume"
-                                 " % for a pool %s" % vol_name, pool_name)
+        # Pool start
+        # If the filesystem cntaining the directory is mounted, then the
+        # directory will show as running, which means the local 'dir' pool
+        # don't need start after restart libvirtd
+        if pool_type != "dir":
+            result = virsh.pool_start(pool_name, ignore_status=True)
+            check_exit_status(result)
 
         # Step (16)
-        if not virsh.pool_destroy(pool_name):
-            raise error.TestFail("Command virsh pool-destroy failed")
-        else:
-            logging.debug("Pool: %s destroyed successfully", pool_name)
+        # Pool info
+        pool_info = _pool.pool_info(pool_name)
+        logging.debug("Pool '%s' info:\n%s", pool_name, pool_info)
 
         # Step (17)
-        result = virsh.pool_undefine(pool_name)
-        if result.exit_status != 0:
-            raise error.TestFail("Command virsh pool-undefine failed:\n%s" %
-                                 result.stdout)
+        # Pool UUID
+        result = virsh.pool_uuid(pool_info["Name"], ignore_status=True)
+        check_exit_status(result)
+        check_pool_info(pool_info, "UUID", result.stdout.strip())
+
+        # Step (18)
+        # Pool Name
+        result = virsh.pool_name(pool_info["UUID"], ignore_status=True)
+        check_exit_status(result)
+        check_pool_info(pool_info, "Name", result.stdout.strip())
+
+        # Step (19)
+        # Pool refresh for 'dir' type pool
+        if pool_type == "dir":
+            os.mknod(vol_path)
+            result = virsh.pool_refresh(pool_name)
+            check_exit_status(result)
+            check_vol_list(vol_name, pool_name)
+
+        # Step(20)
+        # Pool destroy
+        if virsh.pool_destroy(pool_name):
+            logging.debug("Pool %s destroyed.", pool_name)
         else:
-            logging.debug("Pool: %s undefined successfully", pool_name)
+            raise error.TestFail("Destroy pool % failed." % pool_name)
 
+        # Step (21)
+        # Pool delete for 'dir' type pool
+        if pool_type == "dir":
+            if os.path.exists(vol_path):
+                os.remove(vol_path)
+            result = virsh.pool_delete(pool_name, ignore_status=True)
+            check_exit_status(result)
+            option = "--inactive --type %s" % pool_type
+            check_pool_list(pool_name, option)
+            if os.path.exists(pool_target):
+                raise error.TestFail("The target path '%s' still exist." %
+                                     pool_target)
+            result = virsh.pool_start(pool_name, ignore_status=True)
+            check_exit_status(result, True)
+
+        # Step (22)
+        # Pool undefine
+        result = virsh.pool_undefine(pool_name, ignore_status=True)
+        check_exit_status(result)
+        check_pool_list(pool_name, "--all", True)
     finally:
-        if check_list_state(pool_name, "active"):
-            if not virsh.pool_destroy(pool_name):
-                raise error.TestFail("Command virsh pool-destroy failed")
-            result = virsh.pool_undefine(pool_name)
-            if result.exit_status != 0:
-                raise error.TestFail(
-                    "Command virsh pool-undefine failed:\n%s" %
-                    result.stdout)
-        elif check_list_state(pool_name, "inactive"):
-            result = virsh.pool_undefine(pool_name, ignore_status=True)
-            if result.exit_status != 0:
-                raise error.TestFail(
-                    "Command virsh pool-undefine failed:\n%s" %
-                    result.stdout)
-
-        try:
-            logging.debug(
-                "Deleting the pool target: %s directory", pool_target)
-            shutil.rmtree(pool_target)
-        except OSError, detail:
-            raise error.TestFail("Failed to delete the pool target directory"
-                                 "%s:\n %s" % (pool_target, detail))
+        # Clean up
+        if os.path.exists(pool_xml):
+            os.remove(pool_xml)
+        if not _pool.delete_pool(pool_name):
+            logging.error("Can't delete pool: %s", pool_name)
+        if cleanup_env[2]:
+            cmd = "pvs |grep %s |awk '{print $1}'" % vg_name
+            pv_name = utils.system_output(cmd)
+            lv_utils.vg_remove(vg_name)
+            utils.run("pvremove %s" % pv_name)
+        if cleanup_env[1]:
+            utils_test.libvirt.setup_or_cleanup_iscsi(False)
+        if cleanup_env[0]:
+            utils_test.libvirt.setup_or_cleanup_nfs(False)


### PR DESCRIPTION
```
1. Expend case to cover more pool types
2. Expend case to cover more virsh pool commands
3. Remove the vol-create/delete part which can be covered in virsh
   volume testing
```

Signed-off-by: Yanbing Du ydu@redhat.com
