### PR TITLE
Use remote_ip replace 'EXAMPLE.COM'

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_cpu_models.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_cpu_models.cfg
@@ -15,7 +15,7 @@
                 - local_host:
                     target_uri = "qemu:///system"
                 - remote_host:
-                    target_uri = "qemu+ssh://EXAMPLE.COM/system"
+                    target_uri = "qemu+ssh://${remote_ip}/system"
         - negative_test:
             status_error = "yes"
             variants:

--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_domcapabilities.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_domcapabilities.cfg
@@ -15,7 +15,7 @@
             variants:
                 - local_host:
                 - remote_host:
-                    target_uri = "qemu+ssh://EXAMPLE.COM/system"
+                    target_uri = "qemu+ssh://${remote_ip}/system"
         - negative_test:
             status_error = "yes"
             variants:


### PR DESCRIPTION
Use '${remote_ip}' replace 'EXAMPLE.COM' in virsh_cpu_models.cfg
and virsh_domcapabilities.cfg.