### PR TITLE
Catch all Exceptions if guest crashed and fix command for tty1 process c...

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_sendkey.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_sendkey.py
@@ -79,7 +79,7 @@ def run(test, params, env):
 
     try:
         # wait for tty1 started
-        tty1_stat = "ps aux|grep [/]sbin/.*tty.*tty1"
+        tty1_stat = "ps aux|grep tty[1]"
         timeout = 60
         while timeout >= 0 and \
                 session.get_command_status(tty1_stat) != 0:


### PR DESCRIPTION
```
1. Move test steps into try..finally block, so the env can restore in
any reason fail.
2. When crash guest via session command, it may raise 2 type Exceptions,
so catch them all to pass this step.
3. If the guest started with X window, the old grep keyword can not find
the tty1 process, so just use 'tty1' keyword for the checking.
```

Signed-off-by: Yanbing Du ydu@redhat.com
