### PR TITLE
fix delimiter problem about iSCSi

### DIFF
--- a/libvirt/tests/cfg/resource_abnormal.cfg
+++ b/libvirt/tests/cfg/resource_abnormal.cfg
@@ -6,7 +6,7 @@
     pool_name = "test_pool"
     volume_name = "test_vol"
     volume_size = "2G"
-    emulated_image = disk_image
+    emulated_image = disk-image
     emulated_file_remove = no
     target = iqn.2013-10.com.example:iscsi
     mount_dir = disk_dir

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_disk_lxc.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_disk_lxc.cfg
@@ -16,7 +16,7 @@
     at_dt_disk_serial = ""
     at_dt_disk_address = ""
     at_dt_disk_iscsi_device = "yes"
-    emulated_image = "iscsi.img"
+    emulated_image = "iscsi-img"
     image_size = "100M"
     target = "iqn.2013-10.com.example:iscsi"
     variants:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device.cfg
@@ -24,7 +24,7 @@
                 - block_type:
                     dt_device_iscsi_device = 'yes'
                     target = iqn.2013-10.com.example:iscsi
-                    emulated_image = disk_image
+                    emulated_image = disk-image
                     image_size = 1G
                 - file_type:
                     dt_device_iscsi_device = 'no'

--- a/libvirt/tests/cfg/virsh_cmd/pool/virsh_pool_edit.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/pool/virsh_pool_edit.cfg
@@ -44,7 +44,7 @@
             pool_name = "disk_pool"
             pool_type = "disk"
             pool_target = "/dev"
-            emulated_image = "emulated_image_disk"
+            emulated_image = "emulated-image-disk"
             edit_element = "pool_format"
     variants:
         - positive_test:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_copy_storage.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_copy_storage.py
@@ -97,12 +97,12 @@ def run(test, params, env):
             # Create volume group with iscsi
             # For local, target is a device name
             target1 = utlv.setup_or_cleanup_iscsi(is_setup=True, is_login=True,
-                                                  emulated_image="emulated_iscsi1")
+                                                  emulated_image="emulated-iscsi1")
             lv_utils.vg_create(vgname, target1)
             logging.debug("Created VG %s", vgname)
             # For remote, target is real target name
             target2 = utlv.setup_or_cleanup_iscsi(is_setup=True, is_login=False,
-                                                  emulated_image="emulated_iscsi2")
+                                                  emulated_image="emulated-iscsi2")
             logging.debug("Created target: %s", target2)
             # Login on remote host
             remote_device = rdm.iscsi_login_setup(local_host, target2)
@@ -175,6 +175,6 @@ def run(test, params, env):
             except:
                 pass    # let it go to confirm cleanup iscsi device
             utlv.setup_or_cleanup_iscsi(is_setup=False,
-                                        emulated_image="emulated_iscsi1")
+                                        emulated_image="emulated-iscsi1")
             utlv.setup_or_cleanup_iscsi(is_setup=False,
-                                        emulated_image="emulated_iscsi2")
+                                        emulated_image="emulated-iscsi2")

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_virtio_scsi.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_virtio_scsi.py
@@ -137,7 +137,7 @@ def run(test, params, env):
             # Try to build an iscsi device
             # For local, target is a device name
             target = utlv.setup_or_cleanup_iscsi(is_setup=True, is_login=True,
-                                                 emulated_image="emulated_iscsi")
+                                                 emulated_image="emulated-iscsi")
             logging.debug("Created target: %s", target)
             try:
                 # Attach this iscsi device both local and remote
@@ -337,7 +337,7 @@ def run(test, params, env):
                           "/dev/EXAMPLE").count("EXAMPLE"):
                 rdm.iscsi_login_setup(local_host, target, is_login=False)
                 utlv.setup_or_cleanup_iscsi(is_setup=False,
-                                            emulated_image="emulated_iscsi")
+                                            emulated_image="emulated-iscsi")
 
         if runner:
             runner.session.close()

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool.py
@@ -160,7 +160,7 @@ def run(test, params, env):
 
     # Run Testcase
     pvt = utlv.PoolVolumeTest(test, params)
-    emulated_image = "emulated_image"
+    emulated_image = "emulated-image"
     kwargs = {'image_size': '1G', 'pre_disk_vol': ['1M'],
               'source_name': source_name, 'source_path': source_path,
               'source_format': source_format, 'persistent': True,

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool_create.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool_create.py
@@ -43,7 +43,7 @@ def run(test, params, env):
     if pre_def_pool and pool_ins.pool_exists(pool_name):
         raise error.TestFail("Pool %s already exist" % pool_name)
 
-    emulated_image = "emulated_image"
+    emulated_image = "emulated-image"
     kwargs = {'image_size': '1G', 'source_path': source_path,
               'source_name': source_name, 'source_format': source_format}
     pvt = utlv.PoolVolumeTest(test, params)

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool_edit.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool_edit.py
@@ -90,7 +90,7 @@ def run(test, params, env):
                                params.get("pool_target", "pool_target"))
     source_name = params.get("pool_source_name", "gluster-vol1")
     source_path = params.get("pool_source_path", "/")
-    emulated_image = params.get("emulated_image", "emulated_image_disk")
+    emulated_image = params.get("emulated_image", "emulated-image-disk")
     edit_target = params.get("edit_target", "target_path")
 
     if not libvirt_version.version_compare(1, 0, 0):

--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_disk.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_disk.py
@@ -47,7 +47,7 @@ def run(test, params, env):
     pool_name = params.get("pool_name")
     pool_type = params.get("pool_type")
     pool_target = params.get("pool_target")
-    emulated_image = params.get("emulated_image")
+    emulated_image = params.get("emulated_image", "emulated-image")
     vol_format = params.get("vol_format")
     lazy_refcounts = "yes" == params.get("lazy_refcounts")
     options = params.get("snapshot_options", "")


### PR DESCRIPTION
The targetcli doesn't support '_' like below,
    /> /iscsi/ create iqn.2015-06.com:emulated_iscsi.target
    WWN not valid as: iqn, naa, eui
And, There're many string(s) of 'emulated_image',
which selects '-' as the delimiter.

So, replace '_' with '-' to keep consistence.

Signed-off-by: Wei,Jiangang <weijg.fnst@cn.fujitsu.com>