### PR TITLE
libvirt.tests: add new case into virsh send-key command

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_sendkey.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_sendkey.cfg
@@ -52,6 +52,8 @@
                     sendkey_options = "KEY_LEFTALT KEY_SYSRQ KEY_M"
                 - show_task_status:
                     sendkey_options = "KEY_LEFTALT KEY_SYSRQ KEY_T"
+                - reboot_guest:
+                    sendkey_options = "KEY_LEFTALT KEY_SYSRQ KEY_B"
             variants:
                 - non_acl:
                 - acl_test:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_sendkey.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_sendkey.py
@@ -133,6 +133,16 @@ def run(test, params, env):
                 elif "KEY_T" in options:
                     get_status = session.cmd_status("cat /var/log/messages|"
                                                     "grep 'SysRq.*Show State'")
+                elif "KEY_B" in options:
+                    client_session = vm.wait_for_login()
+                    result = virsh.domstate(vm_name, '--reason', ignore_status=True)
+                    output = result.stdout.strip()
+                    logging.debug("The guest state: %s", output)
+                    if not output.count("booted"):
+                        get_status = 1
+                    else:
+                        get_status = 0
+                    client_session.close()
 
                 if get_status == 0:
                     timeout = -1


### PR DESCRIPTION
$ ./run -t libvirt --test type_specific.io-github-autotest-libvirt.virsh.sendkey.sysrq.non_acl.reboot_guest --no-downloads --keep-image --keep-image-between-tests
SETUP: PASS (0.56 s)
DATA DIR: /var/lib/virt_test
DEBUG LOG: /tmp/virt-test/logs/run-2014-07-16-15.06.11/debug.log
TESTS: 1
(1/1) type_specific.io-github-autotest-libvirt.virsh.sendkey.sysrq.non_acl.reboot_guest: PASS (45.68 s)
TOTAL TIME: 45.74 s
TESTS PASSED: 1
TESTS FAILED: 0
SUCCESS RATE: 100.00 %

$ ./run -t libvirt --test type_specific.io-github-autotest-libvirt.virsh.sendkey.sysrq.acl_test.reboot_guest --no-downloads --keep-image --keep-image-between-tests
SETUP: PASS (0.57 s)
DATA DIR: /var/lib/virt_test
DEBUG LOG: /tmp/virt-test/logs/run-2014-07-16-15.04.50/debug.log
TESTS: 1
(1/1) type_specific.io-github-autotest-libvirt.virsh.sendkey.sysrq.acl_test.reboot_guest: PASS (64.16 s)
TOTAL TIME: 64.22 s (01:04)
TESTS PASSED: 1
TESTS FAILED: 0
SUCCESS RATE: 100.00 %
