### PR TITLE
virsh_net_destroy: Add readonly test

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_destroy.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_destroy.cfg
@@ -69,3 +69,8 @@
                     setup_libvirt_polkit = "yes"
                     unprivileged_user = "EXAMPLE"
                     virsh_uri = "qemu:///system"
+                - net_destroy_name_readonly:
+                    net_destroy_readonly = "yes"
+                - net_destroy_uuid_readonly:
+                    net_destroy_readonly = "yes"
+                    net_destroy_net_ref = "uuid"

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_destroy.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_destroy.py
@@ -156,8 +156,9 @@ def run(test, params, env):
             vmxml_backup.sync()
 
     else:
-        status = virsh.net_destroy(net_ref, extra, uri=uri, debug=True,
-                                   unprivileged_user=unprivileged_user,
+        readonly = (params.get("net_destroy_readonly", "no") == "yes")
+        status = virsh.net_destroy(net_ref, extra, uri=uri, readonly=readonly,
+                                   debug=True, unprivileged_user=unprivileged_user,
                                    ignore_status=True).exit_status
         # Confirm the network has been destroied.
         if net_persistent:


### PR DESCRIPTION
Support readonly test for network destroy

Signed-off-by: Yan Li <yannli@redhat.com>