### PR TITLE
Fixed local variable 'vms_list' referenced before assignment issue

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_multivms.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multivms.py
@@ -124,7 +124,8 @@ def run(test, params, env):
     for i in range(2):
         vmxml_backup = vm_xml.VMXML.new_from_inactive_dumpxml(vm_names[i])
         vms_backup.append(vmxml_backup)
-
+    # Initialize VM list
+    vms_list = []
     try:
         # Create disk images if needed.
         disks = []
@@ -163,7 +164,6 @@ def run(test, params, env):
             disks.append({"source": disk_source})
 
         # Compose the new domain xml
-        vms_list = []
         for i in range(2):
             vm = env.get_vm(vm_names[i])
             # Destroy domain first.


### PR DESCRIPTION
vms_list is used to released resouces in finally block,and
sometimes create_scsi_disk failure leads to enter finally block
before vms_list is initialized

Signed-off-by: chunfuwen <chwen@redhat.com>