### PR TITLE
pass different json string according to the auth config

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_ceph.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_ceph.py
@@ -584,9 +584,15 @@ def run(test, params, env):
                 process.run(snap_cmd, ignore_status=False, shell=True)
             if test_json_pseudo_protocol:
                 # Create one frontend image with the rbd backing file.
-                json_str = ('json:{"file.driver":"rbd",'
-                            '"file.filename":"rbd:%s:mon_host=%s"}'
-                            % (disk_src_name, mon_host))
+                # pass different json string according the auth config
+                if auth_user and auth_key:
+                    json_str = ('json:{"file.driver":"rbd",'
+                                '"file.filename":"rbd:%s:mon_host=%s:id=%s:key=%s"}'
+                                % (disk_src_name, mon_host, auth_user, auth_key))
+                else:
+                    json_str = ('json:{"file.driver":"rbd",'
+                                '"file.filename":"rbd:%s:mon_host=%s"}'
+                                % (disk_src_name, mon_host))
                 disk_cmd = ("qemu-img create -f qcow2 -b '%s' %s" %
                             (json_str, front_end_img_file))
                 disk_path = front_end_img_file

--- a/libvirt/tests/src/virtual_disks/virtual_disks_ceph.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_ceph.py
@@ -584,15 +584,12 @@ def run(test, params, env):
                 process.run(snap_cmd, ignore_status=False, shell=True)
             if test_json_pseudo_protocol:
                 # Create one frontend image with the rbd backing file.
-                # pass different json string according the auth config
+                json_str = ('json:{"file.driver":"rbd",'
+                            '"file.filename":"rbd:%s:mon_host=%s"}'
+                            % (disk_src_name, mon_host))
+                # pass different json string according to the auth config
                 if auth_user and auth_key:
-                    json_str = ('json:{"file.driver":"rbd",'
-                                '"file.filename":"rbd:%s:mon_host=%s:id=%s:key=%s"}'
-                                % (disk_src_name, mon_host, auth_user, auth_key))
-                else:
-                    json_str = ('json:{"file.driver":"rbd",'
-                                '"file.filename":"rbd:%s:mon_host=%s"}'
-                                % (disk_src_name, mon_host))
+                    json_str = ('%s:id=%s:key=%s"}' % (json_str[:-2], auth_user, auth_key))
                 disk_cmd = ("qemu-img create -f qcow2 -b '%s' %s" %
                             (json_str, front_end_img_file))
                 disk_path = front_end_img_file


### PR DESCRIPTION
this change affects the following 4 tests:
```
virtual_disks.ceph.hot_plug.with_auth.disk_attach.json_pseudo_protocol
virtual_disks.ceph.hot_plug.without_auth.disk_attach.json_pseudo_protocol
virtual_disks.ceph.cold_plug.with_auth.disk_attach.json_pseudo_protocol
virtual_disks.ceph.cold_plug.without_auth.disk_attach.json_pseudo_protocol
```

I checked them, all passed on my local machine.