### PR TITLE
Fixed stress_run for at_iface

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_hotplug.py
+++ b/libvirt/tests/src/virtual_network/iface_hotplug.py
@@ -133,7 +133,9 @@ def run(test, params, env):
                             raise error.TestFail("Failed to attach-interface")
                     elif stress_test:
                         # Detach the device immediately for stress test
-                        ret = virsh.attach_interface(vm_name, options,
+                        options = ("--type %s --mac %s %s" %
+                                   (iface_type, mac, attach_option))
+                        ret = virsh.detach_interface(vm_name, options,
                                                      ignore_status=True)
                         libvirt.check_exit_status(ret)
                     else:


### PR DESCRIPTION
Currently stress_test for at_iface had only attach_interface. This was causing test to fail after reaching 31 pci slots.. corrected by adding detach_interface as well under at_device stress run.