### PR TITLE
Python 3: Replace process.system_output

### DIFF
--- a/libvirt/tests/src/libvirt_pci_passthrough_hotplug.py
+++ b/libvirt/tests/src/libvirt_pci_passthrough_hotplug.py
@@ -31,6 +31,7 @@ from virttest import utils_package
 from virttest import utils_net
 from provider import libvirt_version
 from virttest.utils_test import libvirt
+from virttest.compat_52lts import decode_to_text as to_text
 
 
 def run(test, params, env):
@@ -121,13 +122,13 @@ def run(test, params, env):
             pci_value = pci_value.replace(".", "_")
             cmd = "lspci -ks %s | grep 'Kernel driver in use' |\
                    awk '{print $5}'" % pci_node
-            driver_name = process.system_output(cmd, shell=True).strip()
+            driver_name = to_text(process.system_output(cmd, shell=True).strip())
             if driver_name == "vfio-pci":
                 logging.debug("device alreay detached")
             else:
                 if virsh.nodedev_detach(pci_value).exit_status:
                     test.error("Hostdev node detach failed")
-                driver_name = process.system_output(cmd, shell=True).strip()
+                driver_name = to_text(process.system_output(cmd, shell=True).strip())
                 if driver_name != "vfio-pci":
                     test.error("driver bind failed after detach")
 
@@ -137,13 +138,13 @@ def run(test, params, env):
             pci_value = pci_value.replace(".", "_")
             cmd = "lspci -ks %s | grep 'Kernel driver in use' |\
                    awk '{print $5}'" % pci_node
-            driver_name = process.system_output(cmd, shell=True).strip()
+            driver_name = to_text(process.system_output(cmd, shell=True).strip())
             if driver_name != "vfio-pci":
                 logging.debug("device alreay attached")
             else:
                 if virsh.nodedev_reattach(pci_value).exit_status:
                     test.fail("Hostdev node reattach failed")
-                driver_name = process.system_output(cmd, shell=True).strip()
+                driver_name = to_text(process.system_output(cmd, shell=True).strip())
                 if driver_name == "vfio-pci":
                     test.error("driver bind failed after reattach")
 

--- a/libvirt/tests/src/limit.py
+++ b/libvirt/tests/src/limit.py
@@ -13,6 +13,7 @@ from virttest import libvirt_xml
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml.devices.interface import Interface
 from virttest.libvirt_xml.devices.disk import Disk
+from virttest.compat_52lts import decode_to_text as to_text
 
 
 def run(test, params, env):
@@ -68,7 +69,7 @@ def run(test, params, env):
                 test.cancel("block partition is not given")
             # Check if valid partition or raise
             cmd = "blkid /dev/%s|awk -F" " '{print $2}'" % blk_partition
-            output = process.system_output(cmd, shell=True)
+            output = to_text(process.system_output(cmd, shell=True))
             if "UUID" not in output:
                 test.cancel("Not a valid partition given for swap creation")
             # Create swap partition

--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -37,6 +37,7 @@ from virttest.utils_net import IPv6Manager
 from virttest.utils_net import block_specific_ip_by_time
 from virttest.utils_net import check_listening_port_remote_by_service
 from virttest.utils_test import libvirt
+from virttest.compat_52lts import decode_to_text as to_text
 
 MIGRATE_RET = False
 
@@ -375,7 +376,7 @@ def get_cpu_xml_from_virsh_caps(runner=None):
     cmd = "virsh capabilities | awk '/<cpu>/,/<\/cpu>/'"
     out = ""
     if not runner:
-        out = process.system_output(cmd, shell=True)
+        out = to_text(process.system_output(cmd, shell=True))
     else:
         out = runner(cmd)
 
@@ -480,7 +481,7 @@ def delete_video_device(vm_name):
     for graphic in graphics:
         vmxml.del_device(graphic)
     vmxml.sync()
-    vm_xml_cxt = process.system_output("virsh dumpxml %s" % vm_name, shell=True)
+    vm_xml_cxt = to_text(process.system_output("virsh dumpxml %s" % vm_name, shell=True))
     logging.debug("The VM XML after deleting video device: \n%s", vm_xml_cxt)
 
 
@@ -1136,7 +1137,7 @@ def run(test, params, env):
     os_ver_cmd = "cat /etc/redhat-release"
 
     if os_ver_from:
-        curr_os_ver = process.system_output(os_ver_cmd, shell=True)
+        curr_os_ver = to_text(process.system_output(os_ver_cmd, shell=True))
         if os_ver_from not in curr_os_ver:
             raise exceptions.TestSkipError("The current OS is %s"
                                            % curr_os_ver)
@@ -1209,7 +1210,7 @@ def run(test, params, env):
     first_disk = vm.get_first_disk_devices()
     disk_source = first_disk['source']
     logging.debug("disk source: %s", disk_source)
-    curr_vm_xml = process.system_output('cat %s' % vmxml_backup.xml, shell=True)
+    curr_vm_xml = to_text(process.system_output('cat %s' % vmxml_backup.xml, shell=True))
     logging.debug("The current VM XML contents: \n%s", curr_vm_xml)
     orig_image_name = os.path.basename(disk_source)
 
@@ -1257,7 +1258,7 @@ def run(test, params, env):
                            target, transport=iscsi_transport)
 
             vmxml_iscsi = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
-            curr_vm_xml = process.system_output('cat %s' % vmxml_iscsi.xml, shell=True)
+            curr_vm_xml = to_text(process.system_output('cat %s' % vmxml_iscsi.xml, shell=True))
             logging.debug("The current VM XML contents: \n%s", curr_vm_xml)
 
         del_vm_video_dev = "yes" == test_dict.get("del_vm_video_dev", "no")
@@ -1278,14 +1279,14 @@ def run(test, params, env):
         if watchdog_model:
             prepare_guest_watchdog(vm_name, vm, watchdog_model, watchdog_action,
                                    watchdog_module_args)
-            curr_vm_xml = process.system_output('cat %s' % vmxml_backup.xml, shell=True)
+            curr_vm_xml = to_text(process.system_output('cat %s' % vmxml_backup.xml, shell=True))
             logging.debug("The current VM XML contents: \n%s", curr_vm_xml)
 
         smartcard_mode = test_dict.get("smartcard_mode")
         smartcard_type = test_dict.get("smartcard_type")
         if smartcard_mode and smartcard_type:
             add_smartcard_device(vm_name, smartcard_type, smartcard_mode)
-            curr_vm_xml = process.system_output('cat %s' % vmxml_backup.xml, shell=True)
+            curr_vm_xml = to_text(process.system_output('cat %s' % vmxml_backup.xml, shell=True))
             logging.debug("The current VM XML contents: \n%s", curr_vm_xml)
 
         pm_mem_enabled = test_dict.get("pm_mem_enabled", "no")
@@ -1303,7 +1304,7 @@ def run(test, params, env):
         if nfs_mount_dir:
             cmd = "mkdir -p %s" % nfs_mount_dir
             logging.debug("Make sure %s exists both local and remote", nfs_mount_dir)
-            output = process.system_output(cmd, shell=True)
+            output = to_text(process.system_output(cmd, shell=True))
             if output:
                 raise exceptions.TestFail("Failed to run '%s' on the local : %s"
                                           % (cmd, output))
@@ -1345,7 +1346,7 @@ def run(test, params, env):
             libvirt.update_vm_disk_source(vm_name, target_image_path,
                                           target_image_name, source_type)
 
-        vm_xml_cxt = process.system_output("virsh dumpxml %s" % vm_name, shell=True)
+        vm_xml_cxt = to_text(process.system_output("virsh dumpxml %s" % vm_name, shell=True))
         logging.debug("The VM XML with new disk source: \n%s", vm_xml_cxt)
 
         # Prepare to update VM first disk driver cache
@@ -1398,7 +1399,7 @@ def run(test, params, env):
             build_disk_xml(vm_name, disk_format, host_ip, disk_src_protocol,
                            vol_name, disk_img, gluster_transport)
 
-            vm_xml_cxt = process.system_output("virsh dumpxml %s" % vm_name, shell=True)
+            vm_xml_cxt = to_text(process.system_output("virsh dumpxml %s" % vm_name, shell=True))
             logging.debug("The VM XML with gluster disk source: \n%s", vm_xml_cxt)
 
         # generate remote IP
@@ -1450,11 +1451,11 @@ def run(test, params, env):
                 fp.write("\n")
                 fp.write(remote_cpu_xml)
                 fp.close()
-                cpu_xml_cxt = process.system_output("cat %s" % cpu_xml, shell=True)
+                cpu_xml_cxt = to_text(process.system_output("cat %s" % cpu_xml, shell=True))
                 logging.debug("The CPU XML contents: \n%s", cpu_xml_cxt)
                 cmd = "sed -i '/<vendor>.*<\/vendor>/d' %s" % cpu_xml
                 process.system(cmd, shell=True)
-                cpu_xml_cxt = process.system_output("cat %s" % cpu_xml, shell=True)
+                cpu_xml_cxt = to_text(process.system_output("cat %s" % cpu_xml, shell=True))
                 logging.debug("The current CPU XML contents: \n%s", cpu_xml_cxt)
                 output = compute_cpu_baseline(cpu_xml, status_error)
                 logging.debug("The baseline CPU XML: \n%s", output)
@@ -1463,16 +1464,16 @@ def run(test, params, env):
                 fp = open(vm_new_xml, "w+")
                 fp.write(str(vmxml_backup))
                 fp.close()
-                vm_new_xml_cxt = process.system_output("cat %s" % vm_new_xml, shell=True)
+                vm_new_xml_cxt = to_text(process.system_output("cat %s" % vm_new_xml, shell=True))
                 logging.debug("The current VM XML contents: \n%s", vm_new_xml_cxt)
                 cpuxml = output
                 cmd = 'sed -i "/<\/features>/ a\%s" %s' % (cpuxml, vm_new_xml)
                 logging.debug("The command: %s", cmd)
                 process.system(cmd, shell=True)
-                vm_new_xml_cxt = process.system_output("cat %s" % vm_new_xml, shell=True)
+                vm_new_xml_cxt = to_text(process.system_output("cat %s" % vm_new_xml, shell=True))
                 logging.debug("The new VM XML contents: \n%s", vm_new_xml_cxt)
                 virsh.define(vm_new_xml)
-                vm_xml_cxt = process.system_output("virsh dumpxml %s" % vm_name, shell=True)
+                vm_xml_cxt = to_text(process.system_output("virsh dumpxml %s" % vm_name, shell=True))
                 logging.debug("The current VM XML contents: \n%s", vm_xml_cxt)
             finally:
                 logging.info("Recovery VM XML configration")
@@ -1490,7 +1491,7 @@ def run(test, params, env):
             update_cmd += vcpu_args + ">" + vcpu_num + r"<\/vcpu>"
             edit_cmd.append(update_cmd)
             libvirt.exec_virsh_edit(vm_name, edit_cmd)
-            vm_xml_cxt = process.system_output("virsh dumpxml %s" % vm_name, shell=True)
+            vm_xml_cxt = to_text(process.system_output("virsh dumpxml %s" % vm_name, shell=True))
             logging.debug("The current VM XML contents: \n%s", vm_xml_cxt)
 
         # setup IPv6
@@ -1590,7 +1591,7 @@ def run(test, params, env):
         if mb_enable:
             logging.info("Add memoryBacking into VM XML")
             vm_xml.VMXML.set_memoryBacking_tag(vm_name)
-            vm_xml_cxt = process.system_output("virsh dumpxml %s" % vm_name, shell=True)
+            vm_xml_cxt = to_text(process.system_output("virsh dumpxml %s" % vm_name, shell=True))
             logging.debug("The current VM XML: \n%s", vm_xml_cxt)
 
         if config_remote_hugepages:
@@ -1608,7 +1609,7 @@ def run(test, params, env):
 
         if create_disk_src_backing_file:
             cmd = create_disk_src_backing_file + orig_image_name
-            out = process.system_output(cmd, ignore_status=True, shell=True)
+            out = to_text(process.system_output(cmd, ignore_status=True, shell=True))
             if not out:
                 raise exceptions.TestFail("Failed to create backing file: %s"
                                           % cmd)
@@ -1633,7 +1634,7 @@ def run(test, params, env):
 
         if memtune_options:
             virsh.memtune_set(vm_name, memtune_options)
-            vm_xml_cxt = process.system_output("virsh dumpxml %s" % vm_name, shell=True)
+            vm_xml_cxt = to_text(process.system_output("virsh dumpxml %s" % vm_name, shell=True))
             logging.debug("The VM XML with memory tune: \n%s", vm_xml_cxt)
 
         # Update disk driver with iothread attribute.
@@ -1681,7 +1682,7 @@ def run(test, params, env):
                                         flagstr="--config", **virsh_dargs)
                     process.run("rm -f %s" % disk_xml, ignore_status=True, shell=True)
 
-                vm_xml_cxt = process.system_output("virsh dumpxml %s" % vm_name, shell=True)
+                vm_xml_cxt = to_text(process.system_output("virsh dumpxml %s" % vm_name, shell=True))
                 logging.debug("The VM XML with attached disk: \n%s", vm_xml_cxt)
                 source_file = None
 
@@ -1715,7 +1716,7 @@ def run(test, params, env):
                 if c_attach.exit_status != 0:
                     logging.error("Attach disk failed before test.")
 
-                vm_xml_cxt = process.system_output("virsh dumpxml %s" % vm_name, shell=True)
+                vm_xml_cxt = to_text(process.system_output("virsh dumpxml %s" % vm_name, shell=True))
                 logging.debug("The VM XML with attached disk: \n%s", vm_xml_cxt)
 
                 attach_disk = True
@@ -1994,7 +1995,7 @@ def run(test, params, env):
                         logging.error("Command output %s" %
                                       ret.stdout.strip())
                         raise exceptions.TestFail("Failed to attach-interface")
-            vm_xml_cxt = process.system_output("virsh dumpxml %s" % vm_name, shell=True)
+            vm_xml_cxt = to_text(process.system_output("virsh dumpxml %s" % vm_name, shell=True))
             logging.debug("The VM XML with attached interface: \n%s",
                           vm_xml_cxt)
 
@@ -2436,7 +2437,7 @@ def run(test, params, env):
         grep_str_local = test_dict.get("grep_str_from_local_libvirt_log")
         if config_libvirtd == "yes" and grep_str_local:
             cmd = "grep -E '%s' %s" % (grep_str_local, log_file)
-            logging.debug("Execute command %s: %s", cmd, process.system_output(cmd, shell=True))
+            logging.debug("Execute command %s: %s", cmd, to_text(process.system_output(cmd, shell=True)))
 
         grep_str_remote = test_dict.get("grep_str_from_remote_libvirt_log")
         if grep_str_remote:

--- a/libvirt/tests/src/nwfilter/nwfilter_update_vm_running.py
+++ b/libvirt/tests/src/nwfilter/nwfilter_update_vm_running.py
@@ -8,6 +8,7 @@ from virttest import libvirt_xml
 from virttest import utils_misc
 from virttest.utils_test import libvirt as utlv
 from virttest.libvirt_xml.devices import interface
+from virttest.compat_52lts import decode_to_text as to_text
 
 
 def run(test, params, env):
@@ -71,7 +72,7 @@ def run(test, params, env):
                                   timeout=30)
         if not ret:
             test.fail("Rum command '%s' failed" % check_cmd)
-        out = process.system_output(check_cmd, ignore_status=False, shell=True)
+        out = to_text(process.system_output(check_cmd, ignore_status=False, shell=True))
         if expect_match and not re.search(expect_match, out):
             test.fail("'%s' not found in output: %s"
                       % (expect_match, out))

--- a/libvirt/tests/src/nwfilter/nwfilter_vm_attach.py
+++ b/libvirt/tests/src/nwfilter/nwfilter_vm_attach.py
@@ -9,6 +9,7 @@ from virttest import utils_libvirtd
 from virttest import utils_misc
 from virttest.utils_test import libvirt as utlv
 from virttest.libvirt_xml.devices import interface
+from virttest.compat_52lts import decode_to_text as to_text
 
 
 def run(test, params, env):
@@ -81,7 +82,7 @@ def run(test, params, env):
                                       timeout=30)
             if not ret:
                 test.fail("Rum command '%s' failed" % check_cmd)
-            out = process.system_output(check_cmd, ignore_status=False, shell=True)
+            out = to_text(process.system_output(check_cmd, ignore_status=False, shell=True))
             if expect_match and not re.search(expect_match, out):
                 test.fail("'%s' not found in output: %s"
                           % (expect_match, out))

--- a/libvirt/tests/src/nwfilter/nwfilter_vm_start.py
+++ b/libvirt/tests/src/nwfilter/nwfilter_vm_start.py
@@ -11,6 +11,7 @@ from virttest import utils_libvirtd
 from virttest import utils_misc
 from virttest.utils_test import libvirt as utlv
 from virttest.libvirt_xml.devices import interface
+from virttest.compat_52lts import decode_to_text as to_text
 
 
 def run(test, params, env):
@@ -114,7 +115,7 @@ def run(test, params, env):
                                           timeout=30)
                 if not ret:
                     test.fail("Rum command '%s' failed" % check_cmd)
-                out = process.system_output(check_cmd, ignore_status=False, shell=True)
+                out = to_text(process.system_output(check_cmd, ignore_status=False, shell=True))
                 if expect_match and not re.search(expect_match, out):
                     test.fail("'%s' not found in output: %s"
                               % (expect_match, out))

--- a/libvirt/tests/src/smt.py
+++ b/libvirt/tests/src/smt.py
@@ -5,6 +5,7 @@ import re
 from avocado.utils import process
 from virttest.libvirt_xml import vm_xml
 from virttest import utils_package
+from virttest.compat_52lts import decode_to_text as to_text
 
 
 def run(test, params, env):
@@ -74,7 +75,7 @@ def run(test, params, env):
             session = vm.wait_for_login()
             output = session.cmd_output("lscpu")
         else:
-            output = process.system_output("lscpu", shell=True)
+            output = to_text(process.system_output("lscpu", shell=True))
         no_cpus = int(re.findall('CPU\(s\):\s*(\d+)', str(output))[0])
         no_threads = int(re.findall('Thread\(s\)\sper\score:\s*(\d+)', str(output))[0])
         no_cores = int(re.findall('Core\(s\)\sper\ssocket:\s*(\d+)', str(output))[0])
@@ -111,7 +112,7 @@ def run(test, params, env):
     vm_sockets = int(params.get("smt_vcpu_sockets", 1))
     vm = env.get_vm(vm_name)
 
-    output = process.system_output(smt_threads_per_core_cmd, shell=True)
+    output = to_text(process.system_output(smt_threads_per_core_cmd, shell=True))
     try:
         host_threads = int(re.findall('Threads per core:\s+(\d+)', output)[0])
     except Exception:

--- a/libvirt/tests/src/svirt/dac_vm_per_image_start.py
+++ b/libvirt/tests/src/svirt/dac_vm_per_image_start.py
@@ -13,6 +13,7 @@ from virttest import utils_libvirtd
 from virttest import data_dir
 from virttest.utils_test import libvirt as utlv
 from virttest.libvirt_xml.vm_xml import VMXML
+from virttest.compat_52lts import decode_to_text as to_text
 
 from provider import libvirt_version
 
@@ -167,8 +168,8 @@ def run(test, params, env):
             if disk_type != "network":
                 disks = vm.get_blk_devices()
                 if libvirt_version.version_compare(3, 1, 0) and disk_type == "block":
-                    output = process.system_output(
-                        "nsenter -t %d -m -- ls -l %s" % (vm_pid, disks[disk_target]['source']))
+                    output = to_text(process.system_output(
+                        "nsenter -t %d -m -- ls -l %s" % (vm_pid, disks[disk_target]['source'])))
                     owner, group = output.strip().split()[2:4]
                     disk_context = format_user_group_str(owner, group)
                 else:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_to_native.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_to_native.py
@@ -6,6 +6,7 @@ from avocado.utils import process
 
 from virttest import virsh
 from virttest import utils_libvirtd
+from virttest.compat_52lts import decode_to_text as to_text
 
 
 def run(test, params, env):
@@ -106,7 +107,7 @@ def run(test, params, env):
                  vm's information.
         """
         pid = vm.get_pid()
-        cmdline_tmp = process.system_output("cat -v /proc/%d/cmdline" % pid, shell=True)
+        cmdline_tmp = to_text(process.system_output("cat -v /proc/%d/cmdline" % pid, shell=True))
 
         # Output has a trailing '^@' which gets converted into an empty
         # element when spliting by '\x20', so strip it on the end.

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
@@ -21,7 +21,6 @@ from virttest import libvirt_vm
 from virttest import utils_package
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices import memory
-from virttest.libvirt_xml.xcepts import LibvirtXMLNotFoundError
 from virttest import utils_misc
 from virttest.utils_misc import SELinuxBoolean
 from virttest.qemu_storage import QemuImg
@@ -29,6 +28,8 @@ from virttest.utils_test import libvirt
 from virttest import test_setup
 from virttest import ssh_key
 from virttest.staging import utils_memory
+from virttest.compat_52lts import decode_to_text as to_text
+from virttest.libvirt_xml.xcepts import LibvirtXMLNotFoundError
 
 from provider import libvirt_version
 
@@ -319,7 +320,7 @@ def run(test, params, env):
                 if (cmd_output[0] != 0):
                     test.cancel("HP not supported/configured")
             else:
-                process.system_output(command, verbose=True, shell=True)
+                to_text(process.system_output(command, verbose=True, shell=True))
 
     def create_mem_hotplug_xml(mem_size, mem_unit, numa_node='',
                                mem_model='dimm'):

--- a/libvirt/tests/src/virsh_cmd/monitor/virsh_domifstat.py
+++ b/libvirt/tests/src/virsh_cmd/monitor/virsh_domifstat.py
@@ -4,6 +4,7 @@ from avocado.utils import process
 
 from virttest import virsh
 from virttest import utils_libvirtd
+from virttest.compat_52lts import decode_to_text as to_text
 
 
 def run(test, params, env):
@@ -29,7 +30,7 @@ def run(test, params, env):
         :return: interface device of VM.
         """
         interface = ""
-        domxml = process.system_output("virsh dumpxml %s" % guest_name, shell=True)
+        domxml = to_text(process.system_output("virsh dumpxml %s" % guest_name, shell=True))
         dom = parseString(domxml)
         root = dom.documentElement
         array = root.getElementsByTagName("interface")

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_find_storage_pool_sources.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_find_storage_pool_sources.py
@@ -7,6 +7,7 @@ from virttest import xml_utils
 from virttest import utils_test
 from virttest import virsh
 from virttest.staging import lv_utils
+from virttest.compat_52lts import decode_to_text as to_text
 
 from provider import libvirt_version
 
@@ -105,7 +106,7 @@ def run(test, params, env):
         # Clean up
         if cleanup_logical:
             cmd = "pvs |grep %s |awk '{print $1}'" % vg_name
-            pv_name = process.system_output(cmd, shell=True)
+            pv_name = to_text(process.system_output(cmd, shell=True))
             lv_utils.vg_remove(vg_name)
             process.run("pvremove %s" % pv_name)
         if cleanup_iscsi:

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_find_storage_pool_sources_as.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_find_storage_pool_sources_as.py
@@ -6,6 +6,7 @@ from avocado.core import exceptions
 from virttest import virsh
 from virttest import utils_test
 from virttest.staging import lv_utils
+from virttest.compat_52lts import decode_to_text as to_text
 
 
 def run(test, params, env):
@@ -73,7 +74,7 @@ def run(test, params, env):
         # Clean up
         if cleanup_logical:
             cmd = "pvs |grep %s |awk '{print $1}'" % vg_name
-            pv_name = process.system_output(cmd, shell=True)
+            pv_name = to_text(process.system_output(cmd, shell=True))
             lv_utils.vg_remove(vg_name)
             process.run("pvremove %s" % pv_name)
         if cleanup_iscsi:

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool_acl.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool_acl.py
@@ -9,6 +9,7 @@ from virttest import data_dir
 from virttest import virsh
 from virttest.staging import lv_utils
 from virttest.utils_test import libvirt as utlv
+from virttest.compat_52lts import decode_to_text as to_text
 
 from provider import libvirt_version
 
@@ -271,7 +272,7 @@ def run(test, params, env):
             logging.error("Can't delete pool: %s", pool_name)
         if cleanup_env[2]:
             cmd = "pvs |grep %s |awk '{print $1}'" % vg_name
-            pv_name = process.system_output(cmd, shell=True)
+            pv_name = to_text(process.system_output(cmd, shell=True))
             lv_utils.vg_remove(vg_name)
             process.run("pvremove %s" % pv_name, shell=True)
         if cleanup_env[1]:

--- a/libvirt/tests/src/virtual_network/iface_network.py
+++ b/libvirt/tests/src/virtual_network/iface_network.py
@@ -17,6 +17,7 @@ from virttest.utils_test import libvirt
 from virttest.utils_test.__init__ import ping
 from virttest.libvirt_xml import vm_xml, xcepts
 from virttest.libvirt_xml.network_xml import NetworkXML
+from virttest.compat_52lts import decode_to_text as to_text
 from provider import libvirt_version
 
 
@@ -176,7 +177,7 @@ TIMEOUT 3"""
         Check bandwidth settings via 'tc class' output
         """
         cmd = "tc class show dev %s" % ifname
-        class_output = process.system_output(cmd)
+        class_output = to_text(process.system_output(cmd))
         logging.debug("Bandwidth class output: %s", class_output)
         class_pattern = (r"class htb %s.*rate (\d+)(K?M?)bit ceil"
                          " (\d+)(K?M?)bit burst (\d+)(K?M?)b.*" % rule_id)
@@ -213,7 +214,7 @@ TIMEOUT 3"""
         Check bandwidth settings via 'tc filter' output
         """
         cmd = "tc -d filter show dev %s parent ffff:" % ifname
-        filter_output = process.system_output(cmd)
+        filter_output = to_text(process.system_output(cmd))
         logging.debug("Bandwidth filter output: %s", filter_output)
         if not filter_output.count("filter protocol all pref"):
             test.fail("Can't find 'protocol all' settings in filter rules")
@@ -247,7 +248,7 @@ TIMEOUT 3"""
                 cmd = "ip route list %s" % addr
                 if "family" in route and route["family"] == "ipv6":
                     cmd = "ip -6 route list %s" % addr
-                output = process.system_output(cmd)
+                output = to_text(process.system_output(cmd))
                 match_obj = re.search(r"via (\S+).*metric (\d+)", output)
                 if match_obj:
                     via_addr = match_obj.group(1)
@@ -275,7 +276,7 @@ TIMEOUT 3"""
             if check_net and net_inbound:
                 # Check qdisc rules
                 cmd = "tc -d qdisc show dev %s" % net_bridge_name
-                qdisc_output = process.system_output(cmd)
+                qdisc_output = to_text(process.system_output(cmd))
                 logging.debug("Bandwidth qdisc output: %s", qdisc_output)
                 if not qdisc_output.count("qdisc ingress ffff:"):
                     test.fail("Can't find ingress setting")
@@ -364,7 +365,7 @@ TIMEOUT 3"""
                           % (net_ipv4, br_name, net_dev_out))]
                 ipv4_rules.extend(rules)
 
-            output = process.system_output('iptables-save')
+            output = to_text(process.system_output('iptables-save'))
             logging.debug("iptables: %s", output)
             for ipt in ipv4_rules:
                 if not re.findall(r"%s" % ipt, output, re.M):
@@ -378,7 +379,7 @@ TIMEOUT 3"""
                          ("FORWARD -s %s -i %s%s -j ACCEPT"
                           % (net_ipv6, br_name, net_dev_out))]
                 ipv6_rules.extend(rules)
-            output = process.system_output("ip6tables-save")
+            output = to_text(process.system_output("ip6tables-save"))
             logging.debug("iptables: %s", output)
             for ipt in ipv6_rules:
                 if not output.count(ipt):
@@ -505,7 +506,7 @@ TIMEOUT 3"""
     # Enabling IPv6 forwarding with RA routes without accept_ra set to 2
     # is likely to cause routes loss
     sysctl_cmd = 'sysctl net.ipv6.conf.all.accept_ra'
-    original_accept_ra = process.system_output(sysctl_cmd + ' -n')
+    original_accept_ra = to_text(process.system_output(sysctl_cmd + ' -n'))
     if test_ipv6_address and original_accept_ra != '2':
         process.system(sysctl_cmd + '=2')
 
@@ -611,8 +612,8 @@ TIMEOUT 3"""
                         br_delay = float(bridge['delay'])
                         cmd = ("brctl showstp %s | grep 'bridge forward delay'"
                                % bridge['name'])
-                        out = process.system_output(
-                            cmd, shell=True, ignore_status=False)
+                        out = to_text(process.system_output(
+                            cmd, shell=True, ignore_status=False))
                         logging.debug("brctl showstp output: %s", out)
                         pattern = (r"\s*forward delay\s+(\d+.\d+)\s+bridge"
                                    " forward delay\s+(\d+.\d+)")

--- a/v2v/tests/src/v2v_options.py
+++ b/v2v/tests/src/v2v_options.py
@@ -20,6 +20,7 @@ from virttest import utils_v2v
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt as utlv
+from virttest.compat_52lts import decode_to_text as to_text
 
 from provider.v2v_vmcheck_helper import VMChecker
 
@@ -117,8 +118,8 @@ def run(test, params, env):
         ovf_content = ""
         if os.path.isdir(export_vm_dir):
             ovf_id = "ovf:id='%s'" % vol_uuid
-            ret = process.system_output("grep -R \"%s\" %s" %
-                                        (ovf_id, export_vm_dir))
+            ret = to_text(process.system_output("grep -R \"%s\" %s" %
+                                                (ovf_id, export_vm_dir)))
             ovf_file = ret.split(":")[0]
             if os.path.isfile(ovf_file):
                 ovf_f = open(ovf_file, "r")


### PR DESCRIPTION
As process.system_output return bytes instead of
string with Python 3, need to convert it to text
with method compatible py2 and py3

Signed-off-by: Yan Li <yannli@redhat.com>