### PR TITLE
Enable --postcopy options for migration cases

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_vm.cfg
+++ b/libvirt/tests/cfg/migration/migrate_vm.cfg
@@ -28,6 +28,13 @@
     set_sebool_remote = "yes"
     migration_timeout = 300
     variants:
+        - with_postcopy:
+            no with_s3_s4, migration_with_nbd, live_storage_migration, pause_vm, with_watchdog
+            no tunnelled_migration, with_hugepages
+            postcopy_options = "--postcopy"
+        - without_postcopy:
+            postcopy_options = ""
+    variants:
         - positive_testing:
             status_error = "no"
             variants:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
@@ -34,6 +34,16 @@
     ping_count = 10
     ping_timeout = 20
     variants:
+        - with_postcopy:
+            no there_p2p_tunnelled, there_suspend, there_suspend_undefinesource
+            no there_vm_suspend_live, there_vm_suspend_online, there_timeout_suspend
+            no with_inactive_guest, there_vm_shutdown_live, there_vm_shutdown_online
+            no there_offline.with_active_guest, with_HP_only, with_HP
+            no with_numa_and_HP, with_HP_pin, there_online, there_online_with_numa
+            postcopy_options = "--postcopy"
+        - without_postcopy:
+            postcopy_options = ""
+    variants:
         - there_and_back:
             # Uni-direction migration with option --live.
             virsh_migrate_options = "--live"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_setmaxdowntime.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_setmaxdowntime.cfg
@@ -11,6 +11,12 @@
     delay_time = 1
     grep_str_from_local_libvirt_log = "migrate_set_downtime.*${migrate_maxdowntime}"
     variants:
+        - with_postcopy:
+            no do_not_migrate
+            postcopy_options = "--postcopy"
+        - without_postcopy:
+            postcopy_options = ""
+    variants:
         - normal_test:
             status_error = "no"
             variants:

--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -875,7 +875,7 @@ def run(test, params, env):
     reboot_vm = "yes" == test_dict.get("reboot_vm", "no")
     abort_job = "yes" == test_dict.get("abort_job", "no")
     ctrl_c = "yes" == test_dict.get("ctrl_c", "no")
-    virsh_options = test_dict.get("virsh_options", "--verbose --live")
+    virsh_options = test_dict.get("virsh_options", "--verbose --live --unsafe")
     remote_path = test_dict.get("remote_libvirtd_conf",
                                 "/etc/libvirt/libvirtd.conf")
     log_file = test_dict.get("libvirt_log", "/var/log/libvirt/libvirtd.log")
@@ -968,6 +968,12 @@ def run(test, params, env):
     write_iops_sec = test_dict.get("blkdevio_write_iops_sec")
     blkdevio_dev = test_dict.get("blkdevio_device")
     blkdevio_options = test_dict.get("blkdevio_options")
+
+    # For --postcopy enable
+    postcopy_options = test_dict.get("postcopy_options")
+    if postcopy_options and not virsh_options.count(postcopy_options):
+        virsh_options = "%s %s" % (virsh_options, postcopy_options)
+        test_dict['virsh_options'] = virsh_options
 
     # For --migrate-disks test
     migrate_disks = "yes" == test_dict.get("migrate_disks", "no")

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
@@ -423,6 +423,11 @@ def run(test, params, env):
         raise error.TestNAError("Do not support 'graphicsuri' option"
                                 "on this version.")
 
+    # For --postcopy enable
+    postcopy_options = params.get("postcopy_options")
+    if postcopy_options and not options.count(postcopy_options):
+        options = "%s %s" % (options, postcopy_options)
+
     src_uri = params.get("virsh_migrate_connect_uri")
     dest_uri = params.get("virsh_migrate_desturi")
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_setmaxdowntime.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_setmaxdowntime.py
@@ -50,6 +50,9 @@ def thread_func_live_migration(vm, dest_uri, dargs):
     debug = dargs.get("debug", "False")
     ignore_status = dargs.get("ignore_status", "False")
     options = "--live --unsafe"
+    postcopy_options = dargs.get("postcopy_options")
+    if postcopy_options:
+        options = "%s %s" % (options, postcopy_options)
     extra = dargs.get("extra")
     global ret_migration
     result = vm.migrate(dest_uri, options, extra, ignore_status, debug)
@@ -124,6 +127,9 @@ def run(test, params, env):
         downtime = int(float(migrate_maxdowntime)) * 1000
     extra = params.get("setmmdt_extra")
 
+    # For --postcopy enable
+    postcopy_options = params.get("postcopy_options", "")
+
     # A delay between threads
     delay_time = int(params.get("delay_time", 1))
     # timeout of threads
@@ -178,7 +184,8 @@ def run(test, params, env):
     ssh_key.setup_ssh_key(remote_host, username, password, port=22)
 
     setmmdt_dargs = {'debug': True, 'ignore_status': True, 'uri': src_uri}
-    migrate_dargs = {'debug': True, 'ignore_status': True}
+    migrate_dargs = {'debug': True, 'ignore_status': True,
+                     'postcopy_options': postcopy_options}
 
     seLinuxBool = None
     nfs_client = None


### PR DESCRIPTION
Using --postcopy option when migration should not impact the migration
result. This is to enable this option for most existing migration cases.

Signed-off-by: Dan Zheng <dzheng@redhat.com>