### PR TITLE
virsh_freepages:force allocate hugepage

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_freepages.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_freepages.cfg
@@ -1,5 +1,6 @@
 - virsh.freepages:
     type = virsh_freepages
+    hugepage_force_allocate = "yes"
     vms = ''
     variants:
         - positive_test:


### PR DESCRIPTION
set hugepage_force_allocate = "yes" to avoid error in calculating
and allocating when Hugepagesize is 2048 kB which is common for p9
hosts

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>