### PR TITLE
blockresize: Add more options for test

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockresize.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockresize.cfg
@@ -1,11 +1,13 @@
 - virsh.blockresize:
     type = virsh_blockresize
     kill_vm_on_error = "yes"
-    initial_disk_size = "1M"
+    initial_disk_size = "500K"
     variants:
         - normal_test:
             status_error = "no"
             variants:
+                - qed_type:
+                    disk_image_format = "qed"
                 - qcow2_type:
                     disk_image_format = "qcow2"
                 - raw_type:
@@ -15,6 +17,18 @@
                     resize_value = "1048576b"
                 - kilobyte:
                     resize_value = "1024k"
+                # Using 'kb' is "legal" according to man page even
+                # though perhaps illogical since it's a 1000 bytes.
+                # For 'qcow2' and 'qed' disks without a fix for
+                # bz1002813 a failure will occur when 1000kb is used
+                # since the resulting value to blockresize is not
+                # evenly divisible by 512.
+                - kb1000:
+                    resize_value = "1000kb"
+                - kb1024:
+                    resize_value = "1024kb"
+                - kib:
+                    resize_value = "1000kib"
                 - megabyte:
                     resize_value = "1m"
                 - gigabyte:


### PR DESCRIPTION
Adjust the cfg matrix to add the 'qed' disk type as well as an option
for using 'kb' and 'kib' as the scale/type of the value provided. The
virsh command will accept k, kib, and kb. Set the initial disk to
500K so that the resize will actually attempt something.  Using 1M
as an initial size and then using values that are the same for 'b', 'k',
and 'm' doesn't do anything.

Modify the test code to handle the new options and be able to account
for the lack of the fix for bz1002813 which results in an error when
'1000kb' is provided since 1000kb is not evenly divisible by 512 as
is required by qemu.  The libvirt code supplied for the bz will resize
the value to be aligned on 512 byte boundaries - so our test test will
need to account for that too.

As a side note the existing math to change values from the cfg
supplied value to an 'expected_value' made an assumption that
the value was 1024M to start with.
