### PR TITLE
Add cases: Forbid using relative path on blockcopy

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcopy.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcopy.cfg
@@ -170,3 +170,12 @@
                     setup_libvirt_polkit = "yes"
                     unprivileged_user = "EXAMPLE"
                     virsh_uri = "qemu:///system"
+                - relative_path:
+                    bug_url = "https://bugzilla.redhat.com/show_bug.cgi?id=1300177"
+                    variants:
+                        - image_name_only:
+                            dest_path = "image" 
+                        - parent_dir:
+                            dest_path = "../image"
+                        - current_dir:
+                            dest_path = "./image"


### PR DESCRIPTION
Negative tests for https://bugzilla.redhat.com/show_bug.cgi?id=1300177