### PR TITLE
Python3: Replace built-in file function

### DIFF
--- a/libvirt/tests/src/virsh_cmd/pool/virsh_find_storage_pool_sources.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_find_storage_pool_sources.py
@@ -82,7 +82,8 @@ def run(test, params, env):
     srcSpec = xml_utils.TempXMLFile()
     srcSpec.write(src_xml)
     srcSpec.flush()
-    logging.debug("srcSpec file content:\n%s", file(srcSpec.name).read())
+    with open(srcSpec.name) as srcSpec_file:
+        logging.debug("srcSpec file content:\n%s", srcSpec_file.read())
 
     if params.get('setup_libvirt_polkit') == 'yes':
         cmd = "chmod 666 %s" % srcSpec.name


### PR DESCRIPTION
The file function is no more supported by python3

Signed-off-by: Yan Li <yannli@redhat.com>