### PR TITLE
virsh_net_edit: Add extensive cases for more edit operations

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_edit.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_edit.cfg
@@ -7,7 +7,28 @@
     skip_image_processing = "yes"
     take_regular_screendumps = "no"
     variants:
-        - normal_test:
+        - changeable:
+            status_error = "no"
+            attribute = "end"
+            old_value = "192.168.100.254"
+            new_value = "192.168.100.253"
+        - unchangeable:
+            status_error = "yes"
+            attribute = "uuid"
+        - readonly_test:
+            only net_define.modify
+            status_error = "yes"
+            net_edit_readonly = "yes"
+            attribute = "end"
+            old_value = "192.168.100.254"
+            new_value = "192.168.100.253"
+    variants:
+        - modify:
+            edit_type = "modify"
+        - delete:
+            edit_type = "delete"
+    variants:
+        - net_define:
             net_edit_net_name = "editnet"
         - net_create:
             test_create = "yes"


### PR DESCRIPTION
The old script only covered "modify changeable attributes", and hard 
coded the attribute to modify. This PR extended the cases to be more
flexible as follows:
1. support 'delete' operation
2. support "unchangeable" attributes. 
3. net_edit_readonly supported
4. configurable params

Signed-off-by: Yan Li <yannli@redhat.com>