### PR TITLE
create_lxc: resolve test vm not exist problem

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_create_lxc.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_create_lxc.cfg
@@ -3,7 +3,9 @@
     take_regular_screendumps = "no"
     start_vm = "no"
     connect_uri = "lxc:///"
-    vms = "lxc_test_vm1"
+    vms = ""
+    main_vm = "lxc_test_vm1"
+    lxc_domtype = "lxc"
     variants:
         - with_passfds:
             create_lxc_fds_options = "--pass-fds"


### PR DESCRIPTION
Modify the vms = '' and main_vm = "lxc_test_vm1" in the cfg file.

Modify the virsh_create_lxc.py file to get vm_name from "main_vm",
and change the way to check the result of the virsh.create().