### PR TITLE
virsh_vol_resize: Correct the configuration for no_space_allocation

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_resize.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_resize.cfg
@@ -53,7 +53,7 @@
             check_vol_size = "no"
             variants:
                 - no_space_allocation:
-                    vol_new_capacity = "10M"
+                    vol_new_capacity = "pool_capacity"
                     resize_option = "--allocate"
                     pool_type = "dir"
                 - unsupport_pool_type:


### PR DESCRIPTION
To trigger no_space_allocation, it shall set the new vol capacity
by using the pool capacity, rather than some hard coding in cfg file.
The old way can fail the case too, but for "invalid argument" not for 
"no space left". 

Signed-off-by: Yan Li <yannli@redhat.com>