### PR TITLE
remote_access: Destroy VM after tests

### DIFF
--- a/libvirt/tests/src/remote_access/remote_access.py
+++ b/libvirt/tests/src/remote_access/remote_access.py
@@ -386,6 +386,11 @@ def run(test, params, env):
 
     finally:
         # recovery test environment
+        # Destroy the VM after all test are done
+        vm = env.get_vm(vm_name)
+        if vm.is_alive():
+            vm.destroy(gracefully=False)
+
         if rmdir_cmd:
             utils.system(rmdir_cmd, ignore_status=True)
 


### PR DESCRIPTION
The VM should be shutdown after all tests are done. Otherwise running vm
will cause following cases to fail.

Signed-off-by: Dan Zheng <dzheng@redhat.com>