### PR TITLE
Reconstruct and enrich domjobabort cfg file

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domjobabort.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domjobabort.cfg
@@ -12,10 +12,19 @@
                 - id_option:
                     jobabort_vm_ref = "id"
                 - name_option:
-                - paused_option:
-                    pre_vm_state = "suspend"
                 - uuid_option:
                     jobabort_vm_ref = "uuid"
+            variants:
+                - running_option:
+                - paused_option:
+                    no migrate_option
+                    pre_vm_state = "suspend"
+            variants:    
+                - dump_option:
+                    variants:
+                        - live_dump:
+                        - crash_dump:
+                            dump_opt = "--crash"
                 - save_option:
                     jobabort_action = "save"
                 - managedsave_option:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domjobabort.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domjobabort.py
@@ -63,6 +63,7 @@ def run(test, params, env):
         return p
 
     action = params.get("jobabort_action", "dump")
+    dump_opt = params.get("dump_opt", None)
     status_error = params.get("status_error", "no")
     job = params.get("jobabort_job", "yes")
     tmp_file = os.path.join(data_dir.get_tmp_dir(), "domjobabort.tmp")
@@ -73,6 +74,10 @@ def run(test, params, env):
     remote_user = params.get("migrate_dest_user", "root")
     remote_pwd = params.get("migrate_dest_pwd")
     saved_data = None
+
+    # Build job action
+    if dump_opt:
+        action = "dump --crash"
 
     if action == "managedsave":
         tmp_pipe = '/var/lib/libvirt/qemu/save/%s.save' % vm.name


### PR DESCRIPTION
Reconstruct virsh_domjobabort.cfg file to be more clear and easier
to extend scenarios. Also add crash dump scenario here.

Signed-off-by: Yanqiu Zhang <yanqzhan@redhat.com>