### PR TITLE
Update cfg to make case name more accurate

### DIFF
--- a/v2v/tests/cfg/convert_from_file.cfg
+++ b/v2v/tests/cfg/convert_from_file.cfg
@@ -81,7 +81,7 @@
                                     checkpoint = 'ova_relative_path'
                                 - ova_abs_path:
                                     input_file = '${ova_dir}/OVA_RELATIVE_PATH_V2V_EXAMPLE'
-                                - ova_vmdk_gz:
+                                - ova_vmdk_gz_zip:
                                     input_file = '${ova_dir}/OVA_VMDKGZ_ZIP_FILE_V2V_EXAMPLE'
                                 - ova_vmdk_gz_tar:
                                     input_file = '${ova_dir}/OVA_VMDKGZ_TAR_FILE_V2V_EXAMPLE'


### PR DESCRIPTION
Replace 'ova_vmdk_gz' by 'ova_vmdk_gz_zip'