### PR TITLE
virsh_event: Extend event_timeout to reduce failure

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_event.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_event.cfg
@@ -11,7 +11,7 @@
             variants:
                 - no_timeout:
                 - timeout:
-                    event_timeout = "30"
+                    event_timeout = "60"
             variants:
                 - other_option:
                 - all_events:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
@@ -140,7 +140,9 @@ def run(test, params, env):
             if event_str in output:
                 continue
             else:
-                raise error.TestFail("Not find expected event")
+                raise error.TestFail("Not find expected event:%s. Is your "
+                                     "guest too slow to get started in %ss?" %
+                                     (event_str, event_timeout))
 
     try:
         # Set vcpu placement to static to avoid emulatorpin fail


### PR DESCRIPTION
Setting `event_timeout` to 30s might be not enough since this process
includes guest booting up, which is definitely possible for some guests.

Extend this timeout will greatly reduce failure rate.
Also added a hint for better troubleshooting if the issue happens again.

Signed-off-by: Hao Liu <hliu@redhat.com>