### PR TITLE
virsh_migrate_stress: enabled setup nfs in remote machine

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_stress.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_stress.cfg
@@ -13,8 +13,6 @@
     # load_vms = "load_vm1 load_vm2 load_vm3"
     load_vms = "${migrate_load_vms}"
     shell_prompt = "^.*@.*[\#\$]\s*$"
-    migrate_dest_uri = "qemu+ssh://${migrate_dest_host}/system"
-    migrate_src_uri = "qemu+ssh://${migrate_source_host}/system"
     thread_timeout = 120
     # value for "virsh migrate --timeout %s"
     virsh_migrate_timeout = 60


### PR DESCRIPTION
Tests got failed as migration of nfs shared storage vms without
configuring nfs in the remote machine. This patch fixes it

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>