### PR TITLE
iface_options: update the max queue number

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_options.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_options.cfg
@@ -33,7 +33,7 @@
                             attach_iface_device = "live"
                 - driver_queues_negative:
                     start_error = "yes"
-                    iface_driver =  "{'name':'vhost','queues':'9'}"
+                    iface_driver =  "{'name':'vhost','queues':'257'}"
                 - driver_vhost:
                     test_vhost_net = "yes"
                     variants:

--- a/libvirt/tests/src/virtual_network/iface_hotplug.py
+++ b/libvirt/tests/src/virtual_network/iface_hotplug.py
@@ -133,7 +133,8 @@ def run(test, params, env):
                             raise error.TestFail("Failed to attach-interface")
                     elif stress_test:
                         # Detach the device immediately for stress test
-                        ret = virsh.attach_interface(vm_name, options,
+                        detach_options = "%s --mac %s" % (iface_type, mac)
+                        ret = virsh.detach_interface(vm_name, detach_options,
                                                      ignore_status=True)
                         libvirt.check_exit_status(ret)
                     else:


### PR DESCRIPTION
Multiqueue is supported up to 256 by the kernel in RHEL7.3 instead of 8.
So the number should be updated.

Signed-off-by: Dan Zheng <dzheng@redhat.com>