### PR TITLE
avoid risk caused by using count() check user-define-value.

### DIFF
--- a/libvirt/tests/src/libvirt_pci_passthrough.py
+++ b/libvirt/tests/src/libvirt_pci_passthrough.py
@@ -41,8 +41,9 @@ def run(test, params, env):
     else:
         pci_dev = params.get("libvirt_pci_storage_dev_label")
 
-    net_ip = params.get("libvirt_pci_net_ip", "")
-    server_ip = params.get("libvirt_pci_server_ip")
+    net_ip = params.get("libvirt_pci_net_ip", "ENTER.YOUR.IP")
+    server_ip = params.get("libvirt_pci_server_ip",
+                           "ENTER.YOUR.SERVER.IP")
 
     # Check the parameters from configuration file.
     if (pci_dev.count("ENTER")):

--- a/libvirt/tests/src/macvtap.py
+++ b/libvirt/tests/src/macvtap.py
@@ -18,13 +18,15 @@ def run(test, params, env):
     4. Recover environment
     """
     vm_names = params.get("vms").split()
-    remote_ip = params.get("remote_ip")
+    remote_ip = params.get("remote_ip", "ENTER.YOUR.REMOTE.IP")
     iface_mode = params.get("mode", "vepa")
-    eth_card_no = params.get("eth_card_no")
-    vm1_ip = params.get("vm1_ip")
-    vm2_ip = params.get("vm2_ip")
-    eth_config_file = params.get("eth_config_file")
-    persistent_net_file = params.get("persistent_net_file")
+    eth_card_no = params.get("eth_card_no", "ENTER.YOUR.DEV.NAME")
+    vm1_ip = params.get("vm1_ip", "ENTER.YOUR.GUEST1.IP")
+    vm2_ip = params.get("vm2_ip", "ENTER.YOUR.GUEST2.IP")
+    eth_config_file = params.get("eth_config_file",
+                                 "ENTER.YOUR.CONFIG.FILE.PATH")
+    persistent_net_file = params.get("persistent_net_file",
+                                     "ENTER.YOUR.RULE.FILE.PATH")
 
     param_keys = ["remote_ip", "vm1_ip", "vm2_ip", "eth_card_no",
                   "eth_config_file", "persistent_net_file"]

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_sendkey.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_sendkey.py
@@ -28,7 +28,7 @@ def run(test, params, env):
     password = params.get("password")
     create_file = params.get("create_file_name")
     uri = params.get("virsh_uri")
-    unprivileged_user = params.get('unprivileged_user')
+    unprivileged_user = params.get('unprivileged_user', "EXAMPLE")
     if unprivileged_user:
         if unprivileged_user.count('EXAMPLE'):
             unprivileged_user = 'testacl'

--- a/libvirt/tests/src/virsh_cmd/interface/virsh_iface.py
+++ b/libvirt/tests/src/virsh_cmd/interface/virsh_iface.py
@@ -120,7 +120,7 @@ def run(test, params, env):
     careful.
     """
 
-    iface_name = params.get("iface_name")
+    iface_name = params.get("iface_name", "ENTER.BRIDGE.NAME")
     iface_xml = params.get("iface_xml")
     iface_type = params.get("iface_type", "ethernet")
     iface_pro = params.get("iface_pro", "")
@@ -140,7 +140,7 @@ def run(test, params, env):
         raise error.TestNAError("Please input a existing bridge/ethernet name")
 
     uri = params.get("virsh_uri")
-    unprivileged_user = params.get('unprivileged_user')
+    unprivileged_user = params.get('unprivileged_user', "EXAMPLE")
     if unprivileged_user:
         if unprivileged_user.count('EXAMPLE'):
             unprivileged_user = 'testacl'


### PR DESCRIPTION
In some scripts,
we use count() to check if the value of self-variable,
needed by special circumstances, has been set or not.
But, it will bring some problem. for example,

 The self-variable declared at the corresponding config file.

 iface_name = "ENTER.BRIDGE.NAME"

 If the user just delete the prompt message and keep it "none".
 the following code will regard 'none' as a valid value without
 any error.

 iface_name = params.get("iface_name")
 if iface_name.count("ENTER"):
     raise error.TestNAError("Please input a existing bridge/ethernet name")

This patch fixes the problem.
