### PR TITLE
Enable virtio-scsi config on lun device

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_iscsi.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_iscsi.cfg
@@ -42,6 +42,7 @@
                                 - ipv6_test:
                                     iscsi_host = "::1"
                         - test_save_snapshot:
+                            only device_disk
                             virt_disk_device_format = "qcow2"
                             test_save_snapshot = "yes"
                 - iothread:
@@ -53,7 +54,13 @@
                     status_error = "no"
                     variants:
                         - device_lun:
+                            virt_disk_device_bus = "scsi"
                             virt_disk_device = "lun"
+                            virt_disk_device_target = "sdb"
+                            controller_type = "scsi"
+                            controller_model = "virtio-scsi"
+                            controller_index = 0
+                            controller_addr_options = "bus=0x00,slot=0x08,function=0x0,domain=0x0000,type=pci"
                         - device_disk:
                             virt_disk_device = "disk"
                 - error_test:


### PR DESCRIPTION
After Virtio 1.0 is enabled,virtio-scci config need to
be used for lun device instead of virtio
Details refer to https://bugzilla.redhat.com/show_bug.cgi?id=1365823

Signed-off-by: chunfuwen <chwen@redhat.com>