### PR TITLE
Use serial login when test dns related cases

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_network.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_network.cfg
@@ -35,6 +35,7 @@
                     dhcp_range = "1"
                 - net_dns_host:
                     test_dns_host = "yes"
+                    serial_login = "yes"
                     net_dns_txt = "{'name':'example','value':'example value'}"
                     net_dns_srv = "{'service':'name','protocol':'tcp','domain':'domain-name','target':'nay.domain-name','port':'1024','priority':'10','weight':'10'}"
                     net_dns_forwarders = "{'addr':'8.8.8.8'}"


### PR DESCRIPTION
Fix the timeout failue when login vm by ssh to use serial login.
In the test 'net_dns_host', it set the dns forward server as
8.8.8.8, which will be used when OpenSSH login. It takes longer
to use other dns forward server than the default setting.

Signed-off-by: yalzhang <yalzhang@redhat.com>