### PR TITLE
Fix a variant error in virtual_disks_multipath.cfg file

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_multipath.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_multipath.cfg
@@ -25,5 +25,5 @@
     variants:
         - rawio_yes:
             rawio = "yes"
-        - sgio_unfiltered:
+        - rawio_no:
             rawio = "no"


### PR DESCRIPTION
It should be 'rawio_no' but not 'sgio_unfiltered' for this branch.

Signed-off-by: Yi Sun <yisun@redhat.com>