### PR TITLE
setvcpus: Fix a TypeError bug and move a case to negative part

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_setvcpus.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_setvcpus.cfg
@@ -48,16 +48,6 @@
                         - option_maximum_config:
                             setvcpus_options = "--maximum --config"
                             setvcpus_count = "5"
-                        - exceeding_topology_limit:
-                            setvcpus_pre_vm_state = "shut off"
-                            set_topology = "yes"
-                            topology_sockets='1'
-                            topology_cores= '2'
-                            topology_threads= '2'
-                            setvcpus_count = "8"
-                            setvcpus_options = "--maximum --config"
-                            start_vm_after_set = "yes"
-                            start_vm_expect_fail = "yes"
                 - remote:
                     setvcpus_vm_ref = "remote"
         - error_test:
@@ -97,6 +87,16 @@
                             setvcpus_options = "--live --config"
                         - current_config_option:
                             setvcpus_options = "--current --config"
+                        - exceeding_topology_limit:
+                            setvcpus_pre_vm_state = "shut off"
+                            set_topology = "yes"
+                            topology_sockets='1'
+                            topology_cores= '2'
+                            topology_threads= '2'
+                            setvcpus_count = "8"
+                            setvcpus_options = "--maximum --config"
+                            start_vm_after_set = "yes"
+                            start_vm_expect_fail = "no"
                 - maximum_option:
                     setvcpus_options = "--maximum --live"
                 - no_acpi_feature:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_setvcpus.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_setvcpus.py
@@ -60,7 +60,7 @@ def get_xmldata(vm_name, xml_file, options):
     extra_opts = ""
     if "--config" in options:
         extra_opts = "--inactive"
-    vcpus_current = ""
+    vcpus_current = 0
     virsh.dumpxml(vm_name, extra=extra_opts, to_file=xml_file)
     dom = parse(xml_file)
     root = dom.documentElement
@@ -68,11 +68,10 @@ def get_xmldata(vm_name, xml_file, options):
     vcpus_parent = root.getElementsByTagName("vcpu")
     vcpus_count = int(vcpus_parent[0].firstChild.data)
     for n in vcpus_parent:
-        vcpus_current += n.getAttribute("current")
-        if vcpus_current != "":
-            vcpus_current = int(vcpus_current)
-        else:
-            vcpus_current = 0
+        try:
+            vcpus_current += int(n.getAttribute("current"))
+        except ValueError:
+            pass
     # get the machine type
     os_parent = root.getElementsByTagName("os")
     os_machine = ""


### PR DESCRIPTION
1. getAttribute("current") will return an unicode type value, so need format it.
2. After set CPU topology, setvcpus should fail, then the VM can start
normally.

Signed-off-by: Yanbing Du <ydu@redhat.com>