### PR TITLE
freepages: Don't append None into cellno list

### DIFF
--- a/libvirt/tests/src/virsh_cmd/host/virsh_freepages.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_freepages.py
@@ -85,6 +85,8 @@ def run(test, params, env):
         cellno_list = range(0, host_cells)
     elif cellno == "OUT_OF_RANGE":
         cellno_list.append(host_cells)
+    elif cellno is None:
+        pass
     else:
         cellno_list.append(cellno)
     pagesize = params.get("freepages_page_size")


### PR DESCRIPTION
If cellno is not set, don't append None to cellno list. This will cause
error when doing final comparison. Just do nothing instead.

Signed-off-by: Hao Liu <hliu@redhat.com>