### PR TITLE
libvirt.test: Modify target_uri param to use remote_ip

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_uri.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_uri.cfg
@@ -12,7 +12,7 @@
                     target_uri = "qemu:///system"
                 - connect_to_remote:
                     uri_remote_ref = "remote"
-                    target_uri = "qemu://TARGET_HOSTNAME.EXAMPLE.COM/system"
+                    target_uri = "qemu+ssh://${remote_ip}/system"
         - unexpect_option:
             virsh_uri_options = "xyz"
             status_error = "yes"


### PR DESCRIPTION
Signed-off-by: Li Yang liyang.fnst@cn.fujitsu.com
