### PR TITLE
Modify return message of v2v guest check

### DIFF
--- a/provider/v2v_vmcheck_helper.py
+++ b/provider/v2v_vmcheck_helper.py
@@ -1,5 +1,6 @@
 import re
 import logging
+import time
 from distutils.version import LooseVersion
 
 from avocado.utils import process
@@ -70,14 +71,14 @@ class VMChecker(object):
             self.check_windows_vm()
         else:
             logging.warn("Unspported os type: %s", self.os_type)
-        return len(self.errors)
+        return self.errors
 
     def compare_version(self, compare_version):
         """
         Compare virt-v2v version against given version.
         """
-        cmd = 'rpm -q virt-v2v'
-        v2v_version = LooseVersion(process.run(cmd).stdout.strip())
+        cmd = 'rpm -q virt-v2v|grep virt-v2v'
+        v2v_version = LooseVersion(process.run(cmd, shell=True).stdout.strip())
         compare_version = LooseVersion(compare_version)
         if v2v_version > compare_version:
             return True
@@ -230,6 +231,8 @@ class VMChecker(object):
         # Make sure windows boot up successfully first
         self.checker.boot_windows()
         self.checker.create_session()
+        logging.info("Wait 60 seconds for installing drivers")
+        time.sleep(60)
         self.errors = []
         # 1. Check viostor file
         logging.info("Checking windows viostor info")

--- a/v2v/tests/src/convert_vm_to_ovirt.py
+++ b/v2v/tests/src/convert_vm_to_ovirt.py
@@ -124,12 +124,13 @@ def run(test, params, env):
         # Check all checkpoints after convert
         vmchecker = VMChecker(test, params, env)
         ret = vmchecker.run()
-        vmchecker.cleanup()
-        if ret == 0:
+        if len(ret) == 0:
             logging.info("All checkpoints passed")
         else:
-            raise exceptions.TestFail("%s checkpoints failed" % ret)
+            raise exceptions.TestFail("%d checkpoints failed: %s" % (len(ret), ret))
     finally:
+        vmcheck = utils_v2v.VMCheck(test, params, env)
+        vmcheck.cleanup()
         if v2v_sasl:
             v2v_sasl.cleanup()
         if hypervisor == "esx":


### PR DESCRIPTION
1. Change the return value from number of failed checkpoints to the list of checkpoints to present clearer error message.
2. Move cleanup to final part. The cleanup part in original code is not placed in final part which will cause skipping cleaning up when test fails ahead of cleanup code. Move to final part will solve the problem.
