### PR TITLE
Libvirtat 540

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_agent_command.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_agent_command.py
@@ -25,7 +25,7 @@ def reset_domain(vm, vm_state, needs_agent=False, guest_cpu_busy=False,
         logging.debug("Attempting to prepare guest agent")
         start_ga = vm_state != 'shut off'
         vm.prepare_guest_agent(start=start_ga)
-    if not vm_state == "shut off":
+    if not vm_state == "shut off" and needs_agent:
         session = vm.wait_for_login()
         if guest_cpu_busy:
             shell_file = "/tmp/test.sh"


### PR DESCRIPTION
[root@localhost tp-libvirt]# avocado run --vt-type libvirt  qemu_agent_command..no_ga
JOB ID     : 6c51f4b22eb1917a00a5a705a0b2794b6b32f39d
JOB LOG    : /root/avocado/job-results/job-2017-08-01T17.58-6c51f4b/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.qemu_agent_command.error_test.no_ga: PASS (0.94 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 2.79 s
