### PR TITLE
blockcopy: Resolve failing cases

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcopy.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcopy.cfg
@@ -39,7 +39,8 @@
             status_error = "yes"
             variants:
                 - timeout_check:
-                    blockcopy_options = "--timeout 1 --wait"
+                    blockcopy_options = "--timeout 1 --wait "
+                    blockcopy_bandwidth = "1"
                 - invalid_external_dest:
                     dest_path = "/path/non-exist"
                     reuse_external = "yes"


### PR DESCRIPTION
Fail #1: blockcopy.positive_test.raw_format
For the raw format, the code mades a special check/call to QemuImg to
get the information about the blockcopy created.  The setup of the
params[] to the initializer was incorrect using 'image_filename'
instead of 'image_name' and the path to the file without the extension.

Had to adjust how the file was created to ensure it was created with
an extension ".raw"; otherwise, the 'image_format' would seem to default
to qcow2 which would be appended onto the "image_file' name passed.

Because the creation was adjusted to add the extenstion we have to
remove it when doing the check call...

Fail #2: blockcopy.negative_test.timeout_check
It seems libvirt commit id '4c297728' has resolved what used to be an
expected failure. The test passes for me now.  The commit in question
deals with blockcopy failing "unexpectedly" which would happen when
the timeout was fired and "quit" would be set in the code. So modify
the expected failure code to check for the expected failure message of
Copy aborted.  Additionally, add a bandwidth argument to hopefully
avoid the possibility that the copy completes very quickly and the
the message "Now in mirroring phase" is provided.
