### PR TITLE
iface_options: Fix inaccurate prompt

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_options.py
+++ b/libvirt/tests/src/virtual_network/iface_options.py
@@ -515,7 +515,7 @@ def run(test, params, env):
                 session = aexpect.ShellSession(cmd)
                 session.sendline()
                 remote.handle_prompts(session, params.get("username"),
-                                      params.get("password"), "[\#\$]", 30)
+                                      params.get("password"), r"[\#\$]\s*$", 30)
                 # Get ip address on guest
                 if not get_guest_ip(session, iface_mac):
                     raise error.TestError("Can't get ip address on guest")


### PR DESCRIPTION
The original prompt is inaccurate which causes the log on guest failure.
This is to make the prompt more accurate.

Signed-off-by: Dan Zheng <dzheng@redhat.com>