### PR TITLE
virsh.undefine: Avoid possibility of removing guest image

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_undefine.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_undefine.cfg
@@ -32,7 +32,7 @@
                     variants:
                         - wipe_data:
                             wipe_data = "yes"
-                        - no_wipe_date:
+                        - no_wipe_data:
                             wipe_data = "no"
             variants:
                 - vm_shut_off:


### PR DESCRIPTION
When undefine with option of removing storage, if current guest image
is managed by libvirt, the guest image will be removed as well.

This will cause following test cases using guest image fail.

This fix try to backup all current guest images before testing, and move
them back when test finished to avoid this problem.

Also a typo in configuration file is fixed along with some code cleaned
up.

Signed-off-by: Hao Liu <hliu@redhat.com>