### PR TITLE
Support to test macvtap migration

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_multi_vms.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_multi_vms.cfg
@@ -48,9 +48,47 @@
             virsh_migration_type = "simultaneous"
             variants:
                 - normal:
+                - macvtap:
+                    virsh_migration_with_macvtap = "yes"
+                    # Interface name should be same in local machine
+                    # and in remote machine for migration to succeed
+                    host_iface_name = "enP1p12s0f0"
+                    udev_rule_file = "/etc/udev/rules.d/70-persistent-net.rules"
+                    variants:
+                        - VEPA:
+                            mode = "vepa"
+                            variants:
+                                - spapr-vlan:
+                                    model = spapr-vlan
+                                - virtio:
+                                    model = virtio
+                                - rtl8139:
+                                    model = rtl8139
+                                - e1000:
+                                    model = e1000
                 - abort_job:
                     # abort migration job
                     virsh_migrate_jobabort = "yes"
                     status_error = "yes"
         - orderly:
             virsh_migration_type = "orderly"
+            variants:
+                - normal:
+                - macvtap:
+                    virsh_migration_with_macvtap = "yes"
+                    # Interface name should be same in local machine
+                    # and in remote machine for migration to succeed
+                    host_iface_name = "enP1p12s0f0"
+                    udev_rule_file = "/etc/udev/rules.d/70-persistent-net.rules"
+                    variants:
+                        - VEPA:
+                            mode = "vepa"
+                            variants:
+                                - spapr-vlan:
+                                    model = spapr-vlan
+                                - virtio:
+                                    model = virtio
+                                - rtl8139:
+                                    model = rtl8139
+                                - e1000:
+                                    model = e1000


### PR DESCRIPTION
This patch adds support to test VMs with macvtap configured and
to perform migration to validate the macvtap network connectivity
before and after migration

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>