### PR TITLE
virsh.resume: Now resume running VM is invalid

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_resume.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_resume.cfg
@@ -15,8 +15,6 @@
                     resume_vm_ref = domuuid
             variants:
                 - vm_paused:
-                - vm_running:
-                    resume_vm_state = running
         - error_test:
             status_error = yes
             variants:
@@ -34,3 +32,5 @@
                     resume_vm_state = shutoff
                 - readonly:
                     readonly = yes
+                - vm_running:
+                    resume_vm_state = running


### PR DESCRIPTION
libvirt commit 3e044e6e fix the running VM can resume issue, so
we can't do it anymore.

Signed-off-by: Yanbing Du <ydu@redhat.com>