### PR TITLE
libvirt.tests: Fix storage_discard bugs.

### DIFF
--- a/libvirt/tests/cfg/storage_discard.cfg
+++ b/libvirt/tests/cfg/storage_discard.cfg
@@ -6,6 +6,10 @@
     # Set it here, otherwise, it will be created
     # through iscsi automatically
     discard_device = "/DEV/EXAMPLE"
+    # This is expected trimmed size for fstrim
+    # It may be different according your environment
+    # So you should adjust it if too strict(0.6 or less)
+    fstrim_tolerable_shift = 0.8
     variants:
         - block_type:
             only bus_scsi


### PR DESCRIPTION
 * Create lvm for given block device too.
 * Delete lvthin before vgthin in cleanup
 * Add sleeping time to wait for fstrim operation

Rely on https://github.com/autotest/autotest/pull/905

Signed-off-by: Yu Mingfei <yumingfei@cn.fujitsu.com>