### PR TITLE
domxml_to_native: Add '-object secret,id' to filter list

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_to_native.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_to_native.py
@@ -90,6 +90,8 @@ def run(test, params, env):
                 continue
             elif re.search("socket,id=", arg):
                 continue
+            elif re.search("secret,id=", arg):
+                continue
             retlist.append(arg)
 
         return retlist


### PR DESCRIPTION
For fixing bug:
https://bugzilla.redhat.com/show_bug.cgi?id=1182074

libvirt commit a1344f7 introduced default secret object created
with a random AES-256 key for domain, the key is under vm dir by
default which depends on the env, so add this part to filter list
and not check it.

Signed-off-by: Wayne Sun <gsun@redhat.com>