### PR TITLE
Add more plug options for interface

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_hotplug.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_hotplug.cfg
@@ -2,7 +2,6 @@
     type = iface_hotplug
     take_regular_screendumps = "no"
     start_vm = "yes"
-    status_error = "no"
     poll_timeout = 10
     variants:
         - iface_attach:
@@ -27,12 +26,40 @@
                     iface_mac  = "9a:9b:b9:f5:51:b0"
                     detach_device = "no"
                 - options_test:
-                    start_vm = "no"
+                    options_test = "yes"
+                    err_msgs1 = "domain is not running"
+                    err_msgs2 = "are mutually exclusive"
+                    only model_virtio
+                    variants:
+                        - active:
+                            start_vm = "yes"
+                        - inactive:
+                            start_vm = "no"
                     variants:
                         - default:
-                            status_error = "yes"
+                            attach_option = ""
                         - persistent:
                             attach_option = "--persistent"
+                        - current:
+                            attach_option = "--current"
+                        - live:
+                            attach_option = "--live"
+                        - config:
+                            attach_option = "--config"
+                        - live_config:
+                            attach_option = "--live --config"
+                        - current_cofig:
+                            attach_option = "--current --config"
+                        - live_persistent:
+                            attach_option = "--live --persistent"
+                        - live_current:
+                            attach_option = "--live --current"
+                        - current_persistent:
+                            attach_option = "--current --persistent"
+                        - config_persistent:
+                            attach_option = "--config --persistent"
+                        - live_config_persistent:
+                            attach_option = "--live --config --persistent"
                 - stress_test:
                     iface_num = '500'
                     stress_test = "yes" 


### PR DESCRIPTION
Add more plug optinos "--config" "--current" and the combination of
them for attach-device and attach-interface. And test the options both
when vm is running or inactive.

Signed-off-by: yalzhang <yalzhang@redhat.com>