### PR TITLE
virsh_shutdown: Using agent requires write acl

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_shutdown.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_shutdown.cfg
@@ -33,7 +33,7 @@
                     shutdown_vm_ref = "remote"
                 - acl_test:
                     setup_libvirt_polkit = "yes"
-                    action_id = "org.libvirt.api.domain.init-control"
+                    action_id = "org.libvirt.api.domain.init-control org.libvirt.api.domain.write"
                     action_lookup = "connect_driver:QEMU domain_name:${main_vm}"
                     unprivileged_user = "EXAMPLE"
                     virsh_uri = "qemu:///system"


### PR DESCRIPTION
Need to add the "write" acl to the list since using the agent requires
it.  Like snapshot_create_as too bad there wasn't a way to add the acl
for just the agent subtest (I didn't see an easy way).
