### PR TITLE
Add vol creation cases for disk and logical pool

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_create.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_create.cfg
@@ -12,6 +12,13 @@
         - positive_test:
             status_error = "no"
             variants:
+                - luks_encryption:
+                    only logical_pool..normal_vol,disk_pool..vol_format_none,fs_like_pool..v_raw
+                    encryption_method = "luks"
+                    encryption_secret_type = "passphrase"
+                    action_lookup = "connect_driver:QEMU"
+                - non_encryption:
+            variants:
                 - logical_pool:
                     src_pool_type = "logical"
                     src_pool_target = "/dev/vg_logical"
@@ -51,7 +58,7 @@
                     variants:
                         - pool_format_none:
                         - pool_format_gpt:
-                            only vol_format_none
+                            only vol_format_none..non_encryption
                             src_pool_format = "gpt"
                             src_pool_vol_num = "128"
                             vol_capacity = "1048576"
@@ -101,11 +108,6 @@
                             variants:
                                 - v_raw:
                                     vol_format = "raw"
-                                - v_raw_luks:
-                                    vol_format = "raw"
-                                    encryption_method = "luks"
-                                    encryption_secret_type = "passphrase"
-                                    action_lookup = "connect_driver:QEMU"
                                 - v_qcow2:
                                     vol_format = "qcow2"
                                 - v_qcow2_with_prealloc:
@@ -265,6 +267,7 @@
                             bad_vol_name = "test\/vol"
     variants:
         - create_as:
+            no luks_encryption
             create_vol_by_xml = "no"
             variants:
                 - by_name:


### PR DESCRIPTION
1. Luks encrypted volume can be created in disk and logical
   pool now (bz1560946 and bz1427049), cases added.
2. Virsh cmd 'vol-create-as' doesn't have encryption related
   parameters, remove useless cases.
3. Reconstruct the cfg file to make it more clear for
   luks_encryption/non_encryption level.

Signed-off-by: Yi Sun <yisun@redhat.com>