### PR TITLE
Add default value to src_pool_format

### DIFF
--- a/libvirt/tests/src/virsh_cmd/volume/virsh_vol_create.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_vol_create.py
@@ -42,7 +42,7 @@ def run(test, params, env):
 
     src_pool_type = params.get("src_pool_type")
     src_pool_target = params.get("src_pool_target")
-    src_pool_format = params.get("src_pool_format", "")
+    src_pool_format = params.get("src_pool_format", "ext4")
     pool_vol_num = int(params.get("src_pool_vol_num", '1'))
     src_emulated_image = params.get("src_emulated_image")
     extra_option = params.get("extra_option", "")


### PR DESCRIPTION
Otherwise it'll call a invalid "mkfs. /dev/sdx"
or "mkfs.None /dev/sdx"

sign-off by: Yi Sun (yisun@redhat.com)

This cause some regression failures after  commit aa889b740db96a8511ac7f4a1a6801a72958f276 in avocado-vt, which has following changes:

```
 -        mkfs(device_name, "ext4")
 -        extra = "--source-dev %s" % device_name
 +        source_format = kwargs.get('source_format', 'ext4')
 +        mkfs(device_name, source_format)
 +        extra = "--source-dev %s --source-format %s" % (device_name, source_format)
```
