### PR TITLE
libvirt.tests: add test cases for libivirtd access via UNIX, SSH, TLS and TCP transports

### DIFF
--- a/libvirt/tests/cfg/remote_access/remote_with_ssh.cfg
+++ b/libvirt/tests/cfg/remote_access/remote_with_ssh.cfg
@@ -1,0 +1,128 @@
+- virsh.remote_with_ssh:
+    type = remote_access
+    main_vm = ""
+    take_regular_screendumps = no
+    # please replace your configuration
+    server_ip = "ENTER.YOUR.REMOTE.EXAMPLE.COM"
+    server_user = "ENTER.YOUR.REMOTE.USER"
+    server_pwd = "ENTER.YOUR.REMOTE.PASSWORD"
+    client_ip = "ENTER.YOUR.CLIENT.EXAMPLE.COM"
+    client_user = "ENTER.YOUR.CLIENT.USER"
+    client_pwd = "ENTER.YOUR.CLIENT.PASSWORD"
+    transport = "ssh"
+    port = "22"
+    client = "ssh"
+    start_vm = "no"
+    ssh_port = "${port}"
+    variants:
+        - positive_testing:
+            status_error = "no"
+            variants:
+                - ssh_diff_libvirt_version:
+                    diff_virt_ver = "yes"
+                    # please change query command based on your
+                    # Linux distribution
+                    query_cmd = "rpm -q libvirt"
+                - ssh_static_ipv6:
+                    # no problem, the test codes will automatically
+                    # clean up created static IPv6 configuration
+                    config_ipv6 = "yes"
+                    ip_addr_suffix = 64
+                    # e.g. ipv6_addr_src = "3fef::101", ipv6_addr_des = "3fef::102"
+                    ipv6_addr_src = "ENTER.YOUR.IPv6.SOURCE"
+                    ipv6_addr_des = "ENTER.YOUR.IPv6.TRAGET"
+                    # change your network interface name, e.g. eth0, enp0s25
+                    client_ifname = "ENTER.YOUR.CLIENT.IFACE.NAME"
+                    client_ipv6_addr = "${ipv6_addr_src}/${ip_addr_suffix}"
+                    server_ifname = "ENTER.YOUR.SERVER.IFACE.NAME"
+                    server_ipv6_addr = "${ipv6_addr_des}/${ip_addr_suffix}"
+                - gssapi_auth:
+                    extra_env = "KRB5CCNAME=libvirt_krb_test"
+                    filter_pattern = ".*${extra_env}.*ssh.*${server_ip}.*libvirt-sock.*"
+                    log_level= "LIBVIRT_DEBUG=1"
+                - test_uri_with_default_user:
+                    test_driver = "test"
+                    uri_path = "/default"
+                    auth_pwd = "${client_pwd}"
+                    no_any_config = "yes"
+                - test_uri_with_root_user:
+                    test_driver = "test"
+                    uri_path = "root@${server_ip}/default"
+                    auth_pwd = "${server_pwd}"
+                    no_any_config = "yes"
+                - xen_uri_with_default_user:
+                    test_driver = "xen"
+                    uri_path = "ENTER.YOUR.REMOTE.XEN.EXAMPLE.COM"
+                    auth_pwd = "ENTER.YOUR.REMOTE.XEN.PASSWORD"
+                    no_any_config = "yes"
+                - xen_uri_with_root_user:
+                    test_driver = "xen"
+                    uri_path = "root@ENTER.YOUR.REMOTE.XEN.EXAMPLE.COM"
+                    auth_pwd = "ENTER.YOUR.REMOTE.XEN.PASSWORD"
+                    no_any_config = "yes"
+                # this is simple cases for esx w/o SSH transport
+                - esx_uri_with_default_user:
+                    transport = ""
+                    test_driver = "esx"
+                    conn_plus = ""
+                    uri_path = "ENTER.YOUR.REMOTE.ESX.EXAMPLE.COM/?no_verify=1"
+                    auth_user = "root"
+                    auth_pwd = "ENTER.YOUR.REMOTE.ESX.PASSWORD"
+                    no_any_config = "yes"
+                - esx_uri_with_root_user:
+                    transport = ""
+                    test_driver = "esx"
+                    conn_plus = ""
+                    uri_path = "root@ENTER.YOUR.REMOTE.ESX.EXAMPLE.COM/?no_verify=1"
+                    auth_pwd = "ENTER.YOUR.REMOTE.ESX.PASSWORD"
+                    no_any_config = "yes"
+        - negative_testing:
+            status_error = "yes"
+            variants:
+                - libssh2_no_auth:
+                    transport = "libssh2"
+                - ssh_no_uri_path:
+                    uri_path = ""
+                - ssh_read_only_mode:
+                    read_only = "-r"
+                    virsh_cmd = "start"
+                    # VM is on remote host, so don't need to deal with it on the local
+                    not_preprocess = yes
+                    # you need to define a VM naming 'virt-tests-vm1' on remote test host
+                    # no problem, the test codes will help you check it.
+                    main_vm = "virt-tests-vm1"
+                - ssh_no_ipv6_config:
+                    config_ipv6 = "no"
+                    ipv6_addr_des = "ENTER.YOUR.IPv6.TRAGET"
+                - stop_libvirtd:
+                    restart_libvirtd = "no"
+                    libvirtd_action = "stop"
+                - incorrect_password:
+                    auth_pwd = "INVALID_PASSWORD"
+                - ipv4_with_readonly:
+                    read_only = "-r"
+                    virsh_cmd = "start"
+                    # VM is on remote host, so don't need to deal with it on the local
+                    not_preprocess = yes
+                    # you need to define a VM naming 'virt-tests-vm1' on remote test host
+                    # no problem, the test codes will help you check it.
+                    main_vm = "virt-tests-vm1"
+                    patterns_virsh_cmd = ".*Domain\s*${main_vm}\s*started.*"
+                - ipv6_with_readonly:
+                    config_ipv6 = "yes"
+                    ip_addr_suffix = 64
+                    ipv6_addr_src = "ENTER.YOUR.IPv6.SOURCE"
+                    ipv6_addr_des = "ENTER.YOUR.IPv6.TRAGET"
+                    client_ifname = "ENTER.YOUR.CLIENT.IFACE.NAME"
+                    client_ipv6_addr = "${ipv6_addr_src}/${ip_addr_suffix}"
+                    server_ifname = "ENTER.YOUR.SERVER.IFACE.NAME"
+                    server_ipv6_addr = "${ipv6_addr_des}/${ip_addr_suffix}"
+                    listen_addr = "${ipv6_addr_des}"
+                    read_only = "-r"
+                    virsh_cmd = "start"
+                    # VM is on remote host, so don't need to deal with it on the local
+                    not_preprocess = yes
+                    # you need to define a VM naming 'virt-tests-vm1' on remote test host
+                    # no problem, the test codes will help you check it.
+                    main_vm = "virt-tests-vm1"
+                    patterns_virsh_cmd = ".*Domain\s*${main_vm}\s*started.*"

--- a/libvirt/tests/cfg/remote_access/remote_with_tcp.cfg
+++ b/libvirt/tests/cfg/remote_access/remote_with_tcp.cfg
@@ -1,0 +1,118 @@
+- virsh.remote_with_tcp:
+    type = remote_access
+    main_vm = ""
+    vms = ""
+    take_regular_screendumps = "no"
+    transport = "tcp"
+    server_ip = "ENTER.YOUR.REMOTE.EXAMPLE.COM"
+    server_user = "ENTER.YOUR.REMOTE.USER"
+    server_pwd = "ENTER.YOUR.REMOTE.PASSWORD"
+    start_vm = "no"
+    port = "22"
+    client = "ssh"
+    tcp_port = "16509"
+    variants:
+        - positive_testing:
+            status_error = "no"
+            variants:
+                - allow_one_sasl_user:
+                    auth_tcp = "sasl"
+                    sasl_user_pwd = "('test', '123456'),"
+                    sasl_allowed_users = ['test']
+                - allow_sasl_users:
+                    auth_tcp = "sasl"
+                    # e.g. ('$SASL_USER', '$SASL_PASSWD')
+                    sasl_user_pwd = "('test', '123456'), ('libvirt', '123456')"
+                    sasl_allowed_users = ['test', 'libvirt']
+                - customized_ipv4_tcp_port:
+                    listen_addr = "${server_ip}"
+                    tcp_port = "16510"
+                - customized_ipv4_listen_address_with_sasl_auth:
+                    auth_tcp = "sasl"
+                    listen_addr = "${server_ip}"
+                    # the ',' must be followed by tuple, although it only contains one tuple string
+                    sasl_user_pwd = "('test', '123456'),"
+                    sasl_allowed_users = ['test']
+                - customized_ipv6_listen_address:
+                    # no problem, the test codes will automatically
+                    # clean up created static IPv6 configuration
+                    config_ipv6 = "yes"
+                    ip_addr_suffix = 64
+                    # e.g. ipv6_addr_src = "3fef::101", ipv6_addr_des = "3fef::102"
+                    ipv6_addr_src = "ENTER.YOUR.IPv6.SOURCE"
+                    ipv6_addr_des = "ENTER.YOUR.IPv6.TRAGET"
+                    # change your network interface name, e.g. eth0, enp0s25
+                    client_ifname = "ENTER.YOUR.CLIENT.IFACE.NAME"
+                    client_ipv6_addr = "${ipv6_addr_src}/${ip_addr_suffix}"
+                    server_ifname = "ENTER.YOUR.SERVER.IFACE.NAME"
+                    server_ipv6_addr = "${ipv6_addr_des}/${ip_addr_suffix}"
+                    listen_addr = "${ipv6_addr_des}"
+                - customized_ipv6_tcp_port:
+                    config_ipv6 = "yes"
+                    ip_addr_suffix = 64
+                    # e.g. ipv6_addr_src = "3fef::101", ipv6_addr_des = "3fef::102"
+                    ipv6_addr_src = "ENTER.YOUR.IPv6.SOURCE"
+                    ipv6_addr_des = "ENTER.YOUR.IPv6.TRAGET"
+                    # change your network interface name, e.g. eth0, enp0s25
+                    client_ifname = "ENTER.YOUR.CLIENT.IFACE.NAME"
+                    client_ipv6_addr = "${ipv6_addr_src}/${ip_addr_suffix}"
+                    server_ifname = "ENTER.YOUR.SERVER.IFACE.NAME"
+                    server_ipv6_addr = "${ipv6_addr_des}/${ip_addr_suffix}"
+                    listen_addr = "${ipv6_addr_des}"
+                    tcp_port = "16510"
+                - customized_ipv6_listen_address_with_sasl_auth:
+                    auth_tcp = "sasl"
+                    sasl_user_pwd = "('test', '123456'),"
+                    sasl_allowed_users = ['test']
+                    config_ipv6 = "yes"
+                    ip_addr_suffix = 64
+                    # e.g. ipv6_addr_src = "3fef::101", ipv6_addr_des = "3fef::102"
+                    ipv6_addr_src = "ENTER.YOUR.IPv6.SOURCE"
+                    ipv6_addr_des = "ENTER.YOUR.IPv6.TRAGET"
+                    # change your network interface name, e.g. eth0, enp0s25
+                    client_ifname = "ENTER.YOUR.CLIENT.IFACE.NAME"
+                    client_ipv6_addr = "${ipv6_addr_src}/${ip_addr_suffix}"
+                    server_ifname = "ENTER.YOUR.SERVER.IFACE.NAME"
+                    server_ipv6_addr = "${ipv6_addr_des}/${ip_addr_suffix}"
+                    listen_addr = "${ipv6_addr_des}"
+        - negative_testing:
+            status_error = "yes"
+            variants:
+                - only_simpy_connect_libvirtd:
+                    no_any_config = "yes"
+                - no_allowed_sasl_user:
+                    auth_tcp = "sasl"
+                    sasl_user_pwd = "('noexist', '123456'),"
+                    sasl_allowed_users = ['test']
+                - ipv4_with_allowed_sasl_user_readonly:
+                    auth_tcp = "sasl"
+                    sasl_user_pwd = "('test', '123456'),"
+                    sasl_allowed_users = ['test']
+                    read_only = "-r"
+                    virsh_cmd = "start"
+                    # VM is on remote host, so don't need to deal with it on the local
+                    not_preprocess = yes
+                    # you need to define a VM naming 'virt-tests-vm1' on remote test host
+                    # no problem, the test codes will help you check it.
+                    main_vm = "virt-tests-vm1"
+                    patterns_virsh_cmd = ".*Domain\s*${main_vm}\s*started.*"
+                - ipv6_with_readonly:
+                    config_ipv6 = "yes"
+                    ip_addr_suffix = 64
+                    # e.g. ipv6_addr_src = "3fef::101", ipv6_addr_des = "3fef::102"
+                    ipv6_addr_src = "ENTER.YOUR.IPv6.SOURCE"
+                    ipv6_addr_des = "ENTER.YOUR.IPv6.TRAGET"
+                    # change your network interface name, e.g. eth0, enp0s25
+                    client_ifname = "ENTER.YOUR.CLIENT.IFACE.NAME"
+                    client_ipv6_addr = "${ipv6_addr_src}/${ip_addr_suffix}"
+                    server_ifname = "ENTER.YOUR.SERVER.IFACE.NAME"
+                    server_ipv6_addr = "${ipv6_addr_des}/${ip_addr_suffix}"
+                    listen_addr = "${ipv6_addr_des}"
+                    read_only = "-r"
+                    virsh_cmd = "start"
+                    # VM is on remote host, so don't need to deal with it on the local
+                    not_preprocess = yes
+                    # you need to define a VM naming 'virt-tests-vm1' on remote test host
+                    # no problem, the test codes will help you check it.
+                    main_vm = "virt-tests-vm1"
+                    patterns_virsh_cmd = ".*Domain\s*${main_vm}\s*started.*"

--- a/libvirt/tests/cfg/remote_access/remote_with_tls.cfg
+++ b/libvirt/tests/cfg/remote_access/remote_with_tls.cfg
@@ -1,0 +1,196 @@
+- virsh.remote_with_tls:
+    type = remote_access
+    main_vm = ""
+    vms = ""
+    take_regular_screendumps = "no"
+    transport = "tls"
+    server_ip = "ENTER.YOUR.REMOTE.EXAMPLE.COM"
+    server_user = "ENTER.YOUR.REMOTE.USER"
+    server_pwd = "ENTER.YOUR.REMOTE.PASSWORD"
+    client_ip = "ENTER.YOUR.CLIENT.EXAMPLE.COM"
+    client_user = "ENTER.YOUR.CLIENT.USER"
+    client_pwd = "ENTER.YOUR.CLIENT.PASSWORD"
+    start_vm = "no"
+    port = "22"
+    client = "ssh"
+    tls_port = "16514"
+    # please change these with your hostname
+    server_cn = "ENTER.YOUR.SERVER.HOSTNAME"
+    client_cn = "ENTER.YOUR.CLIENT.HOSTNAME"
+    variants:
+        - positive_testing:
+            status_error = "no"
+            variants:
+                - default_tls_port_and_auth_tls:
+                - no_verify_certificate:
+                    tls_verify_cert = "no"
+                    # please change your configuration
+                    remove_client_key_cmd = "rm -rf /etc/pki/libvirt/private/clientkey.pem"
+                    remove_client_cert_cmd = "rm -rf  /etc/pki/libvirt/clientcert.pem"
+                - no_sanity_checks_and_no_verify:
+                    tls_sanity_cert = "no"
+                    # please change your configuration
+                    ca_cn_new = "illegal-sign"
+                    no_verify = "yes"
+                - customized_tls_port:
+                    tls_port = "16515"
+                - allow_one_sasl_user:
+                    auth_tls = "sasl"
+                    sasl_user_pwd = "('test', '123456'),"
+                    sasl_allowed_users = ['test']
+                - allow_sasl_users:
+                    auth_tls = "sasl"
+                    sasl_user_pwd = "('test', '123456'), ('libvirt', '123456')"
+                    sasl_allowed_users = ['test', 'libvirt']
+                - allowed_dn_list:
+                    tls_allowed_dn_list = ["CN=${client_cn},O=AUTOTEST.VIRT"]
+                    tls_port = "16515"
+                - customized_ipv4_listen_address:
+                    listen_addr = "${server_ip}"
+                    server_cn = "${server_ip}"
+                    client_cn = "${client_ip}"
+                - customized_ipv4_listen_address_with_sasl_auth:
+                    auth_tls = "sasl"
+                    listen_addr = "${server_ip}"
+                    sasl_user_pwd = "('test', '123456'),"
+                    sasl_allowed_users = ['test']
+                    server_cn = "${server_ip}"
+                    client_cn = "${client_ip}"
+                - customized_ipv6_listen_address:
+                    # no problem, the test codes will automatically
+                    # clean up created static IPv6 configuration
+                    config_ipv6 = "yes"
+                    ip_addr_suffix = 64
+                    # e.g. ipv6_addr_src = "3fef::101", ipv6_addr_des = "3fef::102"
+                    ipv6_addr_src = "ENTER.YOUR.IPv6.SOURCE"
+                    ipv6_addr_des = "ENTER.YOUR.IPv6.TRAGET"
+                    # change your network interface name, e.g. eth0, enp0s25
+                    client_ifname = "ENTER.YOUR.CLIENT.IFACE.NAME"
+                    client_ipv6_addr = "${ipv6_addr_src}/${ip_addr_suffix}"
+                    server_ifname = "ENTER.YOUR.SERVER.IFACE.NAME"
+                    server_ipv6_addr = "${ipv6_addr_des}/${ip_addr_suffix}"
+                    listen_addr = "${ipv6_addr_des}"
+                    server_cn = "${ipv6_addr_des}"
+                    client_cn = "${ipv6_addr_src}"
+                - customized_ipv6_tls_port:
+                    config_ipv6 = "yes"
+                    ip_addr_suffix = 64
+                    # e.g. ipv6_addr_src = "3fef::101", ipv6_addr_des = "3fef::102"
+                    ipv6_addr_src = "ENTER.YOUR.IPv6.SOURCE"
+                    ipv6_addr_des = "ENTER.YOUR.IPv6.TRAGET"
+                    # change your network interface name, e.g. eth0, enp0s25
+                    client_ifname = "ENTER.YOUR.CLIENT.IFACE.NAME"
+                    client_ipv6_addr = "${ipv6_addr_src}/${ip_addr_suffix}"
+                    server_ifname = "ENTER.YOUR.SERVER.IFACE.NAME"
+                    server_ipv6_addr = "${ipv6_addr_des}/${ip_addr_suffix}"
+                    listen_addr = "${ipv6_addr_des}"
+                    server_cn = "${ipv6_addr_des}"
+                    client_cn = "${ipv6_addr_src}"
+                    tls_port = "16515"
+                - customized_ipv6_listen_address_with_sasl_auth:
+                    auth_tls = "sasl"
+                    sasl_user_pwd = "('test', '123456'),"
+                    sasl_allowed_users = ['test']
+                    config_ipv6 = "yes"
+                    ip_addr_suffix = 64
+                    # e.g. ipv6_addr_src = "3fef::101", ipv6_addr_des = "3fef::102"
+                    ipv6_addr_src = "ENTER.YOUR.IPv6.SOURCE"
+                    ipv6_addr_des = "ENTER.YOUR.IPv6.TRAGET"
+                    # change your network interface name, e.g. eth0, enp0s25
+                    client_ifname = "ENTER.YOUR.CLIENT.IFACE.NAME"
+                    client_ipv6_addr = "${ipv6_addr_src}/${ip_addr_suffix}"
+                    server_ifname = "ENTER.YOUR.SERVER.IFACE.NAME"
+                    server_ipv6_addr = "${ipv6_addr_des}/${ip_addr_suffix}"
+                    listen_addr = "${ipv6_addr_des}"
+                    server_cn = "${ipv6_addr_des}"
+                    client_cn = "${ipv6_addr_src}"
+                - customized_x509_cert_path:
+                    custom_pki_path = "/tmp/ca"
+        - negative_testing:
+            status_error = "yes"
+            variants:
+                - only_simpy_connect_libvirtd:
+                    no_any_config = "yes"
+                - invalid_tls_port:
+                    tls_port = "120abcXYZ!@#$%^"
+                    # if 'restart_libvirtd == "no"' then libvirt daemon isn't
+                    # automatically restarted after configuring in
+                    # TLSConnection.server_setup() from utils_conn.py, we need
+                    # to do this by test cases instead
+                    restart_libvirtd = "no"
+                - tls_port_in_use:
+                    tls_port = "22"
+                    restart_libvirtd = "no"
+                - tls_listen_addr_in_use:
+                    listen_addr = "127.0.0.1"
+                    restart_libvirtd = "no"
+                - ipv4_with_allowed_sasl_user_readonly:
+                    auth_tls = "sasl"
+                    sasl_user_pwd = "('test', '123456'),"
+                    sasl_allowed_users = ['test']
+                    read_only = "-r"
+                    virsh_cmd = "start"
+                    # VM is on remote host, so don't need to deal with it on the local
+                    not_preprocess = yes
+                    # you need to define a VM naming 'virt-tests-vm1' on remote test host
+                    # no problem, the test codes will help you check it.
+                    main_vm = "virt-tests-vm1"
+                - no_sanity_checks_without_no_verify:
+                    tls_sanity_cert = "no"
+                    # please change your configuration
+                    ca_cn_new = "illegal-sign"
+                - allowed_dn_disorder_list:
+                    tls_allowed_dn_list = ["O=AUTOTEST.VIRT,CN=${client_cn}"]
+                    tls_port = "16515"
+                - allowed_dn_list_with_invalid_organization:
+                    tls_allowed_dn_list = ["CN=${client_cn},O=120abcXYZ!@#$%^&*()"]
+                    tls_port = "16515"
+                - allowed_dn_list_with_invalid_CN:
+                    tls_allowed_dn_list = ["CN=120abcXYZ!@#$%^&*(),O=AUTOTEST.VIRT"]
+                    tls_port = "16515"
+                - verify_certificate:
+                    tls_verify_cert = "yes"
+                    # please change your configuration
+                    remove_client_key_cmd = "rm -rf /etc/pki/libvirt/private/clientkey.pem"
+                    remove_client_cert_cmd = "rm -rf  /etc/pki/libvirt/clientcert.pem"
+                - incorrect_ipv4_listen_address:
+                    listen_addr = "12.34.56.78"
+                    server_cn = "${server_ip}"
+                    client_cn = "${client_ip}"
+                    restart_libvirtd = "no"
+                - ipv6_with_readonly:
+                    config_ipv6 = "yes"
+                    ip_addr_suffix = 64
+                    # e.g. ipv6_addr_src = "3fef::101", ipv6_addr_des = "3fef::102"
+                    ipv6_addr_src = "ENTER.YOUR.IPv6.SOURCE"
+                    ipv6_addr_des = "ENTER.YOUR.IPv6.TRAGET"
+                    # change your network interface name, e.g. eth0, enp0s25
+                    client_ifname = "ENTER.YOUR.CLIENT.IFACE.NAME"
+                    client_ipv6_addr = "${ipv6_addr_src}/${ip_addr_suffix}"
+                    server_ifname = "ENTER.YOUR.SERVER.IFACE.NAME"
+                    server_ipv6_addr = "${ipv6_addr_des}/${ip_addr_suffix}"
+                    listen_addr = "${ipv6_addr_des}"
+                    read_only = "-r"
+                    virsh_cmd = "start"
+                    # VM is on remote host, so don't need to deal with it on the local
+                    not_preprocess = yes
+                    # you need to define a VM naming 'virt-tests-vm1' on remote test host
+                    # no problem, the test codes will help you check it.
+                    main_vm = "virt-tests-vm1"
+                    patterns_virsh_cmd = ".*Domain\s*${main_vm}\s*started.*"
+                - ipv6_address_unreachable:
+                    config_ipv6 = "yes"
+                    ip_addr_suffix = 64
+                    # e.g. ipv6_addr_src = "3fef::101", ipv6_addr_des = "3fef::102"
+                    ipv6_addr_src = "ENTER.YOUR.IPv6.SOURCE"
+                    ipv6_addr_des = "ENTER.YOUR.IPv6.TRAGET"
+                    # change your network interface name, e.g. eth0, enp0s25
+                    client_ifname = "ENTER.YOUR.CLIENT.IFACE.NAME"
+                    client_ipv6_addr = "${ipv6_addr_src}/${ip_addr_suffix}"
+                    server_ifname = "ENTER.YOUR.SERVER.IFACE.NAME"
+                    server_ipv6_addr = "${ipv6_addr_des}/${ip_addr_suffix}"
+                    check_ipv6_connectivity = "no"
+                    listen_addr = "${ipv6_addr_des}"
+                    server_cn = "${ipv6_addr_des}"
+                    client_cn = "${ipv6_addr_src}"
+                    tls_port = "16515"

--- a/libvirt/tests/cfg/remote_access/remote_with_unix.cfg
+++ b/libvirt/tests/cfg/remote_access/remote_with_unix.cfg
@@ -1,0 +1,131 @@
+- virsh.remote_with_unix:
+    type = remote_access
+    main_vm = ""
+    vms = ""
+    take_regular_screendumps = "no"
+    transport = "unix"
+    # please replace your configuration
+    server_ip = "ENTER.YOUR.CLIENT.EXAMPLE.COM"
+    server_user = "ENTER.YOUR.CLIENT.USER"
+    server_pwd = "ENTER.YOUR.CLIENT.PASSWORD"
+    client_ip = "ENTER.YOUR.CLIENT.EXAMPLE.COM"
+    client_user = "ENTER.YOUR.CLIENT.USER"
+    client_pwd = "ENTER.YOUR.CLIENT.PASSWORD"
+    start_vm = "no"
+    port = "22"
+    client = "ssh"
+    variants:
+        - positive_testing:
+            status_error = "no"
+            variants:
+                - default_unix_config:
+                - readonly:
+                    read_only = "-r"
+                - customized_unix_sock_dir:
+                    unix_sock_dir = "/tmp/libvirt_bob23"
+                    mkdir_cmd = "mkdir -p ${unix_sock_dir}"
+                    rmdir_cmd = "rm -rf ${unix_sock_dir}"
+                - default_config_and_start_vm:
+                    virsh_cmd = "start"
+                    main_vm = "virt-tests-vm1"
+                    patterns_virsh_cmd = ".*Domain\s*${main_vm}\s*started\s*.*"
+                - allow_sasl_users:
+                    auth_unix_rw = "sasl"
+                    # need to create SASL user on the local via ssh
+                    server_ip = "${client_ip}"
+                    tcp_setup = "yes"
+                    sasl_user_pwd = "('test', '123456'), ('libvirt', '123456')"
+                    sasl_allowed_users = ['test', 'libvirt']
+                    unix_auto_recovery = "no"
+                - socket_access_controls:
+                    auth_unix_ro = "none"
+                    auth_unix_rw = "none"
+                    unix_sock_group = "wheel"
+                    unix_sock_ro_perms = "0777"
+                    unix_sock_rw_perms = "0770"
+                    su_user = "bob"
+                    adduser_cmd = "useradd -g ${unix_sock_group} ${su_user}"
+                    deluser_cmd = "userdel -r ${su_user}"
+                - socket_with_auth_conf:
+                    auth_unix_rw = "sasl"
+                    server_ip = "${client_ip}"
+                    user = 'test'
+                    passwd = '123456'
+                    sasl_user_pwd = "('${user}', '${passwd}'),"
+                    auth_conf = "/etc/libvirt/auth.conf"
+                    auth_conf_cxt = "[credentials-${auth_unix_rw}]\nauthname=${user}\npassword=${passwd}\n\n[auth-libvirt-localhost]\ncredentials=${auth_unix_rw}"
+                - socket_with_polkit_and_acl_control:
+                    auth_unix_rw = "polkit"
+                    unix_sock_rw_perms = "0777"
+                    su_user = "bob"
+                    adduser_cmd = "useradd ${su_user}"
+                    deluser_cmd = "userdel -r ${su_user}"
+                    main_vm = "virt-tests-vm1"
+                    virsh_cmd = "start"
+                    patterns_virsh_cmd = ".*Domain\s*${main_vm}\s*started\s*.*"
+                    polkit_pkla = "/etc/polkit-1/localauthority/50-local.d/polkit.pkla"
+                    polkit_pkla_cxt = "[Allow ${su_user} libvirt management permissions]\nIdentity=unix-user:${su_user}\nAction=org.libvirt.unix.manage\nResultAny=yes\nResultInactive=yes\nResultActive=yes"
+                    setup_libvirt_polkit = "yes"
+                    action_id = "org.libvirt.api.domain.start"
+                    action_lookup = "connect_driver:QEMU domain_name:${main_vm}"
+                    unprivileged_user = "${su_user}"
+                - socket_with_polkit_rw:
+                    su_user = "bob"
+                    adduser_cmd = "useradd ${su_user}"
+                    deluser_cmd = "userdel -r ${su_user}"
+                    auth_unix_rw = "polkit"
+                    unix_sock_rw_perms = "0777"
+                    virsh_cmd = "start"
+                    main_vm = "virt-tests-vm1"
+                    patterns_virsh_cmd = ".*Domain\s*${main_vm}\s*started\s*.*"
+                    polkit_pkla = "/etc/polkit-1/localauthority/50-local.d/polkit.pkla"
+                    polkit_pkla_cxt = "[Allow ${su_user} libvirt management permissions]\nIdentity=unix-user:${su_user}\nAction=org.libvirt.unix.manage\nResultAny=yes\nResultInactive=yes\nResultActive=yes"
+        - negative_testing:
+            status_error = "yes"
+            variants:
+                - no_allowed_sasl_user:
+                    auth_unix_rw = "sasl"
+                    server_ip = "${client_ip}"
+                    tcp_setup = "yes"
+                    sasl_user_pwd = "('libvirt', '123456'),"
+                    sasl_allowed_users = ['test']
+                - allow_sasl_user_with_readonly:
+                    server_ip = "${client_ip}"
+                    tcp_setup = "yes"
+                    sasl_user_pwd = "('test', '123456'), "
+                    sasl_allowed_users = ['test']
+                    auth_unix_rw = "sasl"
+                    unix_auto_recovery = "no"
+                    read_only = "-r"
+                    virsh_cmd = "start"
+                    main_vm = "virt-tests-vm1"
+                    patterns_virsh_cmd = ".*Domain\s*${main_vm}\s*started\s*.*"
+                - readonly_without_auth:
+                    read_only = "-r"
+                    virsh_cmd = "start"
+                    main_vm = "virt-tests-vm1"
+                    status_error = "no"
+                    patterns_virsh_cmd = ".*forbidden\s*for\s*read\s*only\s*access.*"
+                - socket_access_controls:
+                    auth_unix_ro = "none"
+                    auth_unix_rw = "none"
+                    unix_sock_group = "root"
+                    unix_sock_ro_perms = "0777"
+                    unix_sock_rw_perms = "0770"
+                    su_user = "bob"
+                    status_error = "no"
+                    patterns_virsh_cmd = ".*Permission denied.*"
+                    adduser_cmd = "useradd -g wheel ${su_user}"
+                    deluser_cmd = "userdel -r ${su_user}"
+                - socket_with_polkit_ro:
+                    su_user = "bob"
+                    adduser_cmd = "useradd ${su_user}"
+                    deluser_cmd = "userdel -r ${su_user}"
+                    auth_unix_rw = "polkit"
+                    unix_sock_rw_perms = "0777"
+                    virsh_cmd = "start"
+                    main_vm = "virt-tests-vm1"
+                    status_error = "no"
+                    patterns_virsh_cmd = ".*authentication failed.*"
+                    polkit_pkla = "/etc/polkit-1/localauthority/50-local.d/polkit.pkla"
+                    polkit_pkla_cxt = "[Allow ${su_user} libvirt monitor permissions]\nIdentity=unix-user:${su_user}\nAction=org.libvirt.unix.monitor\nResultAny=yes\nResultInactive=yes\nResultActive=yes"

--- a/libvirt/tests/src/remote_access/remote_access.py
+++ b/libvirt/tests/src/remote_access/remote_access.py
@@ -1,0 +1,387 @@
+import re
+import os
+import logging
+import commands
+
+from virttest import remote
+from autotest.client.shared import error, utils
+from virttest.utils_sasl import SASL
+from virttest.utils_conn import SSHConnection, TCPConnection, \
+    TLSConnection, UNIXConnection
+from virttest.utils_net import IPv6Manager, \
+    check_listening_port_remote_by_service
+from virttest.utils_test.libvirt import remotely_control_libvirtd, \
+    connect_libvirtd
+
+
+def remote_access(params):
+    """
+    Connect libvirt daemon
+    """
+    uri = params.get("uri")
+    auth_user = params.get("auth_user", "root")
+    auth_pwd = params.get("auth_pwd")
+    virsh_cmd = params.get("virsh_cmd", "list")
+    read_only = params.get("read_only", "")
+    vm_name = params.get("main_vm", "")
+    logfile = params.get("logfile")
+    extra_env = params.get("extra_env", "")
+    pattern = params.get("filter_pattern", "")
+    su_user = params.get("su_user", "")
+    virsh_patterns = params.get("patterns_virsh_cmd", ".*Id\s*Name\s*State\s*.*")
+    log_level = params.get("log_level", "LIBVIRT_DEBUG=3")
+
+    status_error = params.get("status_error", "no")
+    ret = connect_libvirtd(uri, read_only, virsh_cmd, auth_user,
+                           auth_pwd, vm_name, status_error, extra_env,
+                           log_level, su_user, virsh_patterns)
+
+    if status_error == "no":
+        if ret:
+            if pattern != "":
+                fp = open(logfile, "r")
+                if not re.findall(pattern, fp.read()):
+                    fp.close()
+                    raise error.TestFail("Failed to find %s in log!!, pattern")
+                fp.close()
+            logging.info("Succeed to connect libvirt daemon.")
+        else:
+            raise error.TestFail("Failed to connect libvirt daemon!!")
+    else:
+        if not ret:
+            logging.info("It's an expected error!!")
+        else:
+            raise error.TestFail("Unexpected return result")
+
+
+def check_parameters(params):
+    """
+    Make sure all of parameters are assigned a valid value
+    """
+    client_ip = params.get("client_ip")
+    server_ip = params.get("server_ip")
+    ipv6_addr_src = params.get("ipv6_addr_src")
+    ipv6_addr_des = params.get("ipv6_addr_des")
+    auth_pwd = params.get("auth_pwd")
+    uri_path = params.get("uri_path")
+    client_cn = params.get("client_cn")
+    server_cn = params.get("server_cn")
+    client_ifname = params.get("client_ifname")
+    server_ifname = params.get("server_ifname")
+
+    args_list = [client_ip, server_ip, ipv6_addr_src, ipv6_addr_des,
+                 auth_pwd, uri_path, client_cn, server_cn,
+                 client_ifname, server_ifname]
+
+    for arg in args_list:
+        if arg and arg.count("ENTER.YOUR."):
+            raise error.TestNAError("Please assign a value for %s!", arg)
+
+
+def compare_virt_version(server_ip, server_user, server_pwd):
+    """
+    Make sure libvirt version is different
+    """
+    client = "ssh"
+    port = "22"
+    prompt = r"[\#\$]\s*$"
+    query_cmd = "rpm -q libvirt"
+    # query libvirt version on local host
+    status, output_local = commands.getstatusoutput(query_cmd)
+    if status:
+        raise error.TestError(output_local)
+    # query libvirt version on remote host
+    session = remote.wait_for_login(client, server_ip, port,
+                                    server_user, server_pwd, prompt)
+    status, output_remote = session.cmd_status_output(query_cmd)
+    if status:
+        raise error.TestError(output_remote)
+    # compare libvirt version between local and remote host
+    if output_local == output_remote.strip():
+        raise error.TestNAError("To expect different libvirt version "
+                                "<%s>:<%s>", output_local, output_remote)
+
+
+def cleanup(objs_list):
+    """
+    Clean up test environment
+    """
+    # recovery test environment
+    for obj in objs_list:
+        obj.auto_recover = True
+        del obj
+
+
+def run(test, params, env):
+    """
+    Test remote access with TCP, TLS connection
+    """
+
+    test_dict = dict(params)
+    vm_name = test_dict.get("main_vm")
+    vm = env.get_vm(vm_name)
+    status_error = test_dict.get("status_error", "no")
+    allowed_dn_list = params.get("tls_allowed_dn_list")
+    if allowed_dn_list:
+        test_dict['tls_allowed_dn_list'] = eval(allowed_dn_list)
+    transport = test_dict.get("transport")
+    plus = test_dict.get("conn_plus", "+")
+    config_ipv6 = test_dict.get("config_ipv6", "no")
+    tls_port = test_dict.get("tls_port", "")
+    listen_addr = test_dict.get("listen_addr", "0.0.0.0")
+    ssh_port = test_dict.get("ssh_port", "")
+    tcp_port = test_dict.get("tcp_port", "")
+    server_ip = test_dict.get("server_ip")
+    server_user = test_dict.get("server_user")
+    server_pwd = test_dict.get("server_pwd")
+    client_ip = test_dict.get("client_ip")
+    no_any_config = params.get("no_any_config", "no")
+    sasl_user_pwd = test_dict.get("sasl_user_pwd")
+    sasl_allowed_users = test_dict.get("sasl_allowed_users")
+    server_cn = test_dict.get("server_cn")
+    custom_pki_path = test_dict.get("custom_pki_path")
+    rm_client_key_cmd = test_dict.get("remove_client_key_cmd")
+    rm_client_cert_cmd = test_dict.get("remove_client_cert_cmd")
+    ca_cn_new = test_dict.get("ca_cn_new")
+    no_verify = test_dict.get("no_verify", "no")
+    ipv6_addr_des = test_dict.get("ipv6_addr_des")
+    tls_sanity_cert = test_dict.get("tls_sanity_cert")
+    restart_libvirtd = test_dict.get("restart_libvirtd", "yes")
+    diff_virt_ver = test_dict.get("diff_virt_ver", "no")
+    driver = test_dict.get("test_driver", "qemu")
+    uri_path = test_dict.get("uri_path", "/system")
+    virsh_cmd = params.get("virsh_cmd", "list")
+    action = test_dict.get("libvirtd_action", "restart")
+    uri_user = test_dict.get("uri_user", "")
+    unix_sock_dir = test_dict.get("unix_sock_dir")
+    mkdir_cmd = test_dict.get("mkdir_cmd")
+    rmdir_cmd = test_dict.get("rmdir_cmd")
+    adduser_cmd = test_dict.get("adduser_cmd")
+    deluser_cmd = test_dict.get("deluser_cmd")
+    auth_conf = test_dict.get("auth_conf")
+    auth_conf_cxt = test_dict.get("auth_conf_cxt")
+    polkit_pkla = test_dict.get("polkit_pkla")
+    polkit_pkla_cxt = test_dict.get("polkit_pkla_cxt")
+    ssh_setup = test_dict.get("ssh_setup", "no")
+    tcp_setup = test_dict.get("tcp_setup", "no")
+    tls_setup = test_dict.get("tls_setup", "no")
+    unix_setup = test_dict.get("unix_setup", "no")
+    ssh_recovery = test_dict.get("ssh_auto_recovery", "yes")
+    tcp_recovery = test_dict.get("tcp_auto_recovery", "yes")
+    tls_recovery = test_dict.get("tls_auto_recovery", "yes")
+    unix_recovery = test_dict.get("unix_auto_recovery", "yes")
+
+    port = ""
+    # extra URI arguments
+    extra_params = ""
+    # it's used to clean up SSH, TLS, TCP, UNIX and SASL objs later
+    objs_list = []
+    # redirect LIBVIRT_DEBUG log into test log later
+    test_dict["logfile"] = test.logfile
+
+    # Make sure all of parameters are assigned a valid value
+    check_parameters(test_dict)
+
+    # only simply connect libvirt daemon then return
+    if no_any_config == "yes":
+        test_dict["uri"] = "%s%s%s://%s" % (driver, plus, transport, uri_path)
+        remote_access(test_dict)
+        return
+
+    # append extra 'pkipath' argument to URI if exists
+    if custom_pki_path:
+        extra_params = "?pkipath=%s" % custom_pki_path
+
+    # append extra 'no_verify' argument to URI if exists
+    if no_verify == "yes":
+        extra_params = "?no_verify=1"
+
+    # append extra 'socket' argument to URI if exists
+    if unix_sock_dir:
+        extra_params = "?socket=%s/libvirt-sock" % unix_sock_dir
+
+    # generate auth.conf and default under the '/etc/libvirt'
+    if auth_conf_cxt and auth_conf:
+            cmd = "echo -e '%s' > %s" % (auth_conf_cxt, auth_conf)
+            utils.system(cmd, ignore_status=True)
+
+    # generate polkit_pkla and default under the
+    # '/etc/polkit-1/localauthority/50-local.d/'
+    if polkit_pkla_cxt and polkit_pkla:
+            cmd = "echo -e '%s' > %s" % (polkit_pkla_cxt, polkit_pkla)
+            utils.system(cmd, ignore_status=True)
+
+    # generate remote IP
+    if config_ipv6 == "yes" and ipv6_addr_des:
+        remote_ip = "[%s]" % ipv6_addr_des
+    elif config_ipv6 != "yes" and server_cn:
+        remote_ip = server_cn
+    elif config_ipv6 != "yes" and ipv6_addr_des:
+        remote_ip = "[%s]" % ipv6_addr_des
+    elif server_ip and transport != "unix":
+        remote_ip = server_ip
+    else:
+        remote_ip = ""
+
+    # get URI port
+    if tcp_port != "":
+        port = ":" + tcp_port
+
+    if tls_port != "":
+        port = ":" + tls_port
+
+    if ssh_port != "" and not ipv6_addr_des:
+        port = ":" + ssh_port
+
+    # generate URI
+    uri = "%s%s%s://%s%s%s%s%s" % (driver, plus, transport, uri_user,
+                                   remote_ip, port, uri_path, extra_params)
+    test_dict["uri"] = uri
+
+    logging.debug("The final test dict:\n<%s>", test_dict)
+
+    if virsh_cmd == "start" and transport != "unix":
+        session = remote.wait_for_login("ssh", server_ip, "22", "root",
+                                        server_pwd, "#")
+        cmd = "virsh domstate %s" % vm_name
+        status, output = session.cmd_status_output(cmd)
+        if status:
+            session.close()
+            raise error.TestNAError(output)
+
+        session.close()
+
+    try:
+        # setup IPv6
+        if config_ipv6 == "yes":
+            ipv6_obj = IPv6Manager(test_dict)
+            objs_list.append(ipv6_obj)
+            ipv6_obj.setup()
+
+        # compare libvirt version if needs
+        if diff_virt_ver == "yes":
+            compare_virt_version(server_ip, server_user, server_pwd)
+
+        # setup SSH
+        if transport == "ssh" or ssh_setup == "yes":
+            if not test_dict.get("auth_pwd"):
+                ssh_obj = SSHConnection(test_dict)
+                if ssh_recovery == "yes":
+                    objs_list.append(ssh_obj)
+                # setup test environment
+                ssh_obj.conn_setup()
+
+        # setup TLS
+        if transport == "tls" or tls_setup == "yes":
+            tls_obj = TLSConnection(test_dict)
+            if tls_recovery == "yes":
+                objs_list.append(tls_obj)
+            # reserve cert path
+            tmp_dir = tls_obj.tmp_dir
+            # setup test environment
+            if tls_sanity_cert == "no":
+                # only setup CA and client
+                tls_obj.conn_setup(False, True)
+            else:
+                # setup CA, server and client
+                tls_obj.conn_setup()
+
+        # setup TCP
+        if transport == "tcp" or tcp_setup == "yes":
+            tcp_obj = TCPConnection(test_dict)
+            if tcp_recovery == "yes":
+                objs_list.append(tcp_obj)
+            # setup test environment
+            tcp_obj.conn_setup()
+
+        # create a directory if needs
+        if mkdir_cmd:
+            utils.system(mkdir_cmd, ignore_status=True)
+
+        # setup UNIX
+        if transport == "unix" or unix_setup == "yes":
+            unix_obj = UNIXConnection(test_dict)
+            if unix_recovery == "yes":
+                objs_list.append(unix_obj)
+            # setup test environment
+            unix_obj.conn_setup()
+
+        # need to restart libvirt service for negative testing
+        if restart_libvirtd == "no":
+            remotely_control_libvirtd(server_ip, server_user,
+                                      server_pwd, action, status_error)
+
+        # check TCP/IP listening by service
+        if restart_libvirtd != "no" and transport != "unix":
+            service = 'libvirtd'
+            if transport == "ssh":
+                service = 'ssh'
+
+            check_listening_port_remote_by_service(server_ip, server_user,
+                                                   server_pwd, service,
+                                                   port, listen_addr)
+
+        # remove client certifications if exist, only for TLS negative testing
+        if rm_client_key_cmd:
+            utils.system(rm_client_key_cmd, ignore_status=True)
+
+        if rm_client_cert_cmd:
+            utils.system(rm_client_cert_cmd, ignore_status=True)
+
+        # add user to specific group
+        if adduser_cmd:
+            utils.system(adduser_cmd, ignore_status=True)
+
+        # change /etc/pki/libvirt/servercert.pem then
+        # restart libvirt service on the remote host
+        if tls_sanity_cert == "no" and ca_cn_new:
+            test_dict['ca_cn'] = ca_cn_new
+            test_dict['ca_cakey_path'] = tmp_dir
+            test_dict['scp_new_cacert'] = 'no'
+            tls_obj_new = TLSConnection(test_dict)
+            test_dict['tls_obj_new'] = tls_obj_new
+            # only setup new CA and server
+            tls_obj_new.conn_setup(True, False)
+
+        # setup SASL certification
+        if sasl_user_pwd:
+            # covert string tuple and list to python data type
+            sasl_user_pwd = eval(sasl_user_pwd)
+            if sasl_allowed_users:
+                sasl_allowed_users = eval(sasl_allowed_users)
+
+            # create a sasl user
+            sasl_obj = SASL(test_dict)
+            objs_list.append(sasl_obj)
+            sasl_obj.setup()
+
+            for sasl_user, sasl_pwd in sasl_user_pwd:
+                # need't authentication if the auth.conf is configured by user
+                if not auth_conf:
+                    test_dict["auth_user"] = sasl_user
+                    test_dict["auth_pwd"] = sasl_pwd
+                    logging.debug("sasl_user, sasl_pwd = "
+                                  "(%s, %s)", sasl_user, sasl_pwd)
+
+                if sasl_allowed_users and sasl_user not in sasl_allowed_users:
+                    test_dict["status_error"] = "yes"
+
+                remote_access(test_dict)
+        else:
+            remote_access(test_dict)
+
+    finally:
+        # recovery test environment
+        if rmdir_cmd:
+            utils.system(rmdir_cmd, ignore_status=True)
+
+        if deluser_cmd:
+            utils.system(deluser_cmd, ignore_status=True)
+
+        if auth_conf and os.path.isfile(auth_conf):
+            os.unlink(auth_conf)
+
+        if polkit_pkla and os.path.isfile(polkit_pkla):
+            os.unlink(polkit_pkla)
+
+        cleanup(objs_list)


### PR DESCRIPTION
# for UNIX test cases

```
$ ./run -t libvirt --test type_specific.io-github-autotest-libvirt.virsh.remote_with_unix --no-downloads --keep-image
SETUP: PASS (0.34 s)
DATA DIR: /var/lib/virt_test
DEBUG LOG: /tmp/virt-test/logs/run-2014-06-27-16.15.48/debug.log
TESTS: 14
(1/14) type_specific.io-github-autotest-libvirt.virsh.remote_with_unix.positive_testing.default_unix_config: PASS (12.90 s)
(2/14) type_specific.io-github-autotest-libvirt.virsh.remote_with_unix.positive_testing.readonly: PASS (13.20 s)
(3/14) type_specific.io-github-autotest-libvirt.virsh.remote_with_unix.positive_testing.customized_unix_sock_dir: PASS (74.16 s)
(4/14) type_specific.io-github-autotest-libvirt.virsh.remote_with_unix.positive_testing.default_config_and_start_vm: PASS (17.88 s)
(5/14) type_specific.io-github-autotest-libvirt.virsh.remote_with_unix.positive_testing.allow_sasl_users: PASS (90.07 s)
(6/14) type_specific.io-github-autotest-libvirt.virsh.remote_with_unix.positive_testing.socket_access_controls: PASS (14.36 s)
(7/14) type_specific.io-github-autotest-libvirt.virsh.remote_with_unix.positive_testing.socket_with_auth_conf: PASS (76.76 s)
(8/14) type_specific.io-github-autotest-libvirt.virsh.remote_with_unix.positive_testing.socket_with_polkit_and_acl_control: PASS (21.74 s)
(9/14) type_specific.io-github-autotest-libvirt.virsh.remote_with_unix.positive_testing.socket_with_polkit_rw: PASS (18.77 s)
(10/14) type_specific.io-github-autotest-libvirt.virsh.remote_with_unix.negative_testing.no_allowed_sasl_user: PASS (90.55 s)
(11/14) type_specific.io-github-autotest-libvirt.virsh.remote_with_unix.negative_testing.allow_sasl_user_with_readonly: PASS (85.51 s)
(12/14) type_specific.io-github-autotest-libvirt.virsh.remote_with_unix.negative_testing.readonly_without_auth: PASS (12.77 s)
(13/14) type_specific.io-github-autotest-libvirt.virsh.remote_with_unix.negative_testing.socket_access_controls: PASS (14.64 s)
(14/14) type_specific.io-github-autotest-libvirt.virsh.remote_with_unix.negative_testing.socket_with_polkit_ro: PASS (13.98 s)
TOTAL TIME: 557.40 s (09:17)
TESTS PASSED: 14
TESTS FAILED: 0
SUCCESS RATE: 100.00 %
```
# for SSH test cases

```
$ ./run -t libvirt --test type_specific.io-github-autotest-libvirt.virsh.remote_with_ssh --no-downloads --keep-image
SETUP: PASS (0.34 s)
DATA DIR: /var/lib/virt_test
DEBUG LOG: /tmp/virt-test/logs/run-2014-06-27-16.28.26/debug.log
TESTS: 11
(1/11) type_specific.io-github-autotest-libvirt.virsh.remote_with_ssh.positive_testing.ssh_diff_libvirt_version: PASS (10.78 s)
(2/11) type_specific.io-github-autotest-libvirt.virsh.remote_with_ssh.positive_testing.ssh_static_ipv6: PASS (17.66 s)
(3/11) type_specific.io-github-autotest-libvirt.virsh.remote_with_ssh.positive_testing.gssapi_auth: PASS (9.16 s)
(4/11) type_specific.io-github-autotest-libvirt.virsh.remote_with_ssh.negative_testing.libssh2_no_auth: PASS (2.13 s)
(5/11) type_specific.io-github-autotest-libvirt.virsh.remote_with_ssh.negative_testing.ssh_no_uri_path: PASS (9.07 s)
(6/11) type_specific.io-github-autotest-libvirt.virsh.remote_with_ssh.negative_testing.ssh_read_only_mode: PASS (9.15 s)
(7/11) type_specific.io-github-autotest-libvirt.virsh.remote_with_ssh.negative_testing.ssh_no_ipv6_config: PASS (8.79 s)
(8/11) type_specific.io-github-autotest-libvirt.virsh.remote_with_ssh.negative_testing.stop_libvirtd: PASS (10.27 s)
(9/11) type_specific.io-github-autotest-libvirt.virsh.remote_with_ssh.negative_testing.incorrect_password: PASS (13.15 s)
(10/11) type_specific.io-github-autotest-libvirt.virsh.remote_with_ssh.negative_testing.ipv4_with_readonly: PASS (9.11 s)
(11/11) type_specific.io-github-autotest-libvirt.virsh.remote_with_ssh.negative_testing.ipv6_with_readonly: PASS (17.91 s)
TOTAL TIME: 117.27 s (01:57)
TESTS PASSED: 11
TESTS FAILED: 0
SUCCESS RATE: 100.00 %
```
# for TCP test cases

```
$ ./run -t libvirt --test type_specific.io-github-autotest-libvirt.virsh.remote_with_tcp --no-downloads --keep-image
SETUP: PASS (0.34 s)
DATA DIR: /var/lib/virt_test
DEBUG LOG: /tmp/virt-test/logs/run-2014-06-27-16.30.31/debug.log
TESTS: 11
(1/11) type_specific.io-github-autotest-libvirt.virsh.remote_with_tcp.positive_testing.allow_one_sasl_user: PASS (19.12 s)
(2/11) type_specific.io-github-autotest-libvirt.virsh.remote_with_tcp.positive_testing.allow_sasl_users: PASS (21.75 s)
(3/11) type_specific.io-github-autotest-libvirt.virsh.remote_with_tcp.positive_testing.customized_ipv4_tcp_port: PASS (13.88 s)
(4/11) type_specific.io-github-autotest-libvirt.virsh.remote_with_tcp.positive_testing.customized_ipv4_listen_address_with_sasl_auth: PASS (19.15 s)
(5/11) type_specific.io-github-autotest-libvirt.virsh.remote_with_tcp.positive_testing.customized_ipv6_listen_address: PASS (22.53 s)
(6/11) type_specific.io-github-autotest-libvirt.virsh.remote_with_tcp.positive_testing.customized_ipv6_tcp_port: PASS (22.47 s)
(7/11) type_specific.io-github-autotest-libvirt.virsh.remote_with_tcp.positive_testing.customized_ipv6_listen_address_with_sasl_auth: PASS (27.68 s)
(8/11) type_specific.io-github-autotest-libvirt.virsh.remote_with_tcp.negative_testing.no_allowed_sasl_user: PASS (19.30 s)
(9/11) type_specific.io-github-autotest-libvirt.virsh.remote_with_tcp.negative_testing.ipv4_with_allowed_sasl_user_readonly: PASS (19.09 s)
(10/11) type_specific.io-github-autotest-libvirt.virsh.remote_with_tcp.negative_testing.ipv6_with_readonly: PASS (22.52 s)
(11/11) type_specific.io-github-autotest-libvirt.virsh.remote_with_tcp.negative_testing.only_simpy_connect_libvirtd: PASS (0.47 s)
TOTAL TIME: 208.06 s (03:28)
TESTS PASSED: 11
TESTS FAILED: 0
SUCCESS RATE: 100.00 %
```
# for TLS test cases

```
$ ./run -t libvirt --test type_specific.io-github-autotest-libvirt.virsh.remote_with_tls --no-downloads --keep-image
SETUP: PASS (0.34 s)
DATA DIR: /var/lib/virt_test
DEBUG LOG: /tmp/virt-test/logs/run-2014-06-27-16.35.13/debug.log
TESTS: 26
(1/26) type_specific.io-github-autotest-libvirt.virsh.remote_with_tls.positive_testing.default_tls_port_and_auth_tls: PASS (25.63 s)
(2/26) type_specific.io-github-autotest-libvirt.virsh.remote_with_tls.positive_testing.no_verify_certificate: PASS (26.36 s)
(3/26) type_specific.io-github-autotest-libvirt.virsh.remote_with_tls.positive_testing.no_sanity_checks_and_no_verify: PASS (32.22 s)
(4/26) type_specific.io-github-autotest-libvirt.virsh.remote_with_tls.positive_testing.customized_tls_port: PASS (25.87 s)
(5/26) type_specific.io-github-autotest-libvirt.virsh.remote_with_tls.positive_testing.allow_one_sasl_user: PASS (31.49 s)
(6/26) type_specific.io-github-autotest-libvirt.virsh.remote_with_tls.positive_testing.allow_sasl_users: PASS (34.11 s)
(7/26) type_specific.io-github-autotest-libvirt.virsh.remote_with_tls.positive_testing.allowed_dn_list: PASS (27.10 s)
(8/26) type_specific.io-github-autotest-libvirt.virsh.remote_with_tls.positive_testing.customized_ipv4_listen_address: PASS (26.75 s)
(9/26) type_specific.io-github-autotest-libvirt.virsh.remote_with_tls.positive_testing.customized_ipv4_listen_address_with_sasl_auth: PASS (32.83 s)
(10/26) type_specific.io-github-autotest-libvirt.virsh.remote_with_tls.positive_testing.customized_ipv6_listen_address: PASS (35.10 s)
(11/26) type_specific.io-github-autotest-libvirt.virsh.remote_with_tls.positive_testing.customized_ipv6_tls_port: PASS (35.74 s)
(12/26) type_specific.io-github-autotest-libvirt.virsh.remote_with_tls.positive_testing.customized_ipv6_listen_address_with_sasl_auth: PASS (41.41 s)
(13/26) type_specific.io-github-autotest-libvirt.virsh.remote_with_tls.positive_testing.customized_x509_cert_path: PASS (26.42 s)
(14/26) type_specific.io-github-autotest-libvirt.virsh.remote_with_tls.negative_testing.only_simpy_connect_libvirtd: PASS (0.36 s)
(15/26) type_specific.io-github-autotest-libvirt.virsh.remote_with_tls.negative_testing.invalid_tls_port: PASS (24.98 s)
(16/26) type_specific.io-github-autotest-libvirt.virsh.remote_with_tls.negative_testing.tls_port_in_use: PASS (24.93 s)
(17/26) type_specific.io-github-autotest-libvirt.virsh.remote_with_tls.negative_testing.tls_listen_addr_in_use: PASS (24.04 s)
(18/26) type_specific.io-github-autotest-libvirt.virsh.remote_with_tls.negative_testing.ipv4_with_allowed_sasl_user_readonly: PASS (31.37 s)
(19/26) type_specific.io-github-autotest-libvirt.virsh.remote_with_tls.negative_testing.no_sanity_checks_without_no_verify: PASS (31.64 s)
(20/26) type_specific.io-github-autotest-libvirt.virsh.remote_with_tls.negative_testing.allowed_dn_disorder_list: PASS (27.31 s)
(21/26) type_specific.io-github-autotest-libvirt.virsh.remote_with_tls.negative_testing.allowed_dn_list_with_invalid_organization: PASS (27.15 s)
(22/26) type_specific.io-github-autotest-libvirt.virsh.remote_with_tls.negative_testing.allowed_dn_list_with_invalid_CN: PASS (27.82 s)
(23/26) type_specific.io-github-autotest-libvirt.virsh.remote_with_tls.negative_testing.verify_certificate: PASS (25.28 s)
(24/26) type_specific.io-github-autotest-libvirt.virsh.remote_with_tls.negative_testing.incorrect_ipv4_listen_address: PASS (24.26 s)
(25/26) type_specific.io-github-autotest-libvirt.virsh.remote_with_tls.negative_testing.ipv6_with_readonly: PASS (35.71 s)
(26/26) type_specific.io-github-autotest-libvirt.virsh.remote_with_tls.negative_testing.ipv6_address_unreachable: PASS (30.48 s)
TOTAL TIME: 736.55 s (12:16)
TESTS PASSED: 26
TESTS FAILED: 0
SUCCESS RATE: 100.00 %
```
