### PR TITLE
Remove non-disk disks before test

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
@@ -808,6 +808,18 @@ def run(test, params, env):
     5) Restore domain
     6) Handle results
     """
+    # Remove non-disk disks before test to avoid influence.
+    # None-disk disks such as cdrom with bus 'SATA' will be recognized
+    # as 'cdrom', not 'sda' as expected, therefore the attached SATA
+    # disk will not be recognized as 'sdb' as expected.
+    vm_name = params.get('main_vm')
+    backup_vm_xml = vmxml = VMXML.new_from_inactive_dumpxml(vm_name)
+    disks = vmxml.devices.by_device_tag('disk')
+    for disk in disks:
+        if disk.device != 'disk':
+            virsh.detach_disk(vm_name, disk.target['dev'],
+                              extra='--current',
+                              debug=True)
 
     dev_obj = params.get("vadu_dev_objs")
     # Skip chardev hotplug on rhel6 host as it is not supported
@@ -877,3 +889,4 @@ def run(test, params, env):
         # Device cleanup can raise multiple exceptions, do it last:
         logging.info("Cleaning up test devices")
         test_params.cleanup(test_devices)
+        backup_vm_xml.sync()


### PR DESCRIPTION
The whole procedure is to count disks in vm first, generate target
for the to be attached disk, attach disk, then check the status of
the attached disk.

If there's a cdrom disk in original vm, let's say its target is sda,
The attached disk will be 'sdb'. The checking step will try to find
certain string in vm device '/dev/sdb' which does not exist, since
the disk supposed to be 'sda' is acctually 'cdrom' in /dev.

Therefore remove any non-disk disks before test starts.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>