### PR TITLE
fix disk driver native io cache mode issue

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_multivms.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_multivms.cfg
@@ -79,7 +79,7 @@
                     virt_disk_target = "vdb"
                     virt_disk_type = "block"
                     virt_disk_format = "iscsi"
-                    disk_driver_options = "type=raw,cache=default,io=native"
+                    disk_driver_options = "type=raw,cache=none,io=native"
                 - file_type:
                     virt_disk_type = "file"
                     virt_disk_target = "vdb"


### PR DESCRIPTION
when native is set, only no disk cache or directsync cache mode are supported

Signed-off-by: chunfuwen <chwen@redhat.com>