### PR TITLE
tp-libvirt: Fix macvtap

### DIFF
--- a/libvirt/tests/cfg/macvtap.cfg
+++ b/libvirt/tests/cfg/macvtap.cfg
@@ -9,10 +9,14 @@
     remote_ip = "ENTER.YOUR.REMOTE.IP"
     vm1_ip = "ENTER.YOUR.GUEST1.IP"
     vm2_ip = "ENTER.YOUR.GUEST2.IP"
-    # Tested nic
-    eth_card_no = "eth17"
-    eth_config_file = "/etc/sysconfig/network-scripts/ifcfg-eth1"
-    persistent_net_file = "/etc/udev/rules.d/70-persistent-net.rules"
+    # Tested NIC name. For example, "eth1"
+    eth_card_no = "ENTER.YOUR.DEV.NAME"
+    # Network configuration file path.
+    # For example, "/etc/sysconfig/network-scripts/ifcfg-eth1"
+    eth_config_file = "ENTER.YOUR.CONFIG.FILE.PATH"
+    # Persistent net rules file path.
+    # For example, /etc/udev/rules.d/70-persistent-net.rules
+    persistent_net_file = "ENTER.YOUR.RULE.FILE.PATH"
     only Linux
     variants:
         - VEPA:

--- a/libvirt/tests/src/macvtap.py
+++ b/libvirt/tests/src/macvtap.py
@@ -26,10 +26,22 @@ def run(test, params, env):
     eth_config_file = params.get("eth_config_file")
     persistent_net_file = params.get("persistent_net_file")
 
+    param_keys = ["remote_ip", "vm1_ip", "vm2_ip", "eth_card_no",
+                  "eth_config_file", "persistent_net_file"]
+    param_values = [remote_ip, vm1_ip, vm2_ip, eth_card_no,
+                    eth_config_file, persistent_net_file]
+    for key, value in zip(param_keys, param_values):
+        if value.count("ENTER.YOUR"):
+            raise error.TestNAError("Parameter '%s'(%s) is not configured."
+                                    % (key, value))
+
     vm1 = env.get_vm(vm_names[0])
     vm2 = None
     if len(vm_names) > 1:
         vm2 = env.get_vm(vm_names[1])
+
+    if eth_card_no not in utils_net.get_net_if():
+        raise error.TestNAError("Device %s do not exists." % eth_card_no)
     try:
         iface_cls = utils_net.Interface(eth_card_no)
         origin_status = iface_cls.is_up()


### PR DESCRIPTION
The config file use `eth17` as the target interface, but it is not exist on
every host. This path SKIP the test if target interface is not found on
the host.

Signed-off-by: Hao Liu hliu@redhat.com
