### PR TITLE
snapshot_disk: Fix cfg file to list negative test options

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_disk.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_disk.cfg
@@ -45,10 +45,9 @@
             no memory_internal..disk_external, memory_external..disk_internal, memory_no..disk_external
             status_error = "no"
         - negative_test:
-            # internal snapshot for disk unsupported for storage type raw or qed.
-            only disk_internal..attach_img_raw, disk_internal..attach_img_qed
-            # snapshot-create without xmlfile is alias of internal.
-            only snapshot_default..attach_img_raw, snapshot_default..attach_img_qed
-            # disk_snapshot can not be external when memory_snapshot is internal.
-            only memory_internal..disk_external, memory_external..disk_internal, memory_no..disk_external
+            # Unlike the 'no' filter, 'only' seems to be able to only
+            # support one only filter line. Thus this is one long line
+            # of filters with each of the no filters from the positive_test
+            #
+            only disk_internal..attach_img_raw, disk_internal..attach_img_qed, snapshot_default..attach_img_raw, snapshot_default..attach_img_qed, memory_internal..disk_external, memory_external..disk_internal, memory_no..disk_external
             status_error = "yes"


### PR DESCRIPTION
It seems listing more than one "only" filter in the negative_test resulted
in none of the tests being listed as negative.  I found that if I added
all the "no" options from the positive_test on the same line that would
list the 19 negative_test options.
