### PR TITLE
libvirt.tests: Add unsafe option test for virsh.migrate.

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
@@ -23,7 +23,9 @@
     status_error = 'no'
     virsh_migrate_delay = 60
     virsh_migrate_back = 'no'
-    virsh_migrate_shared_storage = ""
+    # Please provide a shared VM image for migration
+    # It could be put into NFS or SAN
+    virsh_migrate_shared_storage = "SHARED_IMAGE.EXAMPLE.COM"
     variants:
         - there_and_back:
             # After migrating, migrate the guest back.
@@ -80,6 +82,12 @@
         - there_verbose:
             # Uni-direction migration with option --verbose.
             virsh_migrate_options = "--live --verbose"
+        - there_unsafe:
+            # Uni-direction migration with option --unsafe.
+            # Set disk cache to default then migrate without unsafe
+            # the first time, confirming its fail then migrat with it.
+            virsh_migrate_options = "--live --unsafe"
+            virsh_migrate_disk_cache = "default"
         - there_timeout:
             # Uni-direction migration with option --timeout.
             virsh_migrate_options = "--live"


### PR DESCRIPTION
- Add one testcase to test unsafe option of migrate
- Add Comments for some parameters

Signed-off-by: Yu Mingfei yumingfei@cn.fujitsu.com
