### PR TITLE
Do not add panic device if already exist

### DIFF
--- a/libvirt/tests/src/conf_file/qemu_conf/auto_dump.py
+++ b/libvirt/tests/src/conf_file/qemu_conf/auto_dump.py
@@ -27,11 +27,12 @@ def run(test, params, env):
     config = utils_config.LibvirtQemuConfig()
     libvirtd = utils_libvirtd.Libvirtd()
     try:
-        # Set panic device
-        panic_dev = Panic()
-        panic_dev.addr_type = "isa"
-        panic_dev.addr_iobase = "0x505"
-        vmxml.add_device(panic_dev)
+        if not vmxml.xmltreefile.find('devices').findall('panic'):
+            # Set panic device
+            panic_dev = Panic()
+            panic_dev.addr_type = "isa"
+            panic_dev.addr_iobase = "0x505"
+            vmxml.add_device(panic_dev)
         vmxml.on_crash = "coredump-restart"
         vmxml.sync()
 

--- a/libvirt/tests/src/virsh_cmd/monitor/virsh_domstate.py
+++ b/libvirt/tests/src/virsh_cmd/monitor/virsh_domstate.py
@@ -108,11 +108,12 @@ def run(test, params, env):
             if vm.is_alive():
                 vm.destroy(gracefully=False)
             vmxml.on_crash = vm_oncrash_action
-            # Add <panic> device to domain
-            panic_dev = Panic()
-            panic_dev.addr_type = "isa"
-            panic_dev.addr_iobase = "0x505"
-            vmxml.add_device(panic_dev)
+            if not vmxml.xmltreefile.find('devices').findall('panic'):
+                # Add <panic> device to domain
+                panic_dev = Panic()
+                panic_dev.addr_type = "isa"
+                panic_dev.addr_iobase = "0x505"
+                vmxml.add_device(panic_dev)
             vmxml.sync()
             # Config auto_dump_path in qemu.conf
             cmd = "echo auto_dump_path = \\\"%s\\\" >> %s" % (dump_path,


### PR DESCRIPTION
If test domain already have panic device, no need to add new one in
xml.

Signed-off-by: Wayne Sun <gsun@redhat.com>