### PR TITLE
remote_access: correct configuration to get vm

### DIFF
--- a/libvirt/tests/cfg/remote_access/remote_with_ssh.cfg
+++ b/libvirt/tests/cfg/remote_access/remote_with_ssh.cfg
@@ -3,12 +3,12 @@
     main_vm = ""
     take_regular_screendumps = no
     # please replace your configuration
-    server_ip = "ENTER.YOUR.REMOTE.EXAMPLE.COM"
-    server_user = "ENTER.YOUR.REMOTE.USER"
-    server_pwd = "ENTER.YOUR.REMOTE.PASSWORD"
-    client_ip = "ENTER.YOUR.CLIENT.EXAMPLE.COM"
-    client_user = "ENTER.YOUR.CLIENT.USER"
-    client_pwd = "ENTER.YOUR.CLIENT.PASSWORD"
+    server_ip = ${remote_ip}
+    server_user = ${remote_user}
+    server_pwd = ${remote_pwd}
+    client_ip = ${local_ip}
+    client_user = root
+    client_pwd = ${local_pwd}
     transport = "ssh"
     port = "22"
     client = "ssh"

--- a/libvirt/tests/cfg/remote_access/remote_with_tcp.cfg
+++ b/libvirt/tests/cfg/remote_access/remote_with_tcp.cfg
@@ -1,12 +1,11 @@
 - virsh.remote_with_tcp:
     type = remote_access
     main_vm = ""
-    vms = ""
     take_regular_screendumps = "no"
     transport = "tcp"
-    server_ip = "ENTER.YOUR.REMOTE.EXAMPLE.COM"
-    server_user = "ENTER.YOUR.REMOTE.USER"
-    server_pwd = "ENTER.YOUR.REMOTE.PASSWORD"
+    server_ip = ${remote_ip}
+    server_user = ${remote_user}
+    server_pwd = ${remote_pwd}
     start_vm = "no"
     port = "22"
     client = "ssh"

--- a/libvirt/tests/cfg/remote_access/remote_with_tls.cfg
+++ b/libvirt/tests/cfg/remote_access/remote_with_tls.cfg
@@ -1,15 +1,14 @@
 - virsh.remote_with_tls:
     type = remote_access
     main_vm = ""
-    vms = ""
     take_regular_screendumps = "no"
     transport = "tls"
-    server_ip = "ENTER.YOUR.REMOTE.EXAMPLE.COM"
-    server_user = "ENTER.YOUR.REMOTE.USER"
-    server_pwd = "ENTER.YOUR.REMOTE.PASSWORD"
-    client_ip = "ENTER.YOUR.CLIENT.EXAMPLE.COM"
-    client_user = "ENTER.YOUR.CLIENT.USER"
-    client_pwd = "ENTER.YOUR.CLIENT.PASSWORD"
+    server_ip = ${remote_ip}
+    server_user = ${remote_user}
+    server_pwd = ${remote_pwd}
+    client_ip = ${local_ip}
+    client_user = root
+    client_pwd = ${local_pwd}
     start_vm = "no"
     port = "22"
     client = "ssh"

--- a/libvirt/tests/cfg/remote_access/remote_with_unix.cfg
+++ b/libvirt/tests/cfg/remote_access/remote_with_unix.cfg
@@ -1,16 +1,15 @@
 - virsh.remote_with_unix:
     type = remote_access
     main_vm = ""
-    vms = ""
     take_regular_screendumps = "no"
     transport = "unix"
     # please replace your configuration
-    server_ip = "ENTER.YOUR.CLIENT.EXAMPLE.COM"
-    server_user = "ENTER.YOUR.CLIENT.USER"
-    server_pwd = "ENTER.YOUR.CLIENT.PASSWORD"
-    client_ip = "ENTER.YOUR.CLIENT.EXAMPLE.COM"
-    client_user = "ENTER.YOUR.CLIENT.USER"
-    client_pwd = "ENTER.YOUR.CLIENT.PASSWORD"
+    server_ip = ${remote_ip}
+    server_user = ${remote_user}
+    server_pwd = ${remote_pwd}
+    client_ip = ${local_ip}
+    client_user = root
+    client_pwd = ${local_pwd}
     start_vm = "no"
     port = "22"
     client = "ssh"

--- a/libvirt/tests/src/remote_access/remote_access.py
+++ b/libvirt/tests/src/remote_access/remote_access.py
@@ -387,9 +387,10 @@ def run(test, params, env):
     finally:
         # recovery test environment
         # Destroy the VM after all test are done
-        vm = env.get_vm(vm_name)
-        if vm.is_alive():
-            vm.destroy(gracefully=False)
+        if vm_name:
+            vm = env.get_vm(vm_name)
+            if vm and vm.is_alive():
+                vm.destroy(gracefully=False)
 
         if rmdir_cmd:
             utils.system(rmdir_cmd, ignore_status=True)


### PR DESCRIPTION
In configuration, vms = "" will cause env.get_vm to return zero vms.

Signed-off-by: Dan Zheng <dzheng@redhat.com>