### PR TITLE
libvirt.test: Fix a typo in update-device test

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_update_device.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_update_device.py
@@ -28,7 +28,7 @@ def create_disk(vm_name, orig_iso, disk_type, target_dev, mode=""):
     try:
         virsh.attach_disk(vm_name, orig_iso, target_dev, options)
     except:
-        os.remote(orig_iso)
+        os.remove(orig_iso)
         raise error.TestFail("Failed to attach")
 
 


### PR DESCRIPTION
Signed-off-by: Li Yang liyang.fnst@cn.fujitsu.com
