### PR TITLE
Python 3: simply replace stdout&stderr returned by process.run()

### DIFF
--- a/libguestfs/tests/guestfish_file_dir.py
+++ b/libguestfs/tests/guestfish_file_dir.py
@@ -557,7 +557,7 @@ def test_cat(test, vm, params):
     gf_result = gf.cat('/file_ops/file_ascii').stdout.strip()
     logging.debug(gf_result)
     run_result = process.run("tar xOf %s file_ops/file_ascii" % params.get("tarball_path"),
-                             ignore_status=True, shell=True).stdout.strip()
+                             ignore_status=True, shell=True).stdout_text.strip()
     logging.debug(run_result)
     if gf_result != run_result:
         gf.close_session()
@@ -594,7 +594,7 @@ def test_checksum(test, vm, params):
     for k, v in list(checksum_map.items()):
         gf_result = gf.checksum(k, '/file_ops/file_ascii').stdout.strip()
         run_result = process.run("tar xOf %s file_ops/file_ascii | %s" % (params.get("tarball_path"), v),
-                                 ignore_status=True, shell=True).stdout.split()[0]
+                                 ignore_status=True, shell=True).stdout_text.split()[0]
         if gf_result != run_result:
             gf.close_session()
             test.fail("checksum failed.")
@@ -602,7 +602,7 @@ def test_checksum(test, vm, params):
     for k, v in list(checksum_map.items()):
         gf_result = gf.checksum(k, '/file_ops/file_elf').stdout.strip()
         run_result = process.run("tar xOf %s file_ops/file_elf | %s" % (params.get("tarball_path"), v),
-                                 ignore_status=True, shell=True).stdout.split()[0]
+                                 ignore_status=True, shell=True).stdout_text.split()[0]
         if gf_result != run_result:
             gf.close_session()
             test.fail("checksum failed.")
@@ -643,7 +643,7 @@ def test_checksum_device(test, vm, params):
         gf_result = gf.checksum_device(k, '/dev/sda').stdout.strip()
         logging.debug(gf_result.split('\n')[-1])
         run_result = process.run("%s %s" % (v, params.get("image_path")),
-                                 ignore_status=True, shell=True).stdout.split()[0]
+                                 ignore_status=True, shell=True).stdout_text.split()[0]
         logging.debug(run_result)
         if gf_result.split('\n')[-1] != run_result and params.get("image_format") == 'raw':
             gf.close_session()
@@ -693,13 +693,13 @@ def test_checksums_out(test, vm, params):
     gf.download('/test/file_ascii', '/tmp/file_ascii')
     for k, v in list(checksum_map.items()):
         gf_result = gf.checksums_out(k, '/test', '/tmp/sumsfile').stdout.strip()
-        run_result = process.run("cat /tmp/sumsfile", shell=True).stdout.split()
+        run_result = process.run("cat /tmp/sumsfile", shell=True).stdout_text.split()
         if k == 'crc':
             run_result[2] = os.path.basename(run_result[2])
             run_result[5] = os.path.basename(run_result[5])
             guest_res = dict(list(zip(run_result[2::3], run_result[0::3])))
             run_result = process.run("%s /tmp/file_elf /tmp/file_ascii" % v,
-                                     ignore_status=True, shell=True).stdout.split()
+                                     ignore_status=True, shell=True).stdout_text.split()
             run_result[2] = os.path.basename(run_result[2])
             run_result[5] = os.path.basename(run_result[5])
             host_res = dict(list(zip(run_result[2::3], run_result[0::3])))
@@ -708,7 +708,7 @@ def test_checksums_out(test, vm, params):
             run_result[3] = os.path.basename(run_result[3])
             guest_res = dict(list(zip(run_result[1::2], run_result[0::2])))
             run_result = process.run("%s /tmp/file_elf /tmp/file_ascii" % v,
-                                     ignore_status=True, shell=True).stdout.split()
+                                     ignore_status=True, shell=True).stdout_text.split()
             run_result[1] = os.path.basename(run_result[1])
             run_result[3] = os.path.basename(run_result[3])
             host_res = dict(list(zip(run_result[1::2], run_result[0::2])))
@@ -784,8 +784,8 @@ def test_fill(test, vm, params):
     gf_result = gf.download('/newfile', '/tmp/newfile')
     gf_result = gf.rm('/newfile')
 
-    run_result = process.run("for((i=0;i<100;i++)); do echo -n '----------'; done > /tmp/tmp", shell=True).stdout.split()
-    run_result = process.run("cmp /tmp/newfile /tmp/tmp", shell=True).stdout.strip()
+    run_result = process.run("for((i=0;i<100;i++)); do echo -n '----------'; done > /tmp/tmp", shell=True).stdout_text.split()
+    run_result = process.run("cmp /tmp/newfile /tmp/tmp", shell=True).stdout_text.strip()
     if run_result != '':
         gf.close_session()
         test.fail("fill failed.")
@@ -877,8 +877,8 @@ def test_fill_pattern(test, vm, params):
     gf_result = gf.download('/newfile', '/tmp/newfile')
     gf_result = gf.rm('/newfile')
 
-    run_result = process.run("for((i=0;i<125;i++)); do echo -n 'abcdefgh'; done > /tmp/tmp", shell=True).stdout.split()
-    run_result = process.run("cmp /tmp/newfile /tmp/tmp", shell=True).stdout.strip()
+    run_result = process.run("for((i=0;i<125;i++)); do echo -n 'abcdefgh'; done > /tmp/tmp", shell=True).stdout_text.split()
+    run_result = process.run("cmp /tmp/newfile /tmp/tmp", shell=True).stdout_text.strip()
     if run_result != '':
         gf.close_session()
         test.fail("fill-pattern failed.")

--- a/libguestfs/tests/guestfs_add.py
+++ b/libguestfs/tests/guestfs_add.py
@@ -183,7 +183,7 @@ def run(test, params, env):
     # Convert sdx in root to vdx for virtio system disk
     if primary_disk_virtio(vm):
         root = process.run("echo %s | sed -e 's/sd/vd/g'" % root,
-                           ignore_status=True, shell=True).stdout.strip()
+                           ignore_status=True, shell=True).stdout_text.strip()
     if login_to_check:
         try:
             vm.start()

--- a/libguestfs/tests/guestfs_block_operations.py
+++ b/libguestfs/tests/guestfs_block_operations.py
@@ -46,7 +46,7 @@ def test_blockdev_info(test, vm, params):
     """
     add_device = params.get("gf_additional_device", "/dev/vdb")
     device_in_gf = process.run("echo %s | sed -e 's/vd/sd/g'" % add_device,
-                               ignore_status=True, shell=True).stdout.strip()
+                               ignore_status=True, shell=True).stdout_text.strip()
     if utils_test.libguestfs.primary_disk_virtio(vm):
         device_in_vm = add_device
     else:
@@ -161,7 +161,7 @@ def test_blockdev_ro(test, vm, params):
     """
     add_device = params.get("gf_additional_device", "/dev/vdb")
     device_in_gf = process.run("echo %s | sed -e 's/vd/sd/g'" % add_device,
-                               ignore_status=True, shell=True).stdout.strip()
+                               ignore_status=True, shell=True).stdout_text.strip()
 
     vt = utils_test.libguestfs.VirtTools(vm, params)
     # Create a new vm with additional disk
@@ -248,7 +248,7 @@ def test_blockdev_rw(test, vm, params):
     """
     add_device = params.get("gf_additional_device", "/dev/vdb")
     device_in_gf = process.run("echo %s | sed -e 's/vd/sd/g'" % add_device,
-                               ignore_status=True, shell=True).stdout.strip()
+                               ignore_status=True, shell=True).stdout_text.strip()
     if utils_test.libguestfs.primary_disk_virtio(vm):
         device_in_vm = add_device
     else:

--- a/libguestfs/tests/guestfs_file_operations.py
+++ b/libguestfs/tests/guestfs_file_operations.py
@@ -131,7 +131,7 @@ def test_tar_out(test, vm, params):
     if cat_result.exit_status:
         test.fail("Cat file failed.")
     else:
-        if not re.search(content, cat_result.stdout):
+        if not re.search(content, cat_result.stdout_text):
             test.fail("Catted file do not match.")
 
 
@@ -229,7 +229,7 @@ def test_copy_out(test, vm, params):
 
     # Check file
     cat_result = process.run("cat %s" % path, ignore_status=True, shell=True)
-    logging.debug(cat_result.stdout)
+    logging.debug(cat_result.stdout_text)
     try:
         os.remove(path)
     except IOError as detail:
@@ -237,7 +237,7 @@ def test_copy_out(test, vm, params):
     if cat_result.exit_status:
         test.fail("Cat file failed.")
     else:
-        if not re.search(content, cat_result.stdout):
+        if not re.search(content, cat_result.stdout_text):
             test.fail("Catted file do not match.")
 
 

--- a/libguestfs/tests/guestfs_part_operations.py
+++ b/libguestfs/tests/guestfs_part_operations.py
@@ -20,7 +20,7 @@ def test_formatted_part(test, vm, params):
     """
     add_device = params.get("gf_additional_device", "/dev/vdb")
     device_in_gf = process.run("echo %s | sed -e 's/vd/sd/g'" % add_device,
-                               ignore_status=True, shell=True).stdout.strip()
+                               ignore_status=True, shell=True).stdout_text.strip()
     if utils_test.libguestfs.primary_disk_virtio(vm):
         device_in_vm = add_device
     else:
@@ -122,7 +122,7 @@ def test_unformatted_part(test, vm, params):
     """
     add_device = params.get("gf_additional_device", "/dev/vdb")
     device_in_gf = process.run("echo %s | sed -e 's/vd/sd/g'" % add_device,
-                               ignore_status=True, shell=True).stdout.strip()
+                               ignore_status=True, shell=True).stdout_text.strip()
 
     vt = utils_test.libguestfs.VirtTools(vm, params)
     # Create a new vm with additional disk
@@ -173,7 +173,7 @@ def test_formatted_disk(test, vm, params):
     """
     add_device = params.get("gf_additional_device", "/dev/vdb")
     device_in_gf = process.run("echo %s | sed -e 's/vd/sd/g'" % add_device,
-                               ignore_status=True, shell=True).stdout.strip()
+                               ignore_status=True, shell=True).stdout_text.strip()
     if utils_test.libguestfs.primary_disk_virtio(vm):
         device_in_vm = add_device
     else:
@@ -317,7 +317,7 @@ def test_fscked_partition(test, vm, params):
     """
     add_device = params.get("gf_additional_device", "/dev/vdb")
     device_in_gf = process.run("echo %s | sed -e 's/vd/sd/g'" % add_device,
-                               ignore_status=True, shell=True).stdout.strip()
+                               ignore_status=True, shell=True).stdout_text.strip()
 
     vt = utils_test.libguestfs.VirtTools(vm, params)
     # Create a new vm with additional disk

--- a/libguestfs/tests/guestfs_volume_operations.py
+++ b/libguestfs/tests/guestfs_volume_operations.py
@@ -48,7 +48,7 @@ def test_create_vol_group(test, vm, params):
     """
     add_device = params.get("gf_additional_device", "/dev/vdb")
     device_in_gf = process.run("echo %s | sed -e 's/vd/sd/g'" % add_device,
-                               ignore_status=True, shell=True).stdout.strip()
+                               ignore_status=True, shell=True).stdout_text.strip()
 
     vt = utils_test.libguestfs.VirtTools(vm, params)
     # Create a new vm with additional disk
@@ -117,7 +117,7 @@ def test_rename_vol_group(test, vm, params):
     """
     add_device = params.get("gf_additional_device", "/dev/vdb")
     device_in_gf = process.run("echo %s | sed -e 's/vd/sd/g'" % add_device,
-                               ignore_status=True, shell=True).stdout.strip()
+                               ignore_status=True, shell=True).stdout_text.strip()
 
     vt = utils_test.libguestfs.VirtTools(vm, params)
     # Create a new vm with additional disk
@@ -195,7 +195,7 @@ def test_remove_vol_group(test, vm, params):
     """
     add_device = params.get("gf_additional_device", "/dev/vdb")
     device_in_gf = process.run("echo %s | sed -e 's/vd/sd/g'" % add_device,
-                               ignore_status=True, shell=True).stdout.strip()
+                               ignore_status=True, shell=True).stdout_text.strip()
 
     vt = utils_test.libguestfs.VirtTools(vm, params)
     # Create a new vm with additional disk
@@ -256,7 +256,7 @@ def test_create_volume(test, vm, params):
     """
     add_device = params.get("gf_additional_device", "/dev/vdb")
     device_in_gf = process.run("echo %s | sed -e 's/vd/sd/g'" % add_device,
-                               ignore_status=True, shell=True).stdout.strip()
+                               ignore_status=True, shell=True).stdout_text.strip()
 
     vt = utils_test.libguestfs.VirtTools(vm, params)
     # Create a new vm with additional disk
@@ -360,7 +360,7 @@ def test_delete_volume(test, vm, params):
     """
     add_device = params.get("gf_additional_device", "/dev/vdb")
     device_in_gf = process.run("echo %s | sed -e 's/vd/sd/g'" % add_device,
-                               ignore_status=True, shell=True).stdout.strip()
+                               ignore_status=True, shell=True).stdout_text.strip()
 
     vt = utils_test.libguestfs.VirtTools(vm, params)
     # Create a new vm with additional disk
@@ -444,7 +444,7 @@ def test_shrink_volume(test, vm, params):
     """
     add_device = params.get("gf_additional_device", "/dev/vdb")
     device_in_gf = process.run("echo %s | sed -e 's/vd/sd/g'" % add_device,
-                               ignore_status=True, shell=True).stdout.strip()
+                               ignore_status=True, shell=True).stdout_text.strip()
 
     vt = utils_test.libguestfs.VirtTools(vm, params)
     # Create a new vm with additional disk
@@ -597,7 +597,7 @@ def test_expand_volume(test, vm, params):
     """
     add_device = params.get("gf_additional_device", "/dev/vdb")
     device_in_gf = process.run("echo %s | sed -e 's/vd/sd/g'" % add_device,
-                               ignore_status=True, shell=True).stdout.strip()
+                               ignore_status=True, shell=True).stdout_text.strip()
 
     vt = utils_test.libguestfs.VirtTools(vm, params)
     # Create a new vm with additional disk

--- a/libguestfs/tests/virt_edit.py
+++ b/libguestfs/tests/virt_edit.py
@@ -110,7 +110,7 @@ def run(test, params, env):
         logging.info("disk to be edit:%s", vm_ref)
         if test_format:
             # Get format:raw or qcow2
-            info = process.run("qemu-img info %s" % vm_ref, shell=True).stdout
+            info = process.run("qemu-img info %s" % vm_ref, shell=True).stdout_text
             for line in info.splitlines():
                 comps = line.split(':')
                 if comps[0].count("format"):

--- a/libguestfs/tests/virt_file_operations.py
+++ b/libguestfs/tests/virt_file_operations.py
@@ -148,7 +148,7 @@ def test_virt_tar_out(test, vm, params):
     if cat_result.exit_status:
         test.fail("Cat file failed.")
     else:
-        if not re.search(content, cat_result.stdout):
+        if not re.search(content, cat_result.stdout_text):
             test.fail("Catted file do not match.")
 
 
@@ -255,7 +255,7 @@ def test_virt_copy_out(test, vm, params):
 
     # Check file
     cat_result = process.run("cat %s" % path, ignore_status=True, shell=True)
-    logging.debug(cat_result.stdout)
+    logging.debug(cat_result.stdout_text)
     try:
         os.remove(path)
     except IOError as detail:
@@ -263,7 +263,7 @@ def test_virt_copy_out(test, vm, params):
     if cat_result.exit_status:
         test.fail("Cat file failed.")
     else:
-        if not re.search(content, cat_result.stdout):
+        if not re.search(content, cat_result.stdout_text):
             test.fail("Catted file do not match.")
 
 

--- a/libguestfs/tests/virt_part_operations.py
+++ b/libguestfs/tests/virt_part_operations.py
@@ -21,7 +21,7 @@ def test_unformatted_part(test, vm, params):
     """
     add_device = params.get("gf_additional_device", "/dev/vdb")
     device_in_lgf = process.run("echo %s | sed -e 's/vd/sd/g'" % add_device,
-                                ignore_status=True, shell=True).stdout.strip()
+                                ignore_status=True, shell=True).stdout_text.strip()
 
     device_part = "%s1" % device_in_lgf
     # Mount specific partition
@@ -62,7 +62,7 @@ def test_formatted_part(test, vm, params):
     """
     add_device = params.get("gf_additional_device", "/dev/vdb")
     device_in_lgf = process.run("echo %s | sed -e 's/vd/sd/g'" % add_device,
-                                ignore_status=True, shell=True).stdout.strip()
+                                ignore_status=True, shell=True).stdout_text.strip()
     if utils_test.libguestfs.primary_disk_virtio(vm):
         device_in_vm = add_device
     else:

--- a/libguestfs/tests/virt_volume_operations.py
+++ b/libguestfs/tests/virt_volume_operations.py
@@ -20,7 +20,7 @@ def test_created_volume_group(test, vm, params):
     """
     add_device = params.get("gf_additional_device", "/dev/vdb")
     device_in_lgf = process.run("echo %s | sed -e 's/vd/sd/g'" % add_device,
-                                ignore_status=True, shell=True).stdout.strip()
+                                ignore_status=True, shell=True).stdout_text.strip()
 
     device_part = "%s1" % device_in_lgf
     # Mount specific partition
@@ -79,7 +79,7 @@ def test_created_volume(test, vm, params):
     """
     add_device = params.get("gf_additional_device", "/dev/vdb")
     device_in_lgf = process.run("echo %s | sed -e 's/vd/sd/g'" % add_device,
-                                ignore_status=True, shell=True).stdout.strip()
+                                ignore_status=True, shell=True).stdout_text.strip()
     if utils_test.libguestfs.primary_disk_virtio(vm):
         device_in_vm = add_device
     else:

--- a/libguestfs/tests/virt_win_reg.py
+++ b/libguestfs/tests/virt_win_reg.py
@@ -120,7 +120,7 @@ def run(test, params, env):
         if result.exit_status:
             test.fail(result)
 
-        output_virt_win_reg = result.stdout.strip()
+        output_virt_win_reg = result.stdout_text.strip()
 
         if not vm.is_alive():
             vm.start()

--- a/provider/v2v_vmcheck_helper.py
+++ b/provider/v2v_vmcheck_helper.py
@@ -91,7 +91,7 @@ class VMChecker(object):
         Compare virt-v2v version against given version.
         """
         cmd = 'rpm -q virt-v2v|grep virt-v2v'
-        v2v_version = LooseVersion(process.run(cmd, shell=True).stdout.strip())
+        v2v_version = LooseVersion(process.run(cmd, shell=True).stdout_text.strip())
         compare_version = LooseVersion(compare_version)
         if v2v_version > compare_version:
             return True

--- a/v2v/tests/src/function_test_xen.py
+++ b/v2v/tests/src/function_test_xen.py
@@ -320,7 +320,7 @@ def run(test, params, env):
                 cmd = "sed -i 's|%s|%s|' %s" % (params['remote_disk_image'],
                                                 params['img_path'], xml_file)
                 process.run(cmd)
-                logging.debug(process.run('cat %s' % xml_file).stdout)
+                logging.debug(process.run('cat %s' % xml_file).stdout_text)
             if checkpoint == 'format_convert':
                 v2v_params['output_format'] = 'qcow2'
         if checkpoint == 'ssh_banner':

--- a/v2v/tests/src/v2v_options.py
+++ b/v2v/tests/src/v2v_options.py
@@ -313,7 +313,7 @@ def run(test, params, env):
         """
         Check if content of man page or help info meets expectation
         """
-        man_page = process.run('man virt-v2v', verbose=False).stdout.strip()
+        man_page = process.run('man virt-v2v', verbose=False).stdout_text.strip()
         if in_man:
             logging.info('Checking man page of virt-v2v for "%s"', in_man)
             if in_man not in man_page:
@@ -442,7 +442,7 @@ def run(test, params, env):
             if checkpoint == 'compress':
                 img_path = get_img_path(output)
                 logging.info('Image path: %s', img_path)
-                disk_check = process.run('qemu-img check %s' % img_path).stdout
+                disk_check = process.run('qemu-img check %s' % img_path).stdout_text
                 logging.info(disk_check)
                 compress_info = disk_check.split(',')[-1].split('%')[0].strip()
                 compress_rate = float(compress_info)


### PR DESCRIPTION
This patch replace stdout&stderr returned  by process.run() for all
python file under libguestfs, provider and v2v.

s/stdout/stdout_text/
s/stderr/stderr_text/

we will modify others stdout&stderr returned not by process methods
in avocado-vt git, which will let us no need to do replacement for
them one by one in tp-libvirt.

Signed-off-by: cuzhang <cuzhang@redhat.com>