### PR TITLE
Fix 'graphic_act' is not defined problem.

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domdisplay.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domdisplay.py
@@ -131,6 +131,7 @@ def run(test, params, env):
         graphics = vmxml_act.devices.by_device_tag('graphics')
         for graph in graphics:
             if graph.type_name == graphic:
+                graphic_act = graph
                 port = graph.port
 
         # Do judgement for result


### PR DESCRIPTION
The defination of 'graphic_act' was removed by last commit, which caused
the exception of 'NameError'.