### PR TITLE
attach_device: return True/False instead of list

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
@@ -643,7 +643,9 @@ class VirtualDiskBasic(AttachDeviceBase):
             if not gotit:
                 logging.debug("Expecting: '%s' in %s", test_data, self.test_data_list)
                 logging.debug("Received: '%s'", output)
-            return gotit
+                return False
+            else:
+                return True
 
 
 def operational_action(test_params, test_devices, operational_results):


### PR DESCRIPTION
attach_device returns empty list instead of True/False and test fails to FAIL. This patch fixes it.