### PR TITLE
Fix test fails for virsh command domstats.

### DIFF
--- a/libvirt/tests/src/virsh_cmd/monitor/virsh_domstats.py
+++ b/libvirt/tests/src/virsh_cmd/monitor/virsh_domstats.py
@@ -150,7 +150,8 @@ def run(test, params, env):
     if vm_list:
         for name in vm_list.split():
             if name != default_vm_name:
-                vms.append(env.get_vm(name))
+                if env.get_vm(name):
+                    vms.append(env.get_vm(name))
     backup_xml_list = []
     try:
         if not status_error:


### PR DESCRIPTION
The configure file for testing virsh domstats sets a
variable 'vm_list' for specifying a guest, but there
maybe no matched guest and results failure.

The original test log:
```
04:33:33 ERROR| FAIL type_specific.io-github-autotest-libvirt.virsh.domstats.normal_test.domain_state.active.no_option.specific_domain -> AttributeError: 'NoneType' object has no attribute 'name'
```