### PR TITLE
Add test case about combint '--live' and '--config' for

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blkdeviotune.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blkdeviotune.cfg
@@ -16,9 +16,9 @@
                                         - none:
                                             blkdevio_options =
                                         - config:
-                                            blkdevio_options = "config"
+                                            blkdevio_options = "--config"
                                         - current:
-                                            blkdevio_options = "current"
+                                            blkdevio_options = "--current"
                         - running_guest:
                             start_vm = "yes"
                             variants:
@@ -27,9 +27,13 @@
                                         - none:
                                             blkdevio_options =
                                         - live:
-                                            blkdevio_options = "live"
+                                            blkdevio_options = "--live"
+                                        - config:
+                                            blkdevio_options = "--config"
                                         - current:
-                                            blkdevio_options = "current"
+                                            blkdevio_options = "--current"
+                                        - live_and_config:
+                                            blkdevio_options = "--live --config"
                 - set_blkdevio_parameter:
                     change_parameters = "yes"
                     variants:
@@ -48,9 +52,9 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_read_bytes_sec:
                                     variants:
                                         - minimum_boundary:
@@ -63,9 +67,9 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_write_bytes_sec:
                                     variants:
                                         - minimum_boundary:
@@ -78,9 +82,9 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_total_read_write_bytes_sec:
                                     variants:
                                         - combination1:
@@ -107,9 +111,9 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_total_iops_sec:
                                     variants:
                                         - minimum_boundary:
@@ -122,9 +126,9 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_read_iops_sec:
                                     variants:
                                         - minimum_boundary:
@@ -137,9 +141,9 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_write_iops_sec:
                                     variants:
                                         - minimum_boundary:
@@ -152,9 +156,9 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_total_read_write_iops_sec:
                                     variants:
                                         - combination1:
@@ -181,9 +185,9 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_total_read_write_bytes_iops_sec:
                                     variants:
                                         - combination1:
@@ -199,9 +203,9 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                         - running_guest:
                             start_vm = "yes"
                             variants:
@@ -217,9 +221,9 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_read_bytes_sec:
                                     variants:
                                         - minimum_boundary:
@@ -232,9 +236,9 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_write_bytes_sec:
                                     variants:
                                         - minimum_boundary:
@@ -247,9 +251,9 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_total_read_write_bytes_sec:
                                     variants:
                                         - combination1:
@@ -276,9 +280,9 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_total_iops_sec:
                                     variants:
                                         - minimum_boundary:
@@ -291,9 +295,9 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_read_iops_sec:
                                     variants:
                                         - minimum_boundary:
@@ -306,9 +310,9 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_write_iops_sec:
                                     variants:
                                         - minimum_boundary:
@@ -321,9 +325,9 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_total_read_write_iops_sec:
                                     variants:
                                         - combination1:
@@ -350,9 +354,9 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_total_read_write_bytes_iops_sec:
                                     variants:
                                         - combination1:
@@ -368,9 +372,9 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
         - negative_testing:
             status_error = "yes"
             blkdevio_device = "vmblk"
@@ -387,7 +391,7 @@
                                         - invalid:
                                             blkdevio_options = "welcome"
                                         - live:
-                                            blkdevio_options = "live"
+                                            blkdevio_options = "--live"
                         - running_guest:
                             start_vm = "yes"
                             variants:
@@ -418,11 +422,11 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - live:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_read_bytes_sec:
                                     variants:
                                         - lower_minimum_boundary:
@@ -435,11 +439,11 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - live:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_write_bytes_sec:
                                     variants:
                                         - lower_minimum_boundary:
@@ -452,11 +456,11 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - live:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_total_iops_sec:
                                     variants:
                                         - lower_minimum_boundary:
@@ -469,11 +473,11 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - live:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_read_iops_sec:
                                     variants:
                                         - lower_minimum_boundary:
@@ -486,11 +490,11 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - live:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_write_iops_sec:
                                     variants:
                                         - lower_minimum_boundary:
@@ -503,11 +507,11 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - live:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_total_read_write_bytes_iops_sec:
                                     variants:
                                         - total_read_bytes_sec:
@@ -540,11 +544,11 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - live:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_read_bytes_sec:
                                     variants:
                                         - lower_minimum_boundary:
@@ -557,11 +561,11 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - live:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_write_bytes_sec:
                                     variants:
                                         - lower_minimum_boundary:
@@ -574,11 +578,11 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - live:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_total_iops_sec:
                                     variants:
                                         - lower_minimum_boundary:
@@ -591,11 +595,11 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - live:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_read_iops_sec:
                                     variants:
                                         - lower_minimum_boundary:
@@ -608,11 +612,11 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - live:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_write_iops_sec:
                                     variants:
                                         - lower_minimum_boundary:
@@ -625,11 +629,11 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - live:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_total_read_write_bytes_iops_sec:
                                     variants:
                                         - total_read_bytes_sec:


### PR DESCRIPTION
virsh blkdeviotune.

No matter getting or setting blkdeviotune value for device,
'--live' and '--config' can be used at the same time.

This PR depends on autotest/virt-test#2221.