### PR TITLE
guestpin: Updated testcases to use stress utils library

### DIFF
--- a/libvirt/tests/cfg/cpu/guestpin.cfg
+++ b/libvirt/tests/cfg/cpu/guestpin.cfg
@@ -19,7 +19,7 @@
                 - with_guest_smt:
                     only ppc64le,ppc64
                     # guest cpu hotplug
-                    condn = "stress"
+                    condn = "avocadotest"
                     avocado_test = "cpu/ppc64_cpu_test.py"
                 - with_save:
                     condn = "save"
@@ -33,9 +33,9 @@
                     condn = "stress"
                     variants:
                         - guestcpu:
-                            avocado_test = "perf/stress.py"
+                            stress_args = '--cpu 8'
                         - guestmem:
-                            avocado_test = "memory/memhotplug.py"
+                            stress_args = '--vm 8 --vm-bytes 256M'
                 - with_cpu_hotplug:
                     current_vcpu = 2
                     max_vcpu = 32
@@ -46,7 +46,7 @@
                 - with_load_switch:
                     only randompin..with_emualorpin
                     condn = "stress"
-                    avocado_test = "perf/stress.py"
+                    stress_args = '--cpu 8'
                     config_pin = yes
                     current_vcpu = 1
                     max_vcpu = 1

--- a/libvirt/tests/src/cpu/guestpin.py
+++ b/libvirt/tests/src/cpu/guestpin.py
@@ -37,13 +37,15 @@ def run(test, params, env):
         """
         bt = None
         if not reset:
-            if condn == "stress":
+            if condn == "avocadotest":
                 bt = utils_test.run_avocado_bg(vm, params, test)
                 if not bt:
                     test.cancel("guest stress failed to start")
                 # Allow stress to start
                 time.sleep(condn_sleep_sec)
                 return bt
+            elif condn == "stress":
+                utils_test.load_stress("stress_in_vms", params=params, vms=[vm])
             elif condn in ["save", "managedsave"]:
                 # No action
                 pass
@@ -91,8 +93,10 @@ def run(test, params, env):
             elif condn == "suspend":
                 result = virsh.resume(vm_name, ignore_status=True, debug=True)
                 libvirt.check_exit_status(result)
-            elif condn == "stress":
+            elif condn == "avocadotest":
                 guestbt.join(ignore_status=True)
+            elif condn == "stress":
+                utils_test.unload_stress("stress_in_vms", params=params, vms=[vm])
             elif condn == "hotplug":
                 result = virsh.setvcpus(vm_name, current_vcpu, "--live",
                                         ignore_status=True, debug=True)


### PR DESCRIPTION
Updated testcases to use stress utils library instead
of avocado for stress testcases.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>