### PR TITLE
Add test to validate the cpu affinity change with load

### DIFF
--- a/libvirt/tests/cfg/cpu/guestpin.cfg
+++ b/libvirt/tests/cfg/cpu/guestpin.cfg
@@ -43,6 +43,17 @@
                     limit_vcpu_threads = 1
                     limit_vcpu_sockets = 1
                     condn = "hotplug"
+                - with_load_switch:
+                    only randompin..with_emualorpin
+                    condn = "stress"
+                    avocado_test = "perf/stress.py"
+                    config_pin = yes
+                    current_vcpu = 1
+                    max_vcpu = 1
+                    itr = 20
+                    limit_vcpu_cores = 1
+                    limit_vcpu_threads = 1
+                    limit_vcpu_sockets = 1
     variants:
         - randompin:
             pin_type = "random"


### PR DESCRIPTION
This patch adds a test to validate the host cpu statistics
with respect to affinity changes while guest under load.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>