### PR TITLE
migrate_vm.cfg: Fix one parameter

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_vm.cfg
+++ b/libvirt/tests/cfg/migration/migrate_vm.cfg
@@ -24,7 +24,7 @@
     nfs_mount_dir = "/var/lib/libvirt/migrate"
     nfs_mount_options = "rw"
     # default to /var/lib/virt_test/images
-    nfs_mount_src = "/var/lib/virt_test/images"
+    nfs_mount_src = "${nfs_mount_src}"
     export_ip = "*"
     export_options = "rw,no_root_squash"
     setup_local_nfs = "yes"


### PR DESCRIPTION
Use shared value in avocado-vt/share/cfg/base.cfg.

Signed-off-by: Dan Zheng <dzheng@redhat.com>