### PR TITLE
libvirtd_start: Add case for only stop iptables

### DIFF
--- a/libvirt/tests/cfg/libvirtd_start.cfg
+++ b/libvirt/tests/cfg/libvirtd_start.cfg
@@ -9,3 +9,4 @@
         # prior to firewalld-0.3.9-7.el7.
         # https://bugzilla.redhat.com/show_bug.cgi?id=1070683
         - with_firewalld:
+        - stop_iptables:


### PR DESCRIPTION
The new started libvirtd subprocess will lack permission on iptables
operation as not with selinux type 'virt_t', the iptables error in
libvirtd log is expected if found.

Signed-off-by: Wayne Sun gsun@redhat.com
