### PR TITLE
nodeinfo: Get host memory size from numa nodes

### DIFF
--- a/libvirt/tests/src/virsh_cmd/host/virsh_nodeinfo.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_nodeinfo.py
@@ -11,7 +11,6 @@ from virttest import virsh
 from virttest import utils_libvirtd
 from virttest import utils_misc
 from virttest.libvirt_xml import capability_xml
-from virttest.staging import utils_memory
 
 
 def run(test, params, env):
@@ -134,7 +133,12 @@ def run(test, params, env):
         # Check Memory size
         memory_size_nodeinfo = int(
             _check_nodeinfo(nodeinfo_output, 'Memory size', 3))
-        memory_size_os = utils_memory.memtotal()
+        memory_size_os = 0
+        for i in node_online_list:
+            node_memory = node_info.read_from_node_meminfo(i, 'MemTotal')
+            memory_size_os += int(node_memory)
+        logging.debug('The host total memory from nodes is %s', memory_size_os)
+
         if memory_size_nodeinfo != memory_size_os:
             raise error.TestFail("Virsh nodeinfo output didn't match "
                                  "Memory size")


### PR DESCRIPTION
As libvirt commit 912813d in 2.0.0 change the api nodeGetInfo with
using common api nodeGetMemory to collect host memory size, current
check with nodeinfo memory size failed.

Update to collect memory size from online nodes meminfo to fix the
case.

Signed-off-by: Wayne Sun <gsun@redhat.com>