### PR TITLE
dompmsuspend: Add acl test case for pm-control

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_dompmsuspend.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_dompmsuspend.cfg
@@ -21,6 +21,15 @@
                     #bug928672
                     pm_suspend_target = mem
                     test_save_restore = yes
+            variants:
+                - non_acl:
+                - acl_test:
+                    no save_restore
+                    setup_libvirt_polkit = "yes"
+                    action_id = "org.libvirt.api.domain.pm-control"
+                    action_lookup = "connect_driver:QEMU domain_name:virt-tests-vm1"
+                    unprivileged_user = "EXAMPLE"
+                    virsh_uri = "qemu:///system"
         - negative_test:
             pm_suspend_target = mem
             pm_enabled = yes
@@ -33,3 +42,8 @@
                     pm_enabled = not_set
                 - pm_disabled:
                     pm_enabled = no
+                - acl_test:
+                    pmsuspend_error = "yes"
+                    setup_libvirt_polkit = "yes"
+                    unprivileged_user = "EXAMPLE"
+                    virsh_uri = "qemu:///system"


### PR DESCRIPTION
Add the test cases for cover api pm-control.

Signed-off-by: Wayne Sun gsun@redhat.com
