### PR TITLE
cpu_compare: Add skip when no host features in xml

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_compare.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_compare.py
@@ -99,12 +99,15 @@ def run(test, params, env):
             vmxml['cpu']['model'] = host_cpu_xml['model']
         # Prepare VM cpu feature if necessary
         if modify_target in ['feature_name', 'feature_policy', 'delete']:
-            if len(vmxml['cpu'].get_feature_list()) == 0:
+            if len(vmxml['cpu'].get_feature_list()) == 0 and host_cpu_xml.get_feature_list():
                 # Add a host feature to VM for testing
                 vmxml_cpu = vmxml['cpu'].copy()
                 vmxml_cpu.add_feature(host_cpu_xml.get_feature_name('-1'))
                 vmxml['cpu'] = vmxml_cpu
                 vmxml.sync()
+            else:
+                raise error.TestNAError("No features present in host "
+                                        "capability XML")
 
         # Prepare temp compare file.
         cpu_compare_xml = get_cpu_xml(target, mode)


### PR DESCRIPTION
virsh_cpu_compare testcases which uses cpu features options present in host capabilities xml,
errors out incase of no features available in xml

domain/virsh_cpu_compare.py", line 63, in get_cpu_xml
     libvirtxml.remove_feature(feature_num)
   File "/usr/lib/python2.7/site-packages/avocado_plugins_vt-39.0-py2.7.egg/virttest/libvirt_xml/vm_xml.py", line 1562, in remove_feature
     node.remove(self.get_feature(num))
   File "/usr/lib/python2.7/site-packages/avocado_plugins_vt-39.0-py2.7.egg/virttest/libvirt_xml/vm_xml.py", line 1534, in get_feature
     raise xcepts.LibvirtXMLError("Only %d feature(s)" % count)
 LibvirtXMLError: Only 0 feature(s)

This patch adds a check for it and skips the test if no features are present.