### PR TITLE
Change memory values to 2 exponent and 1024 multiples

### DIFF
--- a/libvirt/tests/cfg/libvirt_mem.cfg
+++ b/libvirt/tests/cfg/libvirt_mem.cfg
@@ -4,10 +4,10 @@
     status_error = no
     variants:
         - positive_test:
-            max_mem_rt = 2560000
-            max_mem = 1024000
-            current_mem = 1024000
-            numa_cells = "{'id':'0','cpus':'0-1','memory':'512000','unit':'KiB'} {'id':'1','cpus':'2-3','memory':'512000','unit':'KiB'}"
+            max_mem_rt = 2621440
+            max_mem = 1048576
+            current_mem = 1048576
+            numa_cells = "{'id':'0','cpus':'0-1','memory':'524288','unit':'KiB'} {'id':'1','cpus':'2-3','memory':'524288','unit':'KiB'}"
             add_mem_device = "yes"
             tg_size = 524288
             tg_sizeunit = "KiB"
@@ -19,10 +19,10 @@
             test_save_restore = "yes"
             variants:
                 - mem_basic:
-                    max_mem_rt = 2560000
+                    max_mem_rt = 2621440
                     max_mem = 1536000
                     current_mem = 1536000
-                    numa_cells = "{'id':'0','cpus':'0-1','memory':'1024000','unit':'KiB'} {'id':'1','cpus':'2-3','memory':'512000','unit':'KiB'}"
+                    numa_cells = "{'id':'0','cpus':'0-1','memory':'1048576','unit':'KiB'} {'id':'1','cpus':'2-3','memory':'524288','unit':'KiB'}"
                 - hot_plug:
                     attach_device = "yes"
                     detach_device = "no"
@@ -45,7 +45,7 @@
                     test_qemu_cmd = "no"
                     test_mem_binding = "yes"
                     setup_hugepages = "yes"
-                    max_mem_rt = 25600000
+                    max_mem_rt = 26214400
                     max_mem = "2609152"
                     current_mem = "2609152"
                     numa_cells = "{'id':'0','cpus':'0-1','memory':'1048576','unit':'KiB'} {'id':'1','cpus':'2-3','memory':'1048576','unit':'KiB'}"
@@ -75,10 +75,10 @@
                 - without_numa_save_restore:
                     numa_cells = ""
         - negative_test:
-            max_mem_rt = 2560000
-            max_mem = 1024000
-            current_mem = 1024000
-            numa_cells = "{'id':'0','cpus':'0-1','memory':'512000','unit':'KiB'} {'id':'1','cpus':'2-3','memory':'512000','unit':'KiB'}"
+            max_mem_rt = 2621440
+            max_mem = 1048576
+            current_mem = 1048576
+            numa_cells = "{'id':'0','cpus':'0-1','memory':'524288','unit':'KiB'} {'id':'1','cpus':'2-3','memory':'524288','unit':'KiB'}"
             add_mem_device = "yes"
             tg_size = 524288
             tg_sizeunit = "KiB"


### PR DESCRIPTION
Change the memory values to 2 exponent and 1024 multiples.
With the current values, which were not 2 exponent on ppc64le
seeing the test case failures. This patch resolves it.

Signed-off-by: Nageswara R Sastry <rnsastry@linux.vnet.ibm.com>