### PR TITLE
libvirt_mem: Add without_numa as positive test

### DIFF
--- a/libvirt/tests/cfg/libvirt_mem.cfg
+++ b/libvirt/tests/cfg/libvirt_mem.cfg
@@ -71,6 +71,8 @@
                             numa_memnode = "{'cellid':'0','mode':'interleave','nodeset':'0'}"
                             memory_addr = "{'type':'dimm','slot':'0','base':'0x100000000'}"
                             node_mask = 0
+                - without_numa_save_restore:
+                    numa_cells = ""
         - negative_test:
             max_mem_rt = 2560000
             max_mem = 1024000
@@ -95,8 +97,6 @@
                             tg_nddode = 1
                             page_size = 4
                             page_unit = "KiB"
-                        - without_numa:
-                            numa_cells = ""
                 - attach_error:
                     attach_device = "yes"
                     attach_error = "yes"


### PR DESCRIPTION
Guest is now able to boot without numa, moving it as a positive test case in libvirt_mem.cfg

Signed-off-by: Harish harisrir@linux.vnet.ibm.com