### PR TITLE
libvirt.test: Add more options test for attach-disk

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_disk.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_disk.cfg
@@ -13,6 +13,8 @@
     at_dt_disk_bus_type = virtio
     at_dt_disk_device_source = "attach.img"
     at_dt_disk_device_source_path = 'yes'
+    at_dt_disk_serial = ""
+    at_dt_disk_address = ""
     variants:
         - error_test:
             status_error = 'yes'
@@ -65,9 +67,9 @@
             variants:
                 - host_block_vm_id:
                     at_dt_disk_vm_ref = id
-                    at_dt_disk_at_options = "--driver qemu --mode shareable"
+                    at_dt_disk_at_options = "--driver qemu --subdriver raw --mode shareable"
                 - host_block_vm_name:
-                    at_dt_disk_at_options = "--driver qemu --mode readonly"
+                    at_dt_disk_at_options = "--driver qemu --subdriver raw --mode readonly --shareable"
                 - vm_suspend:
                     at_dt_disk_pre_vm_state = paused
                 - host_block_vm_uuid:
@@ -75,22 +77,37 @@
                 - image_file_no_option:
                     at_dt_disk_at_options = ""
                 - vm_shutdown_config:
-                    at_dt_disk_at_options = "--driver qemu --config"
+		    only attach_disk
+                    at_dt_disk_address =  "pci:0x0000.0x00.0x0b.0x0"
+                    at_dt_disk_at_options = "--driver qemu --subdriver raw --config"
                     at_dt_disk_dt_options = "--config"
                     at_dt_disk_pre_vm_state = "shut off"
-                - vm_running_config:
+                - vm_shutdown_serial_config:
+                    only attach_disk
+                    at_dt_disk_serial = "test"
                     at_dt_disk_at_options = "--driver qemu --config"
+                    at_dt_disk_pre_vm_state = "shut off"
+                - vm_running_config:
+                    at_dt_disk_at_options = "--driver qemu --subdriver raw --config"
                     at_dt_disk_dt_options = "--config"
                 - vm_shutdown_persistent:
-                    at_dt_disk_at_options = "--driver qemu --persistent"
+                    at_dt_disk_at_options = "--driver qemu --subdriver raw --persistent --cache writeback"
                     at_dt_disk_dt_options = "--persistent"
                     at_dt_disk_pre_vm_state = "shut off"
                 - vm_running_persistent:
-                    at_dt_disk_at_options = "--driver qemu --persistent"
+                    at_dt_disk_at_options = "--driver qemu --subdriver raw --persistent --cache writethrough"
                     at_dt_disk_dt_options = "--persistent"
                 - twice_diff_target:
                     at_dt_disk_test_twice = 'yes'
                     at_dt_disk_device_target2 = vdx
+                - twice_multifunction:
+                    only attach_disk
+                    at_dt_disk_address =  "pci:0x0000.0x00.0x0b.0x0"
+                    at_dt_disk_address2 =  "pci:0x0000.0x00.0x0b.0x1"
+                    at_dt_disk_at_options = "--driver qemu --config --multifunction"
+                    at_dt_disk_test_twice = 'yes'
+                    at_dt_disk_device_target2 = vdx
+                    at_dt_disk_pre_vm_state = "shut off"
                 - cdrom:
                     at_dt_disk_at_options = "--type cdrom --driver qemu --config"
                     at_dt_disk_dt_options = "--config"
@@ -114,7 +131,13 @@
                         - block_disk_type:
                             at_dt_disk_iscsi_device = "yes"
                             emulated_image = "iscsi.img"
-                            image_size = "100M" 
+                            image_size = "100M"
+                            target = "iqn.2013-10.com.example:iscsi"
+                        - block_disk_type_lun:
+                            at_dt_disk_at_options = "--driver qemu --rawio --type lun"
+                            at_dt_disk_iscsi_device = "yes"
+                            emulated_image = "iscsi.img"
+                            image_size = "100M"
                             target = "iqn.2013-10.com.example:iscsi"
                 - audit_check:
                     at_dt_disk_check_audit = 'yes'


### PR DESCRIPTION
Add some more test for attach-disk, for example:
--serial, --address, --multifunction, --subdriver, etc.

Signed-off-by: Li Yang liyang.fnst@cn.fujitsu.com
