### PR TITLE
Modify check_qemu_cmd to handle different id

### DIFF
--- a/libvirt/tests/src/libvirt_mem.py
+++ b/libvirt/tests/src/libvirt_mem.py
@@ -69,8 +69,9 @@ def run(test, params, env):
                     % (max_mem_slots, max_mem_rt))
         if tg_size:
             size = int(tg_size) * 1024
-            cmd += (" | grep 'memory-backend-ram,id=memdimm.,size=%s"
-                    % size)
+            cmd_str = 'memdimm.\|memory-backend-ram,id=ram-node.'
+            cmd += (" | grep 'memory-backend-ram,id=%s' | grep 'size=%s"
+                    % (cmd_str, size))
             if pg_size:
                 cmd += ",host-nodes=%s" % node_mask
                 if numa_memnode:


### PR DESCRIPTION
Added 'ram-node' to 'check_qemu_cmd' function, this observed in
hugepages backed guest.
And in latest qemu 'memory-backend-ram' and 'size' are not
continuous so separated them as well.

Signed-off-by: Nageswara R Sastry <rnsastry@linux.vnet.ibm.com>