### PR TITLE
virsh_snapshot_disk: disable selinux for start glusterd

### DIFF
--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_disk.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_disk.py
@@ -8,6 +8,7 @@ from virttest import virsh, qemu_storage, data_dir
 from virttest import libvirt_xml
 from virttest import libvirt_storage
 from virttest import utils_libvirtd
+from virttest import utils_selinux
 from virttest.utils_test import libvirt as utlv
 from provider import libvirt_version
 
@@ -53,6 +54,9 @@ def run(test, params, env):
     options = params.get("snapshot_options", "")
     export_options = params.get("export_options", "rw,no_root_squash,fsid=0")
 
+    # Set selinux of host.
+    backup_sestatus = utils_selinux.get_status()
+    utils_selinux.set_status("permissive")
     # Set volume xml attribute dictionary, extract all params start with 'vol_'
     # which are for setting volume xml, except 'lazy_refcounts'.
     vol_arg = {}
@@ -441,3 +445,5 @@ def run(test, params, env):
             except error.TestFail, detail:
                 libvirtd.restart()
                 logging.error(str(detail))
+        # restore the selinux
+        utils_selinux.set_status(backup_sestatus)


### PR DESCRIPTION
Encounter the following errors while start glusterd,
  ERROR: failed to create logfile
         "/var/log/glusterfs/etc-glusterfs-glusterd.vol.l...enied
  ERROR: failed to open logfile
         /var/log/glusterfs/etc-glusterfs-glusterd.vol.log
so disbale selinux for associated cases.