### PR TITLE
snapshot_create_as: Restart libvirtd after gluster cleanup

### DIFF
--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_create_as.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_create_as.py
@@ -580,6 +580,7 @@ def run(test, params, env):
 
         if disk_src_protocol == 'gluster':
             libvirt.setup_or_cleanup_gluster(False, vol_name, brick_path)
+            libvirtd.restart()
 
         # rm bad disks
         if bad_disk is not None:


### PR DESCRIPTION
As gluster cases could also be affected by libgfapi bug, restart
libvirtd in cleanup to avoid the problem. More info:
https://bugzilla.redhat.com/show_bug.cgi?id=1143800

Signed-off-by: Wayne Sun <gsun@redhat.com>