### PR TITLE
Add support for host stress events

### DIFF
--- a/libvirt/tests/cfg/multivm_stress/multivm_cpustress.cfg
+++ b/libvirt/tests/cfg/multivm_stress/multivm_cpustress.cfg
@@ -47,3 +47,16 @@
         - with_hoststress:
             host_stress_args = '--cpu 10 --io 6 --vm 6 --vm-bytes 256M'
             host_stress = "yes"
+            variants:
+                - without_hoststress_events:
+                    host_stress_events = ""
+                - with_host_cpufreq_governor:
+                    host_stress_events = "cpu_freq_governor"
+                - with_host_cpuidle_switch:
+                    host_stress_events = "cpu_idle"
+                - with_host_cpuoffline:
+                    only stress_reboot,stress_suspend
+                    host_stress_events = "cpuoffline"
+                - with_mixed_host_events:
+                    only stress_reboot,stress_suspend
+                    host_stress_events = "cpu_freq_governor,cpu_idle,cpuoffline"


### PR DESCRIPTION
Add support for parallel host events like switching
cpu frequency governor, cpu idlestates, cpu online
states.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>