### PR TITLE
Add readonly for secret define/undefine test

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/secret/virsh_secret_define_undefine.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/secret/virsh_secret_define_undefine.cfg
@@ -6,9 +6,9 @@
     encode_video_files = "no"
     skip_image_processing = "yes"
     take_regular_screendumps = "no"
+    secret_ref = "secret_valid_uuid"
     variants:
         - normal_test:
-            secret_ref = "secret_valid_uuid"
             variants:
                 - ephemeral_yes:
                     ephemeral = "yes"
@@ -60,3 +60,12 @@
                         - get_value_acl:
                             get_value_acl = "yes"
                             get_value_error = "yes"
+                - readonly:
+                    secret_err_msg = "forbidden.* read only"
+                    variants:
+                        - define:
+                            secret_define_readonly = "yes"
+                            define_error = "yes"
+                        - undefine:
+                            secret_undefine_readonly = "yes"
+                            undefine_error = "yes"


### PR DESCRIPTION
Signed-off-by: Kylazhang <weizhan@redhat.com>
```
# avocado run --vt-type libvirt virsh.secret_define_undefine.error_test.readonly
JOB ID     : 58cd8f0e57654d3e7bf040ae411f78a106c16f5f
JOB LOG    : /root/avocado/job-results/job-2018-07-14T16.58-58cd8f0/job.log
 (1/2) type_specific.io-github-autotest-libvirt.virsh.secret_define_undefine.error_test.readonly.define: PASS (4.17 s)
 (2/2) type_specific.io-github-autotest-libvirt.virsh.secret_define_undefine.error_test.readonly.undefine: PASS (4.47 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 29.82 s
```
