### PR TITLE
dac_nfs_disk: Fix the issue that failed to create nfs pool

### DIFF
--- a/libvirt/tests/src/svirt/dac_nfs_disk.py
+++ b/libvirt/tests/src/svirt/dac_nfs_disk.py
@@ -5,7 +5,6 @@ import logging
 from avocado.utils import process
 
 from virttest import qemu_storage
-from virttest import data_dir
 from virttest import utils_selinux
 from virttest import virt_vm
 from virttest import virsh
@@ -141,7 +140,7 @@ def run(test, params, env):
 
         # Init a QemuImg instance and create img on nfs server dir.
         params['image_name'] = vol_name
-        tmp_dir = data_dir.get_tmp_dir()
+        tmp_dir = test.tmpdir
         nfs_path = os.path.join(tmp_dir, nfs_server_dir)
         image = qemu_storage.QemuImg(params, nfs_path, vol_name)
         # Create a image.


### PR DESCRIPTION
the nfs path used for pool preparation is not the one as for exportfs. So 'access denied' is reported while mounting nfs server. Fix by change the path to be unified.

Sign-off-by: Yan Li <yannli@redhat.com>