### PR TITLE
migrate_vm: Do fixes for some test cases

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_vm.cfg
+++ b/libvirt/tests/cfg/migration/migrate_vm.cfg
@@ -125,7 +125,7 @@
                                         - iozone_with_set_max_downtime:
                                             stress_type = "iozone_in_vms"
                                             stress_args = "-a"
-                                            max_down_time = 1000
+                                            max_down_time = 1.000
                                             set_migration_speed = 5
                                             check_job_info_time = 60
                                             run_migrate_cmd_in_front = "no"
@@ -133,7 +133,7 @@
                                             check_job_info = "yes"
                                             config_libvirtd = "yes"
                                             grep_str_from_local_libvirt_log = "migrate_set_downtime.*${max_down_time}"
-                                            virsh_options = "--live --verbose --unsafe --downtime ${max_down_time}"
+                                            virsh_options = "--live --verbose --unsafe"
                                         - memhog_memory_without_swap:
                                             no_swap = "yes"
                                             memhog_install_pkg = "yum install -y numactl"
@@ -452,7 +452,7 @@
                                     swap_path = "${nfs_mount_dir}/swap_image"
                                     set_tgt_pm_wakeup = yes
                                     set_tgt_pm_suspend_target = ${pm_suspend_target}
-                                    target_state_delay = 30
+                                    state_delay = 30
                 - live_storage_migration:
                     setup_nfs = "no"
                     enable_virt_use_nfs = "no"
@@ -467,6 +467,7 @@
                             create_target_image = "yes"
                             virsh_options = "--live --verbose --copy-storage-all"
                         - writethrough_driver_cache:
+                            migration_timeout = 1000
                             nfs_mount_dir =
                             create_target_image = "yes"
                             disk_driver_cache = "writethrough"


### PR DESCRIPTION
- '--downtime' option is invalid now for 'virsh migrate', so remove it
  in migrate_vm.cfg.

- Change grep parameter.
  When executing 'virsh migrate-setmaxdowntime 3 1000', below message
  will be written in libvirtd.log.
  qemuMonitorSend:1033 : QEMU_MONITOR_SEND_MSG:.....
  msg={"execute":"migrate_set_downtime","arguments":{"value":1.000000}
  So change 'max_down_time' to '1.000' from '1000' to grep
  "migrate_set_downtime.*1.000}". The down time now is in seconds, not
  millseconds.

- It is incorrect to use 'disk size' to create an image using 'qemu-img
  create'. 'virtual size' should be used which can be gotten from
  'qemu-img info'.

- Doing dompmwakeup quickly after doing dompmsuspend without any delay
  will cause the guest can not turn to running state and always stays in
  pmsuspended state. So it is necessary to sleep some seconds between
  the two commands.

- The functions in ssh_key are move from autotest to avocado-vt already.
  So it is necessary to change the import.

- The 'pool_name' should be set in function
  setup_or_cleanup_gluster(xxxx, pool_name), otherwise the /tmp
  directory will be cleaned up totally.

- When logging on remote machine with ssh, it needs enough time to wait
  for the prompt. The default timeout value is too little.

- '_' is invalid char for targetcli command which will cause target
  creation failure. So change it to 'emulated-iscsi'.

- It needs longer period to write data with cache 'writethrough' than
  cache 'None'. So it is neccessary to set bigger timeout value to check
  the migration output.

- 'swapon -s' command output should not be taken as 'if' check.
  Only command status's checking is correct.

Signed-off-by: Dan Zheng <dzheng@redhat.com>