### PR TITLE
guest_numa: update set 1g hugepage per node

### DIFF
--- a/libvirt/tests/cfg/numa/guest_numa.cfg
+++ b/libvirt/tests/cfg/numa/guest_numa.cfg
@@ -4,16 +4,16 @@
     kill_vm = "yes"
     status_error = "no"
     vcpu_num = 4
-    max_mem = 615424
+    max_mem = 1048576
     hugepage_force_allocate = "yes"
     variants:
         - possitive_test:
              cell_id_0 = "0"
              cell_cpus_0 = "0-1"
-             cell_memory_0 = "307200"
+             cell_memory_0 = "524288"
              cell_id_1 = "1"
              cell_cpus_1 = "2-3"
-             cell_memory_1 = "308224"
+             cell_memory_1 = "524288"
              variants:
                  - numatune_mem:
                      memory_placement = "static"
@@ -23,8 +23,8 @@
                  - no_numatune_mem:
              variants:
                  - no_numatune_memnode:
-                     qemu_cmdline_numa_cell_0 = "node,nodeid=0,cpus=0-1,mem=300"
-                     qemu_cmdline_numa_cell_1 = "node,nodeid=1,cpus=2-3,mem=301"
+                     qemu_cmdline_numa_cell_0 = "node,nodeid=0,cpus=0-1,mem=512"
+                     qemu_cmdline_numa_cell_1 = "node,nodeid=1,cpus=2-3,mem=512"
                  - numatune_memnode:
                      memnode_nodeset_0 = 1
                      memnode_cellid_0 = 0
@@ -37,7 +37,6 @@
                          - m_preferred:
                              memnode_mode_0 = "preferred"
                              qemu_cmdline_mem_backend_0 = "id=ram-node0,.*?host-nodes=1,policy=preferred"
-
                          - m_interleave:
                              memnode_mode_0 = "interleave"
                              qemu_cmdline_mem_backend_0 = "id=ram-node0,.*?host-nodes=1,policy=interleave"
@@ -68,7 +67,7 @@
                              variants:
                                  - 2M:
                                      hugepage_size_0 = "2048"
-                                     page_num_0 = "150"
+                                     page_num_0 = "256"
                                      page_nodenum_0 = "1"
                                  - 1G:
                                      max_mem = "2097152"
@@ -87,7 +86,7 @@
                                      page_num_0 = "65"
                                      page_nodenum_0 = "1"
                          - host_total:
-                             nr_pagesize_total = "600"
+                             nr_pagesize_total = "1024"
         - negative_test:
              status_error = "yes"
              cell_id_0 = "0"


### PR DESCRIPTION
As 1g hugepage live update is supported in kernel now, update
hugepage page number for each size.

Also update maxmem to 1GiB and guest per node to 512MiB, since
ppc vm memory minimum size is 1GiB and round up base on 256MiB.

Signed-off-by: Wayne Sun <gsun@redhat.com>