### PR TITLE
Remove "\n" matching pattern in stdout

### DIFF
--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool.py
@@ -108,7 +108,7 @@ def run(test, params, env):
         result = virsh.vol_list(pool_name, ignore_status=True)
         utlv.check_exit_status(result)
 
-        output = re.findall(r"(\S+)\ +(\S+)[\ +\n]", str(result.stdout.strip()))
+        output = re.findall(r"(\S+)\ +(\S+)", str(result.stdout.strip()))
         for item in output:
             if vol_name in item[0]:
                 found = True

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool_acl.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool_acl.py
@@ -94,7 +94,7 @@ def run(test, params, env):
         else:
             result = virsh.pool_list(option, ignore_status=True)
         utlv.check_exit_status(result, False)
-        output = re.findall(r"(\S+)\ +(\S+)\ +(\S+)[\ +\n]",
+        output = re.findall(r"(\S+)\ +(\S+)\ +(\S+)",
                             str(result.stdout.strip()))
         for item in output:
             if pool_name in item[0]:

--- a/libvirt/tests/src/virt_cmd/virt_xml_validate.py
+++ b/libvirt/tests/src/virt_cmd/virt_xml_validate.py
@@ -60,7 +60,7 @@ def storagepool_validate(test, pool_name, file=None, **virsh_dargs):
     # Confirm the storagepool exists.
     found = False
     result = virsh.pool_list(ignore_status=True)
-    output = re.findall(r"(\S+)\ +(\S+)\ +(\S+)[\ +\n]", str(result.stdout.strip()))
+    output = re.findall(r"(\S+)\ +(\S+)\ +(\S+)", str(result.stdout.strip()))
     for item in output[1:]:
         if pool_name == item[0]:
             found = True
@@ -84,7 +84,7 @@ def storagevol_validate(test, pool_name, file=None, **virsh_dargs):
     # Confirm the storagepool exists.
     found = False
     result = virsh.pool_list(ignore_status=True)
-    output = re.findall(r"(\S+)\ +(\S+)\ +(\S+)[\ +\n]", str(result.stdout.strip()))
+    output = re.findall(r"(\S+)\ +(\S+)\ +(\S+)", str(result.stdout.strip()))
     for item in output[1:]:
         if pool_name == item[0]:
             found = True
@@ -96,7 +96,7 @@ def storagevol_validate(test, pool_name, file=None, **virsh_dargs):
     cmd_result = virsh.vol_list(pool_name, **virsh_dargs)
     libvirt.check_exit_status(cmd_result)
     try:
-        vol_name = re.findall(r"(\S+)\ +(\S+)[\ +\n]", str(cmd_result.stdout.strip()))[1][0]
+        vol_name = re.findall(r"(\S+)\ +(\S+)", str(cmd_result.stdout.strip()))[1][0]
     except IndexError:
         test.error("Fail to get volume name")
 
@@ -133,7 +133,7 @@ def nwfilter_validate(test, file=None, **virsh_dargs):
     cmd_result = virsh.nwfilter_list(**virsh_dargs)
     libvirt.check_exit_status(cmd_result)
     try:
-        uuid = re.findall(r"(\S+)\ +(\S+)[\ +\n]", str(cmd_result.stdout.strip()))[1][0]
+        uuid = re.findall(r"(\S+)\ +(\S+)", str(cmd_result.stdout.strip()))[1][0]
     except IndexError:
         test.error("Fail to get nwfilter uuid")
 
@@ -149,7 +149,7 @@ def secret_validate(test, file=None, **virsh_dargs):
     cmd_result = virsh.secret_list(**virsh_dargs)
     libvirt.check_exit_status(cmd_result)
     try:
-        uuid = re.findall(r"(\S+)\ +(\S+)[\ +\n]", str(cmd_result.stdout.strip()))[1][0]
+        uuid = re.findall(r"(\S+)\ +(\S+)", str(cmd_result.stdout.strip()))[1][0]
     except IndexError:
         test.error("Fail to get secret uuid")
 
@@ -167,7 +167,7 @@ def interface_validate(test, file=None, **virsh_dargs):
     cmd_result = virsh.iface_list(**virsh_dargs)
     libvirt.check_exit_status(cmd_result)
     try:
-        iface_name = re.findall(r"(\S+)\ +(\S+)\ +(\S+)[\ +\n]",
+        iface_name = re.findall(r"(\S+)\ +(\S+)\ +(\S+)",
                                 str(cmd_result.stdout.strip()))[1][0]
     except IndexError:
         test.error("Fail to get iface name")

--- a/libvirt/tests/src/virtual_disks/at_dt_iscsi_disk.py
+++ b/libvirt/tests/src/virtual_disks/at_dt_iscsi_disk.py
@@ -142,7 +142,7 @@ def run(test, params, env):
                 cmd_result = virsh.vol_list(disk_src_pool, **virsh_dargs)
                 libvirt.check_exit_status(cmd_result)
                 vol_list = []
-                vol_list = re.findall(r"(\S+)\ +(\S+)[\ +\n]",
+                vol_list = re.findall(r"(\S+)\ +(\S+)",
                                       str(cmd_result.stdout.strip()))
                 if len(vol_list) > 1:
                     return vol_list[1]

--- a/libvirt/tests/src/virtual_disks/startup_policy.py
+++ b/libvirt/tests/src/virtual_disks/startup_policy.py
@@ -90,7 +90,7 @@ def run(test, params, env):
             cmd_result = virsh.vol_list(pool_name, **virsh_dargs)
             libvirt.check_exit_status(cmd_result)
             vol_list = []
-            vol_list = re.findall(r"(\S+)\ +(\S+)[\ +\n]",
+            vol_list = re.findall(r"(\S+)\ +(\S+)",
                                   str(cmd_result.stdout.strip()))
             try:
                 return vol_list[1]

--- a/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
@@ -643,7 +643,7 @@ def run(test, params, env):
             cmd_result = virsh.vol_list(pool_name, **virsh_dargs)
             libvirt.check_exit_status(cmd_result)
             vol_list = []
-            vol_list = re.findall(r"(\S+)\ +(\S+)[\ +\n]",
+            vol_list = re.findall(r"(\S+)\ +(\S+)",
                                   str(cmd_result.stdout.strip()))
             if len(vol_list) > 1:
                 return vol_list[1]


### PR DESCRIPTION
Since stdout are stripped during Porting, the old
pattern matching "\n" shall be removed. Bundles of
cases are failed by this

Signed-off-by: Yan Li <yannli@redhat.com>