### PR TITLE
convert_vm_to_ovirt: assign None to parameters for hypervisor kvm

### DIFF
--- a/v2v/tests/cfg/convert_vm_to_libvirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_libvirt.cfg
@@ -87,18 +87,12 @@
             vm_user = "Administrator"
             vm_pwd = "123qweP"
             variants:
-                - win2003:
-                    os_version = "win2003"
-                    screenshots_for_match = "WIN2003_SCREENSHOTS_V2V_EXAMPLE"
                 - win2008:
                     os_version = "win2008"
-                    screenshots_for_match = "WIN2008_SCREENSHOTS_V2V_EXAMPLE"
                 - win2008r2:
                     os_version = "win2008r2"
-                    screenshots_for_match = "WIN2008R2_SCREENSHOTS_V2V_EXAMPLe"
                 - win7:
                     os_version = "win7"
-                    screenshots_for_match = "WIN7_SCREENSHOTS_V2V_EXAMPLE"
                 - win8:
                     os_version = "win8"
                 - win8_1:

--- a/v2v/tests/cfg/convert_vm_to_ovirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_ovirt.cfg
@@ -15,6 +15,7 @@
     remote_shell_port = 22
     remote_shell_prompt = "^\w:\\.*>\s*$|^\[.*\][\#\$]\s*$"
     status_test_command = "echo $?"
+    v2v_timeout = '1200'
 
     #******************************************************
     # Input source of XEN and ESX hypervisors
@@ -50,10 +51,10 @@
     iscsi_cluster_name = "ISCSI_CLUSTER_NAME_V2V_EXAMPLE"
     iscsi_ovirt_node_address = "ISCSI_OVIRT_NODE_ADDRESS_V2V_EXAMPLE"
     # Storage - FC
-    fc_storage = "FC_EXPORT_STORAGE_EXAMPLE"
-    fc_export_name = "FC_EXPORT_NAME_EXAMPLE"
-    fc_storage_name = "FC_STORAGE_NAME_EXAMPLE"
-    fc_cluster_name = "FC_CLUSTER_NAME_EXAMPLE"
+    fc_storage = "FC_EXPORT_STORAGE_V2V_EXAMPLE"
+    fc_export_name = "FC_EXPORT_NAME_V2V_EXAMPLE"
+    fc_storage_name = "FC_STORAGE_NAME_V2V_EXAMPLE"
+    fc_cluster_name = "FC_CLUSTER_NAME_V2V_EXAMPLE"
     fc_ovirt_node_address = "FC_OVIRT_NODE_ADDRESS_V2V_EXAMPLE"
     # Network
     network = "OVIRT_NODE_NETWORK_V2V_EXAMPLE"
@@ -146,18 +147,12 @@
             vm_user = "Administrator"
             vm_pwd = "123qweP"
             variants:
-                - win2003:
-                    os_version = "win2003"
-                    screenshots_for_match = "WIN2003_SCREENSHOTS_V2V_EXAMPLE"
                 - win2008:
                     os_version = "win2008"
-                    screenshots_for_match = "WIN2008_SCREENSHOTS_V2V_EXAMPLE"
                 - win2008r2:
                     os_version = "win2008r2"
-                    screenshots_for_match = "WIN2008R2_SCREENSHOTS_V2V_EXAMPLe"
                 - win7:
                     os_version = "win7"
-                    screenshots_for_match = "WIN7_SCREENSHOTS_V2V_EXAMPLE"
                 - win8:
                     os_version = "win8"
                 - win8_1:

--- a/v2v/tests/src/convert_vm_to_ovirt.py
+++ b/v2v/tests/src/convert_vm_to_ovirt.py
@@ -36,9 +36,9 @@ def run(test, params, env):
     vpx_pwd_file = params.get("vpx_pwd_file")
     vpx_dc = params.get("vpx_dc")
     esx_ip = params.get("esx_ip")
-    hypervisor = params.get("hypervisor")
     address_cache = env.get('address_cache')
     v2v_opts = params.get("v2v_opts")
+    v2v_timeout = params.get('v2v_timeout', 1200)
 
     # Prepare step for different hypervisor
     if hypervisor == "esx":
@@ -57,6 +57,9 @@ def run(test, params, env):
         except:
             process.run("ssh-agent -k")
             raise exceptions.TestError("Fail to setup ssh-agent")
+    elif hypervisor == "kvm":
+        source_ip = None
+        source_pwd = None
     else:
         raise exceptions.TestSkipError("Unspported hypervisor: %s" % hypervisor)
 
@@ -114,7 +117,8 @@ def run(test, params, env):
             raise exceptions.TestFail("Convert VM failed")
 
         # Import the VM to oVirt Data Center from export domain, and start it
-        if not utils_v2v.import_vm_to_ovirt(params, address_cache):
+        if not utils_v2v.import_vm_to_ovirt(params, address_cache,
+                                            timeout=v2v_timeout):
             raise exceptions.TestError("Import VM failed")
 
         # Check all checkpoints after convert


### PR DESCRIPTION
And remove parameters that are no longer needed.