### PR TITLE
virsh_migrate_multi_vms: configure ssh_key in remote host

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_multi_vms.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_multi_vms.py
@@ -217,7 +217,8 @@ def run(test, params, env):
         raise exceptions.TestSkipError("The desturi '%s' is invalid" % desturi)
 
     # Config ssh autologin for remote host
-    ssh_key.setup_ssh_key(remote_host, host_user, host_passwd, port=22)
+    ssh_key.setup_remote_ssh_key(remote_host, host_user, host_passwd, port=22,
+                                 public_key="rsa")
 
     # Prepare local session and remote session
     localrunner = remote.RemoteRunner(host=remote_host, username=host_user,


### PR DESCRIPTION
using rsa_key to configure passwordless ssh with remote host
for migration

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>