### PR TITLE
Minor fix to avoid a false failure

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_options.py
+++ b/libvirt/tests/src/virtual_network/iface_options.py
@@ -383,7 +383,7 @@ def run(test, params, env):
     iface_type = params.get("iface_type", "network")
     iface_source = params.get("iface_source", "{}")
     iface_driver = params.get("iface_driver")
-    iface_model = params.get("iface_model")
+    iface_model = params.get("iface_model", "virtio")
     iface_target = params.get("iface_target")
     iface_backend = params.get("iface_backend", "{}")
     iface_driver_host = params.get("iface_driver_host")
@@ -504,7 +504,7 @@ def run(test, params, env):
                                                 True, timeout=timeout)
                 additional_vm = vm.clone(guest_name)
                 additional_vm.start()
-                #additional_vm.wait_for_login()
+                # additional_vm.wait_for_login()
 
             # Start the VM.
             if unprivileged_user:


### PR DESCRIPTION
In function create_iface_xml we assume if iface_model is not defined for perticular test then it's "virtio". But in 'run_cmdline_test' if iface_model is not defined then model_option chooses "device rtl8139".
I have made a small change now: if iface_model is not defined then it defaults to "virtio".

Without this patch test will fail looking for non-existant rtl8139 device :

23:42:22 DEBUG| New interface xml file: <?xml version='1.0' encoding='UTF-8'?>
<interface type="network">
      <mac address="52:54:00:64:65:66" />
      <model />
      <source network="default" /><driver><guest /><host /></driver></interface>
23:42:22 DEBUG| Undefine VM virt-tests-vm1-mallesh
23:42:22 DEBUG| Define VM from /var/tmp/xml_utils_temp_yG2jxi.xml
23:42:22 DEBUG| Running 'modprobe vhost_net'
23:42:22 DEBUG| Starting vm 'virt-tests-vm1-mallesh'
23:42:23 DEBUG| waiting for domain virt-tests-vm1-mallesh to start (0.000015 secs)
23:42:23 DEBUG| Attempting to log into 'virt-tests-vm1-mallesh' via serial console (timeout 240s)
23:42:49 DEBUG| Running 'ps -ef | grep virt-tests-vm1-mallesh | grep -v grep '
23:42:49 DEBUG| Command line qemu     149569      1 99 23:42 ?        00:00:31 /usr/bin/qemu-system-ppc64 -machine accel=kvm -name guest=virt-tests-vm1-mallesh,debug-threads=on -S -object secret,id=masterKey0,format=raw,file=/var/lib/libvirt/qemu/domain-142-virt-tests-vm1-malle/master-key.aes -machine pseries-2.7,accel=kvm,usb=off -m 32768 -realtime mlock=off -smp 32,sockets=1,cores=4,threads=8 -uuid 84c83bbc-0c97-459b-818d-4ccdd6d2efb7 -display none -no-user-config -nodefaults -chardev socket,id=charmonitor,path=/var/lib/libvirt/qemu/domain-142-virt-tests-vm1-malle/monitor.sock,server,nowait -mon chardev=charmonitor,id=monitor,mode=control -rtc base=utc -no-shutdown -boot strict=on -device pci-ohci,id=usb,bus=pci.0,addr=0x3 -device virtio-scsi-pci,id=scsi0,bus=pci.0,addr=0x2 -drive file=/home/srikanth/avocado-fvt-wrapper/data/avocado-vt/images/f24-ppc64le_srikanth.qcow2,format=qcow2,if=none,id=drive-scsi0-0-0-0 -device scsi-hd,bus=scsi0.0,channel=0,scsi-id=0,lun=0,drive=drive-scsi0-0-0-0,id=scsi0-0-0-0,bootindex=1 -netdev tap,fd=26,id=hostnet0,vhost=on,vhostfd=28 -device virtio-net-pci,netdev=hostnet0,id=net0,mac=52:54:00:64:65:66,bus=pci.0,addr=0x1 -chardev pty,id=charserial0 -device spapr-vty,chardev=charserial0,reg=0x30000000 -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x4 -msg timestamp=on
root     149618 149617  0 23:42 pts/4    00:00:00 /bin/bash -c virsh -c qemu:///system console virt-tests-vm1-mallesh serial0 && echo n1qneI72 > /dev/null
root     149620 149618  2 23:42 pts/4    00:00:00 virsh -c qemu:///system console virt-tests-vm1-mallesh serial0

23:42:49 INFO | Restoring vm...
23:42:49 DEBUG| Destroying VM
23:42:51 WARNI| Requested MAC address release from persistent vm virt-tests-vm1-mallesh. Ignoring.
23:42:51 DEBUG| Undefine VM virt-tests-vm1-mallesh
23:42:51 DEBUG| Define VM from /var/tmp/xml_utils_temp_J3a2w4.xml
23:42:52 DEBUG| Checking image file /home/srikanth/avocado-fvt-wrapper/data/avocado-vt/images/f24-ppc64le_srikanth.qcow2
23:42:52 INFO | Running 'true'
23:42:52 INFO | Command 'true' finished with 0 after 0.000679969787598s
23:42:52 INFO | Running 'ps -o comm 1'
23:42:52 DEBUG| [stdout] COMMAND
23:42:52 INFO | Command 'ps -o comm 1' finished with 0 after 0.080039024353s
23:42:52 DEBUG| [stdout] systemd
23:42:52 ERROR|
23:42:52 ERROR| Reproduced traceback from: /usr/lib/python2.7/site-packages/avocado_plugins_vt-41.0-py2.7.egg/avocado_vt/test.py:420
23:42:52 ERROR| Traceback (most recent call last):
23:42:52 ERROR|   File "/usr/lib/python2.7/site-packages/avocado_plugins_vt-41.0-py2.7.egg/avocado_vt/test.py", line 206, in runTest
23:42:52 ERROR|     raise exceptions.TestFail(details)
23:42:52 ERROR| TestFail: Can't see device rtl8139 with mac 52:54:00:64:65:66 in command line
23:42:52 ERROR|
23:42:52 ERROR| FAIL 02-guest_network.net_virsh_attach_detach_interface_matrix.qemu.qcow2.virtio_scsi.smp2.virtio_net.Fedora.24.ppc64le.powerkvm-libvirt.virtual_network.iface_options.iface_source_default -> TestFail: Can't see device rtl8139 with mac 52:54:00:64:65:66 in command line
23:42:52 INFO |

With this patch, test will not fail looking for non-existant rtl8139 device :

03:54:19 DEBUG| New interface xml file: <?xml version='1.0' encoding='UTF-8'?>
<interface type="network">
      <mac address="52:54:00:8d:8e:8f" />
      <model type="virtio" />
      <source network="default" /><driver><guest /><host /></driver></interface>
03:54:19 DEBUG| Undefine VM virt-tests-vm1-mallesh
03:54:19 DEBUG| Define VM from /var/tmp/xml_utils_temp_FSDsrG.xml
03:54:19 DEBUG| Running 'modprobe vhost_net'
03:54:19 DEBUG| Starting vm 'virt-tests-vm1-mallesh'
03:54:20 DEBUG| waiting for domain virt-tests-vm1-mallesh to start (0.000012 secs)
03:54:20 DEBUG| Attempting to log into 'virt-tests-vm1-mallesh' via serial console (timeout 240s)
03:54:47 DEBUG| Running 'ps -ef | grep virt-tests-vm1-mallesh | grep -v grep '
03:54:47 DEBUG| Command line qemu      89206      1 99 03:54 ?        00:00:32 /usr/bin/qemu-system-ppc64 -machine accel=kvm -name guest=virt-tests-vm1-mallesh,debug-threads=on -S -object secret,id=masterKey0,format=raw,file=/var/lib/libvirt/qemu/domain-237-virt-tests-vm1-malle/master-key.aes -machine pseries-2.7,accel=kvm,usb=off -m 32768 -realtime mlock=off -smp 32,sockets=1,cores=4,threads=8 -uuid 79ac7841-2aa5-4c2c-bca4-85a1fa0aa630 -display none -no-user-config -nodefaults -chardev socket,id=charmonitor,path=/var/lib/libvirt/qemu/domain-237-virt-tests-vm1-malle/monitor.sock,server,nowait -mon chardev=charmonitor,id=monitor,mode=control -rtc base=utc -no-shutdown -boot strict=on -device pci-ohci,id=usb,bus=pci.0,addr=0x3 -device virtio-scsi-pci,id=scsi0,bus=pci.0,addr=0x2 -drive file=/home/srikanth/avocado-fvt-wrapper/data/avocado-vt/images/f24-ppc64le_srikanth.qcow2,format=qcow2,if=none,id=drive-scsi0-0-0-0 -device scsi-hd,bus=scsi0.0,channel=0,scsi-id=0,lun=0,drive=drive-scsi0-0-0-0,id=scsi0-0-0-0,bootindex=1 -netdev tap,fd=25,id=hostnet0,vhost=on,vhostfd=27 -device virtio-net-pci,netdev=hostnet0,id=net0,mac=52:54:00:8d:8e:8f,bus=pci.0,addr=0x1 -chardev pty,id=charserial0 -device spapr-vty,chardev=charserial0,reg=0x30000000 -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x4 -msg timestamp=on
root      89251  89250  0 03:54 pts/4    00:00:00 /bin/bash -c virsh -c qemu:///system console virt-tests-vm1-mallesh serial0 && echo gej25UvE > /dev/null
root      89252  89251  2 03:54 pts/4    00:00:00 virsh -c qemu:///system console virt-tests-vm1-mallesh serial0

03:54:47 DEBUG| Command line options {'netdev': 'hostnet0', 'id': 'net0'}
03:54:47 DEBUG| Sending command (safe): ifconfig -a
03:54:47 DEBUG| Sending command (safe): ip link | grep -B1 '52:54:00:8d:8e:8f' -i
03:54:47 DEBUG| Sending command (safe): ifconfig enp0s1 up; dhclient -r; dhclient enp0s1
03:54:50 DEBUG| Sending command (safe): ifconfig -a
03:54:50 DEBUG| Sending command (safe): ip link | grep -B1 '52:54:00:8d:8e:8f' -i
03:54:50 DEBUG| Sending command: ip addr show enp0s1
03:54:50 DEBUG| Sending command (safe): ifconfig -a
03:54:50 DEBUG| Sending command (safe): ip link | grep -B1 '52:54:00:8d:8e:8f' -i
03:54:50 DEBUG| Sending command: ip addr show enp0s1
03:54:51 INFO | Restoring vm...
03:54:51 DEBUG| Destroying VM
03:54:53 WARNI| Requested MAC address release from persistent vm virt-tests-vm1-mallesh. Ignoring.
03:54:53 DEBUG| Undefine VM virt-tests-vm1-mallesh
03:54:53 DEBUG| Define VM from /var/tmp/xml_utils_temp_CD6R_D.xml
03:54:53 DEBUG| Checking image file /home/srikanth/avocado-fvt-wrapper/data/avocado-vt/images/f24-ppc64le_srikanth.qcow2
03:54:53 INFO | Running 'true'
03:54:53 INFO | Command 'true' finished with 0 after 0.00087308883667s
03:54:53 INFO | Running 'ps -o comm 1'
03:54:53 DEBUG| [stdout] COMMAND
03:54:53 INFO | Command 'ps -o comm 1' finished with 0 after 0.0824928283691s
03:54:53 DEBUG| [stdout] systemd
03:54:54 INFO | PASS 2-guest_network.net_virsh_attach_detach_interface_matrix.qemu.qcow2.virtio_scsi.smp2.virtio_net.Fedora.24.ppc64le.powerkvm-libvirt.virtual_network.iface_options.iface_source_default
03:54:54 INFO |