### PR TITLE
tests.migrate_set_get_speed: Expand testcases with verifying.

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_set_get_speed.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_set_get_speed.cfg
@@ -1,5 +1,6 @@
 - virsh.migrate_set_get_speed:
     type = virsh_migrate_set_get_speed
+    take_regular_screendumps = "no"
     variants:
         - normal_test:
             status_error = "no"


### PR DESCRIPTION
Add more testcases for migrate-set/get-speed by verifying migration time.

Compare two times migration and get result according our setting.
1.The speed of migration first time is half of second time.
2.The speed of migration first time is twice of second time.
2.The speed of migration first time is same as second time.

Signed-off-by: Yu Mingfei yumingfei@cn.fujitsu.com
