### PR TITLE
domfstrim: Sync disk before checking disk map

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domfstrim.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domfstrim.py
@@ -146,10 +146,10 @@ def run(test, params, env):
             """
             map_cmd = "cat /sys/bus/pseudo/drivers/scsi_debug/map"
             diskmap = utils.run(map_cmd).stdout.strip('\n\x00')
-            logging.debug("disk map is %s", diskmap)
             sum = 0
             for i in diskmap.split(","):
                 sum = sum + int(i.split("-")[1]) - int(i.split("-")[0])
+            logging.debug("disk map (size:%d) is %s", sum, diskmap)
             return sum
 
         ori_size = get_diskmap_size()
@@ -193,6 +193,7 @@ def run(test, params, env):
                     return True
 
             empty_size = get_diskmap_size()
+            logging.info("Trimmed disk to %d", empty_size)
 
             if is_fulltrim:
                 return empty_size <= ori_size
@@ -207,7 +208,7 @@ def run(test, params, env):
                 if ori_size < empty_size <= full_size:
                     logging.info("Success to do fstrim partly")
                     return True
-            raise error.TestFail("Fail to do fstrim. (orignal size: %s), "
+            raise error.TestFail("Fail to do fstrim. (original size: %s), "
                                  "(current size: %s), (full size: %s)" %
                                  (ori_size, empty_size, full_size))
         logging.info("Success to do fstrim")

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domfstrim.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domfstrim.py
@@ -155,7 +155,7 @@ def run(test, params, env):
         ori_size = get_diskmap_size()
 
         # Write date in disk
-        dd_cmd = "dd if=/dev/zero of=/home/test/file bs=1048576 count=5"
+        dd_cmd = "dd if=/dev/zero of=/home/test/file bs=1048576 count=5; sync"
         guest_session.cmd(dd_cmd)
 
         def _full_mapped():
@@ -172,7 +172,7 @@ def run(test, params, env):
         full_size = get_diskmap_size()
 
         # Remove disk content in guest
-        guest_session.cmd("rm -rf /home/test/*")
+        guest_session.cmd("rm -rf /home/test/*; sync")
         guest_session.close()
 
         def _trim_completed():


### PR DESCRIPTION
Disk map could possible not changed due to disk cache exists in
guest. This will make the disk map got after executing commands
not up to date. Run `sync` after every commands to make sure cached
data is flushed into disk before checking disk map.

Also fixing a typo and making log more verbose.