### PR TITLE
Fix issue in clear inbound/outdound for domiftune

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domiftune.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domiftune.cfg
@@ -20,13 +20,14 @@
                                             options = "live"
                                         - current:
                                             options = "current"
-                - set_blkio_parameter:
+                - set_domif_parameter:
                     change_parameters = "yes"
                     variants:
                         - running_guest:
                             start_vm = "yes"
                             variants:
                                 - change_inbound:
+                                    test_inbound = "yes"
                                     variants:
                                         # the parameters are 32-bit unsigned
                                         # integers and {in,out}bound is in
@@ -36,11 +37,11 @@
                                         # can only get "this close" on the
                                         # boundary check.
                                         - minimum_boundary:
-                                            inbound = 1
+                                            inbound = 1,1,1
                                         - inside_boundary:
-                                            inbound = 1024
+                                            inbound = 1024,1024,1024
                                         - maximum_boundary:
-                                            inbound = 4294967
+                                            inbound = 4294967,4294967,4294967
                                     variants:
                                         - options:
                                             variants:
@@ -48,14 +49,18 @@
                                                     options = "live"
                                                 - current:
                                                     options = "current"
+                                                - none:
+                                                    options = 
                                 - change_outbound:
+                                    test_outbound = "yes"
                                     variants:
                                         - minimum_boundary:
-                                            outbound = 1
+                                            outbound = '1,1,1'
+                                            serial_login = "yes"
                                         - inside_boundary:
-                                            outbound = 65535
+                                            outbound = '65535,65535,65535'
                                         - maximum_boundary:
-                                            outbound = 4294967
+                                            outbound = '4294967,4294967,4294967'
                                     variants:
                                         - options:
                                             variants:
@@ -63,14 +68,18 @@
                                                     options = "live"
                                                 - current:
                                                     options = "current"
+                                                - none:
+                                                    options =
                                 # As of libvirt 1.2.3 (commid id '14973382')
                                 # setting inbound or outbound to 0 (zero) will
                                 # clear the average value - let's test that.
                                 - clear_inbound:
                                     check_clear = "yes"
+                                    test_inbound = "yes"
                                     inbound = 0
                                 - clear_outbound:
                                     check_clear = "yes"
+                                    test_outbound = "yes"
                                     outbound = 0
 
         - negative_testing:
@@ -83,14 +92,14 @@
                             variants:
                                 - options:
                                     variants:
-                                        - none:
+                                        - invalid:
                                             options = "hello"
                         - shutoff_guest:
                             start_vm = "no"
                             variants:
                                 - options:
                                     variants:
-                                        - none:
+                                        - invalid:
                                             options = "hello"
                                         - live:
                                             options = "live"
@@ -101,6 +110,7 @@
                             start_vm = "yes"
                             variants:
                                 - change_inbound:
+                                    test_inbound = 'yes'
                                     variants:
                                         - invalid_format:
                                             inbound = "~@#$%^-=_:,.[]{}"
@@ -109,7 +119,14 @@
                                             variants:
                                                 - live:
                                                     options = "live"
+                                                - config:
+                                                    options = "config"
+                                                - current:
+                                                    options = "current"
+                                                - none:
+                                                    options =
                                 - change_outbound:
+                                    test_outbound = 'yes'
                                     variants:
                                         - invalid_format:
                                             outbound = "~@#$%^-=_:,.[]{}"
@@ -122,40 +139,45 @@
                                                     options = "config"
                                                 - current:
                                                     options = "current"
+                                                - none:
+                                                    options =
                         - shutoff_guest:
                             start_vm = "no"
                             variants:
                                 - change_inbound:
+                                    test_inbound = 'yes'
                                     variants:
-                                        - minimum_boundary:
-                                            inbound = 1
                                         - inside_boundary:
-                                            inbound = 65535
-                                        - maximum_boundary:
-                                            inbound = 4294967
+                                            inbound = '65535,65535,65535'
                                     variants:
                                         - options:
                                             variants:
                                                 - live:
                                                     options = "live"
+                                - change_outbound:
+                                    test_outbound = 'yes'
+                                    variants:
+                                        - inside_boundary:
+                                            outbound = '65535,65535,65535'
+                                    variants:
+                                        - options:
+                                            variants:
+                                                - live:
+                                                    options = "live"
+                                - invalid_format:
+                                    variants:
+                                        - inbound:
+                                            test_inbound = "yes"
+                                            inbound = "~@#$%^-=_:,.[]{}"
+                                            variants:
                                                 - config:
                                                     options = "config"
                                                 - current:
                                                     options = "current"
-
-                                - change_outbound:
-                                    variants:
-                                        - minimum_boundary:
-                                            outbound = 1
-                                        - inside_boundary:
-                                            outbound = 65535
-                                        - maximum_boundary:
-                                            outbound = 4294967
-                                    variants:
-                                        - options:
+                                        - outbound:
+                                            test_outbound = "yes"
+                                            outbound = "~@#$%^-=_:,.[]{}"
                                             variants:
-                                                - live:
-                                                    options = "live"
                                                 - config:
                                                     options = "config"
                                                 - current:


### PR DESCRIPTION
Fix the name issue in cfg file and the condition judgement.
As the value is unicode type, (u'0' is not '0') will return Ture,
update it to be (u'0' != '0') which will return False, and it is
expected.

Signed-off-by: yalzhang <yalzhang@redhat.com>