### PR TITLE
virsh_migrate_copy_storage: fix multi disks case

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_copy_storage.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_copy_storage.cfg
@@ -3,6 +3,8 @@
     migrate_dest_uri = "qemu+ssh://${migrate_dest_host}/system"
     thread_timeout = 1200
     start_vm = "no"
+    precreation_pool_type = "dir"
+    precreation_pool_name = "precreation_pool"
     variants:
         - file_image:
             copy_storage_type = "file"
@@ -21,7 +23,8 @@
                 - single_disk:
                     added_disks_count = 1
                 - multi_disks:
-                    added_disks_count = 2
+                    added_disks_count = 3
+                    attach_disk_config = "no"
         - error_test:
             # Migrate vm again after repairing the incorrect operation
             migrate_again = "yes"


### PR DESCRIPTION
1. Apply the image pre-creation feature for RHEV
   With qemu-kvm-rhev, it will use libvirt to help create the image on
target host.
   With qemu-kvm, the user needs to manually create the image on target
host before storage migration.

2. Fix for multiple disks.
   'added_disks_count' value has to be changed to match
libvirt.attach_disk().
   'attach_disk_config' is added to make the disks are attached lively.

3. Search in the migration output and skip the test if a known error
message is found.
Signed-off-by: Dan Zheng <dzheng@redhat.com>