### PR TITLE
virsh_iface_edit: fix bug about catching exception

### DIFF
--- a/libvirt/tests/src/virsh_cmd/interface/virsh_iface_edit.py
+++ b/libvirt/tests/src/virsh_cmd/interface/virsh_iface_edit.py
@@ -20,7 +20,7 @@ def get_ifstart_mode(iface_name):
     try:
         xml = virsh.iface_dumpxml(iface_name, "--inactive", "", debug=True)
         start_mode = re.findall("start mode='(\S+)'", xml)[0]
-    except error.CmdError, IndexError:
+    except (error.CmdError, IndexError):
         logging.error("Fail to get start mode for interface %s", iface_name)
     return start_mode
 


### PR DESCRIPTION
If catching more than two exceptions without brackets,
for an example,
    try:
        ...
    except error.CmdError, IndexError:
        pass
The 'IndexError' will be regard as local variable,
not a exception type.

The standing procedure like below,
    try:
        ...
    except (RuntimeError, TypeError):
        pass or handle

This patch is used to solve the above problem.