### PR TITLE
libvirt_mem: Fix invalid attach size

### DIFF
--- a/libvirt/tests/cfg/libvirt_mem.cfg
+++ b/libvirt/tests/cfg/libvirt_mem.cfg
@@ -117,7 +117,7 @@
                             attach_times = 4
                             attach_option = "--config"
                         - attach_invalid_size:
-                            tg_size = 512000
+                            tg_size = 512001
                 - detach_error:
                     add_mem_device = "no"
                     attach_device = "no"


### PR DESCRIPTION
Current tg_size 512000 is not invalid, update it with an invalid
one.

Signed-off-by: Wayne Sun <gsun@redhat.com>