### PR TITLE
blockcommit: Add multiple chain and active commit negative cases

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcommit.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcommit.cfg
@@ -80,6 +80,11 @@
                     disk_target_bus = "virtio"
                     disk_format = "raw"
                     image_size = "10G"
+            variants:
+                - single_chain:
+                - multiple_chain:
+                    only local..no_ga..notimeout
+                    multiple_chain = "yes"
         - error_test:
             status_error = "yes"
             variants:
@@ -94,3 +99,9 @@
                     pivot_opt = "no"
                     needs_agent = "no"
                     with_timeout_option = "yes"
+                - active_commit:
+                    status_error = "yes"
+                    top_inactive = "yes"
+                    base_option = "base"
+                    middle_base = "yes"
+                    with_active_commit = 'yes'


### PR DESCRIPTION
Add active commit case for bug 1135339, with active blockcommit job,
second inactive blockcommit job will fail for now.

Add multiple chain commit cases, after reset domain to one snapshot
and making new chain of snapshots, do blockcommit on the new chain
and check chain status.

Signed-off-by: Wayne Sun <gsun@redhat.com>