### PR TITLE
libvirt.tests: Fix some problems of storage_discard

### DIFF
--- a/libvirt/tests/src/storage_discard.py
+++ b/libvirt/tests/src/storage_discard.py
@@ -11,7 +11,7 @@ from virttest.libvirt_xml import vm_xml, xcepts
 from virttest.libvirt_xml.devices import disk, channel
 from virttest import utils_test, virsh, data_dir, virt_vm
 from virttest.utils_test import libvirt as utlv
-from virttest import iscsi, qemu_storage
+from virttest import iscsi, qemu_storage, libvirt_vm
 
 
 def volumes_capacity(lv_name):
@@ -131,17 +131,19 @@ def occupy_disk(vm, device, size, frmt_type="ext4", mount_options=None):
     :param size: the count in Metabytes
     """
     session = vm.wait_for_login()
-    session.cmd("mkfs -F -t %s %s" % (frmt_type, device))
-    if mount_options is not None:
-        mount_cmd = "mount -o %s %s /mnt" % (mount_options, device)
-    else:
-        mount_cmd = "mount %s /mnt" % device
-    session.cmd(mount_cmd)
-    dd_cmd = "dd if=/dev/zero of=/mnt/test.img bs=1M count=%s" % size
-    session.cmd(dd_cmd, timeout=120)
-    # Delete image to create sparsing space
-    session.cmd("rm -f /mnt/test.img")
-    session.close()
+    try:
+        session.cmd("mkfs -F -t %s %s" % (frmt_type, device), timeout=120)
+        if mount_options is not None:
+            mount_cmd = "mount -o %s %s /mnt" % (mount_options, device)
+        else:
+            mount_cmd = "mount %s /mnt" % device
+        session.cmd(mount_cmd)
+        dd_cmd = "dd if=/dev/zero of=/mnt/test.img bs=1M count=%s" % size
+        session.cmd(dd_cmd, timeout=120)
+        # Delete image to create sparsing space
+        session.cmd("rm -f /mnt/test.img")
+    finally:
+        session.close()
 
 
 def sig_delta(size1, size2, tolerable_shift=0.8):
@@ -208,8 +210,15 @@ def run(test, params, env):
     bf_disks = get_vm_disks(vm)
     vm.destroy()
 
-    # Backup VM XML file
-    backupvmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+    # Create a new vm for test, undefine it at last
+    new_vm_name = "%s_discardtest" % vm.name
+    if not utlv.define_new_vm(vm.name, new_vm_name):
+        raise error.TestError("Define new vm failed.")
+    try:
+        new_vm = libvirt_vm.VM(new_vm_name, vm.params, vm.root_dir,
+                               vm.address_cache)
+    except Exception, detail:
+        raise error.TestError("Create new vm failed:%s" % detail)
 
     disk_type = params.get("disk_type", "file")
     discard_device = params.get("discard_device", "/DEV/EXAMPLE")
@@ -235,19 +244,19 @@ def run(test, params, env):
         status_error = "yes" == params.get("status_error", "no")
         xmlfile = create_disk_xml(disk_type, device_path, discard_type,
                                   target_dev, target_bus)
-        virsh.attach_device(domain_opt=vm_name, file_opt=xmlfile,
+        virsh.attach_device(domain_opt=new_vm_name, file_opt=xmlfile,
                             flagstr="--persistent", ignore_status=False)
         if fstrim_type == "qemu-guest-agent":
-            channelfile = create_channel_xml(vm_name)
-            virsh.attach_device(domain_opt=vm_name, file_opt=channelfile,
+            channelfile = create_channel_xml(new_vm_name)
+            virsh.attach_device(domain_opt=new_vm_name, file_opt=channelfile,
                                 flagstr="--persistent", ignore_status=False)
-        logging.debug("New VMXML:\n%s", virsh.dumpxml(vm_name))
+        logging.debug("New VMXML:\n%s", virsh.dumpxml(new_vm_name))
 
         # Verify attached device in vm
-        if vm.is_dead():
-            vm.start()
-        vm.wait_for_login()
-        af_disks = get_vm_disks(vm)
+        if new_vm.is_dead():
+            new_vm.start()
+        new_vm.wait_for_login()
+        af_disks = get_vm_disks(new_vm)
         logging.debug("\nBefore:%s\nAfter:%s", bf_disks, af_disks)
         # Get new disk name in vm
         new_disk = "".join(list(set(bf_disks) ^ set(af_disks)))
@@ -265,11 +274,11 @@ def run(test, params, env):
         bf_cpy = get_disk_capacity(disk_type, imagefile=device_path,
                                    lvname="lvthin")
         logging.debug("Disk size before using:%s", bf_cpy)
-        occupy_disk(vm, new_disk, "500", frmt_type, mount_options)
+        occupy_disk(new_vm, new_disk, "500", frmt_type, mount_options)
         bf_fstrim_cpy = get_disk_capacity(disk_type, imagefile=device_path,
                                           lvname="lvthin")
         logging.debug("Disk size after used:%s", bf_fstrim_cpy)
-        do_fstrim(fstrim_type, vm, status_error)
+        do_fstrim(fstrim_type, new_vm, status_error)
         af_fstrim_cpy = get_disk_capacity(disk_type, imagefile=device_path,
                                           lvname="lvthin")
         logging.debug("\nBefore occupying disk:%s\n"
@@ -285,13 +294,9 @@ def run(test, params, env):
             if sig_delta(bf_cpy, bf_fstrim_cpy) and not status_error:
                 raise error.TestFail("Automatical 'fstrims' didn't work.")
     finally:
-        if vm.is_alive():
-            vm.destroy()
-        try:
-            backupvmxml.sync()
-        except xcepts.LibvirtXMLError:
-            # TODO: provide another way to clean it up
-            pass    # Do following steps anyway
+        if new_vm.is_alive():
+            new_vm.destroy()
+        new_vm.undefine()
         if disk_type == "block":
             try:
                 lv_utils.vg_remove("vgthin")


### PR DESCRIPTION
```
*Always closing session after logining to vm.
*Change timeout to allow fstrim with large disks.
*Use a new vm for easy cleanup.

* For new version, the output will include human-readable format(Mib)
  Force to use bytes to parse the fstrimmed size.
* Increase the timeout of fstrim because of large device(>1G),
  it may take more time.
* Output the result of vgthin for debug.

*libvirt.tests: Fix attributes' error of channel.
```
