### PR TITLE
Add new cases for net-update testing

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_update.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_update.cfg
@@ -1,45 +1,538 @@
 - virsh.net_update:
     type = virsh_net_update
-    vms = ""
-    main_vm = ""
     start_vm = no
     encode_video_files = "no"
     skip_image_processing = "yes"
     take_regular_screendumps = "no"
     net_update_net_name = "updatenet"
+    use_in_guest = "no"
+    ori_ipv4_range_start = "192.168.100.2"
+    ori_ipv4_range_end = "192.168.100.50"
+    ori_ipv4_host_mac = "52:54:00:5a:a0:8b"
+    ori_ipv4_host_ip = "192.168.100.15"
+    ori_ipv4_host_name = "redhatipv4.redhat.com"
+    ori_ipv6_range_start = "2001:db8:ca2:2:1::10"
+    ori_ipv6_range_end = "2001:db8:ca2:2:1::ff"
+    ori_ipv6_host_id = "00:04:58:fd:e4:15:1b:09:4c:0e:09:af:e4:d3:8c:b8:ca:1e"
+    ori_ipv6_host_name = "redhatipv6.redhat.com"
+    ori_ipv6_host_ip = "2001:db8:ca2:2:1::19"
+    ori_srv_service = "test-name"
+    new_srv_service = "new-service"
+    ori_srv_protocol = "tcp"
+    ori_srv_domain = "test-domain-name"
+    ori_srv_target = "englab.nay.redhat.com"
+    ori_srv_port = "1024"
+    ori_srv_priority = "10"
+    ori_srv_weight = "10"
+    ori_dns_name = "dns-name-1"
+    ori_dns_value = "dns-value-1"
+    new_dns_name = "dns-name-2"
+    new_dns_value = "dns-value-2"
+    ori_dns_hostip = "192.168.100.22"
+    ori_dns_hostname = "dnshostname"
+    ori_dns_hostname2 = "dnshostalias"
     variants:
-        - options_no:
-        - options_config:
-            cmd_options = '--config'
-    variants:
-        - net_active:
+        - normal-test:
+            status_error = "no"
+            variants:
+                - use-in-guest:
+                    no options_config,net_inactive,add..with_ip_dhcp,ip_dhcp_range..default_parent_index
+                    only add-first.ip_dhcp_range,add-first.ip_dhcp_host.ipv4_addr,add..ip_dhcp_range,add..ip_dhcp_host.ipv4_addr,add_delete.forward_interface.macvtap
+                    use_in_guest = "yes"
+                - without-guest:
+                    vms = ""
+                    main_vm = ""
+            variants:
+                - ip_dhcp_opt:
+                    variants:
+                        - default_parent_index:
+                            only ip_dhcp_range.ipv4_addr,ip_dhcp_host.ipv4_addr
+                        - parent_index_set_ipv4:
+                            only ip_dhcp_range.ipv4_addr,ip_dhcp_host.ipv4_addr
+                            no modify
+                            parent_index = 0
+                        - parent_index_set_ipv6:
+                            only ip_dhcp_range.ipv6_addr,ip_dhcp_host.ipv6_addr
+                            parent_index = 1
+                    variants:
+                        - without_ip_dhcp:
+                            no modify,delete,add-last,add-first
+                            only ip_dhcp_range..use-in-guest,ip_dhcp_host.ipv4_addr..use-in-guest,ip_dhcp_host.ipv6_addr..without-guest
+                            without_ip_dhcp = "yes"
+                        - with_ip_dhcp:
+                            without_ip_dhcp = "no"
+                - default_opt:
+                    no ip_dhcp_range,ip_dhcp_host
+            variants:
+                - options_no:
+                - options_current:
+                    only add..dns_txt,delete..dns_txt
+                    cmd_options = "--current"
+                - options_live:
+                    only net_active
+                    cmd_options = "--live"
+                - options_config:
+                    cmd_options = "--config"
+                    check_config_round = 0
+                - options_live_config:
+                    only net_active
+                    cmd_options = "--live --config"
+                    check_config_round = 0
+            variants:
+                - net_active:
+                    net_state = "active"
+                - net_inactive:
+                    net_state = "inactive"
+                - net_state_change:
+                    only add_delete..dns_txt..options_no
+                    net_state = "inactive,active"
+            variants:
+                - dns_oper:
+                    no modify, add-first, add-last
+                    variants:
+                        - dns_host:
+                            no options_config
+                            network_section = "dns-host"
+                        - dns_srv:
+                            no options_config
+                            network_section = "dns-srv"
+                            variants:
+                                - update_service:
+                                    only add
+                                    update_sec = "service"
+                                - for_delete:
+                                    only delete
+                        - dns_txt:
+                            network_section = "dns-txt"
+                            variants:
+                                - update_sec:
+                                    no delete
+                                    update_sec = "name,value"
+                                - for_delete:
+                                    only delete
+                    variants:
+                        - with_dns:
+                            no add..dns_host
+                        - without_dns:
+                            no delete
+                            without_dns = "yes"
+                - portgroup:
+                    network_section = "portgroup"
+                - bridge_t:
+                    network_section = "bridge"
+                - forward:
+                    network_section = "forward"
+                - forward_interface:
+                    network_section = "forward-interface"
+                    variants:
+                        - passthough:
+                            new_forward_iface = "eth4"
+                            forward_mode = "passthrough"
+                        - macvtap:
+                            only add-first,add-last,add_delete
+                            forward_mode = "bridge"
+                            guest_iface_num = 4
+                - ip:
+                    network_section = "ip"
+                - ip_dhcp_range:
+                    network_section = "ip-dhcp-range"
+                    variants:
+                        - ipv4_addr:
+                            ip_version = "ipv4"
+                            start_ip = "192.168.100.100"
+                            end_ip = "192.168.100.200"
+                        - ipv6_addr:
+                            ip_version = "ipv6"
+                            start_ip = "2001:db8:ca2:2::100"
+                            end_ip = "2001:db8:ca2:2::1ff"
+                - ip_dhcp_host:
+                    network_section = "ip-dhcp-host"
+                    variants:
+                        - ipv4_addr:
+                            ip_version = "ipv4"
+                            new_dhcp_host_ip = "192.168.100.53"
+                            new_dhcp_host_mac = "52:54:00:5a:a0:9b"
+                            new_dhcp_host_name = "redhatipv4-2.redhat.com"
+                        - ipv6_addr:
+                            ip_version = "ipv6"
+                            new_dhcp_host_ip = "2001:db8:ca2:2:1::12"
+                            new_dhcp_host_name = "redhatipv6-2.redhat.com"
+                            new_dhcp_host_id = "00:04:58:fd:e4:15:1b:09:4c:0e:09:af:e4:d3:8c:b8:ca:1f"
+            variants:
+                - add_delete:
+                    only net_state_change,forward_interface.macvtap..net_active.options_no
+                    loop_time = 2
+                    update_command = "add,delete"
+                    check_config_round = 1
+                - modify:
+                    update_command = "modify"
+                    variants:
+                        - default:
+                        - ipv4_oper:
+                            only ip_dhcp_host.ipv4_addr.net_active.options_no
+                            variants:
+                                - update_ip_name:
+                                    update_sec = "ip,name"
+                                - update_mac_ip:
+                                    update_sec = "mac,ip"
+                                - update_name_mac:
+                                    update_sec = "name,mac"
+                                - update_ip_without_name:
+                                    update_sec = "ip"
+                                    without_sec = "name"
+                                - update_ip_without_mac:
+                                    update_sec = "ip"
+                                    without_sec = "mac"
+                        - ipv6_oper:
+                            only ip_dhcp_host.ipv6_addr.net_active.options_no
+                            variants:
+                                - update_name:
+                                    update_sec = "name"
+                                    without_sec = "id"
+                                - update_id:
+                                    update_sec = "id"
+                                - update_ip:
+                                    update_sec = "ip"
+                                    without_sec = "id"
+                - delete:
+                    update_command = "delete"
+                    variants:
+                        - default:
+                        - only_mac:
+                            only ip_dhcp_host.ipv4_addr.net_active.options_no
+                            without_sec = "name,ip"
+                            check_without_sec = "mac,name,ip"
+                        - only_name:
+                            only ip_dhcp_host.ipv4_addr.net_active.options_no
+                            without_sec = "mac,ip"
+                            check_without_sec = "mac,name,ip"
+                        - only_ip:
+                            only ip_dhcp_host.ipv4_addr.net_active
+                            without_sec = "mac,name"
+                            check_without_sec = "mac,name,ip"
+                        - only_name_ipv6:
+                            only ip_dhcp_host.ipv6_addr.net_active.options_no
+                            without_sec = "id,ip"
+                        - ip_and_changed_id:
+                            only ip_dhcp_host.ipv6_addr.net_active.options_no
+                            update_sec = "id"
+                            without_sec = "name"
+                        - txt_only_name:
+                            only dns_txt.for_delete.net_active.options_no
+                            without_sec = "value"
+                            check_without_sec = "name,value"
+                        - only_srv_service:
+                            only dns_srv.for_delete.net_active.options_no
+                            without_sec = "protocol,domain,target,port,priority,weight"
+                            check_without_sec = "service,protocol,domain,target,port,priority,weight"
+                        - with_srv_service_protocol:
+                            only dns_srv.for_delete.net_active.options_no
+                            without_sec = "domain,target,port,priority,weight"
+                            check_without_sec = "service,protocol,domain,target,port,priority,weight"
+                        - only_dns_hostip:
+                            only dns_host.net_active.options_no
+                            without_sec = "hostname"
+                - add-last:
+                    only options_no
+                    update_command = "add-last"
+                - add-first:
+                    only options_no
+                    update_command = "add-first"
+                - add:
+                    update_command = "add"
+                    variants:
+                        - default:
+                        - with_same_id:
+                            only ip_dhcp_host.ipv6_addr.net_active.options_no..with_ip_dhcp
+                            update_sec = "ip"
+                            without_sec = "name"
+                        - with_name_ip:
+                            only ip_dhcp_host.ipv4_addr.net_active.options_no..with_ip_dhcp.default_parent_index
+                            update_sec = "name,ip"
+                            without_sec = "mac"
+                        - with_mac_ip:
+                            only ip_dhcp_host.ipv4_addr.net_active.options_no..with_ip_dhcp.default_parent_index
+                            update_sec = "mac,ip"
+                            without_sec = "name"
+                        - update_srv_service:
+                            only dns-srv..net_active.options_no
+                            update_sec = "service"
+        - error_test:
+            status_error = "yes"
+            update_command = "add"
             net_state = "active"
-        - net_inactive:
-            net_state = "inactive"
-    variants:
-        - portgroup:
-            network_section = "portgroup"
-        - bridge_t:
-            network_section = "bridge"
-        - forward:
-            network_section = "forward"
-        - forward_interface:
-            new_forward_iface = "eth4"
-            network_section = "forward-interface"
-        - ip:
-            network_section = "ip"
-        - ip_dhcp_range:
-            network_section = "ip-dhcp-range"
-        - ip_dhcp_host:
-            network_section = "ip-dhcp-host"
-            new_ip_dhcp_host = "192.168.100.153"
-            new_ip_dhcp_mac = "52:54:00:5a:a0:9b"
-    variants:
-        - modify:
-            update_command = "modify"
-        - delete:
-            update_command = "delete"
-        - add-last:
-            update_command = "add-last"
-        - add-first:
-            update_command = "add-first"
+            variants:
+                - interface_duplicate:
+                    network_section = "forward-interface"
+                    forward_mode = "bridge"
+                    update_command = "add-first"
+                    error_type = "interface-duplicate"
+                - dns_oper:
+                    network_section = "dns-txt"
+                    variants:
+                        - delete:
+                            update_command = "delete"
+                            variants:
+                                - without_dns:
+                                    error_type = "dns-mismatch"
+                                    without_dns = "yes"
+                                    cmd_options = "--current"
+                                - options_exclusive:
+                                    error_type = "opt-exclusive"
+                                    variants:
+                                        - live_config_current:
+                                            cmd_options = "--live --config --current"
+                                        - config_current:
+                                            cmd_options = "--config --current"
+                                        - live_current:
+                                            cmd_options = "--live --current"
+                        - inactive_with_live_opt:
+                            net_state = "inactive"
+                            cmd_options = "--live"
+                            error_type = "invalid-state"
+                        - transient_net:
+                            net_state = "transient"
+                            error_type = "transient"
+                            variants:
+                                - options_config:
+                                    cmd_options = "--config"
+                                - options_live_config:
+                                    cmd_options = "--live --config"
+                        - dns_matrix:
+                            variants:
+                                - dns_txt:
+                                - dns_srv:
+                                    network_section = "dns-srv"
+                                - dns_host:
+                                    network_section = "dns-host"
+                            variants:
+                                - modify:
+                                    update_command = "modify"
+                                - dns_disable:
+                                    without_dns_txt = "yes"
+                                    without_dns_srv = "yes"
+                                    without_dns_host = "yes"
+                                    dns_enable = "no"
+                                    error_type = "dns-disable"
+                - ip_dhcp_oper:
+                    variants:
+                        - ip_dhcp_host:
+                            network_section = "ip-dhcp-host"
+                        - ip_dhcp_range:
+                            network_section = "ip-dhcp-range"
+                        - wrong_section:
+                            only wrong_section_name
+                            network_section = "iptest"
+                    variants:
+                        - ipv4_addr:
+                            ip_version = "ipv4"
+                            new_dhcp_host_ip = "192.168.101.153"
+                            new_dhcp_host_name = "redhatipv4-2.redhat.com"
+                            new_dhcp_host_mac = "52:54:00:5a:a0:9b"
+                            start_ip = "192.168.101.100"
+                            end_ip = "192.168.101.200"
+                            variants:
+                                - wrong_section_name:
+                                    only wrong_section
+                                    error_type = "wrong-section-name"
+                                - wrong_command_name:
+                                    error_type = "wrong-command-name"
+                                    update_command = "test"
+                                - add_multi-hosts:
+                                    error_type = "multi-hosts"
+                                    parent_index = 2
+                                    cmd_options = "--live --config"
+                                - index-mismatch:
+                                    error_type = "index-mismatch"
+                                    parent_index = 1
+                                    variants:
+                                        - add-first:
+                                            only ip_dhcp_host
+                                            update_command = "add-first"
+                                        - add:
+                                            only ip_dhcp_range
+                                            update_command = "add"
+                                - delete_host_mismatch:
+                                    only ip_dhcp_host
+                                    error_type = "host-mismatch"
+                                    update_sec = "mac,ip,name"
+                                    variants:
+                                        - wrong_mac:
+                                            loop_time = 5
+                                            new_dhcp_host_ip = "192.168.100.16,192.168.100.17,192.168.100.18,192.168.100.18,192.168.100.19"
+                                            new_dhcp_host_name = "foo1.redhat.com,foo2.redhat.com,foo3.redhat.com,foo1.redhat.com,foo1.redhat.com"
+                                            new_dhcp_host_mac = "52:54:00:5a:a0:65,52:54:00:5a:a0:66,52:54:00:5a:a0:67,52:54:00:5a:a0:65,52:54:00:5a:a0:65"
+                                            update_command = "add-last,add,add-first,delete,delete"
+                                            status_error = "no,no,no,yes,yes"
+                                            check_sec = "mac"
+                                        - wrong_name:
+                                            update_command = "delete"
+                                            update_sec = "name"
+                                            new_dhcp_host_name = "wrong.redhat.com"
+                                            check_without_sec = "mac,ip,name"
+                                        - wrong_ip:
+                                            update_command = "delete"
+                                            update_sec = "ip"
+                                            new_dhcp_host_name = "192.168.100.22"
+                                            check_without_sec = "mac,ip,name"
+                                - delete_range_mismatch:
+                                    only ip_dhcp_range
+                                    error_type = "range-mismatch"
+                                    update_command = "delete"
+                                    start_ip = "192.168.100.3"
+                                    end_ip = "192.168.100.50"
+                                - add_range_duplicate:
+                                    only ip_dhcp_range
+                                    error_type = "range-duplicate"
+                                    start_ip = "192.168.100.2"
+                                    end_ip = "192.168.100.50"
+                                - add_out_of_range:
+                                    only ip_dhcp_range
+                                    error_type = "out-of-range"
+                                    start_ip = "192.168.200.2"
+                                    end_ip = "192.168.200.50"
+                                - add_range_reverse:
+                                    only ip_dhcp_range
+                                    error_type = "range-reverse"
+                                    start_ip = "192.168.100.200"
+                                    end_ip = "192.168.100.100"
+                                - add_range_no_end:
+                                    only ip_dhcp_range
+                                    error_type = "range-no-end"
+                                    start_ip = "192.168.100.200"
+                                    end_ip = ""
+                                - modify_no_match_item:
+                                    only ip_dhcp_host
+                                    error_type = "no-match-item"
+                                    update_command = "modify"
+                                    update_sec = "mac,ip,name"
+                                - with_ip_only:
+                                    only ip_dhcp_host
+                                    error_type = "host-no-name-mac"
+                                    update_sec = "ip"
+                                    without_sec = "name,mac"
+                                    variants:
+                                        - modify:
+                                            update_command = "modify"
+                                        - add:
+                                            update_command = "add"
+                                - without_ip:
+                                    only ip_dhcp_host
+                                    error_type = "host-no-ip"
+                                    without_sec = "ip"
+                                    variants:
+                                        - modify:
+                                            update_command = "modify"
+                                            update_sec = "mac"
+                                        - add:
+                                            update_command = "add"
+                                            update_sec = "mac,name"
+                                - add_with_same_mac:
+                                    only ip_dhcp_host
+                                    error_type = "host-duplicate"
+                                    update_sec = "ip"
+                                    without_sec = "name"
+                                - add_with_same_ip:
+                                    only ip_dhcp_host
+                                    error_type = "host-duplicate"
+                                    update_sec = "mac"
+                                    without_sec = "name"
+                                - add_with_same_name:
+                                    only ip_dhcp_host
+                                    error_type = "host-duplicate"
+                                    update_sec = "ip,mac"
+                                - add_with_mac_only:
+                                    only ip_dhcp_host
+                                    error_type = "host-no-ip"
+                                    update_sec = "mac"
+                                    without_sec = "name,ip"
+                                - add_with_name_only:
+                                    only ip_dhcp_host
+                                    error_type = "host-no-ip"
+                                    update_sec = "name"
+                                    without_sec = "mac,ip"
+                        - ipv6_addr:
+                            ip_version = "ipv6"
+                            new_dhcp_host_ip = "2001:db8:ca2:3:1::12"
+                            new_dhcp_host_id = "00:04:58:fd:e4:15:1b:09:4c:0e:09:af:e4:d3:8c:b8:ca:1f"
+                            new_dhcp_host_name = "redhatipv6-2.redhat.com"
+                            start_ip = "2001:db8:ca2:3:2::10"
+                            end_ip = "2001:db8:ca2:3:2::ff"
+                            variants:
+                                - add_multi-hosts:
+                                    error_type = "multi-hosts"
+                                    parent_index = 3
+                                    cmd_options = "--live --config"
+                                - index-mismatch:
+                                    error_type = "index-mismatch"
+                                    variants:
+                                        - add-first:
+                                            update_command = "add-first"
+                                            parent_index = 2
+                                        - delete:
+                                            only ip_dhcp_range
+                                            update_command = "delete"
+                                - delete_range_mismatch:
+                                    only ip_dhcp_range
+                                    parent_index = 1
+                                    error_type = "range-mismatch"
+                                    update_command = "delete"
+                                    start_ip = "2001:db8:ca2:2:1::11"
+                                    end_ip = "2001:db8:ca2:2:1::ff"
+                                - add_range_duplicate:
+                                    only ip_dhcp_range
+                                    parent_index = 1
+                                    error_type = "range-duplicate"
+                                    start_ip = "2001:db8:ca2:2:1::10"
+                                    end_ip = "2001:db8:ca2:2:1::ff"
+                                - add_out_of_range:
+                                    only ip_dhcp_range
+                                    parent_index = 1
+                                    error_type = "out-of-range"
+                                    start_ip = "2001:db8:ca2:7:1::10"
+                                    end_ip = "2001:db8:ca2:7:1::ff"
+                                - add_range_reverse:
+                                    only ip_dhcp_range
+                                    parent_index = 1
+                                    error_type = "range-reverse"
+                                    start_ip = "2001:db8:ca2:2:2::ff"
+                                    end_ip = "2001:db8:ca2:2:2::10"
+                                - modify_with_id_match:
+                                    only ip_dhcp_host
+                                    parent_index = 1
+                                    new_dhcp_host_ip = "2001:db8:ca2:2:1::12"
+                                    error_type = "no-match-item"
+                                    update_command = "modify"
+                                    update_sec = "name,ip"
+                                - modify_no_match_item:
+                                    only ip_dhcp_host
+                                    parent_index = 1
+                                    new_dhcp_host_ip = "2001:db8:ca2:2:1::12"
+                                    error_type = "no-match-item"
+                                    update_command = "modify"
+                                    update_sec = "id,name,ip"
+                                - add_with_same_name:
+                                    only ip_dhcp_host
+                                    parent_index = 1
+                                    new_dhcp_host_ip = "2001:db8:ca2:2:1::12"
+                                    error_type = "host-duplicate"
+                                    update_sec = "ip"
+                                    without_sec = "id"
+                                - add_with_same_ip:
+                                    only ip_dhcp_host
+                                    parent_index = 1
+                                    error_type = "host-duplicate"
+                                    update_sec = "id,name"
+                                - delete_with_id:
+                                    only ip_dhcp_host
+                                    parent_index = 1
+                                    error_type = "only-id"
+                                    update_command = "delete"
+                                    without_sec = "name,ip"
+                                - delete_with_name_ip:
+                                    only ip_dhcp_host
+                                    parent_index = 1
+                                    error_type = "host-mismatch"
+                                    update_command = "delete"
+                                    update_sec = "ip"
+                                    without_sec = "id"

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_update.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_update.py
@@ -2,20 +2,230 @@ import os
 import logging
 import re
 import tempfile
+import time
+
+from avocado.utils import process
 
 from virttest import data_dir
 from virttest import virsh
+from virttest import utils_net
 from virttest.libvirt_xml import network_xml
 from virttest.libvirt_xml import xcepts
+from virttest.libvirt_xml import vm_xml
+from virttest.compat_52lts import results_stdout_52lts
 
 
 def run(test, params, env):
 
+    global flag_list, flag_list_abs, update_sec, without_sec
+    global check_sec, check_without_sec, newxml
+
+    # Basic network params
     net_name = params.get("net_update_net_name", "updatenet")
-    net_section = params.get("network_section", "ip-dhcp-range")
+    net_section = params.get("network_section")
     update_command = params.get("update_command", "add-last")
     options = params.get("cmd_options", "")
     net_state = params.get("net_state")
+    use_in_guest = params.get("use_in_guest")
+    iface_type = params.get("iface_type", "network")
+    ip_version = params.get("ip_version", "ipv4")
+    new_start_ip = params.get("start_ip")
+    new_end_ip = params.get("end_ip")
+    parent_index = params.get("parent_index")
+    status_error = params.get("status_error", "no")
+
+    # dhcp host test
+    new_dhcp_host_ip = params.get("new_dhcp_host_ip")
+    new_dhcp_host_id = params.get("new_dhcp_host_id")
+    new_dhcp_host_name = params.get("new_dhcp_host_name")
+    new_dhcp_host_mac = params.get("new_dhcp_host_mac")
+
+    # ipv4 range/host test
+    ipv4_range_start = params.get("ori_ipv4_range_start")
+    ipv4_range_end = params.get("ori_ipv4_range_end")
+    ipv4_host_mac = params.get("ori_ipv4_host_mac")
+    ipv4_host_ip = params.get("ori_ipv4_host_ip")
+    ipv4_host_name = params.get("ori_ipv4_host_name")
+
+    # ipv6 range/host test
+    ipv6_range_start = params.get("ori_ipv6_range_start")
+    ipv6_range_end = params.get("ori_ipv6_range_end")
+    ipv6_host_id = params.get("ori_ipv6_host_id")
+    ipv6_host_name = params.get("ori_ipv6_host_name")
+    ipv6_host_ip = params.get("ori_ipv6_host_ip")
+
+    # dns test
+    dns_name = params.get("ori_dns_name")
+    dns_value = params.get("ori_dns_value")
+    new_dns_name = params.get("new_dns_name")
+    new_dns_value = params.get("new_dns_value")
+
+    # srv test
+    srv_service = params.get("ori_srv_service")
+    srv_protocol = params.get("ori_srv_protocol")
+    srv_domain = params.get("ori_srv_domain")
+    srv_target = params.get("ori_srv_target")
+    srv_port = params.get("ori_srv_port")
+    srv_priority = params.get("ori_srv_priority")
+    srv_weight = params.get("ori_srv_weight")
+    new_srv_service = params.get("new_srv_service")
+    new_srv_protocol = params.get("new_srv_protocol")
+    new_srv_domain = params.get("new_srv_domain")
+    new_srv_target = params.get("new_srv_target")
+    new_srv_port = params.get("new_srv_port")
+    new_srv_priority = params.get("new_srv_priority")
+    new_srv_weight = params.get("new_srv_weight")
+
+    # dns host test
+    dns_hostip = params.get("ori_dns_hostip")
+    dns_hostname = params.get("ori_dns_hostname")
+    dns_hostname2 = params.get("ori_dns_hostname2")
+
+    # setting for without part
+    without_ip_dhcp = params.get("without_ip_dhcp", "no")
+    without_dns = params.get("without_dns", "no")
+    without_dns_host = params.get("without_dns_host", "no")
+    without_dns_txt = params.get("without_dns_txt", "no")
+    without_dns_srv = params.get("without_dns_srv", "no")
+
+    # setting for update/check/without section
+    update_sec = params.get("update_sec")
+    check_sec = params.get("check_sec")
+    without_sec = params.get("without_sec")
+    check_without_sec = params.get("check_without_sec")
+
+    # forward test
+    forward_mode = params.get("forward_mode")
+    forward_iface = params.get("forward_iface", "eth2")
+
+    # other params
+    error_type = params.get("error_type", "")
+    vm_name = params.get("main_vm")
+    loop_time = int(params.get("loop_time", 1))
+    check_config_round = params.get("check_config_round", -1)
+    ipv4_host_id = ipv6_host_mac = ""
+    dns_enable = params.get("dns_enable", "yes")
+    guest_iface_num = int(params.get("guest_iface_num", 1))
+    newxml = ""
+
+    def get_hostfile():
+        """
+        Get the content of hostfile
+        """
+        logging.info("Checking network hostfile...")
+        hostfile = "/var/lib/libvirt/dnsmasq/%s.hostsfile" % net_name
+        with open(hostfile) as hostfile_d:
+            hostfile = hostfile_d.readlines()
+        return hostfile
+
+    def find_config(check_file, need_find):
+        """
+        Find configure in check_file
+
+        :param check_file: The file that will check
+        :param need_find: If need to find the item in check_file, Boolean
+        """
+        def _find_config(check_func):
+            def __find_config(*args, **kwargs):
+                logging.info("Checking content of %s", check_file)
+                ret = False
+                item = None
+                with open(check_file) as checkfile_d:
+                    while True:
+                        check_line = checkfile_d.readline()
+                        if not check_line:
+                            break
+                        (ret, item) = check_func(check_line, *args, **kwargs)
+                        if ret:
+                            break
+                if not ret:
+                    if need_find:
+                        test.fail("Fail to find %s in %s" % (item, check_file))
+                    else:
+                        logging.info("Can not find %s in %s as expected" % (item, check_file))
+            return __find_config
+        return _find_config
+
+    conf_file = "/var/lib/libvirt/dnsmasq/%s.conf" % net_name
+
+    @find_config(conf_file, True)
+    def check_item(check_line, item):
+        """
+        Check if the item in config file
+        """
+        if item in check_line:
+            logging.info("Find %s in %s", item, conf_file)
+            return (True, item)
+        else:
+            return (False, item)
+
+    host_file = "/var/lib/libvirt/dnsmasq/%s.addnhosts" % net_name
+
+    @find_config(host_file, True)
+    def check_host(check_line, item):
+        """
+        Check if the item in host_file
+        """
+        if re.search(item, check_line):
+            logging.info("Find %s in %s", item, host_file)
+            return (True, item)
+        else:
+            return (False, item)
+
+    @find_config(conf_file, False)
+    def check_item_absent(check_line, item):
+        """
+        Check if the item not in config file
+        """
+        if item in check_line:
+            test.fail("Find %s in %s" % (item, conf_file))
+        else:
+            return (False, item)
+
+    @find_config(host_file, False)
+    def check_host_absent(check_line, item):
+        """
+        Check if the item not in host_file
+        """
+        if re.search(item, check_line):
+            test.fail("Find %s in %s" % (item, host_file))
+        else:
+            return (False, item)
+
+    def section_update(ori_pre, new_pre):
+        """
+        Deal with update section and without section in func
+
+        :param ori_pre: prefix of original section parameter name
+        :param new_pre: prefix of new section parameter name
+        """
+        global flag_list, flag_list_abs, update_sec, without_sec
+        global check_sec, check_without_sec, newxml
+
+        if update_sec:
+            for sec in update_sec.split(","):
+                newxml = newxml.replace(names[ori_pre+sec],
+                                        names[new_pre+sec])
+            if update_command != "delete":
+                check_sec = update_sec
+        if without_sec:
+            for sec_no in without_sec.split(","):
+                newxml = re.sub(sec_no+"=\".*?\"", "", newxml)
+            if update_command == "modify":
+                check_without_sec = without_sec
+        if check_sec:
+            for c_sec in check_sec.split(","):
+                flag_list.append(names[new_pre+c_sec])
+        if check_without_sec:
+            for c_sec_no in check_without_sec.split(","):
+                flag_list_abs.append(names[ori_pre+c_sec_no])
+
+    dns_host_xml = """
+<host ip='%s'>
+ <hostname>%s</hostname>
+ <hostname>%s</hostname>
+</host>
+""" % (dns_hostip, dns_hostname, dns_hostname2)
 
     virtual_net = """
 <network>
@@ -23,14 +233,31 @@ def run(test, params, env):
   <forward mode='nat'/>
   <bridge name='%s' stp='on' delay='0' />
   <mac address='52:54:00:03:78:6c'/>
+  <dns enable='%s'>
+      <txt name='%s' value='%s'/>
+      <srv service='%s' protocol='%s' domain='%s' target='%s' port='%s' priority='%s' weight='%s'/>
+      %s
+  </dns>
   <ip address='192.168.100.1' netmask='255.255.255.0'>
     <dhcp>
-      <range start='192.168.100.2' end='192.168.100.254' />
-      <host mac='52:54:00:5a:a0:8b' ip='192.168.100.152' />
+      <range start='%s' end='%s' />
+      <host mac='%s' ip='%s' name='%s' />
     </dhcp>
   </ip>
+  <ip family='ipv6' address='2001:db8:ca2:2::1' prefix='64'>
+    <dhcp>
+      <range start='%s' end='%s'/>
+      <host id='%s' name='%s' ip='%s'/>
+    </dhcp>
+  </ip>
+  <route family='ipv6' address='2001:db8:ca2:2::' prefix='64' gateway='2001:db8:ca2:2::4'/>
+  <ip address='192.168.101.1' netmask='255.255.255.0'/>
+  <ip family='ipv6' address='2001:db8:ca2:3::1' prefix='64' />
 </network>
-""" % (net_name, net_name)
+""" % (net_name, net_name, dns_enable, dns_name, dns_value, srv_service, srv_protocol,
+       srv_domain, srv_target, srv_port, srv_priority, srv_weight, dns_host_xml,
+       ipv4_range_start, ipv4_range_end, ipv4_host_mac, ipv4_host_ip, ipv4_host_name,
+       ipv6_range_start, ipv6_range_end, ipv6_host_id, ipv6_host_name, ipv6_host_ip)
 
     port_group = """
 <portgroup name='engineering' default='no'>
@@ -43,143 +270,599 @@ def run(test, params, env):
   </bandwidth>
 </portgroup>
 """
-    try:
-        test_xml = network_xml.NetworkXML(network_name=net_name)
-        test_xml.xml = virtual_net
-        if net_section == "portgroup":
-            portgroup_xml = network_xml.PortgroupXML()
-            portgroup_xml.xml = port_group
-            test_xml.portgroup = portgroup_xml
-        elif net_section == "forward-interface":
-            test_xml.forward = {'mode': 'passthrough'}
-            test_xml.forward_interface = [{'dev': 'eth2'}]
-            del test_xml.bridge
-            del test_xml.mac
-            del test_xml.ip
-        test_xml.define()
-        if net_state == "active":
-            test_xml.start()
-        test_xml.debug_xml()
-        virsh.net_dumpxml(net_name)
-    except xcepts.LibvirtXMLError as detail:
-        test.error("Failed to define a test network.\n"
-                   "Detail: %s." % detail)
+
+    if use_in_guest == "yes":
+        vm = env.get_vm(vm_name)
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        vmxml_backup = vmxml.copy()
 
     try:
-        # Get a tmp_dir.
-        tmp_dir = data_dir.get_tmp_dir()
+        for loop in range(loop_time):
+            if loop_time > 1:
+                logging.info("Round %s:", loop+1)
+                update_command = params.get("update_command").split(",")[loop]
+                if net_section == "ip-dhcp-host":
+                    new_dhcp_host_ip = params.get("new_dhcp_host_ip").split(",")[loop]
+                    new_dhcp_host_name = params.get("new_dhcp_host_name").split(",")[loop]
+                    new_dhcp_host_mac = params.get("new_dhcp_host_mac").split(",")[loop]
+                    status_error = params.get("status_error").split(",")[loop]
+                elif net_section == "dns-txt":
+                    net_state = params.get("net_state").split(",")[loop]
 
-        # Write new xml into a tempfile
-        tmp_file = tempfile.NamedTemporaryFile(prefix=("new_xml_"),
-                                               dir=tmp_dir)
-        xmlfile = tmp_file.name
-        tmp_file.close()
+            # Get a tmp_dir.
+            tmp_dir = data_dir.get_tmp_dir()
 
-        element = "/%s" % net_section.replace('-', '/')
-        section_xml = test_xml.get_section_string(xpath=element)
+            # Write new xml into a tempfile
+            tmp_file = tempfile.NamedTemporaryFile(prefix=("new_xml_"),
+                                                   dir=tmp_dir)
+            xmlfile = tmp_file.name
+            tmp_file.close()
 
-        flag_list = []
-        if update_command == "delete":
-            newxml = section_xml
-        else:
-            if net_section == "bridge":
-                new_bridge_name = net_name + "_new"
-                flag_list.append(new_bridge_name)
-                newxml = section_xml.replace(net_name, new_bridge_name)
-                logging.info("The new bridge xml is %s", newxml)
+            # Generate testxml
+            test_xml = network_xml.NetworkXML(network_name=net_name)
+            test_xml.xml = virtual_net
 
-            elif net_section == "forward":
-                new_mode = "route"
-                flag_list.append(new_mode)
-                newxml = section_xml.replace("nat", new_mode)
-                logging.info("The new forward xml is %s", newxml)
+            names = locals()
 
-            elif net_section == "ip":
-                new_netmask = "255.255.0.0"
-                flag_list.append(new_netmask)
-                newxml = section_xml.replace("255.255.255.0", new_netmask)
-                logging.info("The new xml of ip section is %s", newxml)
-
-            elif net_section == "ip-dhcp-range":
-                new_end_ip = "192.168.100.253"
-                flag_list.append(new_end_ip)
-                newxml = section_xml.replace("192.168.100.254", new_end_ip)
-                logging.info("The new xml of ip-dhcp-range is %s", newxml)
-            elif net_section == "portgroup":
-                new_inbound_average = "2000"
-                flag_list.append(new_inbound_average)
-                newxml = section_xml.replace("1000", new_inbound_average)
-                newxml = newxml.replace("no", "yes")
-                flag_list.append("yes")
-                if update_command in ['add-first', 'add-last']:
-                    newxml = newxml.replace("engineering", "sales")
-                    flag_list.append("sales")
-                logging.info("The new xml of portgroup is %s", newxml)
+            if net_section == "portgroup":
+                portgroup_xml = network_xml.PortgroupXML()
+                portgroup_xml.xml = port_group
+                test_xml.portgroup = portgroup_xml
             elif net_section == "forward-interface":
-                new_forward_iface = params.get("new_forward_iface", "eth4")
-                flag_list.append(new_forward_iface)
-                newxml = section_xml.replace("eth2", new_forward_iface)
-                logging.info("The new xml of forward-interface is %s", newxml)
-            elif net_section == "ip-dhcp-host":
-                new_ip_dhcp_host = params.get("new_ip_dhcp_host",
-                                              "192.168.100.153")
-                flag_list.append(new_ip_dhcp_host)
-                newxml = section_xml.replace("192.168.100.152",
-                                             new_ip_dhcp_host)
-                if update_command in ['add-first', 'add-last']:
-                    new_ip_dhcp_mac = params.get("new_ip_dhcp_mac",
-                                                 "52:54:00:5a:a0:9b")
-                    newxml = newxml.replace("52:54:00:5a:a0:8b",
-                                            new_ip_dhcp_mac)
-                    flag_list.append(new_ip_dhcp_mac)
-                logging.info("The new xml of forward-interface is %s", newxml)
-            else:
-                test.fail("Unknown network section")
+                if forward_mode == "bridge":
+                    forward_iface = utils_net.get_net_if(state="UP")[0]
+                test_xml.forward = {'mode': forward_mode}
+                test_xml.forward_interface = [{'dev': forward_iface}]
+                del test_xml.bridge
+                del test_xml.mac
+                for ip_num in range(4):
+                    del test_xml.ip
+                del test_xml.routes
+                del test_xml.dns
 
-        fd = open(xmlfile, 'w')
-        fd.write(newxml)
-        fd.close()
-
-        cmd_result = virsh.net_update(net_name,
-                                      update_command,
-                                      net_section,
-                                      xmlfile, options, debug=True)
-
-        if cmd_result.exit_status:
-            err = cmd_result.stderr.strip()
-            if re.search("not supported", err):
-                test.cancel("Skip the test: %s" % err)
-            else:
-                test.fail("Failed to execute "
-                          "virsh net-update command")
-
-        # Check the actual xml
-        virsh_option = ""
-        if options == "--config":
-            virsh_option = "--inactive"
-        cmd_result = virsh.net_dumpxml(net_name, virsh_option)
-        actual_net_xml = cmd_result.stdout.strip()
-        logging.info("After net-update, the actual net xml is %s",
-                     actual_net_xml)
-
-        if update_command == "delete":
-            new_xml_obj = network_xml.NetworkXML.new_from_net_dumpxml(
-                net_name, extra=virsh_option)
+            section_index = 0
+            if ip_version == "ipv6":
+                section_index = 1
+            element = "/%s" % net_section.replace('-', '/')
             try:
-                section_str = new_xml_obj.get_section_string(xpath=element)
+                section_xml = test_xml.get_section_string(xpath=element, index=section_index)
             except xcepts.LibvirtXMLNotFoundError:
-                section_str = None
-            if section_str is not None:
-                test.fail("The actual net xml is not expected,"
-                          "element still exists")
+                newxml = section_xml = test_xml.get_section_string(xpath="/ip/dhcp/range")
 
-        else:
-            for flag_string in flag_list:
-                if not re.search(flag_string, actual_net_xml):
-                    test.fail("The actual net xml failed to update")
+            newxml = section_xml
+            logging.debug("section xml is %s", newxml)
+
+            flag_list = []
+            flag_list_abs = []
+
+            if (update_command == "delete" and
+                    error_type not in ["host-mismatch", "range-mismatch"] and
+                    not without_sec and not update_sec):
+                logging.info("The delete xml is %s", newxml)
+            else:
+                if net_section == "bridge":
+                    new_bridge_name = net_name + "_new"
+                    flag_list.append(new_bridge_name)
+                    newxml = section_xml.replace(net_name, new_bridge_name)
+                    logging.info("The new bridge xml is %s", newxml)
+                elif net_section == "forward":
+                    new_mode = "route"
+                    flag_list.append(new_mode)
+                    newxml = section_xml.replace("nat", new_mode)
+                    logging.info("The new forward xml is %s", newxml)
+                elif net_section == "ip":
+                    new_netmask = "255.255.0.0"
+                    flag_list.append(new_netmask)
+                    newxml = section_xml.replace("255.255.255.0", new_netmask)
+                elif net_section == "ip-dhcp-range":
+                    newxml = section_xml.replace(names[ip_version+"_range_start"], new_start_ip)
+                    newxml = newxml.replace(names[ip_version+"_range_end"], new_end_ip)
+                    for location in ["end", "start"]:
+                        if names["new_"+location+"_ip"] == "":
+                            newxml = newxml.replace(location+"=\"\"", "")
+                        else:
+                            flag_list.append(names["new_"+location+"_ip"])
+                elif net_section == "portgroup":
+                    new_inbound_average = "2000"
+                    flag_list.append(new_inbound_average)
+                    newxml = section_xml.replace("1000", new_inbound_average)
+                    newxml = newxml.replace("default=\"no\"", "default=\"yes\"")
+                    flag_list.append("default=('|\")yes")
+                    if update_command in ['add-first', 'add-last', 'add']:
+                        newxml = newxml.replace("engineering", "sales")
+                        flag_list.append("sales")
+                elif net_section == "forward-interface":
+                    new_forward_iface = params.get("new_forward_iface")
+                    if error_type != "interface-duplicate":
+                        find_iface = 0
+                        if not new_forward_iface and forward_mode == "bridge":
+                            new_iface_list = utils_net.get_net_if(qdisc="(mq|pfifo_fast)",
+                                                                  state="(UP|DOWN)",
+                                                                  optional="MULTICAST,UP")
+                            logging.info("new_iface_list is %s", new_iface_list)
+                            for iface in new_iface_list:
+                                if iface[0] != forward_iface:
+                                    new_forward_iface = iface[0]
+                                    find_iface = 1
+                                    break
+                            if not find_iface:
+                                test.cancel("Can not find another physical interface to attach")
+                    else:
+                        new_forward_iface = forward_iface
+                    flag_list.append(new_forward_iface)
+                    newxml = section_xml.replace(forward_iface, new_forward_iface)
+                elif net_section == "ip-dhcp-host":
+                    if (update_sec is None and
+                            update_command not in ['modify', 'delete']):
+                        if ip_version == "ipv4":
+                            update_sec = "ip,mac,name"
+                        elif ip_version == "ipv6":
+                            update_sec = "ip,id,name"
+                    section_update(ip_version+"_host_", "new_dhcp_host_")
+                elif net_section == "dns-txt":
+                    section_update("dns_", "new_dns_")
+                elif net_section == "dns-srv":
+                    section_update("srv_", "new_srv_")
+                elif net_section == "dns-host":
+                    if without_sec == "hostname":
+                        newxml = re.sub("<hostname>.*</hostname>\n", "", newxml)
+                    flag_list.append("ip=.*?"+dns_hostip)
+                    flag_list.append(dns_hostname)
+                    flag_list.append(dns_hostname2)
+                # for negative test may have net_section do not match issues
+                elif status_error == "no":
+                    test.fail("Unknown network section")
+                logging.info("The new xml of %s is %s", net_section, newxml)
+
+            with open(xmlfile, 'w') as xmlfile_d:
+                xmlfile_d.write(newxml)
+
+            if without_ip_dhcp == "yes":
+                test_xml.del_element(element="/ip/dhcp")
+                test_xml.del_element(element="/ip/dhcp")
+
+            if without_dns == "yes":
+                test_xml.del_element(element='/dns')
+            if without_dns_host == "yes":
+                test_xml.del_element(element='/dns/host')
+            if without_dns_txt == "yes":
+                test_xml.del_element(element='/dns/txt')
+            if without_dns_srv == "yes":
+                test_xml.del_element(element='/dns/srv')
+            # Only do net define/start in first loop
+
+            if (net_section == "ip-dhcp-range" and use_in_guest == "yes" and
+                    without_ip_dhcp == "no"):
+                test_xml.del_element(element="/ip/dhcp", index=section_index)
+
+            if loop == 0:
+                try:
+                    # Define and start network
+                    test_xml.debug_xml()
+                    test_xml.define()
+                    ori_net_xml = virsh.net_dumpxml(net_name).stdout.strip()
+                    if "ipv6" in ori_net_xml:
+                        host_ifaces = utils_net.get_net_if(state="UP")
+                        for host_iface in host_ifaces:
+                            process.run("echo 2 > /proc/sys/net/ipv6/conf/%s/accept_ra"
+                                        % host_iface, shell=True)
+                            process.run("cat /proc/sys/net/ipv6/conf/%s/accept_ra"
+                                        % host_iface)
+                    if net_state == "active" or net_state == "transient":
+                        test_xml.start()
+                    if net_state == "transient":
+                        test_xml.del_defined()
+                    list_result = virsh.net_list("--all --name").stdout.strip()
+                    if net_name not in list_result:
+                        test.fail("Can not find %s in net-list" % net_name)
+                except xcepts.LibvirtXMLError as detail:
+                    test.error("Failed to define a test network.\n"
+                               "Detail: %s." % detail)
+            else:
+                # setting net status for following loops
+                if net_state == "active":
+                    test_xml.set_active(True)
+                elif net_state == "inactive":
+                    test_xml.set_active(False)
+
+            # get hostfile before update
+            if without_ip_dhcp == "yes" and net_state == "active":
+                hostfile_before = get_hostfile()
+                if hostfile_before != []:
+                    test.fail("hostfile is not empty before update: %s"
+                              % hostfile_before)
+                logging.info("hostfile is empty before update")
+
+            # Get dnsmasq pid before update
+            check_dnsmasq = ((update_command == "add" or update_command == "delete") and
+                             net_section == "ip-dhcp-range" and status_error == "no" and
+                             net_state == "active" and options != "--config")
+            if check_dnsmasq:
+                cmd = "ps aux|grep dnsmasq|grep -v grep|grep %s|awk '{print $2}'" % net_name
+                pid_list_bef = results_stdout_52lts(process.run(cmd, shell=True)).strip().split('\n')
+
+            if parent_index:
+                options += " --parent-index %s" % parent_index
+
+            # Check config before update
+            if net_state == "active":
+                dns_txt = dns_srv = dns_host_str = None
+                try:
+                    dns_txt = test_xml.get_section_string(xpath="/dns/txt")
+                    dns_srv = test_xml.get_section_string(xpath="/dns/srv")
+                    dns_host_str = test_xml.get_section_string(xpath="/dns/host")
+                except xcepts.LibvirtXMLNotFoundError:
+                    pass
+
+                txt_record = "txt-record=%s,%s" % (dns_name, dns_value)
+                srv_host = "srv-host=_%s._%s.%s,%s,%s,%s,%s" % (srv_service, srv_protocol,
+                                                                srv_domain, srv_target, srv_port,
+                                                                srv_priority, srv_weight)
+                hostline = "%s.*%s.*%s" % (dns_hostip, dns_hostname, dns_hostname2)
+                if dns_txt:
+                    check_item(txt_record)
+                if dns_srv:
+                    check_item(srv_host)
+                if dns_host_str:
+                    check_host(hostline)
+
+            # Do net-update operation
+            cmd_result = virsh.net_update(net_name,
+                                          update_command,
+                                          net_section,
+                                          xmlfile, options, debug=True)
+
+            if cmd_result.exit_status:
+                err = cmd_result.stderr.strip()
+                if re.search("not supported", err):
+                    test.cancel("Skip the test: %s" % err)
+                elif status_error == "yes":
+                    # index-mismatch error info and judgement
+                    index_err1 = "the address family of a host entry IP must match the" + \
+                                 " address family of the dhcp element's parent"
+                    index_err2 = "XML error: Invalid to specify MAC address.* in network" + \
+                                 ".* IPv6 static host definition"
+                    index_err3 = "mismatch of address family in range.* for network"
+                    mismatch_expect = (error_type == "index-mismatch" and
+                                       (re.search(index_err1, err) or
+                                        re.search(index_err2, err) or
+                                        re.search(index_err3, err)))
+                    err_dic = {}
+                    # multi-host error info
+                    err_dic["multi-hosts"] = "dhcp is supported only for a single.*" + \
+                                             " address on each network"
+                    # range-mismatch error info
+                    err_dic["range-mismatch"] = "couldn't locate a matching dhcp " + \
+                                                "range entry in network "
+                    # host-mismatch error info
+                    err_dic["host-mismatch"] = "couldn't locate a matching dhcp " + \
+                                               "host entry in network "
+                    # dns-mismatch error info
+                    err_dic["dns-mismatch"] = "couldn't locate a matching DNS TXT " + \
+                                              "record in network "
+                    # range-duplicate error info
+                    err_dic["range-duplicate"] = "there is an existing dhcp range" + \
+                                                 " entry in network.* that matches"
+                    # host-duplicate error info
+                    err_dic["host-duplicate"] = "there is an existing dhcp host" + \
+                                                " entry in network.* that matches"
+                    # out_of_range error info
+                    err_dic["out-of-range"] = "range.* is not entirely within network"
+                    # no end for range error
+                    err_dic["range-no-end"] = "Missing 'end' attribute in dhcp " + \
+                                              "range for network"
+                    # no match item for host modify err
+                    err_dic["no-match-item"] = "couldn't locate an existing dhcp" + \
+                                               " host entry with.* in network"
+                    # no host name and mac for modify err
+                    err_dic["host-no-name-mac"] = "Static host definition in IPv4 network" + \
+                                                  ".* must have mac or name attribute"
+                    # no host ip for modify err
+                    err_dic["host-no-ip"] = "Missing IP address in static host " + \
+                                            "definition for network"
+                    # wrong command name
+                    err_dic["wrong-command-name"] = "unrecognized command name"
+                    # wrong section name
+                    err_dic["wrong-section-name"] = "unrecognized section name"
+                    # delete with only id
+                    err_dic["only-id"] = "At least one of name, mac, or ip attribute must be" + \
+                                         " specified for static host definition in network"
+                    # options exclusive
+                    err_dic["opt-exclusive"] = "Options --current and.* are mutually exclusive"
+                    # range_reverse error info
+                    if ip_version == "ipv4":
+                        err_dic["range-reverse"] = "range.* is reversed"
+                    elif ip_version == "ipv6":
+                        err_dic["range-reverse"] = "range.*start larger than end"
+                    # --live with inactive net
+                    err_dic["invalid-state"] = "network is not running"
+                    err_dic["transient"] = "cannot change persistent config of a transient network"
+                    err_dic["dns-disable"] = "Extra data in disabled network"
+                    err_dic["interface-duplicate"] = "there is an existing interface entry " + \
+                                                     "in network.* that matches"
+
+                    if (error_type in list(err_dic.keys()) and
+                            re.search(err_dic[error_type], err) or mismatch_expect):
+                        logging.info("Get expect error: %s", err)
+                    else:
+                        test.fail("Do not get expect err msg: %s, %s"
+                                  % (error_type, err_dic))
+                else:
+                    test.fail("Failed to execute net-update command")
+            elif status_error == "yes":
+                test.fail("Expect fail, but succeed")
+
+            # Get dnsmasq pid after update
+            if check_dnsmasq:
+                pid_list_aft = results_stdout_52lts(process.run(cmd, shell=True)).strip().split('\n')
+                for pid in pid_list_aft:
+                    if pid in pid_list_bef:
+                        test.fail("dnsmasq do not updated")
+
+            # Check the actual xml
+            cmd_result = virsh.net_dumpxml(net_name)
+            actual_net_xml = cmd_result.stdout.strip()
+            new_xml_obj = network_xml.NetworkXML.new_from_net_dumpxml(net_name)
+            logging.info("After net-update, the actual net xml is %s",
+                         actual_net_xml)
+
+            if "ip-dhcp" in net_section:
+                if ip_version == "ipv6":
+                    new_xml_obj.del_element(element="/ip", index=0)
+                if ip_version == "ipv4":
+                    new_xml_obj.del_element(element="/ip", index=1)
+
+            config_not_work = ("--config" in options and net_state == "active" and
+                               "--live" not in options)
+            if config_not_work:
+                if update_command != "delete":
+                    flag_list_abs = flag_list
+                    flag_list = []
+                else:
+                    flag_list = flag_list_abs
+                    flag_list_abs = []
+
+            logging.info("The check list is %s, absent list is %s", flag_list, flag_list_abs)
+
+            if (update_command == "delete" and status_error == "no" and
+                    not config_not_work and loop_time == 1):
+                try:
+                    section_str = new_xml_obj.get_section_string(xpath=element)
+                except xcepts.LibvirtXMLNotFoundError:
+                    section_str = None
+                    logging.info("Can not find section %s in xml after delete", element)
+                if section_str is not None:
+                    test.fail("The actual net xml is not expected,"
+                              "element still exists")
+            elif ("duplicate" not in error_type and error_type != "range-mismatch" and
+                    error_type != "host-mismatch"):
+                # check xml should exists
+                for flag_string in flag_list:
+                    logging.info("checking %s should in xml in positive test,"
+                                 "and absent in negative test", flag_string)
+                    if not re.search(flag_string, actual_net_xml):
+                        if ((status_error == "no" and update_command != "delete") or
+                                (update_command == "delete" and status_error == "yes")):
+                            test.fail("The actual net xml failed to update,"
+                                      "or expect delete fail but xml missing"
+                                      ":%s" % flag_string)
+                    else:
+                        if ((status_error == "yes" and update_command != "delete") or
+                                (status_error == "no" and update_command == "delete" and
+                                 not config_not_work)):
+                            test.fail("Expect test fail, but find xml %s"
+                                      " actual, or expect delete succeed,"
+                                      "but fail in fact" % flag_string)
+                # check xml should not exists
+                for flag_string_abs in flag_list_abs:
+                    logging.info("checking %s should NOT in xml in positive test,"
+                                 "and exist in negative test", flag_string_abs)
+                    if re.search(flag_string_abs, actual_net_xml):
+                        if status_error == "no":
+                            test.fail("Expect absent in net xml, but exists"
+                                      "in fact: %s" % flag_string_abs)
+                    else:
+                        if status_error == "yes":
+                            test.fail("Should exists in net xml, but it "
+                                      "disappeared: %s" % flag_string_abs)
+
+                # Check if add-last, add-fist works well
+                if (status_error == "no" and not config_not_work and
+                        update_command in ["add-last", "add", "add-first"]):
+                    if update_command == "add-first":
+                        find_index = 0
+                    else:
+                        find_index = -1
+                    section_str_aft = new_xml_obj.get_section_string(xpath=element,
+                                                                     index=find_index)
+                    logging.info("xpath is %s, find_index is %s, section_str_aft is %s", element, find_index, section_str_aft)
+                    for flag_string in flag_list:
+                        logging.info("flag_string is %s", flag_string)
+                        if not re.search(flag_string, section_str_aft):
+                            test.fail("Can not find %s in %s" %
+                                      (flag_string, section_str_aft))
+                    logging.info("%s %s in right place", update_command, section_str_aft)
+
+            # Check the positive test result
+            if status_error == "no":
+                # Check the network conf file
+                # live update
+                if ("--live" in options or "--config" not in options) and net_state == "active":
+                    if net_section == "ip-dhcp-range" and update_command == "add-first":
+                        ip_range = "%s,%s" % (new_start_ip, new_end_ip)
+                        if ip_version == "ipv6":
+                            ip_range = ip_range + ",64"
+                        check_item(ip_range)
+                    if "dns" in net_section:
+                        if update_command == "delete" and loop == 0:
+                            if net_section == "dns-srv":
+                                check_item_absent(srv_host)
+                            if net_section == "dns-txt":
+                                check_item_absent(txt_record)
+                            if net_section == "dns-host":
+                                check_host_absent(dns_host_str)
+                        elif "add" in update_command:
+                            if net_section == "dns-srv":
+                                for sec in update_sec.split(","):
+                                    srv_host = srv_host.replace(names["srv_"+sec],
+                                                                names["new_srv_"+sec])
+                                check_item(srv_host)
+                            if net_section == "dns-txt":
+                                for sec in update_sec.split(","):
+                                    txt_record = txt_record.replace(names["dns_"+sec],
+                                                                    names["new_dns_"+sec])
+                                check_item(txt_record)
+                            if net_section == "dns-host":
+                                check_host(hostline)
+
+                    # Check the hostfile
+                    if (net_section == "ip-dhcp-host" and update_command != "modify" and
+                            update_command != "delete"):
+                        dic_hostfile = {}
+                        for sec in ["ip", "mac", "name", "id"]:
+                            if update_sec is not None and sec in update_sec.split(","):
+                                dic_hostfile[sec] = names["new_dhcp_host_"+sec]+","
+                            else:
+                                dic_hostfile[sec] = names[ip_version+"_host_"+sec]+","
+
+                            if sec == "ip" and ip_version == "ipv6":
+                                dic_hostfile[sec] = "[" + dic_hostfile[sec].strip(",") + "]"
+
+                            if without_sec is not None and sec in without_sec.split(","):
+                                dic_hostfile[sec] = ""
+
+                        if ip_version == "ipv4":
+                            host_info = (dic_hostfile["mac"] + dic_hostfile["ip"] +
+                                         dic_hostfile["name"])
+                            if dic_hostfile["mac"] == "":
+                                host_info = dic_hostfile["name"] + dic_hostfile["ip"]
+                        if ip_version == "ipv6":
+                            host_info = ("id:" + dic_hostfile["id"] + dic_hostfile["name"] +
+                                         dic_hostfile["ip"])
+
+                        hostfile = get_hostfile()
+                        host_info_patten = host_info.strip(",") + "\n"
+                        if host_info_patten in hostfile:
+                            logging.info("host info %s is in hostfile %s", host_info, hostfile)
+                        else:
+                            test.fail("Can not find %s in host file: %s"
+                                      % (host_info, hostfile))
+
+                # Check the net in guest
+                if use_in_guest == "yes" and loop == 0:
+                    # Detach all interfaces of vm first
+                    iface_index = 0
+                    mac_list = vm_xml.VMXML.get_iface_dev(vm_name)
+                    for mac in mac_list:
+                        iface_dict = vm_xml.VMXML.get_iface_by_mac(vm_name, mac)
+                        virsh.detach_interface(vm_name,
+                                               "--type %s --mac %s --config"
+                                               % (iface_dict.get('type'), mac))
+                        vm.free_mac_address(iface_index)
+                        iface_index += 1
+
+                    # attach new interface to guest
+                    for j in range(guest_iface_num):
+                        if net_section == "ip-dhcp-host" and new_dhcp_host_mac:
+                            mac = new_dhcp_host_mac
+                        else:
+                            mac = utils_net.generate_mac_address_simple()
+                        ret = virsh.attach_interface(vm_name,
+                                                     "--type %s --source %s --mac %s --config"
+                                                     % (iface_type, net_name, mac))
+                        if ret.exit_status:
+                            test.fail("Fail to attach new interface to guest: %s" %
+                                      ret.stderr.strip())
+
+                    # The sleep here is to make sure the update make effect
+                    time.sleep(2)
+
+                    # Start guest and check ip/mac/hostname...
+                    vm.start()
+                    logging.debug("vm xml is %s", vm.get_xml())
+                    session = vm.wait_for_serial_login()
+                    if "ip-dhcp" in net_section:
+                        dhclient_cmd = "kill -9 `pidof dhclient` && dhclient -%s" % ip_version[-1]
+                        session.cmd(dhclient_cmd)
+                        iface_ip = utils_net.get_guest_ip_addr(session, mac,
+                                                               ip_version=ip_version,
+                                                               timeout=10)
+                    if net_section == "ip-dhcp-range":
+                        if new_start_ip <= iface_ip <= new_end_ip:
+                            logging.info("getting ip %s is in range [%s ~ %s]",
+                                         iface_ip, new_start_ip, new_end_ip)
+                        else:
+                            test.fail("getting ip %s not in range [%s ~ %s]" %
+                                      (iface_ip, new_start_ip, new_end_ip))
+                    if net_section == "ip-dhcp-host":
+                        if iface_ip == new_dhcp_host_ip:
+                            logging.info("getting ip is same with set: %s", iface_ip)
+                        else:
+                            test.fail("getting ip %s is not same with setting %s"
+                                      % (iface_ip, new_dhcp_host_ip))
+                        hostname = session.cmd_output("hostname").strip('\n')
+                        if hostname == new_dhcp_host_name.split('.')[0]:
+                            logging.info("getting hostname same with setting: %s", hostname)
+                        else:
+                            test.fail("getting hostname %s is not same with "
+                                      "setting: %s" % (hostname, new_dhcp_host_name))
+
+                    session.close()
+
+                # Check network connection for macvtap
+                if (use_in_guest == "yes" and net_section == "forward-interface" and
+                        forward_mode == "bridge"):
+                    xml_obj_use = network_xml.NetworkXML.new_from_net_dumpxml(net_name)
+                    net_conn = int(xml_obj_use.connection)
+                    iface_conn = xml_obj_use.get_interface_connection()
+                    conn_count = 0
+                    for k in iface_conn:
+                        conn_count = conn_count + int(k)
+                    logging.info("net_conn=%s, conn_count=%s, guest_iface_num=%s")
+                    if (net_conn != conn_count or
+                            (loop == 1 and guest_iface_num != net_conn)):
+                        test.fail("Can not get expected connection num: "
+                                  "net_conn = %s, iface_conn = %s"
+                                  % (net_conn, conn_count))
+
+                #Check --config option after net destroyed
+                if (int(check_config_round) == loop or
+                        (loop_time == 1 and "--current" in options and net_state == "active")):
+                    test_xml.set_active(False)
+                    logging.info("Checking xml after net destroyed")
+                    cmd_result = virsh.net_dumpxml(net_name)
+                    inactive_xml = cmd_result.stdout.strip()
+                    logging.info("inactive_xml is %s", inactive_xml)
+                    #Check the inactive xml
+                    for check_str in flag_list:
+                        if update_command != "delete":
+                            if "--config" in options:
+                                if not re.search(check_str, inactive_xml):
+                                    test.fail("Can not find xml after net destroyed")
+                            if "--current" in options:
+                                if re.search(check_str, inactive_xml):
+                                    test.fail("XML still exists after net destroyed")
+                        else:
+                            if "--config" in options:
+                                if re.search(check_str, inactive_xml):
+                                    test.fail("XML still exists after net destroyed")
+                            if "--current" in options:
+                                if not re.search(check_str, inactive_xml):
+                                    test.fail("Can not find xml after net destroyed")
+
+                    logging.info("Check for net inactive PASS")
 
     finally:
-        test_xml.undefine()
+        if test_xml.get_active():
+            test_xml.del_active()
+        if test_xml.get_defined():
+            test_xml.del_defined()
 
         if os.path.exists(xmlfile):
             os.remove(xmlfile)
+
+        if use_in_guest == "yes":
+            vm = env.get_vm(vm_name)
+            if vm.is_alive():
+                vm.destroy(gracefully=False)
+            vmxml_backup.sync()


### PR DESCRIPTION
#avocado run --vt-type libvirt net_update
RESULTS    : PASS 296 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 87

1 Error because of existing bug - Connections for other interfaces will be gone in net-dumpxml when live delete physical interface in macvtap network 
87 CANCEL because not support operation

Detailed test result
https://pastebin.com/G8Jy3xHD

It depends on PR https://github.com/avocado-framework/avocado-vt/pull/1097