### PR TITLE
dac_nfs_disk: Add test cases for domain vol on netfs pool

### DIFF
--- a/libvirt/tests/cfg/svirt/dac_nfs_disk.cfg
+++ b/libvirt/tests/cfg/svirt/dac_nfs_disk.cfg
@@ -18,7 +18,7 @@
     qemu_group = "qemu"
     img_user = 0
     img_group = 0
-    img_mode = 666
+    img_mode = 438
     variants:
         - root_squash:
             export_options= "rw,root_squash"
@@ -52,6 +52,10 @@
         - nfs_img_oth:
             # stat.S_IRUSR|stat.S_IWUSR|stat.S_IRGRP|stat.S_IWGRP|stat.S_IROTH|stat.S_IWOTH
             img_mode = 438
+        - snapshot_nfs_backing:
+            only no_root_squash..dynamic_ownership_on..qemu_user
+            bk_file_name = "new_backing_vol"
+            image_name_backing_file = ${vol_name}
     variants:
         - positive_test:
             status_error = no


### PR DESCRIPTION
Test start domain with netfs pool vol, while netfs server exportfs
with root_squash, no_root_squash and ro options.

The test scenarios including:
1. ro: domain will fail to start with nfs vol.
2. no_root_squash: start domain depends on the nfs file ownership,
   user, group and dynamic_ownership option in qemu.conf.
3. root_squash: start domain depends on the nfs file ownership,
   user and group option in qemu.conf.

Signed-off-by: Wayne Sun gsun@redhat.com
