### PR TITLE
Python 3: SyntaxError fix for except clause

### DIFF
--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -1731,7 +1731,7 @@ def run(test, params, env):
             result = None
             try:
                 vm.start()
-            except virt_vm.VMStartError, e:
+            except virt_vm.VMStartError as e:
                 logging.info("Recovery VM XML configration")
                 vmxml_backup.sync()
                 logging.debug("The current VM XML:\n%s", vmxml_backup.xmltreefile)
@@ -1764,7 +1764,7 @@ def run(test, params, env):
             if (utils_misc.is_qemu_capability_supported("drive-mirror") and
                     utils_misc.is_qemu_capability_supported("nbd-server")):
                 support_precreation = True
-        except exceptions.TestError, e:
+        except exceptions.TestError as e:
             logging.debug(e)
 
         test_dict["support_precreation"] = support_precreation
@@ -2274,9 +2274,9 @@ def run(test, params, env):
                 # migration on local machine
                 migrate_setup.migrate_pre_setup(src_uri, params, ports=uri_port)
 
-            except (process.CmdError, remote.SCPError), e:
+            except (process.CmdError, remote.SCPError) as e:
                 logging.debug(e)
-            except Exception, details:
+            except Exception as details:
                 logging.debug(details)
             finally:
                 logging.debug("Recover remote guest's XML")
@@ -2331,9 +2331,9 @@ def run(test, params, env):
                                               "is not running."
                                               % target_vm_name)
 
-            except (remote.LoginError, aexpect.ShellError), detail:
+            except (remote.LoginError, aexpect.ShellError) as detail:
                 raise exceptions.TestError(detail)
-            except (process.CmdError, remote.SCPError), detail:
+            except (process.CmdError, remote.SCPError) as detail:
                 raise exceptions.TestError(detail)
             finally:
                 session.close()
@@ -2627,7 +2627,7 @@ def run(test, params, env):
             try:
                 remote_virsh_session = virsh.VirshPersistent(**remote_virsh_dargs)
                 remote_virsh_session.destroy(target_vm_name)
-            except (process.CmdError, remote.SCPError), detail:
+            except (process.CmdError, remote.SCPError) as detail:
                 raise exceptions.TestError(detail)
             finally:
                 remote_virsh_session.close_session()

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domblkerror.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domblkerror.py
@@ -156,7 +156,7 @@ def run(test, params, env):
             try:
                 session.cmd("dd if=/dev/zero of=%s/big_file bs=1024 "
                             "count=51200 && sync" % mnt_dir)
-            except Exception, err:
+            except Exception as err:
                 logging.debug("Expected Fail %s", err)
             session.close()
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_dompmsuspend.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_dompmsuspend.py
@@ -110,7 +110,7 @@ def run(test, params, env):
 
         try:
             vm.prepare_guest_agent()
-        except virt_vm.VMStartError, info:
+        except virt_vm.VMStartError as info:
             if "not supported" in str(info).lower():
                 test.cancel(info)
             else:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_multi_vms.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_multi_vms.py
@@ -147,7 +147,7 @@ def multi_migration(vm, src_uri, dest_uri, options, migrate_type,
                     jobabort_thread.join(migrate_thread_timeout)
             ret_migration = True
 
-        except Exception, info:
+        except Exception as info:
             raise exceptions.TestFail(info)
 
     elif migrate_type.lower() == "orderly":
@@ -165,7 +165,7 @@ def multi_migration(vm, src_uri, dest_uri, options, migrate_type,
                                                      each_vm.get_address()))
                 ping_thread.start()
 
-        except Exception, info:
+        except Exception as info:
             raise exceptions.TestFail(info)
 
     if obj_migration.RET_MIGRATION:
@@ -278,7 +278,7 @@ def run(test, params, env):
         multi_migration(vms, srcuri, desturi, option, migration_type,
                         migrate_timeout, jobabort, lrunner=localrunner,
                         rrunner=remoterunner)
-    except Exception, info:
+    except Exception as info:
         logging.error("Test failed: %s" % info)
         flag_migration = False
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migration.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migration.py
@@ -49,7 +49,7 @@ def run(test, params, env):
                                        migrate_type, migrate_options,
                                        func=postcopy_func,
                                        migrate_start_state=migrate_start_state)
-        except Exception, info:
+        except Exception as info:
             test.fail(info)
         for vm in vm_list:
             if not migrate_setup.check_vm_state(vm, vm_state, dest_uri):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_agent_command_fs.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_agent_command_fs.py
@@ -50,7 +50,7 @@ def run(test, params, env):
                     else:
                         return int(session.cmd_output(data_cmd).strip().
                                    split()[1])
-            except (IndexError, ValueError), details:
+            except (IndexError, ValueError) as details:
                 test.fail("Get dirty info failed: %s" % details)
 
         device_source_path = os.path.join(data_dir.get_tmp_dir(), "disk.img")

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_update_device_matrix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_update_device_matrix.py
@@ -340,7 +340,7 @@ def run(test, params, env):
                 vmxml_backup.define()
                 raise exceptions.TestSkipError("Cann't create the domain")
             vm.wait_for_login().close()
-    except Exception, e:
+    except Exception as e:
         logging.error(str(e))
         if os.path.exists(orig_iso):
             os.remove(orig_iso)

--- a/libvirt/tests/src/virsh_cmd/volume/virsh_vol_create.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_vol_create.py
@@ -120,7 +120,7 @@ def run(test, params, env):
         try:
             encryption_uuid = re.findall(r".+\S+(\ +\S+)\ +.+\S+",
                                          ret.stdout.strip())[0].lstrip()
-        except IndexError, e:
+        except IndexError as e:
             test.error("Fail to get newly created secret uuid")
         logging.debug("Secret uuid %s", encryption_uuid)
 
@@ -292,7 +292,7 @@ def run(test, params, env):
                                               src_pool_name).stdout.strip()
                     logging.debug("Full path of %s: %s", vol_name, vol_path)
                     vol_path_list.append(vol_path)
-            except exceptions.TestFail, e:
+            except exceptions.TestFail as e:
                 stderr = cmd_result.stderr
                 if any(err in stderr for err in fmt_err_list):
                     test.cancel(skip_msg)
@@ -308,7 +308,7 @@ def run(test, params, env):
                 try:
                     virsh.pool_refresh(src_pool_name, ignore_status=False)
                     check_vol(src_pool_name, process_vol, expect_vol_exist)
-                except (process.CmdError, exceptions.TestFail), e:
+                except (process.CmdError, exceptions.TestFail) as e:
                     if process_vol_type == "thin":
                         logging.error(str(e))
                         test.cancel("You may encounter bug BZ#1060287")
@@ -329,7 +329,7 @@ def run(test, params, env):
                              src_emulated_image)
             for secret_uuid in set(secret_uuids):
                 virsh.secret_undefine(secret_uuid)
-        except exceptions.TestFail, detail:
+        except exceptions.TestFail as detail:
             logging.error(str(detail))
         if multipathd_status:
             multipathd.start()

--- a/libvirt/tests/src/virtual_network/iface_coalesce.py
+++ b/libvirt/tests/src/virtual_network/iface_coalesce.py
@@ -254,7 +254,7 @@ def run(test, params, env):
             vmxml.xmltreefile.write()
             try:
                 vmxml.sync()
-            except xcepts.LibvirtXMLError, details:
+            except xcepts.LibvirtXMLError as details:
                 if status_error:
                     # Expect error for negetive test
                     return 0
@@ -269,7 +269,7 @@ def run(test, params, env):
                 ret = virsh.attach_device(vm_name, iface.xml,
                                           ignore_status=False,
                                           debug=True)
-            except process.CmdError, error:
+            except process.CmdError as error:
                 if status_error:
                     # Expect error for negetive test
                     return 0


### PR DESCRIPTION
To fix errors like below when with python3 :

2018-05-03 12:03:43,141 test             L1019 ERROR|     except
virt_vm.VMStartError, info:

2018-05-03 12:03:43,141 test             L1019 ERROR|
^

2018-05-03 12:03:43,141 test             L1019 ERROR| SyntaxError:
invalid syntax

Signed-off-by: Yan Li <yannli@redhat.com>