### PR TITLE
Fix cpu-baseline error

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_baseline.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_baseline.py
@@ -28,7 +28,6 @@ def run(test, params, env):
         :param test_feature: test feature element.
         """
         content = """
-<host>
  <cpu>
   <arch>x86_64</arch>
   <model>pentium3</model>
@@ -43,7 +42,6 @@ def run(test, params, env):
   <feature name="sse2"/>
   <feature name="%s"/>
   </cpu>
-</host>
 """ % (test_feature, test_feature)
         with open(cpu_xmlfile, 'w') as xmlfile:
             xmlfile.write(content)


### PR DESCRIPTION
Fix error as before as new version of libvirt have some update
error: File '/var/tmp/avocado_rCvZEW/cpu.xml' does not contain any <cpu> element or valid domain XML, host capabilities XML, or domain capabilities XML

Signed-off-by: Kylazhang <weizhan@redhat.com>