### PR TITLE
Install dependancy package, cgroup utils

### DIFF
--- a/libvirt/tests/src/cpu/vcpu_hotpluggable.py
+++ b/libvirt/tests/src/cpu/vcpu_hotpluggable.py
@@ -3,8 +3,10 @@ import re
 import copy
 import ast
 import logging
+import platform
 
 from avocado.utils import process
+from avocado.utils.software_manager import SoftwareManager
 
 from virttest import virsh
 from virttest import utils_config, utils_libvirtd, utils_misc
@@ -42,7 +44,13 @@ def run(test, params, env):
     config_vcpus = params.get("set_config_vcpus", "")
     enable_vcpu = params.get("set_enable_vcpu", "")
     disable_vcpu = params.get("set_disable_vcpu", "")
-
+    # Install cgroup utils
+    cgutils = "libcgroup-tools"
+    if "ubuntu" in platform.dist()[0].lower():
+        cgutils = "cgroup-tools"
+    sm = SoftwareManager()
+    if not sm.check_installed(cgutils) and not sm.install(cgutils):
+        test.cancel("cgroup utils package install failed")
     # Backup domain XML
     vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
     vmxml_backup = vmxml.copy()


### PR DESCRIPTION
cgroup utils package is needed by `lscgroup`
command, so lets check and install if not present.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>