### PR TITLE
virsh_migrate_stress: Add Transparent Hugepage enabled stress migration

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_stress.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_stress.cfg
@@ -59,7 +59,6 @@
                         - memory_stress:
                             # Add timeout option to avoid infinite stress.
                             stress_args = "--vm 4 --vm-bytes %s --vm-keep --timeout 3600"
-                            stress_vm_bytes = "128M"
                 - stress_ng:
                     stress_tool = "stress-ng"
                     download_url_stress-ng = "http://kernel.ubuntu.com/~cking/tarballs/stress-ng/stress-ng-0.09.31.tar.xz"
@@ -71,7 +70,20 @@
                         - memory_stress:
                             # Add timeout option to avoid infinite stress.
                             stress-ng_args = "--vm 4 --vm-bytes %s --vm-keep --timeout 3600"
-                            stress_vm_bytes = "128M"
+                        - TransparentHugePage:
+                            # use this param to enable THP in host/VM/remote host along
+                            # with migration_stress_*
+                            transparent_hugepages = "yes"
+                            variants:
+                                - never:
+                                    thp_option = "never"
+                                    stress-ng_args = "--vm 4 --vm-bytes %s --vm-keep --timeout 3600"
+                                - always:
+                                    thp_option = "always"
+                                    stress-ng_args = "--vm 4 --vm-bytes %s --vm-keep --timeout 3600 --no-madvise"
+                                - madvise:
+                                    thp_option = "madvise"
+                                    stress-ng_args = "--vm 4 --vm-bytes %s --vm-keep --timeout 3600 --vm-madvise hugepage"
             variants:
                 - stress_tool_in_vms:
                     migration_stress_vms = "yes"


### PR DESCRIPTION
Enable Transparent Hugepages with enabled, never and madvise to trigger `stress-ng`
commands accordingly to exercise THP in guest/host/remote in the testcase. For
host and remote host THP stress, we align guest boot memory with Huge Page aligned.
If the hugepages are different in host and remote host then we make sure guest boot
memory is aligned to both hugepages. For the `stress-ng` --vm-bytes argument is also
taken care to be aligned with respective hugepage size of host/remote host/guest.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>