### PR TITLE
Add test for secret-define/undefine

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/secret/virsh_secret_define_undefine.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/secret/virsh_secret_define_undefine.cfg
@@ -2,13 +2,11 @@
     type = virsh_secret_define_undefine
     vms = ""
     main_vm = ""
-    status_error = "no"
     encode_video_files = "no"
     skip_image_processing = "yes"
     take_regular_screendumps = "no"
     variants:
         - normal_test:
-            status_error = "no"
             secret_ref = "secret_valid_uuid"
             variants:
                 - ephemeral_yes:
@@ -23,9 +21,41 @@
                     secret_modify_volume = "yes"
                 - redefine_remove_uuid:
                     secret_remove_uuid = "yes"
+            variants:
+                - non_acl:
+                - acl_test:
+                    setup_libvirt_polkit = "yes"
+                    action_lookup = "connect_driver:QEMU"
+                    unprivileged_user = "EXAMPLE"
+                    virsh_uri = "qemu:///system"
+                    variants:
+                        - define_acl:
+                            define_acl = "yes"
+                            action_id = "org.libvirt.api.secret.write org.libvirt.api.secret.save"
+                        - get_value_acl:
+                            get_value_acl = "yes"
+                            action_id = "org.libvirt.api.secret.read-secure"
+                        - undefine_acl:
+                            undefine_acl = "yes"
+                            action_id = "org.libvirt.api.secret.delete"
         - error_test:
-            status_error = "yes"
             variants:
                 - invalid_uuid:
+                    define_error = "yes"
                     secret_ref = "secret_invalid_uuid"
                     secret_invalid_uuid = "99999999-9999-9999-9999-9999999999"
+                - acl_test:
+                    secret_ref = "secret_valid_uuid"
+                    setup_libvirt_polkit = "yes"
+                    unprivileged_user = "EXAMPLE"
+                    virsh_uri = "qemu:///system"
+                    variants:
+                        - undefine_acl:
+                            undefine_acl = "yes"
+                            undefine_error = "yes"
+                        - define_acl:
+                            define_acl = "yes"
+                            define_error = "yes"
+                        - get_value_acl:
+                            get_value_acl = "yes"
+                            get_value_error = "yes"


### PR DESCRIPTION
```
  NAME
    secret-define - define or modify a secret from an XML file

  SYNOPSIS
    secret-define <file>

  DESCRIPTION
    Define or modify a secret.

  OPTIONS
    [--file] <string>  file containing secret attributes in XML


  NAME
    secret-undefine - undefine a secret

  SYNOPSIS
    secret-undefine <secret>

  DESCRIPTION
    Undefine a secret.

  OPTIONS
    [--secret] <string>  secret UUID

```
