### PR TITLE
libvirt.conf: Add test for host_uuid option

### DIFF
--- a/libvirt/tests/cfg/conf_file/libvirtd_conf/host_uuid.cfg
+++ b/libvirt/tests/cfg/conf_file/libvirtd_conf/host_uuid.cfg
@@ -1,0 +1,42 @@
+- conf_file.libvirtd_conf.host_uuid:
+    type = host_uuid
+    start_vm = no
+    variants:
+        - positive_test:
+            expected_result = success
+            variants:
+                - lowercase_uuid:
+                    new_uuid = abcdabcd-abcd-abcd-abcd-abcdabcdabcd
+                - uppercase_uuid:
+                    new_uuid = ABCDABCD-ABCD-ABCD-ABCD-ABCDABCDABCD
+                - no_hyphen_uuid:
+                    uuid_type = nohyphen
+                    new_uuid = 13371337133713371337133713371337
+                - single_quoted_uuid:
+                    uuid_type = single_quoted
+                    new_uuid = abcdabcd-abcd-abcd-abcd-abcdabcdabcd
+                - all_same_uuid:
+                    expected_result = dmi_uuid
+                    new_uuid = 22222222-2222-2222-2222-222222222222
+                - not_set_uuid:
+                    uuid_type = not_set
+                    expected_result = dmi_uuid
+        - negative_test:
+            expected_result = unbootable
+            variants:
+                - empty_uuid:
+                    new_uuid = ""
+                - unquoted_uuid:
+                    uuid_type = unquoted
+                    new_uuid = abcdabcd-abcd-abcd-abcd-abcdabcdabcd
+                - unterminated_uuid:
+                    uuid_type = unterminated
+                    new_uuid = abcdabcd-abcd-abcd-abcd-abcdabcdabcd
+                - over_hyphen_uuid:
+                    new_uuid = 1-3-3-7-1-3-3-7-1-3-3-7-1-3-3-7-1-3-3-7-1-3-3-7-1-3-3-7-1-3-3-7
+                - invalid_uuid:
+                    new_uuid = gggggggg-gggg-gggg-gggg-gggggggggggg
+                - short_uuid:
+                    new_uuid = 22222222-2222-2222-2222-22222222222
+                - long_uuid:
+                    new_uuid = 22222222-2222-2222-2222-2222222222222

--- a/libvirt/tests/src/conf_file/libvirtd_conf/host_uuid.py
+++ b/libvirt/tests/src/conf_file/libvirtd_conf/host_uuid.py
@@ -1,0 +1,101 @@
+import logging
+import uuid
+import os.path
+from virttest import utils_config
+from virttest import utils_libvirtd
+from virttest.libvirt_xml import capability_xml
+from autotest.client.shared import error
+
+
+def run(test, params, env):
+    """
+    Test host_uuid parameter in libvird.conf.
+
+    1) Change host_uuid in libvirtd.conf;
+    2) Restart libvirt daemon;
+    3) Check if libvirtd successfully started;
+    4) Check current host UUID by `virsh capabilities`;
+    """
+    def get_dmi_uuid():
+        """
+        Retrieve the UUID of DMI, which is usually used as libvirt daemon
+        host UUID.
+
+        :return : DMI UUID if it can be located or None if can't.
+        """
+        uuid_paths = [
+            '/sys/devices/virtual/dmi/id/product_uuid',
+            '/sys/class/dmi/id/product_uuid',
+        ]
+        for path in uuid_paths:
+            if os.path.isfile(path):
+                dmi_fp = open(path)
+                try:
+                    uuid = dmi_fp.readline().strip().lower()
+                    return uuid
+                finally:
+                    dmi_fp.close()
+
+    uuid_type = params.get("uuid_type", "lowercase")
+    expected_result = params.get("expected_result", "success")
+    new_uuid = params.get("new_uuid", "")
+
+    # We are expected to get an standard UUID format on success.
+    if expected_result == 'success':
+        expected_uuid = str(uuid.UUID(new_uuid))
+
+    config = utils_config.LibvirtdConfig()
+    libvirtd = utils_libvirtd.Libvirtd()
+    try:
+        orig_uuid = capability_xml.CapabilityXML()['uuid']
+        logging.debug('Original host UUID is %s' % orig_uuid)
+
+        if uuid_type == 'not_set':
+            # Remove `host_uuid` in libvirtd.conf.
+            del config.host_uuid
+        elif uuid_type == 'unterminated':
+            # Change `host_uuid` in libvirtd.conf.
+            config.set_raw('host_uuid', '"%s' % new_uuid)
+        elif uuid_type == 'unquoted':
+            config.set_raw('host_uuid', new_uuid)
+        elif uuid_type == 'single_quoted':
+            config.set_raw('host_uuid', "'%s'" % new_uuid)
+        else:
+            config.host_uuid = new_uuid
+
+        # Restart libvirtd to make change valid. May raise ConfigError
+        # if not succeed.
+        if not libvirtd.restart():
+            if expected_result != 'unbootable':
+                raise error.TestFail('Libvirtd is expected to be started '
+                                     'with host_uuid = %s' % config['host_uuid'])
+            return
+
+        if expected_result == 'unbootable':
+            raise error.TestFail('Libvirtd is not expected to be started '
+                                 'with host_uuid = %s' % config['host_uuid'])
+
+        cur_uuid = capability_xml.CapabilityXML()['uuid']
+        logging.debug('Current host UUID is %s' % cur_uuid)
+
+        if expected_result == 'success':
+            if cur_uuid != expected_uuid:
+                raise error.TestFail(
+                    "Host UUID doesn't changed as expected"
+                    " from %s to %s, but %s" % (orig_uuid, expected_uuid,
+                                                cur_uuid))
+        # libvirtd should use system DMI UUID for all_digit_same or
+        # not_set host_uuid.
+        elif expected_result == 'dmi_uuid':
+            dmi_uuid = get_dmi_uuid()
+            logging.debug("DMI UUID is %s." % dmi_uuid)
+
+            if dmi_uuid is not None and cur_uuid != dmi_uuid:
+                raise error.TestFail(
+                    "Host UUID doesn't changed from "
+                    "%s to DMI UUID %s as expected, but %s" % (
+                        orig_uuid, dmi_uuid, cur_uuid))
+    finally:
+        config.restore()
+        if not libvirtd.is_running():
+            libvirtd.start()


### PR DESCRIPTION
Test host_uuid parameter in libvird.conf. 
This PR depends on https://github.com/autotest/virt-test/pull/1769.

1) Change host_uuid in libvirtd.conf;
2) Restart libvirt daemon;
3) Check if libvirtd successfully started;
4) Check current host UUID by `virsh capabilities`;

Signed-off-by: Hao Liu hliu@redhat.com
