### PR TITLE
libguestfs.tests: Add more testcases for virt-edit options.

### DIFF
--- a/libguestfs/tests/cfg/virt_edit.cfg
+++ b/libguestfs/tests/cfg/virt_edit.cfg
@@ -13,6 +13,12 @@
                             virt_edit_vm_ref = "domname"
                         - dom_disk:
                             virt_edit_vm_ref = "domdisk"
+                            variants:
+                                - auto_format:
+                                    # No format passed
+                                - disk_format:
+                                    # A inspected format of vm passed
+                                    virt_edit_format = "inspect"
                         - dom_uuid:
                             virt_edit_vm_ref = "domuuid"
             variants:
@@ -24,6 +30,15 @@
                 - add_foo_line:
                     # You'd better sure it is unique.
                     foo_line = "#foooooo"
+                - backup_file:
+                    only dom_name
+                    virt_edit_backup_extension = ".vtbak"
+                - connect_uri:
+                    only dom_name
+                    virt_edit_remote_host = "HOST.EXAMPLE"
+                    virt_edit_remote_user = "root"
+                    virt_edit_remote_passwd = "PASSWD.EXAMPLE"
+                    virt_edit_connect_uri = "remote"
         - error_test:
             status_error = yes
             variants:


### PR DESCRIPTION
Add three testcase:
1. test for format option
2. test for backup option
3. test for connect_uri option

```
Usage:
  virt-edit [--options] -d domname file [file ...]
  virt-edit [--options] -a disk.img [-a disk.img ...] file [file ...]
Options:
  -a|--add image       Add image
  -b|--backup .ext     Backup original as original.ext
  -c|--connect uri     Specify libvirt URI for -d option
  -d|--domain guest    Add disks from libvirt guest
  --echo-keys          Don't turn off echo for passphrases
  -e|--expr expr       Non-interactive editing using Perl expr
  --format[=raw|..]    Force disk format for -a option
  --help               Display brief help
  --keys-from-stdin    Read passphrases from stdin
  -v|--verbose         Verbose messages
  -V|--version         Display version and exit
  -x                   Trace libguestfs API calls
```

Signed-off-by: Yu Mingfei yumingfei@cn.fujitsu.com

Rely on:
https://github.com/autotest/virt-test/pull/1596
