### PR TITLE
virsh.domblkstat: It's acceptable not specifying dev

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/monitor/virsh_domblkstat.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/monitor/virsh_domblkstat.cfg
@@ -18,6 +18,8 @@
                     domblkstat_vm_ref = "uuid"
                 - human_option:
                     domblkstat_option = "--human"
+                - no_dev_option:
+                    domblkinfo_dev = "no"
         - error_test:
             status_error = "yes"
             variants:
@@ -43,6 +45,5 @@
                     variants:
                         - extra_option:
                             domblkstat_extra = "xyz"
-                        - null_extra_option:
                         - space_extra_option:
                             domblkstat_extra = "' '"


### PR DESCRIPTION
After bug https://bugzilla.redhat.com/show_bug.cgi?id=1142636 is fixed.
virsh domblkstat will generate summary statistics of domblkstat for QEMU
domain instead of failing.

Signed-off-by: Hao Liu <hliu@redhat.com>