### PR TITLE
virtual_disks_encryption: Adjust cfg to avoid duplicate generation

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_encryption.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_encryption.cfg
@@ -7,34 +7,32 @@
     virt_disk_device_source = "disk"
     virt_disk_device_source_path = 'yes'
     virt_disk_qcow2_format = 'yes'
+    pool_name = "pool-dir"
+    pool_type = "dir"
+    pool_target = "/var/lib/libvirt/images/pool-dir"
+    vol_name = "sparse.img"
+    vol_alloc = "0"
+    vol_cap_unit = "M"
+    vol_cap = "100"
+    target_path = "/var/lib/libvirt/images/pool-dir/sparse.img"
+    target_format = "qcow2"
+    target_label = "virt_image_t"
+    target_encypt = "default"
+    status_error = "no"
+    virt_disk_device_source = "/var/lib/libvirt/images/pool-dir/sparse.img"
+    virt_disk_device_target = "vdb"
+    virt_disk_device_bus = "virtio"
+    virt_disk_device_type = "file"
+    secret_type = "passphrase"
+    secret_password_no_encoded = "redhat"
     variants:
-        - encryption_test:
-            pool_name = "pool-dir"
-            pool_type = "dir"
-            pool_target = "/var/lib/libvirt/images/pool-dir"
-            vol_name = "sparse.img"
-            vol_alloc = "0"
-            vol_cap_unit = "M"
-            vol_cap = "100"
-            target_path = "/var/lib/libvirt/images/pool-dir/sparse.img"
-            target_format = "qcow2"
-            target_label = "virt_image_t"
-            target_encypt = "default"
+        - normal_test:
             status_error = "no"
-            virt_disk_device_source = "/var/lib/libvirt/images/pool-dir/sparse.img"
-            virt_disk_device_target = "vdb"
-            virt_disk_device_bus = "virtio"
-            virt_disk_device_type = "file"
-            secret_type = "passphrase"
-            secret_password_no_encoded = "redhat"
             variants:
-                - normal_test:
-                    status_error = "no"
-                    variants:
-                        - qcow2:
-                        - raw:
-                            target_format = "raw"
-                            target_encypt = "luks"
-                            virt_disk_qcow2_format = 'no'
-                - error_test:
-                    status_error = "yes"
+                - qcow2_t:
+                - raw_t:
+                    target_format = "raw"
+                    target_encypt = "luks"
+                    virt_disk_qcow2_format = 'no'
+        - error_test:
+            status_error = "yes"


### PR DESCRIPTION
Multiple same name cases are generated for this case, while total
cases should be 3.

Need avoid use 'qcow2' and 'raw' as case name as they are disk type
also used in avocado-vt cfg files, which cause cartesian problem.

Signed-off-by: Wayne Sun <gsun@redhat.com>