### PR TITLE
Skip blockcopy relative path for libvirt < 3.0.0

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcopy.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcopy.cfg
@@ -172,6 +172,7 @@
                     virsh_uri = "qemu:///system"
                 - relative_path:
                     bug_url = "https://bugzilla.redhat.com/show_bug.cgi?id=1300177"
+                    relative_path = "yes"
                     variants:
                         - image_name_only:
                             dest_path = "image" 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
@@ -232,6 +232,7 @@ def run(test, params, env):
     setup_libvirt_polkit = "yes" == params.get('setup_libvirt_polkit')
     bug_url = params.get("bug_url", "")
     timeout = int(params.get("timeout", 1200))
+    relative_path = params.get("relative_path")
     rerun_flag = 0
     blkdev_n = None
     back_n = 'blockdev-backing-iscsi'
@@ -250,6 +251,8 @@ def run(test, params, env):
     if bandwidth_byte and not libvirt_version.version_compare(1, 3, 3):
         raise exceptions.TestSkipError("--bytes option not supported in "
                                        "current version")
+    if relative_path == "yes" and not libvirt_version.version_compare(3, 0, 0):
+        test.cancel("Forbid using relative path or file name only is added since libvirt-3.0.0")
 
     # Check the source disk
     if vm_xml.VMXML.check_disk_exist(vm_name, target):


### PR DESCRIPTION
Since patches of https://bugzilla.redhat.com/show_bug.cgi?id=1300177
were merger after 3.0.0. Add skip codes for 3.0.0 lower libvirt.