### PR TITLE
acl-tests: fix config files for all acl test cases that use vm name

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcopy.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcopy.cfg
@@ -40,7 +40,7 @@
                 - acl_test:
                     setup_libvirt_polkit = "yes"
                     action_id = "org.libvirt.api.domain.block-write org.libvirt.api.domain.write"
-                    action_lookup = "connect_driver:QEMU domain_name:virt-tests-vm1"
+                    action_lookup = "connect_driver:QEMU domain_name:${main_vm}"
                     unprivileged_user = "EXAMPLE"
                     virsh_uri = "qemu:///system"
         - negative_test:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_console.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_console.cfg
@@ -26,7 +26,7 @@
                 - acl_test:
                     setup_libvirt_polkit = "yes"
                     action_id = "org.libvirt.api.domain.open-device"
-                    action_lookup = "connect_driver:QEMU domain_name:virt-tests-vm1"
+                    action_lookup = "connect_driver:QEMU domain_name:${main_vm}"
                     unprivileged_user = "EXAMPLE"
                     virsh_uri = "qemu:///system"
         - error_test:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_destroy.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_destroy.cfg
@@ -23,7 +23,7 @@
                 - acl_test:
                     setup_libvirt_polkit = "yes"
                     action_id = "org.libvirt.api.domain.stop"
-                    action_lookup = "connect_driver:QEMU domain_name:virt-tests-vm1"
+                    action_lookup = "connect_driver:QEMU domain_name:${main_vm}"
                     unprivileged_user = "EXAMPLE"
                     virsh_uri = "qemu:///system"
         - error_test:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domfstrim.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domfstrim.cfg
@@ -20,7 +20,7 @@
                 - acl_test:
                     setup_libvirt_polkit = "yes"
                     action_id = "org.libvirt.api.domain.fs-trim"
-                    action_lookup = "connect_driver:QEMU domain_name:virt-tests-vm1"
+                    action_lookup = "connect_driver:QEMU domain_name:${main_vm}"
                     unprivileged_user = "EXAMPLE"
                     virsh_uri = "qemu:///system"
         - negtive_tests:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_dump.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_dump.cfg
@@ -53,7 +53,7 @@
                 - acl_test:
                     setup_libvirt_polkit = "yes"
                     action_id = "org.libvirt.api.domain.core-dump"
-                    action_lookup = "connect_driver:QEMU domain_name:virt-tests-vm1"
+                    action_lookup = "connect_driver:QEMU domain_name:${main_vm}"
                     unprivileged_user = "EXAMPLE"
                     virsh_uri = "qemu:///system"
         - negative_test:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_reset.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_reset.cfg
@@ -29,6 +29,6 @@
                 - acl_test:
                     setup_libvirt_polkit = "yes"
                     action_id = "org.libvirt.api.domain.reset"
-                    action_lookup = "connect_driver:QEMU domain_name:virt-tests-vm1"
+                    action_lookup = "connect_driver:QEMU domain_name:${main_vm}"
                     unprivileged_user = "EXAMPLE"
                     virsh_uri = "qemu:///system"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_restore.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_restore.cfg
@@ -22,7 +22,7 @@
                 - acl_test:
                     setup_libvirt_polkit = "yes"
                     action_id = "org.libvirt.api.domain.start org.libvirt.api.domain.write"
-                    action_lookup = "connect_driver:QEMU domain_name:virt-tests-vm1"
+                    action_lookup = "connect_driver:QEMU domain_name:${main_vm}"
                     unprivileged_user = "EXAMPLE"
                     virsh_uri = "qemu:///system"
         - no_option:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_save.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_save.cfg
@@ -33,7 +33,7 @@
                 - acl_test:
                     setup_libvirt_polkit = "yes"
                     action_id = "org.libvirt.api.domain.hibernate"
-                    action_lookup = "connect_driver:QEMU domain_name:virt-tests-vm1"
+                    action_lookup = "connect_driver:QEMU domain_name:${main_vm}"
                     unprivileged_user = "EXAMPLE"
                     virsh_uri = "qemu:///system"
         - error_test:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_screenshot.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_screenshot.cfg
@@ -32,7 +32,7 @@
                 - acl_test:
                     setup_libvirt_polkit = "yes"
                     action_id = "org.libvirt.api.domain.screenshot"
-                    action_lookup = "connect_driver:QEMU domain_name:virt-tests-vm1"
+                    action_lookup = "connect_driver:QEMU domain_name:${main_vm}"
                     unprivileged_user = "EXAMPLE"
                     virsh_uri = "qemu:///system"
         - error_test:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_sendkey.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_sendkey.cfg
@@ -40,7 +40,7 @@
                 - acl_test:
                     setup_libvirt_polkit = "yes"
                     action_id = "org.libvirt.api.domain.send-input"
-                    action_lookup = "connect_driver:QEMU domain_name:virt-tests-vm1"
+                    action_lookup = "connect_driver:QEMU domain_name:${main_vm}"
                     unprivileged_user = "EXAMPLE"
                     virsh_uri = "qemu:///system"
         - sysrq:
@@ -57,7 +57,7 @@
                 - acl_test:
                     setup_libvirt_polkit = "yes"
                     action_id = "org.libvirt.api.domain.send-input"
-                    action_lookup = "connect_driver:QEMU domain_name:virt-tests-vm1"
+                    action_lookup = "connect_driver:QEMU domain_name:${main_vm}"
                     unprivileged_user = "EXAMPLE"
                     virsh_uri = "qemu:///system"
         - readonly:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_shutdown.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_shutdown.cfg
@@ -34,7 +34,7 @@
                 - acl_test:
                     setup_libvirt_polkit = "yes"
                     action_id = "org.libvirt.api.domain.init-control"
-                    action_lookup = "connect_driver:QEMU domain_name:virt-tests-vm1"
+                    action_lookup = "connect_driver:QEMU domain_name:${main_vm}"
                     unprivileged_user = "EXAMPLE"
                     virsh_uri = "qemu:///system"
         - error_test:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_suspend.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_suspend.cfg
@@ -20,7 +20,7 @@
                 - acl_test:
                     setup_libvirt_polkit = "yes"
                     action_id = "org.libvirt.api.domain.suspend"
-                    action_lookup = "connect_driver:QEMU domain_name:virt-tests-vm1"
+                    action_lookup = "connect_driver:QEMU domain_name:${main_vm}"
                     unprivileged_user = "EXAMPLE"
                     virsh_uri = "qemu:///system"
         - error_test:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_undefine.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_undefine.cfg
@@ -48,7 +48,7 @@
                 - acl_test:
                     setup_libvirt_polkit = "yes"
                     action_id = "org.libvirt.api.domain.write org.libvirt.api.domain.save org.libvirt.api.domain.delete"
-                    action_lookup = "connect_driver:QEMU domain_name:virt-tests-vm1"
+                    action_lookup = "connect_driver:QEMU domain_name:${main_vm}"
                     unprivileged_user = "EXAMPLE"
                     virsh_uri = "qemu:///system"
         - error_test:

--- a/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_create_as.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_create_as.cfg
@@ -75,6 +75,6 @@
                 - acl_test:
                     setup_libvirt_polkit = "yes"
                     action_id = "org.libvirt.api.domain.snapshot"
-                    action_lookup = "connect_driver:QEMU domain_name:virt-tests-vm1"
+                    action_lookup = "connect_driver:QEMU domain_name:${main_vm}"
                     unprivileged_user = "EXAMPLE"
                     virsh_uri = "qemu:///system"


### PR DESCRIPTION
We definitely shouldn't hardcode any name or config options in the
tests or tests configs unless there is no other way, and this is not
the case. Let's say that someone for some reason change the main_vm
name and suddenly a lot of acl tests are for unexpected reason broken.

Signed-off-by: Pavel Hrdina phrdina@redhat.com
