### PR TITLE
tp-libvirt: Move to container based travis infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,19 +6,13 @@ branches:
     only:
         - master
 
-virtualenv:
-    system_site_packages: true
-
-before_script:
-    - echo "deb http://ppa.launchpad.net/lmr/autotest/ubuntu wily main" | sudo tee -a /etc/apt/sources.list
-    - sudo apt-get update -q
-    - sudo apt-get -y --force-yes install autotest
+sudo: false
 
 install:
-    - pip install sphinx tox simplejson MySQL-python pylint autopep8
-    - pip install inspektor
-    - pip install -r requirements.txt
+    - pip install Sphinx
+    - pip install -r requirements-travis.txt
 
 script:
+    - inspekt indent
     - inspekt lint
     - inspekt style

--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,7 @@ using virt test, and commit your changes.
 
 ::
 
+    inspekt indent
     inspekt lint
     inspekt style
 6) Fix any problems

--- a/libguestfs/tests/guestfish_fs_attr_ops.py
+++ b/libguestfs/tests/guestfish_fs_attr_ops.py
@@ -855,8 +855,8 @@ def test_mknod_b(vm, params):
     gf.mknod_b(mode, major, minor, nodename)
     ll_result = gf.ll(nodename)
     if permission not in ll_result.stdout:
-            gf.close_session()
-            raise error.TestFail("test_mknod_b failed.")
+        gf.close_session()
+        raise error.TestFail("test_mknod_b failed.")
     gf.rm_rf(nodename)
     gf.close_session()
 
@@ -895,8 +895,8 @@ def test_mknod_c(vm, params):
     gf.mknod_c(mode, major, minor, nodename)
     ll_result = gf.ll(nodename)
     if permission not in ll_result.stdout:
-            gf.close_session()
-            raise error.TestFail("test_mknod_c failed.")
+        gf.close_session()
+        raise error.TestFail("test_mknod_c failed.")
     gf.rm_rf(nodename)
     gf.close_session()
 

--- a/libvirt/tests/src/remote_access/remote_access.py
+++ b/libvirt/tests/src/remote_access/remote_access.py
@@ -206,14 +206,14 @@ def run(test, params, env):
 
     # generate auth.conf and default under the '/etc/libvirt'
     if auth_conf_cxt and auth_conf:
-            cmd = "echo -e '%s' > %s" % (auth_conf_cxt, auth_conf)
-            utils.system(cmd, ignore_status=True)
+        cmd = "echo -e '%s' > %s" % (auth_conf_cxt, auth_conf)
+        utils.system(cmd, ignore_status=True)
 
     # generate polkit_pkla and default under the
     # '/etc/polkit-1/localauthority/50-local.d/'
     if polkit_pkla_cxt and polkit_pkla:
-            cmd = "echo -e '%s' > %s" % (polkit_pkla_cxt, polkit_pkla)
-            utils.system(cmd, ignore_status=True)
+        cmd = "echo -e '%s' > %s" % (polkit_pkla_cxt, polkit_pkla)
+        utils.system(cmd, ignore_status=True)
 
     # generate remote IP
     if config_ipv6 == "yes" and ipv6_addr_des:

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,0 +1,9 @@
+coverage==3.6
+nose==1.3.0
+nosexcover==1.0.8
+tox==1.5.0
+virtualenv==1.9.1
+simplejson==3.8.1
+MySQL-python==1.2.5
+inspektor==0.1.19
+autotest==0.16.2


### PR DESCRIPTION
Move to the faster, container-based travis tesing infrastructure.
In order to do this, add a new requirements-travis.txt file that
concentrates the requirements of the testing job, plus cleanup
of .travis.yml and addition of sudo: false to that file.