### PR TITLE
domdisplay: update cfg to avoid cartesian keywords

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domdisplay.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domdisplay.cfg
@@ -4,7 +4,7 @@
     take_regular_screendumps = "no"
     qemu_conf_file = "/etc/libvirt/qemu.conf"
     variants:
-        - spice:
+        - spice_t:
             domdisplay_graphic = "spice"
             variants:
                 - with_ssl:
@@ -14,7 +14,7 @@
                     variants:
                         - domain_id:
                             domdisplay_domid = "yes"
-        - vnc:
+        - vnc_t:
             domdisplay_graphic = "vnc"
             variants:
                 - domain_uuid:


### PR DESCRIPTION
Update 'vnc' and 'spice' in cfg to avoid cartersian keywords problem
on some env.

Signed-off-by: Wayne Sun <gsun@redhat.com>