### PR TITLE
libvirt.test: Fix problem in virsh iface test

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/interface/virsh_iface.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/interface/virsh_iface.cfg
@@ -8,7 +8,9 @@
     variants:
         - net_restart:
             only ethernet_type, bridge_type
+            no virsh.iface
             # Caution: This case will restart network
+            # If you want execute these cases, remove 'no virsh.iface' line
             iface_net_restart = "yes"
         - net_no_restart:
             iface_net_restart = "no"

--- a/libvirt/tests/src/virsh_cmd/interface/virsh_iface.py
+++ b/libvirt/tests/src/virsh_cmd/interface/virsh_iface.py
@@ -346,6 +346,9 @@ def run(test, params, env):
                     pass
             if iface_type == "bridge":
                 if iface_name in net_bridge.list_br():
-                    net_bridge.del_bridge(iface_name)
+                    try:
+                        net_bridge.del_bridge(iface_name)
+                    except IOError:
+                        pass
         if NM_is_running:
             NM_service.start()


### PR DESCRIPTION
1.Skip OSError when delete a bridge
2.Filter 'net_restart' cases because it's dangerous

Signed-off-by: Li Yang liyang.fnst@cn.fujitsu.com
