### PR TITLE
blkdeviotune: Fix option error due to command wrap function change

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blkdeviotune.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blkdeviotune.cfg
@@ -16,9 +16,9 @@
                                         - none:
                                             blkdevio_options =
                                         - config:
-                                            blkdevio_options = "config"
+                                            blkdevio_options = "--config"
                                         - current:
-                                            blkdevio_options = "current"
+                                            blkdevio_options = "--current"
                         - running_guest:
                             start_vm = "yes"
                             variants:
@@ -27,9 +27,9 @@
                                         - none:
                                             blkdevio_options =
                                         - live:
-                                            blkdevio_options = "live"
+                                            blkdevio_options = "--live"
                                         - current:
-                                            blkdevio_options = "current"
+                                            blkdevio_options = "--current"
                 - set_blkdevio_parameter:
                     change_parameters = "yes"
                     variants:
@@ -48,9 +48,9 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_read_bytes_sec:
                                     variants:
                                         - minimum_boundary:
@@ -63,9 +63,9 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_write_bytes_sec:
                                     variants:
                                         - minimum_boundary:
@@ -78,9 +78,9 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_total_read_write_bytes_sec:
                                     variants:
                                         - combination1:
@@ -107,9 +107,9 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_total_iops_sec:
                                     variants:
                                         - minimum_boundary:
@@ -122,9 +122,9 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_read_iops_sec:
                                     variants:
                                         - minimum_boundary:
@@ -137,9 +137,9 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_write_iops_sec:
                                     variants:
                                         - minimum_boundary:
@@ -152,9 +152,9 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_total_read_write_iops_sec:
                                     variants:
                                         - combination1:
@@ -181,9 +181,9 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_total_read_write_bytes_iops_sec:
                                     variants:
                                         - combination1:
@@ -199,9 +199,9 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                         - running_guest:
                             start_vm = "yes"
                             variants:
@@ -217,9 +217,9 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_read_bytes_sec:
                                     variants:
                                         - minimum_boundary:
@@ -232,9 +232,9 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_write_bytes_sec:
                                     variants:
                                         - minimum_boundary:
@@ -247,9 +247,9 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_total_read_write_bytes_sec:
                                     variants:
                                         - combination1:
@@ -276,9 +276,9 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_total_iops_sec:
                                     variants:
                                         - minimum_boundary:
@@ -291,9 +291,9 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_read_iops_sec:
                                     variants:
                                         - minimum_boundary:
@@ -306,9 +306,9 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_write_iops_sec:
                                     variants:
                                         - minimum_boundary:
@@ -321,9 +321,9 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_total_read_write_iops_sec:
                                     variants:
                                         - combination1:
@@ -350,9 +350,9 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_total_read_write_bytes_iops_sec:
                                     variants:
                                         - combination1:
@@ -368,9 +368,9 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
         - negative_testing:
             status_error = "yes"
             blkdevio_device = "vmblk"
@@ -387,7 +387,7 @@
                                         - invalid:
                                             blkdevio_options = "welcome"
                                         - live:
-                                            blkdevio_options = "live"
+                                            blkdevio_options = "--live"
                         - running_guest:
                             start_vm = "yes"
                             variants:
@@ -418,11 +418,11 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - live:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_read_bytes_sec:
                                     variants:
                                         - lower_minimum_boundary:
@@ -435,11 +435,11 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - live:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_write_bytes_sec:
                                     variants:
                                         - lower_minimum_boundary:
@@ -452,11 +452,11 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - live:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_total_iops_sec:
                                     variants:
                                         - lower_minimum_boundary:
@@ -469,11 +469,11 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - live:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_read_iops_sec:
                                     variants:
                                         - lower_minimum_boundary:
@@ -486,11 +486,11 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - live:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_write_iops_sec:
                                     variants:
                                         - lower_minimum_boundary:
@@ -503,11 +503,11 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - live:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_total_read_write_bytes_iops_sec:
                                     variants:
                                         - total_read_bytes_sec:
@@ -540,11 +540,11 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - live:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_read_bytes_sec:
                                     variants:
                                         - lower_minimum_boundary:
@@ -557,11 +557,11 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - live:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_write_bytes_sec:
                                     variants:
                                         - lower_minimum_boundary:
@@ -574,11 +574,11 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - live:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_total_iops_sec:
                                     variants:
                                         - lower_minimum_boundary:
@@ -591,11 +591,11 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - live:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_read_iops_sec:
                                     variants:
                                         - lower_minimum_boundary:
@@ -608,11 +608,11 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - live:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_write_iops_sec:
                                     variants:
                                         - lower_minimum_boundary:
@@ -625,11 +625,11 @@
                                         - options:
                                             variants:
                                                 - config:
-                                                    blkdevio_options = "config"
+                                                    blkdevio_options = "--config"
                                                 - live:
-                                                    blkdevio_options = "live"
+                                                    blkdevio_options = "--live"
                                                 - current:
-                                                    blkdevio_options = "current"
+                                                    blkdevio_options = "--current"
                                 - change_total_read_write_bytes_iops_sec:
                                     variants:
                                         - total_read_bytes_sec:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blkdeviotune.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blkdeviotune.py
@@ -23,7 +23,7 @@ def check_blkdeviotune(params):
 
     virt_xml_obj = libvirt_xml.vm_xml.VMXML(virsh_instance=virsh)
 
-    if options == "config" and vm.is_alive():
+    if "config" in options and vm.is_alive():
         blkdev_xml = virt_xml_obj.get_blkdevio_params(vm_name, "--inactive")
     else:
         blkdev_xml = virt_xml_obj.get_blkdevio_params(vm_name)
@@ -33,7 +33,7 @@ def check_blkdeviotune(params):
     blkdevio_list = ["total_bytes_sec", "read_bytes_sec", "write_bytes_sec",
                      "total_iops_sec", "read_iops_sec", "write_iops_sec"]
 
-    if vm.is_alive() and options != "config":
+    if vm.is_alive() and "config" not in options:
         for k in blkdevio_list:
             arg_from_test_input = params.get("blkdevio_" + k)
             arg_from_cmd_output = dicts.get(k)
@@ -63,7 +63,7 @@ def get_blkdevio_parameter(params):
     options = params.get("blkdevio_options")
     device = params.get("blkdevio_device")
 
-    result = virsh.blkdeviotune(vm_name, device, options=options)
+    result = virsh.blkdeviotune(vm_name, device, options=options, debug=True)
     status = result.exit_status
 
     # Check status_error
@@ -100,7 +100,7 @@ def set_blkdevio_parameter(params):
                                 options, total_bytes_sec,
                                 read_bytes_sec, write_bytes_sec,
                                 total_iops_sec, read_iops_sec,
-                                write_iops_sec)
+                                write_iops_sec, debug=True)
     status = result.exit_status
 
     # Check status_error


### PR DESCRIPTION
In virt-test commit https://github.com/liuzzfnst/virt-test/commit/3725b8a9de2b96ad558ba53c08c961d55149961d, option param was updated, update test
case accordingly.

Signed-off-by: Wayne Sun <gsun@redhat.com>