### PR TITLE
remote_with_unix.cfg: change a match pattern

### DIFF
--- a/libvirt/tests/cfg/remote_access/remote_with_unix.cfg
+++ b/libvirt/tests/cfg/remote_access/remote_with_unix.cfg
@@ -126,6 +126,6 @@
                     virsh_cmd = "start"
                     main_vm = "avocado-vt-vm1"
                     status_error = "no"
-                    patterns_virsh_cmd = ".*authentication failed.*"
+                    patterns_virsh_cmd = ".*authentication unavailable.*"
                     polkit_pkla = "/etc/polkit-1/localauthority/50-local.d/polkit.pkla"
                     polkit_pkla_cxt = "[Allow ${su_user} libvirt monitor permissions]\nIdentity=unix-user:${su_user}\nAction=org.libvirt.unix.monitor\nResultAny=yes\nResultInactive=yes\nResultActive=yes"


### PR DESCRIPTION
Error messages are changed to reflect the real situation about the
problem that requested mechanism is unavailable in more descriptive way.
So the match pattern need be updated accordingly.

Refer below patch:
https://www.redhat.com/archives/libvir-list/2016-February/msg00658.html

Signed-off-by: Dan Zheng <dzheng@redhat.com>