### PR TITLE
dumpxml: Add acl test cases for domain api read and read-secure

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_dumpxml.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_dumpxml.cfg
@@ -42,6 +42,19 @@
                 - vm_paused:
                     paused_after_start_vm = "yes"
                     dumpxml_vm_state = "paused"
+            variants:
+                - non_acl:
+                - acl_test:
+                    setup_libvirt_polkit = "yes"
+                    unprivileged_user = "EXAMPLE"
+                    virsh_uri = "qemu:///system"
+                    variants:
+                        - grant_none:
+                            no with_security
+                        - grant_read_secure:
+                            only with_security
+                            action_lookup = "connect_driver:QEMU"
+                            action_id = "org.libvirt.api.domain.read-secure"
         - error_test:
             status_error = "yes"
             variants:
@@ -59,3 +72,15 @@
                     dumpxml_options_suffix = "xyz"
                 - not_exist_options:
                     dumpxml_options_suffix = "--xyz"
+                - acl_test:
+                    no lxc
+                    setup_libvirt_polkit = "yes"
+                    unprivileged_user = "EXAMPLE"
+                    virsh_uri = "qemu:///system"
+                    variants:
+                        - security_info:
+                            start_vm = "no"
+                            dumpxml_vm_state = "shutoff"
+                            dumpxml_options_ref = "--security-info"
+                            dumpxml_security_pwd = "123456"
+                            dumpxml_vm_ref = "domname"


### PR DESCRIPTION
By default access with domain api 'read' will be granted
for unprivileged user, add test cases testing this via
dumpxml command.

And for dumpxml with --security-info, add test cases with
domain api 'read-secure' in normal and error tests.

Signed-off-by: Wayne Sun gsun@redhat.com
