### PR TITLE
Add 16M hugepage size support.

### DIFF
--- a/libvirt/tests/cfg/numa/guest_numa.cfg
+++ b/libvirt/tests/cfg/numa/guest_numa.cfg
@@ -78,6 +78,14 @@
                                      hugepage_size_0 = "1048576"
                                      page_num_0 = "1"
                                      page_nodenum_0 = "1"
+                                 - 16M:
+                                     max_mem = "2097152"
+                                     cell_memory_0 = "1048576"
+                                     cell_memory_1 = "1048576"
+                                     vmpage_size_0 = "16384"
+                                     hugepage_size_0 = "16384"
+                                     page_num_0 = "1"
+                                     page_nodenum_0 = "1"
                          - host_total:
                              nr_pagesize_total = "600"
         - negative_test:


### PR DESCRIPTION
16M hugepage size is used on PPC machine, verify supported hugepage size
before the test, only continue the test if hugepage size is in suppported
size list.