### PR TITLE
libvirt/tests/src/macvtap: fix nested try-except bug

### DIFF
--- a/libvirt/tests/src/macvtap.py
+++ b/libvirt/tests/src/macvtap.py
@@ -206,12 +206,12 @@ def run(test, params, env):
     try:
         try:
             session = guest_config(vm1, vm1_ip)
-        except (remote.LoginTimeoutError, aexpect.ShellCmdError), fail:
+        except remote.LoginTimeoutError, fail:
             raise error.TestFail(str(fail))
         if vm2:
             try:
                 guest_config(vm2, vm2_ip)
-            except (remote.LoginTimeoutError, aexpect.ShellCmdError), fail:
+            except remote.LoginTimeoutError, fail:
                 raise error.TestFail(str(fail))
 
         # Four mode test


### PR DESCRIPTION
def a():
    Maybe raise ShellCmdError

def call_a():
    try:
        a()
    except ShellCmdError, e:
        pass

def call_call_a():
    try:
        call_a()
    except ShellCmdError, e:
        # The following would never be run,
        # even if ShellCmdError is throwed by a()
        TestFail()

so it's need to remove the try-except of call_a().