### PR TITLE
start: Prevent grep its own process

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_start.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_start.py
@@ -131,7 +131,7 @@ def run(test, params, env):
                                          "closed.")
             elif opt.count("force-boot"):
                 session = vm.wait_for_login()
-                status = session.cmd_status("ps %s |grep 'sleep 1000'"
+                status = session.cmd_status("ps %s |grep '[s]leep 1000'"
                                             % sleep_pid)
                 if not status:
                     raise error.TestFail("VM was started with --force-boot,"


### PR DESCRIPTION
Although confined by the process id, there is still a great probability
(~10%) `grep` can sieze its owner process because the predictable
process count of a newly started OS, like:

```
2014-08-12 11:12:59: [root@localhost ~]# ps 241 |grep 'sleep 1000'
2014-08-12 11:12:59:   241 pts/0    S+     0:00 grep --color=auto sleep 1000
```

This patch uses a trick to solve this problem.

Signed-off-by: Hao Liu hliu@redhat.com
