### PR TITLE
Skipping test cases which needs host SELinux to be Enforcing.

### DIFF
--- a/libvirt/tests/src/svirt/dac_nfs_disk.py
+++ b/libvirt/tests/src/svirt/dac_nfs_disk.py
@@ -112,6 +112,8 @@ def run(test, params, env):
 
         # Set selinux of host.
         utils_selinux.set_status(host_sestatus)
+        if backup_sestatus == "disabled":
+            raise error.TestNAError("SKIP: SELinux is set to enforcing")
 
         # set qemu conf
         qemu_conf.user = qemu_user

--- a/libvirt/tests/src/svirt/dac_start_destroy.py
+++ b/libvirt/tests/src/svirt/dac_start_destroy.py
@@ -147,6 +147,8 @@ def run(test, params, env):
 
     # Set selinux of host.
     backup_sestatus = utils_selinux.get_status()
+    if backup_sestatus == "disabled":
+        raise error.TestNAError("SKIP: SELinux is set to enforcing")
     utils_selinux.set_status(host_sestatus)
 
     def _create_user():

--- a/libvirt/tests/src/svirt/dac_vm_per_image_start.py
+++ b/libvirt/tests/src/svirt/dac_vm_per_image_start.py
@@ -100,6 +100,8 @@ def run(test, params, env):
 
     # Set selinux of host.
     backup_sestatus = utils_selinux.get_status()
+    if backup_sestatus == "disabled":
+        raise error.TestNAError("SKIP: SELinux is set to enforcing")
     utils_selinux.set_status(host_sestatus)
 
     qemu_sock_mod = False


### PR DESCRIPTION
In Ubuntu SELinux is not working at the moment. So Skipping testcases which needs the SELinux to be in Enforcing mode. This patch will skip(insted of ERRORing out) the the testcase if SELinux is disabled.

Signed-off-by: Sudeesh John sudeesh@linux.vnet.ibm.com