### PR TITLE
virsh_net_edit: Checking network state after net_edit command.

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_edit.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_edit.cfg
@@ -8,3 +8,5 @@
     variants:
         - normal_test:
             net_edit_net_name = "editnet"
+        - net_create:
+            test_create = "yes"


### PR DESCRIPTION
Network state(active, autostart, persistent) may change after net_edit command,
check the state of a transient network.