### PR TITLE
Fixup virsh_hostname

### DIFF
--- a/libvirt/tests/src/virsh_cmd/host/virsh_hostname.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_hostname.py
@@ -14,7 +14,7 @@ def run(test, params, env):
     (3) Call virsh hostname with libvirtd service stop
     """
 
-    hostname_result = utils.run("hostname", ignore_status=True)
+    hostname_result = utils.run("hostname -f", ignore_status=True)
     hostname = hostname_result.stdout.strip()
 
     # Prepare libvirtd service


### PR DESCRIPTION
For hostname with name abc.github.com, shell cmd "hostname" returns only
abc but "virsh hostname" returns full name abc.github.com, which fails
the test case, "hostname -f" fixes this error.