### PR TITLE
dac_start_destroy: add no qemu user group testcase

### DIFF
--- a/libvirt/tests/cfg/svirt/dac_start_destroy.cfg
+++ b/libvirt/tests/cfg/svirt/dac_start_destroy.cfg
@@ -30,6 +30,12 @@
                     qemu_user = "qemu"
                     qemu_group = "qemu"
                     set_process_name = 1
+                - no_qemu_usr:
+                    no positive_test..disable_dynamic_ownership
+                    no negative_test..enable_dynamic_ownership
+                    qemu_no_usr_grp = "yes"
+                    qemu_user = ""
+                    qemu_group = ""
             variants:
                 - enable_dynamic_ownership:
                     dynamic_ownership = "yes"
@@ -48,6 +54,7 @@
                 - non_root:
                     no root_usr, unconfine
         - sec_label:
+            no no_qemu_usr
             variants:
                 - no_mix:
                     only without_qemu_conf
@@ -111,4 +118,4 @@
             no invalid_label
         - negative_test:
             status_error = "yes"
-            only invalid_label
+            only invalid_label, no_qemu_usr

--- a/libvirt/tests/src/svirt/dac_start_destroy.py
+++ b/libvirt/tests/src/svirt/dac_start_destroy.py
@@ -113,6 +113,7 @@ def run(test, params, env):
         sec_dict['label'] = sec_label
     set_sec_label = "yes" == params.get("set_sec_label", "no")
     set_qemu_conf = "yes" == params.get("set_qemu_conf", "no")
+    qemu_no_usr_grp = "yes" == params.get("qemu_no_usr_grp", "no")
     # Get qemu.conf config variables
     qemu_user = params.get("qemu_user", None)
     qemu_group = params.get("qemu_group", None)
@@ -265,7 +266,8 @@ def run(test, params, env):
                                           "=%s" % disk_context +
                                           ", sec_label_trans=%s."
                                           % sec_label_trans)
-            elif set_qemu_conf and not security_default_confined:
+            elif(set_qemu_conf and not security_default_confined and not
+                 qemu_no_usr_grp):
                 if vm_context != qemu_conf_label_trans:
                     test.fail("Label of VM processs is not expected"
                               " after starting.\nDetail: vm_context="
@@ -334,7 +336,7 @@ def run(test, params, env):
                 if set_sec_label:
                     if sec_label:
                         if sec_relabel == "yes" and sec_label_trans == "0:0":
-                            if set_qemu_conf:
+                            if set_qemu_conf and not qemu_no_usr_grp:
                                 if qemu_conf_label_trans == "107:107":
                                     logging.debug(err_msg)
                         elif sec_relabel == "no" and sec_label_trans == "0:0":


### PR DESCRIPTION
testcase would change the dynamic_ownership and verify whether guest
is able to boot when dynamic_ownership is 1 and guest should fail
to boot when dynamic_ownership is 0.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>