### PR TITLE
managedsave: add expected vcpus for cpu_mode test

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_managedsave.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_managedsave.cfg
@@ -45,6 +45,7 @@
                     cpu_topology_sockets = "2"
                     cpu_topology_cores = "4"
                     cpu_topology_threads = "2"
+                    vcpu_nums = "16"
                 - undefine:
                     managedsave_undefine = "yes"
                 - bypass_cache:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_managedsave.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_managedsave.py
@@ -289,6 +289,7 @@ def run(test, params, env):
                 if cpu_topology:
                     cpuxml.topology = cpu_topology
                 vmxml.cpu = cpuxml
+                vmxml.vcpu = int(params.get("vcpu_nums"))
             if dargs.get("sec_driver"):
                 seclabel_dict = {"type": "dynamic", "model": "selinux",
                                  "relabel": "yes"}


### PR DESCRIPTION
The max cpu (vcpu) must be no less  than socks * thread * cores so that guest can successfully start.