### PR TITLE
Add variable unsupported_conf

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
@@ -529,6 +529,7 @@
             virsh_migrate_options = "--live"
             xml_option = "yes"
             virsh_migrate_extra = "--dname ${vm_new_name}"
+            unsupported_conf = "yes"
             status_error = 'yes'
         - there_xml_with_diff_dname:
             # Do migration with --dname and --xml with different changed
@@ -537,4 +538,5 @@
             virsh_migrate_options = "--live"
             xml_option = "yes"
             virsh_migrate_extra = "--dname ${vm_new_name}-diff"
+            unsupported_conf = "yes"
             status_error = 'yes'

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
@@ -98,7 +98,8 @@ def run(test, params, env):
         :raise: test.cancel when some known messages found
         """
         logging.debug("Migration result:\n%s", migration_res)
-        if migration_res.stderr.find("error: unsupported configuration:") >= 0:
+        if (migration_res.stderr.find("error: unsupported configuration:") >= 0 and
+                not params.get("unsupported_conf", "no") == "yes"):
             test.cancel(migration_res.stderr)
 
     def do_migration(delay, vm, dest_uri, options, extra):


### PR DESCRIPTION
Test should not just cancel when "unsupported conf" error happens 
during migration, because it is expected for some test cases. Add
a variable to distinguish when error "unsupported conf" is expected

Signed-off-by: Fangge Jin <fjin@redhat.com>