### PR TITLE
virsh_dompmsuspend: PowerPC doesn't support ACPI sleep states

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_dompmsuspend.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_dompmsuspend.cfg
@@ -50,6 +50,7 @@
                 - vm_shutoff:
                     vm_state = shutoff
                 - pm_not_set:
+                    no ppc64,ppc64le
                     pm_enabled = not_set
                 - pm_disabled:
                     pm_enabled = no


### PR DESCRIPTION
In x86 pm tags of guest xml is to enable support for (suspend-to-mem) and
S4 (suspend-to-disk) ACPI sleep states, but it is not supported and pm tags
in guest xml are not required for PowerPC.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>