### PR TITLE
Fix qemu_agent_comand_fs fsfreeze failure issues

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_qemu_agent_command_fs.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_qemu_agent_command_fs.cfg
@@ -6,4 +6,3 @@
     status_cmd = "{"execute":"guest-fsfreeze-status"}"
     freeze_cmd = "{"execute":"guest-fsfreeze-freeze"}"
     thaw_cmd = "{"execute":"guest-fsfreeze-thaw"}"
-    tmp_file = "/tmp/test.file"


### PR DESCRIPTION
Fix by change to using another disk instead of local disk to do cp operation to generate
dirty memory which may cause guest hang and agent command have no response. Also remove
the redundant sleep as it may deal with in get_dirty func. Also the tmp_file removed from cfg file as it need to in /mnt dir and no need to do configure in cfg