### PR TITLE
v2v matrix matching problems in v2v cfg

### DIFF
--- a/v2v/tests/cfg/convert_vm_to_libvirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_libvirt.cfg
@@ -17,14 +17,14 @@
     network_dhcp_end = "192.168.10.254"
 
     variants:
-        - i386:
+        - arch_i386:
             no 7_4
             no win2008r2
             no win2012
             no win2012r2
             no win2016
             vm_arch = "i386"
-        - x86_64:
+        - arch_x86_64:
             vm_arch = "x86_64"
     variants:
         - linux:

--- a/v2v/tests/cfg/convert_vm_to_ovirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_ovirt.cfg
@@ -32,14 +32,14 @@
             image_format_n = "-qcow2"
             output_format = "qcow2"
     variants:
-        - i386:
+        - arch_i386:
             no 7_4
             no win2008r2
             no win2012
             no win2012r2
             no win2016
             vm_arch = "i386"
-        - x86_64:
+        - arch_x86_64:
             vm_arch = "x86_64"
     variants:
         - linux:


### PR DESCRIPTION
v2v i386 x86_64 variants are  easy to repeat.
In latest auto job testing will cause the some issue.

Signed-off-by: weikunzz <kuwei@redhat.com>