### PR TITLE
For Infiniband Controllers, we have to set the link for the VF's before pass-through.

### DIFF
--- a/libvirt/tests/src/libvirt_pci_passthrough.py
+++ b/libvirt/tests/src/libvirt_pci_passthrough.py
@@ -81,6 +81,12 @@ def run(test, params, env):
                 pf_filter_re=params.get("pf_filter_re"),
                 pa_type=params.get("pci_assignable"))
 
+            # For Infiniband Controllers, we have to set the link
+            # for the VF's before pass-through.
+            cont = sriov_setup.get_controller_type()
+            if cont == "Infiniband controller":
+                sriov_setup.set_linkvf_ib()
+
             # Based on the PF Device specified, all the VF's
             # belonging to the same iommu group, will be
             # pass-throughed to the guest.


### PR DESCRIPTION
For Infiniband Controllers, we have to set the link for the VF's before pass-through.
If the links are not enabled before pass-through, then the interfaces would be 
in down state in the VM.

Signed-off-by: Santwana Samantray <santwana@linux.vnet.ibm.com>