### PR TITLE
add specify copying bandwidth limit cases in blockcopy

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcopy.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcopy.cfg
@@ -30,6 +30,12 @@
                             variants:
                                 - byte:
                                     bandwidth_byte = 'yes'
+                                - byte_2:
+                                    bandwidth_byte = 'yes'
+                                    blockcopy_bandwidth = "2"
+                                - byte_zero:
+                                    bandwidth_byte = 'yes'
+                                    blockcopy_bandwidth = "0"
                                 - mebibyte:
                         - max:
                             variants:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
@@ -518,8 +518,8 @@ def run(test, params, env):
                         bandwidth += 'B'
                     else:
                         bandwidth += 'M'
-                    if not utl.check_blockjob(vm_name, target, "bandwidth",
-                                              bandwidth):
+                    if not (bandwidth in ['0B', '0M']) and not utl.check_blockjob(vm_name, target, "bandwidth",
+                                                                                  bandwidth):
                         raise exceptions.TestFail("Check bandwidth failed")
                 val = options.count("--pivot") + options.count("--finish")
                 # Don't wait for job finish when using --byte option


### PR DESCRIPTION
bandwidth can be specified in various values in blockcopy parameter,and
correct bandwidth should be displayed during blockcopy operation.

Signed-off-by: chunfuwen <chwen@redhat.com>