### PR TITLE
virsh_pool:Fixup virsh_pool_test not found

### DIFF
--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool.py
@@ -81,7 +81,7 @@ def run(test, params, env):
         # Get the list stored in a variable
         result = virsh.pool_list(option, ignore_status=True)
         utlv.check_exit_status(result, False)
-        output = re.findall(r"(\S+)\ +(\S+)\ +(\S+)[\ +\n]",
+        output = re.findall(r"(\S+)\ +(\S+)\ +(\S+)",
                             str(result.stdout.strip()))
         for item in output:
             if pool_name in item[0]:


### PR DESCRIPTION
The stdout has been stripped, so no need to
match whitespace or "\n" at the end of the
string

Signed-off-by: Yan Li <yannli@redhat.com>