### PR TITLE
Python 3: replace stdout/stderr for libguestfs

### DIFF
--- a/libguestfs/tests/guestfish_augeas.py
+++ b/libguestfs/tests/guestfish_augeas.py
@@ -186,9 +186,9 @@ def test_aug_defnode(test, vm, params):
         test.fail("Can not list augeas nodes under /files/etc/passwd/test. GSERROR_MSG: %s" % aug_ls_result)
     logging.info("List augeas nodes under /files/etc/passwd/test successfully")
 
-    if aug_ls_result.stdout.strip('\n') != '/files/etc/passwd/test/gid\n/files/etc/passwd/test/uid':
+    if aug_ls_result.stdout_text.strip('\n') != '/files/etc/passwd/test/gid\n/files/etc/passwd/test/uid':
         gf.close_session()
-        test.fail("The node value is not correct: %s" % aug_ls_result.stdout)
+        test.fail("The node value is not correct: %s" % aug_ls_result.stdout_text)
     logging.info("The node value is correct")
     gf.close_session()
 
@@ -242,9 +242,9 @@ def test_aug_defvar(test, vm, params):
         test.fail("Can not look up the value of /augeas/variables/test. GSERROR_MSG:%s" % aug_get_result)
     logging.info("Look up the value of /augeas/variables/test successfully")
 
-    if aug_get_result.stdout.strip('\n') != 'This is a test':
+    if aug_get_result.stdout_text.strip('\n') != 'This is a test':
         gf.close_session()
-        test.fail("The variable value is not correct %s != This is a test" % aug_get_result.stdout.strip('\n'))
+        test.fail("The variable value is not correct %s != This is a test" % aug_get_result.stdout_text.strip('\n'))
     logging.info("The variable value is correct")
     gf.close_session()
 
@@ -311,9 +311,9 @@ def test_aug_set_get(test, vm, params):
         test.fail("Can not get the value of /files/etc/passwd/root/home. GSERROR_MSG: %s" % aug_get_result_home)
     logging.info("Get the value of /files/etc/passwd/root/home successfully")
 
-    if aug_get_result_password.stdout.strip('\n') != "9999" or aug_get_result_home.stdout.strip('\n') != '/root':
+    if aug_get_result_password.stdout_text.strip('\n') != "9999" or aug_get_result_home.stdout_text.strip('\n') != '/root':
         gf.close_session()
-        test.fail("The value of /files/etc/passwd/root/password and /files/etc/passwd/root/home is not correct. root password %s != 9999, root home %s != /root" % (aug_get_result_password.stdout.strip('\n'), aug_get_result_home.stdout.strip('\n')))
+        test.fail("The value of /files/etc/passwd/root/password and /files/etc/passwd/root/home is not correct. root password %s != 9999, root home %s != /root" % (aug_get_result_password.stdout_text.strip('\n'), aug_get_result_home.stdout_text.strip('\n')))
     logging.info("The value of /files/etc/passwd/root/password and /files/etc/passwd/root/home is correct")
     gf.close_session()
 
@@ -462,9 +462,9 @@ def test_aug_insert(test, vm, params):
         gf.close_session()
         test.fail("Failed to run the command. GSERROR_MSG: %s" % command_result)
 
-    if command_result.stdout.strip('\n') != '/files/etc/passwd/root/testbefore\n/files/etc/passwd/root/name\n/files/etc/passwd/root/testafter':
+    if command_result.stdout_text.strip('\n') != '/files/etc/passwd/root/testbefore\n/files/etc/passwd/root/name\n/files/etc/passwd/root/testafter':
         gf.close_session()
-        test.fail("The match results is not correct. GSERROR_MSG: %s" % command_result.stdout)
+        test.fail("The match results is not correct. GSERROR_MSG: %s" % command_result.stdout_text)
     gf.close_session()
 
 
@@ -524,9 +524,9 @@ def test_aug_ls(test, vm, params):
         test.fail("Can not list path /files/etc/passwd. GSERROR_MSG: %s" % aug_ls_result)
     logging.info("List path /files/etc/passwd successfully")
 
-    if aug_ls_result.stdout.strip('\n') != '/files/etc/passwd/mysql\n/files/etc/passwd/root':
+    if aug_ls_result.stdout_text.strip('\n') != '/files/etc/passwd/mysql\n/files/etc/passwd/root':
         gf.close_session()
-        test.fail("aug-ls list the wrong results. GSERROR_MSG: %s" % aug_ls_result.stdout)
+        test.fail("aug-ls list the wrong results. GSERROR_MSG: %s" % aug_ls_result.stdout_text)
     logging.info("aug-ls list the right results")
 
     aug_ls_result = gf.aug_ls("/files/etc/passwd/")
@@ -608,9 +608,9 @@ def test_aug_match(test, vm, params):
         test.fail("Can not return augeas nodes which match /files/etc/*/root. GSERROR_MSG: %s" % aug_match_result)
     logging.info("Can return augeas nodes which match /files/etc/*/root successfully")
 
-    if aug_match_result.stdout.strip('\n') != '/files/etc/passwd/root\n/files/etc/config/root':
+    if aug_match_result.stdout_text.strip('\n') != '/files/etc/passwd/root\n/files/etc/config/root':
         gf.close_session()
-        test.fail("The match results is not correct. GSERROR_MSG: %s" % aug_match_result.stdout)
+        test.fail("The match results is not correct. GSERROR_MSG: %s" % aug_match_result.stdout_text)
     gf.close_session()
 
 
@@ -669,7 +669,7 @@ def test_aug_mv(test, vm, params):
         test.fail("Can not list augeas nodes under /files/etc/passwd. GSERROR_MSG: %s" % aug_ls_result)
     logging.info("List augeas nodes under /files/etc/passwd successfully")
 
-    if aug_ls_result.stdout.strip('\n') != '/files/etc/passwd/other_none_root':
+    if aug_ls_result.stdout_text.strip('\n') != '/files/etc/passwd/other_none_root':
         gf.close_session()
         test.fail("aug-mv: can not find the new node /files/etc/passwd/other_none_root")
     gf.close_session()
@@ -730,7 +730,7 @@ def test_aug_rm(test, vm, params):
         test.fail("Can not list augeas nodes under /files/etc/passwd. GSERROR_MSG: %s" % aug_ls_result)
     logging.info("List augeas nodes under /files/etc/passwd successfully")
 
-    if aug_ls_result.stdout.strip('\n') == '/files/etc/passwd/root':
+    if aug_ls_result.stdout_text.strip('\n') == '/files/etc/passwd/root':
         gf.close_session()
         test.fail("aug-rm: failed to remove node /files/etc/passwd/root")
     gf.close_session()
@@ -785,7 +785,7 @@ def test_aug_label(test, vm, params):
         gf.close_session()
         test.fail("Can not get the label of /files/etc/passwd/root. GSERROR_MSG: %s" % aug_label_result)
 
-    if aug_label_result.stdout.strip('\n') != 'root':
+    if aug_label_result.stdout_text.strip('\n') != 'root':
         gf.close_session()
         test.fail("aug-label return the wrong lable")
     gf.close_session()
@@ -856,9 +856,9 @@ def test_aug_setm(test, vm, params):
         gf.close_session()
         test.fail("Can not get the value of /files/etc/passwd/mysql/uid. GSERROR_MSG: %s" % aug_get_result_mysql)
 
-    if aug_get_result_root.stdout.strip('\n') != '2' or aug_get_result_mysql.stdout.strip('\n') != '2':
+    if aug_get_result_root.stdout_text.strip('\n') != '2' or aug_get_result_mysql.stdout_text.strip('\n') != '2':
         gf.close_session()
-        test.fail("aug-setm set the wrong value. GSERROR_MSG: root = %s, mysql = %s" % (aug_get_result_root.stdout.strip('\n'), aug_get_result_mysql.stdout.strip('\n')))
+        test.fail("aug-setm set the wrong value. GSERROR_MSG: root = %s, mysql = %s" % (aug_get_result_root_text.stdout_text.strip('\n'), aug_get_result_mysql.stdout_text.strip('\n')))
     gf.close_session()
 
 
@@ -942,7 +942,7 @@ def test_aug_load(test, vm, params):
         test.fail("Can not list augeas nodes under /files/etc. GSERROR_MSG: %s" % aug_ls_load_result)
     logging.info("List augeas nodes under /files/etc successfully")
 
-    if aug_ls_result.stdout.strip('\n') != '' or aug_ls_load_result.stdout.strip('\n') != '/files/etc/passwd':
+    if aug_ls_result.stdout_text.strip('\n') != '' or aug_ls_load_result.stdout_text.strip('\n') != '/files/etc/passwd':
         gf.close_session()
         test.fail("Failed to load the tree.")
     gf.close_session()
@@ -1055,9 +1055,9 @@ def test_aug_save(test, vm, params):
     if aug_get_result.exit_status:
         gf.close_session()
         test.fail("Can not get the home directory of root user. GSERROR_MSG: %s" % aug_get_result)
-    logging.info("Get the home directory of root user successfully. root directory is %s" % aug_get_result.stdout.strip('\n'))
+    logging.info("Get the home directory of root user successfully. root directory is %s" % aug_get_result.stdout_text.strip('\n'))
 
-    if aug_get_result.stdout.strip('\n') != '/tmp/root':
+    if aug_get_result.stdout_text.strip('\n') != '/tmp/root':
         gf.close_session()
         test.fail("The home directory of root user is not correct")
     gf.close_session()

--- a/libguestfs/tests/guestfish_block_dev.py
+++ b/libguestfs/tests/guestfish_block_dev.py
@@ -76,11 +76,11 @@ def test_blockdev_set_get_ro_rw(test, vm, params):
     gf.run()
     pv_name = params.get("pv_name")
 
-    gf_result.append(gf.blockdev_getro(pv_name).stdout.strip())
+    gf_result.append(gf.blockdev_getro(pv_name).stdout_text.strip())
     gf.blockdev_setro(pv_name)
-    gf_result.append(gf.blockdev_getro(pv_name).stdout.strip())
+    gf_result.append(gf.blockdev_getro(pv_name).stdout_text.strip())
     gf.blockdev_setrw(pv_name)
-    gf_result.append(gf.blockdev_getro(pv_name).stdout.strip())
+    gf_result.append(gf.blockdev_getro(pv_name).stdout_text.strip())
 
     try:
         if gf_result != expect_result:
@@ -105,7 +105,7 @@ def test_blockdev_getsz(test, vm, params):
         gf.add_domain(vm_name, readonly=readonly)
     gf.run()
     pv_name = params.get("pv_name")
-    gf_result = gf.blockdev_getsz(pv_name).stdout.strip()
+    gf_result = gf.blockdev_getsz(pv_name).stdout_text.strip()
     gf.close_session()
 
     get_size = (int(gf_result) * 512)
@@ -135,7 +135,7 @@ def test_blockdev_getbsz(test, vm, params):
         gf.add_domain(vm_name, readonly=readonly)
     gf.run()
     pv_name = params.get("pv_name")
-    gf_result = gf.blockdev_getbsz(pv_name).stdout.strip()
+    gf_result = gf.blockdev_getbsz(pv_name).stdout_text.strip()
     gf.close_session()
 
     logging.debug("Block size of %s is %d" % (pv_name, int(gf_result)))
@@ -160,7 +160,7 @@ def test_blockdev_getss(test, vm, params):
         gf.add_domain(vm_name, readonly=readonly)
     gf.run()
     pv_name = params.get("pv_name")
-    gf_result = gf.blockdev_getss(pv_name).stdout.strip()
+    gf_result = gf.blockdev_getss(pv_name).stdout_text.strip()
     gf.close_session()
 
     logging.debug("Size of %s is %d" % (pv_name, int(gf_result)))
@@ -185,7 +185,7 @@ def test_blockdev_getsize64(test, vm, params):
         gf.add_domain(vm_name, readonly=readonly)
     gf.run()
     pv_name = params.get("pv_name")
-    gf_result = gf.blockdev_getsize64(pv_name).stdout.strip()
+    gf_result = gf.blockdev_getsize64(pv_name).stdout_text.strip()
     gf.close_session()
 
     get_size = int(gf_result)
@@ -242,14 +242,14 @@ def test_canonical_device_name(test, vm, params):
     gf.run()
     pv_name = params.get("pv_name")
 
-    gf_result = gf.list_filesystems().stdout.strip()
+    gf_result = gf.list_filesystems().stdout_text.strip()
     partition_name = gf_result.split(":")[0]
-    gf_result = gf.is_lv(partition_name).stdout.strip()
+    gf_result = gf.is_lv(partition_name).stdout_text.strip()
     if gf_result == "true":
         gf_result = []
         vg, lv = partition_name.split("/")[-2:]
         irregularity = '/dev/mapper/' + vg + '-' + lv
-        gf_result.append(gf.canonical_device_name(irregularity).stdout.strip())
+        gf_result.append(gf.canonical_device_name(irregularity).stdout_text.strip())
         logging.debug("canonical device name is %s" % gf_result)
     else:
         part = partition_name.split("/")
@@ -257,7 +257,7 @@ def test_canonical_device_name(test, vm, params):
         for i in ['h', 'v']:
             part[-1] = i + part[-1][1:]
             irregularity = "/".join(part)
-            s = gf.canonical_device_name(irregularity).stdout.strip()
+            s = gf.canonical_device_name(irregularity).stdout_text.strip()
             gf_result.append(s)
         logging.debug("canonical device name is %s" % gf_result)
 
@@ -290,7 +290,7 @@ def test_device_index(test, vm, params):
     result = {'/dev/sda': '0', '/dev/sdb': '1', '/dev/sdc': '2'}
     try:
         for k, v in list(result.items()):
-            index = gf.device_index(k).stdout.strip()
+            index = gf.device_index(k).stdout_text.strip()
             if index != v:
                 test.fail("Can not get the correct result.")
     finally:
@@ -318,7 +318,7 @@ def test_list_devices(test, vm, params):
 
     result = ['/dev/sda', '/dev/sdb', '/dev/sdc']
     try:
-        devices = gf.list_devices().stdout.strip()
+        devices = gf.list_devices().stdout_text.strip()
         logging.debug("%s" % devices)
     finally:
         gf.close_session()
@@ -354,7 +354,7 @@ def test_disk_format(test, vm, params):
         params['image_format'] = i
         image = qemu_storage.QemuImg(params, image_dir, '')
         image_path, _ = image.create(params)
-        result = gf.disk_format(image_path).stdout.strip()
+        result = gf.disk_format(image_path).stdout_text.strip()
         os.remove(image_path)
 
         if result != i:
@@ -381,7 +381,7 @@ def test_max_disks(test, vm, params):
         vm_name = params.get("main_vm")
         gf.add_domain(vm_name, readonly=readonly)
     gf.run()
-    max_disk = gf.max_disks().stdout.strip()
+    max_disk = gf.max_disks().stdout_text.strip()
     gf.close_session()
 
     logging.debug("The maximum number of disks is %s" % max_disk)
@@ -405,7 +405,7 @@ def test_nr_devices(test, vm, params):
         vm_name = params.get("main_vm")
         gf.add_domain(vm_name, readonly=readonly)
     gf.run()
-    device_num = gf.nr_devices().stdout.strip()
+    device_num = gf.nr_devices().stdout_text.strip()
     gf.close_session()
 
     logging.debug("The number of device is %s" % device_num)
@@ -431,7 +431,7 @@ def test_list_partitions(test, vm, params):
     gf.run()
 
     result = gf.list_partitions()
-    devices = result.stdout.strip()
+    devices = result.stdout_text.strip()
 
     if result.exit_status:
         gf.close_session()
@@ -471,7 +471,7 @@ def test_disk_has_backing_file(test, vm, params):
     image_format = params["image_format"]
     image_path = params.get("image_path")
 
-    result = gf.disk_has_backing_file(image_path).stdout.strip()
+    result = gf.disk_has_backing_file(image_path).stdout_text.strip()
     if result != "false":
         gf.close_session()
         test.fail("The disk has no backing file")
@@ -484,7 +484,7 @@ def test_disk_has_backing_file(test, vm, params):
     image.base_format = None
     image_path, _ = image.create(params)
 
-    result = gf.disk_has_backing_file(image_path).stdout.strip()
+    result = gf.disk_has_backing_file(image_path).stdout_text.strip()
     if result != "true":
         gf.close_session()
         test.fail("The disk has backing file")
@@ -513,7 +513,7 @@ def test_disk_virtual_size(test, vm, params):
 
     image_path = params.get("image_path")
     disk_size = int(os.path.getsize(image_path))
-    result = int(gf.disk_virtual_size(image_path).stdout.strip())
+    result = int(gf.disk_virtual_size(image_path).stdout_text.strip())
 
     power = {'G': 1024 ** 3, "M": 1024 ** 2, "K": 1024}
     image_size = params["image_size"]
@@ -566,9 +566,9 @@ def test_scrub_device(test, vm, params):
     gf.part_disk(pv_name, 'msdos')
     gf.mkfs('ext4', part_name)
 
-    device_info = gf.file(pv_name).stdout.strip()
+    device_info = gf.file(pv_name).stdout_text.strip()
     logging.debug(device_info)
-    part_info = gf.file(part_name).stdout.strip()
+    part_info = gf.file(part_name).stdout_text.strip()
     logging.debug(part_info)
 
     if len(device_info) < 20 and len(part_info) < 20:
@@ -578,13 +578,13 @@ def test_scrub_device(test, vm, params):
     # scrub partition, device info should be kept
     gf.scrub_device(part_name)
 
-    device_info_new = gf.file(pv_name).stdout.strip()
+    device_info_new = gf.file(pv_name).stdout_text.strip()
     logging.debug(device_info_new)
     if device_info_new != device_info:
         gf.close_session()
         test.fail("Device info should be kept")
 
-    part_info_new = gf.file(part_name).stdout.strip()
+    part_info_new = gf.file(part_name).stdout_text.strip()
     logging.debug(part_info_new)
     if part_info_new != "data":
         gf.close_session()
@@ -593,7 +593,7 @@ def test_scrub_device(test, vm, params):
     # scrub the whole device
     gf.scrub_device(pv_name)
 
-    device_info_new = gf.file(pv_name).stdout.strip()
+    device_info_new = gf.file(pv_name).stdout_text.strip()
     logging.debug(device_info_new)
     if device_info_new != 'data':
         gf.close_session()
@@ -623,14 +623,14 @@ def test_scrub_file(test, vm, params):
 
     file_path = "/test.log"
     content = "hello world"
-    gf.write(file_path, content).stdout.strip()
-    ret = gf.cat(file_path).stdout.strip()
+    gf.write(file_path, content).stdout_text.strip()
+    ret = gf.cat(file_path).stdout_text.strip()
     if ret != content:
         gf.close_session()
         test.fail("File content is not correct")
 
     gf.scrub_file(file_path)
-    ret = gf.exists(file_path).stdout.strip()
+    ret = gf.exists(file_path).stdout_text.strip()
     if ret != "false":
         gf.close_session()
         test.fail("scrub file failed")
@@ -680,7 +680,7 @@ def test_scrub_freespace(test, vm, params):
         gf.close_session()
         test.fail("scrub_freespace failed.")
 
-    result = gf.exists(dir_path).stdout.strip()
+    result = gf.exists(dir_path).stdout_text.strip()
     if result != "false":
         gf.close_session()
         test.fail("folder still exist, scrub_freespace failed.")
@@ -718,7 +718,7 @@ def test_md_test(test, vm, params):
 
     gf.run()
 
-    md = gf.list_md_devices().stdout.strip()
+    md = gf.list_md_devices().stdout_text.strip()
     if md:
         # close the existed md device
         gf.md_stop(md)
@@ -726,13 +726,13 @@ def test_md_test(test, vm, params):
     device = "'/dev/sda /dev/sdb /dev/sdc'"
     gf.md_create("md11", device, missingbitmap="0x4",
                  chunk=8192, level="raid6")
-    md = gf.list_md_devices().stdout.strip()
+    md = gf.list_md_devices().stdout_text.strip()
     logging.debug(md)
     if not md:
         gf.close_session()
         test.fail("Can not find the md device")
 
-    detail = gf.md_detail(md).stdout.strip()
+    detail = gf.md_detail(md).stdout_text.strip()
     logging.debug(detail)
     if "level: raid6" not in detail or "devname: md11" not in detail:
         gf.close_session()
@@ -742,12 +742,12 @@ def test_md_test(test, vm, params):
 
     gf.md_create("md21", device, nrdevices=2, spare=1,
                  chunk=8192, level="raid4")
-    md = gf.list_md_devices().stdout.strip()
+    md = gf.list_md_devices().stdout_text.strip()
     logging.debug(md)
     if not md:
         gf.close_session()
         test.fail("Can not find the md device")
-    stat = gf.md_stat(md).stdout.strip()
+    stat = gf.md_stat(md).stdout_text.strip()
     logging.debug(stat)
     for i in re.findall("\w+", device):
         if i not in stat:
@@ -797,7 +797,7 @@ def test_part_add(test, vm, params):
     gf.part_add(partname, 'p', 100001, 200000)
     gf.part_add(partname, 'e', 200001, 300000)
     gf.part_add(partname, 'l', 240000, 280000)
-    result = gf.part_list(partname).stdout.strip()
+    result = gf.part_list(partname).stdout_text.strip()
 
     partnum = result.count("part_num")
     if partnum != 4:
@@ -842,7 +842,7 @@ def test_part_del(test, vm, params):
     gf.part_init(partname, 'msdos')
     gf.part_add(partname, 'p', 2, 100000)
     gf.part_add(partname, 'p', 100001, 200000)
-    result = gf.part_list(partname).stdout.strip()
+    result = gf.part_list(partname).stdout_text.strip()
 
     partnum = result.count("part_num")
     if partnum != 2:
@@ -850,7 +850,7 @@ def test_part_del(test, vm, params):
         test.fail("partnum is %s, expect is 2" % partnum)
 
     gf.part_del(partname, 2)
-    result = gf.part_list(partname).stdout.strip()
+    result = gf.part_list(partname).stdout_text.strip()
 
     partnum = result.count("part_num")
     if partnum != 1:
@@ -895,7 +895,7 @@ def test_part_init(test, vm, params):
         gf.part_init(partname, i)
         gf.part_add(partname, 'p', 100, 100000)
         gf.part_add(partname, 'p', 100001, 200000)
-        result = gf.part_list(partname).stdout.strip()
+        result = gf.part_list(partname).stdout_text.strip()
 
         partnum = result.count("part_num")
         if partnum != 2:
@@ -929,7 +929,7 @@ def test_part_set_get_bootable(test, vm, params):
     if params['partition_types'] == "physical":
         for k, v in list(result.items()):
             gf.part_set_bootable(pv_name, partnum, k)
-            ret = gf.part_get_bootable(pv_name, 1).stdout.strip()
+            ret = gf.part_get_bootable(pv_name, 1).stdout_text.strip()
             if ret != v:
                 gf.close_session()
                 test.fail("Get the uncorrect status")
@@ -959,7 +959,7 @@ def test_part_set_get_mbr_id(test, vm, params):
         for i in ['1', '2', '3', '4']:
             for k, v in list(result.items()):
                 gf.part_set_mbr_id(pv_name, i, k)
-                ret = gf.part_get_mbr_id(pv_name, i).stdout.strip()
+                ret = gf.part_get_mbr_id(pv_name, i).stdout_text.strip()
                 if ret != v:
                     gf.close_session()
                     test.fail("Get the uncorrect mbr id")
@@ -987,14 +987,14 @@ def test_part_disk(test, vm, params):
 
     for ptype in ['msdos', 'gpt']:
         gf.part_disk(pv_name, ptype)
-        result = gf.part_list(pv_name).stdout.strip()
+        result = gf.part_list(pv_name).stdout_text.strip()
         num = re.findall(r'part_num: (\d)', result)
 
         if int(num[0]) != 1:
             gf.close_session()
             test.fail("partnum is %s, expect is 1" % num)
 
-        result = gf.part_get_parttype(pv_name).stdout.strip()
+        result = gf.part_get_parttype(pv_name).stdout_text.strip()
 
         if result != ptype:
             gf.close_session()
@@ -1024,8 +1024,8 @@ def test_part_to_dev(test, vm, params):
 
     for ptype in ['mbr', 'msdos', 'gpt', 'efi']:
         gf.part_disk(pv_name, ptype)
-        partname = gf.list_partitions().stdout.strip()
-        devname = gf.part_to_dev(partname).stdout.strip()
+        partname = gf.list_partitions().stdout_text.strip()
+        devname = gf.part_to_dev(partname).stdout_text.strip()
 
         if devname != pv_name:
             gf.close_session()
@@ -1056,9 +1056,9 @@ def test_part_to_partnum(test, vm, params):
     if params["partition_type"] == "physical":
         for ptype in ['mbr', 'msdos', 'gpt', 'efi']:
             gf.part_disk(pv_name, ptype)
-            partname = gf.list_partitions().stdout.strip()
+            partname = gf.list_partitions().stdout_text.strip()
             num = partname[-1]
-            devnum = gf.part_to_partnum(partname).stdout.strip()
+            devnum = gf.part_to_partnum(partname).stdout_text.strip()
 
             if devnum != num:
                 gf.close_session()
@@ -1096,7 +1096,7 @@ def test_sfdisk(test, vm, params):
 
     gf.part_init(pv_name, 'msdos')
     gf.sfdisk(pv_name, 0, 0, 0, lines)
-    ret = gf.sfdisk_l(pv_name).stdout.strip()
+    ret = gf.sfdisk_l(pv_name).stdout_text.strip()
 
     result = []
     for i in ret.split('\n'):
@@ -1137,7 +1137,7 @@ def test_sfdiskM(test, vm, params):
         lines = '"' + " ".join(partition) + '"'
 
         gf.sfdiskM(pv_name, lines)
-        result = gf.sfdisk_l(pv_name).stdout.strip()
+        result = gf.sfdisk_l(pv_name).stdout_text.strip()
         logging.debug(result)
 
         l = re.findall("/dev/sda[0-9]", result)
@@ -1173,7 +1173,7 @@ def test_sfdisk_N(test, vm, params):
         for i, v in enumerate(lines):
             gf.sfdisk_N(pv_name, i+1, 0, 0, 0, v)
 
-        ret = gf.sfdisk_l(pv_name).stdout.strip()
+        ret = gf.sfdisk_l(pv_name).stdout_text.strip()
 
         result = []
         for i in ret.split('\n'):
@@ -1209,7 +1209,7 @@ def test_sfdisk_disk_geometry(test, vm, params):
     gf.run()
 
     gf.part_init(pv_name, 'msdos')
-    result = gf.sfdisk_disk_geometry(pv_name).stdout.strip()
+    result = gf.sfdisk_disk_geometry(pv_name).stdout_text.strip()
 
     if not result:
         gf.close_session()
@@ -1237,7 +1237,7 @@ def test_sfdisk_kernel_geometry(test, vm, params):
     gf.run()
 
     gf.part_init(pv_name, 'msdos')
-    result = gf.sfdisk_kernel_geometry(pv_name).stdout.strip()
+    result = gf.sfdisk_kernel_geometry(pv_name).stdout_text.strip()
 
     if not result:
         gf.close_session()

--- a/libguestfs/tests/guestfish_file_dir.py
+++ b/libguestfs/tests/guestfish_file_dir.py
@@ -53,7 +53,7 @@ def test_chmod(test, vm, params):
     mount_point = params.get("mount_point")
     gf.mount(mount_point, '/')
     gf_result = gf.ll("/file_ops/file_ascii")
-    ori_perm_oct = gf_result.stdout.split()[0]
+    ori_perm_oct = gf_result.stdout_text.split()[0]
     perm = list(ori_perm_oct)
     i = 0
     while i < len(perm):
@@ -74,12 +74,12 @@ def test_chmod(test, vm, params):
         i += 1
     new_perm = ''.join(new_perm)
     gf_result = gf.ll("/file_ops/file_ascii")
-    if gf_result.stdout.split()[0] != new_perm:
+    if gf_result.stdout_text.split()[0] != new_perm:
         gf.close_session()
         test.fail("chmod failed.")
     gf.chmod(str(ori_perm), "/file_ops/file_ascii")
     gf_result = gf.ll("/file_ops/file_ascii")
-    if gf_result.stdout.split()[0] != ori_perm_oct:
+    if gf_result.stdout_text.split()[0] != ori_perm_oct:
         gf.close_session()
         test.fail("chmod failed.")
     if gf_result.exit_status:
@@ -107,25 +107,25 @@ def test_chown(test, vm, params):
     mount_point = params.get("mount_point")
     gf.mount(mount_point, '/')
     gf_result = gf.ll("/file_ops/file_ascii")
-    logging.debug(gf_result.stdout)
+    logging.debug(gf_result.stdout_text)
     gf.chown(100, 100, "/file_ops/file_ascii")
     gf_result = gf.ll("/file_ops/file_ascii")
-    if gf_result.stdout.split()[2] != '100' or gf_result.stdout.split()[3] != 'users':
+    if gf_result.stdout_text.split()[2] != '100' or gf_result.stdout_text.split()[3] != 'users':
         gf.close_session()
         test.fail("chown failed.")
     gf.chown(500, 500, "/file_ops/file_ascii")
     gf_result = gf.ll("/file_ops/file_ascii")
-    if gf_result.stdout.split()[2] != '500' or gf_result.stdout.split()[3] != '500':
+    if gf_result.stdout_text.split()[2] != '500' or gf_result.stdout_text.split()[3] != '500':
         gf.close_session()
         test.fail("chown failed.")
     gf.chown(100, 100, "/file_ops/file_ascii_softlink")
     gf_result = gf.ll("/file_ops/file_ascii_softlink")
-    if gf_result.stdout.split()[2] != 'root' or gf_result.stdout.split()[3] != 'root':
+    if gf_result.stdout_text.split()[2] != 'root' or gf_result.stdout_text.split()[3] != 'root':
         gf.close_session()
         test.fail("chown failed.")
     gf.chown(500, 500, "/file_ops/file_ascii_softlink")
     gf_result = gf.ll("/file_ops/file_ascii_softlink")
-    if gf_result.stdout.split()[2] != 'root' or gf_result.stdout.split()[3] != 'root':
+    if gf_result.stdout_text.split()[2] != 'root' or gf_result.stdout_text.split()[3] != 'root':
         gf.close_session()
         test.fail("chown failed.")
     gf.close_session()
@@ -149,25 +149,25 @@ def test_lchown(test, vm, params):
     mount_point = params.get("mount_point")
     gf.mount(mount_point, '/')
     gf_result = gf.ll("/file_ops/file_ascii")
-    logging.debug(gf_result.stdout)
+    logging.debug(gf_result.stdout_text)
     gf.lchown(100, 100, "/file_ops/file_ascii")
     gf_result = gf.ll("/file_ops/file_ascii")
-    if gf_result.stdout.split()[2] != '100' or gf_result.stdout.split()[3] != 'users':
+    if gf_result.stdout_text.split()[2] != '100' or gf_result.stdout_text.split()[3] != 'users':
         gf.close_session()
         test.fail("lchown failed.")
     gf.lchown(500, 500, "/file_ops/file_ascii")
     gf_result = gf.ll("/file_ops/file_ascii")
-    if gf_result.stdout.split()[2] != '500' or gf_result.stdout.split()[3] != '500':
+    if gf_result.stdout_text.split()[2] != '500' or gf_result.stdout_text.split()[3] != '500':
         gf.close_session()
         test.fail("lchown failed.")
     gf.lchown(100, 100, "/file_ops/file_ascii_softlink")
     gf_result = gf.ll("/file_ops/file_ascii_softlink")
-    if gf_result.stdout.split()[2] != '100' or gf_result.stdout.split()[3] != 'users':
+    if gf_result.stdout_text.split()[2] != '100' or gf_result.stdout_text.split()[3] != 'users':
         gf.close_session()
         test.fail("lchown failed.")
     gf.lchown(500, 500, "/file_ops/file_ascii_softlink")
     gf_result = gf.ll("/file_ops/file_ascii_softlink")
-    if gf_result.stdout.split()[2] != '500' or gf_result.stdout.split()[3] != '500':
+    if gf_result.stdout_text.split()[2] != '500' or gf_result.stdout_text.split()[3] != '500':
         gf.close_session()
         test.fail("lchown failed.")
     gf.close_session()
@@ -191,7 +191,7 @@ def test_du(test, vm, params):
     mount_point = params.get("mount_point")
     gf.mount(mount_point, '/')
     gf_result = gf.du("/file_ops")
-    if int(gf_result.stdout.split()[0]) > 13200 or int(gf_result.stdout.split()[0]) < 13000:
+    if int(gf_result.stdout_text.split()[0]) > 13200 or int(gf_result.stdout_text.split()[0]) < 13000:
         gf.close_session()
         test.fail("du failed.")
     gf.close_session()
@@ -225,7 +225,7 @@ def test_file(test, vm, params):
                   "/file_ops/file_dev_char": 'character device'}
 
     for k, v in list(file_check.items()):
-        gf_result = gf.file(k).stdout.strip()
+        gf_result = gf.file(k).stdout_text.strip()
         if v not in gf_result:
             gf.close_session()
             test.fail("file failed.")
@@ -258,7 +258,7 @@ def test_file_architecture(test, vm, params):
                                "/file_ops/file_sparc": 'sparc'}
 
     for k, v in list(file_architecture_check.items()):
-        gf_result = gf.file_architecture(k).stdout.strip()
+        gf_result = gf.file_architecture(k).stdout_text.strip()
         if v.upper() not in gf_result.upper():
             gf.close_session()
             test.fail("file-architecture failed.")
@@ -293,7 +293,7 @@ def test_filesize(test, vm, params):
                       "/file_ops/file_dev_char": '0'}
 
     for k, v in list(filesize_check.items()):
-        gf_result = gf.filesize(k).stdout.strip()
+        gf_result = gf.filesize(k).stdout_text.strip()
         if v not in gf_result:
             gf.close_session()
             test.fail("filesize failed.")
@@ -328,7 +328,7 @@ def test_stat(test, vm, params):
                   "/file_ops/file_dev_char": '0'}
 
     for k, v in list(stat_check.items()):
-        gf_result = gf.stat(k).stdout.strip()
+        gf_result = gf.stat(k).stdout_text.strip()
         if v not in gf_result:
             gf.close_session()
             test.fail("stat failed.")
@@ -363,7 +363,7 @@ def test_lstat(test, vm, params):
                    "/file_ops/file_dev_char": '0'}
 
     for k, v in list(lstat_check.items()):
-        gf_result = gf.lstat(k).stdout.strip()
+        gf_result = gf.lstat(k).stdout_text.strip()
         if v not in gf_result:
             gf.close_session()
             test.fail("lstat failed.")
@@ -397,7 +397,7 @@ def test_lstatlist(test, vm, params):
                    "/file_ops/file_ascii_softlink_link": '19',
                    "/file_ops/file_dev_char": '0'}
 
-    gf_result = gf.lstatlist("/file_ops", "\"file_ascii file_ascii_long file_elf file_dev_block file_dev_fifo file_ascii_softlink file_ascii_softlink_link file_dev_char\"").stdout.strip()
+    gf_result = gf.lstatlist("/file_ops", "\"file_ascii file_ascii_long file_elf file_dev_block file_dev_fifo file_ascii_softlink file_ascii_softlink_link file_dev_char\"").stdout_text.strip()
     for k, v in list(lstat_check.items()):
         if v not in gf_result:
             gf.close_session()
@@ -460,36 +460,36 @@ def test_umask(test, vm, params):
     gf.mount(mount_point, '/')
     gf_result = gf.umask("022")
     gf_result = gf.get_umask()
-    if gf_result.stdout.strip() != "022":
+    if gf_result.stdout_text.strip() != "022":
         gf.close_session()
         test.fail("umask failed.")
     gf_result = gf.touch("/file_ops/umask0022")
     gf_result = gf.ll("/file_ops/umask0022")
-    if gf_result.stdout.split()[0] != "-rw-r--r--":
+    if gf_result.stdout_text.split()[0] != "-rw-r--r--":
         gf.close_session()
         test.fail("umask failed.")
     gf_result = gf.rm("/file_ops/umask0022")
 
     gf_result = gf.umask("0")
     gf_result = gf.get_umask()
-    if gf_result.stdout.strip() != "0":
+    if gf_result.stdout_text.strip() != "0":
         gf.close_session()
         test.fail("umask failed.")
     gf_result = gf.touch("/file_ops/umask0000")
     gf_result = gf.ll("/file_ops/umask0000")
-    if gf_result.stdout.split()[0] != "-rw-rw-rw-":
+    if gf_result.stdout_text.split()[0] != "-rw-rw-rw-":
         gf.close_session()
         test.fail("umask failed.")
     gf_result = gf.rm("/file_ops/umask0000")
 
     gf_result = gf.umask("066")
     gf_result = gf.get_umask()
-    if gf_result.stdout.strip() != "066":
+    if gf_result.stdout_text.strip() != "066":
         gf.close_session()
         test.fail("umask failed.")
     gf_result = gf.touch("/file_ops/umask0066")
     gf_result = gf.ll("/file_ops/umask0066")
-    if gf_result.stdout.split()[0] != "-rw-------":
+    if gf_result.stdout_text.split()[0] != "-rw-------":
         gf.close_session()
         test.fail("umask failed.")
     gf_result = gf.rm("/file_ops/umask0066")
@@ -497,7 +497,7 @@ def test_umask(test, vm, params):
 # regress bug 627832
     gf_result = gf.umask("022")
     gf_result = gf.get_umask()
-    if gf_result.stdout.strip() != "022":
+    if gf_result.stdout_text.strip() != "022":
         gf.close_session()
         test.fail("umask failed.")
     gf_result = gf.umask("-1")
@@ -505,7 +505,7 @@ def test_umask(test, vm, params):
         gf.close_session()
         test.fail("umask failed.")
     gf_result = gf.get_umask()
-    if gf_result.stdout.strip() != "022":
+    if gf_result.stdout_text.strip() != "022":
         gf.close_session()
         test.fail("umask failed.")
     gf_result = gf.umask("01000")
@@ -513,7 +513,7 @@ def test_umask(test, vm, params):
         gf.close_session()
         test.fail("umask failed.")
     gf_result = gf.get_umask()
-    if gf_result.stdout.strip() != "022":
+    if gf_result.stdout_text.strip() != "022":
         gf.close_session()
         test.fail("umask failed.")
     gf_result = gf.touch("/testfoo")
@@ -554,10 +554,10 @@ def test_cat(test, vm, params):
     mount_point = params.get("mount_point")
     gf.mount(mount_point, '/')
 
-    gf_result = gf.cat('/file_ops/file_ascii').stdout.strip()
+    gf_result = gf.cat('/file_ops/file_ascii').stdout_text.strip()
     logging.debug(gf_result)
     run_result = process.run("tar xOf %s file_ops/file_ascii" % params.get("tarball_path"),
-                             ignore_status=True, shell=True).stdout.strip()
+                             ignore_status=True, shell=True).stdout_text.strip()
     logging.debug(run_result)
     if gf_result != run_result:
         gf.close_session()
@@ -592,23 +592,23 @@ def test_checksum(test, vm, params):
                     "sha512": 'sha512sum'}
 
     for k, v in list(checksum_map.items()):
-        gf_result = gf.checksum(k, '/file_ops/file_ascii').stdout.strip()
+        gf_result = gf.checksum(k, '/file_ops/file_ascii').stdout_text.strip()
         run_result = process.run("tar xOf %s file_ops/file_ascii | %s" % (params.get("tarball_path"), v),
-                                 ignore_status=True, shell=True).stdout.split()[0]
+                                 ignore_status=True, shell=True).stdout_text.split()[0]
         if gf_result != run_result:
             gf.close_session()
             test.fail("checksum failed.")
 
     for k, v in list(checksum_map.items()):
-        gf_result = gf.checksum(k, '/file_ops/file_elf').stdout.strip()
+        gf_result = gf.checksum(k, '/file_ops/file_elf').stdout_text.strip()
         run_result = process.run("tar xOf %s file_ops/file_elf | %s" % (params.get("tarball_path"), v),
-                                 ignore_status=True, shell=True).stdout.split()[0]
+                                 ignore_status=True, shell=True).stdout_text.split()[0]
         if gf_result != run_result:
             gf.close_session()
             test.fail("checksum failed.")
 
     gf_result = gf.checksum('perfect', '/file_ops/file_elf')
-    logging.debug(gf_result.stdout.strip())
+    logging.debug(gf_result.stdout_text.strip())
     if gf_result.exit_status == 0:
         gf.close_session()
         test.fail("checksum failed.")
@@ -640,17 +640,17 @@ def test_checksum_device(test, vm, params):
                     "sha512": 'sha512sum'}
 
     for k, v in list(checksum_map.items()):
-        gf_result = gf.checksum_device(k, '/dev/sda').stdout.strip()
+        gf_result = gf.checksum_device(k, '/dev/sda').stdout_text.strip()
         logging.debug(gf_result.split('\n')[-1])
         run_result = process.run("%s %s" % (v, params.get("image_path")),
-                                 ignore_status=True, shell=True).stdout.split()[0]
+                                 ignore_status=True, shell=True).stdout_text.split()[0]
         logging.debug(run_result)
         if gf_result.split('\n')[-1] != run_result and params.get("image_format") == 'raw':
             gf.close_session()
             test.fail("checksum failed.")
 
     gf_result = gf.checksum_device('perfect', '/dev/sda')
-    logging.debug(gf_result.stdout.strip())
+    logging.debug(gf_result.stdout_text.strip())
     if gf_result.exit_status == 0:
         gf.close_session()
         test.fail("checksum-device failed.")
@@ -692,14 +692,14 @@ def test_checksums_out(test, vm, params):
     gf.download('/test/subdir/file_elf', '/tmp/file_elf')
     gf.download('/test/file_ascii', '/tmp/file_ascii')
     for k, v in list(checksum_map.items()):
-        gf_result = gf.checksums_out(k, '/test', '/tmp/sumsfile').stdout.strip()
-        run_result = process.run("cat /tmp/sumsfile", shell=True).stdout.split()
+        gf_result = gf.checksums_out(k, '/test', '/tmp/sumsfile').stdout_text.strip()
+        run_result = process.run("cat /tmp/sumsfile", shell=True).stdout_text.split()
         if k == 'crc':
             run_result[2] = os.path.basename(run_result[2])
             run_result[5] = os.path.basename(run_result[5])
             guest_res = dict(list(zip(run_result[2::3], run_result[0::3])))
             run_result = process.run("%s /tmp/file_elf /tmp/file_ascii" % v,
-                                     ignore_status=True, shell=True).stdout.split()
+                                     ignore_status=True, shell=True).stdout_text.split()
             run_result[2] = os.path.basename(run_result[2])
             run_result[5] = os.path.basename(run_result[5])
             host_res = dict(list(zip(run_result[2::3], run_result[0::3])))
@@ -708,7 +708,7 @@ def test_checksums_out(test, vm, params):
             run_result[3] = os.path.basename(run_result[3])
             guest_res = dict(list(zip(run_result[1::2], run_result[0::2])))
             run_result = process.run("%s /tmp/file_elf /tmp/file_ascii" % v,
-                                     ignore_status=True, shell=True).stdout.split()
+                                     ignore_status=True, shell=True).stdout_text.split()
             run_result[1] = os.path.basename(run_result[1])
             run_result[3] = os.path.basename(run_result[3])
             host_res = dict(list(zip(run_result[1::2], run_result[0::2])))
@@ -717,7 +717,7 @@ def test_checksums_out(test, vm, params):
             test.fail("checksum failed.")
 
     gf_result = gf.checksums_out('perfect', '/test', '/tmp/sumsfile')
-    logging.debug(gf_result.stdout.strip())
+    logging.debug(gf_result.stdout_text.strip())
     if gf_result.exit_status == 0:
         gf.close_session()
         test.fail("checksums-out failed.")
@@ -744,17 +744,17 @@ def test_equal(test, vm, params):
     mount_point = params.get("mount_point")
     gf.mount(mount_point, '/')
 
-    gf_result = gf.equal('/file_ops/file_ascii', '/file_ops/file_ascii_long').stdout.strip()
+    gf_result = gf.equal('/file_ops/file_ascii', '/file_ops/file_ascii_long').stdout_text.strip()
     if gf_result != 'false':
         gf.close_session()
         test.fail("equal failed.")
 
-    gf_result = gf.equal('/file_ops/file_ascii', '/file_ops/file_elf').stdout.strip()
+    gf_result = gf.equal('/file_ops/file_ascii', '/file_ops/file_elf').stdout_text.strip()
     if gf_result != 'false':
         gf.close_session()
         test.fail("equal failed.")
 
-    gf_result = gf.equal('/file_ops/file_ascii', '/file_ops/file_ascii_softlink').stdout.strip()
+    gf_result = gf.equal('/file_ops/file_ascii', '/file_ops/file_ascii_softlink').stdout_text.strip()
     if gf_result != 'true':
         gf.close_session()
         test.fail("equal failed.")
@@ -784,34 +784,34 @@ def test_fill(test, vm, params):
     gf_result = gf.download('/newfile', '/tmp/newfile')
     gf_result = gf.rm('/newfile')
 
-    run_result = process.run("for((i=0;i<100;i++)); do echo -n '----------'; done > /tmp/tmp", shell=True).stdout.split()
-    run_result = process.run("cmp /tmp/newfile /tmp/tmp", shell=True).stdout.strip()
+    run_result = process.run("for((i=0;i<100;i++)); do echo -n '----------'; done > /tmp/tmp", shell=True).stdout_text.split()
+    run_result = process.run("cmp /tmp/newfile /tmp/tmp", shell=True).stdout_text.strip()
     if run_result != '':
         gf.close_session()
         test.fail("fill failed.")
 
     gf_result = gf.fill('066', 10000000, '/newtest')
-    gf_result = gf.strings('/newtest').stdout.strip()
+    gf_result = gf.strings('/newtest').stdout_text.strip()
     if 'maybe the reply exceeds the maximum message size in the protocol?' not in gf_result:
         gf.close_session()
         test.fail("fill failed.")
 
-    gf_result = gf.head('/newtest').stdout.strip()
+    gf_result = gf.head('/newtest').stdout_text.strip()
     if 'maybe the reply exceeds the maximum message size in the protocol?' not in gf_result:
         gf.close_session()
         test.fail("fill failed.")
 
-    gf_result = gf.head_n(100000, '/newtest').stdout.strip()
+    gf_result = gf.head_n(100000, '/newtest').stdout_text.strip()
     if 'maybe the reply exceeds the maximum message size in the protocol?' not in gf_result:
         gf.close_session()
         test.fail("fill failed.")
 
-    gf_result = gf.tail('/newtest').stdout.strip()
+    gf_result = gf.tail('/newtest').stdout_text.strip()
     if 'maybe the reply exceeds the maximum message size in the protocol?' not in gf_result:
         gf.close_session()
         test.fail("fill failed.")
 
-    gf_result = gf.pread('/newtest', 10000000, 0).stdout.strip()
+    gf_result = gf.pread('/newtest', 10000000, 0).stdout_text.strip()
     if 'count is too large for the protocol' not in gf_result:
         gf.close_session()
         test.fail("fill failed.")
@@ -840,7 +840,7 @@ def test_fill_dir(test, vm, params):
     fill_num = random.randint(0, 99)
     gf_result = gf.mkdir('/fill/')
     gf_result = gf.fill_dir('/fill/', fill_num)
-    gf_result = gf.ls('/fill/').stdout.strip()
+    gf_result = gf.ls('/fill/').stdout_text.strip()
 
     cmp_result = ''
     for i in range(fill_num):
@@ -877,39 +877,39 @@ def test_fill_pattern(test, vm, params):
     gf_result = gf.download('/newfile', '/tmp/newfile')
     gf_result = gf.rm('/newfile')
 
-    run_result = process.run("for((i=0;i<125;i++)); do echo -n 'abcdefgh'; done > /tmp/tmp", shell=True).stdout.split()
-    run_result = process.run("cmp /tmp/newfile /tmp/tmp", shell=True).stdout.strip()
+    run_result = process.run("for((i=0;i<125;i++)); do echo -n 'abcdefgh'; done > /tmp/tmp", shell=True).stdout_text.split()
+    run_result = process.run("cmp /tmp/newfile /tmp/tmp", shell=True).stdout_text.strip()
     if run_result != '':
         gf.close_session()
         test.fail("fill-pattern failed.")
 
     gf_result = gf.fill_pattern('abcdef', 10000000, '/newtest')
-    gf_result = gf.hexdump('/newtest').stdout.strip()
+    gf_result = gf.hexdump('/newtest').stdout_text.strip()
     if 'maybe the reply exceeds the maximum message size in the protocol?' not in gf_result:
         gf.close_session()
         test.fail("fill-pattern failed.")
 
-    gf_result = gf.strings('/newtest').stdout.strip()
+    gf_result = gf.strings('/newtest').stdout_text.strip()
     if 'maybe the reply exceeds the maximum message size in the protocol?' not in gf_result:
         gf.close_session()
         test.fail("fill-pattern failed.")
 
-    gf_result = gf.head('/newtest').stdout.strip()
+    gf_result = gf.head('/newtest').stdout_text.strip()
     if 'maybe the reply exceeds the maximum message size in the protocol?' not in gf_result:
         gf.close_session()
         test.fail("fill-pattern failed.")
 
-    gf_result = gf.head_n(100000, '/newtest').stdout.strip()
+    gf_result = gf.head_n(100000, '/newtest').stdout_text.strip()
     if 'maybe the reply exceeds the maximum message size in the protocol?' not in gf_result:
         gf.close_session()
         test.fail("fill-pattern failed.")
 
-    gf_result = gf.tail('/newtest').stdout.strip()
+    gf_result = gf.tail('/newtest').stdout_text.strip()
     if 'maybe the reply exceeds the maximum message size in the protocol?' not in gf_result:
         gf.close_session()
         test.fail("fill-pattern failed.")
 
-    gf_result = gf.pread('/newtest', 10000000, 0).stdout.strip()
+    gf_result = gf.pread('/newtest', 10000000, 0).stdout_text.strip()
     if 'count is too large for the protocol' not in gf_result:
         gf.close_session()
         test.fail("fill-pattern failed.")
@@ -935,15 +935,15 @@ def test_head(test, vm, params):
     mount_point = params.get("mount_point")
     gf.mount(mount_point, '/')
 
-    gf_result = gf.head('/file_ops/file_ascii').stdout.strip()
+    gf_result = gf.head('/file_ops/file_ascii').stdout_text.strip()
     if len(gf_result) != 253:
         gf.close_session()
         test.fail("head failed.")
-    gf_result = gf.head_n(3, '/file_ops/file_ascii').stdout.strip()
+    gf_result = gf.head_n(3, '/file_ops/file_ascii').stdout_text.strip()
     if len(gf_result) != 73:
         gf.close_session()
         test.fail("head failed.")
-    gf_result = gf.head_n(1000, '/file_ops/file_ascii').stdout.strip()
+    gf_result = gf.head_n(1000, '/file_ops/file_ascii').stdout_text.strip()
     if len(gf_result) != 652:
         gf.close_session()
         test.fail("head failed.")
@@ -981,14 +981,14 @@ def test_hexdump(test, vm, params):
     mount_point = params.get("mount_point")
     gf.mount(mount_point, '/')
 
-    gf_result = gf.hexdump('/file_ops/file_ascii').stdout.strip()
+    gf_result = gf.hexdump('/file_ops/file_ascii').stdout_text.strip()
     m = hashlib.md5()
     m.update(gf_result)
     logging.debug(m.hexdigest())
     if m.hexdigest() != '3ca9739a70e246745ee6bb55e11f755b':
         gf.close_session()
         test.fail("hexdump failed.")
-    gf_result = gf.hexdump('/file_ops/file_tgz').stdout.strip()
+    gf_result = gf.hexdump('/file_ops/file_tgz').stdout_text.strip()
     m = hashlib.md5()
     m.update(gf_result)
     logging.debug(m.hexdigest())
@@ -1017,7 +1017,7 @@ def test_more(test, vm, params):
     mount_point = params.get("mount_point")
     gf.mount(mount_point, '/')
 
-    gf_result = gf.more('/file_ops/file_ascii').stdout.strip()
+    gf_result = gf.more('/file_ops/file_ascii').stdout_text.strip()
     if len(gf_result) != 652:
         gf.close_session()
         test.fail("more failed.")
@@ -1044,12 +1044,12 @@ def test_pread(test, vm, params):
     gf.mount(mount_point, '/')
 
     # inner cmd will delete the last none empty line
-    gf_result = gf.pread('/file_ops/file_ascii', 11, 80).stdout
+    gf_result = gf.pread('/file_ops/file_ascii', 11, 80).stdout_text
     if len(gf_result) != 11:
         gf.close_session()
         test.fail("pread failed.")
 
-    gf_result = gf.pread('/file_ops/file_ascii', 1000, 0).stdout.strip()
+    gf_result = gf.pread('/file_ops/file_ascii', 1000, 0).stdout_text.strip()
     if len(gf_result) != 652:
         gf.close_session()
         test.fail("pread failed.")

--- a/libguestfs/tests/guestfish_fs_attr_ops.py
+++ b/libguestfs/tests/guestfish_fs_attr_ops.py
@@ -51,19 +51,19 @@ def test_set_get_e2uuid(test, vm, params):
 
     # get_e2uuid
     gf_result = gf.get_e2uuid(mount_point)
-    if gf_result.stdout.split()[0] != uuid:
+    if gf_result.stdout_text.split()[0] != uuid:
         gf.close_session()
         test.fail("set_get_e2uuid failed.")
 
     # vfs_uuid
     gf_result = gf.vfs_uuid(mount_point)
-    if gf_result.stdout.split()[0] != uuid:
+    if gf_result.stdout_text.split()[0] != uuid:
         gf.close_session()
         test.fail("set_get_e2uuid failed.")
 
     # find_uuid
     gf_result = gf.findfs_uuid(uuid)
-    if gf_result.stdout.split()[0] != mount_point:
+    if gf_result.stdout_text.split()[0] != mount_point:
         gf.close_session()
         test.fail("set_get_e2uuid failed.")
 
@@ -95,7 +95,7 @@ def test_set_uuid(test, vm, params):
     gf.set_uuid(mount_point, uuid)
 
     gf_result = gf.vfs_uuid(mount_point)
-    if gf_result.stdout.split()[0] != uuid:
+    if gf_result.stdout_text.split()[0] != uuid:
         gf.close_session()
         test.fail("set_uuid failed.")
     gf.close_session()
@@ -127,19 +127,19 @@ def test_set_get_e2label(test, vm, params):
 
     # get_e2label
     gf_result = gf.get_e2label(mount_point)
-    if gf_result.stdout.split()[0] != label:
+    if gf_result.stdout_text.split()[0] != label:
         gf.close_session()
         test.fail("set_get_e2label failed.")
 
     # vfs_label
     gf_result = gf.vfs_label(mount_point)
-    if gf_result.stdout.split()[0] != label:
+    if gf_result.stdout_text.split()[0] != label:
         gf.close_session()
         test.fail("set_get_e2label failed.")
 
     # findfs_label
     gf_result = gf.findfs_label(label)
-    if gf_result.stdout.split()[0] != mount_point:
+    if gf_result.stdout_text.split()[0] != mount_point:
         gf.close_session()
         test.fail("set_get_e2label failed.")
 
@@ -171,7 +171,7 @@ def test_set_label(test, vm, params):
     gf.set_label(mount_point, label)
 
     gf_result = gf.vfs_label(mount_point)
-    if gf_result.stdout.split()[0] != label:
+    if gf_result.stdout_text.split()[0] != label:
         gf.close_session()
         test.fail("set_label failed.")
     gf.close_session()
@@ -208,7 +208,7 @@ def test_set_get_e2attrs(test, vm, params):
     if fstype == 'ext4':
         expected_attrs = 'et'
     gf_result = gf.get_e2attrs(filename)
-    if gf_result.stdout.split()[0] != expected_attrs:
+    if gf_result.stdout_text.split()[0] != expected_attrs:
         gf.close_session()
         test.fail("set_get_e2attrs failed.")
     # set_e2attrs 'u'
@@ -218,7 +218,7 @@ def test_set_get_e2attrs(test, vm, params):
     if fstype == 'ext4':
         expected_attrs = 'etu'
     gf_result = gf.get_e2attrs(filename)
-    if gf_result.stdout.split()[0] != expected_attrs:
+    if gf_result.stdout_text.split()[0] != expected_attrs:
         gf.close_session()
         test.fail("set_get_e2attrs failed.")
     # set_e2attrs 'a', 'c'
@@ -229,7 +229,7 @@ def test_set_get_e2attrs(test, vm, params):
     if fstype == 'ext4':
         expected_attrs = 'acetu'
     gf_result = gf.get_e2attrs(filename)
-    if gf_result.stdout.split()[0] != expected_attrs:
+    if gf_result.stdout_text.split()[0] != expected_attrs:
         gf.close_session()
         test.fail("set_get_e2attrs failed.")
     # set_e2attrs 'c' clear:true
@@ -239,7 +239,7 @@ def test_set_get_e2attrs(test, vm, params):
     if fstype == 'ext4':
         expected_attrs = 'aetu'
     gf_result = gf.get_e2attrs(filename)
-    if gf_result.stdout.split()[0] != expected_attrs:
+    if gf_result.stdout_text.split()[0] != expected_attrs:
         gf.close_session()
         test.fail("set_get_e2attrs failed.")
 
@@ -247,7 +247,7 @@ def test_set_get_e2attrs(test, vm, params):
     gf.set_e2attrs(filename, 't', 'false')
     # get_e2attrs
     gf_result = gf.get_e2attrs(filename)
-    if gf_result.stdout.split()[0] != expected_attrs:
+    if gf_result.stdout_text.split()[0] != expected_attrs:
         gf.close_session()
         test.fail("set_get_e2attrs failed.")
     gf.close_session()
@@ -282,7 +282,7 @@ def test_set_get_e2generation(test, vm, params):
     gf.set_e2generation(filename, generation)
     # get_e2generation
     gf_result = gf.get_e2generation(filename)
-    if gf_result.stdout.split()[0] != generation:
+    if gf_result.stdout_text.split()[0] != generation:
         gf.close_session()
         test.fail("set_get_e2generation failed.")
     gf.close_session()
@@ -311,7 +311,7 @@ def test_statvfs(test, vm, params):
 
     # statvfs
     gf_result = gf.statvfs('/')
-    List = gf_result.stdout.split()
+    List = gf_result.stdout_text.split()
     atti_list = ['bsize:', 'frsize:', 'blocks:', 'bfree:', 'bavail:',
                  'files:', 'ffree:', 'favail:', 'fsid:', 'flag:', 'namemax:']
     for atti in atti_list:
@@ -321,7 +321,7 @@ def test_statvfs(test, vm, params):
 
     # don't do further free-inodes test for vfat/ntfs as they behave
     # very different from ext2/3/4.
-    fs_type = gf.vfs_type(mount_point).stdout.split()[0]
+    fs_type = gf.vfs_type(mount_point).stdout_text.split()[0]
     if fs_type == 'vfat' or fs_type == 'ntfs':
         gf.close_session()
         return
@@ -333,7 +333,7 @@ def test_statvfs(test, vm, params):
     ffree_value = int(List[ffree_index + 1])
 
     gf.touch('/testfile')
-    List = gf.statvfs('/').stdout.split()
+    List = gf.statvfs('/').stdout_text.split()
     ffree_index = List.index('ffree:')
     new_ffree_value = int(List[ffree_index + 1])
     if new_ffree_value != (ffree_value - 1):
@@ -365,14 +365,14 @@ def test_tune2fs_l(test, vm, params):
     gf.mount(mount_point, '/')
 
     # statvfs
-    List = gf.statvfs('/').stdout.split()
+    List = gf.statvfs('/').stdout_text.split()
     inodes_statvfs_index = List.index('files:')
     inodes_statvfs = List[inodes_statvfs_index + 1]
     inodes_tune2fs_str = 'Inode count: %s' % inodes_statvfs
     # tune2fs_l
     gf_result = gf.tune2fs_l(mount_point)
 
-    if inodes_tune2fs_str not in gf_result.stdout:
+    if inodes_tune2fs_str not in gf_result.stdout_text:
         gf.close_session()
         test.fail("tune2fs_l failed.")
 
@@ -417,7 +417,7 @@ def test_tune2fs(test, vm, params):
 
     gf_result = gf.tune2fs_l(mount_point)
     for expect_str in str_list:
-        if expect_str not in gf_result.stdout:
+        if expect_str not in gf_result.stdout_text:
             gf.close_session()
             test.fail("tune2fs failed.")
 
@@ -447,15 +447,15 @@ def test_checkfs(test, vm, params):
     # vfs_type
     type_list = ['ext2', 'ext3', 'ext4', 'ntfs', 'vfat', 'xfs']
     gf_result = gf.vfs_type(mount_point)
-    if gf_result.stdout.split()[0] not in type_list:
+    if gf_result.stdout_text.split()[0] not in type_list:
         gf.close_session()
         test.fail("checkfs failed.")
 
     # fsck
-    fsck_result = gf.fsck(gf_result.stdout.split()[0], mount_point)
+    fsck_result = gf.fsck(gf_result.stdout_text.split()[0], mount_point)
     logging.debug('test_checkfs: [fsck: %s %s], the result is [%s]' %
-                  (gf_result.stdout.split()[0], mount_point,
-                   fsck_result.stdout.split()[0]))
+                  (gf_result.stdout_text.split()[0], mount_point,
+                   fsck_result.stdout_text.split()[0]))
     gf.close_session()
 
 
@@ -515,7 +515,7 @@ def test_mkfs_opts(test, vm, params):
         # mkfs-opts/mkfs
         aaa = gf.mkfs_opts(fstype, test_mountpoint, blocksize)
         # check type
-        vfs_type_result = gf.vfs_type(test_mountpoint).stdout.split()[0]
+        vfs_type_result = gf.vfs_type(test_mountpoint).stdout_text.split()[0]
         if fstype != vfs_type_result:
             os.system('rm -f ' + test_img + ' > /dev/null')
             gf.close_session()
@@ -529,7 +529,7 @@ def test_mkfs_opts(test, vm, params):
         gf.mount(test_mountpoint, '/')
         blocksize_str = 'bsize: %s' % blocksize
         statvfs_result = gf.statvfs('/')
-        if blocksize_str not in statvfs_result.stdout:
+        if blocksize_str not in statvfs_result.stdout_text:
             gf.close_session()
             os.system('rm -f ' + test_img + ' > /dev/null')
             test.fail("test_mkfs_opts failed.")
@@ -562,7 +562,7 @@ def test_blkid(test, vm, params):
     # blkid
     blkid_result = gf.blkid(mount_point)
     # check all values are not null
-    for pair in blkid_result.stdout.strip().split('\n'):
+    for pair in blkid_result.stdout_text.strip().split('\n'):
         key_value = pair.strip().split(':')
         if len(key_value) < 2:
             gf.close_session()
@@ -573,9 +573,9 @@ def test_blkid(test, vm, params):
             test.fail("blkid failed.")
     # check filesystem output by blkid is correct
 
-    fstype = gf.vfs_type(mount_point).stdout.split()[0]
+    fstype = gf.vfs_type(mount_point).stdout_text.split()[0]
     fstype_str = 'TYPE: %s' % fstype
-    if fstype not in blkid_result.stdout:
+    if fstype not in blkid_result.stdout_text:
         gf.close_session()
         test.fail("blkid failed.")
     gf.close_session()
@@ -606,7 +606,7 @@ def test_filesystem_available(test, vm, params):
               'unknown': 'false'}
     for key, value in list(fs_dic.items()):
         gf_result = gf.filesystem_available(key)
-        if gf_result.stdout.split()[0] != value:
+        if gf_result.stdout_text.split()[0] != value:
             gf.close_session()
             test.fail("test_filesystem_available failed.")
 
@@ -666,9 +666,9 @@ def test_list_filesystems(test, vm, params):
     # list_filesystems
     gf_result = gf.list_filesystems()
     # check mount_point
-    fstype = gf.vfs_type(mount_point).stdout.split()[0]
+    fstype = gf.vfs_type(mount_point).stdout_text.split()[0]
     fstype_str = '%s: %s' % (mount_point, fstype)
-    if fstype_str not in gf_result.stdout:
+    if fstype_str not in gf_result.stdout_text:
         gf.close_session()
         test.fail("test_list_filesystems failed.")
     gf.close_session()
@@ -700,7 +700,7 @@ def test_mkfifo(test, vm, params):
     # check
     gf_result = gf.stat('/node')
     mode_str = 'mode: 4589'
-    if mode_str not in gf_result.stdout:
+    if mode_str not in gf_result.stdout_text:
         gf.close_session()
         test.fail("test_mkfifo failed.")
     gf.close_session()
@@ -814,7 +814,7 @@ def test_mknod(test, vm, params):
             permission = "prwxr-xr-x"
         gf.mknod(mode, major, minor, nodename)
         ll_result = gf.ll(nodename)
-        if permission not in ll_result.stdout:
+        if permission not in ll_result.stdout_text:
             gf.close_session()
             test.fail("test_mknod failed.")
         gf.rm_rf(nodename)
@@ -854,7 +854,7 @@ def test_mknod_b(test, vm, params):
 
     gf.mknod_b(mode, major, minor, nodename)
     ll_result = gf.ll(nodename)
-    if permission not in ll_result.stdout:
+    if permission not in ll_result.stdout_text:
         gf.close_session()
         test.fail("test_mknod_b failed.")
     gf.rm_rf(nodename)
@@ -894,7 +894,7 @@ def test_mknod_c(test, vm, params):
 
     gf.mknod_c(mode, major, minor, nodename)
     ll_result = gf.ll(nodename)
-    if permission not in ll_result.stdout:
+    if permission not in ll_result.stdout_text:
         gf.close_session()
         test.fail("test_mknod_c failed.")
     gf.rm_rf(nodename)
@@ -926,7 +926,7 @@ def test_ntfsresize_opts(test, vm, params):
 
     # statvfs
     statvfs_result = gf.statvfs('/')
-    List = statvfs_result.stdout.split()
+    List = statvfs_result.stdout_text.split()
     bsize_index = List.index('bsize:')
     blocks_index = List.index('blocks:')
     bsize = int(List[bsize_index + 1])
@@ -942,7 +942,7 @@ def test_ntfsresize_opts(test, vm, params):
     # statvfs: check
     gf.mount(mount_point, '/')
     statvfs_result = gf.statvfs('/')
-    List = statvfs_result.stdout.split()
+    List = statvfs_result.stdout_text.split()
     new_blocks_index = List.index('blocks:')
     new_blocks = int(List[new_blocks_index + 1])
     if abs(new_blocks - expected_blocks) >= 2:
@@ -954,7 +954,7 @@ def test_ntfsresize_opts(test, vm, params):
     gf.ntfsresize_opts(mount_point, None, 'true')
     gf.mount(mount_point, '/')
     statvfs_result = gf.statvfs('/')
-    List = statvfs_result.stdout.split()
+    List = statvfs_result.stdout_text.split()
     new_blocks_index = List.index('blocks:')
     new_blocks = int(List[new_blocks_index + 1])
     if abs(new_blocks - blocks) >= 2:
@@ -1010,12 +1010,12 @@ def test_resize2fs(test, vm, params):
     t_result = gf.tune2fs_l(altdev)
     b_result = gf.blockdev_getsize64(altdev)
 
-    for items in t_result.stdout.split('\n'):
+    for items in t_result.stdout_text.split('\n'):
         if 'Block count' in items:
             block_count = int(items.split(':')[1].strip())
         if 'Block size' in items:
             block_size = int(items.split(':')[1].strip())
-    getsize64 = int(b_result.stdout.split()[0])
+    getsize64 = int(b_result.stdout_text.split()[0])
     os.system('rm -rf %s ' % tmpdir)
     if block_count * block_size <= getsize64 * 0.99:
         gf.close_session()
@@ -1094,7 +1094,7 @@ def test_resize2fs_size(test, vm, params):
     gf.run()
 
     t_result = gf.tune2fs_l(mount_point)
-    for items in t_result.stdout.split('\n'):
+    for items in t_result.stdout_text.split('\n'):
         if 'Block count' in items:
             block_count = int(items.split(':')[1].strip())
         if 'Block size' in items:
@@ -1103,7 +1103,7 @@ def test_resize2fs_size(test, vm, params):
     gf.e2fsck_f(mount_point)
     gf.resize2fs_size(mount_point, filesystem_size)
     new_t_result = gf.tune2fs_l(mount_point)
-    for items in new_t_result.stdout.split('\n'):
+    for items in new_t_result.stdout_text.split('\n'):
         if 'Block count' in items:
             new_block_count = int(items.split(':')[1].strip())
     expected_blockcount = block_count / 2

--- a/libguestfs/tests/guestfish_fs_mount.py
+++ b/libguestfs/tests/guestfish_fs_mount.py
@@ -54,7 +54,7 @@ def test_mount(test, vm, params):
         test.fail("test_mount failed, Wrong partition type")
 
     gf_result = gf.inner_cmd("debug sh 'mount|grep %s'" % abs_mount_point)
-    if gf_result.exit_status != 0 or ('/sysroot' not in gf_result.stdout):
+    if gf_result.exit_status != 0 or ('/sysroot' not in gf_result.stdout_text):
         gf.close_session()
         test.fail("test_mount failed")
     gf.close_session()
@@ -90,8 +90,8 @@ def test_mount_options(test, vm, params):
         test.fail("test_mount_options failed, Wrong partition type")
 
     gf_result = gf.inner_cmd("debug sh 'mount|grep %s'" % abs_mount_point)
-    if gf_result.exit_status != 0 or ('/sysroot' not in gf_result.stdout) or (
-       'noatime' not in gf_result.stdout):
+    if gf_result.exit_status != 0 or ('/sysroot' not in gf_result.stdout_text) or (
+       'noatime' not in gf_result.stdout_text):
         gf.close_session()
         test.fail("test_mount_options failed")
     gf.close_session()
@@ -127,8 +127,8 @@ def test_mount_ro(test, vm, params):
         test.fail("test_mount_ro failed, Wrong partition type")
 
     gf_result = gf.inner_cmd("debug sh 'mount|grep %s'" % abs_mount_point)
-    if gf_result.exit_status != 0 or ('/sysroot' not in gf_result.stdout) or (
-       'ro' not in gf_result.stdout):
+    if gf_result.exit_status != 0 or ('/sysroot' not in gf_result.stdout_text) or (
+       'ro' not in gf_result.stdout_text):
         gf.close_session()
         test.fail("test_mount_ro failed")
     gf.close_session()
@@ -153,7 +153,7 @@ def test_mounts(test, vm, params):
     mount_point = params.get("mount_point")
     gf.mount(mount_point, '/')
     gf_result = gf.mounts()
-    if gf_result.exit_status != 0 or (mount_point not in gf_result.stdout):
+    if gf_result.exit_status != 0 or (mount_point not in gf_result.stdout_text):
         gf.close_session()
         test.fail("test_mounts failed")
     gf.close_session()
@@ -191,7 +191,7 @@ def test_mount_loop(test, vm, params):
     gf.rmmountpoint('/loop')
     os.system('rm -f %s; rm -f %s' % (test_img_iso, test_img))
 
-    if mount_loop_result.exit_status != 0 or ('test_mount_loop.img' not in readdir_result.stdout):
+    if mount_loop_result.exit_status != 0 or ('test_mount_loop.img' not in readdir_result.stdout_text):
         gf.close_session()
         logging.error("mount_loop /test_mount_loop.iso /loop:")
         logging.error(mount_loop_result)
@@ -221,7 +221,7 @@ def test_mountpoints(test, vm, params):
     gf.mkmountpoint('/test_mountpoints')
     gf_result = gf.mountpoints()
     expected_str = '%s: /' % mount_point
-    if expected_str not in gf_result.stdout:
+    if expected_str not in gf_result.stdout_text:
         gf.close_session()
         logging.error("Expected string: %s" % expected_str)
         logging.error('mountpoints:')
@@ -252,42 +252,42 @@ def test_umount(test, vm, params):
     gf.mount(mount_point, '/')
     gf.umount(mount_point, 'true')
     gf_result = gf.mounts()
-    mounts_result.append(gf_result.stdout)
+    mounts_result.append(gf_result.stdout_text)
 
     gf.mount(mount_point, '/')
     gf.umount(mount_point, 'false')
     gf_result = gf.mounts()
-    mounts_result.append(gf_result.stdout)
+    mounts_result.append(gf_result.stdout_text)
 
     gf.mount(mount_point, '/')
     gf.umount(mount_point, None, 'true')
     gf_result = gf.mounts()
-    mounts_result.append(gf_result.stdout)
+    mounts_result.append(gf_result.stdout_text)
 
     gf.mount(mount_point, '/')
     gf.umount(mount_point, None, 'false')
     gf_result = gf.mounts()
-    mounts_result.append(gf_result.stdout)
+    mounts_result.append(gf_result.stdout_text)
 
     gf.mount(mount_point, '/')
     gf.umount(mount_point, 'false', 'false')
     gf_result = gf.mounts()
-    mounts_result.append(gf_result.stdout)
+    mounts_result.append(gf_result.stdout_text)
 
     gf.mount(mount_point, '/')
     gf.umount(mount_point, 'true', 'true')
     gf_result = gf.mounts()
-    mounts_result.append(gf_result.stdout)
+    mounts_result.append(gf_result.stdout_text)
 
     gf.mount(mount_point, '/')
     gf.umount(mount_point, 'true', 'false')
     gf_result = gf.mounts()
-    mounts_result.append(gf_result.stdout)
+    mounts_result.append(gf_result.stdout_text)
 
     gf.mount(mount_point, '/')
     gf.umount(mount_point, 'false', 'true')
     gf_result = gf.mounts()
-    mounts_result.append(gf_result.stdout)
+    mounts_result.append(gf_result.stdout_text)
 
     for items in mounts_result:
         if mount_point in items:
@@ -328,7 +328,7 @@ def test_mount_vfs(test, vm, params):
         test.fail("test_mount_vfs failed, Wrong partition type")
 
     gf_result = gf.inner_cmd("debug sh 'mount|grep %s'" % abs_mount_point)
-    if mount_vfs_result.exit_status != 0 or ('/sysroot' not in gf_result.stdout):
+    if mount_vfs_result.exit_status != 0 or ('/sysroot' not in gf_result.stdout_text):
         gf.close_session()
         logging.error(mount_vfs_result)
         logging.error(gf_result)
@@ -355,7 +355,7 @@ def test_umount_all(test, vm, params):
     gf.mount(mount_point, '/')
     gf.umount_all()
     mounts_result = gf.mounts()
-    if mount_point in mounts_result.stdout:
+    if mount_point in mounts_result.stdout_text:
         gf.close_session()
         logging.error(mounts_result)
         test.fail("test_umount_all failed")

--- a/libguestfs/tests/guestfish_fs_swap.py
+++ b/libguestfs/tests/guestfish_fs_swap.py
@@ -73,19 +73,19 @@ def test_swap_device(test, vm, params):
     uuid = '71631235-fbec-4ce8-b1b3-c53366f5ac60'
     mkswap_result = gf.mkswap(test_mountpoint, label, uuid)
     file_result = gf.file(test_mountpoint)
-    if "swap file" not in file_result.stdout:
+    if "swap file" not in file_result.stdout_text:
         gf.close_session()
         os.system('rm -f ' + test_img + ' > /dev/null')
         logging.error(mkswap_result)
         logging.error(file_result)
         test.fail("test_mkswap failed")
-    if label not in file_result.stdout:
+    if label not in file_result.stdout_text:
         gf.close_session()
         os.system('rm -f ' + test_img + ' > /dev/null')
         logging.error("swap file label created not match")
         logging.error(file_result)
         test.fail("test_mkswap failed")
-    if uuid not in file_result.stdout:
+    if uuid not in file_result.stdout_text:
         gf.close_session()
         os.system('rm -f ' + test_img + ' > /dev/null')
         logging.error("swap file uuid created not match")
@@ -94,7 +94,7 @@ def test_swap_device(test, vm, params):
 
     gf.swapon_device(test_mountpoint)
     active_swapdevice = gf.inner_cmd("debug sh \"swapon -sv\" | sed -n '2p' ")
-    if '/dev' not in active_swapdevice.stdout:
+    if '/dev' not in active_swapdevice.stdout_text:
         gf.close_session()
         os.system('rm -f ' + test_img + ' > /dev/null')
         logging.error(active_swapdevice)
@@ -103,7 +103,7 @@ def test_swap_device(test, vm, params):
     gf.swapoff_device(test_mountpoint)
     active_swapdevice = gf.inner_cmd("debug sh \"swapon -sv\" | sed -n '2p' ")
 
-    if '/dev' in active_swapdevice.stdout:
+    if '/dev' in active_swapdevice.stdout_text:
         gf.close_session()
         os.system('rm -f ' + test_img + ' > /dev/null')
         logging.error(active_swapdevice)
@@ -160,13 +160,13 @@ def test_swap_label(test, vm, params):
     label = 'mkswap_label'
     mkswap_L_result = gf.mkswap_L(label, test_mountpoint)
     file_result = gf.file(test_mountpoint)
-    if "swap file" not in file_result.stdout:
+    if "swap file" not in file_result.stdout_text:
         gf.close_session()
         os.system('rm -f ' + test_img + ' > /dev/null')
         logging.error(mkswap_L_result)
         logging.error(file_result)
         test.fail("test_mkswap_L failed")
-    if label not in file_result.stdout:
+    if label not in file_result.stdout_text:
         gf.close_session()
         os.system('rm -f ' + test_img + ' > /dev/null')
         logging.error("swap file label created not match")
@@ -175,7 +175,7 @@ def test_swap_label(test, vm, params):
 
     gf.swapon_label(label)
     active_swapdevice = gf.inner_cmd("debug sh \"swapon -sv\" | sed -n '2p' ")
-    if '/dev' not in active_swapdevice.stdout:
+    if '/dev' not in active_swapdevice.stdout_text:
         gf.close_session()
         os.system('rm -f ' + test_img + ' > /dev/null')
         logging.error(active_swapdevice)
@@ -184,7 +184,7 @@ def test_swap_label(test, vm, params):
     gf.swapoff_label(label)
     active_swapdevice = gf.inner_cmd("debug sh \"swapon -sv\" | sed -n '2p' ")
 
-    if '/dev' in active_swapdevice.stdout:
+    if '/dev' in active_swapdevice.stdout_text:
         gf.close_session()
         os.system('rm -f ' + test_img + ' > /dev/null')
         logging.error(active_swapdevice)
@@ -241,13 +241,13 @@ def test_swap_uuid(test, vm, params):
     temp, uuid = process.getstatusoutput("uuidgen")
     mkswap_U_result = gf.mkswap_U(uuid, test_mountpoint)
     file_result = gf.file(test_mountpoint)
-    if "swap file" not in file_result.stdout:
+    if "swap file" not in file_result.stdout_text:
         gf.close_session()
         os.system('rm -f ' + test_img + ' > /dev/null')
         logging.error(mkswap_U_result)
         logging.error(file_result)
         test.fail("test_mkswap_U failed")
-    if uuid not in file_result.stdout:
+    if uuid not in file_result.stdout_text:
         gf.close_session()
         os.system('rm -f ' + test_img + ' > /dev/null')
         logging.error("swap file uuid created not match")
@@ -256,7 +256,7 @@ def test_swap_uuid(test, vm, params):
 
     gf.swapon_uuid(uuid)
     active_swapdevice = gf.inner_cmd("debug sh \"swapon -sv\" | sed -n '2p' ")
-    if '/dev' not in active_swapdevice.stdout:
+    if '/dev' not in active_swapdevice.stdout_text:
         gf.close_session()
         os.system('rm -f ' + test_img + ' > /dev/null')
         logging.error(active_swapdevice)
@@ -265,7 +265,7 @@ def test_swap_uuid(test, vm, params):
     gf.swapoff_uuid(uuid)
     active_swapdevice = gf.inner_cmd("debug sh \"swapon -sv\" | sed -n '2p' ")
 
-    if '/dev' in active_swapdevice.stdout:
+    if '/dev' in active_swapdevice.stdout_text:
         gf.close_session()
         os.system('rm -f ' + test_img + ' > /dev/null')
         logging.error(active_swapdevice)
@@ -326,7 +326,7 @@ def test_swap_file(test, vm, params):
     gf.fallocate(swapfile, swapfile_size*1024)
     mkswap_file_result = gf.mkswap_file(swapfile)
     file_result = gf.file(swapfile)
-    if "swap file" not in file_result.stdout:
+    if "swap file" not in file_result.stdout_text:
         gf.close_session()
         os.system('rm -f ' + test_img + ' > /dev/null')
         logging.error(mkswap_file_result)
@@ -335,7 +335,7 @@ def test_swap_file(test, vm, params):
 
     gf.swapon_file(swapfile)
     active_swapdevice = gf.inner_cmd("debug sh \"swapon -sv\" | sed -n '2p' ")
-    if swapfile not in active_swapdevice.stdout:
+    if swapfile not in active_swapdevice.stdout_text:
         gf.close_session()
         os.system('rm -f ' + test_img + ' > /dev/null')
         logging.error(active_swapdevice)
@@ -344,7 +344,7 @@ def test_swap_file(test, vm, params):
     gf.swapoff_file(swapfile)
     active_swapdevice = gf.inner_cmd("debug sh \"swapon -sv\" | sed -n '2p' ")
 
-    if swapfile in active_swapdevice.stdout:
+    if swapfile in active_swapdevice.stdout_text:
         gf.close_session()
         os.system('rm -f ' + test_img + ' > /dev/null')
         logging.error(active_swapdevice)

--- a/libguestfs/tests/guestfish_lvm.py
+++ b/libguestfs/tests/guestfish_lvm.py
@@ -27,21 +27,21 @@ def create_lvm(test, gf, mode, pv_name="/dev/sda", vg_name="VG", lv_name="LV", s
     if mode == 'pvcreate':
         gf.part_init(pv_name, "msdos")
         gf.pvcreate(pv_name)
-        ret = gf.pvs().stdout.strip()
+        ret = gf.pvs().stdout_text.strip()
         if not ret:
             gf.close_session()
             test.fail("create PV failed")
         return ret
     elif mode == 'vgcreate':
         gf.vgcreate(vg_name, pv_name)
-        ret = gf.vgs().stdout.strip()
+        ret = gf.vgs().stdout_text.strip()
         if not ret:
             gf.close_session()
             test.fail("create VG failed")
         return ret
     elif mode == 'lvcreate':
         gf.lvcreate(lv_name, vg_name, size)
-        ret = gf.lvs().stdout.strip()
+        ret = gf.lvs().stdout_text.strip()
         if not ret:
             gf.close_session()
             test.fail("create LV failed")
@@ -67,8 +67,8 @@ def test_is_lv(test, vm, params):
     gf.run()
 
     # check physical device
-    name = gf.list_partitions().stdout.strip()
-    ret = gf.is_lv(name).stdout.strip()
+    name = gf.list_partitions().stdout_text.strip()
+    ret = gf.is_lv(name).stdout_text.strip()
     if ret != "false":
         gf.close_session()
         test.fail("It should be a physical device")
@@ -78,8 +78,8 @@ def test_is_lv(test, vm, params):
     create_lvm(test, gf, 'vgcreate')
     create_lvm(test, gf, 'lvcreate')
 
-    name = gf.lvs().stdout.strip()
-    ret = gf.is_lv(name).stdout.strip()
+    name = gf.lvs().stdout_text.strip()
+    ret = gf.is_lv(name).stdout_text.strip()
     if ret != "true":
         gf.close_session()
         test.fail("It should be a lvm device")
@@ -113,13 +113,13 @@ def test_lvcreate(test, vm, params):
 
     part_name = "/dev/%s/%s" % (vg_name, lv_name)
 
-    result = gf.lvs().stdout.strip()
+    result = gf.lvs().stdout_text.strip()
 
     if result != part_name:
         gf.close_session()
         test.fail("lv name is not match")
 
-    result = gf.lvs_full().stdout.strip()
+    result = gf.lvs_full().stdout_text.strip()
     result = re.search("lv_name:\s+(\S+)", result).groups()[0]
 
     if result != lv_name:
@@ -150,11 +150,11 @@ def test_lvm_canonical_lv_name(test, vm, params):
     create_lvm(test, gf, 'vgcreate')
     create_lvm(test, gf, 'lvcreate')
 
-    real_name = gf.lvs().stdout.strip()
+    real_name = gf.lvs().stdout_text.strip()
     vg_name, lv_name = real_name.split("/")[-2:]
 
     test_name = "/dev/mapper/%s-%s" % (vg_name, lv_name)
-    result = gf.lvm_canonical_lv_name(test_name).stdout.strip()
+    result = gf.lvm_canonical_lv_name(test_name).stdout_text.strip()
     logging.debug(result)
 
     if result != real_name:
@@ -185,12 +185,12 @@ def test_lvremove(test, vm, params):
     create_lvm(test, gf, 'vgcreate')
     create_lvm(test, gf, 'lvcreate')
 
-    ret = gf.lvs().stdout.strip()
+    ret = gf.lvs().stdout_text.strip()
     logging.debug(ret)
     if ret:
         gf.lvremove(ret)
 
-    ret = gf.lvs().stdout.strip()
+    ret = gf.lvs().stdout_text.strip()
     if ret:
         gf.close_session()
         test.fail("LV can't be removed")
@@ -219,17 +219,17 @@ def test_lvm_remove_all(test, vm, params):
     create_lvm(test, gf, 'vgcreate')
     create_lvm(test, gf, 'lvcreate')
 
-    pv = gf.pvs().stdout.strip()
-    vg = gf.vgs().stdout.strip()
-    lv = gf.lvs().stdout.strip()
+    pv = gf.pvs().stdout_text.strip()
+    vg = gf.vgs().stdout_text.strip()
+    lv = gf.lvs().stdout_text.strip()
     logging.debug("pv: %s\n vg:%s\n lv:%s\n" % (pv, vg, lv))
 
     if pv and vg and lv:
         gf.lvm_remove_all()
 
-    pv = gf.pvs().stdout.strip()
-    vg = gf.vgs().stdout.strip()
-    lv = gf.lvs().stdout.strip()
+    pv = gf.pvs().stdout_text.strip()
+    vg = gf.vgs().stdout_text.strip()
+    lv = gf.lvs().stdout_text.strip()
     logging.debug("pv: %s\n vg:%s\n lv:%s\n" % (pv, vg, lv))
 
     if pv or vg or lv:
@@ -260,13 +260,13 @@ def test_lvrename(test, vm, params):
     create_lvm(test, gf, 'vgcreate')
     create_lvm(test, gf, 'lvcreate')
 
-    ret = gf.lvs().stdout.strip()
+    ret = gf.lvs().stdout_text.strip()
     logging.debug(ret)
     if ret:
         new_lv_name = "newlv"
         gf.lvrename(ret, new_lv_name)
 
-    ret = gf.lvs().stdout.strip()
+    ret = gf.lvs().stdout_text.strip()
     if new_lv_name not in ret:
         gf.close_session()
         test.fail("LV can't be renamed")
@@ -295,8 +295,8 @@ def test_lvresize(test, vm, params):
     create_lvm(test, gf, 'vgcreate')
     create_lvm(test, gf, 'lvcreate')
 
-    ret = gf.lvs_full().stdout.strip()
-    lv = gf.lvs().stdout.strip()
+    ret = gf.lvs_full().stdout_text.strip()
+    lv = gf.lvs().stdout_text.strip()
     old_size = re.search("lv_size:\s+(\S+)", ret).groups()[0]
 
     ret = gf.lvresize(lv, 200)
@@ -304,7 +304,7 @@ def test_lvresize(test, vm, params):
         gf.close_session()
         test.fail("lvresize execute failed")
 
-    ret = gf.lvs_full().stdout.strip()
+    ret = gf.lvs_full().stdout_text.strip()
     new_size = re.search("lv_size:\s+(\S+)", ret).groups()[0]
 
     logging.debug("old_size is %s, new_size is %s" % (old_size, new_size))
@@ -337,11 +337,11 @@ def test_lvresize_free(test, vm, params):
     create_lvm(test, gf, 'vgcreate')
     create_lvm(test, gf, 'lvcreate', size=200)
 
-    lv = gf.lvs().stdout.strip()
+    lv = gf.lvs().stdout_text.strip()
 
-    ret = gf.lvs_full().stdout.strip()
+    ret = gf.lvs_full().stdout_text.strip()
     old_size = re.search("lv_size:\s+(\S+)", ret).groups()[0]
-    ret = gf.vgs_full().stdout.strip()
+    ret = gf.vgs_full().stdout_text.strip()
     max_size = re.search("vg_size:\s+(\S+)", ret).groups()[0]
 
     ret = gf.lvresize_free(lv, 100)
@@ -349,7 +349,7 @@ def test_lvresize_free(test, vm, params):
         gf.close_session()
         test.fail("lvresize-free execute failed")
 
-    ret = gf.lvs_full().stdout.strip()
+    ret = gf.lvs_full().stdout_text.strip()
     new_size = re.search("lv_size:\s+(\S+)", ret).groups()[0]
 
     logging.debug("old_size is %s, new_size is %s" % (old_size, new_size))
@@ -383,21 +383,21 @@ def test_lvm_set_filter(test, vm, params):
     create_lvm(test, gf, 'vgcreate')
     create_lvm(test, gf, 'lvcreate')
 
-    lv_name = gf.lvs().stdout.strip()
+    lv_name = gf.lvs().stdout_text.strip()
     if not lv_name:
         gf.close_session()
         test.fail("LV should be listed")
 
     # set filter, lvm device should be hided
     gf.lvm_set_filter(lv_name)
-    lv_name = gf.lvs().stdout.strip()
+    lv_name = gf.lvs().stdout_text.strip()
     if lv_name:
         gf.close_session()
         test.fail("LV should not be listed")
 
     # clear the filter, lvm device can be seen
     gf.lvm_clear_filter()
-    lv_name = gf.lvs().stdout.strip()
+    lv_name = gf.lvs().stdout_text.strip()
     if not lv_name:
         gf.close_session()
         test.fail("LV should be listed")
@@ -427,12 +427,12 @@ def test_lvuuid(test, vm, params):
     create_lvm(test, gf, 'vgcreate')
     create_lvm(test, gf, 'lvcreate')
 
-    lv_name = gf.lvs().stdout.strip()
-    uuid = gf.lvuuid(lv_name).stdout.strip()
+    lv_name = gf.lvs().stdout_text.strip()
+    uuid = gf.lvuuid(lv_name).stdout_text.strip()
     uuid = re.sub("-", "", uuid)
     logging.debug("uuid from lvuuid is %s" % uuid)
 
-    ret = gf.lvs_full().stdout.strip()
+    ret = gf.lvs_full().stdout_text.strip()
     result = re.search("lv_uuid:\s+(\S+)", ret).groups()[0]
     logging.debug("uuid from lvs-full is %s" % result)
 
@@ -464,13 +464,13 @@ def test_vgcreate(test, vm, params):
     create_lvm(test, gf, 'pvcreate')
     create_lvm(test, gf, 'vgcreate', vg_name=vg_name)
 
-    result = gf.vgs().stdout.strip()
+    result = gf.vgs().stdout_text.strip()
 
     if result != vg_name:
         gf.close_session()
         test.fail("vg name is not match")
 
-    ret = gf.vgs_full().stdout.strip()
+    ret = gf.vgs_full().stdout_text.strip()
     result = re.search("vg_name:\s+(\S+)", ret).groups()[0]
 
     if result != vg_name:
@@ -501,12 +501,12 @@ def test_vgremove(test, vm, params):
     create_lvm(test, gf, 'vgcreate')
     create_lvm(test, gf, 'lvcreate')
 
-    ret = gf.vgs().stdout.strip()
+    ret = gf.vgs().stdout_text.strip()
     logging.debug(ret)
     if ret:
         gf.vgremove(ret)
 
-    ret = gf.vgs().stdout.strip()
+    ret = gf.vgs().stdout_text.strip()
     if ret:
         gf.close_session()
         test.fail("VG can't be removed")
@@ -535,13 +535,13 @@ def test_vgrename(test, vm, params):
     create_lvm(test, gf, 'vgcreate')
     create_lvm(test, gf, 'lvcreate')
 
-    ret = gf.vgs().stdout.strip()
+    ret = gf.vgs().stdout_text.strip()
     logging.debug(ret)
     if ret:
         new_vg_name = "newvg"
         gf.vgrename(ret, new_vg_name)
 
-    ret = gf.vgs().stdout.strip()
+    ret = gf.vgs().stdout_text.strip()
     if new_vg_name not in ret:
         gf.close_session()
         test.fail("VG can't be renamed")
@@ -600,12 +600,12 @@ def test_vguuid(test, vm, params):
     create_lvm(test, gf, 'vgcreate')
     create_lvm(test, gf, 'lvcreate')
 
-    vg_name = gf.vgs().stdout.strip()
-    uuid = gf.vguuid(vg_name).stdout.strip()
+    vg_name = gf.vgs().stdout_text.strip()
+    uuid = gf.vguuid(vg_name).stdout_text.strip()
     uuid = re.sub("-", "", uuid)
     logging.debug("uuid from vguuid is %s" % uuid)
 
-    ret = gf.vgs_full().stdout.strip()
+    ret = gf.vgs_full().stdout_text.strip()
     result = re.search("vg_uuid:\s+(\S+)", ret).groups()[0]
     logging.debug("uuid from lvs-full is %s" % result)
 
@@ -638,20 +638,20 @@ def test_vg_activate(test, vm, params):
     create_lvm(test, gf, 'vgcreate')
     create_lvm(test, gf, 'lvcreate')
 
-    vg_name = gf.vgs().stdout.strip()
-    result = gf.debug("ls", "/dev").stdout.strip()
+    vg_name = gf.vgs().stdout_text.strip()
+    result = gf.debug("ls", "/dev").stdout_text.strip()
     if vg_name not in result:
         gf.close_session()
         test.fail("Can not find %s in /dev" % vg_name)
 
     gf.vg_activate(0, vg_name)
-    result = gf.debug("ls", "/dev").stdout.strip()
+    result = gf.debug("ls", "/dev").stdout_text.strip()
     if vg_name in result:
         gf.close_session()
         test.fail("Find %s in /dev, it shouldn't be" % vg_name)
 
     gf.vg_activate(1, vg_name)
-    result = gf.debug("ls", "/dev").stdout.strip()
+    result = gf.debug("ls", "/dev").stdout_text.strip()
     if vg_name not in result:
         gf.close_session()
         test.fail("Can not find %s in /dev" % vg_name)
@@ -681,20 +681,20 @@ def test_vg_activate_all(test, vm, params):
     create_lvm(test, gf, 'vgcreate')
     create_lvm(test, gf, 'lvcreate')
 
-    vg_name = gf.vgs().stdout.strip()
-    result = gf.debug("ls", "/dev").stdout.strip()
+    vg_name = gf.vgs().stdout_text.strip()
+    result = gf.debug("ls", "/dev").stdout_text.strip()
     if vg_name not in result:
         gf.close_session()
         test.fail("Can not find %s in /dev" % vg_name)
 
     gf.vg_activate_all(0)
-    result = gf.debug("ls", "/dev").stdout.strip()
+    result = gf.debug("ls", "/dev").stdout_text.strip()
     if vg_name in result:
         gf.close_session()
         test.fail("Find %s in /dev, it shouldn't be" % vg_name)
 
     gf.vg_activate_all(1)
-    result = gf.debug("ls", "/dev").stdout.strip()
+    result = gf.debug("ls", "/dev").stdout_text.strip()
     if vg_name not in result:
         gf.close_session()
         test.fail("Can not find %s in /dev" % vg_name)
@@ -724,10 +724,10 @@ def test_vglvuuids(test, vm, params):
     create_lvm(test, gf, 'vgcreate')
     create_lvm(test, gf, 'lvcreate')
 
-    lv_name = gf.lvs().stdout.strip()
-    uuid = gf.lvuuid(lv_name).stdout.strip()
+    lv_name = gf.lvs().stdout_text.strip()
+    uuid = gf.lvuuid(lv_name).stdout_text.strip()
 
-    result = gf.vglvuuids('VG').stdout.strip()
+    result = gf.vglvuuids('VG').stdout_text.strip()
 
     if uuid != result:
         gf.close_session()
@@ -758,10 +758,10 @@ def test_vgpvuuids(test, vm, params):
     create_lvm(test, gf, 'vgcreate')
     create_lvm(test, gf, 'lvcreate')
 
-    pv_name = gf.pvs().stdout.strip()
-    uuid = gf.pvuuid(pv_name).stdout.strip()
+    pv_name = gf.pvs().stdout_text.strip()
+    uuid = gf.pvuuid(pv_name).stdout_text.strip()
 
-    result = gf.vgpvuuids('VG').stdout.strip()
+    result = gf.vgpvuuids('VG').stdout_text.strip()
 
     if uuid != result:
         gf.close_session()
@@ -789,9 +789,9 @@ def test_pvcreate(test, vm, params):
     gf.run()
 
     create_lvm(test, gf, 'pvcreate')
-    pv_name = gf.pvs().stdout.strip()
+    pv_name = gf.pvs().stdout_text.strip()
 
-    result = gf.pvs_full().stdout.strip()
+    result = gf.pvs_full().stdout_text.strip()
     result = re.search("pv_name:\s+(\S+)", result).groups()[0]
 
     if result != pv_name != "/dev/sda":
@@ -820,14 +820,14 @@ def test_pvremove(test, vm, params):
     gf.run()
 
     create_lvm(test, gf, 'pvcreate')
-    pv_name = gf.pvs().stdout.strip()
+    pv_name = gf.pvs().stdout_text.strip()
 
     if pv_name != "/dev/sda":
         gf.close_session()
         test.fail("pv name is not match")
 
     gf.pvremove('/dev/sda')
-    pv_name = gf.pvs().stdout.strip()
+    pv_name = gf.pvs().stdout_text.strip()
 
     if pv_name:
         gf.close_session()
@@ -855,13 +855,13 @@ def test_pvresize(test, vm, params):
     gf.run()
 
     create_lvm(test, gf, 'pvcreate')
-    result = gf.pvs_full().stdout.strip()
+    result = gf.pvs_full().stdout_text.strip()
     pv_size = re.search("pv_size:\s+(\S+)", result).groups()[0]
 
     new_size = pv_size[:-1]
     gf.pvresize_size("/dev/sda", new_size)
 
-    result = gf.pvs_full().stdout.strip()
+    result = gf.pvs_full().stdout_text.strip()
     get_size = re.search("pv_size:\s+(\S+)", result).groups()[0]
 
     if get_size != new_size:
@@ -870,7 +870,7 @@ def test_pvresize(test, vm, params):
 
     gf.pvresize("/dev/sda")
 
-    result = gf.pvs_full().stdout.strip()
+    result = gf.pvs_full().stdout_text.strip()
     get_size = re.search("pv_size:\s+(\S+)", result).groups()[0]
 
     if get_size != pv_size:
@@ -900,12 +900,12 @@ def test_pvuuid(test, vm, params):
 
     create_lvm(test, gf, 'pvcreate')
 
-    pv_name = gf.pvs().stdout.strip()
-    uuid = gf.pvuuid(pv_name).stdout.strip()
+    pv_name = gf.pvs().stdout_text.strip()
+    uuid = gf.pvuuid(pv_name).stdout_text.strip()
     uuid = re.sub("-", "", uuid)
     logging.debug("uuid from pvuuid is %s" % uuid)
 
-    ret = gf.pvs_full().stdout.strip()
+    ret = gf.pvs_full().stdout_text.strip()
     result = re.search("pv_uuid:\s+(\S+)", ret).groups()[0]
     logging.debug("uuid from pvs-full is %s" % result)
 

--- a/libguestfs/tests/guestfish_misc.py
+++ b/libguestfs/tests/guestfish_misc.py
@@ -42,7 +42,7 @@ def test_df(test, vm, params):
 
     gf.run()
     gf.do_mount("/")
-    result = gf.df().stdout.strip()
+    result = gf.df().stdout_text.strip()
 
     gf.close_session()
 
@@ -71,7 +71,7 @@ def test_df_h(test, vm, params):
 
     gf.run()
     gf.do_mount("/")
-    result = gf.df_h().stdout.strip()
+    result = gf.df_h().stdout_text.strip()
 
     gf.close_session()
 
@@ -107,9 +107,9 @@ def test_dd(test, vm, params):
     gf.write("/src.txt", "Hello World")
     gf.dd("/src.txt", "/dest.txt")
 
-    src_size = gf.filesize("/src.txt").stdout.strip()
-    dest_size = gf.filesize("/dest.txt").stdout.strip()
-    dest_content = gf.cat("/dest.txt").stdout.strip()
+    src_size = gf.filesize("/src.txt").stdout_text.strip()
+    dest_size = gf.filesize("/dest.txt").stdout_text.strip()
+    dest_content = gf.cat("/dest.txt").stdout_text.strip()
 
     gf.close_session()
 
@@ -137,11 +137,11 @@ def test_copy_size(test, vm, params):
     gf.do_mount("/")
 
     gf.write("/src.txt", "Hello World")
-    src_size = gf.filesize("/src.txt").stdout.strip()
+    src_size = gf.filesize("/src.txt").stdout_text.strip()
 
     gf.copy_size("/src.txt", "/dest.txt", src_size)
-    dest_size = gf.filesize("/dest.txt").stdout.strip()
-    dest_content = gf.cat("/dest.txt").stdout.strip()
+    dest_size = gf.filesize("/dest.txt").stdout_text.strip()
+    dest_content = gf.cat("/dest.txt").stdout_text.strip()
 
     gf.close_session()
 
@@ -169,7 +169,7 @@ def test_download(test, vm, params):
     gf.do_mount("/")
 
     gf.write("/src.txt", "Hello World")
-    src_size = gf.filesize("/src.txt").stdout.strip()
+    src_size = gf.filesize("/src.txt").stdout_text.strip()
 
     dest = "%s/dest.txt" % data_dir.get_tmp_dir()
     gf.download("/src.txt", "%s" % dest)
@@ -204,7 +204,7 @@ def test_download_offset(test, vm, params):
     string = "Hello World"
 
     gf.write("/src.txt", string)
-    src_size = gf.filesize("/src.txt").stdout.strip()
+    src_size = gf.filesize("/src.txt").stdout_text.strip()
 
     dest = "%s/dest.txt" % data_dir.get_tmp_dir()
     gf.download_offset("/src.txt", "%s" % dest, 0, len(string))
@@ -241,7 +241,7 @@ def test_upload(test, vm, params):
         fd.write("Hello World")
 
     gf.upload(filename, "/dest.txt")
-    content = gf.cat("/dest.txt").stdout.strip()
+    content = gf.cat("/dest.txt").stdout_text.strip()
     gf.close_session()
     process.getoutput("rm %s" % filename)
 
@@ -273,7 +273,7 @@ def test_upload_offset(test, vm, params):
     process.getoutput("echo %s > %s" % (string, filename))
 
     gf.upload_offset(filename, "/dest.txt", 0)
-    content = gf.cat("/dest.txt").stdout.strip()
+    content = gf.cat("/dest.txt").stdout_text.strip()
     gf.close_session()
     process.getoutput("rm %s" % filename)
 
@@ -302,7 +302,7 @@ def test_fallocate(test, vm, params):
 
     # preallocates a new file
     gf.fallocate("/new", 100)
-    size = gf.filesize("/new").stdout.strip()
+    size = gf.filesize("/new").stdout_text.strip()
 
     if int(size) != 100:
         gf.close_session()
@@ -312,8 +312,8 @@ def test_fallocate(test, vm, params):
     string = "Hello World"
     gf.write("/exist", "Hello world")
     gf.fallocate("/exist", 200)
-    size = gf.filesize("/exist").stdout.strip()
-    content = gf.cat("/exist").stdout.strip()
+    size = gf.filesize("/exist").stdout_text.strip()
+    content = gf.cat("/exist").stdout_text.strip()
     gf.close_session()
 
     if content != "":
@@ -343,7 +343,7 @@ def test_fallocate64(test, vm, params):
 
     # preallocates a new file
     gf.fallocate("/new", 100)
-    size = gf.filesize("/new").stdout.strip()
+    size = gf.filesize("/new").stdout_text.strip()
 
     if int(size) != 100:
         gf.close_session()
@@ -353,8 +353,8 @@ def test_fallocate64(test, vm, params):
     string = "Hello World"
     gf.write("/exist", "Hello world")
     gf.fallocate64("/exist", 200)
-    size = gf.filesize("/exist").stdout.strip()
-    content = gf.cat("/exist").stdout.strip()
+    size = gf.filesize("/exist").stdout_text.strip()
+    content = gf.cat("/exist").stdout_text.strip()
     gf.close_session()
 
     if content != "":

--- a/libguestfs/tests/guestfs_add.py
+++ b/libguestfs/tests/guestfs_add.py
@@ -62,7 +62,7 @@ def launch_disk(test, guestfs):
 
 def get_root(test, guestfs):
     getroot_result = guestfs.inspect_os()
-    roots_list = getroot_result.stdout.splitlines()
+    roots_list = getroot_result.stdout_text.splitlines()
     if getroot_result.exit_status or not len(roots_list):
         guestfs.close_session()
         test.fail("Get root failed:%s" % getroot_result)
@@ -168,7 +168,7 @@ def run(test, params, env):
         fail_info['cat_writed'] = ("Cat writed file failed:"
                                    "%s" % cat_result)
     else:
-        guestfs_writed_text = cat_result.stdout
+        guestfs_writed_text = cat_result.stdout_text
         if not re.search(content, guestfs_writed_text):
             fail_flag = 1
             fail_info['cat_writed'] = ("Catted text is not match with writed:"
@@ -183,7 +183,7 @@ def run(test, params, env):
     # Convert sdx in root to vdx for virtio system disk
     if primary_disk_virtio(vm):
         root = process.run("echo %s | sed -e 's/sd/vd/g'" % root,
-                           ignore_status=True, shell=True).stdout.strip()
+                           ignore_status=True, shell=True).stdout_text.strip()
     if login_to_check:
         try:
             vm.start()

--- a/libguestfs/tests/guestfs_block_operations.py
+++ b/libguestfs/tests/guestfs_block_operations.py
@@ -23,7 +23,7 @@ def prepare_attached_device(test, guestfs, device):
         guestfs.close_session()
         test.fail("List devices failed")
     else:
-        if not re.search(device, list_dev_result.stdout):
+        if not re.search(device, list_dev_result.stdout_text):
             guestfs.close_session()
             test.fail("Did not find additional device.")
     logging.info("List devices successfully.")
@@ -46,7 +46,7 @@ def test_blockdev_info(test, vm, params):
     """
     add_device = params.get("gf_additional_device", "/dev/vdb")
     device_in_gf = process.run("echo %s | sed -e 's/vd/sd/g'" % add_device,
-                               ignore_status=True, shell=True).stdout.strip()
+                               ignore_status=True, shell=True).stdout_text.strip()
     if utils_test.libguestfs.primary_disk_virtio(vm):
         device_in_vm = add_device
     else:
@@ -67,7 +67,7 @@ def test_blockdev_info(test, vm, params):
     if getss_result.exit_status:
         gf.close_session()
         test.fail("Get sectionsize failed")
-    sectorsize = str(getss_result.stdout.strip())
+    sectorsize = str(getss_result.stdout_text.strip())
     logging.info("Get sectionsize successfully.")
 
     # Get total size of device in 512-byte sectors
@@ -76,7 +76,7 @@ def test_blockdev_info(test, vm, params):
     if getsz_result.exit_status:
         gf.close_session()
         test.fail("Get device size failed.")
-    total_size = str(getsz_result.stdout.strip())
+    total_size = str(getsz_result.stdout_text.strip())
     logging.info("Get device size successfully.")
 
     # Get blocksize of device
@@ -85,7 +85,7 @@ def test_blockdev_info(test, vm, params):
     if getbsz_result.exit_status:
         gf.close_session()
         test.fail("Get blocksize failed.")
-    blocksize = str(getbsz_result.stdout.strip())
+    blocksize = str(getbsz_result.stdout_text.strip())
     logging.info("Get blocksize successfully.")
 
     # Get total size in bytes
@@ -94,7 +94,7 @@ def test_blockdev_info(test, vm, params):
     logging.debug(getsize64_result)
     if getsize64_result.exit_status:
         test.fail("Get device size in bytes failed.")
-    total_size_in_bytes = str(getsize64_result.stdout.strip())
+    total_size_in_bytes = str(getsize64_result.stdout_text.strip())
     logging.info("Get device size in bytes successfully")
 
     logging.info("Block device information in guestfish:\n"
@@ -161,7 +161,7 @@ def test_blockdev_ro(test, vm, params):
     """
     add_device = params.get("gf_additional_device", "/dev/vdb")
     device_in_gf = process.run("echo %s | sed -e 's/vd/sd/g'" % add_device,
-                               ignore_status=True, shell=True).stdout.strip()
+                               ignore_status=True, shell=True).stdout_text.strip()
 
     vt = utils_test.libguestfs.VirtTools(vm, params)
     # Create a new vm with additional disk
@@ -188,7 +188,7 @@ def test_blockdev_ro(test, vm, params):
         test.fail("Get readonly status failed.")
     logging.info("Get readonly status successfully.")
 
-    if getro_result.stdout.strip() == "true":
+    if getro_result.stdout_text.strip() == "true":
         logging.info("Partition %s is readonly already.", part_name)
     else:
         setro_result = gf.blockdev_setro(part_name)
@@ -201,7 +201,7 @@ def test_blockdev_ro(test, vm, params):
         # Check readonly status
         getro_result = gf.blockdev_getro(part_name)
         logging.debug(getro_result)
-        if getro_result.stdout.strip() == "false":
+        if getro_result.stdout_text.strip() == "false":
             gf.close_session()
             test.fail("Check readonly status failed.")
 
@@ -220,7 +220,7 @@ def test_blockdev_ro(test, vm, params):
         gf.close_session()
         test.fail("Df failed")
     else:
-        if not re.search(part_name, list_df_result.stdout):
+        if not re.search(part_name, list_df_result.stdout_text):
             gf.close_session()
             test.fail("Did not find mounted device.")
     logging.info("Df successfully.")
@@ -248,7 +248,7 @@ def test_blockdev_rw(test, vm, params):
     """
     add_device = params.get("gf_additional_device", "/dev/vdb")
     device_in_gf = process.run("echo %s | sed -e 's/vd/sd/g'" % add_device,
-                               ignore_status=True, shell=True).stdout.strip()
+                               ignore_status=True, shell=True).stdout_text.strip()
     if utils_test.libguestfs.primary_disk_virtio(vm):
         device_in_vm = add_device
     else:
@@ -280,7 +280,7 @@ def test_blockdev_rw(test, vm, params):
         test.fail("Get readonly status failed.")
     logging.info("Get readonly status successfully.")
 
-    if getro_result.stdout.strip() == "true":
+    if getro_result.stdout_text.strip() == "true":
         logging.info("Paritition %s is readonly already.", part_name)
     else:
         setro_result = gf.blockdev_setro(part_name)
@@ -293,7 +293,7 @@ def test_blockdev_rw(test, vm, params):
         # Check readonly status
         getro_result = gf.blockdev_getro(part_name)
         logging.debug(getro_result)
-        if getro_result.stdout.strip() == "false":
+        if getro_result.stdout_text.strip() == "false":
             gf.close_session()
             test.fail("Check readonly status failed.")
 
@@ -308,7 +308,7 @@ def test_blockdev_rw(test, vm, params):
     # Check read-write status
     getro_result = gf.blockdev_getro(part_name)
     logging.debug(getro_result)
-    if getro_result.stdout.strip() == "true":
+    if getro_result.stdout_text.strip() == "true":
         gf.close_session()
         test.fail("Check read-write status failed.")
 
@@ -327,7 +327,7 @@ def test_blockdev_rw(test, vm, params):
         gf.close_session()
         test.fail("Df failed")
     else:
-        if not re.search(part_name, list_df_result.stdout):
+        if not re.search(part_name, list_df_result.stdout_text):
             gf.close_session()
             test.fail("Did not find mounted device.")
     logging.info("Df successfully.")

--- a/libguestfs/tests/guestfs_file_operations.py
+++ b/libguestfs/tests/guestfs_file_operations.py
@@ -63,7 +63,7 @@ def test_tar_in(test, vm, params):
     if cat_result.exit_status:
         test.fail("Cat file failed.")
     else:
-        if not re.search(content, cat_result.stdout):
+        if not re.search(content, cat_result.stdout_text):
             test.fail("Catted file do not match")
     if rm_result.exit_status:
         test.fail("Rm file failed.")
@@ -131,7 +131,7 @@ def test_tar_out(test, vm, params):
     if cat_result.exit_status:
         test.fail("Cat file failed.")
     else:
-        if not re.search(content, cat_result.stdout):
+        if not re.search(content, cat_result.stdout_text):
             test.fail("Catted file do not match.")
 
 
@@ -182,7 +182,7 @@ def test_copy_in(test, vm, params):
     if cat_result.exit_status:
         test.fail("Cat file failed.")
     else:
-        if not re.search(content, cat_result.stdout):
+        if not re.search(content, cat_result.stdout_text):
             test.fail("Catted file do not match")
     if rm_result.exit_status:
         test.fail("Rm file failed.")
@@ -229,7 +229,7 @@ def test_copy_out(test, vm, params):
 
     # Check file
     cat_result = process.run("cat %s" % path, ignore_status=True, shell=True)
-    logging.debug(cat_result.stdout)
+    logging.debug(cat_result.stdout_text)
     try:
         os.remove(path)
     except IOError as detail:
@@ -237,7 +237,7 @@ def test_copy_out(test, vm, params):
     if cat_result.exit_status:
         test.fail("Cat file failed.")
     else:
-        if not re.search(content, cat_result.stdout):
+        if not re.search(content, cat_result.stdout_text):
             test.fail("Catted file do not match.")
 
 

--- a/libguestfs/tests/guestfs_inspect_operations.py
+++ b/libguestfs/tests/guestfs_inspect_operations.py
@@ -58,7 +58,7 @@ def test_inspect_get(test, vm, params):
     logging.debug(getroot_result)
     if getroot_result.exit_status:
         fail_info.append("Get root with inspect-get-roots failed.")
-    elif not re.search(rootfs, str(getroot_result.stdout)):
+    elif not re.search(rootfs, str(getroot_result.stdout_text)):
         fail_info.append("Something wrong with got roots.")
     else:
         logging.info("Get root successfully.")
@@ -77,7 +77,7 @@ def test_inspect_get(test, vm, params):
     if distro_result.exit_status:
         fail_info.append("Get distro of %s failed." % rootfs)
     elif is_redhat:
-        if str(releaseo) != distro_result.stdout.strip():
+        if str(releaseo) != distro_result.stdout_text.strip():
             fail_info.append("Got distro do not match.")
     else:
         logging.info("Get distro successfully.")
@@ -139,7 +139,7 @@ def test_inspect_get(test, vm, params):
         if vm.is_alive():
             vm.destroy()
 
-    if not re.search(arch_result.stdout.strip(), uname2):
+    if not re.search(arch_result.stdout_text.strip(), uname2):
         fail_info.append("Got arch do not match.")
 
     if len(fail_info):

--- a/libguestfs/tests/guestfs_list_operations.py
+++ b/libguestfs/tests/guestfs_list_operations.py
@@ -106,7 +106,7 @@ def test_list_without_mount(test, vm, params):
     if list_df_result.exit_status == 0:
         test.fail("Df successfully unexpected.")
     else:
-        if not re.search("call.*mount.*first", list_df_result.stdout):
+        if not re.search("call.*mount.*first", list_df_result.stdout_text):
             test.fail("Unknown error.")
     logging.info("Df failed as expected.")
 
@@ -141,7 +141,7 @@ def test_list_without_launch(test, vm, params):
         gf.close_session()
         test.fail("List filesystems successfully")
     else:
-        if not re.search("call\slaunch\sbefore", list_fs_result.stdout):
+        if not re.search("call\slaunch\sbefore", list_fs_result.stdout_text):
             gf.close_session()
             test.fail("Unknown error.")
 
@@ -152,7 +152,7 @@ def test_list_without_launch(test, vm, params):
         gf.close_session()
         test.fail("List partitions successfully")
     else:
-        if not re.search("call\slaunch\sbefore", list_part_result.stdout):
+        if not re.search("call\slaunch\sbefore", list_part_result.stdout_text):
             gf.close_session()
             test.fail("Unknown error.")
 
@@ -163,7 +163,7 @@ def test_list_without_launch(test, vm, params):
         gf.close_session()
         test.fail("List devices successfully")
     else:
-        if not re.search("call\slaunch\sbefore", list_dev_result.stdout):
+        if not re.search("call\slaunch\sbefore", list_dev_result.stdout_text):
             gf.close_session()
             test.fail("Unknown error.")
 
@@ -174,7 +174,7 @@ def test_list_without_launch(test, vm, params):
     if mount_result.exit_status == 0:
         test.fail("Mount filesystem successfully")
     else:
-        if not re.search("call\slaunch\sbefore", mount_result.stdout):
+        if not re.search("call\slaunch\sbefore", mount_result.stdout_text):
             test.fail("Unknown error.")
 
     logging.info("Test end as expected.")

--- a/libguestfs/tests/guestfs_part_operations.py
+++ b/libguestfs/tests/guestfs_part_operations.py
@@ -20,7 +20,7 @@ def test_formatted_part(test, vm, params):
     """
     add_device = params.get("gf_additional_device", "/dev/vdb")
     device_in_gf = process.run("echo %s | sed -e 's/vd/sd/g'" % add_device,
-                               ignore_status=True, shell=True).stdout.strip()
+                               ignore_status=True, shell=True).stdout_text.strip()
     if utils_test.libguestfs.primary_disk_virtio(vm):
         device_in_vm = add_device
     else:
@@ -41,7 +41,7 @@ def test_formatted_part(test, vm, params):
         gf.close_session()
         test.fail("List devices failed")
     else:
-        if not re.search(device_in_gf, list_dev_result.stdout):
+        if not re.search(device_in_gf, list_dev_result.stdout_text):
             gf.close_session()
             test.fail("Did not find additional device.")
     logging.info("List devices successfully.")
@@ -76,7 +76,7 @@ def test_formatted_part(test, vm, params):
         gf.close_session()
         test.fail("Df failed")
     else:
-        if not re.search(part_name_in_gf, list_df_result.stdout):
+        if not re.search(part_name_in_gf, list_df_result.stdout_text):
             gf.close_session()
             test.fail("Did not find mounted device.")
     logging.info("Df successfully.")
@@ -122,7 +122,7 @@ def test_unformatted_part(test, vm, params):
     """
     add_device = params.get("gf_additional_device", "/dev/vdb")
     device_in_gf = process.run("echo %s | sed -e 's/vd/sd/g'" % add_device,
-                               ignore_status=True, shell=True).stdout.strip()
+                               ignore_status=True, shell=True).stdout_text.strip()
 
     vt = utils_test.libguestfs.VirtTools(vm, params)
     # Create a new vm with additional disk
@@ -140,7 +140,7 @@ def test_unformatted_part(test, vm, params):
         gf.close_session()
         test.fail("List devices failed")
     else:
-        if not re.search(device_in_gf, list_dev_result.stdout):
+        if not re.search(device_in_gf, list_dev_result.stdout_text):
             gf.close_session()
             test.fail("Did not find additional device.")
     logging.info("List devices successfully.")
@@ -159,7 +159,7 @@ def test_unformatted_part(test, vm, params):
     if mount_result.exit_status == 0:
         test.fail("Mount %s successfully." % part_name_in_gf)
     else:
-        if not re.search("[filesystem|fs] type", mount_result.stdout):
+        if not re.search("[filesystem|fs] type", mount_result.stdout_text):
             test.fail("Unknown error.")
 
 
@@ -173,7 +173,7 @@ def test_formatted_disk(test, vm, params):
     """
     add_device = params.get("gf_additional_device", "/dev/vdb")
     device_in_gf = process.run("echo %s | sed -e 's/vd/sd/g'" % add_device,
-                               ignore_status=True, shell=True).stdout.strip()
+                               ignore_status=True, shell=True).stdout_text.strip()
     if utils_test.libguestfs.primary_disk_virtio(vm):
         device_in_vm = add_device
     else:
@@ -195,7 +195,7 @@ def test_formatted_disk(test, vm, params):
         gf.close_session()
         test.fail("List devices failed")
     else:
-        if not re.search(device_in_gf, list_dev_result.stdout):
+        if not re.search(device_in_gf, list_dev_result.stdout_text):
             gf.close_session()
             test.fail("Did not find additional device.")
     logging.info("List devices successfully.")
@@ -230,7 +230,7 @@ def test_formatted_disk(test, vm, params):
         gf.close_session()
         test.fail("Df failed")
     else:
-        if not re.search(part_name_in_gf, list_df_result.stdout):
+        if not re.search(part_name_in_gf, list_df_result.stdout_text):
             gf.close_session()
             test.fail("Did not find mounted device.")
     logging.info("Df successfully.")
@@ -317,7 +317,7 @@ def test_fscked_partition(test, vm, params):
     """
     add_device = params.get("gf_additional_device", "/dev/vdb")
     device_in_gf = process.run("echo %s | sed -e 's/vd/sd/g'" % add_device,
-                               ignore_status=True, shell=True).stdout.strip()
+                               ignore_status=True, shell=True).stdout_text.strip()
 
     vt = utils_test.libguestfs.VirtTools(vm, params)
     # Create a new vm with additional disk
@@ -334,7 +334,7 @@ def test_fscked_partition(test, vm, params):
         gf.close_session()
         test.fail("List devices failed")
     else:
-        if not re.search(device_in_gf, list_dev_result.stdout):
+        if not re.search(device_in_gf, list_dev_result.stdout_text):
             gf.close_session()
             test.fail("Did not find additional device.")
     logging.info("List devices successfully.")
@@ -368,7 +368,7 @@ def test_fscked_partition(test, vm, params):
         gf.close_session()
         test.fail("Df failed")
     else:
-        if not re.search(part_name_in_gf, list_df_result.stdout):
+        if not re.search(part_name_in_gf, list_df_result.stdout_text):
             gf.close_session()
             test.fail("Did not find mounted device.")
     logging.info("Df successfully.")

--- a/libguestfs/tests/guestfs_volume_operations.py
+++ b/libguestfs/tests/guestfs_volume_operations.py
@@ -24,7 +24,7 @@ def prepare_attached_device(test, guestfs, device):
         guestfs.close_session()
         test.fail("List devices failed")
     else:
-        if not re.search(device, list_dev_result.stdout):
+        if not re.search(device, list_dev_result.stdout_text):
             guestfs.close_session()
             test.fail("Did not find additional device.")
     logging.info("List devices successfully.")
@@ -48,7 +48,7 @@ def test_create_vol_group(test, vm, params):
     """
     add_device = params.get("gf_additional_device", "/dev/vdb")
     device_in_gf = process.run("echo %s | sed -e 's/vd/sd/g'" % add_device,
-                               ignore_status=True, shell=True).stdout.strip()
+                               ignore_status=True, shell=True).stdout_text.strip()
 
     vt = utils_test.libguestfs.VirtTools(vm, params)
     # Create a new vm with additional disk
@@ -73,7 +73,7 @@ def test_create_vol_group(test, vm, params):
     if vgs_result.exit_status:
         test.fail("List volume groups failed.")
     else:
-        if not re.search(groupname, vgs_result.stdout):
+        if not re.search(groupname, vgs_result.stdout_text):
             test.fail("Can't get volume group %s." % groupname)
     logging.info("Got volume group %s", groupname)
 
@@ -117,7 +117,7 @@ def test_rename_vol_group(test, vm, params):
     """
     add_device = params.get("gf_additional_device", "/dev/vdb")
     device_in_gf = process.run("echo %s | sed -e 's/vd/sd/g'" % add_device,
-                               ignore_status=True, shell=True).stdout.strip()
+                               ignore_status=True, shell=True).stdout_text.strip()
 
     vt = utils_test.libguestfs.VirtTools(vm, params)
     # Create a new vm with additional disk
@@ -142,7 +142,7 @@ def test_rename_vol_group(test, vm, params):
         gf.close_session()
         test.fail("List volume groups failed.")
     else:
-        if not re.search(groupname, vgs_result.stdout):
+        if not re.search(groupname, vgs_result.stdout_text):
             gf.close_session()
             test.fail("Can't get volume group %s." % groupname)
     logging.info("Got volume group %s", groupname)
@@ -195,7 +195,7 @@ def test_remove_vol_group(test, vm, params):
     """
     add_device = params.get("gf_additional_device", "/dev/vdb")
     device_in_gf = process.run("echo %s | sed -e 's/vd/sd/g'" % add_device,
-                               ignore_status=True, shell=True).stdout.strip()
+                               ignore_status=True, shell=True).stdout_text.strip()
 
     vt = utils_test.libguestfs.VirtTools(vm, params)
     # Create a new vm with additional disk
@@ -220,7 +220,7 @@ def test_remove_vol_group(test, vm, params):
         gf.close_session()
         test.fail("List volume groups failed.")
     else:
-        if not re.search(groupname, vgs_result.stdout):
+        if not re.search(groupname, vgs_result.stdout_text):
             gf.close_session()
             test.fail("Can't get volume group %s." % groupname)
     logging.info("Got volume group %s", groupname)
@@ -238,7 +238,7 @@ def test_remove_vol_group(test, vm, params):
     if vgs_result.exit_status:
         test.fail("List volume groups failed.")
     else:
-        if re.search(groupname, vgs_result.stdout):
+        if re.search(groupname, vgs_result.stdout_text):
             test.fail("Are you sure volume group %s deleted "
                       "successfully?" % groupname)
     logging.info("Volume group %s did not deleted as expected!", groupname)
@@ -256,7 +256,7 @@ def test_create_volume(test, vm, params):
     """
     add_device = params.get("gf_additional_device", "/dev/vdb")
     device_in_gf = process.run("echo %s | sed -e 's/vd/sd/g'" % add_device,
-                               ignore_status=True, shell=True).stdout.strip()
+                               ignore_status=True, shell=True).stdout_text.strip()
 
     vt = utils_test.libguestfs.VirtTools(vm, params)
     # Create a new vm with additional disk
@@ -281,7 +281,7 @@ def test_create_volume(test, vm, params):
         gf.close_session()
         test.fail("List volume groups failed.")
     else:
-        if not re.search(groupname, vgs_result.stdout):
+        if not re.search(groupname, vgs_result.stdout_text):
             gf.close_session()
             test.fail("Can't get volume group %s." % groupname)
     logging.info("Got volume group %s", groupname)
@@ -302,7 +302,7 @@ def test_create_volume(test, vm, params):
         gf.close_session()
         test.fail("List volume groups failed.")
     else:
-        if not re.search(volumename, lvs_result.stdout):
+        if not re.search(volumename, lvs_result.stdout_text):
             gf.close_session()
             test.fail("Can't get volume %s." % volumename)
     logging.info("Got volume %s", volumename)
@@ -360,7 +360,7 @@ def test_delete_volume(test, vm, params):
     """
     add_device = params.get("gf_additional_device", "/dev/vdb")
     device_in_gf = process.run("echo %s | sed -e 's/vd/sd/g'" % add_device,
-                               ignore_status=True, shell=True).stdout.strip()
+                               ignore_status=True, shell=True).stdout_text.strip()
 
     vt = utils_test.libguestfs.VirtTools(vm, params)
     # Create a new vm with additional disk
@@ -385,7 +385,7 @@ def test_delete_volume(test, vm, params):
         gf.close_session()
         test.fail("List volume groups failed.")
     else:
-        if not re.search(groupname, vgs_result.stdout):
+        if not re.search(groupname, vgs_result.stdout_text):
             gf.close_session()
             test.fail("Can't get volume group %s." % groupname)
     logging.info("Got volume group %s", groupname)
@@ -406,7 +406,7 @@ def test_delete_volume(test, vm, params):
         gf.close_session()
         test.fail("List volume groups failed.")
     else:
-        if not re.search(volumename, lvs_result.stdout):
+        if not re.search(volumename, lvs_result.stdout_text):
             gf.close_session()
             test.fail("Can't get volume %s." % volumename)
     logging.info("Got volume %s", volumename)
@@ -424,7 +424,7 @@ def test_delete_volume(test, vm, params):
     if lvs_result.exit_status:
         test.fail("List volume groups failed.")
     else:
-        if re.search(volumename, lvs_result.stdout):
+        if re.search(volumename, lvs_result.stdout_text):
             test.fail("Are you sure volume %s removed as "
                       "expected?" % volumename)
 
@@ -444,7 +444,7 @@ def test_shrink_volume(test, vm, params):
     """
     add_device = params.get("gf_additional_device", "/dev/vdb")
     device_in_gf = process.run("echo %s | sed -e 's/vd/sd/g'" % add_device,
-                               ignore_status=True, shell=True).stdout.strip()
+                               ignore_status=True, shell=True).stdout_text.strip()
 
     vt = utils_test.libguestfs.VirtTools(vm, params)
     # Create a new vm with additional disk
@@ -469,7 +469,7 @@ def test_shrink_volume(test, vm, params):
         gf.close_session()
         test.fail("List volume groups failed.")
     else:
-        if not re.search(groupname, vgs_result.stdout):
+        if not re.search(groupname, vgs_result.stdout_text):
             gf.close_session()
             test.fail("Can't get volume group %s." % groupname)
     logging.info("Got volume group %s", groupname)
@@ -490,7 +490,7 @@ def test_shrink_volume(test, vm, params):
         gf.close_session()
         test.fail("List volume groups failed.")
     else:
-        if not re.search(volumename, lvs_result.stdout):
+        if not re.search(volumename, lvs_result.stdout_text):
             gf.close_session()
             test.fail("Can't get volume %s." % volumename)
     logging.info("Got volume %s", volumename)
@@ -567,7 +567,7 @@ def test_shrink_volume(test, vm, params):
         gf.close_session()
         test.fail("Df failed")
     else:
-        if not re.search(volumename, list_df_result.stdout):
+        if not re.search(volumename, list_df_result.stdout_text):
             gf.close_session()
             test.fail("Did not find mounted device.")
     logging.info("Df successfully.")
@@ -597,7 +597,7 @@ def test_expand_volume(test, vm, params):
     """
     add_device = params.get("gf_additional_device", "/dev/vdb")
     device_in_gf = process.run("echo %s | sed -e 's/vd/sd/g'" % add_device,
-                               ignore_status=True, shell=True).stdout.strip()
+                               ignore_status=True, shell=True).stdout_text.strip()
 
     vt = utils_test.libguestfs.VirtTools(vm, params)
     # Create a new vm with additional disk
@@ -622,7 +622,7 @@ def test_expand_volume(test, vm, params):
         gf.close_session()
         test.fail("List volume groups failed.")
     else:
-        if not re.search(groupname, vgs_result.stdout):
+        if not re.search(groupname, vgs_result.stdout_text):
             gf.close_session()
             test.fail("Can't get volume group %s." % groupname)
     logging.info("Got volume group %s", groupname)
@@ -643,7 +643,7 @@ def test_expand_volume(test, vm, params):
         gf.close_session()
         test.fail("List volume groups failed.")
     else:
-        if not re.search(volumename, lvs_result.stdout):
+        if not re.search(volumename, lvs_result.stdout_text):
             gf.close_session()
             test.fail("Can't get volume %s." % volumename)
     logging.info("Got volume %s", volumename)
@@ -719,7 +719,7 @@ def test_expand_volume(test, vm, params):
         gf.close_session()
         test.fail("Df failed")
     else:
-        if not re.search(volumename, list_df_result.stdout):
+        if not re.search(volumename, list_df_result.stdout_text):
             gf.close_session()
             test.fail("Did not find mounted device.")
     logging.info("Df successfully.")

--- a/libguestfs/tests/virt_cat.py
+++ b/libguestfs/tests/virt_cat.py
@@ -75,7 +75,7 @@ def run(test, params, env):
         if result.exit_status:
             test.fail("Cat file failed.")
         else:
-            if not re.search(content, result.stdout):
+            if not re.search(content, result.stdout_text):
                 test.fail("Catted file do not match")
 
     # Cleanup

--- a/libguestfs/tests/virt_edit.py
+++ b/libguestfs/tests/virt_edit.py
@@ -110,7 +110,7 @@ def run(test, params, env):
         logging.info("disk to be edit:%s", vm_ref)
         if test_format:
             # Get format:raw or qcow2
-            info = process.run("qemu-img info %s" % vm_ref, shell=True).stdout
+            info = process.run("qemu-img info %s" % vm_ref, shell=True).stdout_text
             for line in info.splitlines():
                 comps = line.split(':')
                 if comps[0].count("format"):

--- a/libguestfs/tests/virt_file_operations.py
+++ b/libguestfs/tests/virt_file_operations.py
@@ -64,7 +64,7 @@ def test_virt_tar_in(test, vm, params):
     if cat_result.exit_status:
         test.fail("Cat file failed.")
     else:
-        if not re.search(content, cat_result.stdout):
+        if not re.search(content, cat_result.stdout_text):
             test.fail("Catted file do not match")
 
     try:
@@ -148,7 +148,7 @@ def test_virt_tar_out(test, vm, params):
     if cat_result.exit_status:
         test.fail("Cat file failed.")
     else:
-        if not re.search(content, cat_result.stdout):
+        if not re.search(content, cat_result.stdout_text):
             test.fail("Catted file do not match.")
 
 
@@ -192,7 +192,7 @@ def test_virt_copy_in(test, vm, params):
     if cat_result.exit_status:
         test.fail("Cat file failed.")
     else:
-        if not re.search(content, cat_result.stdout):
+        if not re.search(content, cat_result.stdout_text):
             test.fail("Catted file do not match")
 
     try:
@@ -255,7 +255,7 @@ def test_virt_copy_out(test, vm, params):
 
     # Check file
     cat_result = process.run("cat %s" % path, ignore_status=True, shell=True)
-    logging.debug(cat_result.stdout)
+    logging.debug(cat_result.stdout_text)
     try:
         os.remove(path)
     except IOError as detail:
@@ -263,7 +263,7 @@ def test_virt_copy_out(test, vm, params):
     if cat_result.exit_status:
         test.fail("Cat file failed.")
     else:
-        if not re.search(content, cat_result.stdout):
+        if not re.search(content, cat_result.stdout_text):
             test.fail("Catted file do not match.")
 
 

--- a/libguestfs/tests/virt_inspect_operations.py
+++ b/libguestfs/tests/virt_inspect_operations.py
@@ -53,7 +53,7 @@ def test_inspect_get(test, vm, params):
         vm_release = vm_info.get("release")
         if vm_release is None:
             fail_info.append("Get release with inspector failed.")
-        elif not release_result.stdout.strip() == vm_release:
+        elif not release_result.stdout_text.strip() == vm_release:
             fail_info.append("release do not match.")
         else:
             logging.info("Compare release info successfully.")
@@ -77,7 +77,7 @@ def test_inspect_get(test, vm, params):
     if len(vm_filesystems) == 0:
         fail_info.append("Get filesystems with inspector failed.")
     else:
-        list_fs_lines = list_fs_result.stdout.splitlines()
+        list_fs_lines = list_fs_result.stdout_text.splitlines()
         # kick non-filesystem line out
         for line in list_fs_lines:
             if re.search("filesystem", line):
@@ -114,7 +114,7 @@ def test_inspect_get(test, vm, params):
             vm_version = "%s.%s" % (vm_major_version, vm_minor_version)
         else:
             vm_version = vm_major_version
-        if not re.search(vm_version, release_result.stdout):
+        if not re.search(vm_version, release_result.stdout_text):
             fail_info.append("Version do not match:%s" % vm_version)
         logging.info("Get version successfully")
 
@@ -126,7 +126,7 @@ def test_inspect_get(test, vm, params):
         for mountpoint in vm_mountpoints:
             if re.search("mapper", mountpoint):
                 mountpoint = mountpoint.split('-')[-1]
-            if not re.search(mountpoint, df_result.stdout):
+            if not re.search(mountpoint, df_result.stdout_text):
                 fail_info.append("Mountpoint %s do not match." % mountpoint)
         logging.info("Get mountpoints successfully:%s", vm_mountpoints)
 
@@ -144,7 +144,7 @@ def test_inspect_get(test, vm, params):
         if is_redhat:
             release_output = session.cmd_output("cat /etc/redhat-release")
             logging.debug(release_output)
-            if release_output.strip() != release_result.stdout.strip():
+            if release_output.strip() != release_result.stdout_text.strip():
                 fail_info.append("release in vm do not match.")
         hostname_output = session.cmd_output("hostname")
         logging.debug("VM hostname:%s", hostname_output)

--- a/libguestfs/tests/virt_list_operations.py
+++ b/libguestfs/tests/virt_list_operations.py
@@ -18,7 +18,7 @@ def run(test, params, env):
 
     # List filesystems with virt-list-filesystems
     list_fs_result = lgf.virt_list_filesystems(vm_name, debug=True)
-    filesystems1 = list_fs_result.stdout.splitlines()
+    filesystems1 = list_fs_result.stdout_text.splitlines()
     if list_fs_result.exit_status:
         test.fail("List filesystems with virt-list-filesystems "
                   "failed:%s" % list_fs_result)
@@ -26,10 +26,10 @@ def run(test, params, env):
 
     # List filesystems with virt-filesystems
     virt_fs_result = lgf.virt_filesystems(vm_name, debug=True)
-    filesystems2 = virt_fs_result.stdout.splitlines()
+    filesystems2 = virt_fs_result.stdout_text.splitlines()
     if virt_fs_result.exit_status:
         test.fail("List filesystems with virt-filesystems failed:"
-                  "%s" % virt_fs_result.stdout.strip())
+                  "%s" % virt_fs_result.stdout_text.strip())
     logging.info("List filesystems successfully.")
 
     for fs in filesystems1:
@@ -38,7 +38,7 @@ def run(test, params, env):
 
     # List partitions
     list_part_result = lgf.virt_list_partitions(vm_name, debug=True)
-    partitions = list_part_result.stdout.splitlines()
+    partitions = list_part_result.stdout_text.splitlines()
     if list_part_result.exit_status:
         test.fail("List partitions failed:%s" % list_part_result)
     logging.info("List partitions successfully.")

--- a/libguestfs/tests/virt_part_operations.py
+++ b/libguestfs/tests/virt_part_operations.py
@@ -21,7 +21,7 @@ def test_unformatted_part(test, vm, params):
     """
     add_device = params.get("gf_additional_device", "/dev/vdb")
     device_in_lgf = process.run("echo %s | sed -e 's/vd/sd/g'" % add_device,
-                                ignore_status=True, shell=True).stdout.strip()
+                                ignore_status=True, shell=True).stdout_text.strip()
 
     device_part = "%s1" % device_in_lgf
     # Mount specific partition
@@ -62,7 +62,7 @@ def test_formatted_part(test, vm, params):
     """
     add_device = params.get("gf_additional_device", "/dev/vdb")
     device_in_lgf = process.run("echo %s | sed -e 's/vd/sd/g'" % add_device,
-                                ignore_status=True, shell=True).stdout.strip()
+                                ignore_status=True, shell=True).stdout_text.strip()
     if utils_test.libguestfs.primary_disk_virtio(vm):
         device_in_vm = add_device
     else:

--- a/libguestfs/tests/virt_sysprep.py
+++ b/libguestfs/tests/virt_sysprep.py
@@ -180,7 +180,7 @@ def run(test, params, env):
     clone_result = lgf.virt_clone_cmd(vm_name, newname=vm_clone_name, **dargs)
     if clone_result.exit_status:
         test.fail("virt-clone failed:%s"
-                  % clone_result.stderr.strip())
+                  % clone_result.stderr_text.strip())
     try:
         # Modify network to make sure the clone guest can be logging.
         modify_network(vm_clone_name, first_nic)

--- a/libguestfs/tests/virt_sysprep_opt.py
+++ b/libguestfs/tests/virt_sysprep_opt.py
@@ -79,27 +79,27 @@ def run(test, params, env):
         if sysprep_opt.count("enable"):
             if action == "logfiles":
                 au_o = lgf.virt_ls_cmd(vm_name,
-                                       "/var/log/audit").stdout.strip()
-                sa_o = lgf.virt_ls_cmd(vm_name, "/var/log/sa").stdout.strip()
-                gdm_o = lgf.virt_ls_cmd(vm_name, "/var/log/gdm").stdout.strip()
+                                       "/var/log/audit").stdout_text.strip()
+                sa_o = lgf.virt_ls_cmd(vm_name, "/var/log/sa").stdout_text.strip()
+                gdm_o = lgf.virt_ls_cmd(vm_name, "/var/log/gdm").stdout_text.strip()
                 ntp_o = lgf.virt_ls_cmd(vm_name,
-                                        "/var/log/ntpstats").stdout.strip()
+                                        "/var/log/ntpstats").stdout_text.strip()
                 status = 1 if au_o or sa_o or gdm_o or ntp_o else 0
                 return status
             elif action == "tmp-files":
-                tmp_o = lgf.virt_ls_cmd(vm_name, "/tmp").stdout.strip()
-                vartmp_o = lgf.virt_ls_cmd(vm_name, "/var/tmp").stdout.strip()
+                tmp_o = lgf.virt_ls_cmd(vm_name, "/tmp").stdout_text.strip()
+                vartmp_o = lgf.virt_ls_cmd(vm_name, "/var/tmp").stdout_text.strip()
                 status = 1 if tmp_o or vartmp_o else 0
                 return status
             elif action == "firewall-rules":
                 fw_r = lgf.virt_cat_cmd(vm_name,
                                         "/etc/sysconfig/iptables")
-                status = 0 if fw_r.stdout.strip() else 1
+                status = 0 if fw_r.stdout_text.strip() else 1
                 return status
             elif action == "user-account":
                 status = 0
-                pwd_o = lgf.virt_cat_cmd(vm_name, "/etc/passwd").stdout.strip()
-                grp_o = lgf.virt_cat_cmd(vm_name, "/etc/group").stdout.strip()
+                pwd_o = lgf.virt_cat_cmd(vm_name, "/etc/passwd").stdout_text.strip()
+                grp_o = lgf.virt_cat_cmd(vm_name, "/etc/group").stdout_text.strip()
                 if pwd_o.count("test") or grp_o.count("test"):
                     status = 1
                 vm.start()

--- a/libguestfs/tests/virt_volume_operations.py
+++ b/libguestfs/tests/virt_volume_operations.py
@@ -20,7 +20,7 @@ def test_created_volume_group(test, vm, params):
     """
     add_device = params.get("gf_additional_device", "/dev/vdb")
     device_in_lgf = process.run("echo %s | sed -e 's/vd/sd/g'" % add_device,
-                                ignore_status=True, shell=True).stdout.strip()
+                                ignore_status=True, shell=True).stdout_text.strip()
 
     device_part = "%s1" % device_in_lgf
     # Mount specific partition
@@ -79,7 +79,7 @@ def test_created_volume(test, vm, params):
     """
     add_device = params.get("gf_additional_device", "/dev/vdb")
     device_in_lgf = process.run("echo %s | sed -e 's/vd/sd/g'" % add_device,
-                                ignore_status=True, shell=True).stdout.strip()
+                                ignore_status=True, shell=True).stdout_text.strip()
     if utils_test.libguestfs.primary_disk_virtio(vm):
         device_in_vm = add_device
     else:

--- a/libguestfs/tests/virt_win_reg.py
+++ b/libguestfs/tests/virt_win_reg.py
@@ -120,7 +120,7 @@ def run(test, params, env):
         if result.exit_status:
             test.fail(result)
 
-        output_virt_win_reg = result.stdout.strip()
+        output_virt_win_reg = result.stdout_text.strip()
 
         if not vm.is_alive():
             vm.start()


### PR DESCRIPTION
I checked all stdout/stderr is the indirect output of process.run.
So replace them with stdout_text/stderr_text.

Signed-off-by: cuzhang <cuzhang@redhat.com>