### PR TITLE
Python 3: TypeError: object of type 'map' has no len()

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_vcpupin.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_vcpupin.py
@@ -193,7 +193,7 @@ def run(test, params, env):
                                        vcpucount_option).stdout.strip()
 
     # Find the alive cpus list
-    cpus_list = map(str, cpuutils.cpu_online_list())
+    cpus_list = list(map(str, cpuutils.cpu_online_list()))
     logging.info("Active cpus in host are %s", cpus_list)
 
     try:


### PR DESCRIPTION
In Python3, map returns an iterator not a list

Signed-off-by: Yan Li <yannli@redhat.com>