### PR TITLE
Catch process.CmdError instead of error.CmdError

### DIFF
--- a/libvirt/tests/src/libvirt_bench/libvirt_bench_usb_hotplug.py
+++ b/libvirt/tests/src/libvirt_bench/libvirt_bench_usb_hotplug.py
@@ -4,6 +4,8 @@ import logging
 
 from autotest.client.shared import error
 
+from avocado.utils import process
+
 from virttest import data_dir
 from virttest import virsh
 from virttest import utils_test
@@ -91,28 +93,28 @@ def run(test, params, env):
 
                         result = virsh.qemu_monitor_command(vm_name, attach_cmd, options=options)
                         if result.exit_status:
-                            raise error.CmdError(result.command, result)
+                            raise process.CmdError(result.command, result)
                     if keyboard:
                         attach_cmd = "device_add"
                         attach_cmd += " usb-kdb,bus=usb1.0,id=kdb"
 
                         result = virsh.qemu_monitor_command(vm_name, attach_cmd, options=options)
                         if result.exit_status:
-                            raise error.CmdError(result.command, result)
+                            raise process.CmdError(result.command, result)
                     if mouse:
                         attach_cmd = "device_add"
                         attach_cmd += " usb-mouse,bus=usb1.0,id=mouse"
 
                         result = virsh.qemu_monitor_command(vm_name, attach_cmd, options=options)
                         if result.exit_status:
-                            raise error.CmdError(result.command, result)
+                            raise process.CmdError(result.command, result)
                     if tablet:
                         attach_cmd = "device_add"
                         attach_cmd += " usb-tablet,bus=usb1.0,id=tablet"
 
                         result = virsh.qemu_monitor_command(vm_name, attach_cmd, options=options)
                         if result.exit_status:
-                            raise error.CmdError(result.command, result)
+                            raise process.CmdError(result.command, result)
                 else:
                     if disk:
                         utils_test.libvirt.create_local_disk("file", path, size="1M")
@@ -128,7 +130,7 @@ def run(test, params, env):
 
                         result = virsh.attach_device(vm_name, disk_xml.xml)
                         if result.exit_status:
-                            raise error.CmdError(result.command, result)
+                            raise process.CmdError(result.command, result)
                     if mouse:
                         mouse_xml = Input("mouse")
                         mouse_xml.input_bus = "usb"
@@ -137,7 +139,7 @@ def run(test, params, env):
 
                         result = virsh.attach_device(vm_name, mouse_xml.xml)
                         if result.exit_status:
-                            raise error.CmdError(result.command, result)
+                            raise process.CmdError(result.command, result)
                     if tablet:
                         tablet_xml = Input("tablet")
                         tablet_xml.input_bus = "usb"
@@ -146,7 +148,7 @@ def run(test, params, env):
 
                         result = virsh.attach_device(vm_name, tablet_xml.xml)
                         if result.exit_status:
-                            raise error.CmdError(result.command, result)
+                            raise process.CmdError(result.command, result)
                     if keyboard:
                         kbd_xml = Input("keyboard")
                         kbd_xml.input_bus = "usb"
@@ -155,7 +157,7 @@ def run(test, params, env):
 
                         result = virsh.attach_device(vm_name, kbd_xml.xml)
                         if result.exit_status:
-                            raise error.CmdError(result.command, result)
+                            raise process.CmdError(result.command, result)
 
                 if attach_type == "qemu_monitor":
                     options = "--hmp"
@@ -165,46 +167,46 @@ def run(test, params, env):
 
                         result = virsh.qemu_monitor_command(vm_name, attach_cmd, options=options)
                         if result.exit_status:
-                            raise error.CmdError(result.command, result)
+                            raise process.CmdError(result.command, result)
                     if mouse:
                         attach_cmd = "device_del"
                         attach_cmd += (" mouse")
 
                         result = virsh.qemu_monitor_command(vm_name, attach_cmd, options=options)
                         if result.exit_status:
-                            raise error.CmdError(result.command, result)
+                            raise process.CmdError(result.command, result)
                     if keyboard:
                         attach_cmd = "device_del"
                         attach_cmd += (" keyboard")
 
                         result = virsh.qemu_monitor_command(vm_name, attach_cmd, options=options)
                         if result.exit_status:
-                            raise error.CmdError(result.command, result)
+                            raise process.CmdError(result.command, result)
                     if tablet:
                         attach_cmd = "device_del"
                         attach_cmd += (" tablet")
 
                         result = virsh.qemu_monitor_command(vm_name, attach_cmd, options=options)
                         if result.exit_status:
-                            raise error.CmdError(result.command, result)
+                            raise process.CmdError(result.command, result)
                 else:
                     if disk:
                         result = virsh.detach_device(vm_name, disk_xml.xml)
                         if result.exit_status:
-                            raise error.CmdError(result.command, result)
+                            raise process.CmdError(result.command, result)
                     if mouse:
                         result = virsh.detach_device(vm_name, mouse_xml.xml)
                         if result.exit_status:
-                            raise error.CmdError(result.command, result)
+                            raise process.CmdError(result.command, result)
                     if keyboard:
                         result = virsh.detach_device(vm_name, kbd_xml.xml)
                         if result.exit_status:
-                            raise error.CmdError(result.command, result)
+                            raise process.CmdError(result.command, result)
                     if tablet:
                         result = virsh.detach_device(vm_name, tablet_xml.xml)
                         if result.exit_status:
-                            raise error.CmdError(result.command, result)
-        except error.CmdError, e:
+                            raise process.CmdError(result.command, result)
+        except process.CmdError, e:
             if not status_error:
                 raise error.TestFail("failed to attach device.\n"
                                      "Detail: %s." % result)

--- a/libvirt/tests/src/libvirt_scsi.py
+++ b/libvirt/tests/src/libvirt_scsi.py
@@ -7,6 +7,8 @@ import os
 
 from autotest.client.shared import error
 
+from avocado.utils import process
+
 from virttest import virt_vm
 from virttest import qemu_storage
 from virttest import data_dir
@@ -77,7 +79,7 @@ def run(test, params, env):
         try:
             cdrom = CdromDisk(cdrom_path, data_dir.get_tmp_dir())
             cdrom.close()
-        except error.CmdError, detail:
+        except process.CmdError, detail:
             raise error.TestNAError("Failed to create cdrom disk: %s" % detail)
 
         cdrom_disk = Disk(type_name="file")

--- a/libvirt/tests/src/libvirt_usb_hotplug_device.py
+++ b/libvirt/tests/src/libvirt_usb_hotplug_device.py
@@ -6,6 +6,8 @@ from aexpect import ShellTimeoutError
 
 from autotest.client.shared import error
 
+from avocado.utils import process
+
 from virttest import data_dir
 from virttest import virsh
 from virttest import utils_misc
@@ -91,7 +93,7 @@ def run(test, params, env):
 
                     result = virsh.qemu_monitor_command(vm_name, attach_cmd, options=opt)
                     if result.exit_status or (result.stdout.find("OK") == -1):
-                        raise error.CmdError(result.command, result)
+                        raise process.CmdError(result.command, result)
 
                     attach_cmd = "device_add usb-storage,"
                     attach_cmd += ("id=drive-usb-%s,bus=usb1.0,drive=drive-usb-%s" % (i, i))
@@ -101,7 +103,7 @@ def run(test, params, env):
 
                 result = virsh.qemu_monitor_command(vm_name, attach_cmd, options=opt)
                 if result.exit_status:
-                    raise error.CmdError(result.command, result)
+                    raise process.CmdError(result.command, result)
             else:
                 attributes = {'type_name': "usb", 'bus': "1", 'port': "0"}
                 if usb_type == "storage":
@@ -124,7 +126,7 @@ def run(test, params, env):
 
                 result = virsh.attach_device(vm_name, dev_xml.xml)
                 if result.exit_status:
-                    raise error.CmdError(result.command, result)
+                    raise process.CmdError(result.command, result)
 
         if status_error and usb_type == "storage":
             if utils_misc.wait_for(is_hotplug_ok, timeout=30):
@@ -148,12 +150,12 @@ def run(test, params, env):
 
                 result = virsh.qemu_monitor_command(vm_name, attach_cmd, options=opt)
                 if result.exit_status:
-                    raise error.CmdError(result.command, result)
+                    raise process.CmdError(result.command, result)
             else:
                 result = virsh.detach_device(vm_name, dev_xml.xml)
                 if result.exit_status:
-                    raise error.CmdError(result.command, result)
-    except error.CmdError, e:
+                    raise process.CmdError(result.command, result)
+    except process.CmdError, e:
         if not status_error:
             # live attach of device 'input' is not supported
             ret = result.stderr.find("Operation not supported")

--- a/libvirt/tests/src/macvtap.py
+++ b/libvirt/tests/src/macvtap.py
@@ -4,6 +4,8 @@ import aexpect
 
 from autotest.client.shared import error
 
+from avocado.utils import process
+
 from virttest import remote
 from virttest import utils_net
 from virttest import virsh
@@ -52,7 +54,7 @@ def run(test, params, env):
         origin_status = iface_cls.is_up()
         if not origin_status:
             iface_cls.up()
-    except error.CmdError, detail:
+    except process.CmdError, detail:
         raise error.TestNAError(str(detail))
     br_cls = utils_net.Bridge()
     if eth_card_no in br_cls.list_iface():
@@ -154,7 +156,7 @@ def run(test, params, env):
                                  % (vm1.name, vm2.name))
         try:
             iface_cls.down()
-        except error.CmdError, detail:
+        except process.CmdError, detail:
             raise error.TestNAError(str(detail))
         ping_s, _ = ping(vm2_ip, count=1, timeout=5, session=session)
         if not ping_s:
@@ -199,7 +201,7 @@ def run(test, params, env):
                                  % (vm1.name, vm2.name))
         try:
             iface_cls.down()
-        except error.CmdError, detail:
+        except process.CmdError, detail:
             raise error.TestNAError(str(detail))
         ping_s, _ = ping(remote_ip, count=1, timeout=5, session=session)
         if not ping_s:

--- a/libvirt/tests/src/multifunction.py
+++ b/libvirt/tests/src/multifunction.py
@@ -4,6 +4,8 @@ import commands
 
 from autotest.client.shared import error
 
+from avocado.utils import process
+
 from virttest import libvirt_vm
 from virttest import virsh
 from virttest import data_dir
@@ -33,7 +35,7 @@ def cleanup_vm(vm_name=None, disk_removed=None):
     try:
         if vm_name is not None:
             virsh.undefine(vm_name)
-    except error.CmdError:
+    except process.CmdError:
         pass
     try:
         if disk_removed is not None:

--- a/libvirt/tests/src/numa/guest_numa.py
+++ b/libvirt/tests/src/numa/guest_numa.py
@@ -1,8 +1,9 @@
 import re
 import logging
 
-from autotest.client.shared import utils
 from autotest.client.shared import error
+
+from avocado.utils import process
 
 from virttest import virt_vm
 from virttest import libvirt_xml
@@ -359,6 +360,6 @@ def run(test, params, env):
             libvirtd.restart()
             for mt_path in mount_path:
                 try:
-                    utils.system("umount %s" % mt_path)
-                except error.CmdError:
+                    process.run("umount %s" % mt_path, shell=True)
+                except process.CmdError:
                     logging.warning("umount %s failed" % mt_path)

--- a/libvirt/tests/src/svirt/dac_nfs_disk.py
+++ b/libvirt/tests/src/svirt/dac_nfs_disk.py
@@ -3,7 +3,8 @@ import re
 import logging
 
 from autotest.client.shared import error
-from autotest.client import utils
+
+from avocado.utils import process
 
 from virttest import qemu_storage
 from virttest import data_dir
@@ -131,7 +132,8 @@ def run(test, params, env):
                      export_options=export_options)
 
         # set virt_use_nfs
-        result = utils.run("setsebool virt_use_nfs %s" % virt_use_nfs)
+        result = process.run("setsebool virt_use_nfs %s" % virt_use_nfs,
+                             shell=True)
         if result.exit_status:
             raise error.TestNAError("Failed to set virt_use_nfs value")
 
@@ -213,7 +215,7 @@ def run(test, params, env):
         try:
             virsh.detach_disk(vm_name, target="vdf", extra="--persistent",
                               debug=True)
-        except error.CmdError:
+        except process.CmdError:
             raise error.TestFail("Detach disk 'vdf' from VM %s failed."
                                  % vm.name)
     finally:

--- a/libvirt/tests/src/svirt/svirt_attach_disk.py
+++ b/libvirt/tests/src/svirt/svirt_attach_disk.py
@@ -1,7 +1,8 @@
 import logging
 
 from autotest.client.shared import error
-from autotest.client import utils
+
+from avocado.utils import process
 
 from virttest import qemu_storage
 from virttest import data_dir
@@ -130,7 +131,8 @@ def run(test, params, env):
             # set host_sestatus as nfs pool will reset it
             utils_selinux.set_status(host_sestatus)
             # set virt_use_nfs
-            result = utils.run("setsebool virt_use_nfs %s" % virt_use_nfs)
+            result = process.run("setsebool virt_use_nfs %s" % virt_use_nfs,
+                                 shell=True)
             if result.exit_status:
                 raise error.TestNAError("Failed to set virt_use_nfs value")
         else:
@@ -195,7 +197,7 @@ def run(test, params, env):
         try:
             virsh.detach_disk(vm_name, target="vdf", extra="--persistent",
                               debug=True)
-        except error.CmdError:
+        except process.CmdError:
             raise error.TestFail("Detach disk 'vdf' from VM %s failed."
                                  % vm.name)
     finally:

--- a/libvirt/tests/src/timer_management.py
+++ b/libvirt/tests/src/timer_management.py
@@ -9,6 +9,8 @@ import time
 from autotest.client import utils
 from autotest.client.shared import error
 
+from avocado.utils import process
+
 from virttest import utils_test
 from virttest import virsh
 from virttest import data_dir
@@ -253,7 +255,7 @@ def manipulate_vm(vm, operation, params=None):
             try:
                 inject_times -= 1
                 virsh.inject_nmi(vm.name, debug=True, ignore_status=False)
-            except error.CmdError, detail:
+            except process.CmdError, detail:
                 err_msg = "Inject nmi failed: %s" % detail
     elif operation == "dump":
         dump_times = int(params.get("dump_times", 10))
@@ -263,7 +265,7 @@ def manipulate_vm(vm, operation, params=None):
             dump_path = os.path.join(data_dir.get_tmp_dir(), "dump.file")
             try:
                 virsh.dump(vm.name, dump_path, debug=True, ignore_status=False)
-            except (error.CmdError, OSError), detail:
+            except (process.CmdError, OSError), detail:
                 err_msg = "Dump %s failed: %s" % (vm.name, detail)
             try:
                 os.remove(dump_path)
@@ -277,7 +279,7 @@ def manipulate_vm(vm, operation, params=None):
             try:
                 virsh.suspend(vm.name, debug=True, ignore_status=False)
                 virsh.resume(vm.name, debug=True, ignore_status=False)
-            except error.CmdError, detail:
+            except process.CmdError, detail:
                 err_msg = "Suspend-Resume %s failed: %s" % (vm.name, detail)
     elif operation == "save_restore":
         save_times = int(params.get("save_times", 10))
@@ -289,7 +291,7 @@ def manipulate_vm(vm, operation, params=None):
                 virsh.save(vm.name, save_path, debug=True,
                            ignore_status=False)
                 virsh.restore(save_path, debug=True, ignore_status=False)
-            except error.CmdError, detail:
+            except process.CmdError, detail:
                 err_msg = "Save-Restore %s failed: %s" % (vm.name, detail)
             try:
                 os.remove(save_path)

--- a/libvirt/tests/src/vfio.py
+++ b/libvirt/tests/src/vfio.py
@@ -4,6 +4,8 @@ import re
 
 from autotest.client.shared import error
 
+from avocado.utils import process
+
 from virttest import libvirt_vm
 from virttest import virsh
 from virttest import data_dir
@@ -187,7 +189,7 @@ def execute_ttcp(vm, params):
     # Check connection first
     try:
         session1.cmd("ping -c 4 %s" % remote_ip)
-    except error.CmdError:
+    except Exception:
         raise error.TestFail("Couldn't connect to %s through %s"
                              % (remote_ip, vm.name))
 
@@ -247,7 +249,7 @@ def cleanup_vm(vm_name=None):
     try:
         if vm_name is not None:
             virsh.undefine(vm_name)
-    except error.CmdError:
+    except process.CmdError:
         pass
 
 
@@ -292,7 +294,7 @@ def test_nic_group(vm, params):
                                 ignore_status=False)
         logging.debug("VMXML with disk boot:\n%s", virsh.dumpxml(vm.name))
         vm.start()
-    except (error.CmdError, virt_vm.VMStartError), detail:
+    except (process.CmdError, virt_vm.VMStartError), detail:
         cleanup_devices(pci_id, device_type)
         raise error.TestFail("New device does not work well: %s" % detail)
 
@@ -368,7 +370,7 @@ def test_fibre_group(vm, params):
                                 ignore_status=False)
         logging.debug("VMXML with disk boot:\n%s", virsh.dumpxml(vm.name))
         vm.start()
-    except (error.CmdError, virt_vm.VMStartError), detail:
+    except (process.CmdError, virt_vm.VMStartError), detail:
         cleanup_devices(pci_id, device_type)
         raise error.TestFail("New device does not work well: %s" % detail)
 
@@ -437,7 +439,7 @@ def test_win_fibre_group(vm, params):
                             flagstr="--config", debug=True,
                             ignore_status=False)
         vm.start()
-    except (error.CmdError, virt_vm.VMStartError), detail:
+    except (process.CmdError, virt_vm.VMStartError), detail:
         cleanup_devices(pci_id, device_type)
         raise error.TestFail("New device does not work well: %s" % detail)
 
@@ -506,7 +508,7 @@ def test_nic_fibre_group(vm, params):
                             flagstr="--config", debug=True,
                             ignore_status=False)
         vm.start()
-    except (error.CmdError, virt_vm.VMStartError), detail:
+    except (process.CmdError, virt_vm.VMStartError), detail:
         cleanup_devices(nic_pci_id, "Ethernet")
         cleanup_devices(fibre_pci_id, "Fibre")
         raise error.TestFail("New device does not work well: %s" % detail)
@@ -596,7 +598,7 @@ def test_nic_single(vm, params):
         cleanup_devices(pci_id, device_type)
         raise error.TestFail("Start vm succesfully after attaching single "
                              "device to iommu group.Not expected.")
-    except (error.CmdError, virt_vm.VMStartError), detail:
+    except (process.CmdError, virt_vm.VMStartError), detail:
         logging.debug("Expected:New device does not work well: %s" % detail)
 
     # Reattaching all devices in iommu group

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_destroy.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_destroy.py
@@ -1,6 +1,8 @@
 from autotest.client.shared import error
 from autotest.client.shared import ssh_key
 
+from avocado.utils import process
+
 from virttest import libvirt_vm
 from virttest import remote
 from virttest import virsh
@@ -83,7 +85,7 @@ def run(test, params, env):
             status, output = session.cmd_status_output(command,
                                                        internal_timeout=5)
             session.close()
-        except error.CmdError:
+        except process.CmdError:
             status = 1
 
     if libvirtd == "off":

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domid.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domid.py
@@ -1,5 +1,7 @@
 from autotest.client.shared import error
 
+from avocado.utils import process
+
 from virttest import libvirt_vm
 from virttest import remote
 from virttest import virsh
@@ -55,7 +57,7 @@ def run(test, params, env):
             if status != 0:
                 err = output
             session.close()
-        except error.CmdError:
+        except process.CmdError:
             status = 1
             output = ""
             err = "remote test failed"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_multi_vms.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_multi_vms.py
@@ -5,6 +5,8 @@ import time
 from autotest.client.shared import error
 from autotest.client.shared import ssh_key
 
+from avocado.utils import process
+
 from virttest import libvirt_vm
 from virttest import virsh
 from virttest import remote
@@ -126,8 +128,8 @@ def thread_func_migration(virsh_instance, cmd):
     global ret_migration
     # Migrate the domain.
     try:
-        result = virsh_instance.command(cmd, ignore_status=False)
-    except error.CmdError, detail:
+        virsh_instance.command(cmd, ignore_status=False)
+    except process.CmdError, detail:
         logging.error("Migration with %s failed:\n%s" % (cmd, detail))
         ret_migration = False
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_monitor_blockjob.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_monitor_blockjob.py
@@ -5,6 +5,8 @@ import threading
 from autotest.client.shared import error
 from autotest.client.shared import ssh_key
 
+from avocado.utils import process
+
 from virttest import utils_test
 from virttest import libvirt_vm
 from virttest import virsh
@@ -88,7 +90,7 @@ def copied_migration(vm, params, blockjob_type=None, block_target="vda"):
         elif blockjob_type == "complete":
             virsh.qemu_monitor_command(vm.name, complete_cmd, debug=True,
                                        ignore_status=False)
-    except error.CmdError, detail:
+    except process.CmdError, detail:
         blockjob_failures.append(str(detail))
 
     # Job info FYI

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_reboot.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_reboot.py
@@ -5,6 +5,8 @@ import aexpect
 
 from autotest.client.shared import error
 
+from avocado.utils import process
+
 from virttest import libvirt_vm
 from virttest import virt_vm
 from virttest import virsh
@@ -80,7 +82,7 @@ def run(test, params, env):
                 status, output = session.cmd_status_output(command,
                                                            internal_timeout=5)
                 session.close()
-            except (remote.LoginError, error.CmdError, aexpect.ShellError), e:
+            except (remote.LoginError, process.CmdError, aexpect.ShellError), e:
                 logging.error("Exception: %s", str(e))
                 status = -1
         if vm_ref != "remote_name":

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_setvcpus.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_setvcpus.py
@@ -5,6 +5,8 @@ from xml.dom.minidom import parse
 
 from autotest.client.shared import error
 
+from avocado.utils import process
+
 from virttest import remote
 from virttest import virsh
 from virttest import libvirt_vm
@@ -33,7 +35,7 @@ def remote_test(remote_ip, local_ip, remote_pwd, remote_prompt,
         session.close()
         if status != 0:
             err = output
-    except error.CmdError:
+    except process.CmdError:
         status = 1
         err = "remote test failed"
     return status, status_error, err

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_shutdown.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_shutdown.py
@@ -1,5 +1,7 @@
 from autotest.client.shared import error
 
+from avocado.utils import process
+
 from virttest import remote
 from virttest import libvirt_vm
 from virttest import virsh
@@ -88,7 +90,7 @@ def run(test, params, env):
                            % (remote_uri, vm_name, mode))
                 status = session.cmd_status(command, internal_timeout=5)
                 session.close()
-            except error.CmdError:
+            except process.CmdError:
                 status = 1
 
         # recover libvirtd service start

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_undefine.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_undefine.py
@@ -4,7 +4,8 @@ import logging
 import aexpect
 
 from autotest.client.shared import error
-from autotest.client import utils
+
+from avocado.utils import process
 
 from virttest import libvirt_vm
 from virttest import virsh
@@ -154,7 +155,7 @@ def run(test, params, env):
                 cmd_undefine = "virsh -c %s undefine %s" % (uri, vm_name)
                 status, output = session.cmd_status_output(cmd_undefine)
                 logging.info("Undefine output: %s", output)
-            except (error.CmdError, remote.LoginError, aexpect.ShellError), de:
+            except (process.CmdError, remote.LoginError, aexpect.ShellError), de:
                 logging.error("Detail: %s", de)
                 status = 1
 
@@ -167,7 +168,7 @@ def run(test, params, env):
             try:
                 if vm.is_alive():
                     vm.destroy(gracefully=False)
-            except error.CmdError, detail:
+            except process.CmdError, detail:
                 logging.error("Detail: %s", detail)
 
         # Check if VM exists.
@@ -197,7 +198,7 @@ def run(test, params, env):
             if virsh.domain_exists(vm.name):
                 virsh.undefine(vm_ref, ignore_status=True)
             cmd = "chmod 666 %s" % backup_xml.xml
-            utils.run(cmd, ignore_status=False)
+            process.run(cmd, ignore_status=False, shell=True)
             s_define = virsh.define(backup_xml.xml,
                                     unprivileged_user=unprivileged_user,
                                     uri=uri, ignore_status=True, debug=True)

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_vcpuinfo.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_vcpuinfo.py
@@ -2,6 +2,8 @@ import logging
 
 from autotest.client.shared import error
 
+from avocado.utils import process
+
 from virttest import virsh
 from virttest import utils_libvirtd
 
@@ -62,7 +64,7 @@ def run(test, params, env):
             vcback.close_session()
             if status != 0:
                 err = output
-        except error.CmdError:
+        except process.CmdError:
             status = 1
             output = ""
             err = "remote test failed"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_vncdisplay.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_vncdisplay.py
@@ -1,5 +1,7 @@
 from autotest.client.shared import error
 
+from avocado.utils import process
+
 from virttest import libvirt_vm
 from virttest import virsh
 from virttest import remote
@@ -59,7 +61,7 @@ def run(test, params, env):
             status, output = session.cmd_status_output(command,
                                                        internal_timeout=5)
             session.close()
-        except error.CmdError:
+        except process.CmdError:
             status = 1
             output = "remote test failed"
         return status, output

--- a/libvirt/tests/src/virsh_cmd/host/virsh_uri.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_uri.py
@@ -2,6 +2,8 @@ import logging
 
 from autotest.client.shared import error
 
+from avocado.utils import process
+
 from virttest import libvirt_vm
 from virttest import virsh
 from virttest import utils_libvirtd
@@ -48,7 +50,7 @@ def run(test, params, env):
                                        ignore_status=False,
                                        debug=True)
         status = 0  # good
-    except error.CmdError:
+    except process.CmdError:
         status = 1  # bad
         uri_test = ''
 

--- a/libvirt/tests/src/virsh_cmd/interface/virsh_iface_edit.py
+++ b/libvirt/tests/src/virsh_cmd/interface/virsh_iface_edit.py
@@ -4,8 +4,9 @@ import logging
 
 import aexpect
 
-from autotest.client import utils
 from autotest.client.shared import error
+
+from avocado.utils import process
 
 from virttest import remote
 from virttest import utils_net
@@ -23,7 +24,7 @@ def get_ifstart_mode(iface_name):
     try:
         xml = virsh.iface_dumpxml(iface_name, "--inactive", "", debug=True)
         start_mode = re.findall("start mode='(\S+)'", xml)[0]
-    except (error.CmdError, IndexError):
+    except (process.CmdError, IndexError):
         logging.error("Fail to get start mode for interface %s", iface_name)
     return start_mode
 
@@ -72,7 +73,7 @@ def run(test, params, env):
         new_ifstart_mode = "onboot"
     try:
         # Backup interface script
-        utils.run("cp %s %s" % (iface_script, iface_script_bk))
+        process.run("cp %s %s" % (iface_script, iface_script_bk), shell=True)
 
         # Edit interface
         edit_ifstart_mode(iface_name, old_ifstart_mode, new_ifstart_mode)
@@ -80,7 +81,7 @@ def run(test, params, env):
         # Restart interface
         if iface_is_up:
             net_iface.down()
-        utils.run("ifup %s" % iface_name)
+        process.run("ifup %s" % iface_name, shell=True)
 
         after_edit_mode = get_ifstart_mode(iface_name)
         if not after_edit_mode:
@@ -92,6 +93,6 @@ def run(test, params, env):
                                  % after_edit_mode)
     finally:
         net_iface.down()
-        utils.run("mv %s %s" % (iface_script_bk, iface_script))
+        process.run("mv %s %s" % (iface_script_bk, iface_script), shell=True)
         if iface_is_up:
-            utils.run("ifup %s" % iface_name)
+            process.run("ifup %s" % iface_name, shell=True)

--- a/libvirt/tests/src/virsh_cmd/monitor/virsh_domblkinfo.py
+++ b/libvirt/tests/src/virsh_cmd/monitor/virsh_domblkinfo.py
@@ -2,6 +2,8 @@ import os
 
 from autotest.client.shared import error
 
+from avocado.utils import process
+
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 
@@ -46,7 +48,7 @@ def run(test, params, env):
                 output_target = "Xen doesn't support domblkinfo target!"
             virsh.detach_disk(vm_name, front_dev, debug=True)
             return status_target, output_target, status_source, output_source
-        except (error.CmdError, IOError):
+        except (process.CmdError, IOError):
             return 1, "", 1, ""
 
     def check_disk_info():

--- a/libvirt/tests/src/virsh_cmd/monitor/virsh_dominfo.py
+++ b/libvirt/tests/src/virsh_cmd/monitor/virsh_dominfo.py
@@ -1,5 +1,7 @@
 from autotest.client.shared import error
 
+from avocado.utils import process
+
 from virttest import libvirt_vm
 from virttest import remote
 from virttest import virsh
@@ -55,7 +57,7 @@ def run(test, params, env):
             if status != 0:
                 err = output
             session.close()
-        except error.CmdError:
+        except process.CmdError:
             status = 1
             output = ""
             err = "remote test failed"

--- a/libvirt/tests/src/virsh_cmd/monitor/virsh_dommemstat.py
+++ b/libvirt/tests/src/virsh_cmd/monitor/virsh_dommemstat.py
@@ -1,5 +1,7 @@
 from autotest.client.shared import error
 
+from avocado.utils import process
+
 from virttest import libvirt_vm
 from virttest import virsh
 from virttest import remote
@@ -65,7 +67,7 @@ def run(test, params, env):
                                                         extra)
             status = session.cmd_status(command, internal_timeout=5)
             session.close()
-        except error.CmdError:
+        except process.CmdError:
             status = 1
 
     # recover libvirtd service start

--- a/libvirt/tests/src/virsh_cmd/monitor/virsh_domstats.py
+++ b/libvirt/tests/src/virsh_cmd/monitor/virsh_domstats.py
@@ -57,7 +57,7 @@ def prepare_vm_state(vm, vm_state):
             except (ShellTimeoutError, ShellProcessTerminatedError):
                 pass
             session.close()
-        except error.CmdError, e:
+        except Exception, e:
             logging.error("Crash domain failed: %s", e)
     else:
         logging.error("Unknown state for this test")

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_destroy.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_destroy.py
@@ -2,6 +2,8 @@ import re
 
 from autotest.client.shared import error
 
+from avocado.utils import process
+
 from virttest import virsh
 
 from provider import libvirt_version
@@ -59,7 +61,7 @@ def run(test, params, env):
         else:
             if network_status == "inactive":
                 virsh.net_destroy(network_name)
-    except error.CmdError:
+    except process.CmdError:
         raise error.TestError("Prepare network status failed!")
 
     status = virsh.net_destroy(net_ref, extra, uri=uri, debug=True,
@@ -78,7 +80,7 @@ def run(test, params, env):
         if (network_current_status == "inactive" and
                 virsh.net_state_dict()[network_name]['active']):
             virsh.net_destroy(network_name)
-    except error.CmdError:
+    except process.CmdError:
         raise error.TestError("Recover network status failed!")
 
     # Check status_error

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_list.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_list.py
@@ -3,6 +3,8 @@ import os
 
 from autotest.client.shared import error
 
+from avocado.utils import process
+
 from virttest import virsh
 
 from provider import libvirt_version
@@ -54,7 +56,7 @@ def run(test, params, env):
                 virsh.net_destroy(net_name, ignore_status=False)
             virsh.net_undefine(net_name, ignore_status=False)
             virsh.net_create(tmp_xml, ignore_status=False)
-    except error.CmdError:
+    except process.CmdError:
         raise error.TestFail("Transient network test failed!")
 
     # Prepare network's status for testing.
@@ -62,13 +64,13 @@ def run(test, params, env):
         try:
             if not virsh.net_state_dict()[net_name]['active']:
                 virsh.net_start(net_name, ignore_status=False)
-        except error.CmdError:
+        except process.CmdError:
             raise error.TestFail("Active network test failed!")
     else:
         try:
             if virsh.net_state_dict()[net_name]['active']:
                 virsh.net_destroy(net_name, ignore_status=False)
-        except error.CmdError:
+        except process.CmdError:
             raise error.TestFail("Inactive network test failed!")
 
     virsh_dargs = {'ignore_status': True}
@@ -93,7 +95,7 @@ def run(test, params, env):
                 virsh.net_start(net_name, ignore_status=False)
             elif net_current_status == "inactive" and net_status == "active":
                 virsh.net_destroy(net_name, ignore_status=False)
-    except error.CmdError:
+    except process.CmdError:
         raise error.TestFail("Recover network failed!")
 
     # check result

--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot.py
@@ -3,6 +3,8 @@ import re
 
 from autotest.client.shared import error
 
+from avocado.utils import process
+
 from virttest import virt_vm
 from virttest import virsh
 
@@ -23,7 +25,7 @@ def run(test, params, env):
         for snap in snaps:
             try:
                 virsh.snapshot_delete(vm, snap)
-            except error.CmdError:
+            except process.CmdError:
                 logging.debug("Can not remove snapshot %s.", snap)
                 remove_failed = remove_failed + 1
 
@@ -136,7 +138,7 @@ def run(test, params, env):
             check_info(infos["Descendants"], sni["Descendants"],
                        "Incorrect descendants count")
 
-        except error.CmdError:
+        except process.CmdError:
             handle_error("Failed getting snapshots info", vm_name)
         except error.TestFail, e:
             handle_error(str(e), vm_name)
@@ -163,7 +165,7 @@ def run(test, params, env):
             session = vm.wait_for_login()
             test_file(session, sni["to_create"], 0)
             test_file(session, sni["to_delete"], 2)
-        except error.CmdError:
+        except process.CmdError:
             handle_error("Failed to revert snapshot", vm_name)
         except (error.TestFail, virt_vm.VMDeadError), e:
             handle_error(str(e), vm_name)

--- a/libvirt/tests/src/virsh_cmd/volume/virsh_volume_application.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_volume_application.py
@@ -3,6 +3,8 @@ import logging
 
 from autotest.client.shared import error
 
+from avocado.utils import process
+
 from virttest import libvirt_storage
 from virttest import virsh
 from virttest import data_dir
@@ -130,7 +132,7 @@ def run(test, params, env):
                 utils_selinux.set_status("permissive")
                 try:
                     unattended_install.run(test, params, env)
-                except error.CmdError, detail:
+                except process.CmdError, detail:
                     raise error.TestFail("Guest install failed:%s" % detail)
             finally:
                 if selinux_mode is not None:

--- a/libvirt/tests/src/virt_cmd/virt_xml_validate.py
+++ b/libvirt/tests/src/virt_cmd/virt_xml_validate.py
@@ -5,6 +5,8 @@ import re
 from autotest.client import os_dep, utils
 from autotest.client.shared import error
 
+from avocado.utils import process
+
 from virttest import virsh
 from virttest import data_dir
 from virttest.utils_test import libvirt
@@ -25,7 +27,7 @@ def domainsnapshot_validate(vm_name, file=None, **virsh_dargs):
         ss_info = virsh.snapshot_info(vm_name, snapshot_name)
         check_info(ss_info["Name"], snapshot_name, "Incorrect snapshot name")
         check_info(ss_info["Domain"], vm_name, "Incorrect domain name")
-    except error.CmdError, e:
+    except process.CmdError, e:
         error.TestFail(str(e))
     except error.TestFail, e:
         error.TestFail(str(e))
@@ -70,7 +72,7 @@ def storagepool_validate(pool_name, file=None, **virsh_dargs):
 
     try:
         virsh.pool_dumpxml(pool_name, to_file=file)
-    except error.CmdError, e:
+    except process.CmdError, e:
         error.TestFail(str(e))
 
 
@@ -156,7 +158,7 @@ def secret_validate(file=None, **virsh_dargs):
     if uuid:
         try:
             virsh.secret_dumpxml(uuid, to_file=file, **virsh_dargs)
-        except error.CmdError, e:
+        except process.CmdError, e:
             raise error.TestError(str(e))
 
 
@@ -177,7 +179,7 @@ def interface_validate(file=None, **virsh_dargs):
 
     try:
         virsh.iface_dumpxml(iface_name, to_file=file, **virsh_dargs)
-    except error.CmdError, e:
+    except process.CmdError, e:
         raise error.TestError(str(e))
 
 

--- a/libvirt/tests/src/virtual_disks/at_dt_iscsi_disk.py
+++ b/libvirt/tests/src/virtual_disks/at_dt_iscsi_disk.py
@@ -7,6 +7,8 @@ from aexpect import ShellError
 
 from autotest.client.shared import error
 
+from avocado.utils import process
+
 from virttest import virsh
 from virttest.remote import LoginError
 from virttest.virt_vm import VMError
@@ -195,12 +197,12 @@ def run(test, params, env):
 
             try:
                 virsh.snapshot_list(vm_name, **virsh_dargs)
-            except error.CmdError:
+            except process.CmdError:
                 error.TestFail("Failed getting snapshots list for %s", vm_name)
 
             try:
                 virsh.snapshot_info(vm_name, snapshot_name1, **virsh_dargs)
-            except error.CmdError:
+            except process.CmdError:
                 error.TestFail("Failed getting snapshots info for %s", vm_name)
 
             cmd_result = virsh.snapshot_dumpxml(vm_name, snapshot_name1,


### PR DESCRIPTION
Now we using process module from avocado to run commands
and raise exceptiones, so adapt tp-libvirt cases to it.

Signed-off-by: Yanbing Du <ydu@redhat.com>