### PR TITLE
Using the right tmpdir

### DIFF
--- a/libvirt/tests/src/libvirt_vcpu_plug_unplug.py
+++ b/libvirt/tests/src/libvirt_vcpu_plug_unplug.py
@@ -170,8 +170,7 @@ def manipulate_domain(vm_name, vm_operation, recover=False):
     """
     Operate domain to given state or recover it.
     """
-    tmpdir = os.path.join(data_dir.get_root_dir(), 'tmp')
-    save_file = os.path.join(tmpdir, vm_name + ".save")
+    save_file = os.path.join(data_dir.get_tmp_dir(), vm_name + ".save")
     if not recover:
         if vm_operation == "save":
             save_option = ""


### PR DESCRIPTION
If the base dir of save file is not exist, virsh save will fail. And we
already have a function to get public tmpdir, so use it here.

Signed-off-by: Yanbing Du <ydu@redhat.com>