### PR TITLE
attach_device: Attach scsi controller before scsi disk

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_device.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_device.cfg
@@ -192,6 +192,11 @@
                     vadu_dev_obj_devidx_VirtualDiskBasic = 0
                     vadu_dev_obj_targetbus_VirtualDiskBasic = "usb"
                 - single_scsi_file:
+                    # attach scsi disk need scsi controller exist
+                    # so vadu_dev_objs has two classes to attach
+                    vadu_dev_objs = "Controller VirtualDiskBasic"
+                    vadu_dev_obj_type_Controller = "scsi"
+                    vadu_dev_obj_model_Controller = "virtio-scsi"
                     vadu_dev_obj_meg_VirtualDiskBasic = 10
                     vadu_dev_obj_devidx_VirtualDiskBasic = 0
                     vadu_dev_obj_targetbus_VirtualDiskBasic = "scsi"


### PR DESCRIPTION
Attach scsi disk required scsi controller, so try to attach scsi
controller first in case it not exist.

Signed-off-by: Yanbing Du <ydu@redhat.com>