### PR TITLE
Python 3: Port libvirt_bench, daemon and misc dirs

### DIFF
--- a/libvirt/tests/src/controller/controller_functional.py
+++ b/libvirt/tests/src/controller/controller_functional.py
@@ -171,7 +171,7 @@ def run(test, params, env):
             logging.debug("String for address element %s is %s", addr, addr_str)
             return addr_str
 
-    def check_controller_addr():
+    def check_controller_addr(test):
         """
         Check test controller address against expectation.
         """
@@ -194,7 +194,7 @@ def run(test, params, env):
             test.fail('Expect get controller address "%s", '
                       'but got "%s"' % (exp_addr_patt, addr_str))
 
-    def check_qemu_cmdline():
+    def check_qemu_cmdline(test):
         """
         Check domain qemu command line against expectation.
         """
@@ -223,7 +223,7 @@ def run(test, params, env):
             test.fail('Expect get qemu command serial option "%s", '
                       'but got "%s"' % (exp_pcihole_opt, pcihole_opt))
 
-    def check_msi():
+    def check_msi(test):
         """
         Check MSI state against expectation.
         """
@@ -271,7 +271,7 @@ def run(test, params, env):
             logging.debug("Can't define the VM, exiting.")
             return
 
-        check_controller_addr()
+        check_controller_addr(test)
 
         try:
             if not start_and_check():
@@ -280,9 +280,9 @@ def run(test, params, env):
         except virt_vm.VMStartError as detail:
             test.fail(detail)
 
-        check_qemu_cmdline()
+        check_qemu_cmdline(test)
 
         if cntlr_type == 'virtio-serial':
-            check_msi()
+            check_msi(test)
     finally:
         vm_xml_backup.sync()

--- a/libvirt/tests/src/daemon/crash_regression.py
+++ b/libvirt/tests/src/daemon/crash_regression.py
@@ -1,6 +1,8 @@
 import os
 import logging
 
+from six.moves import xrange
+
 from avocado.utils import path
 from avocado.utils import process
 

--- a/libvirt/tests/src/daemon/init_scripts.py
+++ b/libvirt/tests/src/daemon/init_scripts.py
@@ -3,9 +3,8 @@ import glob
 import shutil
 import logging
 
-from autotest.client import os_dep
-from autotest.client import utils
-from autotest.client.shared import error
+from avocado.utils import path
+from avocado.utils import process
 
 from virttest import utils_libvirtd
 
@@ -24,9 +23,9 @@ def run(test, params, env):
         """
         if cmd in ['initctl', 'systemctl']:
             try:
-                os_dep.command(cmd)
+                path.find_command(cmd)
                 return True
-            except ValueError:
+            except path.CmdNotFoundError:
                 return False
         elif cmd == 'initscripts':
             return os.path.exists('/etc/rc.d/init.d/libvirtd')
@@ -38,16 +37,16 @@ def run(test, params, env):
         :param cmd: service name. Can be initctl, systemctl or initscripts
         """
         if cmd == 'systemctl':
-            res = utils.run('systemctl list-unit-files')
+            res = process.run('systemctl list-unit-files', shell=True)
             for ufile in ["libvirt-guests.service",
                           "libvirtd.service", "libvirtd.socket"]:
                 if ufile not in res.stdout:
-                    raise error.TestFail('Missing systemd unit file %s'
-                                         % ufile)
+                    test.fail('Missing systemd unit file %s'
+                              % ufile)
         elif cmd == 'initctl':
             script = glob.glob('/usr/share/doc/*/libvirtd.upstart')
             if not script:
-                raise error.TestFail('Cannot find libvirtd.upstart script')
+                test.fail('Cannot find libvirtd.upstart script')
             if not os.path.exists('/etc/init/libvirtd.conf'):
                 shutil.copyfile(script[0], '/etc/init/libvirtd.conf')
 
@@ -71,12 +70,12 @@ def run(test, params, env):
         if user:
             cmdline = 'su - %s -c "%s"' % (user, cmdline)
 
-        res = utils.run(cmdline, ignore_status=True)
+        res = process.run(cmdline, ignore_status=True, shell=True)
         logging.debug(res)
 
         if res.exit_status != expected_exit_code:
-            raise error.TestFail("Expected exit status is %s, but got %s." %
-                                 (expected_exit_code, res.exit_status))
+            test.fail("Expected exit status is %s, but got %s." %
+                      (expected_exit_code, res.exit_status))
         return res
 
     commands = ['initctl', 'initscripts', 'systemctl']
@@ -90,8 +89,8 @@ def run(test, params, env):
     libvirtd.stop()
 
     username = 'virt-test'
-    utils.run('useradd %s' % username, ignore_status=True)
-    utils.run('usermod -s /bin/bash %s' % username, ignore_status=True)
+    process.run('useradd %s' % username, ignore_status=True, shell=True)
+    process.run('usermod -s /bin/bash %s' % username, ignore_status=True, shell=True)
     try:
         for command in avail_commands:
             if command == 'systemctl':
@@ -126,5 +125,5 @@ def run(test, params, env):
                 service_call(command, 'status',
                              expected_exit_code=3)
     finally:
-        utils.run('userdel -r virt-test', ignore_status=True)
+        process.run('userdel -r virt-test', ignore_status=True, shell=True)
         libvirtd.restart()

--- a/libvirt/tests/src/daemon/kill_qemu.py
+++ b/libvirt/tests/src/daemon/kill_qemu.py
@@ -1,8 +1,6 @@
 import os
 import signal
 
-from autotest.client.shared import error
-
 from virttest import utils_misc
 from virttest.libvirt_xml import vm_xml
 
@@ -33,14 +31,14 @@ def run(test, params, env):
             vm.prepare_guest_agent()
             vm.pmsuspend()
         else:
-            raise error.TestError("Unhandled VM state %s" % vm_state)
+            test.error("Unhandled VM state %s" % vm_state)
 
         os.kill(vm.get_pid(), getattr(signal, sig_name))
 
         stopped = bool(
             utils_misc.wait_for(lambda: vm.state() == 'shut off', 60))
         if stopped != expect_stop:
-            raise error.TestFail('Expected VM stop is "%s", got "%s"'
-                                 % (expect_stop, vm.state()))
+            test.fail('Expected VM stop is "%s", got "%s"'
+                      % (expect_stop, vm.state()))
     finally:
         xml_backup.sync()

--- a/libvirt/tests/src/daemon/kill_started.py
+++ b/libvirt/tests/src/daemon/kill_started.py
@@ -3,8 +3,6 @@ import time
 import signal
 import logging
 
-from autotest.client.shared import error
-
 from virttest.utils_libvirtd import Libvirtd
 
 
@@ -48,18 +46,18 @@ def run(test, params, env):
 
         if libvirtd.is_running():
             if not should_restart:
-                raise error.TestFail(
+                test.fail(
                     "libvirtd should stop running after signal %s"
                     % signal_name)
             new_pid = get_pid(libvirtd)
             logging.debug("New pid of libvirtd is %d" % new_pid)
             if pid == new_pid and pid_should_change:
-                raise error.TestFail("Pid should have been changed.")
+                test.fail("Pid should have been changed.")
             if pid != new_pid and not pid_should_change:
-                raise error.TestFail("Pid should not have been changed.")
+                test.fail("Pid should not have been changed.")
         else:
             if should_restart:
-                raise error.TestFail(
+                test.fail(
                     "libvirtd should still running after signal %s"
                     % signal_name)
 
@@ -68,5 +66,5 @@ def run(test, params, env):
             if os.path.exists(pid_file):
                 os.remove(pid_file)
                 libvirtd.start()
-                raise error.TestFail("Pid file should not reside")
+                test.fail("Pid file should not reside")
             libvirtd.start()

--- a/libvirt/tests/src/daemon/kill_starting.py
+++ b/libvirt/tests/src/daemon/kill_starting.py
@@ -1,7 +1,5 @@
 import logging
 
-from autotest.client.shared import error
-
 from virttest import utils_misc
 from virttest.utils_libvirtd import LibvirtdSession
 
@@ -43,6 +41,6 @@ def run(test, params, env):
         libvirtd.start(wait_for_working=False)
 
         if not utils_misc.wait_for(lambda: bundle['recieved'], 20, 0.5):
-            raise error.TestFail("Expect recieve signal, but not.")
+            test.fail("Expect recieve signal, but not.")
     finally:
         libvirtd.exit()

--- a/libvirt/tests/src/daemon/restart_consist.py
+++ b/libvirt/tests/src/daemon/restart_consist.py
@@ -4,8 +4,6 @@ import difflib
 from aexpect import ExpectTimeoutError
 from aexpect import ShellTimeoutError
 
-from autotest.client.shared import error
-
 from virttest import utils_libvirtd
 from virttest import utils_misc
 from virttest import remote
@@ -46,8 +44,8 @@ def run(test, params, env):
         session = vm.wait_for_serial_login(60, username=username,
                                            password=password)
     except remote.LoginError:
-        raise error.TestNAError('Serial console might needed to be '
-                                'configured before test.')
+        test.cancel('Serial console might needed to be '
+                    'configured before test.')
     # Send a command line without waiting result
     try:
         session.cmd('sleep 30; echo hello', timeout=0)
@@ -63,8 +61,8 @@ def run(test, params, env):
     try:
         vm.serial_console.read_until_any_line_matches(['hello'], timeout=60)
     except ExpectTimeoutError:
-        raise error.TestFail('Timeout when waiting for command output. '
-                             'Maybe your guest is refreshed.')
+        test.fail('Timeout when waiting for command output. '
+                  'Maybe your guest is refreshed.')
 
     # Wait guest agent channel to be reconnected to avoid XML differ
     try:
@@ -84,5 +82,5 @@ def run(test, params, env):
                 lineterm='',
             )
         )
-        raise error.TestFail("XML changed after libvirtd restart:\n%s"
-                             % diff_txt)
+        test.fail("XML changed after libvirtd restart:\n%s"
+                  % diff_txt)

--- a/libvirt/tests/src/libvirt_bench/libvirt_bench_domstate_switch_by_groups.py
+++ b/libvirt/tests/src/libvirt_bench/libvirt_bench_domstate_switch_by_groups.py
@@ -1,4 +1,4 @@
-from autotest.client.shared import error
+from avocado.core import exceptions
 
 from virttest import utils_test
 
@@ -14,7 +14,7 @@ def run(test, params, env):
     # Get VMs.
     vms = env.get_all_vms()
     if len(vms) < 2:
-        raise error.TestNAError("We need at least 2 vms for this test.")
+        test.cancel("We need at least 2 vms for this test.")
     timeout = params.get("LB_domstate_switch_loop_time", 600)
     # Divide vms into two groups.
     odd_group_vms = []
@@ -49,13 +49,13 @@ def run(test, params, env):
     err_msg = ""
     try:
         odd_bt.join(int(timeout) * 2)
-    except error.TestFail, detail:
+    except exceptions.TestFail as detail:
         err_msg += ("Group odd_group failed to run sub test.\n"
                     "Detail: %s." % detail)
     try:
         even_bt.join(int(timeout) * 2)
-    except error.TestFail, detail:
+    except exceptions.TestFail as detail:
         err_msg += ("Group even_group failed to run sub test.\n"
                     "Detail: %s." % detail)
     if err_msg:
-        raise error.TestFail(err_msg)
+        test.fail(err_msg)

--- a/libvirt/tests/src/libvirt_bench/libvirt_bench_dump_with_netperf.py
+++ b/libvirt/tests/src/libvirt_bench/libvirt_bench_dump_with_netperf.py
@@ -1,8 +1,6 @@
 import os
 import logging
 
-from autotest.client.shared import error
-
 from virttest import utils_test
 from virttest import utils_misc
 
@@ -42,10 +40,10 @@ def run(test, params, env):
                     "cat /usr/local/autotest/results/default/debug/client.DEBUG|"
                     "grep \"seconds remaining\""))
         if not utils_misc.wait_for(_is_netperf_running, timeout=120):
-            raise error.TestNAError("Failed to run netperf in guest.\n"
-                                    "Since we need to run a autotest of netperf "
-                                    "in guest, so please make sure there are some "
-                                    "necessary packages in guest, such as gcc, tar, bzip2")
+            test.cancel("Failed to run netperf in guest.\n"
+                        "Since we need to run a autotest of netperf "
+                        "in guest, so please make sure there are some "
+                        "necessary packages in guest, such as gcc, tar, bzip2")
 
     logging.debug("Netperf is already running in VMs.")
 
@@ -55,9 +53,9 @@ def run(test, params, env):
             vm.dump(dump_path)
             # Check the status after vm.dump()
             if not vm.is_alive():
-                raise error.TestFail("VM is shutoff after dump.")
+                test.fail("VM is shutoff after dump.")
             if vm.wait_for_shutdown():
-                raise error.TestFail("VM is going to shutdown after dump.")
+                test.fail("VM is going to shutdown after dump.")
             # Check VM is running normally.
             vm.wait_for_login()
     finally:

--- a/libvirt/tests/src/libvirt_bench/libvirt_bench_dump_with_unixbench.py
+++ b/libvirt/tests/src/libvirt_bench/libvirt_bench_dump_with_unixbench.py
@@ -1,8 +1,6 @@
 import os
 import logging
 
-from autotest.client.shared import error
-
 from virttest import utils_test
 from virttest import utils_misc
 
@@ -39,10 +37,10 @@ def run(test, params, env):
         def _is_unixbench_running():
             return (not session.cmd_status("ps -ef|grep perl|grep Run"))
         if not utils_misc.wait_for(_is_unixbench_running, timeout=120):
-            raise error.TestNAError("Failed to run unixbench in guest.\n"
-                                    "Since we need to run a autotest of unixbench "
-                                    "in guest, so please make sure there are some "
-                                    "necessary packages in guest, such as gcc, tar, bzip2")
+            test.cancel("Failed to run unixbench in guest.\n"
+                        "Since we need to run a autotest of unixbench "
+                        "in guest, so please make sure there are some "
+                        "necessary packages in guest, such as gcc, tar, bzip2")
 
     logging.debug("Unixbench is already running in VMs.")
 
@@ -52,9 +50,9 @@ def run(test, params, env):
             vm.dump(dump_path)
             # Check the status after vm.dump()
             if not vm.is_alive():
-                raise error.TestFail("VM is shutoff after dump.")
+                test.fail("VM is shutoff after dump.")
             if vm.wait_for_shutdown():
-                raise error.TestFail("VM is going to shutdown after dump.")
+                test.fail("VM is going to shutdown after dump.")
             # Check VM is running normally.
             vm.wait_for_login()
     finally:

--- a/libvirt/tests/src/libvirt_bench/libvirt_bench_serial_hotplug.py
+++ b/libvirt/tests/src/libvirt_bench/libvirt_bench_serial_hotplug.py
@@ -5,8 +5,6 @@ import subprocess
 import time
 import shutil
 
-from autotest.client.shared import error
-
 from virttest import virsh
 from virttest import libvirt_vm
 from virttest import utils_test
@@ -96,15 +94,14 @@ def run(test, params, env):
         chardev_c = h_o.count("chardev = %s%s" % (char_dev, index))
         name_c = h_o.count("name = \"%s%s\"" % (char_dev, index))
         if chardev_c == 0 and name_c == 0:
-            raise error.TestFail("Cannot get serial device info: '%s'" % h_o)
+            test.fail("Cannot get serial device info: '%s'" % h_o)
 
         tmp_file = "%s/%s%s" % (tmp_dir, char_dev, index)
         serial_file = "/dev/virtio-ports/%s%s" % (char_dev, index)
         if char_dev == "file":
             session.cmd("echo test > %s" % serial_file)
-            f = open(tmp_file, "r")
-            output = f.read()
-            f.close()
+            with open(tmp_file, "r") as f:
+                output = f.read()
         elif char_dev == "socket":
             session.cmd("echo test > /tmp/file")
             sock = socket.socket(socket.AF_UNIX)
@@ -117,7 +114,7 @@ def run(test, params, env):
             session.cmd("dd if=/tmp/file of=%s &" % serial_file)
             dev_file = "/dev/pts/%s" % id
             if not os.path.exists(dev_file):
-                raise error.TestFail("%s doesn't exist." % dev_file)
+                test.fail("%s doesn't exist." % dev_file)
             p = subprocess.Popen(["/usr/bin/cat", dev_file],
                                  stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             while True:
@@ -128,7 +125,7 @@ def run(test, params, env):
             p.kill()
         if not output.count("test"):
             err_info = "%s device file doesn't match 'test':%s" % (char_dev, output)
-            raise error.TestFail(err_info)
+            test.fail(err_info)
 
     def unhotplug_serial_device(hotplug_type, char_dev, index=1):
         if hotplug_type == "qmp":
@@ -145,9 +142,9 @@ def run(test, params, env):
         result = virsh.qemu_monitor_command(vm_name, "info qtree", "--hmp")
         uh_o = result.stdout.strip()
         if uh_o.count("chardev = %s%s" % (char_dev, index)):
-            raise error.TestFail("Still can get serial device info: '%s'" % uh_o)
+            test.fail("Still can get serial device info: '%s'" % uh_o)
         if not session.cmd_status("test -e %s" % serial_file):
-            raise error.TestFail("File '%s' still exists after unhotplug" % serial_file)
+            test.fail("File '%s' still exists after unhotplug" % serial_file)
 
     # run test case
     try:

--- a/libvirt/tests/src/libvirt_bench/libvirt_bench_usb_hotplug.py
+++ b/libvirt/tests/src/libvirt_bench/libvirt_bench_usb_hotplug.py
@@ -2,8 +2,6 @@ import os
 import shutil
 import logging
 
-from autotest.client.shared import error
-
 from avocado.utils import process
 
 from virttest import data_dir
@@ -61,18 +59,18 @@ def run(test, params, env):
             return (not session_tmp.cmd_status("ps -ef|grep stress|grep -v grep"))
         if bench_type == "stress":
             if not utils_misc.wait_for(_is_stress_running, timeout=160):
-                raise error.TestNAError("Failed to run stress in guest.\n"
-                                        "Since we need to run a autotest of iozone "
-                                        "in guest, so please make sure there are "
-                                        "some necessary packages in guest,"
-                                        "such as gcc, tar, bzip2")
+                test.cancel("Failed to run stress in guest.\n"
+                            "Since we need to run a autotest of iozone "
+                            "in guest, so please make sure there are "
+                            "some necessary packages in guest,"
+                            "such as gcc, tar, bzip2")
         elif bench_type == "iozone":
             if not utils_misc.wait_for(_is_iozone_running, timeout=160):
-                raise error.TestNAError("Failed to run iozone in guest.\n"
-                                        "Since we need to run a autotest of iozone "
-                                        "in guest, so please make sure there are "
-                                        "some necessary packages in guest,"
-                                        "such as gcc, tar, bzip2")
+                test.cancel("Failed to run iozone in guest.\n"
+                            "Since we need to run a autotest of iozone "
+                            "in guest, so please make sure there are "
+                            "some necessary packages in guest,"
+                            "such as gcc, tar, bzip2")
         logging.debug("bench is already running in guest.")
     try:
         try:
@@ -118,7 +116,7 @@ def run(test, params, env):
                 else:
                     if disk:
                         utils_test.libvirt.create_local_disk("file", path, size="1M")
-                        os.chmod(path, 0666)
+                        os.chmod(path, 0o666)
                         disk_xml = Disk(type_name="file")
                         disk_xml.device = "disk"
                         disk_xml.source = disk_xml.new_disk_source(**{"attrs": {'file': path}})
@@ -206,10 +204,10 @@ def run(test, params, env):
                         result = virsh.detach_device(vm_name, tablet_xml.xml)
                         if result.exit_status:
                             raise process.CmdError(result.command, result)
-        except process.CmdError, e:
+        except process.CmdError as e:
             if not status_error:
-                raise error.TestFail("failed to attach device.\n"
-                                     "Detail: %s." % result)
+                test.fail("failed to attach device.\n"
+                          "Detail: %s." % result)
     finally:
         if os.path.isdir(tmp_dir):
             shutil.rmtree(tmp_dir)

--- a/libvirt/tests/src/libvirt_bench/libvirt_bench_vcpu_hotplug.py
+++ b/libvirt/tests/src/libvirt_bench/libvirt_bench_vcpu_hotplug.py
@@ -1,7 +1,7 @@
 import logging
 import re
 
-from autotest.client.shared import error
+from avocado.core import exceptions
 
 from virttest import libvirt_xml
 from virttest import libvirt_vm
@@ -65,48 +65,48 @@ def run(test, params, env):
             # 1.1 check add status
             if add_status:
                 if add_result.stderr.count("support"):
-                    raise error.TestNAError("No need to test any more:\n %s"
-                                            % add_result.stderr.strip())
-                raise error.TestFail("Test failed for:\n %s"
-                                     % add_result.stderr.strip())
+                    test.cancel("No need to test any more:\n %s"
+                                % add_result.stderr.strip())
+                test.fail("Test failed for:\n %s"
+                          % add_result.stderr.strip())
             # 1.2 check dmesg
             domain_add_dmesg = session.cmd_output("dmesg -c")
             dmesg1 = "CPU%d has been hot-added" % (max_count - 1)
             dmesg2 = "CPU %d got hotplugged" % (max_count - 1)
             if (not domain_add_dmesg.count(dmesg1) and
                     not domain_add_dmesg.count(dmesg2)):
-                raise error.TestFail("Cannot find hotplug info in dmesg: %s"
-                                     % domain_add_dmesg)
+                test.fail("Cannot find hotplug info in dmesg: %s"
+                          % domain_add_dmesg)
             # 1.3 check cpu related file
             online_cmd = "cat /sys/devices/system/cpu/cpu%d/online" \
                          % (max_count - 1)
             st, ot = session.cmd_status_output(online_cmd)
             if st:
-                raise error.TestFail("Cannot find CPU%d after hotplug"
-                                     % (max_count - 1))
+                test.fail("Cannot find CPU%d after hotplug"
+                          % (max_count - 1))
             # 1.4 check online
             if not ot.strip().count("1"):
-                raise error.TestFail("CPU%d is not online after hotplug: %s"
-                                     % ((max_count - 1), ot))
+                test.fail("CPU%d is not online after hotplug: %s"
+                          % ((max_count - 1), ot))
             # 1.5 check online interrupts info
             inter_on_output = session.cmd_output("cat /proc/interrupts")
             if not inter_on_output.count("CPU%d" % (int(max_count) - 1)):
-                raise error.TestFail("CPU%d can not be found in "
-                                     "/proc/interrupts when it's online:%s"
-                                     % ((int(max_count) - 1), inter_on_output))
+                test.fail("CPU%d can not be found in "
+                          "/proc/interrupts when it's online:%s"
+                          % ((int(max_count) - 1), inter_on_output))
             # 1.6 offline vcpu
             off_st = session.cmd_status("echo 0 > "
                                         "/sys/devices/system/cpu/cpu%d/online"
                                         % (max_count - 1))
             if off_st:
-                raise error.TestFail("Set cpu%d offline failed!"
-                                     % (max_count - 1))
+                test.fail("Set cpu%d offline failed!"
+                          % (max_count - 1))
             # 1.7 check offline interrupts info
             inter_off_output = session.cmd_output("cat /proc/interrupts")
             if inter_off_output.count("CPU%d" % (int(max_count) - 1)):
-                raise error.TestFail("CPU%d can be found in /proc/interrupts"
-                                     " when it's offline"
-                                     % (int(max_count) - 1))
+                test.fail("CPU%d can be found in /proc/interrupts"
+                          " when it's offline"
+                          % (int(max_count) - 1))
             # 2. Del vcpu
             del_result = libvirt.hotplug_domain_vcpu(vm_name,
                                                      min_count,
@@ -121,26 +121,26 @@ def run(test, params, env):
                 #       remove these codes used to handle kinds of exceptions
                 if re.search("The command cpu-del has not been found",
                              del_result.stderr):
-                    raise error.TestNAError("unhotplug failed")
+                    test.cancel("unhotplug failed")
                 if re.search("cannot change vcpu count", del_result.stderr):
-                    raise error.TestNAError("unhotplug failed")
+                    test.cancel("unhotplug failed")
                 if re.search("got wrong number of vCPU pids from QEMU monitor",
                              del_result.stderr):
-                    raise error.TestNAError("unhotplug failed")
+                    test.cancel("unhotplug failed")
                 # process all tips that contains keyword 'support'
                 # for example, "unsupported"/"hasn't been support" and so on
                 if re.search("support", del_result.stderr):
-                    raise error.TestNAError("unhotplug failed")
+                    test.cancel("unhotplug failed")
 
                 # besides above, regard it failed
-                raise error.TestFail("Test fail for:\n %s"
-                                     % del_result.stderr.strip())
+                test.fail("Test fail for:\n %s"
+                          % del_result.stderr.strip())
             domain_del_dmesg = session.cmd_output("dmesg -c")
             if not domain_del_dmesg.count("CPU %d is now offline"
                                           % (max_count - 1)):
-                raise error.TestFail("Cannot find hot-unplug info in dmesg: %s"
-                                     % domain_del_dmesg)
-    except error.TestNAError:
+                test.fail("Cannot find hot-unplug info in dmesg: %s"
+                          % domain_del_dmesg)
+    except exceptions.TestCancel:
         # So far, QEMU doesn't support unplug vcpu,
         # unplug operation will encounter kind of errors.
         pass


### PR DESCRIPTION
1) Porting python2 to python3 compatible each other
2) Remove autotest dependency

Signed-off-by: Yan Li <yannli@redhat.com>