### PR TITLE
Fix utf-8 can not decode byte 0xff issue

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domjobabort.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domjobabort.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import logging
 import time
+import locale
 
 from virttest import virsh
 from virttest import data_dir
@@ -125,8 +126,8 @@ def run(test, params, env):
         elif action == "migrate":
             f = None
         else:
-            f = open(tmp_pipe, 'r')
-            dummy = f.read(1024 * 1024)
+            f = open(tmp_pipe, 'rb')
+            dummy = f.read(1024 * 1024).decode(locale.getpreferredencoding(), 'ignore')
 
     # Give enough time for starting job
     t = 0


### PR DESCRIPTION
If open file with 'r' mode in python3, hardcoded UTF-8 encoding can not
handle byte 0xff issue.
The way to fix it is to use 'rb' mode,and decode it with locale.getpreferredencoding()

Signed-off-by: chunfuwen <chwen@redhat.com>