### PR TITLE
virsh.domblkerror: fix guest not paused after nfs stop

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domblkerror.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domblkerror.py
@@ -162,7 +162,10 @@ def run(test, params, env):
             return (vm.state() == "paused")
 
         if not utils_misc.wait_for(_check_state, timeout):
-            test.fail("Guest does not paused, it is %s now" % vm.state())
+            # If not paused, perform one more IO operation to the mnt disk
+            session.cmd("echo 'one more write to big file' > %s/big_file" % mnt_dir)
+            if not utils_misc.wait_for(_check_state, 60):
+                test.fail("Guest does not paused, it is %s now" % vm.state())
         else:
             logging.info("Now domain state changed to paused status")
             output = virsh.domblkerror(vm_name)


### PR DESCRIPTION
When stop nfs on host, it is expected guest could be paused
automatically. But this sometimes doesn't work, since seemingly
vm can't detect the nfs status timely. Fix by add one more write
to the vm mnt disk if vm is not paused so that vm can know the 
nfs has gone.

Signed-off-by: Yan Li <yannli@redhat.com>