### PR TITLE
Update iscsi cleanup in snapshot and merge cases

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcommit.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcommit.cfg
@@ -1,6 +1,7 @@
 - virsh.blockcommit:
     type = virsh_blockcommit
     kill_vm_on_error = "no"
+    restart_tgtd = 'yes'
     variants:
         - normal_test:
             status_error = "no"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockpull.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockpull.cfg
@@ -1,6 +1,7 @@
 - virsh.blockpull:
     type = virsh_blockpull
     kill_vm_on_error = "no"
+    restart_tgtd = "yes"
     variants:
         - normal_test:
             status_error = "no"

--- a/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_create_as.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_create_as.cfg
@@ -1,6 +1,7 @@
 - virsh.snapshot_create_as:
     type = virsh_snapshot_create_as
     take_regular_screendumps = "no"
+    restart_tgtd = "yes"
     start_vm = "yes"
     variants:
         - negative_tests:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockcommit.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockcommit.py
@@ -118,6 +118,7 @@ def run(test, params, env):
     # Process domain disk device parameters
     disk_type = params.get("disk_type")
     disk_src_protocol = params.get("disk_source_protocol")
+    restart_tgtd = params.get("restart_tgtd", 'no')
     vol_name = params.get("vol_name")
     tmp_dir = data_dir.get_tmp_dir()
     pool_name = params.get("pool_name", "gluster-pool")
@@ -404,7 +405,8 @@ def run(test, params, env):
                 os.remove(disk)
 
         if disk_src_protocol == 'iscsi':
-            libvirt.setup_or_cleanup_iscsi(is_setup=False)
+            libvirt.setup_or_cleanup_iscsi(is_setup=False,
+                                           restart_tgtd=restart_tgtd)
         elif disk_src_protocol == 'gluster':
             libvirt.setup_or_cleanup_gluster(False, vol_name, brick_path)
             libvirtd = utils_libvirtd.Libvirtd()

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockpull.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockpull.py
@@ -166,6 +166,7 @@ def run(test, params, env):
     disk_type = params.get("disk_type")
     disk_target = params.get("disk_target", 'vda')
     disk_src_protocol = params.get("disk_source_protocol")
+    restart_tgtd = params.get("restart_tgtd", "no")
     vol_name = params.get("vol_name")
     tmp_dir = data_dir.get_tmp_dir()
     pool_name = params.get("pool_name", "gluster-pool")
@@ -338,7 +339,8 @@ def run(test, params, env):
         libvirtd = utils_libvirtd.Libvirtd()
 
         if disk_src_protocol == 'iscsi':
-            libvirt.setup_or_cleanup_iscsi(is_setup=False)
+            libvirt.setup_or_cleanup_iscsi(is_setup=False,
+                                           restart_tgtd=restart_tgtd)
         elif disk_src_protocol == 'gluster':
             libvirt.setup_or_cleanup_gluster(False, vol_name, brick_path)
             libvirtd.restart()

--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_create_as.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_create_as.py
@@ -335,6 +335,7 @@ def run(test, params, env):
     # gluster related params
     replace_vm_disk = "yes" == params.get("replace_vm_disk", "no")
     disk_src_protocol = params.get("disk_source_protocol")
+    restart_tgtd = params.get("restart_tgtd", "no")
     vol_name = params.get("vol_name")
     tmp_dir = data_dir.get_tmp_dir()
     pool_name = params.get("pool_name", "gluster-pool")
@@ -581,6 +582,9 @@ def run(test, params, env):
         if disk_src_protocol == 'gluster':
             libvirt.setup_or_cleanup_gluster(False, vol_name, brick_path)
             libvirtd.restart()
+
+        if disk_src_protocol == 'iscsi':
+            libvirt.setup_or_cleanup_iscsi(False, restart_tgtd=restart_tgtd)
 
         # rm bad disks
         if bad_disk is not None:


### PR DESCRIPTION
As iscsi env got dirty affect lots of snapshot and snapshot merge cases, update using new restart tgtd option to restart tgtd with each iscsi snapshot and snapshot merge related test cases.