### PR TITLE
Made changes to recover the environment, since subsequent test-cases are failing.

### DIFF
--- a/libvirt/tests/src/conf_file/qemu_conf/auto_dump.py
+++ b/libvirt/tests/src/conf_file/qemu_conf/auto_dump.py
@@ -6,7 +6,7 @@ import platform
 from aexpect import ShellTimeoutError
 
 from avocado.utils import process
-
+from virttest import virsh
 from virttest import utils_config
 from virttest import utils_libvirtd
 from virttest.libvirt_xml import vm_xml
@@ -132,8 +132,10 @@ def run(test, params, env):
                         "support")
 
     finally:
-        backup_xml.sync()
+        # Recover Environment
         config.restore()
         libvirtd.restart()
+        virsh.destroy(vm_name)
+        backup_xml.sync()
         if os.path.exists(dump_path):
             shutil.rmtree(dump_path)


### PR DESCRIPTION
Made changes to recover the environment, since subsequent test-cases are failing.

The test-cases of auto_dump are failing since the VM cleanup isn't proper.
The VM is still in the "crashed" state , post which the test-cases are failing.

Signed-off-by: Santwana Samantray <santwana@linux.vnet.ibm.com>