### PR TITLE
virtual_disks: Add wait time for PPC

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_encryption.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_encryption.py
@@ -267,6 +267,7 @@ def run(test, params, env):
             # can be normally started or attached since qemu will just treat
             # it as RAW, so we don't test LUKS with status_error=TRUE.
             vm.start()
+            vm.wait_for_login()
             if status_error:
                 if hotplug:
                     logging.debug("attaching disk, expecting error...")


### PR DESCRIPTION
Add the sleep time for the VM to recognize the attached disk on PPC.

Signed-off-by: Dan Zheng <dzheng@redhat.com>