### PR TITLE
Handle cache directory missing for qemu capability

### DIFF
--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -1439,10 +1439,14 @@ def run(test, params, env):
         # Do not create target image when qemu supports drive-mirror
         # and nbd-server, but need create a specific pool.
         no_create_pool = test_dict.get("no_create_pool", "no")
-        if (utils_misc.is_qemu_capability_supported("drive-mirror") and
-           utils_misc.is_qemu_capability_supported("nbd-server")):
-            support_precreation = True
-            test_dict["support_precreation"] = True
+        try:
+            if (utils_misc.is_qemu_capability_supported("drive-mirror") and
+               utils_misc.is_qemu_capability_supported("nbd-server")):
+                support_precreation = True
+        except exceptions.TestError, e:
+            logging.debug(e)
+
+        test_dict["support_precreation"] = support_precreation
         if create_target_image:
             if support_precreation and no_create_pool == "no":
                 create_target_pool = True


### PR DESCRIPTION
- To determine if a certain qemu capability is supported in current
environment, we check the cache directory which is not implemented on
RHEL6. This only works on RHEL7. So an exception will be raised out on
RHEL6 which we should handle it with correct logic.

- A logic error fix
There is a need to create image or create pool before migration.

Signed-off-by: Dan Zheng <dzheng@redhat.com>