### PR TITLE
nodedev_list: Adjust the usb_ exclude list

### DIFF
--- a/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_list.py
+++ b/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_list.py
@@ -111,10 +111,12 @@ def get_devices_by_cap(cap):
         'scsi': ('/sys/class/scsi_device', 'scsi_', '.*'),
         'scsi_generic': ('/sys/class/scsi_generic', 'scsi_generic_', '.*'),
         'scsi_target': ('/sys/bus/scsi/devices', 'scsi_', r'target.*'),
-        'usb': ('/sys/bus/usb/devices', 'usb_', r'\d+-\d+:\d+\.\d+'),
+        'usb': ('/sys/bus/usb/devices', 'usb_',
+                # Match any string that does not have :X.X at the end
+                r'\S+:\d+\.\d+'),
         'usb_device': ('/sys/bus/usb/devices', 'usb_',
-                       # Match any string is not a 'X-X:X.X'
-                       r'^((?!\d+-\d+:\d+\.\d+).)*$'),
+                       # Match any string that does not have :X.X at the end
+                       r'^((?!\S+:\d+\.\d+).)*$'),
         }
     if cap in cap_map:
         devices = []


### PR DESCRIPTION
The current exclude list only removes "X-X:X-X" devices; however, if
there are "X-X.X:X-X" device it doesn't find them - thus adding to the
list of expected devices, which libvirt doesn't find resulting in a
test error.

Rather than figure out all the nuances, I adjusted the "X-X" to be just
any string before a ":X-X".

FWIW: Output had:
...
2-1.3
3-0:1.0
2-1.3:1.0
...
where ls -al /sys/bus/usb/devices has:

2-1.3 -> ../../../devices/pci0000:00/0000:00:1d.0/usb2/2-1/2-1.3
2-1.3:1.0 -> ../../../devices/pci0000:00/0000:00:1d.0/usb2/2-1/2-1.3/2-1.3:1.0
