### PR TITLE
virsh.cpu_compare: Case update and bug fix

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_cpu_compare.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_cpu_compare.cfg
@@ -11,6 +11,7 @@
         - default_feature:
         - delete_feature:
             cpu_compare_mode = "delete"
+            cpu_compare_modify_target = "delete"
         - modify_feature_policy:
             only host_cpu 
             cpu_compare_mode = "modify"
@@ -99,13 +100,8 @@
             status_error = "yes"
     variants:
         - host_cpu:
+            start_vm = "no"
             cpu_compare_target = "host"
-            vms = ""
-            main_vm = ""
-            kill_vm = "no"
-            kill_unresponsive_vms = "no"
-            encode_video_files = "no"
-            skip_image_processing = "yes"
             variants:
                 - no_cpu_match:
                 - minimum_cpu_match:


### PR DESCRIPTION
1. Add a host feature to VM if it has no cpu feature, avoid skip related
   cases.
2. For 'host-model', as libvirt does not model every aspect of each CPU,
   so the guest CPU will not match the host CPU exactly. So, after start
   guest, just check if the new add cpu features of guest exist on host.
3. Always re-define VM after case finished.

Signed-off-by: Yanbing Du ydu@redhat.com
