### PR TITLE
virsh_attach_detach_disk: cases expand to cover test corners

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_disk.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_disk.cfg
@@ -12,6 +12,7 @@
     at_dt_disk_device_target = vdb
     at_dt_disk_bus_type = virtio
     at_dt_disk_device_source = "attach.img"
+    at_dt_disk_device_source_format = "raw"
     at_dt_disk_device_source_path = 'yes'
     variants:
         - error_test:
@@ -128,6 +129,11 @@
                             target = "iqn.2013-10.com.example:iscsi"
                 - audit_check:
                     at_dt_disk_check_audit = 'yes'
+                - attach_disk_image_format:
+                    variants:
+                        - raw_format:
+                        - qcow2_format:
+                            at_dt_disk_device_source_format = "qcow2"
                 - only_attach_disk:
                     only attach_disk
                     variants:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk.py
@@ -18,19 +18,19 @@ def run(test, params, env):
     4.Confirm the test result.
     """
 
-    def create_device_file(device_source="/tmp/attach.img"):
+    def create_device_image(name, format="raw", extra=""):
         """
-        Create a device source file.
+        Create a device source image by qemu-img command.
 
-        :param device_source: Device source file.
+        :param name: Name of the image
+        :param format: Image format(raw, qcow2, etc.)
+        :param extra: Extra params for creating image
         """
-        try:
-            f = open(device_source, 'wb')
-            f.seek((512 * 1024 * 1024) - 1)
-            f.write(str(0))
-            f.close()
-        except IOError:
-            logging.error("Image file %s created failed." % device_source)
+        params['image_name'] = name
+        params['image_format'] = format
+        image = qemu_storage.QemuImg(params, test.tmpdir, name)
+        image_path, _ = image.create(params)
+        return image_path
 
     def check_vm_partition(vm, device, os_type, target_name):
         """
@@ -113,6 +113,7 @@ def run(test, params, env):
     # Disk specific attributes.
     device = params.get("at_dt_disk_device", "disk")
     device_source_name = params.get("at_dt_disk_device_source", "attach.img")
+    device_source_format = params.get("at_dt_disk_deice_source_format", "raw")
     device_target = params.get("at_dt_disk_device_target", "vdd")
     bus_type = params.get("at_dt_disk_bus_type", "virtio")
     source_path = "yes" == params.get("at_dt_disk_device_source_path", "yes")
@@ -125,13 +126,8 @@ def run(test, params, env):
     vm = env.get_vm(vm_name)
     if vm.is_alive():
         vm.destroy(gracefully=False)
-    # Back up xml file.
-    vm_xml_file = os.path.join(test.tmpdir, "vm.xml")
-    if source_path:
-        device_source = os.path.join(test.virtdir, device_source_name)
-    else:
-        device_source = device_source_name
-    virsh.dumpxml(vm_name, extra="--inactive", to_file=vm_xml_file)
+    # Back up VM xml
+    vmxml_backup = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
 
     # Create virtual device file.
     if test_block_dev:
@@ -142,7 +138,12 @@ def run(test, params, env):
         device_source = iscsi_dev.setup()
         logging.debug("iscsi dev name: %s" % device_source)
     else:
-        create_device_file(device_source)
+        if source_path:
+            device_source = create_device_image(device_source_name,
+                                                device_source_format)
+        else:
+            # No need create source image for negative testing
+            device_source = device_source_name
 
     if vm.is_alive():
         vm.destroy(gracefully=False)
@@ -172,7 +173,7 @@ def run(test, params, env):
         if test_twice:
             device_target2 = params.get("at_dt_disk_device_target2",
                                         device_target)
-            create_device_file(device_source)
+            create_device_image(device_source_name, device_source_format)
             s_attach = virsh.attach_disk(vm_name, device_source, device_target2,
                                          "--driver qemu --config").exit_status
             if s_attach != 0:
@@ -225,7 +226,7 @@ def run(test, params, env):
                                    debug=True).exit_status
     if test_twice:
         device_target2 = params.get("at_dt_disk_device_target2", device_target)
-        create_device_file(device_source)
+        create_device_image(device_source_name, device_source_format)
         if test_cmd == "attach-disk":
             status = virsh.attach_disk(vm_ref, device_source,
                                        device_target2, at_options, debug=True).exit_status
@@ -307,10 +308,7 @@ def run(test, params, env):
 
     finally:
         # Recover VM.
-        if vm.is_alive():
-            vm.destroy(gracefully=False)
-        virsh.undefine(vm_name)
-        virsh.define(vm_xml_file)
+        vmxml_backup.sync()
         if os.path.exists(save_file):
             os.remove(save_file)
         if test_block_dev:


### PR DESCRIPTION
After attach CDROM, eject it by virsh command and do save/restore for the domain, make sure the CDROM still empty.

Signed-off-by: Yanbing Du ydu@redhat.com
