### PR TITLE
Clean up managedsave img after test finished

### DIFF
--- a/libvirt/tests/src/libvirt_hooks.py
+++ b/libvirt/tests/src/libvirt_hooks.py
@@ -398,6 +398,8 @@ def run(test, params, env):
     finally:
         # Recover VM.
         logging.info("Restoring vm...")
+        if test_managedsave:
+            virsh.managedsave_remove(vm_name)
         if vm.is_alive():
             vm.destroy(gracefully=False)
         if os.path.exists(hook_file):


### PR DESCRIPTION
The managedsave image used to exist after test finished, which may
affect test result of the next cases. Therefore, add clean up step
to remove the image.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>