### PR TITLE
libvirt_hooks: Modify interface type before test.

### DIFF
--- a/libvirt/tests/cfg/libvirt_hooks.cfg
+++ b/libvirt/tests/cfg/libvirt_hooks.cfg
@@ -40,6 +40,7 @@
                     hook_script = '#! /bin/bash;echo "$0" "$@" >> %s;exit 1;'
         - network_t:
             test_network = "yes"
+            net_name = "default"
             hook_file = "/etc/libvirt/hooks/network"
             hook_log = "/tmp/network.log"
         - error_test:


### PR DESCRIPTION
Network hook only for interface with network type, reset the domain
xml before the test.