### PR TITLE
virsh.blockcopy: Bug fix and case update

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcopy.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcopy.cfg
@@ -70,6 +70,7 @@
                         - dest_local:
                             copy_to_nfs = "no"
                         - dest_nfs:
+                            bug_url = "https://bugzilla.redhat.com/show_bug.cgi?id=924151"
                             copy_to_nfs = "yes"
                 - block_disk:
                     no min_bandwidth


### PR DESCRIPTION
In some cases, the emulated iscsi target not cleanup, which will cause
the following case fail, so using a list to recorde all emulated iscsi
and cleanup them in the end.
Remove autotest dependency.
Skip or fail case as early as possible.
And other code cleanup update.

Signed-off-by: Yanbing Du <ydu@redhat.com>