### PR TITLE
Modify v2v LIBGUESTFS_BACKEND temporarily

### DIFF
--- a/v2v/tests/src/convert_vm_to_libvirt.py
+++ b/v2v/tests/src/convert_vm_to_libvirt.py
@@ -104,8 +104,7 @@ def run(test, params, env):
         v2v_params.update({"v2v_opts": v2v_opts})
 
     # Set libguestfs environment
-    if hypervisor == 'xen':
-        os.environ['LIBGUESTFS_BACKEND'] = 'direct'
+    os.environ['LIBGUESTFS_BACKEND'] = 'direct'
     try:
         # Execute virt-v2v command
         ret = utils_v2v.v2v_cmd(v2v_params)

--- a/v2v/tests/src/convert_vm_to_ovirt.py
+++ b/v2v/tests/src/convert_vm_to_ovirt.py
@@ -112,8 +112,7 @@ def run(test, params, env):
         v2v_params.update({'output_format': 'qcow2'})
 
     # Set libguestfs environment variable
-    if hypervisor in ('xen', 'kvm'):
-        os.environ['LIBGUESTFS_BACKEND'] = 'direct'
+    os.environ['LIBGUESTFS_BACKEND'] = 'direct'
     try:
         # Execute virt-v2v command
         v2v_ret = utils_v2v.v2v_cmd(v2v_params)


### PR DESCRIPTION
Modify convert_vm_to_libvirt and convert_vm_to_ovirt files,because
auto jobs were blocked by bug 1518517

Signed-off-by: weikunzz <1525690718@qq.com>