### PR TITLE
vol_clone_wipe: Fix dependence of scrub

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_clone_wipe.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_clone_wipe.cfg
@@ -11,7 +11,6 @@
     new_vol_name = "clone_vol_1"
     vol_format = "qcow2"
     vol_capability = "10M"
-    wipe_algorithms = "zero nnsa dod bsi gutmann schneier pfitzner7 pfitzner33 random"
     clone_status_error = "no"
     wipe_status_error = "no"
     variants:


### PR DESCRIPTION
1) Using an algorithm other than `zero` when doing `vol-wipe` needs `scrub`
package. This fix check the existence of `scrub`. If fails, it logs a warning
message and using `zero` algorithm instead.

2) Skip related test if libvirt don't support option --prealloc-metadata.

Signed-off-by: Hao Liu hliu@redhat.com
