### PR TITLE
add blockjob bytes options cases

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockjob.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockjob.cfg
@@ -21,6 +21,11 @@
                     blockjob_options = "--pivot"
                 - info_option:
                     blockjob_options = "--info"
+                - info_bytes_option:
+                    blockjob_options = "--info --bytes"
+                - bandwidth_bytes_option:
+                    blockjob_options = "--bytes  "
+                    blockjob_bandwidth= "10"
         - negative_test:
             status_error = "yes"
             no_blockjob = "yes"


### PR DESCRIPTION
blockjob --info and --bandwidth can combine with bytes options
and expected output unit is bytes

Signed-off-by: chunfuwen <chwen@redhat.com>