### PR TITLE
blockcopy: Fix fail on virtlogd command not found

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
@@ -632,7 +632,9 @@ def run(test, params, env):
             os.remove(snap_path)
         if os.path.exists(save_path):
             os.remove(save_path)
-        # Restart virtlogd serice to release VM log file lock
-        virtlogd = path.find_command('virtlogd')
-        if virtlogd:
+        # Restart virtlogd service to release VM log file lock
+        try:
+            virtlogd = path.find_command('virtlogd')
             process.run('service virtlogd restart')
+        except path.CmdNotFoundError:
+            pass


### PR DESCRIPTION
virtlogd is introduced in libvirt 1.3.1, if not found in earlier
version avocado.utils.path.CmdNotFoundError will be raised, need
caught it in exception and let test pass in such situation.

Signed-off-by: Wayne Sun <gsun@redhat.com>