### PR TITLE
libvirt.tests: add testcases about hotplug serial for char device

### DIFF
--- a/libvirt/tests/cfg/hotplug_serial.cfg
+++ b/libvirt/tests/cfg/hotplug_serial.cfg
@@ -1,0 +1,36 @@
+- hotplug_serial:
+    type = hotplug_serial
+    kill_vm = yes
+    kill_vm_gracefully = no
+    start_vm = no
+    variants:
+        - normal_test:
+            status_error = no
+        - error_test:
+            no all_dev
+            status_error = yes
+            variants:
+                - dup_charid:
+                    only qmp
+                    dup_charid = yes
+                - dup_devid:
+                    dup_devid = yes
+                - one_charid_two_devid:
+                    only qmp
+                    diff_devid = yes
+    variants:
+        - file_dev:
+            char_dev = file
+        - sock_dev:
+            char_dev = socket
+        - pty_dev:
+            char_dev = pty
+        - all_dev:
+            char_dev = all
+    variants:
+        - qmp:
+            hotplug_type = "qmp"
+        - at_dt_device:
+            hotplug_type = "attach"
+            xml_file = "/tmp/xml_file"
+

--- a/libvirt/tests/src/hotplug_serial.py
+++ b/libvirt/tests/src/hotplug_serial.py
@@ -1,0 +1,274 @@
+import logging
+import os
+import stat
+import subprocess
+import time
+import socket
+
+from autotest.client import utils
+from autotest.client.shared import error
+from virttest import virsh
+from virttest import utils_misc
+from virttest.libvirt_xml.devices import channel
+from virttest.libvirt_xml.vm_xml import VMXML
+from virttest.libvirt_xml.devices.controller import Controller
+
+
+def run(test, params, env):
+    """
+    Verify hotplug feature for char device
+    """
+
+    vm_name = params.get("main_vm", "vm1")
+    status_error = "yes" == params.get("status_error", "no")
+    char_dev = params.get("char_dev", "file")
+    hotplug_type = params.get("hotplug_type", "qmp")
+    dup_charid = "yes" == params.get("dup_charid", "no")
+    dup_devid = "yes" == params.get("dup_devid", "no")
+    diff_devid = "yes" == params.get("diff_devid", "no")
+    xml_file = params.get("xml_file", "/tmp/xml_file")
+
+    vm_xml = VMXML.new_from_inactive_dumpxml(vm_name)
+    vm_xml_backup = vm_xml.copy()
+
+    # add controller for each char device
+    devices = vm_xml.get_devices()
+    controllers = vm_xml.get_devices(device_type="controller")
+    for dev in controllers:
+        if dev.type == "virtio-serial":
+            devices.remove(dev)
+    controller = Controller("controller")
+    controller.type = "virtio-serial"
+    controller.index = 0
+    devices.append(controller)
+    vm_xml.set_devices(devices)
+    vm_xml.sync()
+
+    # start and login vm
+    vm = env.get_vm(vm_name)
+    vm.start()
+    session = vm.wait_for_login()
+
+    def create_channel_xml(vm_name, char_type, id=0):
+        """
+        Create a XML contains channel information.
+        """
+        channel_type = char_type
+        if char_type == "file":
+            channel_path = ("/tmp/%s" % char_type)
+            channel_source = {'path': channel_path}
+            channel_target = {'type': 'virtio', 'name': 'file'}
+        if char_type == "socket":
+            channel_type = 'unix'
+            channel_path = ("/tmp/%s" % char_type)
+            channel_source = {'mode': 'bind', 'path': channel_path}
+            channel_target = {'type': 'virtio', 'name': 'socket'}
+        if char_type == "pty":
+            channel_path = ("/dev/pts/%s" % id)
+            channel_source = {'path': channel_path}
+            channel_target = {'type': 'virtio', 'name': 'pty'}
+
+        channel_alias = {'name': char_type}
+        channel_address = {'type': 'virtio-serial', 'controller': '0', 'bus': '0'}
+        channel_params = {'type_name': channel_type, 'source': channel_source,
+                          'target': channel_target, 'alias': channel_alias,
+                          'address': channel_address}
+        channelxml = channel.Channel.new_from_dict(channel_params)
+        logging.debug("Channel XML:\n%s", channelxml)
+
+        xmlf = open(channelxml.xml)
+        try:
+            xml_lines = xmlf.read()
+        finally:
+            xmlf.close()
+        return xml_lines
+
+    def hotplug_device(type, char_dev, id=0):
+        tmp_file = "/tmp/%s" % char_dev
+        if type == "qmp":
+            char_add_opt = "chardev-add "
+            dev_add_opt = "device_add virtserialport,chardev="
+            if char_dev == "file":
+                char_add_opt += "file,path=/tmp/file,id=file"
+                dev_add_opt += "file,name=file,bus=virtio-serial0.0,id=file"
+            elif char_dev == "socket":
+                char_add_opt += "socket,path=/tmp/socket,server,nowait,id=socket"
+                dev_add_opt += "socket,name=socket,bus=virtio-serial0.0,id=socket"
+            elif char_dev == "pty":
+                char_add_opt += ("pty,path=/dev/pts/%s,id=pty" % id)
+                dev_add_opt += "pty,name=pty,bus=virtio-serial0.0,id=pty"
+            result = virsh.qemu_monitor_command(vm_name, char_add_opt, "--hmp")
+            if result.exit_status:
+                raise error.TestError('Failed to add chardev %s to %s. Result:\n %s'
+                                      % (char_dev, vm_name, result))
+            result = virsh.qemu_monitor_command(vm_name, dev_add_opt, "--hmp")
+            if result.exit_status:
+                raise error.TestError('Failed to add device %s to %s. Result:\n %s'
+                                      % (char_dev, vm_name, result))
+        elif type == "attach":
+            if char_dev in ["file", "socket"]:
+                xml_info = create_channel_xml(vm_name, char_dev)
+            elif char_dev == "pty":
+                xml_info = create_channel_xml(vm_name, char_dev, id)
+            f = open(xml_file, "w")
+            f.write(xml_info)
+            f.close()
+            if os.path.exists(tmp_file):
+                os.chmod(tmp_file, stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO)
+            result = virsh.attach_device(vm_name, xml_file)
+        return result
+
+    def dup_hotplug(type, char_dev, id, dup_charid=False, dup_devid=False, diff_devid=False):
+        if type == "qmp":
+            char_add_opt = "chardev-add "
+            dev_add_opt = "device_add virtserialport,chardev="
+            if char_dev == "file":
+                if dup_charid:
+                    char_add_opt += "file,path=/tmp/file,id=file"
+                if dup_devid:
+                    dev_add_opt += "file,name=file,bus=virtio-serial0.0,id=file"
+                if diff_devid:
+                    dev_add_opt += "file,name=file,bus=virtio-serial0.0,id=file1"
+            elif char_dev == "socket":
+                if dup_charid:
+                    char_add_opt += "socket,path=/tmp/socket,server,nowait,id=socket"
+                if dup_devid:
+                    dev_add_opt += "socket,name=socket,bus=virtio-serial0.0,id=socket"
+                if diff_devid:
+                    dev_add_opt += "socket,name=socket,bus=virtio-serial0.0,id=socket1"
+            elif char_dev == "pty":
+                if dup_charid:
+                    char_add_opt += "pty,path=/dev/pts/%s,id=pty" % id
+                if dup_devid:
+                    dev_add_opt += "pty,name=pty,bus=virtio-serial0.0,id=pty"
+                if diff_devid:
+                    dev_add_opt += "pty,name=pty,bus=virtio-serial0.0,id=pty1"
+            if dup_charid:
+                result = virsh.qemu_monitor_command(vm_name, char_add_opt, "--hmp")
+            if dup_devid or diff_devid:
+                result = virsh.qemu_monitor_command(vm_name, dev_add_opt, "--hmp")
+        elif type == "attach":
+            if dup_devid:
+                result = hotplug_device(type, char_dev, id)
+        return result
+
+    def confirm_hotplug_result(char_dev, id=0):
+        tmp_file = "/tmp/%s" % char_dev
+        serial_file = "/dev/virtio-ports/%s" % char_dev
+
+        result = virsh.qemu_monitor_command(vm_name, "info qtree", "--hmp")
+        h_o = result.stdout.strip()
+        if not h_o.count("name = \"%s\"" % char_dev):
+            raise error.TestFail("Cann't find device(%s) from:\n%s" % (char_dev, h_o))
+        if char_dev == "file":
+            session.cmd("echo test > %s" % serial_file)
+            f = open(tmp_file, "r")
+            r_o = f.read()
+            f.close()
+        elif char_dev == "socket":
+            session.cmd("echo test > /tmp/file")
+            sock = socket.socket(socket.AF_UNIX)
+            sock.connect(tmp_file)
+            session.cmd("dd if=/tmp/file of=%s" % serial_file)
+            r_o = sock.recv(1024)
+        elif char_dev == "pty":
+            session.cmd("echo test > /tmp/file")
+            session.cmd("dd if=/tmp/file of=%s &" % serial_file)
+            dev_file = "/dev/pts/%s" % id
+            if not os.path.exists(dev_file):
+                raise error.TestFail("%s doesn't exist." % dev_file)
+            p = subprocess.Popen(["/usr/bin/cat", dev_file],
+                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            session.cmd("echo test >> /tmp/file &")
+            while True:
+                r_o = p.stdout.readline()
+                if r_o or p.poll():
+                    break
+                time.sleep(0.2)
+            p.kill()
+        if not r_o.count("test"):
+            err_info = "%s device file doesn't match 'test':%s" % (char_dev, r_o)
+            raise error.TestFail(err_info)
+
+    def unhotplug_serial_device(type, char_dev):
+        if type == "qmp":
+            del_dev_opt = "device_del %s" % char_dev
+            del_char_opt = "chardev-remove %s" % char_dev
+            result = virsh.qemu_monitor_command(vm_name, del_dev_opt, "--hmp")
+            if result.exit_status:
+                raise error.TestError('Failed to del device %s from %s.Result:\n%s'
+                                      % (char_dev, vm_name, result))
+            result = virsh.qemu_monitor_command(vm_name, del_char_opt, "--hmp")
+        elif type == "attach":
+            result = virsh.detach_device(vm_name, xml_file)
+
+    def confirm_unhotplug_result(char_dev):
+        serial_file = "/dev/virtio-ports/%s" % char_dev
+        result = virsh.qemu_monitor_command(vm_name, "info qtree", "--hmp")
+        uh_o = result.stdout.strip()
+        if uh_o.count("chardev = \"%s\"" % char_dev):
+            raise error.TestFail("Still can get serial device(%s) from: '%s'"
+                                 % (char_dev, uh_o))
+        if os.path.exists(serial_file):
+            raise error.TestFail("File '%s' still exists after unhotplug" % serial_file)
+
+    # run test case
+    try:
+        if char_dev in ['file', 'socket']:
+            # if char_dev is file or socket, it doesn't need pts index
+            pts_id = 0
+        else:
+            pts_id = str(utils_misc.aton(utils_misc.get_dev_pts_max_id()) + 1)
+            if os.path.exists("/dev/pts/%s" % pts_id):
+                raise error.TestError('invalid pts index(%s) provided.' % pts_id)
+        if status_error:
+            hotplug_device(hotplug_type, char_dev, pts_id)
+            ret = dup_hotplug(hotplug_type, char_dev, pts_id, dup_charid, dup_devid, diff_devid)
+            dup_o = ret.stdout.strip()
+            if hotplug_type == "qmp":
+                # although it has failed, ret.exit_status will be returned 0.
+                err_o1 = "Duplicate ID"
+                err_o2 = "Parsing chardev args failed"
+                err_o3 = "Property 'virtserialport.chardev' can't"
+                if (err_o1 not in dup_o) and (err_o2 not in dup_o) and (err_o3 not in dup_o):
+                    raise error.TestFail("Expect fail, but run successfully:\n%s" % ret)
+            else:
+                if "chardev already exists" not in dup_o:
+                    logging.info("Expect fail,but run successfully:\n%s" % ret)
+        else:
+            if char_dev != "all":
+                #1.hotplug serial device
+                hotplug_device(hotplug_type, char_dev, pts_id)
+
+                #2.confirm hotplug result
+                confirm_hotplug_result(char_dev, pts_id)
+
+                #3.unhotplug serial device
+                unhotplug_serial_device(hotplug_type, char_dev)
+
+                #4.confirm unhotplug result
+                confirm_unhotplug_result(char_dev)
+            else:
+                #1.hotplug serial device
+                hotplug_device(hotplug_type, "file")
+                hotplug_device(hotplug_type, "socket")
+                hotplug_device(hotplug_type, "pty", pts_id)
+
+                #2.confirm hotplug result
+                confirm_hotplug_result("file")
+                confirm_hotplug_result("socket")
+                confirm_hotplug_result("pty", pts_id)
+
+                #3.unhotplug serial device
+                unhotplug_serial_device(hotplug_type, "file")
+                unhotplug_serial_device(hotplug_type, "socket")
+                unhotplug_serial_device(hotplug_type, "pty")
+
+                #4.confirm unhotplug result
+                confirm_unhotplug_result("file")
+                confirm_unhotplug_result("socket")
+                confirm_unhotplug_result("pty")
+    finally:
+        vm_xml_backup.sync()
+        if os.path.exists(xml_file):
+            os.remove(xml_file)


### PR DESCRIPTION
[root@localhost virt-test]# ./run -t libvirt --no-downloads -k --keep-image-between-tests  --tests "type_specific.io-github-autotest-libvirt.hotplug_serial" 
SETUP: PASS (0.20 s)
DATA DIR: /var/lib/virt_test
DEBUG LOG: /root/osc/virt-test/logs/run-2014-12-18-17.32.56/debug.log
TESTS: 20
(1/20) type_specific.io-github-autotest-libvirt.hotplug_serial.qmp.file_dev.normal_test: PASS (13.32 s)
(2/20) type_specific.io-github-autotest-libvirt.hotplug_serial.qmp.file_dev.error_test.dup_charid: PASS (13.07 s)
(3/20) type_specific.io-github-autotest-libvirt.hotplug_serial.qmp.file_dev.error_test.dup_devid: PASS (13.30 s)
(4/20) type_specific.io-github-autotest-libvirt.hotplug_serial.qmp.file_dev.error_test.one_charid_two_devid: PASS (13.05 s)
(5/20) type_specific.io-github-autotest-libvirt.hotplug_serial.qmp.sock_dev.normal_test: PASS (13.53 s)
(6/20) type_specific.io-github-autotest-libvirt.hotplug_serial.qmp.sock_dev.error_test.dup_charid: PASS (13.14 s)
(7/20) type_specific.io-github-autotest-libvirt.hotplug_serial.qmp.sock_dev.error_test.dup_devid: PASS (13.05 s)
(8/20) type_specific.io-github-autotest-libvirt.hotplug_serial.qmp.sock_dev.error_test.one_charid_two_devid: PASS (13.05 s)
(9/20) type_specific.io-github-autotest-libvirt.hotplug_serial.qmp.pty_dev.normal_test: PASS (14.27 s)
(10/20) type_specific.io-github-autotest-libvirt.hotplug_serial.qmp.pty_dev.error_test.dup_charid: PASS (13.11 s)
(11/20) type_specific.io-github-autotest-libvirt.hotplug_serial.qmp.pty_dev.error_test.dup_devid: PASS (13.09 s)
(12/20) type_specific.io-github-autotest-libvirt.hotplug_serial.qmp.pty_dev.error_test.one_charid_two_devid: PASS (13.02 s)
(13/20) type_specific.io-github-autotest-libvirt.hotplug_serial.qmp.all_dev.normal_test: PASS (14.88 s)
(14/20) type_specific.io-github-autotest-libvirt.hotplug_serial.at_dt_device.file_dev.normal_test: PASS (13.28 s)
(15/20) type_specific.io-github-autotest-libvirt.hotplug_serial.at_dt_device.file_dev.error_test.dup_devid: PASS (13.06 s)
(16/20) type_specific.io-github-autotest-libvirt.hotplug_serial.at_dt_device.sock_dev.normal_test: PASS (13.50 s)
(17/20) type_specific.io-github-autotest-libvirt.hotplug_serial.at_dt_device.sock_dev.error_test.dup_devid: PASS (13.07 s)
(18/20) type_specific.io-github-autotest-libvirt.hotplug_serial.at_dt_device.pty_dev.normal_test: PASS (13.96 s)
(19/20) type_specific.io-github-autotest-libvirt.hotplug_serial.at_dt_device.pty_dev.error_test.dup_devid: PASS (13.06 s)
(20/20) type_specific.io-github-autotest-libvirt.hotplug_serial.at_dt_device.all_dev.normal_test: PASS (15.02 s)
TOTAL TIME: 268.87 s (04:28)
TESTS PASSED: 20
TESTS FAILED: 0
SUCCESS RATE: 100.00 %
