### PR TITLE
virsh: CPU related cases update to adapt PPC64 arch

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_dumpxml.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_dumpxml.cfg
@@ -18,7 +18,7 @@
                     dumpxml_options_ref = "--inactive"
                 - with_cpu:
                     only vm_shutoff
-                    no lxc
+                    no lxc, ppc64, ppc64le
                     dumpxml_options_ref = "--update-cpu"
                     variants:
                         - minimum_match:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_emulatorpin.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_emulatorpin.cfg
@@ -38,13 +38,15 @@
                                 - cpulist:
                                     variants:
                                         - comma_list:
-                                            emulatorpin_cpulist = 0,1,2
+                                            emulatorpin_cpulist = "x,y"
                                         - ranges:
-                                            emulatorpin_cpulist = 0-2
+                                            no ppc64, ppc64le
+                                            emulatorpin_cpulist = "x-y"
                                         - excluding:
-                                            emulatorpin_cpulist = 1-2,^1
+                                            no ppc64, ppc64le
+                                            emulatorpin_cpulist = "x-y,^z"
                                         - single:
-                                            emulatorpin_cpulist = 1
+                                            emulatorpin_cpulist = "x"
                                     variants:
                                         - emulatorpin_options:
                                             variants:
@@ -58,13 +60,15 @@
                                 - cpulist:
                                     variants:
                                         - comma_list:
-                                            emulatorpin_cpulist = 2,0,1
+                                            emulatorpin_cpulist = "x,y"
                                         - ranges:
-                                            emulatorpin_cpulist = 0-2
+                                            no ppc64, ppc64le
+                                            emulatorpin_cpulist = "x-y"
                                         - excluding:
-                                            emulatorpin_cpulist = 1-2,^1
+                                            no ppc64, ppc64le
+                                            emulatorpin_cpulist = "x-y,^z"
                                         - single:
-                                            emulatorpin_cpulist = 0
+                                            emulatorpin_cpulist = "x"
                                     variants:
                                         - emulatorpin_options:
                                             variants:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_vcpupin.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_vcpupin.cfg
@@ -13,12 +13,15 @@
                         - cpu_list_x:
                             vcpupin_cpu_list = "x"
                         - cpu_list_x-y:
+                            no ppc64, ppc64le
                             vcpupin_cpu_list = "x-y"
                         - cpu_list_comma:
                             vcpupin_cpu_list = "x,y"
                         - cpu_list_exclude:
+                            no ppc64, ppc64le
                             vcpupin_cpu_list = "x-y,^z"
                         - cpu_list_r:
+                            no ppc64, ppc64le
                             only online
                             vcpupin_cpu_list = "r"
                 - dom_name:
@@ -36,6 +39,7 @@
                     only online
                     vcpupin_options = "--current"
                 - multi_dom:
+                    no ppc64, ppc64le
                     multi_dom_pin = "yes"
                     vms = "virt-tests-vm1 virt-tests-vm2"
         - negative_test:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_vcpupin.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_vcpupin.py
@@ -1,6 +1,6 @@
 import logging
 import re
-
+import random
 from autotest.client import utils
 from autotest.client.shared import error
 from virttest import virsh, utils_test
@@ -84,7 +84,7 @@ def run(test, params, env):
         elif vm_ref == "uuid":
             vm_ref = vm.get_uuid()
         # Execute virsh vcpupin command.
-        cmdResult = virsh.vcpupin(vm_ref, vcpu, cpu_list, options)
+        cmdResult = virsh.vcpupin(vm_ref, vcpu, cpu_list, options, debug=True)
         if cmdResult.exit_status:
             if not status_error:
                 # Command fail and it is in positive case.
@@ -211,7 +211,8 @@ def run(test, params, env):
                 if cpu_list == "x-y":
                     cpus = "0-%s" % cpu_max
                 elif cpu_list == "x,y":
-                    cpus = "0,%s" % cpu_max
+                    cpus = ','.join(random.sample(cpus_list, 2))
+                    logging.info(cpus)
                 elif cpu_list == "x-y,^z":
                     cpus = "0-%s,^%s" % (cpu_max, cpu_max)
                 elif cpu_list == "r":


### PR DESCRIPTION
1. On ppc64/ppc64le, processor ID is discontinuous, so the range notaion
is not support(so as the exclusive naotaion).
2. As the processor count may not be a valid processor id, so we fetch
all the valid numbers from /proc/cpuinfo and then select from them
randomly.
3. In case virsh dumpxml, it hard code cpu feature names to update and
check, and the features are not support on PPC64, so disable them too.

Signed-off-by: Yanbing Du <ydu@redhat.com>