### PR TITLE
Remove vms in vcpu pin config file

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_vcpupin.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_vcpupin.cfg
@@ -41,7 +41,6 @@
                 - multi_dom:
                     no ppc64, ppc64le
                     multi_dom_pin = "yes"
-                    vms = "avocado-vt-vm1 avocado-vt-vm2"
                 - initial_check:
                     only online
                     kill_vm_before_test = yes


### PR DESCRIPTION
vms' names should not be hard coded here, it should be replaced in
CI or provided manually by end users.

Signed-off-by: Yi Sun <yisun@redhat.com>