### PR TITLE
virsh.vol_create: Update and extend cases

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_create.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_create.cfg
@@ -1,10 +1,12 @@
 - virsh.vol_create:
     type = virsh_vol_create
     start_vm = no
-    vol_name = "vol_create_test"
-    vol_capacity = "1073741824"
+    prefix_vol_name = "vol_create_test"
+    src_pool_vol_num = "1"
+    vol_capacity = "10485760"
     vol_allocation = "1048576"
     extra_option = ""
+    emulate_image_size = "1G"
     variants:
         - positive_test:
             status_error = "no"
@@ -13,10 +15,42 @@
                     src_pool_type = "logical"
                     src_pool_target = "/dev/vg_logical"
                     src_emulated_image = "logical-pool"
+                    variants:
+                        - normal_vol:
+                        - thin_vol:
+                            # Create thin volume 'thinvolume_virt' in
+                            # thin pool 'thinpool_virt'
+                            process_vol_by = "lvcreate"
+                            process_vol_type = "thin"
+                            process_vol_options = "-T"
+                            process_thin_pool_name = "thinpool_virt"
+                            process_thin_vol_name = "thinvolume_virt"
+                            process_vol_capacity = "10M"
+                        - snapshot_vol:
+                            # Create snapshot volume
+                            process_vol_by = "lvcreate"
+                            process_vol_type = "snapshot"
+                            process_vol_options = "-s"
+                            process_vol_capacity = "10M"
+                        - deactivate_vol:
+                            # Deactivate logical volume
+                            process_vol_by = "lvchange"
+                            process_vol_type = "deactivate"
+                            process_vol_options = "-an"
+                            expect_vol_exist = "no"
+                        - invalid_target:
+                            src_pool_target = "/dev"
                 - disk_pool:
                     src_pool_type = "disk"
                     src_pool_target = "/dev"
                     src_emulated_image = "disk-pool"
+                    variants:
+                        - pool_format_none:
+                        - pool_format_gpt:
+                            only vol_format_none
+                            sr_pool_format = "gpt"
+                            src_pool_vol_num = "128"
+                            vol_capacity = "1048576"
                     variants:
                         - vol_format_none:
                         - vol_format_linux:
@@ -86,6 +120,20 @@
                                     vol_format = "iso"
                                 - v_vmdk:
                                     vol_format = "vmdk"
+                                - v_vmdk_v4:
+                                    only dir
+                                    process_vol_by = "qemu-img"
+                                    process_vol_type = "create"
+                                    process_vol_options = "-f vmdk"
+                                    process_vol_capacity = ${vol_capacity}
+                                    process_vol_name = "vmdk_v4_vol"
+                                - v_vmdk_v5:
+                                    only dir
+                                    process_vol_by = "qemu-img"
+                                    process_vol_type = "create"
+                                    process_vol_options = "-f vmdk -o zeroed_grain"
+                                    process_vol_capacity = ${vol_capacity}
+                                    process_vol_name = "vmdk_v5_vol"
                                 - v_vpc:
                                     vol_format = "vpc"
                                 - v_none:

--- a/libvirt/tests/src/virsh_cmd/volume/virsh_vol_create.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_vol_create.py
@@ -32,10 +32,14 @@ def run(test, params, env):
 
     src_pool_type = params.get("src_pool_type")
     src_pool_target = params.get("src_pool_target")
+    src_pool_format = params.get("src_pool_format", "")
+    pool_vol_num = int(params.get("src_pool_vol_num", '1'))
     src_emulated_image = params.get("src_emulated_image")
     extra_option = params.get("extra_option", "")
-    vol_name = params.get("vol_name", "vol_create_test")
+    prefix_vol_name = params.get("vol_name", "vol_create_test")
     vol_format = params.get("vol_format")
+    vol_capacity = params.get("vol_capacity", 1048576)
+    image_size = params.get("emulate_image_size", "1G")
     lazy_refcounts = "yes" == params.get("lazy_refcounts")
     status_error = "yes" == params.get("status_error", "no")
 
@@ -72,74 +76,168 @@ def run(test, params, env):
             raise error.TestNAError("API acl test not supported in current"
                                     + " libvirt version.")
 
+    def post_process_vol(ori_vol_path):
+        """
+        Create or disactive a volume without libvirt
+
+        :param ori_vol_path: Full path of an original volume
+        :retur: Volume name for checking
+        """
+        process_vol_name = params.get("process_vol_name", "process_vol")
+        process_vol_options = params.get("process_vol_options", "")
+        process_vol_capacity = params.get("process_vol_capacity", vol_capacity)
+        process_vol_cmd = ""
+        unsupport_err = "Unsupport do '%s %s' in this test" % (process_vol_by,
+                                                               process_vol_type)
+        if process_vol_by == "lvcreate":
+            process_vol_cmd = "lvcreate -L %s " % process_vol_capacity
+            if process_vol_type == "thin":
+                if not process_vol_options:
+                    process_vol_options = "-T "
+                process_vol_cmd += "%s " % process_vol_options
+                processthin_pool_name = params.get("processthin_pool_name", "thinpool")
+                processthin_vol_name = params.get("processthin_vol_name", "thinvol")
+                process_vol_capacity = params.get("process_vol_capacity", "1G")
+                os.path.dirname(ori_vol_path)
+                process_vol_cmd += "%s/%s " % (os.path.dirname(ori_vol_path),
+                                               processthin_pool_name)
+                process_vol_cmd += "-V %s " % process_vol_capacity
+                process_vol_cmd += "-n %s " % processthin_vol_name
+                process_vol_name = processthin_vol_name
+            elif process_vol_type == "snapshot":
+                if not process_vol_options:
+                    process_vol_options = "-s "
+                process_vol_cmd += "%s " % process_vol_options
+                process_vol_cmd += "-n %s " % process_vol_name
+                process_vol_cmd += "%s " % (ori_vol_path)
+            else:
+                logging.error(unsupport_err)
+                return
+        elif process_vol_by == "qemu-img" and process_vol_type == "create":
+            process_vol_cmd = "qemu-img create "
+            process_vol_path = os.path.dirname(ori_vol_path) + "/"
+            process_vol_path += process_vol_name
+            process_vol_cmd += "%s " % process_vol_options
+            process_vol_cmd += "%s " % process_vol_path
+            process_vol_cmd += "%s " % process_vol_capacity
+        elif process_vol_by == "lvchange" and process_vol_type == "deactivate":
+            process_vol_cmd = "lvchange %s " % ori_vol_path
+            if not process_vol_options:
+                process_vol_options = "-an"
+            process_vol_cmd += process_vol_options
+        else:
+            logging.error(unsupport_err)
+            return
+        rst = utils.run(process_vol_cmd, ignore_status=True)
+        if rst.exit_status:
+            if "Snapshots of snapshots are not supported" in rst.stderr:
+                logging.debug("%s is already a snapshot volume", ori_vol_path)
+                process_vol_name = os.path.basename(ori_vol_path)
+            else:
+                logging.error(rst.stderr)
+                return
+        return process_vol_name
+
+    def check_vol(pool_name, vol_name, expect_exist=True):
+        """
+        Check volume vol_name in pool pool_name
+        """
+        src_volumes = src_pv.list_volumes().keys()
+        logging.debug("Current volumes in %s: %s", pool_name, src_volumes)
+        if expect_exist:
+            if vol_name not in src_volumes:
+                raise error.TestFail("Can't find volume %s in pool %s"
+                                     % (vol_name, pool_name))
+            # check format in volume xml
+            post_xml = volxml.new_from_vol_dumpxml(vol_name, pool_name)
+            logging.debug("Volume %s XML: %s" % (vol_name,
+                                                 post_xml.xmltreefile))
+            if 'format' in post_xml.keys() and vol_format is not None:
+                if post_xml.format != vol_format:
+                    raise error.TestFail("Volume format %s is not expected"
+                                         % vol_format + " as defined.")
+        else:
+            if vol_name in src_volumes:
+                raise error.TestFail("Find volume %s in pool %s, but expect not"
+                                     % (vol_name, pool_name))
+
+    fmt_err0 = "Unknown file format '%s'" % vol_format
+    fmt_err1 = "Formatting or formatting option not "
+    fmt_err1 += "supported for file format '%s'" % vol_format
+    fmt_err2 = "Driver '%s' does not support " % vol_format
+    fmt_err2 += "image creation"
+    fmt_err_list = [fmt_err0, fmt_err1, fmt_err2]
+    skip_msg = "Volume format '%s' is not supported by qemu-img" % vol_format
     try:
         # Create the src pool
         src_pool_name = "virt-%s-pool" % src_pool_type
         pvt = utlv.PoolVolumeTest(test, params)
         pvt.pre_pool(src_pool_name, src_pool_type, src_pool_target,
-                     src_emulated_image, image_size="2G",
-                     pre_disk_vol=["1M"])
+                     src_emulated_image, image_size=image_size,
+                     source_format=src_pool_format)
 
+        src_pv = libvirt_storage.PoolVolume(src_pool_name)
         # Print current pools for debugging
         logging.debug("Current pools:%s",
                       libvirt_storage.StoragePool().list_pools())
 
-        # Set volume xml file
-        volxml = libvirt_xml.VolXML()
-        newvol = volxml.new_vol(**vol_arg)
-        vol_xml = newvol['xml']
-        if params.get('setup_libvirt_polkit') == 'yes':
-            utils.run("chmod 666 %s" % vol_xml, ignore_status=True)
+        # Create volumes by virsh in a loop
+        vol_path_list = []
+        while pool_vol_num > 0:
+            # Set volume xml file
+            vol_name = prefix_vol_name + "_%s" % pool_vol_num
+            vol_arg['name'] = vol_name
+            pool_vol_num -= 1
+            volxml = libvirt_xml.VolXML()
+            newvol = volxml.new_vol(**vol_arg)
+            vol_xml = newvol['xml']
+            if params.get('setup_libvirt_polkit') == 'yes':
+                utils.run("chmod 666 %s" % vol_xml, ignore_status=True)
 
-        # Run virsh_vol_create to create vol
-        logging.debug("create volume from xml: %s" % newvol.xmltreefile)
-        cmd_result = virsh.vol_create(src_pool_name, vol_xml, extra_option,
-                                      unprivileged_user=unprivileged_user,
-                                      uri=uri, ignore_status=True, debug=True)
-        status = cmd_result.exit_status
-        # Check result
-        if not status_error:
-            if not status:
-                src_pv = libvirt_storage.PoolVolume(src_pool_name)
-                src_volumes = src_pv.list_volumes().keys()
-                logging.debug("Current volumes in %s: %s",
-                              src_pool_name, src_volumes)
-                if vol_name not in src_volumes:
-                    raise error.TestFail("Can't find volume: %s from pool: %s"
-                                         % (vol_name, src_pool_name))
-                # check format in volume xml
-                post_xml = volxml.new_from_vol_dumpxml(vol_name, src_pool_name)
-                logging.debug("the created volume xml is: %s" %
-                              post_xml.xmltreefile)
-                if 'format' in post_xml.keys():
-                    if post_xml.format != vol_format:
-                        raise error.TestFail("Volume format %s is not expected"
-                                             % vol_format + " as defined.")
-            else:
-                # Skip the format not supported by qemu-img error
-                if vol_format:
-                    fmt_err = "Unknown file format '%s'" % vol_format
-                    fmt_err1 = "Formatting or formatting option not "
-                    fmt_err1 += "supported for file format '%s'" % vol_format
-                    fmt_err2 = "Driver '%s' does not support " % vol_format
-                    fmt_err2 += "image creation"
-                    if "qemu-img" in cmd_result.stderr:
-                        er = cmd_result.stderr
-                        if fmt_err in er or fmt_err1 in er or fmt_err2 in er:
-                            err_msg = "Volume format '%s' is not" % vol_format
-                            err_msg += " supported by qemu-img."
-                            raise error.TestNAError(err_msg)
-                    else:
-                        raise error.TestFail("Run failed with right command.")
+            # Run virsh_vol_create to create vol
+            logging.debug("create volume from XML: %s" % newvol.xmltreefile)
+            cmd_result = virsh.vol_create(src_pool_name, vol_xml, extra_option,
+                                          unprivileged_user=unprivileged_user,
+                                          uri=uri, ignore_status=True, debug=True)
+            # Check result
+            try:
+                utlv.check_exit_status(cmd_result, status_error)
+                check_vol(src_pool_name, vol_name)
+                vol_path = virsh.vol_path(vol_name, src_pool_name).stdout.strip()
+                logging.debug("Full path of %s: %s", vol_name, vol_path)
+                vol_path_list.append(vol_path)
+            except error.TestFail, e:
+                stderr = cmd_result.stderr
+                if any(err in stderr for err in fmt_err_list):
+                    raise error.TestNAError(skip_msg)
                 else:
-                    raise error.TestFail("Run failed with right command.")
-        else:
-            if status:
-                logging.debug("Expect error: %s", cmd_result.stderr)
+                    raise e
+        # Post process vol by other programs
+        process_vol_by = params.get("process_vol_by")
+        process_vol_type = params.get("process_vol_type", "")
+        expect_vol_exist = "yes" == params.get("expect_vol_exist", "yes")
+        if process_vol_by and vol_path_list:
+            process_vol = post_process_vol(vol_path_list[0])
+            if process_vol is not None:
+                try:
+                    virsh.pool_refresh(src_pool_name)
+                    check_vol(src_pool_name, process_vol, expect_vol_exist)
+                except error.TestFail, e:
+                    if process_vol_type == "thin":
+                        logging.error(e)
+                        raise error.TestNAError("You may encounter bug BZ#1060287")
+                    else:
+                        raise e
             else:
-                raise error.TestFail("Expect fail, but run successfully!")
+                raise error.TestFail("Post process volume failed")
     finally:
         # Cleanup
+        # For old version lvm2(2.02.106 or early), deactivate volume group
+        # (destroy libvirt logical pool) will fail if which has deactivated
+        # lv snapshot, so before destroy the pool, we need activate it manually
+        if src_pool_type == 'logical':
+            vg_name = vol_path_list[0].split('/')[2]
+            utils.run("lvchange -ay %s" % vg_name)
         try:
             pvt.cleanup_pool(src_pool_name, src_pool_type, src_pool_target,
                              src_emulated_image)


### PR DESCRIPTION
1. Test create 128 partition volume on disk pool(gpt disk)
2. Create thin lvm pool/volume in libvirt logical pool
3. Create snapshopt volume in libvirt logical pool
4. Deactivate volume in libvirt logical pool
5. Use invalid target path('/dev/') to create pool/volume, which should pass
6. Use 'qemu-img' to cretae vmdk v4/v5 images in libvirt dir pool

Signed-off-by: Yanbing Du <ydu@redhat.com>