### PR TITLE
snapshot_par_cur: Add cases for missed option and negative testing

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_par_cur.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_par_cur.cfg
@@ -15,12 +15,29 @@
                     snapshot_parent_option = "--current snap2"
                 - no_current_and_snapname:
                     snapshot_parent_option = " "
+                - invalid_snapshotname:
+                    snapshot_parent_option = "--snapshotname xyz"
+                - without_snapshot:
+                    snapshot_parent_option = "--current"
+                    without_snapshot = "yes"
         - negative_tests_current:
             snapshot_current_status_error = "yes"
-            readonly = "yes"
             variants:
-                - name_with_snapname:
-                    snapshot_current_option = "--name snap3"
+                - readonly:
+                    readonly = "yes"
+                    variants:
+                        - name_with_snapname:
+                            snapshot_current_option = "--name snap3"
+                        - invalid_snapshotname:
+                            snapshot_current_option = "--snapshotname xyz"
+                        - without_snapshot:
+                            snapshot_current_option = " "
+                            without_snapshot = "yes"
+                - without_snapshot:
+                    snapshot_current_option = " "
+                    without_snapshot = "yes"
+                - invalid_snapshotname:
+                    snapshot_current_option = "--snapshotname xyz"
         - mode_option:
             variants:
                 - negtive_tests_readonly:
@@ -42,3 +59,5 @@
                 - readonly:
                     readonly = "yes"
                 - readwrite:
+                - name_option:
+                    snapshot_current_option = "--name"


### PR DESCRIPTION
Add negative cases for invalid snapshotname and run command without
snapshot created first. Add positive case for '--name' option.

Signed-off-by: Wayne Sun gsun@redhat.com
