### PR TITLE
[WIP]virsh_migrate: Enable P8 <-> P9 migration

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
@@ -58,11 +58,14 @@
                     power9_compat = "yes"
                     power9_compat_remote = "yes"
                     restore_smt = "yes"
-                    # Test P8 compat mode guest on P9 host only
-                    host_arch = POWER9
-                    # Migrating Power8 guest between P9 <-> P9 hosts
-                    # and P8 <-> P9 hosts
                     cpu_model = "power8"
+                    variants:
+                        - from_power8:
+                            # Test P8 compat mode guest between P8 <-> P9 host
+                            host_arch = POWER8
+                        - from_power9:
+                            # Test P8 compat mode guest between P9 <-> P9 host
+                            host_arch = POWER9
                 - non_compat_migration:
     variants:
         - with_cpu_hotplug:


### PR DESCRIPTION
The existing configuration only supports P9 <-> P9 migration. So this is
to add P8 <-> P9 migration.

Signed-off-by: Dan Zheng <dzheng@redhat.com>