### PR TITLE
migrate_vm: cancel message changed

### DIFF
--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -2123,7 +2123,7 @@ def run(test, params, env):
                 else:
                     stderr = p.communicate()[1]
                     logging.debug(stderr)
-                    err_str = ".*error.*migration job: canceled by client"
+                    err_str = ".*error.*migration.*job: canceled by client"
                     if not re.search(err_str, stderr):
                         raise exceptions.TestFail("Can't find error: %s."
                                                   % (err_str))


### PR DESCRIPTION
This is to update the message of canceling by client of migration.

Signed-off-by: Dan Zheng <dzheng@redhat.com>