### PR TITLE
iface_options: update the max queue number

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_options.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_options.cfg
@@ -33,7 +33,7 @@
                             attach_iface_device = "live"
                 - driver_queues_negative:
                     start_error = "yes"
-                    iface_driver =  "{'name':'vhost','queues':'9'}"
+                    iface_driver =  "{'name':'vhost','queues':'257'}"
                 - driver_vhost:
                     test_vhost_net = "yes"
                     variants:


### PR DESCRIPTION
Multiqueue is supported up to 256 by the kernel in RHEL7.3
 instead of 8. So the number should be updated.

Signed-off-by: Dan Zheng <dzheng@redhat.com>