### PR TITLE
find_storage_pool_sources_as: Check for required utility

### DIFF
--- a/libvirt/tests/src/virsh_cmd/pool/virsh_find_storage_pool_sources_as.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_find_storage_pool_sources_as.py
@@ -45,12 +45,17 @@ def run(test, params, env):
                 raise error.TestNAError("Command 'tgtadm' and/or 'iscsiadm' "
                                         "is missing. You must install it.")
             # Set up iscsi
-            iscsi_device = utils_test.libvirt.setup_or_cleanup_iscsi(True)
-            cleanup_iscsi = True
-            if source_type == "logical":
-                # Create VG by using iscsi device
-                lv_utils.vg_create(vg_name, iscsi_device)
-                cleanup_logical = True
+            try:
+                iscsi_device = utils_test.libvirt.setup_or_cleanup_iscsi(True)
+                cleanup_iscsi = True
+                if source_type == "logical":
+                    # Create VG by using iscsi device
+                    lv_utils.vg_create(vg_name, iscsi_device)
+                    cleanup_logical = True
+            except Exception, detail:
+                if cleanup_iscsi:
+                    utils_test.libvirt.setup_or_cleanup_iscsi(False)
+                raise error.TestFail("iscsi setup failed:\n%s" % detail)
 
     # Run virsh cmd
     options = "%s %s " % (source_host, source_port) + options


### PR DESCRIPTION
In order to run the iscsi and logical tests, the 'tgtadm' utility
must be installed; otherwise, tests fail.  Add check and skip if
not installed.
