### PR TITLE
Python 3: NameError: name 'cmp' is not defined

### DIFF
--- a/libguestfs/tests/guestfish_file_dir.py
+++ b/libguestfs/tests/guestfish_file_dir.py
@@ -712,7 +712,7 @@ def test_checksums_out(test, vm, params):
             run_result[1] = os.path.basename(run_result[1])
             run_result[3] = os.path.basename(run_result[3])
             host_res = dict(list(zip(run_result[1::2], run_result[0::2])))
-        if cmp(guest_res, host_res) != 0:
+        if guest_res != host_res:
             gf.close_session()
             test.fail("checksum failed.")
 

--- a/libvirt/tests/src/cpu/vcpu_hotpluggable.py
+++ b/libvirt/tests/src/cpu/vcpu_hotpluggable.py
@@ -185,7 +185,7 @@ def run(test, params, env):
             # Recheck VM xml
             re_dump_xml = virsh.dumpxml(vm_name).stdout.strip()
             re_vcpu_items = re.findall(r"vcpu.*", re_dump_xml)
-            if cmp(vcpu_items, re_vcpu_items) != 0:
+            if vcpu_items != re_vcpu_items:
                 test.fail("After restarting libvirtd,"
                           "VM xml changed unexpectedly.")
 

--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -916,7 +916,7 @@ def check_domjobinfo_on_complete(test, source_jobinfo, target_jobinfo):
                    "Operation"]:
             continue
         else:
-            if cmp(value, target_value) != 0:
+            if value != target_value:
                 test.fail("The value '%s' for '%s' on source "
                           "host should be equal to the value "
                           "'%s' on target host"

--- a/libvirt/tests/src/sriov/sriov.py
+++ b/libvirt/tests/src/sriov/sriov.py
@@ -321,7 +321,7 @@ def run(test, params, env):
         if vf_type == "vf" or vf_type == "vf_pool":
             for interface in device.by_device_tag("interface"):
                 if interface.type_name == "hostdev":
-                    if cmp(interface.hostdev_address.attrs, vf_addr_attrs) == 0:
+                    if interface.hostdev_address.attrs == vf_addr_attrs:
                         test.fail("The hostdev interface still in the guest xml after detach\n")
                     break
             driver = os.readlink("%s/%s/driver" % (pci_device_dir, vf_addr)).split('/')[-1]

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
@@ -55,7 +55,7 @@ def run(test, params, env):
             actual_state = virsh.domstate(vm.name, uri=uri).stdout.strip()
         else:
             actual_state = vm.state()
-        if cmp(actual_state, state) != 0:
+        if actual_state != state:
             if not ignore_error:
                 test.fail("The VM state is expected '%s' "
                           "but '%s' found" % (state, actual_state))

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_virtio_scsi.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_virtio_scsi.py
@@ -29,7 +29,7 @@ def run(test, params, env):
             actual_state = vm.state()
         except process.CmdError:
             return False
-        if cmp(actual_state, state) == 0:
+        if actual_state == state:
             return True
         else:
             return False

--- a/libvirt/tests/src/virsh_cmd/host/virsh_capabilities.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_capabilities.py
@@ -33,7 +33,7 @@ def run(test, params, env):
         xml_arch = cap_xml.arch
         logging.debug("Host arch (capabilities_xml): %s", xml_arch)
         exp_arch = process.run("arch", shell=True).stdout_text.strip()
-        if cmp(xml_arch, exp_arch) != 0:
+        if xml_arch != exp_arch:
             test.fail("The host arch in capabilities_xml is "
                       "expected to be %s, but get %s" %
                       (exp_arch, xml_arch))

--- a/libvirt/tests/src/virsh_cmd/host/virsh_hostname.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_hostname.py
@@ -44,7 +44,7 @@ def run(test, params, env):
             test.fail("Command 'virsh hostname %s' succeeded "
                       "(incorrect command)" % option)
     elif status_error == "no":
-        if cmp(hostname, hostname_test) != 0:
+        if hostname != hostname_test:
             test.fail(
                 "Virsh cmd gives hostname %s != %s." % (hostname_test, hostname))
         if status != 0:

--- a/libvirt/tests/src/virsh_cmd/host/virsh_uri.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_uri.py
@@ -79,7 +79,7 @@ def run(test, params, env):
         else:
             logging.info("command: %s is a expected error", cmd)
     elif status_error == "no":
-        if cmp(target_uri, uri_test) != 0:
+        if target_uri != uri_test:
             raise exceptions.TestFail("Virsh cmd uri %s != %s." %
                                       (uri_test, target_uri))
         if status != 0:


### PR DESCRIPTION
cmp function is gone from Python3. So use"==" or "!="
as alternative

Signed-off-by: Yan Li <yannli@redhat.com>