### PR TITLE
virsh.cpu_compare: Prepare cpu related elements before testing

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_compare.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_compare.py
@@ -89,12 +89,16 @@ def run(test, params, env):
     host_cpu_xml = capability_xml.CapabilityXML()
 
     try:
+        # Add cpu element if it not present in VM XML
+        if not vmxml.get('cpu'):
+            new_cpu = vm_xml.VMCPUXML()
+            new_cpu['model'] = host_cpu_xml['model']
+            vmxml['cpu'] = new_cpu
+        # Add cpu model element if it not present in VM XML
+        if not vmxml['cpu'].get('model'):
+            vmxml['cpu']['model'] = host_cpu_xml['model']
         # Prepare VM cpu feature if necessary
         if modify_target in ['feature_name', 'feature_policy', 'delete']:
-            if not vmxml.get('cpu'):
-                new_cpu = vm_xml.VMCPUXML()
-                new_cpu['model'] = "core2duo"
-                vmxml['cpu'] = new_cpu
             if len(vmxml['cpu'].get_feature_list()) == 0:
                 # Add a host feature to VM for testing
                 vmxml_cpu = vmxml['cpu'].copy()


### PR DESCRIPTION
The cpu or cpu model element may not present in VM xml, but both of them
are necessary for guest-cpu related testing.
And avoid hardcode guest cpu model as 'core2duo' is only belong to Intel
platform.

Signed-off-by: Yanbing Du <ydu@redhat.com>