### PR TITLE
add test cases for VM tunnelled migration with SSH, TCP and TLS Transports

### DIFF
--- a/libvirt/tests/cfg/migration/tunnelled_migration_with_ssh.cfg
+++ b/libvirt/tests/cfg/migration/tunnelled_migration_with_ssh.cfg
@@ -1,0 +1,41 @@
+- virsh.tunnelled_migration:
+    type = migrate_vm_with_ipv6
+    take_regular_screendumps = no
+    # please replace your configuration
+    server_ip = "ENTER.YOUR.REMOTE.EXAMPLE.COM"
+    server_user = "ENTER.YOUR.REMOTE.USER"
+    server_pwd = "ENTER.YOUR.REMOTE.PASSWORD"
+    client_ip = "ENTER.YOUR.CLIENT.EXAMPLE.COM"
+    client_user = "ENTER.YOUR.CLIENT.USER"
+    client_pwd = "ENTER.YOUR.CLIENT.PASSWORD"
+    transport = "ssh"
+    port = "22"
+    client = "ssh"
+    start_vm = "no"
+    ssh_port = "${port}"
+    # setup NFS test environment
+    nfs_client_ip = "${server_ip}"
+    nfs_server_ip = "${client_ip}"
+    # in order to avoid selinux issue, it had better to mount
+    # source directory to /tmp or /var/lib/libvirt/images
+    nfs_mount_dir = "/var/lib/libvirt/images"
+    nfs_mount_options = "rw"
+    # default to /var/lib/virt_test/images
+    nfs_mount_src = "/var/lib/virt_test/images"
+    export_ip = "*"
+    export_options = "rw,no_root_squash"
+    setup_local_nfs = "yes"
+    # enable virt_use_nfs SELinux boolean
+    local_boolean_varible = "virt_use_nfs"
+    local_boolean_value = "on"
+    remote_boolean_varible = "virt_use_nfs"
+    remote_boolean_value = "on"
+    set_sebool_local = "yes"
+    set_sebool_remote = "yes"
+    variants:
+        - positive_testing:
+            status_error = "no"
+            variants:
+                - with_ssh:
+                    # change your network interface name, e.g. eth0, enp0s25
+                    virsh_options = "--live --p2p --tunnelled --verbose"

--- a/libvirt/tests/cfg/migration/tunnelled_migration_with_tcp.cfg
+++ b/libvirt/tests/cfg/migration/tunnelled_migration_with_tcp.cfg
@@ -1,0 +1,40 @@
+- virsh.tunnelled_migration:
+    type = migrate_vm_with_ipv6
+    main_vm = "virt-tests-vm1"
+    take_regular_screendumps = "no"
+    transport = "tcp"
+    server_ip = "ENTER.YOUR.REMOTE.EXAMPLE.COM"
+    server_user = "ENTER.YOUR.REMOTE.USER"
+    server_pwd = "ENTER.YOUR.REMOTE.PASSWORD"
+    client_ip = "ENTER.YOUR.CLIENT.EXAMPLE.COM"
+    client_user = "ENTER.YOUR.CLIENT.USER"
+    client_pwd = "ENTER.YOUR.CLIENT.PASSWORD"
+    start_vm = "no"
+    port = "22"
+    client = "ssh"
+    tcp_port = "16509"
+    # setup NFS test environment
+    nfs_client_ip = "${server_ip}"
+    nfs_server_ip = "${client_ip}"
+    # in order to avoid selinux issue, it had better to mount
+    # source directory to /tmp or /var/lib/libvirt/images
+    nfs_mount_dir = "/var/lib/libvirt/images"
+    nfs_mount_options = "rw"
+    # default to /var/lib/virt_test/images
+    nfs_mount_src = "/var/lib/virt_test/images"
+    export_ip = "*"
+    export_options = "rw,no_root_squash"
+    setup_local_nfs = "yes"
+    # enable virt_use_nfs SELinux boolean
+    local_boolean_varible = "virt_use_nfs"
+    local_boolean_value = "on"
+    remote_boolean_varible = "virt_use_nfs"
+    remote_boolean_value = "on"
+    set_sebool_local = "yes"
+    set_sebool_remote = "yes"
+    variants:
+        - positive_testing:
+            status_error = "no"
+            variants:
+                - with_tcp:
+                    virsh_options = "--live --p2p --tunnelled --verbose"

--- a/libvirt/tests/cfg/migration/tunnelled_migration_with_tls.cfg
+++ b/libvirt/tests/cfg/migration/tunnelled_migration_with_tls.cfg
@@ -1,0 +1,42 @@
+- virsh.tunnelled_migration:
+    type = migrate_vm_with_ipv6
+    take_regular_screendumps = "no"
+    transport = "tls"
+    server_ip = "ENTER.YOUR.REMOTE.EXAMPLE.COM"
+    server_user = "ENTER.YOUR.REMOTE.USER"
+    server_pwd = "ENTER.YOUR.REMOTE.PASSWORD"
+    client_ip = "ENTER.YOUR.CLIENT.EXAMPLE.COM"
+    client_user = "ENTER.YOUR.CLIENT.USER"
+    client_pwd = "ENTER.YOUR.CLIENT.PASSWORD"
+    port = "22"
+    client = "ssh"
+    tls_port = "16514"
+    start_vm = "no"
+    # please change these with your hostname
+    server_cn = "server.nay.redhat.com"
+    client_cn = "client.nay.redhat.com"
+    # setup NFS test environment
+    nfs_client_ip = "${server_ip}"
+    nfs_server_ip = "${client_ip}"
+    # in order to avoid selinux issue, it had better to mount
+    # source directory to /tmp or /var/lib/libvirt/images
+    nfs_mount_dir = "/var/lib/libvirt/images"
+    nfs_mount_options = "rw"
+    # default to /var/lib/virt_test/images
+    nfs_mount_src = "/var/lib/virt_test/images"
+    export_ip = "*"
+    export_options = "rw,no_root_squash"
+    setup_local_nfs = "yes"
+    # enable virt_use_nfs SELinux boolean
+    local_boolean_varible = "virt_use_nfs"
+    local_boolean_value = "on"
+    remote_boolean_varible = "virt_use_nfs"
+    remote_boolean_value = "on"
+    set_sebool_local = "yes"
+    set_sebool_remote = "yes"
+    variants:
+        - positive_testing:
+            status_error = "no"
+            variants:
+                - with_tls:
+                    virsh_options = "--live --p2p --tunnelled --verbose"


### PR DESCRIPTION
This PR is based on PR1875, PR1882, PR1884, PR1888 and PR372.

[root@client virt-test]# ./run -t libvirt --tests type_specific.io-github-autotest-libvirt.virsh.tunnelled_migration.positive_testing.with_ssh --no-downloads --keep-image --keep-image-between-tests
SETUP: PASS (0.30 s)
DATA DIR: /var/lib/virt_test
DEBUG LOG: /home/ajia/Workspace/virt-test/logs/run-2014-11-14-16.14.14/debug.log
TESTS: 1
(1/1) type_specific.io-github-autotest-libvirt.virsh.tunnelled_migration.positive_testing.with_ssh: PASS (23.98 s)
TOTAL TIME: 24.04 s
TESTS PASSED: 1
TESTS FAILED: 0
SUCCESS RATE: 100.00 %
[root@client virt-test]# ./run -t libvirt --tests type_specific.io-github-autotest-libvirt.virsh.tunnelled_migration.positive_testing.with_tcp --no-downloads --keep-image --keep-image-between-tests
SETUP: PASS (0.30 s)
DATA DIR: /var/lib/virt_test
DEBUG LOG: /home/ajia/Workspace/virt-test/logs/run-2014-11-14-16.14.48/debug.log
TESTS: 1
(1/1) type_specific.io-github-autotest-libvirt.virsh.tunnelled_migration.positive_testing.with_tcp: PASS (29.70 s)
TOTAL TIME: 29.77 s
TESTS PASSED: 1
TESTS FAILED: 0
SUCCESS RATE: 100.00 %
[root@client virt-test]# ./run -t libvirt --tests type_specific.io-github-autotest-libvirt.virsh.tunnelled_migration.positive_testing.with_tls --no-downloads --keep-image --keep-image-between-tests
SETUP: PASS (0.30 s)
DATA DIR: /var/lib/virt_test
DEBUG LOG: /home/ajia/Workspace/virt-test/logs/run-2014-11-14-16.15.27/debug.log
TESTS: 1
(1/1) type_specific.io-github-autotest-libvirt.virsh.tunnelled_migration.positive_testing.with_tls: PASS (45.70 s)
TOTAL TIME: 45.75 s
TESTS PASSED: 1
TESTS FAILED: 0
SUCCESS RATE: 100.00 %

Signed-off-by: Alex Jia ajia@redhat.com
