### PR TITLE
virsh.migrate: Fix the postcopy option

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
@@ -508,7 +508,7 @@ def run(test, params, env):
 
     # For --postcopy enable
     postcopy_options = params.get("postcopy_options")
-    if postcopy_options and not options.count(postcopy_options):
+    if postcopy_options:
         options = "%s %s" % (options, postcopy_options)
 
     src_uri = params.get("virsh_migrate_connect_uri")


### PR DESCRIPTION
Incorrect logic causes '--postcopy' is not inserted into the migration
options for '--postcopy_after_precopy'

Signed-off-by: Dan Zheng <dzheng@redhat.com>