### PR TITLE
Change the skip match string as new version error output changed

### DIFF
--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_update.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_update.py
@@ -149,7 +149,7 @@ def run(test, params, env):
 
         if cmd_result.exit_status:
             err = cmd_result.stderr.strip()
-            if re.search("is not supported", err):
+            if re.search("not supported", err):
                 raise error.TestNAError("Skip the test: %s" % err)
             else:
                 raise error.TestFail("Failed to execute "


### PR DESCRIPTION
From "this function is not supported by the connection driver" to
"Operation not supported"