### PR TITLE
Add libvirt build test config

### DIFF
--- a/libvirt/cfg/build.cfg
+++ b/libvirt/cfg/build.cfg
@@ -1,1 +1,33 @@
-# TODO: Support libvirt building
+# For other variables in build configuration look at build.cfg in qemu test provider
+
+vm_type = libvirt
+
+variants:
+    - build:
+	type = build
+
+	# Load modules built/installed by the build test?
+	load_modules = no
+	# Save the results of this build on test.resultsdir?
+	save_results = no
+	# Preserve the source code directory between tests?
+	preserve_srcdir = yes
+	profilers=''
+
+	# LIBVIRT installation from a GIT repo
+	git_repo_libvirt_uri = https://github.com/libvirt/libvirt.git
+	git_repo_libvirt_recursive = no
+	git_repo_libvirt_branch = master
+	git_repo_libvirt_lbranch = 
+	git_repo_libvirt_configure_options = 
+
+	installers = git_repo_libvirt
+
+	# Choose wether you want to include debug information/symbols
+	install_debug_info = yes
+
+	start_vm = no
+
+# Comment out the 'no build' line to enable the build test
+# and this cfg can be used as input of --vt-config
+no build


### PR DESCRIPTION
Add libvirt build test config to support virttest.libvirt_installer
enablement.

comment `no build` line from this config and can be used as below
to build, install libvirt package from git source
Usage: avocado run --vt-config build.cfg

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>