### PR TITLE
Fix the error in virsh_net_create.py

### DIFF
--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_create.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_create.py
@@ -116,7 +116,7 @@ def run(test, params, env):
         # find file size
         test_xml.seek(0, 2)  # end
         # write garbage at middle of file
-        test_xml.seek(test_xml.tell() // 2)
+        test_xml.seek(test_xml.open_file.tell() // 2)
         test_xml.write('"<network><<<BAD>>><\'XML</network\>'
                        '!@#$%^&*)>(}>}{CORRUPTE|>!')
         test_xml.flush()


### PR DESCRIPTION
'TempXMLFile' object has no attribute 'tell', fix it.

Signed-off-by: yalzhang <yalzhang@redhat.com>