### PR TITLE
tests.multifunction: Search prompt without specified start(^) and end($)

### DIFF
--- a/libvirt/tests/src/multifunction.py
+++ b/libvirt/tests/src/multifunction.py
@@ -233,6 +233,10 @@ def run(test, params, env):
     """
     vm_name = params.get("main_vm")
     vm = env.get_vm(vm_name)
+
+    # Temparay way to avoid unmatched prompt
+    params['shell_prompt'] = ".*@.*[\#\$]\s*"
+
     # To avoid dirty after starting new vm
     if vm.is_alive():
         vm.destroy()


### PR DESCRIPTION
For some commands, the output may not in normal format:

```
nonempty_lines=['parted /dev/vdb "mklabel msdos"',
'Information: You may need to update /etc/fstab.',
'                                                [root@atest-guest ~]# ']
```

But the shell_prompt defined in configurations will cause unmatched
to catch the last line for prompt.

So remove the symbol "^" and "$" to match it in this condition.

Signed-off-by: Yu Mingfei yumingfei@cn.fujitsu.com
