### PR TITLE
Add cases to cover <encryption> inside disk <source> scenarios

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_encryption.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_encryption.cfg
@@ -26,6 +26,11 @@
     secret_type = "passphrase"
     secret_password_no_encoded = "redhat"
     variants:
+        - encryption_in_source:
+            encryption_in_source = "yes"
+        - encryption_out_source:
+            encryption_out_source = "yes"
+    variants:
         - normal_test:
             status_error = "no"
         - error_test:


### PR DESCRIPTION
Now libvirt support to add <encryption> inside disk source element,
add code to cover this scenario for this script.

Signed-off-by: Yi Sun <yisun@redhat.com>