### PR TITLE
Round memory values to 1024 multiples

### DIFF
--- a/libvirt/tests/cfg/libvirt_mem.cfg
+++ b/libvirt/tests/cfg/libvirt_mem.cfg
@@ -2,6 +2,10 @@
     type = libvirt_mem
     start_vm = no
     status_error = no
+    # 'align_mem_values' takes "yes or no".
+    # If align_mem_values is 'yes' then does aligning memory value based on 'align_to_value'.
+    # If align_to_value is not given then '65536' will be taken as default.
+    align_mem_values = "no"
     variants:
         - positive_test:
             max_mem_rt = 2560000


### PR DESCRIPTION
This patch round memory values to 1024 multiples, this requires
for ppc64le architecture. With out these 1024 multiplesi, most of
the tests fail.

Signed-off-by: Nageswara R Sastry <rnsastry@linux.vnet.ibm.com>