### PR TITLE
Modified the SR-IOV setup by implementing the existing PciAssignable class

### DIFF
--- a/libvirt/tests/src/libvirt_pci_passthrough.py
+++ b/libvirt/tests/src/libvirt_pci_passthrough.py
@@ -1,14 +1,9 @@
-import os
 import re
 import logging
-import aexpect
-from avocado.utils import process
-from avocado.utils import distro
-from virttest import virsh
+import netaddr
 from virttest import utils_test
 from virttest.libvirt_xml.vm_xml import VMXML
 from virttest.libvirt_xml.nodedev_xml import NodedevXML
-from virttest.staging import service
 from virttest.test_setup import PciAssignable
 from virttest import utils_misc
 
@@ -33,6 +28,7 @@ def run(test, params, env):
         5. Compare the result of 'fdisk -l' before and after
             attaching storage pci device to guest.
     """
+
     # get the params from params
     vm_name = params.get("main_vm")
     vm = env.get_vm(vm_name)
@@ -59,7 +55,8 @@ def run(test, params, env):
     if (device_type == "NIC" and (net_ip.count("ENTER") or
                                   server_ip.count("ENTER") or
                                   netmask.count("ENTER"))):
-        test.cancel("Please enter the ips and netmask for NIC test in config file")
+        test.cancel("Please enter the ips and netmask for NIC "
+                    "test in config file")
     fdisk_list_before = None
     vmxml = VMXML.new_from_inactive_dumpxml(vm_name)
     backup_xml = vmxml.copy()
@@ -70,55 +67,44 @@ def run(test, params, env):
         output = session.cmd_output("lspci -nn")
         nic_list_before = output.splitlines()
         if sriov:
-            # set the parameter max_vfs of igb module to 7. Then we can use
-            # the virtual function pci device for network device.
+            # The SR-IOV setup of the VF's should be done by test_setup
+            # based on the driver options.
+            # Usage of the PciAssignable for setting up of the VF's
+            # is generic, and eliminates the need to hardcode the driver
+            # and number of VF's to be created.
 
-            # command 'modprobe -r igb' to unload igb module
-            # command '&& modprobe igb max_vfs=7' to load it again
-            #          with max_vfs=7
-            # command '|| echo 'FAIL' > output_file' is a flag to mean
-            #          modprobe igb with max_vfs=7 failed.
-            # command '|| modprobe igb' is a handler of error occured
-            #          when we load igb again. If command 2 failed,
-            #          this command will be executed to recover network.
-            output_file = os.path.join(test.tmpdir, "output")
-            if os.path.exists(output_file):
-                os.remove(output_file)
-            mod_cmd = ("modprobe -r igb && modprobe igb max_vfs=7 ||"
-                       "echo 'FAIL' > %s && modprobe igb &" % output_file)
-            result = process.run(mod_cmd, ignore_status=True, shell=True)
-            if os.path.exists(output_file):
-                test.error("Failed to modprobe igb with max_vfs=7.")
-            # Get the virtual function pci device which was generated above.
-            pci_xml = NodedevXML.new_from_dumpxml(pci_dev)
-            virt_functions = pci_xml.cap.virt_functions
-            if not virt_functions:
-                test.error("Init virtual function failed.")
-            pci_address = virt_functions[0]
-            pci_dev = utils_test.libvirt.pci_label_from_address(pci_address,
-                                                                radix=16)
-            # Find the network name (ethX) is using this pci device.
-            distro_details = distro.detect()
-            if distro_details.name == 'Ubuntu':
-                network_service = service.Factory.create_service("networking")
-            else:
-                network_service = service.Factory.create_service("network")
-            network_service.restart()
-            result = virsh.nodedev_list("net")
-            nodedev_nets = result.stdout.strip().splitlines()
-            device = None
-            for nodedev in nodedev_nets:
-                netxml = NodedevXML.new_from_dumpxml(nodedev)
-                if netxml.parent == pci_dev:
-                    device = nodedev
-                    break
-            if not device:
-                test.error("There is no network name is using "
-                           "Virtual Function PCI device %s." %
-                           pci_dev)
-            pci_xml = NodedevXML.new_from_dumpxml(pci_dev)
-            pci_address = pci_xml.cap.get_address_dict()
-            vmxml.add_hostdev(pci_address)
+            sriov_setup = PciAssignable(
+                driver=params.get("driver"),
+                driver_option=params.get("driver_option"),
+                host_set_flag=params.get("host_set_flag", 1),
+                vf_filter_re=params.get("vf_filter_re"),
+                pf_filter_re=params.get("pf_filter_re"),
+                pa_type=params.get("pci_assignable"))
+
+            # Based on the PF Device specified, all the VF's
+            # belonging to the same iommu group, will be
+            # pass-throughed to the guest.
+            pci_id = pci_dev.replace("_", ".").strip("pci.").replace(".", ":", 2)
+            pci_ids = sriov_setup.get_same_group_devs(pci_id)
+            pci_devs = []
+            for val in pci_ids:
+                temp = val.replace(":", "_")
+                pci_devs.extend(["pci_"+temp])
+            pci_id = re.sub('[:.]', '_', pci_id)
+            for val in pci_devs:
+                val = val.replace(".", "_")
+                # Get the virtual functions of the pci devices
+                # which was generated above.
+                pci_xml = NodedevXML.new_from_dumpxml(val)
+                virt_functions = pci_xml.cap.virt_functions
+                if not virt_functions:
+                    test.fail("No Virtual Functions found.")
+                for val in virt_functions:
+                    pci_dev = utils_test.libvirt.pci_label_from_address(val,
+                                                                        radix=16)
+                    pci_xml = NodedevXML.new_from_dumpxml(pci_dev)
+                    pci_address = pci_xml.cap.get_address_dict()
+                    vmxml.add_hostdev(pci_address)
         else:
             pci_id = pci_dev.replace("_", ".").strip("pci.").replace(".", ":", 2)
             obj = PciAssignable()
@@ -150,55 +136,54 @@ def run(test, params, env):
         vmxml.sync()
         vm.start()
         session = vm.wait_for_login()
+        # The Network configuration is generic irrespective of PF or SRIOV VF
         if device_type == "NIC":
             output = session.cmd_output("lspci -nn")
             nic_list_after = output.splitlines()
+            net_ip = netaddr.IPAddress(net_ip)
             if nic_list_after == nic_list_before:
                 test.fail("passthrough Adapter not found in guest.")
             else:
                 logging.debug("Adapter passthorughed to guest successfully")
-            if sriov:
-                try:
-                    output = session.cmd_output("lspci -nn | grep %s" % device_name)
-                    nic_id = str(output).split(' ', 1)[0]
-                    nic_name = str(utils_misc.get_interface_from_pci_id(nic_id, session))
-                    session.cmd("ip addr flush dev %s" % nic_name)
-                    session.cmd("ip addr add %s/%s dev %s"
-                                % (net_ip, netmask, nic_name))
-                    session.cmd("ip link set %s up" % nic_name)
-                    session.cmd("ping -I %s %s -c 5" % (nic_name, server_ip))
-                except aexpect.ShellError as detail:
-                    test.error("Succeed to set ip on guest, but failed "
-                               "to ping server ip from guest. %s \n" % detail)
-            else:
-                output = session.cmd_output("lspci -nn | grep %s" % device_name)
-                nic_list = output.splitlines()
-                for val in range(len(nic_list)):
-                    bus_info.append(str(nic_list[val]).split(' ', 1)[0])
-                    nic_list[val] = str(nic_list[val]).split(' ', 1)[0][:-2]
+            output = session.cmd_output("lspci -nn | grep %s" % device_name)
+            nic_list = output.splitlines()
+            for val in range(len(nic_list)):
+                bus_info.append(str(nic_list[val]).split(' ', 1)[0])
+                nic_list[val] = str(nic_list[val]).split(' ', 1)[0][:-2]
+            bus_info.sort()
+            if not sriov:
                 # check all functions get same iommu group
                 if len(set(nic_list)) != 1:
                     test.fail("Multifunction Device passthroughed but "
                               "functions are in different iommu group")
-                # ping to server from each function
-                bus_info.sort()
-                for val in bus_info:
-                    nic_name = str(utils_misc.get_interface_from_pci_id(val, session))
-                    try:
-                        session.cmd("ip addr flush dev %s" % nic_name)
-                        session.cmd("ip addr add %s/%s dev %s"
-                                    % (net_ip, netmask, nic_name))
-                        session.cmd("ip link set %s up" % nic_name)
-                        session.cmd("ping -I %s %s -c 5" % (nic_name, server_ip))
-                    except aexpect.ShellError as detail:
-                        test.error("Succeed to set ip on guest, but failed "
-                                   "to ping server ip from guest. %s\n" % detail)
+            # ping to server from each function
+            for val in bus_info:
+                nic_name = str(utils_misc.get_interface_from_pci_id(val, session))
+                session.cmd("ip addr flush dev %s" % nic_name)
+                session.cmd("ip addr add %s/%s dev %s"
+                            % (net_ip, netmask, nic_name))
+                session.cmd("ip link set %s up" % nic_name)
+                # Pinging using nic_name is having issue,
+                # hence replaced with IPAddress
+                s_ping, o_ping = utils_test.ping(server_ip, count=5,
+                                                 interface=net_ip, timeout=30,
+                                                 session=session)
+                logging.info(o_ping)
+                if s_ping != 0:
+                    err_msg = "Ping test fails, error info: '%s'"
+                    test.fail(err_msg % o_ping)
+                # Each interface should have unique IP
+                net_ip = net_ip + 1
+
         elif device_type == "STORAGE":
-            # Get the result of "fdisk -l" in guest, and compare the result with
-            # fdisk_list_before.
+            # Get the result of "fdisk -l" in guest, and
+            # compare the result with fdisk_list_before.
             output = session.cmd_output("fdisk -l|grep \"Disk identifier:\"")
             fdisk_list_after = output.splitlines()
             if fdisk_list_after == fdisk_list_before:
                 test.fail("Didn't find the disk attached to guest.")
     finally:
         backup_xml.sync()
+        # For SR-IOV , VF's should be cleaned up in the post-processing.
+        if sriov:
+            sriov_setup.release_devs()


### PR DESCRIPTION
Modified the SR-IOV setup by implementing the existing PciAssignable class.
The existing setup for SR-IOV requires the driver and no.of VF's to be hardcoded.
We can reuse the PciAssignable class for setting up the SR-IOV VF's, independent of the
driver.
Also based on the PF device specified, all the VF's belonging to the same iommu group
will be pass-throughed.

Signed-off-by: Santwana Samantray <santwana@linux.vnet.ibm.com>