### PR TITLE
Fix for porting eroor

### DIFF
--- a/libvirt/tests/src/storage_discard.py
+++ b/libvirt/tests/src/storage_discard.py
@@ -6,7 +6,7 @@ import re
 import logging
 import time
 
-from autotest.client import lv_utils
+from avocado.utils import lv_utils
 from autotest.client.shared import error
 
 from avocado.utils import process


### PR DESCRIPTION
existing test case ported to avocado from auto test. but miss the port import statement. in auto test lv_list() expected an argument and lv_list_all() not. while porting lv_list_all()
code copied to lv_list() and called lv_list. so it is expecting argument and errored out

Signed-off-by: Prudhvi Miryala <mprudhvi@linux.vnet.ibm.com>