### PR TITLE
Fixup: To handle incorrect topology incase config mismatch

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_guestvcpus.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_guestvcpus.py
@@ -38,7 +38,7 @@ def run(test, params, env):
         if vm.is_alive():
             vm.destroy()
         vmxml.placement = vcpus_placement
-        vmxml.set_vm_vcpus(vm_name, vcpus_num, vcpus_num)
+        vmxml.set_vm_vcpus(vm_name, vcpus_num, vcpus_num, topology_correction=True)
         logging.debug("Define guest with '%s' vcpus" % str(vcpus_num))
 
         # Start guest agent in vm


### PR DESCRIPTION
Add topology correction inorder to handle incorrect topology
incase of config mismatch situations.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>