### PR TITLE
virsh_migration: optimize migration testcase by using migration_setup

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migration.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migration.cfg
@@ -1,6 +1,7 @@
 - virsh.migration: install setup image_copy unattended_install.cdrom
     type = virsh_migration
     start_vm = yes
+    migration_setup = "yes"
     migrate_vm_state = "running"
     migrate_start_state = "paused"
     ping_count = 20


### PR DESCRIPTION
use migration_setup param to perform pre/post migration setups instead
from testcase

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>