### PR TITLE
[v2 1/1] graphics_functional: Cancel the test for VNC port = -1

### DIFF
--- a/libvirt/tests/src/graphics/graphics_functional.py
+++ b/libvirt/tests/src/graphics/graphics_functional.py
@@ -980,6 +980,14 @@ def run(test, params, env):
     5) Parse and check result with expected.
     6) Clean up environment.
     """
+    # Since 3.1.0, '-1' is not an valid value for the VNC port while
+    # autoport is disabled, it means the VM will be failed to be
+    # started as expected. So, cancel test this case since there is
+    # one similar test scenario in the negative_test, which is
+    # negative_tests.vnc_only.no_autoport.port_-2
+    if libvirt_version.version_compare(3, 1, 0) and (params.get("vnc_port") == '-1'):
+        test.cancel('Cancel this case, since it is equivalence class test '
+                    'with case negative_tests.vnc_only.no_autoport.port_-2')
 
     # Since 2.0.0, there are some changes for listen type and port
     # 1. Two new listen types: 'none' and 'socket'(not covered in this test)


### PR DESCRIPTION
Before libvirt version 3.1.0, the valid VNC port is
[5900, 65535] and -1, the VNC port will be assigned one
valid port number automatically if set to -1.
Since libvirt version 3.1.0, -1 is removed from the valid
port number, it means VM will failed to be started if VNC
port number is -1.
Cancel the test for VNC port = -1 if libvirt version large
than 3.1.0, since there is already one negative test for
VNC port = -2, the test for -1 and -2 are equivalence class

Signed-off-by: Xuesong Zhang <xuesong.zhang1986@gmail.com>