### PR TITLE
Only set LIBGUESTFS_BACKEND for xen

### DIFF
--- a/v2v/tests/src/convert_vm_to_libvirt.py
+++ b/v2v/tests/src/convert_vm_to_libvirt.py
@@ -104,7 +104,8 @@ def run(test, params, env):
         v2v_params.update({"v2v_opts": v2v_opts})
 
     # Set libguestfs environment
-    os.environ['LIBGUESTFS_BACKEND'] = 'direct'
+    if hypervisor == 'xen':
+        os.environ['LIBGUESTFS_BACKEND'] = 'direct'
     try:
         # Execute virt-v2v command
         ret = utils_v2v.v2v_cmd(v2v_params)

--- a/v2v/tests/src/convert_vm_to_ovirt.py
+++ b/v2v/tests/src/convert_vm_to_ovirt.py
@@ -112,7 +112,8 @@ def run(test, params, env):
         v2v_params.update({'output_format': 'qcow2'})
 
     # Set libguestfs environment variable
-    os.environ['LIBGUESTFS_BACKEND'] = 'direct'
+    if hypervisor == 'xen':
+        os.environ['LIBGUESTFS_BACKEND'] = 'direct'
     try:
         # Execute virt-v2v command
         v2v_ret = utils_v2v.v2v_cmd(v2v_params)


### PR DESCRIPTION
Since the bug is fixed, this workaround no longer needs to cover
all hypervisors, only xen still needs it.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>