### PR TITLE
Fixup ppc64le tests and assertion refactor

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_cpu_compare.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_cpu_compare.cfg
@@ -13,7 +13,7 @@
             cpu_compare_mode = "delete"
             cpu_compare_modify_target = "delete"
         - modify_feature_policy:
-            only host_cpu 
+            only host_cpu
             cpu_compare_mode = "modify"
             cpu_compare_modify_target = "feature_policy"
             variants:
@@ -71,6 +71,7 @@
                     status_error = "yes"
         - modify_model:
             only guest_cpu
+            no ppc64le,ppc64
             cpu_compare_mode = "modify"
             cpu_compare_modify_target = "model"
             variants:


### PR DESCRIPTION
1. Skipped unsupported tests
2. Addressed failing CPU compatibility model for ppc64le
3. Removed autotest dependency for assertion.
Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>