### PR TITLE
virsh_net_create: Add readonly test

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_create.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_create.cfg
@@ -17,6 +17,7 @@
     net_create_options_ref = ""
     # Remove existing network name before defining
     net_create_remove_existing = "yes"
+    net_create_readonly = "no"
     variants:
         - normal_test:
             variants:
@@ -42,36 +43,40 @@
             status_error = "yes"
             # test all with libvirtd running and not
             variants:
-                - no_existing_removal:
-                    net_create_remove_existing = "no"
-                - existing_removal:
-                    net_create_remove_existing = "yes"
-            # test bad command-line or bad content, not both
-            variants:
-                - bad_command_line:
-                    # test different argument/option combination
+                - readwrite:
                     variants:
-                        - no_extra_options:
-                            net_create_options_extra = ""
-                        - non_existant_extra_option:
-                            net_create_options_extra = "xyz"
-                        - non_existant_extra_argument:
-                            net_create_options_extra = "--xyz foobar"
-                    # test invalid filename / network name
+                        - no_existing_removal:
+                            net_create_remove_existing = "no"
+                        - existing_removal:
+                            net_create_remove_existing = "yes"
+                    # test bad command-line or bad content, not both
                     variants:
-                        - additional_file:
-                            net_create_options_ref = "extra_file"
-                        - no_file:
-                            net_create_options_ref = "no_file"
-                        - no_exist_file:
-                            net_create_options_ref = "no_exist_file"
-                - bad_contents:
-                    # These may actually define some networks
-                    net_create_remove_existing = "yes"
-                    variants:
-                        - invalid_name:
-                            net_create_net_name = "!@#$%^&*()[]{}:;'',.?/\\|`~-=_+"
-                        - invalid_uuid:
-                            net_create_net_uuid = "1-2-3-4-5-6"
-                        - bad_xml:
-                            net_create_corrupt_xml = "yes"
+                        - bad_command_line:
+                            # test different argument/option combination
+                            variants:
+                                - no_extra_options:
+                                    net_create_options_extra = ""
+                                - non_existant_extra_option:
+                                    net_create_options_extra = "xyz"
+                                - non_existant_extra_argument:
+                                    net_create_options_extra = "--xyz foobar"
+                            # test invalid filename / network name
+                            variants:
+                                - additional_file:
+                                    net_create_options_ref = "extra_file"
+                                - no_file:
+                                    net_create_options_ref = "no_file"
+                                - no_exist_file:
+                                    net_create_options_ref = "no_exist_file"
+                        - bad_contents:
+                            # These may actually define some networks
+                            net_create_remove_existing = "yes"
+                            variants:
+                                - invalid_name:
+                                    net_create_net_name = "!@#$%^&*()[]{}:;'',.?/\\|`~-=_+"
+                                - invalid_uuid:
+                                    net_create_net_uuid = "1-2-3-4-5-6"
+                                - bad_xml:
+                                    net_create_corrupt_xml = "yes"
+                - readonly:
+                    net_create_readonly = "yes"


### PR DESCRIPTION
This PR depends on avocado-vt PR #1638. To support
create network from xml file when readonly enabled

Signed-off-by: Yan Li <yannli@redhat.com>