### PR TITLE
virsh_migrate: Add a case to cover domain migration with ejceted CDROM

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
@@ -120,6 +120,9 @@
             virsh_migrate_extra = ""
             virsh_migrate_src_state = paused
             virsh_migrate_dest_state = paused
+        - there_vm_eject_cdrom:
+            virsh_migrate_options = "--live"
+            eject_cdrom = "yes"
         - there_vm_suspend_offline:
             # Uni-direction offline migration with VM suspend.
             virsh_migrate_options = ""


### PR DESCRIPTION
This patch dependent on https://github.com/autotest/virt-test/pull/1684

Signed-off-by: Yanbing Du ydu@redhat.com
