### PR TITLE
libvirt_hugepage: Always cleanup and trivial bugs fix

### DIFF
--- a/libvirt/tests/cfg/libvirt_hugepage.cfg
+++ b/libvirt/tests/cfg/libvirt_hugepage.cfg
@@ -47,5 +47,6 @@
             target_path = /tmp/test.out
         - unixbench:
             only mount_hugetlbfs..with_mb
+            no with_mb..static_zero.mount_hugetlbfs
             test_type ="unixbench"
             unixbench_control_file = "unixbench5.control"

--- a/libvirt/tests/src/libvirt_hugepage.py
+++ b/libvirt/tests/src/libvirt_hugepage.py
@@ -57,33 +57,33 @@ def run(test, params, env):
     mb_enable = 'yes' == params.get("mb_enable", 'yes')
     delay = int(params.get("delay_time", 10))
 
+    # Skip cases early
+    vm_names = []
+    if test_type == "contrast":
+        vm_names = params.get("vms").split()[:2]
+        if len(vm_names) < 2:
+            raise error.TestNAError("This test requires two VMs")
+        # confirm no VM running
+        allvms = virsh.dom_list('--name').stdout.strip()
+        if allvms != '':
+            raise error.TestNAError("one or more VMs are alive")
+        err_range = float(params.get("mem_error_range", 1.25))
+    else:
+        vm_names.append(params.get("main_vm"))
+        if test_type == "stress":
+            target_path = params.get("target_path", "/tmp/test.out")
+        elif test_type == "unixbench":
+            unixbench_control_file = params.get("unixbench_controle_file",
+                                                "unixbench5.control")
+
     # backup orignal setting
     shp_orig_num = utils_memory.get_num_huge_pages()
     thp_orig_status = utils_memory.get_transparent_hugepage()
     page_size = utils_memory.get_huge_page_size()
 
-    if test_type == "contrast":
-        range = float(params.get("mem_error_range", 1.25))
-    elif test_type == "stress":
-        target_path = params.get("target_path", "/tmp/test.out")
-    elif test_type == "unixbench":
-        unixbench_control_file = params.get("unixbench_controle_file",
-                                            "unixbench5.control")
-
-    vm_names = []
-    if test_type == "contrast":
-        vm_names = params.get("vms").split()[:2]
-        if len(vm_names) < 2:
-            raise error.TestNAError("Hugepage Stress Test need two VM(s).")
-        # confirm no VM(s) running
-        allvms = virsh.dom_list('--name').stdout.strip()
-        if allvms != '':
-            raise error.TestNAError("one or more VM(s) is living.")
-    else:
-        vm_names.append(params.get("main_vm"))
-
     # mount/umount hugetlbfs
-    tlbfs_status = utils_misc.is_mounted("hugetlbfs", "/dev/hugepages", "hugetlbfs")
+    tlbfs_status = utils_misc.is_mounted("hugetlbfs", "/dev/hugepages",
+                                         "hugetlbfs")
     if tlbfs_enable is True:
         if tlbfs_status is not True:
             utils_misc.mount("hugetlbfs", "/dev/hugepages", "hugetlbfs")
@@ -112,137 +112,152 @@ def run(test, params, env):
 
     vms = []
     sessions = []
-    for vm_name in vm_names:
-        # try to start vm and login
-        try:
-            vm = env.get_vm(vm_name)
-            vm.start()
-        except VMError, e:
-            if mb_enable and not tlbfs_enable:
-                # if hugetlbfs not be mounted,
-                # VM start with memoryBacking tag will fail
-                logging.debug(e)
-                pass  # jump out of for-loop
-            else:
-                error_msg = "Test failed in positive case. error: %s\n" % e
+    try:
+        for vm_name in vm_names:
+            # try to start vm and login
+            try:
+                vm = env.get_vm(vm_name)
+                vm.start()
+            except VMError, e:
+                if mb_enable and not tlbfs_enable:
+                    # if hugetlbfs not be mounted,
+                    # VM start with memoryBacking tag will fail
+                    logging.debug(e)
+                else:
+                    error_msg = "Test failed in positive case. error: %s\n" % e
+                    raise error.TestFail(error_msg)
+            if vm.is_alive() is not True:
+                break
+            vms.append(vm)
+
+            # try to login and run some program
+            try:
+                session = vm.wait_for_login()
+            except (LoginError, ShellError), e:
+                error_msg = "Test failed in positive case.\n error: %s\n" % e
                 raise error.TestFail(error_msg)
-        if vm.is_alive() is not True:
-            break
-        vms.append(vm)
+            sessions.append(session)
 
-        # try to login and run some program
-        try:
-            session = vm.wait_for_login()
-        except (LoginError, ShellError), e:
-            error_msg = "Test failed in positive case.\n error: %s\n" % e
-            raise error.TestFail(error_msg)
-        sessions.append(session)
+            if test_type == "stress":
+                # prepare file for increasing stress
+                stress_path = prepare_c_file()
+                remote.scp_to_remote(vm.get_address(), 22,
+                                     'root', params.get('password'),
+                                     stress_path, "/tmp/")
+                # Try to install gcc on guest first
+                utils_misc.yum_install(["gcc"], session, 360)
+                # increasing workload
+                session.cmd("gcc %s -o %s" % (stress_path, target_path))
+                session.cmd("%s &" % target_path)
 
-        if test_type == "stress":
-            # prepare file for increasing stress
-            stress_path = prepare_c_file()
-            remote.scp_to_remote(vm.get_address(), 22, 'root',
-                                 params.get('password'), stress_path, "/tmp/")
-            # Try to install gcc on guest first
-            utils_misc.yum_install(["gcc"], session, 360)
-            # increasing workload
-            session.cmd("gcc %s -o %s" % (stress_path, target_path))
-            session.cmd("%s &" % target_path)
+            if test_type == "unixbench":
+                params["main_vm"] = vm_name
+                params["test_control_file"] = unixbench_control_file
 
-        if test_type == "unixbench":
-            params["main_vm"] = vm_name
-            params["test_control_file"] = unixbench_control_file
+                control_path = os.path.join(test.virtdir, "control",
+                                            unixbench_control_file)
+                # unixbench test need 'patch' and 'perl' commands installed
+                utils_misc.yum_install(["patch", "perl"], session, 360)
+                command = utils_test.run_autotest(vm, session, control_path,
+                                                  None, None, params,
+                                                  copy_only=True)
+                session.cmd("%s &" % command, ignore_all_errors=True)
+                # wait for autotest running on vm
+                time.sleep(delay)
 
-            control_path = os.path.join(test.virtdir, "control",
-                                        unixbench_control_file)
-            command = utils_test.run_autotest(vm, session, control_path,
-                                              None, None,
-                                              params, copy_only=True)
-            session.cmd("%s &" % command)
-            # wait for autotest running on vm
-            time.sleep(delay)
-
-            def _is_unixbench_running():
-                return (not session.cmd_status("ps -ef | grep perl | grep Run"))
-            if not utils_misc.wait_for(_is_unixbench_running, timeout=240):
-                raise error.TestNAError("Failed to run unixbench in guest.\n"
-                                        "so please make sure there are some necessary"
-                                        "packages in guest, such as gcc, tar, bzip2")
-            logging.debug("Unixbench is already running in VM(s).")
-
-    if test_type == "contrast":
-        # wait for vm finish starting completely
-        time.sleep(delay)
-
-    if not (mb_enable and not tlbfs_enable):
-        logging.debug("starting analyzing the hugepage usage...")
-        pid = vms[-1].get_pid()
-        started_free = utils_memory.get_num_huge_pages_free()
-        # Get the thp usage from /proc/pid/smaps
-        started_anon = utils_memory.get_num_anon_huge_pages(pid)
-        static_used = non_started_free - started_free
-        hugepage_used = static_used * page_size
+                def _is_unixbench_running():
+                    cmd = "ps -ef | grep perl | grep Run"
+                    return not session.cmd_status(cmd)
+                if not utils_misc.wait_for(_is_unixbench_running, timeout=240):
+                    raise error.TestNAError("Failed to run unixbench in guest,"
+                                            " please make sure some necessary"
+                                            " packages are installed in guest,"
+                                            " such as gcc, tar, bzip2")
+                logging.debug("Unixbench test is running in VM")
 
         if test_type == "contrast":
-            # get qemu-kvm memory consumption by top
-            cmd = "top -b -n 1|grep 'qemu'|grep '%s'|awk '{print $10}'" % pid
-            rate = utils.run(cmd, ignore_status=False, verbose=True).stdout.strip()
-            qemu_kvm_used = (utils_memory.memtotal() * float(rate)) / 100
-            logging.debug("rate:%s, used-by-qemu-kvm: %f, used-by-vm: %d"
-                          % (rate, qemu_kvm_used, hugepage_used))
-            if abs(qemu_kvm_used - hugepage_used) > hugepage_used * (range - 1):
-                raise error.TestFail("Error for hugepage usage")
-        if test_type == "stress":
-            if non_started_free <= started_free:
-                logging.debug("hugepage usage:%d -> %d" % non_started_free, started_free)
-                raise error.TestFail("Error for hugepage usage with stress")
-        if mb_enable is not True:
-            if static_used > 0:
-                raise error.TestFail("VM use static hugepage without memoryBacking")
-            if thp_enable is not True and started_anon > 0:
-                raise error.TestFail("VM use transparent hugepage, while it's disabled")
-        else:
-            if tlbfs_enable is not True:
+            # wait for vm finish starting completely
+            time.sleep(delay)
+
+        if not (mb_enable and not tlbfs_enable):
+            logging.debug("starting analyzing the hugepage usage...")
+            pid = vms[-1].get_pid()
+            started_free = utils_memory.get_num_huge_pages_free()
+            # Get the thp usage from /proc/pid/smaps
+            started_anon = utils_memory.get_num_anon_huge_pages(pid)
+            static_used = non_started_free - started_free
+            hugepage_used = static_used * page_size
+
+            if test_type == "contrast":
+                # get qemu-kvm memory consumption by top
+                cmd = "top -b -n 1|awk '$1 == %s {print $10}'" % pid
+                rate = utils.run(cmd, ignore_status=False,
+                                 verbose=True).stdout.strip()
+                qemu_kvm_used = (utils_memory.memtotal() * float(rate)) / 100
+                logging.debug("rate: %s, used-by-qemu-kvm: %f, used-by-vm: %d",
+                              rate, qemu_kvm_used, hugepage_used)
+                if abs(qemu_kvm_used - hugepage_used) > hugepage_used * (err_range - 1):
+                    raise error.TestFail("Error for hugepage usage")
+            if test_type == "stress":
+                if non_started_free <= started_free:
+                    logging.debug("hugepage usage:%d -> %d", non_started_free,
+                                  started_free)
+                    raise error.TestFail("Error for hugepage usage with stress")
+            if mb_enable is not True:
                 if static_used > 0:
-                    error.TestFail("VM use static hugepage, while tlbfs won't be mounted")
-                if thp_enable and started_anon <= 0:
-                    raise error.TestFail("VM doesn't use transparent hugepage")
+                    raise error.TestFail("VM use static hugepage without"
+                                         " memoryBacking element")
+                if thp_enable is not True and started_anon > 0:
+                    raise error.TestFail("VM use transparent hugepage, while"
+                                         " it's disabled")
             else:
-                if shp_num > 0:
-                    if static_used <= 0:
-                        raise error.TestFail("VM doesn't use static hugepage")
-                else:
+                if tlbfs_enable is not True:
                     if static_used > 0:
-                        raise error.TestFail("VM use static hugepage, while it's set to zero")
-                if thp_enable is not True:
-                    if started_anon > 0:
-                        raise error.TestFail("VM use transparent hugepage, while it's disabled")
+                        error.TestFail("VM use static hugepage without tlbfs"
+                                       " mounted")
+                    if thp_enable and started_anon <= 0:
+                        raise error.TestFail("VM doesn't use transparent"
+                                             " hugepage")
                 else:
-                    if shp_num == 0 and started_anon <= 0:
-                        raise error.TestFail("VM doesn't use transparent hugepage,"
-                                             "while static hupage is disabled")
+                    if shp_num > 0:
+                        if static_used <= 0:
+                            raise error.TestFail("VM doesn't use static"
+                                                 " hugepage")
+                    else:
+                        if static_used > 0:
+                            raise error.TestFail("VM use static hugepage,"
+                                                 " while it's set to zero")
+                    if thp_enable is not True:
+                        if started_anon > 0:
+                            raise error.TestFail("VM use transparent hugepage,"
+                                                 " while it's disabled")
+                    else:
+                        if shp_num == 0 and started_anon <= 0:
+                            raise error.TestFail("VM doesn't use transparent"
+                                                 " hugepage, while static"
+                                                 " hugepage is disabled")
+    finally:
+        # end up session
+        for session in sessions:
+            session.close()
 
-    # end up session
-    for session in sessions:
-        session.close()
+        for vm in vms:
+            if vm.is_alive():
+                vm.destroy()
 
-    for vm in vms:
-        if vm.is_alive():
-            vm.destroy()
+        for vm_name in vm_names:
+            if mb_enable:
+                vm_xml.VMXML.del_memoryBacking_tag(vm_name)
+            else:
+                vm_xml.VMXML.set_memoryBacking_tag(vm_name)
 
-    for vm_name in vm_names:
-        if mb_enable:
-            vm_xml.VMXML.del_memoryBacking_tag(vm_name)
+        utils_libvirtd.libvirtd_restart()
+
+        if tlbfs_enable is True:
+            if tlbfs_status is not True:
+                utils_misc.umount("hugetlbfs", "/dev/hugepages", "hugetlbfs")
         else:
-            vm_xml.VMXML.set_memoryBacking_tag(vm_name)
-
-    utils_libvirtd.libvirtd_restart()
-
-    if tlbfs_enable is True:
-        if tlbfs_status is not True:
-            utils_misc.umount("hugetlbfs", "/dev/hugepages", "hugetlbfs")
-    else:
-        if tlbfs_status is True:
-            utils_misc.mount("hugetlbfs", "/dev/hugepages", "hugetlbfs")
-    utils_memory.set_num_huge_pages(shp_orig_num)
-    utils_memory.set_transparent_hugepage(thp_orig_status)
+            if tlbfs_status is True:
+                utils_misc.mount("hugetlbfs", "/dev/hugepages", "hugetlbfs")
+        utils_memory.set_num_huge_pages(shp_orig_num)
+        utils_memory.set_transparent_hugepage(thp_orig_status)


### PR DESCRIPTION
1. If any exception raise during the test, the cleanup steps will not
execute, so move the tests steps into try.finally block to aviod the
problem.
2. If the test requirements are not met(multiple Vms), skip them asap.
3. unixbench test need 'patch' and 'perl' commands installed.
4. Remove two invalid unixbench related cases, as if nr_huagepageas is 0,
VM can not started with memoryBackging.
4. Format/typo fix.

Signed-off-by: Yanbing Du <ydu@redhat.com>