### PR TITLE
virt_sysprep: Add CmdError for attach_disk

### DIFF
--- a/libguestfs/tests/virt_sysprep.py
+++ b/libguestfs/tests/virt_sysprep.py
@@ -80,7 +80,7 @@ def run(test, params, env):
             virsh.attach_disk(vm_name, dst_image, target, extra=options,
                               ignore_status=False)
         except (remote.LoginError, virt_vm.VMError,
-                aexpect.ShellError), detail:
+                aexpect.ShellError, error.CmdError), detail:
             raise error.TestFail("Modify guest source failed: %s" % detail)
 
     def modify_network(vm_name, first_nic):


### PR DESCRIPTION
If the exit status of attach_disk is non-zero and
ignore_status=False, CmdError will be raised.
so catch it.