### PR TITLE
Do not account guest login time for expected result and skip tests

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domtime.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domtime.cfg
@@ -25,6 +25,7 @@
                 - managedsave_vm:
                     managedsave_vm = yes
                 - pmsuspend_vm:
+                    no pseries
                     pmsuspend_vm = yes
         - negative:
             variants:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domtime.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domtime.py
@@ -276,6 +276,7 @@ def run(test, params, env):
         Suspend, managedsave, pmsuspend or shutdown a VM for a period of time
         """
         stop_start = time.time()
+        vmlogin_dur = 0.0
         if suspend:
             vm.pause()
             time.sleep(10)
@@ -284,17 +285,21 @@ def run(test, params, env):
             vm.managedsave()
             time.sleep(10)
             vm.start()
+            start_dur = time.time()
             vm.wait_for_login()
+            vmlogin_dur = time.time() - start_dur
         elif pmsuspend:
             vm.pmsuspend()
             time.sleep(10)
             vm.pmwakeup()
+            start_dur = time.time()
             vm.wait_for_login()
+            vmlogin_dur = time.time() - start_dur
         elif shutdown:
             vm.destroy()
 
         # Check real guest stop time
-        stop_seconds = time.time() - stop_start
+        stop_seconds = time.time() - stop_start - vmlogin_dur
         stop_time = datetime.timedelta(seconds=stop_seconds)
         logging.debug("Guest stopped: %s", stop_time)
         return stop_time


### PR DESCRIPTION
Guest login time may vary on environment and taking that into
account for expected result will faill test case sometimes as
it can cross the thershold of 2 secs, So lets not account guest
login time.

Skip pmsuspend test for pseries guest as it do
not support at this moment.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>