### PR TITLE
Update code of function test on xen and add cases

### DIFF
--- a/v2v/tests/cfg/function_test_xen.cfg
+++ b/v2v/tests/cfg/function_test_xen.cfg
@@ -18,6 +18,7 @@
     main_vm = 'XEN_VM_NAME_V2V_EXAMPLE'
     username = 'root'
     password = 'redhat'
+    os_version = 'XEN_VM_OS_VERSION_V2V_EXAMPLE'
 
     # Standard shell parameters
     remote_shell_client = 'ssh'
@@ -32,8 +33,8 @@
                 - libvirt:
                     output_mode = 'libvirt'
                     target = 'libvirt'
-                    network = 'LIBVIRT_NETWORK_V2V_EXAMPLE'
-                    bridge = 'LIBVIRT_BRIDGE_V2V_EXAMPLE'
+                    network = 'default'
+                    bridge = 'virbr0'
                     pool_type = 'dir'
                     pool_name = 'v2v_dir'
                     pool_target = 'v2v_dir_pool'
@@ -63,6 +64,7 @@
                     remote_user = ${remote_node_user}
                     remote_pwd = ${remote_node_password}
     variants:
+        - xen_vm_default:
         - multiconsole:
             main_vm = 'MULTICONSOLE_VM_NAME_V2V_EXAMPLE'
         - console_xvc0:
@@ -76,6 +78,30 @@
             checkpoint = 'guest_uuid'
         - pool_uuid:
             checkpoint = 'pool_uuid'
+        - display:
+            main_vm = 'DISPLAY_VM_NAME_V2V_EXAMPLE'
+            os_version = 'DISPLAY_OS_VERSION_V2V_EXAMPLE'
+            variants:
+                - vnc:
+                    variants:
+                        - autoport:
+                            checkpoint = 'vnc_autoport'
+                        - encrypt:
+                            checkpoint = 'vnc_encrypt'
+                            vnc_passwd = 'redhat'
+                - sdl:
+                    os_version = 'rhel6'
+                    main_vm = 'SDL_VM_NAME_V2V_EXAMPLE'
+                    checkpoint = 'sdl'
+        - scsi_disk:
+            main_vm = 'SCSI_VM_NAME_V2V_EXAMPLE'
+        - ide_disk:
+            main_vm = 'IDE_VM_NAME_V2V_EXAMPLE'
+        - ssh_banner:
+            checkpoint = 'ssh_banner'
+        - pv_with_regular_kernel:
+            checkpoint = 'pv_with_regular_kernel'
+            main_vm = 'VM_NAME_PV_WITH_REGULAR_KERNEL_V2V_EXAMPLE'
         - windows:
             os_type = 'windows'
             shutdown_command = 'shutdown /s /f /t 0'
@@ -99,20 +125,42 @@
             variants:
                 - default_install:
                     windows_root = 'WINDOWS_ROOT_V2V_EXAMPLE'
-                    os_version = 'OS_VERSION_WINDOWS_ROOT_V2V_EXAMPLE'
+                    os_version = 'WINDOWS_ROOT_OS_VERSION_V2V_EXAMPLE'
                     main_vm = 'WINDOWS_ROOT_VM_NAME_V2V_EXAMPLE'
                 - rhev_file:
                     checkpoint = 'rhev_file'
                     os_version = 'OS_VERSION_RHEV_FILE_V2V_EXAMPLE'
                     main_vm = 'RHEV_FILE_VM_NAME_V2V_EXAMPLE'
+                - program_files_2:
+                    os_version = 'PROGRAM_FILES_2_OS_VERSION_V2V_EXAMPLE'
+                    main_vm = 'PROGRAM_FILES_2_VM_NAME_V2V_EXAMPLE'
     variants:
         - positive_test:
             status_error = 'no'
+            no xen_vm_default
             variants:
                 - libvirt:
-                    only pool_uuid, windows.rhev_file
+                    only pool_uuid, windows.rhev_file, display
                     only output_mode.libvirt
                 - rhev:
-                    no pool_uuid, windows.rhev_file
+                    no pool_uuid, windows.rhev_file, display.vnc
                     only output_mode.rhev
-
+        - negative_test:
+            status_error = 'yes'
+            only xen_vm_default
+            only output_mode.libvirt
+            variants:
+                - libguestfs_backend_empty:
+                    checkpoint = 'libguestfs_backend_empty'
+                - libguestfs_backend_test:
+                    checkpoint = 'libguestfs_backend_test'
+                - same_name_guest:
+                    checkpoint = 'same_name'
+                    new_vm_name = 'avocado-vt-vm1'
+                - no_passwordless_SSH:
+                    checkpoint = 'no_passwordless_SSH'
+                - xml_without_image:
+                    checkpoint = 'xml_without_image'
+                - pv_no_regular_kernel:
+                    main_vm = 'VM_NAME_PV_NO_REGULAR_KERNEL_V2V_EXAMPLE'
+                    checkpoint = 'pv_no_regular_kernel'

--- a/v2v/tests/src/function_test_xen.py
+++ b/v2v/tests/src/function_test_xen.py
@@ -11,6 +11,7 @@ from virttest import utils_sasl
 from virttest import ssh_key
 from virttest import remote
 from virttest import data_dir
+from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 
 from provider.v2v_vmcheck_helper import VMChecker
@@ -26,8 +27,10 @@ def run(test, params, env):
     if utils_v2v.V2V_EXEC is None:
         raise ValueError('Missing command: virt-v2v')
     vm_name = params.get('main_vm')
-    new_vm_name = params.get('new_name')
+    new_vm_name = params.get('new_vm_name')
     xen_host = params.get('xen_hostname')
+    xen_host_user = params.get('xen_host_user', 'root')
+    xen_host_passwd = params.get('xen_host_passwd', 'redhat')
     output_mode = params.get('output_mode')
     v2v_timeout = int(params.get('v2v_timeout', 1200))
     status_error = 'yes' == params.get('status_error', 'no')
@@ -36,15 +39,32 @@ def run(test, params, env):
     pool_target = params.get('pool_target_path', 'v2v_pool')
     pvt = libvirt.PoolVolumeTest(test, params)
     address_cache = env.get('address_cache')
-    checkpoint = params.get('checkpoint')
+    checkpoint = params.get('checkpoint', '')
+    bk_list = ['vnc_autoport', 'vnc_encrypt']
+    error_list = []
 
-    def check_rhev_file_exist():
+    def log_fail(msg):
+        """
+        Log error and update error list
+        """
+        logging.error(msg)
+        error_list.append(msg)
+
+    def set_graphics(virsh_instance, param):
+        """
+        Set graphics attributes of vm xml
+        """
+        vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name, virsh_instance=virsh_instance)
+        graphic = vmxml.xmltreefile.find('devices').find('graphics')
+        for key in param:
+            logging.debug('Set %s=\'%s\'' % (key, param[key]))
+            graphic.set(key, param[key])
+        vmxml.sync(virsh_instance=virsh_instance)
+
+    def check_rhev_file_exist(vmcheck):
         """
         Check if rhev files exist
         """
-        vmcheck = utils_v2v.VMCheck(test, params, env)
-        vmcheck.boot_windows()
-        vmcheck.create_session()
         file_path = {
             'rhev-apt.exe': r'C:\rhev-apt.exe',
             'rhsrvany.exe': r'"C:\program files\redhat\rhev\apt\rhsrvany.exe"'
@@ -55,34 +75,40 @@ def run(test, params, env):
             if not status:
                 logging.error('%s exists' % key)
                 fail = True
-        vmcheck.session.close()
         if fail:
-            raise exceptions.TestFail('RHEV file exists after convert to kvm')
+            log_fail('RHEV file exists after convert to kvm')
 
-    def check_grub_file(check):
+    def check_grub_file(vmcheck, check):
         """
         Check grub file content
         """
         logging.info('Checking grub file')
-        vmcheck = utils_v2v.VMCheck(test, params, env)
-        vmcheck.create_session()
-        grub_file = vmcheck.get_grub_path()
-        try:
-            if not grub_file:
-                raise exceptions.TestError('Not found grub file')
-            content = vmcheck.session.cmd('cat %s' % grub_file)
-            if check == 'console_xvc0':
-                if 'console=xvc0' in content:
-                    raise exceptions.TestFail('"console=xvc0" still exists')
-        finally:
-            vmcheck.session.close()
+        grub_file = utils_misc.get_bootloader_cfg(session=vmcheck.session)
+        if not grub_file:
+            raise exceptions.TestError('Not found grub file')
+        content = vmcheck.session.cmd('cat %s' % grub_file)
+        if check == 'console_xvc0':
+            if 'console=xvc0' in content:
+                log_fail('"console=xvc0" still exists')
+
+    def check_kernel(vmcheck):
+        """
+        Check content of /etc/sysconfig/kernel
+        """
+        logging.info('Checking /etc/sysconfig/kernel file')
+        content = vmcheck.session.cmd('cat /etc/sysconfig/kernel')
+        logging.debug(content)
+        if 'DEFAULTKERNEL=kernel' not in content:
+            log_fail('Not find "DEFAULTKERNEL=kernel"')
+        elif 'DEFAULTKERNEL=kernel-xen' in content:
+            log_fail('DEFAULTKERNEL is "kernel-xen"')
 
     def check_v2v_log(output, check=None):
         """
         Check if error/warning meets expectation
         """
         # Fail if found error msg in log
-        error_map = {
+        not_expect_map = {
             'xvda_disk': [
                 r'virt-v2v: WARNING: /boot/grub.*?/device.map references '
                 r'unknown device /dev/vd.*?\n',
@@ -94,14 +120,38 @@ def run(test, params, env):
                 r'unknown device /dev/vd.*?\n',
                 r'virt-v2v: warning: /files/boot/grub/device.map/hd0 '
                 r'references unknown.*?after conversion.'
-            ]
+            ],
+            'libguestfs_backend_empty': ['libguestfs: error: invalid backend:']
         }
-        if check is None or check not in error_map:
+        expect_map = {
+            'same_name': ["virt-v2v: error: a libvirt domain called '.*?' "
+                          "already exists on the target."],
+            'libguestfs_backend_test': ['export LIBGUESTFS_BACKEND=direct',
+                                        'libguestfs: error: invalid backend: .*?'],
+            'no_passwordless_SSH': [
+                'virt-v2v: error: ssh-agent authentication has not been set up',
+                '\$SSH_AUTH_SOCK is not set',
+                'Please read "INPUT FROM RHEL 5 XEN" in the'
+            ],
+            'xml_without_image': ["Could not open '.*?': No such file or directory"],
+            'pv_no_regular_kernel':
+                ['virt-v2v: error: only Xen kernels are installed in this guest']
+        }
+
+        if check is None or not (check in not_expect_map or check in expect_map):
             logging.info('Skip checking v2v log')
         else:
-            if not utils_v2v.check_log(check, error_map[check], expect=False):
-                raise exceptions.TestFail('Check v2v log Failed')
-            logging.info('Finish checking v2v log')
+            logging.info('Checking v2v log')
+            if expect_map.has_key(check):
+                expect = True
+                content_map = expect_map
+            elif not_expect_map.has_key(check):
+                expect = False
+                content_map = not_expect_map
+            if utils_v2v.check_log(output, content_map[check], expect=expect):
+                logging.info('Finish checking v2v log')
+            else:
+                raise exceptions.TestFail('Check v2v log failed')
 
     def check_result(result, status_error):
         """
@@ -119,12 +169,34 @@ def run(test, params, env):
                     virsh.start(vm_name, debug=True, ignore_status=False)
                 except Exception, e:
                     raise exceptions.TestFail('Start vm failed: %s', str(e))
-            if checkpoint:
-                if checkpoint == 'rhev_file':
-                    check_rhev_file_exist()
-                elif checkpoint == 'console_xvc0':
-                    check_grub_file('console_xvc0')
-                check_v2v_log(output, checkpoint)
+            # Check guest following the checkpoint document after convertion
+            logging.info('Checking common checkpoints for v2v')
+            vmchecker = VMChecker(test, params, env)
+            params['vmchecker'] = vmchecker
+            ret = vmchecker.run()
+            if len(ret) == 0:
+                logging.info("All common checkpoints passed")
+            # Check specific checkpoints
+            if checkpoint == 'rhev_file':
+                check_rhev_file_exist(vmchecker.checker)
+            elif checkpoint == 'console_xvc0':
+                check_grub_file(vmchecker.checker, 'console_xvc0')
+            elif checkpoint in ('vnc_autoport', 'vnc_encrypt'):
+                vmchecker.check_graphics(params[checkpoint])
+            elif checkpoint == 'sdl':
+                if output_mode == 'libvirt':
+                    vmchecker.check_graphics({'type': 'vnc'})
+                elif output_mode == 'rhev':
+                    vmchecker.check_graphics({'type': 'spice'})
+            elif checkpoint == 'pv_with_regular_kernel':
+                check_kernel(vmchecker.checker)
+        check_v2v_log(output, checkpoint)
+        # Merge 2 error lists
+        if params.get('vmchecker'):
+            error_list.extend(params['vmchecker'].errors)
+        if len(error_list):
+            raise exceptions.TestFail('%d checkpoints failed: %s' %
+                                      (len(error_list), error_list))
 
     try:
         v2v_params = {
@@ -137,11 +209,10 @@ def run(test, params, env):
             'target':   params.get('target')
         }
 
+        bk_xml = None
         os.environ['LIBGUESTFS_BACKEND'] = 'direct'
 
         # Setup ssh-agent access to xen hypervisor
-        xen_host_user = params.get('xen_host_user', 'root')
-        xen_host_passwd = params.get('xen_host_passwd', 'redhat')
         logging.info('set up ssh-agent access ')
         ssh_key.setup_ssh_key(xen_host, user=xen_host_user,
                               port=22, password=xen_host_passwd)
@@ -165,51 +236,109 @@ def run(test, params, env):
         if output_mode == 'libvirt':
             pvt.pre_pool(pool_name, pool_type, pool_target, '')
 
-        if checkpoint:
-            uri = utils_v2v.Uri('xen').get_uri(xen_host)
-            if checkpoint == 'guest_uuid':
-                uuid = virsh.domuuid(vm_name, uri=uri).stdout.strip()
-                v2v_params['main_vm'] = uuid
-            elif checkpoint == 'xvda_disk':
-                v2v_params['input_mode'] = 'disk'
-                # Get remote disk image path
-                blklist = virsh.domblklist(vm_name, uri=uri).stdout.split('\n')
-                for line in blklist:
-                    if line.startswith(('hda', 'vda', 'sda')):
-                        remote_disk_image = line.split()[-1]
-                        break
-                # Local path of disk image
-                input_file = data_dir.get_tmp_dir() + '/%s.img' % vm_name
-                v2v_params.update({'input_file': input_file})
-                # Copy remote image to local with scp
-                remote.scp_from_remote(xen_host, 22, xen_host_user,
-                                       xen_host_passwd, remote_disk_image,
-                                       input_file)
-            elif checkpoint == 'pool_uuid':
-                virsh.pool_start(pool_name)
-                pooluuid = virsh.pool_uuid(pool_name).stdout.strip()
-                v2v_params['storage'] = pooluuid
+        uri = utils_v2v.Uri('xen').get_uri(xen_host)
 
+        # Check if xen guest exists
+        if not virsh.domain_exists(vm_name, uri=uri):
+            logging.error('VM %s not exists', vm_name)
+
+        if checkpoint in bk_list:
+            virsh_instance = virsh.VirshPersistent()
+            virsh_instance.set_uri(uri)
+            bk_xml = vm_xml.VMXML.new_from_inactive_dumpxml(
+                    vm_name, virsh_instance=virsh_instance)
+        if checkpoint == 'guest_uuid':
+            uuid = virsh.domuuid(vm_name, uri=uri).stdout.strip()
+            v2v_params['main_vm'] = uuid
+        elif checkpoint == 'xvda_disk':
+            v2v_params['input_mode'] = 'disk'
+            # Get remote disk image path
+            blklist = virsh.domblklist(vm_name, uri=uri).stdout.split('\n')
+            logging.debug('domblklist %s:\n%s', vm_name, blklist)
+            for line in blklist:
+                if line.startswith(('hda', 'vda', 'sda')):
+                    remote_disk_image = line.split()[-1]
+                    break
+            # Local path of disk image
+            input_file = data_dir.get_tmp_dir() + '/%s.img' % vm_name
+            v2v_params.update({'input_file': input_file})
+            # Copy remote image to local with scp
+            remote.scp_from_remote(xen_host, 22, xen_host_user,
+                                   xen_host_passwd, remote_disk_image,
+                                   input_file)
+        elif checkpoint == 'pool_uuid':
+            virsh.pool_start(pool_name)
+            pooluuid = virsh.pool_uuid(pool_name).stdout.strip()
+            v2v_params['storage'] = pooluuid
+        elif checkpoint.startswith('vnc'):
+            vm_xml.VMXML.set_graphics_attr(vm_name, {'type': 'vnc'},
+                                           virsh_instance=virsh_instance)
+            if checkpoint == 'vnc_autoport':
+                params[checkpoint] = {'autoport': 'yes'}
+                vm_xml.VMXML.set_graphics_attr(vm_name, params[checkpoint],
+                                               virsh_instance=virsh_instance)
+            elif checkpoint == 'vnc_encrypt':
+                params[checkpoint] = {'passwd': params.get('vnc_passwd', 'redhat')}
+                vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(
+                        vm_name, virsh_instance=virsh_instance)
+                vm_xml.VMXML.add_security_info(
+                        vmxml, params[checkpoint]['passwd'],
+                        virsh_instance=virsh_instance)
+            logging.debug(virsh_instance.dumpxml(vm_name, extra='--security-info'))
+        elif checkpoint.startswith('libguestfs_backend'):
+            value = checkpoint[19:]
+            if value == 'empty':
+                value = ''
+            logging.info('Set LIBGUESTFS_BACKEND to "%s"', value)
+            os.environ['LIBGUESTFS_BACKEND'] = value
+        elif checkpoint == 'same_name':
+            logging.info('Convert guest and rename to %s', new_vm_name)
+            v2v_params.update({'new_name': new_vm_name})
+        elif checkpoint == 'no_passwordless_SSH':
+            logging.info('Unset $SSH_AUTH_SOCK')
+            os.unsetenv('SSH_AUTH_SOCK')
+        elif checkpoint == 'xml_without_image':
+            xml_file = os.path.join(data_dir.get_tmp_dir(), '%s.xml' % vm_name)
+            virsh.dumpxml(vm_name, to_file=xml_file, uri=uri)
+            v2v_params['hypervisor'] = 'kvm'
+            v2v_params['input_mode'] = 'libvirtxml'
+            v2v_params.update({'input_file': xml_file})
+        elif checkpoint == 'ssh_banner':
+            session = remote.remote_login("ssh", xen_host, "22", "root",
+                                          xen_host_passwd, "#")
+            ssh_banner_content = r'"# no default banner path\n' \
+                                 r'#Banner /path/banner file\n' \
+                                 r'Banner /etc/ssh/ssh_banner"'
+            logging.info('Create ssh_banner file')
+            session.cmd('echo -e %s > /etc/ssh/ssh_banner' % ssh_banner_content)
+            logging.info('Content of ssh_banner file:')
+            logging.info(session.cmd_output('cat /etc/ssh/ssh_banner'))
+            logging.info('Restart sshd service on xen host')
+            session.cmd('service sshd restart')
+
+        # Check if xen guest exists again
+        if not virsh.domain_exists(vm_name, uri=uri):
+            logging.error('VM %s not exists', vm_name)
+
+        # Execute virt-v2v
         v2v_result = utils_v2v.v2v_cmd(v2v_params)
 
         if new_vm_name:
             vm_name = new_vm_name
             params['main_vm'] = new_vm_name
-
         check_result(v2v_result, status_error)
-
-        # Check guest following the checkpoint document after convertion
-        if not status_error:
-            vmchecker = VMChecker(test, params, env)
-            ret = vmchecker.run()
-            if ret == 0:
-                logging.info("All checkpoints passed")
-            else:
-                raise exceptions.TestFail("%s checkpoints failed" % ret)
     finally:
         process.run('ssh-agent -k')
-        if output_mode in ['libvirt', 'rhev']:
-            vmcheck = utils_v2v.VMCheck(test, params, env)
-            vmcheck.cleanup()
+        if params.get('vmchecker'):
+            params['vmchecker'].cleanup()
         if output_mode == 'libvirt':
             pvt.cleanup_pool(pool_name, pool_type, pool_target, '')
+        if bk_xml:
+            bk_xml.sync(virsh_instance=virsh_instance)
+            virsh_instance.close_session()
+        if checkpoint == 'ssh_banner':
+            logging.info('Remove ssh_banner file')
+            session = remote.remote_login("ssh", xen_host, "22", "root",
+                                          xen_host_passwd, "#")
+            session.cmd('rm -f /etc/ssh/ssh_banner')
+            session.cmd('service sshd restart')


### PR DESCRIPTION
Update code: Add error list to collect errors during checking vm to
make sure all checkpoints are checked. Call vmcheck object as param
to avoid create it again and again or create and close session.

Add cases:
- convert guest with display type 'vnc' and 'sdl'
- with attirb 'autoport' enable
- with scsi disk and ide disk, with 2 'program file' on win guest
- with empty or wrong environment LIBGUESTFS_BACKEND
- with a same name guest at destination
- with no passwordless SSH access configured on host
- with no regular kernel installed
- with input mode 'libvirtxml' without image file
