### PR TITLE
virsh.migrate: fix case name

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
@@ -224,7 +224,7 @@
                             memnode_mode_2 = "strict"
         - postcopy_after_precopy:
             virsh_migrate_options = "--live --postcopy-after-precopy"
-        - migrate-postcopy:
+        - migrate_postcopy:
             virsh_migrate_options = "--live"
             virsh_postcopy_cmd = "migrate-postcopy"
             # migration thread timeout


### PR DESCRIPTION
Replace '-' with '_' for one case name.

Signed-off-by: Dan Zheng <dzheng@redhat.com>