### PR TITLE
virsh.memtune: Update memory increments to 256MiB

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_memtune.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_memtune.cfg
@@ -3,5 +3,5 @@
     # Values are in kbs
     memtune_base_mem = 1048576
     memtune_min_mem = 262144
-    memtune_hard_base_mem = 120400
-    memtune_soft_base_mem = 204800
+    memtune_hard_base_mem = 262144
+    memtune_soft_base_mem = 262144


### PR DESCRIPTION
As PPC requires the memory sizes to be rounded to 256MiB increments,
while x86 rounded to 1MiB, for fix testing check fail on PPC and make it
working on both platforms, change the increments to 256MiB which is
262144KiB.

Signed-off-by: Wayne Sun <gsun@redhat.com>