### PR TITLE
virsh_qemu_monitor_command: remove unuesed 'start_vm'

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_monitor_command.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_monitor_command.py
@@ -14,7 +14,6 @@ def run(test, params, env):
     vm_state = params.get("vm_state", "running")
     cmd = params.get("qemu_cmd", "")
     options = params.get("options", "")
-    start_vm = "yes" == params.get("start_vm")
     status_error = "yes" == params.get("status_error", "no")
     domuuid = vm.get_uuid()
     domid = ""


### PR DESCRIPTION
The variable 'start_vm' is assigned to but never used,
and The virt-test framework is responsible for checking
parameters and starting a VM or not.

So remove it and it's assignment statement.