### PR TITLE
Add sleep a few seconds before checking virtlogd pipe

### DIFF
--- a/libvirt/tests/src/conf_file/qemu_conf/set_virtlogd.py
+++ b/libvirt/tests/src/conf_file/qemu_conf/set_virtlogd.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import stat
+import time
 
 from pwd import getpwuid
 
@@ -158,6 +159,9 @@ def run(test, params, env):
         for tmp_vm in env.get_all_vms():
             if tmp_vm.is_alive():
                 tmp_vm.destroy(gracefully=False)
+
+        # Sleep a few seconds to let VM syn underlying data
+        time.sleep(3)
 
         # Remove VM previous log file.
         clean_up_vm_log_file(vm_name)


### PR DESCRIPTION
In some situations, after VM shutdown,it may need additional
times to syn underlying VM data
Therefore,the solution to fix it is to add timeout sleep

Signed-off-by: chunfuwen <chwen@redhat.com>