### PR TITLE
fix domain is disappeared issue in block job.

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockjob.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockjob.py
@@ -118,7 +118,7 @@ def run(test, params, env):
 
     # Wait for few seconds to be more like human activity,
     # otherwise, unexpected failure may happen.
-    time.sleep(3)
+    time.sleep(10)
     # Run virsh blockjob command
     cmd_result = virsh.blockjob(vm_name, target, options,
                                 ignore_status=True, debug=True)


### PR DESCRIPTION
allow more time waiting before do blockjob operation
therefore fix it by extending timeout to 10 seconds