### PR TITLE
Fix virsh_resume

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_resume.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_resume.cfg
@@ -15,6 +15,8 @@
                     resume_vm_ref = domuuid
             variants:
                 - vm_paused:
+                - vm_running:
+                    resume_vm_state = running
         - error_test:
             status_error = yes
             variants:
@@ -30,7 +32,5 @@
                     resume_option_suffix = xyz
                 - vm_shutoff:
                     resume_vm_state = shutoff
-                - vm_running:
-                    resume_vm_state = running
                 - readonly:
                     readonly = yes


### PR DESCRIPTION
virsh resume of running domain will returns 0, so it should be
in normal_test variant.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>