### PR TITLE
Fix some bugs in numa cases

### DIFF
--- a/libvirt/tests/cfg/numa/numa_memory.cfg
+++ b/libvirt/tests/cfg/numa/numa_memory.cfg
@@ -34,6 +34,7 @@
                              vcpu_cpuset = "0,8"
         - negative_test:
              status_error = "yes"
+             memory_placement = "static"
              variants:
                  - out_range:
                      memory_nodeset = "200-300"

--- a/libvirt/tests/src/numa/guest_numa.py
+++ b/libvirt/tests/src/numa/guest_numa.py
@@ -131,8 +131,9 @@ def run(test, params, env):
             hp_cl.hugepage_path = m_path
             hp_cl.mount_hugepage_fs()
             mount_path.append(m_path)
-        qemu_conf.hugetlbfs_mount = mount_path
-        libvirtd.restart()
+        if mount_path:
+            qemu_conf.hugetlbfs_mount = mount_path
+            libvirtd.restart()
 
     try:
         # Get host numa node list

--- a/libvirt/tests/src/numa/numa_capabilities.py
+++ b/libvirt/tests/src/numa/numa_capabilities.py
@@ -27,11 +27,14 @@ def run(test, params, env):
             # check node distances
             node_num = node_list[cell_num]
             cell_distance = cell_list[cell_num].sibling
-            logging.debug("cell %s distance is %s", node_num, cell_distance)
-            node_distance = numa_info.distances[node_num]
-            for j in range(len(cell_list)):
-                if cell_distance[j]['value'] != node_distance[j]:
-                    raise error.TestFail("cell distance value not expected.")
+            if cell_distance:
+                logging.debug("cell %s distance is %s", node_num,
+                              cell_distance)
+                node_distance = numa_info.distances[node_num]
+                for j in range(len(cell_list)):
+                    if cell_distance[j]['value'] != node_distance[j]:
+                        raise error.TestFail("cell distance value not "
+                                             "expected.")
             # check node cell cpu
             cell_xml = cell_list[cell_num]
             cpu_list_from_xml = cell_xml.cpu

--- a/libvirt/tests/src/numa/numa_memory.py
+++ b/libvirt/tests/src/numa/numa_memory.py
@@ -1,6 +1,5 @@
 import os
 import logging
-import shutil
 
 from autotest.client import utils
 from autotest.client.shared import error
@@ -240,7 +239,7 @@ def run(test, params, env):
         if config_path:
             config.restore()
             if os.path.exists(config_path):
-                shutil.rmtree(os.path.dirname(config_path))
+                os.remove(config_path)
         if vm.is_alive():
             vm.destroy(gracefully=False)
         backup_xml.sync()

--- a/libvirt/tests/src/numa/numa_memory_migrate.py
+++ b/libvirt/tests/src/numa/numa_memory_migrate.py
@@ -1,6 +1,5 @@
 import os
 import logging
-import shutil
 
 from autotest.client.shared import error
 
@@ -144,7 +143,7 @@ def run(test, params, env):
         if config_path:
             config.restore()
             if os.path.exists(config_path):
-                shutil.rmtree(os.path.dirname(config_path))
+                os.remove(config_path)
         if vm.is_alive():
             vm.destroy(gracefully=False)
         backup_xml.sync()


### PR DESCRIPTION
guest_numa: don't update hugepage config if empty

numa_capabilities: skip distance element check on rhel6

numa_memory: 
Don't remove tmp dir as it will fail tests because env file
can't be found.
Set placement as static when specify nodes in negative cases.

numa_memory_migrate:
Don't remove tmp dir as env is in it.

Signed-off-by: Wayne Sun <gsun@redhat.com>