### PR TITLE
Use interpolation for TestFail() to fix skip message

### DIFF
--- a/libvirt/tests/src/virtual_disks/at_dt_iscsi_disk.py
+++ b/libvirt/tests/src/virtual_disks/at_dt_iscsi_disk.py
@@ -217,12 +217,12 @@ def run(test, params, env):
             try:
                 virsh.snapshot_list(vm_name, **virsh_dargs)
             except process.CmdError:
-                error.TestFail("Failed getting snapshots list for %s", vm_name)
+                error.TestFail("Failed getting snapshots list for %s" % vm_name)
 
             try:
                 virsh.snapshot_info(vm_name, snapshot_name1, **virsh_dargs)
             except process.CmdError:
-                error.TestFail("Failed getting snapshots info for %s", vm_name)
+                error.TestFail("Failed getting snapshots info for %s" % vm_name)
 
             cmd_result = virsh.snapshot_dumpxml(vm_name, snapshot_name1,
                                                 **virsh_dargs)


### PR DESCRIPTION
refer to beacb9d.

Signed-off-by: Wei Jiangang <weijg.fnst@cn.fujitsu.com>