### PR TITLE
Add try/except for os_dep.command failure

### DIFF
--- a/libvirt/tests/src/virt_cmd/virt_clone.py
+++ b/libvirt/tests/src/virt_cmd/virt_clone.py
@@ -16,7 +16,10 @@ def run(test, params, env):
     (3). Check the dest guest.
     """
     # Get the full path of virt-clone command.
-    VIRT_CLONE = os_dep.command("virt-clone")
+    try:
+        VIRT_CLONE = os_dep.command("virt-clone")
+    except ValueError:
+        raise error.TestNAError("Not find virt-clone command on host.")
 
     vm_name = params.get("main_vm", "virt-tests-vm1")
     vm = env.get_vm(vm_name)

--- a/libvirt/tests/src/virt_cmd/virt_xml_validate.py
+++ b/libvirt/tests/src/virt_cmd/virt_xml_validate.py
@@ -11,7 +11,10 @@ def run(test, params, env):
     Test for virt-xml-validate
     """
     # Get the full path of virt-xml-validate command.
-    VIRT_XML_VALIDATE = os_dep.command("virt-xml-validate")
+    try:
+        VIRT_XML_VALIDATE = os_dep.command("virt-xml-validate")
+    except ValueError:
+        raise error.TestNAError("Not find virt-xml-validate command on host.")
 
     vm_name = params.get("main_vm", "virt-tests-vm1")
     vm = env.get_vm(vm_name)


### PR DESCRIPTION
The function os_dep.command() should be surrounded by try/except.
