### PR TITLE
Add cases to cover luks vol-wipe/vol-clone

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_clone_wipe.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_clone_wipe.cfg
@@ -62,6 +62,14 @@
                     action_lookup = "connect_driver:QEMU vol_name:clone_vol_1"
                     unprivileged_user = "EXAMPLE"
                     virsh_uri = "qemu:///system"
+            variants:
+                - non_encrypt:
+                - luks_encrypt:
+                    no acl_test, logical, qcow2_f, qed_f, vdmk_f, sparse_file
+                    encryption_method = "luks"
+                    encryption_secret_type = "passphrase"
+                    vol_capability = 10485760
+                    vol_allocation = 10485760
         - negative_test:
             variants:
                 - oversize_vol:


### PR DESCRIPTION
sing-offed by: Yi Sun (yisun@redhat.com)

Tested with libvirt-3.1.0-2.el7.x86_64
 
Failed cases are due to libvirt's behavior changed during 3.0.0-x, and we need to update
avocado-vt/virttest/utils_test/libvirt.py:pre_pool(), which is being fixed.

~## avocado run --vt-type libvirt type_specific.lento.virsh.vol_clone_wipe.positive_test.luks_encrypt..
JOB ID     : f018b2e4d027b627a16d3ae393bd525cf9864135
JOB LOG    : /root/avocado/job-results/job-2017-03-28T18.34-f018b2e/job.log
TESTS      : 4
 (1/4) type_specific.lento.virsh.vol_clone_wipe.positive_test.luks_encrypt.non_acl.vol_format.raw_f.pool_type.dir: PASS (6.44 s)
 (2/4) type_specific.lento.virsh.vol_clone_wipe.positive_test.luks_encrypt.non_acl.vol_format.raw_f.pool_type.fs: PASS (37.90 s)
 (3/4) type_specific.lento.virsh.vol_clone_wipe.positive_test.luks_encrypt.non_acl.vol_format.raw_f.pool_type.netfs: PASS (12.24 s)
 (4/4) type_specific.lento.virsh.vol_clone_wipe.positive_test.luks_encrypt.non_acl.disk_part.pool_type.disk: FAIL (23.94 s)
