### PR TITLE
virsh_qemu_agent_command: fix invalid id for guest-sync

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_qemu_agent_command.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_qemu_agent_command.cfg
@@ -31,12 +31,8 @@
                     variants:
                         - max_id:
                             agent_id = 9223372036854775807
-                        - max_plus_one_id:
-                            agent_id = 9223372036854775808
                         - min_id:
                             agent_id = -9223372036854775808
-                        - min_minus_one_id:
-                            agent_id = -9223372036854775809
                         - normal_id:
                             agent_id = 123456
                         - string_id:
@@ -105,6 +101,10 @@
                                 - normal_id:
                                     no sync
                                     agent_id = 123456
+                                - max_plus_one_id:
+                                    agent_id = 9223372036854775808
+                                - min_minus_one_id:
+                                    agent_id = -9223372036854775809
                             variants:
                                 - sync:
                                     agent_cmd = "{"execute":"${test_cmd}", "arguments": { "id": ${agent_id} } }"


### PR DESCRIPTION
There're some limitation for valid value on 64 bits machine,
Max is 2^63-1 and Min is -2^63,
Both MAX+1 and MIN+1 are invalid, and lead to following errors,

'/usr/bin/virsh qemu-agent-command g3 --cmd \
'{"execute":"guest-sync", "arguments":{"id": 9223372036854775808 }}''
internal error: unable to execute QEMU agent
command 'guest-sync': Invalid parameter type for 'id',
expected: integer

so we should regard them as negative cases.