### PR TITLE
aexpect module import fix

### DIFF
--- a/libguestfs/tests/guestfs_block_operations.py
+++ b/libguestfs/tests/guestfs_block_operations.py
@@ -1,11 +1,11 @@
 import re
 import logging
+import aexpect
 
 from autotest.client.shared import error
 from autotest.client.shared import utils
 from virttest import virt_vm
 from virttest import remote
-from virttest import aexpect
 from virttest import utils_test
 
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
@@ -5,11 +5,13 @@ Module to exercize virsh attach-device command with various devices/options
 import os
 import os.path
 import logging
+import aexpect
+
 from string import ascii_lowercase
 
 from autotest.client.shared import error
 
-from virttest import virt_vm, virsh, remote, aexpect, utils_misc
+from virttest import virt_vm, virsh, remote, utils_misc
 from virttest.libvirt_xml.vm_xml import VMXML
 from virttest.staging.backports import itertools
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_create_lxc.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_create_lxc.py
@@ -2,11 +2,12 @@ import os
 import logging
 import commands
 import time
+import aexpect
 
 from autotest.client.shared import error
 
 from virttest.libvirt_xml import vm_xml
-from virttest import virsh, aexpect
+from virttest import virsh
 from virttest.libvirt_xml.devices.emulator import Emulator
 from virttest.libvirt_xml.devices.console import Console
 

--- a/libvirt/tests/src/virsh_cmd/virsh_itself.py
+++ b/libvirt/tests/src/virsh_cmd/virsh_itself.py
@@ -1,10 +1,10 @@
 import logging
+import aexpect
 
 from autotest.client import utils
 from autotest.client.shared import error
 
 from virttest import virsh
-from virttest import aexpect
 from virttest import element_tree
 
 


### PR DESCRIPTION
Now aexpect is not anymore part of virttest or avocado but is
installed as a separate package. Thus the remaining imports
should be corrected