### PR TITLE
Add --nvram option for undefine

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
@@ -470,7 +470,7 @@ def run(test, params, env):
 
         # Prepare transient/persistent vm
         if persistent_vm == "no" and vm.is_persistent():
-            vm.undefine()
+            vm.undefine("--nvram")
         elif persistent_vm == "yes" and not vm.is_persistent():
             new_xml.define()
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockjob.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockjob.py
@@ -93,7 +93,7 @@ def run(test, params, env):
     # Prepare transient/persistent vm
     original_xml = vm.backup_xml()
     if not persistent_vm and vm.is_persistent():
-        vm.undefine()
+        vm.undefine("--nvram")
     elif persistent_vm and not vm.is_persistent():
         vm.define(original_xml)
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_undefine.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_undefine.py
@@ -2,6 +2,7 @@ import os
 import logging
 import shutil
 import time
+import platform
 
 import aexpect
 
@@ -58,6 +59,10 @@ def run(test, params, env):
     wipe_data = "yes" == params.get("wipe_data", "no")
     if wipe_data:
         option += " --wipe-storage"
+    nvram_o = None
+    if platform.machine() == 'aarch64':
+        nvram_o = " --nvram"
+        option += nvram_o
 
     vm_name = params.get("main_vm", "avocado-vt-vm1")
     vm = env.get_vm(vm_name)
@@ -157,7 +162,7 @@ def run(test, params, env):
                 logging.debug("Error status, command output: %s",
                               cmdresult.stderr.strip())
             if undefine_twice:
-                status2 = virsh.undefine(vm_ref,
+                status2 = virsh.undefine(vm_ref, nvram_o,
                                          ignore_status=True).exit_status
         else:
             if remote_ip.count("EXAMPLE.COM") or local_ip.count("EXAMPLE.COM"):
@@ -218,7 +223,7 @@ def run(test, params, env):
         # Test define with acl control and recover domain.
         if params.get('setup_libvirt_polkit') == 'yes':
             if virsh.domain_exists(vm.name):
-                virsh.undefine(vm_ref, ignore_status=True)
+                virsh.undefine(vm_ref, nvram_o, ignore_status=True)
             cmd = "chmod 666 %s" % backup_xml.xml
             process.run(cmd, ignore_status=False, shell=True)
             s_define = virsh.define(backup_xml.xml,


### PR DESCRIPTION
For UEFI boot VM, the --nvram option required to undefine vm.

For bios VM, use the option bring no harm.

Update case undefine and blockcopy first as they are in
acceptance test scope.

Signed-off-by: Wayne Sun <gsun@redhat.com>