### PR TITLE
svirt_install: fix virt-install fail on ppc

### DIFF
--- a/libvirt/tests/src/svirt/svirt_install.py
+++ b/libvirt/tests/src/svirt/svirt_install.py
@@ -67,7 +67,7 @@ def run(test, params, env):
         if sec_relabel is not None:
             cmd += ",relabel=%s" % sec_relabel
 
-        cmd += "&"
+        cmd += " --noautoconsole --graphics vnc &"
         utils.run(cmd, ignore_status=True)
 
         def _vm_alive():


### PR DESCRIPTION
ppc vm did not support spice, and without given graphics
virt-install by default use vmport which also not supported
and fail the install.

To avoid this failure, specify graphics as vnc which is
supported by both ppc and x86.

Signed-off-by: Wayne Sun <gsun@redhat.com>