### PR TITLE
Rename case *.no_create_target_image.*

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_vm.cfg
+++ b/libvirt/tests/cfg/migration/migrate_vm.cfg
@@ -677,8 +677,9 @@
                     target_pool_name = "precreation_pool"
                     target_pool_type = "dir"
                     variants:
-                        - no_create_target_image:
+                        - create_neither_target_pool_nor_image:
                             create_target_image = "no"
+                            no_create_pool = "yes"
                             variants:
                                 - simple:
                                     virsh_options = "--live --verbose"


### PR DESCRIPTION
The original name "no_create_target_image" for the negative case
in live storage migration is not proper any more and is ambiguous,
as libvirt has been able to create target image automatically as long
as storage pool exists on target host.

Signed-off-by: Fangge Jin <fjin@redhat.com>