### PR TITLE
libvirt_usb_hotplug_device: eliminate the negative effects of SElinux

### DIFF
--- a/libvirt/tests/src/libvirt_usb_hotplug_device.py
+++ b/libvirt/tests/src/libvirt_usb_hotplug_device.py
@@ -3,7 +3,7 @@ import shutil
 from autotest.client.shared import error
 from autotest.client import utils
 from virttest import data_dir, virsh
-from virttest import aexpect, utils_misc
+from virttest import aexpect, utils_misc, utils_selinux
 from virttest.aexpect import ShellError
 from virttest.remote import LoginError
 from virttest.utils_test import libvirt
@@ -32,6 +32,10 @@ def run(test, params, env):
 
     vm_xml = VMXML.new_from_inactive_dumpxml(vm_name)
     vm_xml_backup = vm_xml.copy()
+
+    # Set selinux of host.
+    backup_sestatus = utils_selinux.get_status()
+    utils_selinux.set_status("permissive")
 
     if usb_type == "storage":
         controllers = vm_xml.get_devices(device_type="controller")
@@ -156,4 +160,5 @@ def run(test, params, env):
         session.close()
         if os.path.isdir(tmp_dir):
             shutil.rmtree(tmp_dir)
+        utils_selinux.set_status(backup_sestatus)
         vm_xml_backup.sync()


### PR DESCRIPTION
The cases about hotplug device will fail to attach device,
while the mode of SELinux is running.

test log:

14:04:23 ERROR| stdout:
14:04:23 ERROR| 2015-01-13T19:04:21.213529Z could not open disk image /home/autotest_fjtest_release/client/tests/virt/tmp/usb_hotplug_files/0.img: Could not open file: Permission denied.
14:04:23 ERROR|
14:04:23 ERROR| FAIL type_specific.io-github-autotest-libvirt.libvirt_usb_hotplug_device.qemu_monitor.one_count.storage -> TestFail: failed to attach device.
Detail: * Command:
    /usr/bin/virsh qemu-monitor-command vm2 --hmp --cmd 'drive_add 0 id
    =drive-usb-0,if=none,file=/home/autotest_fjtest_release/client/tests/virt/
    tmp/usb_hotplug_files/0.img'
Exit status: 0
Duration: 0.0686898231506