### PR TITLE
Dump/reset  the specific nodedevice from different host

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_dumpxml.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_dumpxml.cfg
@@ -4,7 +4,7 @@
     main_vm = ""
     start_vm = "no"
     #nodedev_device_name need to execute dumpxml command.
-    nodedev_device_name = "pci_0000_00_00_0"
+    nodedev_device_name = "ENTER.YOUR.PCI.DEVICE"
     #nodedev_device_opt: options for nodedev-dumpxml cmd.
     nodedev_device_opt = ""
     variants:

--- a/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_reset.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_reset.cfg
@@ -6,11 +6,11 @@
     libvirtd = on
     variants:
         - positive_test:
-            expect_succeed = yes
+            expect_error = no
             device_option = 'resettable'
             specified_device = 'REPLACE_WITH_TEST_DEVICE'
         - negative_test:
-            expect_succeed = no
+            expect_error = yes
             variants:
                 - with_libvirt_off:
                     libvirtd = off
@@ -21,8 +21,5 @@
                     specified_device = 'pci_ffff_ff_ff_f'
                 - non_pci_device:
                     device_option = 'non-pci'
-                - active_device:
-                    device_option = 'active'
-                    specified_device = 'REPLACE_WITH_TEST_DEVICE'
                 - unresettable_device:
                     device_option = 'unresettable'

--- a/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_dumpxml.py
+++ b/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_dumpxml.py
@@ -1,80 +1,91 @@
 import logging
-
+import time
+import os
+import commands
 from autotest.client import utils
-from autotest.client.shared import error
-
 from virttest import virsh
 from virttest.libvirt_xml import nodedev_xml
-
 from provider import libvirt_version
-
-
-def do_nodedev_dumpxml(dev_name, dev_opt="", **dargs):
-    """
-    Do dumpxml and check the result.
-
-    (1).execute nodedev-dumpxml command.
-    (2).compare info in xml with info in sysfs.
-
-    :param dev_name: name of device.
-    :param dev_opt: command extra options
-    :param dargs: extra dict args
-    :raise TestFail: if execute command failed
-                     or check result failed.
-    """
-    result = virsh.nodedev_dumpxml(dev_name, options=dev_opt, **dargs)
-    if result.exit_status:
-        raise error.TestError("Dumpxml node device %s failed.\n"
-                              "Detail:%s." % (dev_name, result.stderr))
-    logging.debug('Executing "virsh nodedev-dumpxml %s" finished.', dev_name)
-    # compare info in xml with info in sysfs.
-    nodedevxml = nodedev_xml.NodedevXML.new_from_dumpxml(dev_name)
-    if not nodedevxml.validates:
-        raise error.TestError("nodedvxml of %s is not validated." % (dev_name))
-    # Get the dict of key to value in xml.
-    # key2value_dict_xml contain the all keys and values in xml need checking.
-    key2value_dict_xml = nodedevxml.get_key2value_dict()
-    # Get the dict of key to path in sysfs.
-    # key2syspath_dict contain the all keys and the path of file which contain
-    #                 information for each key.
-    key2syspath_dict = nodedevxml.get_key2syspath_dict()
-    # Get the values contained in files.
-    # key2value_dict_sys contain the all keys and values in sysfs.
-    key2value_dict_sys = {}
-    for key, filepath in key2syspath_dict.items():
-        value = utils.read_one_line(filepath)
-        key2value_dict_sys[key] = value
-
-    # Compare the value in xml and in syspath.
-    for key in key2value_dict_xml:
-        value_xml = key2value_dict_xml.get(key)
-        value_sys = key2value_dict_sys.get(key)
-        if not value_xml == value_sys:
-            if (key == 'numa_node' and not
-                    libvirt_version.version_compare(1, 2, 5)):
-                logging.warning("key: %s in xml is not supported yet" % key)
-            else:
-                raise error.TestError("key: %s in xml is %s,"
-                                      "but in sysfs is %s." %
-                                      (key, value_xml, value_sys))
-        else:
-            continue
-
-    logging.debug("Compare info in xml and info in sysfs finished"
-                  "for device %s.", dev_name)
+from virttest.utils_test import libvirt
 
 
 def run(test, params, env):
     """
     Test command virsh nodedev-dumpxml.
-
-    (1).get param from params.
-    (2).do nodedev dumpxml.
-    (3).clean up.
+    step1.get param from params.
+    step2.do nodedev dumpxml.
+    step3.clean up.
     """
+
+    def dump_nodedev_xml(dev_name, dev_opt="", **dargs):
+        """
+        Do dumpxml and check the result.
+
+        step1.execute nodedev-dumpxml command.
+        step1.compare info in xml with info in sysfs.
+
+        :param dev_name: name of device.
+        :param dev_opt: command extra options
+        :param dargs: extra dict args
+        """
+        result = virsh.nodedev_dumpxml(dev_name, options=dev_opt, **dargs)
+        libvirt.check_exit_status(result)
+        logging.debug('Executing "virsh nodedev-dumpxml %s" finished.', dev_name)
+        # Compare info in xml with info in sysfs.
+        nodedevice_xml = nodedev_xml.NodedevXML.new_from_dumpxml(dev_name)
+
+        if not nodedevice_xml.validates:
+            test.error("nodedvxml of %s is not validated." % (dev_name))
+        # Get the dict of key to value in xml.
+        # nodedev_dict_xml contain the all keys and values in xml need checking.
+        nodedev_dict_xml = nodedevice_xml.get_key2value_dict()
+
+        # Get the dict of key to path in sysfs.
+        # nodedev_syspath_dict contain the all keys and the path of file which contain
+        #                 information for each key.
+        nodedev_syspath_dict = nodedevice_xml.get_key2syspath_dict()
+
+        # Get the values contained in files.
+        # nodedev_dict_sys contain the all keys and values in sysfs.
+        nodedev_dict_sys = {}
+        for key, filepath in nodedev_syspath_dict.items():
+            value = utils.read_one_line(filepath)
+            nodedev_dict_sys[key] = value
+
+        # Compare the value in xml and in syspath.
+        for key in nodedev_dict_xml:
+            xml_value = nodedev_dict_xml.get(key)
+            sys_value = nodedev_dict_sys.get(key)
+
+            if not xml_value == sys_value:
+                if (key == 'numa_node' and not
+                        libvirt_version.version_compare(1, 2, 5)):
+                    logging.warning("key: %s in xml is not supported yet" % key)
+                else:
+                    test.error("key: %s in xml is %s,"
+                               "but in sysfs is %s." %
+                               (key, xml_value, sys_value))
+            else:
+                continue
+
+        logging.debug("Compare info in xml and info in sysfs finished"
+                      "for device %s.", dev_name)
+
+    def pci_devices_address():
+        """
+        Get the address of pci device
+        """
+        pci_list = virsh.nodedev_list(tree='', cap='pci')
+        pci_devices_address = pci_list.stdout.strip().splitlines()
+        pci_device_address = pci_devices_address[0]
+        return pci_device_address
+
     # Init variables.
     status_error = ('yes' == params.get('status_error', 'no'))
-    device_name = params.get('nodedev_device_name', None)
+    device_name = params.get('nodedev_device_name', 'ENTER.YOUR.PCI.DEVICE')
+    if device_name.find('ENTER.YOUR.PCI.DEVICE') != -1:
+        replace_name = pci_devices_address().strip()
+        device_name = device_name.replace('ENTER.YOUR.PCI.DEVICE', replace_name).strip()
     device_opt = params.get('nodedev_device_opt', "")
 
     # acl polkit params
@@ -86,25 +97,30 @@ def run(test, params, env):
 
     if not libvirt_version.version_compare(1, 1, 1):
         if params.get('setup_libvirt_polkit') == 'yes':
-            raise error.TestNAError("API acl test not supported in current"
-                                    " libvirt version.")
+            test.cancel("API acl test not supported in current"
+                        " libvirt version.")
 
     virsh_dargs = {}
     if params.get('setup_libvirt_polkit') == 'yes':
         virsh_dargs['unprivileged_user'] = unprivileged_user
         virsh_dargs['uri'] = uri
 
+    # change the polkit rule
+    polkit_file = "/etc/polkit-1/rules.d/500-libvirt-acl-virttest.rules"
+    if os.path.exists(polkit_file):
+        replace_cmd = "sed -i 's/'ENTER.YOUR.PCI.DEVICE'/%s/g' /etc/polkit-1/rules.d/500-libvirt-acl-virttest.rules" % device_name
+        cat_cmd = "cat /etc/polkit-1/rules.d/500-libvirt-acl-virttest.rules"
+        replace_output = commands.getoutput(replace_cmd)
+        cat_output = commands.getoutput(cat_cmd)
+
     # do nodedev dumpxml.
     try:
-        do_nodedev_dumpxml(dev_name=device_name, dev_opt=device_opt,
-                           **virsh_dargs)
+        time.sleep(10)
+        dump_nodedev_xml(dev_name=device_name, dev_opt=device_opt,
+                         **virsh_dargs)
         if status_error:
-            raise error.TestFail('Nodedev dumpxml successed in negative test.')
-        else:
-            pass
-    except error.TestError, e:
-        if status_error:
-            pass
-        else:
-            raise error.TestFail('Nodedev dumpxml failed in positive test.'
-                                 'Error: %s' % e)
+            test.fail('Nodedev dumpxml successed in negative test.')
+    except Exception, e:
+        if not status_error:
+            test.fail('Nodedev dumpxml failed in positive test.'
+                      'Error: %s' % e)

--- a/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_reset.py
+++ b/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_reset.py
@@ -1,146 +1,67 @@
 import os
 import re
 import logging
-import tempfile
-
-from autotest.client.shared import error
-
 from virttest import virsh
-from virttest import data_dir
 from virttest import utils_libvirtd
-from virttest.libvirt_xml.vm_xml import VMXML
-
-
-def get_pci_info():
-    """
-    Get infomation for all PCI devices including:
-    1) whether device has reset under its sysfs dir.
-    2) Whether device has driver dir under its sysfs dir.
-
-    :return: A dict using libvirt canonical nodedev name as keys
-             and dicts like {'reset': True, 'driver': True} as values
-    """
-    devices = {}
-    pci_path = '/sys/bus/pci/devices'
-    for device in os.listdir(pci_path):
-        # Generate a virsh nodedev format device name
-        dev_name = re.sub(r'\W', '_', 'pci_' + device)
-
-        dev_path = os.path.join(pci_path, device)
-        # Check whether device has `reset` file
-        reset_path = os.path.join(dev_path, 'reset')
-        has_reset = os.path.isfile(reset_path)
-
-        # Check whether device has `driver` file
-        driver_path = os.path.join(dev_path, 'driver')
-        has_driver = os.path.isdir(driver_path)
-
-        info = {'reset': has_reset, 'driver': has_driver}
-        devices[dev_name] = info
-    return devices
-
-
-def test_nodedev_reset(devices, expect_succeed):
-    """
-    Test nodedev-reset command on a list of devices
-
-    :param devices        : A list of node devices to be tested.
-    :param expect_succeed : 'yes' for expect command run successfully
-                           and 'no' for fail.
-    :raise TestFail       : If result doesn't meet expectation.
-    """
-    for device in devices:
-        result = virsh.nodedev_reset(device)
-        logging.debug(result)
-
-        # Check whether exit code match expectation.
-        if (result.exit_status == 0) != (expect_succeed == 'yes'):
-            raise error.TestFail(
-                'Result do not meet expect_succeed (%s). Result:\n %s' %
-                (expect_succeed, result))
-
-
-def test_active_nodedev_reset(device, vm, expect_succeed):
-    """
-    Test nodedev-reset when the specified device is attached to a VM
-
-    :param devices        : Specified node device to be tested.
-    :param vm             : VM the device is to be attached to.
-    :param expect_succeed : 'yes' for expect command run successfully
-                            and 'no' for fail.
-    :raise TestFail       : If result doesn't meet expectation.
-    :raise TestError      : If failed to recover environment.
-    """
-    # Split device name such as `pci_0000_00_19_0` and fill the XML.
-    hostdev_xml = """
-<hostdev mode='subsystem' type='%s' managed='yes'>
-    <source>
-        <address domain='0x%s' bus='0x%s' slot='0x%s' function='0x%s'/>
-    </source>
-</hostdev>""" % tuple(device.split('_'))
-
-    try:
-        # The device need to be detached before attach to VM.
-        virsh.nodedev_detach(device)
-        try:
-            # Backup VM XML.
-            vmxml = VMXML.new_from_inactive_dumpxml(vm.name)
-
-            # Generate a temp file to store host device XML.
-            dev_fd, dev_fname = tempfile.mkstemp(dir=data_dir.get_tmp_dir())
-            os.close(dev_fd)
-
-            dev_file = open(dev_fname, 'w')
-            dev_file.write(hostdev_xml)
-            dev_file.close()
-
-            # Only live VM allows attach device.
-            if not vm.is_alive():
-                vm.start()
-
-            try:
-                result = virsh.attach_device(vm.name, dev_fname)
-                logging.debug(result)
-
-                test_nodedev_reset([device], expect_succeed)
-            finally:
-                # Detach device from VM.
-                result = virsh.detach_device(vm.name, dev_fname)
-                # Raise error when detach failed.
-                if result.exit_status:
-                    raise error.TestError(
-                        'Failed to dettach device %s from %s. Result:\n %s'
-                        % (device, vm.name, result))
-        finally:
-            # Cleanup temp XML file and recover test VM.
-            os.remove(dev_fname)
-            vmxml.sync()
-    finally:
-        # Reattach node device
-        result = virsh.nodedev_reattach(device)
-        # Raise error when reattach failed.
-        if result.exit_status:
-            raise error.TestError(
-                'Failed to reattach nodedev %s. Result:\n %s'
-                % (device, result))
+from virttest.utils_test import libvirt
 
 
 def run(test, params, env):
     """
     Test command: virsh nodedev-reset <device>
-
     When `device_option` is:
     1) resettable   : Reset specified device if it is resettable.
     2) non-exist    : Try to reset specified device which doesn't exist.
     3) non-pci      : Try to reset all local non-PCI devices.
-    4) active       : Try to reset specified device which is attached to VM.
-    5) unresettable : Try to reset all unresettable PCI devices.
+    4) unresettable : Try to reset all unresettable PCI devices.
     """
+
+    def get_pci_info():
+        """
+        Get infomation for all PCI devices including:
+        1) whether device has reset under its sysfs dir.
+        2) Whether device has driver dir under its sysfs dir.
+
+        :return: A dict using libvirt canonical nodedev name as keys
+                 and dicts like {'reset': True, 'driver': True} as values
+        """
+        devices = {}
+        pci_path = '/sys/bus/pci/devices'
+        for device in os.listdir(pci_path):
+            # Generate a virsh nodedev format device name
+            dev_name = re.sub(r'\W', '_', 'pci_' + device)
+
+            dev_path = os.path.join(pci_path, device)
+            # Check whether device has `reset` file
+            reset_path = os.path.join(dev_path, 'reset')
+            has_reset = os.path.isfile(reset_path)
+
+            # Check whether device has `driver` file
+            driver_path = os.path.join(dev_path, 'driver')
+            has_driver = os.path.isdir(driver_path)
+
+            info = {'reset': has_reset, 'driver': has_driver}
+            devices[dev_name] = info
+        return devices
+
+    def test_nodedev_reset(devices, expect_error):
+        """
+        Test nodedev-reset command on a list of devices
+
+        :param devices        : A list of node devices to be tested.
+        :param expect_error : 'yes' for expect command run successfully
+                                 and 'no' for fail.
+        """
+        for device in devices:
+            result = virsh.nodedev_reset(device)
+            logging.debug(result)
+            # Check whether exit code match expectation.
+            libvirt.check_exit_status(result, expect_error)
+
     # Retrive parameters
-    expect_succeed = params.get('expect_succeed', 'yes')
+    expect_error = params.get('expect_error', 'no') == 'yes'
     device_option = params.get('device_option', 'valid')
     unspecified = 'REPLACE_WITH_TEST_DEVICE'
-    specified_device = params.get('specified_device', unspecified)
 
     # Backup original libvirtd status and prepare libvirtd status
     logging.debug('Preparing libvirtd')
@@ -170,48 +91,39 @@ def run(test, params, env):
 
     try:
         if device_option == 'resettable':
+            specified_device = resettable_nodes[0]
             # Test specified resettable device.
             if specified_device != unspecified:
                 if specified_device in resettable_nodes:
-                    test_nodedev_reset([specified_device], expect_succeed)
+                    test_nodedev_reset([specified_device], expect_error)
                 else:
-                    raise error.TestNAError(
-                        'Param specified_device is not set!')
+                    test.error('Param specified_device is not set!')
             else:
-                raise error.TestNAError('Param specified_device is not set!')
+                test.cancel('Param specified_device is not set!')
         elif device_option == 'non-exist':
+            specified_device = params.get('specified_device', unspecified)
             # Test specified non-exist device.
             if specified_device != unspecified:
                 if specified_device not in all_devices:
-                    test_nodedev_reset([specified_device], expect_succeed)
+                    test_nodedev_reset([specified_device], expect_error)
                 else:
-                    raise error.TestError('Specified device exists!')
+                    test.error('Specified device exists!')
             else:
-                raise error.TestNAError('Param specified_device is not set!')
+                test.cancel('Param specified_device is not set!')
         elif device_option == 'non-pci':
             # Test all non-PCI device.
             if non_pci_nodes:
-                test_nodedev_reset(non_pci_nodes, expect_succeed)
+                test_nodedev_reset(non_pci_nodes, expect_error)
             else:
-                raise error.TestNAError('No non-PCI device found!')
-        elif device_option == 'active':
-            # Test specified device if attached to VM.
-            if specified_device != unspecified:
-                vm_name = params.get('main_vm', 'avocado-vt-vm1')
-                vm = env.get_vm(vm_name)
-                test_active_nodedev_reset(
-                    specified_device, vm, expect_succeed)
-            else:
-                raise error.TestNAError('Param specified_device is not set!')
+                test.cancel('No non-PCI device found!')
         elif device_option == 'unresettable':
             # Test all unresettable device.
             if unresettable_nodes:
-                test_nodedev_reset(unresettable_nodes, expect_succeed)
+                test_nodedev_reset(unresettable_nodes, expect_error)
             else:
-                raise error.TestNAError('No unresettable device found!')
+                test.cancel('No unresettable device found!')
         else:
-            raise error.TestError(
-                'Unrecognisable device option %s!' % device_option)
+            test.error('Unrecognisable device option %s!' % device_option)
     finally:
         # Restore libvirtd status
         logging.debug('Restoring libvirtd')


### PR DESCRIPTION
For different hosts have different devices, device address is not the
same one written in cfg, this patch can  get the device_name from the host on testing not from the cfg.

Signed-off-by: Jingjing Shao <jishao@redhat.com>