### PR TITLE
libvirt_bench_dump_with_unixbench.py: remove useless code

### DIFF
--- a/libvirt/tests/src/libvirt_bench/libvirt_bench_domstate_switch_with_unixbench.py
+++ b/libvirt/tests/src/libvirt_bench/libvirt_bench_domstate_switch_with_unixbench.py
@@ -51,7 +51,6 @@ def run(test, params, env):
                                         "unixbench5.control")
     timeout = int(params.get("LB_domstate_with_unixbench_loop_time", "600"))
     # Run unixbench on guest.
-    guest_unixbench_pids = []
     params["test_control_file"] = unixbench_control_file
     # Fork a new process to run unixbench on each guest.
     for vm in vms:

--- a/libvirt/tests/src/libvirt_bench/libvirt_bench_dump_with_unixbench.py
+++ b/libvirt/tests/src/libvirt_bench/libvirt_bench_dump_with_unixbench.py
@@ -18,7 +18,6 @@ def run(test, params, env):
     unixbench_control_file = params.get("unixbench_controle_file",
                                         "unixbench5.control")
     # Run unixbench on guest.
-    guest_unixbench_pids = []
     params["test_control_file"] = unixbench_control_file
     # Fork a new process to run unixbench on each guest.
     for vm in vms:
@@ -57,8 +56,6 @@ def run(test, params, env):
             # Check VM is running normally.
             vm.wait_for_login()
     finally:
-        for pid in guest_unixbench_pids:
-            utils_misc.kill_process_tree(pid)
         # Destroy VM.
         for vm in vms:
             vm.destroy()


### PR DESCRIPTION
the variable guest_unixbench_pids keeps None all the time,
so utils_misc.kill_process_tree(pid) never be called.
this patch used to remove these useless code.
