### PR TITLE
qemu_agent_command: fix no_ga issue

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_agent_command.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_agent_command.py
@@ -25,7 +25,7 @@ def reset_domain(vm, vm_state, needs_agent=False, guest_cpu_busy=False,
         logging.debug("Attempting to prepare guest agent")
         start_ga = vm_state != 'shut off'
         vm.prepare_guest_agent(start=start_ga)
-    if not vm_state == "shut off":
+    if not vm_state == "shut off" and needs_agent:
         session = vm.wait_for_login()
         if guest_cpu_busy:
             shell_file = "/tmp/test.sh"


### PR DESCRIPTION
When with no guest agent, wait_for_login shall not be performed.

Signed-off-by: Yan Li <yannli@redhat.com>