### PR TITLE
Skip guest dmesg verify for host tests

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_qemu_attach.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_qemu_attach.cfg
@@ -2,6 +2,7 @@
     type = virsh_qemu_attach
     vm_type = "default"
     vms = ''
+    start_vm = no
     variants:
         - normal_test:
             status_error = "no"

--- a/libvirt/tests/cfg/virsh_cmd/filter/virsh_nwfilter_define.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/filter/virsh_nwfilter_define.cfg
@@ -2,6 +2,7 @@
     type = virsh_nwfilter_define
     main_vm = ""
     vms = ""
+    start_vm = no
     filter_chain = root
     filter_name = testcase
     filter_uuid = "11111111-b071-6127-b4ec-111111111111"

--- a/libvirt/tests/cfg/virsh_cmd/filter/virsh_nwfilter_dumpxml.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/filter/virsh_nwfilter_dumpxml.cfg
@@ -2,6 +2,7 @@
     type = virsh_nwfilter_dumpxml
     main_vm = ""
     vms = ""
+    start_vm = no
     dumpxml_filter_name = 'no-mac-spoofing'
     variants:
         - normal_test:

--- a/libvirt/tests/cfg/virsh_cmd/filter/virsh_nwfilter_edit.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/filter/virsh_nwfilter_edit.cfg
@@ -2,6 +2,7 @@
     type = virsh_nwfilter_edit
     main_vm = ""
     vms = ""
+    start_vm = no
     edit_filter_name = "no-mac-spoofing"
     edit_filter_ref = "name"
     edit_priority = "-100"

--- a/libvirt/tests/cfg/virsh_cmd/filter/virsh_nwfilter_list.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/filter/virsh_nwfilter_list.cfg
@@ -2,6 +2,7 @@
     type = virsh_nwfilter_list
     main_vm = ""
     vms = ""
+    start_vm = no
     variants:
         - normal_test:
             status_error = "no"

--- a/libvirt/tests/cfg/virsh_cmd/filter/virsh_nwfilter_undefine.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/filter/virsh_nwfilter_undefine.cfg
@@ -2,6 +2,7 @@
     type = virsh_nwfilter_undefine
     main_vm = ""
     vms = ""
+    start_vm = no
     # undefine_filter_ref could be filter name or uuid
     undefine_filter_ref = 'no-mac-spoofing'
     variants:

--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_capabilities.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_capabilities.cfg
@@ -1,6 +1,7 @@
 - virsh.capabilities:
     type = virsh_capabilities
     vms = ''
+    start_vm = no
     variants:
         - no_option:
             virsh_cap_options = ""

--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_cpu_models.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_cpu_models.cfg
@@ -3,6 +3,7 @@
     vms = ''
     cpu_arch = ""
     option = ""
+    start_vm = no
     variants:
         - positive_test:
             status_error = "no"

--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_domcapabilities.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_domcapabilities.cfg
@@ -3,6 +3,7 @@
     vms = ''
     check_image = 'no'
     encode_video_files = 'no'
+    start_vm = no
     variants:
         - positive_test:
             status_error = "no"

--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_freecell.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_freecell.cfg
@@ -3,6 +3,7 @@
     vms = ''
     virsh_freecell_args = ""
     virsh_freecell_opts = ""
+    start_vm = no
     variants:
         - expected_options:
             status_error = "no"

--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_freepages.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_freepages.cfg
@@ -2,6 +2,7 @@
     type = virsh_freepages
     hugepage_force_allocate = "yes"
     vms = ''
+    start_vm = no
     variants:
         - positive_test:
             status_error = "no"

--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_hostname.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_hostname.cfg
@@ -1,6 +1,7 @@
 - virsh.hostname: install setup image_copy unattended_install.cdrom
     type = virsh_hostname
     vms = ''
+    start_vm = no
     variants:
         - no_option:
             virsh_hostname_options = ""

--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_maxvcpus.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_maxvcpus.cfg
@@ -1,6 +1,7 @@
 - virsh.maxvcpus:
     type = virsh_maxvcpus
     vms = ''
+    start_vm = no
     variants:
         - connect_to_local:
             connect_arg = "qemu:///system"

--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_node_memtune.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_node_memtune.cfg
@@ -2,6 +2,7 @@
     type = virsh_node_memtune
     vms = ""
     main_vm = ""
+    start_vm = no
     take_regular_screendumps = no
     variants:
         - positive_testing:

--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_nodecpumap.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_nodecpumap.cfg
@@ -1,6 +1,7 @@
 - virsh.nodecpumap:
     type = virsh_nodecpumap
     vms = ''
+    start_vm = no
     variants:
         - no_option:
             virsh_node_options = ""

--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_nodecpustats.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_nodecpustats.cfg
@@ -1,7 +1,7 @@
 - virsh.nodecpustats:
     type = virsh_nodecpustats
     vms = ''
-
+    start_vm = no
     # this is number of iterations the command will be executed and
     # the actual delta values will be listed at the end of testcase for
     # all iterations

--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_nodeinfo.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_nodeinfo.cfg
@@ -1,6 +1,7 @@
 - virsh.nodeinfo:
     type = virsh_nodeinfo
     vms = ''
+    start_vm = no
     variants:
         - no_option:
             virsh_node_options = ""

--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_nodememstats.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_nodememstats.cfg
@@ -1,6 +1,7 @@
 - virsh.nodememstats:
     type = virsh_nodememstats
-    vms = '' 
+    vms = ''
+    start_vm = no
     # This delta value to be considered for checking against expected and
     # acutal memory statistics value, the value has been arrived after
     # multiple iterations of this test (Still, the value needs to be

--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_sysinfo.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_sysinfo.cfg
@@ -1,6 +1,7 @@
 - virsh.sysinfo:
     type = virsh_sysinfo
     vms = ''
+    start_vm = no
     readonly = "no"
     variants:
         - normal_test:

--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_uri.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_uri.cfg
@@ -1,6 +1,7 @@
 - virsh.uri: install setup image_copy unattended_install.cdrom
     type = virsh_uri
     vms = ''
+    start_vm = no
     variants:
         - no_option:
             virsh_uri_options = ""

--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_version.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_version.cfg
@@ -1,6 +1,7 @@
 - virsh.version: install setup image_copy unattended_install.cdrom
     type = virsh_version
     vms = ''
+    start_vm = no
     virsh_version_options = ""
     status_error = "no"
     variants:

--- a/libvirt/tests/cfg/virsh_cmd/interface/virsh_iface_bridge.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/interface/virsh_iface_bridge.cfg
@@ -2,6 +2,7 @@
     type = virsh_iface_bridge
     vms = ''
     main_vm = ''
+    start_vm = no
     # Replace iface_name by actual Interface
     # Caveat, this may cause terrible network problem like ring network
     iface_name = "HOST_INTERFACE"

--- a/libvirt/tests/cfg/virsh_cmd/interface/virsh_iface_edit.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/interface/virsh_iface_edit.cfg
@@ -2,6 +2,7 @@
     type = virsh_iface_edit
     vms = ""
     main_vm = ""
+    start_vm = no
     variants:
         - positive_test:
             status_error = "no"

--- a/libvirt/tests/cfg/virsh_cmd/interface/virsh_iface_trans.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/interface/virsh_iface_trans.cfg
@@ -2,6 +2,7 @@
     type = virsh_iface_trans
     vms = ""
     main_vm = ""
+    start_vm = no
     libvirtd = "on"
     variants:
         - positive_testing:

--- a/libvirt/tests/cfg/virsh_cmd/monitor/virsh_list.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/monitor/virsh_list.cfg
@@ -1,6 +1,6 @@
 - virsh.list:
     type = virsh_list
-    vm_start = yes
+    start_vm = yes
     kill_vm = yes
     kill_vm_on_error = yes
     addition_status_error = "no"

--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_autostart.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_autostart.cfg
@@ -2,6 +2,7 @@
     type = virsh_net_autostart
     vms = ""
     main_vm = ""
+    start_vm = no
     encode_video_files = no
     skip_image_processing = yes
     take_regular_screendumps = no

--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_define_undefine.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_define_undefine.cfg
@@ -2,6 +2,7 @@
     type = virsh_net_define_undefine
     vms = ""
     main_vm = ""
+    start_vm = no
     # net_(un)define_options_ref is for special handling of option:
     # "correct_arg": a file for net-define or a name for net-undefine
     # "no_option": nothing passed to command

--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_destroy.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_destroy.cfg
@@ -3,6 +3,7 @@
     vms = ""
     main_vm = ""
     kill_vm = "no"
+    start_vm = no
     kill_unresponsive_vms = "no"
     encode_video_files = "no"
     skip_image_processing = "yes"

--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_dumpxml.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_dumpxml.cfg
@@ -2,6 +2,7 @@
     type = virsh_net_dumpxml
     vms = ""
     main_vm = ""
+    start_vm = no
     kill_vm = "no"
     kill_unresponsive_vms = "no"
     encode_video_files = "no"

--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_edit.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_edit.cfg
@@ -2,6 +2,7 @@
     type = virsh_net_edit
     vms = ""
     main_vm = ""
+    start_vm = no
     encode_video_files = "no"
     skip_image_processing = "yes"
     take_regular_screendumps = "no"

--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_info.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_info.cfg
@@ -2,6 +2,7 @@
     type = virsh_net_info
     vms = ""
     main_vm = ""
+    start_vm = no
     status_error = "no"
     encode_video_files = "no"
     skip_image_processing = "yes"

--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_list.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_list.cfg
@@ -2,6 +2,7 @@
     type = virsh_net_list
     vms = ""
     main_vm = ""
+    start_vm = no
     kill_vm = "no"
     kill_unresponsive_vms = "no"
     encode_video_files = "no"

--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_start.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_start.cfg
@@ -1,6 +1,7 @@
 - virsh.net_start:
     vms = ""
     main_vm = ""
+    start_vm = no
     type = virsh_net_start
     # make default network inactive for starting test.
     net_start_inactive_default = yes

--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_update.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_update.cfg
@@ -2,6 +2,7 @@
     type = virsh_net_update
     vms = ""
     main_vm = ""
+    start_vm = no
     encode_video_files = "no"
     skip_image_processing = "yes"
     take_regular_screendumps = "no"

--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_uuid.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_uuid.cfg
@@ -2,6 +2,7 @@
     type = virsh_net_uuid
     vms = ""
     main_vm = ""
+    start_vm = no
     status_error = "no"
     kill_vm = "no"
     kill_unresponsive_vms = "no"

--- a/libvirt/tests/cfg/virsh_cmd/pool/virsh_find_storage_pool_sources.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/pool/virsh_find_storage_pool_sources.cfg
@@ -2,6 +2,7 @@
     type = "virsh_find_storage_pool_sources"
     vms = ''
     main_vm = ''
+    start_vm = no
     source_type = ""
     source_host = "127.0.0.1"
     source_Spec = ""

--- a/libvirt/tests/cfg/virsh_cmd/pool/virsh_find_storage_pool_sources_as.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/pool/virsh_find_storage_pool_sources_as.cfg
@@ -1,7 +1,8 @@
 - virsh.find_storage_pool_sources_as:
     type = "virsh_find_storage_pool_sources_as"
     vms = ''
-	main_vm = ''
+    main_vm = ''
+    start_vm = no
     # Support source type: [netfs, iscsi, logical, rbd, sheepdog]
     source_type = ""
     source_host = "127.0.0.1"

--- a/libvirt/tests/cfg/virsh_cmd/pool/virsh_pool.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/pool/virsh_pool.cfg
@@ -2,6 +2,7 @@
     type = virsh_pool
     vms = ''
     main_vm = ''
+    start_vm = no
     pool_name = "virsh_pool_test"
     pool_type = "dir"
     vol_name = "vol_1"

--- a/libvirt/tests/cfg/virsh_cmd/pool/virsh_pool_acl.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/pool/virsh_pool_acl.cfg
@@ -2,6 +2,7 @@
     type = virsh_pool_acl
     vms = ''
     main_vm = ''
+    start_vm = no
     pool_name = "virsh_pool_acl_test"
     pool_type = "dir"
     vol_name = "vol_1"

--- a/libvirt/tests/cfg/virsh_cmd/pool/virsh_pool_create_as.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/pool/virsh_pool_create_as.cfg
@@ -1,6 +1,7 @@
 - virsh.pool_create_as:
     type = virsh_pool_create_as
     vms = ""
+    start_vm = no
     # type in [ 'dir', 'fs', 'netfs', 'disk', 'iscsi', 'logical' ]
     pool_type = dir
     pool_name = custom_pool_name

--- a/libvirt/tests/cfg/virsh_cmd/pool/virsh_pool_edit.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/pool/virsh_pool_edit.cfg
@@ -2,6 +2,7 @@
     type = virsh_pool_edit
     main_vm = ""
     vms = ""
+    start_vm = no
     pool_ref = "name"
     pool_name = "edit_test_pool"
     pool_target = "pool_target"

--- a/libvirt/tests/cfg/virsh_cmd/secret/virsh_secret_define_undefine.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/secret/virsh_secret_define_undefine.cfg
@@ -2,6 +2,7 @@
     type = virsh_secret_define_undefine
     vms = ""
     main_vm = ""
+    start_vm = no
     encode_video_files = "no"
     skip_image_processing = "yes"
     take_regular_screendumps = "no"

--- a/libvirt/tests/cfg/virsh_cmd/secret/virsh_secret_dumpxml.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/secret/virsh_secret_dumpxml.cfg
@@ -2,6 +2,7 @@
     type = virsh_secret_dumpxml
     vms = ""
     main_vm = ""
+    start_vm = no
     status_error = "no"
     encode_video_files = "no"
     skip_image_processing = "yes"

--- a/libvirt/tests/cfg/virsh_cmd/secret/virsh_secret_list.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/secret/virsh_secret_list.cfg
@@ -2,6 +2,7 @@
     type = virsh_secret_list
     vms = ""
     main_vm = ""
+    start_vm = no
     status_error = "no"
     encode_video_files = "no"
     skip_image_processing = "yes"

--- a/libvirt/tests/cfg/virsh_cmd/secret/virsh_secret_set_get.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/secret/virsh_secret_set_get.cfg
@@ -2,6 +2,7 @@
     type = virsh_secret_set_get
     main_vm = ""
     vms = ""
+    start_vm = no
     take_regular_screendumps = no
     secret_usage_volume = "/var/lib/libvirt/images/foo-bar.secret"
     set_secret = "yes"

--- a/libvirt/tests/cfg/virsh_cmd/virsh_help.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/virsh_help.cfg
@@ -2,6 +2,7 @@
     type = virsh_help
     vms = ""
     main_vm = ""
+    start_vm = no
     kill_vm = "no"
     kill_unresponsive_vms = "no"
     encode_video_files = "no"

--- a/libvirt/tests/cfg/virsh_cmd/virsh_itself.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/virsh_itself.cfg
@@ -2,6 +2,7 @@
     type = virsh_itself
     vms = ""
     main_vm = ""
+    start_vm = no
     kill_vm = "no"
     cd_option = "/"
     exit_cmd = "exit"

--- a/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_clone_wipe.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_clone_wipe.cfg
@@ -2,6 +2,7 @@
     type = "virsh_vol_clone_wipe"
     main_vm = ""
     vms = ""
+    start_vm = no
     pool_name = "vol_clone_wipe_pool"
     pool_type = "dir"
     pool_target = "pool_target"

--- a/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_resize.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_resize.cfg
@@ -2,6 +2,7 @@
     type = virsh_vol_resize
     vms = ''
     main_vm = ''
+    start_vm = no
     pool_name = "vol_resize_pool"
     pool_target = "pool_target"
     emulated_image = "test-image"

--- a/libvirt/tests/cfg/virsh_cmd/volume/virsh_volume.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/volume/virsh_volume.cfg
@@ -2,6 +2,7 @@
     type = virsh_volume
     vms = ''
     main_vm = ''
+    start_vm = no
     pool_name = "temp_pool"
     pool_target = "virsh_volume"
     volume_name = "temp_vol"


### PR DESCRIPTION
Set start_vm param to skip tests that do not require
guests and hence to help skip dmesg verify for them.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>