### PR TITLE
libvirt.test: Fix a bug for update-device test

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_update_device.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_update_device.py
@@ -71,7 +71,10 @@ def is_attached(vmxml_devices, source_file, target_dev):
             continue
         if disk.target['dev'] != target_dev:
             continue
-        if disk.source.attrs['file'] != source_file:
+        if disk.xmltreefile.find('source') is not None:
+            if disk.source.attrs['file'] != source_file:
+                continue
+        else:
             continue
         # All three conditions met
         return True


### PR DESCRIPTION
Disk maybe doesn't contain source element, use
'disk.source' will get LibvirtXMLNotFoundError.

Signed-off-by: Li Yang liyang.fnst@cn.fujitsu.com
