### PR TITLE
virsh.emulatorpin: Move auto replacement to positive

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_emulatorpin.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_emulatorpin.cfg
@@ -47,6 +47,9 @@
                                             emulatorpin_cpulist = "x-y,^z"
                                         - single:
                                             emulatorpin_cpulist = "x"
+                                        - auto_placement:
+                                            emulatorpin_placement = "auto"
+                                            emulatorpin_cpulist = "x"
                                     variants:
                                         - emulatorpin_options:
                                             variants:
@@ -116,9 +119,6 @@
                                             emulatorpin_cpulist = x
                                         - noexist:
                                             emulatorpin_cpulist = 0-123456
-                                        - auto_placement:
-                                            emulatorpin_placement = "auto"
-                                            emulatorpin_cpulist = 1
                                     variants:
                                         - emulatorpin_options:
                                             variants:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_emulatorpin.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_emulatorpin.py
@@ -118,7 +118,7 @@ def get_emulatorpin_parameter(params):
             logging.info("It's an expected : %s", result.stderr)
         else:
             raise error.TestFail("%d not a expected command "
-                                 "return value", status)
+                                 "return value" % status)
     elif status_error == "no":
         if status:
             raise error.TestFail(result.stderr)
@@ -146,18 +146,12 @@ def set_emulatorpin_parameter(params):
     # Check status_error
     status_error = params.get("status_error")
 
-    # Changing affinity for emulator thread dynamically is
-    # not allowed when CPU placement is 'auto'
-    placement = vm_xml.VMXML().new_from_dumpxml(vm_name).placement
-    if placement == "auto":
-        status_error = "yes"
-
     if status_error == "yes":
         if status or not check_emulatorpin(params):
             logging.info("It's an expected : %s", result.stderr)
         else:
             raise error.TestFail("%d not a expected command "
-                                 "return value", status)
+                                 "return value" % status)
     elif status_error == "no":
         if status:
             raise error.TestFail(result.stderr)


### PR DESCRIPTION
Using auto replacement when pinning CPU is currently supported by a
bugfix https://bugzilla.redhat.com/show_bug.cgi?id=1308317

This commit also included some trivial fixes.

Signed-off-by: Hao Liu <hliu@redhat.com>