### PR TITLE
libvirt.test: Raise TestNAError if option not be supported

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_setvcpus.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_setvcpus.py
@@ -20,7 +20,8 @@ def remote_test(remote_ip, local_ip, remote_pwd, remote_prompt,
         session.cmd_output('LANG=C')
         command = "virsh -c %s setvcpus %s 1 --live" % (remote_uri, vm_name)
         if virsh.has_command_help_match("setvcpus", "--live") is None:
-            status_error = "yes"
+            raise error.TestNAError("The current libvirt doesn't support"
+                                    " '--live' option for setvcpus")
         status, output = session.cmd_status_output(command, internal_timeout=5)
         session.close()
         if status != 0:
@@ -192,8 +193,9 @@ def run(test, params, env):
             option_list = options.split(" ")
             for item in option_list:
                 if virsh.has_command_help_match(command, item) is None:
-                    status_error = "yes"
-                    break
+                    raise error.TestNAError("The current libvirt version"
+                                            " doesn't support '%s' option"
+                                            % item)
             status = virsh.setvcpus(dom_option, count_option, options,
                                     ignore_status=True, debug=True)
             setvcpu_exit_status = status.exit_status

--- a/libvirt/tests/src/virsh_cmd/monitor/virsh_domblkstat.py
+++ b/libvirt/tests/src/virsh_cmd/monitor/virsh_domblkstat.py
@@ -44,8 +44,8 @@ def run(test, params, env):
     option_list = options.split(" ")
     for option in option_list:
         if virsh.has_command_help_match("domblkstat", option) is None:
-            status_error = "yes"
-            break
+            raise error.TestNAError("The current libvirt doesn't support"
+                                    " '%s' option" % option)
     if libvirtd == "off":
         utils_libvirtd.libvirtd_stop()
 

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_dumpxml.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_dumpxml.py
@@ -54,9 +54,11 @@ def run(test, params, env):
             for option in options:
                 if option.strip() == "":
                     continue
-                if not virsh.has_command_help_match("net-dumpxml", option.strip()):
-                    status_error = "yes"
-                    break
+                if not virsh.has_command_help_match("net-dumpxml",
+                                                    option.strip()):
+                    raise error.TestNAError("The current libvirt version"
+                                            " doesn't support '%s' option"
+                                            % option.strip())
     finally:
         # Recover network
         if net_status == "inactive" and net_status_current == "active":


### PR DESCRIPTION
The original source make the case to be negative case when option is not supported. now modify them to skip such cases.
