### PR TITLE
Fix local variable 'nfs_service' referenced before assignment

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domblkerror.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domblkerror.py
@@ -150,8 +150,9 @@ def run(test, params, env):
         create_large_image()
         if error_type == "unspecified error":
             # umount nfs to trigger error after create large image
-            nfs_service.stop()
-            logging.debug("nfs status is %s", nfs_service.status())
+            if nfs_service is not None:
+                nfs_service.stop()
+                logging.debug("nfs status is %s", nfs_service.status())
 
         # wait and check the guest status with timeout
         def _check_state():
@@ -177,7 +178,8 @@ def run(test, params, env):
     finally:
         logging.info("Do clean steps")
         if error_type == "unspecified error":
-            nfs_service.start()
+            if nfs_service is not None:
+                nfs_service.start()
             vm.destroy()
             if os.path.isfile("%s.bak" % export_file):
                 shutil.move("%s.bak" % export_file, export_file)


### PR DESCRIPTION
In finally block, nfs_service may be one None object,and add
None check before start

Signed-off-by: chunfuwen <chwen@redhat.com>