### PR TITLE
multiqueue: remove impossible except error.TestFail

### DIFF
--- a/libvirt/tests/src/multiqueue.py
+++ b/libvirt/tests/src/multiqueue.py
@@ -61,7 +61,7 @@ def setting_channel(vm, interface, parameter, value):
     try:
         if int(current['Combined']) == int(value):
             return True
-    except KeyError, error.TestFail:
+    except KeyError:
         pass
     logging.debug("Setting passed, but checking failed:%s", current)
     return False


### PR DESCRIPTION
The wrapped statements would never throw error.TestFail,
so discard it.