### PR TITLE
virsh.vol_create_from: Split with/without prealloc

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_create_from.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_create_from.cfg
@@ -78,6 +78,8 @@
                             dest_vol_format = "raw"
                         - v_qcow2:
                             dest_vol_format = "qcow2"
+                        - v_qcow2_with_prealloc:
+                            dest_vol_format = "qcow2"
                             prealloc_option = "--prealloc-metadata"
                         - v_qed:
                             dest_vol_format = "qed"


### PR DESCRIPTION
Older version of libvirt don't support --prealloc-metadata option. We'll
miss all qcow2 test cases when testing these version of libvirt. So the
best way to solve this is to split these cases.

Signed-off-by: Hao Liu <hliu@redhat.com>