### PR TITLE
Fix a typo of filter definition and fix kill cmd

### DIFF
--- a/libvirt/tests/cfg/nwfilter/nwfilter_vm_start.cfg
+++ b/libvirt/tests/cfg/nwfilter/nwfilter_vm_start.cfg
@@ -93,7 +93,7 @@
                             filterref_name_2 = "allow-incoming-ipv4"
                             filterref_name_3 = "no-arp-spoofing"
                             filterref_name_4 = "no-other-l2-traffic"
-                            filterref_name_4 = "qemu-announce-self"
+                            filterref_name_5 = "qemu-announce-self"
                             rule = "rule_action=accept rule_direction=out rule_priority=-650 protocol=mac protocolid=ipv4 EOL rule_action=accept rule_direction=inout rule_priority=-500 protocol=mac protocolid=arp"
                             check_cmd = "ebtables -t nat -L libvirt-O-DEVNAME"
                             expect_match = "-p ARP -j ACCEPT"
@@ -180,7 +180,7 @@
                     filterref_name_2 = "allow-incoming-ipv4"
                     filterref_name_3 = "no-arp-spoofing"
                     filterref_name_4 = "no-other-l2-traffic"
-                    filterref_name_4 = "qemu-announce-self"
+                    filterref_name_5 = "qemu-announce-self"
                     rule = "rule_action=accept rule_direction=out rule_priority=-650 protocol=mac protocolid=ipv4 EOL rule_action=accept rule_direction=inout rule_priority=-500 protocol=mac protocolid=arp"
                     parameter_name_0 = 'CTRL_IP_LEARNING'
                     parameter_value_0 = 'invalid'

--- a/libvirt/tests/src/nwfilter/nwfilter_vm_start.py
+++ b/libvirt/tests/src/nwfilter/nwfilter_vm_start.py
@@ -126,7 +126,7 @@ def run(test, params, env):
                           " %s\n%s" % (e, bug_url))
 
         if kill_libvirtd:
-            cmd = "kill -SIGTERM `pidof libvirtd`"
+            cmd = "kill -s TERM `pidof libvirtd`"
             process.run(cmd, shell=True)
             ret = utils_misc.wait_for(lambda: not libvirtd.is_running(),
                                       timeout=30)


### PR DESCRIPTION
The clean-traffic nwfilter should include filter 'no-other-l2-traffic'.
Fix the referred filter index typo to correct it. 'kill -SIGTERM' is not
recommended and it cause 'invalid signal specification' error. Modify
the cmd to 'kill -s TERM'.