### PR TITLE
conf_file.qemu_conf.auto_dump: Use shutil to remove directory

### DIFF
--- a/libvirt/tests/src/conf_file/qemu_conf/auto_dump.py
+++ b/libvirt/tests/src/conf_file/qemu_conf/auto_dump.py
@@ -1,5 +1,6 @@
 import os
 import logging
+import shutil
 
 from aexpect import ShellTimeoutError
 
@@ -119,4 +120,4 @@ def run(test, params, env):
         config.restore()
         libvirtd.restart()
         if os.path.exists(dump_path):
-            os.rmdir(dump_path)
+            shutil.rmtree(dump_path)


### PR DESCRIPTION
Dump path is a folder and need to be removed by shutil.rmtree

Signed-off-by: Hao Liu <hliu@redhat.com>