### PR TITLE
Fix init_scripts the expected exit code

### DIFF
--- a/libvirt/tests/src/daemon/init_scripts.py
+++ b/libvirt/tests/src/daemon/init_scripts.py
@@ -96,28 +96,28 @@ def run(test, params, env):
             if command == 'systemctl':
                 service_call(command, 'start',
                              user=username,
-                             expected_exit_code=4)
+                             expected_exit_code=1)
             service_call(command, 'start')
             service_call(command, 'status')
 
             if command == 'systemctl':
                 service_call(command, 'reload',
                              user=username,
-                             expected_exit_code=4)
+                             expected_exit_code=1)
             service_call(command, 'reload')
             service_call(command, 'status')
 
             if command == 'systemctl':
                 service_call(command, 'restart',
                              user=username,
-                             expected_exit_code=4)
+                             expected_exit_code=1)
             service_call(command, 'restart')
             service_call(command, 'status')
 
             if command == 'systemctl':
                 service_call(command, 'stop',
                              user=username,
-                             expected_exit_code=4)
+                             expected_exit_code=1)
             service_call(command, 'stop')
             if command == 'initctl':
                 service_call(command, 'status')


### PR DESCRIPTION
Exit code is Access denied(4) after input a error
password, but exit code is Interactive authentication
required(1) with no ask password

Signed-off-by: Junxiang Li <junli@redhat.com>