### PR TITLE
libvirtd_start: Refactor test while fixing bugs

### DIFF
--- a/libvirt/tests/cfg/libvirtd_start.cfg
+++ b/libvirt/tests/cfg/libvirtd_start.cfg
@@ -3,10 +3,14 @@
     start_vm = no
     check_image = no
     take_regular_screendumps = no
-    variants test_type:
+    iptables_service = off
+    firewalld_service = off
+    variants:
         - with_iptables:
+            iptables_service = on
         # This is a regression test for a known bug for firewalld
         # prior to firewalld-0.3.9-7.el7.
         # https://bugzilla.redhat.com/show_bug.cgi?id=1070683
         - with_firewalld:
-        - stop_iptables:
+            firewalld_service = on
+        - no_firewall:


### PR DESCRIPTION
1) This tests requires iptables-services package to be installed before
   testing. So check and install all required packages before testing.

2) Change all autotest references to avocado.

3) Use LibvirtSession in avocado-vt instead of building one from
   scratch.

4) Refactor the code structure to make it more clear.

Signed-off-by: Hao Liu <hliu@redhat.com>