### PR TITLE
virttest: Fix skip message for TestNAError()

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_setvcpus.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_setvcpus.py
@@ -289,8 +289,8 @@ def run(test, params, env):
             if re.search("unable to execute QEMU command 'cpu-add'",
                          setvcpu_exit_stderr):
                 raise error.TestNAError("guest <os> machine property '%s' "
-                                        "may be too old to allow hotplug.",
-                                        mtype)
+                                        "may be too old to allow hotplug."
+                                        % mtype)
 
             # A qemu older than 1.5 or an unplug for 1.6 will result in
             # the following failure.  In general, any time libvirt determines

--- a/v2v/tests/src/convert_vm_to_ovirt.py
+++ b/v2v/tests/src/convert_vm_to_ovirt.py
@@ -37,8 +37,8 @@ def get_args_dict(params):
         if val is None:
             raise KeyError("%s doesn't exist" % key)
         elif val.count("EXAMPLE"):
-            raise error.TestNAError("Please provide specific value for %s: %s",
-                                    key, val)
+            raise error.TestNAError("Please provide specific value for %s: %s"
+                                    % (key, val))
         else:
             args_dict[key] = val
 


### PR DESCRIPTION
In order to display message to users correctly,
The exception message has to use interpolation.