### PR TITLE
tp-libvirt: Skip test if tgtadm is not found

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk.py
@@ -134,7 +134,10 @@ def run(test, params, env):
 
     # Create virtual device file.
     if test_block_dev:
-        iscsi_dev = qemu_storage.Iscsidev(params, test.virtdir, "iscsi")
+        try:
+            iscsi_dev = qemu_storage.Iscsidev(params, test.virtdir, "iscsi")
+        except ValueError, detail:
+            raise error.TestNAError("Cannot create iscsi device: %s" % detail)
         device_source = iscsi_dev.setup()
         logging.debug("iscsi dev name: %s" % device_source)
     else:


### PR DESCRIPTION
When the optional binary `tgtadm` is not available on the host, we don't
expect the test case fail and should skip it instead.

Signed-off-by: Hao Liu hliu@redhat.com
