### PR TITLE
Add disk with duplicate controller index

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
@@ -526,6 +526,20 @@
                                             status_error = "yes"
                                             define_error = "yes"
                                             virt_disk_addr_options = "type=pci,domain=0x0000,bus=0x00,slot=0x0a,function=0x0"
+                - disk_duplicate_scsi_controller_index_error_test:
+                    virt_disk_path = "/var/lib/libvirt/images/seconddisk.qcow2"
+                    virt_disk_with_duplicate_scsi_controller_index = "yes"
+                    virt_disk_device = "disk"
+                    virt_disk_device_source = "disk1"
+                    virt_disk_device_target = "sda"
+                    virt_disk_device_format = "qcow2"
+                    virt_disk_device_bus = "scsi"
+                    virt_disk_device_type = "file"
+                    driver_option = "type=qcow2,cache=none"
+                    virtio_scsi_controller_model = "virtio-scsi"
+                    virtio_scsi_controller = "yes"
+                    define_error = "yes"
+                    virt_disk_addr_options = "type=drive,controller=0,bus=0,target=0,unit=0"
     variants:
         - hotplug:
             virt_disk_device_hotplug = "yes"


### PR DESCRIPTION
If cold plug,attach expect succeed,but throw error:Found duplicate drive address for disk
when redefine VM.
On the other hand, if hot plug,attach expect fail with error:internal error:
unable to execute QEMU command '__com.redhat_drive_add': Duplicate ID '

Details refer bug:https://bugzilla.redhat.com/show_bug.cgi?id=1036715

Signed-off-by: chunfuwen <chwen@redhat.com>