### PR TITLE
libvirt.tests: Add test module for timer management.

### DIFF
--- a/libvirt/tests/cfg/timer_management.cfg
+++ b/libvirt/tests/cfg/timer_management.cfg
@@ -64,6 +64,7 @@
     variants:
         # Setting of timer elements in libvirt XML
         - no_timer:
+            no banned_timer
             xml_timer = "no"
         - ban_xml_timer:
             only banned_timer
@@ -77,11 +78,14 @@
                     banned_timer = "kvm-clock"
                     timers_attr = "name=kvmclock;present=no"
                 - tsc:
+                    timer_start_error = "yes"
                     banned_timer = "tsc"
                     timers_attr = "name=tsc;present=no"
                 - hpet:
+                    timer_start_error = "yes"
                     banned_timer = "hpet"
                     timers_attr = "name=hpet;present=no"
                 - platform:
+                    timer_start_error = "yes"
                     banned_timer = "acpi_pm"
                     timers_attr = "name=platform;present=no"


### PR DESCRIPTION
1. Test timers available in vms
2. Test clock setting in libvirt XML: offset and timer elements

Signed-off-by: Yu Mingfei yumingfei@cn.fujitsu.com
