### PR TITLE
virtual_disks_multidisks: Fix dracut timeout corrupt vm problem

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
@@ -530,7 +530,7 @@ def run(test, params, env):
         if add_disk_driver:
             # Ignore errors here
             session.cmd("dracut --force --add-drivers '%s'"
-                        % add_disk_driver)
+                        % add_disk_driver, timeout=360)
         session.close()
         vm.shutdown()
 


### PR DESCRIPTION
The default timeout for session cmd is 60 which might not enough
for dracut command to finish. As --force is used, it will
overwrite initramfs image and corrupt the vm if failed, so set
the timeout longer to avoid such corruption.

Signed-off-by: Wayne Sun <gsun@redhat.com>