### PR TITLE
Import fixes and cleanups

### DIFF
--- a/libguestfs/tests/guestfish_augeas.py
+++ b/libguestfs/tests/guestfish_augeas.py
@@ -3,6 +3,7 @@ This file is used to run autotest cases related to augeas
 """
 import re
 import logging
+
 from autotest.client.shared import error
 from virttest import utils_test
 

--- a/libguestfs/tests/guestfish_block_dev.py
+++ b/libguestfs/tests/guestfish_block_dev.py
@@ -1,11 +1,11 @@
-from autotest.client.shared import error, utils
-from virttest import utils_test, utils_misc, data_dir
-from virttest.tests import unattended_install
-from virttest import qemu_storage
 import logging
-import shutil
 import os
 import re
+
+from autotest.client.shared import error
+from virttest import utils_test
+from virttest import data_dir
+from virttest import qemu_storage
 
 
 def prepare_image(params):

--- a/libguestfs/tests/guestfish_file_dir.py
+++ b/libguestfs/tests/guestfish_file_dir.py
@@ -1,13 +1,14 @@
-from autotest.client.shared import error, utils
-from virttest import utils_test, utils_misc, data_dir
-from virttest.tests import unattended_install
 import logging
-import shutil
 import os
 import re
 import random
 import string
 import hashlib
+
+from autotest.client.shared import error
+from autotest.client.shared import utils
+from virttest import utils_test
+from virttest import data_dir
 
 
 def prepare_image(params):

--- a/libguestfs/tests/guestfish_fs_attr_ops.py
+++ b/libguestfs/tests/guestfish_fs_attr_ops.py
@@ -1,12 +1,11 @@
-from autotest.client.shared import error, utils
-from virttest import utils_test, utils_misc, data_dir
-from virttest.tests import unattended_install
-from virttest import qemu_storage
 import logging
-import shutil
 import os
 import re
 import commands
+
+from autotest.client.shared import error
+from virttest import utils_test
+from virttest import data_dir
 
 
 def prepare_image(params):

--- a/libguestfs/tests/guestfish_fs_mount.py
+++ b/libguestfs/tests/guestfish_fs_mount.py
@@ -1,12 +1,10 @@
-from autotest.client.shared import error, utils
-from virttest import utils_test, utils_misc, data_dir
-from virttest.tests import unattended_install
-from virttest import qemu_storage
 import logging
-import shutil
 import os
 import re
-import commands
+
+from autotest.client.shared import error
+from virttest import utils_test
+from virttest import data_dir
 
 
 def prepare_image(params):

--- a/libguestfs/tests/guestfish_fs_swap.py
+++ b/libguestfs/tests/guestfish_fs_swap.py
@@ -1,12 +1,11 @@
-from autotest.client.shared import error, utils
-from virttest import utils_test, utils_misc, data_dir
-from virttest.tests import unattended_install
-from virttest import qemu_storage
 import logging
-import shutil
 import os
 import re
 import commands
+
+from autotest.client.shared import error
+from virttest import utils_test
+from virttest import data_dir
 
 
 def prepare_image(params):

--- a/libguestfs/tests/guestfish_lvm.py
+++ b/libguestfs/tests/guestfish_lvm.py
@@ -1,10 +1,8 @@
-from autotest.client.shared import error, utils
-from virttest import utils_test, utils_misc, data_dir
-from virttest.tests import unattended_install
 import logging
-import shutil
-import os
 import re
+
+from autotest.client.shared import error
+from virttest import utils_test
 
 
 def prepare_image(params):

--- a/libguestfs/tests/guestfish_misc.py
+++ b/libguestfs/tests/guestfish_misc.py
@@ -1,11 +1,9 @@
-from autotest.client.shared import error, utils
-from virttest import utils_test, utils_misc, data_dir
-from virttest.tests import unattended_install
 import commands
-import logging
-import shutil
-import os
 import re
+
+from autotest.client.shared import error
+from virttest import utils_test
+from virttest import data_dir
 
 
 def prepare_image(params):

--- a/libguestfs/tests/guestfs_add.py
+++ b/libguestfs/tests/guestfs_add.py
@@ -1,9 +1,12 @@
 import logging
 import re
 import commands
-from autotest.client.shared import error, utils
+
+import aexpect
+
+from autotest.client.shared import error
+from autotest.client.shared import utils
 from virttest import utils_libguestfs as lgf
-from virttest import aexpect
 
 
 def primary_disk_virtio(vm):

--- a/libguestfs/tests/guestfs_block_operations.py
+++ b/libguestfs/tests/guestfs_block_operations.py
@@ -1,7 +1,11 @@
 import re
 import logging
-from autotest.client.shared import error, utils
-from virttest import virt_vm, remote, aexpect
+
+from autotest.client.shared import error
+from autotest.client.shared import utils
+from virttest import virt_vm
+from virttest import remote
+from virttest import aexpect
 from virttest import utils_test
 
 

--- a/libguestfs/tests/guestfs_file_operations.py
+++ b/libguestfs/tests/guestfs_file_operations.py
@@ -2,8 +2,11 @@ import re
 import os
 import logging
 import tarfile
-from autotest.client.shared import utils, error
-from virttest import data_dir, utils_test
+
+from autotest.client.shared import utils
+from autotest.client.shared import error
+from virttest import data_dir
+from virttest import utils_test
 
 
 def test_tar_in(vm, params):

--- a/libguestfs/tests/guestfs_inspect_operations.py
+++ b/libguestfs/tests/guestfs_inspect_operations.py
@@ -1,7 +1,10 @@
 import logging
 import re
+
 from autotest.client.shared import error
-from virttest import virt_vm, remote, utils_test
+from virttest import virt_vm
+from virttest import remote
+from virttest import utils_test
 
 
 def test_inspect_get(vm, params):

--- a/libguestfs/tests/guestfs_list_operations.py
+++ b/libguestfs/tests/guestfs_list_operations.py
@@ -1,5 +1,6 @@
 import logging
 import re
+
 from autotest.client.shared import error
 from virttest import utils_test
 

--- a/libguestfs/tests/guestfs_operated_disk.py
+++ b/libguestfs/tests/guestfs_operated_disk.py
@@ -1,7 +1,11 @@
 import logging
-from autotest.client.shared import error, utils
+
+import aexpect
+from autotest.client.shared import error
+from autotest.client.shared import utils
 from virttest import utils_test
-from virttest import virt_vm, aexpect, remote
+from virttest import virt_vm
+from virttest import remote
 from virttest.libvirt_xml import vm_xml
 
 

--- a/libguestfs/tests/guestfs_part_operations.py
+++ b/libguestfs/tests/guestfs_part_operations.py
@@ -1,8 +1,13 @@
 import re
 import os
 import logging
-from autotest.client.shared import error, utils
-from virttest import virt_vm, data_dir, remote, aexpect
+
+import aexpect
+from autotest.client.shared import error
+from autotest.client.shared import utils
+from virttest import virt_vm
+from virttest import data_dir
+from virttest import remote
 from virttest import utils_test
 
 

--- a/libguestfs/tests/guestfs_volume_operations.py
+++ b/libguestfs/tests/guestfs_volume_operations.py
@@ -1,8 +1,13 @@
 import re
 import os
 import logging
-from autotest.client.shared import error, utils
-from virttest import virt_vm, data_dir, remote, aexpect
+
+import aexpect
+from autotest.client.shared import error
+from autotest.client.shared import utils
+from virttest import virt_vm
+from virttest import data_dir
+from virttest import remote
 from virttest import utils_test
 
 

--- a/libguestfs/tests/guestmount.py
+++ b/libguestfs/tests/guestmount.py
@@ -1,7 +1,11 @@
 import logging
 import os
-from autotest.client.shared import error, utils
-from virttest import data_dir, utils_test
+
+from autotest.client.shared import error
+from autotest.client.shared import utils
+
+from virttest import data_dir
+from virttest import utils_test
 
 
 def umount_fs(mountpoint):

--- a/libguestfs/tests/virt_edit.py
+++ b/libguestfs/tests/virt_edit.py
@@ -1,7 +1,12 @@
 import logging
 import re
-from autotest.client.shared import utils, error, ssh_key
-from virttest import libvirt_vm, utils_libvirtd
+
+from autotest.client.shared import utils
+from autotest.client.shared import error
+from autotest.client.shared import ssh_key
+
+from virttest import libvirt_vm
+from virttest import utils_libvirtd
 import virttest.utils_libguestfs as lgf
 
 

--- a/libguestfs/tests/virt_file_operations.py
+++ b/libguestfs/tests/virt_file_operations.py
@@ -2,8 +2,17 @@ import re
 import os
 import logging
 import tarfile
-from autotest.client.shared import utils, error
-from virttest import data_dir, utils_test, virt_vm, remote, aexpect, utils_misc
+
+import aexpect
+
+from autotest.client.shared import utils
+from autotest.client.shared import error
+
+from virttest import data_dir
+from virttest import utils_test
+from virttest import virt_vm
+from virttest import remote
+from virttest import utils_misc
 
 
 def test_virt_tar_in(vm, params):

--- a/libguestfs/tests/virt_inspect_operations.py
+++ b/libguestfs/tests/virt_inspect_operations.py
@@ -1,8 +1,12 @@
 import logging
 import re
 import os
+
 from autotest.client.shared import error
-from virttest import virt_vm, remote, utils_test
+
+from virttest import virt_vm
+from virttest import remote
+from virttest import utils_test
 
 
 def test_inspect_get(vm, params):

--- a/libguestfs/tests/virt_list_operations.py
+++ b/libguestfs/tests/virt_list_operations.py
@@ -1,6 +1,8 @@
 import logging
 import re
+
 from autotest.client.shared import error
+
 from virttest import utils_libguestfs as lgf
 from virttest import utils_test
 

--- a/libguestfs/tests/virt_part_operations.py
+++ b/libguestfs/tests/virt_part_operations.py
@@ -2,9 +2,17 @@ import re
 import os
 import logging
 import commands
-from autotest.client.shared import error, utils
-from virttest import virt_vm, data_dir, remote, aexpect
-from virttest import utils_test, utils_misc
+
+import aexpect
+
+from autotest.client.shared import error
+from autotest.client.shared import utils
+
+from virttest import virt_vm
+from virttest import data_dir
+from virttest import remote
+from virttest import utils_test
+from virttest import utils_misc
 
 
 def test_unformatted_part(vm, params):

--- a/libguestfs/tests/virt_sysprep.py
+++ b/libguestfs/tests/virt_sysprep.py
@@ -1,10 +1,18 @@
 import logging
 import os
+
+import aexpect
+
 from autotest.client.shared import error
-from virttest import libvirt_vm, virsh, remote, aexpect, virt_vm, utils_test
+from autotest.client import utils
+
+from virttest import libvirt_vm
+from virttest import virsh
+from virttest import remote
+from virttest import virt_vm
+from virttest import utils_test
 from virttest.libvirt_xml import vm_xml
 import virttest.utils_libguestfs as lgf
-from autotest.client import utils
 
 
 def run(test, params, env):

--- a/libguestfs/tests/virt_sysprep_opt.py
+++ b/libguestfs/tests/virt_sysprep_opt.py
@@ -1,6 +1,8 @@
 import os
 import stat
+
 from autotest.client.shared import error
+
 from virttest import data_dir
 from virttest import remote
 import virttest.utils_libguestfs as lgf

--- a/libguestfs/tests/virt_volume_operations.py
+++ b/libguestfs/tests/virt_volume_operations.py
@@ -2,9 +2,17 @@ import re
 import os
 import logging
 import commands
-from autotest.client.shared import error, utils
-from virttest import virt_vm, data_dir, remote, aexpect
-from virttest import utils_test, utils_misc
+
+import aexpect
+
+from autotest.client.shared import error
+from autotest.client.shared import utils
+
+from virttest import virt_vm
+from virttest import data_dir
+from virttest import remote
+from virttest import utils_test
+from virttest import utils_misc
 
 
 def test_created_volume_group(vm, params):

--- a/libguestfs/tests/virt_win_reg.py
+++ b/libguestfs/tests/virt_win_reg.py
@@ -1,9 +1,11 @@
 import os
 import logging
 
-from virttest import data_dir, remote
-from autotest.client import os_dep, utils
+from autotest.client import os_dep
+from autotest.client import utils
 from autotest.client.shared import error
+
+from virttest import data_dir
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/conf_file/libvirtd_conf/host_uuid.py
+++ b/libvirt/tests/src/conf_file/libvirtd_conf/host_uuid.py
@@ -1,10 +1,12 @@
 import logging
 import uuid
-import os.path
+import os
+
+from autotest.client.shared import error
+
 from virttest import utils_config
 from virttest import utils_libvirtd
 from virttest.libvirt_xml import capability_xml
-from autotest.client.shared import error
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/conf_file/libvirtd_conf/unix_sock.py
+++ b/libvirt/tests/src/conf_file/libvirtd_conf/unix_sock.py
@@ -1,12 +1,14 @@
 import grp
 import stat
 import logging
-import os.path
+import os
+
+from autotest.client.shared import error
+
 from virttest import virsh
 from virttest import data_dir
 from virttest import utils_config
 from virttest import utils_libvirtd
-from autotest.client.shared import error
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/conf_file/qemu_conf/auto_dump.py
+++ b/libvirt/tests/src/conf_file/qemu_conf/auto_dump.py
@@ -1,12 +1,15 @@
 import os
 import logging
+
+from aexpect import ShellTimeoutError
+
+from autotest.client.shared import error
+from autotest.client.shared import utils
+
 from virttest import utils_config
 from virttest import utils_libvirtd
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.panic import Panic
-from virttest.aexpect import ShellTimeoutError
-from autotest.client.shared import error
-from autotest.client.shared import utils
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/conf_file/qemu_conf/clear_emulator_capabilities.py
+++ b/libvirt/tests/src/conf_file/qemu_conf/clear_emulator_capabilities.py
@@ -1,7 +1,9 @@
 import logging
+
+from autotest.client.shared import error
+
 from virttest import utils_config
 from virttest import utils_libvirtd
-from autotest.client.shared import error
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/conf_file/qemu_conf/seccomp_sandbox.py
+++ b/libvirt/tests/src/conf_file/qemu_conf/seccomp_sandbox.py
@@ -1,9 +1,11 @@
 import re
 import logging
-from virttest import utils_config
-from virttest import utils_libvirtd
+
 from autotest.client import utils
 from autotest.client.shared import error
+
+from virttest import utils_config
+from virttest import utils_libvirtd
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/conf_file/qemu_conf/set_process_name.py
+++ b/libvirt/tests/src/conf_file/qemu_conf/set_process_name.py
@@ -1,10 +1,11 @@
 import re
-import time
 import logging
-from virttest import utils_config
-from virttest import utils_libvirtd
+
 from autotest.client import utils
 from autotest.client.shared import error
+
+from virttest import utils_config
+from virttest import utils_libvirtd
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/conf_file/sysconfig_libvirtd/libvirtd_config.py
+++ b/libvirt/tests/src/conf_file/sysconfig_libvirtd/libvirtd_config.py
@@ -1,10 +1,12 @@
 import os
 import logging
+
+from autotest.client.shared import error
+
 from virttest import utils_config
 from virttest import utils_libvirtd
 from virttest import data_dir
 from virttest.libvirt_xml import capability_xml
-from autotest.client.shared import error
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/controller/controller_functional.py
+++ b/libvirt/tests/src/controller/controller_functional.py
@@ -1,6 +1,8 @@
 import re
 import logging
+
 from autotest.client.shared import error
+
 from virttest import virt_vm
 from virttest import virsh
 from virttest.utils_test import libvirt

--- a/libvirt/tests/src/daemon/daemon_functional.py
+++ b/libvirt/tests/src/daemon/daemon_functional.py
@@ -1,12 +1,14 @@
 import os
 import time
 import logging
+
+from autotest.client.shared import error
+from autotest.client import utils
+
 from virttest import virsh
 from virttest import utils_config
 from virttest.utils_libvirtd import LibvirtdSession
 from virttest.libvirt_xml import capability_xml
-from autotest.client.shared import error
-from autotest.client import utils
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/daemon/init_scripts.py
+++ b/libvirt/tests/src/daemon/init_scripts.py
@@ -2,10 +2,12 @@ import os
 import glob
 import shutil
 import logging
-from virttest import utils_libvirtd
+
 from autotest.client import os_dep
 from autotest.client import utils
 from autotest.client.shared import error
+
+from virttest import utils_libvirtd
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/daemon/kill_qemu.py
+++ b/libvirt/tests/src/daemon/kill_qemu.py
@@ -1,6 +1,8 @@
 import os
 import signal
+
 from autotest.client.shared import error
+
 from virttest import utils_misc
 from virttest.libvirt_xml import vm_xml
 

--- a/libvirt/tests/src/daemon/kill_started.py
+++ b/libvirt/tests/src/daemon/kill_started.py
@@ -2,7 +2,9 @@ import os
 import time
 import signal
 import logging
+
 from autotest.client.shared import error
+
 from virttest.utils_libvirtd import Libvirtd
 
 

--- a/libvirt/tests/src/daemon/kill_starting.py
+++ b/libvirt/tests/src/daemon/kill_starting.py
@@ -1,5 +1,7 @@
 import logging
+
 from autotest.client.shared import error
+
 from virttest import utils_misc
 from virttest.utils_libvirtd import LibvirtdSession
 

--- a/libvirt/tests/src/daemon/restart_consist.py
+++ b/libvirt/tests/src/daemon/restart_consist.py
@@ -1,8 +1,11 @@
 import logging
 import difflib
+
+from aexpect import ExpectTimeoutError
+from aexpect import ShellTimeoutError
+
 from autotest.client.shared import error
-from virttest.aexpect import ExpectTimeoutError
-from virttest.aexpect import ShellTimeoutError
+
 from virttest import utils_libvirtd
 from virttest import utils_misc
 from virttest import remote

--- a/libvirt/tests/src/graphics/graphics_functional.py
+++ b/libvirt/tests/src/graphics/graphics_functional.py
@@ -7,8 +7,10 @@ import random
 import socket
 import shutil
 import logging
+
 from autotest.client.shared import error
 from autotest.client.shared import utils
+
 from virttest.libvirt_xml.vm_xml import VMXML
 from virttest import virt_vm
 from virttest import utils_net

--- a/libvirt/tests/src/guest_kernel_debugging/nmi_test.py
+++ b/libvirt/tests/src/guest_kernel_debugging/nmi_test.py
@@ -1,8 +1,10 @@
 import logging
 
 from virttest import virsh
-from provider import libvirt_version
+
 from autotest.client.shared import error
+
+from provider import libvirt_version
 
 
 def run_cmd_in_guest(vm, cmd):

--- a/libvirt/tests/src/hotplug_serial.py
+++ b/libvirt/tests/src/hotplug_serial.py
@@ -7,11 +7,12 @@ import socket
 import shutil
 
 from autotest.client.shared import error
+
 from virttest import virsh
 from virttest import utils_misc
 from virttest.libvirt_xml.vm_xml import VMXML
-from virttest.libvirt_xml.devices.controller import Controller
 from virttest.utils_test import libvirt as utlv
+from virttest.libvirt_xml.devices.controller import Controller
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/kernel_panic.py
+++ b/libvirt/tests/src/kernel_panic.py
@@ -1,6 +1,11 @@
 import logging
+
+import aexpect
+
 from autotest.client.shared import error
-from virttest import virt_vm, aexpect, virsh
+
+from virttest import virt_vm
+from virttest import virsh
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/libvirt_bench/libvirt_bench_domstate_switch_by_groups.py
+++ b/libvirt/tests/src/libvirt_bench/libvirt_bench_domstate_switch_by_groups.py
@@ -1,4 +1,5 @@
 from autotest.client.shared import error
+
 from virttest import utils_test
 
 

--- a/libvirt/tests/src/libvirt_bench/libvirt_bench_domstate_switch_in_loop.py
+++ b/libvirt/tests/src/libvirt_bench/libvirt_bench_domstate_switch_in_loop.py
@@ -2,6 +2,7 @@ import time
 import logging
 
 from autotest.client.shared import error
+
 from virttest import virsh
 
 

--- a/libvirt/tests/src/libvirt_bench/libvirt_bench_domstate_switch_with_iozone.py
+++ b/libvirt/tests/src/libvirt_bench/libvirt_bench_domstate_switch_with_iozone.py
@@ -3,7 +3,10 @@ import time
 import logging
 
 from autotest.client.shared import error
-from virttest import virsh, utils_test, utils_misc
+
+from virttest import virsh
+from virttest import utils_test
+from virttest import utils_misc
 
 
 def func_in_thread(vm, timeout):

--- a/libvirt/tests/src/libvirt_bench/libvirt_bench_domstate_switch_with_unixbench.py
+++ b/libvirt/tests/src/libvirt_bench/libvirt_bench_domstate_switch_with_unixbench.py
@@ -5,8 +5,11 @@ import shutil
 import subprocess
 
 from autotest.client.shared import error
-from autotest.client import utils
-from virttest import virsh, utils_test, utils_misc, data_dir
+
+from virttest import virsh
+from virttest import utils_test
+from virttest import utils_misc
+from virttest import data_dir
 
 
 def func_in_thread(vm, timeout):

--- a/libvirt/tests/src/libvirt_bench/libvirt_bench_dump_with_netperf.py
+++ b/libvirt/tests/src/libvirt_bench/libvirt_bench_dump_with_netperf.py
@@ -2,7 +2,9 @@ import os
 import logging
 
 from autotest.client.shared import error
-from virttest import utils_test, utils_misc
+
+from virttest import utils_test
+from virttest import utils_misc
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/libvirt_bench/libvirt_bench_dump_with_unixbench.py
+++ b/libvirt/tests/src/libvirt_bench/libvirt_bench_dump_with_unixbench.py
@@ -2,7 +2,9 @@ import os
 import logging
 
 from autotest.client.shared import error
-from virttest import utils_test, utils_misc
+
+from virttest import utils_test
+from virttest import utils_misc
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/libvirt_bench/libvirt_bench_serial_hotplug.py
+++ b/libvirt/tests/src/libvirt_bench/libvirt_bench_serial_hotplug.py
@@ -4,8 +4,13 @@ import socket
 import subprocess
 import time
 import shutil
+
 from autotest.client.shared import error
-from virttest import virsh, libvirt_vm, utils_test, utils_misc
+
+from virttest import virsh
+from virttest import libvirt_vm
+from virttest import utils_test
+from virttest import utils_misc
 from virttest.utils_test import libvirt as utlv
 
 

--- a/libvirt/tests/src/libvirt_bench/libvirt_bench_ttcp_from_guest_to_host.py
+++ b/libvirt/tests/src/libvirt_bench/libvirt_bench_ttcp_from_guest_to_host.py
@@ -1,9 +1,14 @@
 import time
 import logging
 
-from autotest.client import os_dep, utils
+import aexpect
+
+from autotest.client import os_dep
 from autotest.client.shared import error
-from virttest import virsh, utils_net, remote, aexpect, utils_misc
+
+from virttest import utils_net
+from virttest import remote
+from virttest import utils_misc
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/libvirt_bench/libvirt_bench_usb_hotplug.py
+++ b/libvirt/tests/src/libvirt_bench/libvirt_bench_usb_hotplug.py
@@ -1,12 +1,16 @@
 import os
 import shutil
 import logging
+
 from autotest.client.shared import error
-from virttest import data_dir, virsh
+
+from virttest import data_dir
+from virttest import virsh
+from virttest import utils_test
+from virttest import utils_misc
 from virttest.libvirt_xml.vm_xml import VMXML
 from virttest.libvirt_xml.devices.disk import Disk
 from virttest.libvirt_xml.devices.input import Input
-from virttest import utils_test, utils_misc
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/libvirt_bench/libvirt_bench_vcpu_hotplug.py
+++ b/libvirt/tests/src/libvirt_bench/libvirt_bench_vcpu_hotplug.py
@@ -1,7 +1,11 @@
 import logging
 import re
+
 from autotest.client.shared import error
-from virttest import libvirt_xml, libvirt_vm, utils_test
+
+from virttest import libvirt_xml
+from virttest import libvirt_vm
+from virttest import utils_test
 from virttest.utils_test import libvirt
 
 

--- a/libvirt/tests/src/libvirt_hugepage.py
+++ b/libvirt/tests/src/libvirt_hugepage.py
@@ -2,13 +2,18 @@ import logging
 import os
 import time
 
+from aexpect import ShellError
+
 from autotest.client import utils
 from autotest.client.shared import error
 
-from virttest import virsh, utils_libvirtd, remote, utils_misc, utils_test
+from virttest import virsh
+from virttest import utils_libvirtd
+from virttest import remote
+from virttest import utils_misc
+from virttest import utils_test
 from virttest.remote import LoginError
 from virttest.virt_vm import VMError
-from virttest.aexpect import ShellError
 from virttest.libvirt_xml import vm_xml
 from virttest.staging import utils_memory
 

--- a/libvirt/tests/src/libvirt_mem.py
+++ b/libvirt/tests/src/libvirt_mem.py
@@ -2,8 +2,10 @@ import os
 import re
 import ast
 import logging
+
 from autotest.client.shared import error
 from autotest.client import utils
+
 from virttest import virsh
 from virttest import utils_libvirtd
 from virttest import utils_misc

--- a/libvirt/tests/src/libvirt_network_bandwidth.py
+++ b/libvirt/tests/src/libvirt_network_bandwidth.py
@@ -3,7 +3,9 @@ import time
 
 from autotest.client.shared import error
 from autotest.client import utils
-from virttest import data_dir, virsh
+
+from virttest import data_dir
+from virttest import virsh
 from virttest.libvirt_xml.vm_xml import VMXML
 from virttest.libvirt_xml.network_xml import NetworkXML, PortgroupXML
 

--- a/libvirt/tests/src/libvirt_pci_passthrough.py
+++ b/libvirt/tests/src/libvirt_pci_passthrough.py
@@ -1,8 +1,12 @@
 import os
 
+import aexpect
+
 from autotest.client import utils
 from autotest.client.shared import error
-from virttest import virsh, utils_test, aexpect
+
+from virttest import virsh
+from virttest import utils_test
 from virttest.libvirt_xml.vm_xml import VMXML
 from virttest.libvirt_xml.nodedev_xml import NodedevXML
 from virttest.staging import service

--- a/libvirt/tests/src/libvirt_qemu_cmdline.py
+++ b/libvirt/tests/src/libvirt_qemu_cmdline.py
@@ -3,10 +3,13 @@ Test libvirt support features in qemu cmdline.
 BTW it not limited to hypervisors CPU/machine features.
 """
 import logging
+
 from autotest.client.shared import error
+
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/libvirt_scsi.py
+++ b/libvirt/tests/src/libvirt_scsi.py
@@ -6,13 +6,15 @@ libvirt scsi test
 import os
 
 from autotest.client.shared import error
+
+from virttest import virt_vm
+from virttest import qemu_storage
+from virttest import data_dir
 from virttest.utils_disk import CdromDisk
-from virttest import virt_vm, qemu_storage
 from virttest.libvirt_xml.vm_xml import VMXML
 from virttest.libvirt_xml.devices.disk import Disk
 from virttest.libvirt_xml.devices.controller import Controller
 from virttest.libvirt_xml.xcepts import LibvirtXMLError
-from virttest import data_dir
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/libvirt_usb_hotplug_controller.py
+++ b/libvirt/tests/src/libvirt_usb_hotplug_controller.py
@@ -1,9 +1,11 @@
+from aexpect import ShellError
+
 from autotest.client.shared import error
+
 from virttest.virt_vm import VMStartError
 from virttest.libvirt_xml.vm_xml import VMXML
 from virttest.libvirt_xml.devices.controller import Controller
 from virttest.libvirt_xml.xcepts import LibvirtXMLError
-from virttest.aexpect import ShellError
 from virttest.remote import LoginError
 
 

--- a/libvirt/tests/src/libvirt_usb_hotplug_device.py
+++ b/libvirt/tests/src/libvirt_usb_hotplug_device.py
@@ -1,10 +1,15 @@
 import os
 import shutil
+
+from aexpect import ShellError
+from aexpect import ShellTimeoutError
+
 from autotest.client.shared import error
-from autotest.client import utils
-from virttest import data_dir, virsh
-from virttest import aexpect, utils_misc, utils_selinux
-from virttest.aexpect import ShellError
+
+from virttest import data_dir
+from virttest import virsh
+from virttest import utils_misc
+from virttest import utils_selinux
 from virttest.remote import LoginError
 from virttest.utils_test import libvirt
 from virttest.virt_vm import VMError
@@ -62,7 +67,7 @@ def run(test, params, env):
                 return False
             else:
                 return True
-        except aexpect.ShellTimeoutError, detail:
+        except ShellTimeoutError, detail:
             raise error.TestFail("unhotplug failed: %s, " % detail)
 
     tmp_dir = os.path.join(data_dir.get_tmp_dir(), "usb_hotplug_files")

--- a/libvirt/tests/src/libvirt_vcpu_plug_unplug.py
+++ b/libvirt/tests/src/libvirt_vcpu_plug_unplug.py
@@ -1,8 +1,10 @@
 import os
 import re
 import logging
+
 from autotest.client import utils
 from autotest.client.shared import error
+
 from virttest import virsh
 from virttest import data_dir
 from virttest import utils_misc

--- a/libvirt/tests/src/libvirtd_start.py
+++ b/libvirt/tests/src/libvirtd_start.py
@@ -1,13 +1,16 @@
 import os
 import re
 import logging
-from virttest import aexpect
+
+import aexpect
+
+from autotest.client.shared import error
+from autotest.client.shared import utils
+
 from virttest import utils_libvirtd
 from virttest import utils_misc
 from virttest import utils_selinux
 from virttest.staging import service
-from autotest.client.shared import error
-from autotest.client.shared import utils
 
 
 class LibvirtdSession(aexpect.Tail):

--- a/libvirt/tests/src/macvtap.py
+++ b/libvirt/tests/src/macvtap.py
@@ -1,11 +1,14 @@
 import os
+
+import aexpect
+
 from autotest.client.shared import error
+
 from virttest import remote
 from virttest import utils_net
-from virttest import aexpect
+from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import ping
-from virttest import virsh
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/multifunction.py
+++ b/libvirt/tests/src/multifunction.py
@@ -1,9 +1,14 @@
 import logging
 import os
 import commands
+
 from autotest.client.shared import error
-from virttest import libvirt_vm, virsh, data_dir
-from virttest.libvirt_xml import xcepts, vm_xml
+
+from virttest import libvirt_vm
+from virttest import virsh
+from virttest import data_dir
+from virttest.libvirt_xml import xcepts
+from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices import disk
 
 

--- a/libvirt/tests/src/multiqueue.py
+++ b/libvirt/tests/src/multiqueue.py
@@ -2,8 +2,13 @@ import logging
 import time
 import threading
 import re
-from autotest.client.shared import error, utils
-from virttest import libvirt_vm, virsh, remote
+
+from autotest.client.shared import error
+from autotest.client.shared import utils
+
+from virttest import virsh
+from virttest import remote
+from virttest import libvirt_vm
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt as utlv
 

--- a/libvirt/tests/src/numa/guest_numa.py
+++ b/libvirt/tests/src/numa/guest_numa.py
@@ -1,5 +1,9 @@
 import re
 import logging
+
+from autotest.client.shared import utils
+from autotest.client.shared import error
+
 from virttest import virt_vm
 from virttest import libvirt_xml
 from virttest import utils_misc
@@ -7,8 +11,7 @@ from virttest import utils_config
 from virttest import utils_libvirtd
 from virttest import test_setup
 from virttest.utils_test import libvirt as utlv
-from autotest.client.shared import utils
-from autotest.client.shared import error
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/numa/numa_capabilities.py
+++ b/libvirt/tests/src/numa/numa_capabilities.py
@@ -1,8 +1,10 @@
 import logging
+
+from autotest.client.shared import error
+
 from virttest import libvirt_xml
 from virttest import utils_libvirtd
 from virttest import utils_misc
-from autotest.client.shared import error
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/numa/numa_memory.py
+++ b/libvirt/tests/src/numa/numa_memory.py
@@ -1,5 +1,9 @@
 import os
 import logging
+
+from autotest.client import utils
+from autotest.client.shared import error
+
 from virttest import virt_vm
 from virttest import libvirt_xml
 from virttest import virsh
@@ -7,8 +11,6 @@ from virttest import utils_misc
 from virttest import utils_test
 from virttest import utils_config
 from virttest import utils_libvirtd
-from autotest.client import utils
-from autotest.client.shared import error
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/numa/numa_memory_migrate.py
+++ b/libvirt/tests/src/numa/numa_memory_migrate.py
@@ -1,5 +1,8 @@
 import os
 import logging
+
+from autotest.client.shared import error
+
 from virttest import virt_vm
 from virttest import libvirt_xml
 from virttest import virsh
@@ -7,7 +10,6 @@ from virttest import utils_misc
 from virttest import utils_test
 from virttest import utils_config
 from virttest import utils_libvirtd
-from autotest.client.shared import error
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/numa/numa_preferred_undefine.py
+++ b/libvirt/tests/src/numa/numa_preferred_undefine.py
@@ -1,8 +1,10 @@
 import logging
+
+from autotest.client.shared import error
+
 from virttest import libvirt_xml
 from virttest import virsh
 from virttest import utils_libvirtd
-from autotest.client.shared import error
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/numa/numad_vcpupin.py
+++ b/libvirt/tests/src/numa/numad_vcpupin.py
@@ -1,11 +1,13 @@
 import logging
+
+from autotest.client import utils
+from autotest.client.shared import error
+
 from virttest import libvirt_xml
 from virttest import virsh
 from virttest import utils_misc
 from virttest import utils_test
 from virttest import utils_libvirtd
-from autotest.client import utils
-from autotest.client.shared import error
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/nwfilter/nwfilter_edit_uuid.py
+++ b/libvirt/tests/src/nwfilter/nwfilter_edit_uuid.py
@@ -1,9 +1,13 @@
 import logging
+
+import aexpect
+
 from autotest.client.shared import error
+
 from virttest import virsh
 from virttest import libvirt_xml
-from virttest import aexpect
 from virttest import remote
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/nwfilter/nwfilter_update_lock.py
+++ b/libvirt/tests/src/nwfilter/nwfilter_update_lock.py
@@ -1,12 +1,15 @@
 import time
 import threading
 import logging
+
 from autotest.client.shared import error
+
 from virttest import virsh
 from virttest import libvirt_xml
 from virttest import utils_libvirtd
 from virttest import utils_misc
 from virttest.libvirt_xml.devices import interface
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/nwfilter/nwfilter_update_vm_running.py
+++ b/libvirt/tests/src/nwfilter/nwfilter_update_vm_running.py
@@ -1,6 +1,9 @@
 import re
 import logging
-from autotest.client.shared import utils, error
+
+from autotest.client.shared import utils
+from autotest.client.shared import error
+
 from virttest import virsh
 from virttest import libvirt_xml
 from virttest import utils_misc

--- a/libvirt/tests/src/nwfilter/nwfilter_vm_attach.py
+++ b/libvirt/tests/src/nwfilter/nwfilter_vm_attach.py
@@ -1,6 +1,9 @@
 import re
 import logging
-from autotest.client.shared import utils, error
+
+from autotest.client.shared import utils
+from autotest.client.shared import error
+
 from virttest import virsh
 from virttest import libvirt_xml
 from virttest import utils_libvirtd

--- a/libvirt/tests/src/nwfilter/nwfilter_vm_start.py
+++ b/libvirt/tests/src/nwfilter/nwfilter_vm_start.py
@@ -1,7 +1,10 @@
 import re
 import logging
+
 from autotest.client import os_dep
-from autotest.client.shared import utils, error
+from autotest.client.shared import utils
+from autotest.client.shared import error
+
 from virttest import virsh
 from virttest import virt_vm
 from virttest import libvirt_xml

--- a/libvirt/tests/src/perf_kvm.py
+++ b/libvirt/tests/src/perf_kvm.py
@@ -1,11 +1,15 @@
 import os
 import re
 import shutil
-import time
 
-from virttest import data_dir, aexpect
-from autotest.client import os_dep, utils
-from autotest.client.shared import error, ssh_key
+import aexpect
+
+from autotest.client import os_dep
+from autotest.client import utils
+from autotest.client.shared import error
+from autotest.client.shared import ssh_key
+
+from virttest import data_dir
 
 
 def _perf_kvm_help():

--- a/libvirt/tests/src/remote_access/remote_access.py
+++ b/libvirt/tests/src/remote_access/remote_access.py
@@ -3,15 +3,19 @@ import os
 import logging
 import commands
 
+from autotest.client.shared import error
+from autotest.client.shared import utils
+
 from virttest import remote
-from autotest.client.shared import error, utils
 from virttest.utils_sasl import SASL
-from virttest.utils_conn import SSHConnection, TCPConnection, \
-    TLSConnection, UNIXConnection
-from virttest.utils_net import IPv6Manager, \
-    check_listening_port_remote_by_service
-from virttest.utils_test.libvirt import remotely_control_libvirtd, \
-    connect_libvirtd
+from virttest.utils_conn import SSHConnection
+from virttest.utils_conn import TCPConnection
+from virttest.utils_conn import TLSConnection
+from virttest.utils_conn import UNIXConnection
+from virttest.utils_net import IPv6Manager
+from virttest.utils_net import check_listening_port_remote_by_service
+from virttest.utils_test.libvirt import remotely_control_libvirtd
+from virttest.utils_test.libvirt import connect_libvirtd
 
 
 def remote_access(params):

--- a/libvirt/tests/src/resource_abnormal.py
+++ b/libvirt/tests/src/resource_abnormal.py
@@ -4,8 +4,10 @@ import stat
 import signal
 import logging
 import threading
+
 from autotest.client.shared import error
 from autotest.client.shared import utils
+
 from virttest import libvirt_storage
 from virttest import utils_selinux
 from virttest import qemu_storage

--- a/libvirt/tests/src/storage_discard.py
+++ b/libvirt/tests/src/storage_discard.py
@@ -76,7 +76,7 @@ def create_volume(device, vgname="vgthin", lvname="lvthin"):
     iscsi service if it is None.
     """
     # Create volume group
-    lv_utils.vg_create(vgname, device, force=True)
+    lv_utils.vg_create(vgname, device)
     # Create thin volume
     thinpool, thinlv = lv_utils.thin_lv_create(vgname, thinlv_name=lvname)
     logging.debug("Created thin volume successfully.")

--- a/libvirt/tests/src/storage_discard.py
+++ b/libvirt/tests/src/storage_discard.py
@@ -5,11 +5,17 @@ Test module for Storage Discard.
 import re
 import logging
 import time
+
 from autotest.client import utils, lv_utils
 from autotest.client.shared import error
-from virttest import virsh, data_dir
+
+from virttest import virsh
+from virttest import data_dir
+from virttest import iscsi
+from virttest import qemu_storage
+from virttest import libvirt_vm
+from virttest import utils_misc
 from virttest.utils_test import libvirt as utlv
-from virttest import iscsi, qemu_storage, libvirt_vm, utils_misc
 
 
 def volumes_capacity(lv_name):

--- a/libvirt/tests/src/svirt/dac_nfs_disk.py
+++ b/libvirt/tests/src/svirt/dac_nfs_disk.py
@@ -1,14 +1,15 @@
 import os
 import re
 import logging
+
 from autotest.client.shared import error
 from autotest.client import utils
+
 from virttest import qemu_storage
 from virttest import data_dir
 from virttest import utils_selinux
 from virttest import virt_vm
 from virttest import virsh
-from virttest import libvirt_storage
 from virttest import utils_config
 from virttest import utils_libvirtd
 from virttest.utils_test import libvirt as utlv

--- a/libvirt/tests/src/svirt/dac_nfs_save_restore.py
+++ b/libvirt/tests/src/svirt/dac_nfs_save_restore.py
@@ -1,14 +1,13 @@
 import os
-import re
 import logging
+
 from autotest.client.shared import error
 from autotest.client import utils
-from virttest import qemu_storage
+
 from virttest import data_dir
 from virttest import utils_selinux
 from virttest import virt_vm
 from virttest import virsh
-from virttest import libvirt_storage
 from virttest import utils_config
 from virttest import utils_libvirtd
 from virttest.utils_test import libvirt as utlv

--- a/libvirt/tests/src/svirt/dac_per_disk_hotplug.py
+++ b/libvirt/tests/src/svirt/dac_per_disk_hotplug.py
@@ -2,7 +2,9 @@ import os
 import pwd
 import grp
 import logging
+
 from autotest.client.shared import error
+
 from virttest import qemu_storage
 from virttest import data_dir
 from virttest import virsh
@@ -10,6 +12,7 @@ from virttest import utils_config
 from virttest import utils_libvirtd
 from virttest.utils_test import libvirt as utlv
 from virttest.libvirt_xml.vm_xml import VMXML
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/svirt/dac_start_destroy.py
+++ b/libvirt/tests/src/svirt/dac_start_destroy.py
@@ -3,8 +3,10 @@ import stat
 import pwd
 import grp
 import logging
+
 from autotest.client import utils
 from autotest.client.shared import error
+
 from virttest import utils_selinux
 from virttest import virt_vm
 from virttest import utils_config

--- a/libvirt/tests/src/svirt/dac_vm_per_image_start.py
+++ b/libvirt/tests/src/svirt/dac_vm_per_image_start.py
@@ -3,7 +3,9 @@ import stat
 import pwd
 import grp
 import logging
+
 from autotest.client.shared import error
+
 from virttest import utils_selinux
 from virttest import virt_vm
 from virttest import utils_config

--- a/libvirt/tests/src/svirt/svirt_attach_disk.py
+++ b/libvirt/tests/src/svirt/svirt_attach_disk.py
@@ -1,6 +1,8 @@
 import logging
+
 from autotest.client.shared import error
 from autotest.client import utils
+
 from virttest import qemu_storage
 from virttest import data_dir
 from virttest import utils_selinux

--- a/libvirt/tests/src/svirt/svirt_install.py
+++ b/libvirt/tests/src/svirt/svirt_install.py
@@ -2,8 +2,12 @@ import os
 
 from autotest.client import utils
 from autotest.client.shared import error
-from virttest import data_dir, storage, utils_selinux
-from virttest import virsh, utils_test, utils_misc
+
+from virttest import data_dir
+from virttest import utils_selinux
+from virttest import virsh
+from virttest import utils_test
+from virttest import utils_misc
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/svirt/svirt_save_restore.py
+++ b/libvirt/tests/src/svirt/svirt_save_restore.py
@@ -2,10 +2,11 @@
 svirt guest_save_restore test.
 """
 import os
-import logging
 
 from autotest.client.shared import error
-from virttest import utils_selinux, virt_vm
+
+from virttest import utils_selinux
+from virttest import virt_vm
 from virttest.libvirt_xml.vm_xml import VMXML
 
 

--- a/libvirt/tests/src/svirt/svirt_start_destroy.py
+++ b/libvirt/tests/src/svirt/svirt_start_destroy.py
@@ -1,6 +1,8 @@
 import os
 import logging
+
 from autotest.client.shared import error
+
 from virttest import utils_selinux
 from virttest import virt_vm
 from virttest import utils_config

--- a/libvirt/tests/src/svirt/svirt_undefine_define.py
+++ b/libvirt/tests/src/svirt/svirt_undefine_define.py
@@ -4,7 +4,10 @@ svirt guest_undefine_define test.
 import os
 
 from autotest.client.shared import error
-from virttest import utils_selinux, virsh, data_dir
+
+from virttest import utils_selinux
+from virttest import virsh
+from virttest import data_dir
 from virttest.libvirt_xml.vm_xml import VMXML
 
 

--- a/libvirt/tests/src/svirt/svirt_virt_clone.py
+++ b/libvirt/tests/src/svirt/svirt_virt_clone.py
@@ -3,7 +3,11 @@ svirt virt-clone test.
 """
 from autotest.client import utils
 from autotest.client.shared import error
-from virttest import utils_selinux, virt_vm, utils_misc, virsh, libvirt_vm
+
+from virttest import utils_selinux
+from virttest import utils_misc
+from virttest import virsh
+from virttest import libvirt_vm
 from virttest.libvirt_xml.vm_xml import VMXML
 
 

--- a/libvirt/tests/src/timer_management.py
+++ b/libvirt/tests/src/timer_management.py
@@ -5,13 +5,15 @@ Test module for timer management.
 import os
 import logging
 import time
+
 from autotest.client import utils
 from autotest.client.shared import error
-from virttest.libvirt_xml import vm_xml
+
 from virttest import utils_test
 from virttest import virsh
 from virttest import data_dir
 from virttest import virt_vm
+from virttest.libvirt_xml import vm_xml
 
 CLOCK_SOURCE_PATH = '/sys/devices/system/clocksource/clocksource0/'
 

--- a/libvirt/tests/src/usb_passthrough.py
+++ b/libvirt/tests/src/usb_passthrough.py
@@ -1,7 +1,9 @@
 import logging
 import re
+
 from autotest.client import utils
 from autotest.client.shared import error
+
 from virttest.libvirt_xml.vm_xml import VMXML
 
 

--- a/libvirt/tests/src/vfio.py
+++ b/libvirt/tests/src/vfio.py
@@ -1,10 +1,15 @@
 import logging
 import tempfile
 import re
+
 from autotest.client.shared import error
-from virttest import libvirt_vm, virsh, data_dir
-from virttest import remote, utils_misc, virt_vm
-from virttest.libvirt_xml import vm_xml
+
+from virttest import libvirt_vm
+from virttest import virsh
+from virttest import data_dir
+from virttest import remote
+from virttest import utils_misc
+from virttest import virt_vm
 from virttest.utils_test import libvirt as utlv
 
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk.py
@@ -1,10 +1,13 @@
 import os
 import time
 import logging
+
+import aexpect
+
 from autotest.client.shared import error
 from autotest.client.shared import utils
 from autotest.client import lv_utils
-from virttest import aexpect
+
 from virttest import virt_vm
 from virttest import virsh
 from virttest import remote
@@ -12,6 +15,7 @@ from virttest import utils_libvirtd
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 from virttest.staging.service import Factory
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk_lxc.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk_lxc.py
@@ -1,6 +1,8 @@
 import logging
+
 from autotest.client.shared import error
 from autotest.client.shared import utils
+
 from virttest import virsh
 from virttest import utils_test
 from virttest.utils_test import libvirt

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_interface.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_interface.py
@@ -1,7 +1,12 @@
 import logging
 import re
+
 from autotest.client.shared import error
-from virttest import libvirt_vm, virsh, utils_net, utils_misc
+
+from virttest import libvirt_vm
+from virttest import virsh
+from virttest import utils_net
+from virttest import utils_misc
 from virttest.libvirt_xml import vm_xml
 
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
@@ -6,11 +6,13 @@ import os
 import os.path
 import logging
 from string import ascii_lowercase
+
 from autotest.client.shared import error
+
 from virttest import virt_vm, virsh, remote, aexpect, utils_misc
 from virttest.libvirt_xml.vm_xml import VMXML
-# The backports module will take care of using the builtins if available
 from virttest.staging.backports import itertools
+
 from provider import libvirt_version
 
 # TODO: Move all these helper classes someplace else

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_autostart.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_autostart.py
@@ -1,5 +1,6 @@
 import logging
 import os
+
 from autotest.client.shared import error
 from virttest import virsh, utils_libvirtd
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blkdeviotune.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blkdeviotune.py
@@ -1,6 +1,10 @@
 import logging
+
 from autotest.client.shared import error
-from virttest import libvirt_xml, utils_libvirtd, virsh
+
+from virttest import libvirt_xml
+from virttest import utils_libvirtd
+from virttest import virsh
 
 
 def check_blkdeviotune(params):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockcommit.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockcommit.py
@@ -1,12 +1,17 @@
 import os
 import logging
 import tempfile
+
+import aexpect
+
 from autotest.client.shared import error
-from virttest import virsh, data_dir
-from virttest import aexpect
+
+from virttest import virsh
+from virttest import data_dir
 from virttest import utils_libvirtd
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
@@ -2,18 +2,22 @@ import logging
 import os
 import time
 import re
+
+import aexpect
+
 from autotest.client import utils
 from autotest.client.shared import error
+
 from virttest import utils_libvirtd
 from virttest import utils_config
 from virttest import virsh
 from virttest import qemu_storage
 from virttest import data_dir
-from virttest import aexpect
 from virttest import utils_misc
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import snapshot_xml
 from virttest.utils_test import libvirt as utl
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockjob.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockjob.py
@@ -1,12 +1,14 @@
 import os
 import time
 import logging
+
 from autotest.client.shared import error
+
 from virttest import data_dir
 from virttest import utils_libvirtd
+from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt as utl
-from virttest import virsh
 
 
 def finish_job(vm_name, target, timeout):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockpull.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockpull.py
@@ -1,11 +1,16 @@
 import os
 import logging
 import tempfile
+
 from autotest.client.shared import error
-from virttest import virsh, data_dir, utils_libvirtd
+
+from virttest import virsh
+from virttest import data_dir
+from virttest import utils_libvirtd
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import snapshot_xml
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockresize.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockresize.py
@@ -2,10 +2,14 @@ import os
 import re
 import logging
 import commands
-from autotest.client.shared import error
-from virttest import virsh, data_dir, utils_misc
-from provider import libvirt_version
 
+from autotest.client.shared import error
+
+from virttest import virsh
+from virttest import data_dir
+from virttest import utils_misc
+
+from provider import libvirt_version
 
 OVER_SIZE = (1 << 64)
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_change_media.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_change_media.py
@@ -1,7 +1,13 @@
 import os
 import logging
-from autotest.client.shared import error, utils
-from virttest import virsh, data_dir, virt_vm, utils_misc
+
+from autotest.client.shared import error
+from autotest.client.shared import utils
+
+from virttest import virsh
+from virttest import data_dir
+from virttest import virt_vm
+from virttest import utils_misc
 from virttest.libvirt_xml import vm_xml
 
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_console.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_console.py
@@ -1,7 +1,12 @@
 import logging
+
+import aexpect
+
 from autotest.client.shared import error
-from virttest import aexpect, utils_test
+
+from virttest import utils_test
 from virttest.libvirt_xml import vm_xml
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_baseline.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_baseline.py
@@ -1,9 +1,11 @@
 import re
 import os
 import logging
-from autotest.client.shared import error
-from virttest import virsh
 from xml.dom.minidom import parseString
+
+from autotest.client.shared import error
+
+from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_compare.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_compare.py
@@ -1,6 +1,8 @@
 import os
 import logging
+
 from autotest.client.shared import error
+
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import capability_xml

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_stats.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_stats.py
@@ -2,7 +2,9 @@ import re
 import os.path
 import logging
 import multiprocessing
+
 from autotest.client.shared import error
+
 from virttest import virsh
 from virttest.staging import utils_cgroup
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_create.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_create.py
@@ -1,8 +1,13 @@
-import time
 import commands
 import logging
+
+import aexpect
+
 from autotest.client.shared import error
-from virttest import aexpect, utils_test, virsh, utils_misc
+
+from virttest import utils_test
+from virttest import virsh
+from virttest import utils_misc
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_create_lxc.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_create_lxc.py
@@ -2,7 +2,9 @@ import os
 import logging
 import commands
 import time
+
 from autotest.client.shared import error
+
 from virttest.libvirt_xml import vm_xml
 from virttest import virsh, aexpect
 from virttest.libvirt_xml.devices.emulator import Emulator

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_define.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_define.py
@@ -1,7 +1,10 @@
 import logging
+
 from autotest.client.shared import error
-from virttest.libvirt_xml import VMXML, LibvirtXMLError
+
 from virttest import virt_vm
+from virttest.libvirt_xml import VMXML
+from virttest.libvirt_xml import LibvirtXMLError
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_desc.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_desc.py
@@ -1,6 +1,8 @@
 import logging
 import os
+
 from autotest.client.shared import error
+
 from virttest import virsh
 
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_destroy.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_destroy.py
@@ -1,5 +1,11 @@
-from autotest.client.shared import error, ssh_key
-from virttest import libvirt_vm, remote, virsh, utils_libvirtd
+from autotest.client.shared import error
+from autotest.client.shared import ssh_key
+
+from virttest import libvirt_vm
+from virttest import remote
+from virttest import virsh
+from virttest import utils_libvirtd
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device.py
@@ -1,8 +1,11 @@
 import os
 import logging
 import shutil
+
+import aexpect
+
 from autotest.client.shared import error
-from virttest import aexpect
+
 from virttest import virt_vm
 from virttest import virsh
 from virttest import remote

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domblkerror.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domblkerror.py
@@ -2,13 +2,18 @@ import logging
 import time
 import shutil
 import os
-from autotest.client.shared import error
+
 from autotest.client import utils
-from virttest import virsh, data_dir, utils_test, utils_misc
+from autotest.client.shared import error
+
+from virttest import virsh
+from virttest import data_dir
+from virttest import utils_test
+from virttest import utils_misc
 from virttest import utils_selinux
+from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.disk import Disk
 from virttest.staging.service import Factory
-from virttest.libvirt_xml import vm_xml
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domblklist.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domblklist.py
@@ -1,11 +1,12 @@
 import os
 import logging
+
 from autotest.client.shared import error
+
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices import disk
 from virttest import element_tree as ElementTree
-
 
 SOURCE_LIST = ['file', 'dev', 'dir', 'name']
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domcontrol.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domcontrol.py
@@ -1,6 +1,8 @@
 import os
 import subprocess
+
 from autotest.client.shared import error
+
 from virttest import virsh
 
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domdisplay.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domdisplay.py
@@ -2,10 +2,15 @@ import re
 import os
 import shutil
 import logging
+
 from autotest.client.shared import error
-from virttest import utils_misc, utils_libvirtd, virsh
+
+from virttest import utils_misc
+from virttest import utils_libvirtd
+from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.graphics import Graphics
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domfsthaw.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domfsthaw.py
@@ -1,4 +1,5 @@
 from autotest.client.shared import error
+
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domfstrim.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domfstrim.py
@@ -1,11 +1,15 @@
 import os
 import logging
+
 from autotest.client.shared import error
 from autotest.client import utils
-from virttest import virsh, utils_misc
+
+from virttest import virsh
+from virttest import utils_misc
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.disk import Disk
 from virttest.libvirt_xml.devices.controller import Controller
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domid.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domid.py
@@ -1,5 +1,9 @@
 from autotest.client.shared import error
-from virttest import libvirt_vm, remote, virsh, utils_libvirtd
+
+from virttest import libvirt_vm
+from virttest import remote
+from virttest import virsh
+from virttest import utils_libvirtd
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domif_setlink_getlink.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domif_setlink_getlink.py
@@ -1,7 +1,9 @@
 import logging
 import os
 import re
+
 from autotest.client.shared import error
+
 from virttest import virsh
 from virttest import utils_net
 from virttest.libvirt_xml import vm_xml

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domiflist.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domiflist.py
@@ -1,7 +1,10 @@
 import re
 import logging
+
 from autotest.client.shared import error
-from virttest import virsh, utils_net
+
+from virttest import virsh
+from virttest import utils_net
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domiftune.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domiftune.py
@@ -1,7 +1,10 @@
 import logging
+
 from autotest.client.shared import error
+
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domjobabort.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domjobabort.py
@@ -2,8 +2,10 @@ import os
 import subprocess
 import logging
 import time
+
 from autotest.client.shared import error
 from autotest.client.shared import ssh_key
+
 from virttest import virsh
 from virttest.utils_test import libvirt as utlv
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domjobinfo.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domjobinfo.py
@@ -1,6 +1,9 @@
 import os
+
 from autotest.client.shared import error
-from virttest import virsh, utils_libvirtd
+
+from virttest import virsh
+from virttest import utils_libvirtd
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domname.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domname.py
@@ -1,6 +1,9 @@
 import logging
+
 from autotest.client.shared import error
-from virttest import virsh, utils_libvirtd
+
+from virttest import virsh
+from virttest import utils_libvirtd
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_dompmsuspend.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_dompmsuspend.py
@@ -1,11 +1,14 @@
 import logging
 import os
+
 from autotest.client.shared import error
+
 from virttest import virsh
 from virttest import utils_libvirtd
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import xcepts
 from virttest.utils_test import libvirt
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domuuid.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domuuid.py
@@ -1,6 +1,10 @@
 import logging
+
 from autotest.client.shared import error
-from virttest import virsh, libvirt_xml, utils_libvirtd
+
+from virttest import virsh
+from virttest import libvirt_xml
+from virttest import utils_libvirtd
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_from_native.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_from_native.py
@@ -1,8 +1,11 @@
 import re
 import os
+
 from autotest.client.shared import error
 from autotest.client import utils
-from virttest import virsh, utils_libvirtd
+
+from virttest import virsh
+from virttest import utils_libvirtd
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_to_native.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_to_native.py
@@ -1,9 +1,12 @@
 import re
 import os
 import logging
+
 from autotest.client.shared import error
 from autotest.client import utils
-from virttest import virsh, utils_libvirtd
+
+from virttest import virsh
+from virttest import utils_libvirtd
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_dump.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_dump.py
@@ -3,12 +3,15 @@ import logging
 import commands
 import time
 import signal
+
 from autotest.client.shared import error
 from autotest.client.shared import utils
+
 from virttest import virsh
 from virttest import utils_libvirtd
 from virttest import utils_config
 from virttest.libvirt_xml import vm_xml
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_dumpxml.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_dumpxml.py
@@ -1,9 +1,12 @@
 import re
 import logging
+
 from autotest.client.shared import error
+
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import capability_xml
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_edit.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_edit.py
@@ -1,6 +1,7 @@
 import logging
-from virttest import remote
+
 from autotest.client.shared import error
+
 from virttest import virsh
 from virttest import utils_libvirtd
 from virttest import utils_misc

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_emulatorpin.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_emulatorpin.py
@@ -1,17 +1,14 @@
 import os
 import logging
 import random
-from virttest.libvirt_xml import vm_xml
+
 from autotest.client.shared import error
 from autotest.client import utils
+
+from virttest.libvirt_xml import vm_xml
 from virttest import utils_libvirtd, virsh
 from virttest.utils_test.libvirt import cpus_parser
-
-try:
-    from virttest.staging import utils_cgroup
-except ImportError:
-    # TODO: Obsoleted path used prior autotest-0.15.2/virttest-2013.06.24
-    from autotest.client.shared import utils_cgroup
+from virttest.staging import utils_cgroup
 
 
 def get_emulatorpin_from_cgroup(params):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
@@ -1,9 +1,12 @@
 import os
 import time
 import logging
-from virttest import virsh
+
+import aexpect
+
 from autotest.client.shared import error
-from virttest import aexpect
+
+from virttest import virsh
 from virttest import data_dir
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt as utlv

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_managedsave.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_managedsave.py
@@ -2,8 +2,10 @@ import os
 import re
 import time
 import logging
+
 from autotest.client import utils
 from autotest.client.shared import error
+
 from virttest import virsh
 from virttest import utils_libvirtd
 from virttest import utils_config

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_memtune.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_memtune.py
@@ -1,13 +1,11 @@
 import logging
+
 from autotest.client.shared import error
+
 from virttest import virsh
 
-try:
-    from virttest.staging import utils_memory
-    from virttest.staging import utils_cgroup
-except ImportError:
-    from autotest.client.shared import utils_memory
-    from autotest.client.shared import utils_cgroup
+from virttest.staging import utils_memory
+from virttest.staging import utils_cgroup
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_metadata.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_metadata.py
@@ -1,9 +1,12 @@
 import logging
 import xml.dom.minidom
-from virttest import aexpect
+
+import aexpect
+
+from autotest.client.shared import error
+
 from virttest import remote
 from virttest import virsh
-from autotest.client.shared import error
 from virttest.utils_test import libvirt as utlv
 from virttest.utils_libvirtd import Libvirtd
 from virttest.libvirt_xml import vm_xml

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
@@ -3,9 +3,13 @@ import os
 import re
 import time
 import codecs
+
 from autotest.client.shared import error
 from autotest.client.shared import utils
-from virttest import utils_test, virsh, utils_libvirtd
+
+from virttest import utils_test
+from virttest import virsh
+from virttest import utils_libvirtd
 from virttest.libvirt_xml import vm_xml
 
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_compcache.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_compcache.py
@@ -1,10 +1,13 @@
 import logging
 import subprocess
 import time
+
 from autotest.client.shared import error
 from autotest.client.shared import utils
 from autotest.client.shared import ssh_key
-from virttest import virsh, utils_misc
+
+from virttest import virsh
+from virttest import utils_misc
 from virttest.utils_test import libvirt as utlv
 
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_copy_storage.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_copy_storage.py
@@ -1,8 +1,11 @@
 import os
 import logging
+
 from autotest.client import lv_utils
 from autotest.client.shared import error, ssh_key
-from virttest import utils_test, libvirt_vm
+
+from virttest import utils_test
+from virttest import libvirt_vm
 from virttest.utils_test import libvirt as utlv
 
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_multi_vms.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_multi_vms.py
@@ -1,8 +1,10 @@
 import logging
 import threading
 import time
+
 from autotest.client.shared import error
 from autotest.client.shared import ssh_key
+
 from virttest import libvirt_vm
 from virttest import virsh
 from virttest import remote

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_set_get_speed.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_set_get_speed.py
@@ -1,9 +1,14 @@
 import logging
+
 from autotest.client.shared import error
 from autotest.client.shared import ssh_key
-from virttest import virsh, libvirt_vm, utils_test
-from provider import libvirt_version
+
+from virttest import virsh
+from virttest import libvirt_vm
+from virttest import utils_test
 from virttest.utils_test import libvirt as utlv
+
+from provider import libvirt_version
 
 UINT32_MAX = (1 << 32) - 1
 INT64_MAX = (1 << 63) - 1

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_setmaxdowntime.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_setmaxdowntime.py
@@ -1,10 +1,14 @@
 import logging
 import threading
 import time
+
 from autotest.client.shared import error
 from autotest.client.shared import ssh_key
+
 from virttest import virsh
+
 from provider import libvirt_version
+
 
 # To get result in thread, using global parameters
 # result of virsh migrate-setmaxdowntime command

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_stress.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_stress.py
@@ -1,11 +1,15 @@
 import os
 import logging
 import time
+
 from autotest.client.shared import utils_memory
 from autotest.client.shared import error
 from autotest.client.shared import ssh_key
+
 from virttest import libvirt_vm
-from virttest import utils_test, remote, data_dir
+from virttest import utils_test
+from virttest import remote
+from virttest import data_dir
 from virttest.utils_test import libvirt as utlv
 from virttest.libvirt_xml import vm_xml
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_virtio_scsi.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_virtio_scsi.py
@@ -2,16 +2,17 @@ import os
 import logging
 import threading
 import time
+
 from autotest.client.shared import error
 from autotest.client.shared import utils
 from autotest.client.shared import ssh_key
+
 from virttest import utils_test
 from virttest import virsh
 from virttest import utils_misc
 from virttest import libvirt_vm
 from virttest import virt_vm
 from virttest import remote
-from virttest import aexpect
 from virttest.utils_test import libvirt as utlv
 
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_numatune.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_numatune.py
@@ -1,14 +1,14 @@
-import re
 import logging
+
+from autotest.client.shared import error
+
+from virttest import libvirt_xml
+from virttest import virsh
+from virttest import utils_libvirtd
+from virttest import utils_misc
 from virttest.utils_test.libvirt import cpus_parser
-from autotest.client.shared import error, utils
-from virttest import libvirt_xml, virsh, utils_libvirtd, utils_misc
 from virttest.libvirt_xml.xcepts import LibvirtXMLAccessorError
-try:
-    from virttest.staging import utils_cgroup
-except ImportError:
-    # TODO: Obsoleted path used prior autotest-0.15.2/virttest-2013.06.24
-    from autotest.client.shared import utils_cgroup
+from virttest.staging import utils_cgroup
 
 
 def check_numatune_xml(params):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_agent_command.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_agent_command.py
@@ -1,9 +1,12 @@
 import os
 import time
 import logging
+
+import aexpect
+
 from autotest.client.shared import error
+
 from virttest import virsh
-from virttest import aexpect
 from virttest import remote
 from virttest import utils_libvirtd
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_agent_command_fs.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_agent_command_fs.py
@@ -1,6 +1,8 @@
 import time
 import logging
+
 from autotest.client.shared import error
+
 from virttest import virsh
 from virttest import utils_misc
 from virttest.utils_test import libvirt

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_attach.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_attach.py
@@ -1,7 +1,11 @@
 import re
 import logging
+
 from autotest.client.shared import error
-from virttest import virsh, utils_libvirtd, qemu_vm
+
+from virttest import virsh
+from virttest import utils_libvirtd
+from virttest import qemu_vm
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_monitor_blockjob.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_monitor_blockjob.py
@@ -1,10 +1,16 @@
 import logging
 import time
 import threading
-from autotest.client.shared import error, ssh_key
-from virttest import utils_test, libvirt_vm, virsh
+
+from autotest.client.shared import error
+from autotest.client.shared import ssh_key
+
+from virttest import utils_test
+from virttest import libvirt_vm
+from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt as utlv
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_monitor_command.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_monitor_command.py
@@ -1,6 +1,9 @@
 import logging
+
 from autotest.client.shared import error
-from virttest import virsh, utils_libvirtd
+
+from virttest import virsh
+from virttest import utils_libvirtd
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_reboot.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_reboot.py
@@ -1,7 +1,12 @@
 import re
 import logging
+
+import aexpect
+
 from autotest.client.shared import error
-from virttest import libvirt_vm, virt_vm, aexpect
+
+from virttest import libvirt_vm
+from virttest import virt_vm
 from virttest import virsh
 from virttest import remote
 from virttest import utils_libvirtd

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_reset.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_reset.py
@@ -1,8 +1,12 @@
 import logging
 import commands
+
 from autotest.client.shared import error
-from virttest import utils_misc, virsh
+
+from virttest import utils_misc
+from virttest import virsh
 from virttest.libvirt_xml import vm_xml
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_restore.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_restore.py
@@ -1,7 +1,11 @@
 import re
 import os
+
 from autotest.client.shared import error
-from virttest import virsh, utils_libvirtd
+
+from virttest import virsh
+from virttest import utils_libvirtd
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_resume.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_resume.py
@@ -1,5 +1,7 @@
 import logging
+
 from autotest.client.shared import error
+
 from virttest import virsh
 
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_save.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_save.py
@@ -1,7 +1,10 @@
 import os
+
 from autotest.client.shared import error
+
 from virttest import virsh
 from virttest import utils_libvirtd
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_save_image_define.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_save_image_define.py
@@ -2,7 +2,9 @@ import os
 import logging
 import tempfile
 import re
+
 from autotest.client.shared import error
+
 from virttest import data_dir
 from virttest import virsh
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_save_image_edit.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_save_image_edit.py
@@ -1,8 +1,11 @@
 import logging
 import os
 import re
+
+import aexpect
+
 from autotest.client.shared import error
-from virttest import aexpect
+
 from virttest import data_dir
 from virttest import remote
 from virttest import virsh

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_schedinfo_qemu_posix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_schedinfo_qemu_posix.py
@@ -1,14 +1,14 @@
 import re
 import logging
 import os
-from autotest.client.shared import error
-from virttest.libvirt_xml import vm_xml, xcepts
-from virttest import virsh
 
-try:
-    from virttest.staging import utils_cgroup
-except ImportError:
-    from autotest.client.shared import utils_cgroup
+from autotest.client.shared import error
+
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.libvirt_xml import xcepts
+
+from virttest.staging import utils_cgroup
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_schedinfo_xen_credit.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_schedinfo_xen_credit.py
@@ -1,6 +1,8 @@
 import re
 import logging
+
 from autotest.client.shared import error
+
 from virttest import virsh
 
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_screenshot.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_screenshot.py
@@ -1,9 +1,12 @@
 import os
 import logging
+
 from autotest.client.shared import error
+
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.video import Video
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_sendkey.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_sendkey.py
@@ -1,7 +1,10 @@
 import logging
 import time
+
 from autotest.client.shared import error
+
 from virttest import virsh
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_setmaxmem.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_setmaxmem.py
@@ -1,6 +1,10 @@
 import logging
-from autotest.client.shared import utils, error
-from virttest import virsh, virt_vm
+
+from autotest.client.shared import utils
+from autotest.client.shared import error
+
+from virttest import virsh
+from virttest import virt_vm
 from virttest.libvirt_xml import vm_xml
 
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_setmem.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_setmem.py
@@ -2,12 +2,14 @@ import re
 import os
 import logging
 import time
+
 from autotest.client.shared import error
+
 from virttest import virsh
 from virttest import utils_libvirtd
 from virttest import data_dir
-from virttest.utils_test import libvirt
 from virttest import utils_misc
+from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
 
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_setvcpus.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_setvcpus.py
@@ -1,13 +1,15 @@
 import re
 import os
 import logging
+from xml.dom.minidom import parse
+
 from autotest.client.shared import error
+
 from virttest import remote
 from virttest import virsh
-from virttest.libvirt_xml import vm_xml
 from virttest import libvirt_vm
+from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
-from xml.dom.minidom import parse
 
 
 def remote_test(remote_ip, local_ip, remote_pwd, remote_prompt,

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_shutdown.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_shutdown.py
@@ -1,9 +1,11 @@
 from autotest.client.shared import error
+
 from virttest import remote
 from virttest import libvirt_vm
 from virttest import virsh
 from virttest import utils_libvirtd
 from virttest.libvirt_xml import vm_xml
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_start.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_start.py
@@ -1,5 +1,10 @@
 from autotest.client.shared import error
-from virttest import remote, libvirt_vm, virsh, libvirt_xml, utils_libvirtd
+
+from virttest import remote
+from virttest import libvirt_vm
+from virttest import virsh
+from virttest import libvirt_xml
+from virttest import utils_libvirtd
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_suspend.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_suspend.py
@@ -1,5 +1,7 @@
 from autotest.client.shared import error
+
 from virttest import virsh
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_ttyconsole.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_ttyconsole.py
@@ -1,6 +1,9 @@
 import logging
+
 from autotest.client.shared import error
-from virttest import libvirt_vm, virsh
+
+from virttest import libvirt_vm
+from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_undefine.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_undefine.py
@@ -1,15 +1,19 @@
 import os
 import logging
+
+import aexpect
+
 from autotest.client.shared import error
 from autotest.client import utils
+
 from virttest import libvirt_vm
 from virttest import virsh
 from virttest import remote
 from virttest import utils_libvirtd
-from virttest import aexpect
 from virttest import libvirt_storage
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt as utlv
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_update_device.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_update_device.py
@@ -1,9 +1,12 @@
 import os
 import shutil
 import logging
+
 from autotest.client.shared import error
+
 from virttest import virsh
 from virttest.libvirt_xml import VMXML
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_vcpucount.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_vcpucount.py
@@ -1,7 +1,10 @@
 import os
 import logging
+
 from autotest.client.shared import error
-from virttest import virsh, libvirt_xml
+
+from virttest import virsh
+from virttest import libvirt_xml
 
 
 def reset_domain(vm, vm_state, needs_agent=False):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_vcpuinfo.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_vcpuinfo.py
@@ -1,6 +1,9 @@
 import logging
+
 from autotest.client.shared import error
-from virttest import virsh, utils_libvirtd
+
+from virttest import virsh
+from virttest import utils_libvirtd
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_vcpupin.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_vcpupin.py
@@ -1,12 +1,15 @@
 import logging
 import re
 import random
+
 from autotest.client import utils
 from autotest.client.shared import error
-from virttest import virsh, utils_test
+
+from virttest import virsh
+from virttest import utils_test
+from virttest import utils_misc
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
-from virttest import utils_misc
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_vncdisplay.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_vncdisplay.py
@@ -1,4 +1,5 @@
 from autotest.client.shared import error
+
 from virttest import libvirt_vm
 from virttest import virsh
 from virttest import remote

--- a/libvirt/tests/src/virsh_cmd/filter/virsh_nwfilter_define.py
+++ b/libvirt/tests/src/virsh_cmd/filter/virsh_nwfilter_define.py
@@ -1,10 +1,14 @@
 import os
 import logging
-from autotest.client.shared import error
-from virttest import virsh, xml_utils, libvirt_xml
-from virttest.utils_test import libvirt as utlv
-from provider import libvirt_version
 
+from autotest.client.shared import error
+
+from virttest import virsh
+from virttest import xml_utils
+from virttest import libvirt_xml
+from virttest.utils_test import libvirt as utlv
+
+from provider import libvirt_version
 
 NWFILTER_ETC_DIR = "/etc/libvirt/nwfilter"
 

--- a/libvirt/tests/src/virsh_cmd/filter/virsh_nwfilter_dumpxml.py
+++ b/libvirt/tests/src/virsh_cmd/filter/virsh_nwfilter_dumpxml.py
@@ -1,6 +1,10 @@
 import logging
+
 from autotest.client.shared import error
-from virttest import virsh, libvirt_xml
+
+from virttest import virsh
+from virttest import libvirt_xml
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/filter/virsh_nwfilter_edit.py
+++ b/libvirt/tests/src/virsh_cmd/filter/virsh_nwfilter_edit.py
@@ -1,6 +1,12 @@
 import logging
+
+import aexpect
+
 from autotest.client.shared import error
-from virttest import virsh, libvirt_xml, aexpect, remote
+
+from virttest import virsh
+from virttest import libvirt_xml
+from virttest import remote
 
 
 def edit_filter_xml(filter_name, edit_cmd):

--- a/libvirt/tests/src/virsh_cmd/filter/virsh_nwfilter_list.py
+++ b/libvirt/tests/src/virsh_cmd/filter/virsh_nwfilter_list.py
@@ -1,9 +1,11 @@
 import os
 import logging
-from autotest.client.shared import error
-from virttest import virsh
-from provider import libvirt_version
 
+from autotest.client.shared import error
+
+from virttest import virsh
+
+from provider import libvirt_version
 
 NWFILTER_ETC_DIR = "/etc/libvirt/nwfilter"
 

--- a/libvirt/tests/src/virsh_cmd/filter/virsh_nwfilter_undefine.py
+++ b/libvirt/tests/src/virsh_cmd/filter/virsh_nwfilter_undefine.py
@@ -1,6 +1,10 @@
 import logging
+
 from autotest.client.shared import error
-from virttest import virsh, libvirt_xml
+
+from virttest import virsh
+from virttest import libvirt_xml
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/host/virsh_capabilities.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_capabilities.py
@@ -1,8 +1,14 @@
 import logging
 import re
-from autotest.client.shared import utils, error
+
 from autotest.client import os_dep
-from virttest import libvirt_vm, virsh, utils_libvirtd, utils_misc
+from autotest.client.shared import utils
+from autotest.client.shared import error
+
+from virttest import libvirt_vm
+from virttest import virsh
+from virttest import utils_libvirtd
+from virttest import utils_misc
 from virttest.libvirt_xml import capability_xml
 
 

--- a/libvirt/tests/src/virsh_cmd/host/virsh_cpu_models.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_cpu_models.py
@@ -1,5 +1,7 @@
 import logging
+
 from autotest.client.shared import error
+
 from virttest import virsh
 from virttest import libvirt_vm
 from virttest.libvirt_xml import capability_xml

--- a/libvirt/tests/src/virsh_cmd/host/virsh_domcapabilities.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_domcapabilities.py
@@ -1,4 +1,5 @@
 from autotest.client.shared import error
+
 from virttest import libvirt_vm
 from virttest import virsh
 from virttest.utils_test import libvirt as utlv

--- a/libvirt/tests/src/virsh_cmd/host/virsh_freecell.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_freecell.py
@@ -1,6 +1,9 @@
 import re
+
 from autotest.client.shared import error
-from virttest import libvirt_vm, virsh, utils_libvirtd
+
+from virttest import virsh
+from virttest import utils_libvirtd
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/host/virsh_freepages.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_freepages.py
@@ -1,8 +1,10 @@
 import logging
+
 from autotest.client.shared import error
 from autotest.client import utils
-from virttest.staging import utils_memory
+
 from virttest import virsh
+from virttest.staging import utils_memory
 from virttest.utils_test import libvirt as utlv
 
 

--- a/libvirt/tests/src/virsh_cmd/host/virsh_hostname.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_hostname.py
@@ -1,5 +1,8 @@
-from autotest.client.shared import utils, error
-from virttest import virsh, utils_libvirtd
+from autotest.client.shared import utils
+from autotest.client.shared import error
+
+from virttest import virsh
+from virttest import utils_libvirtd
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/host/virsh_maxvcpus.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_maxvcpus.py
@@ -1,7 +1,10 @@
 import logging
 
 from autotest.client.shared import error
-from virttest import libvirt_vm, virsh, utils_conn
+
+from virttest import libvirt_vm
+from virttest import virsh
+from virttest import utils_conn
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/host/virsh_node_memtune.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_node_memtune.py
@@ -1,8 +1,9 @@
 import os
 import logging
-from autotest.client.shared import error
-from virttest import virsh
 
+from autotest.client.shared import error
+
+from virttest import virsh
 
 _SYSFS_MEMORY_KSM_PATH = "/sys/kernel/mm/ksm"
 

--- a/libvirt/tests/src/virsh_cmd/host/virsh_nodecpumap.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_nodecpumap.py
@@ -1,9 +1,10 @@
 import os
 import logging
+
 from autotest.client import utils
 from autotest.client.shared import error
-from virttest import virsh
 
+from virttest import virsh
 
 SYSFS_SYSTEM_PATH = "/sys/devices/system/cpu"
 

--- a/libvirt/tests/src/virsh_cmd/host/virsh_nodecpustats.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_nodecpustats.py
@@ -1,7 +1,10 @@
 import re
+
 from autotest.client.shared import error
 from autotest.client import utils
-from virttest import virsh, utils_libvirtd
+
+from virttest import virsh
+from virttest import utils_libvirtd
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/host/virsh_nodeinfo.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_nodeinfo.py
@@ -1,13 +1,13 @@
 import re
 import logging
+
 from autotest.client import utils
 from autotest.client.shared import error
-from virttest import virsh, utils_libvirtd
+
+from virttest import virsh
+from virttest import utils_libvirtd
 from virttest.libvirt_xml import capability_xml
-try:
-    from virttest.staging import utils_memory
-except ImportError:
-    from autotest.client.shared import utils_memory
+from virttest.staging import utils_memory
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/host/virsh_nodememstats.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_nodememstats.py
@@ -1,14 +1,12 @@
 import logging
 import re
+
 from autotest.client.shared import error
-from virttest import virsh, utils_libvirtd
+
+from virttest import virsh
+from virttest import utils_libvirtd
 from virttest import utils_test
-
-
-try:
-    from virttest.staging import utils_memory
-except ImportError:
-    from autotest.client.shared import utils_memory
+from virttest.staging import utils_memory
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/host/virsh_nodesuspend.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_nodesuspend.py
@@ -1,10 +1,13 @@
 import time
 import logging
-from virttest import virsh
-from virttest import libvirt_vm
-from virttest.remote import LoginTimeoutError, LoginProcessTerminatedError
+
 from autotest.client.shared import error
 from autotest.client import utils
+
+from virttest import virsh
+from virttest import libvirt_vm
+from virttest.remote import LoginTimeoutError
+from virttest.remote import LoginProcessTerminatedError
 
 
 class TimeoutError(Exception):

--- a/libvirt/tests/src/virsh_cmd/host/virsh_sysinfo.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_sysinfo.py
@@ -1,6 +1,8 @@
 import logging
+
 from autotest.client import utils
 from autotest.client.shared import error
+
 from virttest import libvirt_xml
 from virttest import virsh
 

--- a/libvirt/tests/src/virsh_cmd/host/virsh_uri.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_uri.py
@@ -1,6 +1,10 @@
 import logging
+
 from autotest.client.shared import error
-from virttest import libvirt_vm, virsh, utils_libvirtd
+
+from virttest import libvirt_vm
+from virttest import virsh
+from virttest import utils_libvirtd
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/host/virsh_version.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_version.py
@@ -1,4 +1,5 @@
 from autotest.client.shared import error
+
 from virttest import libvirt_vm
 from virttest import virsh
 from virttest import utils_libvirtd

--- a/libvirt/tests/src/virsh_cmd/interface/virsh_iface.py
+++ b/libvirt/tests/src/virsh_cmd/interface/virsh_iface.py
@@ -1,14 +1,17 @@
 import os
 import logging
+
 from autotest.client import utils
 from autotest.client.shared import error
-from virttest.utils_test import libvirt
-from virttest.staging import service
+
 from virttest import utils_net
 from virttest import utils_misc
 from virttest import virsh
 from virttest import remote
 from virttest.libvirt_xml import vm_xml
+from virttest.utils_test import libvirt
+from virttest.staging import service
+
 from provider import libvirt_version
 
 NETWORK_SCRIPT = "/etc/sysconfig/network-scripts/ifcfg-"

--- a/libvirt/tests/src/virsh_cmd/interface/virsh_iface_bridge.py
+++ b/libvirt/tests/src/virsh_cmd/interface/virsh_iface_bridge.py
@@ -3,11 +3,12 @@ import logging
 
 from autotest.client.shared import error
 from autotest.client import utils
-from virttest.utils_test import libvirt
-from virttest.staging import service
+
 from virttest import utils_misc
 from virttest import utils_net
 from virttest import virsh
+from virttest.utils_test import libvirt
+from virttest.staging import service
 
 NETWORK_SCRIPT = "/etc/sysconfig/network-scripts/ifcfg-"
 

--- a/libvirt/tests/src/virsh_cmd/interface/virsh_iface_edit.py
+++ b/libvirt/tests/src/virsh_cmd/interface/virsh_iface_edit.py
@@ -1,13 +1,16 @@
 import os
 import re
 import logging
+
+import aexpect
+
 from autotest.client import utils
 from autotest.client.shared import error
-from virttest import aexpect
+
 from virttest import remote
-from virttest.utils_test import libvirt
 from virttest import utils_net
 from virttest import virsh
+from virttest.utils_test import libvirt
 
 NETWORK_SCRIPT = "/etc/sysconfig/network-scripts/ifcfg-"
 

--- a/libvirt/tests/src/virsh_cmd/interface/virsh_iface_trans.py
+++ b/libvirt/tests/src/virsh_cmd/interface/virsh_iface_trans.py
@@ -3,10 +3,11 @@ import re
 import logging
 import commands
 
+from autotest.client.shared import error
+
 from virttest import virsh
 from virttest import utils_libvirtd
 from virttest import utils_misc
-from autotest.client.shared import error
 
 
 def netcf_trans_control(command="status"):

--- a/libvirt/tests/src/virsh_cmd/monitor/virsh_domblkinfo.py
+++ b/libvirt/tests/src/virsh_cmd/monitor/virsh_domblkinfo.py
@@ -1,5 +1,7 @@
 import os
+
 from autotest.client.shared import error
+
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 

--- a/libvirt/tests/src/virsh_cmd/monitor/virsh_domblkstat.py
+++ b/libvirt/tests/src/virsh_cmd/monitor/virsh_domblkstat.py
@@ -1,4 +1,5 @@
 from autotest.client.shared import error
+
 from virttest import virsh
 from virttest import libvirt_xml
 from virttest import utils_libvirtd

--- a/libvirt/tests/src/virsh_cmd/monitor/virsh_domifstat.py
+++ b/libvirt/tests/src/virsh_cmd/monitor/virsh_domifstat.py
@@ -1,6 +1,10 @@
-from autotest.client.shared import error, utils
-from virttest import virsh, utils_libvirtd
 from xml.dom.minidom import parseString
+
+from autotest.client.shared import error
+from autotest.client.shared import utils
+
+from virttest import virsh
+from virttest import utils_libvirtd
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/monitor/virsh_dominfo.py
+++ b/libvirt/tests/src/virsh_cmd/monitor/virsh_dominfo.py
@@ -1,5 +1,9 @@
 from autotest.client.shared import error
-from virttest import libvirt_vm, remote, virsh, utils_libvirtd
+
+from virttest import libvirt_vm
+from virttest import remote
+from virttest import virsh
+from virttest import utils_libvirtd
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/monitor/virsh_dommemstat.py
+++ b/libvirt/tests/src/virsh_cmd/monitor/virsh_dommemstat.py
@@ -1,5 +1,9 @@
 from autotest.client.shared import error
-from virttest import libvirt_vm, virsh, remote, utils_libvirtd
+
+from virttest import libvirt_vm
+from virttest import virsh
+from virttest import remote
+from virttest import utils_libvirtd
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/monitor/virsh_domstate.py
+++ b/libvirt/tests/src/virsh_cmd/monitor/virsh_domstate.py
@@ -2,17 +2,20 @@ import re
 import os
 import shutil
 import logging
+
+from aexpect import ShellTimeoutError
+from aexpect import ShellProcessTerminatedError
+
 from autotest.client.shared import error
-from virttest.utils_misc import kill_process_by_pattern
 from autotest.client.shared import utils
+
 from virttest import libvirt_vm
 from virttest import remote
 from virttest import virsh
 from virttest import utils_libvirtd
+from virttest.utils_misc import kill_process_by_pattern
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.panic import Panic
-from virttest.aexpect import ShellTimeoutError
-from virttest.aexpect import ShellProcessTerminatedError
 
 QEMU_CONF = "/etc/libvirt/qemu.conf"
 QEMU_CONF_BK = "/etc/libvirt/qemu.conf.bk"

--- a/libvirt/tests/src/virsh_cmd/monitor/virsh_domstats.py
+++ b/libvirt/tests/src/virsh_cmd/monitor/virsh_domstats.py
@@ -1,10 +1,13 @@
 import logging
+
+from aexpect import ShellTimeoutError
+from aexpect import ShellProcessTerminatedError
+
 from autotest.client.shared import error
+
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.panic import Panic
-from virttest.aexpect import ShellTimeoutError
-from virttest.aexpect import ShellProcessTerminatedError
 
 
 def prepare_vm_state(vm, vm_state):

--- a/libvirt/tests/src/virsh_cmd/monitor/virsh_list.py
+++ b/libvirt/tests/src/virsh_cmd/monitor/virsh_list.py
@@ -1,7 +1,9 @@
 import re
 import logging
 import time
+
 from autotest.client.shared import error
+
 from virttest import virsh
 from virttest import libvirt_vm
 from virttest import remote

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_autostart.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_autostart.py
@@ -1,7 +1,11 @@
 import logging
+
 from autotest.client.shared import error
-from virttest import virsh, utils_libvirtd
-from virttest.libvirt_xml import network_xml, xcepts
+
+from virttest import virsh
+from virttest import utils_libvirtd
+from virttest.libvirt_xml import network_xml
+from virttest.libvirt_xml import xcepts
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_create.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_create.py
@@ -1,6 +1,11 @@
 import logging
+
 from autotest.client.shared import error
-from virttest import libvirt_vm, libvirt_xml, virsh, xml_utils
+
+from virttest import libvirt_vm
+from virttest import libvirt_xml
+from virttest import virsh
+from virttest import xml_utils
 
 
 def do_low_level_test(virsh_dargs, test_xml, options_ref, extra):

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_define_undefine.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_define_undefine.py
@@ -1,8 +1,13 @@
 import logging
+
 from autotest.client.shared import utils, error
-from virttest import virsh, libvirt_vm, xml_utils
-from virttest.libvirt_xml import network_xml, xcepts
+
+from virttest import virsh
+from virttest import libvirt_vm
+from virttest import xml_utils
 from virttest import utils_libvirtd
+from virttest.libvirt_xml import network_xml
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_destroy.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_destroy.py
@@ -1,6 +1,9 @@
 import re
+
 from autotest.client.shared import error
+
 from virttest import virsh
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_dhcp_leases.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_dhcp_leases.py
@@ -1,13 +1,14 @@
 import re
 import logging
+
 from autotest.client.shared import error
-from virttest.libvirt_xml import vm_xml
-from virttest.libvirt_xml import network_xml
-from virttest.utils_test import libvirt as utlv
+
 from virttest import utils_net
 from virttest import utils_misc
 from virttest import virsh
-
+from virttest.libvirt_xml import vm_xml
+from virttest.libvirt_xml import network_xml
+from virttest.utils_test import libvirt as utlv
 
 BUG_URL = "https://bugzilla.redhat.com/show_bug.cgi?id=%s"
 

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_dumpxml.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_dumpxml.py
@@ -1,7 +1,10 @@
 import os
+
 from autotest.client.shared import error
 from autotest.client.shared import utils
+
 from virttest import virsh
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_edit.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_edit.py
@@ -1,11 +1,15 @@
 import logging
 import re
-from virttest.libvirt_xml import network_xml, xcepts
-from virttest import aexpect
-from virttest import remote
+
+import aexpect
+
 from autotest.client.shared import error
+
+from virttest import remote
 from virttest import virsh
 from virttest import utils_libvirtd
+from virttest.libvirt_xml import network_xml
+from virttest.libvirt_xml import xcepts
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_event.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_event.py
@@ -1,8 +1,11 @@
 import time
 import logging
-from virttest import virsh
+
+import aexpect
+
 from autotest.client.shared import error
-from virttest import aexpect
+
+from virttest import virsh
 from virttest.utils_test import libvirt as utlv
 
 

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_info.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_info.py
@@ -1,5 +1,7 @@
 from autotest.client.shared import error
-from virttest import virsh, libvirt_vm
+
+from virttest import virsh
+from virttest import libvirt_vm
 from virttest.libvirt_xml import network_xml
 
 

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_list.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_list.py
@@ -1,7 +1,10 @@
 import re
 import os
+
 from autotest.client.shared import error
+
 from virttest import virsh
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_name.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_name.py
@@ -1,4 +1,5 @@
 from autotest.client.shared import error
+
 from virttest import virsh
 
 

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_start.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_start.py
@@ -1,7 +1,11 @@
 import logging
+
 from autotest.client.shared import error
-from virttest import virsh, libvirt_vm
+
+from virttest import virsh
+from virttest import libvirt_vm
 from virttest.libvirt_xml import network_xml
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_update.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_update.py
@@ -2,10 +2,13 @@ import os
 import logging
 import re
 import tempfile
+
 from autotest.client.shared import error
+
 from virttest import data_dir
-from virttest.libvirt_xml import network_xml, xcepts
 from virttest import virsh
+from virttest.libvirt_xml import network_xml
+from virttest.libvirt_xml import xcepts
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_uuid.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_uuid.py
@@ -1,6 +1,8 @@
 import re
 import logging
+
 from autotest.client.shared import error
+
 from virttest import virsh
 from virttest.libvirt_xml import network_xml
 

--- a/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_create_destroy.py
+++ b/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_create_destroy.py
@@ -3,11 +3,12 @@ import re
 import logging
 from tempfile import mktemp
 
-from virttest import virsh
 from autotest.client.shared import error
-from virttest.libvirt_xml.nodedev_xml import NodedevXML
-from provider import libvirt_version
 
+from virttest import virsh
+from virttest.libvirt_xml.nodedev_xml import NodedevXML
+
+from provider import libvirt_version
 
 _FC_HOST_PATH = "/sys/class/fc_host"
 

--- a/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_detach_reattach.py
+++ b/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_detach_reattach.py
@@ -1,8 +1,11 @@
 import os
 import logging
+
 from autotest.client.shared import error
+
 from virttest import virsh
 from virttest.libvirt_xml import nodedev_xml
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_dumpxml.py
+++ b/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_dumpxml.py
@@ -1,8 +1,11 @@
 import logging
+
 from autotest.client import utils
 from autotest.client.shared import error
+
 from virttest import virsh
 from virttest.libvirt_xml import nodedev_xml
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_list.py
+++ b/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_list.py
@@ -1,9 +1,13 @@
 import logging
 import os
 import re
-from autotest.client.shared import error, utils
+
+from autotest.client.shared import error
+from autotest.client.shared import utils
+
 from virttest import virsh
 from virttest import utils_misc
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_reset.py
+++ b/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_reset.py
@@ -2,11 +2,13 @@ import os
 import re
 import logging
 import tempfile
+
+from autotest.client.shared import error
+
 from virttest import virsh
 from virttest import data_dir
 from virttest import utils_libvirtd
 from virttest.libvirt_xml.vm_xml import VMXML
-from autotest.client.shared import error
 
 
 def get_pci_info():

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_find_storage_pool_sources.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_find_storage_pool_sources.py
@@ -1,10 +1,13 @@
 import logging
-from virttest import xml_utils
-from virttest import utils_test
+
 from autotest.client import utils
 from autotest.client import lv_utils
 from autotest.client.shared import error
+
+from virttest import xml_utils
+from virttest import utils_test
 from virttest import virsh
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_find_storage_pool_sources_as.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_find_storage_pool_sources_as.py
@@ -1,8 +1,11 @@
 import logging
-import os
-from virttest import virsh, utils_test, utils_misc
-from autotest.client import utils, lv_utils
+
+from autotest.client import utils
+from autotest.client import lv_utils
 from autotest.client.shared import error
+
+from virttest import virsh
+from virttest import utils_test
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool.py
@@ -1,12 +1,15 @@
 import re
 import os
 import logging
+
 from autotest.client.shared import error
+
 from virttest import utils_libvirtd
 from virttest import libvirt_storage
 from virttest import virsh
 from virttest.utils_test import libvirt as utlv
 from virttest.staging import service
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool_acl.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool_acl.py
@@ -1,13 +1,16 @@
 import re
 import os
 import logging
+
 from autotest.client import utils
 from autotest.client import lv_utils
 from autotest.client.shared import error
+
 from virttest import libvirt_storage
 from virttest import utils_test
 from virttest import virsh
 from virttest.libvirt_xml.pool_xml import PoolXML
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool_create.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool_create.py
@@ -1,12 +1,15 @@
 import os
 import logging
+
 from autotest.client.shared import error
 from autotest.client import utils
+
 from virttest import virsh
 from virttest import xml_utils
 from virttest import libvirt_storage
 from virttest import libvirt_xml
 from virttest.utils_test import libvirt as utlv
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool_create_as.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool_create_as.py
@@ -1,6 +1,8 @@
 import os
 import logging
+
 from autotest.client.shared import error
+
 from virttest import libvirt_storage
 from virttest import virsh
 

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool_edit.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool_edit.py
@@ -1,13 +1,17 @@
 import os
 import logging
+
+import aexpect
+
 from autotest.client.shared import error
+
 from virttest import virsh
 from virttest import libvirt_storage
 from virttest import data_dir
 from virttest import remote
-from virttest import aexpect
 from virttest.libvirt_xml import pool_xml
 from virttest.utils_test import libvirt
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/secret/virsh_secret_define_undefine.py
+++ b/libvirt/tests/src/virsh_cmd/secret/virsh_secret_define_undefine.py
@@ -1,13 +1,15 @@
 import os
-import tempfile
 import commands
 import logging
+
 from autotest.client import utils
 from autotest.client.shared import error
-from virttest import virsh, data_dir
-from virttest.libvirt_xml.secret_xml import SecretXML
-from provider import libvirt_version
 
+from virttest import virsh
+from virttest import data_dir
+from virttest.libvirt_xml.secret_xml import SecretXML
+
+from provider import libvirt_version
 
 SECRET_DIR = "/etc/libvirt/secrets/"
 SECRET_BASE64 = "c2VjcmV0X3Rlc3QK"

--- a/libvirt/tests/src/virsh_cmd/secret/virsh_secret_dumpxml.py
+++ b/libvirt/tests/src/virsh_cmd/secret/virsh_secret_dumpxml.py
@@ -1,10 +1,13 @@
 import os
 import re
 import commands
-import logging
 import tempfile
+
 from autotest.client.shared import error
-from virttest import virsh, data_dir
+
+from virttest import virsh
+from virttest import data_dir
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/secret/virsh_secret_list.py
+++ b/libvirt/tests/src/virsh_cmd/secret/virsh_secret_list.py
@@ -1,10 +1,13 @@
 import os
 import re
 import commands
+
 from autotest.client.shared import error
+
 from virttest import virsh
 from virttest import data_dir
 from virttest.libvirt_xml.secret_xml import SecretXML
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/secret/virsh_secret_set_get.py
+++ b/libvirt/tests/src/virsh_cmd/secret/virsh_secret_set_get.py
@@ -4,11 +4,11 @@ import base64
 import logging
 from tempfile import mktemp
 
-from virttest import virsh
 from autotest.client import utils
 from autotest.client.shared import error
-from virttest.libvirt_xml.secret_xml import SecretXML
 
+from virttest import virsh
+from virttest.libvirt_xml.secret_xml import SecretXML
 
 _VIRT_SECRETS_PATH = "/etc/libvirt/secrets"
 

--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot.py
@@ -1,7 +1,9 @@
 import logging
 import re
-from virttest import virt_vm
+
 from autotest.client.shared import error
+
+from virttest import virt_vm
 from virttest import virsh
 
 

--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_create_as.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_create_as.py
@@ -4,18 +4,21 @@ import time
 import commands
 import string
 import logging
+
 from autotest.client.shared import error
 from autotest.client import utils
+
 from virttest import virsh
 from virttest import utils_misc
 from virttest import xml_utils
-from virttest import libvirt_xml
 from virttest import utils_config
 from virttest import utils_libvirtd
 from virttest import data_dir
-from virttest.libvirt_xml import vm_xml, xcepts
-from virttest.libvirt_xml.devices import disk
 from virttest.utils_test import libvirt
+from virttest.libvirt_xml import vm_xml
+from virttest.libvirt_xml import xcepts
+from virttest.libvirt_xml.devices import disk
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_disk.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_disk.py
@@ -2,13 +2,18 @@ import os
 import logging
 import re
 import tempfile
+
 from autotest.client.shared import error
 from autotest.client import utils
-from virttest import virsh, qemu_storage, data_dir
+
+from virttest import virsh
+from virttest import qemu_storage
+from virttest import data_dir
 from virttest import libvirt_xml
 from virttest import libvirt_storage
 from virttest import utils_libvirtd
 from virttest.utils_test import libvirt as utlv
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_dumpxml.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_dumpxml.py
@@ -1,9 +1,11 @@
 import re
-import os
 import time
 import logging
+
 from autotest.client.shared import error
-from virttest import virsh, utils_test
+
+from virttest import virsh
+from virttest import utils_test
 from virttest.libvirt_xml import vm_xml
 
 

--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_edit.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_edit.py
@@ -1,8 +1,14 @@
 import re
 import time
 import logging
+
+import aexpect
+
 from autotest.client.shared import error
-from virttest import virsh, aexpect, utils_test, remote
+
+from virttest import virsh
+from virttest import utils_test
+from virttest import remote
 from virttest.libvirt_xml import vm_xml
 
 

--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_par_cur.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_par_cur.py
@@ -2,8 +2,11 @@ import os
 import re
 import time
 import logging
+
 from autotest.client.shared import error
-from virttest import virsh, utils_test
+
+from virttest import virsh
+from virttest import utils_test
 from virttest.libvirt_xml import vm_xml
 
 

--- a/libvirt/tests/src/virsh_cmd/virsh_connect.py
+++ b/libvirt/tests/src/virsh_cmd/virsh_connect.py
@@ -3,9 +3,12 @@ import os
 import re
 import shutil
 
-from autotest.client import os_dep
 from autotest.client.shared import error
-from virttest import libvirt_vm, utils_libvirtd, virsh, utils_conn
+
+from virttest import libvirt_vm
+from virttest import utils_libvirtd
+from virttest import virsh
+from virttest import utils_conn
 
 
 def do_virsh_connect(uri, options):

--- a/libvirt/tests/src/virsh_cmd/virsh_help.py
+++ b/libvirt/tests/src/virsh_cmd/virsh_help.py
@@ -1,5 +1,7 @@
 import logging
+
 from autotest.client.shared import error
+
 from virttest import virsh
 
 

--- a/libvirt/tests/src/virsh_cmd/virsh_itself.py
+++ b/libvirt/tests/src/virsh_cmd/virsh_itself.py
@@ -1,7 +1,11 @@
 import logging
+
 from autotest.client import utils
 from autotest.client.shared import error
-from virttest import virsh, aexpect, element_tree
+
+from virttest import virsh
+from virttest import aexpect
+from virttest import element_tree
 
 
 def sh_escape(sh_str):

--- a/libvirt/tests/src/virsh_cmd/volume/virsh_vol_clone_wipe.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_vol_clone_wipe.py
@@ -1,12 +1,15 @@
 import os
 import random
 import logging
+
 from autotest.client import utils
 from autotest.client.shared import error
+
 from virttest.utils_test import libvirt
 from virttest import libvirt_storage
 from virttest import virsh
 from virttest import utils_misc
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/volume/virsh_vol_create.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_vol_create.py
@@ -1,11 +1,16 @@
 import os
 import logging
-from virttest import virsh, libvirt_storage, libvirt_xml
-from virttest.utils_test import libvirt as utlv
-from autotest.client.shared import error
+
 from autotest.client import utils
-from provider import libvirt_version
+from autotest.client.shared import error
+
+from virttest import virsh
+from virttest import libvirt_storage
+from virttest import libvirt_xml
+from virttest.utils_test import libvirt as utlv
 from virttest.staging import service
+
+from provider import libvirt_version
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/volume/virsh_vol_create_from.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_vol_create_from.py
@@ -1,8 +1,12 @@
 import logging
 import os
-from virttest import virsh, libvirt_storage
-from virttest.utils_test import libvirt as utlv
+
 from autotest.client.shared import error
+
+from virttest import virsh
+from virttest import libvirt_storage
+from virttest.utils_test import libvirt as utlv
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/volume/virsh_vol_download_upload.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_vol_download_upload.py
@@ -2,9 +2,13 @@ import os
 import logging
 import string
 import hashlib
-from autotest.client.shared import utils, error
+
+from autotest.client.shared import utils
+from autotest.client.shared import error
+
 from virttest import virsh
 from virttest.utils_test import libvirt as utlv
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/volume/virsh_vol_resize.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_vol_resize.py
@@ -1,10 +1,13 @@
 import re
 import logging
+
 from autotest.client.shared import error
-from virttest.utils_test import libvirt
+
 from virttest import libvirt_storage
 from virttest import utils_misc
 from virttest import virsh
+from virttest.utils_test import libvirt
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/volume/virsh_volume.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_volume.py
@@ -1,14 +1,17 @@
 import os
 import re
 import logging
+
 from autotest.client.shared import error
 from autotest.client import utils
+
 from virttest import utils_misc
 from virttest import virsh
 from virttest import libvirt_storage
 from virttest.libvirt_xml import vol_xml
 from virttest.utils_test import libvirt as utlv
 from virttest.staging import service
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virsh_cmd/volume/virsh_volume_application.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_volume_application.py
@@ -1,6 +1,8 @@
 import os
 import logging
+
 from autotest.client.shared import error
+
 from virttest import libvirt_storage
 from virttest import virsh
 from virttest import data_dir

--- a/libvirt/tests/src/virt_cmd/virt_clone.py
+++ b/libvirt/tests/src/virt_cmd/virt_clone.py
@@ -3,7 +3,9 @@ import os
 from autotest.client import os_dep, utils
 from autotest.client.shared import error
 
-from virttest import common, virsh, data_dir, utils_misc
+from virttest import virsh
+from virttest import data_dir
+from virttest import utils_misc
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virt_cmd/virt_top.py
+++ b/libvirt/tests/src/virt_cmd/virt_top.py
@@ -1,9 +1,11 @@
 import os
 
-from autotest.client import os_dep, utils
+from autotest.client import os_dep
+from autotest.client import utils
 from autotest.client.shared import error
 
-from virttest import common, virsh, data_dir
+from virttest import virsh
+from virttest import data_dir
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virt_cmd/virt_xml_validate.py
+++ b/libvirt/tests/src/virt_cmd/virt_xml_validate.py
@@ -5,7 +5,8 @@ import re
 from autotest.client import os_dep, utils
 from autotest.client.shared import error
 
-from virttest import common, virsh, data_dir
+from virttest import virsh
+from virttest import data_dir
 from virttest.utils_test import libvirt
 
 

--- a/libvirt/tests/src/virtual_disks/at_dt_iscsi_disk.py
+++ b/libvirt/tests/src/virtual_disks/at_dt_iscsi_disk.py
@@ -2,15 +2,19 @@ import os
 import re
 import base64
 import logging
+
+from aexpect import ShellError
+
 from autotest.client.shared import error
+
 from virttest import virsh
 from virttest.remote import LoginError
 from virttest.virt_vm import VMError
-from virttest.aexpect import ShellError
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import pool_xml
 from virttest.libvirt_xml.secret_xml import SecretXML
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virtual_disks/startup_policy.py
+++ b/libvirt/tests/src/virtual_disks/startup_policy.py
@@ -1,11 +1,13 @@
 import os
 import logging
 import shutil
+
 from autotest.client import utils
 from autotest.client.shared import error
+
+from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
-from virttest import virsh
 
 
 def create_disk_xml(xml_file, device_type, source_file, target_dev, policy):

--- a/libvirt/tests/src/virtual_disks/virtual_disks_encryption.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_encryption.py
@@ -1,9 +1,17 @@
 import logging
 import os
+
+import aexpect
+
 from autotest.client.shared import error
+
+from virttest import remote
+from virttest import virt_vm
+from virttest import virsh
 from virttest.utils_test import libvirt
-from virttest import aexpect, remote, virt_vm, virsh
-from virttest.libvirt_xml import vm_xml, vol_xml, pool_xml
+from virttest.libvirt_xml import vm_xml
+from virttest.libvirt_xml import vol_xml
+from virttest.libvirt_xml import pool_xml
 from virttest.libvirt_xml.devices.disk import Disk
 
 

--- a/libvirt/tests/src/virtual_disks/virtual_disks_gluster.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_gluster.py
@@ -1,7 +1,9 @@
 import os
 import logging
+
 from autotest.client.shared import error
 from autotest.client import utils
+
 from virttest import virsh
 from virttest import data_dir
 from virttest import utils_misc

--- a/libvirt/tests/src/virtual_disks/virtual_disks_iscsi.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_iscsi.py
@@ -2,13 +2,16 @@ import os
 import re
 import logging
 import base64
-from virttest.utils_test import libvirt
+
+import aexpect
+
 from autotest.client.shared import error
 from autotest.client import utils
-from virttest import aexpect
+
 from virttest import remote
 from virttest import virt_vm
 from virttest import virsh
+from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import secret_xml
 from virttest.libvirt_xml.devices.disk import Disk

--- a/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
@@ -2,10 +2,15 @@ import os
 import re
 import json
 import logging
-from autotest.client.shared import error
+
+import aexpect
+
 from autotest.client import utils
-from provider import libvirt_version
-from virttest import aexpect, virt_vm, virsh, remote
+from autotest.client.shared import error
+
+from virttest import virt_vm
+from virttest import virsh
+from virttest import remote
 from virttest import nfs
 from virttest import utils_libvirtd
 from virttest import utils_misc
@@ -16,6 +21,8 @@ from virttest.libvirt_xml.devices.disk import Disk
 from virttest.libvirt_xml.devices.input import Input
 from virttest.libvirt_xml.devices.hub import Hub
 from virttest.libvirt_xml.devices.controller import Controller
+
+from provider import libvirt_version
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtual_disks/virtual_disks_multivms.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multivms.py
@@ -1,8 +1,14 @@
 import os
 import logging
+
+import aexpect
+
 from autotest.client.shared import error
+
 from virttest import utils_selinux
-from virttest import aexpect, virt_vm, virsh, remote, qemu_storage
+from virttest import virt_vm
+from virttest import virsh
+from virttest import remote
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.disk import Disk

--- a/libvirt/tests/src/virtual_network/iface_hotplug.py
+++ b/libvirt/tests/src/virtual_network/iface_hotplug.py
@@ -1,13 +1,15 @@
 import time
 import logging
+
 from autotest.client.shared import error
+
 from virttest import virt_vm
 from virttest import virsh
 from virttest import utils_net
 from virttest import utils_libvirtd
 from virttest.utils_test import libvirt
-from virttest.libvirt_xml.devices.interface import Interface
 from virttest.libvirt_xml import vm_xml
+from virttest.libvirt_xml.devices.interface import Interface
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtual_network/iface_network.py
+++ b/libvirt/tests/src/virtual_network/iface_network.py
@@ -1,8 +1,11 @@
 import re
 import logging
+
 from autotest.client.shared import error
 from autotest.client import utils
-from virttest import virt_vm, virsh
+
+from virttest import virt_vm
+from virttest import virsh
 from virttest import utils_net
 from virttest import utils_misc
 from virttest import utils_libguestfs

--- a/libvirt/tests/src/virtual_network/iface_options.py
+++ b/libvirt/tests/src/virtual_network/iface_options.py
@@ -3,9 +3,12 @@ import re
 import ast
 import time
 import logging
+
+import aexpect
+
 from autotest.client.shared import error
 from autotest.client import utils
-from virttest import aexpect
+
 from virttest import remote
 from virttest import virt_vm
 from virttest import virsh
@@ -14,8 +17,9 @@ from virttest import utils_misc
 from virttest import utils_libguestfs
 from virttest import utils_libvirtd
 from virttest.utils_test import libvirt
-from virttest.libvirt_xml.devices.interface import Interface
 from virttest.libvirt_xml import vm_xml
+from virttest.libvirt_xml.devices.interface import Interface
+
 from provider import libvirt_version
 
 

--- a/libvirt/tests/src/virtual_network/iface_ovs.py
+++ b/libvirt/tests/src/virtual_network/iface_ovs.py
@@ -1,7 +1,10 @@
 import logging
+
 from autotest.client.shared import error
 from autotest.client import utils
-from virttest import virt_vm, virsh
+
+from virttest import virt_vm
+from virttest import virsh
 from virttest import utils_net
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml

--- a/lvsb/tests/src/lvsb_complex_options.py
+++ b/lvsb/tests/src/lvsb_complex_options.py
@@ -1,5 +1,7 @@
 import logging
+
 from autotest.client.shared import error
+
 from virttest.lvsb import make_sandboxes
 
 

--- a/lvsb/tests/src/lvsb_date.py
+++ b/lvsb/tests/src/lvsb_date.py
@@ -3,7 +3,9 @@ Simple test that executes date command in a sanbox and verifies it is correct
 """
 
 import datetime
+
 from autotest.client.shared import error
+
 from virttest.lvsb import make_sandboxes
 
 

--- a/lvsb/tests/src/lvsb_network_options.py
+++ b/lvsb/tests/src/lvsb_network_options.py
@@ -1,6 +1,7 @@
-import re
 import logging
+
 from autotest.client.shared import error
+
 from virttest.lvsb import make_sandboxes
 
 

--- a/lvsb/tests/src/lvsb_security_options.py
+++ b/lvsb/tests/src/lvsb_security_options.py
@@ -4,7 +4,9 @@ This case is used for testing security option of the virt-sandbox command.
 
 import re
 import logging
+
 from autotest.client.shared import error
+
 from virttest.lvsb import make_sandboxes
 
 # The default base context, please check virt-sandbox man page.

--- a/provider/libvirt_version.py
+++ b/provider/libvirt_version.py
@@ -2,9 +2,10 @@
 Shared code for tests that need to get the libvirt version
 """
 
-from virttest import virsh
 import re
 import logging
+
+from virttest import virsh
 
 LIBVIRT_LIB_VERSION = 0
 

--- a/v2v/tests/src/convert_vm_to_libvirt.py
+++ b/v2v/tests/src/convert_vm_to_libvirt.py
@@ -1,8 +1,10 @@
 import os
 import logging
+
 from autotest.client import utils
 from autotest.client.shared import ssh_key
 from autotest.client.shared import error
+
 from virttest import utils_v2v
 from virttest import libvirt_storage
 from virttest import libvirt_vm

--- a/v2v/tests/src/convert_vm_to_ovirt.py
+++ b/v2v/tests/src/convert_vm_to_ovirt.py
@@ -1,9 +1,12 @@
 import os
 import logging
+
+from autotest.client import utils
+from autotest.client.shared import ssh_key
+from autotest.client.shared import error
+
 from virttest import utils_v2v
 from virttest import utils_misc
-from autotest.client import utils
-from autotest.client.shared import ssh_key, error
 
 
 def get_args_dict(params):

--- a/v2v/tests/src/install.py
+++ b/v2v/tests/src/install.py
@@ -2,9 +2,10 @@ import os
 import time
 import glob
 
-from autotest.client.shared import error
 from virttest import installer
+
 from autotest.client import utils
+from autotest.client.shared import error
 from autotest.client.shared import software_manager
 
 

--- a/v2v/tests/src/v2v_options.py
+++ b/v2v/tests/src/v2v_options.py
@@ -6,9 +6,11 @@ import re
 import pwd
 import logging
 import shutil
+
 from autotest.client import utils
 from autotest.client.shared import ssh_key
 from autotest.client.shared import error
+
 from virttest import virsh
 from virttest import utils_v2v
 from virttest import utils_misc

--- a/v2v/tests/src/vm_check.py
+++ b/v2v/tests/src/vm_check.py
@@ -3,7 +3,9 @@ import re
 import time
 import logging
 import commands
+
 from autotest.client.shared import error
+
 from virttest import utils_v2v
 from virttest import utils_sasl
 from virttest import data_dir


### PR DESCRIPTION
This PR accomplishes some goals:

* Reflect the fact that `virttest.aexpect` no longer exists in avocado-vt, the new runner for the tp-libvirt tests.
* Clean up imports according to a set of rules. This cleanup ultimately aims to pave the way for a future PR that replaces the use of autotest libraries with avocado ones.