### PR TITLE
libvirt_mem: Change hotplug memory size to multiple of 128MiB

### DIFF
--- a/libvirt/tests/cfg/libvirt_mem.cfg
+++ b/libvirt/tests/cfg/libvirt_mem.cfg
@@ -9,7 +9,7 @@
             current_mem = 1024000
             numa_cells = "{'id':'0','cpus':'0-1','memory':'512000','unit':'KiB'} {'id':'1','cpus':'2-3','memory':'512000','unit':'KiB'}"
             add_mem_device = "yes"
-            tg_size = 512000
+            tg_size = 524288
             tg_sizeunit = "KiB"
             tg_node = 0
             test_qemu_cmd = "yes"
@@ -35,7 +35,7 @@
                     test_qemu_cmd = "no"
                 - no_attach:
                 - with_source:
-                    tg_size = 512000
+                    tg_size = 524288
                     tg_node = 0
                     page_size = 4
                     page_unit = "KiB"
@@ -51,7 +51,7 @@
                     numa_cells = "{'id':'0','cpus':'0-1','memory':'1048576','unit':'KiB'} {'id':'1','cpus':'2-3','memory':'1048576','unit':'KiB'}"
                     cpu_mode = "host-model"
                     model_fallback = "forbid"
-                    tg_size = 512000
+                    tg_size = 524288
                     tg_node = 0
                     page_size = 4
                     page_unit = "KiB"
@@ -77,7 +77,7 @@
             current_mem = 1024000
             numa_cells = "{'id':'0','cpus':'0-1','memory':'512000','unit':'KiB'} {'id':'1','cpus':'2-3','memory':'512000','unit':'KiB'}"
             add_mem_device = "yes"
-            tg_size = 512000
+            tg_size = 524288
             tg_sizeunit = "KiB"
             tg_node = 0
             variants:
@@ -115,6 +115,8 @@
                         - attach_many_times:
                             attach_times = 4
                             attach_option = "--config"
+                        - attach_invalid_size:
+                            tg_size = 512000
                 - detach_error:
                     add_mem_device = "no"
                     attach_device = "no"


### PR DESCRIPTION
According to the linux kernel, backend memory size must be
multiple of 128MiB.

Signed-off-by: Ruifeng Bian <rbian@redhat.com>