### PR TITLE
libvirt.tests: Support value for --timeout in .cfg files for virsh migrate.

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_set_get_speed.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_set_get_speed.cfg
@@ -42,6 +42,8 @@
             # Allowed delta between two time of migration
             # Migration may be disturbed by environment!
             allowed_delta = 0.2
+            # value for "virsh migrate --timeout %s"
+            virsh_migrate_timeout = 60
             # Add load vms accroding your need
             load_vms = "${migrate_load_vms}"
             variants:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_stress.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_stress.cfg
@@ -15,6 +15,8 @@
     migrate_dest_uri = "qemu+ssh://${migrate_dest_host}/system"
     migrate_src_uri = "qemu+ssh://${migrate_source_host}/system"
     thread_timeout = 120
+    # value for "virsh migrate --timeout %s"
+    virsh_migrate_timeout = 60
     variants:
         - set_vcpu_1:
             smp = 2

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_multi_vms.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_multi_vms.py
@@ -74,6 +74,7 @@ class MigrationHelper(object):
                                 env.get("address_cache"))
         self.virsh_instance = None
         self.migration_cmd = None
+        self.virsh_migrate_timeout = int(params.get("virsh_migrate_timeout", 60))
 
     def __str__(self):
         return "Migration VM %s, Command '%s'" % (self.vm_name,
@@ -89,13 +90,13 @@ class MigrationHelper(object):
         #rvirsh = virsh.VirshConnectBack(**rs_dargs)
         self.virsh_instance = virsh.VirshPersistent()
 
-    def set_migration_cmd(self, options, method, desturi, timeout=60):
+    def set_migration_cmd(self, options, method, desturi):
         """
         Set command for migration.
         """
         self.migration_cmd = make_migration_cmd(
             self.vm_name, method, desturi,
-            make_migration_options(options, timeout))
+            make_migration_options(options, self.virsh_migrate_timeout))
 
     def cleanup_vm(self, srcuri, desturi):
         """

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_set_get_speed.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_set_get_speed.py
@@ -159,6 +159,9 @@ def run(test, params, env):
         migration_type = params.get("migration_type", "orderly")
         thread_timeout = int(params.get("thread_timeout", "60"))
         delta = float(params.get("allowed_delta", "0.1"))
+        virsh_migrate_timeout = int(params.get("virsh_migrate_timeout", "60"))
+        # virsh migrate options
+        virsh_migrate_options = "--live --timeout %s" % virsh_migrate_timeout
         # Migrate vms to remote host
         mig_first = utlv.MigrationTest()
         virsh_dargs = {"debug": True}
@@ -167,7 +170,7 @@ def run(test, params, env):
             vm.wait_for_login()
         utils_test.load_stress(stress_type, vms, params)
         mig_first.do_migration(vms, src_uri, dest_uri, migration_type,
-                               options="--live", thread_timeout=thread_timeout)
+                               options=virsh_migrate_options, thread_timeout=thread_timeout)
         for vm in vms:
             mig_first.cleanup_dest_vm(vm, None, dest_uri)
             # Keep it clean for second migration
@@ -195,7 +198,7 @@ def run(test, params, env):
         utils_test.load_stress(stress_type, vms, params)
         mig_second = utlv.MigrationTest()
         mig_second.do_migration(vms, src_uri, dest_uri, migration_type,
-                                options="--live", thread_timeout=thread_timeout)
+                                options=virsh_migrate_options, thread_timeout=thread_timeout)
         for vm in vms:
             mig_second.cleanup_dest_vm(vm, None, dest_uri)
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_stress.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_stress.py
@@ -77,7 +77,8 @@ def do_stress_migration(vms, srcuri, desturi, stress_type,
         logging.warning("Add stress for migration failed:%s", fail_info)
 
     logging.debug("Starting migration...")
-    migtest.do_migration(vms, srcuri, desturi, migration_type, options=options,
+    migrate_options = "--live --timeout %s" % params.get("virsh_migrate_timeout", 60)
+    migtest.do_migration(vms, srcuri, desturi, migration_type, options=migrate_options,
                          thread_timeout=thread_timeout)
 
     # vms will be shutdown, so no need to do this cleanup


### PR DESCRIPTION
Migrate with stress may cost more than the old default value for
"virsh migrate --timeout", which was 60 and was assigned in the .py files.
This patch provides "virsh_migrate_timeout" param in .cfg files.
