### PR TITLE
Empty domain operation should not trigger logging.error

### DIFF
--- a/libvirt/tests/src/virtual_disks/at_dt_iscsi_disk.py
+++ b/libvirt/tests/src/virtual_disks/at_dt_iscsi_disk.py
@@ -250,7 +250,8 @@ def run(test, params, env):
             cmd_result = virsh.snapshot_list(vm_name, **virsh_dargs)
             if snapshot_name2 not in cmd_result:
                 raise error.TestError("Snapshot %s not found" % snapshot_name2)
-
+        elif domain_operation == "":
+            logging.debug("No domain operation provided, so skip it")
         else:
             logging.error("Unsupport operation %s in this case, so skip it",
                           domain_operation)


### PR DESCRIPTION
For empty domain operation, just skip related test step is ok,
no need to log it as an error, it's confusing. Now change it to
logging.debug.

Signed-off-by: Yi Sun <yisun@redhat.com>