### PR TITLE
[tmp - no need to review] Emergent revert for tp-libvirt pr 1312

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
@@ -45,22 +45,6 @@
             no postcopy_after_precopy, migrate_postcopy
             postcopy_options = ""
     variants:
-        - compat_migration:
-            variants:
-                - ppc_compat_migration:
-                    only ppc64le,ppc64
-                    only there_live,there_live_with_numa,there_and_back,there_and_back_with_numa,postcopy_after_precopy,migrate_postcopy
-                    compat_mode = "yes"
-                    power9_compat = "yes"
-                    power9_compat_remote = "yes"
-                    restore_smt = "yes"
-                    # Test P8 compat mode guest on P9 host only
-                    host_arch = POWER9
-                    # Migrating Power8 guest between P9 <-> P9 hosts
-                    # and P8 <-> P9 hosts
-                    cpu_model = "power8"
-                - non_compat_migration:
-    variants:
         - with_cpu_hotplug:
             only there_live,there_live_with_numa,there_and_back,there_and_back_with_numa,postcopy_after_precopy,migrate_postcopy
             virsh_migrate_cpu_hotplug = "yes"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
@@ -46,10 +46,10 @@
             postcopy_options = ""
     variants:
         - compat_migration:
-            only there_live,there_live_with_numa,there_and_back,there_and_back_with_numa,postcopy_after_precopy,migrate_postcopy
             variants:
-                - with_compat_mode:
+                - ppc_compat_migration:
                     only ppc64le,ppc64
+                    only there_live,there_live_with_numa,there_and_back,there_and_back_with_numa,postcopy_after_precopy,migrate_postcopy
                     compat_mode = "yes"
                     power9_compat = "yes"
                     power9_compat_remote = "yes"
@@ -59,8 +59,7 @@
                     # Migrating Power8 guest between P9 <-> P9 hosts
                     # and P8 <-> P9 hosts
                     cpu_model = "power8"
-                - without_compat_mode:
-                    only ppc64le,ppc64
+                - non_compat_migration:
     variants:
         - with_cpu_hotplug:
             only there_live,there_live_with_numa,there_and_back,there_and_back_with_numa,postcopy_after_precopy,migrate_postcopy

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
@@ -668,31 +668,6 @@ def run(test, params, env):
                                                 "no")
     hotunplug_after_migrate = "yes" == params.get("virsh_hotunplug_cpu_after",
                                                   "no")
-    compat_guest_migrate = (params.get("host_arch", "all_arch") in
-                            utils_misc.get_cpu_info()['Model name'])
-    compat_mode = "yes" == params.get("compat_mode", "no")
-
-    # Configurations for cpu compat guest to boot
-    if compat_mode:
-        if compat_guest_migrate:
-            if not libvirt_version.version_compare(3, 2, 0):
-                test.cancel("host CPU model is not supported")
-            if vm.is_alive():
-                vm.destroy()
-            cpu_model = params.get("cpu_model", None)
-            vm_xml.VMXML.set_cpu_mode(vm.name, mode='host-model',
-                                      model=cpu_model)
-            vm.start()
-            session = vm.wait_for_login()
-            actual_cpu_model = utils_misc.get_cpu_info(session)['Model name']
-            if cpu_model not in actual_cpu_model.lower():
-                test.error("Failed to configure cpu model,\nexpected: %s but "
-                           "actual cpu model: %s" % (cpu_model,
-                                                     actual_cpu_model))
-            logging.debug("Configured cpu model successfully! Guest booted "
-                          "with CPU model: %s", actual_cpu_model)
-        else:
-            test.cancel("Host arch is not POWER9")
     # Configurations for cpu hotplug and cpu hotunplug
     if cpu_hotplug:
         # To check cpu hotplug is supported or not


### PR DESCRIPTION
With that pr, all virsh.migrate cases are lost on x86 platform.
Since it's in our highest priority acceptance test scope, I revert
that PR for now by this PR.

Signed-off-by: Yi Sun <yisun@redhat.com>