### PR TITLE
virsh_domstate: timing issue cause to check domstate before prior action

### DIFF
--- a/libvirt/tests/src/virsh_cmd/monitor/virsh_domstate.py
+++ b/libvirt/tests/src/virsh_cmd/monitor/virsh_domstate.py
@@ -4,6 +4,7 @@ import shutil
 import logging
 import platform
 import signal
+import time
 
 from aexpect import ShellTimeoutError
 from aexpect import ShellProcessTerminatedError
@@ -227,6 +228,11 @@ def run(test, params, env):
 
         if libvirtd_state == "off":
             libvirtd.stop()
+
+        # Timing issue cause test to check domstate before prior action
+        # kill gets completed
+        if vm_action == "kill":
+            time.sleep(2)
 
         if vm_ref == "remote":
             remote_ip = params.get("remote_ip", "REMOTE.EXAMPLE.COM")


### PR DESCRIPTION
kill_process_tree() performs safe_kill() and test checks the domstate
and fails before kill would send the signal.SIGKILL

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>