### PR TITLE
macvtap: fix ping failure for passthrough case

### DIFF
--- a/libvirt/tests/src/macvtap.py
+++ b/libvirt/tests/src/macvtap.py
@@ -93,17 +93,17 @@ def run(test, params, env):
                                         params.get('password'), 22,
                                         eth_config_file)
         remote_file.truncate()
-        remote_file.add(eth_config_detail_list)
+        remote_file.add(eth_config_detail_list, linesep='\n')
         try:
             # Attached interface maybe already active
             session.cmd("ifdown %s" % eth_name)
         except aexpect.ShellCmdError:
-            pass
+            raise error.TestFail("ifdown %s failed." % eth_name)
 
         try:
             session.cmd("ifup %s" % eth_name)
         except aexpect.ShellCmdError:
-            pass
+            raise error.TestFail("ifup %s failed." % eth_name)
         return session
 
     def guest_clean(vm, vmxml):


### PR DESCRIPTION
1) The macvtap NIC ifcfg-file that created by RemoteFile.add()
doesn't includes newline char '\n', which leads to ifup fails,
at the end, ping the remote server also fails. As following,

[root@atest-guest ~]# cat /etc/redhat-release
Red Hat Enterprise Linux Server release 7.2 Beta (Maipo)
[root@atest-guest ~]# cat /etc/sysconfig/network-scripts/ifcfg-eth1
DEVICE=eth1
HWADDR=52:54:00:5b:96:02
ONBOOT=yes
BOOTPROTO=static
IPADDR=193.168.236.112[root@atest-guest ~]#
[root@atest-guest ~]# ifup eth1
Could not load file '/etc/sysconfig/network-scripts/ifcfg-eth1'
Could not load file '/etc/sysconfig/network-scripts/ifcfg-eth1'

*Fix it by adding newline char to the end of ifcfg-eth1.

[root@atest-guest ~]# cat /etc/sysconfig/network-scripts/ifcfg-eth1
DEVICE=eth1
HWADDR=52:54:00:5b:96:02
ONBOOT=yes
BOOTPROTO=static
IPADDR=193.168.236.112
[root@atest-guest ~]# ifup eth1
[root@atest-guest ~]# ifconfig -a
eth1: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
  inet 193.168.236.112  netmask 255.255.255.0 broadcast 193.168.236.255
  inet6 fe80::5054:ff:fe51:fca3  prefixlen 64 scopeid  0x20<link>
  ... skip ...

2) checking the result of ifdown and ifup.

Signed-off-by: Wei,Jiangang <weijg.fnst@cn.fujitsu.com>