### PR TITLE
Update image info cmd for locking feature

### DIFF
--- a/libguestfs/tests/virt_edit.py
+++ b/libguestfs/tests/virt_edit.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from avocado.utils import process
 
 from autotest.client.shared import utils
 from autotest.client.shared import error
@@ -111,7 +112,11 @@ def run(test, params, env):
         logging.info("disk to be edit:%s", vm_ref)
         if test_format:
             # Get format:raw or qcow2
-            info = utils.run("qemu-img info %s" % vm_ref).stdout
+            if "-U" in process.run("qemu-img -h").stdout:
+                img_info_cmd = "qemu-img info -U"
+            else:
+                img_info_cmd = "qemu-img info"
+            info = utils.run("%s %s" % (img_info_cmd, vm_ref)).stdout
             for line in info.splitlines():
                 comps = line.split(':')
                 if comps[0].count("format"):

--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_create_as.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_create_as.py
@@ -4,6 +4,7 @@ import time
 import commands
 import string
 import logging
+from avocado.utils import process
 
 from autotest.client.shared import error
 from autotest.client import utils
@@ -50,7 +51,11 @@ def check_snap_in_image(vm_name, snap_name):
     domxml = virsh.dumpxml(vm_name).stdout.strip()
     xtf_dom = xml_utils.XMLTreeFile(domxml)
 
-    cmd = "qemu-img info " + xtf_dom.find("devices/disk/source").get("file")
+    if "-U" in process.run("qemu-img -h").stdout:
+        img_info_cmd = "qemu-img info -U"
+    else:
+        img_info_cmd = "qemu-img info"
+    cmd = img_info_cmd + " " + xtf_dom.find("devices/disk/source").get("file")
     img_info = commands.getoutput(cmd).strip()
 
     if re.search(snap_name, img_info):

--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_disk.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_disk.py
@@ -2,6 +2,7 @@ import os
 import logging
 import re
 import tempfile
+from avocado.utils import process
 
 from autotest.client.shared import error
 from autotest.client import utils
@@ -178,7 +179,12 @@ def run(test, params, env):
 
         if not multi_gluster_disks:
             # Do the attach action.
-            out = utils.run("qemu-img info %s" % img_path)
+            if "-U" in process.run("qemu-img -h").stdout:
+                img_info_cmd = "qemu-img info -U"
+            else:
+                img_info_cmd = "qemu-img info"
+
+            out = utils.run("%s %s" % (img_info_cmd, img_path))
             logging.debug("The img info is:\n%s" % out.stdout.strip())
             result = virsh.attach_disk(vm_name, source=img_path, target="vdf",
                                        extra=extra, debug=True)


### PR DESCRIPTION
After https://bugzilla.redhat.com/show_bug.cgi?id=1378241 fixed,
'qemu-img info' cannot directly check a image of a running VM. Add '-U'
option in 'qemu-img info' command if locking feature is supported in
qemu.