### PR TITLE
virsh_domstate: add new test case virsh reset for preserve on crash action

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/monitor/virsh_domstate.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/monitor/virsh_domstate.cfg
@@ -38,6 +38,11 @@
                                     domstate_vm_oncrash = "restart"
                                 - oncrash_preserve:
                                     domstate_vm_oncrash = "preserve"
+                                    variants:
+                                        - @normal:
+                                            reset_action = "no"
+                                        - reset:
+                                            reset_action = "yes"
                                 - oncrash_coredump_destroy:
                                     domstate_vm_oncrash = "coredump-destroy"
                                 - oncrash_coredump_restart:


### PR DESCRIPTION
perform virsh reset after crashing vm with preserve as crash action, VM
will be in preseved debug state and virsh reset is expected to reboot
the guest and domstate should change from crashed to running.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>