### PR TITLE
Fix expect match issue

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_save_image_edit.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_save_image_edit.py
@@ -41,8 +41,8 @@ def run(test, params, env):
             session.sendline(edit_cmd)
             session.send('\x1b')
             session.send('ZZ')
-            session.read_until_last_line_matches(
-                    patterns=['edited', 'not changed'],
+            session.read_until_any_line_matches(
+                    patterns=['State file.*%s edited' % vm_save, 'not changed'],
                     timeout=5,
                     print_func=logging.debug)
         except (aexpect.ShellError, aexpect.ExpectError,


### PR DESCRIPTION
Two changes:
1) matched string is not last line, so change to match any line
2) use more precise match pattern words to improve case credibility

Match string is like below:
[u'[root@localhost aexpect]# \x0c\x1b[24;1H"/tmp/virsh0thCpN.xml" 67L,
2481C written', u'State file /var/tmp/avocado_uK2uJ_/vm.save edited.',
u'[root@localhost aexpect]# ']

Signed-off-by: czhang0 <47047802@qq.com>