### PR TITLE
migrate_vm: use ssh_timeout to avoid of timeout

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_vm.cfg
+++ b/libvirt/tests/cfg/migration/migrate_vm.cfg
@@ -1,6 +1,7 @@
 - virsh.migrate_vm:
     type = migrate_vm
     take_regular_screendumps = no
+    ssh_timeout = 60
     # please replace your configuration
     server_ip = "ENTER.YOUR.REMOTE.EXAMPLE.COM"
     server_user = "ENTER.YOUR.REMOTE.USER"


### PR DESCRIPTION
NFSClient can read the parameter 'ssh_timeout' to setup the ssh
connection. So the ssh_timeout value is provided here to decrease the
time out possibility.

Signed-off-by: Dan Zheng <dzheng@redhat.com>