### PR TITLE
Fixup: virsh domtime issue due to guest's time zone differences

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domtime.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domtime.cfg
@@ -2,6 +2,7 @@
     type = virsh_domtime
     start_vm = no
     take_regular_screendumps = "no"
+    vm_stop_duration = 10
     variants:
         - positive:
             variants:


### PR DESCRIPTION
Fixup domtime issue due to guest's time zone difference
due to day light savings in certain regions, so it affects
the guest time considerably when we change time for tests and
add param for vm stop duration.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>