### PR TITLE
V2V: Resolve uefi guest fail to check device.map

### DIFF
--- a/provider/v2v_vmcheck_helper.py
+++ b/provider/v2v_vmcheck_helper.py
@@ -212,7 +212,9 @@ class VMChecker(object):
 
         # 5. Check virtio disk partition
         logging.info("Checking virtio disk partition in device map")
-        if not self.checker.get_grub_device():
+        if self.checker.is_uefi_guest():
+            logging.info("The guest is uefi mode,skip the checkpoint")
+        elif not self.checker.get_grub_device():
             err_msg = "Not find vd? in disk partition"
             self.log_err(err_msg)
         else:

--- a/v2v/tests/cfg/convert_vm_to_libvirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_libvirt.cfg
@@ -18,7 +18,7 @@
 
     variants:
         - arch_i386:
-            no 7_4
+            no 7_LATEST7
             no win2008r2
             no win2012
             no win2012r2
@@ -32,10 +32,10 @@
             vm_user = ${username}
             vm_pwd = ${password}
             variants:
-                - 7_4:
-                    os_version = "rhel7.4"
-                - 6_9:
-                    os_version = "rhel6.9"
+                - 7_LATEST7:
+                    os_version = "rhel7.LATEST7"
+                - 6_LATEST6:
+                    os_version = "rhel6.LATEST6"
                 - 5_11:
                     os_version = "rhel5.11"
         - windows:
@@ -91,7 +91,7 @@
             v2v_opts = "-v -x"
             variants:
                 - pv:
-                    no 7_4
+                    no 7_LATEST7
                     vir_mode = "pv"
                 - hvm:
                     vir_mode = "hvm"

--- a/v2v/tests/cfg/convert_vm_to_ovirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_ovirt.cfg
@@ -33,7 +33,7 @@
             output_format = "qcow2"
     variants:
         - arch_i386:
-            no 7_4
+            no 7_LATEST7
             no win2008r2
             no win2012
             no win2012r2
@@ -47,10 +47,10 @@
             vm_user = ${username}
             vm_pwd = "redhat"
             variants:
-                - 7_4:
-                    os_version = "rhel7.4"
-                - 6_9:
-                    os_version = "rhel6.9"
+                - 7_LATEST7:
+                    os_version = "rhel7.LATEST6"
+                - 6_LATEST6:
+                    os_version = "rhel6.LATEST6"
                 - 5_11:
                     os_version = "rhel5.11"
         - windows:
@@ -112,7 +112,7 @@
             v2v_opts = "-v -x"
             variants:
                 - pv:
-                    no 7_4
+                    no 7_LATEST7
                     vir_mode = "pv"
                 - hvm:
                     vir_mode = "hvm"


### PR DESCRIPTION
Modify  "provider/v2v_vmcheck_helper.py" file ,resolve the uefi guest fail to check "device.map" part.

Signed-off-by: Kun Wei kuwei@redhat.com