### PR TITLE
Add support of enable/disable second video device screenshot

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_screenshot.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_screenshot.cfg
@@ -16,36 +16,36 @@
                     vm_ref = "domid"
                     variants:
                         - screen_0:
-                            options = "--screen 0"
+                            screen_number = 0
                         - screen_1:
-                            options = "--screen 1"
+                            screen_number = 1
                 - name_option:
                     variants:
                         - screen_0:
-                            options = "--screen 0"
+                            screen_number = 0
                         - screen_1:
-                            options = "--screen 1"
+                            screen_number = 1
                 - paused_option:
                     vm_state = "paused"
                     variants:
                         - screen_0:
-                            options = "--screen 0"
+                            screen_number = 0
                         - screen_1:
-                            options = "--screen 1"
+                            screen_number = 1
                 - uuid_option:
                     vm_ref = "domuuid"
                     variants:
                         - screen_0:
-                            options = "--screen 0"
+                            screen_number = 0
                         - screen_1:
-                            options = "--screen 1"
+                            screen_number = 1
                 - no_filename_option:
                     filename = ""
                     variants:
                         - screen_0:
-                            options = "--screen 0"
+                            screen_number = 0
                         - screen_1:
-                            options = "--screen 1"
+                            screen_number = 1
                 - no_screen_option:
         - error_test:
             status_error = "yes"
@@ -66,7 +66,9 @@
                     options = "--xyz"
                 - multiple_screen_option:
                     options = "--screen 0 --screen 1"
+                - empty_screen_number:
+                    options = "--screen"
                 - unexpected_screen_number:
-                    options = "--screen 3"
+                    options = "--screen 99"
                 - empty_filename_option:
                     filename = " "


### PR DESCRIPTION
RHEL support multiple video devices screenshot with given screen
number while Fedora upstream did not support it. With this change,
user can config enable/disable multiple_screen in cfg file to
enable/disable tests with screen number as 1. By default in cfg
file multiple_screen is set as 'no'.

RHEL multiple video device screenshot tracking bug:
  https://bugzilla.redhat.com/show_bug.cgi?id=1026966
  https://bugzilla.redhat.com/show_bug.cgi?id=710489

Signed-off-by: Wayne Sun gsun@redhat.com
