### PR TITLE
snapshot_create_as: Add test case for "snapshot=no" in diskspec option

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_create_as.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_create_as.cfg
@@ -70,6 +70,12 @@
                     diskspec_opts1 = "vda,snapshot=internal,driver=raw,file=test1.img"
                     diskspec_opts2 = "vdb,snapshot=external,driver=raw,file=test2.img"
                     memspec_opts = "snapshot=external,file=test3.img"
+                - multi_diskspec_no_snapshot:
+                    # for more than 1 diskspec diskspec_num must be given and second one with snapshot=no
+                    diskspec_num = 2
+                    snap_createas_opts = "--print-xml --name tt --description hello --disk-only"
+                    diskspec_opts1 = "vda,snapshot=internal,driver=raw,file=test1.img"
+                    diskspec_opts2 = "vdb,snapshot=no"
             variants:
                 - non_acl:
                 - acl_test:

--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_create_as.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_create_as.py
@@ -57,6 +57,8 @@ def compose_disk_options(test, params, opt_names):
     :params: test & params: system parameters
     :params: opt_names: params get from cfg of {disk,mem}spec options
     """
+    if "snapshot=no" in opt_names:
+        return opt_names
     if opt_names.find("file=") >= 0:
         opt_disk = opt_names.split("file=")
         opt_list = opt_disk[1].split(",")


### PR DESCRIPTION
When snapshot=no given in diskspec, the specific disk will not be taken
snapshot. For support this, check "snapshot=no" in compose_disk_options
function and update cfg file.

Signed-off-by: Wayne Sun gsun@redhat.com
