### PR TITLE
libvirt_bench_ttcp_from_guest_to_host: adjust the timeout

### DIFF
--- a/libvirt/tests/cfg/libvirt_bench/libvirt_bench_ttcp_from_guest_to_host.cfg
+++ b/libvirt/tests/cfg/libvirt_bench/libvirt_bench_ttcp_from_guest_to_host.cfg
@@ -1,6 +1,6 @@
 - libvirt_bench.ttcp_from_guest_to_host:
     type = libvirt_bench_ttcp_from_guest_to_host
-    LB_ttcp_timeout = 600
+    LB_ttcp_timeout = 300
     LB_ttcp_server_command = "ttcp -s -r -v -D -p5015"
     LB_ttcp_client_command = "ttcp -s -t -v -D -p5015 -b65536 -l65536 -n1000 -f K"
     # A full OS install is required due to ttcp dependencies

--- a/libvirt/tests/src/libvirt_bench/libvirt_bench_ttcp_from_guest_to_host.py
+++ b/libvirt/tests/src/libvirt_bench/libvirt_bench_ttcp_from_guest_to_host.py
@@ -28,7 +28,7 @@ def run(test, params, env):
         if status:
             raise error.TestNAError("Not find ttcp command on guest.")
     # Get parameters from params.
-    timeout = int(params.get("LB_ttcp_timeout", "600"))
+    timeout = int(params.get("LB_ttcp_timeout", "300"))
     ttcp_server_command = params.get("LB_ttcp_server_command",
                                      "ttcp -s -r -v -D -p5015")
     ttcp_client_command = params.get("LB_ttcp_client_command",
@@ -54,7 +54,7 @@ def run(test, params, env):
                         return False
                     return True
 
-                if not utils_misc.wait_for(_ttcp_good, timeout=5):
+                if not utils_misc.wait_for(_ttcp_good, timeout=60):
                     status, output = session.cmd_status_output(cmd)
                     if status:
                         raise error.TestFail("Failed to run ttcp command on guest.\n"


### PR DESCRIPTION
The timeout used by utils_misc.wait_for is set to 5, there's
not enough time to start ttcp server, so provide more time to it.
On the other hand,
The maximum duration time between server and client is too long,
so diminish it to half of the original.