### PR TITLE
daemon.kill_qemu: Enable sleep to memory before pmsuspend

### DIFF
--- a/libvirt/tests/src/daemon/kill_qemu.py
+++ b/libvirt/tests/src/daemon/kill_qemu.py
@@ -18,13 +18,18 @@ def run(test, params, env):
     expect_stop = params.get('expect_stop', 'yes') == 'yes'
     vm = env.get_vm(vm_name)
 
-    xml_backup = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    xml_backup = vmxml.copy()
     try:
         if vm_state == 'running':
             pass
         elif vm_state == 'paused':
             vm.pause()
         elif vm_state == 'pmsuspended':
+            pm_xml = vm_xml.VMPMXML()
+            pm_xml.mem_enabled = 'yes'
+            vmxml.pm = pm_xml
+            vmxml.sync()
             vm.prepare_guest_agent()
             vm.pmsuspend()
         else:


### PR DESCRIPTION
Pmsuspend will fail if VM does not have S3 enabled. So make sure that
the VM have this been set.

Signed-off-by: Hao Liu <hliu@redhat.com>