### PR TITLE
libvirt.tests: fix missed items and typo in test configuration of the remote access cases

### DIFF
--- a/libvirt/tests/cfg/remote_access/remote_with_tls.cfg
+++ b/libvirt/tests/cfg/remote_access/remote_with_tls.cfg
@@ -170,6 +170,8 @@
                     server_ifname = "ENTER.YOUR.SERVER.IFACE.NAME"
                     server_ipv6_addr = "${ipv6_addr_des}/${ip_addr_suffix}"
                     listen_addr = "${ipv6_addr_des}"
+                    server_cn = "${ipv6_addr_des}"
+                    client_cn = "${ipv6_addr_src}"
                     read_only = "-r"
                     virsh_cmd = "start"
                     # VM is on remote host, so don't need to deal with it on the local

--- a/libvirt/tests/cfg/remote_access/remote_with_unix.cfg
+++ b/libvirt/tests/cfg/remote_access/remote_with_unix.cfg
@@ -105,7 +105,7 @@
                     virsh_cmd = "start"
                     main_vm = "virt-tests-vm1"
                     status_error = "no"
-                    patterns_virsh_cmd = ".*forbidden\s*for\s*read\s*only\s*access.*"
+                    patterns_virsh_cmd = ".*forbidden:\s*read\s*only\s*access.*"
                 - socket_access_controls:
                     auth_unix_ro = "none"
                     auth_unix_rw = "none"


### PR DESCRIPTION
As subject.
