### PR TITLE
virsh_migrate_multi_vms: Fix wrong params for multi_migration

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_multi_vms.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_multi_vms.py
@@ -277,7 +277,7 @@ def run(test, params, env):
         helper.vm_ip = vm.get_address()
 
     try:
-        multi_migration(helpers, simultaneous=False, jobabort=False,
+        multi_migration(helpers, simultaneous, jobabort,
                         lrunner=localrunner, rrunner=remoterunner)
     finally:
         for helper in helpers:


### PR DESCRIPTION
The value of simultaneous and jobabort should have been obtained
from cfg file. But they're all fixed to False.