### PR TITLE
virsh_attach_detach_interface_matrix: Fix wait time

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_interface_matrix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_interface_matrix.py
@@ -65,7 +65,7 @@ def run(test, params, env):
             # All three conditions met
             logging.debug("Find %s in given iface XML", iface_mac)
             return True
-        logging.debug("Not find %s in gievn iface XML", iface_mac)
+        logging.debug("Not find %s in given iface XML", iface_mac)
         return False
 
     def check_result(vm_name, iface_source, iface_type, iface_mac,
@@ -294,7 +294,7 @@ def run(test, params, env):
             vm.resume()
             vm.wait_for_login().close()
         #Sleep a while for vm is stable
-        time.sleep(3)
+        time.sleep(10)
         if not ret.exit_status:
             check_result(vm_name, iface_source,
                          iface_type, iface_mac,


### PR DESCRIPTION
Adjust the sleep time for the VM to be stable after detaching the
interface on PPC.

Signed-off-by: Dan Zheng <dzheng@redhat.com>