### PR TITLE
Automate domblkinfo command cases

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domblklist.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domblklist.cfg
@@ -29,6 +29,11 @@
                     domblklist_options = "--details --inactive"
                 - no_option:
                     domblklist_options = ""
+                - domblkinfo:
+                    domblkinfo = "yes"
+                - domblkinfo_human:
+                    domblkinfo = "yes"
+                    info_options = "--human"
         - error_test:
             status_error = "yes"
             variants:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domblklist.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domblklist.py
@@ -1,7 +1,9 @@
 import os
+import re
 import logging
 from six import iteritems
 
+from avocado.utils import process
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices import disk
@@ -106,9 +108,11 @@ def run(test, params, env):
     # Get all parameters from configuration.
     vm_ref = params.get("domblklist_vm_ref")
     options = params.get("domblklist_options", "")
+    info_options = params.get("info_options", "")
     status_error = params.get("status_error", "no")
     front_dev = params.get("domblkinfo_front_dev", "vdd")
     test_attach_disk = os.path.join(test.virtdir, "tmp.img")
+    domblkinfo = params.get("domblkinfo", "no")
     extra = ""
 
     domid = vm.get_id()
@@ -128,6 +132,22 @@ def run(test, params, env):
 
     # run domblklist and check
     domblklist_test()
+
+    # Test domblkinfo as well
+    if domblkinfo == "yes":
+        ret = virsh.domblklist(vm_ref, options,
+                               ignore_status=True, debug=True)
+        target_disks = re.findall(r"[v, s]d[a-z]", ret.stdout)
+        if info_options == "":
+            check_list = ["Capacity", "Allocation", "Physical"]
+            ret2 = virsh.domblkinfo(vm_ref, target_disks[0])
+        elif info_options == "--human":
+            check_list = ["Capacity", "Allocation", "Physical", "GiB"]
+            cmd = "virsh domblkinfo %s %s %s" % (vm_ref, target_disks[0], info_options)
+            ret2 = process.run(cmd, shell=True, ignore_status=True)
+        for check in check_list:
+            if re.search(check, ret2.stdout):
+                test.fail("Cmd domblkinfo run failed")
 
     if status_error == "no":
         try:


### PR DESCRIPTION
Automate domblkinfo command cases
RHEL-113539
Add 2 cases in domblklist
[root@localhost zongqing]# avocado run --vt-type libvirt --vt-machine-type i440fx virsh.domblklist.normal_test.domblkinfo
JOB ID     : 09e24b79132061dd38419451b3c655a280b68d0d
JOB LOG    : /root/avocado/job-results/job-2018-05-24T15.19-09e24b7/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.domblklist.normal_test.domblkinfo: PASS (214.67 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 219.26 s
[root@localhost zongqing]# avocado run --vt-type libvirt --vt-machine-type i440fx virsh.domblklist.normal_test.domblkinfo_human
JOB ID     : d1181f04261f135c4c49bdeeff73910d888c3852
JOB LOG    : /root/avocado/job-results/job-2018-05-24T15.23-d1181f0/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.domblklist.normal_test.domblkinfo_human: PASS (149.54 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 153.86 s

Signed-off-by: zonqi