### PR TITLE
add invalid exclusive option cases into blockcopy

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcopy.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcopy.cfg
@@ -123,6 +123,12 @@
                     reuse_external = "yes"
                 - invalid_format:
                     blockcopy_options = "--format fda"
+                - exclusive_options:
+                    variants:
+                        - xml_exclusive_with_format:
+                            blockcopy_options = "--xml destdisk.xml --format qcow2"
+                        - xml_exclusive_with_dest:
+                            blockcopy_options = "--xml destdisk.xml.1 --dest /tmp/1.img"
                 - invalid_bandwidth:
                     blockcopy_bandwidth = "abc"
                 - invalid_timeout:


### PR DESCRIPTION
add exclusive options scenarios cases into blockcopy
and command should throw error when mix use of exclusive options

Signed-off-by: chunfuwen <chwen@redhat.com>