### PR TITLE
XMLToNative: Don't compare -cpu

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_to_native.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_to_native.py
@@ -92,6 +92,8 @@ def run(test, params, env):
                 continue
             elif re.search("secret,id=", arg):
                 continue
+            elif re.search("-cpu", arg):
+                continue
             retlist.append(arg)
 
         return retlist


### PR DESCRIPTION
libvirt will detect qemu support cpu during start guest,
so the cpu flags in domxml-to-native output won't equal
the real qemu command cpu flags

Signed-off-by: root <yanqzhan@redhat.com>