### PR TITLE
libvirt_qemu_cmdline: set hard limit when enable mlock

### DIFF
--- a/libvirt/tests/src/libvirt_qemu_cmdline.py
+++ b/libvirt/tests/src/libvirt_qemu_cmdline.py
@@ -69,11 +69,16 @@ def config_feature_memory_backing(vmxml, **kwargs):
         qemu_flags.append(['mem-merge=off', 'redhat-disable-KSM'])
     if locked:
         qemu_flags.append("mlock=on")
+        memtune_xml = vm_xml.VMMemTuneXML()
+        memtune_xml.hard_limit = vmxml.max_mem * 4
+        vmxml.memtune = memtune_xml
+        vmxml.sync()
     try:
         vm_xml.VMXML.set_memoryBacking_tag(vmxml.vm_name,
                                            hpgs=False,
                                            nosp=no_sharepages,
                                            locked=locked)
+        logging.debug("xml updated to %s", vmxml.xmltreefile)
     except Exception, detail:
         logging.error("Update VM XML fail: %s", detail)
     return qemu_flags


### PR DESCRIPTION
memtune hard limit is required when enable mlock, or else test
could fail.

Signed-off-by: Wayne Sun <gsun@redhat.com>