### PR TITLE
libvirt_vcpu_plug_unplug: fix bug for qemu-agent

### DIFF
--- a/libvirt/tests/src/libvirt_vcpu_plug_unplug.py
+++ b/libvirt/tests/src/libvirt_vcpu_plug_unplug.py
@@ -417,7 +417,7 @@ def run(test, params, env):
                     if status_start != 0:
                         raise error.TestFail("Fail to start qemu-guest-agent")
                 if status_ps == 0 and not start_qemuga:
-                    cmd = "kill %s" % output_ps.strip().split()[1]
+                    cmd = "service qemu-guest-agent stop"
                     session.cmd(cmd, timeout=10)
             finally:
                 session.close()


### PR DESCRIPTION
After suspending the process of qemu-agent by kill,
it will start itself again on RHEL7.1,
which could lead to the failure of
libvirt_vcpu_plug_unplug.negative_test.no_start_qemuga.

so, it's more better that stop qemu-guest-agent service.