### PR TITLE
Add test case for virsh domtime.

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domtime.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domtime.cfg
@@ -1,0 +1,47 @@
+- virsh.domtime:
+    type = virsh_domtime
+    vm_ref = "name"
+    start_vm = "yes"
+    take_regular_screendumps = "no"
+    variants:
+        - positive_tests:
+            status_error = "no"
+            variants:
+                - get_time:
+                    domtime_get = "yes"
+                    variants:
+                        - get_time_with_name:
+                        - get_time_with_id:
+                            vm_ref = "id"
+                        - get_time_with_uuid:
+                            vm_ref = "uuid"
+                        - get_time_with_pretty_option:
+                            domtime_pretty = "yes"
+        - negative_tests:
+            status_error = "yes"
+            variants:
+                - no_qemu_guest_agent:
+                    no_qemu_ga = "yes"
+                - no_start_qemu_guest_agent:
+                    no_start_qemu_ga = "yes"
+                - not_active_domain:
+                    start_vm = "no"
+                - no_exist_domain:
+                    vm_ref = "invalid"
+                - no_domain_ref:
+                    vm_ref = "none"
+                - invalid_options:
+                    domtime_options = "--xyz"
+                - set_time_with_sync_now:
+                    domtime_now = "yes"
+                    domtime_sync = "yes"
+                - set_time_with_sync_time_param:
+                    domtime_sync = "yes"
+                    domtime_time = "1427000000"
+                - set_time_with_now_time_param:
+                    domtime_now = "yes"
+                    domtime_time = "1427000000"
+                - set_time_with_invalid_time_param:
+                    domtime_time = "xyz"
+                - set_time_with_none_time_param:
+                    domtime_options = "--time"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domtime.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domtime.py
@@ -1,0 +1,100 @@
+import re
+import uuid
+from autotest.client.shared import error
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+
+
+def run(test, params, env):
+    """
+    Test domtime command, make sure that all supported options work well
+
+    Test scenaries:
+    1. domtime to get time
+    2. domtime with wrong options
+
+    Notice: set time has not been supported, so not tests here.
+    """
+
+    if not virsh.has_help_command('domtime'):
+        raise error.TestNAError("This version of libvirt does not support "
+                                "the domtime test")
+
+    vm_ref = params.get("vm_ref", "name")
+    vm_name = params.get("main_vm", "virt-tests-vm1")
+    start_vm = ("yes" == params.get("start_vm", "yes"))
+    has_qemu_ga = not ("yes" == params.get("no_qemu_ga", "no"))
+    start_qemu_ga = not ("yes" == params.get("no_start_qemu_ga", "no"))
+    status_error = ("yes" == params.get("status_error", "no"))
+    domtime_opts = params.get("domtime_options", "")
+    pretty_opt = ("yes" == params.get("domtime_pretty", "no"))
+    get_time = ("yes" == params.get("domtime_get", "no"))
+    sync_opt = ("yes" == params.get("domtime_sync", "no"))
+    now_opt = ("yes" == params.get("domtime_now", "no"))
+    time_opt = params.get("domtime_time", None)
+
+    # Do backup for origin xml
+    xml_backup = vm_xml.VMXML.new_from_dumpxml(vm_name)
+    try:
+        vm = env.get_vm(vm_name)
+
+        vm.destroy()
+
+        if has_qemu_ga:
+            vm.prepare_guest_agent(start=start_qemu_ga)
+        else:
+            # Remove qemu-ga channel
+            vm.prepare_guest_agent(channel=has_qemu_ga, start=False)
+
+        if start_vm:
+            if not vm.is_alive():
+                vm.start()
+            domid = vm.get_id()
+        else:
+            vm.destroy()
+
+        domuuid = vm.get_uuid()
+
+        if vm_ref == "id":
+            vm_ref = domid
+        elif vm_ref == "uuid":
+            vm_ref = domuuid
+        elif vm_ref.count("invalid"):
+            vm_ref = uuid.uuid1()
+        elif vm_ref == "none":
+            vm_ref = ""
+        elif vm_ref == "name":
+            vm_ref = vm_name
+
+        # Execute domtime command
+        cmd_result = virsh.domtime(vm_ref, now=now_opt, pretty=pretty_opt,
+                                   sync=sync_opt, time=time_opt,
+                                   options=domtime_opts, debug=True)
+
+        if not status_error:
+            if cmd_result.exit_status != 0:
+                raise error.TestFail("Fail to do virsh domtime, error %s" %
+                                     cmd_result.stderr)
+            # Prove the time format
+            if get_time:
+                if pretty_opt:
+                    date = cmd_result.stdout.split()[1]
+                    time = cmd_result.stdout.split()[2]
+                    if not re.match(r"^\d{4}-\d{2}-\d{2}$", date) or \
+                       not re.match(r"^[0-2][0-9]:[0-5][0-9]:[0-5][0-9]$",
+                                    time):
+                        raise error.TestFail("Return pretty time is error: %s" %
+                                             cmd_result.stdout)
+
+                else:
+                    time = cmd_result.stdout.split()[1]
+                    if not time.isdigit():
+                        raise error.TestFail("Return time is error: %s" %
+                                             cmd_result.stdout)
+        else:
+            if cmd_result.exit_status == 0:
+                raise error.TestFail("Command 'virsh domtime' failed ")
+
+    finally:
+        # Do domain recovery
+        xml_backup.sync()


### PR DESCRIPTION
Test getting time for virsh command domtime.

The test result on libvirt-1.2.8-16.el7.x86_64:
```
# ./run -k --no-downloads -t libvirt --tests virsh.domtime
SETUP: PASS (0.50 s)
DATA DIR: /var/lib/virt_test
DEBUG LOG: /root/community/autotest/client/tests/virt-test/logs/run-2015-06-23-23.51.37/debug.log
TESTS: 15
(1/15) type_specific.io-github-autotest-libvirt.virsh.domtime.positive_tests.get_time.get_time_with_name: PASS (37.69 s)
(2/15) type_specific.io-github-autotest-libvirt.virsh.domtime.positive_tests.get_time.get_time_with_id: PASS (36.92 s)
(3/15) type_specific.io-github-autotest-libvirt.virsh.domtime.positive_tests.get_time.get_time_with_uuid: PASS (37.00 s)
(4/15) type_specific.io-github-autotest-libvirt.virsh.domtime.positive_tests.get_time.get_time_with_pretty_option: PASS (37.02 s)
(5/15) type_specific.io-github-autotest-libvirt.virsh.domtime.negative_tests.no_qemu_guest_agent: PASS (36.63 s)
(6/15) type_specific.io-github-autotest-libvirt.virsh.domtime.negative_tests.no_start_qemu_guest_agent: PASS (41.41 s)
(7/15) type_specific.io-github-autotest-libvirt.virsh.domtime.negative_tests.not_active_domain: PASS (30.34 s)
(8/15) type_specific.io-github-autotest-libvirt.virsh.domtime.negative_tests.no_exist_domain: PASS (37.64 s)
(9/15) type_specific.io-github-autotest-libvirt.virsh.domtime.negative_tests.no_domain_ref: PASS (36.91 s)
(10/15) type_specific.io-github-autotest-libvirt.virsh.domtime.negative_tests.invalid_options: PASS (36.73 s)
(11/15) type_specific.io-github-autotest-libvirt.virsh.domtime.negative_tests.set_time_with_sync_now: PASS (36.88 s)
(12/15) type_specific.io-github-autotest-libvirt.virsh.domtime.negative_tests.set_time_with_sync_time_param: PASS (36.89 s)
(13/15) type_specific.io-github-autotest-libvirt.virsh.domtime.negative_tests.set_time_with_now_time_param: PASS (36.77 s)
(14/15) type_specific.io-github-autotest-libvirt.virsh.domtime.negative_tests.set_time_with_invalid_time_param: PASS (36.98 s)
(15/15) type_specific.io-github-autotest-libvirt.virsh.domtime.negative_tests.set_time_with_none_time_param: PASS (36.88 s)
TOTAL TIME: 552.77 s (09:12)
TESTS PASSED: 15
TESTS FAILED: 0
SUCCESS RATE: 100.00 %
```