### PR TITLE
add --transient-job option case in blockcopy

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcopy.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcopy.cfg
@@ -59,6 +59,9 @@
                     blockcopy_options = "--wait --pivot --async --verbose"
                 - finish_async_option:
                     blockcopy_options = "--wait --finish --async --verbose"
+                - transient_job_option:
+                    only non_acl.local_disk.no_blockdev.no_shallow
+                    blockcopy_options = "--transient-job --wait --verbose --async"
             variants:
                 - shallow:
                     no mirror_state_lock, raw_format


### PR DESCRIPTION
if --transient-job option is given, even acting blockcopy job is interupted by accident,
the job doesn't recover.

Signed-off-by: chunfuwen <chwen@redhat.com>