### PR TITLE
migrate_vm: Fix cancel migration

### DIFF
--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -2043,6 +2043,7 @@ def run(test, params, env):
                     if utils_misc.safe_kill(p.pid, signal.SIGINT):
                         logging.info("Succeed to cancel migration:"
                                      " [%s].", p.pid)
+                        time.sleep(delay)
                     else:
                         raise exceptions.TestError("Fail to cancel"
                                                    " migration: [%s]", p.pid)


### PR DESCRIPTION
After canceling migration, we do migration again without any dealy which
causes the qemu has no enough time to clean up the guest on target host.
So new migration will fail with founding guest on target host. This is
to fix this problem by adding some waiting seconds.

Signed-off-by: Dan Zheng <dzheng@redhat.com>