### PR TITLE
Raise more clear error when VM can't be started

### DIFF
--- a/libvirt/tests/src/libvirt_rng.py
+++ b/libvirt/tests/src/libvirt_rng.py
@@ -325,14 +325,13 @@ def run(test, params, env):
 
             if test_snapshot:
                 check_snapshot(bgjob)
-        except virt_vm.VMStartError, details:
+        except virt_vm.VMStartError as details:
             logging.info(str(details))
-            if start_error:
-                pass
-            else:
-                raise error.TestFail('VM Failed to start for some reason,'
+            if not start_error:
+                raise error.TestFail('VM failed to start, '
                                      'please refer to https://bugzilla.'
-                                     'redhat.com/show_bug.cgi?id=1220252')
+                                     'redhat.com/show_bug.cgi?id=1220252:'
+                                     '\n%s' % details)
 
     finally:
         # Delete snapshots.

--- a/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
@@ -789,15 +789,11 @@ def run(test, params, env):
                     attach_error = "yes" == device_attach_error[i]
                 libvirt.check_exit_status(ret, attach_error)
 
-    except virt_vm.VMStartError:
-        if status_error:
-            pass
-        else:
-            raise error.TestFail('VM Failed to start for some reason!')
+    except virt_vm.VMStartError as details:
+        if not status_error:
+            raise error.TestFail('VM failed to start:\n%s' % details)
     except xcepts.LibvirtXMLError:
-        if define_error:
-            pass
-        else:
+        if not define_error:
             raise error.TestFail("Failed to define VM")
     else:
         # VM is started, perform the tests.

--- a/libvirt/tests/src/virtual_network/iface_hotplug.py
+++ b/libvirt/tests/src/virtual_network/iface_hotplug.py
@@ -198,9 +198,9 @@ def run(test, params, env):
                             raise error.TestFail("Interface still exist"
                                                  " after detachment")
             session.close()
-        except virt_vm.VMStartError, e:
+        except virt_vm.VMStartError as e:
             logging.info(str(e))
-            raise error.TestFail('VM Failed to start for some reason!')
+            raise error.TestFail('VM failed to start:\n%s' % e)
 
     finally:
         # Recover VM.

--- a/libvirt/tests/src/virtual_network/iface_network.py
+++ b/libvirt/tests/src/virtual_network/iface_network.py
@@ -770,12 +770,10 @@ TIMEOUT 3"""
                     run_guest_libvirt(session)
 
                 session.close()
-        except virt_vm.VMStartError, details:
+        except virt_vm.VMStartError as details:
             logging.info(str(details))
-            if start_error or restart_error:
-                pass
-            else:
-                raise error.TestFail('VM Failed to start for some reason!')
+            if not (start_error or restart_error):
+                raise error.TestFail('VM failed to start:\n%s' % details)
 
     finally:
         # Recover VM.

--- a/libvirt/tests/src/virtual_network/iface_options.py
+++ b/libvirt/tests/src/virtual_network/iface_options.py
@@ -591,12 +591,10 @@ def run(test, params, env):
                                           flagstr="", ignore_status=True)
                 libvirt.check_exit_status(ret)
 
-        except virt_vm.VMStartError, e:
+        except virt_vm.VMStartError as e:
             logging.info(str(e))
-            if start_error:
-                pass
-            else:
-                raise error.TestFail('VM Failed to start for some reason!')
+            if not start_error:
+                raise error.TestFail('VM failed to start\n%s' % e)
 
     finally:
         # Recover VM.

--- a/libvirt/tests/src/virtual_network/iface_ovs.py
+++ b/libvirt/tests/src/virtual_network/iface_ovs.py
@@ -134,12 +134,10 @@ def run(test, params, env):
             if test_ovs_port:
                 check_ovs_port(iface_name, bridge_name)
 
-        except virt_vm.VMStartError, details:
+        except virt_vm.VMStartError as details:
             logging.info(str(details))
-            if start_error:
-                pass
-            else:
-                raise error.TestFail('VM Failed to start for some reason!')
+            if not start_error:
+                raise error.TestFail('VM failed to start:\n%s' % details)
 
     finally:
         # Recover VM.


### PR DESCRIPTION
This will make debugging the cause of failure more easier. We don't
have to go through the log to find out why the VM can't be started.

Also used some simpler logic to check status and changed some syntax
in except clause which will be work on both python 2&3.

Signed-off-by: Hao Liu <hliu@redhat.com>