### PR TITLE
Add topology correction if provided by test

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_setvcpus.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_setvcpus.cfg
@@ -8,6 +8,7 @@
     setvcpus_max = "4"
     setvcpus_extra_param = ""
     setvcpus_options = ""
+    topology_correction = "yes"
     variants:
         - normal_test:
             status_error = "no"
@@ -64,7 +65,7 @@
                         - id_current_live_option:
                             setvcpus_options = "--current --live"
                         - invalid_id_option:
-                            setvcpus_invalid_id =  "9999"
+                            setvcpus_invalid_id = "9999"
                 - unexpected_domain_option:
                     setvcpus_vm_ref = "\#"
                 - invalid_uuid_option:
@@ -91,10 +92,6 @@
                             # With topology setvcpus api itself fails out
                             # https://bugzilla.redhat.com/show_bug.cgi?id=1426220
                             setvcpus_pre_vm_state = "running"
-                            set_topology = "yes"
-                            sockets='1'
-                            cores= '2'
-                            threads= '2'
                             setvcpus_count = "8"
                             setvcpus_max = "4"
                             setvcpus_options = "--maximum --config"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_setvcpus.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_setvcpus.py
@@ -78,10 +78,7 @@ def run(test, params, env):
     remote_pwd = params.get("remote_pwd", "")
     remote_prompt = params.get("remote_prompt", "#")
     tmpxml = os.path.join(data_dir.get_tmp_dir(), 'tmp.xml')
-    set_topology = (params.get("set_topology", "no") == "yes")
-    sockets = params.get("sockets")
-    cores = params.get("cores")
-    threads = params.get("threads")
+    topology_correction = "yes" == params.get("topology_correction", "yes")
     result = True
 
     # Early death 1.1
@@ -147,17 +144,13 @@ def run(test, params, env):
         # Set maximum vcpus, so we can run all kinds of normal tests without
         # encounter requested vcpus greater than max allowable vcpus error
         topology = vmxml.get_cpu_topology()
-        if all([topology, sockets, cores, threads]) or set_topology:
-            vmxml.set_vm_vcpus(vm_name, max_vcpu, current_vcpu,
-                               sockets, cores, threads, True)
-        else:
-            vmxml.set_vm_vcpus(vm_name, max_vcpu, current_vcpu)
-
         if topology and ("config" and "maximum" in options) and not status_error:
             # https://bugzilla.redhat.com/show_bug.cgi?id=1426220
             vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
             del vmxml.cpu
             vmxml.sync()
+        vmxml.set_vm_vcpus(vm_name, max_vcpu, current_vcpu,
+                           topology_correction=topology_correction)
 
         vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
         logging.debug("Pre-test xml is %s", vmxml.xmltreefile)


### PR DESCRIPTION
Add topology correction argument as provided by
test, to correct if topology mismatch in guest xml

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>