### PR TITLE
migrate_vm: skip to compare 'expected downtime'

### DIFF
--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -907,7 +907,10 @@ def check_domjobinfo_on_complete(test, source_jobinfo, target_jobinfo):
                       "does not has the field: '%s'" % key)
 
         target_value = target_info[key]
-        if key in ["Time elapsed", "Time elapsed w/o network", "Operation"]:
+        if key in ["Time elapsed",
+                   "Time elapsed w/o network",
+                   "Operation",
+                   "Expected downtime"]:
             continue
         else:
             if cmp(value, target_value) != 0:


### PR DESCRIPTION
"Expected Downtime" is newly added in domjobinfo on source host for
migration and "Total Downtime" for target host, too. Currently we do not
need to compare this two fields. So they are skipped for comparison.

Signed-off-by: Dan Zheng <dzheng@redhat.com>