### PR TITLE
bvirt_bench_serial_hotplug: remove unused module and code

### DIFF
--- a/libvirt/tests/src/libvirt_bench/libvirt_bench_serial_hotplug.py
+++ b/libvirt/tests/src/libvirt_bench/libvirt_bench_serial_hotplug.py
@@ -1,13 +1,11 @@
 import os
 import stat
-import logging
 import socket
 import subprocess
 import time
 import shutil
 from autotest.client.shared import error
 from virttest import virsh, libvirt_vm, utils_test, utils_misc
-from virttest.libvirt_xml.devices import channel
 from virttest.utils_test import libvirt as utlv
 
 
@@ -17,7 +15,6 @@ def run(test, params, env):
     """
 
     vm_name = params.get("main_vm", "vm1")
-    status_error = "yes" == params.get("status_error", "no")
     char_dev = params.get("char_dev", "file")
     hotplug_type = params.get("hotplug_type", "qmp")
     load_type = params.get("load_type", "")


### PR DESCRIPTION
1) remove logging and channel module.
2) There's no status_error in cfg file,
   so it's no need to get it's value by params.get()