### PR TITLE
virsh_memtune: Error msg differ between rhel7 and rhel8

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_memtune.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_memtune.cfg
@@ -34,7 +34,7 @@
             variants:
                 - invalid_1:
                     mt_hard_limit = 0
-                    error_info="Unable to write to '.*scope/memory.limit_in_bytes': Device or resource busy"
+                    error_info="Unable to write to '.*/memory.limit_in_bytes': Device or resource busy"
                 - invalid_2:
                     mt_soft_limit = "aaaa"
                     error_info="Unable to parse integer parameter soft-limit"


### PR DESCRIPTION
Affect case virsh.memtune.negative_test.invalid_1, where the error
msg is different between RHEL7 and RHEL8. So fix it to make them
compatible

Signed-off-by: Yan Li <yannli@redhat.com>