### PR TITLE
Rename vm name when converting disk

### DIFF
--- a/v2v/tests/cfg/v2v_options.cfg
+++ b/v2v/tests/cfg/v2v_options.cfg
@@ -77,8 +77,8 @@
                             input_mode = disk
                         - guest:
                             input_mode = libvirt
-                            new_vm_name = ${main_vm}_new
-                            v2v_options = "-on ${new_vm_name}"
+                    new_vm_name = ${main_vm}_new
+                    v2v_options = "-on ${new_vm_name}"
                 - libvirt:
                     input_mode = "libvirt"
                     variants:
@@ -100,6 +100,7 @@
                         - esx:
                             only source_esx
                             hypervisor = "esx"
+                            v2v_timeout = 2400
                             variants:
                                 - esx_60:
                                     only source_esx.esx_60
@@ -199,11 +200,10 @@
                     variants:
                         - privileged:
                             oc_uri = "qemu:///system"
-                            v2v_options = "-oc ${oc_uri}"
                         - unprivileged:
                             oc_uri = "qemu:///session"
-                            v2v_options = "-oc ${oc_uri}"
                             unprivileged_user = "USER._V2V_EXAMPLE"
+                    v2v_options = "-oc ${oc_uri} -on ${new_vm_name}"
                 - option_vdsm:
                     # Set the output method to vdsm
                     # And create a fake storage domain to test BZ#1176591


### PR DESCRIPTION
In case vm with same name exists.
Also extend timeout to 2400s for esx cases since it will usually
take more time than 1200s.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>