### PR TITLE
qemu_monitor_command: Add two more negative cases

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_qemu_monitor_command.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_qemu_monitor_command.cfg
@@ -48,6 +48,11 @@
                             vm_ref = ""
                         - invalid_options:
                             options = "--xyz"
+                        - unknown_cmd:
+                            options = "--hmp"
+                            qemu_cmd = "xyz"
+                        - invalid_qmp_cmd:
+                            qemu_cmd = "{system_reset}"
                 - vm_shutoff:
                     vm_ref = "domname"
                     vm_state = "shutoff"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_monitor_command.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_monitor_command.py
@@ -49,6 +49,7 @@ def run(test, params, env):
         cmd_result = virsh.qemu_monitor_command(vm_ref, cmd, options,
                                                 ignore_status=True,
                                                 debug=True)
+        output = cmd_result.stdout.strip()
         status = cmd_result.exit_status
 
         # Check result
@@ -56,7 +57,11 @@ def run(test, params, env):
             raise error.TestFail("Libvirtd is not running after run command.")
         if status_error:
             if not status:
-                raise error.TestFail("Expect fail, but run successfully.")
+                # Return status is 0 with unknown command
+                if "unknown command:" in output:
+                    logging.debug("Command failed: %s" % output)
+                else:
+                    raise error.TestFail("Expect fail, but run successfully.")
             else:
                 logging.debug("Command failed as expected.")
         else:


### PR DESCRIPTION
Add a negative case for cover unknow cmd error, and another one
for invalid qmp command.

Signed-off-by: Wayne Sun gsun@redhat.com
