### PR TITLE
svirt: fix failed cases

### DIFF
--- a/libvirt/tests/cfg/svirt/dac_nfs_save_restore.cfg
+++ b/libvirt/tests/cfg/svirt/dac_nfs_save_restore.cfg
@@ -58,7 +58,7 @@
     variants:
         - positive_test:
             status_error = no
-            no readonly, root_squash..nfs_file_root, nfs_file_qemu..root_user..root_squash, nfs_file_qemu_grp..root_user..root_squash, root_squash..non_exist_file
+            no readonly, root_squash..nfs_file_root, nfs_file_qemu..root_user..root_squash, nfs_file_qemu_grp..root_user..root_squash, root_squash..non_exist_file, nfs_file_qemu_grp.qemu_user.dynamic_ownership_on.root_squash
         - negative_test:
             status_error = yes
-            only readonly, root_squash..nfs_file_root, nfs_file_qemu..root_user..root_squash, nfs_file_qemu_grp..root_user..root_squash, root_squash..non_exist_file
+            only readonly, root_squash..nfs_file_root, nfs_file_qemu..root_user..root_squash, nfs_file_qemu_grp..root_user..root_squash, root_squash..non_exist_file, nfs_file_qemu_grp.qemu_user.dynamic_ownership_on.root_squash

--- a/libvirt/tests/cfg/svirt/svirt_virt_clone.cfg
+++ b/libvirt/tests/cfg/svirt/svirt_virt_clone.cfg
@@ -7,6 +7,7 @@
     # Label for VM.
     svirt_virt_clone_vm_sec_label = "system_u:system_r:svirt_t:s0:c87,c520"
     svirt_virt_clone_host_selinux = "enforcing"
+    status_error = no
     variants:
         - sec_type_dynamic:
             svirt_virt_clone_vm_sec_type = "dynamic"
@@ -25,13 +26,3 @@
             svirt_virt_clone_disk_label = "system_u:object_r:svirt_image_t:s0"
         - disk_label_svirt_image_MCS1:
             svirt_virt_clone_disk_label = "system_u:object_r:svirt_image_t:s0:c87,c520"
-    variants:
-        - positive_test:
-            status_error = no
-            no sec_relabel_no..disk_label_virt_content
-        - negative_test:
-            # only when seclabel of VM is not relabeled and
-            # img is labeld with "system_u:object_r:virt_content_t:s0",
-            # VM will not be able to access image.
-            status_error = yes
-            only sec_relabel_no..disk_label_virt_content


### PR DESCRIPTION
svirt_virt_clone: remove the negative case
As src vm is inactive, the clone vm also will be inactive after
clone, and virt-clone command did not check the label, so clone
will succeed. So the only negative case is not a negative
scenario, remove it in the cfg.
Only if start the cloned vm will fail but that's not related to
virt-clone testing and it's covered in svirt_start_destroy.

dac_nfs_save_restore: mark one pre-create save file to negative
After bug fix of:

https://bugzilla.redhat.com/show_bug.cgi?id=1158036

when dynamic_ownership is on, with qemu user save to a pre-create
file (dac as qemu group user) on root_squash nfs will fail now.
So move this case to negative.

Signed-off-by: Wayne Sun <gsun@redhat.com>