### PR TITLE
blockcopy:Ignore non-disk disks

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
@@ -367,6 +367,10 @@ def run(test, params, env):
         # Add all disks into xml file.
         vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
         disks = vmxml.devices.by_device_tag('disk')
+        # Remove non-storage disk such as 'cdrom'
+        for disk in disks:
+            if disk.device != 'disk':
+                disks.remove(disk)
         new_disks = []
         src_disk_xml = disks[0]
         disk_xml = snap_xml.SnapDiskXML()


### PR DESCRIPTION
In case making invalid snapshot that has not 'source' attrib

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>