### PR TITLE
Replace os.fork with multiprocessing for background bypass check

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_dump.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_dump.cfg
@@ -8,7 +8,7 @@
     kill_vm = "yes"
     kill_vm_befor_test = "yes"
     take_regular_screendumps = "no"
-    check_pid_timeout = 5
+    check_bypass_timeout = 120
     variants:
         - positive_test:
             status_error = "no"


### PR DESCRIPTION
The original way of forking a new process is quite confusing and
won't give fail reason when it comes as bypass cache fail.Therefore
replace it with multiprocessing which is much clearer and will
throw out the correct errors.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>