### PR TITLE
Fixup: stress functions args position - Minor-Hotfix

### DIFF
--- a/libvirt/tests/src/multivm_stress/multivm_stress.py
+++ b/libvirt/tests/src/multivm_stress/multivm_stress.py
@@ -16,7 +16,7 @@ def run(test, params, env):
     stress_event = utils_stress.VMStressEvents(params, env)
     if guest_stress:
         try:
-            utils_test.load_stress("stress_in_vms", vms, params)
+            utils_test.load_stress("stress_in_vms", params=params, vms=vms)
         except Exception as err:
             test.fail("Error running stress in vms: %s" % err)
     try:


### PR DESCRIPTION
This patch fixes below error as args passed to stress function has
been misplaced.

TestFail: Error running stress in vms: 'str' object has no attribute 'params'

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>