### PR TITLE
add more wait time to allow libvirtd restarted sucessfully

### DIFF
--- a/libvirt/tests/src/numa/numa_memory.py
+++ b/libvirt/tests/src/numa/numa_memory.py
@@ -138,6 +138,13 @@ def run(test, params, env):
         except path.CmdNotFoundError:
             pass
 
+        # Allow for more times to libvirtd restarted sucessfully.
+        ret = utils_misc.wait_for(lambda: libvirtd.is_working(),
+                                  timeout=240,
+                                  step=1)
+        if ret:
+            test.fail("Libvirtd hang after restarted")
+
         # Get host numa node list
         host_numa_node = utils_misc.NumaInfo()
         node_list = host_numa_node.online_nodes_withmem

--- a/libvirt/tests/src/numa/numa_memory_migrate.py
+++ b/libvirt/tests/src/numa/numa_memory_migrate.py
@@ -87,6 +87,13 @@ def run(test, params, env):
         except path.CmdNotFoundError:
             pass
 
+        # Allow for more times to libvirtd restarted sucessfully.
+        ret = utils_misc.wait_for(lambda: libvirtd.is_working(),
+                                  timeout=240,
+                                  step=1)
+        if ret:
+            test.fail("Libvirtd hang after restarted")
+
         if numa_memory.get('nodeset'):
             used_node = utils_test.libvirt.cpus_parser(numa_memory['nodeset'])
             logging.debug("set node list is %s", used_node)


### PR DESCRIPTION
In some cases, libvirtd may not be completely restarted sucessfully,
therefore use utils_misc.wait_for to allow for more time for libvird to be restored

Signed-off-by: chunfuwen <chwen@redhat.com>