### PR TITLE
Destroy active pools on target when create_target_pool is "no"

### DIFF
--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -24,6 +24,7 @@ from virttest import utils_selinux
 from virttest import utils_test
 from virttest import virsh
 from virttest import virt_vm
+from virttest import xml_utils
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.disk import Disk
 from virttest.libvirt_xml.devices.smartcard import Smartcard
@@ -42,6 +43,38 @@ from virttest.compat_52lts import decode_to_text as to_text
 from provider import libvirt_version
 
 MIGRATE_RET = False
+
+
+def destroy_active_pool_on_remote(params):
+    """
+    This is to destroy active pool with same target path as pool_target
+    on remote host
+    :param params: a dict for parameters
+    :return True if successful, otherwise False
+    """
+    ret = True
+    
+    remote_ip = params.get("migrate_dest_host")
+    remote_user = params.get("migrate_dest_user", "root")
+    remote_pwd = params.get("migrate_dest_pwd")
+    
+    virsh_dargs = {'remote_ip': remote_ip, 'remote_user': remote_user,
+                   'remote_pwd': remote_pwd, 'unprivileged_user': None,
+                   'ssh_remote_auth': True}
+    
+    new_session = virsh.VirshPersistent(**virsh_dargs)
+    
+    active_pools = new_session.pool_list(option="--name")
+    
+    for pool in active_pools.stdout.strip().split("\n"):
+        pool_dump = new_session.pool_dumpxml(pool)
+        xtf = xml_utils.XMLTreeFile(pool_dump)
+        if xtf.findtext('.//target/path') == params.get("pool_target"):
+            ret = new_session.pool_destroy(pool)
+    
+    new_session.close_session()
+    
+    return ret
 
 
 def create_destroy_pool_on_remote(action, params):
@@ -1786,6 +1819,12 @@ def run(test, params, env):
                 raise exceptions.TestError("Create pool on remote host '%s' "
                                            "failed." % server_ip)
             remote_image_list.append(target_image_source)
+        else:
+            pool_destroyed = destroy_active_pool_on_remote(test_dict)
+            if not pool_destroyed:
+                raise exceptions.TestError("Destroy pool on remote host '%s'"
+                                           "failed." % server_ip)
+
         if create_target_image:
             if not target_image_size and image_info_dict:
                 target_image_size = image_info_dict.get('vsize')


### PR DESCRIPTION
If parameter create_target_pool_pool is "no" but an active pool with
same target path as paramter pool_target already exists on target host,
migration may succeed unexpectedly.

Signed-off-by: Fangge Jin <fjin@redhat.com>