### PR TITLE
Timer_Management: support tsc timer, and close its present=no scenario

### DIFF
--- a/libvirt/tests/cfg/timer_management.cfg
+++ b/libvirt/tests/cfg/timer_management.cfg
@@ -99,11 +99,10 @@
                             timer_name = 'pit,rtc'
                         - hpet_tsc:
                             timer_name = 'hpet,tsc'
-                            timer_start_error = "yes"
                 - tsc:
-                    # Support hypervisor: libxml
+                    # Support hypervisor: libxml,qemu
                     timer_name = "tsc"
-                    timer_start_error = "yes"
+                    no present_no         #Temporary does not work according to feature testing
                 - platform:
                     # currently unsupported
                     timer_name = "platform"

--- a/libvirt/tests/src/timer_management.py
+++ b/libvirt/tests/src/timer_management.py
@@ -17,6 +17,8 @@ from virttest import data_dir
 from virttest import virt_vm
 from virttest.libvirt_xml import vm_xml
 
+from provider import libvirt_version
+
 CLOCK_SOURCE_PATH = '/sys/devices/system/clocksource/clocksource0/'
 
 
@@ -440,7 +442,10 @@ def test_specific_timer(vm, params):
     :param params: Test parameters
     """
     timers = params.get("timer_name", "").split(',')
-    start_error = "yes" == params.get("timer_start_error", "no")
+    if 'tsc' in timers and not libvirt_version.version_compare(3, 2, 0):
+        start_error = True
+    else:
+        start_error = "yes" == params.get("timer_start_error", "no")
     if vm.is_dead():
         vm.start()
     vm.wait_for_login()


### PR DESCRIPTION
Tsc is support timer after this patch:commit 7373c4e48f293fb4d361b1bf2d0986166d8480be.
And disabling it by present=no in xml doesn't work according to feature testing, so
close this auto scenario.

Signed-off-by: Yanqiu Zhang <yanqzhan@redhat.com>