### PR TITLE
memtune: add some new cases and more strict result checking

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_memtune.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_memtune.cfg
@@ -1,7 +1,50 @@
 - virsh.memtune: install setup image_copy unattended_install.cdrom
     type = virsh_memtune
-    # Values are in kbs
-    memtune_base_mem = 1048576
-    memtune_min_mem = 262144
-    memtune_hard_base_mem = 262144
-    memtune_soft_base_mem = 262144
+    # Values are in KiB
+    variants:
+        - positive_test:
+            acceptable_minus = 8
+            variants:
+                - normal_1:
+                    mt_hard_limit = -1
+                - normal_2:
+                    mt_soft_limit = -1
+                - normal_3:
+                    mt_swap_hard_limit = -1
+                - normal_4:
+                    mt_hard_limit = -100
+                - normal_5:
+                    mt_hard_limit = 600000
+                - normal_6:
+                    mt_soft_limit = 0
+                - normal_7:
+                    restart_libvirtd = "yes"
+                    set_in_one_command = "yes"
+                    mt_hard_limit = 1111111
+                    mt_soft_limit = 222222
+                    mt_swap_hard_limit = 3333333
+                - step_increment:
+                    mt_step_mem = "yes"
+                    mt_base_mem = 1048576
+                    mt_min_mem = 262144
+                    mt_hard_base_mem = 262144
+                    mt_soft_base_mem = 262144
+        - negative_test:
+            expect_error = "yes"
+            variants:
+                - invalid_1:
+                    mt_hard_limit = 0
+                    error_info="Unable to write to '.*scope/memory.limit_in_bytes': Device or resource busy"
+                - invalid_2:
+                    mt_soft_limit = "aaaa"
+                    error_info="Unable to parse integer parameter soft-limit"
+                - invalid_3:
+                    mt_swap_hard_limit = 0xffff
+                    error_info="invalid argument: unknown suffix"
+                - invalid_4:
+                    set_in_one_command = "yes"
+                    # hard_limit is bigger than swap_hard_limit
+                    mt_hard_limit = 1111111
+                    mt_soft_limit = 10000
+                    mt_swap_hard_limit = 333333
+                    error_info="invalid argument:.*hard_limit.*lower than.*swap_hard_limit"


### PR DESCRIPTION
 memtune: add some new cases and more strict result checking

Newly added checking point:
1) check memtune value from the output of "virsh dumpxml"
2) check vm is alive

New added test cases:
1) normal case:
   -1(unlimited),
   positive value
   negative value(unlimited),
   0 for soft_limit,
   both set 3 limits in one command line
   restart testing
2) invalid case:
   0 for hard_limit
   hard limit is bigger than swap_hard_limit
   non-integer
   invalid suffix

Signed-off-by: cuzhang <cuzhang@redhat.com>