### PR TITLE
virsh.net_dhcp_leases: Fix bug for "attach_interface_before_vm_start" cases

### DIFF
--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_dhcp_leases.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_dhcp_leases.py
@@ -156,17 +156,15 @@ def run(test, params, env):
                 virsh.attach_interface(vm_name, option=op, debug=True,
                                        ignore_status=False)
                 vm.start()
-                vm.wait_for_login().close()
-                expected_find = True
             else:
                 vm.start()
                 virsh.attach_interface(vm_name, option=op, debug=True,
                                        ignore_status=False)
-                new_interface_ip = get_ip_by_mac(iface_mac, try_dhclint=True)
-                # Allocate IP address for the new interface may fail, so only
-                # check the result if get new IP address
-                if new_interface_ip:
-                    expected_find = True
+            new_interface_ip = get_ip_by_mac(iface_mac, try_dhclint=True)
+            # Allocate IP address for the new interface may fail, so only
+            # check the result if get new IP address
+            if new_interface_ip:
+                expected_find = True
             result = virsh.net_dhcp_leases(net_name, mac=nic_mac,
                                            debug=False, ignore_status=True)
             utlv.check_exit_status(result, status_error)


### PR DESCRIPTION
"attach_interface_before_vm_start" case return FAIL:
  ERROR|     raise error.TestFail("Lease info is empty")
  ERROR| TestFail: Lease info is empty

Allocate IP address for the new interface is necessary before 
check the dhcp lease info, both hotplug_interface or not.