### PR TITLE
virsh_domstats: default vms and main_vm can be used for vm_list

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/monitor/virsh_domstats.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/monitor/virsh_domstats.cfg
@@ -2,7 +2,7 @@
     take_regular_screendumps = no
     type = "virsh_domstats"
     # vm_list is a space separated list
-    vm_list = ""
+    vm_list = ${vms}
     vm_state = "running"
     domstats_option = ""
     enforce_command = "no"
@@ -14,7 +14,7 @@
                 - all_domains:
                 - specific_domain:
                     # This option can NOT combined with --list-* options
-                    vm_list = "avocado-vt-vm1"
+                    vm_list = ${main_vm}
             variants:
                 - no_option:
                     domstats_option = ""


### PR DESCRIPTION
list of vms can be defaulted from existing param vms for all_domains and
param main_vm can be used for specific domain, use test.fail(),
test.error() and test.cancel() instead of using error from autotest.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>