### PR TITLE
attach_detach_interface: Fix vm state check logic

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_interface.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_interface.py
@@ -133,8 +133,9 @@ def run(test, params, env):
     dom_id = vm.get_id()
 
     # To confirm vm's state and make sure os fully started
-    if start_vm == "no" and vm.is_alive():
-        vm.destroy()
+    if start_vm == "no":
+        if vm.is_alive():
+            vm.destroy()
     else:
         vm.wait_for_login().close()
 


### PR DESCRIPTION
Current check will fail with start_vm as 'no' and vm is shut off
negative cases. So only login vm when start_vm as 'yes'.

Signed-off-by: Wayne Sun <gsun@redhat.com>