### PR TITLE
virsh.migrate: Update set virsh_migrate_desturi params

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
@@ -12,10 +12,13 @@
     # SSH connection time out
     ssh_timeout = 60
     # Fully qualified desturi (qemu+ssh://other.hostname.example.com/system)
+    # is set using API for all scenarios in virsh_migrate.py, for negative
+    # tests there_desturi_nonexist and there_desturi_missing let us use it
+    # from respective variants in cfg
+
     # Remember to open ports 49152-49216 on destination and
     # NAT-based host networking will cause external connectivity-loss
     # to guest, consider a shared-bridge setup instead.
-    virsh_migrate_desturi = "qemu+ssh://${migrate_dest_host}/system"
     # FIXME: Implement libvirt URI connect user/password
     # virsh_migrate_destuser = root
     # virsh_migrate_destpwd = ""
@@ -257,7 +260,7 @@
         - there_migrateuri:
             # Uni-direction migration with option --migrateuri.
             virsh_migrate_options = "--live"
-            virsh_migrate_migrateuri = "${migrate_proto}://${migrate_dest_host}:${migrate_port}"
+            virsh_migrate_migrateuri = "yes"
         - there_dname:
             # Uni-direction migration with option --dname.
             virsh_migrate_options = "--live"
@@ -398,7 +401,7 @@
             virsh_migrate_options = "--live --verbose --unsafe"
             # The default spice port is 5900 for graphic configuration
             # <graphics type='spice' autoport='yes'/> in the guest XML.
-            virsh_migrate_graphics_uri = "spice://${migrate_dest_host}:5900"
+            virsh_migrate_graphics_uri = "yes"
             graphics_type = "spice"
             graphics_port = 5900
             graphics_listen = 0.0.0.0


### PR DESCRIPTION
virsh_migrate_desturi param can be set using API with existing param, instead declaring
in cfg

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>