### PR TITLE
Added Numatune scenarios for migration - Version 2

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
@@ -33,15 +33,68 @@
     variants:
         - there_and_back_with_numa:
             # After migrating with numa enabled, migrate the guest back.
-            virsh_migrate_back = 'yes'
-            virsh_migrate_with_numa = 'yes'
+            variants:
+                - with_numa_only:
+                    virsh_migrate_back = 'yes'
+                    virsh_migrate_with_numa = 'yes'
+                - with_numa_pinning:
+                    virsh_migrate_back = 'yes'
+                    virsh_migrate_with_numa = 'yes'
+                    virsh_migrate_with_numa_pin = 'yes'
+                    variants:
+                        - strict_memory_mode:
+                            memory_mode = "strict"
+                            memory_placement = "static"
+                        - interleave_memory_mode:
+                            memory_mode = "interleave"
+                            memory_placement = "static"
+                        - preferred_memory_mode:
+                            memory_mode = "preferred"
+                            memory_placement = "static"
+                    variants:
+                        - memnode_with_strict_interleave:
+                            memnode_mode_1 = "strict"
+                            memnode_mode_2 = "interleave"
+                        - memnode_with_interleave_preferred:
+                            memnode_mode_1 = "interleave"
+                            memnode_mode_2 = "preferred"
+                        - memnode_with_preferred_strict:
+                            memnode_mode_1 = "preferred"
+                            memnode_mode_2 = "strict"
         - there_live:
             # Uni-direction migration with option --live.
             virsh_migrate_options = "--live"
         - there_live_with_numa:
             # Numa enabled uni-direction migration with option --live.
-            virsh_migrate_options = "--live"
-            virsh_migrate_with_numa = 'yes'
+            variants:
+                - with_numa_only:
+                    virsh_migrate_options = "--live"
+                    virsh_migrate_with_numa = 'yes'
+                - with_numa_pinning:
+                    virsh_migrate_options = "--live"
+                    virsh_migrate_with_numa = 'yes'
+                    virsh_migrate_with_numa_pin = 'yes'
+                    variants:
+                        - strict_memory_mode:
+                            memory_mode = "strict"
+                            memory_placement = "static"
+                        - interleave_memory_mode:
+                            memory_mode = "interleave"
+                            memory_placement = "static"
+                        - preferred_memory_mode:
+                            memory_mode = "preferred"
+                            memory_placement = "static"
+                    variants:
+                        - memnode_with_strict_interleave:
+                            memnode_mode_1 = "strict"
+                            memnode_mode_2 = "interleave"
+                        - memnode_with_interleave_preferred:
+                            memnode_mode_1 = "interleave"
+                            memnode_mode_2 = "preferred"
+                        - memnode_with_preferred_strict:
+                            memnode_mode_1 = "preferred"
+                            memnode_mode_2 = "strict"
+
         - there_p2p:
             # Uni-direction migration with option --p2p.
             virsh_migrate_options = "--live --p2p"
@@ -116,9 +169,37 @@
             virsh_migrate_extra = ""
         - there_online_with_numa:
             # Uni-direction numa enabled online migration.
-            virsh_migrate_options = ""
-            virsh_migrate_extra = ""
-            virsh_migrate_with_numa = 'yes'
+            variants:
+                - with_numa_only:
+                    virsh_migrate_options = ""
+                    virsh_migrate_extra = ""
+                    virsh_migrate_with_numa = 'yes'
+                - with_numa_pinning:
+                    virsh_migrate_options = ""
+                    virsh_migrate_extra = ""
+                    virsh_migrate_with_numa = 'yes'
+                    virsh_migrate_with_numa_pin = 'yes'
+                    variants:
+                        - strict_memory_mode:
+                            memory_mode = "strict"
+                            memory_placement = "static"
+                        - interleave_memory_mode:
+                            memory_mode = "interleave"
+                            memory_placement = "static"
+                        - preferred_memory_mode:
+                            memory_mode = "preferred"
+                            memory_placement = "static"
+                    variants:
+                        - memnode_with_strict_interleave:
+                            memnode_mode_1 = "strict"
+                            memnode_mode_2 = "interleave"
+                        - memnode_with_interleave_preferred:
+                            memnode_mode_1 = "interleave"
+                            memnode_mode_2 = "preferred"
+                        - memnode_with_preferred_strict:
+                            memnode_mode_1 = "preferred"
+                            memnode_mode_2 = "strict"
+
         - there_xml_with_dname:
             # Do migration with --dname and --xml with same changed
             # name from guest XML


### PR DESCRIPTION
This patch adds tests that will pin guest numa node with host numa 
node and performs live, online and live_there_and_back migration 
scenarios. It covers different memory modes strict, preferred and 
interleave. Memory placement is static currently.