### PR TITLE
virsh_sendkey: keystrokes get missed if all of them are sent simultaneously

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_sendkey.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_sendkey.cfg
@@ -4,44 +4,60 @@
     take_regular_screendumps = "no"
     variants:
         - params_test:
-            create_file_name = "/root/ab"
+            create_file_name = "/root/abc"
+            # This param will invoke each keystroke separately to ensure guest
+            # receives in correct order, as if keystokes are sent simultaneous
+            # guest may receive it in random order.
+            sendkey_simultaneous = "no"
             variants:
                 # All code implement "touch create_file_name" command in guest
-                - with_holdtime:
+                - without_codeset:
                     only Linux
-                    sendkey_options = "--holdtime 1000 20 24 22 46 35 57 30 48 28"
+                    sendkey = "20 24 22 46 35 57 30 48 46 28"
                     sendkey_sleeptime = 15
                 - linux_keycode:
                     only Linux
-                    sendkey_options = "--codeset linux 20 24 22 46 35 57 30 48 28"
+                    codeset = "linux"
+                    sendkey = "20 24 22 46 35 57 30 48 46 28"
                 - os-x_name:
                     no Linux, Windows
-                    sendkey_options = "--codeset os_x ANSI_T ANSI_O ANSI_U ANSI_C ANSI_H Space ANSI_A ANSI_B Return"
+                    codeset = "os_x"
+                    sendkey = "ANSI_T ANSI_O ANSI_U ANSI_C ANSI_H Space ANSI_A ANSI_B ANSI_C Return"
                 - os-x_keycode:
                     no Linux, Windows
-                    sendkey_options = "--codeset os_x 0x11 0x1f 0x20 0x8 0x4 0x31 0x0 0xb 0x24"
+                    codeset = "os_x"
+                    sendkey = "0x11 0x1f 0x20 0x8 0x4 0x31 0x0 0xb 0x8 0x24"
                 - at_set1_keycode:
-                    sendkey_options = "--codeset atset1 20 24 22 46 35 57 30 48 28"
+                    codeset = "atset1"
+                    sendkey = "20 24 22 46 35 57 30 48 46 28"
                 - at_set2_keycode:
-                    sendkey_options = "--codeset atset2 44 68 60 33 51 41 28 50 90"
+                    codeset = "atset2"
+                    sendkey = "44 68 60 33 51 41 28 50 33 90"
                 - at_set3_keycode:
-                    sendkey_options = "--codeset atset3 44 68 60 33 51 41 28 50 90"
+                    codeset = "atset3"
+                    sendkey = "44 68 60 33 51 41 28 50 33 90"
                 - xt_keycode:
-                    sendkey_options = "--codeset xt 20 24 22 46 35 57 30 48 28"
+                    codeset = "xt"
+                    sendkey = "20 24 22 46 35 57 30 48 46 28"
                 - xt_kbd_keycode:
-                    sendkey_options = "--codeset xt_kbd 20 24 22 46 35 57 30 48 28"
+                    codeset = "xt_kbd"
+                    sendkey = "20 24 22 46 35 57 30 48 46 28"
                 - usb_keycode:
-                    sendkey_options = "--codeset usb 23 18 24 6 11 44 4 5 40"
+                    codeset = "usb"
+                    sendkey = "23 18 24 6 11 44 4 5 6 40"
                 - win32_name:
                     only Windows
-                    sendkey_options = "--codeset win32 VK_T VK_O VK_U VK_C VK_H VK_SPACE VK_A VK_B VK_RETURN"
+                    codeset = "win32"
+                    sendkey = "VK_T VK_O VK_U VK_C VK_H VK_SPACE VK_A VK_B VK_C VK_RETURN"
                 - win32_keycode:
                     only Windows
-                    sendkey_options = "--codeset win32 0x54 0x4f 0x55 0x43 0x48 0x20 0x41 0x42 0x0d"
+                    codeset = "win32"
+                    sendkey = "0x54 0x4f 0x55 0x43 0x48 0x20 0x41 0x42 0x43 0x0d"
                 - rfb_keycode:
-                    sendkey_options = "--codeset rfb 20 24 22 46 35 57 30 48 28"
+                    codeset = "rfb"
+                    sendkey = "20 24 22 46 35 57 30 48 46 28"
                 - default_name:
-                    sendkey_options = "KEY_T KEY_O KEY_U KEY_C KEY_H KEY_SPACE KEY_A KEY_B KEY_ENTER"
+                    sendkey = "KEY_T KEY_O KEY_U KEY_C KEY_H KEY_SPACE KEY_A KEY_B KEY_C KEY_ENTER"
             variants:
                 - non_acl:
                 - acl_test:
@@ -54,13 +70,13 @@
             sendkey_sysrq = "yes"
             variants:
                 - help:
-                    sendkey_options = "KEY_LEFTALT KEY_SYSRQ KEY_H"
+                    sendkey = "KEY_LEFTALT KEY_SYSRQ KEY_H"
                 - show_memory_usage:
-                    sendkey_options = "KEY_LEFTALT KEY_SYSRQ KEY_M"
+                    sendkey = "KEY_LEFTALT KEY_SYSRQ KEY_M"
                 - show_task_status:
-                    sendkey_options = "KEY_LEFTALT KEY_SYSRQ KEY_T"
+                    sendkey = "KEY_LEFTALT KEY_SYSRQ KEY_T"
                 - reboot_guest:
-                    sendkey_options = "KEY_LEFTALT KEY_SYSRQ KEY_B"
+                    sendkey = "KEY_LEFTALT KEY_SYSRQ KEY_B"
             variants:
                 - non_acl:
                 - acl_test:
@@ -72,12 +88,12 @@
         - readonly:
             readonly = True
             status_error = "yes"
-            sendkey_options = "KEY_T"
+            sendkey = "KEY_T"
         - negative_test:
             status_error = "yes"
             variants:
                 - acl_test:
-                    sendkey_options = "KEY_T"
+                    sendkey = "KEY_T"
                     setup_libvirt_polkit = "yes"
                     unprivileged_user = "EXAMPLE"
                     virsh_uri = "qemu:///system"


### PR DESCRIPTION
Test fails when keystrokes are sent in a shot it gets missed or received in
random order, provision is given for multiple invocations to avoid the failures

param sendkey_simultaneous can be set to "no" to invoke each keystroke separately
and can be set to "yes" if all the keystrokes to be invoked at a time.
    
with_holdtime: holdtime with keystrokes will emulate keys in different count
for the milliseconds eachtime and will create filename with different name,
we can't validate the filename when keys are pressed with holdtime milliseconds
as it is not persistent

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>