### PR TITLE
iscsi: Refresh the pool after pool creation.

### DIFF
--- a/libvirt/tests/src/virtual_disks/at_dt_iscsi_disk.py
+++ b/libvirt/tests/src/virtual_disks/at_dt_iscsi_disk.py
@@ -110,6 +110,9 @@ def run(test, params, env):
             # Create iscsi pool
             cmd_result = virsh.pool_create(poolxml.xml, **virsh_dargs)
             libvirt.check_exit_status(cmd_result)
+            # refresh the pool
+            cmd_result = virsh.pool_refresh(disk_src_pool)
+            libvirt.check_exit_status(cmd_result)
             # Get volume name
             cmd_result = virsh.vol_list(disk_src_pool, **virsh_dargs)
             libvirt.check_exit_status(cmd_result)


### PR DESCRIPTION
In some cases, automation tests is running so fast that vol-list
command couldn't get volume info after pool creation, manual test
haven't his problem. Run pool-reresh command after pool creation
to solve this problem.