### PR TITLE
freepages: Fix empty run and problem on specific hardware

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_freepages.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_freepages.cfg
@@ -16,7 +16,7 @@
             variants:
                 - no_hugepage:
                 - default_hugepage:
-                    huge_pages = "1"
+                    huge_pages_num = "1"
         - negative_test:
             status_error = "yes"
             variants:


### PR DESCRIPTION
The empty run is caused by commit c631db0, the None value of
cellno is valid and should be append into the cellno_list, or
else the loop will not happen for run freepages command at
following.

Updated methods for get host node numbers, supported huagepage
size values, set node hugepage numbers.

For ppc host, some machine with configuration only part of nodes
is populated with banks, then on host only part of the nodes are
with memory connected. For testing freepages command, exclude
the empty nodes out of freepages_cellno as 'AUTO'.

Signed-off-by: Wayne Sun <gsun@redhat.com>