### PR TITLE
Fix the way to cancel migration process

### DIFF
--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -1893,8 +1893,12 @@ def run(test, params, env):
             if ctrl_c:
                 if p.pid:
                     logging.info("Send SIGINT signal to cancel migration.")
-                    utils_misc.kill_process_tree(p.pid, signal.SIGINT)
-                    logging.info("Succeed to cancel migration: [%s].", p.pid)
+                    if utils_misc.safe_kill(p.pid, signal.SIGINT):
+                        logging.info("Succeed to cancel migration:"
+                                     " [%s].", p.pid)
+                    else:
+                        raise exceptions.TestError("Fail to cancel"
+                                                   " migration: [%s]", p.pid)
                 else:
                     p.kill()
                     raise exceptions.TestFail("Migration process is dead")


### PR DESCRIPTION
The old way sometimes will make the migration result unstable.
Simply sending SIGINT to the migration process can work in the fix.

Signed-off-by: Dan Zheng <dzheng@redhat.com>