### PR TITLE
Add per-image disk DAC seclabel test cases

### DIFF
--- a/libvirt/tests/cfg/svirt/dac_per_disk_hotplug.cfg
+++ b/libvirt/tests/cfg/svirt/dac_per_disk_hotplug.cfg
@@ -1,0 +1,46 @@
+- dac_per_disk_hotplug:
+    type = dac_per_disk_hotplug
+    start_vm = 'no'
+    kill_vm = 'yes'
+    vol_name = "dac_per_image_vol"
+    vol_format = "qcow2"
+    qemu_user = "qemu"
+    qemu_group = "qemu"
+    img_user = 0
+    img_group = 0
+    sec_model = 'dac'
+    relabel = 'yes'
+    disk_type_name = "file"
+    target_dev = "vdf"
+    target_bus = "virtio"
+    driver_type = ${vol_format}
+    variants:
+        - dynamic_ownership_on:
+            dynamic_ownership = "yes"
+        - dynamic_ownership_off:
+            dynamic_ownership = "no"
+    variants:
+        - qemu_user:
+        - root_user:
+            qemu_user = "root"
+            qemu_group = "root"
+    variants:
+        - img_root:
+        - img_qemu:
+            img_user = 'qemu'
+            img_group = 'qemu'
+        - img_qemu_grp:
+            img_user = 0
+            img_group = 107
+    variants:
+        - relabel_yes:
+        - relabel_no:
+            only dynamic_ownership_on..qemu_user..img_qemu
+            relabel = 'no'
+    variants:
+        - positive_test:
+            no relabel_no, img_qemu..root_user, img_root..qemu_user..dynamic_ownership_on, img_root..root_user..dynamic_ownership_off, img_qemu_grp..root_user..dynamic_ownership_off
+            status_error = no
+        - negative_test:
+            status_error = yes
+            only relabel_no, img_qemu..root_user, img_root..qemu_user..dynamic_ownership_on, img_root..root_user..dynamic_ownership_off, img_qemu_grp..root_user..dynamic_ownership_off

--- a/libvirt/tests/cfg/svirt/dac_vm_per_image_start.cfg
+++ b/libvirt/tests/cfg/svirt/dac_vm_per_image_start.cfg
@@ -1,0 +1,103 @@
+- dac_vm_per_image_start:
+    type = dac_vm_per_image_start
+    start_vm = "no"
+    kill_vm = "yes"
+    kill_vm_gracefully = "yes"
+    kill_vm_on_error = "yes"
+    host_selinux = "enforcing"
+    replace_vm_disk = "yes"
+    set_qemu_conf = "yes"
+    vm_sec_relabel = "yes"
+    variants:
+        - per_img_relabel_no:
+            per_img_sec_relabel = "no"
+        - per_img_relabel_yes:
+            per_img_sec_relabel = "yes"
+            variants:
+                - per_img_qemu:
+                    per_img_sec_label = "qemu:qemu"
+                - per_img_qemu_grp:
+                    per_img_sec_label = "0:qemu"
+                - invalid_per_img_label:
+                    invalid_label = "yes"
+                    per_sec_label = "dskajflsjdlfjlkds"
+    variants:
+        - vm_t_dynamic:
+            vm_sec_type = "dynamic"
+        - vm_t_static:
+            vm_sec_type = "static"
+            variants:
+                - s_qemu:
+                    vm_sec_label = "qemu:qemu"
+                - s_qemu_group_user:
+                    vm_sec_label = "0:107"
+    variants:
+        - file_disk:
+            variants:
+                - local:
+                    disk_type = 'file'
+                    disk_target = "vda"
+                    disk_target_bus = "virtio"
+                    disk_format = "qcow2"
+                - nfs:
+                    no invalid_per_img_label
+                    disk_source_protocol = "netfs"
+                    export_options = "rw,no_root_squash,fsid=0"
+                    disk_type = "file"
+                    disk_target = "vda"
+                    disk_target_bus = "virtio"
+                    disk_format = "qcow2"
+                    image_size = "10G"
+        - network_disk:
+            disk_type = "network"
+            disk_target = "vda"
+            disk_target_bus = "virtio"
+            disk_format = "raw"
+            image_size = "10G"
+            variants:
+                - iscsi:
+                    only s_qemu..per_img_qemu
+                    disk_source_protocol = "iscsi"
+                    disk_source_host = "127.0.0.1"
+                    disk_source_port = "3260"
+                - gluster:
+                    only s_qemu..per_img_qemu_grp
+                    disk_source_protocol = "gluster"
+                    vol_name = "gluster-vol1"
+                    pool_name = "gluster-pool"
+                    transport = "tcp"
+                    disk_format = "qcow2"
+        - block_disk:
+            only s_qemu..per_img_qemu
+            disk_source_protocol = "iscsi"
+            disk_type = "block"
+            disk_target = "vda"
+            disk_target_bus = "virtio"
+            disk_format = "raw"
+            image_size = "10G"
+            variants:
+                - lun:
+                    disk_device = 'lun'
+                    disk_target_bus = "scsi"
+                    disk_target = "sdd"
+                - disk:
+                    disk_device = 'disk'
+    variants:
+        - model_default:
+            per_sec_model = 'dac'
+        - model_none:
+            only local..s_qemu..per_img_qemu
+            per_sec_model = 'none'
+        - model_invalid:
+            only local..s_qemu..per_img_qemu
+            invalid_label = "yes"
+            per_sec_model = 'invalid'
+    variants:
+        - positive_test:
+             only vm_t_dynamic..per_img_qemu, s_qemu..per_img_qemu, gluster..s_qemu..per_img_qemu_grp, s_qemu_group_user..per_img_qemu_grp, nfs..s_qemu_group_user..per_img_qemu, local..s_qemu_group_user..per_img_relabel_no, nfs..s_qemu_group_user..per_img_relabel_no, model_none
+             no model_invalid
+            status_error = "no"
+        - negative_test:
+            only per_img_relabel_no, s_qemu..invalid_per_img_label, vm_t_dynamic..per_img_qemu_grp, s_qemu..per_img_qemu_grp, local..s_qemu_group_user..per_img_qemu, model_invalid
+            no local..s_qemu_group_user..per_img_relabel_no, nfs..s_qemu_group_user..per_img_relabel_no, gluster..s_qemu..per_img_qemu_grp
+            status_error = "yes"

--- a/libvirt/tests/src/svirt/dac_per_disk_hotplug.py
+++ b/libvirt/tests/src/svirt/dac_per_disk_hotplug.py
@@ -1,0 +1,171 @@
+import os
+import pwd
+import grp
+import logging
+from autotest.client.shared import error
+from virttest import qemu_storage
+from virttest import data_dir
+from virttest import virsh
+from virttest import utils_config
+from virttest import utils_libvirtd
+from virttest.utils_test import libvirt as utlv
+from virttest.libvirt_xml.vm_xml import VMXML
+from provider import libvirt_version
+
+
+def check_ownership(file_path):
+    """
+    Return file ownership string user:group
+
+    :params file_path: the file path
+    :return: ownership string user:group or false when file not exist
+    """
+    try:
+        f = os.open(file_path, 0)
+    except OSError:
+        return False
+    stat_re = os.fstat(f)
+    label = "%s:%s" % (stat_re.st_uid, stat_re.st_gid)
+    os.close(f)
+    logging.debug("File %s ownership is: %s" % (file_path, label))
+    return label
+
+
+def format_user_group_str(user, group):
+    """
+    Check given user and group, then return "uid:gid" string
+
+    :param user: given user name or id string
+    :param group: given group name or id string
+    :return: "uid:gid" string
+    """
+    try:
+        user_id = int(user)
+    except ValueError:
+        try:
+            user_id = pwd.getpwnam(user).pw_uid
+        except KeyError:
+            # user did not exist will definitly fail start domain, log warning
+            # here, let the test continue
+            logging.warning("the user name: %s not found on host" % user)
+            user_id = user
+
+    try:
+        grp_id = int(group)
+    except ValueError:
+        try:
+            grp_id = grp.getgrnam(group).gr_gid
+        except KeyError:
+            # group name not exist will fail start vm, only add warning info
+            # here, let the test continue
+            logging.warning("the group name: %s not found on host" % group)
+            grp_id = group
+
+    label_str = "%s:%s" % (user_id, grp_id)
+    return label_str
+
+
+def run(test, params, env):
+    """
+    Test per-image DAC disk hotplug to VM.
+
+    (1).Init variables for test.
+    (2).Creat disk xml with per-image DAC
+    (3).Start VM
+    (4).Attach the disk to VM and check result.
+    """
+    # Get general variables.
+    status_error = ('yes' == params.get("status_error", 'no'))
+    # Get qemu.conf config variables
+    qemu_user = params.get("qemu_user")
+    qemu_group = params.get("qemu_group")
+    dynamic_ownership = "yes" == params.get("dynamic_ownership", "yes")
+
+    # Get per-image DAC setting
+    vol_name = params.get('vol_name')
+    target_dev = params.get('target_dev')
+    disk_type_name = params.get("disk_type_name")
+    img_user = params.get("img_user")
+    img_group = params.get("img_group")
+    relabel = 'yes' == params.get('relabel', 'yes')
+
+    if not libvirt_version.version_compare(1, 2, 7):
+        raise error.TestNAError("per-image DAC only supported on version 1.2.7"
+                                " and after.")
+
+    # Get variables about VM and get a VM object and VMXML instance.
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    vmxml = VMXML.new_from_inactive_dumpxml(vm_name)
+
+    img_path = None
+    qemu_conf = utils_config.LibvirtQemuConfig()
+    libvirtd = utils_libvirtd.Libvirtd()
+    try:
+        # set qemu conf
+        qemu_conf.user = qemu_user
+        qemu_conf.group = qemu_group
+        if dynamic_ownership:
+            qemu_conf.dynamic_ownership = 1
+        else:
+            qemu_conf.dynamic_ownership = 0
+        logging.debug("the qemu.conf content is: %s" % qemu_conf)
+        libvirtd.restart()
+
+        first_disk = vm.get_first_disk_devices()
+        blk_source = first_disk['source']
+        owner_str = format_user_group_str(qemu_user, qemu_group)
+        src_usr, src_grp = owner_str.split(':')
+        os.chown(blk_source, int(src_usr), int(src_grp))
+        vm.start()
+
+        # Init a QemuImg instance and create a img.
+        params['image_name'] = vol_name
+        tmp_dir = data_dir.get_tmp_dir()
+        image = qemu_storage.QemuImg(params, tmp_dir, vol_name)
+        # Create a image.
+        img_path, result = image.create(params)
+
+        # Create disk xml for attach.
+        params['source_file'] = img_path
+        sec_label = "%s:%s" % (img_user, img_group)
+        params['sec_label'] = sec_label
+        params['type_name'] = disk_type_name
+        sec_label_id = format_user_group_str(img_user, img_group)
+
+        disk_xml = utlv.create_disk_xml(params)
+
+        # Change img file to qemu:qemu and 660 mode
+        os.chown(img_path, 107, 107)
+        os.chmod(img_path, 432)
+
+        img_label_before = check_ownership(img_path)
+        if img_label_before:
+            logging.debug("the image ownership before "
+                          "attach: %s" % img_label_before)
+
+        # Do the attach action.
+        option = "--persistent"
+        result = virsh.attach_device(vm_name, filearg=disk_xml,
+                                     flagstr=option, debug=True)
+        utlv.check_exit_status(result, status_error)
+
+        if not result.exit_status:
+            img_label_after = check_ownership(img_path)
+            if dynamic_ownership and relabel:
+                if img_label_after != sec_label_id:
+                    raise error.TestFail("The image dac label %s is not "
+                                         "expected." % img_label_after)
+
+            ret = virsh.detach_disk(vm_name, target=target_dev,
+                                    extra=option,
+                                    debug=True)
+            utlv.check_exit_status(ret, status_error)
+    finally:
+        # clean up
+        vm.destroy()
+        qemu_conf.restore()
+        vmxml.sync()
+        libvirtd.restart()
+        if img_path and os.path.exists(img_path):
+            os.unlink(img_path)

--- a/libvirt/tests/src/svirt/dac_vm_per_image_start.py
+++ b/libvirt/tests/src/svirt/dac_vm_per_image_start.py
@@ -1,0 +1,197 @@
+import os
+import stat
+import pwd
+import grp
+import logging
+from autotest.client.shared import error
+from virttest import utils_selinux
+from virttest import virt_vm
+from virttest import utils_config
+from virttest import utils_libvirtd
+from virttest import data_dir
+from virttest.utils_test import libvirt as utlv
+from virttest.libvirt_xml.vm_xml import VMXML
+
+
+def format_user_group_str(user, group):
+    """
+    Check given user and group, then return "uid:gid" string
+
+    :param user: given user name or id string
+    :param group: given group name or id string
+    :return: "uid:gid" string
+    """
+    try:
+        user_id = int(user)
+    except ValueError:
+        try:
+            user_id = pwd.getpwnam(user).pw_uid
+        except KeyError:
+            # user did not exist will definitly fail start domain, log warning
+            # here, let the test continue
+            logging.warning("the user name: %s not found on host" % user)
+            user_id = user
+
+    try:
+        grp_id = int(group)
+    except ValueError:
+        try:
+            grp_id = grp.getgrnam(group).gr_gid
+        except KeyError:
+            # group name not exist will fail start vm, only add warning info
+            # here, let the test continue
+            logging.warning("the group name: %s not found on host" % group)
+            grp_id = group
+
+    label_str = "%s:%s" % (user_id, grp_id)
+    return label_str
+
+
+def run(test, params, env):
+    """
+    Test DAC setting in both domain xml and qemu.conf.
+
+    (1) Init variables for test.
+    (2) Set VM xml and qemu.conf with proper DAC label, also set
+        monitor socket parent dir with propoer ownership and mode.
+    (3) Start VM and check the context.
+    """
+
+    # Get general variables.
+    status_error = ('yes' == params.get("status_error", 'no'))
+    host_sestatus = params.get("host_selinux", "enforcing")
+    # Get variables about seclabel for VM.
+    sec_type = params.get("vm_sec_type", "dynamic")
+    vm_sec_model = params.get("vm_sec_model", "dac")
+    vm_sec_label = params.get("vm_sec_label", None)
+    vm_sec_relabel = params.get("vm_sec_relabel", "yes")
+    sec_dict = {'type': sec_type, 'model': vm_sec_model,
+                'relabel': vm_sec_relabel}
+    if vm_sec_label:
+        sec_dict['label'] = vm_sec_label
+    set_qemu_conf = "yes" == params.get("set_qemu_conf", "no")
+    # Get per-img seclabel variables
+    disk_type = params.get("disk_type")
+    disk_target = params.get('disk_target')
+    disk_src_protocol = params.get("disk_source_protocol")
+    vol_name = params.get("vol_name")
+    tmp_dir = data_dir.get_tmp_dir()
+    pool_name = params.get("pool_name", "gluster-pool")
+    brick_path = os.path.join(tmp_dir, pool_name)
+    invalid_label = 'yes' == params.get("invalid_label", "no")
+    relabel = params.get("per_img_sec_relabel")
+    sec_label = params.get("per_img_sec_label")
+    per_sec_model = params.get("per_sec_model", 'dac')
+    per_img_dict = {'sec_model': per_sec_model, 'relabel': relabel,
+                    'sec_label': sec_label}
+    params.update(per_img_dict)
+    # Get qemu.conf config variables
+    qemu_user = params.get("qemu_user", 'qemu')
+    qemu_group = params.get("qemu_group", 'qemu')
+    dynamic_ownership = "yes" == params.get("dynamic_ownership", "yes")
+
+    # Get variables about VM and get a VM object and VMXML instance.
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    vmxml = VMXML.new_from_inactive_dumpxml(vm_name)
+    backup_xml = vmxml.copy()
+
+    # Set selinux of host.
+    backup_sestatus = utils_selinux.get_status()
+    utils_selinux.set_status(host_sestatus)
+
+    qemu_sock_mod = False
+    qemu_sock_path = '/var/lib/libvirt/qemu/'
+    qemu_conf = utils_config.LibvirtQemuConfig()
+    libvirtd = utils_libvirtd.Libvirtd()
+    try:
+        if set_qemu_conf:
+            # Set qemu.conf for user and group
+            if qemu_user:
+                qemu_conf.user = qemu_user
+            if qemu_group:
+                qemu_conf.group = qemu_group
+            if dynamic_ownership:
+                qemu_conf.dynamic_ownership = 1
+            else:
+                qemu_conf.dynamic_ownership = 0
+            logging.debug("the qemu.conf content is: %s" % qemu_conf)
+            libvirtd.restart()
+            st = os.stat(qemu_sock_path)
+            if not bool(st.st_mode & stat.S_IWGRP):
+                # chmod g+w
+                os.chmod(qemu_sock_path, st.st_mode | stat.S_IWGRP)
+                qemu_sock_mod = True
+
+        # Set the context of the VM.
+        logging.debug("sec_dict is %s" % sec_dict)
+        vmxml.set_seclabel([sec_dict])
+        vmxml.sync()
+
+        # Get per-image seclabel in id string
+        if sec_label:
+            per_img_usr, per_img_grp = sec_label.split(':')
+            sec_label_id = format_user_group_str(per_img_usr, per_img_grp)
+
+        # Start VM to check the qemu process and image.
+        try:
+            # Set per-img sec context and start vm
+            utlv.set_vm_disk(vm, params)
+            # Start VM successfully.
+            if status_error:
+                if invalid_label:
+                    # invalid label should fail, more info in bug 1165485
+                    raise error.TestNAError("The label or model not valid, "
+                                            "check more info in bug: https://"
+                                            "bugzilla.redhat.com/show_bug.cgi"
+                                            "?id=1165485")
+                else:
+                    raise error.TestFail("Test succeeded in negative case.")
+
+            # Get vm process label when VM is running.
+            vm_pid = vm.get_pid()
+            pid_stat = os.stat("/proc/%d" % vm_pid)
+            vm_process_uid = pid_stat.st_uid
+            vm_process_gid = pid_stat.st_gid
+            vm_context = "%s:%s" % (vm_process_uid, vm_process_gid)
+            logging.debug("vm process label is: %s", vm_context)
+
+            # Get vm image label when VM is running
+            if disk_type != "network":
+                disks = vm.get_blk_devices()
+                f = os.open(disks[disk_target]['source'], 0)
+                stat_re = os.fstat(f)
+                disk_context = "%s:%s" % (stat_re.st_uid, stat_re.st_gid)
+                os.close(f)
+                logging.debug("The disk dac label after vm start is: %s",
+                              disk_context)
+                if sec_label and relabel == 'yes':
+                    if disk_context != sec_label_id:
+                        raise error.TestFail("The disk label is not equal to "
+                                             "'%s'." % sec_label_id)
+
+        except virt_vm.VMStartError, e:
+            # Starting VM failed.
+            if not status_error:
+                raise error.TestFail("Test failed in positive case."
+                                     "error: %s" % e)
+    finally:
+        # clean up
+        if vm.is_alive():
+            vm.destroy(gracefully=False)
+        backup_xml.sync()
+        if qemu_sock_mod:
+            st = os.stat(qemu_sock_path)
+            os.chmod(qemu_sock_path, st.st_mode ^ stat.S_IWGRP)
+        if set_qemu_conf:
+            qemu_conf.restore()
+            libvirtd.restart()
+        utils_selinux.set_status(backup_sestatus)
+        if disk_src_protocol == 'iscsi':
+            utlv.setup_or_cleanup_iscsi(is_setup=False)
+        elif disk_src_protocol == 'gluster':
+            utlv.setup_or_cleanup_gluster(False, vol_name, brick_path)
+            libvirtd.restart()
+        elif disk_src_protocol == 'netfs':
+            utlv.setup_or_cleanup_nfs(is_setup=False,
+                                      restore_selinux=backup_sestatus)


### PR DESCRIPTION
per-image dac seclabel only supported since libvirt 1.2.7.
Add disk hotplug test cases with per-image dac setting.
Add per-image dac seclabel start test cases.