### PR TITLE
Add test for killing daemon when starting or started

### DIFF
--- a/libvirt/tests/cfg/daemon/kill_started.cfg
+++ b/libvirt/tests/cfg/daemon/kill_started.cfg
@@ -1,0 +1,24 @@
+- daemon.kill_started:
+    type = kill_started
+    start_vm = no
+    check_image = no
+    take_regular_screendumps = no
+    expect_pid_change = yes
+    expect_restart = no
+    variants:
+        - sigquit:
+            signal = 'SIGQUIT'
+        - sigint:
+            signal = 'SIGINT'
+        - sigterm:
+            signal = 'SIGTERM'
+        - sighup:
+            signal = 'SIGHUP'
+            expect_restart = yes
+            expect_pid_change = no
+        - sigabrt:
+            signal = 'SIGABRT'
+            expect_restart = yes
+        - sigkill:
+            signal = 'SIGKILL'
+            expect_restart = yes

--- a/libvirt/tests/cfg/daemon/kill_starting.cfg
+++ b/libvirt/tests/cfg/daemon/kill_starting.cfg
@@ -1,0 +1,17 @@
+- daemon.kill_starting:
+    type = kill_starting
+    start_vm = no
+    check_image = no
+    take_regular_screendumps = no
+    signal = 'SIGTERM'
+    variants:
+        - virStateInitialize:
+            send_signal_at = virStateInitialize
+        - qemuStateInitialize:
+            send_signal_at = qemuStateInitialize
+        - netcfStateInitialize:
+            send_signal_at = netcfStateInitialize
+        - networkStateInitialize:
+            send_signal_at = networkStateInitialize
+        - nwfilterStateInitialize:
+            send_signal_at = nwfilterStateInitialize

--- a/libvirt/tests/src/daemon/kill_started.py
+++ b/libvirt/tests/src/daemon/kill_started.py
@@ -1,0 +1,70 @@
+import os
+import time
+import signal
+import logging
+from autotest.client.shared import error
+from virttest.utils_libvirtd import Libvirtd
+
+
+def run(test, params, env):
+    """
+    Kill libvirt daemon with different signals and check
+    whether daemon restart properly and leaving no pid file
+    if stopped.
+    """
+    def get_pid(libvirtd):
+        """
+        Get the pid of libvirt daemon process.
+        """
+        pid = int(open(pid_file).read())
+        return pid
+
+    def send_signal(pid, signal_name):
+        """
+        Send signal to a process by pid.
+        """
+        signal_num = getattr(signal, signal_name)
+        os.kill(pid, signal_num)
+
+    pid_file = '/var/run/libvirtd.pid'
+    signal_name = params.get("signal", "SIGTERM")
+    should_restart = params.get("expect_restart", "yes") == "yes"
+    pid_should_change = params.get("expect_pid_change", "yes") == "yes"
+
+    libvirtd = Libvirtd()
+    try:
+        libvirtd.start()
+
+        pid = get_pid(libvirtd)
+        logging.debug("Pid of libvirtd is %d" % pid)
+
+        logging.debug("Killing process %s with %s" % (pid, signal_name))
+        send_signal(pid, signal_name)
+
+        # Wait for libvirtd to restart or reload
+        time.sleep(1)
+
+        if libvirtd.is_running():
+            if not should_restart:
+                raise error.TestFail(
+                    "libvirtd should stop running after signal %s"
+                    % signal_name)
+            new_pid = get_pid(libvirtd)
+            logging.debug("New pid of libvirtd is %d" % new_pid)
+            if pid == new_pid and pid_should_change:
+                raise error.TestFail("Pid should have been changed.")
+            if pid != new_pid and not pid_should_change:
+                raise error.TestFail("Pid should not have been changed.")
+        else:
+            if should_restart:
+                raise error.TestFail(
+                    "libvirtd should still running after signal %s"
+                    % signal_name)
+
+    finally:
+        if not libvirtd.is_running():
+            if os.path.exists(pid_file):
+                os.remove(pid_file)
+                libvirtd.start()
+                raise error.TestFail("Pid file should not reside")
+            libvirtd.start()

--- a/libvirt/tests/src/daemon/kill_starting.py
+++ b/libvirt/tests/src/daemon/kill_starting.py
@@ -1,0 +1,46 @@
+import logging
+from autotest.client.shared import error
+from virttest import utils_misc
+from virttest.utils_libvirtd import LibvirtdSession
+
+
+def run(test, params, env):
+    """
+    Start libvirt daemon with break point inserted.
+    And then kill daemon ensure no sigsegv happends.
+    """
+    signal_name = params.get("signal", "SIGTERM")
+    send_signal_at = params.get("send_signal_at", None)
+
+    def _signal_callback(gdb, info, params):
+        """
+        Callback function when a signal is recieved by libvirtd.
+        """
+        params['recieved'] = True
+        logging.debug("Signal recieved:")
+        logging.debug(info)
+
+    def _break_callback(gdb, info, params):
+        """
+        Callback function when a breakpoint is reached.
+        """
+        for line in gdb.back_trace():
+            logging.debug(line)
+        gdb.send_signal(signal_name)
+        gdb.cont()
+
+    bundle = {'recieved': False}
+
+    libvirtd = LibvirtdSession(gdb=True)
+    try:
+        libvirtd.set_callback('break', _break_callback)
+        libvirtd.set_callback('signal', _signal_callback, bundle)
+
+        libvirtd.insert_break(send_signal_at)
+
+        libvirtd.start(wait_for_working=False)
+
+        if not utils_misc.wait_for(lambda: bundle['recieved'], 20, 0.5):
+            raise error.TestFail("Expect recieve signal, but not.")
+    finally:
+        libvirtd.exit()


### PR DESCRIPTION
This PR depends on https://github.com/autotest/virt-test/pull/1947.

These test focus on testing whether libvirtd works properly
when recieved different kill signals. It includes two parts:

kill_started:
    Kill libvirt daemon with different signals and check
    whether daemon restart properly and leaving no pid file
    if stopped.

kill_starting:
    Start libvirt daemon with break point inserted.
    And then kill daemon ensure no sigsegv happends.

Signed-off-by: Hao Liu <hliu@redhat.com>