### PR TITLE
Update for cpu hotplug timeout

### DIFF
--- a/libvirt/tests/src/libvirt_vcpu_plug_unplug.py
+++ b/libvirt/tests/src/libvirt_vcpu_plug_unplug.py
@@ -345,7 +345,7 @@ def run(test, params, env):
                     expect_vcpu_num['guest_live'] = vcpu_plug_num
                     if not status_error:
                         if not utils_misc.wait_for(lambda: utils_misc.check_if_vm_vcpu_match(vcpu_plug_num, vm),
-                                                   60, text="wait for vcpu online") or not online_new_vcpu(vm, vcpu_plug_num):
+                                                   120, text="wait for vcpu online") or not online_new_vcpu(vm, vcpu_plug_num):
                             test.fail("Fail to enable new added cpu")
 
                 # Pin vcpu


### PR DESCRIPTION
Specific parameters can not be completed within 60s
e.g: add vcpu from 1 to 240

Signed-off-by: Junxiang Li <junli@redhat.com>