### PR TITLE
virsh_migrate: Iscsi Hotplug/Hotunplug with migration

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
@@ -45,6 +45,45 @@
             no postcopy_after_precopy, migrate-postcopy
             postcopy_options = ""
     variants:
+        - with_iscsi_hotplug:
+            virsh_migrate_iscsi_hotplug = "yes"
+            type_name = "network"
+            target_bus = "virtio"
+            device_type = "disk"
+            source_protocol = "iscsi"
+            source_host_port = "3260"
+            auth_user = "avocadokvm"
+            iscsi_auth_password = "password"
+            secret_type = "iscsi"
+            secret_usage = "libvirtiscsi"
+            image_size = "1G"
+            variants:
+                - with_hotplug:
+                    variants:
+                        - hotplug_before_migration:
+                            virsh_hotplug_iscsi_before = "yes"
+                        - hotplug_after_migration:
+                            virsh_hotplug_iscsi_after = "yes"
+                - with_hotunplug:
+                    virsh_migrate_iscsi_hotunplug = "yes"
+                    variants:
+                        - hotplug_before_unplug_before_migration:
+                            virsh_hotplug_iscsi_before = "yes"
+                            virsh_hotunplug_iscsi_before = "yes"
+                        - hotplug_before_unplug_after_migration:
+                            virsh_hotplug_iscsi_before = "yes"
+                            virsh_hotunplug_iscsi_after = "yes"
+                        - hotplug_after_unplug_after_migration:
+                            virsh_hotplug_iscsi_after = "yes"
+                            virsh_hotunplug_iscsi_after = "yes"
+                        - hotplug_unplug_before_hotplug_unplug_after:
+                            virsh_hotplug_iscsi_before = "yes"
+                            virsh_hotunplug_iscsi_before = "yes"
+                            virsh_hotplug_iscsi_after = "yes"
+                            virsh_hotunplug_iscsi_after = "yes"
+        - without_iscsi_hotplug:
+            virsh_migrate_iscsi_hotplug = "no"
+    variants:
         - with_cpu_hotplug:
             virsh_migrate_cpu_hotplug = "yes"
             variants:


### PR DESCRIPTION
This patch adds testcases to validate emulated iscsi disk
hotplug/hotunplug with migration (pre and post).

configure iscsi target with iscsi target and initiator utils,
generates iscsi disk xml and performs hotplug/hotunplug to guest,
validates iscsi disk can be used to make filesystem, mount, creates file
and checks md5sum after migration for iscsi disk hotplugged before migration

scenarios covered,

1. Hotplug before migration
2. Hotplug after migration
3. Hotplug/Hotunplug before migration
4. Hotplug/Hotunplug after migration
5. Hotplug before migration and hotunplug after migration
6. Hotplug/Hotunplug before and hotplug/hotunplug after migration

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>