### PR TITLE
tp-libvirt: Fix libvirt network bandwidth

### DIFF
--- a/libvirt/tests/src/libvirt_network_bandwidth.py
+++ b/libvirt/tests/src/libvirt_network_bandwidth.py
@@ -93,6 +93,9 @@ def run(test, params, env):
             vm_xml.devices = devices
             vm_xml.sync()
         elif config_type == "portgroup":
+            if nettype != 'network':
+                raise error.TestNAError("Portgroup is only applicable with "
+                                        "virtual network")
             # Add a portgroup into default network
             portgroup_name = "test_portgroup"
             portgroup = PortgroupXML()


### PR DESCRIPTION
- The portgroup attribute is only applicable with virtual network
  interface, So skip the test if the default interface is not a
  'network' type.

This patch fix test case `libvirt_network_bandwidth.portgroup`.
When run it on a VM with bridged network, result into a FAIL:

```
18:58:14 ERROR| 
18:58:14 ERROR| Traceback (most recent call last):
18:58:14 ERROR|   File "/tmp/virt-test-259/virttest/standalone_test.py", line 219, in run_once
18:58:14 ERROR|     run_func(self, params, env)
18:58:14 ERROR|   File "/tmp/virt-test-259/test-providers.d/downloads/io-github-autotest-libvirt/libvirt/tests/src/libvirt_network_bandwidth.py", line 135, in run
18:58:14 ERROR|     % (speed_actual, speed_expected))
18:58:14 ERROR| TestFail: Speed from host to guest is 13610.2362939.
18:58:14 ERROR| But the average of bandwidth.inbound is 512.
18:58:14 ERROR| 
18:58:14 ERROR| 
18:58:14 ERROR| FAIL type_specific.io-github-autotest-libvirt.libvirt_network_bandwidth.portgroup -> TestFail: Speed from host to guest is 13610.2362939.
But the average of bandwidth.inbound is 512.
```

Signed-off-by: Hao Liu hliu@redhat.com
