### PR TITLE
virsh_domblkerror: Fixup to check nfs package availablity in host, n

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domblkerror.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domblkerror.py
@@ -45,13 +45,10 @@ def run(test, params, env):
 
     vm = env.get_vm(vm_name)
     if error_type == "unspecified error":
-        session = vm.wait_for_login()
         if not ubuntu:
             nfs_service_package = "nfs"
-        if not utils_package.package_install(nfs_service_package, session):
-            session.close()
+        if not utils_package.package_install(nfs_service_package):
             test.cancel("NFS package not available in guest to test")
-        session.close()
         # backup /etc/exports
         shutil.copyfile(export_file, "%s.bak" % export_file)
     # backup xml


### PR DESCRIPTION
For unspecified_error test would require nfs packages to be installed and
available in host, commit 4f78942 checks and installs in guest which breaks
the test.

Signed-off-by: Junxiang Li <junli@redhat.com>
Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>