### PR TITLE
Modify no screen option test

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_screenshot.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_screenshot.cfg
@@ -22,7 +22,10 @@
                 - no_filename_option:
                     filename = ""
                 - no_screen_option:
+                    only acl_test..default
             variants:
+                - default:
+                    only no_screen_option
                 - screen_0:
                     screen_number = 0
                 - screen_1:


### PR DESCRIPTION
Previous no screen option test do not really work

Signed-off-by: Kylazhang <weizhan@redhat.com>
```
#avocado run --vt-type libvirt virsh.screenshot.normal_test.acl_test.screen_0.name_option
JOB ID     : cc64bd5c12256c1cd7efe0585776733c436ebe54
JOB LOG    : /root/avocado/job-results/job-2018-07-09T12.15-cc64bd5/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.screenshot.normal_test.acl_test.screen_0.name_option: PASS (41.49 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 69.00 s
```