### PR TITLE
libvirt.tests: Add virsh vol-create command case

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_create.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_create.cfg
@@ -1,0 +1,169 @@
+- virsh.vol_create:
+    type = virsh_vol_create
+    start_vm = no
+    vol_name = "vol_create_test"
+    vol_capacity = "1073741824"
+    vol_allocation = "1048576"
+    extra_option = ""
+    variants:
+        - positive_test:
+            status_error = "no"
+            variants:
+                - logical_pool:
+                    src_pool_type = "logical"
+                    src_pool_target = "/dev/vg_logical"
+                    src_emulated_image = "logical-pool"
+                - disk_pool:
+                    src_pool_type = "disk"
+                    src_pool_target = "/dev"
+                    src_emulated_image = "disk-pool"
+                    variants:
+                        - vol_format_none:
+                        - vol_format_linux:
+                            vol_format = "linux"
+                        - vol_format_fat16:
+                            vol_format = "fat16"
+                        - vol_format_fat32:
+                            vol_format = "fat32"
+                        - vol_format_linux-swap:
+                            vol_format = "linux-swap"
+                        - vol_format_linux-lvm:
+                            vol_format = "linux-lvm"
+                        - vol_format_linux-raid:
+                            vol_format = "linux-raid"
+                        - vol_format_extended:
+                            vol_format = "extended"
+                - fs_like_pool:
+                    variants:
+                        - src_pool_type:
+                            variants:
+                                - dir:
+                                    src_pool_type = "dir"
+                                    src_pool_target = "dir-pool"
+                                - fs:
+                                    src_pool_type = "fs"
+                                    src_pool_target = "fs"
+                                    src_emulated_image = "fs-pool"
+                                - netfs:
+                                    src_pool_type = "netfs"
+                                    src_pool_target = "nfs-mount"
+                                    nfs_server_dir = "nfs-server"
+                                    source_host = "localhost"
+                    variants:
+                        - vol_format:
+                            variants:
+                                - v_raw:
+                                    vol_format = "raw"
+                                - v_qcow2:
+                                    vol_format = "qcow2"
+                                - v_qcow2_with_prealloc:
+                                    vol_format = "qcow2"
+                                    extra_option = "--prealloc-metadata"
+                                - v_qcow2v3:
+                                    vol_format = "qcow2"
+                                    vol_compat = "1.1"
+                                    lazy_refcounts = "yes"
+                                - v_qcow2_with_compat:
+                                    vol_format = "qcow2"
+                                    vol_compat = "1.1"
+                                - v_qed:
+                                    vol_format = "qed"
+                                - v_bochs:
+                                    vol_format = "bochs"
+                                - v_cloop:
+                                    vol_format = "cloop"
+                                - v_dmg:
+                                    vol_format = "dmg"
+                                - v_iso:
+                                    vol_format = "iso"
+                                - v_vmdk:
+                                    vol_format = "vmdk"
+                                - v_vpc:
+                                    vol_format = "vpc"
+                                - v_none:
+        - negative_test:
+            status_error = "yes"
+            variants:
+                - unsupported_extra_option:
+                    src_pool_type = "dir"
+                    src_pool_target = "dir-pool"
+                    extra_option = "--xyz"
+                - iscsi_pool_without_format:
+                    src_pool_type = "iscsi"
+                    src_pool_target = "/dev/disk/by-path"
+                    src_emulated_image = "iscsi-pool"
+                - scsi_pool_without_format:
+                    src_pool_type = "scsi"
+                    scsi_xml_file = "scsi.xml"
+                    src_pool_target = "scsi"
+                    src_emulated_image = "scsi-pool"
+                - fs_like_pool_with_prealloc:
+                    extra_option = "--prealloc-metadata"
+                    variants:
+                        - src_pool_type:
+                            variants:
+                                - dir:
+                                    src_pool_type = "dir"
+                                    src_pool_target = "dir-pool"
+                                - fs:
+                                    src_pool_type = "fs"
+                                    src_pool_target = "fs"
+                                    src_emulated_image = "fs-pool"
+                                - netfs:
+                                    src_pool_type = "netfs"
+                                    src_pool_target = "nfs-mount"
+                                    nfs_server_dir = "nfs-server"
+                                    source_host = "localhost"
+                    variants:
+                        - none_qcow2_format:
+                            variants:
+                                - v_raw:
+                                    vol_format = "raw"
+                                - v_qed:
+                                    vol_format = "qed"
+                                - v_bochs:
+                                    vol_format = "bochs"
+                                - v_cloop:
+                                    vol_format = "cloop"
+                                - v_dmg:
+                                    vol_format = "dmg"
+                                - v_iso:
+                                    vol_format = "iso"
+                                - v_vmdk:
+                                    vol_format = "vmdk"
+                                - v_vpc:
+                                    vol_format = "vpc"
+                                - v_none:
+                - none_fs_like_pool_with_format:
+                    variants:
+                        - src_pool_type:
+                            variants:
+                                - disk:
+                                    src_pool_type = "disk"
+                                    src_pool_target = "/dev"
+                                    src_emulated_image = "disk-pool"
+                                - iscsi:
+                                    src_pool_type = "iscsi"
+                                    src_pool_target = "/dev/disk/by-path"
+                                    src_emulated_image = "iscsi-pool"
+                                - scsi:
+                                    src_pool_type = "scsi"
+                                    scsi_xml_file = "scsi.xml"
+                                    src_pool_target = "scsi"
+                                    src_emulated_image = "scsi-pool"
+                    variants:
+                        - vol_format:
+                            variants:
+                                - v_raw:
+                                    vol_format = "raw"
+                                - v_qcow2:
+                                    vol_format = "qcow2"
+                                - v_qcow2v3:
+                                    vol_format = "qcow2"
+                                    vol_compat = "1.1"
+                                    lazy_refcounts = "yes"
+                                - v_qcow2_with_compat:
+                                    vol_format = "qcow2"
+                                    vol_compat = "1.1"
+                                - v_qed:
+                                    vol_format = "qed"

--- a/libvirt/tests/src/virsh_cmd/volume/virsh_vol_create.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_vol_create.py
@@ -1,0 +1,121 @@
+import os
+import logging
+from virttest import virsh, libvirt_storage, libvirt_xml
+from virttest.utils_test import libvirt as utlv
+from autotest.client.shared import error
+
+
+def run(test, params, env):
+    """
+    Test virsh vol-create command to cover the following matrix:
+    pool_type = [dir, fs, netfs]
+    volume_format = [raw, bochs, cloop, cow, dmg, iso, qcow, qcow2, qed,
+                     vmdk, vpc]
+
+    pool_type = [disk]
+    volume_format = [none, linux, fat16, fat32, linux-swap, linux-lvm,
+                     linux-raid, extended]
+
+    pool_type = [logical]
+    volume_format = [none]
+
+    pool_type = [iscsi, scsi]
+    Not supported with format type
+
+    TODO:
+    pool_type = [rbd, glusterfs]
+
+    Reference: http://www.libvirt.org/storage.html
+    """
+
+    src_pool_type = params.get("src_pool_type")
+    src_pool_target = params.get("src_pool_target")
+    src_emulated_image = params.get("src_emulated_image")
+    extra_option = params.get("extra_option", "")
+    vol_name = params.get("vol_name", "vol_create_test")
+    vol_format = params.get("vol_format")
+    lazy_refcounts = "yes" == params.get("lazy_refcounts")
+    status_error = "yes" == params.get("status_error", "no")
+
+    # Set volume xml attribute dictionary, extract all params start with 'vol_'
+    # which are for setting volume xml, except 'lazy_refcounts'.
+    vol_arg = {}
+    for key in params.keys():
+        if key.startswith('vol_'):
+            if key[4:] in ['capacity', 'allocation', 'owner', 'group']:
+                vol_arg[key[4:]] = int(params[key])
+            else:
+                vol_arg[key[4:]] = params[key]
+    vol_arg['lazy_refcounts'] = lazy_refcounts
+
+    pool_type = ['dir', 'disk', 'fs', 'logical', 'netfs', 'iscsi', 'scsi']
+    if src_pool_type not in pool_type:
+        raise error.TestNAError("pool type %s not in supported type list: %s" %
+                                (src_pool_type, pool_type))
+
+    try:
+        # Create the src pool
+        src_pool_name = "virt-%s-pool" % src_pool_type
+        pvt = utlv.PoolVolumeTest(test, params)
+        pvt.pre_pool(src_pool_name, src_pool_type, src_pool_target,
+                     src_emulated_image, image_size="2G",
+                     pre_disk_vol=["1M"])
+
+        # Print current pools for debugging
+        logging.debug("Current pools:%s",
+                      libvirt_storage.StoragePool().list_pools())
+
+        # Set volume xml file
+        volxml = libvirt_xml.VolXML()
+        newvol = volxml.new_vol(**vol_arg)
+        vol_xml = newvol['xml']
+
+        # Run virsh_vol_create to create vol
+        logging.debug("create volume from xml: %s" % newvol.xmltreefile)
+        cmd_result = virsh.vol_create(src_pool_name, vol_xml, extra_option,
+                                      ignore_status=True, debug=True)
+        status = cmd_result.exit_status
+        # Check result
+        if not status_error:
+            if not status:
+                src_pv = libvirt_storage.PoolVolume(src_pool_name)
+                src_volumes = src_pv.list_volumes().keys()
+                logging.debug("Current volumes in %s: %s",
+                              src_pool_name, src_volumes)
+                if vol_name not in src_volumes:
+                    raise error.TestFail("Can't find volume: %s from pool: %s"
+                                         % (vol_name, src_pool_name))
+                # check format in volume xml
+                post_xml = volxml.new_from_vol_dumpxml(vol_name, src_pool_name)
+                logging.debug("the created volume xml is: %s" %
+                              post_xml.xmltreefile)
+                if 'format' in post_xml.keys():
+                    if post_xml.format != vol_format:
+                        raise error.TestFail("Volume format %s is not expected"
+                                             % vol_format + " as defined.")
+            else:
+                # Skip the format not supported by qemu-img error
+                if vol_format:
+                    fmt_err = "qemu-img: Unknown file format '%s'" % vol_format
+                    fmt_err1 = "qemu-img: Formatting or formatting option " +\
+                               "not supported for file format '%s'" % vol_format
+                    if fmt_err in cmd_result.stderr or \
+                       fmt_err1 in cmd_result.stderr:
+                        raise error.TestNAError("Volume format %s is not " %
+                                                vol_format + "supported.")
+                    else:
+                        raise error.TestFail("Run failed with right command.")
+                else:
+                    raise error.TestFail("Run failed with right command.")
+        else:
+            if status:
+                logging.debug("Expect error: %s", cmd_result.stderr)
+            else:
+                raise error.TestFail("Expect fail, but run successfully!")
+    finally:
+        # Cleanup
+        try:
+            pvt.cleanup_pool(src_pool_name, src_pool_type, src_pool_target,
+                             src_emulated_image)
+        except error.TestFail, detail:
+            logging.error(str(detail))


### PR DESCRIPTION
Add test case for virsh command vol-create, prepare different type
of pools before run the command within the case.

The case covers pool of default format with supported volume format
matrix.

Reference:
http://www.libvirt.org/storage.html

Signed-off-by: Wayne Sun gsun@redhat.com
