### PR TITLE
Fix issues for domxml_from_native

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_from_native.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_from_native.py
@@ -50,7 +50,8 @@ def run(test, params, env):
             if qemu_binary in each_opt:
                 change_bin = each_opt
                 break
-        qemu_binary = process.getoutput("which %s" % qemu_binary)
+        exec_str = "export PATH=$PATH:/usr/libexec;which %s"
+        qemu_binary = process.getoutput(exec_str % qemu_binary, shell=True)
         if change_bin.strip() != qemu_binary.strip():
             cmdline_tmp = re.sub(change_bin, qemu_binary, cmdline_tmp)
 


### PR DESCRIPTION
Bring from commit 7ef2975429ca3dead6ded1e2181965372f839887
can not get qemu-kvm absolute path as it is in /usr/libexec

Signed-off-by: Kylazhang <weizhan@redhat.com>