### PR TITLE
Remove --unsafe option

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domjobabort.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domjobabort.py
@@ -53,7 +53,7 @@ def run(test, params, env):
             # Slow down migration for domjobabort
             virsh.migrate_setspeed(vm_name, "1")
             file = remote_uri
-        command = "virsh %s %s %s --unsafe" % (action, vm_name, file)
+        command = "virsh %s %s %s" % (action, vm_name, file)
         logging.debug("Action: %s", command)
         p = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE)


### PR DESCRIPTION
1. we do not need it for migrate command to do migration
2. other commands do not support this option and it may cause error