### PR TITLE
Revert "virsh.domdisplay: Only add port if nonzero for vnc"

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domdisplay.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domdisplay.py
@@ -6,7 +6,6 @@ from autotest.client.shared import error
 from virttest import utils_misc, utils_libvirtd, virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.graphics import Graphics
-from provider import libvirt_version
 
 
 def run(test, params, env):
@@ -115,19 +114,9 @@ def run(test, params, env):
         graphic_act = vmxml_act.devices.by_device_tag('graphics')[0]
         port = graphic_act.port
 
-        # Commit id '9976c4b9' only prints the port if non zero.  That change
-        # is in libvirt 1.1.3. In order to allow for backwards compatible
-        # comparisons - we'll need to check for that
-        printZeroPort = True
-        if libvirt_version.version_compare(1, 1, 3):
-            printZeroPort = False
-
         # Do judgement for result
         if graphic == "vnc":
-            if printZeroPort:
-                expect = "vnc://%s:%s" % (expect_addr, str(int(port) - 5900))
-            else:
-                expect = "vnc://%s" % (expect_addr)
+            expect = "vnc://%s:%s" % (expect_addr, str(int(port)-5900))
         elif graphic == "spice" and is_ssl:
             tlsport = graphic_act.tlsPort
             expect = "spice://%s:%s?tls-port=%s" % \
@@ -138,11 +127,8 @@ def run(test, params, env):
         if options != "" and passwd is not None:
             # have --include-passwd and have passwd in xml
             if graphic == "vnc":
-                if printZeroPort:
-                    expect = "vnc://:%s@%s:%s" % \
-                        (passwd, expect_addr, str(int(port) - 5900))
-                else:
-                    expect = "vnc://:%s@%s" % (passwd, expect_addr)
+                expect = "vnc://:%s@%s:%s" % \
+                         (passwd, expect_addr, str(int(port)-5900))
             elif graphic == "spice" and is_ssl:
                 expect = expect + "&password=" + passwd
             elif graphic == "spice":


### PR DESCRIPTION
This reverts commit 9cba9b688c72181af5574cfbc4512f17db77ec13.

This patch is wrong as it was a libvirt bug. We should be careful
about adapting tests to actual libvirt behavior as the libvirt could
be wrong, not the test itself.

Signed-off-by: Pavel Hrdina phrdina@redhat.com
