### PR TITLE
timer_management: Re-write test and add more cases

### DIFF
--- a/libvirt/tests/cfg/timer_management.cfg
+++ b/libvirt/tests/cfg/timer_management.cfg
@@ -7,20 +7,19 @@
     # Timestamp may have small devition(seconds)
     allowed_delta = "50"
     variants:
-        - all_timers_in_vm:
-            only Linux
-            # Test all available timers in vm
-            timer_type = "all_timers"
-        - banned_timer:
-            only Linux
-            # Check whether banned timer exists
-            timer_type = "banned_timer"
-        - windows_timer:
-            timer_type = "windows_timer"
-            only Windows
+        - test_timers_in_vm:
+            timer_test_type = "test_timers_in_vm"
+            variants:
+                - linux_guest:
+                    only Linux
+                - windows_guest:
+                    only Windows
+                    windows_test = "yes"
+        - test_specific_timer:
+            timer_test_type = "test_specific_timer"
     variants:
         - under_stress:
-            only offset_utc..all_timers_in_vm
+            only offset_utc..test_timers_in_vm
             # Add some stress operations when testing
             variants:
                 - stress_in_vm:
@@ -62,30 +61,49 @@
         - offset_localtime:
             clock_offset = "localtime"
     variants:
-        # Setting of timer elements in libvirt XML
         - no_timer:
-            no banned_timer
-            xml_timer = "no"
-        - ban_xml_timer:
-            only banned_timer
+            no test_specific_timer
+            specific_timer = "no"
+        - specific_timer:
+            only test_specific_timer
             # Start vm here to login and get available
             # clocksources before banning
             start_vm = "yes"
-            xml_timer = "yes"
+            specific_timer = "yes"
+            variants:
+                - present_no:
+                    timer_present = "no"
+                - present_yes:
+                    timer_present = "yes"
+                - present_mix:
+                    # Mix 'present' in test case
+                    only multi_timers
+                    timer_present = "mix"
             variants:
                 - kvmclock:
-                    # This parameter means timers' name in vm
-                    banned_timer = "kvm-clock"
-                    timers_attr = "name=kvmclock;present=no"
-                - tsc:
-                    timer_start_error = "yes"
-                    banned_timer = "tsc"
-                    timers_attr = "name=tsc;present=no"
+                    # Support hypervisor: qemu
+                    timer_name = 'kvmclock'
                 - hpet:
+                    # Support hypervisor: libxl, xen, qemu
+                    timer_name = "hpet"
+                - pit:
+                    # Support hypervisor: qemu
+                    timer_name = 'pit'
+                - rtc:
+                    # Support hypervisor: qemu
+                    timer_name = 'rtc'
+                - multi_timers:
+                    variants:
+                        - pit_rtc:
+                            timer_name = 'pit,rtc'
+                        - hpet_tsc:
+                            timer_name = 'hpet,tsc'
+                            timer_start_error = "yes"
+                - tsc:
+                    # Support hypervisor: libxml
+                    timer_name = "tsc"
                     timer_start_error = "yes"
-                    banned_timer = "hpet"
-                    timers_attr = "name=hpet;present=no"
                 - platform:
+                    # currently unsupported
+                    timer_name = "platform"
                     timer_start_error = "yes"
-                    banned_timer = "acpi_pm"
-                    timers_attr = "name=platform;present=no"


### PR DESCRIPTION
1. No need test all VMs on the host, run cases against one VM is enough.
2. Merge functions which has similar structures and steps.
3. Add more cases to cover specific timer name and 'present' value.

Signed-off-by: Yanbing Du ydu@redhat.com
