### PR TITLE
v2v: Add new cases

### DIFF
--- a/v2v/tests/cfg/v2v_options.cfg
+++ b/v2v/tests/cfg/v2v_options.cfg
@@ -7,6 +7,12 @@
     vpx60_hostname = VPX_60_HOSTNAME_EXAMPLE
     vpx60_dc = VPX_60_DC_EXAMPLE
     esx60_hostname = ESX_60_HOSTNAME_EXAMPLE
+    vpx55_hostname = VPX_55_HOSTNAME_EXAMPLE
+    vpx55_dc = VPX_55_DC_EXAMPLE
+    esx55_hostname = ESX_55_HOSTNAME_EXAMPLE
+    vpx51_hostname = VPX_51_HOSTNAME_EXAMPLE
+    vpx51_dc = VPX_51_DC_EXAMPLE
+    esx51_hostname = ESX_51_HOSTNAME_EXAMPLE
     ovirt_engine_url = "OVIRT_SERVER_EXAMPLE"
     ovirt_engine_user = "OVIRT_USER_EXAMPLE"
     ovirt_engine_password = "OVIRT_PASSWORD_EXAMPLE"
@@ -153,11 +159,53 @@
                             default_output_format = "qcow2"
                         - esx:
                             hypervisor = "esx"
-                            remote_host = ${vpx60_hostname}
-                            vpx_dc = ${vpx60_dc}
-                            esx_ip = ${esx60_hostname}
-                            vpx_passwd = "VPX_PASSWORD"
-                            main_vm = "VM_NAME_ESX_EXAMPLE"
+                            variants:
+                                - esx_51:
+                                    remote_host = ${vpx51_hostname}
+                                    vpx_dc = ${vpx51_dc}
+                                    esx_ip = ${esx51_hostname}
+                                    vpx_passwd = "VPX51_PASSWORD"
+                                - esx_55:
+                                    remote_host = ${vpx55_hostname}
+                                    vpx_dc = ${vpx55_dc}
+                                    esx_ip = ${esx55_hostname}
+                                    vpx_passwd = "VPX55_PASSWORD"
+                                - esx_60:
+                                    remote_host = ${vpx60_hostname}
+                                    vpx_dc = ${vpx60_dc}
+                                    esx_ip = ${esx60_hostname}
+                                    vpx_passwd = "VPX60_PASSWORD"
+                            variants:
+                                - default:
+                                    only esx_60
+                                    main_vm = "VM_NAME_ESX_EXAMPLE"
+                                - with_cdrom:
+                                    only esx_55
+                                    main_vm = "VM_NAME_ESX_CDROM_EXAMPLE"
+                                - migrated_vm:
+                                    only esx_55
+                                    main_vm = "VM_NAME_ESX_MIGRATED_EXAMPLE"
+                                - local_storage:
+                                    only esx_55
+                                    main_vm = "VM_NAME_ESX_LOCALSTORAGE_EXAMPLE"
+                                - multiple_disks:
+                                    only esx_55
+                                    main_vm = "VM_NAME_ESX_MULDISKS_EXAMPLE"
+                                - multiple_cpus:
+                                    only esx_55
+                                    main_vm = "VM_NAME_ESX_MULCPUS_EXAMPLE"
+                                - with_snapshot:
+                                    only esx_55
+                                    main_vm = "VM_NAME_ESX_SNAPSHOT_EXAMPLE"
+                                - special_name:
+                                    only esx_55
+                                    main_vm = "VM_NAME_ESX_SPECIALNAME_EXAMPLE"
+                                - cloned_vm:
+                                    only esx_55
+                                    main_vm = "VM_NAME_ESX_CLONED_EXAMPLE"
+                                - esx_template:
+                                    only esx_55
+                                    main_vm = "VM_NAME_ESX_TEMPLATE_EXAMPLE"
                 - libvirtxml:
                     # No test yet
                     input_mode = "libvirtxml"
@@ -250,8 +298,9 @@
                     vdsm_ovf_output = "${output_storage}/master/vms/${vdsm_vm_uuid}"
                 - specific_vm:
                     # Convert specific VM to rhev
-                    only input_mode.libvirt.kvm
+                    only input_mode.libvirt
                     no input_mode.libvirt.kvm.default
+                    no input_mode.libvirt.xen
                     only output_mode.rhev
         - negative_test:
             status_error = "yes"

--- a/v2v/tests/cfg/v2v_options.cfg
+++ b/v2v/tests/cfg/v2v_options.cfg
@@ -1,6 +1,6 @@
 - v2v_options:
     type = "v2v_options"
-    vm_type = "v2v"
+    vm_type = "libvirt"
     start_vm = "no"
     take_regular_screendumps = no
     xen_hostname = XEN_HOSTNAME_EXAMPLE
@@ -10,6 +10,10 @@
     ovirt_engine_url = "OVIRT_SERVER_EXAMPLE"
     ovirt_engine_user = "OVIRT_USER_EXAMPLE"
     ovirt_engine_password = "OVIRT_PASSWORD_EXAMPLE"
+    remote_shell_client = "ssh"
+    remote_shell_port = 22
+    remote_shell_prompt = "^\w:\\.*>\s*$|^\[.*\][\#\$]\s*$"
+    status_test_command = "echo $?"
     pool_type = "dir"
     pool_name = "v2v_dir"
     pool_target = "v2v_dir_pool"
@@ -17,13 +21,14 @@
     mount_point = "/mnt_v2v"
     output_storage = ${pool_name}
     output_network = "default"
-    output_bridge = "rhevm"
+    output_bridge = "virbr0"
     os_type = "linux"
     # Using NFS storage here
     export_name = "NFS_EXPORT_EXAMPLE"
     storage_name = "NFS_DATA_EXAMPLE"
     cluster_name = "NFS"
     v2v_timeout = "1200"
+    # Full types input disks
     variants:
         - output_mode:
             variants:
@@ -32,7 +37,6 @@
                     output_mode = "glance"
                 - libvirt:
                     output_mode = "libvirt"
-                    output_bridge = "virbr0"
                     target = "libvirt"
                 - local:
                     output_mode = "local"
@@ -45,9 +49,20 @@
                     output_mode = "qemu"
                 - rhev:
                     output_mode = "rhev"
+                    output_network = "rhevm"
                     output_bridge = "rhevm"
                     target = "ovirt"
                     output_storage = ${nfs_storage}
+                    # Libvirt SASL authencation(under VDSM control)
+                    sasl_user = "vdsm@rhevh"
+                    sasl_pwd = "shibboleth"
+                    remote_ip = "OVIRT_NODE_IP_EXAMPLE"
+                    remote_preprocess = "yes"
+                    remote_node_address = ${remote_ip}
+                    remote_node_user = "root"
+                    remote_node_password = "redhat"
+                    remote_user = ${remote_node_user}
+                    remote_pwd = ${remote_node_password}
                 - vdsm:
                     output_mode = "vdsm"
                 - none:
@@ -57,18 +72,78 @@
                 - disk:
                     input_mode = "disk"
                     variants:
+                        # Explicit 'sparse' and 'preallocated' here for
+                        # parameters replacement
+                        # This will cover option '-if'
                         - raw_format:
-                            input_disk_image = "/PATH/VM_NAME_RAW_EXAMPLE.IMG"
-                            main_vm = "VM_NAME_RAW_EXAMPLE"
+                            input_format = "raw"
+                            variants:
+                                - sparse:
+                                    input_allo_mode = "sparse"
+                                    main_vm = "VM_NAME_RAW_SPARSE_EXAMPLE"
+                                    input_disk_image = "/DISK_IMAGE_PATH/${main_vm}.img"
+                                - preallocated:
+                                    input_allo_mode = "preallocated"
+                                    main_vm = "VM_NAME_RAW_PREALLOCATED_EXAMPLE"
+                                    input_disk_image = "/DISK_IMAGE_PATH/${main_vm}.img"
                         - qcow2_format:
-                            input_disk_image = "/PATH/VM_NAME_QCOW2_EXAMPLE.IMG"
-                            main_vm = "VM_NAME_QCOW2_EXAMPLE"
+                            input_format = "qcow2"
+                            variants:
+                                - sparse:
+                                    input_allo_mode = "sparse"
+                                    main_vm = "VM_NAME_QCOW2_SPARSE_EXAMPLE"
+                                    input_disk_image = "/DISK_IMAGE_PATH/${main_vm}.img"
+                                - preallocated:
+                                    input_allo_mode = "preallocated"
+                                    main_vm = "VM_NAME_QCOW2_PREALLOCATEd_EXAMPLE"
+                                    input_disk_image = "/DISK_IMAGE_PATH/${main_vm}.img"
                 - libvirt:
                     input_mode = "libvirt"
                     variants:
                         - kvm:
+                            # All VM defined on the test machine
                             hypervisor = "kvm"
-                            main_vm = "VM_NAME_KVM_EXAMPLE"
+                            variants:
+                                - default:
+                                    main_vm = "VM_NAME_KVM_EXAMPLE"
+                                - virtioscis_disk:
+                                    main_vm = "VM_NAME_KVM_VIRTIOSCSI_EXAMPLE"
+                                - sata_disk:
+                                    main_vm = "VM_NAME_KVM_SATA_EXAMPLE"
+                                - multiple_disks:
+                                    attach_disk_config = "yes"
+                                    variants:
+                                        - linux:
+                                            os_type = "linux"
+                                            added_disks_count = 5
+                                            main_vm = "VM_NAME_KVM_LINUX_MULDISKS_EXAMPLE"
+                                            vms = ${main_vm}
+                                            vm_user = "root"
+                                            vm_pwd = "123456"
+                                        - windows:
+                                            os_type = "windows"
+                                            os_version = "win7"
+                                            added_disks_count = 3
+                                            main_vm = "VM_NAME_KVM_WIN_MULDISKS_EXAMPLE"
+                                            vms = ${main_vm}
+                                            shutdown_command = "shutdown /s /f /t 0"
+                                            reboot_command = "shutdown /r /f /t 0"
+                                            status_test_command = "echo %errorlevel%"
+                                            shell_prompt = "^\w:\\.*>\s*$"
+                                            shell_linesep = "\r\n"
+                                            shell_client = "nc"
+                                            shell_port = 10022
+                                            file_transfer_client = "rss"
+                                            file_transfer_port = 10023
+                                            redirs += " file_transfer"
+                                            guest_port_remote_shell = 10022
+                                            guest_port_file_transfer = 10023
+                                            rtc_base = "localtime"
+                                            network_query = "ipconfig /all"
+                                            restart_network = "ipconfig /renew"
+                                            vm_user = "Administrator"
+                                            vm_pwd = "123qweP"
+                                            images_for_match = "WIN_IMAGES_FOR_MATCH"
                         - xen:
                             hypervisor = "xen"
                             remote_host = ${xen_hostname}
@@ -122,15 +197,18 @@
                             v2v_options = "-oa ${oa_mode}"
                 - option_of:
                     # Set output format
-                    only input_mode.libvirt.xen
+                    only input_mode.disk
                     only output_mode.libvirt
                     variants:
                         - raw_format:
                             output_format = "raw"
-                            v2v_options = "-of ${output_format}"
                         - qcow2_format:
                             output_format = "qcow2"
-                            v2v_options = "-of ${output_format}"
+                    variants:
+                        - sparse:
+                            output_allo_mode = "sparse"
+                        - preallocated:
+                            output_allo_mode = "preallocated"
                 - option_on:
                     # Rename guest when converting
                     only input_mode.libvirt.xen
@@ -142,25 +220,13 @@
                     only input_mode.libvirt.xen
                     only output_mode.local
                     v2v_options = "--no-copy"
-                - option_if:
-                    # Input format (for -i disk)
-                    only output_mode.libvirt
-                    variants:
-                        - raw_format:
-                            only input_mode.disk.raw_format
-                            input_format = "raw"
-                            v2v_options = "-if ${input_format}"
-                        - qcow2_format:
-                            only input_mode.disk.qcow2_format
-                            input_format = "qcow2"
-                            v2v_options = "-if ${input_format}"
                 - option_ic:
                     # input libvirt URI
                     only input_mode.libvirt.xen,input_mode.libvirt.esx
                     only output_mode.libvirt
                 - option_oc:
                     # output libvirt URI
-                    only input_mode.disk.qcow2_format
+                    only input_mode.disk.qcow2_format.sparse
                     only output_mode.libvirt
                     variants:
                         - privileged:
@@ -173,7 +239,7 @@
                 - option_vdsm:
                     # Set the output method to vdsm
                     # And create a fake storage domain to test BZ#1176591
-                    only input_mode.libvirt.kvm
+                    only input_mode.libvirt.kvm.default
                     only output_mode.vdsm
                     export_domain_uuid = "EXPORT_DOMAIN_UUDI_EXAMPLE"
                     fake_domain_uuid = "12345678-1234-1234-1234-123456789000"
@@ -182,6 +248,11 @@
                     vdsm_vm_uuid = "12345678-1234-1234-1234-123456789003"
                     output_storage = ${mount_point}/${export_domain_uuid}
                     vdsm_ovf_output = "${output_storage}/master/vms/${vdsm_vm_uuid}"
+                - specific_vm:
+                    # Convert specific VM to rhev
+                    only input_mode.libvirt.kvm
+                    no input_mode.libvirt.kvm.default
+                    only output_mode.rhev
         - negative_test:
             status_error = "yes"
             variants:

--- a/v2v/tests/src/v2v_options.py
+++ b/v2v/tests/src/v2v_options.py
@@ -12,6 +12,8 @@ from autotest.client.shared import error
 from virttest import virsh
 from virttest import utils_v2v
 from virttest import utils_misc
+from virttest import utils_sasl
+from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt as utlv
 
 
@@ -24,7 +26,7 @@ def run(test, params, env):
     vm_name = params.get("main_vm", "EXAMPLE")
     new_vm_name = params.get("new_vm_name")
     input_mode = params.get("input_mode")
-    v2v_options = params.get("v2v_options", "EXAMPLE")
+    v2v_options = params.get("v2v_options", "")
     hypervisor = params.get("hypervisor", "kvm")
     remote_host = params.get("remote_host", "EXAMPLE")
     vpx_dc = params.get("vpx_dc", "EXAMPLE")
@@ -37,7 +39,7 @@ def run(test, params, env):
     output_storage = params.get("output_storage", "default")
     export_name = params.get("export_name", "EXAMPLE")
     storage_name = params.get("storage_name", "EXAMPLE")
-    disk_img = params.get("input_disk_image")
+    disk_img = params.get("input_disk_image", "")
     nfs_storage = params.get("nfs_storage")
     mnt_point = params.get("mount_point")
     export_domain_uuid = params.get("export_domain_uuid", "")
@@ -49,7 +51,6 @@ def run(test, params, env):
     v2v_user = params.get("unprivileged_user", "")
     v2v_timeout = int(params.get("v2v_timeout", 1200))
     status_error = "yes" == params.get("status_error", "no")
-    address_cache = env.get('address_cache')
     for param in [vm_name, remote_host, esx_ip, vpx_dc, ovirt_engine_url,
                   ovirt_engine_user, ovirt_engine_passwd, output_storage,
                   export_name, storage_name, disk_img, export_domain_uuid,
@@ -64,10 +65,10 @@ def run(test, params, env):
     pool_target = params.get("pool_target_path", "v2v_pool")
     emulated_img = params.get("emulated_image_path", "v2v-emulated-img")
     pvt = utlv.PoolVolumeTest(test, params)
-    global vm_imported
-    vm_imported = False
     new_v2v_user = False
     restore_image_owner = False
+    address_cache = env.get('address_cache')
+    params['vmcheck'] = None
 
     def create_pool():
         """
@@ -101,7 +102,7 @@ def run(test, params, env):
         Get export domain uuid, image uuid and vol uuid from command output.
         """
         tmp_target = re.findall(r"qemu-img\sconvert\s.+\s'(\S+)'\n", output)
-        if len(tmp_target) != 1:
+        if len(tmp_target) < 1:
             raise error.TestError("Fail to find tmp target file name when"
                                   " converting vm disk image")
         targets = tmp_target[0].split('/')
@@ -142,6 +143,8 @@ def run(test, params, env):
             export_domain_uuid, image_uuid, vol_uuid = get_all_uuids(output)
             img_path = os.path.join(mnt_point, export_domain_uuid, 'images',
                                     image_uuid, vol_uuid)
+        if not img_path or not os.path.isfile(img_path):
+            raise error.TestError("Get image path: '%s' is invalid", img_path)
         return img_path
 
     def check_vmtype(ovf, expected_vmtype):
@@ -162,32 +165,30 @@ def run(test, params, env):
         else:
             raise error.TestFail("VmType check failed")
 
-    def check_image(output, check_point, expected_value):
+    def check_image(img_path, check_point, expected_value):
         """
-        Verify converted image file allocation mode and format
+        Verify image file allocation mode and format
         """
-        img_path = get_img_path(output)
-        if not img_path or not os.path.isfile(img_path):
-            logging.error("Fail to get image path: %s", img_path)
-            return
         img_info = utils_misc.get_image_info(img_path)
-        logging.info("Image info after converted: %s", img_info)
+        logging.debug("Image info: %s", img_info)
         if check_point == "allocation":
             if expected_value == "sparse":
                 if img_info['vsize'] > img_info['dsize']:
-                    logging.info("Image file is sparse")
+                    logging.info("%s is a sparse image", img_path)
                 else:
-                    raise error.TestFail("Image allocation check fail")
+                    raise error.TestFail("%s is not a sparse image" % img_path)
             elif expected_value == "preallocated":
                 if img_info['vsize'] <= img_info['dsize']:
-                    logging.info("Image file is preallocated")
+                    logging.info("%s is a preallocated image", img_path)
                 else:
-                    raise error.TestFail("Image allocation check fail")
+                    raise error.TestFail("%s is not a preallocated image"
+                                         % img_path)
         if check_point == "format":
             if expected_value == img_info['format']:
-                logging.info("Image file format is %s", expected_value)
+                logging.info("%s format is %s", img_path, expected_value)
             else:
-                raise error.TestFail("Image format check fail")
+                raise error.TestFail("%s format is not %s"
+                                     % (img_path, expected_value))
 
     def check_new_name(output, expected_name):
         """
@@ -229,6 +230,44 @@ def run(test, params, env):
         else:
             raise error.TestFail("Not find message: %s" % init_msg)
 
+    def check_disks(ori_disks):
+        """
+        Check disk counts inside the VM
+        """
+        vmcheck = params.get("vmcheck")
+        if vmcheck is None:
+            raise error.TestError("VM check object is None")
+        # Initialize windows boot up
+        os_type = params.get("os_type", "linux")
+        if os_type == "windows":
+            virsh_session = utils_sasl.VirshSessionSASL(params)
+            virsh_session_id = virsh_session.get_id()
+            vmcheck.virsh_session_id = virsh_session_id
+            vmcheck.init_windows()
+            virsh_session.close()
+        # Creatge VM session
+        vmcheck.create_session()
+        expected_disks = int(params.get("added_disks_count", "1")) - ori_disks
+        logging.debug("Expect %s disks im VM after convert", expected_disks)
+        # Get disk counts
+        disks = 0
+        if os_type == "linux":
+            cmd = "lsblk |grep disk |wc -l"
+            disks = int(vmcheck.session.cmd(cmd).strip())
+        else:
+            cmd = r"echo list disk > C:\list_disk.txt"
+            vmcheck.session.cmd(cmd)
+            cmd = r"diskpart /s C:\list_disk.txt"
+            output = vmcheck.session.cmd(cmd).strip()
+            logging.debug("Disks in VM: %s", output)
+            disks = len(output.splitlines()) - 6
+        logging.debug("Find %s disks in VM after convert", disks)
+        vmcheck.session.close()
+        if disks == expected_disks:
+            logging.info("Disk counts is expected")
+        else:
+            raise error.TestFail("Disk counts is wrong")
+
     def check_result(cmd, result, status_error):
         """
         Check virt-v2v command result
@@ -244,10 +283,12 @@ def run(test, params, env):
                     check_vmtype(ovf, expected_vmtype)
             if '-oa' in cmd and '--no-copy' not in cmd:
                 expected_mode = re.findall(r"-oa\s(\w+)", cmd)[0]
-                check_image(output, "allocation", expected_mode)
+                img_path = get_img_path(output)
+                check_image(img_path, "allocation", expected_mode)
             if '-of' in cmd and '--no-copy' not in cmd:
                 expected_format = re.findall(r"-of\s(\w+)", cmd)[0]
-                check_image(output, "format", expected_format)
+                img_path = get_img_path(output)
+                check_image(img_path, "format", expected_format)
             if '-on' in cmd:
                 expected_name = re.findall(r"-on\s(\w+)", cmd)[0]
                 check_new_name(output, expected_name)
@@ -256,16 +297,21 @@ def run(test, params, env):
             if '-oc' in cmd:
                 expected_uri = re.findall(r"-oc\s(\S+)", cmd)[0]
                 check_connection(output, expected_uri)
-            global vm_imported
             if output_mode == "rhev":
                 if not utils_v2v.import_vm_to_ovirt(params, address_cache):
                     raise error.TestFail("Import VM failed")
                 else:
-                    vm_imported = True
+                    params['vmcheck'] = utils_v2v.VMCheck(test, params, env)
+                    if attach_disks:
+                        check_disks(params.get("ori_disks"))
             if output_mode == "libvirt":
                 if "qemu:///session" not in v2v_options:
                     virsh.start(vm_name, debug=True, ignore_status=False)
 
+    backup_xml = None
+    attach_disks = "yes" == params.get("attach_disk_config", "no")
+    attach_disk_path = os.path.join(test.tmpdir, "attach_disks")
+    vdsm_domain_dir, vdsm_image_dir, vdsm_vm_dir = ("", "", "")
     try:
         # Build input options
         input_option = ""
@@ -275,23 +321,44 @@ def run(test, params, env):
             uri_obj = utils_v2v.Uri(hypervisor)
             ic_uri = uri_obj.get_uri(remote_host, vpx_dc, esx_ip)
             input_option = "-i %s -ic %s %s" % (input_mode, ic_uri, vm_name)
-            # Build network/bridge option
+            # Build network&bridge option to avoid network error
             v2v_options += " -b %s -n %s" % (params.get("output_bridge"),
                                              params.get("output_network"))
+            # Multiple disks testing
+            if attach_disks:
+                backup_xml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+                # Get original vm disk counts
+                params['ori_disks'] = backup_xml.get_disk_count(vm_name)
+                utlv.attach_disks(env.get_vm(vm_name), attach_disk_path,
+                                  None, params)
         elif input_mode == "disk":
             input_option += "-i %s %s" % (input_mode, disk_img)
         elif input_mode in ['libvirtxml', 'ova']:
             raise error.TestNAError("Unsupported input mode: %s" % input_mode)
         else:
             raise error.TestError("Unknown input mode %s" % input_mode)
+        input_format = params.get("input_format")
+        input_allo_mode = params.get("input_allo_mode")
+        if input_format:
+            input_option += " -if %s" % input_format
+            if not status_error:
+                logging.info("Check image before convert")
+                check_image(disk_img, "format", input_format)
+                if input_allo_mode:
+                    check_image(disk_img, "allocation", input_allo_mode)
 
         # Build output options
         output_option = ""
         if output_mode:
             output_option = "-o %s -os %s" % (output_mode, output_storage)
+        output_format = params.get("output_format")
+        if output_format:
+            output_option += " -of %s" % output_format
+        output_allo_mode = params.get("output_allo_mode")
+        if output_allo_mode:
+            output_option += " -oa %s" % output_allo_mode
 
         # Build vdsm related options
-        vdsm_domain_dir, vdsm_image_dir, vdsm_vm_dir = ("", "", "")
         if output_mode in ['vdsm', 'rhev']:
             if not os.path.isdir(mnt_point):
                 os.mkdir(mnt_point)
@@ -400,10 +467,14 @@ def run(test, params, env):
             else:
                 virsh.remove_domain(vm_name)
             cleanup_pool()
-        if output_mode == "rhev" and vm_imported:
-            vm_c = utils_v2v.VMCheck(test, params, env)
-            vm_c.cleanup()
+        vmcheck = params.get("vmcheck")
+        if vmcheck:
+            vmcheck.cleanup()
         if new_v2v_user:
             utils.system("userdel -f %s" % v2v_user)
         if restore_image_owner:
             os.chown(disk_img, ori_owner, ori_group)
+        if backup_xml:
+            backup_xml.sync()
+        if os.path.exists(attach_disk_path):
+            shutil.rmtree(attach_disk_path)


### PR DESCRIPTION
1. Fix the vm_type to 'libvirt' in this test as the VMs which need
to be handled are in local host(libvirt).
2. Expend rhev related cases, now we can login the VM and do checks.
3. Expend input disks, so the related cases matrix could be:
    in :
        format: raw/qcow2
        allocation: sparse/preallocated
    out:
        format: raw/qcow2
        allocation: sparse/preallocated
4. Add cases for specific disk types: virtio scis, sata.
5. Add cases for multiple disks VMs(including Linux and Windows VM).

Signed-off-by: Yanbing Du <ydu@redhat.com>