### PR TITLE
v2v: Add win2016 to windows version list in convert_vm_ovirt file

### DIFF
--- a/v2v/tests/src/convert_vm_to_ovirt.py
+++ b/v2v/tests/src/convert_vm_to_ovirt.py
@@ -170,6 +170,7 @@ def run(test, params, env):
             'win8',
             'win8.1',
             'win10',
+            'win2016'
             'win2012',
             'win2012r2',
             'win2008']


### PR DESCRIPTION
1.add win2016 windows version to liwq

Signed-off-by: weikun <weikunzz@qq.com>