### PR TITLE
Fixup: incorrect format specifier for test.fail- Minor hotfix

### DIFF
--- a/libvirt/tests/src/cpu/guestpin.py
+++ b/libvirt/tests/src/cpu/guestpin.py
@@ -176,8 +176,8 @@ def run(test, params, env):
 
         cpucount = vm.get_cpu_count()
         if cpucount != current_vcpu:
-            test.fail("Incorrect initial guest vcpu\nExpected:%s Actual:%s",
-                      cpucount, current_vcpu)
+            test.fail("Incorrect initial guest vcpu\nExpected:%s Actual:%s" %
+                      (cpucount, current_vcpu))
 
         if config_pin:
             cpustats = utils_hotplug.get_cpustats(vm)
@@ -238,8 +238,8 @@ def run(test, params, env):
         # Check for guest functional
         cpucount = vm.get_cpu_count()
         if cpucount != current_vcpu:
-            test.fail("Incorrect final guest vcpu\nExpected:%s Actual:%s",
-                      cpucount, current_vcpu)
+            test.fail("Incorrect final guest vcpu\nExpected:%s Actual:%s" %
+                      (cpucount, current_vcpu))
     finally:
         if fail:
             test.fail("Consult previous errors")


### PR DESCRIPTION
Fixed incorrect format specifier was used for
test.fail

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>