### PR TITLE
virsh_dump: Rename parameter to avoid collision

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_dump.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_dump.cfg
@@ -7,7 +7,7 @@
     kill_vm = "yes"
     kill_vm_befor_test = "yes"
     take_regular_screendumps = "no"
-    timeout = 5
+    check_pid_timeout = 5
     variants:
         - positive_test:
             status_error = "no"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_dump.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_dump.py
@@ -108,7 +108,7 @@ def run(test, params, env):
     start_vm = params.get("start_vm") == "yes"
     paused_after_start_vm = params.get("paused_after_start_vm") == "yes"
     status_error = params.get("status_error", "no") == "yes"
-    timeout = int(params.get("timeout", "5"))
+    timeout = int(params.get("check_pid_timeout", "5"))
     memory_dump_format = params.get("memory_dump_format", "")
     uri = params.get("virsh_uri")
     unprivileged_user = params.get('unprivileged_user')


### PR DESCRIPTION
It seems `timeout` parameter is already taken for avocado. Reusing of
this parameter lead this case occasionally fail if the duration is
longer than 5s.

Signed-off-by: Hao Liu <hliu@redhat.com>