### PR TITLE
iface_hotplug: fix the stress test

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_hotplug.py
+++ b/libvirt/tests/src/virtual_network/iface_hotplug.py
@@ -133,8 +133,10 @@ def run(test, params, env):
                             raise error.TestFail("Failed to attach-interface")
                     elif stress_test:
                         # Detach the device immediately for stress test
-                        ret = virsh.attach_interface(vm_name, options,
+                        options = "%s --mac %s" % (iface_type, mac)
+                        ret = virsh.detach_interface(vm_name, options,
                                                      ignore_status=True)
+
                         libvirt.check_exit_status(ret)
                     else:
                         iface_list.append({'mac': mac})


### PR DESCRIPTION
Detach the interface after attaching the interface for stress test.

Signed-off-by: Dan Zheng <dzheng@redhat.com>