### PR TITLE
virsh_migration: PCI hotplug/hotunplug with migration

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migration.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migration.cfg
@@ -4,6 +4,7 @@
     migration_setup = "yes"
     virsh_migrated_state = "running"
     migrate_start_state = "paused"
+    migrate_thread_timeout = 300
     ping_count = 10
     variants:
         - migrate_precopy:
@@ -29,3 +30,32 @@
                     migrate_all_machine_types = "no"
                 - all:
                     migrate_all_machine_types = "yes"
+    variants:
+        - hotplug:
+            variants:
+                - network_pci:
+                    hotplug_type = "network"
+            variants:
+                - hotplug:
+                    hotplug_times = "2"
+                    variants:
+                        - before:
+                            hotplug_before_migration = "yes"
+                        - after:
+                            hotplug_after_migration = "yes"
+                - hotunplug:
+                    variants:
+                        - hotplug_before_hotunplug_before:
+                            hotplug_before_migration = "yes"
+                            hotunplug_before_migration = "yes"
+                        - hotplug_before_hotunplug_after:
+                            hotplug_before_migration = "yes"
+                            hotunplug_after_migration = "yes"
+                        - hotplug_after_hotunplug_after:
+                            hotplug_after_migration = "yes"
+                            hotunplug_after_migration = "yes"
+                        - hotplug_hotunplug_before_hotplug_hotunplug_after:
+                            hotplug_before_migration = "yes"
+                            hotunplug_before_migration = "yes"
+                            hotplug_after_migration = "yes"
+                            hotunplug_after_migration = "yes"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migration.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migration.py
@@ -1,8 +1,12 @@
 import logging
 import platform
 
+from avocado.core import exceptions
+
 from virttest import libvirt_vm
 from virttest import virsh
+from virttest import utils_net
+from virttest import test_setup
 from virttest.utils_test import libvirt
 from virttest import libvirt_xml
 
@@ -48,6 +52,83 @@ def cleanup_vm(vm_list, vmxml_dict, migration_obj, src_uri, dest_uri):
         vmxml_dict[key].define()
 
 
+def hotplug(vm, xml, uri=None, hotunplug=False):
+    """
+    Perform hotplug/hotunplug operation
+
+    :param vm: VM Object
+    :param xml: xml file used to hotplug/hotunplug
+    :param uri: virsh connect uri
+    :param hotunplug: True to hotunplug, False to hotplug
+
+    :raise: checks the exit status and raise TestFail
+    """
+    func = virsh.attach_device
+    if hotunplug:
+        func = virsh.detach_device
+    ret = func(vm.name, xml, flagstr="--live", uri=uri, debug=True)
+    libvirt.check_exit_status(ret)
+
+
+def check_interface(vm, nic_index, params, test, hotunplug=False, uri=None):
+    """
+    Checks the hotplugged/hotunplugged interface is visible to guest
+    based upon the operation and performs ping test for hotplugged
+    interface.
+
+    :param vm: VM object
+    :param nic_index: nic index of hotplugged/hotunplugged interface
+    :param params: Test dict params
+    :param test: Test Object
+    :param hotunplug: set True to check for hotunplug and False for hotplug
+    :param uri: virsh connect uri
+
+    :raise: test.fail if interface is still available after hotunplug
+    :raise: test.fail if interface is not available/pingable after hotplig
+    """
+    iface_name = ''
+    remote_host = None
+    if uri:
+        vm.connect_uri = uri
+        session = vm.wait_for_serial_login()
+        remote_host = test_setup.remote_session(params)
+    else:
+        session = vm.wait_for_login()
+    networks = params.get("vms_network")
+    ping_test = int(params.get("ping_test_count", 5))
+    mac = networks[vm.name][nic_index]['mac']
+    try:
+        iface_name = utils_net.get_linux_ifname(session, mac_address=mac)
+        networks[vm.name][nic_index]['iface'] = iface_name
+    except exceptions.TestError:
+        if hotunplug:
+            logging.debug("Expected the interface with mac %s on %s not to be "
+                          "found, as it is hotunplugged", mac, vm.name)
+        else:
+            session.close()
+            test.fail("Failed to retrieve hotplugged interface"
+                      " with mac: %s in %s" % (mac, vm.name))
+    if iface_name and hotunplug:
+        test.fail("Interface: %s exists in %s even after hotunplug operation" %
+                  (iface_name, vm.name))
+    if not hotunplug:
+        if session.cmd_status("dhclient %s" % iface_name) != 0:
+            test.error("Failed to perform dhclient for %s in %s" %
+                       (iface_name, vm.name))
+        ip_address = utils_net.parse_arp()[mac]
+        networks[vm.name][nic_index]['ip_address'] = ip_address
+        s_ping, o_ping = utils_net.ping(ip_address,
+                                        count=ping_test, output_func=logging.debug,
+                                        session=remote_host)
+        if s_ping != 0:
+            test.fail("Interface: %s with IP: %s on %s failed to ping after network"
+                      "Hotplug operation" % (iface_name, ip_address, vm.name))
+    params['vms_network'] = networks
+    session.close()
+    if uri:
+        vm.connect_uri = None
+
+
 def run(test, params, env):
     """
     Test KVM migration scenarios
@@ -59,6 +140,7 @@ def run(test, params, env):
     migrate_start_state = params.get("migrate_start_state", "paused")
     machine_types = params.get("migrate_all_machine_types", "no") == "yes"
     migrate_back = params.get("migrate_back", "yes") == "yes"
+    migrate_thread_timeout = int(params.get("migrate_thread_timeout", 60))
     postcopy_func = None
     if migrate_postcopy:
         postcopy_func = virsh.migrate_postcopy
@@ -66,7 +148,16 @@ def run(test, params, env):
     vm_state = params.get("migrate_vm_state", "running")
     ping_count = int(params.get("ping_count", 10))
     thread_timeout = int(params.get("thread_timeout", 3600))
-
+    hotplug_operation = params.get("hotplug_type", None)
+    hotplug_times = int(params.get("hotplug_times", 1))
+    hotplug_before_migration = "yes" == params.get("hotplug_before_migration",
+                                                   "no")
+    hotplug_after_migration = "yes" == params.get("hotplug_after_migration",
+                                                  "no")
+    hotunplug_before_migration = "yes" == params.get("hotunplug_before_migration",
+                                                     "no")
+    hotunplug_after_migration = "yes" == params.get("hotunplug_after_migration",
+                                                    "no")
     vm_list = env.get_all_vms()
 
     # Params to update disk using shared storage
@@ -111,6 +202,9 @@ def run(test, params, env):
         logging.debug("Supported machine types that are common in  source and "
                       "target are: %s", ", ".join(map(str, machine_list)))
 
+    if hotplug_operation and hotplug_operation == "network":
+        networks = params.get("vms_network", {})
+
     migrate_setup = libvirt.MigrationTest()
     # Perform migration with each machine type
     try:
@@ -120,6 +214,23 @@ def run(test, params, env):
             if vm.is_alive():
                 vm.destroy()
             libvirt.set_vm_disk(vm, params)
+
+            # Hotplug/Hotunplug PCI device before migration
+            if hotplug_operation and hotplug_operation == "network":
+                for nic_index in range(hotplug_times):
+                    mac, iface = libvirt.create_network_vmxml(params)
+                    networks[vm.name] = {nic_index: {'xml': iface, 'mac': mac}}
+                    params["vms_network"] = networks
+            if hotplug_before_migration:
+                for nic_index in range(hotplug_times):
+                    hotplug(vm, networks[vm.name][nic_index]['xml'])
+                    check_interface(vm, nic_index, params, test)
+                if hotunplug_before_migration:
+                    for nic_index in range(hotplug_times):
+                        hotplug(vm, networks[vm.name][nic_index]['xml'],
+                                hotunplug=True)
+                        check_interface(vm, nic_index, params, test,
+                                        hotunplug=True)
         info_list = []
         for machine in machine_list:
             uptime = {}
@@ -181,6 +292,19 @@ def run(test, params, env):
                     uptime = migrate_setup.post_migration_check(vm_list, params,
                                                                 uptime)
                     migrate_setup.migrate_pre_setup(src_uri, params, cleanup=True)
+
+        # Hotplug/Hotunplug PCI device after migration
+        for vm in vm_list:
+            if hotplug_after_migration:
+                for nic_index in range(hotplug_times):
+                    hotplug(vm, networks[vm.name][nic_index]['xml'], uri=dest_uri)
+                    check_interface(vm, nic_index, params, test, uri=dest_uri)
+                if hotunplug_after_migration:
+                    for nic_index in range(hotplug_times):
+                        hotplug(vm, networks[vm.name][nic_index]['xml'],
+                                uri=dest_uri, hotunplug=True)
+                        check_interface(vm, nic_index, params, test,
+                                        uri=dest_uri, hotunplug=True)
         if info_list:
             test.fail(" |".join(map(str, info_list)))
     finally:


### PR DESCRIPTION
```
This testcases would test DRC state migration with respect to
PCI and hotplug/hotunplug with migration, network virtio device
is used in these scenarios,
        - create network xml with random mac generations
        - perform no of hotplug/hotunplug to no of vms in environment
        - configure, check and ping interfaces hotplugged/hotunplugged
        - perform hotplug/hotunplug before/after with all the combinations

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>
```