### PR TITLE
Added topology support, removed few tests for ppc64le

### DIFF
--- a/libvirt/tests/cfg/libvirt_vcpu_plug_unplug.cfg
+++ b/libvirt/tests/cfg/libvirt_vcpu_plug_unplug.cfg
@@ -29,10 +29,12 @@
                                     vm_operation = "managedsave"
                                     vcpu_unplug = "no"
                                 - suspend_to_mem:
+                                    no ppc64le
                                     vm_operation = "s3"
                                     install_qemuga = "yes"
                                     start_qemuga = "yes"
                                 - suspend_to_disk:
+                                    no ppc64le
                                     vm_operation = "s4"
                                     install_qemuga = "yes"
                                     start_qemuga = "yes"


### PR DESCRIPTION
1. Added topology support
2. Skipped power management tests for power
3. Changed cpus count method to make it work in all platforms 

Earlier, it was failing if the guest has topology
definition.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>