### PR TITLE
attach_detach_interface: Fix can't find interface in vm

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_interface.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_interface.py
@@ -132,9 +132,11 @@ def run(test, params, env):
     dom_uuid = vm.get_uuid()
     dom_id = vm.get_id()
 
-    # To confirm vm's state
+    # To confirm vm's state and make sure os fully started
     if start_vm == "no" and vm.is_alive():
         vm.destroy()
+    else:
+        vm.wait_for_login().close()
 
     # Test both detach and attach, So collect info
     # both of them for result check.


### PR DESCRIPTION
In some testing, the attached interface can't be found inside the
vm, that's because attach happend before vm os fully started.
Fix this by wait for vm os fully started before attach interface.

Signed-off-by: Wayne Sun <gsun@redhat.com>