### PR TITLE
setmem: fix dmidecode not supported problem

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_setmem.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_setmem.py
@@ -279,7 +279,12 @@ def run(test, params, env):
     if not vm.is_alive():
         vm.start()
     session = vm.wait_for_login()
-    unusable_mem = vm_unusable_mem(session)
+    if session.cmd_status('dmidecode'):
+        # The physical memory size is in vm xml, use it when dmideode not
+        # supported
+        unusable_mem = int(vmxml.max_mem) - vm_usable_mem(session)
+    else:
+        unusable_mem = vm_unusable_mem(session)
     original_outside_mem = vm.get_used_mem()
     original_inside_mem = vm_usable_mem(session)
     session.close()


### PR DESCRIPTION
dmidecode is not supported in ppc, and also it could be not present
in some vm, that'll cause test fail. Fix it by use max_mem from
vm xml to get physical memory, as the value is needed only at the
beginning of the test, the xml memory setting refected the physical
memory already.

Signed-off-by: Wayne Sun <gsun@redhat.com>