### PR TITLE
Add two tests about dac_start_destroy

### DIFF
--- a/libvirt/tests/cfg/svirt/dac_start_destroy.cfg
+++ b/libvirt/tests/cfg/svirt/dac_start_destroy.cfg
@@ -36,6 +36,10 @@
                     qemu_no_usr_grp = "yes"
                     qemu_user = ""
                     qemu_group = ""
+                - none_existing_qemu_usr:
+                    only negative_test.qemu_conf_only.non_root.with_qemu_conf.enable_dynamic_ownership
+                    qemu_user = "test-non"
+                    qemu_group = "test-non"
             variants:
                 - enable_dynamic_ownership:
                     dynamic_ownership = "yes"
@@ -118,4 +122,4 @@
             no invalid_label
         - negative_test:
             status_error = "yes"
-            only invalid_label, no_qemu_usr
+            only invalid_label, no_qemu_usr, none_existing_qemu_usr 


### PR DESCRIPTION
Add two tests about dac_start_destroy:
1.Test for setting non-existing user in qemu.conf
2.Test for disable_dynamic_ownership with non_root user

Signed-off-by: yafu <yafu@redhat.com>