### PR TITLE
virsh.blkdeviotune: Change boundary according to fixed bug

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blkdeviotune.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blkdeviotune.cfg
@@ -43,7 +43,7 @@
                                         - inside_boundary:
                                             blkdevio_total_bytes_sec = 1024
                                         - maximum_boundary:
-                                            blkdevio_total_bytes_sec = 9223372036854775807
+                                            blkdevio_total_bytes_sec = 1000000000000000
                                     variants:
                                         - options:
                                             variants:
@@ -58,7 +58,7 @@
                                         - inside_boundary:
                                             blkdevio_read_bytes_sec = 1048576
                                         - maximum_boundary:
-                                            blkdevio_read_bytes_sec = 9223372036854775807
+                                            blkdevio_read_bytes_sec = 1000000000000000
                                     variants:
                                         - options:
                                             variants:
@@ -73,7 +73,7 @@
                                         - inside_boundary:
                                             blkdevio_write_bytes_sec = 1073741824
                                         - maximum_boundary:
-                                            blkdevio_write_bytes_sec = 9223372036854775807
+                                            blkdevio_write_bytes_sec = 1000000000000000
                                     variants:
                                         - options:
                                             variants:
@@ -93,8 +93,8 @@
                                             blkdevio_write_bytes_sec = 0
                                         - combination3:
                                             blkdevio_total_bytes_sec = 0
-                                            blkdevio_read_bytes_sec = 9223372036854775807
-                                            blkdevio_write_bytes_sec = 9223372036854775807
+                                            blkdevio_read_bytes_sec = 1000000000000000
+                                            blkdevio_write_bytes_sec = 1000000000000000
                                         - combination4:
                                             blkdevio_total_bytes_sec = 0
                                             blkdevio_read_bytes_sec = 1099511627776
@@ -102,7 +102,7 @@
                                         - combination5:
                                             blkdevio_total_bytes_sec = 0
                                             blkdevio_read_bytes_sec = 0
-                                            blkdevio_write_bytes_sec = 1125899906842624
+                                            blkdevio_write_bytes_sec = 112589990684262
                                     variants:
                                         - options:
                                             variants:
@@ -117,7 +117,7 @@
                                         - inside_boundary:
                                             blkdevio_total_iops_sec = 1099511627776
                                         - maximum_boundary:
-                                            blkdevio_total_iops_sec = 9223372036854775807
+                                            blkdevio_total_iops_sec = 1000000000000000
                                     variants:
                                         - options:
                                             variants:
@@ -130,9 +130,9 @@
                                         - minimum_boundary:
                                             blkdevio_read_iops_sec = 0
                                         - inside_boundary:
-                                            blkdevio_read_iops_sec = 1125899906842624
+                                            blkdevio_read_iops_sec = 112589990684262
                                         - maximum_boundary:
-                                            blkdevio_read_iops_sec = 9223372036854775807
+                                            blkdevio_read_iops_sec = 1000000000000000
                                     variants:
                                         - options:
                                             variants:
@@ -145,9 +145,9 @@
                                         - minimum_boundary:
                                             blkdevio_write_iops_sec = 0
                                         - inside_boundary:
-                                            blkdevio_write_iops_sec = 1152921504606846976
+                                            blkdevio_write_iops_sec = 112589990684262
                                         - maximum_boundary:
-                                            blkdevio_write_iops_sec = 9223372036854775807
+                                            blkdevio_write_iops_sec = 1000000000000000
                                     variants:
                                         - options:
                                             variants:
@@ -167,8 +167,8 @@
                                             blkdevio_write_iops_sec = 0
                                         - combination3:
                                             blkdevio_total_iops_sec = 0
-                                            blkdevio_read_iops_sec = 9223372036854775807
-                                            blkdevio_write_iops_sec = 9223372036854775807
+                                            blkdevio_read_iops_sec = 1000000000000000
+                                            blkdevio_write_iops_sec = 1000000000000000
                                         - combination4:
                                             blkdevio_total_iops_sec = 0
                                             blkdevio_read_iops_sec = 1099511627776
@@ -176,7 +176,7 @@
                                         - combination5:
                                             blkdevio_total_iops_sec = 0
                                             blkdevio_read_iops_sec = 0
-                                            blkdevio_write_iops_sec = 1125899906842624
+                                            blkdevio_write_iops_sec = 112589990684262
                                     variants:
                                         - options:
                                             variants:
@@ -191,7 +191,7 @@
                                             blkdevio_total_iops_sec = 1073741824
                                         - combination2:
                                             blkdevio_write_bytes_sec = 1073741824
-                                            blkdevio_total_iops_sec = 9223372036854775807
+                                            blkdevio_total_iops_sec = 1000000000000000
                                         - combination3:
                                             blkdevio_total_bytes_sec = 1073741824
                                             blkdevio_total_iops_sec = 1099511627776
@@ -212,7 +212,7 @@
                                         - inside_boundary:
                                             blkdevio_total_bytes_sec = 1
                                         - maximum_boundary:
-                                            blkdevio_total_bytes_sec = 9223372036854775807
+                                            blkdevio_total_bytes_sec = 1000000000000000
                                     variants:
                                         - options:
                                             variants:
@@ -227,7 +227,7 @@
                                         - inside_boundary:
                                             blkdevio_read_bytes_sec = 4096
                                         - maximum_boundary:
-                                            blkdevio_read_bytes_sec = 9223372036854775807
+                                            blkdevio_read_bytes_sec = 1000000000000000
                                     variants:
                                         - options:
                                             variants:
@@ -242,7 +242,7 @@
                                         - inside_boundary:
                                             blkdevio_write_bytes_sec = 16777216
                                         - maximum_boundary:
-                                            blkdevio_write_bytes_sec = 9223372036854775807
+                                            blkdevio_write_bytes_sec = 1000000000000000
                                     variants:
                                         - options:
                                             variants:
@@ -262,8 +262,8 @@
                                             blkdevio_write_bytes_sec = 0
                                         - combination3:
                                             blkdevio_total_bytes_sec = 0
-                                            blkdevio_read_bytes_sec = 9223372036854775807
-                                            blkdevio_write_bytes_sec = 9223372036854775807
+                                            blkdevio_read_bytes_sec = 1000000000000000
+                                            blkdevio_write_bytes_sec = 1000000000000000
                                         - combination4:
                                             blkdevio_total_bytes_sec = 0
                                             blkdevio_read_bytes_sec = 1099511627776
@@ -271,7 +271,7 @@
                                         - combination5:
                                             blkdevio_total_bytes_sec = 0
                                             blkdevio_read_bytes_sec = 0
-                                            blkdevio_write_bytes_sec = 1125899906842624
+                                            blkdevio_write_bytes_sec = 112589990684262
                                     variants:
                                         - options:
                                             variants:
@@ -286,7 +286,7 @@
                                         - inside_boundary:
                                             blkdevio_total_iops_sec = 4294967296
                                         - maximum_boundary:
-                                            blkdevio_total_iops_sec = 9223372036854775807
+                                            blkdevio_total_iops_sec = 1000000000000000
                                     variants:
                                         - options:
                                             variants:
@@ -301,7 +301,7 @@
                                         - inside_boundary:
                                             blkdevio_read_iops_sec = 17592186044416
                                         - maximum_boundary:
-                                            blkdevio_read_iops_sec = 9223372036854775807
+                                            blkdevio_read_iops_sec = 1000000000000000
                                     variants:
                                         - options:
                                             variants:
@@ -314,9 +314,9 @@
                                         - minimum_boundary:
                                             blkdevio_write_iops_sec = 0
                                         - inside_boundary:
-                                            blkdevio_write_iops_sec = 72057594037927936
+                                            blkdevio_write_iops_sec = 720575940379279
                                         - maximum_boundary:
-                                            blkdevio_write_iops_sec = 9223372036854775807
+                                            blkdevio_write_iops_sec = 1000000000000000
                                     variants:
                                         - options:
                                             variants:
@@ -336,8 +336,8 @@
                                             blkdevio_write_iops_sec = 0
                                         - combination3:
                                             blkdevio_total_iops_sec = 0
-                                            blkdevio_read_iops_sec = 9223372036854775807
-                                            blkdevio_write_iops_sec = 9223372036854775807
+                                            blkdevio_read_iops_sec = 1000000000000000
+                                            blkdevio_write_iops_sec = 1000000000000000
                                         - combination4:
                                             blkdevio_total_iops_sec = 0
                                             blkdevio_read_iops_sec = 1099511627776
@@ -345,7 +345,7 @@
                                         - combination5:
                                             blkdevio_total_iops_sec = 0
                                             blkdevio_read_iops_sec = 0
-                                            blkdevio_write_iops_sec = 1125899906842624
+                                            blkdevio_write_iops_sec = 112589990684262
                                     variants:
                                         - options:
                                             variants:
@@ -360,7 +360,7 @@
                                             blkdevio_read_bytes_sec = 1073741824
                                         - combination2:
                                             blkdevio_total_iops_sec = 1073741824
-                                            blkdevio_write_bytes_sec = 9223372036854775807
+                                            blkdevio_write_bytes_sec = 1000000000000000
                                         - combination3:
                                             blkdevio_total_iops_sec = 1073741824
                                             blkdevio_total_bytes_sec = 1099511627776
@@ -405,13 +405,13 @@
                             variants:
                                 - invalid_device:
                                     blkdevio_device = "ceph"
-                                    blkdevio_total_bytes_sec = 9223372036854775807
+                                    blkdevio_total_bytes_sec = 1000000000000000
                                 - change_total_bytes_sec:
                                     variants:
                                         - lower_minimum_boundary:
                                             blkdevio_total_bytes_sec = -1
                                         - upper_maximum_boundary:
-                                            blkdevio_total_bytes_sec = 9223372036854775808
+                                            blkdevio_total_bytes_sec = 1000000000000001
                                         - invalid_value:
                                             blkdevio_total_bytes_sec = "~@#$%^-=_:,.[]{}"
                                     variants:
@@ -428,7 +428,7 @@
                                         - lower_minimum_boundary:
                                             blkdevio_read_bytes_sec = -1
                                         - upper_maximum_boundary:
-                                            blkdevio_read_bytes_sec = 9223372036854775808
+                                            blkdevio_read_bytes_sec = 1000000000000001
                                         - invalid_value:
                                             blkdevio_read_bytes_sec = "~@#$%^-=_:,.[]{}"
                                     variants:
@@ -445,7 +445,7 @@
                                         - lower_minimum_boundary:
                                             blkdevio_write_bytes_sec = -1
                                         - upper_maximum_boundary:
-                                            blkdevio_write_bytes_sec = 9223372036854775808
+                                            blkdevio_write_bytes_sec = 1000000000000001
                                         - invalid_value:
                                             blkdevio_write_bytes_sec = "~@#$%^-=_:,.[]{}"
                                     variants:
@@ -462,7 +462,7 @@
                                         - lower_minimum_boundary:
                                             blkdevio_total_iops_sec = -1
                                         - upper_maximum_boundary:
-                                            blkdevio_total_iops_sec = 9223372036854775808
+                                            blkdevio_total_iops_sec = 1000000000000001
                                         - invalid_value:
                                             blkdevio_total_iops_sec = "~@#$%^-=_:,.[]{}"
                                     variants:
@@ -479,7 +479,7 @@
                                         - lower_minimum_boundary:
                                             blkdevio_read_iops_sec = -1
                                         - upper_maximum_boundary:
-                                            blkdevio_read_iops_sec = 9223372036854775808
+                                            blkdevio_read_iops_sec = 1000000000000001
                                         - invalid_value:
                                             blkdevio_read_iops_sec = "~@#$%^-=_:,.[]{}"
                                     variants:
@@ -496,7 +496,7 @@
                                         - lower_minimum_boundary:
                                             blkdevio_write_iops_sec = -1
                                         - upper_maximum_boundary:
-                                            blkdevio_write_iops_sec = 9223372036854775808
+                                            blkdevio_write_iops_sec = 1000000000000001
                                         - invalid_value:
                                             blkdevio_write_iops_sec = "~@#$%^-=_:,.[]{}"
                                     variants:
@@ -527,13 +527,13 @@
                             variants:
                                 - invalid_device:
                                     blkdevio_device = "nfs"
-                                    blkdevio_write_iops_sec = 9223372036854775807
+                                    blkdevio_write_iops_sec = 1000000000000000
                                 - change_total_bytes_sec:
                                     variants:
                                         - lower_minimum_boundary:
                                             blkdevio_total_bytes_sec = -1
                                         - upper_maximum_boundary:
-                                            blkdevio_total_bytes_sec = 9223372036854775808
+                                            blkdevio_total_bytes_sec = 1000000000000001
                                         - invalid_value:
                                             blkdevio_total_bytes_sec = "~@#$%^-=_:,.[]{}"
                                     variants:
@@ -550,7 +550,7 @@
                                         - lower_minimum_boundary:
                                             blkdevio_read_bytes_sec = -1
                                         - upper_maximum_boundary:
-                                            blkdevio_read_bytes_sec = 9223372036854775808
+                                            blkdevio_read_bytes_sec = 1000000000000001
                                         - invalid_value:
                                             blkdevio_read_bytes_sec = "~@#$%^-=_:,.[]{}"
                                     variants:
@@ -567,7 +567,7 @@
                                         - lower_minimum_boundary:
                                             blkdevio_write_bytes_sec = -1
                                         - upper_maximum_boundary:
-                                            blkdevio_write_bytes_sec = 9223372036854775808
+                                            blkdevio_write_bytes_sec = 1000000000000001
                                         - invalid_value:
                                             blkdevio_write_bytes_sec = "~@#$%^-=_:,.[]{}"
                                     variants:
@@ -584,7 +584,7 @@
                                         - lower_minimum_boundary:
                                             blkdevio_total_iops_sec = -1
                                         - upper_maximum_boundary:
-                                            blkdevio_total_iops_sec = 9223372036854775808
+                                            blkdevio_total_iops_sec = 1000000000000001
                                         - invalid_value:
                                             blkdevio_total_iops_sec = "~@#$%^-=_:,.[]{}"
                                     variants:
@@ -601,7 +601,7 @@
                                         - lower_minimum_boundary:
                                             blkdevio_read_iops_sec = -1
                                         - upper_maximum_boundary:
-                                            blkdevio_read_iops_sec = 9223372036854775808
+                                            blkdevio_read_iops_sec = 1000000000000001
                                         - invalid_value:
                                             blkdevio_read_iops_sec = "~@#$%^-=_:,.[]{}"
                                     variants:
@@ -618,7 +618,7 @@
                                         - lower_minimum_boundary:
                                             blkdevio_write_iops_sec = -1
                                         - upper_maximum_boundary:
-                                            blkdevio_write_iops_sec = 9223372036854775808
+                                            blkdevio_write_iops_sec = 1000000000000001
                                         - invalid_value:
                                             blkdevio_write_iops_sec = "~@#$%^-=_:,.[]{}"
                                     variants:


### PR DESCRIPTION
According to bug: https://bugzilla.redhat.com/show_bug.cgi?id=1329041
Current blkdeviotune should be 1e15.

Signed-off-by: Hao Liu <hliu@redhat.com>