### PR TITLE
virsh_migrate: Forcely keep nfs export dir

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
@@ -1294,7 +1294,8 @@ def run(test, params, env):
     mount_dir = params.get("mnt_path_name")
     libvirt.setup_or_cleanup_nfs(False, export_dir=exp_dir,
                                  mount_dir=mount_dir,
-                                 restore_selinux=local_selinux_bak)
+                                 restore_selinux=local_selinux_bak,
+                                 rm_export_dir=False)
     # cleanup pre migration setup for remote machine
     migrate_setup.migrate_pre_setup(dest_uri, params, cleanup=True)
     if skip_exception:


### PR DESCRIPTION
The nfs export dir needs to be kept after test.

Signed-off-by: Dan Zheng <dzheng@redhat.com>