### PR TITLE
blockcopy: make sure blockjob exist

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
@@ -158,6 +158,10 @@ def finish_job(vm_name, target, timeout):
     :param target: Domain disk target dev
     :param timeout: Timeout value of this function
     """
+    # Need blockjob exist
+    if utl.check_blockjob(vm_name, target, 'none', '0'):
+        raise exceptions.TestFail("No blockjob find for '%s'" % target)
+
     job_time = 0
     while job_time < timeout:
         if utl.check_blockjob(vm_name, target, "progress", "100"):
@@ -634,7 +638,7 @@ def run(test, params, env):
             os.remove(save_path)
         # Restart virtlogd service to release VM log file lock
         try:
-            virtlogd = path.find_command('virtlogd')
+            path.find_command('virtlogd')
             process.run('service virtlogd restart')
         except path.CmdNotFoundError:
             pass


### PR DESCRIPTION
When wait for the block copy job finish, we need make sure the job
exist.
And remove a unused var.

Signed-off-by: Yanbing Du <ydu@redhat.com>