### PR TITLE
Fixes for remote job

### DIFF
--- a/libvirt/tests/cfg/remote_access/remote_with_tls.cfg
+++ b/libvirt/tests/cfg/remote_access/remote_with_tls.cfg
@@ -43,7 +43,7 @@
                     sasl_user_pwd = "('test', '123456'), ('libvirt', '123456')"
                     sasl_allowed_users = ['test', 'libvirt']
                 - allowed_dn_list:
-                    tls_allowed_dn_list = ["CN=${client_cn},O=AUTOTEST.VIRT"]
+                    tls_allowed_dn_list = "CN=${client_cn},O=AUTOTEST.VIRT"
                     tls_port = "16515"
                 - customized_ipv4_listen_address:
                     listen_addr = "${server_ip}"
@@ -140,13 +140,13 @@
                     # please change your configuration
                     ca_cn_new = "illegal-sign"
                 - allowed_dn_disorder_list:
-                    tls_allowed_dn_list = ["O=AUTOTEST.VIRT,CN=${client_cn}"]
+                    tls_allowed_dn_list = "O=AUTOTEST.VIRT,CN=${client_cn}"
                     tls_port = "16515"
                 - allowed_dn_list_with_invalid_organization:
-                    tls_allowed_dn_list = ["CN=${client_cn},O=120abcXYZ!@#$%^&*()"]
+                    tls_allowed_dn_list = "CN=${client_cn},O=120abcXYZ!@#$%^&*()"
                     tls_port = "16515"
                 - allowed_dn_list_with_invalid_CN:
-                    tls_allowed_dn_list = ["CN=120abcXYZ!@#$%^&*(),O=AUTOTEST.VIRT"]
+                    tls_allowed_dn_list = "CN=120abcXYZ!@#$%^&*(),O=AUTOTEST.VIRT"
                     tls_port = "16515"
                 - verify_certificate:
                     tls_verify_cert = "yes"

--- a/libvirt/tests/cfg/remote_access/remote_with_unix.cfg
+++ b/libvirt/tests/cfg/remote_access/remote_with_unix.cfg
@@ -105,7 +105,7 @@
                     virsh_cmd = "start"
                     main_vm = "avocado-vt-vm1"
                     status_error = "no"
-                    patterns_virsh_cmd = ".*forbidden:\s*read\s*only\s*access.*"
+                    patterns_virsh_cmd = ".*forbidden\s*read\s*only\s*access.*"
                 - socket_access_controls:
                     auth_unix_ro = "none"
                     auth_unix_rw = "none"

--- a/libvirt/tests/src/remote_access/remote_access.py
+++ b/libvirt/tests/src/remote_access/remote_access.py
@@ -17,6 +17,8 @@ from virttest.utils_net import check_listening_port_remote_by_service
 from virttest.utils_test.libvirt import remotely_control_libvirtd
 from virttest.utils_test.libvirt import connect_libvirtd
 
+from provider import libvirt_version
+
 
 def remote_access(params):
     """
@@ -124,9 +126,17 @@ def run(test, params, env):
     test_dict = dict(params)
     vm_name = test_dict.get("main_vm")
     status_error = test_dict.get("status_error", "no")
-    allowed_dn_list = params.get("tls_allowed_dn_list")
-    if allowed_dn_list:
-        test_dict['tls_allowed_dn_list'] = eval(allowed_dn_list)
+    allowed_dn_str = params.get("tls_allowed_dn_list")
+    if allowed_dn_str:
+        allowed_dn_list = []
+        if not libvirt_version.version_compare(1, 0, 0):
+            # Reverse the order in the dn list to workaround the
+            # feature changes between RHEL 6 and RHEL 7
+            dn_list = allowed_dn_str.split(",")
+            dn_list.reverse()
+            allowed_dn_str = ','.join(dn_list)
+        allowed_dn_list.append(allowed_dn_str)
+        test_dict['tls_allowed_dn_list'] = allowed_dn_list
     transport = test_dict.get("transport")
     plus = test_dict.get("conn_plus", "+")
     config_ipv6 = test_dict.get("config_ipv6", "no")


### PR DESCRIPTION
1. Fix incorrectly matching error messages
The original pattern to match error messages ('forbidden: xxx') only
applies to 7.3, not 6.8. In order to apply to both 6.8 and 7.3, the
pattern to match is updated with the common part.

2. Fix tls_allowed_dn_list for RHEL6

The dn list order in tls_allowed_dn_list is opposite between RHEL6 and
RHEL7. Current order for 'tls_allowed_dn_list' only applies to RHEL7.
The fix is to make the test correctly work on RHEL6 via reversing the
order of dn when on RHEL6.

Signed-off-by: Dan Zheng <dzheng@redhat.com>