### PR TITLE
libvirt.test: Raise TestNAError for all qed type disk for snapshot.

### DIFF
--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_disk.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_disk.py
@@ -80,7 +80,7 @@ def run(test, params, env):
 
     # Skip 'qed' cases for libvirt version greater than 1.1.0
     if libvirt_version.version_compare(1, 1, 0):
-        if vol_format == "qed":
+        if vol_format == "qed" or image_format == "qed":
             raise error.TestNAError("QED support changed, check bug: "
                                     "https://bugzilla.redhat.com/show_bug.cgi"
                                     "?id=731570")


### PR DESCRIPTION
As bugzilla reported, all qed type disk should be skipped:
qemu-kvm component, BZ#731570
The QEMU Enhanced Disk format (QED) for KVM guest virtual machines
is not supported in Red Hat Enterprise Linux 7. Use the qcow2 image
format instead.

Signed-off-by: Yu Mingfei <yumingfei@cn.fujitsu.com>