### PR TITLE
Add v2v function cases

### DIFF
--- a/v2v/tests/cfg/v2v_options.cfg
+++ b/v2v/tests/cfg/v2v_options.cfg
@@ -70,7 +70,6 @@
         - input_mode:
             variants:
                 - disk:
-                    input_mode = "disk"
                     variants:
                         # Explicit 'sparse' and 'preallocated' here for
                         # parameters replacement
@@ -97,6 +96,13 @@
                                     input_allo_mode = "preallocated"
                                     main_vm = "VM_NAME_QCOW2_PREALLOCATED_V2V_EXAMPLE"
                                     input_disk_image = "/DISK_IMAGE_PATH_V2V_EXAMPLE/${main_vm}.img"
+                    variants:
+                        - image:
+                            input_mode = disk
+                        - guest:
+                            input_mode = libvirt
+                            new_vm_name = ${main_vm}_new
+                            v2v_options = "-on ${new_vm_name}"
                 - libvirt:
                     input_mode = "libvirt"
                     variants:
@@ -105,6 +111,7 @@
                             hypervisor = "kvm"
                             variants:
                                 - default:
+                                - format:
                         - xen:
                             hypervisor = "xen"
                             remote_host = ${xen_hostname}
@@ -124,6 +131,8 @@
                                 - default:
                                     only esx_60
                                     main_vm = "VM_NAME_ESX_DEFAULT_V2V_EXAMPLE"
+                                    checkpoint = 'tail_log'
+                                    msg_content = 'cannot list vcpu pinning for an inactive domain'
                 - libvirtxml:
                     input_mode = "libvirtxml"
                     variants:
@@ -185,7 +194,7 @@
                                     output_allo_mode = "sparse"
                                 - preallocated:
                                     output_allo_mode = "preallocated"
-                        - from_guest:
+                        - from_xen:
                             only input_mode.libvirt.xen
                             variants:
                                 - raw_format:
@@ -209,7 +218,7 @@
                     only output_mode.libvirt
                 - option_oc:
                     # output libvirt URI
-                    only input_mode.disk.qcow2_format.sparse
+                    only input_mode.disk.disk.qcow2_format.sparse
                     only output_mode.libvirt
                     variants:
                         - privileged:
@@ -231,10 +240,52 @@
                     vdsm_vm_uuid = "12345678-1234-1234-1234-123456789003"
                     output_storage = ${mount_point}/${export_domain_uuid}
                     vdsm_ovf_output = "${output_storage}/master/vms/${vdsm_vm_uuid}"
+                - qemu_session:
+                    only input_mode.libvirt.kvm.default
+                    only output_mode.libvirt
+                    ori_pool = ori_pool
+                    unprivileged_user = USER.V2V_EXAMPLE
+                    sh_install_vm = INSTALL_VM_SCRIPT_V2V_EXAMPLE
+                    main_vm = vm_nonroot
+                    new_vm_name = vm_test_ic
+                    no_root = yes
+                    variants:
+                        - with:
+                            checkpoint = with_ic
+                        - without:
+                            checkpoint = without_ic
                 - quiet:
                     only input_mode.libvirt.xen
                     only output_mode.rhev, output_mode.libvirt
                     checkpoint = 'quiet'
+                - print_source:
+                    only input_mode.libvirt.kvm.default
+                    only output_mode.none
+                    checkpoint = print_source
+                    v2v_options = --print-source
+                - machine_readable:
+                    only input_mode.none
+                    only output_mode.none
+                    v2v_options = --machine-readable
+                    checkpoint = machine_readable
+                    example_file = /DISK_IMAGE_PATH_V2V_EXAMPLE/MACHINE_READABLE_V2V_EXAMPLE
+                - compress:
+                    only input_mode.libvirt.kvm.default
+                    only output_mode.libvirt
+                    checkpoint = compress
+                    new_vm_name = ${main_vm}_compress
+                    v2v_options = --compressed -on ${new_vm_name}
+                - empty_nic_source:
+                    only input_mode.none
+                    only output_mode.none
+                    input_mode = libvirtxml
+                    v2v_options = --print-source
+                    checkpoint = empty_nic_source
+                    variants:
+                        - net:
+                            checkpoint += _network
+                        - br:
+                            checkpoint += _bridge
                 - rhev_snapshot_id:
                     only input_mode.libvirt.kvm.default
                     only output_mode.rhev
@@ -244,8 +295,13 @@
                 - vbox:
                     only input_mode.none
                     only output_mode.none
-                    input_disk_image = '/DISK_IMAGE_PATH_V2V_EXAMPLE/IMAGE_WITH_VBOX_ADD'
+                    input_disk_image = '/DISK_IMAGE_PATH_V2V_EXAMPLE/IMAGE_WITH_VBOX_ADD_V2V_EXAMPLE'
                     v2v_options = '-i disk ${input_disk_image} -o null'
+                - debug_overlays:
+                    only input_mode.libvirt.xen
+                    only output_mode.rhev
+                    checkpoint = 'debug_overlays'
+                    v2v_options = '--debug-overlays'
                 - cmd_free:
                     only input_mode.none
                     only output_mode.none
@@ -289,6 +345,11 @@
                             v2v_options = '-i libvirt --vdsm-ovf-output abc --vdsm-ovf-output abc'
                         - 2_vmtype:
                             v2v_options = '-i libvirt --vmtype abc --vmtype abc'
+                - in_place:
+                    only input_mode.libvirt.xen
+                    only output_mode.libvirt
+                    checkpoint = 'in_place'
+                    v2v_options = '--in-place'
                 - xen_no_output_format:
                     only input_mode.libvirt.xen
                     only output_mode.libvirt
@@ -302,3 +363,7 @@
                             v2v_options = '-ic sdll://sdfl test'
                         - without_domain:
                             v2v_options = '-ic sdll://sdfl'
+                - disk_not_exist:
+                    only input_mode.libvirt.xen
+                    only output_mode.libvirt
+                    checkpoint = disk_not_exist


### PR DESCRIPTION
- remove support of --in-place
- with option --debug-overlays
- with option --print-source
- with option --machine-readable
- with option --compressed
- with empty string set in interface source
- check disk existance after conversion aborted
- check /var/log/messages for error
- replace cases of focusing on '-of' option with cases focusing on
  '-if' option when the output_format is identical with input_format
  by removing '-of'

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>