### PR TITLE
vfio: fix the bug associated with the boot sequence

### DIFF
--- a/libvirt/tests/cfg/vfio.cfg
+++ b/libvirt/tests/cfg/vfio.cfg
@@ -11,8 +11,9 @@
     vfio_remote_ip = REMOTE_IP.EXAMPLE
     vfio_remote_passwd = REMOTE_PWD.EXAMPLE
     # Fibre PCI device configurations
-    # Warning: The data on partition1 will be wipped
+    # Warning: wipe data if fibre_pci_disk_check is yes
     fibre_pci_id = FIBRE:DEVICE.EXAMPLE
+    fibre_pci_disk_check = "no"
     variants:
         - nic_group:
             test_type = "nic_group"


### PR DESCRIPTION
the case vfio.primary_boot.nic suffer from the following,
1) VM starts normally, while alter the boot sequence and
   set NIC PCI device as the only and first boot option.
   It should report no bootable device and startup fails.
2) The OS boot element and PCI Device boot elements are
   mutually exclusive.
   It's necessary that remove all of OS boots and
   add PCI boot attribute before re-defining VM.
   otherwise,
   it will keep the primary configuration or throw errors,
   such as,
   'unsupported configuration: per-device boot elements
   cannot be used together with os/boot elements'

This patch can fix all of these problems.