### PR TITLE
migrate_vm: Update the grep string

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_vm.cfg
+++ b/libvirt/tests/cfg/migration/migrate_vm.cfg
@@ -378,19 +378,19 @@
                                 - write_bytes_sec:
                                     blkdevio_val = 1048576
                                     blkdevio_write_bytes_sec = ${blkdevio_val}
-                                    target_qemu_filter = "ps auxf | grep qemu-kvm | grep bps_wr=${blkdevio_val}"
+                                    target_qemu_filter = "ps auxf | grep qemu-kvm | grep bps[-_]wr.*=${blkdevio_val}"
                                 - read_bytes_sec:
                                     blkdevio_val = 10485760
                                     blkdevio_read_bytes_sec = ${blkdevio_val}
-                                    target_qemu_filter = "ps auxf | grep qemu-kvm | grep bps_rd=${blkdevio_val}"
+                                    target_qemu_filter = "ps auxf | grep qemu-kvm | grep bps[-_]r.*=${blkdevio_val}"
                                 - total_bytes_sec:
                                     blkdevio_val = 41943040
                                     blkdevio_total_bytes_sec = ${blkdevio_val}
-                                    target_qemu_filter = "ps auxf | grep qemu-kvm | grep bps=${blkdevio_val}"
+                                    target_qemu_filter = "ps auxf | grep qemu-kvm | grep bps.*=${blkdevio_val}"
                                 - total_iops_sec:
                                     blkdevio_val = 10
                                     blkdevio_total_iops_sec = ${blkdevio_val}
-                                    target_qemu_filter = "ps auxf | grep qemu-kvm | grep iops=${blkdevio_val}"
+                                    target_qemu_filter = "ps auxf | grep qemu-kvm | grep iops.*=${blkdevio_val}"
                         - with_watchdog:
                             variants:
                                 - ib700:


### PR DESCRIPTION
There are some differences between RHEL7.3 and RHEL7.4 in qemu command
line when setting write-bytes-sec, read-bytes-sec, total-bytes-sec and
total-iops-sec.
Take total-iops-sec for example:
RHEL7.3: qemu command line: iops=1000
RHEL7.4: qemu command line: iops-total=1000

So the fixes are to adjust the grep string to meet both scenarios.

Signed-off-by: Dan Zheng <dzheng@redhat.com>