### PR TITLE
virsh_migrate: update basic migration test

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
@@ -4,10 +4,13 @@
     start_vm = yes
     # Console output can only be monitored via virsh console output
     only_pty = True
+    take_regular_screendumps = no
     # Options to pass to virsh migrate command before <domain> <desturi>
     virsh_migrate_options = "--live --undefinesource --persistent"
     # Extra options to pass after <domain> <desturi>
     virsh_migrate_extra = "--timeout 60"
+    # SSH connection time out
+    ssh_timeout = 60
     # Fully qualified desturi (qemu+ssh://other.hostname.example.com/system)
     # Remember to open ports 49152-49216 on destination and
     # NAT-based host networking will cause external connectivity-loss
@@ -19,35 +22,19 @@
     virsh_migrate_dest_state = running
     virsh_migrate_src_state = running
     virsh_migrate_libvirtd_state = 'on'
-    virsh_migrate_connect_uri = "qemu+ssh://${migrate_source_host}/system"
+    # Local URI
+    virsh_migrate_connect_uri = "qemu:///system"
     status_error = 'no'
-    virsh_migrate_delay = 60
+    virsh_migrate_delay = 10
     virsh_migrate_back = 'no'
-    # A VM image used for migration
-    virsh_migrate_shared_storage = "${migrate_shared_storage}"
+    # ping args
+    ping_count = 10
+    ping_timeout = 20
     variants:
-        - there_and_back:
-            # After migrating, migrate the guest back.
-            virsh_migrate_back = 'yes'
-            # By 'default', use same options and extra with the
-            # virsh_migrate_back_desturi set to the original connect_uri
-            # virsh_migrate_back_options = 'default'
-            # virsh_migrate_back_extra = 'default'
-            # virsh_migrate_back_desturi = 'default'
         - there_and_back_with_numa:
             # After migrating with numa enabled, migrate the guest back.
             virsh_migrate_back = 'yes'
             virsh_migrate_with_numa = 'yes'
-        - there_and_back_a_lot:
-            iterations = 100
-            virsh_migrate_back = 'yes'
-            # don't kill anything between iterations, you'll need to
-            # shut it down manually or by including a shutdown test
-            kill_vm = no
-            kill_vm_gracefully = no
-            kill_unresponsive_vms = no
-            # migrate as fast as possible
-            virsh_migrate_delay = 0
         - there_live:
             # Uni-direction migration with option --live.
             virsh_migrate_options = "--live"
@@ -75,6 +62,10 @@
         - there_undefinesource:
             # Uni-direction migration with option --undefinesource.
             virsh_migrate_options = "--live --undefinesource"
+        - there_suspend_undefinesource:
+            # Uni-direction migration with option --undefinesource.
+            virsh_migrate_options = "--live --suspend --undefinesource"
+            virsh_migrate_dest_state = paused
         - there_change-protection:
             # Uni-direction migration with option --change-protection.
             virsh_migrate_options = "--live --change-protection"
@@ -82,6 +73,7 @@
             # Uni-direction migration with another scsi disk
             virsh_migrate_options = "--live"
             attach_scsi_disk = "yes"
+            image_size = "100M"
         - there_verbose:
             # Uni-direction migration with option --verbose.
             virsh_migrate_options = "--live --verbose"
@@ -91,6 +83,11 @@
             # the first time, confirming its fail then migrate with it.
             virsh_migrate_options = "--live --unsafe"
             virsh_migrate_disk_cache = "default"
+        - there_unsafe_cache_writeback:
+            # Uni-direction migration with option --unsafe.
+            # Set disk cache to writeback then migrate with unsafe
+            virsh_migrate_options = "--live --unsafe"
+            virsh_migrate_disk_cache = "writeback"
         - there_timeout:
             # Uni-direction migration with option --timeout.
             virsh_migrate_options = "--live"
@@ -111,8 +108,8 @@
         - there_xml:
             # Uni-direction migration with option --xml.
             virsh_migrate_options = "--live"
-            virsh_migrate_extra = "--xml /tmp/virsh_migrate.xml"
-            virsh_migrate_xml = /tmp/virsh_migrate.xml
+            virsh_migrate_extra = ""
+            xml_option = "yes"
         - there_online:
             # Uni-direction online migration.
             virsh_migrate_options = ""
@@ -122,6 +119,12 @@
             virsh_migrate_options = ""
             virsh_migrate_extra = ""
             virsh_migrate_with_numa = 'yes'
+        - there_xml_with_dname:
+            # Do migration with --dname and --xml with same changed
+            # name from guest XML
+            virsh_migrate_options = "--live"
+            xml_option = "yes"
+            virsh_migrate_extra = "--dname guest-new-name"
         - there_vm_suspend_live:
             # Uni-direction live migration with VM suspend.
             virsh_migrate_options = "--live"
@@ -161,6 +164,17 @@
         - there_compressed:
             # Uni-direction migration with option --compressed.
             virsh_migrate_options = "--live --compressed"
+        - there_seamless_migration_with_graphicsuri:
+            virsh_migrate_options = "--live --verbose --unsafe"
+            # The default spice port is 5900 for graphic configuration
+            # <graphics type='spice' autoport='yes'/> in the guest XML.
+            virsh_migrate_graphics_uri = "spice://${migrate_dest_host}:5900"
+            graphics_type = "spice"
+            graphics_port = 5900
+            graphics_listen = 0.0.0.0
+            graphics_listen_type = "address"
+            graphics_listen_addr = ${graphics_listen}
+            graphics_server = "${graphics_type}://${graphics_listen}:${graphics_port}"
         # ERROR
         - there_domain_nonexist:
             # Uni-direction migration with non-exist domain.
@@ -207,4 +221,27 @@
             # Uni-direction migration with a non-existing xmlfile.
             virsh_migrate_options = "--live"
             virsh_migrate_extra = "--xml xyz"
+            xml_option = "yes"
+            status_error = 'yes'
+        - there_cache_writeback_without_unsafe:
+            # Uni-direction migration with option --unsafe.
+            # Set disk cache to writeback then migrate without unsafe
+            virsh_migrate_options = "--live"
+            virsh_migrate_disk_cache = "writeback"
+            status_error = 'yes'
+        - there_xml_with_same_dname:
+            # Do migration with --dname and --xml with same changed
+            # name from guest XML
+            vm_new_name = "guest-new-name"
+            virsh_migrate_options = "--live"
+            xml_option = "yes"
+            virsh_migrate_extra = "--dname ${vm_new_name}"
+            status_error = 'yes'
+        - there_xml_with_diff_dname:
+            # Do migration with --dname and --xml with different changed
+            # name from guest XML
+            vm_new_name = "guest-new-name"
+            virsh_migrate_options = "--live"
+            xml_option = "yes"
+            virsh_migrate_extra = "--dname ${vm_new_name}-diff"
             status_error = 'yes'


### PR DESCRIPTION
The current existing migration cases can't be ran automitically, you need manually setup sharing storage and enable virt_use_nfs seboolean if you're using a NFS storage to share VM image, in addition, if the migration URI transport is SSH, you also need to configure SSH passwordless manually, this patch is used for solving these question and let tester run migartion testing automitically with simple test configuration. Meanwhile, to add new test scenarios for migration testing.

  1. Automitically setup NFS sharing ENV and enable virt_use_nfs seboolean

  2. Delete complex testing scenarios, such as ping-pong migration, it needs we setup passwordless access
    from local/remote to remote/local firstly, we may put these scenarios into ping-pong migration testing.

  3. Add some new testing scenarios to cover migration options or options combination, such as "--graphicsuri", "--live --suspend --undefinesource",.

  4. Enhance VM network connectivity check after migariton

    use local URI qemu:///system to instead of qemu+ssh://${migrate_source_host}/system, it's not necessary to use qemu+ssh://${migrate_source_host}/system URI for the local connecting, if you do this, you also need to setup passwordless access local URI firstly.

  5. Add parameters setting for migration test

  6. Change the nfs env setting order

 7.Change to use some neccesary parameters in avocado/avocado-vt/shared/cfg/base.cfg.
 8.Remove the hardcoded parameter for shared storage
9.Remove hardcoded command and use process instead of subprocess