### PR TITLE
Add v2v function cases

### DIFF
--- a/v2v/tests/cfg/specific_kvm.cfg
+++ b/v2v/tests/cfg/specific_kvm.cfg
@@ -4,6 +4,7 @@
     start_vm = 'no'
     take_regular_screendumps = no
     v2v_timeout = '1200'
+    image_format = 'qcow2'
 
     # Regular kvm guest parameters
     os_type = 'linux'
@@ -155,6 +156,25 @@
                     checkpoint = 'selinux_enforcing'
                 - vm_disable:
                     checkpoint = 'selinux_disabled'
+        - firewalld:
+            variants:
+                - host_start:
+                    checkpoint = 'host_firewalld_start'
+                - host_stop:
+                    checkpoint = 'host_firewalld_stop'
+                - guest_status:
+                    checkpoint = 'guest_firewalld_status'
+        - remove_securetty:
+            checkpoint = 'remove_securetty'
+        - blank_2nd_disk:
+            checkpoint = 'blank_2nd_disk'
+        - time:
+            ntp_server = 'NTP_SERVER_V2V_EXAMPLE'
+            variants:
+                - ntpd_on:
+                    checkpoint = 'ntpd_on'
+                - sync_ntp:
+                    checkpoint = 'sync_ntp'
 
     variants:
         - positive_test:


### PR DESCRIPTION
Including
- 2 of setting service firewalld start or stop on host
- 1 of checking service firewalld status before and after v2v
- 1 of removing securetty file on guest and convert it
- 2 of check time keeping after convertion

Modify case of converting win8 guest with unclean file system for
windows guests are mounted and define from an NFS storage to which
test process doesn't have the writing permission.Therefore, it would
not be possible to power up vm and power off to make unclean file
system.Instead, we'll prepare a vm and store it in the NFS storage.
