### PR TITLE
virtual_disks_multivms: Add test case for shared readonly iso img

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_multivms.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_multivms.cfg
@@ -71,15 +71,31 @@
         - vms_sharable_test:
             only coldplug
             virt_disk_test_shareable = "yes"
-            virt_disk_bus = "virtio"
-            virt_disk_target = "vdb"
-            virt_disk_type = "block"
-            virt_disk_format = "iscsi"
+            image_size = "100M"
             virt_disk_vms_share = "shareable shareable"
-            disk_driver_options = "type=raw,cache=writeback,io=native"
-            image_size = "100M" 
+            variants:
+                - block_type:
+                    virt_disk_bus = "virtio"
+                    virt_disk_target = "vdb"
+                    virt_disk_type = "block"
+                    virt_disk_format = "iscsi"
+                    disk_driver_options = "type=raw,cache=writeback,io=native"
+                - file_type:
+                    virt_disk_type = "file"
+                    virt_disk_target = "vdb"
+                    virt_disk_bus = "virtio"
+                    virt_disk_format = "qcow2"
+        - vms_readonly_test:
+            only coldplug
+            virt_disk_test_readonly = "yes"
+            virt_disk_bus = "ide"
+            virt_disk_target = "hdc"
+            virt_disk_type = "file"
+            virt_disk_device = "cdrom"
+            virt_disk_vms_readonly = "readonly readonly"
+            image_size = "100M"
     variants:
         - hotplug:
             virt_disk_vms_hotplug = "yes"
         - coldplug:
-            virt_disk_vms_hotplug = "no"    
+            virt_disk_vms_hotplug = "no"


### PR DESCRIPTION
Add test case for readonly iso for multiple vms, also add check
with seclabel of shared img and iso.

Signed-off-by: Wayne Sun gsun@redhat.com
