### PR TITLE
blockcopy: more bugs fix

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcopy.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcopy.cfg
@@ -5,7 +5,6 @@
     dest_path = ""
     dest_format = ""
     blockcopy_bandwidth = ""
-    default_timeout = "300"
     blockcopy_timemout = "no"
     reuse_external = "no"
     persistent_vm = "no"
@@ -23,15 +22,24 @@
                     reuse_external = "yes"
                 - raw_format:
                     dest_format = "raw"
-                - min_bandwidth:
-                    blockcopy_bandwidth = "1"
+                - bandwidth:
+                    only non_acl.local_disk.no_blockdev.no_shallow
                     variants:
-                        - normal:
-                        - mirror_state_lock:
-                            check_state_lock = "yes"
-                            take_regular_screendumps="no"
-                - max_bandwidth:
-                    blockcopy_bandwidth ="8796093022207"
+                        - min:
+                            blockcopy_bandwidth = "1"
+                            variants:
+                                - byte:
+                                    bandwidth_byte = 'yes'
+                                - mebibyte:
+                        - max:
+                            variants:
+                                - byte:
+                                    bandwidth_byte = 'yes'
+                                    blockcopy_bandwidth = "9223372036854775807"
+                                - mebibyte:
+                                    blockcopy_bandwidth = "8796093022207"
+                - mirror_state_lock:
+                    check_state_lock = "yes"
                 - wait_option:
                     blockcopy_options = "--wait --verbose"
                 - pivot_option:
@@ -47,7 +55,6 @@
                     no mirror_state_lock, raw_format
                     with_shallow = "yes"
                 - no_shallow:
-                    no normal
             variants:
                 - blockdev:
                     no no_shallow..mirror_state_lock
@@ -73,7 +80,6 @@
                             bug_url = "https://bugzilla.redhat.com/show_bug.cgi?id=924151"
                             copy_to_nfs = "yes"
                 - block_disk:
-                    no min_bandwidth
                     replace_vm_disk = "yes"
                     disk_source_protocol = "iscsi"
                     disk_target = "vda"


### PR DESCRIPTION
1. Raise TestFail if 'bandwidth' check fail
2. VM log file may locked by virtlogd if it destroyed with blockjob
still running, so abort blockjob before restore VM.
3. As 'setup_or_cleanup_iscsi' will restart iscsid and the exist iscsis
session need time to get back, so sleep few seconds before the next calling.
4. A typo fix.

Signed-off-by: Yanbing Du <ydu@redhat.com>