### PR TITLE
v2v:Modify the special version to flexible

### DIFF
--- a/v2v/tests/cfg/convert_vm_to_libvirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_libvirt.cfg
@@ -18,7 +18,7 @@
 
     variants:
         - arch_i386:
-            no 7_4
+            no 7_LATEST7
             no win2008r2
             no win2012
             no win2012r2
@@ -32,10 +32,10 @@
             vm_user = ${username}
             vm_pwd = ${password}
             variants:
-                - 7_4:
-                    os_version = "rhel7.4"
-                - 6_9:
-                    os_version = "rhel6.9"
+                - 7_LATEST7:
+                    os_version = "rhel7.LATEST7"
+                - 6_LATEST6:
+                    os_version = "rhel6.LATEST6"
                 - 5_11:
                     os_version = "rhel5.11"
         - windows:
@@ -91,7 +91,7 @@
             v2v_opts = "-v -x"
             variants:
                 - pv:
-                    no 7_4
+                    no 7_LATEST7
                     vir_mode = "pv"
                 - hvm:
                     vir_mode = "hvm"

--- a/v2v/tests/cfg/convert_vm_to_ovirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_ovirt.cfg
@@ -33,7 +33,7 @@
             output_format = "qcow2"
     variants:
         - arch_i386:
-            no 7_4
+            no 7_LATEST7
             no win2008r2
             no win2012
             no win2012r2
@@ -47,10 +47,10 @@
             vm_user = ${username}
             vm_pwd = "redhat"
             variants:
-                - 7_4:
-                    os_version = "rhel7.4"
-                - 6_9:
-                    os_version = "rhel6.9"
+                - 7_LATEST7:
+                    os_version = "rhel7.LATEST6"
+                - 6_LATEST6:
+                    os_version = "rhel6.LATEST6"
                 - 5_11:
                     os_version = "rhel5.11"
         - windows:
@@ -112,7 +112,7 @@
             v2v_opts = "-v -x"
             variants:
                 - pv:
-                    no 7_4
+                    no 7_LATEST7
                     vir_mode = "pv"
                 - hvm:
                     vir_mode = "hvm"


### PR DESCRIPTION
1.Modify the special version to flexible,
libvirt_ci jobs.yaml can replace it quickly
include rhel7 and rhel6, expect rhel5,it has been stable.

Signed-off-by: kuwei <kuwei@redhat.com>