### PR TITLE
Fixup: Update test cases to adhere to library changes

### DIFF
--- a/libvirt/tests/src/libvirt_bench/libvirt_bench_serial_hotplug.py
+++ b/libvirt/tests/src/libvirt_bench/libvirt_bench_serial_hotplug.py
@@ -152,9 +152,9 @@ def run(test, params, env):
     try:
         # increase workload
         if load_type in ['cpu', 'memory']:
-            utils_test.load_stress("stress_in_vms", load_vms, params)
+            utils_test.load_stress("stress_in_vms", params=params, vms=load_vms)
         else:
-            utils_test.load_stress("iozone_in_vms", load_vms, params)
+            utils_test.load_stress("iozone_in_vms", params=params, vms=load_vms)
 
         if test_type == "multi":
             for i in range(test_count):

--- a/libvirt/tests/src/libvirt_bench/libvirt_bench_vcpu_hotplug.py
+++ b/libvirt/tests/src/libvirt_bench/libvirt_bench_vcpu_hotplug.py
@@ -52,9 +52,9 @@ def run(test, params, env):
         params["stress_args"] = stress_param
     load_vms.append(vm)
     if stress_type in ['cpu', 'memory']:
-        utils_test.load_stress("stress_in_vms", vms=load_vms, params=params)
+        utils_test.load_stress("stress_in_vms", params, vms=load_vms)
     else:
-        utils_test.load_stress("iozone_in_vms", vms=load_vms, params=params)
+        utils_test.load_stress("iozone_in_vms", params, vms=load_vms)
 
     session = vm.wait_for_login()
     try:
@@ -168,7 +168,7 @@ def run(test, params, env):
         # unplug operation will encounter kind of errors.
         pass
     finally:
-        utils_test.unload_stress("stress_in_vms", vms=load_vms)
+        utils_test.unload_stress("stress_in_vms", params, load_vms)
         if session:
             session.close()
         # Cleanup

--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -2667,7 +2667,7 @@ def run(test, params, env):
         # And migrated vms may be not login if the network is local lan
         if stress_type == "stress_on_host":
             logging.info("Unload stress from host")
-            utils_test.unload_stress(stress_type, [vm])
+            utils_test.unload_stress(stress_type, params=test_dict, vms=[vm])
 
         if HUGETLBFS_MOUNT:
             cmds = ["umount -l %s" % remote_hugetlbfs_path,

--- a/libvirt/tests/src/multivm_stress/multivm_stress.py
+++ b/libvirt/tests/src/multivm_stress/multivm_stress.py
@@ -23,3 +23,4 @@ def run(test, params, env):
         stress_event.run_threads()
     finally:
         stress_event.wait_for_threads()
+        utils_test.unload_stress("stress_in_vms", params=params, vms=vms)

--- a/libvirt/tests/src/timer_management.py
+++ b/libvirt/tests/src/timer_management.py
@@ -247,7 +247,7 @@ def manipulate_vm(vm, operation, params=None):
     # Special operations for test
     if operation == "stress":
         logging.debug("Load stress in VM")
-        err_msg = utils_test.load_stress(operation, [vm], params)[0]
+        err_msg = utils_test.load_stress(operation, params=params, vms=[vm])[0]
     elif operation == "inject_nmi":
         inject_times = int(params.get("inject_times", 10))
         logging.info("Trying to inject nmi %s times", inject_times)

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_set_get_speed.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_set_get_speed.py
@@ -175,7 +175,7 @@ def run(test, params, env):
         for vm in vms:
             set_get_speed(vm.name, bandwidth, virsh_dargs=virsh_dargs)
             vm.wait_for_login()
-        utils_test.load_stress(stress_type, vms, params)
+        utils_test.load_stress(stress_type, params=params, vms=vms)
         mig_first.do_migration(vms, src_uri, dest_uri, migration_type,
                                options=virsh_migrate_options, thread_timeout=thread_timeout)
         for vm in vms:
@@ -202,7 +202,7 @@ def run(test, params, env):
                 vm.start()
             vm.wait_for_login()
             set_get_speed(vm.name, second_bandwidth, virsh_dargs=virsh_dargs)
-        utils_test.load_stress(stress_type, vms, params)
+        utils_test.load_stress(stress_type, params=params, vms=vms)
         mig_second = utlv.MigrationTest()
         mig_second.do_migration(vms, src_uri, dest_uri, migration_type,
                                 options=virsh_migrate_options, thread_timeout=thread_timeout)

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_monitor_blockjob.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_monitor_blockjob.py
@@ -57,7 +57,7 @@ def copied_migration(test, vm, params, blockjob_type=None, block_target="vda"):
     elif stress_type == "memory":
         params['stress_args'] = "--vm 2 --vm-bytes 256M --vm-keep --timeout 60"
     if stress_type is not None:
-        utils_test.load_stress("stress_in_vms", [vm], params)
+        utils_test.load_stress("stress_in_vms", params=params, vms=[vm])
 
     cp_mig = utlv.MigrationTest()
     migration_thread = threading.Thread(target=cp_mig.thread_func_migration,


### PR DESCRIPTION
Recently stress method from utils_test has been updated
and that requires changes to be done for testcase aswell,
this patch address it.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>