### PR TITLE
Skip luks encryption vol clone for disk pool type

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_clone_wipe.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_clone_wipe.cfg
@@ -65,7 +65,7 @@
             variants:
                 - non_encrypt:
                 - luks_encrypt:
-                    no acl_test, logical, qcow2_f, qed_f, vdmk_f, sparse_file
+                    no acl_test, logical, qcow2_f, qed_f, vdmk_f, sparse_file, pool_type.disk
                     encryption_method = "luks"
                     encryption_secret_type = "passphrase"
                     vol_capability = 10485760


### PR DESCRIPTION
Currently we do not have support for luks encryption for disk pool.
This patch excludes this test scenario as we cover non encrypted
in non_encrypt.[acl_test/non_acl].disk_part.pool_type.disk

Signed-off-by: Srikanth Aithal <sraithal@linux.vnet.ibm.com>