### PR TITLE
virsh_iface_bridge: bugfix and improvement for iface-bridge test

### DIFF
--- a/libvirt/tests/src/virsh_cmd/interface/virsh_iface_bridge.py
+++ b/libvirt/tests/src/virsh_cmd/interface/virsh_iface_bridge.py
@@ -131,10 +131,11 @@ def run(test, params, env):
         if create_bridge and check_iface:
             if libvirt.check_iface(bridge_name, "exists", "--all"):
                 virsh.iface_unbridge(bridge_name)
-            if not os.path.exists(iface_script):
+            if os.path.exists(iface_script_bk):
                 utils.run("mv %s %s" % (iface_script_bk, iface_script))
             if iface_is_up:
                 # Need reload script
+                utils.run("ifdown %s" % iface_name)
                 utils.run("ifup %s" % iface_name)
             else:
                 net_iface.down()


### PR DESCRIPTION
1) bugfix for recovering iface script
   the iface configuration script maybe changed and it will be backed up
   as iface_script_bk. finally, all procedure of test ends up,
   the existence of 'iface_script_bk' should be checked, not iface_script.

2) imporve the procedure of reloading script
   'ifdown' should be executed before 'ifup'.