### PR TITLE
migrate_vm: Changes for two parameters

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_vm.cfg
+++ b/libvirt/tests/cfg/migration/migrate_vm.cfg
@@ -34,6 +34,7 @@
     remote_boolean_value = "on"
     set_sebool_local = "yes"
     set_sebool_remote = "yes"
+    migration_timeout = 300
     variants:
         - positive_testing:
             status_error = "no"
@@ -50,7 +51,6 @@
                             diff_cpu_vendor = "yes"
                         - cpuset:
                             cpu_set = "yes"
-                            vcpu_cpuset = '1'
                             vcpu_num = '2'
                         - timeout:
                             set_migration_speed = 1


### PR DESCRIPTION
- Some migration cases need more than 30 seconds to finish the
  migration, so a default migration_timeout with longer period
  is added.
- Remove vcpu_cpuset parameter.
  Local and remote hosts may have different cpu processor ids.
  The guest fails to start with specified cpuset statically
  which does't exist on that host. So the new implementation is
  to select a processor id automatically which exists on both
  local and remote host and then set it to the guest.

Signed-off-by: Dan Zheng <dzheng@redhat.com>