### PR TITLE
Fix the virsh_vol_create case spelling mistake

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_create.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_create.cfg
@@ -52,7 +52,7 @@
                         - pool_format_none:
                         - pool_format_gpt:
                             only vol_format_none
-                            sr_pool_format = "gpt"
+                            src_pool_format = "gpt"
                             src_pool_vol_num = "128"
                             vol_capacity = "1048576"
                     variants:


### PR DESCRIPTION
Signed-off-by: Junxiang Li <junli@redhat.com>