### PR TITLE
daemon.host_uuid: All same UUID is a negative case

### DIFF
--- a/libvirt/tests/cfg/conf_file/libvirtd_conf/host_uuid.cfg
+++ b/libvirt/tests/cfg/conf_file/libvirtd_conf/host_uuid.cfg
@@ -15,9 +15,6 @@
                 - single_quoted_uuid:
                     uuid_type = single_quoted
                     new_uuid = abcdabcd-abcd-abcd-abcd-abcdabcdabcd
-                - all_same_uuid:
-                    expected_result = dmi_uuid
-                    new_uuid = 22222222-2222-2222-2222-222222222222
                 - not_set_uuid:
                     uuid_type = not_set
                     expected_result = dmi_uuid
@@ -36,6 +33,8 @@
                     new_uuid = 1-3-3-7-1-3-3-7-1-3-3-7-1-3-3-7-1-3-3-7-1-3-3-7-1-3-3-7-1-3-3-7
                 - invalid_uuid:
                     new_uuid = gggggggg-gggg-gggg-gggg-gggggggggggg
+                - all_same_uuid:
+                    new_uuid = 22222222-2222-2222-2222-222222222222
                 - short_uuid:
                     new_uuid = 22222222-2222-2222-2222-22222222222
                 - long_uuid:


### PR DESCRIPTION
Host UUID with all same digits should not be started and will be a
negative test case.

This bug has been fixed by following libvirt commit
    6fe81c3: daemon: add option to read host uuid from /etc/machine-id

Signed-off-by: Hao Liu <hliu@redhat.com>