### PR TITLE
Minorfix: float num with str type could not be int in Python 3

### DIFF
--- a/libvirt/tests/src/virsh_cmd/host/virsh_freepages.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_freepages.py
@@ -79,7 +79,7 @@ def modify_expect(cell, expect, pagesize='4KiB'):
     with system current freememory is less than 4*1024Kib, check would pass.
     """
     if pagesize in expect.keys():
-        if abs(int(expect[pagesize]) - int(cell[pagesize])) < 1024:
+        if abs(int(float(expect[pagesize])) - int(float(cell[pagesize]))) < 1024:
             expect[pagesize] = cell[pagesize]
 
 


### PR DESCRIPTION
int("5.0") will raise ValueError in Python 3

Signed-off-by: Junxiang Li <junli@redhat.com>