### PR TITLE
libvirt_scsi: Fix some bugs.

### DIFF
--- a/libvirt/tests/cfg/libvirt_scsi.cfg
+++ b/libvirt/tests/cfg/libvirt_scsi.cfg
@@ -2,7 +2,7 @@
     type = libvirt_scsi
     start_vm = no
     # Enter a partition name for partition case in scsi test.
-    libvirt_scsi_partition = "/dev/sda7"
+    libvirt_scsi_partition = "ENTER.YOUR.AVAILABLE.PARTITION"
     status_error = no
     variants:
         - disk_type_img:


### PR DESCRIPTION
1) Use `EXAMPLE*` for disk device type.
2) Raise `TestNAError` when dependent `mkisofs` don't exists.
3) Cleanup image files after test.
4) Check partition first to skip before other disk image are
   created.

Signed-off-by: Hao Liu hliu@redhat.com
