### PR TITLE
virsh.cpu_compare: TypeError: a bytes-like object is required

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_compare.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_compare.py
@@ -114,7 +114,7 @@ def run(test, params, env):
 
         # Prepare temp compare file.
         cpu_compare_xml = get_cpu_xml(target, mode)
-        with open(tmp_file, 'w+b') as cpu_compare_xml_f:
+        with open(tmp_file, 'w+') as cpu_compare_xml_f:
             if mode == "clear":
                 cpu_compare_xml_f.truncate(0)
             else:


### PR DESCRIPTION
Open file with "w+b" is incorrect

Signed-off-by: Yan Li <yannli@redhat.com>