### PR TITLE
Revert "Fixup: Changed maxvcpus value based on libvirt commit"

### DIFF
--- a/libvirt/tests/src/virsh_cmd/host/virsh_maxvcpus.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_maxvcpus.py
@@ -1,11 +1,10 @@
 import logging
 
-from avocado.core import exceptions
+from autotest.client.shared import error
 
 from virttest import libvirt_vm
 from virttest import virsh
 from virttest import utils_conn
-from virttest.libvirt_xml import capability_xml
 
 
 def run(test, params, env):
@@ -22,19 +21,6 @@ def run(test, params, env):
     option = params.get("virsh_maxvcpus_options")
     status_error = params.get("status_error")
     connect_arg = params.get("connect_arg", "")
-    capa = capability_xml.CapabilityXML()
-    host_arch = capa.arch
-    xmltreefile = capa.__dict_get__('xml')
-    maxvcpus = None
-    try:
-        maxvcpus = capa.get_guest_capabilities()['hvm'][host_arch]['maxcpus']
-    except:
-        raise exceptions.TestFail("Failed to get maxvcpus from capabilities"
-                                  " xml\n%s", xmltreefile)
-
-    if not maxvcpus:
-        raise exceptions.TestFail("Failed to get guest section for host arch: %s "
-                                  "from capabilities xml\n%s", host_arch, xmltreefile)
 
     # params for transport connect.
     local_ip = params.get("local_ip", "ENTER.YOUR.LOCAL.IP")
@@ -48,13 +34,13 @@ def run(test, params, env):
     if (connect_arg == "transport" and
             transport_type == "remote" and
             local_ip.count("ENTER")):
-        raise exceptions.TestNAError("Parameter local_ip is not configured"
-                                     "in remote test.")
+        raise error.TestNAError("Parameter local_ip is not configured"
+                                "in remote test.")
     if (connect_arg == "transport" and
             transport_type == "remote" and
             local_pwd.count("ENTER")):
-        raise exceptions.TestNAError("Parameter local_pwd is not configured"
-                                     "in remote test.")
+        raise error.TestNAError("Parameter local_pwd is not configured"
+                                "in remote test.")
 
     if connect_arg == "transport":
         canonical_uri_type = virsh.driver()
@@ -86,21 +72,21 @@ def run(test, params, env):
     # Check status_error
     if status_error == "yes":
         if status == 0:
-            raise exceptions.TestFail("Run successed with unsupported option!")
+            raise error.TestFail("Run successed with unsupported option!")
         else:
             logging.info("Run failed with unsupported option %s " % option)
     elif status_error == "no":
         if status == 0:
             if "kqemu" in option:
                 if not maxvcpus_test == '1':
-                    raise exceptions.TestFail("Command output %s is not expected "
-                                              "for %s " % (maxvcpus_test, option))
+                    raise error.TestFail("Command output %s is not expected "
+                                         "for %s " % (maxvcpus_test, option))
             elif option == 'qemu' or option == '--type qemu' or option == '':
-                if not maxvcpus_test == maxvcpus:
-                    raise exceptions.TestFail("Command output %s is not expected "
-                                              "for %s " % (maxvcpus_test, option))
+                if not maxvcpus_test == '16':
+                    raise error.TestFail("Command output %s is not expected "
+                                         "for %s " % (maxvcpus_test, option))
             else:
                 # No check with other types
                 pass
         else:
-            raise exceptions.TestFail("Run command failed")
+            raise error.TestFail("Run command failed")


### PR DESCRIPTION
This reverts commit 8dac28a5855c82d2221ebd5907f69deb55d496f4.

This patch is not complete:
    1). The 'maxCpus' in capabilities XML only for kvm type domain.
    2). And it needs a remote virsh instance for remote host testing.
    3). This also break the test for old version libvirt.