### PR TITLE
nodedev_dumpxml: add check for numa_node key value

### DIFF
--- a/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_dumpxml.py
+++ b/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_dumpxml.py
@@ -47,9 +47,13 @@ def do_nodedev_dumpxml(dev_name, dev_opt="", **dargs):
         value_xml = key2value_dict_xml.get(key)
         value_sys = key2value_dict_sys.get(key)
         if not value_xml == value_sys:
-            raise error.TestError("key: %s in xml is %s,"
-                                  "but in sysfs is %s." %
-                                  (key, value_xml, value_sys))
+            if (key == 'numa_node' and not
+                    libvirt_version.version_compare(1, 2, 5)):
+                logging.warning("key: %s in xml is not supported yet" % key)
+            else:
+                raise error.TestError("key: %s in xml is %s,"
+                                      "but in sysfs is %s." %
+                                      (key, value_xml, value_sys))
         else:
             continue
 


### PR DESCRIPTION
As pci numa node attribute support is added in 1.2.5, so only log
warning message if not satisfied.

More info check in bug:
https://bugzilla.redhat.com/show_bug.cgi?id=1093127

Signed-off-by: Wayne Sun <gsun@redhat.com>