### PR TITLE
virsh_domblkerror:add params for cleanup step

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domblkerror.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domblkerror.py
@@ -184,6 +184,8 @@ def run(test, params, env):
             if os.path.isfile("%s.bak" % export_file):
                 shutil.move("%s.bak" % export_file, export_file)
             res = libvirt.setup_or_cleanup_nfs(is_setup=False,
+                                               mount_dir=nfs_dir,
+                                               export_dir=img_dir,
                                                restore_selinux=selinux_bak)
         elif error_type == "no space":
             vm.destroy()


### PR DESCRIPTION
nfs mount point could not be unmounted for not all necessary params
are provided including export_dir and mount_dir.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>