### PR TITLE
blockpull: Add various disk types for testing

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockpull.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockpull.cfg
@@ -4,8 +4,13 @@
     variants:
         - normal_test:
             status_error = "no"
+            needs_agent = "yes"
             variants:
                 - nobase:
+                    variants:
+                        - async:
+                            base_option = "async"
+                        - no_async:
                 - shallow:
                     base_option = "shallow"
                 - base_snap_one:
@@ -14,9 +19,60 @@
                 - notimeout:
                 - timeout:
                     with_timeout_option = "yes"
-
+            variants:
+                - file_disk:
+                    variants:
+                        - local:
+                        - nfs:
+                            no timeout, no_async
+                            replace_vm_disk = "yes"
+                            disk_source_protocol = "netfs"
+                            export_options = "rw,no_root_squash,fsid=0"
+                            disk_type = "file"
+                            disk_target = "vda"
+                            disk_target_bus = "virtio"
+                            disk_format = "qcow2"
+                            image_size = "10G"
+                - network_disk:
+                    no timeout, no_async
+                    replace_vm_disk = "yes"
+                    disk_type = "network"
+                    disk_target = "vda"
+                    disk_target_bus = "virtio"
+                    disk_format = "raw"
+                    image_size = "10G"
+                    variants:
+                        - iscsi:
+                            disk_source_protocol = "iscsi"
+                            disk_source_host = "127.0.0.1"
+                            disk_source_port = "3260"
+                        - gluster:
+                            disk_source_protocol = "gluster"
+                            vol_name = "gluster-vol1"
+                            pool_name = "gluster-pool"
+                            variants:
+                                - transport_default:
+                                - transport_rdma:
+                                    transport = "rdma"
+                                - transport_tcp:
+                                    transport = "tcp"
+                            variants:
+                                - disk_qcow2:
+                                    disk_format = "qcow2"
+                                - disk_raw:
+                - block_disk:
+                    no timeout, no_async
+                    replace_vm_disk = "yes"
+                    disk_source_protocol = "iscsi"
+                    disk_type = "block"
+                    disk_target = "vda"
+                    disk_target_bus = "virtio"
+                    disk_format = "raw"
+                    image_size = "10G"
         - error_test:
             status_error = "yes"
             variants:
                 - top_base:
                     base_option = "top"
+                - null_base_keep_relative:
+                    keep_relative = "yes"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockpull.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockpull.cfg
@@ -15,6 +15,10 @@
                     base_option = "shallow"
                 - base_snap_one:
                     base_option = "base"
+                    variants:
+                        - with_bandwidth:
+                            bandwidth = "10"
+                        - no_bandwidth:
             variants:
                 - notimeout:
                 - timeout:
@@ -24,7 +28,7 @@
                     variants:
                         - local:
                         - nfs:
-                            no timeout, no_async
+                            no timeout, no_async, with_bandwidth
                             replace_vm_disk = "yes"
                             disk_source_protocol = "netfs"
                             export_options = "rw,no_root_squash,fsid=0"
@@ -34,7 +38,7 @@
                             disk_format = "qcow2"
                             image_size = "10G"
                 - network_disk:
-                    no timeout, no_async
+                    no timeout, no_async, with_bandwidth
                     replace_vm_disk = "yes"
                     disk_type = "network"
                     disk_target = "vda"
@@ -61,7 +65,7 @@
                                     disk_format = "qcow2"
                                 - disk_raw:
                 - block_disk:
-                    no timeout, no_async
+                    no timeout, no_async, with_bandwidth
                     replace_vm_disk = "yes"
                     disk_source_protocol = "iscsi"
                     disk_type = "block"
@@ -76,3 +80,7 @@
                     base_option = "top"
                 - null_base_keep_relative:
                     keep_relative = "yes"
+                - snap_in_mirror:
+                    snap_in_mirror = "yes"
+                    status_error = "no"
+                    snap_in_mirror_err = "yes"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockpull.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockpull.py
@@ -2,7 +2,7 @@ import os
 import logging
 import tempfile
 from autotest.client.shared import error
-from virttest import virsh, data_dir
+from virttest import virsh, data_dir, utils_libvirtd
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import snapshot_xml
@@ -335,10 +335,13 @@ def run(test, params, env):
                 if os.path.exists(disk):
                     os.remove(disk)
 
+        libvirtd = utils_libvirtd.Libvirtd()
+
         if disk_src_protocol == 'iscsi':
             libvirt.setup_or_cleanup_iscsi(is_setup=False)
         elif disk_src_protocol == 'gluster':
             libvirt.setup_or_cleanup_gluster(False, vol_name, brick_path)
+            libvirtd.restart()
         elif disk_src_protocol == 'netfs':
             restore_selinux = params.get('selinux_status_bak')
             libvirt.setup_or_cleanup_nfs(is_setup=False,

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockpull.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockpull.py
@@ -3,7 +3,39 @@ import logging
 import tempfile
 from autotest.client.shared import error
 from virttest import virsh, data_dir
+from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
+from provider import libvirt_version
+
+
+def check_chain_xml(disk_xml, chain_lst):
+    """
+    param disk_xml: disk xmltreefile
+    param chain_lst: list, expected backing chain list
+    return: True or False
+    """
+    logging.debug("expected backing chain list is %s", chain_lst)
+    src_file = disk_xml.find('source').get('file')
+    if src_file != chain_lst[0]:
+        logging.error("Current top img %s is not expected", src_file)
+        return False
+    for i in range(1, len(chain_lst)):
+        backing_xml = disk_xml.find('backingStore')
+        src_element = backing_xml.find('source')
+        src_file = None
+        for elem in ('file', 'name', 'dev'):
+            elem_val = src_element.get(elem)
+            if elem_val:
+                src_file = elem_val
+                break
+        if src_file != chain_lst[i]:
+            logging.error("backing store chain file %s is "
+                          "not expected" % src_file)
+            return False
+        disk_xml = disk_xml.reroot('backingStore')
+        logging.debug("after reroot the xml is %s", disk_xml)
+
+    return True
 
 
 def run(test, params, env):
@@ -21,7 +53,7 @@ def run(test, params, env):
         disks = vm.get_disk_devices()
 
         # Make three external snapshots for disks only
-        for count in range(1, 4):
+        for count in range(1, 5):
             options = "snapshot%s snap%s-desc " \
                       "--disk-only --atomic --no-metadata" % (count, count)
 
@@ -57,12 +89,22 @@ def run(test, params, env):
     # Process cartesian parameters
     vm_name = params.get("main_vm")
     vm = env.get_vm(vm_name)
-    session = vm.wait_for_login()
+    needs_agent = "yes" == params.get("needs_agent", "yes")
+    replace_vm_disk = "yes" == params.get("replace_vm_disk", "no")
 
     with_timeout = ("yes" == params.get("with_timeout_option", "no"))
     status_error = ("yes" == params.get("status_error", "no"))
-    base_option = params.get("base_option", "none")
+    base_option = params.get("base_option", None)
+    keep_relative = "yes" == params.get("keep_relative", 'no')
     virsh_dargs = {'debug': True}
+
+    # Process domain disk device parameters
+    disk_type = params.get("disk_type")
+    disk_src_protocol = params.get("disk_source_protocol")
+    vol_name = params.get("vol_name")
+    tmp_dir = data_dir.get_tmp_dir()
+    pool_name = params.get("pool_name", "gluster-pool")
+    brick_path = os.path.join(tmp_dir, pool_name)
 
     # A backup of original vm
     vmxml_backup = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
@@ -73,17 +115,35 @@ def run(test, params, env):
     if len(exsiting_snaps) != 0:
         raise error.TestFail("There are snapshots created for %s already" % vm_name)
 
+    snapshot_external_disks = []
     try:
-        # Get a tmp_dir.
-        tmp_dir = data_dir.get_tmp_dir()
+        if disk_src_protocol == 'iscsi' and disk_type == 'network':
+            if not libvirt_version.version_compare(1, 0, 4):
+                raise error.TestNAError("'iscsi' disk doesn't support in"
+                                        + " current libvirt version.")
+
+        # Set vm xml and guest agent
+        if replace_vm_disk:
+            libvirt.set_vm_disk(vm, params, tmp_dir)
+
+        if needs_agent:
+            libvirt.set_guest_agent(vm)
 
         # The first disk is supposed to include OS
         # We will perform blockpull operation for it.
         first_disk = vm.get_first_disk_devices()
-
-        snapshot_external_disks = []
+        blk_source = first_disk['source']
+        blk_target = first_disk['target']
         snapshot_flag_files = []
+
+        # get a vm session before snapshot
+        session = vm.wait_for_login()
+        # do snapshot
         make_disk_snapshot()
+
+        # snapshot src file list
+        snap_src_lst = [blk_source]
+        snap_src_lst += snapshot_external_disks
 
         blockpull_options = "--wait --verbose"
 
@@ -91,28 +151,66 @@ def run(test, params, env):
             blockpull_options += " --timeout 1"
 
         base_image = None
-        basename = os.path.basename(first_disk['source'])
+        basename = os.path.basename(blk_source)
         diskname = basename.split(".")[0]
         if base_option == "shallow":
-            base_image = os.path.join(tmp_dir, "%s.snap2" % diskname)
-        elif base_option == "base":
-            base_image = os.path.join(tmp_dir, "%s.snap1" % diskname)
-        elif base_option == "top":
             base_image = os.path.join(tmp_dir, "%s.snap3" % diskname)
+        elif base_option == "base":
+            base_image = os.path.join(tmp_dir, "%s.snap2" % diskname)
+        elif base_option == "top":
+            base_image = os.path.join(tmp_dir, "%s.snap4" % diskname)
+        elif base_option == "async":
+            blockpull_options += " --async"
 
-        if base_option != "none":
+        if base_option and base_image:
             blockpull_options += " --base %s" % base_image
 
+        if keep_relative:
+            blockpull_options += " --keep-relative"
+
         # Run test case
-        result = virsh.blockpull(vm_name, first_disk['target'],
+        result = virsh.blockpull(vm_name, blk_target,
                                  blockpull_options, **virsh_dargs)
         status = result.exit_status
 
         # Check status_error
-        if status_error and status == 0:
-            raise error.TestFail("Expect fail, but run successfully!")
-        elif not status_error and status != 0:
-            raise error.TestFail("Run failed with right command")
+        libvirt.check_exit_status(result, status_error)
+
+        if not status and not with_timeout:
+            vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+            disks = vmxml.devices.by_device_tag('disk')
+            for disk in disks:
+                if disk.target['dev'] != blk_target:
+                    continue
+                else:
+                    disk_xml = disk.xmltreefile
+                    break
+
+            logging.debug("after pull the disk xml is: %s"
+                          % disk_xml)
+            if libvirt_version.version_compare(1, 2, 4):
+                err_msg = "Domain image backing chain check failed"
+                if not base_option:
+                    chain_lst = snap_src_lst[-1:]
+                    ret = check_chain_xml(disk_xml, chain_lst)
+                    if not ret:
+                        raise error.TestFail(err_msg)
+                elif "shallow" in base_option:
+                    chain_lst = snap_src_lst[::-1]
+                    ret = check_chain_xml(disk_xml, chain_lst)
+                    if not ret:
+                        raise error.TestFail(err_msg)
+                elif "base" in base_option:
+                    chain_lst = snap_src_lst[::-1]
+                    base_index = chain_lst.index(base_image)
+                    val_tmp = []
+                    for i in range(1, base_index):
+                        val_tmp.append(chain_lst[i])
+                    for i in val_tmp:
+                        chain_lst.remove(i)
+                    ret = check_chain_xml(disk_xml, chain_lst)
+                    if not ret:
+                        raise error.TestFail(err_msg)
 
         # If base image is the top layer of snapshot chain,
         # virsh blockpull should fail, return directly
@@ -126,9 +224,20 @@ def run(test, params, env):
                 raise error.TestFail("blockpull failed: %s" % output)
 
     finally:
+        if vm.is_alive():
+            vm.destroy(gracefully=False)
+        # Recover xml of vm.
+        vmxml_backup.sync("--snapshots-metadata")
+
         for disk in snapshot_external_disks:
             if os.path.exists(disk):
                 os.remove(disk)
 
-        # Recover xml of vm.
-        vmxml_backup.sync()
+        if disk_src_protocol == 'iscsi':
+            libvirt.setup_or_cleanup_iscsi(is_setup=False)
+        elif disk_src_protocol == 'gluster':
+            libvirt.setup_or_cleanup_gluster(False, vol_name, brick_path)
+        elif disk_src_protocol == 'netfs':
+            restore_selinux = params.get('selinux_status_bak')
+            libvirt.setup_or_cleanup_nfs(is_setup=False,
+                                         restore_selinux=restore_selinux)

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockpull.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockpull.py
@@ -5,6 +5,7 @@ from autotest.client.shared import error
 from virttest import virsh, data_dir
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
+from virttest.libvirt_xml import snapshot_xml
 from provider import libvirt_version
 
 
@@ -15,7 +16,10 @@ def check_chain_xml(disk_xml, chain_lst):
     return: True or False
     """
     logging.debug("expected backing chain list is %s", chain_lst)
-    src_file = disk_xml.find('source').get('file')
+    for elem in ('file', 'name', 'dev'):
+        src_file = disk_xml.find('source').get(elem)
+        if src_file:
+            break
     if src_file != chain_lst[0]:
         logging.error("Current top img %s is not expected", src_file)
         return False
@@ -49,34 +53,92 @@ def run(test, params, env):
     """
 
     def make_disk_snapshot():
-        # Add all disks into commandline.
-        disks = vm.get_disk_devices()
-
-        # Make three external snapshots for disks only
+        # Make four external snapshots for disks only
         for count in range(1, 5):
-            options = "snapshot%s snap%s-desc " \
-                      "--disk-only --atomic --no-metadata" % (count, count)
+            snap_xml = snapshot_xml.SnapshotXML()
+            snapshot_name = "snapshot_test%s" % count
+            snap_xml.snap_name = snapshot_name
+            snap_xml.description = "Snapshot Test %s" % count
 
-            for disk in disks:
-                disk_detail = disks[disk]
-                basename = os.path.basename(disk_detail['source'])
+            # Add all disks into xml file.
+            vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+            disks = vmxml.devices.by_device_tag('disk')
+            new_disks = []
+            for src_disk_xml in disks:
+                disk_xml = snap_xml.SnapDiskXML()
+                disk_xml.xmltreefile = src_disk_xml.xmltreefile
+                del disk_xml.device
+                del disk_xml.address
+                disk_xml.snapshot = "external"
+                disk_xml.disk_name = disk_xml.target['dev']
 
-                # Remove the original suffix if any, appending ".snap[0-9]"
-                diskname = basename.split(".")[0]
-                disk_external = os.path.join(tmp_dir,
-                                             "%s.snap%s" % (diskname, count))
+                # Only qcow2 works as external snapshot file format, update it
+                # here
+                driver_attr = disk_xml.driver
+                driver_attr.update({'type': 'qcow2'})
+                disk_xml.driver = driver_attr
 
-                snapshot_external_disks.append(disk_external)
-                options += " %s,snapshot=external,file=%s" % (disk, disk_external)
+                new_attrs = disk_xml.source.attrs
+                if disk_xml.source.attrs.has_key('file'):
+                    file_name = disk_xml.source.attrs['file']
+                    new_file = "%s.snap%s" % (file_name.split('.')[0],
+                                              count)
+                    snapshot_external_disks.append(new_file)
+                    new_attrs.update({'file': new_file})
+                    hosts = None
+                elif (disk_xml.source.attrs.has_key('name') and
+                      disk_src_protocol == 'gluster'):
+                    src_name = disk_xml.source.attrs['name']
+                    new_name = "%s.snap%s" % (src_name.split('.')[0],
+                                              count)
+                    new_attrs.update({'name': new_name})
+                    snapshot_external_disks.append(new_name)
+                    hosts = disk_xml.source.hosts
+                elif (disk_xml.source.attrs.has_key('dev') or
+                      disk_xml.source.attrs.has_key('name')):
+                    if (disk_xml.type_name == 'block' or
+                            disk_src_protocol == 'iscsi'):
+                        # Use local file as external snapshot target for block
+                        # and iscsi network type.
+                        # As block device will be treat as raw format by
+                        # default, it's not fit for external disk snapshot
+                        # target. A work around solution is use qemu-img again
+                        # with the target.
+                        # And external active snapshots are not supported on
+                        # 'network' disks using 'iscsi' protocol
+                        disk_xml.type_name = 'file'
+                        if new_attrs.has_key('dev'):
+                            del new_attrs['dev']
+                        elif new_attrs.has_key('name'):
+                            del new_attrs['name']
+                            del new_attrs['protocol']
+                        new_file = "%s/blk_src_file.snap%s" % (tmp_dir, count)
+                        snapshot_external_disks.append(new_file)
+                        new_attrs.update({'file': new_file})
+                        hosts = None
 
-            cmd_result = virsh.snapshot_create_as(vm_name, options,
-                                                  ignore_status=True, debug=True)
-            status = cmd_result.exit_status
-            if status != 0:
-                raise error.TestFail("Failed to make snapshots for disks!")
+                new_src_dict = {"attrs": new_attrs}
+                if hosts:
+                    new_src_dict.update({"hosts": hosts})
+                disk_xml.source = disk_xml.new_disk_source(**new_src_dict)
+
+                new_disks.append(disk_xml)
+
+            snap_xml.set_disks(new_disks)
+            snapshot_xml_path = snap_xml.xml
+            logging.debug("The snapshot xml is: %s" % snap_xml.xmltreefile)
+
+            options = "--disk-only --xmlfile %s " % snapshot_xml_path
+
+            snapshot_result = virsh.snapshot_create(
+                vm_name, options, debug=True)
+
+            if snapshot_result.exit_status != 0:
+                raise error.TestFail(snapshot_result.stderr)
 
             # Create a file flag in VM after each snapshot
-            flag_file = tempfile.NamedTemporaryFile(prefix=("snapshot_test_"), dir="/tmp")
+            flag_file = tempfile.NamedTemporaryFile(prefix=("snapshot_test_"),
+                                                    dir="/tmp")
             file_path = flag_file.name
             flag_file.close()
 
@@ -91,7 +153,9 @@ def run(test, params, env):
     vm = env.get_vm(vm_name)
     needs_agent = "yes" == params.get("needs_agent", "yes")
     replace_vm_disk = "yes" == params.get("replace_vm_disk", "no")
-
+    snap_in_mirror = "yes" == params.get("snap_in_mirror", 'no')
+    snap_in_mirror_err = "yes" == params.get("snap_in_mirror_err", 'no')
+    bandwidth = params.get("bandwidth", None)
     with_timeout = ("yes" == params.get("with_timeout_option", "no"))
     status_error = ("yes" == params.get("status_error", "no"))
     base_option = params.get("base_option", None)
@@ -100,6 +164,7 @@ def run(test, params, env):
 
     # Process domain disk device parameters
     disk_type = params.get("disk_type")
+    disk_target = params.get("disk_target", 'vda')
     disk_src_protocol = params.get("disk_source_protocol")
     vol_name = params.get("vol_name")
     tmp_dir = data_dir.get_tmp_dir()
@@ -121,6 +186,14 @@ def run(test, params, env):
             if not libvirt_version.version_compare(1, 0, 4):
                 raise error.TestNAError("'iscsi' disk doesn't support in"
                                         + " current libvirt version.")
+        if disk_src_protocol == 'gluster':
+            if not libvirt_version.version_compare(1, 2, 7):
+                raise error.TestNAError("Snapshot on glusterfs not"
+                                        " support in current "
+                                        "version. Check more info "
+                                        " with https://bugzilla.re"
+                                        "dhat.com/show_bug.cgi?id="
+                                        "1017289")
 
         # Set vm xml and guest agent
         if replace_vm_disk:
@@ -141,26 +214,47 @@ def run(test, params, env):
         # do snapshot
         make_disk_snapshot()
 
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        logging.debug("The domain xml after snapshot is %s" % vmxml)
+
         # snapshot src file list
         snap_src_lst = [blk_source]
         snap_src_lst += snapshot_external_disks
 
-        blockpull_options = "--wait --verbose"
+        if snap_in_mirror:
+            blockpull_options = "--bandwidth 1"
+        else:
+            blockpull_options = "--wait --verbose"
 
         if with_timeout:
             blockpull_options += " --timeout 1"
 
-        base_image = None
-        basename = os.path.basename(blk_source)
-        diskname = basename.split(".")[0]
-        if base_option == "shallow":
-            base_image = os.path.join(tmp_dir, "%s.snap3" % diskname)
-        elif base_option == "base":
-            base_image = os.path.join(tmp_dir, "%s.snap2" % diskname)
-        elif base_option == "top":
-            base_image = os.path.join(tmp_dir, "%s.snap4" % diskname)
-        elif base_option == "async":
+        if bandwidth:
+            blockpull_options += " --bandwidth %s" % bandwidth
+
+        if base_option == "async":
             blockpull_options += " --async"
+
+        base_image = None
+        base_index = None
+        if (libvirt_version.version_compare(1, 2, 4) or
+                disk_src_protocol == 'gluster'):
+            if base_option == "shallow":
+                base_index = 1
+                base_image = "%s[%s]" % (disk_target, base_index)
+            elif base_option == "base":
+                base_index = 2
+                base_image = "%s[%s]" % (disk_target, base_index)
+            elif base_option == "top":
+                base_index = 0
+                base_image = "%s[%s]" % (disk_target, base_index)
+        else:
+            if base_option == "shallow":
+                base_image = snap_src_lst[3]
+            elif base_option == "base":
+                base_image = snap_src_lst[2]
+            elif base_option == "top":
+                base_image = snap_src_lst[4]
 
         if base_option and base_image:
             blockpull_options += " --base %s" % base_image
@@ -177,6 +271,17 @@ def run(test, params, env):
         libvirt.check_exit_status(result, status_error)
 
         if not status and not with_timeout:
+            if snap_in_mirror:
+                snap_mirror_path = "%s/snap_mirror" % tmp_dir
+                snap_options = "--diskspec vda,snapshot=external,"
+                snap_options += "file=%s --disk-only" % snap_mirror_path
+                snapshot_external_disks.append(snap_mirror_path)
+                ret = virsh.snapshot_create_as(vm_name, snap_options,
+                                               ignore_status=True,
+                                               debug=True)
+                libvirt.check_exit_status(ret, snap_in_mirror_err)
+                return
+
             vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
             disks = vmxml.devices.by_device_tag('disk')
             for disk in disks:
@@ -190,19 +295,15 @@ def run(test, params, env):
                           % disk_xml)
             if libvirt_version.version_compare(1, 2, 4):
                 err_msg = "Domain image backing chain check failed"
-                if not base_option:
+                if not base_option or "async" in base_option:
                     chain_lst = snap_src_lst[-1:]
                     ret = check_chain_xml(disk_xml, chain_lst)
                     if not ret:
                         raise error.TestFail(err_msg)
-                elif "shallow" in base_option:
+                elif "base" or "shallow" in base_option:
                     chain_lst = snap_src_lst[::-1]
-                    ret = check_chain_xml(disk_xml, chain_lst)
-                    if not ret:
-                        raise error.TestFail(err_msg)
-                elif "base" in base_option:
-                    chain_lst = snap_src_lst[::-1]
-                    base_index = chain_lst.index(base_image)
+                    if not base_index and base_image:
+                        base_index = chain_lst.index(base_image)
                     val_tmp = []
                     for i in range(1, base_index):
                         val_tmp.append(chain_lst[i])
@@ -229,9 +330,10 @@ def run(test, params, env):
         # Recover xml of vm.
         vmxml_backup.sync("--snapshots-metadata")
 
-        for disk in snapshot_external_disks:
-            if os.path.exists(disk):
-                os.remove(disk)
+        if not disk_src_protocol or disk_src_protocol != 'gluster':
+            for disk in snapshot_external_disks:
+                if os.path.exists(disk):
+                    os.remove(disk)
 
         if disk_src_protocol == 'iscsi':
             libvirt.setup_or_cleanup_iscsi(is_setup=False)


### PR DESCRIPTION
Add network disk with gluster and iscsi type, block disk use iscsi
backend, netfs disk mounted on local for testing.

Also added test case for option --async and --keep-relative.

Signed-off-by: Wayne Sun <gsun@redhat.com>