### PR TITLE
Fix several issues on numa_memory part

### DIFF
--- a/libvirt/tests/cfg/numa/numa_memory.cfg
+++ b/libvirt/tests/cfg/numa/numa_memory.cfg
@@ -19,10 +19,11 @@
                      memory_placement = "static"
                      variants:
                          - node1:
+                             no interleave
                              memory_nodeset = "0"
                          - node2:
                              no preferred
-                             memory_nodeset = "2-3"
+                             memory_nodeset = "0-1"
              variants:
                  - no_vcpu:
                  - vcpu:
@@ -31,7 +32,7 @@
                              vcpu_placement = "auto"
                          - vcpu_static:
                              vcpu_placement = "static"
-                             vcpu_cpuset = "0,8"
+                             vcpu_cpuset = "2,4"
         - negative_test:
              status_error = "yes"
              memory_placement = "static"

--- a/libvirt/tests/src/numa/numa_memory.py
+++ b/libvirt/tests/src/numa/numa_memory.py
@@ -42,7 +42,7 @@ def run(test, params, env):
         for i in left_node:
             left_node_mem_total += int(memory_status[i])
         if left_node_mem_total > used_mem_total:
-            raise exceptions.TestFail("nodes memory usage not expected.")
+            test.fail("nodes memory usage not expected.")
 
     def format_affinity_str(cpu_list):
         """
@@ -85,7 +85,21 @@ def run(test, params, env):
         ret = format_affinity_str(cpu_list)
         logging.debug("expect cpu affinity is %s", ret)
         if cpu_affinity != ret:
-            raise exceptions.TestFail("vcpuinfo cpu affinity not expected")
+            test.fail("vcpuinfo cpu affinity not expected")
+
+    def numa_mode_check(mode_nodeset):
+        """
+        when the mode = 'preferred' or 'interleave', it is better to check
+        numa_maps.
+        """
+        vm_pid = vm.get_pid()
+        numa_map = '/proc/%s/numa_maps' % vm_pid
+        # Open a file
+        with open(numa_map) as file:
+            for line in file.readlines():
+                if line.split()[1] != mode_nodeset:
+                    test.fail("numa node and nodeset %s is "
+                              "not expected" % mode_nodeset)
 
     vcpu_placement = params.get("vcpu_placement")
     vcpu_cpuset = params.get("vcpu_cpuset")
@@ -152,7 +166,6 @@ def run(test, params, env):
             if not set(pre_cpuset).issubset(cpu_list):
                 raise exceptions.TestSkipError("cpuset %s out of range" %
                                                vcpu_cpuset)
-
         vmxml = libvirt_xml.VMXML.new_from_dumpxml(vm_name)
         vmxml.numa_memory = numa_memory
         vcpu_num = vmxml.vcpu
@@ -180,9 +193,9 @@ def run(test, params, env):
                 pre_numa_memory = numa_memory
 
             if pre_numa_memory != numa_memory_new:
-                raise exceptions.TestFail("memory config %s not expected "
-                                          "after domain start" %
-                                          numa_memory_new)
+                test.fail("memory config %s not expected "
+                          "after domain start" %
+                          numa_memory_new)
 
             pos_vcpu_placement = vmxml_new.placement
             logging.debug("vcpu placement after domain start is %s",
@@ -192,16 +205,15 @@ def run(test, params, env):
                 logging.debug("vcpu cpuset after vm start is %s", pos_cpuset)
             except libvirt_xml.xcepts.LibvirtXMLNotFoundError:
                 if vcpu_cpuset and vcpu_placement != 'auto':
-                    raise exceptions.TestFail("cpuset not found in domain "
-                                              "xml.")
+                    test.fail("cpuset not found in domain xml.")
 
         except virt_vm.VMStartError as e:
             # Starting VM failed.
             if status_error:
                 return
             else:
-                raise exceptions.TestFail("Test failed in positive case.\n "
-                                          "error: %s\n%s" % (e, bug_url))
+                test.fail("Test failed in positive case.\n "
+                          "error: %s\n%s" % (e, bug_url))
 
         # Check qemu process numa memory usage
         memory_status, qemu_cpu = utils_test.qemu.get_numa_status(
@@ -216,35 +228,46 @@ def run(test, params, env):
                 total_cpu += node_cpu
             for i in total_cpu:
                 if int(i) not in pre_cpuset:
-                    raise exceptions.TestFail("cpu %s is not expected" % i)
+                    test.fail("cpu %s is not expected" % i)
             cpu_affinity_check(cpuset=pre_cpuset)
         if numa_memory.get('nodeset'):
             # If there are inconsistent node numbers on host,
             # convert it into sequence number so that it can be used
             # in mem_compare
-            left_node = [node_list.index(i) for i in node_list if i not in used_node]
-            used_node = [node_list.index(i) for i in used_node]
-            mem_compare(used_node, left_node)
-
+            if numa_memory.get('mode') == 'strict':
+                left_node = [node_list.index(i) for i in node_list if i not in used_node]
+                used_node = [node_list.index(i) for i in used_node]
+                mem_compare(used_node, left_node)
+            elif numa_memory.get('mode') == 'preferred':
+                mode_nodeset = 'prefer:' + numa_memory.get('nodeset')
+                numa_mode_check(mode_nodeset)
+            else:
+                mode_nodeset = numa_memory.get('mode') + ':' + numa_memory.get('nodeset')
+                numa_mode_check(mode_nodeset)
         logging.debug("numad log list is %s", numad_log)
         if vcpu_placement == 'auto' or numa_memory.get('placement') == 'auto':
             if not numad_log:
-                raise exceptions.TestFail("numad usage not found in libvirtd "
-                                          "log")
+                test.fail("numad usage not found in libvirtd log")
             if numad_log[0].split("numad ")[-1] != numad_cmd_opt:
-                raise exceptions.TestFail("numad command not expected in log")
+                test.fail("numad command not expected in log")
             numad_ret = numad_log[1].split("numad: ")[-1]
             numad_node = utils_test.libvirt.cpus_parser(numad_ret)
             left_node = [node_list.index(i) for i in node_list if i not in numad_node]
             numad_node_seq = [node_list.index(i) for i in numad_node]
             logging.debug("numad nodes are %s", numad_node)
             if numa_memory.get('placement') == 'auto':
-                mem_compare(numad_node_seq, left_node)
+                if numa_memory.get('mode') == 'strict':
+                    mem_compare(numad_node_seq, left_node)
+                elif numa_memory.get('mode') == 'preferred':
+                    mode_nodeset = 'prefer:' + numad_ret
+                    numa_mode_check(mode_nodeset)
+                else:
+                    mode_nodeset = numa_memory.get('mode') + ':' + numad_ret
+                    numa_mode_check(mode_nodeset)
             if vcpu_placement == 'auto':
                 for i in left_node:
                     if qemu_cpu[i]:
-                        raise exceptions.TestFail("cpu usage in node %s is "
-                                                  "not expected" % i)
+                        test.fail("cpu usage in node %s is not expected" % i)
                 cpu_affinity_check(node=numad_node)
 
     finally:


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/LIBVIRTAT-859
https://projects.engineering.redhat.com/browse/LIBVIRTAT-1047

cfg part:
1. Delete the interleave when nodeset=0
2. Change the memory_nodeset = "0-1" instead of "2-3"
3. Change the vcpu_cpuset = "2,4" instead of "0,8"

py part:
When the memory_mode = "preferred" or "interleave", the orignal
checkpoint on memory allocation is not good and exact enough, so the
result will pass or fail according to the host. So I add the exact
checkpoint after communicated with lhuang.

Signed-off-by: Jingjing Shao <jishao@redhat.com>