### PR TITLE
Add case:Remove reference info about --dcpath in virt-v2v manual page

### DIFF
--- a/v2v/tests/cfg/v2v_options.cfg
+++ b/v2v/tests/cfg/v2v_options.cfg
@@ -238,15 +238,25 @@
                 - rhev_snapshot_id:
                     only input_mode.libvirt.kvm.default
                     only output_mode.rhev
-                - dependency:
-                    only input_mode.none
-                    only output_mode.none
-                    checkpoint = 'dependency'
-                    check_command = 'rpm -qR virt-v2v'
-                    win_image = '/DISK_IMAGE_PATH_V2V_EXAMPLE/WINDOWS_IMAGE_V2V_EXAMPLE'
                 - format_convert:
                     only input_mode.libvirtxml
                     only output_mode.rhev
+                - vbox:
+                    only input_mode.none
+                    only output_mode.none
+                    input_disk_image = '/DISK_IMAGE_PATH_V2V_EXAMPLE/IMAGE_WITH_VBOX_ADD'
+                    v2v_options = '-i disk ${input_disk_image} -o null'
+                - cmd_free:
+                    only input_mode.none
+                    only output_mode.none
+                    variants:
+                        - dependency:
+                            checkpoint = 'dependency'
+                            check_command = 'rpm -qR virt-v2v'
+                            win_image = '/DISK_IMAGE_PATH_V2V_EXAMPLE/WINDOWS_IMAGE_V2V_EXAMPLE'
+                        - no_dcpath:
+                            checkpoint = 'no_dcpath'
+                            check_command = 'man virt-v2v'
         - negative_test:
             status_error = "yes"
             variants:

--- a/v2v/tests/src/v2v_options.py
+++ b/v2v/tests/src/v2v_options.py
@@ -314,6 +314,9 @@ def run(test, params, env):
                 command = 'guestfish -a %s -i'
                 if process.run(command % win_img, ignore_status=True).exit_status == 0:
                     raise exceptions.TestFail('Command "%s" success' % command % win_img)
+            if checkpoint == 'no_dcpath':
+                if not utils_v2v.check_log(output, ['--dcpath'], expect=False):
+                    raise exceptions.TestFail('"--dcpath" is not removed')
 
     backup_xml = None
     vdsm_domain_dir, vdsm_image_dir, vdsm_vm_dir = ("", "", "")
@@ -450,7 +453,7 @@ def run(test, params, env):
         if v2v_user:
             cmd = su_cmd + "'%s'" % cmd
 
-        if checkpoint == 'dependency':
+        if checkpoint in ['dependency', 'no_dcpath']:
             cmd = params.get('check_command')
         cmd_result = process.run(cmd, timeout=v2v_timeout, verbose=True,
                                  ignore_status=True)


### PR DESCRIPTION
And update cfg to move similar cases into same group