### PR TITLE
add persistent config domif_setlink_getlink cases

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domif_setlink_getlink.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domif_setlink_getlink.cfg
@@ -34,6 +34,10 @@
                     if_options = "--config"
                     no interface_net
                     no shutoff_guest
+                - with_persistent:
+                    if_options = "--persistent"
+                    no interface_net
+                    no shutoff_guest
             variants:
                 - interface_net:
                     if_device = "net"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domif_setlink_getlink.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domif_setlink_getlink.py
@@ -197,8 +197,8 @@ def run(test, params, env):
                           "equal with setlink operation")
 
         logging.info("Getlink done")
-        # If --config is given should restart the vm then test link status
-        if options == "--config" and vm.is_alive():
+        # If --config or --persistent is given should restart the vm then test link status
+        if any(options == option for option in ["--config", "--persistent"]) and vm.is_alive():
             vm.destroy()
             vm.start()
             logging.info("Restart VM")


### PR DESCRIPTION
if virsh cmd with permistent config, expected those config can be in effect even if VM restarted

Signed-off-by: chunfuwen <chwen@redhat.com>