### PR TITLE
libvirt_mem: DIMM for memory is not always zero

### DIFF
--- a/libvirt/tests/src/libvirt_mem.py
+++ b/libvirt/tests/src/libvirt_mem.py
@@ -67,7 +67,7 @@ def run(test, params, env):
                     % (max_mem_slots, max_mem_rt))
         if tg_size:
             size = int(tg_size) * 1024
-            cmd += (" | grep 'memory-backend-ram,id=memdimm0,size=%s"
+            cmd += (" | grep 'memory-backend-ram,id=memdimm.,size=%s"
                     % size)
             if pg_size:
                 cmd += ",host-nodes=%s" % node_mask


### PR DESCRIPTION
It could be 1 for newer version of libvirt

Signed-off-by: Hao Liu <hliu@redhat.com>