### PR TITLE
virsh_node_memtune.cfg: shell escaping added

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_node_memtune.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_node_memtune.cfg
@@ -42,7 +42,7 @@
                                 - shm_pages_to_scan:
                                     shm_pages_to_scan = -0x1
                                 - shm_sleep_millisecs:
-                                    shm_sleep_millisecs = "~!@#$%^*()\-=[]{}|_+":;'`,>?."
+                                    shm_sleep_millisecs = "~!@#$%^*()\-=[]{}|_+\":;\'\`,>?."
                                 - shm_merge_across_nodes:
                                     variants:
                                         - invalid_number:


### PR DESCRIPTION
Based on PR (https://github.com/avocado-framework/avocado/pull/875)
in avocado, the test cfg file is modified to contain the proper
escaping (for shlex module needs)