### PR TITLE
libvirt.test: Remove a tab in attach-disk configuration

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_disk.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_disk.cfg
@@ -77,7 +77,7 @@
                 - image_file_no_option:
                     at_dt_disk_at_options = ""
                 - vm_shutdown_config:
-		    only attach_disk
+	            only attach_disk
                     at_dt_disk_address =  "pci:0x0000.0x00.0x0b.0x0"
                     at_dt_disk_at_options = "--driver qemu --subdriver raw --config"
                     at_dt_disk_dt_options = "--config"


### PR DESCRIPTION
Signed-off-by: Li Yang liyang.fnst@cn.fujitsu.com
