### PR TITLE
Controller_functional: adapt more machine type by auto

### DIFF
--- a/libvirt/tests/src/controller/controller_functional.py
+++ b/libvirt/tests/src/controller/controller_functional.py
@@ -51,6 +51,8 @@ def run(test, params, env):
         """
         Prepare os part of VM XML according to params.
         """
+        if os_machine == 'auto':
+            return
         osxml = vm_xml.os
         orig_machine = osxml.machine
         if '-' in orig_machine:
@@ -246,7 +248,7 @@ def run(test, params, env):
                 raise error.TestFail('Expect MSI enable with non-zero vectors,'
                                      ' but got %s' % output)
 
-    os_machine = params.get('os_machine', 'i440fx')
+    os_machine = params.get('os_machine', 'auto')
     cntlr_type = params.get('controller_type', None)
     model = params.get('controller_model', None)
     index = params.get('controller_index', None)


### PR DESCRIPTION
The case should adpat more machine type instead of q35 or i440fx

Signed-off-by: hsmj1412 <ljx1412@gmail.com>