### PR TITLE
virsh_freepages: bugfix

### DIFF
--- a/libvirt/tests/src/virsh_cmd/host/virsh_freepages.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_freepages.py
@@ -79,9 +79,7 @@ def run(test, params, env):
         host_cells = int(host_cells)
     except (TypeError, ValueError), e:
         raise error.TestError("Fail to get host nodes number: %s" % e)
-    if not cellno:
-        pass
-    elif cellno == "AUTO":
+    if cellno == "AUTO":
         cellno_list = range(0, host_cells)
     elif cellno == "OUT_OF_RANGE":
         cellno_list.append(host_cells)
@@ -95,9 +93,7 @@ def run(test, params, env):
         raise error.TestError("Fail to get default page size: %s" % e)
     default_huge_pagesize = utils_memory.get_huge_page_size()
     pagesize_list = []
-    if not pagesize:
-        pass
-    elif pagesize == "AUTO":
+    if pagesize == "AUTO":
         pagesize_list.append(default_pagesize)
         pagesize_list.append(default_huge_pagesize)
     else:


### PR DESCRIPTION
If freepages_cellno is not set，cellno will be None, and then the 
for loops will never be processed
113     # Run test
114     for cell in cellno_list:
115         for page in pagesize_list:
116             result = virsh.freepages(cellno=cell,
some test cases will always return PASS.
pagesize has the same problem.