### PR TITLE
libvirt_network_bandwidth: fix bug for AttributeError

### DIFF
--- a/libvirt/tests/src/libvirt_network_bandwidth.py
+++ b/libvirt/tests/src/libvirt_network_bandwidth.py
@@ -87,8 +87,9 @@ def run(test, params, env):
                         default_interface.device_tag):
                     continue
                 if devices[index].mac_address == default_interface.mac_address:
-                    default_interface.bandwidth_inbound = bandwidth_inbound
-                    default_interface.bandwidth_outbound = bandwidth_outbound
+                    bound = {'inbound': bandwidth_inbound,
+                             'outbound': bandwidth_outbound}
+                    default_interface.bandwidth = default_interface.new_bandwidth(**bound)
                     devices[index] = default_interface
                     break
             vm_xml.devices = devices
@@ -112,7 +113,8 @@ def run(test, params, env):
                         default_interface.device_tag):
                     continue
                 if devices[index].mac_address == default_interface.mac_address:
-                    default_interface.portgroup = portgroup_name
+                    default_interface.source = {nettype: netdst,
+                                                'portgroup': portgroup_name}
                     devices[index] = default_interface
                     break
             vm_xml.devices = devices


### PR DESCRIPTION
since the class Interface has been updated, the setting about network
bandwidth for interface will suffer from AttributeError.as following,
07:11:09 ERROR| AttributeError: Key 'bandwidth_inbound' not found in super class attributes or in ('source', 'mac_address', 'bandwidth', 'model', 'link_state', 'driver', 'address', 'type_name', 'device_tag', 'xml', 'virsh', 'xmltreefile', 'validates', 'get_bandwidth_inbound', 'set_bandwidth_inbound', 'del_bandwidth_inbound')

This patch fixes the problem.
