### PR TITLE
Dettach node device from host without device driver

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_detach_reattach.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_detach_reattach.cfg
@@ -6,6 +6,7 @@
     nodedev_device = 'ENTER.YOUR.PCI.DEVICE.TO.DETACH'
     #nodedev_device_opt: options for nodedev cmd.
     nodedev_device_opt = ""
+    with_driver = "yes"
     variants:
         - positive:
             status_error = "no"
@@ -17,6 +18,8 @@
                     action_lookup = "connect_driver:QEMU"
                     unprivileged_user = "EXAMPLE"
                     virsh_uri = "qemu:///system"
+                - non_driver_test:
+                    with_driver = 'no' 
         - negative:
             status_error = "yes"
             variants:

--- a/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_detach_reattach.py
+++ b/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_detach_reattach.py
@@ -28,6 +28,16 @@ def run(test, params, env):
             return None
         return driver
 
+    def get_device_driver(device_address):
+        """
+        Get the driver of device.
+        :param device_address: The address of device, such as pci_0000_19_00_0
+        :return: The driver of device, such as ixgbe, igb
+        """
+        driver_strings = get_driver_readlink(device_address).strip().split('/')
+        driver = driver_strings[-1]
+        return driver
+
     def detach_reattach_nodedev(device_address, params, options=""):
         """
         Do the detach and reattach.
@@ -84,11 +94,19 @@ def run(test, params, env):
         route_cmd = " route | grep default"
         route_default = process.run(route_cmd, shell=True).stdout_text.strip().split(' ')
         ip_default = route_default[-1]
+
+        for default_net_name in net_lists:
+            if default_net_name.find(ip_default):
+                default_net_address = nodedev_xml.NodedevXML.new_from_dumpxml(default_net_name).parent
+                default_net_driver = get_device_driver(default_net_address)
+                break
         for net_device_name in net_lists:
             if net_device_name.find(ip_default) == -1:
                 net_device_address = nodedev_xml.NodedevXML.new_from_dumpxml(net_device_name).parent
                 if 'pci' in net_device_address:
-                    return net_device_address
+                    net_device_driver = get_device_driver(net_device_address)
+                    if net_device_driver != default_net_driver:
+                        return net_device_address
 
     def check_kernel_option():
         """
@@ -116,16 +134,24 @@ def run(test, params, env):
             test.cancel('Param device_address is not configured.')
     device_opt = params.get('nodedev_device_opt', '')
     status_error = ('yes' == params.get('status_error', 'no'))
+    with_driver = params.get('with_driver', 'yes') == 'yes'
     # check variables.
     if not libvirt_version.version_compare(1, 1, 1):
         if params.get('setup_libvirt_polkit') == 'yes':
             test.cancel("API acl test not supported in current"
                         " libvirt version.")
 
+    # check the device driver and delete the driver
+    if not with_driver:
+        device_driver = get_device_driver(device_address)
+        remove_cmd = "modprobe -r %s" % device_driver
+        remove_opt = process.system(remove_cmd, shell=True)
+        if remove_opt != 0:
+            test.fail("Fail to remove the device driver : %s" % device_driver)
     # Do nodedev_detach_reattach
     try:
         detach_reattach_nodedev(device_address, params, device_opt)
-    except exceptions.TestFail, e:
+    except exceptions.TestFail as e:
         # Do nodedev detach and reattach failed.
         if status_error:
             return
@@ -136,3 +162,10 @@ def run(test, params, env):
     # Do nodedev detach and reattach success.
     if status_error:
         test.fail('Test successed in negative case.')
+
+    # reload the device driver
+    if not with_driver:
+        reload_cmd = "modprobe %s" % device_driver
+        reload_opt = process.system(reload_cmd, shell=True)
+        if reload_opt != 0:
+            test.fail("Fail to reload the device driver : %s" % device_driver)


### PR DESCRIPTION
Check the driver of device and remove the driver.
Then detach the node device and reattach it.

Signed-off-by: Jingjing Shao <jishao@redhat.com>