### PR TITLE
graphics_functional: Case update for some new changes

### DIFF
--- a/libvirt/tests/cfg/graphics/graphics_functional.cfg
+++ b/libvirt/tests/cfg/graphics/graphics_functional.cfg
@@ -117,6 +117,14 @@
                             playback_compression = on
                         - playback_compression_off:
                             playback_compression = off
+                        - default_insecure_mode:
+                            spice_autoport = no
+                            defaultMode = insecure
+                            spice_listen_type = 'none'
+                        - with_insecure_channel:
+                            spice_autoport = no
+                            channels = main:insecure
+                            spice_listen_type = 'none'
                 - vnc_only:
                     vnc_xml = yes
                     variants:
@@ -215,12 +223,8 @@
                                     spice_tls = 0
                                 - default_secure_mode:
                                     defaultMode = secure
-                                - default_insecure_mode:
-                                    defaultMode = insecure
                                 - with_secure_channel:
                                     channels = main:secure
-                                - with_insecure_channel:
-                                    channels = main:insecure
                                 - with_both_channel:
                                     channels = main:secure,inputs:insecure,display:secure,cursor:insecure,playback:secure,record:insecure,smartcard:secure,usbredir:insecure
                                 - equal_ports_1:


### PR DESCRIPTION
For new version libvirt, there are some changes, so update test case
to adapt them:
1. A new listen type 'none' is added. When no port given and autoport is
'no', libvirt will add listen type='none' automatically, so these two
autoport='no' and insecure mode/channel spice cases are valid now.
2. Now spice port accept negative number less than -1, If spice port
less than -1, the VM can start normally, but both listen address and port
will be omitted when pass to qemu.
3. Some error messages and vnc socket path also changed, so add new
match patterns and change two boolean values to string type to use
re.match for result compare.

Signed-off-by: Yanbing Du ydu@redhat.com
