### PR TITLE
virsh_migrate_setmaxdowntime: use local uri

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_setmaxdowntime.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_setmaxdowntime.cfg
@@ -6,7 +6,7 @@
     # Set a millsecond for maxdowntime
     migrate_maxdowntime = 1000
     virsh_migrate_dest_uri = "qemu+ssh://${migrate_dest_host}/system"
-    virsh_migrate_src_uri = "qemu+ssh://${migrate_source_host}/system"
+    virsh_migrate_src_uri = "qemu:///system"
     take_regular_screendumps = "no"
     delay_time = 1
     variants:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_setmaxdowntime.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_setmaxdowntime.py
@@ -3,9 +3,9 @@ import threading
 import time
 
 from autotest.client.shared import error
-from autotest.client.shared import ssh_key
 
 from virttest import virsh
+from virttest import ssh_key
 
 from provider import libvirt_version
 
@@ -105,7 +105,7 @@ def run(test, params, env):
     domid = vm.get_id()
     if dest_uri.count('///') or dest_uri.count('EXAMPLE'):
         raise error.TestNAError("Set your destination uri first.")
-    if src_uri.count('///') or src_uri.count('EXAMPLE'):
+    if src_uri.count('EXAMPLE'):
         raise error.TestNAError("Set your source uri first.")
     if src_uri == dest_uri:
         raise error.TestNAError("You should not set dest uri same as local.")


### PR DESCRIPTION
Use local URI qemu:///system instead of
qemu+ssh://${migrate_source_host}/system. It's not necessary to use
qemu+ssh://${migrate_source_host}/system URI for the local connecting.

Signed-off-by: Dan Zheng <dzheng@redhat.com>