### PR TITLE
virsh.attach_device: Add console, channel and controller devices

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_device.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_device.cfg
@@ -42,7 +42,7 @@
                     variants:
                         - persistent:
                             vadu_extra = "--persistent"
-                        - livr_config:
+                        - live_config:
                             # Avoid driver-dependant default behavior
                             vadu_extra = "--live"
                             vadu_config_option = "yes"
@@ -134,22 +134,47 @@
 
     variants:
         - character:
-            # Hot attach serial not supported (ISA bus limitation)
-            no normal_test.hot_attach_hot_vm
-            no normal_test.hot_attach_hot_vm_current
             variants:
-                - single_serial:
-                    # SerialFile is name of class in test-module
-                    vadu_dev_objs = "SerialPipe"
-                    # vadu_dev_obj_count_SerialPipe inherited as 1
-                - multi_serial:
-                    vadu_dev_objs = "SerialFile"
-                    vadu_dev_obj_count_SerialFile = 3
-                - multi_type:
-                    vadu_dev_objs = "SerialFile SerialPipe"
-                    vadu_dev_obj_count_SerialFile = 1
-                    # vadu_dev_obj_source_sfile ingerited as file
-                    vadu_dev_obj_count_SerialPipe = 2
+                - serial:
+                    # Hot attach serial not supported (ISA bus limitation)
+                    no normal_test.hot_attach_hot_vm
+                    no normal_test.hot_attach_hot_vm_current
+                    variants:
+                        - single_serial:
+                            # SerialFile is name of class in test-module
+                            vadu_dev_objs = "SerialPipe"
+                            # vadu_dev_obj_count_SerialPipe inherited as 1
+                        - multi_serial:
+                            vadu_dev_objs = "SerialFile"
+                            vadu_dev_obj_count_SerialFile = 3
+                        - multi_type:
+                            vadu_dev_objs = "SerialFile SerialPipe"
+                            vadu_dev_obj_count_SerialFile = 1
+                            # vadu_dev_obj_source_sfile ingerited as file
+                            vadu_dev_obj_count_SerialPipe = 2
+                - console:
+                    vadu_dev_objs = "Console"
+                    variants:
+                        - type_pty:
+                            vadu_dev_obj_type_Console = "pty"
+                            vadu_dev_obj_targettype_Console = "virtio"
+                - channel:
+                    vadu_dev_objs = "Channel"
+                    vadu_dev_obj_targettype_Channel = "virtio"
+                    vadu_dev_obj_targetname_Channel = "virt-test.unix.channel"
+                    variants:
+                        - type_pty:
+                            vadu_dev_obj_type_Channel = "pty"
+                        - type_unix:
+                            vadu_dev_obj_type_Channel = "unix"
+                            vadu_dev_obj_sourcemode_Channel = "bind"
+                            vadu_dev_obj_sourcepath_Channel = "/var/lib/libvirt/qemu/virt-test.attach_device.test_channel"
+        - controller:
+            vadu_dev_objs = "Controller"
+            variants:
+                - type_scsi:
+                    vadu_dev_obj_type_Controller = "scsi"
+                    vadu_dev_obj_model_Controller = "virtio-scsi"
         - block:
             vadu_dev_objs = "VirtualDiskBasic"
             variants:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
@@ -436,6 +436,63 @@ class SerialPipe(SerialFile):
         return super(SerialPipe, self).init_device(index)  # stub for now
 
 
+class Console(AttachDeviceBase):
+
+    """
+    Simple console device
+    """
+
+    def init_device(self, index):
+        consoleclass = self.test_params.vmxml.get_device_class('console')
+        console_device = consoleclass(type_name=self.type,
+                                      virsh_instance=self.test_params.virsh)
+        # Assume default domain console device on port 0 and index starts at 0
+        console_device.add_target(type=self.targettype, port=str(index + 1))
+        return console_device
+
+    def function(self, index):
+        return not self.test_params.status_error
+
+
+class Channel(AttachDeviceBase):
+
+    """
+    Simple channel device
+    """
+
+    def init_device(self, index):
+        channelclass = self.test_params.vmxml.get_device_class('channel')
+        channel_device = channelclass(type_name=self.type,
+                                      virsh_instance=self.test_params.virsh)
+        if hasattr(self, 'sourcemode') and hasattr(self, 'sourcepath'):
+            channel_device.add_source(mode=self.sourcemode,
+                                      path=self.sourcepath)
+        if hasattr(self, 'targettype') and hasattr(self, 'targetname'):
+            channel_device.add_target(type=self.targettype,
+                                      name=self.targetname)
+        return channel_device
+
+    def function(self, index):
+        return not self.test_params.status_error
+
+
+class Controller(AttachDeviceBase):
+
+    """
+    Simple controller device
+    """
+
+    def init_device(self, index):
+        controllerclass = self.test_params.vmxml.get_device_class('controller')
+        controller_device = controllerclass(type_name=self.type,
+                                            virsh_instance=self.test_params.virsh)
+        controller_device.model = self.model
+        return controller_device
+
+    def function(self, index):
+        return not self.test_params.status_error
+
+
 class VirtualDiskBasic(AttachDeviceBase):
 
     """
@@ -695,7 +752,7 @@ def analyze_results(test_params, operational_results=None,
 
 def run(test, params, env):
     """
-    Test virsh {at|de}tach-interface command.
+    Test virsh {at|de}tach-device command.
 
     1) Prepare test environment and its parameters
     2) Operate virsh on one or more devices


### PR DESCRIPTION
Added device attach and detach tests for pty console, pty channel,
unix channle and scsi controller.

Signed-off-by: Hao Liu <hliu@redhat.com>