### PR TITLE
travis: Using a newer autotest for Travis CI [EXPERIENT! DO NOT MERGE!]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ virtualenv:
     system_site_packages: true
 
 before_script:
-    - echo "deb http://ppa.launchpad.net/lmr/autotest/ubuntu trusty main" | sudo tee -a /etc/apt/sources.list
+    - echo "deb http://ppa.launchpad.net/lmr/autotest/ubuntu utopic main" | sudo tee -a /etc/apt/sources.list
     - sudo apt-get update -q
     - sudo apt-get -y --force-yes install autotest
 


### PR DESCRIPTION
Apparently the testing autotest package used for Travis CI is not
able to fulfill the new tests. Upgrade it to a newer version.

Signed-off-by: Hao Liu <hliu@redhat.com>