### PR TITLE
snapshot_disk: Add pool volume snapshot cases

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_disk.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_disk.cfg
@@ -29,12 +29,60 @@
                 - revert_paused:
                     snapshot_revert_paused = "yes"
     variants:
-        - attach_img_raw:
-            snapshot_image_format = "raw"
-        - attach_img_qcow2:
-            snapshot_image_format = "qcow2"
-        - attach_img_qed:
-            snapshot_image_format = "qed"
+        - no_pool:
+            variants:
+                - attach_img_raw:
+                    snapshot_image_format = "raw"
+                - attach_img_qcow2:
+                    snapshot_image_format = "qcow2"
+                - attach_img_qed:
+                    snapshot_image_format = "qed"
+        - pool_vol:
+            snapshot_with_pool = "yes"
+            pool_name = "snap_disk_pool"
+            vol_name = "snap_pool_vol"
+            vol_capacity = "1073741824"
+            vol_allocation = "1048576"
+            variants:
+                - attach_img_raw:
+                    vol_format = "raw"
+                - attach_img_qcow2:
+                    vol_format = "qcow2"
+                    variants:
+                        - v_qcow2:
+                        - v_qcow2v3:
+                            vol_compat = "1.1"
+                            lazy_refcounts = "yes"
+                - attach_img_qed:
+                    vol_format = "qed"
+            variants:
+                - dir_pool:
+                    pool_type = "dir"
+                    pool_target = "dir-pool"
+                - fs_pool:
+                    pool_type = "fs"
+                    pool_target = "fs"
+                    emulated_image = "fs-pool"
+                - netfs_pool:
+                    pool_type = "netfs"
+                    pool_target = "nfs-mount"
+                    nfs_server_dir = "nfs-server"
+                    source_host = "localhost"
+                - logical_pool:
+                    no v_qcow2v3
+                    pool_type = "logical"
+                    pool_target = "/dev/vg_logical"
+                    emulated_image = "logical-pool"
+                - iscsi_pool:
+                    no v_qcow2v3
+                    pool_type = "iscsi"
+                    pool_target = "/dev/disk/by-path"
+                    emulated_image = "iscsi-pool"
+                - disk_pool:
+                    no v_qcow2v3
+                    pool_type = "disk"
+                    pool_target = "/dev"
+                    emulated_image = "disk-pool"
     variants:
         - positive_test:
             # internal snapshot for disk unsupported for storage type raw or qed.

--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_disk.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_disk.py
@@ -3,8 +3,11 @@ import logging
 import re
 import tempfile
 from autotest.client.shared import error
+from autotest.client import utils
 from virttest import virsh, qemu_storage, data_dir
-from virttest.libvirt_xml import vm_xml
+from virttest import libvirt_xml
+from virttest import libvirt_storage
+from virttest.utils_test import libvirt as utlv
 from provider import libvirt_version
 
 
@@ -29,35 +32,122 @@ def run(test, params, env):
     snapshot_current = ("yes" == params.get("snapshot_current", "no"))
     snapshot_revert_paused = ("yes" == params.get("snapshot_revert_paused",
                                                   "no"))
+    # Pool variables.
+    snapshot_with_pool = "yes" == params.get("snapshot_with_pool", "no")
+    pool_name = params.get("pool_name")
+    pool_type = params.get("pool_type")
+    pool_target = params.get("pool_target")
+    emulated_image = params.get("emulated_image")
+    vol_name = params.get("vol_name")
+    vol_format = params.get("vol_format")
+    lazy_refcounts = "yes" == params.get("lazy_refcounts")
+
+    # Set volume xml attribute dictionary, extract all params start with 'vol_'
+    # which are for setting volume xml, except 'lazy_refcounts'.
+    vol_arg = {}
+    for key in params.keys():
+        if key.startswith('vol_'):
+            if key[4:] in ['capacity', 'allocation', 'owner', 'group']:
+                vol_arg[key[4:]] = int(params[key])
+            else:
+                vol_arg[key[4:]] = params[key]
+    vol_arg['lazy_refcounts'] = lazy_refcounts
+
+    supported_pool_list = ["dir", "fs", "netfs", "logical", "iscsi",
+                           "disk", "gluster"]
+    if snapshot_with_pool:
+        if pool_type not in supported_pool_list:
+            raise error.TestNAError("%s not in support list %s" %
+                                    (pool_target, supported_pool_list))
 
     # Do xml backup for final recovery
-    vmxml_backup = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    vmxml_backup = libvirt_xml.VMXML.new_from_inactive_dumpxml(vm_name)
 
     # Some variable for xmlfile of snapshot.
     snapshot_memory = params.get("snapshot_memory", "internal")
     snapshot_disk = params.get("snapshot_disk", "internal")
 
-    # Get a tmp_dir.
-    tmp_dir = data_dir.get_tmp_dir()
-    # Create a image.
-    params['image_name'] = "snapshot_test"
-    params['image_format'] = image_format
-    params['image_size'] = "1M"
-    image = qemu_storage.QemuImg(params, tmp_dir, "snapshot_test")
-    img_path, _ = image.create(params)
-    # Do the attach action.
-    extra = "--persistent --subdriver %s" % image_format
-    result = virsh.attach_disk(vm_name, source=img_path, target="vdf",
-                               extra=extra, debug=True)
-    if result.exit_status:
-        raise error.TestNAError("Failed to attach disk %s to VM."
-                                "Detail: %s." % (img_path, result.stderr))
+    # Skip 'qed' cases for libvirt version greater than 1.1.0
+    if libvirt_version.version_compare(1, 1, 0):
+        if vol_format == "qed":
+            raise error.TestNAError("QED support changed, check bug: "
+                                    "https://bugzilla.redhat.com/show_bug.cgi"
+                                    "?id=731570")
 
     # Init snapshot_name
     snapshot_name = None
     snapshot_external_disk = []
+    snapshot_xml_path = None
     del_status = None
+    image = None
+    pvt = None
+    # Get a tmp dir
+    tmp_dir = data_dir.get_tmp_dir()
     try:
+        if snapshot_with_pool:
+            # Create dst pool for create attach vol img
+            pvt = utlv.PoolVolumeTest(test, params)
+            pvt.pre_pool(pool_name, pool_type, pool_target,
+                         emulated_image, image_size="1G",
+                         pre_disk_vol=["20M"])
+
+            if pool_type in ["iscsi", "disk"]:
+                # iscsi and disk pool did not support create volume in libvirt,
+                # logical pool could use libvirt to create volume but volume
+                # format is not supported and will be 'raw' as default.
+                pv = libvirt_storage.PoolVolume(pool_name)
+                vols = pv.list_volumes().keys()
+                if vols:
+                    vol_name = vols[0]
+                else:
+                    raise error.TestNAError("No volume in pool: %s", pool_name)
+            else:
+                # Set volume xml file
+                volxml = libvirt_xml.VolXML()
+                newvol = volxml.new_vol(**vol_arg)
+                vol_xml = newvol['xml']
+
+                # Run virsh_vol_create to create vol
+                logging.debug("create volume from xml: %s" % newvol.xmltreefile)
+                cmd_result = virsh.vol_create(pool_name, vol_xml,
+                                              ignore_status=True,
+                                              debug=True)
+                if cmd_result.exit_status:
+                    raise error.TestNAError("Failed to create attach volume.")
+
+            cmd_result = virsh.vol_path(vol_name, pool_name, debug=True)
+            if cmd_result.exit_status:
+                raise error.TestNAError("Failed to get volume path from pool.")
+            img_path = cmd_result.stdout.strip()
+
+            if pool_type in ["logical", "iscsi", "disk"]:
+                # Use qemu-img to format logical, iscsi and disk block device
+                if vol_format != "raw":
+                    cmd = "qemu-img create -f %s %s 10M" % (vol_format,
+                                                            img_path)
+                    cmd_result = utils.run(cmd, ignore_status=True)
+                    if cmd_result.exit_status:
+                        raise error.TestNAError("Failed to format volume, %s" %
+                                                cmd_result.stdout.strip())
+            extra = "--persistent --subdriver %s" % vol_format
+        else:
+            # Create a image.
+            params['image_name'] = "snapshot_test"
+            params['image_format'] = image_format
+            params['image_size'] = "1M"
+            image = qemu_storage.QemuImg(params, tmp_dir, "snapshot_test")
+            img_path, _ = image.create(params)
+            extra = "--persistent --subdriver %s" % image_format
+
+        # Do the attach action.
+        out = utils.run("qemu-img info %s" % img_path)
+        logging.debug("The img info is:\n%s" % out.stdout.strip())
+        result = virsh.attach_disk(vm_name, source=img_path, target="vdf",
+                                   extra=extra, debug=True)
+        if result.exit_status:
+            raise error.TestNAError("Failed to attach disk %s to VM."
+                                    "Detail: %s." % (img_path, result.stderr))
+
         # Create snapshot.
         if snapshot_from_xml:
             snapshot_name = "snapshot_test"
@@ -234,10 +324,20 @@ def run(test, params, env):
 
     finally:
         virsh.detach_disk(vm_name, target="vdf", extra="--persistent")
-        image.remove()
+        if image:
+            image.remove()
         if del_status and snapshot_name:
             virsh.snapshot_delete(vm_name, snapshot_name, "--metadata")
         for disk in snapshot_external_disk:
             if os.path.exists(disk):
                 os.remove(disk)
         vmxml_backup.sync("--snapshots-metadata")
+        if snapshot_xml_path:
+            if os.path.exists(snapshot_xml_path):
+                os.unlink(snapshot_xml_path)
+        if pvt:
+            try:
+                pvt.cleanup_pool(pool_name, pool_type, pool_target,
+                                 emulated_image)
+            except error.TestFail, detail:
+                logging.error(str(detail))


### PR DESCRIPTION
Current test is with snapshot disk in a created tmp dir, for support
pool volume testing with snapshot, create certain type pool and use
volume in the pool for snapshot testing.

Covered pool: "dir", "fs", "netfs", "iscsi", "logical" and "disk"

Signed-off-by: Wayne Sun gsun@redhat.com
