### PR TITLE
pool_acl: Fix the cleanup_env list out of range problem

### DIFF
--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool_acl.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool_acl.py
@@ -61,7 +61,7 @@ def run(test, params, env):
     # Clean up flags:
     # cleanup_env[0] for nfs, cleanup_env[1] for iscsi, cleanup_env[2] for lvm
     # cleanup_env[3] for selinux backup status.
-    cleanup_env = [False, False, False, ""]
+    cleanup_env = [False, False, False, "", False]
     # libvirt acl related params
     uri = params.get("virsh_uri")
     unprivileged_user = params.get('unprivileged_user')


### PR DESCRIPTION
After gluster pool code change in virt-test, the clean list should
be initialized with length as 5.

Signed-off-by: Wayne Sun gsun@redhat.com
