### PR TITLE
Python 3: Type error fix for base64

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domfsinfo.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domfsinfo.py
@@ -2,7 +2,7 @@ import re
 import logging
 import os
 import time
-import sys
+import locale
 
 from avocado.utils import process
 
@@ -104,7 +104,7 @@ def check_domfsinfo(domfsinfo, expected_results, test):
     """
     expected_fs_count = len(expected_results)
     real_fs_count = len(domfsinfo)
-    encoding = sys.getdefaultencoding()
+    encoding = locale.getpreferrencoding()
     if real_fs_count != expected_fs_count:
         test.fail("Expected number of mounted filesystems is %s, "
                   "but got %s from virsh command" %

--- a/libvirt/tests/src/virsh_cmd/secret/virsh_secret_set_get.py
+++ b/libvirt/tests/src/virsh_cmd/secret/virsh_secret_set_get.py
@@ -2,6 +2,7 @@ import os
 import re
 import base64
 import logging
+import locale
 from tempfile import mktemp
 
 from avocado.utils import process
@@ -27,8 +28,8 @@ def check_secret(params):
 
     if os.access(base64_file, os.R_OK):
         with open(base64_file, 'rb') as base64file:
-            base64_encoded_string = base64file.read().strip().decode('utf-8')
-        secret_decoded_string = base64.b64decode(base64_encoded_string)
+            base64_encoded_string = base64file.read().strip()
+        secret_decoded_string = base64.b64decode(base64_encoded_string).decode(locale.getpreferredencoding())
     else:
         logging.error("Did not find base64_file: %s", base64_file)
         return False
@@ -139,7 +140,8 @@ def set_secret_value(test, params):
 
     # Encode secret string if it exists
     if secret_string:
-        secret_string = base64.b64encode(secret_string)
+        encoding = locale.getpreferredencoding()
+        secret_string = base64.b64encode(secret_string.encode(encoding)).decode(encoding)
 
     result = virsh.secret_set_value(uuid, secret_string, options)
     status = result.exit_status

--- a/libvirt/tests/src/virtual_disks/at_dt_iscsi_disk.py
+++ b/libvirt/tests/src/virtual_disks/at_dt_iscsi_disk.py
@@ -4,6 +4,7 @@ import time
 import base64
 import logging
 import platform
+import locale
 
 from aexpect import ShellError
 
@@ -103,7 +104,8 @@ def run(test, params, env):
                 test.error("Fail to get new created secret uuid")
 
             # Set secret value
-            secret_string = base64.b64encode(chap_passwd.encode()).decode()
+            encoding = locale.getpreferredencoding()
+            secret_string = base64.b64encode(chap_passwd.encode(encoding)).decode(encoding)
             cmd_result = virsh.secret_set_value(secret_uuid, secret_string,
                                                 **virsh_dargs)
             libvirt.check_exit_status(cmd_result)

--- a/libvirt/tests/src/virtual_disks/virtual_disks_iscsi.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_iscsi.py
@@ -1,5 +1,6 @@
 import os
 import re
+import locale
 import logging
 import base64
 
@@ -198,7 +199,8 @@ def run(test, params, env):
                 test.error("Failed to get secret uuid")
 
             # Set secret value
-            secret_string = base64.b64encode(chap_passwd.encode()).decode()
+            encoding = locale.getpreferredencoding()
+            secret_string = base64.b64encode(chap_passwd.encode(encoding)).decode(encoding)
             ret = virsh.secret_set_value(secret_uuid, secret_string,
                                          **virsh_dargs)
             libvirt.check_exit_status(ret)

--- a/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
@@ -6,7 +6,7 @@ import json
 import logging
 import platform
 import aexpect
-
+import locale
 
 from avocado.utils import process
 
@@ -586,7 +586,8 @@ def run(test, params, env):
             test.error("Failed to get secret uuid")
 
         # Set secret value
-        secret_string = base64.b64encode(chap_passwd.encode()).decode()
+        encoding = locale.getpreferredencoding()
+        secret_string = base64.b64encode(chap_passwd.encode(encoding)).decode(encoding)
         ret = virsh.secret_set_value(secet_uuid_value, secret_string,
                                      **virsh_dargs)
         libvirt.check_exit_status(ret)


### PR DESCRIPTION
This PR is to fix below issue when with base64 encode and decode:
TypeError: a bytes-like object is required, not 'str'

Signed-off-by: Yan Li <yannli@redhat.com>