### PR TITLE
dac_start_destroy: adjust certain cases

### DIFF
--- a/libvirt/tests/cfg/svirt/dac_start_destroy.cfg
+++ b/libvirt/tests/cfg/svirt/dac_start_destroy.cfg
@@ -108,7 +108,7 @@
     variants:
         - positive_test:
             status_error = "no"
-            no invalid_label, with_id..root_usr..relabel_no..107, with_name..s_qemu..root_usr..relabel_no
+            no invalid_label
         - negative_test:
             status_error = "yes"
-            only invalid_label, with_id..root_usr..relabel_no..107, with_name..s_qemu..root_usr..relabel_no
+            only invalid_label


### PR DESCRIPTION
With root user in qemu conf and 107 dac in xml, it used to fail at
start vm. After bug 1146886 fix, start vm will success now, so move
the cases into possitive.

Signed-off-by: Wayne Sun <gsun@redhat.com>