### PR TITLE
Fix a parameter position error

### DIFF
--- a/libvirt/tests/src/virsh_cmd/volume/virsh_vol_resize.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_vol_resize.py
@@ -275,8 +275,8 @@ def run(test, params, env):
 
         # Create a volume
         if b_luks_encrypt:
-            luks_sec_uuid = create_luks_secret(os.path.join(pool_target, vol_name, test),
-                                               encryption_password)
+            luks_sec_uuid = create_luks_secret(os.path.join(pool_target, vol_name),
+                                               encryption_password, test)
             secret_uuids.append(luks_sec_uuid)
             create_luks_vol(vol_name, luks_sec_uuid, params)
         else:


### PR DESCRIPTION
Wrongly put 'test' in to os.path.join(), fixed.

Signed-off-by: Yi Sun <yisun@redhat.com>