### PR TITLE
migrate_options_shared: Add new case for mPHB migration

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -87,3 +87,8 @@
                             hpt_resize = "enabled"
                         - disabled:
                             hpt_resize = "disabled"
+                - multiple_phbs:
+                    virsh_migrate_options = "--live --verbose"
+                    virsh_migrate_extra = ""
+                    new_contrl_index = 5
+                    guest_xml_check_after_mig = "controller type='pci' index='[0-${new_contrl_index}]' model='pci-root'"


### PR DESCRIPTION
Multiple PHB is supported in papar guest already. This is to test the migration
with multiple PHB between two PPC hosts.

Signed-off-by: Dan Zheng <dzheng@redhat.com>