### PR TITLE
Adjust filter to avoid -S

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_to_native.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_to_native.py
@@ -81,6 +81,10 @@ def run(test, params, env):
                 continue
             elif re.search("tap", arg):
                 continue
+            # Upstream libvirt commit id 'e8400564':
+            # XMLToNative: Don't show -S
+            elif re.search ("-S", arg):
+                continue
             retlist.append(arg)
 
         return retlist


### PR DESCRIPTION
Upstream libvirt has removed '-S' from domxml_to_native processing, so
let's just avoid processing it if we find it.
