### PR TITLE
add check domstate reason case after restart libvirtd

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/monitor/virsh_domstate.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/monitor/virsh_domstate.cfg
@@ -35,6 +35,8 @@
                                     start_action = "normal"
                                 - rename:
                                     start_action = "rename"
+                                - restart_libvirtd:
+                                    start_action = "restart_libvirtd"
                         - crash_vm:
                             domstate_vm_action = crash
                             variants:

--- a/libvirt/tests/src/virsh_cmd/monitor/virsh_domstate.py
+++ b/libvirt/tests/src/virsh_cmd/monitor/virsh_domstate.py
@@ -191,6 +191,8 @@ def run(test, params, env):
                     virsh.start(vm_name, ignore_status=True)
                 else:
                     virsh.start(vm_name, ignore_status=False)
+                    if start_action == "restart_libvirtd":
+                        libvirtd.restart()
             elif vm_action == "kill":
                 if kill_action == "stop_libvirtd":
                     libvirtd.stop()


### PR DESCRIPTION
Even after libvirtd restart, domstate --reason still can return correct boot information

Signed-off-by: chunfuwen <chwen@redhat.com>