### PR TITLE
Python 3: Fixup virsh.capabilities failure

### DIFF
--- a/libvirt/tests/src/virsh_cmd/host/virsh_capabilities.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_capabilities.py
@@ -97,7 +97,7 @@ def run(test, params, env):
             if set(exp_pms) != set(pms):
                 test.fail("Expected supported PMs are %s, got %s "
                           "instead." % (exp_pms, pms))
-        except ValueError:
+        except path.CmdNotFoundError:
             logging.debug('Power management checking is skipped, since command'
                           ' pm-is-supported is not found.')
 


### PR DESCRIPTION
PR #1443 replaced autotest 'os_dep.command' with
avocado 'path.find_command', but missed to update
the returned exception, So case would be failed when
cmd can't be found

Signed-off-by: Yan Li <yannli@redhat.com>