### PR TITLE
Python 3:Fix use a string pattern on a bytes-like object in virsh_nod…

### DIFF
--- a/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_list.py
+++ b/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_list.py
@@ -42,7 +42,7 @@ def get_storage_devices():
         for device in os.listdir(storage_path):
             info = process.run(
                                'udevadm info %s' % os.path.join(storage_path, device),
-                               timeout=5, ignore_status=True, shell=True).stdout
+                               timeout=5, ignore_status=True, shell=True).stdout_text
             # Only disk devices are list, not partition
             dev_type = re.search(r'(?<=E: DEVTYPE=)\S*', info)
             dev_real_virtual = re.search(r'P: /devices/virtual', info)


### PR DESCRIPTION
…edev_list

process.run norally return bytes on python 3, but the patterns is still string
So fix it by getting text type output from process.run

Signed-off-by: chunfuwen <chwen@redhat.com>