### PR TITLE
remote_access: Fix ipv6 test configuration problem

### DIFF
--- a/libvirt/tests/cfg/remote_access/remote_with_ssh.cfg
+++ b/libvirt/tests/cfg/remote_access/remote_with_ssh.cfg
@@ -93,7 +93,7 @@
                     main_vm = "avocado-vt-vm1"
                 - ssh_no_ipv6_config:
                     config_ipv6 = "no"
-                    ipv6_addr_des = "ENTER.YOUR.IPv6.TRAGET"
+                    ipv6_addr_des = "None"
                 - stop_libvirtd:
                     restart_libvirtd = "no"
                     libvirtd_action = "stop"

--- a/libvirt/tests/cfg/remote_access/remote_with_tls.cfg
+++ b/libvirt/tests/cfg/remote_access/remote_with_tls.cfg
@@ -185,7 +185,7 @@
                     ip_addr_suffix = 64
                     # e.g. ipv6_addr_src = "3fef::101", ipv6_addr_des = "3fef::102"
                     ipv6_addr_src = "ENTER.YOUR.IPv6.SOURCE"
-                    ipv6_addr_des = "ENTER.YOUR.IPv6.TRAGET"
+                    ipv6_addr_des = "3fef::102"
                     # change your network interface name, e.g. eth0, enp0s25
                     client_ifname = "ENTER.YOUR.CLIENT.IFACE.NAME"
                     client_ipv6_addr = "${ipv6_addr_src}/${ip_addr_suffix}"


### PR DESCRIPTION
For no ipv6 configuration test and ipv6 address unreachable test,
currently the test configuration is set with actual ipv6 address
of the target host which is not to be expected. The fix is to set
an invalid value to the configuration for target host.

Signed-off-by: Dan Zheng <dzheng@redhat.com>