### PR TITLE
virsh_migrate: memory hotplug/hotunplug with migration

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
@@ -91,7 +91,7 @@
                 - with_numa_only:
                     virsh_migrate_with_numa = 'yes'
                     variants:
-                        - with_mem_hotplug:
+                        - with_memory_hotplug:
                             virsh_migrate_mem_hotplug = "yes"
                             virsh_migrate_mem_hotplug_count = "2"
                             # min memory that can be hotplugged
@@ -99,6 +99,29 @@
                             virsh_migrate_hotplug_mem = "262144"
                             virsh_migrate_hotplug_mem_unit = "KiB"
                             virsh_migrate_max_dimm_slots = "32"
+                            variants:
+                                - with_hotplug:
+                                    variants:
+                                        - mem_hotplug_before_migration:
+                                            virsh_hotplug_mem_before = "yes"
+                                        - mem_hotplug_after_migration:
+                                            virsh_hotplug_mem_after = "yes"
+                                - with_hotunplug:
+                                    variants:
+                                        - hotplug_before_unplug_before_migration:
+                                            virsh_hotplug_mem_before = "yes"
+                                            virsh_hotunplug_mem_before = "yes"
+                                        - hotplug_before_unplug_after_migration:
+                                            virsh_hotplug_mem_before = "yes"
+                                            virsh_hotunplug_mem_after = "yes"
+                                        - hotplug_after_unplug_after_migration:
+                                            virsh_hotplug_mem_after = "yes"
+                                            virsh_hotunplug_mem_after = "yes"
+                                        - hotplug_unplug_before_hotplug_unplug_after:
+                                            virsh_hotplug_mem_before = "yes"
+                                            virsh_hotunplug_mem_before = "yes"
+                                            virsh_hotplug_mem_after = "yes"
+                                            virsh_hotunplug_mem_after = "yes"
                         - without_mem_hotplug:
                             virsh_migrate_mem_hotplug = "no"
                 - with_numa_and_HP:
@@ -164,7 +187,7 @@
                 - with_numa_only:
                     virsh_migrate_with_numa = 'yes'
                     variants:
-                        - with_mem_hotplug:
+                        - with_memory_hotplug:
                             virsh_migrate_mem_hotplug = "yes"
                             virsh_migrate_mem_hotplug_count = "2"
                             # min memory that can be hotplugged
@@ -172,6 +195,29 @@
                             virsh_migrate_hotplug_mem = "262144"
                             virsh_migrate_hotplug_mem_unit = "KiB"
                             virsh_migrate_max_dimm_slots = "32"
+                            variants:
+                                - with_hotplug:
+                                    variants:
+                                        - mem_hotplug_before_migration:
+                                            virsh_hotplug_mem_before = "yes"
+                                        - mem_hotplug_after_migration:
+                                            virsh_hotplug_mem_after = "yes"
+                                - with_hotunplug:
+                                    variants:
+                                        - hotplug_before_unplug_before_migration:
+                                            virsh_hotplug_mem_before = "yes"
+                                            virsh_hotunplug_mem_before = "yes"
+                                        - hotplug_before_unplug_after_migration:
+                                            virsh_hotplug_mem_before = "yes"
+                                            virsh_hotunplug_mem_after = "yes"
+                                        - hotplug_after_unplug_after_migration:
+                                            virsh_hotplug_mem_after = "yes"
+                                            virsh_hotunplug_mem_after = "yes"
+                                        - hotplug_unplug_before_hotplug_unplug_after:
+                                            virsh_hotplug_mem_before = "yes"
+                                            virsh_hotunplug_mem_before = "yes"
+                                            virsh_hotplug_mem_after = "yes"
+                                            virsh_hotunplug_mem_after = "yes"
                         - without_mem_hotplug:
                             virsh_migrate_mem_hotplug = "no"
                 - with_numa_and_HP:
@@ -326,7 +372,7 @@
                 - with_numa_only:
                     virsh_migrate_with_numa = 'yes'
                     variants:
-                        - with_mem_hotplug:
+                        - with_memory_hotplug:
                             virsh_migrate_mem_hotplug = "yes"
                             virsh_migrate_mem_hotplug_count = "2"
                             # min memory that can be hotplugged
@@ -334,6 +380,29 @@
                             virsh_migrate_hotplug_mem = "262144"
                             virsh_migrate_hotplug_mem_unit = "KiB"
                             virsh_migrate_max_dimm_slots = "32"
+                            variants:
+                                - with_hotplug:
+                                    variants:
+                                        - mem_hotplug_before_migration:
+                                            virsh_hotplug_mem_before = "yes"
+                                        - mem_hotplug_after_migration:
+                                            virsh_hotplug_mem_after = "yes"
+                                - with_hotunplug:
+                                    variants:
+                                        - hotplug_before_unplug_before_migration:
+                                            virsh_hotplug_mem_before = "yes"
+                                            virsh_hotunplug_mem_before = "yes"
+                                        - hotplug_before_unplug_after_migration:
+                                            virsh_hotplug_mem_before = "yes"
+                                            virsh_hotunplug_mem_after = "yes"
+                                        - hotplug_after_unplug_after_migration:
+                                            virsh_hotplug_mem_after = "yes"
+                                            virsh_hotunplug_mem_after = "yes"
+                                        - hotplug_unplug_before_hotplug_unplug_after:
+                                            virsh_hotplug_mem_before = "yes"
+                                            virsh_hotunplug_mem_before = "yes"
+                                            virsh_hotplug_mem_after = "yes"
+                                            virsh_hotunplug_mem_after = "yes"
                         - without_mem_hotplug:
                             virsh_migrate_mem_hotplug = "no"
                 - with_numa_and_HP:


### PR DESCRIPTION
added testcases that perform memory hotplug/hotunplug along with migration
of guests, testcases cover different scenarios as below,

1. memory hotplug before migration
2. memory hotplug after migration
3. memory hotplug & hotunplug before migration
4. memory hotplug & hotunplug after migration
5. memory hotplug before and hotunplug after migration
6. memory Hotplug & hotunplug before and hotplug & hotunplug after migration

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>