### PR TITLE
Add some cases for virsh event/qemu_monitor_event

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_event.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_event.cfg
@@ -66,7 +66,15 @@
             status_error = "yes"
             variants:
                 - invalid_event:
-                    net_event_name = "xyz"
+                    event_name = "xyz"
                 - invalid_timeout:
-                    net_event_name = "lifecycle"
-                    net_event_timeout = "xyz"
+                    event_name = "lifecycle"
+                    event_timeout = "xyz"
+            variants:
+                - virsh_event:
+                    # Test virsh event
+                    qemu_monitor_test = "no"
+                - qemu_monitor_event:
+                    # Test virsh qemu_monitor_event
+                    no invalid_event
+                    qemu_monitor_test = "yes"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
@@ -165,6 +165,11 @@ def run(test, params, env):
             # various events
             logging.info("Sending '%s' to virsh shell", event_cmd)
             virsh_session.sendline(event_cmd)
+        elif qemu_monitor_test:
+            result = virsh.qemu_monitor_event(domain=vm_name, event=event_name,
+                                              event_timeout=event_timeout,
+                                              options=event_option, **virsh_dargs)
+            utlv.check_exit_status(result, status_error)
         else:
             result = virsh.event(domain=vm_name, event=event_name,
                                  event_timeout=event_timeout,


### PR DESCRIPTION
1. "net_event_xxx" aren't used in cfg file, so replacing 'net_event_xxx'  with 'event_xxx'.
2. add some negative cases for qemu_monitor_event

This PR depends on autotest/virt-test#2271