### PR TITLE
vol_create: Skip bug 106028

### DIFF
--- a/libvirt/tests/src/virsh_cmd/volume/virsh_vol_create.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_vol_create.py
@@ -311,7 +311,7 @@ def run(test, params, env):
                 except (process.CmdError, exceptions.TestFail), e:
                     if process_vol_type == "thin":
                         logging.error(str(e))
-                        test.fail("You may encounter bug BZ#1060287")
+                        test.cancel("You may encounter bug BZ#1060287")
                     else:
                         raise e
             else:


### PR DESCRIPTION
This PR is to fix PR  #1211 for tp-libvirt,
where the exception shall be skipped instead
of test.fail

Signed-off-by: Yan Li <yannli@redhat.com>