### PR TITLE
Update v2v_timeout value

### DIFF
--- a/v2v/tests/cfg/convert_from_file.cfg
+++ b/v2v/tests/cfg/convert_from_file.cfg
@@ -3,7 +3,7 @@
     vm_type = 'libvirt'
     start_vm = 'no'
     take_regular_screendumps = no
-    v2v_timeout = '1200'
+    v2v_timeout = '3600'
 
     # Regular kvm guest parameters
     os_type = 'linux'

--- a/v2v/tests/cfg/convert_vm_to_ovirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_ovirt.cfg
@@ -14,7 +14,7 @@
     remote_shell_port = 22
     remote_shell_prompt = "^\w:\\.*>\s*$|^\[.*\][\#\$]\s*$"
     status_test_command = "echo $?"
-    v2v_timeout = '1200'
+    v2v_timeout = '3600'
 
     variants:
         - rhv_upload:

--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -3,7 +3,7 @@
     vm_type = 'libvirt'
     start_vm = 'no'
     take_regular_screendumps = no
-    v2v_timeout = '1200'
+    v2v_timeout = '3600'
     default_output_format = 'qcow2'
     vpx_passwd_file = "/tmp/v2v_vpx_passwd"
 

--- a/v2v/tests/cfg/function_test_xen.cfg
+++ b/v2v/tests/cfg/function_test_xen.cfg
@@ -3,7 +3,7 @@
     vm_type = 'libvirt'
     start_vm = 'no'
     take_regular_screendumps = no
-    v2v_timeout = '1200'
+    v2v_timeout = '3600'
     default_output_format = 'qcow2'
 
     # Xen host info

--- a/v2v/tests/cfg/specific_kvm.cfg
+++ b/v2v/tests/cfg/specific_kvm.cfg
@@ -3,7 +3,7 @@
     vm_type = 'libvirt'
     start_vm = 'no'
     take_regular_screendumps = no
-    v2v_timeout = '1200'
+    v2v_timeout = '3600'
     image_format = 'qcow2'
 
     # Regular kvm guest parameters

--- a/v2v/tests/cfg/v2v_options.cfg
+++ b/v2v/tests/cfg/v2v_options.cfg
@@ -13,7 +13,7 @@
     os_type = "linux"
     username = 'root'
     password = 'redhat'
-    v2v_timeout = "1200"
+    v2v_timeout = "3600"
     # Full types input disks
     variants:
         - output_mode:


### PR DESCRIPTION
When importing some guests which have large images, like windows
guests, in some special conditions, the speed is slow and 1200s
is not enough. Let's update the value to 2400s to verify it.

Signed-off-by: xiaodwan <xiaodwan@redhat.com>