### PR TITLE
migrate_options_shared: Fix xbzrle_cache_size issue

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -54,9 +54,8 @@
                             grep_str_remote_log = '"compress-level":${level},"compress-threads":${threads},"decompress-threads":${dthreads}'
                         - xbzrle_method:
                             check_complete_job = "yes"
-                            cache = 640000000
-                            search_str_domjobinfo = "Compression cache: 512.000 MiB"
-                            virsh_migrate_extra = "--comp-methods xbzrle --comp-xbzrle-cache ${cache}"
+                            search_str_domjobinfo = "Compression cache:"
+                            virsh_migrate_extra = "--comp-methods xbzrle --comp-xbzrle-cache"
                 - timeout_postcopy:
                     only with_postcopy
                     virsh_migrate_options = "--live --verbose"


### PR DESCRIPTION
Qemu-kvm's new behaviour will raise the error for --comp-xbzrle-cache:

Parameter 'xbzrle_cache_size' expects is invalid, it should be bigger than target page size
and a power of two

So this is to use valid number for --comp-xbzrle-cache.

Signed-off-by: Dan Zheng <dzheng@redhat.com>