### PR TITLE
virsh_snapshot: repalce variable snaps with snap

### DIFF
--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot.py
@@ -22,7 +22,7 @@ def run(test, params, env):
             try:
                 virsh.snapshot_delete(vm, snap)
             except error.CmdError:
-                logging.debug("Can not remove snapshot %s.", snaps)
+                logging.debug("Can not remove snapshot %s.", snap)
                 remove_failed = remove_failed + 1
 
         return remove_failed


### PR DESCRIPTION
The snapshot will be removed one by one.
When we get failure, the whole snapshot list will be logged,
not a specific snapshot. so,
It's hard to find out which snapshot is the cause of failure.