### PR TITLE
virsh_cpu_baseline: Remove stderr check for negative test

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_baseline.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_baseline.py
@@ -83,7 +83,6 @@ def run(test, params, env):
     result = virsh.cpu_baseline(cpu_ref, ignore_status=True, debug=True)
     status = result.exit_status
     output = result.stdout.strip()
-    err = result.stderr.strip()
     if os.path.exists(cpu_xmlfile):
         os.remove(cpu_xmlfile)
 
@@ -91,8 +90,7 @@ def run(test, params, env):
     if status_error:
         if status == 0:
             raise error.TestFail("Run successfully with wrong command!")
-        if err == "":
-            raise error.TestFail("The wrong command has no error outputed!")
+        logging.debug("Command fail as expected")
     else:
         if status != 0:
             raise error.TestFail("Run failed with right command")


### PR DESCRIPTION
The stderr may be empty if command failed, so remove the check
condition.

Signed-off-by: Yanbing Du <ydu@redhat.com>