### PR TITLE
Ioeventfd is only supported by virtio-scsi controller

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
@@ -249,9 +249,11 @@
                                             define_error = "yes"
                                             virt_disk_bootdisk_driver = "name=qemu,type=qcow2,ioeventfd=on"
                                         - ioeventfd_on:
+                                            only with_controller_model
                                             virtio_scsi_controller_driver = "ioeventfd=on"
                                             virt_disk_bootdisk_driver = "name=qemu,type=qcow2"
                                         - ioeventfd_off:
+                                            only with_controller_model
                                             virt_disk_bootdisk_driver = "name=qemu,type=qcow2"
                                             virtio_scsi_controller_driver = "ioeventfd=off"
                                     variants:


### PR DESCRIPTION
Previous ioeventfd cases combined with without_controller_model failed
So need filter them out

Signed-off-by: chunfuwen <chwen@redhat.com>