### PR TITLE
libvirt.test: Fix hide bug in volume application test

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/volume/virsh_volume_application.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/volume/virsh_volume_application.cfg
@@ -3,6 +3,7 @@
     take_regular_screendumps = no
     volume_count = 1
     volume_size = "1G"
+    kill_vm = "yes"
     variants:
         - dir:
             pool_type = "dir"
@@ -35,7 +36,6 @@
             application = "install"
             volume_size = 10G
             start_vm = no
-            kill_vm = yes
             image_size_stg = ${volume_size}
             image_size = ${volume_size}
             install_timeout = 1800
@@ -45,3 +45,5 @@
             application = "attach"
             disk_target = "vdb"
             test_message = "This is a test message"
+            kill_vm_before_test = yes
+            kill_vm_on_error = yes


### PR DESCRIPTION
Without this modification, when the first case is over,
the domain is still running, and it will cause failure
on next case.

Signed-off-by: Li Yang liyang.fnst@cn.fujitsu.com
