### PR TITLE
Fixup typo incorrect format separator

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_emulatorpin.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_emulatorpin.py
@@ -199,7 +199,7 @@ def run(test, params, env):
             # Recover the VM and failout early
             vmxml_backup.sync()
             logging.debug("Used VM XML:\n %s", vmxml)
-            test.fail("VM Fails to start: %s", detail)
+            test.fail("VM Fails to start: %s" % detail)
 
     test_dicts = dict(params)
     test_dicts['vm'] = vm


### PR DESCRIPTION
This patch fixes below issue
ERROR|     test.fail("VM Fails to start: %s", detail)
TypeError: fail() takes at most 2 arguments (3 given)

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>