### PR TITLE
Python 3: Port another 6 directories

### DIFF
--- a/libvirt/tests/src/npiv/npiv_concurrent.py
+++ b/libvirt/tests/src/npiv/npiv_concurrent.py
@@ -33,7 +33,7 @@ def convert_img_to_dev(test, src_fmt, dest_fmt, img_src, blk_dev):
            (src_fmt, dest_fmt, img_src, blk_dev))
     try:
         result = process.run(cmd, shell=True)
-    except process.cmdError, detail:
+    except process.cmdError as detail:
         test.fail("Failed to convert img with exception %s",
                   detail)
 
@@ -51,7 +51,7 @@ def create_file_in_vm(vm, file_name, content, repeat):
         time.sleep(_TIMEOUT)
         try:
             status, output = client_session.cmd_status_output(cmd_echo)
-        except process.cmdError, detail:
+        except process.cmdError as detail:
             logging.error("Fail to echo '%s' to '%s' in vm with"
                           " exception %s", content, file_name, detail)
             client_session = vm.wait_for_login()
@@ -126,8 +126,8 @@ def get_blks_by_scsi(test, scsi_bus, blk_prefix="sd"):
     cmd %= (scsi_bus, blk_prefix)
     try:
         result = process.run(cmd, shell=True)
-        logging.debug("multipath result: %s", result.stdout)
-    except process.cmdError, detail:
+        logging.debug("multipath result: %s", result.stdout.strip())
+    except process.cmdError as detail:
         test.error("Error happend for multipath: %s",
                    str(detail))
     blk_names = result.stdout.strip().splitlines()
@@ -155,7 +155,7 @@ def get_symbols_by_blk(test, blkdev, method="by-path"):
         cmd += "{if ($f ~ /pci/){print $f}}}'"
         cmd %= (dir_path, blkdev, blkdev)
         result = process.run(cmd, shell=True)
-    except process.cmdError, detail:
+    except process.cmdError as detail:
         test.error("cmd wrong with error %s", str(detail))
     symbolic_links = result.stdout.strip().splitlines()
     return symbolic_links
@@ -302,7 +302,7 @@ def run(test, params, env):
             else:
                 test.fail("Failed to check the test file in vm")
             session.close()
-    except Exception, detail:
+    except Exception as detail:
         test.fail("Test failed with exception: %s", detail)
     finally:
         logging.debug("Start to clean up env...")

--- a/libvirt/tests/src/npiv/npiv_pool_regression.py
+++ b/libvirt/tests/src/npiv/npiv_pool_regression.py
@@ -105,17 +105,14 @@ def run(test, params, env):
             lambda: nodedev.is_vhbas_added(old_vhbas), _DELAY_TIME)
         virsh.pool_dumpxml(pool_name, to_file=pool_xml_f)
         virsh.pool_destroy(pool_name)
-    except Exception, e:
+    except Exception as e:
         pvt.cleanup_pool(pool_name, pool_type, pool_target,
                          emulated_image, **kwargs)
         raise exceptions.TestError(
             "Error occurred when prepare pool xml:\n %s" % e)
     if os.path.exists(pool_xml_f):
-        f = open(pool_xml_f, 'r')
-        try:
+        with open(pool_xml_f, 'r') as f:
             logging.debug("Create pool from file:\n %s", f.read())
-        finally:
-            f.close()
 
     try:
         cmd_result = virsh.pool_define(pool_xml_f, ignore_status=True,
@@ -129,7 +126,7 @@ def run(test, params, env):
         logging.debug("Pool detail: %s", pool_detail)
 
         vol_list = utlv.get_vol_list(pool_name, timeout=10)
-        test_unit = vol_list.keys()[0]
+        test_unit = list(vol_list.keys())[0]
         logging.info(
             "Using the first LUN unit %s to attach to a guest", test_unit)
 

--- a/libvirt/tests/src/npiv/npiv_pool_vol.py
+++ b/libvirt/tests/src/npiv/npiv_pool_vol.py
@@ -146,7 +146,7 @@ def run(test, params, env):
         try:
             cmd = "parted %s mklabel msdos -s" % source_dev
             cmd_result = process.run(cmd, shell=True)
-        except Exception, e:
+        except Exception as e:
             raise exceptions.TestError("Error occurred when parted mklable")
         if define_pool_as == "yes":
             pool_extra_args = ""
@@ -178,7 +178,7 @@ def run(test, params, env):
         try:
             cmd = "parted %s mklabel msdos -s" % mpath_vol_path
             cmd_result = process.run(cmd, shell=True)
-        except Exception, e:
+        except Exception as e:
             raise exceptions.TestError("Error occurred when parted mklable")
     if pre_def_pool == "yes":
         try:
@@ -191,17 +191,14 @@ def run(test, params, env):
                     _DELAY_TIME*2)
             virsh.pool_dumpxml(pool_name, to_file=pool_xml_f)
             virsh.pool_destroy(pool_name)
-        except Exception, e:
+        except Exception as e:
             pvt.cleanup_pool(pool_name, pool_type, pool_target,
                              emulated_image, **pool_kwargs)
             raise exceptions.TestError(
                 "Error occurred when prepare pool xml:\n %s" % e)
         if os.path.exists(pool_xml_f):
-            try:
-                f = open(pool_xml_f, 'r')
+            with open(pool_xml_f, 'r') as f:
                 logging.debug("Create pool from file: %s", f.read())
-            finally:
-                f.close()
     try:
         # define/create/start the pool
         if (pre_def_pool == "yes") and (define_pool == "yes"):
@@ -272,7 +269,7 @@ def run(test, params, env):
             logging.info(
                 "Using %s to attach to a guest", test_unit)
         else:
-            test_unit = vol_list.keys()[0]
+            test_unit = list(vol_list.keys())[0]
             logging.info(
                 "Using the first volume %s to attach to a guest", test_unit)
 
@@ -318,7 +315,7 @@ def run(test, params, env):
             logging.debug(vmxml)
             try:
                 vm.start()
-            except virt_vm.VMStartError, e:
+            except virt_vm.VMStartError as e:
                 logging.debug(e)
                 if pool_type == "mpath":
                     raise exceptions.TestSkipError("'mpath' pools for backing "

--- a/libvirt/tests/src/npiv/npiv_snapshot.py
+++ b/libvirt/tests/src/npiv/npiv_snapshot.py
@@ -40,7 +40,7 @@ def get_symbols_by_blk(blkdev, method="by-path"):
         cmd += "{if ($f ~ /pci/){print $f}}}'"
         cmd %= (dir_path, blkdev, blkdev)
         result = process.run(cmd, shell=True)
-    except process.cmdError, detail:
+    except process.cmdError as detail:
         raise exceptions.TestError(str(detail))
     symbolic_links = result.stdout.strip().splitlines()
     return symbolic_links
@@ -63,8 +63,8 @@ def get_blks_by_scsi(scsi_bus, blk_prefix="sd"):
     cmd %= (scsi_bus, blk_prefix)
     try:
         result = process.run(cmd, shell=True)
-        logging.debug("multipath result: %s", result.stdout)
-    except process.cmdError, detail:
+        logging.debug("multipath result: %s", result.stdout.strip())
+    except process.cmdError as detail:
         raise exceptions.TestError(str(detail))
     blk_names = result.stdout.strip().splitlines()
     return blk_names
@@ -97,7 +97,7 @@ def create_qcow2_blk(path_to_dev, size):
     cmd = "qemu-img create -f qcow2 %s %s" % (path_to_dev, size)
     try:
         process.run(cmd, shell=True)
-    except process.cmdError, detail:
+    except process.cmdError as detail:
         raise exceptions.TestError("Failed to create qcow2 with %s: %s"
                                    % (path_to_dev, str(detail)))
 
@@ -319,7 +319,7 @@ def run(test, params, env):
             cmd = "qemu-img create -f qcow2 %s %s" % (path_to_blk, disk_size)
             try:
                 process.run(cmd, shell=True)
-            except process.cmdError, detail:
+            except process.cmdError as detail:
                 raise exceptions.TestFail("Fail to create qcow2 on blk dev: %s",
                                           detail)
         else:
@@ -329,7 +329,7 @@ def run(test, params, env):
         if "vol" in vd_format:
             vol_list = utlv.get_vol_list(pool_name, vol_check=True,
                                          timeout=_TIMEOUT*3)
-            test_vol = vol_list.keys()[0]
+            test_vol = list(vol_list.keys())[0]
             disk_params = {'type_name': disk_type,
                            'target_dev': device_target,
                            'target_bus': target_bus,
@@ -429,7 +429,7 @@ def run(test, params, env):
         snapshot_list = virsh.snapshot_list(vm_name)
         if snapshot_list:
             raise exceptions.TestFail("Snapshot not deleted: %s", snapshot_list)
-    except Exception, detail:
+    except Exception as detail:
         raise exceptions.TestFail("exception happens: %s", detail)
     finally:
         logging.debug("Start to clean up env...")

--- a/libvirt/tests/src/npiv/npiv_virtual_disk.py
+++ b/libvirt/tests/src/npiv/npiv_virtual_disk.py
@@ -38,7 +38,7 @@ def get_symbols_by_blk(blkdev, method="by-path"):
                awk '{FS=\" \"} {for (f=1; f<=NF; f+=1) \
                {if ($f ~ /pci/){print $f}}}'" % (dir_path, blkdev, blkdev)
         result = process.run(cmd, shell=True)
-    except Exception, e:
+    except Exception as e:
         raise exceptions.TestError(str(e))
     symbolic_links = result.stdout.strip().splitlines()
     return symbolic_links
@@ -59,7 +59,7 @@ def get_blks_by_scsi(scsi_bus, blk_prefix="sd"):
            {if ($f ~ /%s/) {print $f}}}'" % (scsi_bus, blk_prefix)
     try:
         result = process.run(cmd, shell=True)
-    except Exception, e:
+    except Exception as e:
         raise exceptions.TestError(str(e))
     blk_names = result.stdout.strip().splitlines()
     return blk_names

--- a/libvirt/tests/src/numa/guest_numa.py
+++ b/libvirt/tests/src/numa/guest_numa.py
@@ -254,7 +254,7 @@ def run(test, params, env):
             vmxml_new = libvirt_xml.VMXML.new_from_dumpxml(vm_name)
             logging.debug("vm xml after start is %s", vmxml_new)
 
-        except virt_vm.VMStartError, e:
+        except virt_vm.VMStartError as e:
             # Starting VM failed.
             if status_error:
                 return
@@ -265,9 +265,8 @@ def run(test, params, env):
         vm_pid = vm.get_pid()
         # numa hugepage check
         if page_list:
-            numa_maps = open("/proc/%s/numa_maps" % vm_pid)
-            numa_map_info = numa_maps.read()
-            numa_maps.close()
+            with open("/proc/%s/numa_maps" % vm_pid) as numa_maps:
+                numa_map_info = numa_maps.read()
             hugepage_info = re.findall(".*file=\S*hugepages.*", numa_map_info)
             if not hugepage_info:
                 test.fail("Can't find hugepages usage info in vm "
@@ -303,9 +302,8 @@ def run(test, params, env):
                                           " not expected" % map_dict)
 
         # qemu command line check
-        f_cmdline = open("/proc/%s/cmdline" % vm_pid)
-        q_cmdline_list = f_cmdline.read().split("\x00")
-        f_cmdline.close()
+        with open("/proc/%s/cmdline" % vm_pid) as f_cmdline:
+            q_cmdline_list = f_cmdline.read().split("\x00")
         logging.debug("vm qemu cmdline list is %s" % q_cmdline_list)
         for cmd in cmdline_list:
             logging.debug("checking '%s' in qemu cmdline", cmd['cmdline'])

--- a/libvirt/tests/src/numa/numa_preferred_undefine.py
+++ b/libvirt/tests/src/numa/numa_preferred_undefine.py
@@ -1,7 +1,5 @@
 import logging
 
-from autotest.client.shared import error
-
 from virttest import libvirt_xml
 from virttest import virsh
 from virttest import utils_libvirtd
@@ -33,7 +31,7 @@ def run(test, params, env):
         vmxml.sync()
         result = virsh.undefine(vm_name, debug=True, ignore_status=True)
         if result.exit_status:
-            raise error.TestFail("Undefine vm failed, check %s" % bug_url)
+            test.fail("Undefine vm failed, check %s" % bug_url)
     finally:
         libvirtd.restart()
         backup_xml.sync()

--- a/libvirt/tests/src/numa/numad_vcpupin.py
+++ b/libvirt/tests/src/numa/numad_vcpupin.py
@@ -60,7 +60,7 @@ def run(test, params, env):
         vm.wait_for_login()
 
         # Test vcpupin to the alive cpus list
-        cpus_list = map(str, cpuutils.cpu_online_list())
+        cpus_list = list(map(str, cpuutils.cpu_online_list()))
         logging.info("active cpus in host are %s", cpus_list)
         for cpu in cpus_list:
             ret = virsh.vcpupin(vm_name, 0, cpu, debug=True,

--- a/libvirt/tests/src/nwfilter/nwfilter_edit_uuid.py
+++ b/libvirt/tests/src/nwfilter/nwfilter_edit_uuid.py
@@ -2,8 +2,6 @@ import logging
 
 import aexpect
 
-from autotest.client.shared import error
-
 from virttest import virsh
 from virttest import libvirt_xml
 from virttest import remote
@@ -53,15 +51,15 @@ def run(test, params, env):
             if not status_error:
                 logging.info("Succeed to do nwfilter edit")
             else:
-                raise error.TestFail("edit uuid should fail but got succeed.")
-        except (aexpect.ShellError, aexpect.ExpectError, remote.LoginTimeoutError), details:
+                test.fail("edit uuid should fail but got succeed.")
+        except (aexpect.ShellError, aexpect.ExpectError, remote.LoginTimeoutError) as details:
             log = session.get_output()
             session.close()
             if "Try again? [y,n,f,?]:" in log and status_error:
                 logging.debug("edit uuid failed as expected.")
             else:
-                raise error.TestFail("Failed to do nwfilter-edit: %s\n%s"
-                                     % (details, log))
+                test.fail("Failed to do nwfilter-edit: %s\n%s"
+                          % (details, log))
     finally:
         # Clean env
         virsh.nwfilter_undefine(filter_name, debug=True)

--- a/libvirt/tests/src/nwfilter/nwfilter_update_lock.py
+++ b/libvirt/tests/src/nwfilter/nwfilter_update_lock.py
@@ -2,8 +2,6 @@ import time
 import threading
 import logging
 
-from autotest.client.shared import error
-
 from virttest import virsh
 from virttest import libvirt_xml
 from virttest import utils_libvirtd
@@ -28,7 +26,7 @@ def run(test, params, env):
     vm_name = params.get("main_vm")
 
     if not libvirt_version.version_compare(1, 2, 6):
-        raise error.TestNAError("Bug %s not fixed on current build" % bug_url)
+        test.cancel("Bug %s not fixed on current build" % bug_url)
 
     vm = env.get_vm(vm_name)
     # Prepare vm filterref parameters dict list
@@ -88,7 +86,7 @@ def run(test, params, env):
         filter_thread.join()
         vm_thread.join()
         if ret:
-            raise error.TestFail("Libvirtd hang, %s" % bug_url)
+            test.fail("Libvirtd hang, %s" % bug_url)
 
     finally:
         libvirtd.exit()

--- a/libvirt/tests/src/nwfilter/nwfilter_update_vm_running.py
+++ b/libvirt/tests/src/nwfilter/nwfilter_update_vm_running.py
@@ -1,8 +1,7 @@
 import re
 import logging
 
-from autotest.client.shared import utils
-from autotest.client.shared import error
+from avocado.utils import process
 
 from virttest import virsh
 from virttest import libvirt_xml
@@ -68,22 +67,22 @@ def run(test, params, env):
         if "DEVNAME" in check_cmd:
             check_cmd = check_cmd.replace("DEVNAME", iface_target)
         ret = utils_misc.wait_for(lambda: not
-                                  utils.system(check_cmd, ignore_status=True),
+                                  process.system(check_cmd, ignore_status=True, shell=True),
                                   timeout=30)
         if not ret:
-            raise error.TestFail("Rum command '%s' failed" % check_cmd)
-        out = utils.system_output(check_cmd, ignore_status=False)
+            test.fail("Rum command '%s' failed" % check_cmd)
+        out = process.system_output(check_cmd, ignore_status=False, shell=True)
         if expect_match and not re.search(expect_match, out):
-            raise error.TestFail("'%s' not found in output: %s"
-                                 % (expect_match, out))
+            test.fail("'%s' not found in output: %s"
+                      % (expect_match, out))
 
         # Check in vm
         if check_vm_cmd:
             output = session.cmd_output(check_vm_cmd)
             logging.debug("cmd output: %s", output)
             if vm_expect_match and not re.search(vm_expect_match, output):
-                raise error.TestFail("'%s' not found in output: %s"
-                                     % (vm_expect_match, output))
+                test.fail("'%s' not found in output: %s"
+                          % (vm_expect_match, output))
     finally:
         # Clean env
         if vm.is_alive():

--- a/libvirt/tests/src/nwfilter/nwfilter_vm_attach.py
+++ b/libvirt/tests/src/nwfilter/nwfilter_vm_attach.py
@@ -1,8 +1,7 @@
 import re
 import logging
 
-from autotest.client.shared import utils
-from autotest.client.shared import error
+from avocado.utils import process
 
 from virttest import virsh
 from virttest import libvirt_xml
@@ -68,23 +67,24 @@ def run(test, params, env):
             utlv.check_exit_status(ret, status_error)
 
         if not libvirtd.is_running():
-            raise error.TestFail("libvirtd not running after attach "
-                                 "interface.")
+            test.fail("libvirtd not running after attach "
+                      "interface.")
 
         # Check iptables or ebtables on host
         if check_cmd:
             if "DEVNAME" in check_cmd:
                 check_cmd = check_cmd.replace("DEVNAME", iface_target)
             ret = utils_misc.wait_for(lambda: not
-                                      utils.system(check_cmd,
-                                                   ignore_status=True),
+                                      process.system(check_cmd,
+                                                     ignore_status=True,
+                                                     shell=True),
                                       timeout=30)
             if not ret:
-                raise error.TestFail("Rum command '%s' failed" % check_cmd)
-            out = utils.system_output(check_cmd, ignore_status=False)
+                test.fail("Rum command '%s' failed" % check_cmd)
+            out = process.system_output(check_cmd, ignore_status=False, shell=True)
             if expect_match and not re.search(expect_match, out):
-                raise error.TestFail("'%s' not found in output: %s"
-                                     % (expect_match, out))
+                test.fail("'%s' not found in output: %s"
+                          % (expect_match, out))
 
     finally:
         if attach_twice_invalid:

--- a/libvirt/tests/src/nwfilter/nwfilter_vm_start.py
+++ b/libvirt/tests/src/nwfilter/nwfilter_vm_start.py
@@ -1,9 +1,8 @@
 import re
 import logging
 
-from autotest.client import os_dep
-from autotest.client.shared import utils
-from autotest.client.shared import error
+from avocado.utils import process
+from avocado.utils import path
 
 from virttest import virsh
 from virttest import virt_vm
@@ -83,16 +82,16 @@ def run(test, params, env):
             device_name = utlv.setup_or_cleanup_iscsi(is_setup=True)
             utlv.mkfs(device_name, 'ext4')
             cmd = "mount %s /tmp -o noexec,nosuid" % device_name
-            utils.run(cmd)
+            process.run(cmd, shell=True)
 
         if ipset_command:
             try:
-                os_dep.command("ipset")
-            except ValueError:
-                ret = utils.run("yum install ipset -y")
+                path.find_command("ipset")
+            except path.CmdNotFoundError:
+                ret = process.run("yum install ipset -y", shell=True)
                 if ret.exit_status:
-                    raise error.TestNAError("Can't install ipset on host")
-            utils.run(ipset_command)
+                    test.cancel("Can't install ipset on host")
+            process.run(ipset_command, shell=True)
 
         # Run command
         try:
@@ -109,29 +108,30 @@ def run(test, params, env):
                 if "DEVNAME" in check_cmd:
                     check_cmd = check_cmd.replace("DEVNAME", iface_target)
                 ret = utils_misc.wait_for(lambda: not
-                                          utils.system(check_cmd,
-                                                       ignore_status=True),
+                                          process.system(check_cmd,
+                                                         ignore_status=True,
+                                                         shell=True),
                                           timeout=30)
                 if not ret:
-                    raise error.TestFail("Rum command '%s' failed" % check_cmd)
-                out = utils.system_output(check_cmd, ignore_status=False)
+                    test.fail("Rum command '%s' failed" % check_cmd)
+                out = process.system_output(check_cmd, ignore_status=False, shell=True)
                 if expect_match and not re.search(expect_match, out):
-                    raise error.TestFail("'%s' not found in output: %s"
-                                         % (expect_match, out))
+                    test.fail("'%s' not found in output: %s"
+                              % (expect_match, out))
 
-        except virt_vm.VMStartError, e:
+        except virt_vm.VMStartError as e:
             # Starting VM failed.
             if not status_error:
-                raise error.TestFail("Test failed in positive case.\n error:"
-                                     " %s\n%s" % (e, bug_url))
+                test.fail("Test failed in positive case.\n error:"
+                          " %s\n%s" % (e, bug_url))
 
         if kill_libvirtd:
             cmd = "kill -SIGTERM `pidof libvirtd`"
-            utils.run(cmd)
+            process.run(cmd, shell=True)
             ret = utils_misc.wait_for(lambda: not libvirtd.is_running(),
                                       timeout=30)
             if not ret:
-                raise error.TestFail("Failed to kill libvirtd. %s" % bug_url)
+                test.fail("Failed to kill libvirtd. %s" % bug_url)
 
     finally:
         if kill_libvirtd:
@@ -146,7 +146,7 @@ def run(test, params, env):
             virsh.nwfilter_undefine(filter_name, debug=True)
         if mount_noexec_tmp:
             if device_name:
-                utils.run("umount -l %s" % device_name, ignore_status=True)
+                process.run("umount -l %s" % device_name, ignore_status=True, shell=True)
             utlv.setup_or_cleanup_iscsi(is_setup=False)
         if ipset_command:
-            utils.run("ipset destroy blacklist")
+            process.run("ipset destroy blacklist", shell=True)

--- a/libvirt/tests/src/svirt/dac_nfs_disk.py
+++ b/libvirt/tests/src/svirt/dac_nfs_disk.py
@@ -84,7 +84,7 @@ def run(test, params, env):
     # Backup domain disk label
     disks = vm.get_disk_devices()
     backup_labels_of_disks = {}
-    for disk in disks.values():
+    for disk in list(disks.values()):
         disk_path = disk['source']
         label = check_ownership(disk_path)
         if label:
@@ -113,7 +113,7 @@ def run(test, params, env):
     libvirtd = utils_libvirtd.Libvirtd()
     try:
         # chown domain disk to qemu:qemu to avoid fail on local disk
-        for file_path in backup_labels_of_disks.keys():
+        for file_path in list(backup_labels_of_disks.keys()):
             if qemu_user == "root":
                 os.chown(file_path, 0, 0)
             elif qemu_user == "qemu":
@@ -203,7 +203,7 @@ def run(test, params, env):
 
             if status_error:
                 test.fail('Test succeeded in negative case.')
-        except virt_vm.VMStartError, e:
+        except virt_vm.VMStartError as e:
             # Starting VM failed.
             if not status_error:
                 test.fail("Test failed in positive case."
@@ -222,7 +222,7 @@ def run(test, params, env):
 
         if snapshot_name:
             disks_snap = vm.get_disk_devices()
-            for disk in disks_snap.values():
+            for disk in list(disks_snap.values()):
                 disk_snap_path.append(disk['source'])
             virsh.snapshot_delete(vm_name, snapshot_name, "--metadata",
                                   debug=True)
@@ -237,7 +237,7 @@ def run(test, params, env):
         # clean up
         vm.destroy()
         qemu_conf.restore()
-        for path, label in backup_labels_of_disks.items():
+        for path, label in list(backup_labels_of_disks.items()):
             label_list = label.split(":")
             os.chown(path, int(label_list[0]), int(label_list[1]))
         if snapshot_name:
@@ -251,7 +251,7 @@ def run(test, params, env):
             try:
                 pvt.cleanup_pool(pool_name, pool_type, pool_target,
                                  emulated_image)
-            except test.fail, detail:
+            except test.fail as detail:
                 logging.error(str(detail))
         utils_selinux.set_status(backup_sestatus)
         libvirtd.restart()

--- a/libvirt/tests/src/svirt/dac_per_disk_hotplug.py
+++ b/libvirt/tests/src/svirt/dac_per_disk_hotplug.py
@@ -3,8 +3,6 @@ import pwd
 import grp
 import logging
 
-from autotest.client.shared import error
-
 from virttest import qemu_storage
 from virttest import data_dir
 from virttest import virsh
@@ -93,8 +91,8 @@ def run(test, params, env):
     relabel = 'yes' == params.get('relabel', 'yes')
 
     if not libvirt_version.version_compare(1, 2, 7):
-        raise error.TestNAError("per-image DAC only supported on version 1.2.7"
-                                " and after.")
+        test.cancel("per-image DAC only supported on version 1.2.7"
+                    " and after.")
 
     # Get variables about VM and get a VM object and VMXML instance.
     vm_name = params.get("main_vm")
@@ -157,8 +155,8 @@ def run(test, params, env):
             img_label_after = check_ownership(img_path)
             if dynamic_ownership and relabel:
                 if img_label_after != sec_label_id:
-                    raise error.TestFail("The image dac label %s is not "
-                                         "expected." % img_label_after)
+                    test.fail("The image dac label %s is not "
+                              "expected." % img_label_after)
 
             ret = virsh.detach_disk(vm_name, target=target_dev,
                                     extra=option,

--- a/libvirt/tests/src/svirt/dac_start_destroy.py
+++ b/libvirt/tests/src/svirt/dac_start_destroy.py
@@ -131,7 +131,7 @@ def run(test, params, env):
     disks = vm.get_disk_devices()
     backup_labels_of_disks = {}
     qemu_disk_mod = False
-    for disk in disks.values():
+    for disk in list(disks.values()):
         disk_path = disk['source']
         f = os.open(disk_path, 0)
         stat_re = os.fstat(f)
@@ -243,7 +243,7 @@ def run(test, params, env):
             vm_context = "%s:%s" % (vm_process_uid, vm_process_gid)
 
             # Get vm image label when VM is running
-            f = os.open(disks.values()[0]['source'], 0)
+            f = os.open(list(disks.values())[0]['source'], 0)
             stat_re = os.fstat(f)
             disk_context = "%s:%s" % (stat_re.st_uid, stat_re.st_gid)
             os.close(f)
@@ -298,7 +298,7 @@ def run(test, params, env):
 
             # Check the label of disk after VM being destroyed.
             vm.destroy()
-            f = os.open(disks.values()[0]['source'], 0)
+            f = os.open(list(disks.values())[0]['source'], 0)
             stat_re = os.fstat(f)
             img_label_after = "%s:%s" % (stat_re.st_uid, stat_re.st_gid)
             os.close(f)
@@ -326,7 +326,7 @@ def run(test, params, env):
                                   "Detail: img_label_after=%s, "
                                   "img_label=%s.\n"
                                   % (img_label_after, img_label))
-        except virt_vm.VMStartError, e:
+        except virt_vm.VMStartError as e:
             # Starting VM failed.
             # VM with seclabel can not access the image with the context.
             if not status_error:
@@ -347,7 +347,7 @@ def run(test, params, env):
                               "error: %s" % e)
     finally:
         # clean up
-        for path, label in backup_labels_of_disks.items():
+        for path, label in list(backup_labels_of_disks.items()):
             label_list = label.split(":")
             os.chown(path, int(label_list[0]), int(label_list[1]))
             if qemu_disk_mod:

--- a/libvirt/tests/src/svirt/dac_vm_per_image_start.py
+++ b/libvirt/tests/src/svirt/dac_vm_per_image_start.py
@@ -181,7 +181,7 @@ def run(test, params, env):
                         test.fail("The disk label is not equal to "
                                   "'%s'." % sec_label_id)
 
-        except virt_vm.VMStartError, e:
+        except virt_vm.VMStartError as e:
             # Starting VM failed.
             if not status_error:
                 test.fail("Test failed in positive case."

--- a/libvirt/tests/src/svirt/svirt_undefine_define.py
+++ b/libvirt/tests/src/svirt/svirt_undefine_define.py
@@ -3,8 +3,6 @@ svirt guest_undefine_define test.
 """
 import os
 
-from autotest.client.shared import error
-
 from virttest import utils_selinux
 from virttest import virsh
 from virttest import data_dir
@@ -42,7 +40,7 @@ def run(test, params, env):
     # Label the disks of VM with img_label.
     disks = vm.get_disk_devices()
     backup_labels_of_disks = {}
-    for disk in disks.values():
+    for disk in list(disks.values()):
         disk_path = disk['source']
         backup_labels_of_disks[disk_path] = utils_selinux.get_context_of_file(
             filename=disk_path)
@@ -62,15 +60,15 @@ def run(test, params, env):
         virsh.dumpxml(vm.name, to_file=xml_file)
         cmd_result = virsh.undefine(vm.name)
         if cmd_result.exit_status:
-            raise error.TestFail("Failed to undefine vm."
-                                 "Detail: %s" % cmd_result)
+            test.fail("Failed to undefine vm."
+                      "Detail: %s" % cmd_result)
         cmd_result = virsh.define(xml_file)
         if cmd_result.exit_status:
-            raise error.TestFail("Failed to define vm."
-                                 "Detail: %s" % cmd_result)
+            test.fail("Failed to define vm."
+                      "Detail: %s" % cmd_result)
     finally:
         # clean up
-        for path, label in backup_labels_of_disks.items():
+        for path, label in list(backup_labels_of_disks.items()):
             utils_selinux.set_context_of_file(filename=path, context=label)
         backup_xml.sync()
         utils_selinux.set_status(backup_sestatus)

--- a/libvirt/tests/src/svirt/svirt_virt_install.py
+++ b/libvirt/tests/src/svirt/svirt_virt_install.py
@@ -1,7 +1,6 @@
 import os
 
 from avocado.utils import process
-from autotest.client.shared import error
 
 from virttest import data_dir
 from virttest import utils_selinux
@@ -75,10 +74,10 @@ def run(test, params, env):
             return virsh.is_alive(vm_name)
         if (utils_misc.wait_for(_vm_alive, timeout=5)):
             if status_error:
-                raise error.TestFail('Test succeeded in negative case.')
+                test.fail('Test succeeded in negative case.')
         else:
             if not status_error:
-                raise error.TestFail("Test failed in positive case.")
+                test.fail("Test failed in positive case.")
     finally:
         # cleanup
         utils_selinux.set_status(backup_sestatus)


### PR DESCRIPTION
1. Port Python3 for tp-libvirt 6 directories as:
lxc, npiv, numa, nwfilter, remote_access and svirt
2. Remove autotest dependencies

Signed-off-by: Yan Li <yannli@redhat.com>