### PR TITLE
virsh_hostname.py: hostname test fix for Avocado usage

### DIFF
--- a/libvirt/tests/src/virsh_cmd/host/virsh_hostname.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_hostname.py
@@ -26,13 +26,12 @@ def run(test, params, env):
 
     # Run test case
     option = params.get("virsh_hostname_options")
-    try:
-        hostname_test = virsh.hostname(option,
-                                       ignore_status=False,
-                                       debug=True)
-        status = 0  # good
-    except error.CmdError:
-        status = 1  # bad
+    hostname_test = virsh.hostname(option,
+                                   ignore_status=True,
+                                   debug=True)
+    status = 0
+    if hostname_test == '':
+        status = 1
         hostname_test = None
 
     # Recover libvirtd service start


### PR DESCRIPTION
The exception handler is not necessary here while being used
with Avocado. In Virt-test it was working properly in any case,
while Avocado reports test failures which are related to extra
exception handlers