### PR TITLE
Add multi vm cpu stress tests

### DIFF
--- a/libvirt/tests/cfg/multivm_stress/multivm_cpustress.cfg
+++ b/libvirt/tests/cfg/multivm_stress/multivm_cpustress.cfg
@@ -1,0 +1,41 @@
+- multivm_cpustress: install setup image_copy unattended_install.cdrom
+    virt_test_type = libvirt
+    type = multivm_stress
+    master_images_clone = img1
+    vms = vm1 vm2 vm3
+    main_vm = vm1
+    login_timeout = 240
+    kill_vm = yes
+    kill_vm_libvirt = yes
+    create_vm_libvirt = yes
+    event_sleep_time = 10
+    guest_stress = yes
+    stress_itrs = 20
+    ignore_status = no
+    virsh_maxcpus = 32
+    vcpu_cores = 32
+    vcpu_threads = 1
+    vcpu_sockets = 1
+    smp = 32
+    variants:
+        - stress_vcpupin:
+            stress_events = "vcpupin"
+            stress_itrs = 100
+        - stress_emulatorpin:
+            stress_events = "emulatorpin"
+            stress_itrs = 100
+        - stress_cpuhotplug:
+            stress_events = "cpuhotplug"
+            virsh_maxcpus = 128
+        - stress_suspend:
+            stress_events = "suspend"
+        - stress_pin_hotplug_suspend:
+            ignore_status = yes
+            stress_events = "cpuhotplug,suspend,vcpupin,emulatorpin"
+            stress_itrs = 10
+            virsh_maxcpus = 64
+        - stress_reboot:
+            guest_stress = no
+            stress_events = "reboot"
+            stress_boot = yes
+            stress_itrs = 50

--- a/libvirt/tests/src/multivm_stress/multivm_stress.py
+++ b/libvirt/tests/src/multivm_stress/multivm_stress.py
@@ -1,0 +1,25 @@
+from virttest import utils_stress
+from virttest import error_context
+from virttest import utils_test
+
+
+@error_context.context_aware
+def run(test, params, env):
+    """
+    :param test:   kvm test object
+    :param params: Dictionary with the test parameters
+    :param env:    Dictionary with test environment.
+    """
+
+    guest_stress = params.get("guest_stress", "no") == "yes"
+    vms = env.get_all_vms()
+    stress_event = utils_stress.VMStressEvents(params, env)
+    if guest_stress:
+        try:
+            utils_test.load_stress("stress_in_vms", vms, params)
+        except Exception as err:
+            test.fail("Error running stress in vms: %s" % err)
+    try:
+        stress_event.run_threads()
+    finally:
+        stress_event.wait_for_threads()


### PR DESCRIPTION
This patch adds tests which would use multiple vms in
the environment and run tests in parallel in all those
vms, which stresses vcpupin, vcpu hotplug, suspend/resume
with guest running stress tests, and it stresses boot of
guests in parallel.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>