### PR TITLE
add case to cover attach hostdev with --persistent option

### DIFF
--- a/libvirt/tests/cfg/sriov/sriov.cfg
+++ b/libvirt/tests/cfg/sriov/sriov.cfg
@@ -70,6 +70,11 @@
             variants:
                 - hotplug:
                     attach = "yes"
+                    variants:
+                        - without_option:
+                        - persistent:
+                            option = "--persistent"
+                            only guest_with_vf.hotplug.nop.vf_pool.vf_list
                 - cold_plug:
                     attach = "yes"
                     option = "--config"

--- a/libvirt/tests/src/sriov/sriov.py
+++ b/libvirt/tests/src/sriov/sriov.py
@@ -369,6 +369,11 @@ def run(test, params, env):
         if option == "--config":
             result = virsh.start(vm_name)
             utils_test.libvirt.check_exit_status(result, expect_error=False)
+        # For option == "--persistent", after VM destroyed and then start, the device should still be there.
+        if option == "--persistent":
+            virsh.destroy(vm_name)
+            result = virsh.start(vm_name, debug=True)
+            utils_test.libvirt.check_exit_status(result, expect_error=False)
         live_xml = vm_xml.VMXML.new_from_dumpxml(vm_name)
         logging.debug(live_xml)
         get_ip_by_mac(mac_addr, timeout=60)


### PR DESCRIPTION
device attached by persistent option should be there after VM reboot

Signed-off-by: chunfuwen <chwen@redhat.com>