### PR TITLE
virsh_migrate: Fix the incorrect exception

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
@@ -7,6 +7,7 @@ import threading
 
 from avocado.utils import process
 from avocado.utils import path
+from avocado.core import exceptions
 
 from virttest import nfs
 from virttest import remote
@@ -795,6 +796,7 @@ def run(test, params, env):
     nfs_client = None
     seLinuxBool = None
     skip_exception = False
+    fail_exception = False
     exception = False
     remote_viewer_pid = None
     asynch_migration = False
@@ -1297,8 +1299,10 @@ def run(test, params, env):
             if not re.search(new_nic_mac, vm_dest_xml):
                 check_dest_xml = False
 
-    except test.cancel, detail:
+    except exceptions.TestCancel, detail:
         skip_exception = True
+    except exceptions.TestFail, detail:
+        fail_exception = True
     except Exception, detail:
         exception = True
         logging.error("%s: %s", detail.__class__, detail)
@@ -1367,6 +1371,8 @@ def run(test, params, env):
 
     if skip_exception:
         test.cancel(detail)
+    if fail_exception:
+        test.fail(detail)
     if exception:
         test.error("Error occurred. \n%s: %s" % (detail.__class__, detail))
 


### PR DESCRIPTION
Old exceptions catching can not catch the exception objects, like
TestCancel, TestFail. So this is to fix it.

Signed-off-by: Dan Zheng <dzheng@redhat.com>