### PR TITLE
Virsh desc add cases

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_desc.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_desc.cfg
@@ -1,42 +1,68 @@
 - virsh.desc:
     type = virsh_desc
     desc_option = ""
-    desc_str = "New Description/title for the vm"
+    desc_str = "New Description for the vm"
+    desc_title_str = "New title for the vm"
     persistent_vm = "yes"
+    domain = "name"
     variants:
         - positive_test:
-            status_error = "no"
-            variants:
-                - no_option:
-                    desc_option = ""
-                - title_option:
-                    desc_option = "--title"
-                - live_desc:
-                    desc_option = "--live"
-                - current_desc:
-                    desc_option = "--current"
-                - config_desc:
-                    desc_option = "--config"
-                - live_config_desc:
-                    desc_option = "--live --config"
-                - live_title:
-                    desc_option = "--live --title"
-                - current_title:
-                    desc_option = "--current --title"
-                - config_title:
-                    desc_option = "--config --title"
-                - live_config_title:
-                    desc_option = "--live --config --title"
-                - transient_live:
-                    persistent_vm = "no"
-                    desc_option = "--live"
+             status_error = "no"
+             variants:
+                 - no_option:
+                     desc_option = ""
+                 - domain_ID_no_option:
+                     domain = "ID"
+                     desc_option = ""
+                 - domain_UUID_no_option:
+                     domain = "UUID"
+                     desc_option = ""
+                 - title_option:
+                     desc_option = "--title"
+                     desc_str = ${desc_title_str}
+                 - live_desc:
+                     desc_option = "--live"
+                 - current_desc:
+                     desc_option = "--current"
+                 - config_desc:
+                     desc_option = "--config"
+                 - live_config_desc:
+                     desc_option = "--live --config"
+                 - live_title:
+                     desc_option = "--live --title"
+                     desc_str = ${desc_title_str}
+                 - current_title:
+                     desc_option = "--current --title"
+                     desc_str = ${desc_title_str}
+                 - config_title:
+                     desc_option = "--config --title"
+                     desc_str = ${desc_title_str}
+                 - live_config_title:
+                     desc_option = "--live --config --title"
+                     desc_str = ${desc_title_str}
+                 - edit_option:
+                     desc_option = "--edit"
+                 - new_desc_option:
+                     desc_option = "--new-desc"
+                 - transient_live:
+                     persistent_vm = "no"
+                     desc_option = "--live"
         - negative_test:
             status_error = "yes"
             variants:
+                - invalid_domain_name:
+                    domain = "invalid_domain"
+                - invalid_domain_uuid:
+                    domain = "invalid_uuid"
                 - invalid_option1:
-                    desc_option = "--xyz"
+                    desc_option = "--invalid"
                 - invalid_option2:
                     desc_option = "--live --current"
+                - invalid_option3:
+                    desc_option = "--config --current"
+                - new_desc_without_string:
+                    desc_option = "--new-desc"
+                    desc_str = ""
                 - transient_config:
                     persistent_vm = "no"
                     desc_option = "--config --title"


### PR DESCRIPTION
Set the tittle and description with different string in virsh desc.
    
Currently the string for testing set tittle and description is the
same in virsh desc, maybe make then different is better.
Add the new case for '--edit' option.
