### PR TITLE
Add the Usb controller 3.0 test, and fix some mistakes

### DIFF
--- a/libvirt/tests/cfg/controller/controller_functional.cfg
+++ b/libvirt/tests/cfg/controller/controller_functional.cfg
@@ -37,6 +37,11 @@
                             companion_controller_num = 3
                             # companion index value should be equal to master controller
                             controller_index = 0
+                        # nec-xhci and qemu-xhci are USB3.0 controller model
+                        - nec-xhci_model:
+                            controller_model = nec-xhci
+                        - qemu-xhci_model:
+                            controller_model = qemu-xhci 
                     variants:
                         - auto_addr:
                         - manual_addr:

--- a/libvirt/tests/cfg/controller/controller_functional.cfg
+++ b/libvirt/tests/cfg/controller/controller_functional.cfg
@@ -21,24 +21,26 @@
                     controller_type = virtio-serial
                     controller_vectors = '0'
                 - usb_controller:
-                    os_machine = q35
                     controller_type = usb
-                    usb_controller_address = 00:08.2
                     variants:
-                        - master_ehci:
+                        - q35_machine:
+                            os_machine = q35
+                        - i440fx_machine:
+                            os_machine = i440fx
+                    variants:
+                        # ehci and ich9-ehci1 are USB2.0 controller model
+                        - ehci_model:
                             controller_model = ehci
-                        - master_ich9-ehci1:
+                        - ich9-ehci1_model:
                             controller_model = ich9-ehci1
-                    variants:
-                        - ich9-uhci1:
-                            usb_controller = ich9-uhci1
-                        - ich9-uhci2:
-                            usb_controller = ich9-uhci2
-                        - ich9-uhci3:
-                            usb_controller = ich9-uhci3
+                            companion_controller_model = ich9-uhci
+                            companion_controller_num = 3
+                            # companion index value should be equal to master controller
+                            controller_index = 0
                     variants:
                         - auto_addr:
                         - manual_addr:
+                            no ich9-ehci1_model
                             controller_address = 00:09.1
         - negative_tests:
             variants:

--- a/libvirt/tests/src/controller/controller_functional.py
+++ b/libvirt/tests/src/controller/controller_functional.py
@@ -108,7 +108,7 @@ def run(test, params, env):
         known_models = {
             'pci': ['pci-root', 'pcie-root', 'pci-bridge'],
             'virtio-serial': [],
-            'usb': ['ehci', 'ich9-ehci1'],
+            'usb': ['ehci', 'ich9-ehci1', 'nec-xhci', 'qemu-xhci'],
         }
 
         if cntlr_type == 'pci' and model is None:
@@ -227,6 +227,8 @@ def run(test, params, env):
             for item in model_list:
                 if item == "ehci":
                     pattern = r"-device.usb-ehci"
+                elif item == "qemu-xhci":
+                    pattern = r"-device.qemu-xhci"
                 else:
                     name = item.split('-')
                     pattern = pattern + r"-device.%s-usb-%s.*" % (name[0], name[1])

--- a/libvirt/tests/src/controller/controller_functional.py
+++ b/libvirt/tests/src/controller/controller_functional.py
@@ -92,19 +92,12 @@ def run(test, params, env):
         logging.debug("Controller XML is:%s", ctrl)
         vm_xml.add_device(ctrl)
 
-        if usb_cntlr_model is not None:
-            ctrl = Controller(type_name='usb')
-            ctrl.model = usb_cntlr_model
-            if usb_cntlr_addr is not None:
-                match = re.match(r"(?P<bus>[0-9]*):(?P<slot>[0-9]*).(?P<function>[0-9])", usb_cntlr_addr)
-                if match:
-                    addr_dict = match.groupdict()
-                    addr_dict['bus'] = hex(int(addr_dict['bus']))
-                    addr_dict['slot'] = hex(int(addr_dict['slot']))
-                    addr_dict['function'] = hex(int(addr_dict['function']))
-                    addr_dict['domain'] = '0x0000'
-                    ctrl.address = ctrl.new_controller_address(attrs=addr_dict)
-            vm_xml.add_device(ctrl)
+        if cmpnn_cntlr_model is not None:
+            for num in range(int(cmpnn_cntlr_num)):
+                ctrl = Controller(type_name='usb')
+                ctrl.model = cmpnn_cntlr_model + str(num+1)
+                ctrl.index = index
+                vm_xml.add_device(ctrl)
 
     def define_and_check():
         """
@@ -223,6 +216,26 @@ def run(test, params, env):
             test.fail('Expect get qemu command serial option "%s", '
                       'but got "%s"' % (exp_pcihole_opt, pcihole_opt))
 
+        # Check usb options against expectation
+        if cntlr_type == "usb":
+            model_list = [model]
+            if cmpnn_cntlr_num is not None:
+                for num in range(int(cmpnn_cntlr_num)):
+                    model_list.append(cmpnn_cntlr_model+str(num+1))
+
+            pattern = ""
+            for item in model_list:
+                if item == "ehci":
+                    pattern = r"-device.usb-ehci"
+                else:
+                    name = item.split('-')
+                    pattern = pattern + r"-device.%s-usb-%s.*" % (name[0], name[1])
+
+            logging.debug("pattern is %s", pattern)
+
+            if not re.search(pattern, cmdline):
+                test.fail("Expect get usb model info in qemu cmdline, but failed!")
+
     def check_msi(test):
         """
         Check MSI state against expectation.
@@ -252,8 +265,8 @@ def run(test, params, env):
     vectors = params.get('controller_vectors', None)
     pcihole = params.get('controller_pcihole64', None)
     addr_str = params.get('controller_address', None)
-    usb_cntlr_model = params.get('usb_controller_model', None)
-    usb_cntlr_addr = params.get('usb_controller_address', None)
+    cmpnn_cntlr_model = params.get('companion_controller_model', None)
+    cmpnn_cntlr_num = params.get('companion_controller_num', None)
     vm_name = params.get("main_vm", "avocado-vt-vm1")
 
     vm = env.get_vm(vm_name)


### PR DESCRIPTION
Add the USB3.0 controller test. Before Adding the test, 
some mistakes in the script and cfg file is also been fixed.
Fix the following mistakes:
(1) the usb_controller params in cfg file is never been used in
the script.
(2) the usb controller can be used in both i440fx and q35 machine.
(3) the companian controller models, such as ich9-uhci[123], are
usually used only with ich9-ehci1 all together, rather than used with
ich9-ehci1 alone.
(4) qemu cmdline is never been checked in usb controller tests.