### PR TITLE
libvirt.test: Fix a typo in vcpucount test

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_vcpucount.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_vcpucount.py
@@ -175,7 +175,7 @@ def run(test, params, env):
         reset_domain(vm, pre_vm_state, ("--guest" in options))
     except Exception, details:
         reset_env(vm_name, xml_file)
-        error.TestFail(details)
+        raise error.TestFail(details)
 
     # Perform guest vcpu hotplug
     for i in range(len(set_option)):


### PR DESCRIPTION
Signed-off-by: Li Yang liyang.fnst@cn.fujitsu.com
