### PR TITLE
virsh_uri: Use setup_ssh_key

### DIFF
--- a/libvirt/tests/src/virsh_cmd/host/virsh_uri.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_uri.py
@@ -52,10 +52,8 @@ def run(test, params, env):
     logging.info("The command: %s", cmd)
 
     # setup autologin for ssh to remote machine to execute commands
-    config_opt = ["StrictHostKeyChecking=no"]
     if remote_ref:
-        ssh_key.setup_remote_ssh_key(remote_ip, remote_user, remote_pwd,
-                                     config_options=config_opt)
+        ssh_key.setup_ssh_key(remote_ip, remote_user, remote_pwd)
 
     try:
         if remote_ref == "remote":


### PR DESCRIPTION
set_remote_ssh_key is used to setup remote machine to login other
host or to be logged in. In virsh_uri, need to setup autologin
for ssh to remote machine. So change to setup_ssh_key.