### PR TITLE
add auth is placed in source part when using ceph

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_ceph.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_ceph.cfg
@@ -127,6 +127,11 @@
             secret_type = "ceph"
             secret_usage = "EXAMPLE_SECRET_USAGE"
             auth_user = "EXAMPLE_AUTH_USER"
+                variants:
+                    - auth_place_in_source:
+                        only disk_attach.attach_device
+                        auth_place_in_source = 'source'
+                    - default:
         - without_auth:
     variants:
         - hot_plug:

--- a/libvirt/tests/src/virtual_disks/virtual_disks_ceph.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_ceph.py
@@ -518,11 +518,16 @@ def run(test, params, env):
     test_disk_internal_snapshot = "yes" == params.get("test_disk_internal_snapshot", "no")
     test_json_pseudo_protocol = "yes" == params.get("json_pseudo_protocol", "no")
     disk_snapshot_with_sanlock = "yes" == params.get("disk_internal_with_sanlock", "no")
+    auth_place_in_source = params.get("auth_place_in_source")
 
     # Prepare a blank params to confirm if delete the configure at the end of the test
     ceph_cfg = ""
     # Create config file if it doesn't exist
     ceph_cfg = ceph.create_config_file(mon_host)
+
+    # After libvirt 3.9.0, auth element can be put into source part.
+    if auth_place_in_source and not libvirt_version.version_compare(3, 9, 0):
+        test.cancel("place auth in source is not supported in current libvirt version")
 
     # Start vm and get all partions in vm.
     if vm.is_dead():
@@ -770,6 +775,9 @@ def run(test, params, env):
                     params.pop("secret_uuid")
                 if "secret_usage" in params:
                     params.pop("secret_usage")
+            # After 3.9.0,the auth element can be place in source part.
+            if auth_place_in_source:
+                params.update({"auth_in_source": auth_place_in_source})
             xml_file = libvirt.create_disk_xml(params)
             if additional_guest:
                 # Copy xml_file for additional guest VM.


### PR DESCRIPTION
After libvirt 3.9.0, auth element can be placed in source part, as
well as disk directly.

Signed-off-by: chunfuwen <chwen@redhat.com>