### PR TITLE
Remove win8 on xen from matrix

### DIFF
--- a/v2v/tests/cfg/convert_vm_to_libvirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_libvirt.cfg
@@ -94,6 +94,7 @@
                 - win7:
                     os_version = "win7"
                 - win8:
+                    only esx
                     os_version = "win8"
                 - win8_1:
                     only esx

--- a/v2v/tests/cfg/convert_vm_to_ovirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_ovirt.cfg
@@ -154,6 +154,7 @@
                 - win7:
                     os_version = "win7"
                 - win8:
+                    no xen
                     os_version = "win8"
                 - win8_1:
                     no xen


### PR DESCRIPTION
For some windows 8 guests could not be successfully installed on
xen host, remove the cases from matrix as manual team required.