### PR TITLE
virsh.snapshot_disk: Raise NAError when we get a message about "not supp...

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_disk.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_disk.cfg
@@ -4,6 +4,7 @@
     # Switching screendumps off as creating can pause guest for long time
     # and cause error messages
     take_regular_screendumps = "no"
+    snapshot_options = ""
     variants:
         - snapshot_from_xml:
             snapshot_from_xml = "yes"
@@ -19,6 +20,10 @@
                     snapshot_disk = "internal"
                 - disk_external:
                     snapshot_disk = "external"
+                    variants:
+                        - default:
+                        - live:
+                            snapshot_options = "--live"
         - snapshot_default:
             snapshot_from_xml = "no"
             variants:


### PR DESCRIPTION
...orted".

When we run test for virsh.snapshot_disk in RHEL6:
Compiled against library: libvirt 0.10.2
Using library: libvirt 0.10.2
Using API: QEMU 0.10.2
Running hypervisor: QEMU 0.12.1

We will get some FAILs and error message:
"live disk snapshot not supported with this QEMU binary"

In this case, we should raise an NAError rather than FailError.

We are testing libvirt in tp-libvirt, and libvirt works well in
this case, but qemu-kvm.0.12.1 does not support live snapshot. It
is out of our testing project, and it should be NAError.

Signed-off-by: Dongsheng Yang yangds.fnst@cn.fujitsu.com
