### PR TITLE
tp-libvirt: Decouple secret_set_get

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/secret/virsh_secret_set_get.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/secret/virsh_secret_set_get.cfg
@@ -3,62 +3,35 @@
     main_vm = ""
     vms = ""
     take_regular_screendumps = no
+    secret_usage_volume = "/var/lib/libvirt/images/foo-bar.secret"
+    set_secret = "yes"
+    get_secret = "yes"
+    check_get_status = "yes"
+    check_set_status = "yes"
+    secret_base64_no_encoded = "~!@#$%^\-=[]{}|_+":;'`,>"
     variants:
-        - create_secret_volume:
-            status_error = "no"
-            variants:
-                - secret_private:
-                     secret_define = "yes"
-                     secret_private = "yes"
-                     secret_usage_volume = "/var/lib/libvirt/images/foo-bar.secret"
-                - secret_public:
-                     secret_define = "yes"
-                     secret_private = "no"
-                     secret_usage_volume = "/var/lib/libvirt/images/bar-foo.secret"
+        - public_secret:
+            secret_private = "yes"
+        - private_secret:
+            secret_private = "no"
+    variants:
         - negative_testing:
             status_error = "yes"
             variants:
                 - get_secret_value:
+                    check_set_status = "no"
                     variants:
                         - no_secret_value:
-                             secret_usage_volume = "/var/lib/libvirt/images/foo-bar.secret"
+                            set_secret = "no"
                         - invalid_options:
-                            secret_usage_volume = "/var/lib/libvirt/images/foo-bar.secret"
-                            secret_options = "--invalid"
+                            get_secret_options = "--invalid"
                 - set_secret_value:
-                    secret_change_parameters = "yes"
+                    get_secret = "no"
+                    check_get_status = "no"
                     variants:
                         - noexist_secret_uuid:
-                            secret_uuid = 11111111-2222-3333-4444-555555555555
-                            secret_base64_no_encoded = "~!@#$%^\-=[]{}|_+":;'`,>"
+                            secret_ref = 11111111-2222-3333-4444-555555555555
                         - invalid_options:
-                            secret_usage_volume = "/var/lib/libvirt/images/foo-bar.secret"
-                            secret_base64_no_encoded = "libvirt"
-                            secret_options = "--invalid"
+                            set_secret_options = "--invalid"
         - positive_testing:
             status_error = "no"
-            variants:
-                - set_secret_value:
-                    variants:
-                        - secret_public:
-                            secret_change_parameters = "yes"
-                            secret_usage_volume = "/var/lib/libvirt/images/bar-foo.secret"
-                            secret_base64_no_encoded = "redhat"
-                - get_secret_value:
-                    variants:
-                        - secret_public:
-                            cleanup_volume = "yes"
-                            secret_undefine = "yes"
-                            secret_usage_volume = "/var/lib/libvirt/images/bar-foo.secret"
-                - set_secret_value:
-                    variants:
-                        - secret_private:
-                            secret_change_parameters = "yes"
-                            secret_usage_volume = "/var/lib/libvirt/images/foo-bar.secret"
-                            secret_base64_no_encoded = "redhat"
-                - get_secret_value:
-                    variants:
-                        - secret_private:
-                            cleanup_volume = "yes"
-                            secret_undefine = "yes"
-                            secret_usage_volume = "/var/lib/libvirt/images/foo-bar.secret"


### PR DESCRIPTION
The original version of virsh_secret_set_get generates test cases that
couples to each other, which means one test case depends on another test
case. For example, first test case defines a secret, the following three
test case test on the former defined secret and a last test case clean
up the environment.

This method is helpful if we try to reuse some cases and works well when
we make them run together. But if we run a single case, it will fail or
leave a contaminated environment.

This patch decouples these dependencies and make every test case define
and clean up environment, making every case can work independently.

Signed-off-by: Hao Liu hliu@redhat.com
