### PR TITLE
Add case about setting a network to be autostart

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_autostart.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_autostart.cfg
@@ -31,3 +31,5 @@
                     net_autostart_extra = "xyz"
                 - additional_option:
                     net_autostart_extra = "--xyz"
+                - transient_network:
+                    net_transient = 'yes'


### PR DESCRIPTION
net_autostart: add 2 negative scenarios, set transisent network to be
autostart; and undefine a persistent&autostart network, which will make
the network to be not autostart.

Signed-off-by: yalzhang <yalzhang@redhat.com>