### PR TITLE
auto_dump: Add exception handling to kill process

### DIFF
--- a/libvirt/tests/src/conf_file/qemu_conf/auto_dump.py
+++ b/libvirt/tests/src/conf_file/qemu_conf/auto_dump.py
@@ -107,7 +107,10 @@ def run(test, params, env):
             logging.debug(cmdline.split())
 
         # Kill core dump process to speed up test
-        process.run('kill %s' % iohelper_pid)
+        try:
+            process.run('kill %s' % iohelper_pid)
+        except process.CmdError as detail:
+            logging.debug("Dump already done:\n%s", detail)
 
         arch = platform.machine()
 


### PR DESCRIPTION
Avoid to raise CmdError "that process can not found" when trying
to kill the dump process when dump already accomplished

Signed-off-by: Yan Li <yannli@redhat.com>