### PR TITLE
python 3: fix base64.b64encode() return bytes instead of string issue

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_encryption.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_encryption.py
@@ -2,6 +2,7 @@ import logging
 import os
 import re
 import base64
+import locale
 
 import aexpect
 
@@ -100,7 +101,8 @@ def run(test, params, env):
         logging.debug("Secret uuid %s", encryption_uuid)
 
         # Set secret value.
-        secret_string = base64.b64encode(secret_password_no_encoded.encode()).decode()
+        encoding = locale.getpreferredencoding()
+        secret_string = base64.b64encode(secret_password_no_encoded.encode(encoding)).decode(encoding)
         ret = virsh.secret_set_value(encryption_uuid, secret_string,
                                      **virsh_dargs)
         libvirt.check_exit_status(ret)


### PR DESCRIPTION
When prepare for sesecret_string, it need call base64.b64encode() to return
one string, but on python 3,it will return bytes instead.

Fix it by forcedly decoding by locale preferred encoding

Signed-off-by: chunfuwen <chwen@redhat.com>