### PR TITLE
Add missing negative cases for setvcpus with guest agent

### DIFF
--- a/libvirt/tests/cfg/libvirt_vcpu_plug_unplug.cfg
+++ b/libvirt/tests/cfg/libvirt_vcpu_plug_unplug.cfg
@@ -121,3 +121,9 @@
                     setvcpu_option = "--guest"
                     install_qemuga = "yes"
                     start_qemuga = "yes"
+                    check_after_plug_fail = "yes"
+                    variants:
+                        - more_than_current:
+                        - more_than_max:
+                            vcpu_current_num = "4"
+                            vcpu_plug_num = "5"


### PR DESCRIPTION
##avocado run --vt-type libvirt libvirt_vcpu_plug_unplug.negative_test.guest_plug.more_than_max
JOB ID     : ea900dc21801f3e82f549ec95939d66acfe3979a
JOB LOG    : /root/avocado/job-results/job-2017-12-27T13.41-ea900dc/job.log
 (1/1) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.negative_test.guest_plug.more_than_max: PASS (55.64 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 59.58 s
##avocado run --vt-type libvirt libvirt_vcpu_plug_unplug.negative_test.guest_plug.more_than_current
JOB ID     : e6256a0d404e07bf73fde0beba228e0838db6658
JOB LOG    : /root/avocado/job-results/job-2017-12-27T13.42-e6256a0/job.log
 (1/1) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.negative_test.guest_plug.more_than_current: PASS (55.22 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 58.33 s
