### PR TITLE
virsh_domstate: configure less guest memory for coredump testcase

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/monitor/virsh_domstate.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/monitor/virsh_domstate.cfg
@@ -44,8 +44,12 @@
                                         - reset:
                                             reset_action = "yes"
                                 - oncrash_coredump_destroy:
+                                    memory_value = "2097152"
+                                    memory_unit = "KiB"
                                     domstate_vm_oncrash = "coredump-destroy"
                                 - oncrash_coredump_restart:
+                                    memory_value = "2097152"
+                                    memory_unit = "KiB"
                                     domstate_vm_oncrash = "coredump-restart"
         - error_test:
             status_error = "yes"

--- a/libvirt/tests/src/virsh_cmd/monitor/virsh_domstate.py
+++ b/libvirt/tests/src/virsh_cmd/monitor/virsh_domstate.py
@@ -108,9 +108,23 @@ def run(test, params, env):
 
     dump_path = os.path.join(test.tmpdir, "dump/")
     logging.debug("dump_path: %s", dump_path)
-    os.mkdir(dump_path)
+    try:
+        os.mkdir(dump_path)
+    except OSError:
+        # If the path already exists then pass
+        pass
     dump_file = ""
     try:
+        # Let's have guest memory less so that dumping core takes
+        # time which doesn't timeout the testcase
+        if vm_oncrash_action in ['coredump-destroy', 'coredump-restart']:
+            memory_value = int(params.get("memory_value", "2097152"))
+            memory_unit = params.get("memory_unit", "KiB")
+            vmxml.set_memory(memory_value)
+            vmxml.set_memory_unit(memory_unit)
+            logging.debug(vmxml)
+            vmxml.sync()
+
         if vm_action == "crash":
             if vm.is_alive():
                 vm.destroy(gracefully=False)

--- a/libvirt/tests/src/virsh_cmd/monitor/virsh_domstate.py
+++ b/libvirt/tests/src/virsh_cmd/monitor/virsh_domstate.py
@@ -141,7 +141,7 @@ def run(test, params, env):
             qemu_conf.auto_dump_path = dump_path
             libvirtd_service.restart()
             if vm_oncrash_action in ['coredump-destroy', 'coredump-restart']:
-                dump_file = dump_path + "*" + vm_name + "-*"
+                dump_file = dump_path + "*" + vm_name[:20] + "-*"
             # Start VM and check the panic device
             virsh.start(vm_name, ignore_status=False)
             vmxml_new = vm_xml.VMXML.new_from_dumpxml(vm_name)


### PR DESCRIPTION
guest with huge memory takes more time for dumping core which timeout
the testcase and cause error, instead configuring less memory would
ensure test to work properly

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>