### PR TITLE
schedinfo_qemu_posix: Add cases change schedinfo by xml

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_schedinfo_qemu_posix.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_schedinfo_qemu_posix.cfg
@@ -17,6 +17,14 @@
                 # Do not set, just show the parameters
                 - show_schedinfo:
                 - set_cpu_param:
+                    variants:
+                        - set_by_cmd:
+                            schedinfo_set_method = 'cmd'
+                        - set_by_xml:
+                            # When set 'shares' to 0 by XML, the tests will FAIL if
+                            # tested version of libvirt don't have a fix for a known bug:
+                            # https://bugzilla.redhat.com/show_bug.cgi?id=1040784
+                            schedinfo_set_method = 'xml'
                     schedinfo_param = "vcpu"
                     variants:
                         # The cpu_shares parameter has a valid value range of 0-262144.

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_emulatorpin.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_emulatorpin.py
@@ -66,10 +66,10 @@ def check_emulatorpin(params):
     # with 'inactive' option to get guest XML changes.
     if options == "config" and vm and not vm.is_alive():
         emulatorpin_from_xml = \
-            vm_xml.VMXML().new_from_dumpxml(vm_name, "--inactive").emulatorpin
+            vm_xml.VMXML().new_from_dumpxml(vm_name, "--inactive").cputune.emulatorpin
     else:
         emulatorpin_from_xml = \
-            vm_xml.VMXML().new_from_dumpxml(vm_name).emulatorpin
+            vm_xml.VMXML().new_from_dumpxml(vm_name).cputune.emulatorpin
 
     # To get guest corresponding emulator/cpuset.cpus value
     # from cpuset controller of the cgroup.


### PR DESCRIPTION
This patch changed cputune info in domain xml and then restart the
domain to validate it with cgroup observation. This is a regression
test base on a known bug.

Also the emulatorpin test is changed to fit new vm_xml.

Signed-off-by: Hao Liu hliu@redhat.com
