### PR TITLE
Fixup for virsh_capabilities

### DIFF
--- a/libvirt/tests/src/virsh_cmd/host/virsh_capabilities.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_capabilities.py
@@ -54,7 +54,11 @@ def run(test, params, env):
         try:
             img = utils_path.find_command("qemu-kvm")
         except utils_path.CmdNotFoundError:
-            raise error.TestNAError("Cannot find qemu-kvm")
+            try:
+                # For Ubuntu /usr/bin/kvm is available instead of qemu-kvm
+                img = utils_path.find_command("kvm")
+            except utils_path.CmdNotFoundError:
+                raise error.TestNAError("Cannot find {qemu-}kvm binary in host")
         if re.search("ppc", process.run("arch", shell=True).stdout):
             cmd = img + " --cpu ? | grep ppc"
         else:


### PR DESCRIPTION
ubuntu1610 have /usr/bin/kvm instead of /usr/bin/qemu-kvm due to
which test got skipped, this fix enables it.