### PR TITLE
case vm_shutoff fail fix

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_interface.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_interface.py
@@ -136,7 +136,7 @@ def run(test, params, env):
     if start_vm == "no":
         if vm.is_alive():
             vm.destroy()
-    else:
+    elif start_vm == "yes":
         vm.wait_for_login().close()
 
     # Test both detach and attach, So collect info


### PR DESCRIPTION
there was a patch which added vm.wait_for_login().close(), but there
is a missing check of vm start status which causes a failure