### PR TITLE
virsh_cpu_baseline.py: Unsupported CPU/flag (AMD) fail case fix

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_baseline.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_baseline.py
@@ -117,6 +117,9 @@ def run(test, params, env):
             result = virsh.start(vm_name, ignore_status=True, debug=True)
             libvirt.check_exit_status(result)
             vm_pid = vm.get_pid()
+        except:
+            pass
+        else:
             # Check qemu cmdline
             with open("/proc/%d/cmdline" % vm_pid) as vm_cmdline_file:
                 vm_cmdline = vm_cmdline_file.read()


### PR DESCRIPTION
This particular test and its config by default are designed to be
run on Intel CPUs. I was running it on AMD-Opteron based systems and
the test virsh.cpu_baseline.positive_test.config_guest was raising
an exception (due to unnsupported CPU/flags, e.g. on AMD /proc/cpuinfo
has no flag "acpi") resulting in test failure. Additional exception
handling is added to avoid this situation.
TODO: In the future might be a good idea to adjust the test for AMD
      CPUs too.