### PR TITLE
remote_with_unix: Correct wrong regular expression

### DIFF
--- a/libvirt/tests/cfg/remote_access/remote_with_unix.cfg
+++ b/libvirt/tests/cfg/remote_access/remote_with_unix.cfg
@@ -105,7 +105,7 @@
                     virsh_cmd = "start"
                     main_vm = "avocado-vt-vm1"
                     status_error = "no"
-                    patterns_virsh_cmd = ".*forbidden\s*read\s*only\s*access.*"
+                    patterns_virsh_cmd = ".*forbidden.*read\s*only\s*access.*"
                 - socket_access_controls:
                     auth_unix_ro = "none"
                     auth_unix_rw = "none"


### PR DESCRIPTION
Existing regular expression can not match both 'forbidden for read only
access' and 'forbidden: read only access'. The fix is to correct it.

Signed-off-by: Dan Zheng <dzheng@redhat.com>