### PR TITLE
Create virsh instance while initiate vmchecker object

### DIFF
--- a/provider/v2v_vmcheck_helper.py
+++ b/provider/v2v_vmcheck_helper.py
@@ -35,6 +35,7 @@ class VMChecker(object):
         self.setup_session()
         self.checker = utils_v2v.VMCheck(test, params, env)
         self.checker.virsh_session_id = self.virsh_session_id
+        self.virsh_instance = virsh.VirshPersistent(session_id=self.virsh_session_id)
         self.vmxml = virsh.dumpxml(self.vm_name,
                                    session_id=self.virsh_session_id).stdout.strip()
 
@@ -307,10 +308,9 @@ class VMChecker(object):
         Check if graphics attributes value in vm xml match with given param.
         """
         logging.info('Check graphics parameters')
-        virsh_instance = virsh.VirshPersistent(session_id=self.virsh_session_id)
         vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(
                 self.vm_name, options='--security-info',
-                virsh_instance=virsh_instance)
+                virsh_instance=self.virsh_instance)
         graphic = vmxml.xmltreefile.find('devices').find('graphics')
         status = True
         for key in param:

--- a/v2v/tests/src/specific_kvm.py
+++ b/v2v/tests/src/specific_kvm.py
@@ -246,11 +246,10 @@ def run(test, params, env):
         line += ' --current'
         logging.debug(virsh.attach_interface(vm_name, option=line))
 
-    def check_multi_netcards(mac_list, virsh_session_id):
+    def check_multi_netcards(mac_list, virsh_instance):
         """
         Check if number and type of network cards meet expectation
         """
-        virsh_instance = virsh.VirshPersistent(session_id=virsh_session_id)
         vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(
                 vm_name, virsh_instance=virsh_instance)
         iflist = vmxml.get_iface_all()
@@ -567,7 +566,7 @@ def run(test, params, env):
                 check_disks(vmchecker.checker)
             elif checkpoint == 'multi_netcards':
                 check_multi_netcards(params['mac_address'],
-                                     vmchecker.virsh_session_id)
+                                     vmchecker.virsh_instance)
             elif checkpoint.startswith('spice'):
                 vmchecker.check_graphics({'type': 'spice'})
                 if checkpoint == 'spice_encrypt':


### PR DESCRIPTION
A virsh instance is needed in check_graphics function.Creating a
virsh persistent object inside the function seems not appropriate.
For the virsh persistent object will be destroied after the function
being called, which will close living virsh session and make future
call on the function not available.Therefore move the virsh instance
creation from check_graphics funciton to __init__ function.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>