### PR TITLE
Add 4 cases of virt-v2v network

### DIFF
--- a/v2v/tests/cfg/specific_kvm.cfg
+++ b/v2v/tests/cfg/specific_kvm.cfg
@@ -130,6 +130,16 @@
         - unclean_fs:
             checkpoint = 'unclean_fs'
             main_vm = 'VM_WIN_8_V2V_EXAMPLE'
+        - network:
+            variants:
+                - multi_netcards:
+                    checkpoint = 'multi_netcards'
+                - virtio:
+                    checkpoint = 'network_virtio'
+                - rtl8139:
+                    checkpoint = 'network_rtl8139'
+                - e1000:
+                    checkpoint = 'network_e1000'
 
     variants:
         - positive_test:


### PR DESCRIPTION
test result:

> JOB ID     : 8349bf05548986b520584bb1d44bf5ed67550127
> JOB LOG    : /root/avocado/job-results/job-2016-06-02T10.50-8349bf0/job.log
> TESTS      : 4
>  (1/4) type_specific.local.specific_kvm.positive_test.linux.network.multi_netcards.output_mode.rhev: PASS (835.10 s)
>  (2/4) type_specific.local.specific_kvm.positive_test.linux.network.virtio.output_mode.rhev: PASS (718.39 s)
>  (3/4) type_specific.local.specific_kvm.positive_test.linux.network.rtl8139.output_mode.rhev: PASS (707.81 s)
>  (4/4) type_specific.local.specific_kvm.positive_test.linux.network.e1000.output_mode.rhev: PASS (707.27 s)
> RESULTS    : PASS 4 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0
> JOB HTML   : /root/avocado/job-results/job-2016-06-02T10.50-8349bf0/html/results.html
> TIME       : 2968.57 s
