### PR TITLE
find_storage_pool_sources: Fix invalid srcSpec negative case

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/pool/virsh_find_storage_pool_sources.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/pool/virsh_find_storage_pool_sources.cfg
@@ -23,8 +23,8 @@
                 - invalid_type:
                     source_type = "Unknow"
                 - invalid_srcSpec:
-                    source_type = "netfs
-                    source_Spec: = "INVALID.XML"
+                    source_type = "netfs"
+                    source_Spec = "INVALID.XML"
                 - readonly_test:
                     source_type = "logical"
                     readonly_mode = "yes"

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_find_storage_pool_sources.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_find_storage_pool_sources.py
@@ -56,14 +56,16 @@ def run(test, params, env):
                 cleanup_logical = True
 
     # Prepare srcSpec xml
-    if not srcSpec or srcSpec == "INVALID.XML":
-        srcSpec = xml_utils.TempXMLFile()
+    if srcSpec:
         if srcSpec == "INVALID.XML":
             src_xml = "<invalid><host name='#@!'/><?source>"
         else:
-            src_xml = "<source><host name='%s'/></source>" % source_host
-        srcSpec.write(src_xml)
-        srcSpec.flush()
+            src_xml = srcSpec
+    else:
+        src_xml = "<source><host name='%s'/></source>" % source_host
+    srcSpec = xml_utils.TempXMLFile()
+    srcSpec.write(src_xml)
+    srcSpec.flush()
     logging.debug("srcSpec file content:\n%s", file(srcSpec.name).read())
 
     if ro_flag:


### PR DESCRIPTION
The invalid srcSpec negative case run PASS but is not with expected case
design.

Fix typo in cfg file, delete ":" which make srcSpec always none, add the
missing right quote mark for source_type.

Fix the reassign before check problem in py case, and add if branch when
srcSpec is not empty and also not equal as "INVALID.XML".

Signed-off-by: Wayne Sun gsun@redhat.com
