### PR TITLE
libvirt/tests/src/virt_cmd: don't get VM object

### DIFF
--- a/libvirt/tests/src/virt_cmd/virt_top.py
+++ b/libvirt/tests/src/virt_cmd/virt_top.py
@@ -18,7 +18,6 @@ def run(test, params, env):
         raise error.TestNAError("No virt-top command found.")
 
     vm_name = params.get("main_vm", "virt-tests-vm1")
-    vm = env.get_vm(vm_name)
     output = params.get("output_file", "output")
     output_path = os.path.join(data_dir.get_tmp_dir(), output)
 

--- a/libvirt/tests/src/virt_cmd/virt_xml_validate.py
+++ b/libvirt/tests/src/virt_cmd/virt_xml_validate.py
@@ -191,7 +191,6 @@ def run(test, params, env):
         raise error.TestNAError("Not find virt-xml-validate command on host.")
 
     vm_name = params.get("main_vm", "virt-tests-vm1")
-    vm = env.get_vm(vm_name)
     net_name = params.get("net_dumpxml_name", "default")
     pool_name = params.get("pool_dumpxml_name", "default")
     schema = params.get("schema", "domain")


### PR DESCRIPTION
It's meaningless to get VM object, VM name is enough.