### PR TITLE
start: Long names must start correctly

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_start.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_start.cfg
@@ -17,7 +17,7 @@
                     vs_new_vm_name = "12345678"
                 - vm_named_long:
                     vs_pre_operation = "rename"
-                    vs_new_vm_name = "1234567890123456789012345678901234567890123456789012345"
+                    vs_new_vm_name = "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
                 - vm_name_start_with_special:
                     vs_pre_operation = "rename"
                     vs_new_vm_name = "-vm1"
@@ -45,9 +45,6 @@
                     vm_ref = ""
                 - dom_name_not_found:
                     vs_pre_operation = "undefine"
-                - vm_named_too_long:
-                    vs_pre_operation = "rename"
-                    vs_new_vm_name = "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
                 - vm_running:
                     start_vm = yes
                 - vm_paused:


### PR DESCRIPTION
Until now the test assumed that VMs with long names should not be
startable.  There is no reason for that as that was just a temporary
bug.  And because that is now fixed upstream (with varios commits) this
test now fails due to that invalid presumption.

Signed-off-by: Martin Kletzander <mkletzan@redhat.com>