### PR TITLE
virsh.migrate: Perform cpu hotplug/hotunplug with migration

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
@@ -34,15 +34,34 @@
     ping_count = 10
     ping_timeout = 20
     variants:
-        - with_postcopy:
-            no there_p2p_tunnelled, there_suspend, there_suspend_undefinesource
-            no there_vm_suspend_live, there_vm_suspend_online, there_timeout_suspend
-            no with_inactive_guest, there_vm_shutdown_live, there_vm_shutdown_online
-            no there_offline.with_active_guest, with_HP_only, with_HP
-            no with_numa_and_HP, with_HP_pin, there_online, there_online_with_numa
-            postcopy_options = "--postcopy"
-        - without_postcopy:
-            postcopy_options = ""
+        - with_cpu_hotplug:
+            virsh_migrate_cpu_hotplug = "yes"
+            variants:
+                - with_hotplug:
+                    variants:
+                        - hotplug_before_migration:
+                            virsh_hotplug_cpu_before = "yes"
+                        - hotplug_after_migration:
+                            virsh_hotplug_cpu_after = "yes"
+                - with_hotunplug:
+                    virsh_migrate_cpu_hotunplug = "yes"
+                    variants:
+                        - hotplug_before_unplug_before_migration:
+                            virsh_hotplug_cpu_before = "yes"
+                            virsh_hotunplug_cpu_before = "yes"
+                        - hotplug_before_unplug_after_migration:
+                            virsh_hotplug_cpu_before = "yes"
+                            virsh_hotunplug_cpu_after = "yes"
+                        - hotplug_after_unplug_after_migration:
+                            virsh_hotplug_cpu_after = "yes"
+                            virsh_hotunplug_cpu_after = "yes"
+                        - hotplug_unplug_before_hotplug_unplug_after:
+                            virsh_hotplug_cpu_before = "yes"
+                            virsh_hotunplug_cpu_before = "yes"
+                            virsh_hotplug_cpu_after = "yes"
+                            virsh_hotunplug_cpu_after = "yes"
+        - without_cpu_hotplug:
+            virsh_migrate_cpu_hotplug = "no"
     variants:
         - there_and_back:
             # Uni-direction migration with option --live.


### PR DESCRIPTION
This patch adds test scenarios to test migration with CPU Hotplug
and Hotunplug. It covers live, online, there and back, postcopy migration
with different configurations of Numa, Numa pinning, Hugepage, Hugepage pinning,
memory hotplug and default without any of above with following cases,

1. CPU Hotplug before migration
2. CPU Hotplug after migration
3. CPU Hotplug & Hotunplug before migration
4. CPU Hotplug & Hotunplug after migration
5. CPU Hotplug before and Hotunplug after migration
6. CPU Hotplug & Hotunplug before and Hotplug & Hotunplug after migration

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>