### PR TITLE
remove_guest.cfg: remove 'restart_vm'

### DIFF
--- a/libvirt/tests/cfg/remove_guest.cfg
+++ b/libvirt/tests/cfg/remove_guest.cfg
@@ -5,7 +5,6 @@
     kill_vm_gracefully = no
     force_remove_vm = yes
     start_vm = no
-    restart_vm = no
     variants:
         - without_disk:
             remove_image = no


### PR DESCRIPTION
restart_vm option had been removed by virt-test#1ff9dc2.
so it's meaningless now.