### PR TITLE
virsh_dump: Use SIGKILL to terminate the forked process

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_dump.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_dump.py
@@ -280,6 +280,6 @@ def run(test, params, env):
         qemu_config.restore()
         libvirtd.restart()
         if child_pid:
-            os.kill(child_pid, signal.SIGTERM)
+            os.kill(child_pid, signal.SIGKILL)
         if os.path.isfile(dump_file):
             os.remove(dump_file)


### PR DESCRIPTION
Use SIGKILL to avoid the following failure:
    SystemExit: Test interrupted by SIGTERM