### PR TITLE
Remove cputune from xml before test

### DIFF
--- a/libvirt/tests/cfg/numa/numa_memory.cfg
+++ b/libvirt/tests/cfg/numa/numa_memory.cfg
@@ -14,6 +14,7 @@
                      memory_mode = "interleave"
              variants:
                  - mem_auto:
+                     no preferred
                      memory_placement = "auto"
                  - mem_nodeset:
                      memory_placement = "static"

--- a/libvirt/tests/src/numa/numa_memory.py
+++ b/libvirt/tests/src/numa/numa_memory.py
@@ -170,6 +170,10 @@ def run(test, params, env):
         vmxml.numa_memory = numa_memory
         vcpu_num = vmxml.vcpu
         max_mem = vmxml.max_mem
+        if vmxml.xmltreefile.find('cputune'):
+            vmxml.xmltreefile.remove_by_xpath('/cputune')
+        else:
+            logging.debug('No vcpupin found')
         if vcpu_placement:
             vmxml.placement = vcpu_placement
         if vcpu_cpuset:


### PR DESCRIPTION
To avoid influence from original cpuset while checking results.

Also remove test cases with memory_placement as 'auto' while mode
as 'preferred'. The reason is that with both attribs setup, system
will eventually return 2 nodes which will cause the failure of
'NUMA memory tuning in 'preferred' mode only supports single node'.
Therefore these cases are not legitimate.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>
  