### PR TITLE
virsh_migrate_stress: Enable stress migration scenarios

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_stress.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_stress.cfg
@@ -46,26 +46,48 @@
             migrate_options = "--live --persistent --postcopy --postcopy-after-precopy"
     variants:
         - run_stress_app:
-            stress_tool = "stress"
+            stress_work_path = ''
+            only stress_tool_in_vms,stress_tool_on_hosts
             variants:
-                - cpu_stress:
-                    stress_args = "--cpu 4 --quiet --timeout 3600"
-                    download_url_stress = http://people.seas.harvard.edu/~apw/stress/stress-1.0.4.tar.gz
+                - stress:
+                    stress_tool = "stress"
+                    download_url_stress = "http://people.seas.harvard.edu/~apw/stress/stress-1.0.4.tar.gz"
                     make_cmds_stress = "./configure && make install"
-                    stress_work_path = ''
-                - memory_stress:
-                    # Add timeout option to avoid infinite stress.
-                    stress_args = "--vm 4 --vm-bytes %s --vm-keep --timeout 3600"
-                    stress_vm_bytes = "128M"
-                    download_url_stress = http://people.seas.harvard.edu/~apw/stress/stress-1.0.4.tar.gz
-                    make_cmds_stress = "./configure && make install"
-                    stress_work_path = ''
+                    variants:
+                        - cpu_stress:
+                            stress_args = "--cpu 4 --quiet --timeout 3600"
+                        - memory_stress:
+                            # Add timeout option to avoid infinite stress.
+                            stress_args = "--vm 4 --vm-bytes %s --vm-keep --timeout 3600"
+                            stress_vm_bytes = "128M"
+                - stress_ng:
+                    stress_tool = "stress-ng"
+                    download_url_stress-ng = "http://kernel.ubuntu.com/~cking/tarballs/stress-ng/stress-ng-0.09.31.tar.xz"
+                    make_cmds_stress-ng = "make && make install"
+                    stress-ng_dependency_packages_list = ["@Development Tools"]
+                    variants:
+                        - cpu_stress:
+                            stress-ng_args = "--cpu 4 --quiet --timeout 3600"
+                        - memory_stress:
+                            # Add timeout option to avoid infinite stress.
+                            stress-ng_args = "--vm 4 --vm-bytes %s --vm-keep --timeout 3600"
+                            stress_vm_bytes = "128M"
             variants:
                 - stress_tool_in_vms:
-                    migration_stress_type = "stress_in_vms"
-                - stress_tool_on_host:
-                    only memory_stress
-                    migration_stress_type = "stress_on_host"
+                    migration_stress_vms = "yes"
+                - stress_tool_on_hosts:
+                    variants:
+                        - with_host:
+                        - with_host_and_vms:
+                            migration_stress_vms = "yes"
+                    variants:
+                        - on_source:
+                            migration_stress_host = "yes"
+                        - on_target:
+                            migration_stress_remote = "yes"
+                        - on_source_and_on_target:
+                            migration_stress_host = "yes"
+                            migration_stress_remote = "yes"
                     variants:
                         - half_memory:
                             # Consume half of the memory on host


### PR DESCRIPTION
This patch enables new stress migration scenarios,
 - stress source host and migrate VMs(without stress) from source <-> target
 - stress source host and migrate VMs(with stress) from source <-> target
 - stress remote target host and migrate VMs(without stress) from source <-> target
 - stress remote target host and migrate VMs(with stress) from source <-> target
 - stress source and stress target and migrate VMs (without stress) source <-> target
 - stress source and stress target and migrate VMs (with stress) source <-> target

currently stress and stress-ng tools are added and given place holder to use
any stress tool like iozone, kselftest, ltp etc., by using HostStress and VMStress
APIs directly instead of using load_stress().

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>