### PR TITLE
Add test for domain reset

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_reset.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_reset.cfg
@@ -1,0 +1,22 @@
+- virsh.reset:
+    type = virsh_reset
+    take_regular_screendumps = "no"
+    variants:
+        - negative_test:
+            status_error = "yes"
+            variants:
+                - readonly:
+                    readonly = "yes"
+                    start_vm = "yes"
+                - shutdown_guest:
+                    start_vm = "no"
+        - positive_test:
+            start_vm = "yes"
+            status_error = "no"
+            variants:
+                - id_options:
+                    reset_vm_ref = "id"
+                - uuid_options:
+                    reset_vm_ref = "uuid"
+                - name_options:
+                    reset_vm_ref = "name"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_reset.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_reset.py
@@ -1,0 +1,96 @@
+import logging
+import commands
+from autotest.client.shared import error
+from virttest import utils_misc, virsh
+from virttest.libvirt_xml import vm_xml
+
+
+def run(test, params, env):
+    """
+    Test virsh reset command
+    """
+
+    if not virsh.has_help_command('reset'):
+        raise error.TestNAError("This version of libvirt does not support "
+                                "the reset test")
+
+    vm_name = params.get("main_vm", "virt-tests-vm1")
+    vm_ref = params.get("reset_vm_ref")
+    readonly = params.get("readonly", False)
+    status_error = ("yes" == params.get("status_error", "no"))
+    start_vm = ("yes" == params.get("start_vm"))
+
+    vm = env.get_vm(vm_name)
+    domid = vm.get_id()
+    domuuid = vm.get_uuid()
+    bef_pid = commands.getoutput("pidof -s qemu-kvm")
+
+    if vm_ref == 'id':
+        vm_ref = domid
+    elif vm_ref == 'uuid':
+        vm_ref = domuuid
+    else:
+        vm_ref = vm_name
+
+    # change the disk cache to default
+    vmxml_backup = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+
+    def change_cache(vmxml, mode):
+        """
+        Change the cache mode
+
+        :param vmxml: instance of VMXML
+        :param mode: cache mode you want to change
+        """
+        devices = vmxml.devices
+        disk_index = devices.index(devices.by_device_tag('disk')[0])
+        disk = devices[disk_index]
+        disk_driver = disk.driver
+        disk_driver['cache'] = mode
+        disk.driver = disk_driver
+        vmxml.devices = devices
+        vmxml.define()
+
+    try:
+        change_cache(vmxml_backup.copy(), "default")
+
+        tmpfile = "/home/%s" % utils_misc.generate_random_string(6)
+        logging.debug("tmpfile is %s", tmpfile)
+        if start_vm:
+            session = vm.wait_for_login()
+            session.cmd("rm -rf %s && sync" % tmpfile)
+            status = session.get_command_status("touch %s && ls %s" %
+                                                (tmpfile, tmpfile))
+            if status == 0:
+                logging.info("Succeed generate file %s", tmpfile)
+            else:
+                raise error.TestFail("Touch command failed!")
+
+        # record the pid before reset for compare
+        output = virsh.reset(vm_ref, readonly=readonly)
+        if output.exit_status != 0:
+            if status_error:
+                logging.info("Failed to reset guest as expected, Error:%s.",
+                             output.stderr)
+                return
+            else:
+                raise error.TestFail("Failed to reset guest, Error:%s." %
+                                     output.stderr)
+        elif status_error:
+            raise error.TestFail("Expect fail, but succeed indeed.")
+
+        session.close()
+        session = vm.wait_for_login()
+        status = session.get_command_status("ls %s" % tmpfile)
+        if status == 0:
+            raise error.TestFail("Fail to reset guest, tmpfile still exist!")
+        else:
+            aft_pid = commands.getoutput("pidof -s qemu-kvm")
+            if bef_pid == aft_pid:
+                logging.info("Succeed to check reset, tmpfile is removed.")
+            else:
+                raise error.TestFail("Domain pid changed after reset!")
+        session.close()
+
+    finally:
+        vmxml_backup.sync()


### PR DESCRIPTION
Following https://github.com/autotest/virt-test/pull/1318
Changes:
1. Change cache='default' before test, and do xml recovery at last according to cevich's comments
2. Do change

```
-        session.cmd("touch %s" % tmpfile)
-        status = session.get_command_status("ls %s" % tmpfile)
+        session.cmd_status("rm -rf %s && sync" % tmpfile)
+        status = session.get_command_status("touch %s && ls %s" % (tmpfile, tmpfile))
```

According to yangdongsheng's comments
Signed-off-by: Kyla Zhang weizhan@redhat.com
