### PR TITLE
virsh_console: use hypervisor console hvc0 for PAPR guests

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_console.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_console.py
@@ -1,4 +1,5 @@
 import logging
+import platform
 
 import aexpect
 
@@ -180,6 +181,12 @@ def run(test, params, env):
     domid = ""
     uri = params.get("virsh_uri")
     unprivileged_user = params.get('unprivileged_user')
+
+    # PAPR guests don't usually have a true serial device (ttyS0),
+    # they only have the hypervisor console (/dev/hvc0)
+    if 'ppc64' in platform.machine():
+        params["console_device"] = 'hvc0'
+
     console_dev = params.get("console_device", "ttyS0")
     console_speed = params.get("console_speed", "115200")
     if unprivileged_user:


### PR DESCRIPTION
PAPR guests don't usually have a true serial device (ttyS0),
they only have the hypervisor console (/dev/hvc0). Using invalid
device configured in guest kernel cmdline cause killing init
panic during guest boot.

Kernel panic output:
[  117.056098] shutdown: 7 output lines suppressed due to ratelimiting
[  117.058785] Kernel panic - not syncing: Attempted to kill init! exitcode=0x00000100
[  117.058785]
[  117.060152] CPU: 6 PID: 1 Comm: shutdown Not tainted 4.11.0-44.2.1.el7a.ppc64le #1
[  117.061281] Call Trace:
[  117.061645] [c0000000fda83c60] [c000000000c095c8] dump_stack+0xb0/0xf0 (unreliable)
[  117.062786] [c0000000fda83ca0] [c000000000bfd624] panic+0x150/0x31c
[  117.063726] [c0000000fda83d30] [c00000000012d5ec] do_exit+0xcdc/0xce0
[  117.064688] [c0000000fda83df0] [c00000000012d7cc] SyS_exit_group+0x5c/0x100
[  117.065733] [c0000000fda83e30] [c00000000000b004] system_call+0x38/0xe0
[  117.066734] Sending IPI to other CPUs
[  117.068298] IPI complete
[  117.072990] kexec: Starting switchover sequence.
I'm in purgatory

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>