### PR TITLE
virsh_undefine: Fixed a bug related to test pool creation and deletion

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_undefine.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_undefine.py
@@ -108,22 +108,12 @@ def run(test, params, env):
                     raise error.TestNAError("This domain has snapshot(s), "
                                             "cannot be undefined!")
         if option.count("remove-all-storage"):
-            for disk in vm_xml.VMXML.get_disk_source(vm_name):
-                try:
-                    disk_source = disk.find('source')
-                    disk_path = disk_source.get('file') or disk_source.get('dev')
-                except AttributeError:
-                    continue
-                if disk_path in utlv.get_all_vol_paths():
-                    raise error.TestNAError("This case will remove '%s',"
-                                            " it's dangerous that skip"
-                                            " this case" % disk_path)
             pvtest = utlv.PoolVolumeTest(test, params)
             pvtest.pre_pool(pool_name, pool_type, pool_target, emulated_img,
-                            emulated_size)
+                            emulated_size=emulated_size)
             new_pool = libvirt_storage.PoolVolume(pool_name)
             if not new_pool.create_volume(vol_name, volume_size):
-                raise error.TestFail("Create volume %s failed." % vol_name)
+                raise error.TestFail("Creation of volume %s failed." % vol_name)
             volumes = new_pool.list_volumes()
             volume = volumes[vol_name]
             virsh.attach_disk(vm_name, volume, disk_target, "--config")


### PR DESCRIPTION
The unnecessary checks are removed from the '--remove-all-storage'
option processing block which allows the test flow to continue.
It doesn't look dangerous for the domain.

Fixed the 'emulated_size' parameter bug in test pool creation function
pre_pool() call. The 'emulated_size=emulated_size' is the correct way
to pass it.

Now the test pool is being created and deleted (wiped) correctly.

Minor: text message fixed