### PR TITLE
libvirt.tests: Fix missed configurations.

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_setmaxdowntime.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_setmaxdowntime.cfg
@@ -5,9 +5,6 @@
     start_vm = "yes"
     # Set a millsecond for maxdowntime
     migrate_maxdowntime = 1000
-    # Confirm you have prepare dest host for migration
-    # And you should configure autologin to dest host
-    # Then replace EXAMPLE with your dest hostip or hostname
     virsh_migrate_dest_uri = "qemu+ssh://${migrate_dest_host}/system"
     virsh_migrate_src_uri = "qemu+ssh://${migrate_source_host}/system"
     take_regular_screendumps = "no"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_copy_storage.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_copy_storage.py
@@ -11,10 +11,10 @@ def copied_migration(vms, params):
     Migrate vms with storage copied.
     """
     dest_uri = params.get("migrate_dest_uri")
-    remote_host = params.get("remote_ip")
+    remote_host = params.get("migrate_dest_host")
     copy_option = params.get("copy_storage_option", "")
-    username = params.get("remote_user")
-    password = params.get("remote_pwd")
+    username = params.get("migrate_dest_user", "root")
+    password = params.get("migrate_dest_pwd")
     timeout = int(params.get("thread_timeout", 1200))
     options = "--live %s" % copy_option
 
@@ -62,10 +62,10 @@ def run(test, params, env):
     # Convert to Gib
     file_size = int(file_size) / 1073741824
 
-    remote_host = params.get("remote_ip", "REMOTE.EXAMPLE")
-    local_host = params.get("local_ip", "LOCAL.EXAMPLE")
-    remote_user = params.get("remote_user", "root")
-    remote_passwd = params.get("remote_pwd", "PASSWORD.EXAMPLE")
+    remote_host = params.get("migrate_dest_host", "REMOTE.EXAMPLE")
+    local_host = params.get("migrate_source_host", "LOCAL.EXAMPLE")
+    remote_user = params.get("migrate_dest_user", "root")
+    remote_passwd = params.get("migrate_dest_pwd")
     if remote_host.count("EXAMPLE") or local_host.count("EXAMPLE"):
         raise error.TestNAError("Config remote or local host first.")
     # Config ssh autologin for it

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_multi_vms.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_multi_vms.py
@@ -5,7 +5,9 @@ import commands
 import shutil
 import threading
 import time
-from autotest.client.shared import utils, error
+from autotest.client.shared import error
+from autotest.client.shared import utils
+from autotest.client.shared import ssh_key
 from virttest import libvirt_vm, virsh
 
 
@@ -212,6 +214,9 @@ def run(test, params, env):
         raise error.TestNAError("The srcuri '%s' is invalid", srcuri)
     if desturi.count('///') or desturi.count('EXAMPLE'):
         raise error.TestNAError("The desturi '%s' is invalid", desturi)
+
+    # Config ssh autologin for remote host
+    ssh_key.setup_ssh_key(remote_host, host_user, host_passwd, port=22)
 
     # Prepare MigrationHelper instance
     helpers = []

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_set_get_speed.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_set_get_speed.py
@@ -1,5 +1,6 @@
 import logging
 from autotest.client.shared import error, utils
+from autotest.client.shared import ssh_key
 from virttest import virsh, libvirt_vm, utils_test
 from provider import libvirt_version
 from virttest.utils_test import libvirt as utlv
@@ -128,6 +129,18 @@ def run(test, params, env):
         vms = env.get_all_vms()
         src_uri = params.get("migrate_src_uri", "qemu+ssh://EXAMPLE/system")
         dest_uri = params.get("migrate_dest_uri", "qemu+ssh://EXAMPLE/system")
+
+        if src_uri.count('///') or src_uri.count('EXAMPLE'):
+            raise error.TestNAError("The src_uri '%s' is invalid", src_uri)
+
+        if dest_uri.count('///') or dest_uri.count('EXAMPLE'):
+            raise error.TestNAError("The dest_uri '%s' is invalid", dest_uri)
+
+        remote_host = params.get("migrate_dest_host")
+        username = params.get("migrate_dest_user", "root")
+        password = params.get("migrate_dest_pwd")
+        # Config ssh autologin for remote host
+        ssh_key.setup_ssh_key(remote_host, username, password, port=22)
 
         # Check migrated vms' state
         for vm in vms:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_setmaxdowntime.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_setmaxdowntime.py
@@ -2,6 +2,7 @@ import logging
 import threading
 import time
 from autotest.client.shared import error
+from autotest.client.shared import ssh_key
 from virttest import virsh
 
 
@@ -104,6 +105,12 @@ def run(test, params, env):
         raise error.TestNAError("Set your source uri first.")
     if src_uri == dest_uri:
         raise error.TestNAError("You should not set dest uri same as local.")
+
+    remote_host = params.get("migrate_dest_host")
+    username = params.get("migrate_dest_user", "root")
+    password = params.get("migrate_dest_pwd")
+    # Config ssh autologin for remote host
+    ssh_key.setup_ssh_key(remote_host, username, password, port=22)
 
     setmmdt_dargs = {'debug': True, 'ignore_status': True, 'uri': src_uri}
     migrate_dargs = {'debug': True, 'ignore_status': True}

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_stress.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_stress.py
@@ -110,9 +110,9 @@ def run(test, params, env):
     migration_type = params.get("migration_type")
     start_migration_vms = "yes" == params.get("start_migration_vms", "yes")
     thread_timeout = int(params.get("thread_timeout", 120))
-    remote_host = params.get("remote_ip")
-    username = params.get("remote_user", "root")
-    password = params.get("remote_pwd")
+    remote_host = params.get("migrate_dest_host")
+    username = params.get("migrate_dest_user", "root")
+    password = params.get("migrate_dest_pwd")
     prompt = params.get("shell_prompt", r"[\#\$]")
 
     # Set vm_bytes for start_cmd


### PR DESCRIPTION
1.Some parameters for migration were not replaced by new parameters in base.cfg.
2.Create ssh-autologin for migration tests.

Signed-off-by: Yu Mingfei yumingfei@cn.fujitsu.com
