### PR TITLE
Fix migration VM failure due to stress_type NoneType issue

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_vm.cfg
+++ b/libvirt/tests/cfg/migration/migrate_vm.cfg
@@ -118,6 +118,7 @@
                                     server_ipv6_addr = "${ipv6_addr_des}/${ip_addr_suffix}"
                                     portal_ip = "${ipv6_addr_src}"
                         - stress:
+                            enable_stress_test = "yes"
                             variants:
                                 - vm:
                                     variants:

--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -1080,6 +1080,7 @@ def run(test, params, env):
     cpu_set = "yes" == test_dict.get("cpu_set", "no")
     vcpu_num = test_dict.get("vcpu_num", "1")
 
+    enable_stress_test = "yes" == test_dict.get("enable_stress_test", "no")
     stress_type = test_dict.get("stress_type")
     stress_args = test_dict.get("stress_args")
 
@@ -1906,7 +1907,7 @@ def run(test, params, env):
                                           % (run_cmd_in_vm, output))
             logging.debug(output)
 
-        if stress_args:
+        if enable_stress_test and stress_args:
             s_list = stress_type.split("_")
 
             if s_list and s_list[-1] == "vms":


### PR DESCRIPTION
stress_type may not be set in normal cases, and only set under stress
therefore stress_type.split("_")may throw NoneType exception
The way to fix it is to add variable as precondition before call stress_type.split("_")

Signed-off-by: chunfuwen <chwen@redhat.com>