### PR TITLE
virsh_cpu_models: restart libvirtd for remote test

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_cpu_models.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_cpu_models.cfg
@@ -15,6 +15,7 @@
                 - local_host:
                     target_uri = "qemu:///system"
                 - remote_host:
+                    restart_libvirtd_remotely = "yes"
                     target_uri = "qemu+ssh://${remote_ip}/system"
         - negative_test:
             status_error = "yes"

--- a/libvirt/tests/src/virsh_cmd/host/virsh_cpu_models.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_cpu_models.py
@@ -1,7 +1,9 @@
 import logging
 
-from autotest.client.shared import error
+from avocado.utils import process
 
+from virttest import remote
+from virttest import ssh_key
 from virttest import virsh
 from virttest import libvirt_vm
 from virttest.libvirt_xml import capability_xml
@@ -16,10 +18,36 @@ def run(test, params, env):
     option = params.get("option", "")
     target_uri = params.get("target_uri", "default")
     status_error = "yes" == params.get("status_error", "no")
-    logging.debug(target_uri.count('EXAMPLE.COM'))
-    if target_uri.count('EXAMPLE.COM'):
-        raise error.TestNAError("Please replace '%s' with valid uri" %
-                                target_uri)
+    restart_libvirtd_remotely = "yes" == params.get(
+        "restart_libvirtd_remotely", "no")
+
+    remote_ip = params.get("remote_ip", "REMOTE.EXAMPLE.COM")
+    remote_pwd = params.get("remote_pwd", None)
+
+    local_ip = params.get("local_ip", "LOCAL.EXAMPLE.COM")
+    local_pwd = params.get("local_pwd", None)
+
+    if 'EXAMPLE.COM' in (target_uri, remote_ip, local_ip):
+        test.error("Please replace '%s/%s/%s' with valid uri or remote_ip or "
+                   "local_ip" % (target_uri, remote_ip, local_ip))
+
+    if restart_libvirtd_remotely:
+        try:
+            session = remote.remote_login("ssh", remote_ip, "22", "root",
+                                          remote_pwd, "#")
+            session.cmd_output('LANG=C')
+            ssh_key.setup_remote_ssh_key(remote_ip, "root", remote_pwd,
+                                         local_ip, "root", local_pwd)
+
+            cmd = "service libvirtd restart"
+            status, output = session.cmd_status_output(cmd, internal_timeout=5)
+            logging.debug("cmd: %s, status: %s, output: %s"
+                          % (cmd, status, output))
+        except process.CmdError, info:
+            test.error("Fail to restart libvirtd on remote: %s" % info)
+        finally:
+            session.close()
+
     connect_uri = libvirt_vm.normalize_connect_uri(target_uri)
     arch_list = []
     if not cpu_arch:
@@ -32,8 +60,8 @@ def run(test, params, env):
             for arch in set(guest_arch):
                 arch_list.append(arch)
         except Exception, e:
-            raise error.TestError("Fail to get guest arch list of the"
-                                  " host supported:\n%s" % e)
+            test.error("Fail to get guest arch list of the host"
+                       " supported:\n%s" % e)
     else:
         arch_list.append(cpu_arch)
     for arch in arch_list:


### PR DESCRIPTION
Restart remotely libvirtd to avoid test failed.