### PR TITLE
add --wait --async option into block_copy

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcopy.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcopy.cfg
@@ -42,6 +42,9 @@
                     check_state_lock = "yes"
                 - wait_option:
                     blockcopy_options = "--wait --verbose"
+                - sync_wait_option:
+                    only non_acl.local_disk.no_blockdev.no_shallow
+                    blockcopy_options = "--async --wait --verbose"
                 - pivot_option:
                     blockcopy_options = "--wait --pivot --verbose"
                 - finish_option:


### PR DESCRIPTION
--wait --async options case is missed, this option will pull operation
into mirroring phase

Signed-off-by: chunfuwen <chwen@redhat.com>