### PR TITLE
virsh.migrate: Adjust param for calling vm.migrate

### DIFF
--- a/libvirt/tests/src/migration/migrate_options_shared.py
+++ b/libvirt/tests/src/migration/migrate_options_shared.py
@@ -102,7 +102,7 @@ def run(test, params, env):
         logging.info("Sleeping 10 seconds before migration")
         time.sleep(10)
         # Migrate the guest.
-        migration_res = vm.migrate(dest_uri, options, extra, True, True)
+        migration_res = vm.migrate(dest_uri, options, extra, **virsh_args)
         logging.info("Migration out: %s", results_stdout_52lts(migration_res).strip())
         logging.info("Migration error: %s", results_stderr_52lts(migration_res).strip())
         if int(migration_res.exit_status) != 0:
@@ -243,6 +243,7 @@ def run(test, params, env):
     params["mnt_path_name"] = params.get("nfs_mount_dir")
 
     # Local variables
+    virsh_args = {"ignore_status": True, "debug": True}
     server_ip = params.get("server_ip")
     server_user = params.get("server_user", "root")
     server_pwd = params.get("server_pwd")

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
@@ -105,7 +105,7 @@ def run(test, params, env):
         logging.info("Sleeping %d seconds before migration", delay)
         time.sleep(delay)
         # Migrate the guest.
-        migration_res = vm.migrate(dest_uri, options, extra, True, True)
+        migration_res = vm.migrate(dest_uri, options, extra, **virsh_args)
         logging.info("Migration exit status: %d", migration_res.exit_status)
         check_migration_result(migration_res)
         if int(migration_res.exit_status) != 0:
@@ -544,6 +544,7 @@ def run(test, params, env):
         if isinstance(v, string_types) and v.count("EXAMPLE"):
             test.cancel("Please set real value for %s" % v)
 
+    virsh_args = {"ignore_status": True, "debug": True}
     options = params.get("virsh_migrate_options")
     # Direct migration is supported only for Xen in libvirt
     if options.count("direct") or extra.count("direct"):


### PR DESCRIPTION
Due to avocado-vt commit b43df1ff, all functions using migrate() may need adjust the parameters.


Signed-off-by: Dan Zheng <dzheng@redhat.com>