### PR TITLE
snapshot_dumpxml: Handle exception for variant password is not None

### DIFF
--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_dumpxml.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_dumpxml.py
@@ -123,8 +123,11 @@ def run(test, params, env):
             vm = env.get_vm(vm_name)
             if vm.is_alive():
                 vm.destroy()
-            vm_xml.VMXML.add_security_info(
-                vm_xml.VMXML.new_from_dumpxml(vm_name), passwd)
+            try:
+                vm_xml.VMXML.add_security_info(
+                    vm_xml.VMXML.new_from_dumpxml(vm_name), passwd)
+            except Exception, info:
+                raise error.TestNAError(info)
             vm.start()
             if secu_opt is not None:
                 opt_dict['passwd'] = passwd


### PR DESCRIPTION
Have fixed the test case where the exception was not handled when password was not None.
try:
                vm_xml.VMXML.add_security_info(
                    vm_xml.VMXML.new_from_dumpxml(vm_name), passwd)
            except Exception, info:
                raise error.TestNAError(info)

