### PR TITLE
virsh_attach_detach_disk_matrix: Fix sleep time

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk_matrix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk_matrix.py
@@ -248,6 +248,7 @@ def run(test, params, env):
             vm.wait_for_login().close()
 
         #Sleep a while for vm is stable
+        time.sleep(10)
         if not ret.exit_status:
             check_result(device_source, device, device_target,
                          dt_options, False)


### PR DESCRIPTION
Adjust the sleep time for the VM to be stabe after detaching disk on
PPC.

Signed-off-by: Dan Zheng <dzheng@redhat.com>