### PR TITLE
Recover postcopy option for all migration

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
@@ -34,6 +34,17 @@
     ping_count = 10
     ping_timeout = 20
     variants:
+        - with_postcopy:
+            no there_p2p_tunnelled, there_suspend, there_suspend_undefinesource
+            no there_vm_suspend_live, there_vm_suspend_online, there_timeout_suspend
+            no with_inactive_guest, there_vm_shutdown_live, there_vm_shutdown_online
+            no there_offline.with_active_guest, with_HP_only, with_HP
+            no with_numa_and_HP, with_HP_pin, there_online, there_online_with_numa
+            postcopy_options = "--postcopy"
+        - without_postcopy:
+            no postcopy_after_precopy, migrate-postcopy
+            postcopy_options = ""
+    variants:
         - with_cpu_hotplug:
             virsh_migrate_cpu_hotplug = "yes"
             variants:
@@ -211,16 +222,13 @@
                         - memnode_with_preferred_strict:
                             memnode_mode_1 = "preferred"
                             memnode_mode_2 = "strict"
-        - postcopy_migration:
-            # postcopy migration with --live
-            variants:
-                - postcopy_after_precopy:
-                    virsh_migrate_options = "--live --postcopy --postcopy-after-precopy"
-                - postcopy:
-                    virsh_migrate_options = "--live --postcopy"
-                    virsh_postcopy_cmd = "migrate-postcopy"
-                    # migration thread timeout
-                    postcopy_migration_timeout = "200"
+        - postcopy_after_precopy:
+            virsh_migrate_options = "--live --postcopy-after-precopy"
+        - migrate-postcopy:
+            virsh_migrate_options = "--live"
+            virsh_postcopy_cmd = "migrate-postcopy"
+            # migration thread timeout
+            postcopy_migration_timeout = "200"
         - there_p2p:
             # Uni-direction migration with option --p2p.
             virsh_migrate_options = "--live --p2p"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
@@ -493,6 +493,11 @@ def run(test, params, env):
             virsh.has_command_help_match("migrate", "--graphicsuri")):
         test.cancel("Do not support 'graphicsuri' option on this version.")
 
+    # For --postcopy enable
+    postcopy_options = params.get("postcopy_options")
+    if postcopy_options and not options.count(postcopy_options):
+        options = "%s %s" % (options, postcopy_options)
+
     src_uri = params.get("virsh_migrate_connect_uri")
     dest_uri = params.get("virsh_migrate_desturi")
 


### PR DESCRIPTION
The purpose of this patch is to make sure '--postcopy' option will not impact other existing test cases. The exising test cases should have same behavior as before even though with '--postcopy'.


Signed-off-by: Dan Zheng <dzheng@redhat.com>