### PR TITLE
Change test.error to test.cancel when remote ip not provided in 2 cases

### DIFF
--- a/libvirt/tests/src/virsh_cmd/host/virsh_cpu_models.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_cpu_models.py
@@ -23,7 +23,7 @@ def run(test, params, env):
                                                               "default"))
 
     if 'EXAMPLE.COM' in remote_ip:
-        test.error("Please replace '%s' with valid remote_ip" % remote_ip)
+        test.cancel("Please replace '%s' with valid remote_ip" % remote_ip)
 
     if remote_ref == "remote":
         ssh_key.setup_ssh_key(remote_ip, "root", remote_pwd)

--- a/libvirt/tests/src/virsh_cmd/host/virsh_domcapabilities.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_domcapabilities.py
@@ -17,7 +17,7 @@ def run(test, params, env):
                                                               "default"))
 
     if 'EXAMPLE.COM' in remote_ip:
-        test.error("Please replace '%s' with valid remote_ip" % remote_ip)
+        test.cancel("Please replace '%s' with valid remote_ip" % remote_ip)
 
     if remote_ref == "remote":
         ssh_key.setup_ssh_key(remote_ip, "root", remote_pwd)


### PR DESCRIPTION
Existing virsh_cmd cases always skipped if env not ready such as
remote host ip not provided. But these 2 cases will be failed if
ip not provided. Change them to make things consistent and avoid
regression case failure.

Signed-off-by: Yi Sun <yisun@redhat.com>