### PR TITLE
Add checkpoint of snapshot id when convert to rhev

### DIFF
--- a/v2v/tests/cfg/v2v_options.cfg
+++ b/v2v/tests/cfg/v2v_options.cfg
@@ -7,12 +7,6 @@
     vpx60_hostname = VPX_60_HOSTNAME_V2V_EXAMPLE
     vpx60_dc = VPX_60_DC_V2V_EXAMPLE
     esx60_hostname = ESX_60_HOSTNAME_V2V_EXAMPLE
-    vpx55_hostname = VPX_55_HOSTNAME_V2V_EXAMPLE
-    vpx55_dc = VPX_55_DC_V2V_EXAMPLE
-    esx55_hostname = ESX_55_HOSTNAME_V2V_EXAMPLE
-    vpx51_hostname = VPX_51_HOSTNAME_V2V_EXAMPLE
-    vpx51_dc = VPX_51_DC_V2V_EXAMPLE
-    esx51_hostname = ESX_51_HOSTNAME_V2V_EXAMPLE
     ovirt_engine_url = "https://OVIRT_ENGINE_URL_V2V_EXAMPLE/api"
     ovirt_engine_user = "OVIRT_ENGINE_USER_V2V_EXAMPLE"
     ovirt_engine_password = "OVIRT_ENGINE_PASSWORD_V2V_EXAMPLE"
@@ -111,7 +105,6 @@
                             hypervisor = "kvm"
                             variants:
                                 - default:
-                                    main_vm = "VM_NAME_KVM_DEFAULT_V2V_EXAMPLE"
                         - xen:
                             hypervisor = "xen"
                             remote_host = ${xen_hostname}
@@ -122,21 +115,11 @@
                         - esx:
                             hypervisor = "esx"
                             variants:
-                                - esx_51:
-                                    remote_host = ${vpx51_hostname}
-                                    vpx_dc = ${vpx51_dc}
-                                    esx_ip = ${esx51_hostname}
-                                    vpx_passwd = "VPX51_PASSWORD"
-                                - esx_55:
-                                    remote_host = ${vpx55_hostname}
-                                    vpx_dc = ${vpx55_dc}
-                                    esx_ip = ${esx55_hostname}
-                                    vpx_passwd = "VPX55_PASSWORD"
                                 - esx_60:
                                     remote_host = ${vpx60_hostname}
                                     vpx_dc = ${vpx60_dc}
                                     esx_ip = ${esx60_hostname}
-                                    vpx_passwd = "VPX60_PASSWORD"
+                                    vpx_passwd = "VPX_PASSWORD_V2V_EXAMPLE"
                             variants:
                                 - default:
                                     only esx_60
@@ -244,6 +227,9 @@
                     only input_mode.libvirt.xen
                     only output_mode.rhev, output_mode.libvirt
                     checkpoint = 'quiet'
+                - rhev_snapshot_id:
+                    only input_mode.libvirt.kvm.default
+                    only output_mode.rhev
         - negative_test:
             status_error = "yes"
             variants:


### PR DESCRIPTION
- Snapshot id in ovf file should not consists of '0's.
- Remove paramters of esx5.1 and esx5.5 for no longer needed.
- Update search pattern of uuids, for content of log changes from
"qemu convert" to "qemu 'convert'" with an extra pair of single
quote.