### PR TITLE
virsh_dump: Use SIGTERM to terminate the forked process

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_dump.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_dump.py
@@ -201,10 +201,10 @@ def run(test, params, env):
             try:
                 wait_pid_active(pid, timeout)
             finally:
-                os.kill(child_pid, signal.SIGUSR1)
+                os.kill(child_pid, signal.SIGTERM)
         else:
             check_bypass(dump_file)
-            # Wait for parent process over
+            # Wait for parent process kills us
             while True:
                 time.sleep(1)
 
@@ -278,7 +278,7 @@ def run(test, params, env):
                 raise error.TestFail("The format of dumped file is wrong.")
     finally:
         if child_pid:
-            os.kill(child_pid, signal.SIGUSR1)
+            os.kill(child_pid, signal.SIGTERM)
         if os.path.isfile(dump_file):
             os.remove(dump_file)
         if vm.is_alive():


### PR DESCRIPTION
Hello guys,

first let me say that I saw this code for the first time while debugging issue https://github.com/avocado-framework/avocado/issues/898 I don't really know what it's suppose to do, but from my debugging I think the code is suppose to use SIGTERM rather than SIGUSR1. Please double check I'm not mistaken.

The problem is, for some reason you need to fork and run some function. When the timeout runs-out you interrupt the forked process with SIGUSR1 and in the old avocado/virttest the default handler was used, which is destroy the process. Lately avocado added custom SIGUSR1 handler, which raises an exception and proceeds with cleanup. The problem is that your forked process instead of dying executes the avocado cleanup, which is also executed in the main test process, causing another failure during postprocess as the environment is already cleaned.

I looked into the code and haven't found any custom SIGUSR1 handler, so I guess the code is really just suppose to kill the process, so SIGTERM seems more appropriate than SIGUSR1.