### PR TITLE
Iscsidev: Skip the test if dependence is missing

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk.py
@@ -150,6 +150,9 @@ def run(test, params, env):
             iscsi_dev = qemu_storage.Iscsidev(params, test.virtdir, "iscsi")
             device_source = iscsi_dev.setup()
             logging.debug("iscsi dev name: %s" % device_source)
+        except ValueError, details:
+            raise error.TestNAError("Can find dependent binary in host: "
+                                    "%s" % details)
         except error.TestError:
             # We should skip this case
             raise error.TestNAError("Can not get iscsi device name in host")

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk_lxc.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk_lxc.py
@@ -59,6 +59,9 @@ def run(test, params, env):
             device_source = iscsi_dev.setup()
             logging.debug("iscsi dev name: %s" % device_source)
             test_block_dev = True
+        except ValueError, details:
+            raise error.TestNAError("Can find dependent binary in host: "
+                                    "%s" % details)
         except error.TestError:
             # We should skip this case
             raise error.TestNAError("Can not get iscsi device name in host")

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device.py
@@ -164,10 +164,13 @@ def run(test, params, env):
             iscsi_dev = qemu_storage.Iscsidev(params, test.virtdir, "iscsi")
             device_source = iscsi_dev.setup()
             logging.debug("iscsi dev name: %s" % device_source)
-        except ValueError, detail:
+        except ValueError, details:
+            raise error.TestNAError("Can find dependent binary in host: "
+                                    "%s" % details)
+        except error.TestError, details:
             # We should skip this case
             raise error.TestNAError("Can not get iscsi device name in host: %s"
-                                    % detail)
+                                    % details)
     else:
         create_device_file(device_source)
 

--- a/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
@@ -118,10 +118,17 @@ def run(test, params, env):
 
         elif disk_format == "iscsi":
             # Create iscsi device if needed.
-            disk_dev = qemu_storage.Iscsidev(params, os.path.dirname(path),
-                                             "iscsi")
-            device_source = disk_dev.setup()
-            logging.debug("iscsi dev name: %s", device_source)
+            try:
+                disk_dev = qemu_storage.Iscsidev(params, os.path.dirname(path),
+                                                 "iscsi")
+                device_source = disk_dev.setup()
+                logging.debug("iscsi dev name: %s", device_source)
+            except ValueError, details:
+                raise error.TestNAError("Can find dependent binary in host: "
+                                        "%s" % details)
+            except error.TestError:
+                # We should skip this case
+                raise error.TestNAError("Can not get iscsi device name in host")
 
             # Format the disk and make file system.
             open("/tmp/fdisk-cmd", "w").write("n\np\n\n\n\nw\n")


### PR DESCRIPTION
If binaries like `tgtadm` is not found on the host, we should skip the
test.

Signed-off-by: Hao Liu hliu@redhat.com
