### PR TITLE
Update blockcopy timeout

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcopy.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcopy.cfg
@@ -9,7 +9,7 @@
     reuse_external = "no"
     persistent_vm = "no"
     take_regular_screendumps = 'no'
-    timeout = "1200"
+    timeout = "2400"
     skip_cluster_leak_warn = "yes"
     variants:
         - positive_test:


### PR DESCRIPTION
Blockcopy with 1M/s could not be completed within 1200s

Signed-off-by: Junxiang Li <junli@redhat.com>