### PR TITLE
virsh.dump: Cover --format option

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_dump.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_dump.cfg
@@ -34,6 +34,16 @@
                     dump_options = "--reset --bypass-cache"
                 - memory_dump:
                     dump_options = "--memory-only"
+                    variants:
+                        - default_format:
+                        - elf_format:
+                            memory_dump_format = 'elf'
+                        - kdump-zlib_format:
+                            memory_dump_format = 'kdump-zlib'
+                        - kdump-lzo_format:
+                            memory_dump_format = 'kdump-lzo'
+                        - kdump-snappy_format:
+                            memory_dump_format = 'kdump-snappy'
                 - memory_crash_dump:
                     dump_options = "--crash --memory-only"
                 - memory_bypass_cache_dump:


### PR DESCRIPTION
1. New version libvirt/QEMU support compression when --memory-only option is specified for virsh dump, so and case to cover it.
2. Use the exist module to do libvirt/qemu configuration.

Signed-off-by: Yanbing Du ydu@redhat.com
