### PR TITLE
libvirt.volume_application: Support self-defined block device during test

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/volume/virsh_volume_application.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/volume/virsh_volume_application.cfg
@@ -4,6 +4,9 @@
     volume_count = 1
     volume_size = "1G"
     kill_vm = "yes"
+    # If this parameter remains as following content,
+    # test module will create one iscsi device instead
+    block_device = "/DEV/EXAMPLE"
     variants:
         - dir:
             pool_type = "dir"

--- a/libvirt/tests/src/virsh_cmd/volume/virsh_volume_application.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_volume_application.py
@@ -45,6 +45,7 @@ def run(test, params, env):
     disk_target = params.get("disk_target", "vdb")
     test_message = params.get("test_message", "")
     vm_name = params.get("main_vm", "virt-tests-vm1")
+    block_device = params.get("block_device", "/DEV/EXAMPLE")
     if application == "install":
         cdrom_path = os.path.join(data_dir.get_data_dir(),
                                   params.get("cdrom_cd1"))
@@ -57,7 +58,8 @@ def run(test, params, env):
     try:
         pvtest = utlv.PoolVolumeTest(test, params)
         pvtest.pre_pool(pool_name, pool_type, pool_target, emulated_img,
-                        emulated_size, pre_disk_vol=[volume_size])
+                        emulated_size, pre_disk_vol=[volume_size],
+                        device_name=block_device)
 
         logging.debug("Current pools:\n%s",
                       libvirt_storage.StoragePool().list_pools())
@@ -141,4 +143,5 @@ def run(test, params, env):
                 virsh.detach_disk(vm_name, disk_target)
         finally:
             pvtest.cleanup_pool(pool_name, pool_type,
-                                pool_target, emulated_img)
+                                pool_target, emulated_img,
+                                device_name=block_device)


### PR DESCRIPTION
Support to provide own block device during test.

Based on: https://github.com/autotest/virt-test/pull/1990

Signed-off-by: Yu Mingfei <yumingfei@cn.fujitsu.com>