### PR TITLE
virsh_migrate: enable POWER8 compat guest migration on POWER9 host

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
@@ -52,6 +52,7 @@
                     only ppc64le,ppc64
                     compat_mode = "yes"
                     power9_compat = "yes"
+                    power9_compat_remote = "yes"
                     restore_smt = "yes"
                     # Test P8 compat mode guest on P9 host only
                     host_arch = POWER9
@@ -62,6 +63,7 @@
                     only ppc64le,ppc64
     variants:
         - with_cpu_hotplug:
+            only there_live,there_live_with_numa,there_and_back,there_and_back_with_numa,postcopy_after_precopy,migrate_postcopy
             virsh_migrate_cpu_hotplug = "yes"
             variants:
                 - with_hotplug:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
@@ -45,6 +45,22 @@
             no postcopy_after_precopy, migrate_postcopy
             postcopy_options = ""
     variants:
+        - compat_migration:
+            only there_live,there_live_with_numa,there_and_back,there_and_back_with_numa,postcopy_after_precopy,migrate_postcopy
+            variants:
+                - with_compat_mode:
+                    only ppc64le,ppc64
+                    compat_mode = "yes"
+                    power9_compat = "yes"
+                    restore_smt = "yes"
+                    # Test P8 compat mode guest on P9 host only
+                    host_arch = POWER9
+                    # Migrating Power8 guest between P9 <-> P9 hosts
+                    # and P8 <-> P9 hosts
+                    cpu_model = "power8"
+                - without_compat_mode:
+                    only ppc64le,ppc64
+    variants:
         - with_cpu_hotplug:
             virsh_migrate_cpu_hotplug = "yes"
             variants:


### PR DESCRIPTION
1. Enable migration testcases to work for POWER8 compat guest on POWER9
host.
2. cpu hotplug/hotunplug scenarios can be shrinked to live migration
    there and back migration, postcopy migration and online migration
    for better confined coverage
