### PR TITLE
Python3: Fixup dict object has no attribute 'has_key'

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_iothreadadd.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_iothreadadd.py
@@ -117,7 +117,7 @@ def run(test, params, env):
             # Check iothreadinfo by virsh command
             iothread_info = libvirt.get_iothreadsinfo(dom_option, options)
             logging.debug("iothreadinfo: %s", iothread_info)
-            if not iothread_info.has_key(iothread_id):
+            if iothread_id not in iothread_info:
                 raise exceptions.TestFail("Failed to add iothread %s", iothread_id)
 
     finally:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_iothreaddel.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_iothreaddel.py
@@ -117,7 +117,7 @@ def run(test, params, env):
             # Check iothreadinfo by virsh command
             iothread_info = libvirt.get_iothreadsinfo(dom_option, options)
             logging.debug("iothreadinfo: %s", iothread_info)
-            if iothread_info.has_key(iothread_id):
+            if iothread_id in iothread_info:
                 raise exceptions.TestFail("Failed to add iothread %s", iothread_id)
 
     finally:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_iothreadpin.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_iothreadpin.py
@@ -126,7 +126,7 @@ def run(test, params, env):
             # Check iothreadinfo by virsh command
             iothread_info = libvirt.get_iothreadsinfo(dom_option, options)
             logging.debug("iothreadinfo: %s", iothread_info)
-            if (not iothread_info.has_key(iothread_id) or
+            if (iothread_id not in iothread_info or
                     iothread_info[iothread_id] != cpuset):
                 raise exceptions.TestFail("Failed to add iothreadpins %s", iothread_id)
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_update_device_matrix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_update_device_matrix.py
@@ -225,7 +225,7 @@ def run(test, params, env):
                         "rhel7": "Red Hat Enterprise Linux Server release 7",
                         "fedora": "Fedora release"}
         version_file = "/etc/redhat-release"
-        if not rhel_release.has_key(release_ver):
+        if release_ver not in rhel_release:
             logging.error("Can't support this version of guest: %s",
                           release_ver)
             return False


### PR DESCRIPTION
dict.has_key method removed from python3. 
All issued files in tp-libvirt files are fixed in this PR

Signed-off-by: Yan Li <yannli@redhat.com>