### PR TITLE
Fix uri test issues

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_uri.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_uri.cfg
@@ -15,6 +15,7 @@
                     remote_ip = "REMOTE.EXAMPLE.COM"
                     remote_user = "root"
                     remote_pwd = "password"
+                    target_uri = "qemu+ssh://${remote_ip}/system"
         - unexpect_option:
             virsh_uri_options = "xyz"
             status_error = "yes"


### PR DESCRIPTION
1. change the target_uri get from param because complete_uri also call virsh uri, we can not use virsh to verify virsh
2. resolve the local uri execute issues, the previous change cause local execute disappear.

Signed-off-by: Kylazhang <weizhan@redhat.com>