### PR TITLE
virsh_test: update usage of remove_agent_channel and set_agent_channel

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_reboot.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_reboot.py
@@ -35,12 +35,15 @@ def run(test, params, env):
     mode = params.get("reboot_mode", "")
     pre_domian_status = params.get("reboot_pre_domian_status", "running")
     xml_backup = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    test_xml = xml_backup.copy()
     try:
         # Add or remove qemu-agent from guest before test
         if agent:
-            vm_xml.VMXML.set_agent_channel(vm_name)
+            test_xml.set_agent_channel()
+            test_xml.sync()
         else:
-            vm_xml.VMXML.remove_agent_channel(vm_name)
+            test_xml.remove_agent_channels()
+            test_xml.sync()
 
         virsh.start(vm_name)
         guest_session = vm.wait_for_login()

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_shutdown.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_shutdown.py
@@ -29,6 +29,7 @@ def run(test, params, env):
     pre_domian_status = params.get("reboot_pre_domian_status", "running")
     libvirtd = params.get("libvirtd", "on")
     xml_backup = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    test_xml = xml_backup.copy()
 
     # Libvirt acl test related params
     uri = params.get("virsh_uri")
@@ -46,9 +47,11 @@ def run(test, params, env):
 
         # Add or remove qemu-agent from guest before test
         if agent:
-            vm_xml.VMXML.set_agent_channel(vm_name)
+            test_xml.set_agent_channel()
+            test_xml.sync()
         else:
-            vm_xml.VMXML.remove_agent_channel(vm_name)
+            test_xml.remove_agent_channels()
+            test_xml.sync()
         virsh.start(vm_name)
         guest_session = vm.wait_for_login()
         if agent:

--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_create_as.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_create_as.py
@@ -486,7 +486,8 @@ def run(test, params, env):
             if vm.is_alive():
                 vm.destroy(gracefully=False)
             xml_inst = vm_xml.VMXML.new_from_dumpxml(vm_name)
-            xml_inst.remove_agent_channel(vm_name)
+            xml_inst.remove_agent_channels()
+            xml_inst.sync()
             vm.start()
 
         # Record the previous snapshot-list


### PR DESCRIPTION
There was an update in virt-tests the updated those functions
(commit 002d51fe). Update usage of those function in virsh tests.

Signed-off-by: Pavel Hrdina <phrdina@redhat.com>