### PR TITLE
libvirt.test: Fix bugs and remove cases from detach-device

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device.cfg
@@ -8,6 +8,7 @@
     dt_device_xml = device.xml
     variants:
         - cdrom_test:
+            dt_device_pre_vm_state = "shut off"
             dt_device_device = cdrom
             dt_device_options = "--config"
             dt_device_device = cdrom
@@ -39,6 +40,7 @@
                 - no_vm_name:
                     dt_device_vm_ref = ""
                 - hex_vm_id:
+                    no cdrom_test
                     dt_device_vm_ref = hex_id
                 - invalid_vm_id:
                     dt_device_vm_ref = invalid_id
@@ -66,11 +68,13 @@
             status_error = 'no'
             variants:
                 - host_vm_id:
+                    no cdrom_test
                     dt_device_vm_ref = id
                 - host_vm_name:
                 - host_vm_uuid:
                     dt_device_vm_ref = uuid
                 - vm_suspend:
+                    no cdrom_test
                     dt_device_pre_vm_state = paused
                 - image_file_no_option:
                     no cdrom_test

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device.py
@@ -136,6 +136,11 @@ def run(test, params, env):
     no_attach = "yes" == params.get("dt_device_no_attach", 'no')
     os_type = params.get("os_type", "linux")
     device = params.get("dt_device_device", "disk")
+    test_cmd = "detach-device"
+    if not virsh.has_command_help_match(test_cmd, dt_options) and\
+       not status_error:
+        raise error.TestNAError("Current libvirt version doesn't support '%s'"
+                                " for %s" % (dt_options, test_cmd))
 
     # Disk specific attributes.
     device_source_name = params.get("dt_device_device_source", "attach.img")


### PR DESCRIPTION
1.Remove some cases for cdrom test
2.Check if option is supported by libvirt

Signed-off-by: Li Yang liyang.fnst@cn.fujitsu.com
