### PR TITLE
Update matching expression in function_test_xen

### DIFF
--- a/v2v/tests/cfg/function_test_xen.cfg
+++ b/v2v/tests/cfg/function_test_xen.cfg
@@ -186,7 +186,7 @@
                 - same_name_guest:
                     checkpoint = 'same_name'
                     new_vm_name = 'avocado-vt-vm1'
-                    msg_content = "virt-v2v: error: a libvirt domain called '.*?' already exists on the target"
+                    msg_content = "virt-v2v: error: a libvirt domain called .* already exists on the target"
                     expect_msg = yes
                 - no_passwordless_SSH:
                     checkpoint = 'no_passwordless_SSH'


### PR DESCRIPTION
V2V uses unicode single quote character instead of ascii single quote
character in error message. The original matching expression needs to
be updated.

Signed-off-by: xiaodwan <xiaodwan@redhat.com>