### PR TITLE
Fix virtual_disk_multidisks case

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
@@ -308,7 +308,7 @@
                                             snapshot_error = "yes"
                                             snapshot_option = ""
                                         - error_disk_read_only_test:
-                                            virt_disk_option_readonly = "yes"
+                                            virt_disk_option_readonly = "no yes"
                                             snapshot_error = "yes"
                                             snapshot_option = "--disk-only"
                                 - disk_snapshot_no:
@@ -321,7 +321,7 @@
                                             snapshot_before_start = "yes"
                                             snapshot_option = ""
                                         - error_disk_read_only_test:
-                                            virt_disk_option_readonly = "yes"
+                                            virt_disk_option_readonly = "no yes"
                                             snapshot_option = "--disk-only"
                 - disk_source_file_name:
                     only coldplug


### PR DESCRIPTION
Boot disk couldn't be set readonly

Signed-off-by: Junxiang Li <junli@redhat.com>