### PR TITLE
virsh_migrate_copy_storage: Remove the redundant clean method

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_copy_storage.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_copy_storage.py
@@ -164,7 +164,6 @@ def run(test, params, env):
         if disks_count and vm.name == new_vm_name:
             vm.undefine()
         for disk in added_disks_list:
-            utlv.delete_local_disk(disk_type, disk)
             rdm.remove_path(disk_type, disk)
         rdm.remove_path("file", file_path)
         if disk_type == "lvm":


### PR DESCRIPTION
Both delete_local_disk() and remove_path() do the same job to remove
file/logical volume, so remove one of them.

Signed-off-by: Yanbing Du ydu@redhat.com
