### PR TITLE
migrate_vm: Do fixes for bi_directional cases

### DIFF
--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -772,8 +772,14 @@ def run(test, params, env):
     ssh_key.setup_ssh_key(server_ip, server_user, server_pwd, 22)
 
     migr_vm_back = "yes" == test_dict.get("migrate_vm_back", "no")
+    remote_known_hosts_obj = None
     if migr_vm_back:
         ssh_key.setup_remote_ssh_key(server_ip, server_user, server_pwd)
+        remote_known_hosts_obj = ssh_key.setup_remote_known_hosts_file(
+                                  client_ip,
+                                  server_ip,
+                                  server_user,
+                                  server_pwd)
 
     # It's used to clean up SSH, TLS and TCP objs later
     objs_list = []


### PR DESCRIPTION
The bi_directional tests fail due to known_hosts of remote host does not
have the host key of local host. This is newly implemented in ssh_key.py
under avocado_vt/virttest. So this fix is to invoke that new function to
support the bi_directional tests.

Signed-off-by: Dan Zheng <dzheng@redhat.com>