### PR TITLE
Set LIBGUESTFS_BACKEND=direct for kvm guests

### DIFF
--- a/v2v/tests/src/convert_vm_to_ovirt.py
+++ b/v2v/tests/src/convert_vm_to_ovirt.py
@@ -112,7 +112,7 @@ def run(test, params, env):
         v2v_params.update({'output_format': 'qcow2'})
 
     # Set libguestfs environment variable
-    if hypervisor == 'xen':
+    if hypervisor in ('xen', 'kvm'):
         os.environ['LIBGUESTFS_BACKEND'] = 'direct'
     try:
         # Execute virt-v2v command


### PR DESCRIPTION
Since there's an unresolved issue for v2v conversion.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>