### PR TITLE
virsh.setvcpus: fix remote test

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_setvcpus.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_setvcpus.py
@@ -12,8 +12,9 @@ def remote_test(remote_ip, local_ip, remote_pwd, remote_prompt,
     Test remote case
     """
     err = ""
+    status = 1
+    status_error = status_error_test
     try:
-        status_error = status_error_test
         remote_uri = libvirt_vm.complete_uri(local_ip)
         session = remote.remote_login("ssh", remote_ip, "22",
                                       "root", remote_pwd, remote_prompt)


### PR DESCRIPTION
The variables error and status_error should be configured before the
try-except block as they must exist always when it comes to return.

Signed-off-by: Pavel Hrdina phrdina@redhat.com
