### PR TITLE
fix sendkey non_acl test problem

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_sendkey.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_sendkey.py
@@ -28,7 +28,7 @@ def run(test, params, env):
     password = params.get("password")
     create_file = params.get("create_file_name")
     uri = params.get("virsh_uri")
-    unprivileged_user = params.get('unprivileged_user', "EXAMPLE")
+    unprivileged_user = params.get('unprivileged_user')
     if unprivileged_user:
         if unprivileged_user.count('EXAMPLE'):
             unprivileged_user = 'testacl'


### PR DESCRIPTION
$ ./run -kt libvirt --tests virsh.sendkey --no-downloads --keep-image-between-tests
SETUP: PASS (0.00 s)
DATA DIR: /var/lib/virt_test
DEBUG LOG: /tmp/kyla-debug-autotest-7.2-x86_64-runtest-1/logs/run-2015-08-27-07.40.34/debug.log
TESTS: 38
(1/38) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.non_acl.with_holdtime: PASS (57.75 s)
(2/38) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.non_acl.linux_keycode: PASS (43.80 s)
(3/38) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.non_acl.os-x_name: PASS (44.66 s)
(4/38) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.non_acl.os-x_keycode: PASS (43.71 s)
(5/38) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.non_acl.at_set1_keycode: PASS (44.64 s)
(6/38) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.non_acl.at_set2_keycode: PASS (43.67 s)
(7/38) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.non_acl.at_set3_keycode: PASS (44.64 s)
(8/38) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.non_acl.xt_keycode: PASS (43.61 s)
(9/38) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.non_acl.xt_kbd_keycode: PASS (44.65 s)
(10/38) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.non_acl.usb_keycode: PASS (44.58 s)
(11/38) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.non_acl.win32_name: PASS (44.61 s)
(12/38) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.non_acl.win32_keycode: PASS (44.58 s)
(13/38) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.non_acl.rfb_keycode: PASS (44.60 s)
(14/38) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.non_acl.default_name: PASS (43.62 s)
(15/38) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.acl_test.with_holdtime:PolicyKit daemon disconnected from the bus.
We are no longer a registered authentication agent.
 PASS (59.41 s)
(16/38) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.acl_test.linux_keycode:PolicyKit daemon disconnected from the bus.
We are no longer a registered authentication agent.
 PASS (45.75 s)
(17/38) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.acl_test.os-x_name:PolicyKit daemon disconnected from the bus.
We are no longer a registered authentication agent.
 PASS (45.57 s)
(18/38) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.acl_test.os-x_keycode:PolicyKit daemon disconnected from the bus.
We are no longer a registered authentication agent.
 PASS (47.73 s)
(19/38) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.acl_test.at_set1_keycode:PolicyKit daemon disconnected from the bus.
We are no longer a registered authentication agent.
 PASS (46.78 s)
(20/38) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.acl_test.at_set2_keycode:PolicyKit daemon disconnected from the bus.
We are no longer a registered authentication agent.
PolicyKit daemon reconnected to bus.
Attempting to re-register as an authentication agent.
 PASS (46.45 s)
(21/38) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.acl_test.at_set3_keycode:PolicyKit daemon disconnected from the bus.
We are no longer a registered authentication agent.
 PASS (46.56 s)
(22/38) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.acl_test.xt_keycode:PolicyKit daemon disconnected from the bus.
We are no longer a registered authentication agent.
 PASS (46.39 s)
(23/38) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.acl_test.xt_kbd_keycode:PolicyKit daemon disconnected from the bus.
We are no longer a registered authentication agent.
 PASS (46.58 s)
(24/38) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.acl_test.usb_keycode:PolicyKit daemon disconnected from the bus.
We are no longer a registered authentication agent.
 PASS (46.85 s)
(25/38) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.acl_test.win32_name:PolicyKit daemon disconnected from the bus.
We are no longer a registered authentication agent.
 PASS (46.71 s)
(26/38) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.acl_test.win32_keycode:PolicyKit daemon disconnected from the bus.
We are no longer a registered authentication agent.
 PASS (45.53 s)
(27/38) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.acl_test.rfb_keycode:PolicyKit daemon disconnected from the bus.
We are no longer a registered authentication agent.
 PASS (48.72 s)
(28/38) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.acl_test.default_name:PolicyKit daemon disconnected from the bus.
We are no longer a registered authentication agent.
PolicyKit daemon reconnected to bus.
Attempting to re-register as an authentication agent.
 PASS (46.46 s)
(29/38) type_specific.io-github-autotest-libvirt.virsh.sendkey.sysrq.non_acl.help: PASS (45.71 s)
(30/38) type_specific.io-github-autotest-libvirt.virsh.sendkey.sysrq.non_acl.show_memory_usage: PASS (45.66 s)
(31/38) type_specific.io-github-autotest-libvirt.virsh.sendkey.sysrq.non_acl.show_task_status: PASS (45.68 s)
(32/38) type_specific.io-github-autotest-libvirt.virsh.sendkey.sysrq.non_acl.reboot_guest: PASS (72.29 s)
(33/38) type_specific.io-github-autotest-libvirt.virsh.sendkey.sysrq.acl_test.help:PolicyKit daemon disconnected from the bus.
We are no longer a registered authentication agent.
 PASS (46.52 s)
(34/38) type_specific.io-github-autotest-libvirt.virsh.sendkey.sysrq.acl_test.show_memory_usage:PolicyKit daemon disconnected from the bus.
We are no longer a registered authentication agent.
PolicyKit daemon reconnected to bus.
Attempting to re-register as an authentication agent.
 PASS (46.37 s)
(35/38) type_specific.io-github-autotest-libvirt.virsh.sendkey.sysrq.acl_test.show_task_status:PolicyKit daemon disconnected from the bus.
We are no longer a registered authentication agent.
 PASS (46.53 s)
(36/38) type_specific.io-github-autotest-libvirt.virsh.sendkey.sysrq.acl_test.reboot_guest:PolicyKit daemon disconnected from the bus.
We are no longer a registered authentication agent.
 PASS (72.13 s)
(37/38) type_specific.io-github-autotest-libvirt.virsh.sendkey.readonly: PASS (42.99 s)
(38/38) type_specific.io-github-autotest-libvirt.virsh.sendkey.negative_test.acl_test:PolicyKit daemon disconnected from the bus.
We are no longer a registered authentication agent.
 PASS (44.90 s)
TOTAL TIME: 1808.00 s (30:07)
TESTS PASSED: 38
TESTS FAILED: 0
SUCCESS RATE: 100.00 %
