### PR TITLE
remove python 2.6.9 travis and add 3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,19 @@
 language: python
 python:
     - "2.7"
-    - "2.6"
+    - "3.4"
 
 branches:
     only:
         - master
 
+matrix:
+    allow_failures:
+        - python: "3.4"
+
 sudo: false
 
 install:
-    - if [ "$TRAVIS_PYTHON_VERSION" = '2.6' ]; then SPHINX_VERSION=1.4.9; fi
     - pip install sphinx${SPHINX_VERSION:+==$SPHINX_VERSION}
     - pip install -r requirements-travis.txt
 


### PR DESCRIPTION
Since in real tp-libvirt runtime environment, python 2.6.x is not used now,
and new version 3.4 need support

Signed-off-by: chunfuwen <chwen@redhat.com>