### PR TITLE
virsh.volume: Fix bug for dir_pool cases

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/volume/virsh_volume.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/volume/virsh_volume.cfg
@@ -17,8 +17,6 @@
     variants:
         - dir_pool:
             pool_type = "dir"
-            volume_size = "1048576B"
-            volume_allocation = "1048576B"
             variants:
                 - vol_format_raw:
                     volume_format = "raw"


### PR DESCRIPTION
Both '- vol_allocation' and '- dir_pool' variants declare 'volume_allocation',
the former will be covered by the latter