### PR TITLE
virsh_migrate_setmaxdowntime: Fix syntax error

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_setmaxdowntime.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_setmaxdowntime.py
@@ -14,7 +14,7 @@ from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 from virttest import utils_libvirtd
 from virttest import utils_config
-from virttest.utils_misc import SELinuxBoolean
+from virttest import utils_misc
 
 from provider import libvirt_version
 
@@ -196,7 +196,7 @@ def run(test, params, env):
         nfs_client.setup()
 
         logging.info("Enable virt NFS SELinux boolean on target host")
-        seLinuxBool = SELinuxBoolean(params)
+        seLinuxBool = utils_misc.SELinuxBoolean(params)
         seLinuxBool.setup()
 
         if not vm.is_alive():


### PR DESCRIPTION
utils_misc.wait_for function is invoked, so there is a need to import
utils_misc. Therefore, it seems no need to include
"from virttest.utils_misc import SELinuxBoolean".

Signed-off-by: Dan Zheng <dzheng@redhat.com>