### PR TITLE
domif_setlink_getlink: fix link state change too fast problem

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domif_setlink_getlink.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domif_setlink_getlink.py
@@ -177,6 +177,8 @@ def run(test, params, env):
 
             # Set the link up make host connect with vm
             domif_setlink(vm_name, device, "up", "")
+            # wait for login to make sure link is up
+            vm.wait_for_login()
             # Ignore status of this one
             cmd_status = session.cmd_status('ip link set dev %s down'
                                             % guest_if_name)


### PR DESCRIPTION
As set link down command follow behind set link up command, in some
test it got:

  ShellTimeoutError: Timeout expired while waiting for shell command
  to complete: 'ip link set dev eth0 down'

and in output:

  IPv6: ADDRCONF(NETDEV_UP): eth0: link is not ready

the cause could be time gap between up and down operation, so use
wait_for_login to confirm the link is up and ready, then set link
down in serial console to avoid this problem.

Signed-off-by: Wayne Sun <gsun@redhat.com>