### PR TITLE
Blockpull test config fix

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockpull.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockpull.cfg
@@ -85,3 +85,8 @@
                     snap_in_mirror = "yes"
                     status_error = "no"
                     snap_in_mirror_err = "yes"
+    # Now blockpull commands in virsh in some cases return different values for success and error cases. 
+    # The corresponding changes were done in libvirt before. So in virt-test the blockpull tests must process
+    # the return values (success/fail) correctly
+    normal_test.file_disk.local.timeout.nobase.async: status_error = "yes"
+    normal_test.file_disk.local.timeout.nobase.no_async: status_error = "yes"


### PR DESCRIPTION
Now blockpull commands in virsh in some cases return different values
for success and error cases. The corresponding changes were done in
libvirt before. So in virt-test the blockpull tests must process
the return values (success/fail) correctly