### PR TITLE
virsh_find_storage_pool_sources_as: Error checking

### DIFF
--- a/libvirt/tests/src/virsh_cmd/pool/virsh_find_storage_pool_sources_as.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_find_storage_pool_sources_as.py
@@ -47,6 +47,9 @@ def run(test, params, env):
             # Set up iscsi
             try:
                 iscsi_device = utils_test.libvirt.setup_or_cleanup_iscsi(True)
+                # If we got nothing, force failure
+                if not iscsi_device:
+                    raise error.TestFail("Did not setup an iscsi device")
                 cleanup_iscsi = True
                 if source_type == "logical":
                     # Create VG by using iscsi device


### PR DESCRIPTION
If the setup_or_cleanup_iscsi() fails to configure our iscsi device,
just cause the test to fail. It's not getting much further anyway.
