### PR TITLE
libvirt.test: Fix a bug in start test

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_start.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_start.py
@@ -104,6 +104,7 @@ def run(test, params, env):
                 status = session.cmd_status("sleep 1000&")
                 if status:
                     raise error.TestError("Can not execute command in guest.")
+                sleep_pid = session.cmd_output("echo $!").strip()
                 virsh.managedsave(vm_ref)
                 virsh.start(vm_ref, options=opt)
             else:
@@ -130,7 +131,8 @@ def run(test, params, env):
                                          "closed.")
             elif opt.count("force-boot"):
                 session = vm.wait_for_login()
-                status = session.cmd_status("ps -ef|grep sleep|grep -v grep")
+                status = session.cmd_status("ps %s |grep 'sleep 1000'"
+                                            % sleep_pid)
                 if not status:
                     raise error.TestFail("VM was started with --force-boot,"
                                          "but it is restored from a"


### PR DESCRIPTION
Perhaps there'is a process 'sleep 60' always exists, so the
original filter will fail to get the right sleep process.

Signed-off-by: Li Yang liyang.fnst@cn.fujitsu.com
