### PR TITLE
Check route

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_start.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_start.cfg
@@ -25,6 +25,10 @@
                     action_lookup = "connect_driver:QEMU network_name:default"
                     unprivileged_user = "EXAMPLE"
                     virsh_uri = "qemu:///system"
+        - route_test:
+            status_error = yes
+            route_test = yes
+            expect_start_fail = yes
         - error_test:
             status_error = yes
             variants:

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_start.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_start.py
@@ -2,9 +2,9 @@ import logging
 
 from virttest import virsh
 from virttest import libvirt_vm
-from virttest.libvirt_xml import network_xml
-
+from virttest.libvirt_xml import network_xml, IPXML
 from provider import libvirt_version
+from virttest.utils_test import libvirt
 
 
 def run(test, params, env):
@@ -18,6 +18,7 @@ def run(test, params, env):
     inactive_default = "yes" == params.get("net_start_inactive_default", "yes")
     net_ref = params.get("net_start_net_ref", "netname")  # default is tested
     extra = params.get("net_start_options_extra", "")  # extra cmd-line params.
+    route_test = "yes" == params.get("route_test", "no")
 
     # make easy to maintain
     virsh_dargs = {'uri': uri, 'debug': True, 'ignore_status': True}
@@ -58,16 +59,52 @@ def run(test, params, env):
         origin_state = virsh_instance.net_state_dict()
         logging.debug("Origin network(s) state: %s", origin_state)
 
-        if net_ref == "netname":
-            net_ref = default_netxml.name
-        elif net_ref == "netuuid":
-            net_ref = default_netxml.uuid
+        if route_test:
+            # define a network "def" with route address is "192.168.122.x"
+            # 1. start def first then start default
+            current_state = virsh_instance.net_state_dict()
+            if 'def' in current_state:
+                virsh.net_destroy("def", ignore_status=True)
+                virsh.net_undefine("def", ignore_status=True)
+            expect_fail = "yes" == params.get("expect_start_fail", "no")
+            test_xml = network_xml.NetworkXML(network_name="def")
+            test_xml.forward = {'mode': 'nat'}
+            test_xml.routes = [{'address': '192.168.122.0', 'prefix': '24', 'gateway': '192.168.100.1'}]
+            ipxml = IPXML(address='192.168.100.1', netmask='255.255.255.0')
+            ipxml.dhcp_ranges = {'start': '192.168.100.2', 'end': '192.168.100.254'}
+            test_xml.ip = ipxml
+            test_xml.define()
+            virsh.net_start("def")
+            # start default, should fail
+            result = virsh.net_start("default")
+            logging.debug(result)
+            libvirt.check_exit_status(result, expect_error=expect_fail)
 
-        if params.get('setup_libvirt_polkit') == 'yes':
-            virsh_dargs = {'uri': virsh_uri, 'unprivileged_user': unprivileged_user,
-                           'debug': False, 'ignore_status': True}
-        if params.get('net_start_readonly', 'no') == 'yes':
-            virsh_dargs = {'uri': uri, 'debug': True, 'readonly': True, 'ignore_status': True}
+            # 2. start default then start def
+            virsh.net_destroy("def")
+            virsh.net_start("default")
+            current_state11 = virsh_instance.net_state_dict()
+            logging.debug("before start 2nd network(s) state: %s", current_state11)
+            # start def, should fail
+            result = virsh.net_start("def")
+            logging.debug(result)
+            libvirt.check_exit_status(result, expect_error=expect_fail)
+            current_state12 = virsh_instance.net_state_dict()
+            logging.debug("after start 2nd network(s) state: %s", current_state12)
+            # clear the env
+            virsh.net_undefine("def")
+
+        else:
+            if net_ref == "netname":
+                net_ref = default_netxml.name
+            elif net_ref == "netuuid":
+                net_ref = default_netxml.uuid
+
+            if params.get('setup_libvirt_polkit') == 'yes':
+                virsh_dargs = {'uri': virsh_uri, 'unprivileged_user': unprivileged_user,
+                               'debug': False, 'ignore_status': True}
+            if params.get('net_start_readonly', 'no') == 'yes':
+                virsh_dargs = {'uri': uri, 'debug': True, 'readonly': True, 'ignore_status': True}
 
         # Run test case
         if 'unprivileged_user' in virsh_dargs and status_error:
@@ -75,7 +112,7 @@ def run(test, params, env):
             virsh_dargs.pop('unprivileged_user')
             result = test_virsh.net_start(net_ref, extra, **virsh_dargs)
             test_virsh.close_session()
-        else:
+        elif not route_test:
             result = virsh.net_start(net_ref, extra, **virsh_dargs)
         logging.debug(result)
         status = result.exit_status
@@ -85,8 +122,6 @@ def run(test, params, env):
         logging.debug("Current network(s) state: %s", current_state)
         if 'default' not in current_state:
             test.fail('Network "default" cannot be found')
-        is_default_active = current_state['default']['active']
-
         # Check status_error
         if status_error:
             if not status:
@@ -94,10 +129,17 @@ def run(test, params, env):
         else:
             if status:
                 test.fail("Run failed with right command")
-            else:
-                if not is_default_active:
-                    test.fail("Execute cmd successfully but "
-                              "default is inactive actually.")
+
+            # Get current net_stat_dict
+            current_state = virsh_instance.net_state_dict()
+            logging.debug("Current network(s) state: %s", current_state)
+            is_default_active = current_state['default']['active']
+            if not is_default_active:
+                test.fail("Execute cmd successfully but default is inactive actually.")
     finally:
         virsh_instance.close_session()
+        current_state = virsh_instance.net_state_dict()
+        if "def" in current_state:
+            virsh.net_destroy("def", ignore_status=True)
+            virsh.net_undefine("def", ignore_status=True)
         virsh.net_start('default', debug=True, ignore_status=True)


### PR DESCRIPTION
add only 1 case: type_specific.io-github-autotest-libvirt.virsh.net_start.route_test
all test cases pass:
$ run type_specific.io-github-autotest-libvirt.virsh.net_start
JOB ID     : 0663af4574e9318be583526d7dedba8770ffe935
JOB LOG    : /root/avocado/job-results/job-2018-09-05T18.42-0663af4/job.log
 (01/12) type_specific.io-github-autotest-libvirt.virsh.net_start.normal_test.non_acl.valid_netname: PASS (8.63 s)
 (02/12) type_specific.io-github-autotest-libvirt.virsh.net_start.normal_test.non_acl.valid_netuuid: PASS (7.43 s)
 (03/12) type_specific.io-github-autotest-libvirt.virsh.net_start.normal_test.acl_test.valid_netname: PASS (9.91 s)
 (04/12) type_specific.io-github-autotest-libvirt.virsh.net_start.normal_test.acl_test.valid_netuuid: PASS (9.73 s)
 (05/12) type_specific.io-github-autotest-libvirt.virsh.net_start.route_test: PASS (8.19 s)
 (06/12) type_specific.io-github-autotest-libvirt.virsh.net_start.error_test.none: PASS (8.22 s)
 (07/12) type_specific.io-github-autotest-libvirt.virsh.net_start.error_test.start_twice: PASS (5.41 s)
 (08/12) type_specific.io-github-autotest-libvirt.virsh.net_start.error_test.invalid_netname: PASS (8.18 s)
 (09/12) type_specific.io-github-autotest-libvirt.virsh.net_start.error_test.additional_args: PASS (8.17 s)
 (10/12) type_specific.io-github-autotest-libvirt.virsh.net_start.error_test.additional_option: PASS (8.11 s)
 (11/12) type_specific.io-github-autotest-libvirt.virsh.net_start.error_test.acl_test: PASS (10.49 s)
 (12/12) type_specific.io-github-autotest-libvirt.virsh.net_start.error_test.net_start_readonly_test: PASS (8.25 s)
RESULTS    : PASS 12 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 105.13 s
