### PR TITLE
Fix mem allocate failure

### DIFF
--- a/libvirt/tests/cfg/libvirt_mem.cfg
+++ b/libvirt/tests/cfg/libvirt_mem.cfg
@@ -57,6 +57,7 @@
                     page_unit = "KiB"
                     node_mask = 0
                     huge_pages = "{'size':'2048','unit':'KiB','nodeset':'0'}"
+                    hugepage_force_allocate = "yes"
                     variants:
                         - hot_plug:
                             max_mem = "2097152"


### PR DESCRIPTION
when libvirt mem testing with hugepages, it shall not use the system available memory to set hugepages. Otherwise vm may fail to start because the target mem can't allocate  
Signed-off-by: Yan Li <yannli@redhat.com>