### PR TITLE
virsh_migrate: fix improper filter for migration tests

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
@@ -46,10 +46,10 @@
             postcopy_options = ""
     variants:
         - compat_migration:
-            only there_live,there_live_with_numa,there_and_back,there_and_back_with_numa,postcopy_after_precopy,migrate_postcopy
             variants:
-                - with_compat_mode:
+                - ppc_compat_migration:
                     only ppc64le,ppc64
+                    only there_live,there_live_with_numa,there_and_back,there_and_back_with_numa,postcopy_after_precopy,migrate_postcopy
                     compat_mode = "yes"
                     power9_compat = "yes"
                     power9_compat_remote = "yes"
@@ -59,8 +59,7 @@
                     # Migrating Power8 guest between P9 <-> P9 hosts
                     # and P8 <-> P9 hosts
                     cpu_model = "power8"
-                - without_compat_mode:
-                    only ppc64le,ppc64
+                - non_compat_migration:
     variants:
         - with_cpu_hotplug:
             only there_live,there_live_with_numa,there_and_back,there_and_back_with_numa,postcopy_after_precopy,migrate_postcopy


### PR DESCRIPTION
improper filter caused migration to get lost on x86 platform,
fixed it in the patch.

Signed-off-by: Junxiang Li junli@redhat.com
Signed-off-by: Yi Sun yisun@redhat.com
Reported-by: Yi Sun yisun@redhat.com
Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>