### PR TITLE
Add cases of loading virtio-win drivers from iso or custom dir

### DIFF
--- a/v2v/tests/cfg/function_test_xen.cfg
+++ b/v2v/tests/cfg/function_test_xen.cfg
@@ -97,6 +97,7 @@
             main_vm = 'SCSI_VM_NAME_V2V_EXAMPLE'
         - ide_disk:
             main_vm = 'IDE_VM_NAME_V2V_EXAMPLE'
+            checkpoint = cdrom
         - ssh_banner:
             checkpoint = 'ssh_banner'
         - pv_with_regular_kernel:
@@ -146,16 +147,39 @@
                 - program_files_2:
                     os_version = 'PROGRAM_FILES_2_OS_VERSION_V2V_EXAMPLE'
                     main_vm = 'PROGRAM_FILES_2_VM_NAME_V2V_EXAMPLE'
+                - virtio_win:
+                    main_vm = 'XEN_VM_NAME_VIRTIO_WIN_V2V_EXAMPLE'
+                    os_version = 'OS_VERSION_VIRTIO_WIN_V2V_EXAMPLE'
+                    virtio_win_dir = '/usr/share/virtio-win/'
+                    virtio_win_env = 'VIRTIO_WIN'
+                    checkpoint = 'virtio_win_'
+                    variants:
+                        - unset:
+                            checkpoint += 'unset'
+                            missing = 'Red Hat VirtIO SCSI,Red Hat VirtIO Ethernet Adapte'
+                        - custom:
+                            checkpoint += 'custom'
+                        - iso_mount:
+                            checkpoint += 'iso_mount'
+                        - iso_file:
+                            checkpoint += 'iso_file'
+                - rhsrvany_md5:
+                    checkpoint = rhsrvany_md5
+                    val_md5 = 460f8985213cc6ec45e7635aca81cd68
+                    val_sha1 = 2bd96e478fc004cd323b5bd754c856641877dac6
+                    cmd_sha1 = 'certutil -hashfile "C:\Program Files\Red Hat\Firstboot\rhsrvany.exe"'
+                    main_vm = XEN_VM_NAME_RHSRVANYMD5_V2V_EXAMPLE
+                    os_version = OS_VERSION_RHSRVANYMD5_V2V_EXAMPLE
     variants:
         - positive_test:
             status_error = 'no'
             no xen_vm_default
             variants:
                 - libvirt:
-                    only pool_uuid, windows.rhev_file, display, sound
+                    only pool_uuid, windows.rhev_file, display, sound, virtio_win
                     only output_mode.libvirt
                 - rhev:
-                    no pool_uuid, windows.rhev_file, display.vnc, sound
+                    no pool_uuid, windows.rhev_file, display.vnc, sound, virtio_win
                     only output_mode.rhev
         - negative_test:
             status_error = 'yes'


### PR DESCRIPTION
Add cases of:
- unset env param of VIRTIO_WIN
- set VIRTIO_WIN to custom dir
- set VIRTIO_WIN dir to the mount point of virtio-win.iso
- set VIRTIO_WIN dir to path of file virtio-win.iso
- check md5 and sha1 of rhsrvany.exe

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>