### PR TITLE
libvirt.tests: update basic options testing for migration

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
@@ -4,6 +4,7 @@
     start_vm = yes
     # Console output can only be monitored via virsh console output
     only_pty = True
+    take_regular_screendumps = no
     # Options to pass to virsh migrate command before <domain> <desturi>
     virsh_migrate_options = "--live --undefinesource --persistent"
     # Extra options to pass after <domain> <desturi>
@@ -19,31 +20,48 @@
     virsh_migrate_dest_state = running
     virsh_migrate_src_state = running
     virsh_migrate_libvirtd_state = 'on'
-    virsh_migrate_connect_uri = "qemu+ssh://${migrate_source_host}/system"
+    # Local URI
+    virsh_migrate_connect_uri = "qemu:///system"
     status_error = 'no'
-    virsh_migrate_delay = 60
+    virsh_migrate_delay = 10
     virsh_migrate_back = 'no'
-    # A VM image used for migration
+    # ping args
+    ping_count = 10
+    ping_timeout = 20
+    # setup SSH
+    server_ip = "${migrate_dest_host}"
+    server_user = "root"
+    server_pwd = "migrate_dest_pwd"
+    client_ip = "${migrate_source_host}"
+    client_user = "root"
+    client_pwd = "${migrate_source_pwd}"
+    transport = "ssh"
+    port = "22"
+    client = "ssh"
+    # setup NFS test environment
+    nfs_client_ip = "${migrate_dest_host}"
+    nfs_server_ip = "${migrate_source_host}"
+    # in order to avoid selinux issue, it had better to mount
+    # source directory to /tmp or /var/lib/libvirt/images
+    nfs_mount_dir = "/var/lib/libvirt/images"
+    nfs_mount_options = "rw"
+    # default to /var/lib/virt_test/images
+    nfs_mount_src = "${nfs_mount_dir}"
+    export_ip = "*"
+    export_options = "rw,no_root_squash"
+    setup_local_nfs = "yes"
+    # enable virt_use_nfs SELinux boolean
+    local_boolean_varible = "virt_use_nfs"
+    local_boolean_value = "on"
+    remote_boolean_varible = "virt_use_nfs"
+    remote_boolean_value = "on"
+    set_sebool_local = "yes"
+    set_sebool_remote = "yes"
+    # A VM image used for migration, it looks like
+    # "${nfs_mount_dir}/${vm_image_name}", e.g.
+    # "/var/lib/virt_test/images/jeos-19-64.qcow2"
     virsh_migrate_shared_storage = "${migrate_shared_storage}"
     variants:
-        - there_and_back:
-            # After migrating, migrate the guest back.
-            virsh_migrate_back = 'yes'
-            # By 'default', use same options and extra with the
-            # virsh_migrate_back_desturi set to the original connect_uri
-            # virsh_migrate_back_options = 'default'
-            # virsh_migrate_back_extra = 'default'
-            # virsh_migrate_back_desturi = 'default'
-        - there_and_back_a_lot:
-            iterations = 100
-            virsh_migrate_back = 'yes'
-            # don't kill anything between iterations, you'll need to
-            # shut it down manually or by including a shutdown test
-            kill_vm = no
-            kill_vm_gracefully = no
-            kill_unresponsive_vms = no
-            # migrate as fast as possible
-            virsh_migrate_delay = 0
         - there_live:
             # Uni-direction migration with option --live.
             virsh_migrate_options = "--live"
@@ -67,6 +85,10 @@
         - there_undefinesource:
             # Uni-direction migration with option --undefinesource.
             virsh_migrate_options = "--live --undefinesource"
+        - there_suspend_undefinesource:
+            # Uni-direction migration with option --undefinesource.
+            virsh_migrate_options = "--live --suspend --undefinesource"
+            virsh_migrate_dest_state = paused
         - there_change-protection:
             # Uni-direction migration with option --change-protection.
             virsh_migrate_options = "--live --change-protection"
@@ -83,6 +105,11 @@
             # the first time, confirming its fail then migrate with it.
             virsh_migrate_options = "--live --unsafe"
             virsh_migrate_disk_cache = "default"
+        - there_unsafe_cache_writeback:
+            # Uni-direction migration with option --unsafe.
+            # Set disk cache to writeback then migrate with unsafe
+            virsh_migrate_options = "--live --unsafe"
+            virsh_migrate_disk_cache = "writeback"
         - there_timeout:
             # Uni-direction migration with option --timeout.
             virsh_migrate_options = "--live"
@@ -105,6 +132,12 @@
             virsh_migrate_options = "--live"
             virsh_migrate_extra = "--xml /tmp/virsh_migrate.xml"
             virsh_migrate_xml = /tmp/virsh_migrate.xml
+        - there_xml_with_dname:
+            # Do migration with --dname and --xml with same changed
+            # name from guest XML
+            virsh_migrate_options = "--live"
+            virsh_migrate_src_xml = /tmp/virsh_migrate_src.xml
+            virsh_migrate_extra = "--dname guest-new-name --xml ${virsh_migrate_src_xml}"
         - there_offline:
             # Uni-direction offline migration.
             virsh_migrate_options = ""
@@ -148,6 +181,17 @@
         - there_compressed:
             # Uni-direction migration with option --compressed.
             virsh_migrate_options = "--live --compressed"
+        - there_seamless_migration_with_graphicsuri:
+            virsh_migrate_options = "--live --verbose --unsafe"
+            # The default spice port is 5900 for graphic configuration
+            # <graphics type='spice' autoport='yes'/> in the guest XML.
+            virsh_migrate_graphics_uri = "spice://${migrate_dest_host}:5900"
+            graphics_type = "spice"
+            graphics_port = 5900
+            graphics_listen = 0.0.0.0
+            graphics_listen_type = "address"
+            graphics_listen_addr = ${graphics_listen}
+            graphics_server = "${graphics_type}://${graphics_listen}:${graphics_port}"
         # ERROR
         - there_domain_nonexist:
             # Uni-direction migration with non-exist domain.
@@ -194,4 +238,26 @@
             # Uni-direction migration with a non-existing xmlfile.
             virsh_migrate_options = "--live"
             virsh_migrate_extra = "--xml xyz"
+            status_error = 'yes'
+        - there_cache_writeback_without_unsafe:
+            # Uni-direction migration with option --unsafe.
+            # Set disk cache to writeback then migrate without unsafe
+            virsh_migrate_options = "--live"
+            virsh_migrate_disk_cache = "writeback"
+            status_error = 'yes'
+        - there_xml_with_same_dname:
+            # Do migration with --dname and --xml with same changed
+            # name from guest XML
+            vm_new_name = "guest-new-name"
+            virsh_migrate_options = "--live"
+            virsh_migrate_src_xml = /tmp/virsh_migrate_src.xml
+            virsh_migrate_extra = "--xml ${virsh_migrate_src_xml} --dname ${vm_new_name}"
+            status_error = 'yes'
+        - there_xml_with_diff_dname:
+            # Do migration with --dname and --xml with different changed
+            # name from guest XML
+            vm_new_name = "guest-new-name"
+            virsh_migrate_options = "--live"
+            virsh_migrate_src_xml = /tmp/virsh_migrate_src.xml
+            virsh_migrate_extra = "--xml ${virsh_migrate_src_xml} --dname ${vm_new_name}-diff"
             status_error = 'yes'


### PR DESCRIPTION
The current existing migration cases can't be ran automitically,  you need manually setup sharing storage and enable virt_use_nfs seboolean if you're using a NFS storage to share VM image, in addition, if the migration URI transport is SSH, you also need to configure SSH passwordless manually, this patch is used for solving these question and let tester run migartion testing automitically with simple test configuration. Meanwhile, to add new test scenarios for migration testing.

1. automitically setup NFS sharing ENV and enable virt_use_nfs seboolean

2. delete complex testing scenarios, such as ping-pong migration, it needs we setup passwordless access
from local/remote to remote/local firstly, we may put these scenarios into ping-pong migration testing.

3. add some new testing scenarios to cover migration options or options combination, such as "--graphicsuri", "--live --suspend --undefinesource",.

4. enhance VM network connectivity check  after migariton

5. use local URI qemu:///system to instead of qemu+ssh://${migrate_source_host}/system, it's not necessary to use qemu+ssh://${migrate_source_host}/system URI for the local connecting, if you do this, you also need to setup passwordless access local URI firstly. 

BTW. This PR is based on PR https://github.com/autotest/virt-test/pull/1992 

Signed-off-by: Alex Jia <ajia@redhat.com>