### PR TITLE
migrate_options_shared: Add case for htm migration

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -92,3 +92,13 @@
                     virsh_migrate_extra = ""
                     new_contrl_index = 5
                     guest_xml_check_after_mig = "controller type='pci' index='[0-${new_contrl_index}]' model='pci-root'"
+                - htm:
+                    virsh_migrate_options = "--live --verbose"
+                    virsh_migrate_extra = ""
+                    qemu_check = 'cap-htm='
+                    guest_xml_check_after_mig = 'htm state='
+                    variants:
+                        - state_on:
+                            htm_state = "on"
+                        - state_off:
+                            htm_state = "off"


### PR DESCRIPTION
Libvirt supports <htm state='xxx'/> feature on PPC now. So this is to
test the migration with htm feature setting.

Signed-off-by: Dan Zheng <dzheng@redhat.com>