### PR TITLE
Fix nodedevices detach/reattach issues

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_detach_reattach.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_detach_reattach.cfg
@@ -3,7 +3,7 @@
     start_vm = "no"
     # Name of pci device witch is detachable in host.
     # eg. pci_0000_00_1f_5
-    nodedev_device_name = 'ENTER.YOUR.PCI.DEVICE.TO.DETACH'
+    nodedev_device = 'ENTER.YOUR.PCI.DEVICE.TO.DETACH'
     #nodedev_device_opt: options for nodedev cmd.
     nodedev_device_opt = ""
     variants:
@@ -21,13 +21,13 @@
             status_error = "yes"
             variants:
                 - no_arg:
-                    nodedev_device_name = ''
+                    nodedev_device = ''
                 - name_unrecognized:
-                    nodedev_device_name = 'unrecognize'
+                    nodedev_device = 'unrecognize'
                 - multi_detach:
-                    nodedev_device_name = "${nodedev_device_name} xyz"
+                    nodedev_device = "${nodedev_device_name} xyz"
                 - not_pci_device:
-                    nodedev_device_name = 'computer'
+                    nodedev_device = 'computer'
                 - nodedev_unknowopt:
                     nodedev_device_opt = "--xyz"
                 - acl_test:

--- a/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_detach_reattach.py
+++ b/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_detach_reattach.py
@@ -1,110 +1,124 @@
 import os
 import logging
-
-from autotest.client.shared import error
-
 from virttest import virsh
 from virttest.libvirt_xml import nodedev_xml
-
 from provider import libvirt_version
-
-
-def driver_readlink(device_name):
-    """
-    readlink the driver of device.
-    """
-    nodedevxml = nodedev_xml.NodedevXML.new_from_dumpxml(device_name)
-    driver_path = ('%s/driver') % (nodedevxml.get_sysfs_path())
-    try:
-        driver = os.readlink(driver_path)
-    except (OSError, UnicodeError):
-        return None
-    return driver
-
-
-def do_nodedev_detach_reattach(device_name, params, options=""):
-    """
-    do the detach and reattach.
-
-    (1).do detach.
-    (2).check the result of detach.
-    (3).do reattach.
-    (4).check the result of reattach
-    """
-    # libvirt acl polkit related params
-    uri = params.get("virsh_uri")
-    unprivileged_user = params.get('unprivileged_user')
-    if unprivileged_user:
-        if unprivileged_user.count('EXAMPLE'):
-            unprivileged_user = 'testacl'
-
-    # do the detach
-    logging.debug('Node device name is %s.', device_name)
-    CmdResult = virsh.nodedev_detach(device_name, options,
-                                     unprivileged_user=unprivileged_user,
-                                     uri=uri)
-    # check the exit_status.
-    if CmdResult.exit_status:
-        raise error.TestFail("Failed to detach %s.\n"
-                             "Detail: %s."
-                             % (device_name, CmdResult.stderr))
-    # check the driver.
-    driver = driver_readlink(device_name)
-    logging.debug('Driver after detach is %s.', driver)
-    if (driver is None) or (not driver.endswith('pci-stub')):
-        raise error.TestFail("Driver for %s is not pci-stub "
-                             "after nodedev-detach" % (device_name))
-    else:
-        pass
-    logging.debug('Nodedev-detach %s successed.', device_name)
-    # do the reattach.
-    CmdResult = virsh.nodedev_reattach(device_name, options)
-    # check the exit_status.
-    if CmdResult.exit_status:
-        raise error.TestFail("Failed to reattach %s.\n"
-                             "Detail: %s."
-                             % (device_name, CmdResult.stderr))
-    # check the driver.
-    driver = driver_readlink(device_name)
-    if (driver is None) or (not driver.endswith('pci-stub')):
-        pass
-    else:
-        raise error.TestFail("Driver for %s is not be reset after "
-                             "nodedev-reattach" % (device_name))
-    logging.debug('Nodedev-reattach %s successed.', device_name)
+from virttest.utils_test import libvirt
+from avocado.utils import process
+from avocado.core import exceptions
 
 
 def run(test, params, env):
     """
     Test virsh nodedev-detach and virsh nodedev-reattach
 
-    (1).Init variables for test.
-    (2).Check variables.
-    (3).do nodedev_detach_reattach.
+    Step1.Init variables for test.
+    Step2.Check variables.
+    Step3.Do nodedev_detach_reattach.
     """
+    def get_driver_readlink(device_address):
+        """
+        Readlink the driver of device.
+        """
+        nodedevxml = nodedev_xml.NodedevXML.new_from_dumpxml(device_address)
+        driver_path = ('%s/driver') % (nodedevxml.get_sysfs_path())
+        try:
+            driver = os.readlink(driver_path)
+        except (OSError, UnicodeError):
+            return None
+        return driver
+
+    def detach_reattach_nodedev(device_address, params, options=""):
+        """
+        Do the detach and reattach.
+
+        Step1.Do detach.
+        Step2.Check the result of detach.
+        Step3.Do reattach.
+        Step4.Check the result of reattach
+        """
+        # Libvirt acl polkit related params
+        uri = params.get("virsh_uri")
+        unprivileged_user = params.get('unprivileged_user')
+        if unprivileged_user:
+            if unprivileged_user.count('EXAMPLE'):
+                unprivileged_user = 'testacl'
+
+        # Do the detach
+        logging.debug('Node device name is %s.', device_address)
+        CmdResult = virsh.nodedev_detach(device_address, options,
+                                         unprivileged_user=unprivileged_user,
+                                         uri=uri)
+        # Check the exit_status.
+        libvirt.check_exit_status(CmdResult)
+        # Check the driver.
+        driver = get_driver_readlink(device_address)
+        logging.debug('Driver after detach is %s.', driver)
+        if libvirt_version.version_compare(1, 1, 1):
+            device_driver_name = 'vfio-pci'
+        else:
+            device_driver_name = 'pci-stub'
+        if (driver is None) or (not driver.endswith(device_driver_name)):
+            test.fail("Driver for %s is not %s "
+                      "after nodedev-detach" % (device_address, device_driver_name))
+        # Do the reattach.
+        CmdResult = virsh.nodedev_reattach(device_address, options)
+        # Check the exit_status.
+        libvirt.check_exit_status(CmdResult)
+        # Check the driver.
+        driver = get_driver_readlink(device_address)
+        if libvirt_version.version_compare(1, 1, 1):
+            device_driver_name = 'vfio-pci'
+        else:
+            device_driver_name = 'pci-stub'
+        if driver and driver.endswith(device_driver_name):
+            test.fail("Driver for %s is not %s "
+                      "after nodedev-detach" % (device_address, device_driver_name))
+
+    def pci_device_address():
+        """
+        Get the address of pci device
+        """
+        net_list = virsh.nodedev_list(tree='', cap='net')
+        net_lists = net_list.stdout.strip().splitlines()
+        route_cmd = " route | grep default"
+        route_default = process.run(route_cmd, shell=True).stdout.strip().split(' ')
+        ip_default = route_default[-1]
+        for net_device_name in net_lists:
+            if net_device_name.find(ip_default) == -1:
+                net_device_address = nodedev_xml.NodedevXML.new_from_dumpxml(net_device_name).parent
+                if 'pci' in net_device_address:
+                    return net_device_address
+
     # Init variables
-    device_name = params.get('nodedev_device_name', 'ENTER.YOUR.PCI.DEVICE')
+    device_address = params.get('nodedev_device', 'ENTER.YOUR.PCI.DEVICE.TO.DETACH')
+    if device_address.find('ENTER.YOUR.PCI.DEVICE.TO.DETACH') != -1:
+        replace_address = pci_device_address()
+        if replace_address:
+            device_address = device_address.replace('ENTER.YOUR.PCI.DEVICE.TO.DETACH', replace_address)
+        else:
+            test.cancel('Param device_address is not configured.')
+
     device_opt = params.get('nodedev_device_opt', '')
     status_error = ('yes' == params.get('status_error', 'no'))
     # check variables.
-    if device_name.count('ENTER'):
-        raise error.TestNAError('Param device_name is not configured.')
 
     if not libvirt_version.version_compare(1, 1, 1):
         if params.get('setup_libvirt_polkit') == 'yes':
-            raise error.TestNAError("API acl test not supported in current"
-                                    " libvirt version.")
+            test.cancel("API acl test not supported in current"
+                        " libvirt version.")
 
-    # do nodedev_detach_reattach
+    # Do nodedev_detach_reattach
     try:
-        do_nodedev_detach_reattach(device_name, params, device_opt)
-    except error.TestFail, e:
+        detach_reattach_nodedev(device_address, params, device_opt)
+    except exceptions.TestFail, e:
         # Do nodedev detach and reattach failed.
         if status_error:
             return
         else:
-            raise error.TestFail("Test failed in positive case."
-                                 "error: %s" % e)
+            test.fail("Test failed in positive case."
+                      "error: %s" % e)
+
     # Do nodedev detach and reattach success.
     if status_error:
-        raise error.TestFail('Test successed in negative case.')
+        test.fail('Test successed in negative case.')


### PR DESCRIPTION
(1) Get the device_name from the host on testing not from the cfg
(2) Check the driver with vfio or pci-stub according to libvirt version

Signed-off-by: Jingjing Shao <jishao@redhat.com>