### PR TITLE
migrate_vm: Fix unsafe migration error

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_vm.cfg
+++ b/libvirt/tests/cfg/migration/migrate_vm.cfg
@@ -479,6 +479,8 @@
                             nfs_mount_dir =
                             no_create_pool = "yes"
                             virsh_options = "--live --verbose"
+                            status_error = "yes"
+                            err_msg = "Unsafe migration: Migration without shared storage is unsafe"
                         - basic:
                             nfs_mount_dir =
                             virsh_options = "--live --verbose --copy-storage-all"

--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -104,6 +104,11 @@ def check_output(output_msg, params):
     :raise TestSkipError: raised if the known error is found together
                           with some conditions satisfied
     """
+    err_msg = params.get("err_msg", None)
+    if err_msg and err_msg in output_msg:
+        logging.debug("Expected error '%s' was found", err_msg)
+        return
+
     ERR_MSGDICT = {"Bug 1249587": "error: Operation not supported: " +
                    "pre-creation of storage targets for incremental " +
                    "storage migration is not supported",


### PR DESCRIPTION
In RHEL7.6, if migration without nfs setup and --copy-storage-all will
be blocked and return error "Unsafe migration: Migration without shared
storage is unsafe", while permitted in previous release.

Signed-off-by: Dan Zheng <dzheng@redhat.com>