### PR TITLE
Add case to validate bugzilla bug:521053

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
@@ -413,6 +413,16 @@
                     virt_disk_device_bus = "fdc"
                     virt_disk_device_format = "raw"
                     driver_option = "type=raw"
+                - disk_ide_place_correct_boot_order:
+                    only coldplug
+                    virt_disk_with_source = "yes"
+                    virt_disk_device = "disk"
+                    virt_disk_device_source = "ide1"
+                    virt_disk_device_target = "hda"
+                    virt_disk_device_type = "file"
+                    virt_disk_device_bus = "ide"
+                    virt_disk_device_format = "raw"
+                    driver_option = "type=raw"
                 - disks_startup_policy:
                     variants:
                         - error_test:


### PR DESCRIPTION
IDE disk can not always be placed before virtio/scsi disks

Signed-off-by: chunfuwen <chwen@redhat.com>