### PR TITLE
Add test for rom enable updating

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_hotplug.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_hotplug.cfg
@@ -12,6 +12,28 @@
             err_msgs1 = "domain is not running"
             err_msgs2 = "are mutually exclusive"
             variants:
+                - rom_bar_off:
+                    only at_device
+                    iface_rom = "{'bar':'off'}"
+                    err_msg_rom = "Hot-plugged device without ROM bar can't have an option ROM"
+                - rom_enable_no_bar_off:
+                    only at_device
+                    iface_rom = "{'enabled':'no','bar':'off'}"
+                    err_msg_rom = "ROM tuning is not supported when ROM is disabled"
+                    variants:
+                        - hot:
+                        - cold:
+                            start_vm = "no"
+                            attach_option = "--persistent"
+                - rom_enable_no:
+                    only at_device
+                    iface_num = '2'
+                    iface_rom = "{'enabled':'no'}"
+                    detach_device = "yes"
+                - rom_enable_yes:
+                    only at_device
+                    iface_rom = "{'enabled':'yes','file':'/usr/share/qemu-kvm/pxe-virtio.rom','bar':'on'}"
+                    detach_device = "yes"
                 - large_scale:
                     iface_num = '32'
                     detach_device = "yes"

--- a/libvirt/tests/cfg/virtual_network/iface_network.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_network.cfg
@@ -5,6 +5,17 @@
     status_error = "no"
     start_error = "no"
     variants:
+        - rom_test:
+            variants:
+                - negative:
+                    change_iface_option = "yes"
+                    status_error = "yes"
+                    define_error = "yes"
+                    variants:
+                        - enable_no_bar_off:
+                            iface_rom = "{'enabled':'no','bar':'off'}"
+                        - enable_no_with_file:
+                            iface_rom = "{'enabled':'no','file':'/usr/share/qemu-kvm/pxe-virtio.rom'}"
         - bridge_test:
             create_network = "yes"
             net_name = "test_noip"
@@ -137,6 +148,21 @@
             net_name = pxetest
             iface_source = "{'network':'pxetest'}"
             change_iface_option = "yes"
+            variants:
+                - default:
+                - boot_failure:
+                    boot_failure = "yes"
+                    iface_rom = "{'enabled':'no'}"
+                    iface_boot = "1"
+                    variants:
+                        - virtio:
+                            iface_model = "virtio"
+                        - e1000:
+                            iface_model = "e1000"
+                        - rtl8139:
+                            iface_model = "rtl8139"
+                        - e1000e:
+                            iface_model = "e1000e"
         - net_guest:
             test_guest_libvirt = "yes"
         - net_macvtap:

--- a/libvirt/tests/src/virtual_network/iface_hotplug.py
+++ b/libvirt/tests/src/virtual_network/iface_hotplug.py
@@ -36,6 +36,8 @@ def run(test, params, env):
         if iface_target:
             iface.target = {'dev': iface_target}
         iface.mac_address = mac
+        if iface_rom:
+            iface.rom = eval(iface_rom)
         logging.debug("Create new interface xml: %s", iface)
         return iface
 
@@ -47,6 +49,7 @@ def run(test, params, env):
     iface_model = params.get("iface_model")
     iface_target = params.get("iface_target")
     iface_mac = params.get("iface_mac")
+    iface_rom = params.get("iface_rom")
     attach_device = "yes" == params.get("attach_device", "no")
     attach_iface = "yes" == params.get("attach_iface", "no")
     attach_option = params.get("attach_option", "")
@@ -61,6 +64,7 @@ def run(test, params, env):
     poll_timeout = int(params.get("poll_timeout", 10))
     err_msgs1 = params.get("err_msgs1")
     err_msgs2 = params.get("err_msgs2")
+    err_msg_rom = params.get("err_msg_rom")
 
     # stree_test require detach operation
     stress_test_detach_device = False
@@ -115,7 +119,8 @@ def run(test, params, env):
                     iface_xml_obj.xmltreefile.write()
                     ret = virsh.attach_device(vm_name, iface_xml_obj.xml,
                                               flagstr=attach_option,
-                                              ignore_status=True)
+                                              ignore_status=True,
+                                              debug=True)
                 elif attach_iface:
                     logging.info("Try to attach interface loop %s" % i)
                     mac = utils_net.generate_mac_address_simple()
@@ -138,6 +143,8 @@ def run(test, params, env):
                         logging.debug("options %s are mutually exclusive" % attach_option)
                         if not ("--current" in sep_options and len(sep_options) > 1):
                             test.fail("return mutualy exclusive, but it is unexpected")
+                    elif err_msg_rom in ret.stderr:
+                        logging.debug("Attach failed with expect err msg: %s" % err_msg_rom)
                     else:
                         test.fail("Failed to attach-interface: %s" % ret.stderr.strip())
                 elif stress_test:

--- a/libvirt/tests/src/virtual_network/iface_network.py
+++ b/libvirt/tests/src/virtual_network/iface_network.py
@@ -7,6 +7,8 @@ import logging
 from avocado.utils import process
 from avocado.utils import stacktrace
 
+from aexpect.exceptions import ExpectTimeoutError
+
 from virttest import virt_vm
 from virttest import virsh
 from virttest import utils_net
@@ -116,8 +118,13 @@ TIMEOUT 3"""
             source['dev'] = net_ifs[0]
         del iface.source
         iface.source = source
-        iface_model = params.get("iface_model", "virtio")
-        iface.model = iface_model
+        if iface_model:
+            iface.model = iface_model
+        if iface_rom:
+            iface.rom = eval(iface_rom)
+        if iface_boot:
+            vmxml.remove_all_boots()
+            iface.boot = iface_boot
         logging.debug("New interface xml file: %s", iface)
         vmxml.devices = xml_devices
         vmxml.xmltreefile.write()
@@ -497,6 +504,9 @@ TIMEOUT 3"""
     iface_bandwidth_outbound = params.get("iface_bandwidth_outbound", "{}")
     iface_num = params.get("iface_num", "1")
     iface_source = params.get("iface_source", "{}")
+    iface_rom = params.get("iface_rom")
+    iface_boot = params.get("iface_boot")
+    iface_model = params.get("iface_model")
     multiple_guests = params.get("multiple_guests")
     create_network = "yes" == params.get("create_network", "no")
     attach_iface = "yes" == params.get("attach_iface", "no")
@@ -519,6 +529,7 @@ TIMEOUT 3"""
     username = params.get("username")
     password = params.get("password")
     forward = ast.literal_eval(params.get("net_forward", "{}"))
+    boot_failure = "yes" == params.get("boot_failure", "no")
     ipt_rules = []
 
     # Destroy VM first
@@ -627,11 +638,19 @@ TIMEOUT 3"""
 
         # Edit the interface xml.
         if change_iface_option:
-            modify_iface_xml()
+            try:
+                modify_iface_xml()
+            except xcepts.LibvirtXMLError as details:
+                logging.info(str(details))
+                if define_error:
+                    if not str(details).count("Failed to define"):
+                        test.fail("VM sync failed msg not expected")
+                    return
+                else:
+                    test.fail("Failed to sync VM")
         # Attach interface if needed
         if attach_iface:
             iface_type = params.get("iface_type", "network")
-            iface_model = params.get("iface_model", "virtio")
             for i in range(int(iface_num)):
                 logging.info("Try to attach interface loop %s" % i)
                 options = ("%s %s --model %s --config" %
@@ -754,12 +773,17 @@ TIMEOUT 3"""
                 test.fail("VM started unexpectedly")
             if pxe_boot:
                 # Just check network boot messages here
-                vm.serial_console.read_until_output_matches(
-                    ["Loading vmlinuz", "Loading initrd.img"],
-                    utils_misc.strip_console_codes)
-                output = vm.serial_console.get_stripped_output()
-                logging.debug("Boot messages: %s", output)
-
+                try:
+                    vm.serial_console.read_until_output_matches(
+                        ["Loading vmlinuz", "Loading initrd.img"],
+                        utils_misc.strip_console_codes)
+                    output = vm.serial_console.get_stripped_output()
+                    logging.debug("Boot messages: %s", output)
+                except ExpectTimeoutError as details:
+                    if boot_failure:
+                        logging.info("Fail to boot from pxe as expected")
+                    else:
+                        test.fail("Fail to boot from pxe")
             else:
                 if serial_login:
                     session = vm.wait_for_serial_login(username=username,


### PR DESCRIPTION
Add a new attribute in rom element "enabled" and it can be "yes" or "no", default if no set is "yes". Set to "no" to disable network boot.
1. Test for xml and related combination with <rom enabled='no'>, <rom enabled='yes'>
2. Test for update-device, hotplug, define, start