### PR TITLE
libvirt.tests: add test cases for virsh blkdeviotune

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blkdeviotune.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blkdeviotune.cfg
@@ -1,0 +1,646 @@
+- virsh.blkdeviotune:
+    type = virsh_blkdeviotune
+    libvirtd = "on"
+    variants:
+        - positive_testing:
+            status_error = "no"
+            blkdevio_device = "hda"
+            variants:
+                - get_blkdevio_parameter:
+                    variants:
+                        - shutoff_guest:
+                            start_vm = "no"
+                            variants:
+                                - options:
+                                    variants:
+                                        - none:
+                                            blkdevio_options =
+                                        - config:
+                                            blkdevio_options = "config"
+                                        - current:
+                                            blkdevio_options = "current"
+                        - running_guest:
+                            start_vm = "yes"
+                            variants:
+                                - options:
+                                    variants:
+                                        - none:
+                                            blkdevio_options =
+                                        - live:
+                                            blkdevio_options = "live"
+                                        - current:
+                                            blkdevio_options = "current"
+                - set_blkdevio_parameter:
+                    change_parameters = "yes"
+                    variants:
+                        - shutoff_guest:
+                            start_vm = "no"
+                            variants:
+                                - change_total_bytes_sec:
+                                    variants:
+                                        - minimum_boundary:
+                                            blkdevio_total_bytes_sec = 0
+                                        - inside_boundary:
+                                            blkdevio_total_bytes_sec = 1024
+                                        - maximum_boundary:
+                                            blkdevio_total_bytes_sec = 9223372036854775807
+                                    variants:
+                                        - options:
+                                            variants:
+                                                - config:
+                                                    blkdevio_options = "config"
+                                                - current:
+                                                    blkdevio_options = "current"
+                                - change_read_bytes_sec:
+                                    variants:
+                                        - minimum_boundary:
+                                            blkdevio_read_bytes_sec = 0
+                                        - inside_boundary:
+                                            blkdevio_read_bytes_sec = 1048576
+                                        - maximum_boundary:
+                                            blkdevio_read_bytes_sec = 9223372036854775807
+                                    variants:
+                                        - options:
+                                            variants:
+                                                - config:
+                                                    blkdevio_options = "config"
+                                                - current:
+                                                    blkdevio_options = "current"
+                                - change_write_bytes_sec:
+                                    variants:
+                                        - minimum_boundary:
+                                            blkdevio_write_bytes_sec = 0
+                                        - inside_boundary:
+                                            blkdevio_write_bytes_sec = 1073741824
+                                        - maximum_boundary:
+                                            blkdevio_write_bytes_sec = 9223372036854775807
+                                    variants:
+                                        - options:
+                                            variants:
+                                                - config:
+                                                    blkdevio_options = "config"
+                                                - current:
+                                                    blkdevio_options = "current"
+                                - change_total_read_write_bytes_sec:
+                                    variants:
+                                        - combination1:
+                                            blkdevio_total_bytes_sec = 0
+                                            blkdevio_read_bytes_sec = 0
+                                            blkdevio_write_bytes_sec = 0
+                                        - combination2:
+                                            blkdevio_total_bytes_sec = 1073741824
+                                            blkdevio_read_bytes_sec = 0
+                                            blkdevio_write_bytes_sec = 0
+                                        - combination3:
+                                            blkdevio_total_bytes_sec = 0
+                                            blkdevio_read_bytes_sec = 9223372036854775807
+                                            blkdevio_write_bytes_sec = 9223372036854775807
+                                        - combination4:
+                                            blkdevio_total_bytes_sec = 0
+                                            blkdevio_read_bytes_sec = 1099511627776
+                                            blkdevio_write_bytes_sec = 0
+                                        - combination5:
+                                            blkdevio_total_bytes_sec = 0
+                                            blkdevio_read_bytes_sec = 0
+                                            blkdevio_write_bytes_sec = 1125899906842624
+                                    variants:
+                                        - options:
+                                            variants:
+                                                - config:
+                                                    blkdevio_options = "config"
+                                                - current:
+                                                    blkdevio_options = "current"
+                                - change_total_iops_sec:
+                                    variants:
+                                        - minimum_boundary:
+                                            blkdevio_total_iops_sec = 0
+                                        - inside_boundary:
+                                            blkdevio_total_iops_sec = 1099511627776
+                                        - maximum_boundary:
+                                            blkdevio_total_iops_sec = 9223372036854775807
+                                    variants:
+                                        - options:
+                                            variants:
+                                                - config:
+                                                    blkdevio_options = "config"
+                                                - current:
+                                                    blkdevio_options = "current"
+                                - change_read_iops_sec:
+                                    variants:
+                                        - minimum_boundary:
+                                            blkdevio_read_iops_sec = 0
+                                        - inside_boundary:
+                                            blkdevio_read_iops_sec = 1125899906842624
+                                        - maximum_boundary:
+                                            blkdevio_read_iops_sec = 9223372036854775807
+                                    variants:
+                                        - options:
+                                            variants:
+                                                - config:
+                                                    blkdevio_options = "config"
+                                                - current:
+                                                    blkdevio_options = "current"
+                                - change_write_iops_sec:
+                                    variants:
+                                        - minimum_boundary:
+                                            blkdevio_write_iops_sec = 0
+                                        - inside_boundary:
+                                            blkdevio_write_iops_sec = 1152921504606846976
+                                        - maximum_boundary:
+                                            blkdevio_write_iops_sec = 9223372036854775807
+                                    variants:
+                                        - options:
+                                            variants:
+                                                - config:
+                                                    blkdevio_options = "config"
+                                                - current:
+                                                    blkdevio_options = "current"
+                                - change_total_read_write_iops_sec:
+                                    variants:
+                                        - combination1:
+                                            blkdevio_total_iops_sec = 0
+                                            blkdevio_read_iops_sec = 0
+                                            blkdevio_write_iops_sec = 0
+                                        - combination2:
+                                            blkdevio_total_iops_sec = 1073741824
+                                            blkdevio_read_iops_sec = 0
+                                            blkdevio_write_iops_sec = 0
+                                        - combination3:
+                                            blkdevio_total_iops_sec = 0
+                                            blkdevio_read_iops_sec = 9223372036854775807
+                                            blkdevio_write_iops_sec = 9223372036854775807
+                                        - combination4:
+                                            blkdevio_total_iops_sec = 0
+                                            blkdevio_read_iops_sec = 1099511627776
+                                            blkdevio_write_iops_sec = 0
+                                        - combination5:
+                                            blkdevio_total_iops_sec = 0
+                                            blkdevio_read_iops_sec = 0
+                                            blkdevio_write_iops_sec = 1125899906842624
+                                    variants:
+                                        - options:
+                                            variants:
+                                                - config:
+                                                    blkdevio_options = "config"
+                                                - current:
+                                                    blkdevio_options = "current"
+                                - change_total_read_write_bytes_iops_sec:
+                                    variants:
+                                        - combination1:
+                                            blkdevio_read_bytes_sec = 1234567890
+                                            blkdevio_total_iops_sec = 1073741824
+                                        - combination2:
+                                            blkdevio_write_bytes_sec = 1073741824
+                                            blkdevio_total_iops_sec = 9223372036854775807
+                                        - combination3:
+                                            blkdevio_total_bytes_sec = 1073741824
+                                            blkdevio_total_iops_sec = 1099511627776
+                                    variants:
+                                        - options:
+                                            variants:
+                                                - config:
+                                                    blkdevio_options = "config"
+                                                - current:
+                                                    blkdevio_options = "current"
+                        - running_guest:
+                            start_vm = "yes"
+                            variants:
+                                - change_total_bytes_sec:
+                                    variants:
+                                        - minimum_boundary:
+                                            blkdevio_total_bytes_sec = 0
+                                        - inside_boundary:
+                                            blkdevio_total_bytes_sec = 1
+                                        - maximum_boundary:
+                                            blkdevio_total_bytes_sec = 9223372036854775807
+                                    variants:
+                                        - options:
+                                            variants:
+                                                - config:
+                                                    blkdevio_options = "live"
+                                                - current:
+                                                    blkdevio_options = "current"
+                                - change_read_bytes_sec:
+                                    variants:
+                                        - minimum_boundary:
+                                            blkdevio_read_bytes_sec = 0
+                                        - inside_boundary:
+                                            blkdevio_read_bytes_sec = 4096
+                                        - maximum_boundary:
+                                            blkdevio_read_bytes_sec = 9223372036854775807
+                                    variants:
+                                        - options:
+                                            variants:
+                                                - config:
+                                                    blkdevio_options = "live"
+                                                - current:
+                                                    blkdevio_options = "current"
+                                - change_write_bytes_sec:
+                                    variants:
+                                        - minimum_boundary:
+                                            blkdevio_write_bytes_sec = 0
+                                        - inside_boundary:
+                                            blkdevio_write_bytes_sec = 16777216
+                                        - maximum_boundary:
+                                            blkdevio_write_bytes_sec = 9223372036854775807
+                                    variants:
+                                        - options:
+                                            variants:
+                                                - config:
+                                                    blkdevio_options = "live"
+                                                - current:
+                                                    blkdevio_options = "current"
+                                - change_total_read_write_bytes_sec:
+                                    variants:
+                                        - combination1:
+                                            blkdevio_total_bytes_sec = 0
+                                            blkdevio_read_bytes_sec = 0
+                                            blkdevio_write_bytes_sec = 0
+                                        - combination2:
+                                            blkdevio_total_bytes_sec = 1073741824
+                                            blkdevio_read_bytes_sec = 0
+                                            blkdevio_write_bytes_sec = 0
+                                        - combination3:
+                                            blkdevio_total_bytes_sec = 0
+                                            blkdevio_read_bytes_sec = 9223372036854775807
+                                            blkdevio_write_bytes_sec = 9223372036854775807
+                                        - combination4:
+                                            blkdevio_total_bytes_sec = 0
+                                            blkdevio_read_bytes_sec = 1099511627776
+                                            blkdevio_write_bytes_sec = 0
+                                        - combination5:
+                                            blkdevio_total_bytes_sec = 0
+                                            blkdevio_read_bytes_sec = 0
+                                            blkdevio_write_bytes_sec = 1125899906842624
+                                    variants:
+                                        - options:
+                                            variants:
+                                                - config:
+                                                    blkdevio_options = "live"
+                                                - current:
+                                                    blkdevio_options = "current"
+                                - change_total_iops_sec:
+                                    variants:
+                                        - minimum_boundary:
+                                            blkdevio_total_iops_sec = 0
+                                        - inside_boundary:
+                                            blkdevio_total_iops_sec = 4294967296
+                                        - maximum_boundary:
+                                            blkdevio_total_iops_sec = 9223372036854775807
+                                    variants:
+                                        - options:
+                                            variants:
+                                                - config:
+                                                    blkdevio_options = "live"
+                                                - current:
+                                                    blkdevio_options = "current"
+                                - change_read_iops_sec:
+                                    variants:
+                                        - minimum_boundary:
+                                            blkdevio_read_iops_sec = 0
+                                        - inside_boundary:
+                                            blkdevio_read_iops_sec = 17592186044416
+                                        - maximum_boundary:
+                                            blkdevio_read_iops_sec = 9223372036854775807
+                                    variants:
+                                        - options:
+                                            variants:
+                                                - config:
+                                                    blkdevio_options = "live"
+                                                - current:
+                                                    blkdevio_options = "current"
+                                - change_write_iops_sec:
+                                    variants:
+                                        - minimum_boundary:
+                                            blkdevio_write_iops_sec = 0
+                                        - inside_boundary:
+                                            blkdevio_write_iops_sec = 72057594037927936
+                                        - maximum_boundary:
+                                            blkdevio_write_iops_sec = 9223372036854775807
+                                    variants:
+                                        - options:
+                                            variants:
+                                                - config:
+                                                    blkdevio_options = "live"
+                                                - current:
+                                                    blkdevio_options = "current"
+                                - change_total_read_write_iops_sec:
+                                    variants:
+                                        - combination1:
+                                            blkdevio_total_iops_sec = 0
+                                            blkdevio_read_iops_sec = 0
+                                            blkdevio_write_iops_sec = 0
+                                        - combination2:
+                                            blkdevio_total_iops_sec = 1073741824
+                                            blkdevio_read_iops_sec = 0
+                                            blkdevio_write_iops_sec = 0
+                                        - combination3:
+                                            blkdevio_total_iops_sec = 0
+                                            blkdevio_read_iops_sec = 9223372036854775807
+                                            blkdevio_write_iops_sec = 9223372036854775807
+                                        - combination4:
+                                            blkdevio_total_iops_sec = 0
+                                            blkdevio_read_iops_sec = 1099511627776
+                                            blkdevio_write_iops_sec = 0
+                                        - combination5:
+                                            blkdevio_total_iops_sec = 0
+                                            blkdevio_read_iops_sec = 0
+                                            blkdevio_write_iops_sec = 1125899906842624
+                                    variants:
+                                        - options:
+                                            variants:
+                                                - config:
+                                                    blkdevio_options = "live"
+                                                - current:
+                                                    blkdevio_options = "current"
+                                - change_total_read_write_bytes_iops_sec:
+                                    variants:
+                                        - combination1:
+                                            blkdevio_total_iops_sec = 1234567890
+                                            blkdevio_read_bytes_sec = 1073741824
+                                        - combination2:
+                                            blkdevio_total_iops_sec = 1073741824
+                                            blkdevio_write_bytes_sec = 9223372036854775807
+                                        - combination3:
+                                            blkdevio_total_iops_sec = 1073741824
+                                            blkdevio_total_bytes_sec = 1099511627776
+                                    variants:
+                                        - options:
+                                            variants:
+                                                - config:
+                                                    blkdevio_options = "live"
+                                                - current:
+                                                    blkdevio_options = "current"
+        - negative_testing:
+            status_error = "yes"
+            blkdevio_device = "hda"
+            variants:
+                - get_blkdevio_parameter:
+                    variants:
+                        - shutoff_guest:
+                            start_vm = "no"
+                            variants:
+                                - invalid_device:
+                                    blkdevio_device = "unknown"
+                                - options:
+                                    variants:
+                                        - invalid:
+                                            blkdevio_options = "welcome"
+                                        - live:
+                                            blkdevio_options = "live"
+                        - running_guest:
+                            start_vm = "yes"
+                            variants:
+                                - invalid_device:
+                                    blkdevio_device = "unknown"
+                                - options:
+                                    variants:
+                                        - invalid:
+                                            blkdevio_options = "welcome"
+                - set_blkdevio_parameter:
+                    change_parameters = "yes"
+                    variants:
+                        - shutoff_guest:
+                            start_vm = "no"
+                            variants:
+                                - invalid_device:
+                                    blkdevio_device = "ceph"
+                                    blkdevio_total_bytes_sec = 9223372036854775807
+                                - change_total_bytes_sec:
+                                    variants:
+                                        - lower_minimum_boundary:
+                                            blkdevio_total_bytes_sec = -1
+                                        - upper_maximum_boundary:
+                                            blkdevio_total_bytes_sec = 9223372036854775808
+                                        - invalid_value:
+                                            blkdevio_total_bytes_sec = "~@#$%^-=_:,.[]{}"
+                                    variants:
+                                        - options:
+                                            variants:
+                                                - config:
+                                                    blkdevio_options = "config"
+                                                - live:
+                                                    blkdevio_options = "live"
+                                                - current:
+                                                    blkdevio_options = "current"
+                                - change_read_bytes_sec:
+                                    variants:
+                                        - lower_minimum_boundary:
+                                            blkdevio_read_bytes_sec = -1
+                                        - upper_maximum_boundary:
+                                            blkdevio_read_bytes_sec = 9223372036854775808
+                                        - invalid_value:
+                                            blkdevio_read_bytes_sec = "~@#$%^-=_:,.[]{}"
+                                    variants:
+                                        - options:
+                                            variants:
+                                                - config:
+                                                    blkdevio_options = "config"
+                                                - live:
+                                                    blkdevio_options = "live"
+                                                - current:
+                                                    blkdevio_options = "current"
+                                - change_write_bytes_sec:
+                                    variants:
+                                        - lower_minimum_boundary:
+                                            blkdevio_write_bytes_sec = -1
+                                        - upper_maximum_boundary:
+                                            blkdevio_write_bytes_sec = 9223372036854775808
+                                        - invalid_value:
+                                            blkdevio_write_bytes_sec = "~@#$%^-=_:,.[]{}"
+                                    variants:
+                                        - options:
+                                            variants:
+                                                - config:
+                                                    blkdevio_options = "config"
+                                                - live:
+                                                    blkdevio_options = "live"
+                                                - current:
+                                                    blkdevio_options = "current"
+                                - change_total_iops_sec:
+                                    variants:
+                                        - lower_minimum_boundary:
+                                            blkdevio_total_iops_sec = -1
+                                        - upper_maximum_boundary:
+                                            blkdevio_total_iops_sec = 9223372036854775808
+                                        - invalid_value:
+                                            blkdevio_total_iops_sec = "~@#$%^-=_:,.[]{}"
+                                    variants:
+                                        - options:
+                                            variants:
+                                                - config:
+                                                    blkdevio_options = "config"
+                                                - live:
+                                                    blkdevio_options = "live"
+                                                - current:
+                                                    blkdevio_options = "current"
+                                - change_read_iops_sec:
+                                    variants:
+                                        - lower_minimum_boundary:
+                                            blkdevio_read_iops_sec = -1
+                                        - upper_maximum_boundary:
+                                            blkdevio_read_iops_sec = 9223372036854775808
+                                        - invalid_value:
+                                            blkdevio_read_iops_sec = "~@#$%^-=_:,.[]{}"
+                                    variants:
+                                        - options:
+                                            variants:
+                                                - config:
+                                                    blkdevio_options = "config"
+                                                - live:
+                                                    blkdevio_options = "live"
+                                                - current:
+                                                    blkdevio_options = "current"
+                                - change_write_iops_sec:
+                                    variants:
+                                        - lower_minimum_boundary:
+                                            blkdevio_write_iops_sec = -1
+                                        - upper_maximum_boundary:
+                                            blkdevio_write_iops_sec = 9223372036854775808
+                                        - invalid_value:
+                                            blkdevio_write_iops_sec = "~@#$%^-=_:,.[]{}"
+                                    variants:
+                                        - options:
+                                            variants:
+                                                - config:
+                                                    blkdevio_options = "config"
+                                                - live:
+                                                    blkdevio_options = "live"
+                                                - current:
+                                                    blkdevio_options = "current"
+                                - change_total_read_write_bytes_iops_sec:
+                                    variants:
+                                        - total_read_bytes_sec:
+                                            blkdevio_total_bytes_sec = 1
+                                            blkdevio_read_bytes_sec = 2
+                                        - total_write_bytes_sec:
+                                            blkdevio_total_bytes_sec = 3
+                                            blkdevio_write_bytes_sec = 4
+                                        - total_read_iops_sec:
+                                            blkdevio_total_iops_sec = 5
+                                            blkdevio_read_iops_sec = 6
+                                        - total_write_iops_sec:
+                                            blkdevio_total_iops_sec = 7
+                                            blkdevio_write_iops_sec = 8
+                        - running_guest:
+                            start_vm = "yes"
+                            variants:
+                                - invalid_device:
+                                    blkdevio_device = "nfs"
+                                    blkdevio_write_iops_sec = 9223372036854775807
+                                - change_total_bytes_sec:
+                                    variants:
+                                        - lower_minimum_boundary:
+                                            blkdevio_total_bytes_sec = -1
+                                        - upper_maximum_boundary:
+                                            blkdevio_total_bytes_sec = 9223372036854775808
+                                        - invalid_value:
+                                            blkdevio_total_bytes_sec = "~@#$%^-=_:,.[]{}"
+                                    variants:
+                                        - options:
+                                            variants:
+                                                - config:
+                                                    blkdevio_options = "config"
+                                                - live:
+                                                    blkdevio_options = "live"
+                                                - current:
+                                                    blkdevio_options = "current"
+                                - change_read_bytes_sec:
+                                    variants:
+                                        - lower_minimum_boundary:
+                                            blkdevio_read_bytes_sec = -1
+                                        - upper_maximum_boundary:
+                                            blkdevio_read_bytes_sec = 9223372036854775808
+                                        - invalid_value:
+                                            blkdevio_read_bytes_sec = "~@#$%^-=_:,.[]{}"
+                                    variants:
+                                        - options:
+                                            variants:
+                                                - config:
+                                                    blkdevio_options = "config"
+                                                - live:
+                                                    blkdevio_options = "live"
+                                                - current:
+                                                    blkdevio_options = "current"
+                                - change_write_bytes_sec:
+                                    variants:
+                                        - lower_minimum_boundary:
+                                            blkdevio_write_bytes_sec = -1
+                                        - upper_maximum_boundary:
+                                            blkdevio_write_bytes_sec = 9223372036854775808
+                                        - invalid_value:
+                                            blkdevio_write_bytes_sec = "~@#$%^-=_:,.[]{}"
+                                    variants:
+                                        - options:
+                                            variants:
+                                                - config:
+                                                    blkdevio_options = "config"
+                                                - live:
+                                                    blkdevio_options = "live"
+                                                - current:
+                                                    blkdevio_options = "current"
+                                - change_total_iops_sec:
+                                    variants:
+                                        - lower_minimum_boundary:
+                                            blkdevio_total_iops_sec = -1
+                                        - upper_maximum_boundary:
+                                            blkdevio_total_iops_sec = 9223372036854775808
+                                        - invalid_value:
+                                            blkdevio_total_iops_sec = "~@#$%^-=_:,.[]{}"
+                                    variants:
+                                        - options:
+                                            variants:
+                                                - config:
+                                                    blkdevio_options = "config"
+                                                - live:
+                                                    blkdevio_options = "live"
+                                                - current:
+                                                    blkdevio_options = "current"
+                                - change_read_iops_sec:
+                                    variants:
+                                        - lower_minimum_boundary:
+                                            blkdevio_read_iops_sec = -1
+                                        - upper_maximum_boundary:
+                                            blkdevio_read_iops_sec = 9223372036854775808
+                                        - invalid_value:
+                                            blkdevio_read_iops_sec = "~@#$%^-=_:,.[]{}"
+                                    variants:
+                                        - options:
+                                            variants:
+                                                - config:
+                                                    blkdevio_options = "config"
+                                                - live:
+                                                    blkdevio_options = "live"
+                                                - current:
+                                                    blkdevio_options = "current"
+                                - change_write_iops_sec:
+                                    variants:
+                                        - lower_minimum_boundary:
+                                            blkdevio_write_iops_sec = -1
+                                        - upper_maximum_boundary:
+                                            blkdevio_write_iops_sec = 9223372036854775808
+                                        - invalid_value:
+                                            blkdevio_write_iops_sec = "~@#$%^-=_:,.[]{}"
+                                    variants:
+                                        - options:
+                                            variants:
+                                                - config:
+                                                    blkdevio_options = "config"
+                                                - live:
+                                                    blkdevio_options = "live"
+                                                - current:
+                                                    blkdevio_options = "current"
+                                - change_total_read_write_bytes_iops_sec:
+                                    variants:
+                                        - total_read_bytes_sec:
+                                            blkdevio_total_bytes_sec = 1
+                                            blkdevio_read_bytes_sec = 2
+                                        - total_write_bytes_sec:
+                                            blkdevio_total_bytes_sec = 3
+                                            blkdevio_write_bytes_sec = 4
+                                        - total_read_iops_sec:
+                                            blkdevio_total_iops_sec = 5
+                                            blkdevio_read_iops_sec = 6
+                                        - total_write_iops_sec:
+                                            blkdevio_total_iops_sec = 7
+                                            blkdevio_write_iops_sec = 8

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blkdeviotune.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blkdeviotune.py
@@ -1,0 +1,178 @@
+import logging
+from autotest.client.shared import error
+from virttest import libvirt_xml, utils_libvirtd, virsh
+
+
+def check_blkdeviotune(params):
+    """
+    Check block device I/O parameters
+    """
+    vm_name = params.get("main_vm")
+    vm = params.get("vm")
+    options = params.get("blkdevio_options")
+    device = params.get("blkdevio_device", "")
+    result = virsh.blkdeviotune(vm_name, device)
+    dicts = {}
+    # Parsing command output and putting them into python dictionary.
+    cmd_output = result.stdout.strip().splitlines()
+    for l in cmd_output:
+        k, v = l.split(':')
+        dicts[k.strip()] = int(v.strip())
+
+    logging.debug("The arguments are from test input %s", dicts)
+
+    virt_xml_obj = libvirt_xml.vm_xml.VMXML(virsh_instance=virsh)
+
+    if options == "config" and vm.is_alive():
+        blkdev_xml = virt_xml_obj.get_blkdevio_params(vm_name, "--inactive")
+    else:
+        blkdev_xml = virt_xml_obj.get_blkdevio_params(vm_name)
+
+    logging.debug("The parameters are from XML parser %s", blkdev_xml)
+
+    blkdevio_list = ["total_bytes_sec", "read_bytes_sec", "write_bytes_sec",
+                     "total_iops_sec", "read_iops_sec", "write_iops_sec"]
+
+    if vm.is_alive() and options != "config":
+        for k in blkdevio_list:
+            arg_from_test_input = params.get("blkdevio_" + k)
+            arg_from_cmd_output = dicts.get(k)
+            if (arg_from_test_input and
+                    int(arg_from_test_input) != arg_from_cmd_output):
+                logging.error("To expect <%s=%s>",
+                              arg_from_test_input, arg_from_cmd_output)
+                return False
+    else:
+        for k in blkdevio_list:
+            arg_from_test_input = params.get("blkdevio_" + k)
+            arg_from_xml_output = blkdev_xml.get(k)
+            if (arg_from_test_input and
+                    int(arg_from_test_input) != arg_from_xml_output):
+                logging.error("To expect <%s=%s>",
+                              arg_from_test_input, arg_from_xml_output)
+                return False
+    return True
+
+
+def get_blkdevio_parameter(params):
+    """
+    Get the blkdevio parameters
+    @params: the parameter dictionary
+    """
+    vm_name = params.get("main_vm")
+    options = params.get("blkdevio_options")
+    device = params.get("blkdevio_device")
+
+    result = virsh.blkdeviotune(vm_name, device, options=options)
+    status = result.exit_status
+
+    # Check status_error
+    status_error = params.get("status_error", "no")
+
+    if status_error == "yes":
+        if status:
+            logging.info("It's an expected %s", result.stderr)
+        else:
+            raise error.TestFail("Unexpected return code %d" % status)
+    elif status_error == "no":
+        if status:
+            raise error.TestFail(result.stderr)
+        else:
+            logging.info(result.stdout)
+
+
+def set_blkdevio_parameter(params):
+    """
+    Set the blkdevio parameters
+    @params: the parameter dictionary
+    """
+    vm_name = params.get("main_vm")
+    total_bytes_sec = params.get("blkdevio_total_bytes_sec")
+    read_bytes_sec = params.get("blkdevio_read_bytes_sec")
+    write_bytes_sec = params.get("blkdevio_write_bytes_sec")
+    total_iops_sec = params.get("blkdevio_total_iops_sec")
+    read_iops_sec = params.get("blkdevio_read_iops_sec")
+    write_iops_sec = params.get("blkdevio_write_iops_sec")
+    device = params.get("blkdevio_device")
+    options = params.get("blkdevio_options")
+
+    result = virsh.blkdeviotune(vm_name, device,
+                                options, total_bytes_sec,
+                                read_bytes_sec, write_bytes_sec,
+                                total_iops_sec, read_iops_sec,
+                                write_iops_sec)
+    status = result.exit_status
+
+    # Check status_error
+    status_error = params.get("status_error", "no")
+
+    if status_error == "yes":
+        if status:
+            logging.info("It's an expected %s", result.stderr)
+        else:
+            raise error.TestFail("Unexpected return code %d" % status)
+    elif status_error == "no":
+        if status:
+            raise error.TestFail(result.stderr)
+        else:
+            if check_blkdeviotune(params):
+                logging.info(result.stdout)
+            else:
+                raise error.TestFail("The result is inconsistent between "
+                                     "test input and command/XML output")
+
+
+def run(test, params, env):
+    """
+    Test blkdevio tuning
+
+    Positive test has covered the following combination.
+    -------------------------
+    | total | read  | write |
+    -------------------------
+    |   0   |   0   |   0   |
+    | non-0 |   0   |   0   |
+    |   0   | non-0 | non-0 |
+    |   0   | non-0 |  0    |
+    |   0   |   0   | non-0 |
+    -------------------------
+
+    Negative test has covered unsupported combination and
+    invalid command arguments.
+
+    NB: only qemu-kvm-rhev supports block I/O throttling on >= RHEL6.5,
+    the qemu-kvm is okay for block I/O throttling on >= RHEL7.0.
+    """
+
+    # Run test case
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    start_vm = params.get("start_vm", "yes")
+    change_parameters = params.get("change_parameters", "no")
+    original_vm_xml = libvirt_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+
+    # Make sure vm is down if start not requested
+    if start_vm == "no" and vm and vm.is_alive():
+        vm.destroy()
+
+    # Recover previous running guest
+    if vm and not vm.is_alive() and start_vm == "yes":
+        vm.start()
+
+    test_dict = dict(params)
+    test_dict['vm'] = vm
+
+    # Make sure libvirtd service is running
+    if not utils_libvirtd.libvirtd_is_running():
+        raise error.TestNAError("libvirt service is not running!")
+
+    ########## positive and negative testing #########
+
+    try:
+        if change_parameters == "no":
+            get_blkdevio_parameter(test_dict)
+        else:
+            set_blkdevio_parameter(test_dict)
+    finally:
+        # Restore guest
+        original_vm_xml.sync()


### PR DESCRIPTION
```
Test blkdevio tuning

Positive test has covered the following combination.
-------------------------
| total | read  | write |
-------------------------
|   0   |   0   |   0   |
| non-0 |   0   |   0   |
|   0   | non-0 | non-0 |
|   0   | non-0 |  0    |
|   0   |   0   | non-0 |
-------------------------

Negative test has covered unsupported combination and
invalid command arguments.

NB: only qemu-kvm-rhev supports block I/O throttling on >= RHEL6.5,
the qemu-kvm is okay for block I/O throttling on >= RHEL7.0.
```

BTW, This PR is based on https://github.com/autotest/virt-test/pull/1682
