### PR TITLE
virsh_update-device: case expand and tiny bugs fix

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_update_device.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_update_device.cfg
@@ -4,6 +4,7 @@
     take_regular_screendumps = "no"
     updatedevice_vm_ref = "name"
     updatedevice_extra = ""
+    disk_mode = "readonly"
     variants:
         - normal_test:
             status_error = "no"
@@ -11,9 +12,15 @@
                 - ide_option:
                     updatedevice_target_bus = "ide"
                     updatedevice_target_dev = "hdc"
+                    disk_type = "cdrom"
                 - scsi_option:
                     updatedevice_target_bus = "scsi"
                     updatedevice_target_dev = "sdc"
+                    disk_type = "cdrom"
+                - floppy_option:
+                    updatedevice_target_bus = "fdc"
+                    updatedevice_target_dev = "fda"
+                    disk_type = "floppy"
             variants:
                 - id_option:
                     updatedevice_vm_ref = "id"
@@ -22,19 +29,35 @@
                         - force_option:
                             updatedevice_flag = "--force"
                             updatedevice_twice = "yes"
+                        - force_live_option:
+                            updatedevice_flag = "--force --live"
+                            updatedevice_twice = "yes"
+                            updatedevice_twice = "yes"
+                            updatedevice_diff_iso = "yes"
+                        - force_current_option:
+                            updatedevice_flag = "--force --current"
+                            updatedevice_twice = "yes"
+                            updatedevice_twice = "yes"
+                            updatedevice_diff_iso = "yes"
                         - live_option:
                             updatedevice_flag = "--live"
+                        - current_option:
+                            updatedevice_flag = "--current"
                         - config_option:
                             updatedevice_flag = "--config"
                         - diff_iso_option:
                             updatedevice_twice = "yes"
                             updatedevice_diff_iso = "yes"
+                        - shareable_disk:
+                            disk_mode = "shareable"
                 - name_option:
+                    updatedevice_vm_ref = "name"
                 - pause_option:
                     paused_after_start_vm = "yes"
                 - uuid_option:
                     updatedevice_vm_ref = "uuid"
                 - name_live_option:
+                    updatedevice_vm_ref = "name"
                     updatedevice_flag = "--live"
                 - config_option:
                     updatedevice_flag = "--config"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_update_device.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_update_device.py
@@ -1,4 +1,3 @@
-import re
 import os
 import shutil
 import logging
@@ -8,10 +7,13 @@ from virttest.libvirt_xml import VMXML
 from provider import libvirt_version
 
 
-def create_cdrom(vm_name, orig_iso, target_dev):
+def create_disk(vm_name, orig_iso, disk_type, target_dev, mode=""):
     """
     :param vm_name : vm_name
-    :param source_iso : disk's source backing file.
+    :param source_iso : disk's source backing file
+    :param disk_type: disk's device type: cdrom or floppy
+    :param target_dev: disk's target device name
+    :param mode: readonly or shareable
     """
     try:
         _file = open(orig_iso, 'wb')
@@ -20,22 +22,27 @@ def create_cdrom(vm_name, orig_iso, target_dev):
         _file.close()
     except IOError:
         raise error.TestFail("Create orig_iso failed!")
+    options = "--type %s --sourcetype=file --config" % disk_type
+    if mode:
+        options += " --mode %s" % mode
     try:
-        virsh.attach_disk(vm_name, orig_iso, target_dev,
-                          "--type cdrom --sourcetype=file --config")
+        virsh.attach_disk(vm_name, orig_iso, target_dev, options)
     except:
         os.remote(orig_iso)
         raise error.TestFail("Failed to attach")
 
 
-def create_attach_xml(update_xmlfile, source_iso, target_bus, target_dev):
+def create_attach_xml(update_xmlfile, source_iso, disk_type, target_bus,
+                      target_dev, disk_mode=""):
     """
     Create a xml file to update a device.
 
     :param update_xmlfile : path/file to save device XML
     :param source_iso : disk's source backing file.
-    :param target_bus : disk's target bus
-    :param target_dev : disk's target device name
+    :param disk_type: disk's device type: cdrom or floppy
+    :param target_bus: disk's target bus
+    :param target_dev: disk's target device name
+    :param disk_mode: readonly or shareable
     """
     try:
         _file = open(source_iso, 'wb')
@@ -47,36 +54,41 @@ def create_attach_xml(update_xmlfile, source_iso, target_bus, target_dev):
     disk_class = VMXML.get_device_class('disk')
     disk = disk_class(type_name='file')
     # Static definition for comparison in check_attach()
-    disk.device = 'cdrom'
-    disk.driver = dict(name='file')
+    disk.device = disk_type
+    disk.driver = dict(name='qemu')
     disk.source = disk.new_disk_source(attrs={'file': source_iso})
     disk.target = dict(bus=target_bus, dev=target_dev)
-    disk.readonly = True
+    if disk_mode == "readonly":
+        disk.readonly = True
+    if disk_mode == "shareable":
+        disk.share = True
     disk.xmltreefile.write()
     shutil.copyfile(disk.xml, update_xmlfile)
 
 
-def is_attached(vmxml_devices, source_file, target_dev):
+def is_attached(vmxml_devices, disk_type, source_file, target_dev):
     """
     Check attached device and disk exist or not.
 
-    :param source_file : disk's source file to check
     :param vmxml_devices: VMXMLDevices instance
+    :param disk_type: disk's device type: cdrom or floppy
+    :param source_file : disk's source file to check
     :param target_dev : target device name
     :return: True/False if backing file and device found
     """
     disks = vmxml_devices.by_device_tag('disk')
     for disk in disks:
-        if disk.device != 'cdrom':
+        logging.debug("Check disk XML:\n%s", open(disk['xml']).read())
+        if disk.device != disk_type:
             continue
         if disk.target['dev'] != target_dev:
             continue
         if disk.source.attrs['file'] != source_file:
             continue
         # All three conditions met
+        logging.debug("Find %s in given disk XML", source_file)
         return True
-    logging.error('No cdrom device for "%s" in devices XML: "%s"',
-                  source_file, vmxml_devices)
+    logging.debug("Not find %s in gievn disk XML", source_file)
     return False
 
 
@@ -85,7 +97,7 @@ def run(test, params, env):
     Test command: virsh update-device.
 
     Update device from an XML <file>.
-    1.Prepare test environment, adding a cdrom to VM.
+    1.Prepare test environment, adding a cdrom/floppy to VM.
     2.Perform virsh update-device operation.
     3.Recover test environment.
     4.Confirm the test result.
@@ -125,21 +137,28 @@ def run(test, params, env):
     start_vm = "yes" == params.get("start_vm", "no")
 
     # Get the target bus/dev
+    disk_type = params.get("disk_type", "cdrom")
     target_bus = params.get("updatedevice_target_bus", "ide")
     target_dev = params.get("updatedevice_target_dev", "hdc")
+    disk_mode = params.get("disk_mode", "")
+    support_mode = ['readonly', 'shareable']
+    if not disk_mode and disk_mode not in support_mode:
+        raise error.TestError("%s not in support mode %s"
+                              % (disk_mode, support_mode))
 
     # Prepare tmp directory and files.
     orig_iso = os.path.join(test.virtdir, "orig.iso")
     test_iso = os.path.join(test.virtdir, "test.iso")
     test_diff_iso = os.path.join(test.virtdir, "test_diff.iso")
     update_xmlfile = os.path.join(test.tmpdir, "update.xml")
-    create_attach_xml(update_xmlfile, test_iso, target_bus, target_dev)
+    create_attach_xml(update_xmlfile, test_iso, disk_type, target_bus,
+                      target_dev, disk_mode)
 
-    # This test needs a cdrom attached first - attach a cdrom
+    # This test needs a cdrom/floppy attached first - attach a cdrom/floppy
     # to a shutdown vm. Then decide to restart or not
     if vm.is_alive():
         vm.destroy()
-    create_cdrom(vm_name, orig_iso, target_dev)
+    create_disk(vm_name, orig_iso, disk_type, target_dev, disk_mode)
     if start_vm:
         vm.start()
         domid = vm.get_id()
@@ -164,8 +183,8 @@ def run(test, params, env):
             if diff_iso:
                 # Swap filename of device backing file in update.xml
                 os.remove(update_xmlfile)
-                create_attach_xml(update_xmlfile, test_diff_iso,
-                                  target_bus, target_dev)
+                create_attach_xml(update_xmlfile, test_diff_iso, disk_type,
+                                  target_bus, target_dev, disk_mode)
         elif vm_ref == "uuid":
             vm_ref = vmxml.uuid
         elif vm_ref == "hex_id":
@@ -206,15 +225,15 @@ def run(test, params, env):
         if status != 0:
             errmsg = "Run failed with right command"
         if diff_iso:  # Expect the backing file to have updated
-            active_attached = is_attached(active_vmxml.devices,
+            active_attached = is_attached(active_vmxml.devices, disk_type,
                                           test_diff_iso, target_dev)
-            inactive_attached = is_attached(inactive_vmxml.devices,
+            inactive_attached = is_attached(inactive_vmxml.devices, disk_type,
                                             test_diff_iso, target_dev)
         else:  # Expect backing file to remain the same
-            active_attached = is_attached(active_vmxml.devices, test_iso,
-                                          target_dev)
-            inactive_attached = is_attached(inactive_vmxml.devices, test_iso,
-                                            target_dev)
+            active_attached = is_attached(active_vmxml.devices, disk_type,
+                                          test_iso, target_dev)
+            inactive_attached = is_attached(inactive_vmxml.devices, disk_type,
+                                            test_iso, target_dev)
 
         # Check behavior of combination before individual!
         if "config" in flag_list and "live" in flag_list:


### PR DESCRIPTION
1. Support different disk type: cdrom, floppy
2. Support different disk mode: none, readonly, shareable
3. Cover more sub test cases
4. Tiny bugs fix

Signed-off-by: Yanbing Du ydu@redhat.com
