### PR TITLE
Add a check for feature support and skip test

### DIFF
--- a/libvirt/tests/src/libvirt_vcpu_plug_unplug.py
+++ b/libvirt/tests/src/libvirt_vcpu_plug_unplug.py
@@ -438,6 +438,10 @@ def run(test, params, env):
                                         setvcpu_option,
                                         readonly=setvcpu_readonly,
                                         ignore_status=True, debug=True)
+                unsupport_str = utils_hotplug.vcpuhotunplug_unsupport_str()
+                if unsupport_str and (unsupport_str in result.stderr):
+                    test.cancel("Vcpu hotunplug is not supported in this host:"
+                                "\n%s" % result.stderr)
                 try:
                     session = vm.wait_for_login()
                     cmd = "lscpu | grep \"^CPU(s):\""

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_setvcpu.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_setvcpu.py
@@ -32,6 +32,7 @@ def run(test, params, env):
     iteration = int(params.get("setvcpu_iteration", 1))
     invalid_vcpulist = params.get("invalid_vcpulist", "")
     convert_err = "Can't convert {0} to integer type"
+    unsupport_str = params.get("unsupport_str", "")
     try:
         current_vcpu = int(params.get("setvcpu_current", "1"))
     except ValueError:
@@ -207,6 +208,10 @@ def run(test, params, env):
                     status = virsh.setvcpu(
                         dom_option, vcpu_list_option, options,
                         ignore_status=True, debug=True)
+                    unsupport_str = utils_hotplug.vcpuhotunplug_unsupport_str()
+                    if unsupport_str and (unsupport_str in status.stderr):
+                        test.cancel("Vcpu hotunplug is not supported in this host:"
+                                    "\n%s" % status.stderr)
                     # Preserve the first failure
                     if status.exit_status != 0:
                         setvcpu_exit_status = status.exit_status


### PR DESCRIPTION
Add a check for vcpu hotunplug feature as there is
no support in certain qemu package versions and accordingly
skip the test.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>