### PR TITLE
libvirt.tests: Fix network persistent bug.

### DIFF
--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_create.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_create.py
@@ -153,10 +153,7 @@ def run(test, params, env):
 
         # Recover from backup
         for netxml in backup.values():
-            netxml.create()
-            # autostart = True requires persistent = True first!
-            for state in ['active', 'persistent', 'autostart']:
-                netxml[state] = backup_state[netxml.name][state]
+            netxml.sync(backup_state[netxml.name])
 
         # Close down persistent virsh session (including for all netxml copies)
         vrsh.close_session()

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_define_undefine.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_define_undefine.py
@@ -156,18 +156,7 @@ def run(test, params, env):
 
         # Recover from backup
         for netxml in backup.values():
-            # If network is transient
-            if ((not backup_state[netxml.name]['persistent'])
-                    and backup_state[netxml.name]['active']):
-                netxml.create()
-                continue
-            # autostart = True requires persistent = True first!
-            for state in ['persistent', 'autostart', 'active']:
-                try:
-                    netxml[state] = backup_state[netxml.name][state]
-                except xcepts.LibvirtXMLError, detail:
-                    fail_flag = 1
-                    result_info.append(str(detail))
+            netxml.sync(backup_state[netxml.name])
 
         # Close down persistent virsh session (including for all netxml copies)
         if hasattr(virsh_instance, 'close_session'):


### PR DESCRIPTION
On older libvirt, defining an exist network will cause failure,
but for latest libvirt, it allows to define exist network if
this network is transient.
So on older libvirt, network will be erased after network testing.

Function sync(...) can solve this problem for both versions.
