### PR TITLE
Python 3: Fix missing call parameter issue

### DIFF
--- a/libvirt/tests/src/libvirt_qemu_cmdline.py
+++ b/libvirt/tests/src/libvirt_qemu_cmdline.py
@@ -110,7 +110,7 @@ def run(test, params, env):
     virsh_dargs = {'debug': True, 'ignore_status': False}
     try:
         # Run test case
-        qemu_flags = testcase(vmxml, **test_dargs)
+        qemu_flags = testcase(test, vmxml, **test_dargs)
         result = virsh.start(vm_name, **virsh_dargs)
         libvirt.check_exit_status(result, expect_fail)
 


### PR DESCRIPTION
config_feature_*() need 3 parameters, so fix it to add
missing 'test' argument.

Signed-off-by: cuzhang <cuzhang@redhat.com>