### PR TITLE
tests.volume_application: Fix installation.

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/volume/virsh_volume_application.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/volume/virsh_volume_application.cfg
@@ -38,6 +38,7 @@
             kill_vm = yes
             image_size_stg = ${volume_size}
             image_size = ${volume_size}
+            install_timeout = 1800
             main_vm = ""
             vms = ""
         - disk_attach:


### PR DESCRIPTION
After having checked with a pure virt-test/tp-libvirt tree, these problems were fixed:
1. Process problems for new installation with changed main_vm.
2. Run installation and fix some problems.

```
     * As this line in unattended_install module:
       [vm = env.get_vm(params["main_vm"])]
       It needs 'main_vm' and a VM object for a new installation.
       So new vm should be registered to env.
     * Unattended_install sets kickstart ISO to /dev/sr0 as default.
       So changing the cdroms order to fit this.
```
