### PR TITLE
libvirt.test: Fix a bug for attach-device

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_device.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_device.cfg
@@ -59,6 +59,7 @@
                     variants:
                         - persistent:
                             vadu_extra = "--persistent"
+                            vadu_config_option = "no"
                         - config:
                             vadu_config_option = "yes"
                 - cold_attach_hot_vm:


### PR DESCRIPTION
In old libvirt version, '--config' and '--persistent'
cannot be used together. and we'd better test them
separately.

Signed-off-by: Li Yang liyang.fnst@cn.fujitsu.com
