### PR TITLE
virsh_uri: Remove remote_ip parameter from virsh_uri.cfg

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_uri.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_uri.cfg
@@ -12,9 +12,6 @@
                     target_uri = "qemu:///system"
                 - connect_to_remote:
                     uri_remote_ref = "remote"
-                    remote_ip = "REMOTE.EXAMPLE.COM"
-                    remote_user = "root"
-                    remote_pwd = "password"
                     target_uri = "qemu+ssh://${remote_ip}/system"
         - unexpect_option:
             virsh_uri_options = "xyz"


### PR DESCRIPTION
Remove remote_ip/remote_user/remote_pwd params from virsh_uri.cfg.
Use remote_ip/remote_user/remote_pwd params in base.cfg.