### PR TITLE
libvirt_pci_passthrough: Rewrite the configuration file.

### DIFF
--- a/libvirt/tests/cfg/libvirt_pci_passthrough.cfg
+++ b/libvirt/tests/cfg/libvirt_pci_passthrough.cfg
@@ -8,19 +8,23 @@
     variants:
         - NIC:
             libvirt_pci_device_type = "NIC"
-            # Please enter the network name on host
-            # which is using the pci device. And you
-            # want to attach this device to guest with
-            # passthrough mode. It means this network
-            # device will be not available for host in
-            # test. example: "eth1"
-            libvirt_pci_net_name = "ENTER.YOUR.NETWORK.NAME"
+            # Please enter the PCI device label for
+            # a network device. We will attach this
+            # device to guest. Then this network device
+            # will be unavailable on host.
+            # E.g: pci_0000_05_00_0
+            libvirt_pci_net_dev_label = "ENTER.YOUR.PCI.LABEL"
+            # Please enter the ip what is used by the device
+            # you are going to attach to guest.
+            libvirt_pci_net_ip = "ENTER.YOUR.IP"
             # Please enter a vailable ip from the net device.
             # We need to ping it after attaching pci device
             # to guest to verify this device works well in guest.
             libvirt_pci_server_ip = "ENTER.YOUR.SERVER.IP"
         - STORAGE:
             libvirt_pci_device_type = "STORAGE"
-            # Please enter the device path that is going
-            # to be attached to guest, such as "/dev/sdb"
-            libvirt_pci_storage_dev_name = "ENTER.YOUR.DEVICE.NAME"
+            # Please enter the PCI device label for
+            # a storage device. We will attach this
+            # device to guest.
+            # E.g: pci_0000_0d_00_0
+            libvirt_pci_storage_dev_label = "ENTER.YOUR.PCI.LABEL"


### PR DESCRIPTION
As the original way to test pci passthrough is not secure
for all host. This patch make user to provide the pci_label
to find the pci device.

Signed-off-by: Dongsheng Yang yangds.fnst@cn.fujitsu.com
