### PR TITLE
Fix pool related cases to recover selinux state.

### DIFF
--- a/libvirt/tests/src/virsh_cmd/pool/virsh_find_storage_pool_sources.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_find_storage_pool_sources.py
@@ -48,7 +48,8 @@ def run(test, params, env):
     if source_host == "localhost":
         if source_type == "netfs":
             # Set up nfs
-            utils_test.libvirt.setup_or_cleanup_nfs(True)
+            res = utils_test.libvirt.setup_or_cleanup_nfs(True)
+            selinux_bak = res["selinux_status_bak"]
             cleanup_nfs = True
         if source_type in ["iscsi", "logical"]:
             # Set up iscsi
@@ -116,4 +117,5 @@ def run(test, params, env):
         if cleanup_iscsi:
             utils_test.libvirt.setup_or_cleanup_iscsi(False)
         if cleanup_nfs:
-            utils_test.libvirt.setup_or_cleanup_nfs(False)
+            utils_test.libvirt.setup_or_cleanup_nfs(
+                False, restore_selinux=selinux_bak)

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_find_storage_pool_sources_as.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_find_storage_pool_sources_as.py
@@ -34,7 +34,8 @@ def run(test, params, env):
     if source_host == "localhost":
         if source_type == "netfs":
             # Set up nfs
-            utils_test.libvirt.setup_or_cleanup_nfs(True)
+            res = utils_test.libvirt.setup_or_cleanup_nfs(True)
+            selinux_bak = res["selinux_status_bak"]
             cleanup_nfs = True
         if source_type in ["iscsi", "logical"]:
             # Do we have the necessary tools?
@@ -91,4 +92,5 @@ def run(test, params, env):
         if cleanup_iscsi:
             utils_test.libvirt.setup_or_cleanup_iscsi(False)
         if cleanup_nfs:
-            utils_test.libvirt.setup_or_cleanup_nfs(False)
+            utils_test.libvirt.setup_or_cleanup_nfs(
+                False, restore_selinux=selinux_bak)

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool.py
@@ -57,7 +57,8 @@ def run(test, params, env):
     vol_path = os.path.join(pool_target, vol_name)
     # Clean up flags:
     # cleanup_env[0] for nfs, cleanup_env[1] for iscsi, cleanup_env[2] for lvm
-    cleanup_env = [False, False, False]
+    # cleanup_env[3] for selinux backup status.
+    cleanup_env = [False, False, False, ""]
 
     def check_exit_status(result, expect_error=False):
         """
@@ -304,4 +305,5 @@ def run(test, params, env):
         if cleanup_env[1]:
             utils_test.libvirt.setup_or_cleanup_iscsi(False)
         if cleanup_env[0]:
-            utils_test.libvirt.setup_or_cleanup_nfs(False)
+            utils_test.libvirt.setup_or_cleanup_nfs(
+                False, restore_selinux=cleanup_env[3])

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool_acl.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool_acl.py
@@ -59,7 +59,8 @@ def run(test, params, env):
     vol_list_error = "yes" == params.get("vol_list_error", "no")
     # Clean up flags:
     # cleanup_env[0] for nfs, cleanup_env[1] for iscsi, cleanup_env[2] for lvm
-    cleanup_env = [False, False, False]
+    # cleanup_env[3] for selinux backup status.
+    cleanup_env = [False, False, False, ""]
     # libvirt acl related params
     uri = params.get("virsh_uri")
     unprivileged_user = params.get('unprivileged_user')
@@ -272,4 +273,5 @@ def run(test, params, env):
         if cleanup_env[1]:
             utils_test.libvirt.setup_or_cleanup_iscsi(False)
         if cleanup_env[0]:
-            utils_test.libvirt.setup_or_cleanup_nfs(False)
+            utils_test.libvirt.setup_or_cleanup_nfs(
+                False, restore_selinux=cleanup_env[3])

--- a/libvirt/tests/src/virsh_cmd/volume/virsh_vol_create_from.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_vol_create_from.py
@@ -123,3 +123,5 @@ def run(test, params, env):
         if src_pool_type != dest_pool_type:
             pvt.cleanup_pool(dest_pool_name, dest_pool_type, dest_pool_target,
                              dest_emulated_image)
+        if os.path.isfile(vol_file):
+            os.remove(vol_file)

--- a/libvirt/tests/src/virsh_cmd/volume/virsh_vol_download_upload.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_vol_download_upload.py
@@ -189,6 +189,7 @@ def run(test, params, env):
             logging.debug("original digest read from %s is %s", vol_path,
                           ori_digest)
 
+            utils.run("touch %s" % file_path)
             if params.get('setup_libvirt_polkit') == 'yes':
                 utils.run("chmod 666 %s" % file_path)
 
@@ -214,6 +215,6 @@ def run(test, params, env):
                                  operation)
 
     finally:
-        utlv.PoolVolumeTest(test, params).cleanup_pool(pool_name, pool_type,
-                                                       pool_target,
-                                                       "volumetest")
+        pvt.cleanup_pool(pool_name, pool_type, pool_target, "volumetest")
+        if os.path.isfile(file_path):
+            os.remove(file_path)

--- a/libvirt/tests/src/virsh_cmd/volume/virsh_volume.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_volume.py
@@ -34,7 +34,7 @@ def run(test, params, env):
             if not os.path.isdir(pool_target):
                 os.makedirs(pool_target)
             # There is no need to cleanup anything for dir type
-            cleanup_env = [False, False, False]
+            cleanup_env = [False, False, False, ""]
             result = utlv.define_pool(pool_name, pool_type, pool_target,
                                       cleanup_env)
             if result.exit_status != 0:


### PR DESCRIPTION
This PR depends on https://github.com/autotest/virt-test/pull/1751.
This commit is base on a virt-test change to recover selinux state
after creating an NFS pool. Besides this change, this commit also
fixed a few bugs.
1) Stop virsh.domblkerror cleanup entire temp directory.
2) Clean virsh.vol_create_from and virsh.vol_download_upload file.
3) Create the file before chmod in virsh.vol_download_upload to
   prevent error.

Signed-off-by: Hao Liu hliu@redhat.com
