### PR TITLE
Add negative case for virsh domcapabilities.

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_domcapabilities.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_domcapabilities.cfg
@@ -23,8 +23,11 @@
                 - invalid_virttype:
                     virttype_value = "xyz"
                 - invalid_emulatorbin:
-                    emulatorbin_value = "xyz"
+                    emulatorbin_value = "/usr/libexec/qemu-invalid"
                 - invalid_arch:
-                    arch_value = "xyz"
+                    arch_value = "armv7l"
                 - invalid_machine:
                     machine_value = "xyz"
+                - no_match_emulatorbin_arch:
+                    emulatorbin_value = "/usr/libexec/qemu-kvm"
+                    arch_value = "armv7l"


### PR DESCRIPTION
When emulatorbin and arch option do not match,
 virsh domcapabilities would fail.
 Add this situation in negative case.