### PR TITLE
Add test for option libvirtd_config in sysconfig file

### DIFF
--- a/libvirt/tests/cfg/conf_file/sysconfig_libvirtd/libvirtd_config.cfg
+++ b/libvirt/tests/cfg/conf_file/sysconfig_libvirtd/libvirtd_config.cfg
@@ -1,0 +1,16 @@
+- conf_file.sysconfig_libvirtd.libvirtd_config:
+    type = libvirtd_config
+    expected_result = unchanged
+    start_vm = yes
+    variants:
+        - positive_test:
+            variants:
+                - default:
+                - set:
+                    expected_result = changed
+                    libvirtd_config = exist_file
+        - negative_test:
+            variants:
+                - invalid:
+                    expected_result = unbootable
+                    libvirtd_config = /invalid/file

--- a/libvirt/tests/src/conf_file/sysconfig_libvirtd/libvirtd_config.py
+++ b/libvirt/tests/src/conf_file/sysconfig_libvirtd/libvirtd_config.py
@@ -1,0 +1,81 @@
+import os
+import logging
+from virttest import utils_config
+from virttest import utils_libvirtd
+from virttest import data_dir
+from virttest.libvirt_xml import capability_xml
+from autotest.client.shared import error
+
+
+def run(test, params, env):
+    """
+    Test libvirtd_config parameter in /etc/sysconfig/libvirtd.
+
+    1) Change libvirtd_config in sysconfig;
+    2) Change host_uuid in newly defined libvirtd.conf file;
+    3) Restart libvirt daemon;
+    4) Check if libvirtd successfully started;
+    5) Check if host_uuid updated accordingly;
+    """
+    def get_init_name():
+        """
+        Internal function to determine what executable is PID 1,
+        :return: executable name for PID 1, aka init
+        """
+        fp = open('/proc/1/comm')
+        name = fp.read().strip()
+        fp.close()
+        return name
+
+    libvirtd_config = params.get('libvirtd_config', 'not_set')
+    expected_result = params.get('expected_result', 'success')
+
+    if get_init_name() == 'systemd':
+        logging.info('Init process is systemd, '
+                     'LIBVIRTD_CONFIG should not working.')
+        expected_result = 'unchanged'
+
+    sysconfig = utils_config.LibvirtdSysConfig()
+    libvirtd = utils_libvirtd.Libvirtd()
+    config_path = ""
+    check_uuid = '13371337-1337-1337-1337-133713371337'
+    try:
+        if libvirtd_config == 'not_set':
+            del sysconfig.LIBVIRTD_CONFIG
+        elif libvirtd_config == 'exist_file':
+            config_path = os.path.join(data_dir.get_tmp_dir(), 'test.conf')
+            open(config_path, 'a').close()
+
+            config = utils_config.LibvirtdConfig(config_path)
+            config.host_uuid = check_uuid
+
+            sysconfig.LIBVIRTD_CONFIG = config_path
+        else:
+            sysconfig.LIBVIRTD_CONFIG = libvirtd_config
+
+        if not libvirtd.restart():
+            if expected_result != 'unbootable':
+                raise error.TestFail('Libvirtd is expected to be started '
+                                     'with LIBVIRTD_CONFIG = '
+                                     '%s' % sysconfig.LIBVIRTD_CONFIG)
+        if expected_result == 'unbootable':
+            raise error.TestFail('Libvirtd is not expected to be started '
+                                 'with LIBVIRTD_CONFIG = '
+                                 '%s' % sysconfig.LIBVIRTD_CONFIG)
+        cur_uuid = capability_xml.CapabilityXML()['uuid']
+        if cur_uuid == check_uuid:
+            if expected_result == 'unchange':
+                raise error.TestFail('Expected host UUID is not changed, '
+                                     'but got %s' % cur_uuid)
+        else:
+            if expected_result == 'change':
+                raise error.TestFail('Expected host UUID is %s, but got %s' %
+                                     (check_uuid, cur_uuid))
+
+    finally:
+        if libvirtd_config == 'exist_file':
+            config.restore()
+            if os.path.isfile(config_path):
+                os.remove(config_path)
+        sysconfig.restore()
+        libvirtd.restart()


### PR DESCRIPTION
Test libvirtd_config parameter in /etc/sysconfig/libvirtd.

1) Change libvirtd_config in sysconfig;
2) Change host_uuid in newly defined libvirtd.conf file;
3) Restart libvirt daemon;
4) Check if libvirtd successfully started;
5) Check if host_uuid updated accordingly;

Signed-off-by: Hao Liu hliu@redhat.com
