### PR TITLE
hotplug_serial: fix 'unknown device type'

### DIFF
--- a/libvirt/tests/src/hotplug_serial.py
+++ b/libvirt/tests/src/hotplug_serial.py
@@ -6,11 +6,9 @@ import time
 import socket
 import shutil
 
-from autotest.client import utils
 from autotest.client.shared import error
 from virttest import virsh
 from virttest import utils_misc
-from virttest.libvirt_xml.devices import channel
 from virttest.libvirt_xml.vm_xml import VMXML
 from virttest.libvirt_xml.devices.controller import Controller
 from virttest.utils_test import libvirt as utlv
@@ -105,6 +103,12 @@ def run(test, params, env):
             elif char_dev == "pty":
                 prepare_channel_xml(xml_file, char_dev, id)
             result = virsh.attach_device(vm_name, xml_file)
+            # serial device was introduced by the following commit,
+            # http://libvirt.org/git/?
+            # p=libvirt.git;a=commit;h=b63ea467617e3cbee4282ab2e5e780b4119cef3d
+            if "unknown device type" in result.stderr:
+                raise error.TestNAError('Failed to attach %s to %s. Result:\n %s'
+                                        % (char_dev, vm_name, result))
         return result
 
     def dup_hotplug(type, char_dev, id, dup_charid=False, dup_devid=False, diff_devid=False):


### PR DESCRIPTION
Error while running it on RHEL6.7 Beta.

02:54:30 DEBUG| Running virsh command: attach-device vm1
/home/autotest/client/tests/virt/tmp/hotplug_serial/xml_pty
02:54:30 DEBUG| Running '/usr/bin/virsh attach-device vm1
/home/autotest/client/tests/virt/tmp/hotplug_serial/xml_pty'
02:54:30 DEBUG| status: 1
02:54:30 DEBUG| stdout:
02:54:30 DEBUG| stderr: error:
Failed to attach device from
/home/autotest/client/tests/virt/tmp/hotplug_serial/xml_pty
error: XML error: unknown device type

Obviously,
serial device is not supported by old libvirt.
It's necessary to check the libvirt version before test.