### PR TITLE
snapshot_create_as: Add fs-freeze to/for acl list

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_create_as.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_create_as.cfg
@@ -74,7 +74,7 @@
                 - non_acl:
                 - acl_test:
                     setup_libvirt_polkit = "yes"
-                    action_id = "org.libvirt.api.domain.snapshot"
+                    action_id = "org.libvirt.api.domain.snapshot org.libvirt.api.domain.fs-freeze"
                     action_lookup = "connect_driver:QEMU domain_name:${main_vm}"
                     unprivileged_user = "EXAMPLE"
                     virsh_uri = "qemu:///system"


### PR DESCRIPTION
Using the --quiesce option requires the 'fs-freeze' acl/permission, so
add it to the action_id value. I tried adding it "just" to the quiesce
specific test to no avail seems the value in
