### PR TITLE
virsh.domxml_to_native.expected_option dir name filter fix

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_to_native.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_to_native.py
@@ -88,6 +88,8 @@ def run(test, params, env):
             # XMLToNative: Don't show -S
             elif re.search("-S", arg):
                 continue
+            elif re.search("socket,id=", arg):
+                continue
             retlist.append(arg)
 
         return retlist


### PR DESCRIPTION
domxml_to_native fails during virsh.domxml_to_native.expected_option
It's due to libvirt commits a89f05ba8df095875f5ec8a9065a585af63a010b
and f1f68ca33433825ce0deed2d96f1990200bc6618.
A new way of dir/path is introduced , so the tests must be compatible
with it.
Now the "socket,id=" param is added to filtlist() function to be
filtered out.