### PR TITLE
Fixup virsh_edit.py

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_edit.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_edit.cfg
@@ -14,7 +14,7 @@
                     mem_value = "1048576"
                 - mib_unit:
                     mem_unit = 'M'
-                    mem_value = "1000"
+                    mem_value = "1024"
                 - gib_unit:
                     mem_unit = "G"
                     mem_value = "1"


### PR DESCRIPTION
1. vpcu count is changed without topology check, so tests fails with,
"Maximum CPUs greater than topology limit\nFailed. Try again?
[y,n,i,f,?]"

2. mem_value assigned as 1000 for mem_unit M, but validating with
1024000 which fails the test - mem_value=1024 fixes it.

This patch fixes these issues and works with and without topology.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>