### PR TITLE
controller.functional: Add case for PPC usb

### DIFF
--- a/libvirt/tests/cfg/controller/controller_functional.cfg
+++ b/libvirt/tests/cfg/controller/controller_functional.cfg
@@ -60,13 +60,14 @@
                     controller_type = virtio-serial
                     controller_vectors = '0'
                 - usb_controller:
-                    no machine_pseries
                     controller_type = usb
                     variants:
                         # ehci and ich9-ehci1 are USB2.0 controller model
                         - ehci_model:
+                            no machine_pseries
                             controller_model = ehci
                         - ich9_ehci1_model:
+                            no machine_pseries
                             controller_model = ich9-ehci1
                             companion_controller_model = ich9-uhci
                             companion_controller_num = 3
@@ -74,9 +75,16 @@
                             controller_index = 0
                         # nec-xhci and qemu-xhci are USB3.0 controller model
                         - nec_xhci_model:
+                            no machine_pseries
                             controller_model = nec-xhci
                         - qemu_xhci_model:
-                            controller_model = qemu-xhci 
+                            variants:
+                                - non_pseries_machine:
+                                    no machine_pseries
+                                    controller_model = qemu-xhci
+                                - pseries_machine:
+                                    only machine_pseries
+                                    setup_controller = "no"
                     variants:
                         - auto_addr:
                         - manual_addr:

--- a/libvirt/tests/src/controller/controller_functional.py
+++ b/libvirt/tests/src/controller/controller_functional.py
@@ -388,24 +388,19 @@ def run(test, params, env):
 
         # Check usb options against expectation
         if cntlr_type == "usb":
-            model_list = [model]
+            pattern = ""
             if cmpnn_cntlr_num is not None:
                 for num in range(int(cmpnn_cntlr_num)):
-                    model_list.append(cmpnn_cntlr_model+str(num+1))
-
-            pattern = ""
-            for item in model_list:
-                if item == "ehci":
-                    pattern = r"-device.usb-ehci"
-                elif item == "qemu-xhci":
-                    pattern = r"-device.qemu-xhci"
-                else:
-                    name = item.split('-')
+                    name = (cmpnn_cntlr_model+str(num+1)).split('-')
                     pattern = pattern + r"-device.%s-usb-%s.*" % (name[0], name[1])
+            elif model == "ehci":
+                pattern = r"-device.usb-ehci"
+            elif model == "qemu-xhci":
+                pattern = r"-device.qemu-xhci"
 
             logging.debug("pattern is %s", pattern)
 
-            if not re.search(pattern, cmdline):
+            if pattern and not re.search(pattern, cmdline):
                 test.fail("Expect get usb model info in qemu cmdline, but failed!")
 
     def check_guest(cntlr_type, cntlr_model, cntlr_index=None):


### PR DESCRIPTION
The default usb controller on PPC is 'qemu-xhci'. This is to test this
feature.

Signed-off-by: Dan Zheng <dzheng@redhat.com>