### PR TITLE
libvirtd should not crash after destroy network/vm

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_destroy.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_destroy.cfg
@@ -1,7 +1,6 @@
 - virsh.net_destroy:
     type = virsh_net_destroy
     vms = ""
-    main_vm = ""
     kill_vm = "no"
     start_vm = no
     kill_unresponsive_vms = "no"
@@ -22,6 +21,7 @@
     variants:
         - normal_test:
             status_error = "no"
+            main_vm = ""
             variants:
                 - default_option:
                 - uuid_option:
@@ -34,8 +34,25 @@
                     action_lookup = "connect_driver:QEMU network_name:default"
                     unprivileged_user = "EXAMPLE"
                     virsh_uri = "qemu:///system"
+        - check_libvirtd:
+            only persistent
+            check_libvirtd = "yes"
+            start_vm = "no"
+            variants:
+                - create_vm:
+                    vm_defined = "no"
+                - start_vm:
+                    vm_defined = "yes"
+            variants:
+                - net_inactive:
+                    status_error = "yes"
+                    net_destroy_status = "inactive"
+                - net_active:
+                    status_error = "no"
+                    net_destroy_status = "active"
         - error_test:
             status_error = "yes"
+            main_vm = ""
             variants:
                 - no_option:
                     net_destroy_net_ref = ""

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_destroy.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_destroy.py
@@ -4,6 +4,8 @@ import logging
 from avocado.utils import process
 from virttest import virsh
 from provider import libvirt_version
+from virttest import utils_test
+from virttest.libvirt_xml import vm_xml
 
 
 # if the net is transisent, dump the xml then define it to make it persistent
@@ -13,6 +15,15 @@ def make_net_persistent(net_name):
         f.write(virsh.net_dumpxml(net_name).stdout)
     virsh.net_define("/tmp/default.xml", ignore_status=False)
     return None
+
+
+def check_libvirtd_restart(pid, cmd):
+    """
+    check if libvirtd service has been restarted
+    return 1 if it is restarted, 0 for not restarted
+    """
+    libvirt_pid_now = process.run(cmd, shell=True).stdout_text.strip().split()[1]
+    return libvirt_pid_now != pid
 
 
 def run(test, params, env):
@@ -35,6 +46,8 @@ def run(test, params, env):
     status_error = params.get("status_error", "no")
     net_persistent = "yes" == params.get("net_persistent", "yes")
     net_cfg_file = params.get("net_cfg_file", "/usr/share/libvirt/networks/default.xml")
+    check_libvirtd = "yes" == params.get("check_libvirtd")
+    vm_defined = "yes" == params.get("vm_defined")
 
     # libvirt acl polkit related params
     if not libvirt_version.version_compare(1, 1, 1):
@@ -58,7 +71,7 @@ def run(test, params, env):
             virsh.create(net_cfg_file, ignore_status=False)
     if net_persistent:
         if not virsh.net_state_dict()[network_name]['persistent']:
-            logging.debug("!!!make the network persistent")
+            logging.debug("make the network persistent...")
             make_net_persistent(network_name)
     else:
         if virsh.net_state_dict()[network_name]['persistent']:
@@ -68,7 +81,7 @@ def run(test, params, env):
             virsh.net_start(network_name, ignore_status=False)
     else:
         if network_status == "inactive":
-            logging.debug("!!!destroy the network as we need to test inactive")
+            logging.debug("destroy network as we need to test inactive network...")
             virsh.net_destroy(network_name, ignore_status=False)
     logging.debug("After prepare: %s" % virsh.net_state_dict())
 
@@ -78,19 +91,83 @@ def run(test, params, env):
     elif net_ref == "name":
         net_ref = network_name
 
-    status = virsh.net_destroy(net_ref, extra, uri=uri, debug=True,
-                               unprivileged_user=unprivileged_user,
-                               ignore_status=True).exit_status
+    if check_libvirtd:
+        vm_name = params.get("main_vm")
+        if virsh.is_alive(vm_name):
+            virsh.destroy(vm_name)
+        vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+        vmxml_backup = vmxml
+        # make sure there is interface with source network as default
+        iface_devices = vmxml.get_devices(device_type="interface")
+        has_default_net = False
+        for iface in iface_devices:
+            source = iface.get_source()
+            if 'network' in source.keys() and source['network'] == 'default':
+                has_default_net = True
+                break
+            elif 'bridge' in source.keys() and source['bridge'] == 'virbr0':
+                has_default_net = True
+                break
+        if not has_default_net:
+            options = "network default --current"
+            virsh.attach_interface(vm_name, options, ignore_status=False)
+        try:
+            if vm_defined:
+                ret = virsh.start(vm_name)
+            else:
+                logging.debug("undefine the vm, then create the vm...")
+                vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+                virsh.undefine(vm_name)
+                ret = virsh.create(vmxml.xml)
+                logging.debug(ret.stdout)
+            # check the create or start cmd status
+            utils_test.libvirt.check_exit_status(ret, expect_error=(network_status != 'active'))
+            status = 1
 
-    # Confirm the network has been destroied.
-    if net_persistent:
-        if virsh.net_state_dict()[network_name]['active']:
-            status = 1
+            if status_error != 'yes':
+                cmd = "ps -ef | grep /usr/sbin/libvirtd | grep -v grep"
+                # record the libvirt pid then destroy network
+                libvirtd_pid = process.run(cmd, shell=True).stdout_text.strip().split()[1]
+                ret = virsh.net_destroy(net_ref, extra, uri=uri, debug=True,
+                                        unprivileged_user=unprivileged_user,
+                                        ignore_status=True)
+                utils_test.libvirt.check_exit_status(ret, expect_error=False)
+                # check_libvirtd pid no change
+                result = check_libvirtd_restart(libvirtd_pid, cmd)
+                if result:
+                    test.fail("libvirtd crash after destroy network!")
+                    status = 1
+                else:
+                    logging.debug("libvirtd do not crash after destroy network!")
+                    status = 0
+                # destroy vm, check libvirtd pid no change
+                ret = virsh.destroy(vm_name)
+                utils_test.libvirt.check_exit_status(ret, expect_error=False)
+                result = check_libvirtd_restart(libvirtd_pid, cmd)
+                if result:
+                    test.fail("libvirtd crash after destroy vm!")
+                    status = 1
+                else:
+                    logging.debug("libvirtd do not crash after destroy vm!")
+                    status = 0
+        finally:
+            if not vm_defined:
+                vmxml_backup.define()
+            vmxml_backup.sync()
+
     else:
-        output_all = virsh.net_list("--all").stdout.strip()
-        if re.search(network_name, output_all):
-            status = 1
-            logging.debug("transient network should not exists after destroy")
+        status = virsh.net_destroy(net_ref, extra, uri=uri, debug=True,
+                                   unprivileged_user=unprivileged_user,
+                                   ignore_status=True).exit_status
+        # Confirm the network has been destroied.
+        if net_persistent:
+            if virsh.net_state_dict()[network_name]['active']:
+                status = 1
+        else:
+            output_all = virsh.net_list("--all").stdout.strip()
+            if re.search(network_name, output_all):
+                status = 1
+                logging.debug("transient network should not exists after destroy")
 
     # Recover network status to system default status
     try:


### PR DESCRIPTION
net_destroy: add test cases to check the status of libvirtd service.
libvirtd should not crash after destroy network or vm.

Signed-off-by: yalzhang <yalzhang@redhat.com>