### PR TITLE
virsh_sendkey: reinitialize session to cleanup

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_sendkey.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_sendkey.py
@@ -198,5 +198,6 @@ def run(test, params, env):
 
     finally:
         if create_file is not None:
+            session = vm.wait_for_login()
             session.cmd("rm -rf %s" % create_file)
         session.close()


### PR DESCRIPTION
guest session might be invalidated/expired after sysrq tests as
it might reboot the guest, cause test to error during cleanup.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>