### PR TITLE
iface_network.py: Fix "cp" CmdError

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_network.py
+++ b/libvirt/tests/src/virtual_network/iface_network.py
@@ -50,7 +50,7 @@ def run(test, params, env):
         process.system("wget %s -O %s/initrd.img" % (boot_initrd, tftp_root))
         process.system("wget %s -O %s/vmlinuz" % (boot_vmlinuz, tftp_root))
         process.system("cp -f /usr/share/syslinux/pxelinux.0 {0};"
-                       " mkdir -m 777 -p {0}/pxelinux.cfg".format(tftp_root))
+                       " mkdir -m 777 -p {0}/pxelinux.cfg".format(tftp_root), shell=True)
         pxe_file = "%s/pxelinux.cfg/default" % tftp_root
         boot_txt = """
 DISPLAY boot.txt


### PR DESCRIPTION
This issue is caused by process.system which has two cmds in one line.
After add shell=True, this issue resolved.

Signed-off-by: Yan Li <yannli@redhat.com>