### PR TITLE
Wait for vm to booted up before detaching interface test

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_interface_matrix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_interface_matrix.py
@@ -281,6 +281,9 @@ def run(test, params, env):
         if pre_vm_state == "paused":
             if not vm.pause():
                 raise exceptions.TestFail("Cann't pause the domain")
+        # Virsh detach will take effect if it's executed after vm booted up
+        if pre_vm_state == 'transient':
+            vm.wait_for_serial_login().close()
         ret = virsh.detach_interface(vm_ref, options,
                                      **virsh_dargs)
         if rhel6_host and pre_vm_state in ['paused', 'running']:


### PR DESCRIPTION
For virsh detach should be executed after vm booted up in case it
won't take effect.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>