### PR TITLE
domcontrol: fix process poll check problem

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domcontrol.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domcontrol.py
@@ -119,8 +119,5 @@ def run(test, params, env):
     if pre_vm_state == "suspend":
         vm.resume()
     if process:
-        if process.poll():
-            try:
-                process.kill()
-            except OSError:
-                pass
+        if process.poll() is None:
+            process.kill()


### PR DESCRIPTION
The process poll return None when process exist, else return negative value
if terminated. The check at cleanup got this wrong.

Signed-off-by: Wayne Sun gsun@redhat.com
