### PR TITLE
svirt_start_destroy: Add test cases for baselabel

### DIFF
--- a/libvirt/tests/cfg/svirt/svirt_start_destroy.cfg
+++ b/libvirt/tests/cfg/svirt/svirt_start_destroy.cfg
@@ -18,50 +18,67 @@
                     security_require_confined = 1
         - without_qemu_conf:
     variants:
-        - no_sec_model:
+        - no_model:
             no_sec_model = 'yes'
-        - multiple_sec_model:
+        - multi_model:
             svirt_start_destroy_vm_sec_model = "selinux,dac"
-        - default_sec_model:
+        - default_model:
     variants:
-        - sec_type_dynamic:
+        - st_dynamic:
             svirt_start_destroy_vm_sec_type = "dynamic"
-        - sec_type_static:
-            no no_sec_model
+        - st_static:
+            no no_model
             svirt_start_destroy_vm_sec_type = "static"
-        - sec_type_none:
-            no no_sec_model
+        - st_none:
+            no no_model
             svirt_start_destroy_vm_sec_type = "none"
     variants:
-        - sec_relabel_no:
+        - relabel_no:
             svirt_start_destroy_vm_sec_relabel = no
-        - sec_relabel_yes:
-            no sec_type_none, multiple_sec_model
+        - relabel_yes:
+            no st_none, multi_model
             svirt_start_destroy_vm_sec_relabel = yes
     variants:
-        - disk_label_virt_content:
-            no no_sec_model, sec_type_none
+        - d_virt_content:
+            no no_model, st_none
             svirt_start_destroy_disk_label = "system_u:object_r:virt_content_t:s0"
-        - disk_label_svirt_image_s0:
+        - d_svirt_img_s0:
             svirt_start_destroy_disk_label = "system_u:object_r:svirt_image_t:s0"
-        - disk_label_svirt_image_MCS1:
-            no no_sec_model, sec_type_none
+            variants:
+                - no_baselabel:
+                - with_baselabel:
+                    only default_model..st_dynamic
+                    variants:
+                        - legit:
+                            svirt_start_destroy_vm_sec_baselabel = "system_u:system_r:svirt_t:s0"
+                        - mess_MCS:
+                            svirt_start_destroy_vm_sec_baselabel = "system_u:system_r:svirt_t:xxxxxx"
+                        - mess_t:
+                            svirt_start_destroy_vm_sec_baselabel = "system_u:system_r:xxxxxx:s0"
+                        - mess_u_r:
+                            svirt_start_destroy_vm_sec_baselabel = "xxxxxx:xxxxxx:svirt_t:s0"
+                        - invalid_str:
+                            svirt_start_destroy_vm_sec_baselabel = "xxxxxx"
+        - d_svirt_img_MCS:
+            no no_model, st_none
             svirt_start_destroy_disk_label = "system_u:object_r:svirt_image_t:s0:c87,c520"
     variants:
-        - poweroff_with_destroy:
+        - off_destroy:
             svirt_start_destroy_vm_poweroff = "destroy"
-        - poweroff_with_shutdown:
-            no no_sec_model, sec_type_none, with_qemu_conf
+        - off_shutdown:
+            no no_model, st_none, with_qemu_conf, with_baselabel
             svirt_start_destroy_vm_poweroff = "shutdown"
     variants:
         - positive_test:
             status_error = no
-            no default_sec_model..sec_type_dynamic..sec_relabel_no, multiple_sec_model..sec_type_dynamic..sec_relabel_no, multiple_sec_model..sec_type_static..sec_relabel_no, sec_relabel_no..sec_type_dynamic..no_sec_model
-            no sec_relabel_no..disk_label_virt_content, security_driver_none..default_sec_model, security_driver_none..multiple_sec_model..sec_type_none, unconfined..sec_relabel_yes, sec_type_dynamic..multiple_sec_model..unconfined, sec_type_static..multiple_sec_model..unconfined, required_confined
+            no default_model..st_dynamic..relabel_no, multi_model..st_dynamic..relabel_no, multi_model..st_static..relabel_no, relabel_no..st_dynamic..no_model
+            no relabel_no..d_virt_content, security_driver_none..default_model, security_driver_none..multi_model..st_none, unconfined..relabel_yes, st_dynamic..multi_model..unconfined, st_static..multi_model..unconfined, required_confined, mess_t, invalid_str
         - negative_test:
             # only when seclabel of VM is not relabeled and
             # img is labeld with "system_u:object_r:virt_content_t:s0",
             # VM will not be able to access image.
             status_error = yes
-            no sec_relabel_no..sec_type_dynamic, poweroff_with_shutdown..disk_label_virt_content, sec_type_dynamic..without_qemu_conf, sec_relabel_yes..sec_type_static..unconfined, sec_relabel_yes..sec_type_dynamic..unconfined, sec_relabel_yes..sec_type_static..without_qemu_conf, disk_label_virt_content..required_confined
-            only default_sec_model..disk_label_virt_content, default_sec_model..security_driver_none, security_driver_none..multiple_sec_model..sec_type_none, sec_type_none..required_confined
+            no relabel_no..st_dynamic, legit, mess_MCS, mess_u_r
+            no off_shutdown..d_virt_content, relabel_yes..st_static..unconfined, relabel_yes..st_dynamic..unconfined, relabel_yes..st_static..without_qemu_conf, d_virt_content..required_confined
+            no d_virt_content.relabel_yes.st_dynamic.default_model.without_qemu_conf, with_baselabel.mess_t.relabel_yes.st_dynamic.default_model.with_qemu_conf.security_driver_none, with_baselabel.invalid_str.relabel_yes.st_dynamic.default_model.with_qemu_conf.security_driver_none
+            only mess_t..without_qemu_conf, invalid_str..without_qemu_conf, default_model..d_virt_content, default_model..security_driver_none, security_driver_none..multi_model..st_none, st_none..required_confined

--- a/libvirt/tests/src/svirt/svirt_start_destroy.py
+++ b/libvirt/tests/src/svirt/svirt_start_destroy.py
@@ -25,6 +25,7 @@ def run(test, params, env):
     sec_type = params.get("svirt_start_destroy_vm_sec_type", "dynamic")
     sec_model = params.get("svirt_start_destroy_vm_sec_model", "selinux")
     sec_label = params.get("svirt_start_destroy_vm_sec_label", None)
+    sec_baselabel = params.get("svirt_start_destroy_vm_sec_baselabel", None)
     security_driver = params.get("security_driver", None)
     security_default_confined = params.get("security_default_confined", None)
     security_require_confined = params.get("security_require_confined", None)
@@ -32,20 +33,27 @@ def run(test, params, env):
     sec_relabel = params.get("svirt_start_destroy_vm_sec_relabel", "yes")
     sec_dict = {'type': sec_type, 'relabel': sec_relabel}
     sec_dict_list = []
+
+    def _set_sec_model(model):
+        """
+        Set sec_dict_list base on given sec model type
+        """
+        sec_dict_copy = sec_dict.copy()
+        sec_dict_copy['model'] = model
+        if sec_type != "none":
+            if sec_type == "dynamic" and sec_baselabel:
+                sec_dict_copy['baselabel'] = sec_baselabel
+            else:
+                sec_dict_copy['label'] = sec_label
+        sec_dict_list.append(sec_dict_copy)
+
     if not no_sec_model:
         if "," in sec_model:
             sec_models = sec_model.split(",")
             for model in sec_models:
-                sec_dict['model'] = model
-                if sec_type != "none":
-                    sec_dict['label'] = sec_label
-                sec_dict_copy = sec_dict.copy()
-                sec_dict_list.append(sec_dict_copy)
+                _set_sec_model(model)
         else:
-            sec_dict['model'] = sec_model
-            if sec_type != "none":
-                sec_dict['label'] = sec_label
-            sec_dict_list.append(sec_dict)
+            _set_sec_model(sec_model)
     else:
         sec_dict_list.append(sec_dict)
 


### PR DESCRIPTION
Add test cases for selinux baselabel, also simplify filter names
in cfg.

Signed-off-by: Wayne Sun gsun@redhat.com
