### PR TITLE
Modify for ppc capability support

### DIFF
--- a/libvirt/tests/src/virsh_cmd/host/virsh_capabilities.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_capabilities.py
@@ -50,7 +50,10 @@ def run(test, params, env):
             img = utils_misc.find_command("qemu-kvm")
         except ValueError:
             raise error.TestNAError("Cannot find qemu-kvm")
-        cmd = img + " --cpu ? | grep qemu"
+        if re.search("ppc", utils.run("arch").stdout):
+            cmd = img + " --cpu ? | grep ppc"
+        else:
+            cmd = img + " --cpu ? | grep qemu"
         cmd_result = utils.run(cmd, ignore_status=True)
         for guest in xmltreefile.findall('guest'):
             guest_wordsize = guest.find('arch').find('wordsize').text


### PR DESCRIPTION
on ppc
# /usr/libexec/qemu-kvm --cpu ?|grep -i ppc

PowerPC ppc32            (alias for 604)
PowerPC ppc              (alias for 604)
PowerPC ppc64            (alias for 970fx_v3.1)

on x86_64
# /usr/libexec/qemu-kvm --cpu ?|grep qemu

x86           qemu64  QEMU Virtual CPU version 2.1.2  
x86           qemu32  QEMU Virtual CPU version 2.1.2 
