### PR TITLE
Configuration to add network and disk hotplug into multivm tests

### DIFF
--- a/libvirt/tests/cfg/multivm_stress/multivm_iostress.cfg
+++ b/libvirt/tests/cfg/multivm_stress/multivm_iostress.cfg
@@ -1,0 +1,45 @@
+- multivm_iostress: install setup image_copy unattended_install.cdrom
+    virt_test_type = libvirt
+    type = multivm_stress
+    login_timeout = 240
+    kill_vm = yes
+    kill_vm_libvirt = yes
+    create_vm_import = yes
+    guest_stress = yes
+    ignore_status = no
+    event_sleep_time = 5 
+    iface_model = "virtio"
+    iface_type = "network"
+    iface_source = "{'network':'default'}"
+    attach_option = "--live"
+    detach_option = "--live"
+    stress_itrs = 20 
+    stress_test = yes
+    variants:
+        - stress_nethotplug:
+            stress_events = "nethotplug"
+            iface_num = '1'
+        - stress_nethotplug_suspend:
+            ignore_status = yes
+            stress_events = "nethotplug,suspend"
+            iface_num = '1'
+        - stress_diskhotplug:
+            stress_events = "diskhotplug"
+            disk_type = "file"
+            disk_device = "disk"
+            virt_disk_device_source = "disk1"
+            disk_format = "qcow2"
+            path = "/home/"
+            virt_disk_device_size = "1"
+            virt_disk_device_target = "vdb"
+            driver_name = "qemu"
+        - stress_diskhotplug_suspend:
+            stress_events = "diskhotplug,suspend"
+            disk_type = "file"
+            disk_device = "disk"
+            virt_disk_device_source = "disk1"
+            disk_format = "qcow2"
+            path = "/home/"
+            virt_disk_device_size = "1"
+            virt_disk_device_target = "vdb"
+            driver_name = "qemu"


### PR DESCRIPTION
This commit will add the required configuration for running network and disk
hotplug operations as stress events in existing multivm test.

Signed-off-by: Srikanth Aithal <sraithal@linux.vnet.ibm.com>