### PR TITLE
virsh_domblkstat.cfg: Space extra option cfg fix

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/monitor/virsh_domblkstat.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/monitor/virsh_domblkstat.cfg
@@ -45,4 +45,4 @@
                             domblkstat_extra = "xyz"
                         - null_extra_option:
                         - space_extra_option:
-                            domblkstat_extra = "''"
+                            domblkstat_extra = "' '"


### PR DESCRIPTION
domblkstat_extra field should contain a space (space_extra_option).
Currently there is only '' (empty) which means that in fact no extra
option is passed to virsh domblkstat command, thus the error case
is not properly formed and some of the virsh versions return success
because of omitting the empty '' paramater