### PR TITLE
update hugepage size for pagesize.

### DIFF
--- a/libvirt/tests/cfg/libvirt_mem.cfg
+++ b/libvirt/tests/cfg/libvirt_mem.cfg
@@ -62,7 +62,7 @@
                     model_fallback = "forbid"
                     tg_size = 524288
                     tg_node = 0
-                    page_size = 4
+                    page_size = 2048
                     page_unit = "KiB"
                     node_mask = 0
                     huge_pages = "{'size':'2048','unit':'KiB','nodeset':'0'}"


### PR DESCRIPTION
Default hugepage size is 2MB, replaced 4KB with 2MB.
Tests now runs with out any failures.

Signed-off-by: Hariharan T.S <hari@linux.vnet.ibm.com>