### PR TITLE
Add test scenario about destroy transient network

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_destroy.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_destroy.cfg
@@ -12,6 +12,13 @@
     net_destroy_net_ref = "name"
     net_destroy_extra = ""
     net_destroy_status = "active"
+    # the cfg file of the built-in default network:
+    net_cfg_file = "/usr/share/libvirt/networks/default.xml"
+    variants:
+        - persistent:
+            net_persistent = "yes"
+        - transient:
+            net_persistent = "no"
     variants:
         - normal_test:
             status_error = "no"

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_destroy.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_destroy.py
@@ -1,8 +1,18 @@
 import re
+import logging
 
 from avocado.utils import process
 from virttest import virsh
 from provider import libvirt_version
+
+
+# if the net is transisent, dump the xml then define it to make it persistent
+def make_net_persistent(net_name):
+    logging.debug(virsh.net_dumpxml(net_name).stdout)
+    with open("/tmp/default.xml", "w") as f:
+        f.write(virsh.net_dumpxml(net_name).stdout)
+    virsh.net_define("/tmp/default.xml", ignore_status=False)
+    return None
 
 
 def run(test, params, env):
@@ -23,6 +33,8 @@ def run(test, params, env):
     network_name = params.get("net_destroy_network", "default")
     network_status = params.get("net_destroy_status", "active")
     status_error = params.get("status_error", "no")
+    net_persistent = "yes" == params.get("net_persistent", "yes")
+    net_cfg_file = params.get("net_cfg_file", "/usr/share/libvirt/networks/default.xml")
 
     # libvirt acl polkit related params
     if not libvirt_version.version_compare(1, 1, 1):
@@ -36,10 +48,29 @@ def run(test, params, env):
         if unprivileged_user.count('EXAMPLE'):
             unprivileged_user = 'testacl'
 
-    # Confirm the network exists.
     output_all = virsh.net_list("--all").stdout.strip()
+    # prepare the network status: active, persistent
     if not re.search(network_name, output_all):
-        test.cancel("Make sure the network exists!!")
+        if net_persistent:
+            virsh.net_define(net_cfg_file, ignore_status=False)
+            virsh.net_start(network_name, ignore_status=False)
+        else:
+            virsh.create(net_cfg_file, ignore_status=False)
+    if net_persistent:
+        if not virsh.net_state_dict()[network_name]['persistent']:
+            logging.debug("!!!make the network persistent")
+            make_net_persistent(network_name)
+    else:
+        if virsh.net_state_dict()[network_name]['persistent']:
+            virsh.net_undefine(network_name, ignore_status=False)
+    if not virsh.net_state_dict()[network_name]['active']:
+        if network_status == "active":
+            virsh.net_start(network_name, ignore_status=False)
+    else:
+        if network_status == "inactive":
+            logging.debug("!!!destroy the network as we need to test inactive")
+            virsh.net_destroy(network_name, ignore_status=False)
+    logging.debug("After prepare: %s" % virsh.net_state_dict())
 
     # Run test case
     if net_ref == "uuid":
@@ -47,38 +78,32 @@ def run(test, params, env):
     elif net_ref == "name":
         net_ref = network_name
 
-    # Get status of network and prepare network status.
-    network_current_status = "active"
-    try:
-        if not virsh.net_state_dict()[network_name]['active']:
-            network_current_status = "inactive"
-            if network_status == "active":
-                virsh.net_start(network_name)
-        else:
-            if network_status == "inactive":
-                virsh.net_destroy(network_name)
-    except process.CmdError:
-        test.error("Prepare network status failed!")
-
     status = virsh.net_destroy(net_ref, extra, uri=uri, debug=True,
                                unprivileged_user=unprivileged_user,
                                ignore_status=True).exit_status
 
     # Confirm the network has been destroied.
-    if virsh.net_state_dict()[network_name]['active']:
-        status = 1
+    if net_persistent:
+        if virsh.net_state_dict()[network_name]['active']:
+            status = 1
+    else:
+        output_all = virsh.net_list("--all").stdout.strip()
+        if re.search(network_name, output_all):
+            status = 1
+            logging.debug("transient network should not exists after destroy")
 
-    # Recover network status
+    # Recover network status to system default status
     try:
-        if (network_current_status == "active" and
-                not virsh.net_state_dict()[network_name]['active']):
-            virsh.net_start(network_name)
-        if (network_current_status == "inactive" and
-                virsh.net_state_dict()[network_name]['active']):
-            virsh.net_destroy(network_name)
+        if network_name not in virsh.net_state_dict():
+            virsh.net_define(net_cfg_file, ignore_status=False)
+        if not virsh.net_state_dict()[network_name]['active']:
+            virsh.net_start(network_name, ignore_status=False)
+        if not virsh.net_state_dict()[network_name]['persistent']:
+            make_net_persistent(network_name)
+        if not virsh.net_state_dict()[network_name]['autostart']:
+            virsh.net_autostart(network_name, ignore_status=False)
     except process.CmdError:
         test.error("Recover network status failed!")
-
     # Check status_error
     if status_error == "yes":
         if status == 0:

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_edit.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_edit.py
@@ -97,6 +97,14 @@ def run(test, params, env):
                 test.fail("Found wrong network states"
                           " after restarting libvirtd: %s"
                           % net_state)
+        else:
+            libvirtd.restart()
+            net_state = virsh.net_state_dict()
+            if (net_state[net_name]['active'] or
+                    net_state[net_name]['autostart'] or
+                    not net_state[net_name]['persistent']):
+                test.fail("Found wrong network states: %s" % net_state)
+            virsh.net_start(net_name)
         edit_net_xml()
         if test_create:
             # Network become persistent after editing
@@ -118,6 +126,16 @@ def run(test, params, env):
         xml = cmd_result.stdout.strip()
         if not re.search(match_string, xml):
             test.fail("The xml is not expected")
+        # The active xml should not contain the match_string
+        cmd_result = virsh.net_dumpxml(net_name, debug=True)
+        if cmd_result.exit_status:
+            test.fail("Failed to dump active xml of virtual network %s" %
+                      net_name)
+        # The xml should contain the match_string
+        match_string = "100.253"
+        xml = cmd_result.stdout.strip()
+        if re.search(match_string, xml):
+            test.fail("The active xml should not change")
 
     finally:
         test_xml.orbital_nuclear_strike()


### PR DESCRIPTION
virsh_net_destroy: add the test about destroy transisent network.
After destroy, the network will disappear. virsh_net_edit: add 2
checkpoint, one is check the status after define network and libvirtd
restart, another is check active xml do not change after edit.

Signed-off-by: yalzhang <yalzhang@redhat.com>