### PR TITLE
virsh_migrate_stress: fix bug for option --compressed

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_stress.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_stress.py
@@ -59,9 +59,9 @@ def do_stress_migration(vms, srcuri, desturi, stress_type,
     fail_info = utils_test.load_stress(stress_type, vms, params)
 
     migtest = utlv.MigrationTest()
-    options = None
+    options = ''
     if migration_type == "compressed":
-        options = "--live --compressed --timeout 60"
+        options = "--compressed"
         migration_type = "orderly"
         shared_dir = os.path.dirname(data_dir.get_data_dir())
         src_file = os.path.join(shared_dir, "scripts", "duplicate_pages.py")
@@ -77,8 +77,8 @@ def do_stress_migration(vms, srcuri, desturi, stress_type,
         logging.warning("Add stress for migration failed:%s", fail_info)
 
     logging.debug("Starting migration...")
-    migrate_options = ("--live --unsafe --timeout %s"
-                       % params.get("virsh_migrate_timeout", 60))
+    migrate_options = ("--live --unsafe %s --timeout %s"
+                       % (options, params.get("virsh_migrate_timeout", 60)))
     migtest.do_migration(vms, srcuri, desturi, migration_type, options=migrate_options,
                          thread_timeout=thread_timeout)
 


### PR DESCRIPTION
The variable 'options' that may be set with '--compressed'
in order to compresss repeated pages during live migration.

The fed9e53 declares a new variable 'migrate_options' and
replace 'options' with it for do_migration(), which leads
to all of cases that used to test compresss repeated pages
during live migration don't do what they ought to do.