### PR TITLE
Add case to cover vol-create for luks encrypted volume

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_create.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_create.cfg
@@ -82,7 +82,7 @@
                                         - non_acl:
                                         - acl_test:
                                             setup_libvirt_polkit = "yes"
-                                            action_id = "org.libvirt.api.storage-vol.create org.libvirt.api.storage-vol.delete"
+                                            action_id = "org.libvirt.api.storage-vol.create org.libvirt.api.storage-vol.delete org.libvirt.api.secret.read-secure"
                                             action_lookup = "connect_driver:QEMU pool_name:virt-dir-pool"
                                             unprivileged_user = "EXAMPLE"
                                             virsh_uri = "qemu:///system"
@@ -100,6 +100,11 @@
                             variants:
                                 - v_raw:
                                     vol_format = "raw"
+                                - v_raw_luks:
+                                    vol_format = "raw"
+                                    encryption_method = "luks"
+                                    encryption_secret_type = "passphrase"
+                                    action_lookup = "connect_driver:QEMU"
                                 - v_qcow2:
                                     vol_format = "qcow2"
                                 - v_qcow2_with_prealloc:


### PR DESCRIPTION
sign-off by: Yi Sun (lentosun@163.com)

Test on x86_64 with libvirt-3.1.0-2.el7.x86_64, passed 
root@localhost # avocado run --vt-type libvirt type_specific.lento.virsh.vol_create.positive_test.fs_like_pool.vol_format.v_raw_luks..
JOB ID     : c5b8734a4655327122916c7b72761c0bfb741931
JOB LOG    : /root/avocado/job-results/job-2017-03-14T13.53-c5b8734/job.log
TESTS      : 4
 (1/4) type_specific.lento.virsh.vol_create.positive_test.fs_like_pool.vol_format.v_raw_luks.src_pool_type.dir.non_acl: PASS (6.75 s)
 (2/4) type_specific.lento.virsh.vol_create.positive_test.fs_like_pool.vol_format.v_raw_luks.src_pool_type.dir.acl_test: /PolicyKit daemon disconnected from the bus.
We are no longer a registered authentication agent.
PASS (8.97 s)
 (3/4) type_specific.lento.virsh.vol_create.positive_test.fs_like_pool.vol_format.v_raw_luks.src_pool_type.fs: PASS (30.16 s)
 (4/4) type_specific.lento.virsh.vol_create.positive_test.fs_like_pool.vol_format.v_raw_luks.src_pool_type.netfs: PASS (7.16 s)
RESULTS    : PASS 4 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0
JOB HTML   : /root/avocado/job-results/job-2017-03-14T13.53-c5b8734/html/results.html
TESTS TIME : 53.05 s
