### PR TITLE
Make sure guest agent is present in guest xml

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_guestvcpus.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_guestvcpus.py
@@ -42,7 +42,7 @@ def run(test, params, env):
         logging.debug("Define guest with '%s' vcpus" % str(vcpus_num))
 
         # Start guest agent in vm
-        vm.prepare_guest_agent(prepare_xml=False)
+        vm.prepare_guest_agent()
 
         # Normal test: disable/ enable guest vcpus
         if option and status_error == "no":


### PR DESCRIPTION
Make sure qemu guest is present in guest xml,
if not let's add it as it needed for test to
proceed.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>