### PR TITLE
virsh_domiftune: Support 'config' option with mac address

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domiftune.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domiftune.cfg
@@ -3,6 +3,7 @@
     libvirtd = "on"
     take_regular_screendumps = "no"
     check_clear = "no"
+    interface_ref = "name"
     variants:
         - positive_testing:
             status_error = "no"
@@ -50,7 +51,7 @@
                                                 - current:
                                                     options = "current"
                                                 - none:
-                                                    options = 
+                                                    options =
                                 - change_outbound:
                                     test_outbound = "yes"
                                     variants:
@@ -81,7 +82,15 @@
                                     check_clear = "yes"
                                     test_outbound = "yes"
                                     outbound = 0
-
+                                - mac_address:
+                                    variants:
+                                        - config:
+                                            options = "config"
+                                            test_inbound = "yes"
+                                            test_outbound = "yes"
+                                            inbound = '1024,1024,1024'
+                                            outbound = '65535,65535,65535'
+                                            interface_ref = "mac"
         - negative_testing:
             status_error = "yes"
             variants:
@@ -114,6 +123,8 @@
                                     variants:
                                         - invalid_format:
                                             inbound = "~@#$%^-=_:,.[]{}"
+                                        - outside_boundary:
+                                            inbound = '4294967296'
                                     variants:
                                         - options:
                                             variants:
@@ -130,6 +141,8 @@
                                     variants:
                                         - invalid_format:
                                             outbound = "~@#$%^-=_:,.[]{}"
+                                        - outside_boundary:
+                                            outbound = '4294968'
                                     variants:
                                         - options:
                                             variants:
@@ -143,6 +156,7 @@
                                                     options =
                         - shutoff_guest:
                             start_vm = "no"
+                                interface_ref = "mac"
                             variants:
                                 - change_inbound:
                                     test_inbound = 'yes'


### PR DESCRIPTION
1) Add 'config' option test
2) Add set_domiftune by interface name or by MAC address
3) Add outside boundary test

Signed-off-by: Yan Li <yannli@redhat.com>