### PR TITLE
Added migration scenarios for numa enabled guest

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
@@ -34,6 +34,10 @@
             # virsh_migrate_back_options = 'default'
             # virsh_migrate_back_extra = 'default'
             # virsh_migrate_back_desturi = 'default'
+        - there_and_back_with_numa:
+            # After migrating with numa enabled, migrate the guest back.
+            virsh_migrate_back = 'yes'
+            virsh_migrate_with_numa = 'yes'
         - there_and_back_a_lot:
             iterations = 100
             virsh_migrate_back = 'yes'
@@ -47,6 +51,10 @@
         - there_live:
             # Uni-direction migration with option --live.
             virsh_migrate_options = "--live"
+        - there_live_with_numa:
+            # Numa enabled uni-direction migration with option --live.
+            virsh_migrate_options = "--live"
+            virsh_migrate_with_numa = 'yes'
         - there_p2p:
             # Uni-direction migration with option --p2p.
             virsh_migrate_options = "--live --p2p"
@@ -109,6 +117,11 @@
             # Uni-direction online migration.
             virsh_migrate_options = ""
             virsh_migrate_extra = ""
+        - there_online_with_numa:
+            # Uni-direction numa enabled online migration.
+            virsh_migrate_options = ""
+            virsh_migrate_extra = ""
+            virsh_migrate_with_numa = 'yes'
         - there_vm_suspend_live:
             # Uni-direction live migration with VM suspend.
             virsh_migrate_options = "--live"


### PR DESCRIPTION
Migrating guest with 2 numa nodes that are created based on available vcpus and memory, only 1 Numa node is created if 1 vcpu is available 