### PR TITLE
Add test to check state consistency after daemon restarts

### DIFF
--- a/libvirt/tests/cfg/daemon/restart_consist.cfg
+++ b/libvirt/tests/cfg/daemon/restart_consist.cfg
@@ -1,0 +1,3 @@
+- daemon.restart_consist:
+    type = restart_consist
+    take_regular_screendumps = no

--- a/libvirt/tests/src/daemon/restart_consist.py
+++ b/libvirt/tests/src/daemon/restart_consist.py
@@ -1,0 +1,82 @@
+import logging
+import difflib
+from autotest.client.shared import error
+from virttest.aexpect import ExpectTimeoutError
+from virttest.aexpect import ShellTimeoutError
+from virttest import utils_libvirtd
+from virttest import utils_misc
+from virttest import remote
+from virttest.libvirt_xml import VMXML
+from virttest.libvirt_xml.xcepts import LibvirtXMLNotFoundError
+
+
+def run(test, params, env):
+    """
+    Restart libvirtd and check the consistent of VM states.
+    """
+
+    def agent_connected():
+        """
+        Callback function to check if agent channel connected.
+        """
+        ga_tgt = VMXML.new_from_dumpxml(vm_name).get_section_string(
+            '/devices/channel/target')
+        return 'state="connected"' in ga_tgt
+
+    vm_name = params.get('main_vm')
+    vm = env.get_vm(vm_name)
+
+    # Wait guest agent channel to be connected to avoid XML differ
+    try:
+        if not utils_misc.wait_for(agent_connected, 30):
+            logging.warning('Agent channel not connected')
+    except LibvirtXMLNotFoundError:
+        pass
+
+    vm_xml = VMXML.new_from_dumpxml(vm_name)
+    logging.debug(vm_xml)
+
+    # Skip the test when serial login is not available
+    try:
+        session = vm.wait_for_serial_login(60)
+    except remote.LoginError:
+        raise error.TestNAError('Serial console might needed to be '
+                                'configured before test.')
+    # Send a command line without waiting result
+    try:
+        session.cmd('sleep 30; echo hello', timeout=0)
+    except ShellTimeoutError:
+        pass
+
+    # Restart libvirtd
+    utils_libvirtd.Libvirtd().restart()
+
+    # Check whether guest is still working
+    vm.cleanup_serial_console()
+    vm.create_serial_console()
+    try:
+        vm.serial_console.read_until_any_line_matches(['hello'], timeout=60)
+    except ExpectTimeoutError:
+        raise error.TestFail('Timeout when waiting for command output. '
+                             'Maybe your guest is refreshed.')
+
+    # Wait guest agent channel to be reconnected to avoid XML differ
+    try:
+        if not utils_misc.wait_for(agent_connected, 30):
+            logging.warning('Agent channel not recovered after libvirtd '
+                            'restart')
+    except LibvirtXMLNotFoundError:
+        pass
+
+    # Check whether domain XML changed
+    vm_xml_new = VMXML.new_from_dumpxml(vm_name)
+    if str(vm_xml) != str(vm_xml_new):
+        diff_txt = '\n'.join(
+            difflib.unified_diff(
+                str(vm_xml).splitlines(),
+                str(vm_xml_new).splitlines(),
+                lineterm='',
+            )
+        )
+        raise error.TestFail("XML changed after libvirtd restart:\n%s"
+                             % diff_txt)


### PR DESCRIPTION
Restart libvirtd and check the consistent of VM states.
It currently check two things:
1) Whether the domain is still working.
2) Whether the domain XML is unchanged.

Signed-off-by: Hao Liu <hliu@redhat.com>