### PR TITLE
Python 3: Permission denial re-fix for acceptance test

### DIFF
--- a/libvirt/tests/src/svirt/dac_nfs_disk.py
+++ b/libvirt/tests/src/svirt/dac_nfs_disk.py
@@ -13,6 +13,7 @@ from virttest import utils_libvirtd
 from virttest.utils_test import libvirt as utlv
 from virttest.libvirt_xml import xcepts
 from virttest.libvirt_xml.vm_xml import VMXML
+from virttest import data_dir
 
 
 def check_ownership(file_path):
@@ -154,7 +155,7 @@ def run(test, params, env):
 
         # Init a QemuImg instance and create img on nfs server dir.
         params['image_name'] = vol_name
-        tmp_dir = test.tmpdir
+        tmp_dir = data_dir.get_tmp_dir()
         nfs_path = os.path.join(tmp_dir, nfs_server_dir)
         image = qemu_storage.QemuImg(params, nfs_path, vol_name)
         # Create a image.

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk.py
@@ -15,6 +15,7 @@ from virttest.utils_test import libvirt
 from virttest.staging.service import Factory
 from virttest.staging import lv_utils
 from virttest import utils_misc
+from virttest import data_dir
 
 from provider import libvirt_version
 
@@ -176,7 +177,7 @@ def run(test, params, env):
     backup_xml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
 
     # Create virtual device file.
-    device_source_path = os.path.join(test.tmpdir, device_source_name)
+    device_source_path = os.path.join(data_dir.get_tmp_dir(), device_source_name)
     if test_block_dev:
         device_source = libvirt.setup_or_cleanup_iscsi(True)
         if not device_source:
@@ -389,7 +390,7 @@ def run(test, params, env):
     # Eject cdrom test
     eject_cdrom = "yes" == params.get("at_dt_disk_eject_cdrom", "no")
     save_vm = "yes" == params.get("at_dt_disk_save_vm", "no")
-    save_file = os.path.join(test.tmpdir, "vm.save")
+    save_file = os.path.join(data_dir.get_tmp_dir(), "vm.save")
     try:
         if eject_cdrom:
             eject_params = {'type_name': "file", 'device_type': "cdrom",

--- a/libvirt/tests/src/virsh_cmd/interface/virsh_iface.py
+++ b/libvirt/tests/src/virsh_cmd/interface/virsh_iface.py
@@ -10,6 +10,7 @@ from virttest import remote
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 from virttest.staging import service
+from virttest import data_dir
 
 from provider import libvirt_version
 
@@ -175,7 +176,7 @@ def run(test, params, env):
     if vm:
         xml_bak = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     iface_script = NETWORK_SCRIPT + iface_name
-    iface_script_bk = os.path.join(test.tmpdir, "iface-%s.bk" % iface_name)
+    iface_script_bk = os.path.join(data_dir.get_tmp_dir(), "iface-%s.bk" % iface_name)
     net_bridge = utils_net.Bridge()
     if use_exist_iface:
         if iface_type == "bridge":
@@ -194,7 +195,7 @@ def run(test, params, env):
     if use_exist_iface:
         if not libvirt.check_iface(iface_name, "exists", "--all"):
             test.error("Interface '%s' not exists" % iface_name)
-        iface_xml = os.path.join(test.tmpdir, "iface.xml.tmp")
+        iface_xml = os.path.join(data_dir.get_tmp_dir(), "iface.xml.tmp")
         iface_is_up = net_iface.is_up()
     else:
         # Note, if not use the interface which already exists, iface_name must
@@ -203,7 +204,7 @@ def run(test, params, env):
             test.error("Interface '%s' already exists" % iface_name)
         if not iface_xml:
             test.error("XML file is needed.")
-        iface_xml = os.path.join(test.tmpdir, iface_xml)
+        iface_xml = os.path.join(data_dir.get_tmp_dir(), iface_xml)
         create_xml_file(iface_xml, params)
 
     # Stop NetworkManager as which may conflict with virsh iface commands

--- a/libvirt/tests/src/virtual_disks/virtual_disks_ceph.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_ceph.py
@@ -17,6 +17,7 @@ from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import vol_xml
 from virttest.libvirt_xml import pool_xml
 from virttest.libvirt_xml import secret_xml
+from virttest import data_dir
 
 
 def run(test, params, env):
@@ -216,7 +217,7 @@ def run(test, params, env):
         """
         Test save and restore operation
         """
-        save_file = os.path.join(test.tmpdir,
+        save_file = os.path.join(data_dir.get_tmp_dir(),
                                  "%s.save" % vm_name)
         ret = virsh.save(vm_name, save_file, **virsh_dargs)
         libvirt.check_exit_status(ret)
@@ -232,8 +233,8 @@ def run(test, params, env):
         Test snapshot operation.
         """
         snap_name = "s1"
-        snap_mem = os.path.join(test.tmpdir, "rbd.mem")
-        snap_disk = os.path.join(test.tmpdir, "rbd.disk")
+        snap_mem = os.path.join(data_dir.get_tmp_dir(), "rbd.mem")
+        snap_disk = os.path.join(data_dir.get_tmp_dir(), "rbd.disk")
         xml_snap_exp = ["disk name='%s' snapshot='external' type='file'" % target_dev]
         xml_dom_exp = ["source file='%s'" % snap_disk,
                        "backingStore type='network' index='1'",
@@ -276,7 +277,7 @@ def run(test, params, env):
         """
         Block copy operation test.
         """
-        blk_file = os.path.join(test.tmpdir, "blk.rbd")
+        blk_file = os.path.join(data_dir.get_tmp_dir, "blk.rbd")
         if os.path.exists(blk_file):
             os.remove(blk_file)
         blk_mirror = ("mirror type='file' file='%s' "
@@ -468,10 +469,10 @@ def run(test, params, env):
     vmxml_backup = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     key_opt = ""
     secret_uuid = None
-    key_file = os.path.join(test.tmpdir, "ceph.key")
-    img_file = os.path.join(test.tmpdir,
+    key_file = os.path.join(data_dir.get_tmp_dir(), "ceph.key")
+    img_file = os.path.join(data_dir.get_tmp_dir(),
                             "%s_test.img" % vm_name)
-    front_end_img_file = os.path.join(test.tmpdir,
+    front_end_img_file = os.path.join(data_dir.get_tmp_dir(),
                                       "%s_frontend_test.img" % vm_name)
     # Construct a unsupported error message list to skip these kind of tests
     unsupported_err = []

--- a/libvirt/tests/src/virtual_disks/virtual_disks_usb.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_usb.py
@@ -11,6 +11,7 @@ from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.disk import Disk
 from virttest.libvirt_xml.devices.controller import Controller
+from virttest import data_dir
 
 
 def run(test, params, env):
@@ -142,7 +143,7 @@ def run(test, params, env):
         image_filename = params.get("image_filename", "raw.img")
         image_format = params.get("image_format", "raw")
         image_size = params.get("image_size", "1G")
-        image_path = os.path.join(test.tmpdir, image_filename)
+        image_path = os.path.join(data_dir.get_tmp_dir(), image_filename)
         try:
             if image_format in ["raw", "qcow2"]:
                 image_path = libvirt.create_local_disk("file",


### PR DESCRIPTION
Refix for commit d910ba9. Previously test.tmpdir is used by tp-libvirt
to store test images for case running. However avocado master 60 did
some changes(avocado #2543), where the tmpdir isn't accessable by public
user anymore. So need to change to virttest.data_dir.get_tmp_dir to
provide public access. This PR only updated the acceptance test, and
will apply to all tp-libvirt test cases after acceptance test passed in CI

Signed-off-by: Yan Li <yannli@redhat.com>