### PR TITLE
virsh_migrate: virsh instance for dumpxml of guest in remote machine

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
@@ -356,7 +356,9 @@ def run(test, params, env):
             test.fail("CPU Hotplug failed - %s" % status.stderr.strip())
         logging.debug("Checking CPU %s gets reflected in xml", operation)
         try:
-            guest_xml = vm_xml.VMXML.new_from_dumpxml(vm.name, uri=uri)
+            virsh_inst = virsh.Virsh(uri=uri)
+            guest_xml = vm_xml.VMXML.new_from_dumpxml(vm.name,
+                                                      virsh_instance=virsh_inst)
             vcpu_list = guest_xml.vcpus.vcpu
             enabled_cpus_count = 0
             for each_vcpu in vcpu_list:


### PR DESCRIPTION
using remote virsh instance to new_from_dumpxml() for retrieving the
guest xml from remote machine

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>