### PR TITLE
Python 3: Fixup cpu_online_list replacement issue

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_emulatorpin.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_emulatorpin.py
@@ -215,7 +215,8 @@ def run(test, params, env):
         if cpulist is None:
             pass
         elif cpulist == "x":
-            cpulist = random.choice(cpu.cpu_online_list())
+            cpu_online_map = list(map(str, cpu.cpu_online_list()))
+            cpulist = random.choice(cpu_online_map)
         elif cpulist == "x-y":
             # By default, emulator is pined to all cpus, and element
             # 'cputune/emulatorpin' may not exist in VM's XML.
@@ -227,7 +228,8 @@ def run(test, params, env):
             else:
                 cpulist = "0-%s" % (cpu_max - 1)
         elif cpulist == "x,y":
-            cpulist = ','.join(random.sample(cpu.cpu_online_list(), 2))
+            cpu_online_map = list(map(str, cpu.cpu_online_list()))
+            cpulist = ','.join(random.sample(cpu_online_map, 2))
         elif cpulist == "x-y,^z":
             cpulist = "0-%s,^%s" % (cpu_max, cpu_max)
         elif cpulist == "-1":


### PR DESCRIPTION
Replace autotest cpu_online_map with avocado
cpu_online_list. Since cpu_online list return int
sequence while cpu_online_map return str sequence,
so some extra convertion needed here.

Signed-off-by: Yan Li <yannli@redhat.com>