### PR TITLE
Fixup virsh_migrate_multi_vms

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_multi_vms.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_multi_vms.cfg
@@ -8,7 +8,9 @@
     # Remote host's name or ip
     remote_host = "${migrate_dest_host}"
     local_host = "${migrate_source_host}"
+    virsh_migrate_thread_timeout = 900
     virsh_migrate_timeout = 60
+    virsh_device_target = "sda"
     # Start vms for migration
     start_vm = "yes"
     main_vm = ""
@@ -27,13 +29,23 @@
             status_error = "yes"
     variants:
         - live:
-            virsh_migrate_options = "live timeout unsafe"
+            variants:
+                - live:
+                    virsh_migrate_options = "live timeout auto-converge"
+                - live_unsafe:
+                    virsh_migrate_options = "live timeout unsafe auto-converge"
+        - online:
+            variants:
+                - online:
+                    virsh_migrate_options = ""
+                - online_unsafe:
+                    virsh_migrate_options = "unsafe"
         - combination_options:
-            virsh_migrate_options = "live persistent suspend change-protection timeout unsafe"
+            virsh_migrate_options = "live persistent suspend change-protection timeout unsafe auto-converge"
     variants:
         - simultaneous:
             # Migrate all vms at same time with thread
-            simultaneous_migration = "yes"
+            virsh_migration_type = "simultaneous"
             variants:
                 - normal:
                 - abort_job:
@@ -41,4 +53,4 @@
                     virsh_migrate_jobabort = "yes"
                     status_error = "yes"
         - orderly:
-            simultaneous_migration = "no"
+            virsh_migration_type = "orderly"


### PR DESCRIPTION
1. Reused avocado/avocado-vt libvirt.py for migration threading code
   to avoid redundancy (API: MigrationTest()).

2. Thread timeout during migration was not handled to Fail, instead
   considered as Error, reusing libvirt.py code fixes it.

3. Added support for unsafe option, and handled disk with cache=none
   when --unsafe option is not used.

4. Added testcases for online migration and with --auto-converge option

5. Remote NFS mounting was not handled earlier, fixed it in this patch.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>