### PR TITLE
add attach-detach interface with readonly case

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_interface.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_interface.cfg
@@ -88,6 +88,9 @@
                             at_detach_iface_vm_ref = "9999-9999-9999-9999-9999"
                         - domname:
                             at_detach_iface_vm_ref = "domname"
+                        - readonly:
+                            readonly = "yes"
+                            only type_none
                     variants:
                         - type_unknow:
                             at_detach_iface_type = "xyz"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_interface.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_interface.py
@@ -166,6 +166,7 @@ def run(test, params, env):
     start_vm = params.get("start_vm")
     # Should attach must be pass for detach test.
     correct_attach = "yes" == params.get("correct_attach", "no")
+    readonly = ("yes" == params.get("readonly", "no"))
 
     # Interface specific attributes.
     iface_type = params.get("at_detach_iface_type", "network")
@@ -282,6 +283,8 @@ def run(test, params, env):
         # Set attach-interface options and Start attach-interface test
         if correct_attach:
             options = set_options("network", "default", iface_mac, "", "attach")
+            if readonly:
+                virsh_dargs.update({'readonly': True, 'debug': True})
             attach_result = virsh.attach_interface(vm_name, options,
                                                    **virsh_dargs)
         else:


### PR DESCRIPTION
if virsh attach or detach interface in readony mode, permission will be denied
Signed-off-by: chunfuwen <chwen@redhat.com>