### PR TITLE
blockcopy: Refactor the code

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcopy.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcopy.cfg
@@ -11,8 +11,10 @@
     persistent_vm = "no"
     take_regular_screendumps = 'no'
     timeout = "1200"
+    skip_cluster_leak_warn = "yes"
     variants:
         - positive_test:
+            bug_url = "https://bugzilla.redhat.com/show_bug.cgi?id=1197592"
             status_error = "no"
             variants:
                 - no_option:


### PR DESCRIPTION
Caught JobTimeout exception only when call finish_job, and other fail will
be raised directly.

When "--finish" with "--async" specified, the xml could take seconds to end
the mirror phase, so use wait_for with 5 seconds to avoid checking fail.

The blockcopy_chk will be call after all succeed blockcopy command, the bug
1134294 is fixed but the source cause is qemu-kvm support problem, so left
it in check and track.

Also do following fixes:
Fix the netfs cleanup problem when copy_to_nfs as 'no'.
Fix cluster leak warning error by setting skip_cluster_leak_warn as 'yes'.
Fix fail check with 'Copy aborted' by also check libvirtd log.

Signed-off-by: Wayne Sun <gsun@redhat.com>