### PR TITLE
virsh_sendkey: regex to grep tty console errors for available tty

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_sendkey.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_sendkey.cfg
@@ -8,13 +8,17 @@
             variants:
                 # All code implement "touch create_file_name" command in guest
                 - with_holdtime:
+                    only Linux
                     sendkey_options = "--holdtime 1000 20 24 22 46 35 57 30 48 46 28"
                     sendkey_sleeptime = 15
                 - linux_keycode:
+                    only Linux
                     sendkey_options = "--codeset linux 20 24 22 46 35 57 30 48 46 28"
                 - os-x_name:
+                    no Linux, Windows
                     sendkey_options = "--codeset os_x ANSI_T ANSI_O ANSI_U ANSI_C ANSI_H Space ANSI_A ANSI_B ANSI_C Return"
                 - os-x_keycode:
+                    no Linux, Windows
                     sendkey_options = "--codeset os_x 0x11 0x1f 0x20 0x8 0x4 0x31 0x0 0xb 0x8 0x24"
                 - at_set1_keycode:
                     sendkey_options = "--codeset atset1 20 24 22 46 35 57 30 48 46 28"
@@ -29,8 +33,10 @@
                 - usb_keycode:
                     sendkey_options = "--codeset usb 23 18 24 6 11 44 4 5 6 40"
                 - win32_name:
+                    only Windows
                     sendkey_options = "--codeset win32 VK_T VK_O VK_U VK_C VK_H VK_SPACE VK_A VK_B VK_C VK_RETURN"
                 - win32_keycode:
+                    only Windows
                     sendkey_options = "--codeset win32 0x54 0x4f 0x55 0x43 0x48 0x20 0x41 0x42 0x43 0x0d"
                 - rfb_keycode:
                     sendkey_options = "--codeset rfb 20 24 22 46 35 57 30 48 46 28"


### PR DESCRIPTION
tty[1] fails to grep available tty and test specific to Linux, Windows are
filtered out.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>