### PR TITLE
virsh_migrate: memory hotplug and migration

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
@@ -47,6 +47,17 @@
             variants:
                 - with_numa_only:
                     virsh_migrate_with_numa = 'yes'
+                    variants:
+                        - with_mem_hotplug:
+                            virsh_migrate_mem_hotplug = "yes"
+                            virsh_migrate_mem_hotplug_count = "2"
+                            # min memory that can be hotplugged
+                            # 256 MiB - 256 * 1024 = 262144
+                            virsh_migrate_hotplug_mem = "262144"
+                            virsh_migrate_hotplug_mem_unit = "KiB"
+                            virsh_migrate_max_dimm_slots = "32"
+                        - without_mem_hotplug:
+                            virsh_migrate_mem_hotplug = "no"
                 - with_numa_and_HP:
                     variants:
                         - with_HP:
@@ -109,6 +120,17 @@
             variants:
                 - with_numa_only:
                     virsh_migrate_with_numa = 'yes'
+                    variants:
+                        - with_mem_hotplug:
+                            virsh_migrate_mem_hotplug = "yes"
+                            virsh_migrate_mem_hotplug_count = "2"
+                            # min memory that can be hotplugged
+                            # 256 MiB - 256 * 1024 = 262144
+                            virsh_migrate_hotplug_mem = "262144"
+                            virsh_migrate_hotplug_mem_unit = "KiB"
+                            virsh_migrate_max_dimm_slots = "32"
+                        - without_mem_hotplug:
+                            virsh_migrate_mem_hotplug = "no"
                 - with_numa_and_HP:
                     variants:
                         - with_HP:
@@ -261,6 +283,17 @@
             variants:
                 - with_numa_only:
                     virsh_migrate_with_numa = 'yes'
+                    variants:
+                        - with_mem_hotplug:
+                            virsh_migrate_mem_hotplug = "yes"
+                            virsh_migrate_mem_hotplug_count = "2"
+                            # min memory that can be hotplugged
+                            # 256 MiB - 256 * 1024 = 262144
+                            virsh_migrate_hotplug_mem = "262144"
+                            virsh_migrate_hotplug_mem_unit = "KiB"
+                            virsh_migrate_max_dimm_slots = "32"
+                        - without_mem_hotplug:
+                            virsh_migrate_mem_hotplug = "no"
                 - with_numa_and_HP:
                     variants:
                         - with_HP:


### PR DESCRIPTION
Added test scenarios to perform memory hotplug and then migrate,
migration scenario includes live and online.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>