### PR TITLE
virsh_qemu_attach: disable preprocess libvirt vm and consider actual fail

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_qemu_attach.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_qemu_attach.cfg
@@ -3,6 +3,7 @@
     vm_type = "default"
     vms = ''
     start_vm = no
+    not_preprocess = "yes"
     variants:
         - normal_test:
             status_error = "no"


### PR DESCRIPTION
Test case creates qemu vm to validate virsh qemu-attach, so disable
preprocess of libvirt vm for avoiding env_process error. Secondly, actual
fail is considered as test.cancel which is handled and caught in right way.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>