### PR TITLE
migrate_vm: Fix a bug for --migrate-disks case

### DIFF
--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -1195,7 +1195,8 @@ def run(test, params, env):
         # Update VM disk source to NFS sharing directory
         logging.debug("Migration mounting point: %s", nfs_mount_dir)
         new_disk_source = test_dict.get("new_disk_source")
-        if nfs_mount_dir and nfs_mount_dir != os.path.dirname(disk_source):
+        if (nfs_mount_dir and not migrate_disks and
+           nfs_mount_dir != os.path.dirname(disk_source)):
             libvirt.update_vm_disk_source(vm_name, nfs_mount_dir, "", source_type)
 
         target_image_path = test_dict.get("target_image_path")


### PR DESCRIPTION
The vda disk should be non-shared image when used by --migrate-disks,
otherwise the vda image data will be corrupted which may cause the VM
can not be logged in later.

Signed-off-by: Dan Zheng <dzheng@redhat.com>