### PR TITLE
Fix the mistakes in USB controller tests

### DIFF
--- a/libvirt/tests/cfg/controller/controller_functional.cfg
+++ b/libvirt/tests/cfg/controller/controller_functional.cfg
@@ -21,24 +21,26 @@
                     controller_type = virtio-serial
                     controller_vectors = '0'
                 - usb_controller:
-                    os_machine = q35
                     controller_type = usb
-                    usb_controller_address = 00:08.2
                     variants:
-                        - master_ehci:
+                        - q35_machine:
+                            os_machine = q35
+                        - i440fx_machine:
+                            os_machine = i440fx
+                    variants:
+                        # ehci and ich9-ehci1 are USB2.0 controller model
+                        - ehci_model:
                             controller_model = ehci
-                        - master_ich9-ehci1:
+                        - ich9-ehci1_model:
                             controller_model = ich9-ehci1
-                    variants:
-                        - ich9-uhci1:
-                            usb_controller = ich9-uhci1
-                        - ich9-uhci2:
-                            usb_controller = ich9-uhci2
-                        - ich9-uhci3:
-                            usb_controller = ich9-uhci3
+                            companian_controller_model = ich9-uhci
+                            companian_controller_num = 3
+                            # companion index value should be equal to master controller
+                            controller_index = 0
                     variants:
                         - auto_addr:
                         - manual_addr:
+                            no ich9-ehci1_model
                             controller_address = 00:09.1
         - negative_tests:
             variants:


### PR DESCRIPTION
Fix the following mistakes:
(1) the usb_controller params in cfg file is never been used in
the script.
(2) the usb controller can be used in both i440fx and q35 machine.
(3) the companian controller models, such as ich9-uhci[123], are
usually used only with ich9-ehci1 all together, rather than used with
ich9-ehci1 alone.
(4) qemu cmdline is never been checked in usb controller tests.

Signed-off-by: Lily Zhu <lizhu@redhat.com>