### PR TITLE
migrate_vm.cfg: use some parameters in base.cfg

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_vm.cfg
+++ b/libvirt/tests/cfg/migration/migrate_vm.cfg
@@ -3,12 +3,12 @@
     take_regular_screendumps = no
     ssh_timeout = 60
     # please replace your configuration
-    server_ip = "ENTER.YOUR.REMOTE.EXAMPLE.COM"
-    server_user = "ENTER.YOUR.REMOTE.USER"
-    server_pwd = "ENTER.YOUR.REMOTE.PASSWORD"
-    client_ip = "ENTER.YOUR.CLIENT.EXAMPLE.COM"
-    client_user = "ENTER.YOUR.CLIENT.USER"
-    client_pwd = "ENTER.YOUR.CLIENT.PASSWORD"
+    server_ip = "${migrate_dest_host}"
+    server_user = "root"
+    server_pwd = "${migrate_dest_pwd}"
+    client_ip = "${migrate_source_host}"
+    client_user = "root"
+    client_pwd = "${migrate_source_pwd}"
     start_vm = "no"
     transport = "ssh"
     port = "22"


### PR DESCRIPTION
Some paramters are already shared in avocado-vt base.cfg. So it is
better to use them instead of creating again.

Signed-off-by: Dan Zheng <dzheng@redhat.com>