### PR TITLE
Add more scenarios with cpu hot(un)plug

### DIFF
--- a/libvirt/tests/cfg/libvirt_vcpu_plug_unplug.cfg
+++ b/libvirt/tests/cfg/libvirt_vcpu_plug_unplug.cfg
@@ -28,6 +28,9 @@
                                 - managedsave:
                                     vm_operation = "managedsave"
                                     vcpu_unplug = "no"
+                                - suspend:
+                                    vm_operation = "suspend"
+                                    vcpu_unplug = "no"
                                 - suspend_to_mem:
                                     no ppc64le
                                     vm_operation = "s3"
@@ -38,6 +41,12 @@
                                     vm_operation = "s4"
                                     install_qemuga = "yes"
                                     start_qemuga = "yes"
+                                - save_with_unplug:
+                                    vm_operation = "save"
+                                - managedsave_with_unplug:
+                                    vm_operation = "managedsave"
+                                - suspend_with_unplug:
+                                    vm_operation = "suspend"
                         - libvirtd_restart:
                                 restart_libvirtd = "yes"
                         - vcpu_pin:

--- a/libvirt/tests/src/libvirt_vcpu_plug_unplug.py
+++ b/libvirt/tests/src/libvirt_vcpu_plug_unplug.py
@@ -200,6 +200,9 @@ def manipulate_domain(vm_name, vm_operation, recover=False):
             libvirt.check_exit_status(result)
             # Wait domain state change: 'in shutdown' -> 'shut off'
             utils_misc.wait_for(lambda: virsh.is_dead(vm_name), 5)
+        elif vm_operation == "suspend":
+            result = virsh.suspend(vm_name, ignore_status=True, debug=True)
+            libvirt.check_exit_status(result)
         else:
             logging.debug("No operation for the domain")
 
@@ -217,6 +220,9 @@ def manipulate_domain(vm_name, vm_operation, recover=False):
         elif vm_operation == "s3":
             suspend_target = "mem"
             result = virsh.dompmwakeup(vm_name, ignore_status=True, debug=True)
+            libvirt.check_exit_status(result)
+        elif vm_operation == "suspend":
+            result = virsh.resume(vm_name, ignore_status=True, debug=True)
             libvirt.check_exit_status(result)
         else:
             logging.debug("No need recover the domain")


### PR DESCRIPTION
Add hot(un)plug tests with following scenarios
1. save/restore with hotunplug
2. managedsave/restore with hotunplug
3. suspend/resume with hot(un)plug.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>