### PR TITLE
Remove host_threads check for guest smt

### DIFF
--- a/libvirt/tests/src/smt.py
+++ b/libvirt/tests/src/smt.py
@@ -116,8 +116,6 @@ def run(test, params, env):
         host_threads = int(re.findall('Threads per core:\s+(\d+)', output)[0])
     except:
         test.cancel("Unable to get the host threads")
-    if vm_threads > host_threads and not status_error:
-        test.cancel("Host threads is less than requested guest threads")
 
     logging.info("Guest: cores:%d, threads:%d, sockets:%d", vm_cores,
                  vm_threads, vm_sockets)


### PR DESCRIPTION
Removed host_threads check for guest smt as it is independant
now, the change got introduced in the below qemu commit.
Reference: https://github.com/qemu/qemu/commit/03ee51d3548f5f553a3089f466483c1c6d5c666b

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>