### PR TITLE
Fix - E722 do not use bare except in libvirt_mem.py

### DIFF
--- a/libvirt/tests/src/libvirt_mem.py
+++ b/libvirt/tests/src/libvirt_mem.py
@@ -257,7 +257,7 @@ def run(test, params, env):
             try:
                 del vmxml.numa_memory
                 del vmxml.numa_memnode
-            except:
+            except Exception:
                 # Not exists
                 pass
 


### PR DESCRIPTION
Fix E722 do not use bare except
in libvirt_mem.py

Signed-off-by: Nageswara R Sastry <rnsastry@linux.vnet.ibm.com>