### PR TITLE
Fixup virsh_dumpxml.py

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_dumpxml.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_dumpxml.py
@@ -150,7 +150,10 @@ def run(test, params, env):
         custom_cpu(vm_name, cpu_match)
     elif options_ref.count("security-info"):
         new_xml = backup_xml.copy()
-        vm_xml.VMXML.add_security_info(new_xml, security_pwd)
+        try:
+            vm_xml.VMXML.add_security_info(new_xml, security_pwd)
+        except Exception, info:
+            raise error.TestNAError(info)
     domuuid = vm.get_uuid()
     domid = vm.get_id()
 


### PR DESCRIPTION
If graphics device is not available "with_security.domname" testcases
errors out, this patch handles and skips it.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>