### PR TITLE
Update device_source_path from test.virtdir to /var/tmp

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
@@ -544,7 +544,7 @@ def run(test, params, env):
     # Get device path.
     device_source_path = ""
     if source_path:
-        device_source_path = test.virtdir
+        device_source_path = "/var/lib/libvirt/images"
 
     # Prepare test environment.
     qemu_config = LibvirtQemuConfig()


### PR DESCRIPTION
since previous one may be interrupted by avocado itself
Signed-off-by: chunfuwen <chwen@redhat.com>