### PR TITLE
migrate_vm: increase the migration timeout

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_vm.cfg
+++ b/libvirt/tests/cfg/migration/migrate_vm.cfg
@@ -245,7 +245,7 @@
                     variants:
                         - nbd_port:
                             virsh_options = "--live --verbose --unsafe --copy-storage-all"
-                            migration_timeout = 300
+                            migration_timeout = 1800
                             nbd_port = "49153"
                             create_target_image = "yes"
                             config_libvirtd = "yes"
@@ -459,7 +459,7 @@
                 - live_storage_migration:
                     setup_nfs = "no"
                     enable_virt_use_nfs = "no"
-                    migration_timeout = 300
+                    migration_timeout = 1800
                     target_pool_name = "precreation_pool"
                     target_pool_type = "dir"
                     variants:
@@ -473,7 +473,7 @@
                             create_target_image = "yes"
                             virsh_options = "--live --verbose --copy-storage-all"
                         - writethrough_driver_cache:
-                            migration_timeout = 1000
+                            migration_timeout = 1800
                             nfs_mount_dir =
                             create_target_image = "yes"
                             disk_driver_cache = "writethrough"
@@ -642,7 +642,7 @@
                     setup_nfs = "no"
                     enable_virt_use_nfs = "no"
                     nfs_mount_dir =
-                    migration_timeout = 300
+                    migration_timeout = 1800
                     target_pool_name = "precreation_pool"
                     target_pool_type = "dir"
                     variants:


### PR DESCRIPTION
For storage migration, the current timeout duration is too short which
will cause timeout exception. So now it is increased to a larger value.

Signed-off-by: Dan Zheng <dzheng@redhat.com>