### PR TITLE
virsh_setvcpus: fix local variable 'result' referenced before assignment

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_setvcpus.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_setvcpus.py
@@ -81,6 +81,7 @@ def run(test, params, env):
     sockets = params.get("sockets")
     cores = params.get("cores")
     threads = params.get("threads")
+    result = True
 
     # Early death 1.1
     if vm_ref == "remote" and (remote_ip.count("EXAMPLE.COM") or


### PR DESCRIPTION
Signed-off-by: Liping Cheng <lcheng@redhat.com>