### PR TITLE
virsh_domif_setlink_getlink: Fix a code bug.

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domif_setlink_getlink.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domif_setlink_getlink.py
@@ -177,8 +177,9 @@ def run(test, params, env):
 
             # Set the link up make host connect with vm
             domif_setlink(vm_name, device, "up", "")
-            # wait for login to make sure link is up
-            vm.wait_for_login()
+            if not guest_if_state(guest_if_name, session):
+                error_msg = "Link state isn't up in guest"
+
             # Ignore status of this one
             cmd_status = session.cmd_status('ip link set dev %s down'
                                             % guest_if_name)


### PR DESCRIPTION
Since login by ssh may timeout, remove the operation before setlink on guest.