### PR TITLE
virsh_domdisplay: spice graphic is not supported by ppc64le

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domdisplay.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domdisplay.cfg
@@ -5,6 +5,7 @@
     qemu_conf_file = "/etc/libvirt/qemu.conf"
     variants:
         - spice_t:
+            no ppc64,ppc64le
             domdisplay_graphic = "spice"
             variants:
                 - with_ssl:


### PR DESCRIPTION
filtered spice graphic test cases for ppc64le

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>