### PR TITLE
volume_application: Avoid using underscore in iqn

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/volume/virsh_volume_application.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/volume/virsh_volume_application.cfg
@@ -4,6 +4,7 @@
     volume_count = 1
     volume_size = "1G"
     kill_vm = "yes"
+    emulated_image = 'emulated-image'
     # If this parameter remains as following content,
     # test module will create one iscsi device instead
     block_device = "/DEV/EXAMPLE"

--- a/libvirt/tests/src/virsh_cmd/volume/virsh_volume_application.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_volume_application.py
@@ -41,7 +41,7 @@ def run(test, params, env):
     pool_type = params.get("pool_type")
     pool_name = "test_%s_app" % pool_type
     pool_target = params.get("pool_target")
-    emulated_img = params.get("emulated_img", "emulated_img")
+    emulated_img = params.get("emulated_image", "emulated-image")
     volume_count = int(params.get("volume_count", 1))
     volume_size = params.get("volume_size", "1G")
     emulated_size = "%sG" % (volume_count * int(volume_size[:-1]) + 1)


### PR DESCRIPTION
Underscore are not accepted in iqn. Use hyphen instead.

Signed-off-by: Hao Liu <hliu@redhat.com>