### PR TITLE
virsh.migrate: Add case for auto-converge

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
@@ -436,6 +436,15 @@
         - there_compressed:
             # Uni-direction migration with option --compressed.
             virsh_migrate_options = "--live --compressed"
+        - there_converge:
+            config_libvirtd = "yes"
+            stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20"
+            max_converge = 99
+            converge_initial = 30
+            converge_increment = 15
+            migration_start_timeout = 50
+            virsh_migrate_extra = "--auto-converge --auto-converge-initial ${converge_initial} --auto-converge-increment ${converge_increment}"
+            virsh_migrate_options = " --live --verbose --compressed "
         - there_seamless_migration_with_graphicsuri:
             virsh_migrate_options = "--live --verbose --unsafe"
             # The default spice port is 5900 for graphic configuration


### PR DESCRIPTION
Add a case for options '--auto-converge --auto-converge-initial
--auto-converge-increment'.

Load stress in the VM, then migrate the VM. Due to the stress, the
memory in VM produced newly causes the migration can not complete soon.
So qemu will take action to make the VM's CPU converge which will make
less memory is newly produced. In this way, the migration is expected to
finish soon. The converge will allign with the initial and increment
value to increase and reach the maximum value of 99.

Signed-off-by: Dan Zheng <dzheng@redhat.com>