### PR TITLE
Enabling SELinux mode check

### DIFF
--- a/libvirt/tests/src/svirt/dac_vm_per_image_start.py
+++ b/libvirt/tests/src/svirt/dac_vm_per_image_start.py
@@ -4,8 +4,6 @@ import pwd
 import grp
 import logging
 
-from autotest.client.shared import error
-
 from virttest import utils_selinux
 from virttest import virt_vm
 from virttest import utils_config
@@ -100,6 +98,10 @@ def run(test, params, env):
 
     # Set selinux of host.
     backup_sestatus = utils_selinux.get_status()
+    if backup_sestatus == "disabled":
+        test.cancel("SELinux is in Disabled "
+                    "mode. it must be in Enforcing "
+                    "mode to run this test")
     utils_selinux.set_status(host_sestatus)
 
     qemu_sock_mod = False
@@ -147,7 +149,7 @@ def run(test, params, env):
                                   "details see bug: bugzilla.redhat.com/show_bug.cgi"
                                   "?id=1165485")
                 else:
-                    raise error.TestFail("Test succeeded in negative case.")
+                    test.fail("Test succeeded in negative case.")
 
             # Get vm process label when VM is running.
             vm_pid = vm.get_pid()
@@ -168,14 +170,14 @@ def run(test, params, env):
                               disk_context)
                 if sec_label and relabel == 'yes':
                     if disk_context != sec_label_id:
-                        raise error.TestFail("The disk label is not equal to "
-                                             "'%s'." % sec_label_id)
+                        test.fail("The disk label is not equal to "
+                                  "'%s'." % sec_label_id)
 
         except virt_vm.VMStartError, e:
             # Starting VM failed.
             if not status_error:
-                raise error.TestFail("Test failed in positive case."
-                                     "error: %s" % e)
+                test.fail("Test failed in positive case."
+                          "error: %s" % e)
     finally:
         # clean up
         if vm.is_alive():


### PR DESCRIPTION
In Ubuntu SELinux is not working at the moment.
So Skipping testcases which needs the SELinux to be in
Enforcing mode. This patch will skip(insted of ERRORing out)
the the testcase if SELinux is disabled.

Signed-off-by: Sudeesh John sudeesh@linux.vnet.ibm.com