### PR TITLE
virsh_volume_application: fix the wrong keyword argument

### DIFF
--- a/libvirt/tests/src/virsh_cmd/volume/virsh_volume_application.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_volume_application.py
@@ -58,7 +58,8 @@ def run(test, params, env):
     try:
         pvtest = utlv.PoolVolumeTest(test, params)
         pvtest.pre_pool(pool_name, pool_type, pool_target, emulated_img,
-                        emulated_size, pre_disk_vol=[volume_size],
+                        image_size=emulated_size,
+                        pre_disk_vol=[volume_size],
                         device_name=block_device)
 
         logging.debug("Current pools:\n%s",


### PR DESCRIPTION
  Error Message:
  TypeError: pre_pool() takes exactly 5 arguments (8 given)