### PR TITLE
Modify the regular expression in line 235 of virsh_boot.cfg

### DIFF
--- a/libvirt/tests/cfg/bios/virsh_boot.cfg
+++ b/libvirt/tests/cfg/bios/virsh_boot.cfg
@@ -232,7 +232,7 @@
                     variants:
                         - not_existing_loader:
                             loader = "noexist"
-                            checkpoint = "error: Path.+is not accessible: No such file or directory"
+                            checkpoint = "error:(.|\n)*: No such file or directory"
                         - not_existing_loader_type:
                             loader_type = "noexist"
                             define_error = "yes"


### PR DESCRIPTION
Signed-off-by: buaaweaker <2923040052@qq.com>

Because in the line 235 of file tp-libvirt/libvirt/tests/cfg/bios/virsh_boot.cfg, the outputs are more than one
sort, so we should modify the regression formula so that we can deal with more kinds of outputs.
