### PR TITLE
fix delet snapshot error in multidisks

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
@@ -1520,6 +1520,9 @@ def run(test, params, env):
     finally:
         # Delete snapshots.
         if virsh.domain_exists(vm_name):
+            #To Delet snapshot, destroy vm first.
+            if vm.is_alive():
+                vm.destroy()
             libvirt.clean_up_snapshots(vm_name, domxml=vmxml_backup)
 
         # Recover VM.


### PR DESCRIPTION
If we want to clean up the snapshots successfully in the recover process of the test, we need to destroy vm.
Signed-off-by: zonqi <zonqi@redhat.com>