### PR TITLE
virsh.nodeinfo: Using different ways to check host memory

### DIFF
--- a/libvirt/tests/src/virsh_cmd/host/virsh_nodeinfo.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_nodeinfo.py
@@ -11,6 +11,9 @@ from virttest import virsh
 from virttest import utils_libvirtd
 from virttest import utils_misc
 from virttest.libvirt_xml import capability_xml
+from virttest.staging import utils_memory
+
+from provider import libvirt_version
 
 
 def run(test, params, env):
@@ -134,9 +137,12 @@ def run(test, params, env):
         memory_size_nodeinfo = int(
             _check_nodeinfo(nodeinfo_output, 'Memory size', 3))
         memory_size_os = 0
-        for i in node_online_list:
-            node_memory = node_info.read_from_node_meminfo(i, 'MemTotal')
-            memory_size_os += int(node_memory)
+        if libvirt_version.version_compare(2, 0, 0):
+            for i in node_online_list:
+                node_memory = node_info.read_from_node_meminfo(i, 'MemTotal')
+                memory_size_os += int(node_memory)
+        else:
+            memory_size_os = utils_memory.memtotal()
         logging.debug('The host total memory from nodes is %s', memory_size_os)
 
         if memory_size_nodeinfo != memory_size_os:


### PR DESCRIPTION
Commit 5a145f3c change the way to check host memory size as 'nodeinfo'
using a different way to collect host memory size since 2.0.0, but for
older versions, we should check it in a different way.

Signed-off-by: Yanbing Du <ydu@redhat.com>