### PR TITLE
virsh_domstate: err_msg is not initialized tracebacks TypeError

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/monitor/virsh_domstate.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/monitor/virsh_domstate.cfg
@@ -94,6 +94,7 @@
                 - kill_vm:
                     status_error = "no"
                     domstate_extra = "--reason"
+                    err_msg = "virsh domstate for action %s doesn't return state as expected"
                     domstate_vm_action = kill
                     variants:
                         - normal:


### PR DESCRIPTION
initialize err_msg to fix the TypeError at L283,
TypeError: not all arguments converted during string formatting

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>