### PR TITLE
virsh_attach_detach_disk: fix bug for --cache

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk.py
@@ -446,6 +446,8 @@ def run(test, params, env):
                                          " attach.")
                 if not check_audit_after_cmd:
                     raise error.TestFail("Audit hotplug failure after attach")
+                if not check_cache_after_cmd:
+                    raise error.TestFail("Check cache failure after attach")
                 if at_options.count("persistent"):
                     if not check_count_after_shutdown:
                         raise error.TestFail("Cannot see device attached "


### PR DESCRIPTION
The variable 'check_cache_after_cmd' is assigned
but never used by 5c10eef.
In fact, it should be used to check if failure
of --cache occurs.