### PR TITLE
Python 3: remove autotest for libvirt_bench

### DIFF
--- a/libvirt/tests/src/libvirt_bench/libvirt_bench_domstate_switch_with_unixbench.py
+++ b/libvirt/tests/src/libvirt_bench/libvirt_bench_domstate_switch_with_unixbench.py
@@ -78,7 +78,7 @@ def run(test, params, env):
     logging.debug("Unixbench is already running in VMs.")
 
     # Run unixbench on host.
-    from autotest.client import common
+    from virttest.utils_test import common
     autotest_client_dir = os.path.dirname(common.__file__)
     autotest_local_path = os.path.join(autotest_client_dir, "autotest-local")
     unixbench_control_path = os.path.join(data_dir.get_root_dir(),


### PR DESCRIPTION
This PR depends on avocado-vt#1403

Signed-off-by: Yan Li <yannli@redhat.com>