### PR TITLE
Drop the package virttest.staging.backports

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
@@ -6,6 +6,7 @@ import os
 import os.path
 import logging
 import aexpect
+import itertools
 from string import ascii_lowercase
 
 from six import iteritems
@@ -15,7 +16,6 @@ from avocado.utils import astring
 from virttest import virt_vm, virsh, remote, utils_misc, data_dir
 from virttest.libvirt_xml import xcepts
 from virttest.libvirt_xml.vm_xml import VMXML
-from virttest.staging.backports import itertools
 
 from provider import libvirt_version
 


### PR DESCRIPTION
Since legacy python (2.4-2.6) is no longer supported by avocado-vt,
now it is the time to drop the package `virttest.staging.backports`
as it is used for backward compatibility.

Signed-off-by: Xu Han <xuhan@redhat.com>