### PR TITLE
virsh_net_dhcp_leases: Don't remove the original interfaces

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_dhcp_leases.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_dhcp_leases.cfg
@@ -27,6 +27,4 @@
                     prepare_net = "no"
                     net_name = "xyz"
                 - invalid_mac:
-                    # There's a bug BZ#1205045 about this case
-                    exist_bug = "1205045"
-                    nic_mac = "xyz"
+                    invalid_mac = "yes"

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_dhcp_leases.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_dhcp_leases.py
@@ -10,7 +10,7 @@ from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import network_xml
 from virttest.utils_test import libvirt as utlv
 
-BUG_URL = "https://bugzilla.redhat.com/show_bug.cgi?id=%s"
+from provider import libvirt_version
 
 
 def run(test, params, env):
@@ -25,13 +25,21 @@ def run(test, params, env):
     vm_name = params.get("main_vm")
     vm = env.get_vm(vm_name)
     net_name = params.get("net_name", "default")
-    nic_mac = params.get("nic_mac", "")
     net_option = params.get("net_option", "")
     status_error = "yes" == params.get("status_error", "no")
     prepare_net = "yes" == params.get("prepare_net", "yes")
     hotplug_iface = "yes" == params.get("hotplug_interface", "no")
     filter_by_mac = "yes" == params.get("filter_by_mac", "no")
-    exist_bug = params.get("exist_bug")
+    invalid_mac = "yes" == params.get("invalid_mac", "no")
+    # Generate a random string as the MAC address
+    nic_mac = None
+    if invalid_mac:
+        nic_mac = utils_misc.generate_random_string(17)
+
+    # Command won't fail on old libvirt
+    if not libvirt_version.version_compare(1, 3, 1) and invalid_mac:
+        logging.debug("Reset case to positive as BZ#1261432")
+        status_error = False
 
     def create_network():
         """


### PR DESCRIPTION
Remove interfaces outside the VM is not enough to update the virtnet
info. Actually, there's no need to remove all the interfaces before
testing , as we will also create a new network for the testing.
And if login VM by IP address failed, we should try serial and run
'dhclient' inside the VM to assign a new IP address for the NIC.

Signed-off-by: Yanbing Du <ydu@redhat.com>