### PR TITLE
Fixup virsh_edit

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_edit.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_edit.cfg
@@ -36,7 +36,7 @@
                     backend_model = "random"
                 - backend_dev:
                     backend_model = "random"
-                    edit_error = "yes"
+                    edit_error = "no"
                     rng_backend = "\/dev\/urandom"
                 - backend_type_unix:
                     backend_model = "egd"


### PR DESCRIPTION
1. Better way of handling topology and fixed the failure.
2. edit_error = "no" is the positive test case to test \<rng model='virtio'\>\<backend model='random' >/dev/urandom\</backend\>\</rng\> to be edited and saved.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>