### PR TITLE
In Ubuntu there is no group called "nobody", "nogroup" instead.

### DIFF
--- a/libvirt/tests/cfg/conf_file/libvirtd_conf/unix_sock.cfg
+++ b/libvirt/tests/cfg/conf_file/libvirtd_conf/unix_sock.cfg
@@ -1,7 +1,6 @@
 - conf_file.libvirtd_conf.unix_sock:
     type = unix_sock
     start_vm = no
-    unix_sock_group = root
     unix_sock_ro_perms = 0777
     unix_sock_rw_perms = 0770
     unix_sock_dir = /var/run/libvirt
@@ -10,14 +9,17 @@
             expected_result = success
             variants:
                 - default_setting:
+                    unix_sock_group = root
                 - change_dir:
+                    unix_sock_group = root
                     unix_sock_dir = /tmp
                 - change_group:
-                    unix_sock_group = nobody
                 - change_perms:
+                    unix_sock_group = root
                     unix_sock_ro_perms = 0123
                     unix_sock_rw_perms = 0654
                 - short_perms:
+                    unix_sock_group = root
                     unix_sock_ro_perms = 77
         - negative_test:
             expected_result = unbootable
@@ -27,4 +29,5 @@
                 - invalid_dir:
                     unix_sock_group = /tmp/not_exist_dir
                 - invalid_perms:
+                    unix_sock_group = root
                     unix_sock_ro_perms = 0888


### PR DESCRIPTION
In Ubuntu there is no group called "nobody", "nogroup" instead.
Signed-off-by: Sudeesh John <sudeesh@linux.vnet.ibm.com>