### PR TITLE
libvirt.tests: Add testcase for ethernet iommu group.

### DIFF
--- a/libvirt/tests/cfg/vfio.cfg
+++ b/libvirt/tests/cfg/vfio.cfg
@@ -5,6 +5,8 @@
     nic_pci_id = NIC:DEVICE.EXAMPLE
     nic_pci_ip = "192.168.2.49"
     nic_pci_mask = "255.255.255.0"
+    # Uncomment it if no gateway needed
+    # nic_pci_gateway = "192.168.2.1"
     # A remote host which connect to this nic device
     vfio_remote_ip = REMOTE_IP.EXAMPLE
     vfio_remote_passwd = REMOTE_PWD.EXAMPLE
@@ -22,6 +24,7 @@
             test_type = "nic_single"
         - primary_boot:
             primary_boot = "yes"
+            boot_timeout = 60
             variants:
                 - nic:
                     test_type = "nic_group"


### PR DESCRIPTION
Test VFIO function on virtual machine.
Plan:
1.nic: attach one nic in iommu group to vm
2.fibre: attach one disk in iommu group to vm

Signed-off-by: Yu Mingfei yumingfei@cn.fujitsu.com
