### PR TITLE
Update 'bridge' in cfg to avoid cartersian keywords problem on some env.

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_update.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_update.cfg
@@ -19,7 +19,7 @@
         - portgroup:
             network_section = "portgroup"
             add_portgroup = "yes"
-        - bridge:
+        - bridge_t:
             network_section = "bridge"
         - forward:
             network_section = "forward"


### PR DESCRIPTION
Fix same issue as autotest/tp-libvirt#610