### PR TITLE
libvirt-tests: Add test case for nodesuspend

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_nodesuspend.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_nodesuspend.cfg
@@ -4,9 +4,13 @@
     check_image = no
     take_regular_screendumps = no
     libvirtd = on
-    remote_ip = ENTER.YOUR.REMOTE.EXAMPLE.COM
-    remote_user = root
-    remote_pwd = EXAMPLE.PWD
+    # WARNING:
+    # Changing these remote* parameters might shutdown remote host *FOREVER*.
+    # Please make sure you can physically start the remote host before proceed
+    # or you might lose control of it.
+    nodesuspend_remote_ip = ENTER.YOUR.REMOTE.EXAMPLE.COM
+    nodesuspend_remote_user = root
+    nodesuspend_remote_pwd = EXAMPLE.PWD
     suspend_target = mem
     suspend_time = 60
     upper_tolerance = 15

--- a/libvirt/tests/src/virsh_cmd/host/virsh_nodesuspend.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_nodesuspend.py
@@ -1,6 +1,7 @@
 import time
 import logging
 from virttest import virsh
+from virttest import libvirt_vm
 from virttest.remote import LoginTimeoutError, LoginProcessTerminatedError
 from autotest.client.shared import error
 from autotest.client import utils
@@ -80,9 +81,10 @@ def run(test, params, env):
     the remote_xxx parameters in configuration file to corresponding value.
     """
     # Retrive parameters
-    remote_ip = params.get('remote_ip', 'ENTER.YOUR.REMOTE.EXAMPLE.COM')
-    remote_user = params.get('remote_user', 'root')
-    remote_pwd = params.get('remote_pwd')
+    remote_ip = params.get('nodesuspend_remote_ip',
+                           'ENTER.YOUR.REMOTE.EXAMPLE.COM')
+    remote_user = params.get('nodesuspend_remote_user', 'root')
+    remote_pwd = params.get('nodesuspend_remote_pwd', 'EXAMPLE.PWD')
     suspend_target = params.get('suspend_target', 'mem')
     suspend_time = int(params.get('suspend_time', '60'))
     upper_tolerance = int(params.get('upper_tolerance', '8'))
@@ -91,12 +93,13 @@ def run(test, params, env):
 
     # Check if remote_ip is set
     if 'EXAMPLE' in remote_ip:
-        msg = ('Configuration parameter `remote_ip` need to be changed to the '
-               'ip of host to be tested')
+        msg = ('Configuration parameter `nodesuspend_remote_ip` need to be '
+               'changed to the ip of host to be tested')
         raise error.TestNAError(msg)
 
     # Create remote virsh session
-    remote_uri = 'qemu+ssh://' + remote_ip + '/system'
+    remote_uri = libvirt_vm.get_uri_with_transport(
+        transport="ssh", dest_ip=remote_ip)
     virsh_dargs = {
         'remote_user': remote_user,
         'remote_pwd': remote_pwd,


### PR DESCRIPTION
Test command: `virsh nodesuspend <target> <duration>`

This command will make host suspend or hibernate, running tests on testing
grid may cause unexpected behavior.

This tests only work when test runner setup a remote host (physical or
virtual) with testing version of libvirt daemon running. After that change
the `remote_xxx` parameters in configuration file to corresponding value.

Signed-off-by: Hao Liu hliu@redhat.com
