### PR TITLE
Fixed distro specific issues for "iface_network"

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_network.py
+++ b/libvirt/tests/src/virtual_network/iface_network.py
@@ -446,8 +446,12 @@ TIMEOUT 3"""
         Check guest libvirt network
         """
         # Try to install required packages
-        if not utils_package.package_install(['libvirt'], session):
-            test.error("Failed ot install libvirt package on guest")
+        if "ubuntu" in vm.get_distro().lower():
+            pkg = "libvirt-bin"
+        else:
+            pkg = "libvirt"
+        if not utils_package.package_install(pkg, session):
+            test.error("Failed to install libvirt package on guest")
         # Try to load tun module first
         session.cmd("lsmod | grep tun || modprobe  tun")
         # Check network state on guest


### PR DESCRIPTION
The test-case was failing in Ubuntu during 'libvirt' package installation.

Signed-off-by: Santwana Samantray <santwana@linux.vnet.ibm.com>