### PR TITLE
libvirt.tests: Add virsh domcontrol test case

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domcontrol.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domcontrol.cfg
@@ -1,0 +1,52 @@
+- virsh.domcontrol:
+    type = virsh_domcontrol
+    take_regular_screendumps = "no"
+    domcontrol_vm_ref = "name"
+    domcontrol_job = "yes"
+    domcontrol_action = "dump"
+    kill_vm = "yes"
+    readonly = "no"
+    domcontrol_options = ""
+    variants:
+        - normal_test:
+            status_error = "no"
+            variants:
+                - id_option:
+                    domcontrol_vm_ref = "id"
+                - name_option:
+                - paused_option:
+                    pre_vm_state = "suspend"
+                - uuid_option:
+                    domcontrol_vm_ref = "uuid"
+                - save_option:
+                    domcontrol_action = "save"
+                - managedsave_option:
+                    domcontrol_action = "managedsave"
+                - restore_option:
+                    domcontrol_action = "restore"
+                - readonly_option:
+                    readonly = "yes"
+                    domcontrol_job = "no"
+        - error_test:
+            status_error = "yes"
+            domcontrol_job = "no"
+            variants:
+                - no_option:
+                    domcontrol_vm_ref = ""
+                - hex_id_option:
+                    domcontrol_vm_ref = "hex_id"
+                - invalid_id_option:
+                    domcontrol_vm_ref = "domcontrol_invalid_id"
+                    domcontrol_invalid_id = "9999"
+                - unexpect_option:
+                    domcontrol_vm_ref = "\#"
+                - invalid_uuid_option:
+                    domcontrol_vm_ref = "domcontrol_invalid_uuid"
+                    domcontrol_invalid_uuid = "99999999-9999-9999-9999-999999999999"
+                - shut_off_option:
+                    start_vm = "no"
+                - invalid_option:
+                    domcontrol_options = "--xyz"
+                - readonly_with_invalid_option:
+                    readonly = "yes"
+                    domcontrol_options = "--xyz"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domcontrol.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domcontrol.py
@@ -1,0 +1,126 @@
+import os
+import subprocess
+from autotest.client.shared import error
+from virttest import virsh
+
+
+def get_subprocess(action, vm_name, filepath):
+    """
+    Execute background virsh command, return subprocess w/o waiting for exit()
+
+    :param action : virsh command.
+    :param vm_name : VM's name
+    :param filepath : virsh command's file option.
+    """
+    if action == "managedsave":
+        filepath = ""
+    if action == "restore":
+        vm_name = ""
+    command = "virsh %s %s %s" % (action, vm_name, filepath)
+    p = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE)
+    return p
+
+
+def run(test, params, env):
+    """
+    Test command: virsh domcontrol.
+
+    The command can show the state of a control interface to the domain.
+    1.Prepare test environment, destroy or suspend a VM.
+    2.Do action to get a subprocess(dump, save, restore, managedsave) if
+      domcontrol_job is set as yes.
+    3.Perform virsh domcontrol to check state of a control interface to the
+      domain.
+    4.Recover the VM's status and wait for the subprocess over.
+    5.Confirm the test result.
+    """
+
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    start_vm = params.get("start_vm")
+    pre_vm_state = params.get("pre_vm_state", "running")
+    options = params.get("domcontrol_options", "")
+    action = params.get("domcontrol_action", "dump")
+    tmp_file = os.path.join(test.tmpdir, "domcontrol.tmp")
+    vm_ref = params.get("domcontrol_vm_ref")
+    job = params.get("domcontrol_job", "yes")
+    readonly = "yes" == params.get("readonly", "no")
+    status_error = params.get("status_error", "no")
+    if start_vm == "no" and vm.is_alive():
+        vm.destroy()
+
+    # Instead of "paused_after_start_vm", use "pre_vm_state".
+    # After start the VM, wait for some time to make sure the job
+    # can be created on this domain.
+    if start_vm == "yes":
+        vm.wait_for_login()
+        if params.get("pre_vm_state") == "suspend":
+            vm.pause()
+
+    domid = vm.get_id()
+    domuuid = vm.get_uuid()
+
+    if vm_ref == "id":
+        vm_ref = domid
+    elif vm_ref == "hex_id":
+        vm_ref = hex(int(domid))
+    elif vm_ref == "uuid":
+        vm_ref = domuuid
+    elif vm_ref.find("invalid") != -1:
+        vm_ref = params.get(vm_ref)
+    elif vm_ref == "name":
+        vm_ref = vm_name
+
+    if action == "managedsave":
+        tmp_file = '/var/lib/libvirt/qemu/save/%s.save' % vm.name
+
+    if action == "restore":
+        virsh.save(vm_name, tmp_file, ignore_status=True)
+
+    process = None
+    if job == "yes" and start_vm == "yes" and status_error == "no":
+        # Check domain contorl interface state with job on domain.
+        process = get_subprocess(action, vm_name, tmp_file)
+        while process.poll() is None:
+            if vm.is_alive():
+                ret = virsh.domcontrol(vm_ref, options, ignore_status=True,
+                                       debug=True)
+                status = ret.exit_status
+                # check status_error
+                if status != 0:
+                    # Do not raise error if domain is not running, as save,
+                    # managedsave and restore will change the domain state
+                    # from running to shutoff or reverse, and the timing of
+                    # the state change is not predicatable, so skip the error
+                    # of domain state change and focus on domcontrol command
+                    # status while domain is running.
+                    if vm.is_alive():
+                        raise error.TestFail("Run failed with right command")
+    else:
+        # Check domain contorl interface state without job on domain.
+        ret = virsh.domcontrol(vm_ref, options, readonly=readonly,
+                               ignore_status=True, debug=True)
+        status = ret.exit_status
+
+        # check status_error
+        if status_error == "yes":
+            if status == 0:
+                raise error.TestFail("Run successfully with wrong command!")
+        elif status_error == "no":
+            if status != 0:
+                raise error.TestFail("Run failed with right command")
+
+    # Recover the environment.
+    if action == "managedsave":
+        virsh.managedsave_remove(vm_name, ignore_status=True)
+    if os.path.exists(tmp_file):
+        os.unlink(tmp_file)
+    if pre_vm_state == "suspend":
+        vm.resume()
+    if process:
+        if process.poll():
+            try:
+                process.kill()
+            except OSError:
+                pass


### PR DESCRIPTION
Check domain control interface state while with or without job (dump,
save, restore, managedsave) on domain. When with job on domain, "occupied"
or "background job" is expected, "ok" is also expected since state is in
change. When without job on domain, 'ok' is expected.

In the test case, use subprocess to create job on domain, while run
domcontrol in loop to check domain control interface state, no strict
check on state as it is changing, only check the command status.

Signed-off-by: Wayne Sun gsun@redhat.com
