### PR TITLE
schedinfo_qemu_posix: Fix "VM dead"

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_schedinfo_qemu_posix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_schedinfo_qemu_posix.py
@@ -166,7 +166,7 @@ def run(test, params, env):
 
     set_value_of_cgroup = get_parameter_in_cgroup(vm, cgroup_type=schedinfo_param,
                                                   parameter=cgroup_ref)
-    vm.destroy()
+    vm.destroy(gracefully=False)
 
     if set_ref:
         set_value_of_output = schedinfo_output_analyse(result, set_ref,


### PR DESCRIPTION
VM is not destroying forcefully. Then verify_guest_dmesg
is performed in postprocess. However, the vm has not been
able to login already. So "VM dead" is reported. Fix by
set gracefully=False for vm.destroy.

Signeg-off-by: Yan Li <yannli@redhat.com>