### PR TITLE
Travis.yaml: Add filter W605

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ install:
     - pip install -r requirements-travis.txt
 
 script:
-    - inspekt checkall --disable-style E501,E265,W601,E402,E722,E741 --no-license-check
+    - inspekt checkall --disable-style E501,E265,W601,W605,E402,E722,E741 --no-license-check


### PR DESCRIPTION
This PR is to fix issue below during inspekt style check,
so many failures raised with '\'. However it has ever been
successful before

.../virsh_net_create.py:120:44:
W605 invalid escape sequence '\>'

Signed-off-by: Yan Li <yannli@redhat.com>