### PR TITLE
Modify the keycode 'touch abc\n' to 'touch ab\n'

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_sendkey.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_sendkey.cfg
@@ -4,44 +4,44 @@
     take_regular_screendumps = "no"
     variants:
         - params_test:
-            create_file_name = "/root/abc"
+            create_file_name = "/root/ab"
             variants:
                 # All code implement "touch create_file_name" command in guest
                 - with_holdtime:
                     only Linux
-                    sendkey_options = "--holdtime 1000 20 24 22 46 35 57 30 48 46 28"
+                    sendkey_options = "--holdtime 1000 20 24 22 46 35 57 30 48 28"
                     sendkey_sleeptime = 15
                 - linux_keycode:
                     only Linux
-                    sendkey_options = "--codeset linux 20 24 22 46 35 57 30 48 46 28"
+                    sendkey_options = "--codeset linux 20 24 22 46 35 57 30 48 28"
                 - os-x_name:
                     no Linux, Windows
-                    sendkey_options = "--codeset os_x ANSI_T ANSI_O ANSI_U ANSI_C ANSI_H Space ANSI_A ANSI_B ANSI_C Return"
+                    sendkey_options = "--codeset os_x ANSI_T ANSI_O ANSI_U ANSI_C ANSI_H Space ANSI_A ANSI_B Return"
                 - os-x_keycode:
                     no Linux, Windows
-                    sendkey_options = "--codeset os_x 0x11 0x1f 0x20 0x8 0x4 0x31 0x0 0xb 0x8 0x24"
+                    sendkey_options = "--codeset os_x 0x11 0x1f 0x20 0x8 0x4 0x31 0x0 0xb 0x24"
                 - at_set1_keycode:
-                    sendkey_options = "--codeset atset1 20 24 22 46 35 57 30 48 46 28"
+                    sendkey_options = "--codeset atset1 20 24 22 46 35 57 30 48 28"
                 - at_set2_keycode:
-                    sendkey_options = "--codeset atset2 44 68 60 33 51 41 28 50 33 90"
+                    sendkey_options = "--codeset atset2 44 68 60 33 51 41 28 50 90"
                 - at_set3_keycode:
-                    sendkey_options = "--codeset atset3 44 68 60 33 51 41 28 50 33 90"
+                    sendkey_options = "--codeset atset3 44 68 60 33 51 41 28 50 90"
                 - xt_keycode:
-                    sendkey_options = "--codeset xt 20 24 22 46 35 57 30 48 46 28"
+                    sendkey_options = "--codeset xt 20 24 22 46 35 57 30 48 28"
                 - xt_kbd_keycode:
-                    sendkey_options = "--codeset xt_kbd 20 24 22 46 35 57 30 48 46 28"
+                    sendkey_options = "--codeset xt_kbd 20 24 22 46 35 57 30 48 28"
                 - usb_keycode:
-                    sendkey_options = "--codeset usb 23 18 24 6 11 44 4 5 6 40"
+                    sendkey_options = "--codeset usb 23 18 24 6 11 44 4 5 40"
                 - win32_name:
                     only Windows
-                    sendkey_options = "--codeset win32 VK_T VK_O VK_U VK_C VK_H VK_SPACE VK_A VK_B VK_C VK_RETURN"
+                    sendkey_options = "--codeset win32 VK_T VK_O VK_U VK_C VK_H VK_SPACE VK_A VK_B VK_RETURN"
                 - win32_keycode:
                     only Windows
-                    sendkey_options = "--codeset win32 0x54 0x4f 0x55 0x43 0x48 0x20 0x41 0x42 0x43 0x0d"
+                    sendkey_options = "--codeset win32 0x54 0x4f 0x55 0x43 0x48 0x20 0x41 0x42 0x0d"
                 - rfb_keycode:
-                    sendkey_options = "--codeset rfb 20 24 22 46 35 57 30 48 46 28"
+                    sendkey_options = "--codeset rfb 20 24 22 46 35 57 30 48 28"
                 - default_name:
-                    sendkey_options = "KEY_T KEY_O KEY_U KEY_C KEY_H KEY_SPACE KEY_A KEY_B KEY_C KEY_ENTER"
+                    sendkey_options = "KEY_T KEY_O KEY_U KEY_C KEY_H KEY_SPACE KEY_A KEY_B KEY_ENTER"
             variants:
                 - non_acl:
                 - acl_test:


### PR DESCRIPTION
Since the 'virsh send-key' send all the keys simulataneously, so the
string contains the same keys will have the possibility that the key
only received one time by the guest.

Signed-off-by: Yan Fu <yafu@redhat.com>