### PR TITLE
remote_access.py: Fix skip message

### DIFF
--- a/libvirt/tests/src/remote_access/remote_access.py
+++ b/libvirt/tests/src/remote_access/remote_access.py
@@ -75,7 +75,7 @@ def check_parameters(params):
 
     for arg in args_list:
         if arg and arg.count("ENTER.YOUR."):
-            raise error.TestNAError("Please assign a value for %s!", arg)
+            raise error.TestNAError("Please assign a value for %s!" % arg)
 
 
 def compare_virt_version(server_ip, server_user, server_pwd):


### PR DESCRIPTION
The exception message has to use interpolation if you
want it to be correctly displayed to the user.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>