### PR TITLE
virsh.resume: Resuming a running guest should be negative

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_resume.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_resume.cfg
@@ -13,8 +13,6 @@
                     resume_vm_ref = domuuid
             variants:
                 - vm_paused:
-                - vm_running:
-                    resume_vm_state = running
         - error_test:
             status_error = yes
             variants:
@@ -31,3 +29,5 @@
                     resume_option_suffix = xyz
                 - vm_shutoff:
                     resume_vm_state = shutoff
+                - vm_running:
+                    resume_vm_state = running

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_resume.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_resume.cfg
@@ -1,12 +1,14 @@
 - virsh.resume:
     type = virsh_resume
     start_vm = yes
+    resume_vm_state = paused
+    resume_vm_ref = domname
+    readonly = no
     variants:
         - normal_test:
             status_error = no
             variants:
                 - valid_domname:
-                    resume_vm_ref = domname
                 - valid_domid:
                     resume_vm_ref = domid
                 - valid_domuuid:
@@ -25,9 +27,10 @@
                 - hex_domid:
                     resume_vm_ref = hex_id
                 - additional_arg:
-                    resume_vm_ref = domname
                     resume_option_suffix = xyz
                 - vm_shutoff:
                     resume_vm_state = shutoff
                 - vm_running:
                     resume_vm_state = running
+                - readonly:
+                    readonly = yes


### PR DESCRIPTION
libvirt commit 3e044e6:
    qemu, lxc: Raise error message when resuming running domain
fixed a bug: https://bugzilla.redhat.com/show_bug.cgi?id=1009008

So the test cases should be changed accordingly.

Another commit in this PR is to add a negative case testing
resuming a VM with read-only permission. 

Signed-off-by: Hao Liu <hliu@redhat.com>