### PR TITLE
Skip guest dmesg check for tests without guest start

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_cpu_baseline.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_cpu_baseline.cfg
@@ -13,12 +13,14 @@
     cpu_baseline_cpu_ref = "file"
     cpu_baseline_extra = ""
     cpu_baseline_test_feature = "acpi"
+    verify_guest_dmesg = no
     variants:
         - positive_test:
             status_error = "no"
             variants:
                 - default_test:
                 - config_guest:
+                    verify_guest_dmesg = yes
                     vms = "avocado-vt-vm1"
                     main_vm = "avocado-vt-vm1"
                     config_guest = "yes"


### PR DESCRIPTION
Skip guest dmesg check for tests that do
not need to start guest.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>