### PR TITLE
virsh_domxml_to_native: consider expected_option as positive test

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domxml_to_native.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domxml_to_native.cfg
@@ -4,7 +4,7 @@
     dtn_file_xml = "guest.xml"
     libvirtd = "on"
     dtn_format  = "qemu-argv"
-    dtn_extra_param = ""
+    dtn_extra_param = "--xml"
     variants:
         - negative_test:
             status_error = "yes"
@@ -12,8 +12,6 @@
                 - no_option:
                     dtn_format = ""
                     dtn_file_xml = ""
-                - expected_option:
-                    status_error = "no"
                 - invalid_format_option:
                     dtn_format = "xyz"
                 - extra_option:
@@ -29,15 +27,16 @@
             status_error = "no"
             dtn_extra = ""
             variants:
+                - expected_option:
                 - id_option:
                     dtn_vm_id = "id"
-                    dtn_extra_param = "--domain "
+                    dtn_extra_param = "--domain"
                     dtn_file_xml = ""
                 - uuid_option:
                     dtn_vm_id = "uuid"
-                    dtn_extra_param = "--domain "
+                    dtn_extra_param = "--domain"
                     dtn_file_xml = ""
                 - name_option:
                     dtn_vm_id = "name"
-                    dtn_extra_param = "--domain "
+                    dtn_extra_param = "--domain"
                     dtn_file_xml = ""

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_to_native.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_to_native.py
@@ -119,7 +119,7 @@ def run(test, params, env):
         # argument list and we find "qemu-system-x86_64 -machine accel=kvm"
         # in the running guest's cmdline
         # ubuntu use /usr/bin/kvm as qemu binary
-        qemu_bin = ["/usr/bin/qemu-kvm", "/usr/bin/kvm"]
+        qemu_bin = ["/usr/bin/qemu-kvm", "/usr/bin/kvm", "/usr/libexec/qemu-kvm"]
         arch_bin = ["/usr/bin/qemu-system-x86_64 -machine accel=kvm",
                     "/usr/bin/qemu-system-ppc64 -machine accel=kvm",
                     "qemu-system-ppc64 -enable-kvm"]
@@ -195,7 +195,7 @@ def run(test, params, env):
         elif vm_id == "name":
             vm_id = "%s %s" % (vm_name, extra)
         if file_xml == "":
-            extra_param = extra_param + vm_id
+            file_xml = vm_id
 
     virsh.dumpxml(vm_name, extra="", to_file=file_xml)
     if libvirtd == "off":


### PR DESCRIPTION
expected_option scenario is positive test and --xml option to use
as default for virsh domxml-to-native to consider the input as xml
file.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>