### PR TITLE
libvirt.test: Add 2 more options test for undefine

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_undefine.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_undefine.cfg
@@ -16,6 +16,19 @@
                 - snapshots:
                     only vm_shut_off
                     undefine_option = "--snapshots-metadata"
+                - remove_storage:
+                    undefine_option = "--remove-all-storage"
+                    volume_size = "1G"
+                    vol_name = "test_vol"
+                    pool_type = "dir"
+                    pool_name = "test"
+                    pool_target = "dir-pool"
+                    disk_target = "vdx"
+                    variants:
+                        - wipe_data:
+                            wipe_data = "yes"
+                        - no_wipe_date:
+                            wipe_data = "no"
             variants:
                 - vm_shut_off:
                 - vm_uuid:


### PR DESCRIPTION
Add '--wipe-storage' and '--remove-all-storage' option
test for virsh undefine.

Signed-off-by: Li Yang liyang.fnst@cn.fujitsu.com
