### PR TITLE
Storage related cases fix and update

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/pool/virsh_pool.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/pool/virsh_pool.cfg
@@ -2,9 +2,9 @@
     type = virsh_pool
     vms = ''
     main_vm = ''
-    pool_name = "temp_pool_1"
+    pool_name = "virsh_pool_test"
     pool_type = "dir"
-    vol_name = "temp_vol_1"
+    vol_name = "vol_1"
     variants:
         - positive_test:
             status_error = "no"

--- a/libvirt/tests/cfg/virsh_cmd/pool/virsh_pool_acl.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/pool/virsh_pool_acl.cfg
@@ -2,15 +2,15 @@
     type = virsh_pool_acl
     vms = ''
     main_vm = ''
-    pool_name = "temp_pool_1"
+    pool_name = "virsh_pool_acl_test"
     pool_type = "dir"
-    vol_name = "temp_vol_1"
+    vol_name = "vol_1"
     variants:
         - acl_test:
     variants:
         - positive_test:
             setup_libvirt_polkit = "yes"
-            action_lookup = "connect_driver:QEMU pool_name:temp_pool_1"
+            action_lookup = "connect_driver:QEMU pool_name:${pool_name}"
             unprivileged_user = "EXAMPLE"
             virsh_uri = "qemu:///system"
             variants:

--- a/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_resize.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_resize.cfg
@@ -2,11 +2,11 @@
     type = virsh_vol_resize
     vms = ''
     main_vm = ''
-    pool_name = "temp_pool_1"
+    pool_name = "vol_resize_pool"
     pool_target = "pool_target"
     emulated_image = "test-image"
     emulated_image_size = "1G"
-    vol_name = "temp_vol_1"
+    vol_name = "vol_1"
     vol_format = "raw"
     vol_capacity = "10M"
     vol_new_capacity = "20M"
@@ -45,7 +45,7 @@
                 - acl_test:
                     setup_libvirt_polkit = "yes"
                     action_id = "org.libvirt.api.storage-vol.resize"
-                    action_lookup = "connect_driver:QEMU vol_name:temp_vol_1"
+                    action_lookup = "connect_driver:QEMU vol_name:${vol_name}"
                     unprivileged_user = "EXAMPLE"
                     virsh_uri = "qemu:///system"
         - negative_test:

--- a/libvirt/tests/src/virsh_cmd/volume/virsh_vol_create_from.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_vol_create_from.py
@@ -52,7 +52,7 @@ def run(test, params, env):
 
         if src_pool_type != dest_pool_type:
             pvt.pre_pool(dest_pool_name, dest_pool_type, dest_pool_target,
-                         dest_emulated_image, image_size="50M",
+                         dest_emulated_image, image_size="100M",
                          pre_disk_vol=["1M"])
 
         # Print current pools for debugging
@@ -60,19 +60,14 @@ def run(test, params, env):
                       libvirt_storage.StoragePool().list_pools())
 
         # Create the src vol
-        vol_size = "1048576"
+        vol_size = "4194304"  # 4M is the minimal size for logical volume
         if src_pool_type in ["dir", "logical", "netfs", "fs"]:
             src_vol_name = "src_vol"
             pvt.pre_vol(vol_name=src_vol_name, vol_format=src_vol_format,
                         capacity=vol_size, allocation=None,
                         pool_name=src_pool_name)
         else:
-            src_pv = libvirt_storage.PoolVolume(src_pool_name)
-            src_vols = src_pv.list_volumes().keys()
-            if src_vols:
-                src_vol_name = src_vols[0]
-            else:
-                raise error.TestFail("No volume in pool: %s" % src_pool_name)
+            src_vol_name = utlv.get_vol_list(src_pool_name).keys()[0]
         # Prepare vol xml file
         dest_vol_name = "dest_vol"
         # According to BZ#1138523, we need inpect the right name


### PR DESCRIPTION
For virsh_pool_acl test, iSCSI type pool always start, that because
libvirt just calling iscsiadm command to login the target which is not
discovery first. So hardcode the discovery command for it.
For virsh_vol_create_from test, the default volume in iSCSI pool is the
iSCSI lun, so the input volume size is the pool size, which require the
destination pool size should larger than the input volume size. And LVM
allocates storage in multiples of the physical extent size, which is 4MB
by default.
BTW, this patch also rename the pool/volume name in different tests to
make the debug message more clear.

Signed-off-by: Yanbing Du <ydu@redhat.com>