### PR TITLE
blockpull: Reset expect exit status for timeout option

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockpull.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockpull.cfg
@@ -99,8 +99,3 @@
                     snap_in_mirror = "yes"
                     status_error = "no"
                     snap_in_mirror_err = "yes"
-    # Now blockpull commands in virsh in some cases return different values for success and error cases. 
-    # The corresponding changes were done in libvirt before. So in virt-test the blockpull tests must process
-    # the return values (success/fail) correctly
-    normal_test.file_disk.local.timeout.nobase.async: status_error = "yes"
-    normal_test.file_disk.local.timeout.nobase.no_async: status_error = "yes"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockpull.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockpull.py
@@ -282,6 +282,14 @@ def run(test, params, env):
                                  blockpull_options, **virsh_dargs)
         status = result.exit_status
 
+        # If pull job aborted as timeout, the exit status is different
+        # on RHEL6(0) and RHEL7(1)
+        if with_timeout and 'Pull aborted' in result.stdout:
+            if libvirt_version.version_compare(1, 1, 1):
+                status_error = True
+            else:
+                status_error = False
+
         # Check status_error
         libvirt.check_exit_status(result, status_error)
 


### PR DESCRIPTION
If pull job aborted as timeout, the exit status is different on RHEL6
and RHEL7

Signed-off-by: Yanbing Du <ydu@redhat.com>