### PR TITLE
snapshot_create_as: Add reuse external diskonly negative case

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_create_as.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_create_as.cfg
@@ -14,6 +14,16 @@
                     memspec_opts = "tt.img"
                     # the bad_disk here in diskspec_opts is a parameter which is set above
                     diskspec_opts = "vda,file=bad_disk"
+                - reuse_external_with_DAC_denial:
+                    # for more than 1 diskspec diskspec_num must be given
+                    diskspec_num = 2
+                    dac_denial = "yes"
+                    reuse_external = "yes"
+                    external_disk0 = "reuse_external0.img"
+                    external_disk1 = "reuse_external1.img"
+                    snap_createas_opts = "--reuse-external --disk-only"
+                    diskspec_opts1 = "vda,file=external_disk0"
+                    diskspec_opts2 = "vdb,file=external_disk1"
                 - incompatible_options:
                     snap_createas_opts = "--no-metadata --print-xml"
                 - quiesce_without_ga:
@@ -55,10 +65,11 @@
                     snap_createas_opts = "--no-metadata"
                     memspec_opts = "no_meta.img"
                 - reuse_external:
-                    external_disk = "reuse_external.img"
+                    reuse_external = "yes"
+                    external_disk0 = "reuse_external.img"
                     snap_createas_opts = "--reuse-external --disk-only"
                     # the external_disk here in diskspec_opts is a parameter which is set above
-                    diskspec_opts = "vda,file=external_disk"
+                    diskspec_opts = "vda,file=external_disk0"
                 - multi_snapshots:
                     multi_num = 5
                     snap_createas_opts = ""

--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_create_as.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_create_as.py
@@ -1,8 +1,10 @@
 import re
 import os
 import commands
+import string
 import logging
 from autotest.client.shared import error
+from autotest.client import utils
 from virttest import virsh, utils_misc, xml_utils, libvirt_xml
 from virttest.libvirt_xml import vm_xml, xcepts
 from provider import libvirt_version
@@ -69,10 +71,10 @@ def compose_disk_options(test, params, opt_names):
             left_opt = ""
 
         if params.get("bad_disk") is not None or \
-           params.get("external_disk") is not None:
-            spec_disk = os.path.join(test.virtdir, params.get(opt_list[0]))
+           params.get("reuse_external") == "yes":
+            spec_disk = os.path.join(test.tmpdir, params.get(opt_list[0]))
         else:
-            spec_disk = os.path.join(test.virtdir, opt_list[0])
+            spec_disk = os.path.join(test.tmpdir, opt_list[0])
 
         return opt_disk[0] + "file=" + spec_disk + left_opt
 
@@ -306,12 +308,13 @@ def run(test, params, env):
     multi_num = params.get("multi_num", "1")
     diskspec_num = params.get("diskspec_num", "1")
     bad_disk = params.get("bad_disk")
-    external_disk = params.get("external_disk")
+    reuse_external = "yes" == params.get("reuse_external", "no")
     start_ga = params.get("start_ga", "yes")
     domain_state = params.get("domain_state")
     memspec_opts = params.get("memspec_opts")
     diskspec_opts = params.get("diskspec_opts")
     create_autodestroy = 'yes' == params.get("create_autodestroy", "no")
+    dac_denial = "yes" == params.get("dac_denial", "no")
 
     uri = params.get("virsh_uri")
     usr = params.get('unprivileged_user')
@@ -330,7 +333,7 @@ def run(test, params, env):
         # if the parameters have the disk without "file=" then we only need to
         # add testdir for it.
         if mem_options is None:
-            mem_options = os.path.join(test.virtdir, memspec_opts)
+            mem_options = os.path.join(test.tmpdir, memspec_opts)
         options += " --memspec " + mem_options
 
     tag_diskspec = 0
@@ -364,13 +367,21 @@ def run(test, params, env):
 
     # Generate empty image for negative test
     if bad_disk is not None:
-        bad_disk = os.path.join(test.virtdir, bad_disk)
+        bad_disk = os.path.join(test.tmpdir, bad_disk)
         os.open(bad_disk, os.O_RDWR | os.O_CREAT)
 
     # Generate external disk
-    if external_disk is not None:
-        external_disk = os.path.join(test.virtdir, external_disk)
-        commands.getoutput("qemu-img create -f qcow2 %s 1G" % external_disk)
+    if reuse_external:
+        disk_path = ''
+        for i in range(dnum):
+            external_disk = "external_disk%s" % i
+            if params.get(external_disk):
+                disk_path = os.path.join(test.tmpdir,
+                                         params.get(external_disk))
+                utils.run("qemu-img create -f qcow2 %s 1G" % disk_path)
+        # Only chmod of the last external disk for negative case
+        if dac_denial:
+            utils.run("chmod 500 %s" % disk_path)
 
     try:
         # Start qemu-ga on guest if have --quiesce
@@ -420,6 +431,16 @@ def run(test, params, env):
         # Record the previous snapshot-list
         snaps_before = virsh.snapshot_list(vm_name)
 
+        # Attach disk before create snapshot if not print xml and multi disks
+        # specified in cfg
+        if dnum > 1 and "--print-xml" not in options:
+            for i in range(1, dnum):
+                disk_path = os.path.join(test.tmpdir, 'disk%s.qcow2' % i)
+                utils.run("qemu-img create -f qcow2 %s 200M" % disk_path)
+                virsh.attach_disk(vm_name, disk_path,
+                                  'vd%s' % list(string.lowercase)[i],
+                                  debug=True)
+
         # Run virsh command
         # May create several snapshots, according to configuration
         for count in range(int(multi_num)):
@@ -457,6 +478,12 @@ def run(test, params, env):
                         else:
                             logging.info("Run failed as expected and memspec file"
                                          " already beed removed")
+                    # Check domain xml is not updated if reuse external fail
+                    elif reuse_external and dac_denial:
+                        output = virsh.dumpxml(vm_name).stdout.strip()
+                        if "reuse_external" in output:
+                            raise error.TestFail("Domain xml should not be "
+                                                 "updated with snapshot image")
                     else:
                         logging.info("Run failed as expected")
 
@@ -486,3 +513,13 @@ def run(test, params, env):
         # rm bad disks
         if bad_disk is not None:
             os.remove(bad_disk)
+        # rm attach disks and reuse external disks
+        if dnum > 1 and "--print-xml" not in options:
+            for i in range(dnum):
+                disk_path = os.path.join(test.tmpdir, 'disk%s.qcow2' % i)
+                if os.path.exists(disk_path):
+                    os.unlink(disk_path)
+                external_disk = "external_disk%s" % i
+                disk_path = os.path.join(test.tmpdir, params.get(external_disk))
+                if os.path.exists(disk_path):
+                    os.unlink(disk_path)


### PR DESCRIPTION
When create diskonly snapshot with --reuse-external option fail,
the domain xml should remain not updated.

Signed-off-by: Wayne Sun gsun@redhat.com
