### PR TITLE
virsh_blockjob: wait a while before abort

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockjob.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockjob.py
@@ -116,6 +116,9 @@ def run(test, params, env):
     if invalid_disk:
         target = invalid_disk
 
+    # Wait for few seconds to be more like human activity,
+    # otherwise, unexpected failure may happen.
+    time.sleep(3)
     # Run virsh blockjob command
     cmd_result = virsh.blockjob(vm_name, target, options,
                                 ignore_status=True, debug=True)


### PR DESCRIPTION
No interval between blockcopy and blockjob --abort will cause unexpected
failure and also is not like real human activity. The fix is just give a
few seconds to wait before abort the job.

Signed-off-by: Dan Zheng <dzheng@redhat.com>