### PR TITLE
expand virsh_vol_create to cover vol-create-as

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_create.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_create.cfg
@@ -57,6 +57,7 @@
                             vol_capacity = "1048576"
                     variants:
                         - vol_format_none:
+                            vol_format = "none"
                         - vol_format_linux:
                             vol_format = "linux"
                         - vol_format_fat16:
@@ -164,7 +165,8 @@
                     vol_capacity = "1073741824000"
                     vol_allocation = "1073741824000"
                 - nfs_pool_malformed_size:
-                    create_vol_by_xml = "no"
+                    only create_as
+                    # create_vol_by_xml = "no"
                     src_pool_type = "netfs"
                     src_pool_target = "nfs-mount"
                     nfs_server_dir = "nfs-server"
@@ -247,3 +249,18 @@
                     setup_libvirt_polkit = "yes"
                     unprivileged_user = "EXAMPLE"
                     virsh_uri = "qemu:///system"
+                - virsh_readonly_mode:
+                    only create_as
+                    virsh_readonly = "yes"
+                    src_pool_type = "dir"
+                    src_pool_target = "dir-pool"
+                    vol_format = "raw"
+    variants:
+        - create_as:
+            create_vol_by_xml = "no"
+            variants:
+                - by_name:
+                - by_uuid:
+                    create_vol_by_pool_uuid = "yes"
+        - create:
+            create_vol_by_xml = "yes"


### PR DESCRIPTION
expand the test case to cover vol-create-as. Since vol-create and vol-create-as have similar functions, I only have to add some variants to cfg file, and change the py code according to the cfg file.

the original test cases and newly added test cases PASS on my local machine, the origin test results are the same with Jenkins result, so this change doesn't break old tests

Signed-off-by: yachang <yachang@redhat.com>