### PR TITLE
Skipping test cases which needs host SELinux to be Enforcing

### DIFF
--- a/libvirt/tests/src/libvirtd_start.py
+++ b/libvirt/tests/src/libvirtd_start.py
@@ -127,6 +127,11 @@ def run(test, params, env):
             time.sleep(3)
 
             libvirt_pid = libvirtd_session.tail.get_pid()
+            sestatus = utils_selinux.get_status()
+            if sestatus == "disabled":
+                raise exceptions.TestSkipError("SELinux is in Disabled mode."
+                                               "It must be Enabled to"
+                                               "run this test")
             libvirt_context = utils_selinux.get_context_of_process(libvirt_pid)
             logging.debug(
                 "The libvirtd process context is: %s", libvirt_context)

--- a/libvirt/tests/src/svirt/dac_nfs_disk.py
+++ b/libvirt/tests/src/svirt/dac_nfs_disk.py
@@ -5,6 +5,7 @@ import logging
 from autotest.client.shared import error
 
 from avocado.utils import process
+from avocado.core import exceptions
 
 from virttest import qemu_storage
 from virttest import data_dir
@@ -111,6 +112,10 @@ def run(test, params, env):
                 os.chown(disk_path, 107, 107)
 
         # Set selinux of host.
+        if backup_sestatus == "disabled":
+            raise exceptions.TestSkipError("SELinux is in Disabled "
+                                           "mode.it must be in Enforcing "
+                                           "mode to run this test")
         utils_selinux.set_status(host_sestatus)
 
         # set qemu conf

--- a/libvirt/tests/src/svirt/dac_start_destroy.py
+++ b/libvirt/tests/src/svirt/dac_start_destroy.py
@@ -7,6 +7,8 @@ import logging
 from autotest.client import utils
 from autotest.client.shared import error
 
+from avocado.core import exceptions
+
 from virttest import utils_selinux
 from virttest import virt_vm
 from virttest import utils_config
@@ -147,6 +149,10 @@ def run(test, params, env):
 
     # Set selinux of host.
     backup_sestatus = utils_selinux.get_status()
+    if backup_sestatus == "disabled":
+        raise exceptions.TestSkipError("SELinux is in Disabled "
+                                       "mode. it must be in Enforcing "
+                                       "mode to run this test")
     utils_selinux.set_status(host_sestatus)
 
     def _create_user():

--- a/libvirt/tests/src/svirt/dac_vm_per_image_start.py
+++ b/libvirt/tests/src/svirt/dac_vm_per_image_start.py
@@ -6,6 +6,8 @@ import logging
 
 from autotest.client.shared import error
 
+from avocado.core import exceptions
+
 from virttest import utils_selinux
 from virttest import virt_vm
 from virttest import utils_config
@@ -100,6 +102,10 @@ def run(test, params, env):
 
     # Set selinux of host.
     backup_sestatus = utils_selinux.get_status()
+    if backup_sestatus == "disabled":
+        raise exceptions.TestSkipError("SELinux is in Disabled "
+                                       "mode. it must be in Enforcing "
+                                       "mode to run this test")
     utils_selinux.set_status(host_sestatus)
 
     qemu_sock_mod = False


### PR DESCRIPTION
In Ubuntu SELinux is not working at the moment.
So Skipping testcases which needs the SELinux to be in
Enforcing mode. This patch will skip(insted of ERRORing out)
the the testcase if SELinux is disabled.

Signed-off-by: Sudeesh John sudeesh@linux.vnet.ibm.com