### PR TITLE
Fixed distro specific issues for "iface_network.dnsmasq_test".

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_network.py
+++ b/libvirt/tests/src/virtual_network/iface_network.py
@@ -320,7 +320,11 @@ TIMEOUT 3"""
         Check dns resolving on guest
         """
         # Check if bind-utils is installed
-        if not utils_package.package_install(['bind-utils'], session):
+        if "ubuntu" in vm.get_distro().lower():
+            pkg = "bind9"
+        else:
+            pkg = "bind-utils"
+        if not utils_package.package_install(pkg, session):
             test.error("Failed to install bind-utils on guest")
         # Run host command to check if hostname can be resolved
         if not guest_ipv4 and not guest_ipv6:


### PR DESCRIPTION
The test-cases are failing due to incorrect package name for Ubuntu.

Signed-off-by: Santwana Samantray <santwana@linux.vnet.ibm.com>