### PR TITLE
migrate_vm: Fix incorrect logic

### DIFF
--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -1683,6 +1683,7 @@ def run(test, params, env):
 
                 vm_xml_cxt = process.system_output("virsh dumpxml %s" % vm_name, shell=True)
                 logging.debug("The VM XML with attached disk: \n%s", vm_xml_cxt)
+                source_file = None
 
         if local_image and not os.path.exists(local_image):
             image_fmt = test_dict.get("local_image_format", "raw")


### PR DESCRIPTION
The changed variable was not assigned expected value before which
causing the cdrom disk and floopy disk have some source file name
incorrectly. But the problem was not exposed as the case luckily passed
in the past, while the qemu image lock caused this case to fail in
RHEL7.5 now. So we need correct the wrong logic here to make it use
different image names.

Signed-off-by: Dan Zheng <dzheng@redhat.com>