### PR TITLE
Get only 1 vm for the virsh event cases, unless otherwise noted

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_event.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_event.cfg
@@ -54,7 +54,7 @@
                         - test_multiple_domains:
                             only no_timeout 
                             only lifecycle_events
-                            vms = vm1 avocado-vt-vm1
+                            multi_vms = "yes" 
                 - qemu_monitor_event:
                     # Test virsh qemu_monitor_event
                     no other_option

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
@@ -21,7 +21,12 @@ def run(test, params, env):
     3. Catch the return of virsh event and qemu-monitor-event, and check it.
     """
 
-    vms = env.get_all_vms()
+    vms = []
+    if params.get("multi_vms") == "yes":
+        vms = env.get_all_vms()
+    else:
+        vm_name = params.get("main_vm")
+        vms.append(env.get_vm(vm_name))
 
     event_name = params.get("event_name")
     event_all_option = "yes" == params.get("event_all_option", "no")


### PR DESCRIPTION
Before this fix, getting all the vms will cause some events belonging
to the second vm been not tracked, as virsh event is one-shot by
default. Hence, errors will be reported when get all the vms.
Thus submit a patch to fix it.

Signed-off-by: Lily Zhu <lizhu@redhat.com>