### PR TITLE
nwfilter_define: Update case under update_exist_filter

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/filter/virsh_nwfilter_define.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/filter/virsh_nwfilter_define.cfg
@@ -9,6 +9,19 @@
     exist_filter = "no-mac-spoofing"
     filter_create_xml_file = "/tmp/filter-define-test.xml"
     variants:
+        - update_exist_filter:
+            status_error = "yes"
+            update_exist_filter = "yes"
+            filter_name = "no-mac-spoofing"
+            action_lookup = "connect_driver:QEMU nwfilter_name:no-mac-spoofing"
+            variants:
+                - non_acl:
+                - acl_test:
+                    setup_libvirt_polkit = "yes"
+                    action_id = "org.libvirt.api.nwfilter.write org.libvirt.api.nwfilter.save"
+                    action_lookup = "connect_driver:QEMU nwfilter_name:testcase"
+                    unprivileged_user = "EXAMPLE"
+                    virsh_uri = "qemu:///system"
         - negative_test:
             status_error = "yes"
             variants:
@@ -74,9 +87,6 @@
                     unprivileged_user = "EXAMPLE"
                     virsh_uri = "qemu:///system"
             variants:
-                - update_exist_filter:
-                    filter_name = "no-mac-spoofing"
-                    action_lookup = "connect_driver:QEMU nwfilter_name:no-mac-spoofing"
                 - mac_test:
                     rule = "rule_action=accept rule_direction=out protocol=mac srcmacaddr=1:2:3:4:5:6 srcmacmask=ff:ff:ff:ff:ff:ff protocolid=arp EOL rule_action=accept rule_direction=in protocol=mac srcmacaddr=aa:bb:cc:dd:ee:ff srcmacmask=ff:ff:ff:ff:ff:ff protocolid=ipv4 EOL rule_action=accept rule_direction=out protocol=mac srcmacaddr=aa:bb:cc:dd:ee:ff srcmacmask=ff:ff:ff:ff:ff:ff protocolid=1536 EOL rule_action=accept rule_direction=out protocol=mac srcmacaddr=aa:bb:cc:dd:ee:ff srcmacmask=ff:ff:ff:ff:ff:ff protocolid=65535"
                 - vlan_test:

--- a/libvirt/tests/src/virsh_cmd/filter/virsh_nwfilter_define.py
+++ b/libvirt/tests/src/virsh_cmd/filter/virsh_nwfilter_define.py
@@ -55,6 +55,7 @@ def run(test, params, env):
     options_ref = params.get("options_ref", "")
     status_error = params.get("status_error", "no")
     boundary_test_skip = "yes" == params.get("boundary_test_skip")
+    update_exist_filter = "yes" == params.get("update_exist_filter", 'no')
 
     # libvirt acl polkit related params
     uri = params.get("virsh_uri")
@@ -67,6 +68,14 @@ def run(test, params, env):
         if params.get('setup_libvirt_polkit') == 'yes':
             raise error.TestNAError("API acl test not supported in current"
                                     + " libvirt version.")
+
+    if update_exist_filter:
+        # Since commit 46a811d, the logic changed for not allow update filter
+        # with same name, so decide status_error with libvirt version.
+        if libvirt_version.version_compare(1, 2, 7):
+            status_error = 'yes'
+        else:
+            status_error = 'no'
 
     # prepare rule and protocol attributes
     protocol = {}


### PR DESCRIPTION
Since bug 1077009 fixed, the logic updated to not allow update
filter with same name after 1.2.7, so decide the status_error
according to libvirt version for work around this.

Signed-off-by: Wayne Sun gsun@redhat.com
