### PR TITLE
add cdrom and floppy update boot order case

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
@@ -387,6 +387,32 @@
                         disks_attach_option = "--type cdrom --mode readonly"
                         virt_disk_option_readonly = "yes"
                         virt_disk_check_partitions_hotunplug = "no"
+                - disk_cdrom_update_boot_order:
+                    only coldplug
+                    iso_path = '/var/lib/libvirt/images/second.iso'
+                    disk_cdrom_update_boot_order = "yes"
+                    virt_disk_with_source = "yes"
+                    test_disk_option_cmd = "yes"
+                    virt_disk_device = "cdrom"
+                    virt_disk_device_source = "first"
+                    virt_disk_device_target = "hdc"
+                    virt_disk_device_type = "file"
+                    virt_disk_device_bus = "ide"
+                    virt_disk_device_format = "raw"
+                    driver_option = "type=raw"
+                - disk_floppy_update_boot_order:
+                    only coldplug
+                    floppy_path = '/var/lib/libvirt/images/fd2.img'
+                    disk_floppy_update_boot_order = "yes"
+                    virt_disk_with_source = "yes"
+                    test_disk_option_cmd = "yes"
+                    virt_disk_device = "floppy"
+                    virt_disk_device_source = "fd1"
+                    virt_disk_device_target = "fda"
+                    virt_disk_device_type = "file"
+                    virt_disk_device_bus = "fdc"
+                    virt_disk_device_format = "raw"
+                    driver_option = "type=raw"
                 - disks_startup_policy:
                     variants:
                         - error_test:


### PR DESCRIPTION
If update cdrom or floppy with different boot order value,
it expect fail,details see:https://bugzilla.redhat.com/show_bug.cgi?id=1007228

Signed-off-by: chunfuwen <chwen@redhat.com>