### PR TITLE
Domiftune changes

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domiftune.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domiftune.cfg
@@ -1,6 +1,8 @@
 - virsh.domiftune:
     type = virsh_domiftune
     libvirtd = "on"
+    take_regular_screendumps = "no"
+    check_clear = "no"
     variants:
         - positive_testing:
             status_error = "no"
@@ -61,6 +63,15 @@
                                                     options = "live"
                                                 - current:
                                                     options = "current"
+                                # As of libvirt 1.2.3 (commid id '14973382')
+                                # setting inbound or outbound to 0 (zero) will
+                                # clear the average value - let's test that.
+                                - clear_inbound:
+                                    check_clear = "yes"
+                                    inbound = 0
+                                - clear_outbound:
+                                    check_clear = "yes"
+                                    outbound = 0
 
         - negative_testing:
             status_error = "yes"
@@ -91,9 +102,6 @@
                             variants:
                                 - change_inbound:
                                     variants:
-                                        # inbound average is mandatory
-                                        - average:
-                                            inbound = 0
                                         - invalid_format:
                                             inbound = "~@#$%^-=_:,.[]{}"
                                     variants:
@@ -103,8 +111,6 @@
                                                     options = "live"
                                 - change_outbound:
                                     variants:
-                                        - average:
-                                            outbound = 0
                                         - invalid_format:
                                             outbound = "~@#$%^-=_:,.[]{}"
                                     variants:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domiftune.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domiftune.py
@@ -2,9 +2,10 @@ import logging
 from autotest.client.shared import error
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
+from provider import libvirt_version
 
 
-def check_domiftune(params):
+def check_domiftune(params, test_clear):
     """
     Compare inbound and outbound value with guest XML configuration
     and virsh command output.
@@ -18,7 +19,13 @@ def check_domiftune(params):
     outbound = params.get("outbound", "")
     inbound_from_cmd_output = None
     outbound_from_cmd_output = None
+    peak_in_from_cmd_output = None
+    peak_out_from_cmd_output = None
+    burst_in_from_cmd_output = None
+    burst_out_from_cmd_output = None
     domiftune_params = {}
+
+    logging.debug("Checking inbound=%s outbound=%s", inbound, outbound)
     if vm and vm.is_alive():
         result = virsh.domiftune(vm_name, interface, options=options)
         dicts = {}
@@ -31,6 +38,12 @@ def check_domiftune(params):
         logging.debug(dicts)
         inbound_from_cmd_output = dicts['inbound.average']
         outbound_from_cmd_output = dicts['outbound.average']
+        logging.debug("inbound_from_cmd_output=%s, outbound_from_cmd_output=%s",
+                      inbound_from_cmd_output, outbound_from_cmd_output)
+        peak_in_from_cmd_output = dicts['inbound.peak']
+        peak_out_from_cmd_output = dicts['outbound.peak']
+        burst_in_from_cmd_output = dicts['inbound.peak']
+        burst_out_from_cmd_output = dicts['outbound.peak']
 
     virt_xml_obj = vm_xml.VMXML(virsh_instance=virsh)
 
@@ -45,8 +58,35 @@ def check_domiftune(params):
 
     inbound_from_xml = domiftune_params.get("inbound")
     outbound_from_xml = domiftune_params.get("outbound")
+    logging.debug("inbound_from_xml=%s, outbound_from_xml=%s",
+                  inbound_from_xml, outbound_from_cmd_output)
 
     if vm and vm.is_alive() and options != "config":
+        if test_clear and inbound:
+            if inbound_from_xml is not None or \
+               inbound_from_cmd_output is not "0" or \
+               peak_in_from_cmd_output is not "0" or \
+               burst_in_from_cmd_output is not "0":
+                logging.error("Inbound was not cleared, xml=%s "
+                              "avg=%s peak=%s burst=%s",
+                              inbound_from_xml,
+                              inbound_from_cmd_output,
+                              peak_in_from_cmd_output,
+                              burst_in_from_cmd_output)
+                return False
+        if test_clear and outbound:
+            if outbound_from_xml is not None or \
+               outbound_from_cmd_output is not "0" or \
+               peak_out_from_cmd_output is not "0" or \
+               burst_out_from_cmd_output is not "0":
+                logging.error("Outbound was not cleared, xml=%s "
+                              "avg=%s peak=%s burst=%s",
+                              outbound_from_xml,
+                              outbound_from_cmd_output,
+                              peak_out_from_cmd_output,
+                              burst_out_from_cmd_output)
+        if test_clear:
+            return True
         if inbound and inbound != inbound_from_cmd_output:
             logging.error("To expect inbound %s: %s", inbound,
                           inbound_from_cmd_output)
@@ -86,13 +126,14 @@ def get_domiftune_parameter(params):
         if status:
             logging.info("It's an expected error: %s", result.stderr)
         else:
-            raise error.TestFail("%d not a expected command "
-                                 "return value", status)
+            raise error.TestFail("%d not a expected command return value" %
+                                 status)
     elif status_error == "no":
         if status:
-            raise error.TestFail(result.stderr)
+            raise error.TestFail("Unexpected result, get domiftune: %s" %
+                                 result.stderr)
         else:
-            logging.info(result.stdout)
+            logging.info("getdominfo return succesfully")
 
 
 def set_domiftune_parameter(params):
@@ -101,33 +142,82 @@ def set_domiftune_parameter(params):
     :params: the parameter dictionary
     """
     vm_name = params.get("vms")
-    inbound = params.get("inbound")
-    outbound = params.get("outbound")
+    inbound = params.get("inbound", "")
+    outbound = params.get("outbound", "")
     options = params.get("options", None)
     interface = params.get("iface_dev")
+    check_clear = params.get("check_clear", "no")
+    status_error = params.get("status_error", "no")
+
+    test_clear = False
+    if check_clear == "yes":
+        # In libvirt 1.2.3, commit id '14973382' it will now be possible
+        # to pass a zero (0) as an inbound or outbound parameter to virsh
+        # domiftune in order to clear all the settings found. So we'll
+        # handle that difference here
+        if libvirt_version.version_compare(1, 2, 3):
+            test_clear = True
+            # Although the .cfg file has "0" for these that will
+            # not test whether we can clear the value. So let's
+            # set it to "1", then after we are sure we can set it
+            # we will clear it and check that it's clear
+            if inbound:
+                save_inbound = inbound
+                # average,peak,burst
+                inbound = "1,4,6"
+                params['inbound'] = "1"
+            if outbound:
+                save_outbound = outbound
+                # average,peak,burst
+                outbound = "1,4,6"
+                params['outbound'] = "1"
+        else:
+            # Prior to libvirt 1.2.3 this would be an error
+            # So let's just treat it as such. Leaving the
+            # inbound/outbound as zero should result in an
+            # error on the following set, but a pass for
+            # the test since the error is expected.
+            status_error = "yes"
 
     result = virsh.domiftune(vm_name, interface, options, inbound, outbound)
     status = result.exit_status
-
-    # Check status_error
-    status_error = params.get("status_error", "no")
 
     if status_error == "yes":
         if status:
             logging.info("It's an expected error: %s", result.stderr)
         else:
-            raise error.TestFail("%d not a expected command "
-                                 "return value", status)
+            raise error.TestFail("%d not a expected command return value" %
+                                 status)
     elif status_error == "no":
         if status:
-            raise error.TestFail(result.stderr)
+            raise error.TestFail("Unexpected set domiftune error: %s" %
+                                 result.stderr)
         else:
-            if check_domiftune(params):
-                logging.info(result.stdout)
-            else:
-                error.TestFail("The 'inbound' or/and 'outbound' are"
-                               " inconsistent with domiftune XML"
-                               " and/or virsh command output")
+            if not check_domiftune(params, False):
+                raise error.TestFail("The 'inbound' or/and 'outbound' are"
+                                     " inconsistent with domiftune XML"
+                                     " and/or virsh command output")
+
+    # If supported, then here's where we reset the inbound/outbound
+    # back to what they were input as and then run the same domiftune
+    # command.  That should result in a successful return and should
+    # clear the parameter.
+    if test_clear:
+        if inbound:
+            inbound = save_inbound
+            params['inbound'] = save_inbound
+        if outbound:
+            outbound = save_outbound
+            params['outbound'] = save_outbound
+        result = virsh.domiftune(vm_name, interface, options, inbound, outbound)
+        status = result.exit_status
+        if status:
+            raise error.TestFail("Unexpected failure when clearing: %s" %
+                                 result.stderr)
+        else:
+            if not check_domiftune(params, True):
+                raise error.TestFail("The 'inbound' or/and 'outbound' were "
+                                     "not cleared.")
 
 
 def run(test, params, env):


### PR DESCRIPTION
There are two commits within this change - the first just changes the value of the maximum value allowed. Libvirt expects a kilobyte value not a byte value for input. Also there was a rounding bug in the package libvirt calls so the issue was masked; however, recent versions of that code fix the rounding problem - thus this showed as a error in the test.  Note that the libvirt documentation was updated to more clearly reflect the kilobyte value.  The second commit handles an upstream change to allow using the value "0" (zero) as a mechanism to clear the current value - thus this code will handle that.  It requires PR #82 to be pushed first however.
