### PR TITLE
update_device: Revisit old changes and fix

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_update_device.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_update_device.cfg
@@ -19,7 +19,7 @@
                             updatedevice_flag = "--live"
                         - config_option:
                             updatedevice_flag = "--config"
-                        - force_diff_iso_option:
+                        - diff_iso_option:
                             updatedevice_twice = "yes"
                             updatedevice_diff_iso = "yes"
                 - name_option:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_update_device.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_update_device.py
@@ -5,14 +5,37 @@ import logging
 from autotest.client.shared import error
 from virttest import virsh
 from virttest.libvirt_xml import VMXML
+from provider import libvirt_version
 
 
-def create_attach_xml(update_xmlfile, source_iso):
+def create_cdrom(vm_name, orig_iso, target_dev):
+    """
+    :param vm_name : vm_name
+    :param source_iso : disk's source backing file.
+    """
+    try:
+        _file = open(orig_iso, 'wb')
+        _file.seek((1024 * 1024) - 1)
+        _file.write(str(0))
+        _file.close()
+    except IOError:
+        raise error.TestFail("Create orig_iso failed!")
+    try:
+        virsh.attach_disk(vm_name, orig_iso, target_dev,
+                          "--type cdrom --sourcetype=file --config")
+    except:
+        os.remote(orig_iso)
+        raise error.TestFail("Failed to attach")
+
+
+def create_attach_xml(update_xmlfile, source_iso, target_bus, target_dev):
     """
     Create a xml file to update a device.
 
     :param update_xmlfile : path/file to save device XML
     :param source_iso : disk's source backing file.
+    :param target_bus : disk's target bus
+    :param target_dev : disk's target device name
     """
     try:
         _file = open(source_iso, 'wb')
@@ -27,74 +50,34 @@ def create_attach_xml(update_xmlfile, source_iso):
     disk.device = 'cdrom'
     disk.driver = dict(name='file')
     disk.source = disk.new_disk_source(attrs={'file': source_iso})
-    disk.target = dict(bus='ide', dev='hdc')
+    disk.target = dict(bus=target_bus, dev=target_dev)
     disk.readonly = True
     disk.xmltreefile.write()
     shutil.copyfile(disk.xml, update_xmlfile)
 
 
-def is_attached(vmxml_devices, source_file):
+def is_attached(vmxml_devices, source_file, target_dev):
     """
     Check attached device and disk exist or not.
 
     :param source_file : disk's source file to check
     :param vmxml_devices: VMXMLDevices instance
+    :param target_dev : target device name
     :return: True/False if backing file and device found
     """
     disks = vmxml_devices.by_device_tag('disk')
     for disk in disks:
         if disk.device != 'cdrom':
             continue
-        if disk.target['dev'] != 'hdc':
+        if disk.target['dev'] != target_dev:
             continue
         if disk.source.attrs['file'] != source_file:
             continue
         # All three conditions met
-            return True
+        return True
     logging.error('No cdrom device for "%s" in devices XML: "%s"',
                   source_file, vmxml_devices)
     return False
-
-
-def libvirt_library_version():
-    """Parse and return tuple of libvirt's x.y.z version numbers"""
-    try:
-        regex = r'[Uu]sing\s*[Ll]ibrary:\s*[Ll]ibvirt\s*'
-        regex += r'(\d+)\.(\d+)\.(\d+)'
-        lines = virsh.version().splitlines()
-        ver_x = ver_y = ver_z = None
-        for line in lines:
-            mobj = re.search(regex, line)
-            if bool(mobj):
-                ver_x = int(mobj.group(1))
-                ver_y = int(mobj.group(2))
-                ver_z = int(mobj.group(3))
-                break
-        return (ver_x, ver_y, ver_z)
-    except (ValueError, TypeError, AttributeError):
-        # Early versions didn't have 'version' command
-        logging.warning("Error determining libvirt version")
-        return None
-
-
-def version_cmp(ver_x1, ver_y1, ver_z1, ver_x2, ver_y2, ver_z2):
-    """Compare ver_?1 to ver_?2 using cmp() logic"""
-    if int(ver_x1) > int(ver_x2):
-        return 1
-    elif int(ver_x1) < int(ver_x2):
-        return -1
-    else:  # ver_x1 == ver_x2
-        if int(ver_y1) > int(ver_y2):
-            return 1
-        elif int(ver_y1) < int(ver_y2):
-            return -1
-        else:  # ver_y1 == ver_y2
-            if int(ver_z1) > int(ver_z2):
-                return 1
-            elif int(ver_z1) == int(ver_z2):
-                return 0
-            else:  # ver_z1 < ver_z2
-                return -1
 
 
 def run(test, params, env):
@@ -102,34 +85,19 @@ def run(test, params, env):
     Test command: virsh update-device.
 
     Update device from an XML <file>.
-    1.Prepare test environment.Make sure a cdrom exists in VM.
-      If not, please attach one cdrom manually.
+    1.Prepare test environment, adding a cdrom to VM.
     2.Perform virsh update-device operation.
     3.Recover test environment.
     4.Confirm the test result.
     """
 
-    # Prepare initial vm state
-    vm_name = params.get("main_vm")
-    vmxml = VMXML.new_from_dumpxml(vm_name, options="--inactive")
-    vm = env.get_vm(vm_name)
-    start_vm = "yes" == params.get("start_vm", "no")
-    if vm.is_alive() and not start_vm:
-        vm.destroy()
-        domid = "domid invalid; domain is shut-off"
-    else:
-        domid = vm.get_id()
-
-    # Get all parameters for configuration.
-    flag = params.get("updatedevice_flag", "")
-    twice = "yes" == params.get("updatedevice_twice", "no")
-    diff_iso = "yes" == params.get("updatedevice_diff_iso", "no")
-    vm_ref = params.get("updatedevice_vm_ref", "")
-    status_error = "yes" == params.get("status_error", "no")
-    extra = params.get("updatedevice_extra", "")
-
+    # Before doing anything - let's be sure we can support this test
     # Parse flag list, skip testing early if flag is not supported
-    flag_list = flag.split("--")
+    # NOTE: "".split("--") returns [''] which messes up later empty test
+    flag = params.get("updatedevice_flag", "")
+    flag_list = []
+    if flag.count("--"):
+        flag_list = flag.split("--")
     for item in flag_list:
         option = item.strip()
         if option == "":
@@ -139,28 +107,54 @@ def run(test, params, env):
                                     % option)
 
     # As per RH BZ 961443 avoid testing before behavior changes
-    current_version = libvirt_library_version()
-    # SKIP tests using --config if libvirt is 0.9.10 or earlier
-    skip_if_config = (0, 9, 19)
-    # SKIP tests using --persistent if libvirt 1.0.5 or earlier
-    skip_if_persistent = (1, 0, 5)
     if 'config' in flag_list:
-        cmp_args = current_version + skip_if_config
-        if version_cmp(*cmp_args) < 1:  # current <= skip_if_config
+        # SKIP tests using --config if libvirt is 0.9.10 or earlier
+        if not libvirt_version.LibVersionCompare(0, 9, 10):
             raise error.TestNAError("BZ 961443: --config behavior change "
-                                    "in version %s" % skip_if_config)
+                                    "in version 0.9.10")
     if 'persistent' in flag_list:
-        cmp_args = current_version + skip_if_persistent
-        if version_cmp(*cmp_args) < 1:  # current <= skip_if_persistent
+        # SKIP tests using --persistent if libvirt 1.0.5 or earlier
+        if not libvirt_version.LibVersionCompare(1, 0, 5):
             raise error.TestNAError("BZ 961443: --persistent behavior change "
-                                    "in version %s" % skip_if_persistent)
+                                    "in version 1.0.5")
+
+    # Prepare initial vm state
+    vm_name = params.get("main_vm")
+    vmxml = VMXML.new_from_dumpxml(vm_name, options="--inactive")
+    vm = env.get_vm(vm_name)
+    start_vm = "yes" == params.get("start_vm", "no")
+
+    # Define target bus/dev (these could be params some day to
+    # test virtio/vdc for example)
+    target_bus = "ide"
+    target_dev = "hdc"
 
     # Prepare tmp directory and files.
+    orig_iso = os.path.join(test.virtdir, "orig.iso")
     test_iso = os.path.join(test.virtdir, "test.iso")
     test_diff_iso = os.path.join(test.virtdir, "test_diff.iso")
     update_xmlfile = os.path.join(test.tmpdir, "update.xml")
-    create_attach_xml(update_xmlfile, test_iso)
+    create_attach_xml(update_xmlfile, test_iso, target_bus, target_dev)
 
+    # This test needs a cdrom attached first - attach a cdrom
+    # to a shutdown vm. Then decide to restart or not
+    if vm.is_alive():
+        vm.destroy()
+    create_cdrom(vm_name, orig_iso, target_dev)
+    if start_vm:
+        vm.start()
+        domid = vm.get_id()
+    else:
+        domid = "domid invalid; domain is shut-off"
+
+    # Get remaining parameters for configuration.
+    twice = "yes" == params.get("updatedevice_twice", "no")
+    diff_iso = "yes" == params.get("updatedevice_diff_iso", "no")
+    vm_ref = params.get("updatedevice_vm_ref", "")
+    status_error = "yes" == params.get("status_error", "no")
+    extra = params.get("updatedevice_extra", "")
+
+    # OK let's give this a whirl...
     try:
         if vm_ref == "id":
             vm_ref = domid
@@ -168,10 +162,11 @@ def run(test, params, env):
                 # Don't pass in any flags
                 virsh.update_device(domainarg=domid, filearg=update_xmlfile,
                                     ignore_status=True, debug=True)
-            if diff_iso == "yes":
+            if diff_iso:
                 # Swap filename of device backing file in update.xml
                 os.remove(update_xmlfile)
-                create_attach_xml(update_xmlfile, test_diff_iso)
+                create_attach_xml(update_xmlfile, test_diff_iso,
+                                  target_bus, target_dev)
         elif vm_ref == "uuid":
             vm_ref = vmxml.uuid
         elif vm_ref == "hex_id":
@@ -196,6 +191,8 @@ def run(test, params, env):
         vmxml.undefine()
         vmxml.restore()
         vmxml.define()
+        if os.path.exists(orig_iso):
+            os.remove(orig_iso)
         if os.path.exists(test_iso):
             os.remove(test_iso)
         if os.path.exists(test_diff_iso):
@@ -211,12 +208,14 @@ def run(test, params, env):
             errmsg = "Run failed with right command"
         if diff_iso:  # Expect the backing file to have updated
             active_attached = is_attached(active_vmxml.devices,
-                                          test_diff_iso)
-            inactive_attached = is_attached(active_vmxml.devices,
-                                            test_diff_iso)
+                                          test_diff_iso, target_dev)
+            inactive_attached = is_attached(inactive_vmxml.devices,
+                                            test_diff_iso, target_dev)
         else:  # Expect backing file to remain the same
-            active_attached = is_attached(active_vmxml.devices, test_iso)
-            inactive_attached = is_attached(active_vmxml.devices, test_iso)
+            active_attached = is_attached(active_vmxml.devices, test_iso,
+                                          target_dev)
+            inactive_attached = is_attached(inactive_vmxml.devices, test_iso,
+                                            target_dev)
 
         # Check behavior of combination before individual!
         if "config" in flag_list and "live" in flag_list:


### PR DESCRIPTION
There are 3 commits in this - 

Commits 1 & 2 were part of a change I started long ago that @cevich picked up and generated PR  1171 in virt-test before the split, see

https://github.com/autotest/virt-test/pull/1171

Since it's just been sitting there as the one test I don't run regularly - I figured it was time to pick the ball up and just get it work again - this is the result and is why there's a 3rd commit - to fix issues I found while working through the original changes.

Using these changes I get all 19 tests to pass

I'm ok with merging all these changes into one, but I thought it would be easier to compare where I started and where I finished up by splitting them up...
