### PR TITLE
Added Npiv image from pool test case

### DIFF
--- a/libvirt/tests/cfg/npiv/npiv_image_from_pool.cfg
+++ b/libvirt/tests/cfg/npiv/npiv_image_from_pool.cfg
@@ -1,0 +1,23 @@
+- npiv.image_from_pool:
+    type = npiv_image_from_pool
+    vms = virt-tests-vm1
+    main_vm = virt-tests-vm1
+    start_vm = "no"
+    pool_create_xml_file = "virt-test-pool.xml"
+    pool_create_name = "new-pool"
+    pool_create_use_exist_pool = "no"
+    variants:
+        - positive_test:
+            status_error = "no"
+            variants:
+                - from_multi_mapper_def_pool:
+                    variants:
+                        - npiv_pool:
+                            pool_source_dev = "/dev/mapper/mpathe"
+                            pool_type = "logical"
+                            pool_target = "/dev/new-pool"
+                            disk_target_dev = "vdb"
+                            volume_name = "imagefrommapper.qcow2"
+                            volume_capacity = '15G'
+                            allocation = '15G'
+                            volume_format = 'qcow2'

--- a/libvirt/tests/cfg/npiv/npiv_nodedev_create_destroy.cfg
+++ b/libvirt/tests/cfg/npiv/npiv_nodedev_create_destroy.cfg
@@ -1,0 +1,41 @@
+- npiv.nodedev_create_destroy:
+    type = npiv_nodedev_create_destroy
+    start_vm = "no"
+    main_vm = ""
+    vms = ""
+    scsi_wwnn = "21000024ff370145"
+    scsi_wwpn = "2101001b32a90000"
+    take_regular_screendumps = "no"
+    kill_unresponsive_vms = "no"
+    variants:
+        - positive_testing:
+            status_error = "no"
+            variants:
+                - create_destroy_device:
+                    create_number = 1
+                    destroy_number = 1
+                    create_then_destroy = "yes"
+        - negative_testing:                                               
+            status_error = "no"
+            variants:
+                - frequently_create_destroy_vhbas: 
+                    create_number = 2
+                    destroy_number = 2
+                    create_then_destroy = "yes" 
+                    variants:
+                        - fixed_wwn:
+                        - random_wwn:
+                            scsi_wwnn = ""
+                            scsi_wwpn = ""      
+                - create_max_vhbas:
+                    number_vhba = 10
+                    scsi_wwnn = ""
+                    scsi_wwpn = ""
+                    create_number = 6
+                    destroy_number = 0
+                    create_then_destroy = "no"
+                - create_more_destroy_less:
+                    create_number = 5
+                    destroy_number = 3
+                    create_then_destroy = "no"
+                    set_valid_wwn_to_first_vhba = "yes"

--- a/libvirt/tests/src/npiv/npiv_image_from_pool.py
+++ b/libvirt/tests/src/npiv/npiv_image_from_pool.py
@@ -1,0 +1,169 @@
+import logging
+import time
+from avocado.core import exceptions
+from virttest import virsh
+from virttest import libvirt_storage
+from virttest import libvirt_xml
+from virttest.utils_test import libvirt as utlv
+from npiv import npiv_nodedev_create_destroy as nodedev
+from avocado.utils import process
+
+
+def mount_and_dd(session, mount_disk):
+    """
+    Mount given disk and perform a dd operation on it
+    """
+    output = session.cmd_status_output('mount /dev/%s /mnt' % mount_disk)
+    logging.debug("%s", output[1])
+    output = session.cmd_status_output(
+        'dd if=/dev/zero of=/mnt/testfile bs=4k', timeout=120)
+    logging.debug("dd output: %s", output[1])
+    output = session.cmd_status_output('mount')
+    logging.debug("Mount output: %s", output[1])
+    if '/mnt' in output[1]:
+        logging.debug("Mount Successful")
+
+
+def run(test, params, env):
+    """
+    Test command: virsh pool-define-as; pool-build; pool-start; vol-create-as;
+    vol-list; attach-device; login; mount and dd; reboot; check persistence;
+    detach-device; pool-destroy; pool-undefine; clear lv,vg and pv;
+
+    Create a libvirt npiv pool from a device mapper device and create a volume
+    out of the newly created pool and attach it to a guest, mount it, reboot
+    and check persistence after reboot.
+
+    Pre-requisite :
+    Host should have a multipath mapper device
+
+    """
+    pool_name = params.get("pool_create_name", "virt_test_pool_tmp")
+    pool_type = params.get("pool_type", "dir")
+    source_dev = params.get("pool_source_dev", "/dev/mapper/mpatha")
+    pool_target = params.get("pool_target", "pool_target")
+    target_device = params.get("disk_target_dev", "vda")
+    volume_name = params.get("volume_name", "imagefrommapper.qcow2")
+    volume_capacity = params.get("volume_capacity", '1G')
+    allocation = params.get("allocation", '1G')
+    frmt = params.get("volume_format", 'qcow2')
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    mount_disk = None
+    test_unit = None
+
+    if not vm.is_alive():
+        vm.start()
+    pool_extra_args = ""
+    if source_dev:
+        pool_extra_args = ' --source-dev %s' % source_dev
+    pool_ins = libvirt_storage.StoragePool()
+    if pool_ins.pool_exists(pool_name):
+        raise exceptions.TestFail("Pool %s already exist" % pool_name)
+    online_hbas_list = nodedev.find_hbas("hba")
+    # if no online hba cards on host, mark case failed
+    if not online_hbas_list:
+        raise exceptions.TestSkipError("Host doesn't have online hba cards")
+    try:
+        cmd_result = virsh.pool_define_as(pool_name, pool_type, pool_target, pool_extra_args, ignore_status=True,
+                                          debug=True)
+        err = cmd_result.stderr.strip()
+        status = cmd_result.exit_status
+        if status:
+            raise exceptions.TestFail(err)
+        else:
+            logging.info("Successfully define pool: %s", pool_name)
+
+        cmd_result = virsh.pool_build(pool_name)
+        err = cmd_result.stderr.strip()
+        status = cmd_result.exit_status
+        if status:
+            raise exceptions.TestFail(err)
+        else:
+            logging.info("Successfully built pool: %s", pool_name)
+
+        cmd_result = virsh.pool_start(pool_name)
+        err = cmd_result.stderr.strip()
+        status = cmd_result.exit_status
+        if status:
+            raise exceptions.TestFail(err)
+        else:
+            logging.info("Successfully start pool: %s", pool_name)
+
+        utlv.check_actived_pool(pool_name)
+        pool_detail = libvirt_xml.PoolXML.get_pool_details(pool_name)
+        logging.debug("Pool detail: %s", pool_detail)
+
+        cmd_result = virsh.vol_create_as(
+            volume_name, pool_name, volume_capacity, allocation, frmt, "", debug=True)
+        err = cmd_result.stderr.strip()
+        status = cmd_result.exit_status
+        if status:
+            raise exceptions.TestFail(err)
+        else:
+            logging.info(
+                "Successfully created volume out of pool: %s", pool_name)
+
+        # Time for pool to be listed
+        time.sleep(5)
+
+        vol_list = utlv.get_vol_list(pool_name)
+        logging.debug('Volume list %s', vol_list)
+        for unit in vol_list:
+            test_unit = vol_list[unit]
+            logging.debug(unit)
+
+        disk_params = {'type_name': "file", 'target_dev': target_device,
+                       'target_bus': "virtio", 'source_file': test_unit,
+                       'driver_name': "qemu", 'driver_type': "raw"}
+        disk_xml = utlv.create_disk_xml(disk_params)
+        session = vm.wait_for_login()
+
+        attach_success = virsh.attach_device(
+            vm_name, disk_xml, debug=True).exit_status
+
+        if attach_success:
+            raise exceptions.TestFail(
+                "Failed to attach disk %s" % disk_xml)
+        else:
+            logging.debug('Device attached successfully')
+
+        # Time for attached disk to display in guest
+        time.sleep(10)
+
+        output = session.cmd_status_output('lsblk')
+        logging.debug("%s", output[1])
+        mount_disk = None
+        for line in output[1].splitlines():
+            if line.startswith('vd'):
+                mount_disk = line.split(' ')[0]
+
+        session.cmd_status_output('mkfs.ext4 /dev/%s' % mount_disk)
+        if mount_disk:
+            logging.info("%s", mount_disk)
+            mount_and_dd(session, mount_disk)
+
+        virsh.reboot(vm_name, debug=True)
+
+        session = vm.wait_for_login()
+        output = session.cmd_status_output('mount')
+        logging.debug("Mount output: %s", output[1])
+        if '/mnt' in output[1]:
+            logging.debug("Mount Successful accross reboot")
+
+        status = virsh.detach_device(vm_name, disk_xml,
+                                     debug=True).exit_status
+        if status:
+            raise exceptions.TestFail("Disk detach unsuccessful")
+        else:
+            logging.debug("Disk detach successful")
+
+    finally:
+        vm.destroy(gracefully=False)
+        logging.debug('Destroying pool %s', pool_name)
+        virsh.pool_destroy(pool_name)
+        logging.debug('Undefining pool %s', pool_name)
+        virsh.pool_undefine(pool_name)
+        process.system('lvremove %s' % test_unit, verbose=True)
+        process.system('vgremove %s' % pool_name, verbose=True)
+        process.system('pvremove %s' % source_dev, verbose=True)

--- a/libvirt/tests/src/npiv/npiv_nodedev_create_destroy.py
+++ b/libvirt/tests/src/npiv/npiv_nodedev_create_destroy.py
@@ -1,0 +1,358 @@
+import os
+import re
+import logging
+import time
+from tempfile import mktemp
+from avocado.core import exceptions
+from virttest import virsh
+from virttest.libvirt_xml.nodedev_xml import NodedevXML
+from virttest import utils_misc
+
+_FC_HOST_PATH = "/sys/class/fc_host"
+_DELAY_TIME = 2
+
+
+def check_nodedev(dev_name, dev_parent=None):
+    """
+    Check node device relevant values
+
+    :params dev_name: name of the device
+    :params dev_parent: parent name of the device, None is default
+    :return: True if nodedev is normal.
+    """
+    host = dev_name.split("_")[1]
+    fc_host_path = os.path.join(_FC_HOST_PATH, host)
+
+    # Check if the /sys/class/fc_host/host$NUM exists
+    if not os.access(fc_host_path, os.R_OK):
+        logging.debug("Can't access %s", fc_host_path)
+        return False
+
+    dev_xml = NodedevXML.new_from_dumpxml(dev_name)
+    if not dev_xml:
+        logging.error("Can't dumpxml %s XML", dev_name)
+        return False
+
+    # Check device parent name
+    if dev_parent != dev_xml.parent:
+        logging.error("The parent name is different: %s is not %s",
+                      dev_parent, dev_xml.parent)
+        return False
+
+    wwnn_from_xml = dev_xml.wwnn
+    wwpn_from_xml = dev_xml.wwpn
+    fabric_wwn_from_xml = dev_xml.fabric_wwn
+
+    fc_dict = {}
+    name_list = ["node_name", "port_name", "fabric_name"]
+    for name in name_list:
+        fc_file = os.path.join(fc_host_path, name)
+        fc_dict[name] = open(fc_file, "r").read().strip().split("0x")[1]
+
+    # Check wwnn, wwpn and fabric_wwn
+    if len(wwnn_from_xml) != 16:
+        logging.debug("The wwnn is not valid: %s", wwnn_from_xml)
+        return False
+    if len(wwpn_from_xml) != 16:
+        logging.debug("The wwpn is not valid: %s", wwpn_from_xml)
+        return False
+    if fc_dict["node_name"] != wwnn_from_xml:
+        logging.debug("The node name is differnet: %s is not %s",
+                      fc_dict["node_name"], wwnn_from_xml)
+        return False
+    if fc_dict["port_name"] != wwpn_from_xml:
+        logging.debug("The port name is different: %s is not %s",
+                      fc_dict["port_name"], wwpn_from_xml)
+        return False
+    if fc_dict["fabric_name"] != fabric_wwn_from_xml:
+        logging.debug("The fabric wwpn is differnt: %s is not %s",
+                      fc_dict["fabric_name"], fabric_wwn_from_xml)
+        return False
+
+    fc_type_from_xml = dev_xml.fc_type
+    cap_type_from_xml = dev_xml.cap_type
+
+    # Check capability type
+    if (cap_type_from_xml != "scsi_host") or (fc_type_from_xml != "fc_host"):
+        logging.debug("The capability type isn't 'scsi_host' or 'fc_host'")
+        return False
+
+    return True
+
+
+def find_hbas(hba_type="hba", status="online"):
+    """
+    Find online hba/vhba cards.
+
+    :params hba_type: "vhba" or "hba"
+    :params status: "online" or "offline"
+    :return: A list contains the online/offline vhba/hba list
+    """
+    # TODO: add offline/online judgement, fc storage not stable for now, so
+    # leave this part after we buy npiv server
+    result = virsh.nodedev_list(cap="scsi_host")
+    if result.exit_status:
+        raise exceptions.testfail(result.stderr)
+
+    scsi_hosts = result.stdout.strip().splitlines()
+    online_hbas_list = []
+    online_vhbas_list = []
+    # go through all scsi hosts, and split hbas/vhbas into lists
+    for scsi_host in scsi_hosts:
+        result = virsh.nodedev_dumpxml(scsi_host)
+        stdout = result.stdout.strip()
+        if result.exit_status:
+            raise exceptions.TestFail(result.stderr)
+        if re.search('vport_ops', stdout) and not re.search('<fabric_wwn>ffffffffffffffff</fabric_wwn>', stdout):
+            online_hbas_list.append(scsi_host)
+        # if re.search('fc_host', result.stdout.strip()) and not
+        # re.search('vport_ops', result.stdout.strip()) and not
+        # re.search('<fabric_wwn>ffffffffffffffff</fabric_wwn>',
+        # result.stdout.strip()):
+        if re.search('fc_host', stdout) and not re.search('vport_ops', stdout):
+            online_vhbas_list.append(scsi_host)
+    if hba_type == "hba":
+        return online_hbas_list
+    if hba_type == "vhba":
+        return online_vhbas_list
+
+
+def is_vhbas_added(old_vhbas):
+    # TODO: this func need to be implemented when we have new npiv machine.
+    """
+    new_vhbas = find_hbas("vhba")
+    new_vhbas.sort()
+    old_vhbas.sort()
+    if len(new_vhbas)-len(old_vhbas) >= 1:
+        return True
+    else:
+        return False
+    """
+    time.sleep(_DELAY_TIME)
+    return True
+
+
+def is_vhbas_removed(old_vhbas):
+    # TODO: this func need to be implemented when we have new npiv machine.
+    """
+    new_vhbas = find_hbas("vhba")
+    new_vhbas.sort()
+    old_vhbas.sort()
+    if len(new_vhbas)-len(old_vhbas) < 0:
+        return True
+    else:
+        return False
+    """
+    time.sleep(_DELAY_TIME)
+    return True
+
+
+def nodedev_create_from_xml(params):
+    """
+    Create a node device with a xml object.
+
+    :param params: Including nodedev_parent, scsi_wwnn, scsi_wwpn set in xml
+    :return: The scsi device name just created
+    """
+    nodedev_parent = params.get("nodedev_parent")
+    scsi_wwnn = params.get("scsi_wwnn")
+    scsi_wwpn = params.get("scsi_wwpn")
+    status_error = params.get("status_error", "no")
+
+    vhba_xml = """
+<device>
+    <parent>%s</parent>
+    <capability type='scsi_host'>
+        <capability type='fc_host'>
+        <wwnn>%s</wwnn>
+        <wwpn>%s</wwpn>
+        </capability>
+    </capability>
+</device>
+""" % (nodedev_parent, scsi_wwnn, scsi_wwpn)
+    logging.debug("Prepare the nodedev XML: %s", vhba_xml)
+    vhba_file = mktemp()
+    xml_object = open(vhba_file, 'w')
+    xml_object.write(vhba_xml)
+    xml_object.close()
+
+    result = virsh.nodedev_create(vhba_file,
+                                  debug=True,
+                                  )
+    status = result.exit_status
+
+    # Remove temprorary file
+    os.unlink(vhba_file)
+
+    # Check status_error
+    if status_error == "yes":
+        if status:
+            logging.info("It's an expected %s", result.stderr)
+        else:
+            raise exceptions.TestFail("%d not a expected command "
+                                      "return value", status)
+    elif status_error == "no":
+        if status:
+            raise exceptions.TestFail(result.stderr)
+        else:
+            output = result.stdout
+            logging.info(output)
+            for scsi in output.split():
+                if scsi.startswith('scsi_host'):
+                    # Check node device
+                    if check_nodedev(scsi, nodedev_parent):
+                        return scsi
+                    else:
+                        raise exceptions.TestFail("Can't find %s" % scsi)
+
+
+def nodedev_destroy(scsi_host, params={}):
+    """
+    Destroy a nodedev of scsi_host#.
+
+    :param scsi_host: The scsi to destroy
+    :param params: Contain status_error
+    """
+    status_error = params.get("status_error", "no")
+    result = virsh.nodedev_destroy(scsi_host)
+    logging.info("destroying scsi:%s", scsi_host)
+    status = result.exit_status
+    # Check status_error
+    if status_error == "yes":
+        if status:
+            logging.info("It's an expected %s", result.stderr)
+        else:
+            raise exceptions.TestFail("%d not a expected command "
+                                      "return value", status)
+    elif status_error == "no":
+        if status:
+            raise exceptions.TestFail(result.stderr)
+        else:
+            # Check nodedev value
+            if not check_nodedev(scsi_host):
+                logging.info(result.stdout)
+            else:
+                raise exceptions.TestFail("The relevant directory still exists"
+                                          "or mismatch with result")
+
+
+def check_nodedev_exist(scsi_host):
+    """
+    Check if scsi_host# exist.
+
+    :param scsi_host: The scsi host to be checked
+    :return: True if scsi_host exist, False if not
+    """
+    host = scsi_host.split("_")[1]
+    fc_host_path = os.path.join(_FC_HOST_PATH, host)
+    if os.path.exists(fc_host_path):
+        return True
+    else:
+        return False
+
+
+def vhbas_cleanup(new_vhbas):
+    """
+    Clean up all vhbas.
+    """
+    vhbas = []
+    logging.info("cleanup all vhbas of the test")
+    vhbas = find_hbas("vhba")
+    logging.info("OH, the online vhbas are %s", vhbas)
+    for scsi_host in new_vhbas:
+        nodedev_destroy(scsi_host)
+    left_vhbas = find_hbas("vhba")
+    if left_vhbas:
+        logging.error("old vhbas are: %s", left_vhbas)
+    logging.debug("all scsi_hosts destroied: %s", new_vhbas)
+
+
+def run(test, params, env):
+    """
+    NPIV test for vhba create/destroy, contains following sceraions:
+
+    1. create a vhba then destroy it
+    2. create and destroy vhba frequently
+    3. create a lot of vhbas
+    4. create some vhbas, then destroy part of them
+    """
+    destroy_number = int(params.get("destroy_number", 1))
+    create_number = int(params.get("create_number", 1))
+    left_number = create_number - destroy_number
+    create_then_destroy = "yes" == params.get("create_then_destroy", "no")
+    set_valid_wwn_to_first_vhba = "yes" == params.get(
+        "set_valid_wwn_to_first_vhba", "no")
+    scsi_wwnn = params.get("scsi_wwnn", "")
+    scsi_wwpn = params.get("scsi_wwpn", "")
+    online_hbas = []
+    online_hbas = find_hbas("hba")
+    random_wwnn = ""
+    random_wwpn = ""
+    new_vhbas = []
+    if not online_hbas:
+        raise exceptions.TestSkipError("Host doesn't have online hba cards")
+    # use the first online hba as parent hba to all vhbas
+    first_online_hba = online_hbas[0]
+    try:
+        for i in range(create_number):
+            # steps in case 4: create some vhbas, and first vhba is valid,
+            # rest vhbas with random wwns
+            # set valid wwn to first vhba
+            if set_valid_wwn_to_first_vhba and i == 0:
+                logging.info("create %s round with valid wwn", i)
+                logging.info("doing something")
+                old_vhbas = find_hbas("vhba")
+                new_vhba = nodedev_create_from_xml({"nodedev_parent": first_online_hba,
+                                                    "scsi_wwnn": scsi_wwnn,
+                                                    "scsi_wwpn": scsi_wwpn})
+                utils_misc.wait_for(
+                    lambda: is_vhbas_added(old_vhbas), timeout=5)
+                new_vhbas.append(new_vhba)
+            # set random wwn to rest vhbas
+            elif set_valid_wwn_to_first_vhba and i != 0:
+                logging.info("create %s round with random wwn", i)
+                old_vhbas = find_hbas("vhba")
+                new_vhba = nodedev_create_from_xml({"nodedev_parent": first_online_hba,
+                                                    "scsi_wwnn": random_wwnn,
+                                                    "scsi_wwpn": random_wwpn})
+                if not utils_misc.wait_for(lambda: is_vhbas_added(old_vhbas), timeout=5):
+                    logging.error("vhba not successfully created")
+                new_vhbas.append(new_vhba)
+            # steps in cases 1,2,3: create vhbas
+            # set wwn (valid or random depending on test case variables) to
+            # vhbas
+            else:
+                old_vhbas = find_hbas("vhba")
+                new_vhba = nodedev_create_from_xml({"nodedev_parent": first_online_hba,
+                                                    "scsi_wwnn": scsi_wwnn,
+                                                    "scsi_wwpn": scsi_wwpn})
+                if not utils_misc.wait_for(lambda: is_vhbas_added(old_vhbas), timeout=5):
+                    logging.error("vhba not successfully created")
+                new_vhbas.append(new_vhba)
+                logging.info("create %s round with valid/random wwn", i)
+
+            # 1,2,3 destroy vhbas just after creation
+            if create_then_destroy and destroy_number > 0:
+                logging.info("destroy %s round", i)
+                old_vhbas = find_hbas("vhba")
+                nodedev_destroy(new_vhbas[-1])
+                if not utils_misc.wait_for(lambda: is_vhbas_removed(old_vhbas), timeout=5):
+                    logging.error("vhba not successfully created")
+                del new_vhbas[-1]
+                destroy_number = destroy_number - 1
+        # steps in case 4: destroy vhbas in a row
+        if not create_then_destroy and destroy_number > 0:
+            for i in range(destroy_number):
+                logging.info("destroy %s round", i)
+                old_vhbas = find_hbas("vhba")
+                nodedev_destroy(new_vhbas[-1])
+                if not utils_misc.wait_for(lambda: is_vhbas_removed(old_vhbas), timeout=5):
+                    logging.error("vhba not successfully created")
+                del new_vhbas[-1]
+                logging.info("list left: %s", new_vhbas)
+
+        logging.info("left number is: %s", left_number)
+        logging.info("length of new_vhbas: %d", len(new_vhbas))
+    finally:
+        # clean up all vhbas
+        vhbas_cleanup(new_vhbas)


### PR DESCRIPTION
Create a libvirt npiv pool from a device mapper device and create a volume out of the newly created pool and attach it to a guest, mount it, reboot and check persistence after reboot. 

This test is dependent on [avocado-framework/avocado-vt#702](https://github.com/avocado-framework/avocado-vt/pull/702)

Signed-off-by: Harish [harisrir@linux.vnet.ibm.com](mailto:harisrir@linux.vnet.ibm.com)