### PR TITLE
Add cache=directsync option if io=native is used for disk driver.

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
@@ -237,7 +237,7 @@
                                 - ioeventfd_on:
                                     virt_disk_bootdisk_driver = "io=threads,ioeventfd=on,event_idx=off"
                                 - ioeventfd_off:
-                                    virt_disk_bootdisk_driver = "io=native,ioeventfd=off,event_idx=off"
+                                    virt_disk_bootdisk_driver = "io=native,ioeventfd=off,event_idx=off,cache=directsync"
                                 - scsi_ioeventfd:
                                     virt_disk_bootdisk_target = "sda"
                                     virt_disk_bootdisk_bus = "scsi"


### PR DESCRIPTION
It's a feature of qemu-kvm. Qemu will report "aio=native was specified,
but it requires cache.direct=on, which was not specified" if there is
no cache=directsync option.

Signed-off-by: Ruifeng Bian <rbian@redhat.com>