### PR TITLE
add negative integer bandwidth value cases into blockpull

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockpull.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockpull.cfg
@@ -20,6 +20,8 @@
                     variants:
                         - with_bandwidth:
                             bandwidth = "10"
+                        - with_zero_bandwidth:
+                            bandwidth = "0"
                         - no_bandwidth:
                 - relative_path:
                     needs_agent = "no"
@@ -105,3 +107,14 @@
                     snap_in_mirror = "yes"
                     status_error = "no"
                     snap_in_mirror_err = "yes"
+                - invalid_bytes_bandwidth:
+                    base_option = "base"
+                    variants:
+                        - negative_integer_bandwidth_minus_1:
+                            bandwidth = "-1"
+                        - negative_integer_bandwidth_minus_1000:
+                            bandwidth = "-1000"
+                        - negative_integer_bandwidth_minus_maxnum:
+                            bandwidth = "-10000000000000000000000000000"
+                        - outof_range_integer_bandwidth:
+                            bandwidth = "922337203685477580800000"


### PR DESCRIPTION
Whenever bandwidth are negative values, the command should throw errors
Those scenarios need covered.

Signed-off-by: chunfuwen <chwen@redhat.com>