### PR TITLE
Replace string.lowercase with string.ascii_lowercase

### DIFF
--- a/v2v/tests/src/specific_kvm.py
+++ b/v2v/tests/src/specific_kvm.py
@@ -185,7 +185,7 @@ def run(test, params, env):
                 continue
             target = disk.find('target')
             target.set('bus', dest)
-            target.set('dev', dev_table[dest] + 'd' + string.lowercase[index])
+            target.set('dev', dev_table[dest] + 'd' + string.ascii_lowercase[index])
             disk.remove(disk.find('address'))
             index += 1
         vmxml.sync()


### PR DESCRIPTION
string.lowercase doesn't exist in python3, replace it with string.ascii_lowercase
for compatibility of python2 and python3

Signed-off-by: xiaodwan <xiaodwan@redhat.com>