### PR TITLE
RFC: Demonstrate benefit of config re-order through cpu hotplug tests

### DIFF
--- a/libvirt/tests/cfg/cpu/cpuhotplug.cfg
+++ b/libvirt/tests/cfg/cpu/cpuhotplug.cfg
@@ -1,0 +1,114 @@
+- cpuhotplug:
+    type = cpuhotplug
+    start_vm = yes
+    create_vm_libvirt = yes
+    kill_vm_libvirt =  yes
+    virtinstall_extra_args = " --channel name='org.qemu.guest_agent.0',mode=bind,target_type=virtio,char_type=unix"
+    cores = 4
+    sockets = 1
+    smp = 2
+    threads = 1
+    vcpu_maxcpus = 4
+    mem = 8192
+    env_cleanup = yes
+    vcpu_plug = "yes"
+    vcpu_unplug = "yes"
+    variants:
+        - positive_test:
+            status_error = "no"
+            variants:
+                - vcpu_set:
+                    variants:
+                        - vm_operate:
+                            variants:
+                                - no_operation:
+                                - save:
+                                    vm_operation = "save"
+                                    vcpu_unplug = "no"
+                                - managedsave:
+                                    vm_operation = "managedsave"
+                                    vcpu_unplug = "no"
+                                - suspend:
+                                    vm_operation = "suspend"
+                                    vcpu_unplug = "no"
+                                - suspend_to_mem:
+                                    no ppc64le
+                                    vm_operation = "s3"
+                                    install_qemuga = "yes"
+                                - suspend_to_disk:
+                                    no ppc64le
+                                    vm_operation = "s4"
+                                    install_qemuga = "yes"
+                                - save_with_unplug:
+                                    vm_operation = "save"
+                                - managedsave_with_unplug:
+                                    vm_operation = "managedsave"
+                                - suspend_with_unplug:
+                                    vm_operation = "suspend"
+                                - reboot:
+                                    vm_operation = "reboot"
+                        - libvirtd_restart:
+                                restart_libvirtd = "yes"
+                        - vcpu_pin:
+                            only live
+                            variants:
+                                - pin_plug_unplug:
+                                    pin_before_plug = "yes"
+                                    pin_vcpu = "0"
+                                    pin_cpu_list = "x,y"
+                                - pin_unplug:
+                                    vcpu_plug = "no"
+                                    pin_before_unplug = "yes"
+                                    pin_vcpu = "2"
+                                    pin_cpu_list = "x-y,^z"
+                                - plug_pin:
+                                    vcpu_unplug = "no"
+                                    pin_after_plug = "yes"
+                                    pin_vcpu = "2"
+                                    pin_cpu_list = "x-y"
+                                - unplug_pin:
+                                    vcpu_plug = "no"
+                                    pin_after_unplug = "yes"
+                                    pin_vcpu = "0"
+                                    pin_cpu_list = "x"
+                        - with_stress:
+                            only live
+                            test_itr = 4
+                            run_stress = "yes"
+                            avocado_test = "cpu/ebizzy.py"
+                        - with_iteration:
+                            only live
+                            test_itr = 12
+                        - with_maxvcpu:
+                            only live
+                            test_itr = 2
+                            vcpu_max_timeout = 480
+                            vcpu_maxcpus = 240
+
+                    variants:
+                        - live:
+                            setvcpu_option = "--live"
+                        - config:
+                            setvcpu_option = "--config"
+                        - guest:
+                            vcpu_plug = "no"
+                            setvcpu_option = "--guest"
+
+        - negative_test:
+            status_error = "yes"
+            variants:
+                - greater_plug_number:
+                    vcpu_plug_num = "8"
+                    vcpu_unplug = "no"
+                    check_after_plug_fail = "yes"
+                - readonly_setvcpu:
+                    setvcpu_readonly = "yes"
+                - guest_plug:
+                    vcpu_unplug = "no"
+                    setvcpu_option = "--guest"
+                    check_after_plug_fail = "yes"
+                    variants:
+                        - more_than_current:
+                        - more_than_max:
+                            smp = "4"
+                            vcpu_plug_num = "5"


### PR DESCRIPTION
With reference to this mail, https://www.redhat.com/archives/avocado-devel/2018-May/msg00011.html
I have come up with cpuhotplug testcase which is copy of
libvirt_vcpu_plug_unplug testcase with changes to incorporate
the features described in mail.

Here is what I have changed:
1. Re-used global config params for vcpus and other params used in test.
2. Removed xml changes inside the test as we define,boot
the guest at every subtest in the way we want.
3. Dependancy it needs subtests.cfg to be placed at last in tests-shared.cfg
as mentioned in the above mail for this to work.
4. Added new params in test config to define and delete guest as part of test.

What is the benefit for us:
1. Reducing unwanted multiple params to represent same vm attributes e:g:- vcpus (simplicity)
2. We can reuse the library function not with much changes in other tests (modularity and reduce maintenance overhead)
3. Test execution time is reduced by around ~66%

libvirt_vcpu_plug_unplug.positive_test.vcpu_set.live.vm_operate.no_operation: PASS (128.45 s)
libvirt_vcpu_plug_unplug: JOB TIME   : 11356.14 s

cpuhotplug.positive_test.vcpu_set.live.vm_operate.no_operation: PASS (87.46 s)
cpuhotplug: JOB TIME   : 3894.54 s

I have not faced any other obvious framework issue with this change.
I agree this will require quite a change to our old testcases, but given
the benefit its worth doing it :-), we can discuss further on this and
we can get to common grounds.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>