### PR TITLE
Fix connection failure of converted vm by update netdst in params

### DIFF
--- a/v2v/tests/src/convert_vm_to_libvirt.py
+++ b/v2v/tests/src/convert_vm_to_libvirt.py
@@ -89,6 +89,7 @@ def run(test, params, env):
     libvirt_net = utlv.LibvirtNetwork('vnet', **net_kwargs)
     net_info = virsh.net_info(network).stdout.strip()
     bridge = re.search(r'Bridge:\s+(\S+)', net_info).group(1)
+    params['netdst'] = bridge
 
     # Maintain a single params for v2v to avoid duplicate parameters
     v2v_params = {'target': target, 'hypervisor': hypervisor,


### PR DESCRIPTION
For a new bridge created for the v2v conversion, the old 'netdst' value
is outdated.In some cases it will cause connection failure of the
converted vm.Therefore update the netdst value with the new bridge.