### PR TITLE
Update disk_device to disk for virtio disk scenario

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/at_dt_iscsi_disk.cfg
+++ b/libvirt/tests/cfg/virtual_disks/at_dt_iscsi_disk.cfg
@@ -15,8 +15,7 @@
             variants:
                 - ipv4_virtio_bus:
                 - ipv6_virtio_bus:
-                    disk_device = "lun"
-                    disk_source_host = "::1"
+		    disk_source_host = "::1"
                 - usb_bus:
                     disk_target = "sda"
                     disk_target_bus = "usb"


### PR DESCRIPTION
Virtio1.0 bus disk do not working well with
"disk_device = lun" settings, it's one know issue,
see BZ1365823 for reference. The scenario of updated cfg
is mainly testing hotplug/unplug ipv6 protocal iscsi
network backend disk, no need to specify one special
disk_device. So, remove "disk_device = lun", and use
the general default disk_device value "disk".

Signed-off-by: Xuesong Zhang <xuesong.zhang1986@gmail.com>