### PR TITLE
Fixup for virsh.migrate

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
@@ -105,8 +105,8 @@
             virsh_migrate_options = "--live"
             virsh_migrate_extra = "--xml /tmp/virsh_migrate.xml"
             virsh_migrate_xml = /tmp/virsh_migrate.xml
-        - there_offline:
-            # Uni-direction offline migration.
+        - there_online:
+            # Uni-direction online migration.
             virsh_migrate_options = ""
             virsh_migrate_extra = ""
         - there_vm_suspend_live:
@@ -115,8 +115,8 @@
             virsh_migrate_extra = ""
             virsh_migrate_src_state = paused
             virsh_migrate_dest_state = paused
-        - there_vm_suspend_offline:
-            # Uni-direction offline migration with VM suspend.
+        - there_vm_suspend_online:
+            # Uni-direction online migration with VM suspend.
             virsh_migrate_options = ""
             virsh_migrate_extra = ""
             virsh_migrate_src_state = paused
@@ -127,8 +127,8 @@
             virsh_migrate_extra = ""
             virsh_migrate_src_state = "shut off"
             status_error = 'yes'
-        - there_vm_shutdown_offline:
-            # Uni-direction offline migration with VM shutdown.
+        - there_vm_shutdown_online:
+            # Uni-direction online migration with VM shutdown.
             virsh_migrate_options = ""
             virsh_migrate_extra = ""
             virsh_migrate_src_state = "shut off"
@@ -139,8 +139,8 @@
             virsh_migrate_extra = ""
             virsh_migrate_libvirtd_state = 'off'
             status_error = 'yes'
-        - there_libvirtd_stop_offline:
-            # Uni-direction offline migration with libvirtd stop.
+        - there_libvirtd_stop_online:
+            # Uni-direction online migration with libvirtd stop.
             virsh_migrate_options = ""
             virsh_migrate_extra = ""
             virsh_migrate_libvirtd_state = 'off'
@@ -179,8 +179,8 @@
             virsh_migrate_options = "--live"
             virsh_migrate_extra = "--timeout -1"
             status_error = 'yes'
-        - there_timeout_offline:
-            # Uni-direction offline migration with option --timeout.
+        - there_timeout_online:
+            # Uni-direction online migration with option --timeout.
             virsh_migrate_options = ""
             virsh_migrate_extra = "--timeout 60"
             status_error = 'yes'


### PR DESCRIPTION
Changed test case variant names for virsh migrate as when virsh_migrate_options="", it performs online migration.