### PR TITLE
virsh.attach_detach_disk: Check invalid XML for config option

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk.py
@@ -395,11 +395,10 @@ def run(test, params, env):
         # Destroy VM.
         vm.destroy(gracefully=False)
 
-        # Need wait a while for xml to sync
-        time.sleep(float(time_sleep))
         # Check disk count after VM shutdown (with --config).
         check_count_after_shutdown = True
-        disk_count_after_shutdown = vm_xml.VMXML.get_disk_count(vm_name)
+        inactive_vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+        disk_count_after_shutdown = len(inactive_vmxml.get_disk_all())
         if test_cmd == "attach-disk":
             if disk_count_after_shutdown == disk_count_before_cmd:
                 check_count_after_shutdown = False


### PR DESCRIPTION
For config option, the expected change will be in the inactive XML.
Checking active XML will not be reliable here since it'll last for
a while for the XML to be changed.

Signed-off-by: Hao Liu <hliu@redhat.com>