### PR TITLE
virsh.list: When setting title, add proper option to virsh.desc

### DIFF
--- a/libvirt/tests/src/virsh_cmd/monitor/virsh_list.py
+++ b/libvirt/tests/src/virsh_cmd/monitor/virsh_list.py
@@ -88,7 +88,10 @@ def run(test, params, env):
         logging.info("%s's uuid is: %s", vm_name, domuuid)
     elif list_ref == "--title":
         vm_backup = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
-        virsh.desc(vm_name, "--config --title", desc)
+        if options_ref == "inactive":
+            virsh.desc(vm_name, "--config --title", desc)
+        else:
+            virsh.desc(vm_name, "--live --title", desc)
         result_expected = desc
         logging.info("%s's title is: %s", vm_name, desc)
     else:


### PR DESCRIPTION
Commit id '58fd81a8' added the --title testing for virsh.list; however,
the add of the title was done to the --config and for a running domain
that didn't have expected results. Adjust the add of the title to be
based on the expected state of the domain.

Signed-off-by: John Ferlan jferlan@redhat.com
