### PR TITLE
virsh_nodedev_detach_reattach: Add readonly test for detach

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_detach_reattach.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_detach_reattach.cfg
@@ -19,7 +19,7 @@
                     unprivileged_user = "EXAMPLE"
                     virsh_uri = "qemu:///system"
                 - non_driver_test:
-                    with_driver = 'no' 
+                    with_driver = 'no'
         - negative:
             status_error = "yes"
             variants:
@@ -37,3 +37,5 @@
                     setup_libvirt_polkit = "yes"
                     unprivileged_user = "EXAMPLE"
                     virsh_uri = "qemu:///system"
+                - readonly_test:
+                    nodedev_detach_readonly = "yes"

--- a/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_detach_reattach.py
+++ b/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_detach_reattach.py
@@ -50,6 +50,7 @@ def run(test, params, env):
         # Libvirt acl polkit related params
         uri = params.get("virsh_uri")
         unprivileged_user = params.get('unprivileged_user')
+        readonly = (params.get('nodedev_detach_readonly', 'no') == 'yes')
         if unprivileged_user:
             if unprivileged_user.count('EXAMPLE'):
                 unprivileged_user = 'testacl'
@@ -58,7 +59,7 @@ def run(test, params, env):
         logging.debug('Node device name is %s.', device_address)
         CmdResult = virsh.nodedev_detach(device_address, options,
                                          unprivileged_user=unprivileged_user,
-                                         uri=uri)
+                                         uri=uri, readonly=readonly)
         # Check the exit_status.
         libvirt.check_exit_status(CmdResult)
         # Check the driver.


### PR DESCRIPTION
Support detach nodedevice from its device driver when readonly
is enabled

Signed-off-by: Yan Li <yannli@redhat.com>