### PR TITLE
virtual_disks_multivms: Fix the error:Fail to start domain vm2 

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_multivms.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multivms.py
@@ -14,6 +14,8 @@ from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.disk import Disk
 from virttest.libvirt_xml.devices.controller import Controller
 
+from provider import libvirt_version
+
 
 def run(test, params, env):
     """
@@ -179,6 +181,11 @@ def run(test, params, env):
             if len(vms_sgio) > i:
                 disk_sgio = vms_sgio[i]
             shareable = ""
+
+            # Since lock feature is introduced in libvirt 3.9.0 afterwards, disk shareable attribute
+            # need be set if both of VMs need be started successfully in case they share the same disk
+            if test_error_policy and libvirt_version.version_compare(3, 9, 0):
+                vms_share = ["shareable", "shareable"]
             if len(vms_share) > i:
                 shareable = vms_share[i]
             readonly = ""


### PR DESCRIPTION
At the time of testing, the same virtual hard disk is loaded
because of the two VM, which causes vm2 to not start.
Add a piece of code to the virtual_disks_multivms.py
file so that the XML of the second virtual disks added
during the test has a shareable attribute,
which solves the problem of the vm2 start failure

Signed-off-by: zonqi <zonqi@redhat.com>