### PR TITLE
Add change-media test for scsi cdrom

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_change_media.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_change_media.cfg
@@ -89,7 +89,11 @@
     variants:
         - cdrom_test:
             change_media_device_type = "cdrom"
-            change_media_target_device = "hdc"
+            variants:
+                - ide:
+                    change_media_target_device = "hdc"
+                - scsi:
+                    change_media_target_device = "sdc"
         - floppy_test:
             change_media_device_type = "floppy"
             change_media_target_device = "fda"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_change_media.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_change_media.py
@@ -42,7 +42,7 @@ def run(test, params, env):
         """
         if action != "--eject ":
             error.context("Checking guest %s files" % target_device)
-            if target_device == "hdc":
+            if target_device == "hdc" or target_device == "sdc":
                 mount_cmd = "mount /dev/sr0 /media"
             else:
                 if session.cmd_status("ls /dev/fd0"):
@@ -61,7 +61,7 @@ def run(test, params, env):
 
         else:
             error.context("Ejecting guest cdrom files")
-            if target_device == "hdc":
+            if target_device == "hdc" or target_device == "sdc":
                 if session.cmd_status("mount /dev/sr0 /media -o loop") == 32:
                     logging.info("Eject succeeded")
             else:


### PR DESCRIPTION
$ ./run -kt libvirt --tests virsh.change_media.cdrom_test.scsi   --no-downloads --keep-image-between-testsSETUP: PASS (0.20 s)
DATA DIR: /var/lib/virt_test
DEBUG LOG: /tmp/virsh-command-other-9/logs/run-2015-01-07-16.06.56/debug.log
TESTS: 49
(1/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.positive_test.eject.options.none.running_guest: PASS (15.12 s)
(2/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.positive_test.eject.options.none.shutoff_guest: PASS (15.60 s)
(3/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.positive_test.eject.options.current.running_guest: PASS (16.09 s)
(4/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.positive_test.eject.options.current.shutoff_guest: PASS (15.50 s)
(5/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.positive_test.eject.options.live.running_guest: PASS (16.10 s)
(6/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.positive_test.eject.options.force.running_guest: PASS (16.05 s)
(7/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.positive_test.eject.options.force.shutoff_guest: PASS (15.52 s)
(8/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.positive_test.eject.options.config.running_guest: PASS (26.98 s)
(9/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.positive_test.eject.options.config.shutoff_guest: PASS (15.60 s)
(10/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.positive_test.insert.options.none.running_guest: PASS (16.44 s)
(11/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.positive_test.insert.options.none.shutoff_guest: PASS (16.03 s)
(12/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.positive_test.insert.options.current.running_guest: PASS (16.55 s)
(13/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.positive_test.insert.options.current.shutoff_guest: PASS (15.97 s)
(14/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.positive_test.insert.options.live.running_guest: PASS (16.56 s)
(15/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.positive_test.insert.options.force.running_guest: PASS (16.53 s)
(16/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.positive_test.insert.options.force.shutoff_guest: PASS (15.97 s)
(17/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.positive_test.insert.options.config.running_guest: PASS (27.43 s)
(18/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.positive_test.insert.options.config.shutoff_guest: PASS (15.96 s)
(19/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.positive_test.update.options.none.running_guest: PASS (16.59 s)
(20/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.positive_test.update.options.none.shutoff_guest: PASS (16.01 s)
(21/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.positive_test.update.options.current.running_guest: PASS (16.57 s)
(22/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.positive_test.update.options.current.shutoff_guest: PASS (16.22 s)
(23/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.positive_test.update.options.live.running_guest: PASS (16.51 s)
(24/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.positive_test.update.options.force.running_guest: PASS (16.70 s)
(25/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.positive_test.update.options.force.shutoff_guest: PASS (16.03 s)
(26/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.positive_test.update.options.config.running_guest: PASS (27.44 s)
(27/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.positive_test.update.options.config.shutoff_guest: PASS (15.97 s)
(28/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.negative_test.eject.no_name: PASS (1.98 s)
(29/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.negative_test.eject.no_source_path_running: PASS (3.28 s)
(30/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.negative_test.eject.no_source_path_running_config: PASS (3.31 s)
(31/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.negative_test.eject.no_source_path_shutoff: PASS (2.05 s)
(32/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.negative_test.eject.unexpect_option: PASS (1.97 s)
(33/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.negative_test.eject.invalid_option: PASS (1.98 s)
(34/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.negative_test.eject.shutoff_guest_with_live: PASS (1.98 s)
(35/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.negative_test.insert.no_option: PASS (1.97 s)
(36/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.negative_test.insert.no_name: PASS (1.96 s)
(37/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.negative_test.insert.no_source_path_running: PASS (3.27 s)
(38/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.negative_test.insert.no_source_path_running_config: PASS (2.79 s)
(39/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.negative_test.insert.no_source_path_shutoff: PASS (1.41 s)
(40/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.negative_test.insert.unexpect_option: PASS (1.98 s)
(41/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.negative_test.insert.invalid_option: PASS (1.99 s)
(42/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.negative_test.insert.shutoff_guest_with_live: PASS (2.00 s)
(43/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.negative_test.update.no_name: PASS (1.97 s)
(44/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.negative_test.update.no_source_path_running: PASS (3.22 s)
(45/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.negative_test.update.no_source_path_running_config: PASS (2.78 s)
(46/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.negative_test.update.no_source_path_shutoff: PASS (1.51 s)
(47/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.negative_test.update.unexpect_option: PASS (1.97 s)
(48/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.negative_test.update.invalid_option: PASS (1.99 s)
(49/49) type_specific.io-github-autotest-libvirt.virsh.change_media.cdrom_test.scsi.negative_test.update.shutoff_guest_with_live: PASS (1.97 s)
TOTAL TIME: 517.53 s (08:37)
TESTS PASSED: 49
TESTS FAILED: 0
SUCCESS RATE: 100.00 %
