### PR TITLE
Python3: Fixup error a bytes-like object is required

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
@@ -6,9 +6,11 @@ import os
 import os.path
 import logging
 import aexpect
+from string import ascii_lowercase
+
 from six import iteritems
 
-from string import ascii_lowercase
+from avocado.utils import astring
 
 from virttest import virt_vm, virsh, remote, utils_misc, data_dir
 from virttest.libvirt_xml import xcepts
@@ -610,7 +612,7 @@ class VirtualDiskBasic(AttachDeviceBase):
             # Write simple unique data to file before end
             image_file.seek(byte_size - len(image_file_path) - 1)
             # newline required by aexpect in function()
-            image_file.write(image_file_path + '\n')
+            image_file.write((image_file_path + '\n').encode(encoding=astring.ENCODING))
 
     def init_device(self, index):
         """


### PR DESCRIPTION
File opened with wb, so need encode the writing data
to bytes to get it compatible with py2 and py3

Signed-off-by: Yan Li <yannli@redhat.com>