### PR TITLE
vcpupin: Reduce test iterations for certain scenarios

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_vcpupin.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_vcpupin.cfg
@@ -12,6 +12,7 @@
                     variants:
                         - cpu_list_x:
                             vcpupin_cpu_list = "x"
+                            vcpupin_cpu_itrs = "20"
                         - cpu_list_x-y:
                             no ppc64, ppc64le
                             vcpupin_cpu_list = "x-y"


### PR DESCRIPTION
Testcase `cpu_list.cpu_list_x` iterates over all
the available host cpus for each guest vcpu, this
becomes a huge number when host has more cpus, lets
introduce a check by reducing the iterations
and still have the coverage by introducing some
randomness.

In test run with 32 guest vcpus and 128 host cpus
,test got interrupted due to test timeout of 4 hours.
virsh.vcpupin.offline.positive_test.cpu_list.cpu_list_x: INTERRUPTED (14401.76 s)

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>