### PR TITLE
virsh.migrate: Load stress in VM

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
@@ -42,7 +42,7 @@
             no with_numa_and_HP, with_HP_pin, there_online, there_online_with_numa
             postcopy_options = "--postcopy"
         - without_postcopy:
-            no postcopy_after_precopy, migrate-postcopy
+            no postcopy_after_precopy, migrate_postcopy
             postcopy_options = ""
     variants:
         - with_cpu_hotplug:
@@ -225,10 +225,12 @@
         - postcopy_after_precopy:
             virsh_migrate_options = "--live --postcopy-after-precopy"
         - migrate_postcopy:
+            stress_args = "--cpu 8 --io 8 --vm 2 --vm-bytes 256M --timeout 60s"
             virsh_migrate_options = "--live"
             virsh_postcopy_cmd = "migrate-postcopy"
             # migration thread timeout
             postcopy_migration_timeout = "200"
+            migration_start_timeout = "50"
         - there_p2p:
             # Uni-direction migration with option --p2p.
             virsh_migrate_options = "--live --p2p"


### PR DESCRIPTION
Some cases need migration process to turn slow down in order to get
sufficient time to handle special matters. So one way is to load stress
within the VM.

Signed-off-by: Dan Zheng <dzheng@redhat.com>