### PR TITLE
virtual_disks_multidisks: Modify code of getting guest console output.

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_multivms.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_multivms.cfg
@@ -79,7 +79,7 @@
                     virt_disk_target = "vdb"
                     virt_disk_type = "block"
                     virt_disk_format = "iscsi"
-                    disk_driver_options = "type=raw,cache=writeback,io=native"
+                    disk_driver_options = "type=raw,cache=default,io=native"
                 - file_type:
                     virt_disk_type = "file"
                     virt_disk_target = "vdb"

--- a/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
@@ -6,6 +6,7 @@ from autotest.client import utils
 from virttest import aexpect, virt_vm, virsh, remote
 from virttest import nfs
 from virttest import utils_libvirtd
+from virttest import utils_misc
 from virttest.utils_test import libvirt
 from virttest.utils_config import LibvirtQemuConfig
 from virttest.libvirt_xml import vm_xml, xcepts
@@ -308,8 +309,10 @@ def run(test, params, env):
         Get console output and check bootorder.
         """
         # Get console output.
-        vm.serial_console.read_until_output_matches(["login"])
+        vm.serial_console.read_until_output_matches(
+            ["Hard Disk"], utils_misc.strip_console_codes)
         output = vm.serial_console.get_stripped_output()
+        logging.debug("serial output: %s", output)
         lines = re.findall(r"^Booting from (.+)...", output, re.M)
         logging.debug("lines: %s", lines)
         if len(lines) != len(bootorders):


### PR DESCRIPTION
Only get stripped output of bios,
get rid of kernel serial output can't be decoded.