### PR TITLE
Rename case *.no_create_target_image.*

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_vm.cfg
+++ b/libvirt/tests/cfg/migration/migrate_vm.cfg
@@ -677,8 +677,9 @@
                     target_pool_name = "precreation_pool"
                     target_pool_type = "dir"
                     variants:
-                        - no_create_target_image:
+                        - no_create_target_pool_nor_image:
                             create_target_image = "no"
+                            no_create_pool = "yes"
                             variants:
                                 - simple:
                                     virsh_options = "--live --verbose"

--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -24,6 +24,7 @@ from virttest import utils_selinux
 from virttest import utils_test
 from virttest import virsh
 from virttest import virt_vm
+from virttest import xml_utils
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.disk import Disk
 from virttest.libvirt_xml.devices.smartcard import Smartcard
@@ -43,6 +44,36 @@ from provider import libvirt_version
 
 MIGRATE_RET = False
 
+def destroy_active_pool_on_remote(params):
+    """
+    This is to destroy active pool with same target path as pool_target
+    on remote host
+    :param params: a dict for parameters
+    :return True if successful, otherwise False
+    """
+    ret = True
+
+    remote_ip = params.get("migrate_dest_host")
+    remote_user = params.get("migrate_dest_user", "root")
+    remote_pwd = params.get("migrate_dest_pwd")
+
+    virsh_dargs = {'remote_ip': remote_ip, 'remote_user': remote_user,
+                   'remote_pwd': remote_pwd, 'unprivileged_user': None,
+                   'ssh_remote_auth': True}
+
+    new_session = virsh.VirshPersistent(**virsh_dargs)
+
+    active_pools = new_session.pool_list(option="--name")
+
+    for pool in active_pools.stdout.strip().split("\n"):
+        pool_dump = new_session.pool_dumpxml(pool)
+        xtf = xml_utils.XMLTreeFile(pool_dump)
+        if xtf.findtext('.//target/path') == params.get("pool_target"):
+            ret = new_session.pool_destroy(pool)
+
+    new_session.close_session()
+
+    return ret
 
 def create_destroy_pool_on_remote(action, params):
     """
@@ -1786,6 +1817,12 @@ def run(test, params, env):
                 raise exceptions.TestError("Create pool on remote host '%s' "
                                            "failed." % server_ip)
             remote_image_list.append(target_image_source)
+        else:
+            pool_destroyed = destroy_active_pool_on_remote(test_dict)
+            if not pool_destroyed:
+                raise exceptions.TestError("Destroy pool on remote '%s' failed."
+                                           % server_ip)
+
         if create_target_image:
             if not target_image_size and image_info_dict:
                 target_image_size = image_info_dict.get('vsize')

--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -44,6 +44,7 @@ from provider import libvirt_version
 
 MIGRATE_RET = False
 
+
 def destroy_active_pool_on_remote(params):
     """
     This is to destroy active pool with same target path as pool_target
@@ -74,6 +75,7 @@ def destroy_active_pool_on_remote(params):
     new_session.close_session()
 
     return ret
+
 
 def create_destroy_pool_on_remote(action, params):
     """


### PR DESCRIPTION
The original name "no_create_target_image" for the negative case
in live storage migration is not proper any more and is ambiguous,
as libvirt has been able to create target image automatically as long 
as storage pool exists on target host.

Signed-off-by: Fangge Jin <fjin@redhat.com>