### PR TITLE
Remove extra ip check for virsh list tests.

### DIFF
--- a/libvirt/tests/src/virsh_cmd/monitor/virsh_list.py
+++ b/libvirt/tests/src/virsh_cmd/monitor/virsh_list.py
@@ -76,9 +76,6 @@ def run(test, params, env):
     local_user = params.get("username", "root")
     local_pwd = params.get("local_pwd", None)
 
-    if "EXAMPLE" in remote_ip or "EXAMPLE" in local_ip:
-        test.cancel("Please set real value for remote_ip or local_ip")
-
     vm = env.get_vm(vm_name)
     domuuid = vm.get_uuid()
     domid = vm.get_id()


### PR DESCRIPTION
Ip check only used for 'remote' scenarios, remove the head extra
ip check since one already exists in later lines.

Signed-off-by: Yanqiu Zhang <yanqzhan@redhat.com>