### PR TITLE
setvcpus: Case update and add new cases

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_setvcpus.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_setvcpus.cfg
@@ -4,7 +4,8 @@
     setvcpus_pre_vm_state = "null"
     setvcpus_vm_ref = "name"
     setvcpus_count = "1"
-    setvcpus_current = "0"
+    setvcpus_current = "1"
+    setvcpus_max = "4"
     setvcpus_extra_param = ""
     setvcpus_options = ""
     variants:
@@ -14,8 +15,7 @@
                 - guest_on:
                     variants:
                         -add:
-                            # less than setvcpus_count
-                            setvcpus_current = "1"
+                            # less than setvcpus_max
                             setvcpus_count = "2"
                         -del:
                     variants:
@@ -47,7 +47,7 @@
                             setvcpus_options = "--current"
                         - option_maximum_config:
                             setvcpus_options = "--maximum --config"
-                            setvcpus_count = "4"
+                            setvcpus_count = "5"
                         - exceeding_topology_limit:
                             setvcpus_pre_vm_state = "shut off"
                             set_topology = "yes"
@@ -86,8 +86,8 @@
                     setvcpus_count = ""
                 - invalid_vcpu_count_is_0:
                     setvcpus_count = "0"
-                - invalid_vcpu_count_is_3:
-                    setvcpus_count = "3"
+                - invalid_vcpu_count_is_5:
+                    setvcpus_count = "5"
                 - shut_off_error_option:
                     setvcpus_pre_vm_state = "shut off"
                     variants:
@@ -99,3 +99,7 @@
                             setvcpus_options = "--current --config"
                 - maximum_option:
                     setvcpus_options = "--maximum --live"
+                - no_acpi_feature:
+                    remove_vm_feature = "acpi"
+                    setvcpus_current = "3"
+                    setvcpus_count = "4"


### PR DESCRIPTION
1. The original test hard code the maximum vcpu number to 2, and the
   test steps are not clear and maintain, so re-organize the case to make
   it more clear.
2. Add a case to test vcpu hotplug without <acpi> feature
3. Add a case to test maximum CPUs exceeding topology limit.

Signed-off-by: Yanbing Du ydu@redhat.com
