### PR TITLE
graphics: Fix case for recent libvirt change

### DIFF
--- a/libvirt/tests/cfg/graphics/graphics_functional.cfg
+++ b/libvirt/tests/cfg/graphics/graphics_functional.cfg
@@ -61,11 +61,11 @@
                         - listen_type_network:
                             spice_listen_type = 'network'
                             variants:
-                                - vnet:
+                                - network_vnet:
                                     spice_network_type = 'vnet'
-                                - macvtap:
+                                - network_macvtap:
                                     spice_network_type = 'macvtap'
-                                - bridge:
+                                - network_bridge:
                                     spice_network_type = 'bridge'
                         - defaultMode_secure:
                             defaultMode = secure
@@ -81,6 +81,14 @@
                             defaultMode = insecure
                         - defaultMode_any:
                             defaultMode = any
+                        - autoport_no:
+                            spice_autoport = no
+                            variants:
+                                - ports_not_set:
+                                - spice_tls_disabled:
+                                    spice_tls = 0
+                                - tlsport_-2:
+                                    spice_tlsPort = -2
                         - image_compression_auto_glz:
                             image_compression = auto_glz
                         - image_compression_auto_lz:
@@ -147,11 +155,11 @@
                         - listen_type_network:
                             vnc_listen_type = 'network'
                             variants:
-                                - vnet:
+                                - network_vnet:
                                     vnc_network_type = 'vnet'
-                                - macvtap:
+                                - network_macvtap:
                                     vnc_network_type = 'macvtap'
-                                - bridge:
+                                - network_bridge:
                                     vnc_network_type = 'bridge'
                         - vnc_tls_enabled:
                             vnc_tls = 1
@@ -191,6 +199,7 @@
                             spice_listen_type = 'address'
                             spice_listen_address = '0.0.0.0'
         - negative_tests:
+            negative_test = yes
             variants:
                 - spice_only:
                     spice_xml = yes
@@ -201,8 +210,6 @@
                         - autoport_no:
                             spice_autoport = no
                             variants:
-                                - spice_tls_disabled:
-                                    spice_tls = 0
                                 - spice_tls_disabled_tlsport_set:
                                     spice_tlsPort = 65535
                                     spice_tls = 0
@@ -231,15 +238,12 @@
                                 - without_cert:
                                     spice_tlsPort = 65535
                                     spice_prepare_cert = no
-                                - ports_not_set:
                                 - port_-2:
                                     spice_port = -2
                                 - port_1:
                                     spice_port = 1
                                 - port_65536:
                                     spice_port = 65536
-                                - tlsport_-2:
-                                    spice_tlsPort = -2
                                 - tlsport_1:
                                     spice_tlsPort = 1
                                 - tlsport_65536:

--- a/libvirt/tests/src/graphics/graphics_functional.py
+++ b/libvirt/tests/src/graphics/graphics_functional.py
@@ -208,6 +208,9 @@ def check_addr_port(all_ips, expected_ips, ports):
     """
     for ip in all_ips:
         for port in ports:
+            # port 0 means port not set. No need to check here.
+            if int(port) == 0:
+                continue
             logging.debug("Checking %s %s:%s", ip.iface, ip, port)
             if not ip.listening_on(port) and ip in expected_ips:
                 raise error.TestFail(
@@ -226,6 +229,8 @@ def qemu_spice_options(libvirt_vm):
     match = re.search(r'-spice\s*(\S*)', res.stdout)
     if match:
         spice_opt = match.groups()[0]
+    logging.info('Qemu spice option is: %s', spice_opt)
+
     spice_dict = {}
     plaintext_channels = set()
     tls_channels = set()
@@ -436,10 +441,12 @@ def get_expected_ports(params, expected_result):
             if secure_autoport:
                 expected_tls_port = port_allocator.allocate()
 
-        if expected_port != 'not_set' and int(expected_port) < -1:
-            expected_port = 'not_set'
         if expected_tls_port != 'not_set' and int(expected_tls_port) < -1:
             expected_tls_port = 'not_set'
+
+        if expected_port != 'not_set' and int(expected_port) < -1:
+            if expected_tls_port != 'not_set':
+                expected_port = 'not_set'
 
         logging.debug('Expected SPICE port: ' + expected_port)
         logging.debug('Expected SPICE tls_port: ' + expected_tls_port)
@@ -518,10 +525,7 @@ def get_fail_pattern(params, expected_result):
             fail_patts += tls_fail_patts + plaintext_fail_patts
 
         if expected_spice_port == expected_spice_tls_port:
-            if expected_spice_port == 'not_set':
-                fail_patts.append(r'neither port nor tls-port specified')
-                fail_patts.append(r'port is out of range')
-            else:
+            if expected_spice_port != 'not_set':
                 if 0 <= int(expected_spice_port) < 1024:
                     fail_patts.append(r'binding socket to \S* failed')
                 elif int(expected_spice_port) > 65535 or int(expected_spice_port) < -1:
@@ -564,10 +568,12 @@ def get_fail_pattern(params, expected_result):
             vnc_fail_patts.append('Failed to find x509 certificates')
 
         if expected_vnc_port != 'not_set':
-            if int(expected_vnc_port) - 5900 < 0:
+            if int(expected_vnc_port) < 5900:
                 vnc_fail_patts.append('Failed to start VNC server')
+                vnc_fail_patts.append(r'vnc port must be in range \[5900,65535\]')
             elif int(expected_vnc_port) > 65535:
                 vnc_fail_patts.append('Failed to start VNC server')
+                vnc_fail_patts.append(r'vnc port must be in range \[5900,65535\]')
         fail_patts += vnc_fail_patts
 
         if any([ip not in utils_net.get_all_ips() for ip in expected_vnc_ips]):
@@ -612,6 +618,9 @@ def get_expected_spice_options(params, networks, expected_result):
 
     if expected_port != 'not_set':
         expected_opts['port'] = expected_port
+    else:
+        expected_opts['port'] = ['0', None]
+
     if expected_tls_port != 'not_set':
         expected_opts['tls-port'] = expected_tls_port
         expected_opts['x509-dir'] = x509_dir
@@ -657,7 +666,8 @@ def get_expected_vnc_options(params, networks, expected_result):
 
     if auto_unix_socket == '1':
         listen_address = 'unix'
-        port = '/var/lib/libvirt/qemu/%s.vnc' % vm_name
+        port = ['/var/lib/libvirt/qemu/%s.vnc' % vm_name,
+                '/var/lib/libvirt/qemu/domain-%s/vnc.sock' % vm_name]
     else:
         if expected_port != 'not_set':
             port = str(int(expected_port) - 5900)
@@ -694,6 +704,7 @@ def get_expected_results(params, networks):
     except ValueError:
         expected_result['fail_patts'] = ['Unable to find an unused port']
     else:
+
         get_fail_pattern(params, expected_result)
         if spice_xml:
             get_expected_spice_options(params, networks, expected_result)
@@ -709,6 +720,15 @@ def compare_opts(opts, exp_opts):
     """
     created = set(opts) - set(exp_opts)
     deleted = set(exp_opts) - set(opts)
+
+    # Ignore changed keys that are list containing None.
+    created = set(
+        key for key in created
+        if isinstance(exp_opts[key], list) and None not in exp_opts[key])
+    deleted = set(
+        key for key in deleted
+        if isinstance(exp_opts[key], list) and None not in exp_opts[key])
+
     if len(created) or len(deleted):
         logging.debug("Created: %s", created)
         logging.debug("Deleted: %s", deleted)
@@ -716,13 +736,21 @@ def compare_opts(opts, exp_opts):
                              % (exp_opts, opts))
     else:
         if type(opts) == dict:
-            for key in exp_opts:
-                if opts[key] != exp_opts[key]:
-                    logging.debug("Key %s expected %s, but got %s",
-                                  key, exp_opts[key], opts[key])
-                    raise error.TestFail(
-                        "Expect qemu spice options is %s, but get %s"
-                        % (exp_opts, opts))
+            for key in opts:
+                if isinstance(exp_opts[key], list):
+                    if all(opts[key] != opt for opt in exp_opts[key]):
+                        logging.debug("Key %s expected one in %s, but got %s",
+                                      key, exp_opts[key], opts[key])
+                        raise error.TestFail(
+                            "Expect qemu options is %s, but get %s"
+                            % (exp_opts, opts))
+                else:
+                    if opts[key] != exp_opts[key]:
+                        logging.debug("Key %s expected %s, but got %s",
+                                      key, exp_opts[key], opts[key])
+                        raise error.TestFail(
+                            "Expect qemu options is %s, but get %s"
+                            % (exp_opts, opts))
 
 
 def check_spice_result(spice_opts,
@@ -924,6 +952,7 @@ def run(test, params, env):
     vm_name = params.get("main_vm", "virt-tests-vm1")
     spice_xml = params.get("spice_xml", "no") == 'yes'
     vnc_xml = params.get("vnc_xml", "no") == 'yes'
+    is_negative = params.get("negative_test", "no") == 'yes'
 
     sockets = block_ports(params)
     networks = setup_networks(params)
@@ -974,7 +1003,8 @@ def run(test, params, env):
             vnc_opts = qemu_vnc_options(vm)
             check_vnc_result(vnc_opts, expected_result, all_ips)
 
-        logging.debug("Test Succeed!")
+        if is_negative:
+            raise error.TestFail("Expect negative result. But start succeed!")
     except error.TestFail, detail:
         bug_url = params.get('bug_url', None)
         if bug_url:


### PR DESCRIPTION
1) Renamed some options in config files to avoid name collision.
2) Some negative cases became positive after qemu change.
    http://git.qemu.org/?p=qemu.git;a=commitdiff;h=cf7856ad
3) Add option negative_test to ensure all negative cases are really
    negative.
4) Message changed for port range checking.
5) VNC unix socket file location changed.
6) Some logic and logging tweaks.

Signed-off-by: Hao Liu <hliu@redhat.com>