### PR TITLE
Fix parted disk error without mklabel

### DIFF
--- a/libvirt/tests/src/resource_abnormal.py
+++ b/libvirt/tests/src/resource_abnormal.py
@@ -182,6 +182,7 @@ class Virt_clone(object):
                 self.iscsi_dev.cleanup()
                 raise error.TestNAError("Cannot get iscsi device on this"
                                         " host:%s\n" % detail)
+            libvirt.mk_label(device_source)
             libvirt.mk_part(device_source, iscsi_size)
             self.mount_dir = os.path.join(test.virtdir,
                                           params.get('mount_dir'))

--- a/libvirt/tests/src/virtual_disks/virtual_disks_encryption.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_encryption.py
@@ -139,7 +139,9 @@ def run(test, params, env):
                 logging.error("Cann't see added partition in VM")
                 return False
 
-            libvirt.mk_part("/dev/%s" % added_part, size="10M", session=session)
+            device_source = os.path.join(os.sep, 'dev', added_part)
+            libvirt.mk_label(device_source)
+            libvirt.mk_part(device_source, size="10M", session=session)
             # Run partprobe to make the change take effect.
             process.run("partprobe", ignore_status=True, shell=True)
             libvirt.mkfs("/dev/%s1" % added_part, "ext3", session=session)

--- a/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
@@ -133,6 +133,7 @@ def run(test, params, env):
             logging.debug("iscsi dev name: %s", device_source)
 
             # Format the disk and make file system.
+            libvirt.mk_label(device_source)
             libvirt.mk_part(device_source)
             # Run partprobe to make the change take effect.
             process.run("partprobe", ignore_status=True, shell=True)

--- a/libvirt/tests/src/virtual_disks/virtual_disks_multivms.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multivms.py
@@ -142,6 +142,7 @@ def run(test, params, env):
                 is_setup=True, is_login=True, image_size=image_size)
             logging.debug("iscsi dev name: %s", disk_source)
             # Format the disk and make the file system.
+            libvirt.mk_label(disk_source)
             libvirt.mk_part(disk_source, size="10M")
             libvirt.mkfs("%s1" % disk_source, "ext3")
             disk_source += "1"


### PR DESCRIPTION
Signed-off-by: chunfuwen <chwen@redhat.com>
Address issue:CmdError: Command 'parted -s /dev/sdb print' failed (rc=1)&#10;
Jira link:https://projects.engineering.redhat.com/browse/LIBVIRTAT-1341
