### PR TITLE
Fix the sysinfo problem when dmidecode can not give the version

### DIFF
--- a/libvirt/tests/src/virsh_cmd/host/virsh_sysinfo.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_sysinfo.py
@@ -15,9 +15,8 @@ def get_processor_version():
     processor_version = []
     cmd = "dmidecode -t processor | awk -F: '/Version/ {print $2}'"
     cmd_result = utils.run(cmd, ignore_status=True)
-    status = cmd_result.exit_status
     output = cmd_result.stdout.strip()
-    if not status:
+    if output:
         output_list = output.split('\n')
         for i in output_list:
             processor_version.append(i.strip())


### PR DESCRIPTION
Remove the status check for dmidecode commands output as with pipe it can not show the right commands status, and use output check instead