### PR TITLE
clean up and remove meaningless code

### DIFF
--- a/libvirt/tests/src/svirt/svirt_undefine_define.py
+++ b/libvirt/tests/src/svirt/svirt_undefine_define.py
@@ -28,8 +28,6 @@ def run(test, params, env):
     sec_relabel = params.get("svirt_undefine_define_vm_sec_relabel", "yes")
     sec_dict = {'type': sec_type, 'model': sec_model, 'label': sec_label,
                 'relabel': sec_relabel}
-    poweroff_with_destroy = ("destroy" == params.get(
-        "svirt_undefine_define_vm_poweroff", "destroy"))
     # Get variables about VM and get a VM object and VMXML instance.
     vm_name = params.get("main_vm")
     vm = env.get_vm(vm_name)

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domblkerror.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domblkerror.py
@@ -32,7 +32,6 @@ def run(test, params, env):
     target_dev = params.get("domblkerror_target_dev", "vdb")
     pool_name = params.get("domblkerror_pool_name", "fs_pool")
     vol_name = params.get("domblkerror_vol_name", "vol1")
-    loop_dev = params.get("domblkerror_loop_dev", "/dev/loop0")
 
     vm = env.get_vm(vm_name)
     # backup /etc/exports


### PR DESCRIPTION
1) svirt/svirt_undefine_define.py
   There's no configuration for 'svirt_undefine_define_vm_poweroff'
   and no call for variable poweroff_with_destroy.
2) virsh_cmd/domain/virsh_domblkerror.py
   There's no configuration for 'domblkerror_loop_dev' and
   no call for variable loop_dev.