### PR TITLE
Sync paramters with earlier cases

### DIFF
--- a/v2v/tests/cfg/specific_kvm.cfg
+++ b/v2v/tests/cfg/specific_kvm.cfg
@@ -13,15 +13,15 @@
     password = 'redhat'
 
     # RHEVM parameters
-    ovirt_engine_url = 'OVIRT_SERVER_V2V_EXAMPLE'
-    ovirt_engine_user = 'OVIRT_USER_V2V_EXAMPLE'
-    ovirt_engine_password = 'OVIRT_PASSWORD_V2V_EXAMPLE'
+    ovirt_engine_url = 'OVIRT_ENGINE_URL_V2V_EXAMPLE'
+    ovirt_engine_user = 'OVIRT_ENGINE_USER_V2V_EXAMPLE'
+    ovirt_engine_password = 'OVIRT_ENGINE_PASSWORD_V2V_EXAMPLE'
 
     # Using NFS storage here
-    export_name = 'NFS_EXPORT_V2V_EXAMPLE'
-    storage_name = 'NFS_DATA_V2V_EXAMPLE'
-    cluster_name = 'NFS_CLUSTER_V2V_EXAMPLE'
-    nfs_storage = 'STORAGE_PATH_V2V_EXAMPLE'
+    export_name = 'NFS_EXPORT_NAME_V2V_EXAMPLE'
+    storage_name = 'NFS_STORAGE_NAME_V2V_EXAMPLE'
+    cluster_name = 'NFS_CLUSTER_NAME_V2V_EXAMPLE'
+    nfs_storage = 'NFS_EXPORT_STORAGE_V2V_EXAMPLE'
 
     # Shell paramters
     remote_shell_client = 'ssh'
@@ -37,14 +37,14 @@
                     target = ${output_mode}
                 - rhev:
                     output_mode = 'rhev'
-                    network = 'OVIRT_NETWORK_V2V_EXAMPLE'
-                    bridge = 'OVIRT_BRIDGE_V2V_EXAMPLE'
+                    network = 'OVIRT_NODE_NETWORK_V2V_EXAMPLE'
+                    bridge = 'OVIRT_NODE_BRIDGE_V2V_EXAMPLE'
                     target = 'ovirt'
                     output_storage = ${nfs_storage}
                     # Libvirt SASL authencation(under VDSM control)
                     sasl_user = 'v2v_tester@ovirt'
                     sasl_pwd = 'v2v_tester_pwd'
-                    remote_ip = 'OVIRT_NODE_IP_V2V_EXAMPLE'
+                    remote_ip = 'NFS_OVIRT_NODE_ADDRESS_V2V_EXAMPLE'
                     remote_preprocess = 'yes'
                     remote_node_address = ${remote_ip}
                     remote_node_user = 'root'
@@ -53,7 +53,7 @@
                     remote_pwd = ${remote_node_password}
     variants:
         - default:
-            main_vm = 'VM_NAME_KVM_V2V_EXAMPLE'
+            main_vm = 'VM_NAME_KVM_DEFAULT_V2V_EXAMPLE'
         - virtioscis_disk:
             checkpoint = 'virtioscis_disk'
             main_vm = 'VM_VIRTIOSCIC_DISK_V2V_EXAMPLE'

--- a/v2v/tests/cfg/v2v_options.cfg
+++ b/v2v/tests/cfg/v2v_options.cfg
@@ -3,19 +3,19 @@
     vm_type = "libvirt"
     start_vm = "no"
     take_regular_screendumps = no
-    xen_hostname = XEN_HOSTNAME_EXAMPLE
-    vpx60_hostname = VPX_60_HOSTNAME_EXAMPLE
-    vpx60_dc = VPX_60_DC_EXAMPLE
-    esx60_hostname = ESX_60_HOSTNAME_EXAMPLE
-    vpx55_hostname = VPX_55_HOSTNAME_EXAMPLE
-    vpx55_dc = VPX_55_DC_EXAMPLE
-    esx55_hostname = ESX_55_HOSTNAME_EXAMPLE
-    vpx51_hostname = VPX_51_HOSTNAME_EXAMPLE
-    vpx51_dc = VPX_51_DC_EXAMPLE
-    esx51_hostname = ESX_51_HOSTNAME_EXAMPLE
-    ovirt_engine_url = "OVIRT_SERVER_EXAMPLE"
-    ovirt_engine_user = "OVIRT_USER_EXAMPLE"
-    ovirt_engine_password = "OVIRT_PASSWORD_EXAMPLE"
+    xen_hostname = XEN_HOSTNAME_V2V_EXAMPLE
+    vpx60_hostname = VPX_60_HOSTNAME_V2V_EXAMPLE
+    vpx60_dc = VPX_60_DC_V2V_EXAMPLE
+    esx60_hostname = ESX_60_HOSTNAME_V2V_EXAMPLE
+    vpx55_hostname = VPX_55_HOSTNAME_V2V_EXAMPLE
+    vpx55_dc = VPX_55_DC_V2V_EXAMPLE
+    esx55_hostname = ESX_55_HOSTNAME_V2V_EXAMPLE
+    vpx51_hostname = VPX_51_HOSTNAME_V2V_EXAMPLE
+    vpx51_dc = VPX_51_DC_V2V_EXAMPLE
+    esx51_hostname = ESX_51_HOSTNAME_V2V_EXAMPLE
+    ovirt_engine_url = "OVIRT_ENGINE_URL_V2V_EXAMPLE"
+    ovirt_engine_user = "OVIRT_ENGINE_USER_V2V_EXAMPLE"
+    ovirt_engine_password = "OVIRT_ENGINE_PASSWORD_V2V_EXAMPLE"
     remote_shell_client = "ssh"
     remote_shell_port = 22
     remote_shell_prompt = "^\w:\\.*>\s*$|^\[.*\][\#\$]\s*$"
@@ -23,16 +23,16 @@
     pool_type = "dir"
     pool_name = "v2v_dir"
     pool_target = "v2v_dir_pool"
-    nfs_storage = STORAGE_PATH_EXAMPLE
+    nfs_storage = NFS_EXPORT_STORAGE_V2V_EXAMPLE
     mount_point = "/mnt_v2v"
     output_storage = ${pool_name}
     output_network = "default"
     output_bridge = "virbr0"
     os_type = "linux"
     # Using NFS storage here
-    export_name = "NFS_EXPORT_EXAMPLE"
-    storage_name = "NFS_DATA_EXAMPLE"
-    cluster_name = "NFS"
+    export_name = "NFS_EXPORT_NAME_V2V_EXAMPLE"
+    storage_name = "NFS_STORAGE_NAME_V2V_EXAMPLE"
+    cluster_name = "NFS_CLUSTER_NAME_V2V_EXAMPLE"
     v2v_timeout = "1200"
     # Full types input disks
     variants:
@@ -55,14 +55,14 @@
                     output_mode = "qemu"
                 - rhev:
                     output_mode = "rhev"
-                    output_network = "rhevm"
-                    output_bridge = "rhevm"
+                    output_network = "OVIRT_NODE_NETWORK_V2V_EXAMPLE"
+                    output_bridge = "OVIRT_NODE_BRIDGE_V2V_EXAMPLE"
                     target = "ovirt"
                     output_storage = ${nfs_storage}
                     # Libvirt SASL authencation(under VDSM control)
-                    sasl_user = "vdsm@rhevh"
-                    sasl_pwd = "shibboleth"
-                    remote_ip = "OVIRT_NODE_IP_EXAMPLE"
+                    sasl_user = "v2v_tester@ovirt"
+                    sasl_pwd = "v2v_tester_pwd"
+                    remote_ip = "NFS_OVIRT_NODE_ADDRESS_V2V_EXAMPLE"
                     remote_preprocess = "yes"
                     remote_node_address = ${remote_ip}
                     remote_node_user = "root"
@@ -86,23 +86,23 @@
                             variants:
                                 - sparse:
                                     input_allo_mode = "sparse"
-                                    main_vm = "VM_NAME_RAW_SPARSE_EXAMPLE"
-                                    input_disk_image = "/DISK_IMAGE_PATH/${main_vm}.img"
+                                    main_vm = "VM_NAME_RAW_SPARSE_V2V_EXAMPLE"
+                                    input_disk_image = "/DISK_IMAGE_PATH_V2V_EXAMPLE/${main_vm}.img"
                                 - preallocated:
                                     input_allo_mode = "preallocated"
-                                    main_vm = "VM_NAME_RAW_PREALLOCATED_EXAMPLE"
-                                    input_disk_image = "/DISK_IMAGE_PATH/${main_vm}.img"
+                                    main_vm = "VM_NAME_RAW_PREALLOCATED_V2V_EXAMPLE"
+                                    input_disk_image = "/DISK_IMAGE_PATH_V2V_EXAMPLE/${main_vm}.img"
                         - qcow2_format:
                             input_format = "qcow2"
                             variants:
                                 - sparse:
                                     input_allo_mode = "sparse"
-                                    main_vm = "VM_NAME_QCOW2_SPARSE_EXAMPLE"
-                                    input_disk_image = "/DISK_IMAGE_PATH/${main_vm}.img"
+                                    main_vm = "VM_NAME_QCOW2_SPARSE_V2V_EXAMPLE"
+                                    input_disk_image = "/DISK_IMAGE_PATH_V2V_EXAMPLE/${main_vm}.img"
                                 - preallocated:
                                     input_allo_mode = "preallocated"
-                                    main_vm = "VM_NAME_QCOW2_PREALLOCATEd_EXAMPLE"
-                                    input_disk_image = "/DISK_IMAGE_PATH/${main_vm}.img"
+                                    main_vm = "VM_NAME_QCOW2_PREALLOCATED_V2V_EXAMPLE"
+                                    input_disk_image = "/DISK_IMAGE_PATH_V2V_EXAMPLE/${main_vm}.img"
                 - libvirt:
                     input_mode = "libvirt"
                     variants:
@@ -111,13 +111,13 @@
                             hypervisor = "kvm"
                             variants:
                                 - default:
-                                    main_vm = "VM_NAME_KVM_EXAMPLE"
+                                    main_vm = "VM_NAME_KVM_DEFAULT_V2V_EXAMPLE"
                         - xen:
                             hypervisor = "xen"
                             remote_host = ${xen_hostname}
                             xen_host_user = "root"
                             xen_host_passwd = "redhat"
-                            main_vm = "VM_NAME_XEN_EXAMPLE"
+                            main_vm = "VM_NAME_XEN_DEFAULT_V2V_EXAMPLE"
                             default_output_format = "qcow2"
                         - esx:
                             hypervisor = "esx"
@@ -140,7 +140,7 @@
                             variants:
                                 - default:
                                     only esx_60
-                                    main_vm = "VM_NAME_ESX_EXAMPLE"
+                                    main_vm = "VM_NAME_ESX_DEFAULT_V2V_EXAMPLE"
                 - libvirtxml:
                     # No test yet
                     input_mode = "libvirtxml"
@@ -218,13 +218,13 @@
                         - unprivileged:
                             oc_uri = "qemu:///session"
                             v2v_options = "-oc ${oc_uri}"
-                            unprivileged_user = "USER.EXAMPLE"
+                            unprivileged_user = "USER._V2V_EXAMPLE"
                 - option_vdsm:
                     # Set the output method to vdsm
                     # And create a fake storage domain to test BZ#1176591
                     only input_mode.libvirt.kvm.default
                     only output_mode.vdsm
-                    export_domain_uuid = "EXPORT_DOMAIN_UUDI_EXAMPLE"
+                    export_domain_uuid = "EXPORT_DOMAIN_UUDI_V2V_EXAMPLE"
                     fake_domain_uuid = "12345678-1234-1234-1234-123456789000"
                     vdsm_image_uuid = "12345678-1234-1234-1234-123456789001"
                     vdsm_vol_uuid = "12345678-1234-1234-1234-123456789002"


### PR DESCRIPTION
Unify names of parameters in different cfg files but with same
function to reduce number of config lines of replace part in ci.
