### PR TITLE
Remove --unsafe from virsh options 

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_vm.cfg
+++ b/libvirt/tests/cfg/migration/migrate_vm.cfg
@@ -45,7 +45,7 @@
                         - reboot_vm:
                             reboot_vm = "yes"
                         - listen_address:
-                            virsh_options = "--live --verbose --unsafe --listen-address ${server_ip}"
+                            virsh_options = "--live --verbose --listen-address ${server_ip}"
                         - diff_cpu_vendor:
                             diff_cpu_vendor = "yes"
                         - cpuset:
@@ -58,12 +58,12 @@
                             run_migrate_cmd_in_back = "yes"
                             check_job_info = "yes"
                             check_complete_job = "no"
-                            virsh_options = "--live --verbose --unsafe --timeout ${migration_cmd_timeout}"
+                            virsh_options = "--live --verbose --timeout ${migration_cmd_timeout}"
                         - track_statistics:
                             run_migrate_cmd_in_front = "no"
                             run_migrate_cmd_in_back = "yes"
                             set_migration_speed = 15
-                            virsh_options = "--live --verbose --unsafe"
+                            virsh_options = "--live --verbose"
                             check_job_info = "yes"
                             check_complete_job = "yes"
                         - default_cache_size:
@@ -72,7 +72,7 @@
                             run_migrate_cmd_in_back = "yes"
                             set_migration_speed = 10
                             check_job_info = "yes"
-                            virsh_options = "--live --verbose --unsafe --compressed"
+                            virsh_options = "--live --verbose --compressed"
                         - set_cache_size:
                             set_migrate_compcache_size = 640000000
                             set_migration_speed = 15
@@ -82,7 +82,7 @@
                             check_complete_job = "yes"
                             config_libvirtd = "yes"
                             grep_str_from_local_libvirt_log = "virDomainMigrateSetCompressionCache.*cacheSize=${set_migrate_compcache_size}"
-                            virsh_options = "--live --verbose --unsafe --compressed"
+                            virsh_options = "--live --verbose --compressed"
                         - with_hugepages:
                             setup_hugepages = "yes"
                             target_hugepages = 600
@@ -92,7 +92,7 @@
                             remote_hugetlbfs_path = "/dev/hugepages"
                             restart_libvirtd_remotely = "yes"
                         - bi_directional:
-                            virsh_options = "--live --verbose --unsafe"
+                            virsh_options = "--live --verbose"
                             migrate_vm_back = "yes"
                             migration_source_uri = "qemu+ssh://${client_ip}/system"
                         - iscsi:
@@ -100,7 +100,7 @@
                             enable_virt_use_nfs = "no"
                             nfs_mount_dir =
                             disk_source_protocol = "iscsi"
-                            virsh_options = "--live --verbose --unsafe"
+                            virsh_options = "--live --verbose"
                             iscsi_setup = "yes"
                             disk_format = "raw"
                             variants:
@@ -133,11 +133,11 @@
                                             check_job_info = "yes"
                                             config_libvirtd = "yes"
                                             grep_str_from_local_libvirt_log = "migrate_set_downtime.*${max_down_time}"
-                                            virsh_options = "--live --verbose --unsafe"
+                                            virsh_options = "--live --verbose"
                                         - memhog_memory_without_swap:
                                             no_swap = "yes"
                                             memhog_install_pkg = "yum install -y numactl"
-                                            virsh_options = "--live --verbose --unsafe"
+                                            virsh_options = "--live --verbose"
                                 - host:
                                     variants:
                                         - stress_cpu:
@@ -145,13 +145,13 @@
                                             stress_args = "--cpu 8 --timeout 1000s"
                                             load_timeout = 300
                                             migration_timeout = 600
-                                            virsh_options = "--live --verbose --unsafe"
+                                            virsh_options = "--live --verbose"
                                         - stress_memory:
                                             stress_type = "stress_on_host"
                                             stress_args = "--vm 6 --vm-bytes 256M --vm-keep --timeout 1000s"
                                             load_timeout = 300
                                             migration_timeout = 600
-                                            virsh_options = "--live --verbose --unsafe"
+                                            virsh_options = "--live --verbose"
                                         - netperf_network:
                                             netperf_version = "netperf-2.6.0"
                                             netperf_source = "shared/deps/netperf/${netperf_version}.tar.bz2"
@@ -160,13 +160,13 @@
                                             netperf_test_duration = 300
                                             netperf_para_sessions = 1
                                             migration_timeout = 600
-                                            virsh_options = "--live --verbose --unsafe"
+                                            virsh_options = "--live --verbose"
                         - iothread:
                             driver_iothread = 4
                 - p2p_migration:
                     variants:
                         - basic:
-                            virsh_options = "--live --p2p --verbose --unsafe"
+                            virsh_options = "--live --p2p --verbose"
                             variants:
                                 - with_ssh:
                                     uri_port = ":22"
@@ -183,7 +183,7 @@
                                 - with_tls_reverse:
                                     status_error = "yes"
                                     target_vm_name = "avocado-vt-remote-vm1"
-                                    virsh_options = " --p2p --verbose --unsafe"
+                                    virsh_options = " --p2p --verbose"
                                     transport = "tls"
                                     uri_port = "16514"
                                     server_cn = "ENTER.YOUR.SERVER_CN"
@@ -191,12 +191,12 @@
                                     extra_opt = "-c qemu+tls://${server_cn}/system"
                                     target_xml_path = "/tmp/avocado_vt_remote_vm1.xml"
                         - bi_directional:
-                            virsh_options = "--live --p2p --verbose --unsafe"
+                            virsh_options = "--live --p2p --verbose"
                             migrate_vm_back = "yes"
                             migration_source_uri = "qemu+ssh://${client_ip}/system"
                         - listen_address:
                             listen_address = "${server_ip}"
-                            virsh_options = "--live --p2p --verbose --unsafe --listen-address ${server_ip}"
+                            virsh_options = "--live --p2p --verbose --listen-address ${server_ip}"
                             variants:
                                 - with_ssh:
                                     uri_port = ":22"
@@ -214,7 +214,7 @@
                             set_migration_speed = 1
                             run_migrate_cmd_in_front = "no"
                             run_migrate_cmd_in_back = "yes"
-                            virsh_options = "--live --p2p --verbose --unsafe"
+                            virsh_options = "--live --p2p --verbose"
                             variants:
                                 - default_conf_less_than_keepalive_time:
                                     # the format looks like 'N ${time}', and N >=1, the ${time}
@@ -229,7 +229,7 @@
                 - tunnelled_migration:
                     variants:
                         - basic:
-                            virsh_options = "--live --p2p --tunnelled --verbose --unsafe"
+                            virsh_options = "--live --p2p --tunnelled --verbose"
                             variants:
                                 - with_ssh:
                                     uri_port = ":22"
@@ -244,7 +244,7 @@
                                     server_cn = "ENTER.YOUR.SERVER_CN"
                                     client_cn = "ENTER.YOUR.CLIENT_CN"
                         - bi_directional:
-                            virsh_options = "--live --p2p --tunnelled --verbose --unsafe"
+                            virsh_options = "--live --p2p --tunnelled --verbose"
                             migrate_vm_back = "yes"
                             migration_source_uri = "qemu+ssh://${client_ip}/system"
                 - migration_with_nbd:
@@ -255,7 +255,7 @@
                     nfs_mount_dir =
                     variants:
                         - nbd_port:
-                            virsh_options = "--live --verbose --unsafe --copy-storage-all"
+                            virsh_options = "--live --verbose --copy-storage-all"
                             migration_timeout = 1800
                             nbd_port = "49153"
                             create_target_image = "yes"
@@ -274,7 +274,7 @@
                     nfs_mount_dir =
                     variants:
                         - gluster:
-                            virsh_options = "--live --verbose --unsafe"
+                            virsh_options = "--live --verbose"
                             migration_timeout = 300
                             gluster_disk = "yes"
                             disk_source_protocol = "gluster"
@@ -283,7 +283,7 @@
                             migrate_vm_back = "yes"
                             migration_source_uri = "qemu+ssh://${client_ip}/system"
                         - rdma:
-                            virsh_options = "--live --verbose --unsafe"
+                            virsh_options = "--live --verbose"
                             gluster_transport = "rdma"
                             migration_timeout = 300
                             gluster_disk = "yes"
@@ -321,7 +321,7 @@
                 - migration_with_devices:
                     variants:
                         - eject_cdrom_in_guest:
-                            virsh_options = "--live --verbose --unsafe"
+                            virsh_options = "--live --verbose"
                             guest_cmd = "eject -v /dev/cdrom"
                             local_disk_image = "${nfs_mount_dir}/virt_iso.img"
                             local_image_format = "raw"
@@ -369,15 +369,15 @@
                             target_dev = "vdb"
                             run_cmd_in_vm_after_migration = "dd if=/dev/zero of=/tmp/test count=1 bs=1 seek=10M"
                             attach_disk_args = "--config --driver qemu --subdriver ${local_image_format} --cache none"
-                            virsh_options = "--live --verbose --unsafe"
+                            virsh_options = "--live --verbose"
                         - attach_virtual_nic:
                             attach_iface_times = 7
                             attach_iface_options = "--type bridge --source virbr0"
-                            virsh_options = "--live --verbose --unsafe"
+                            virsh_options = "--live --verbose"
                 - cross_rhel_platform_migration:
                     # only work well on RHEL platform
                     migration_timeout = 600
-                    virsh_options = "--live --verbose --unsafe"
+                    virsh_options = "--live --verbose"
                     variants:
                         - vm_without_video:
                             del_vm_video_dev = "yes"
@@ -521,7 +521,7 @@
                             check_image_size = "yes"
                             check_disk_size_cmd = "qemu-img info ${new_disk_source}"
                             local_image_source = "${new_disk_source}"
-                            virsh_options = "--live --verbose --copy-storage-inc --unsafe"
+                            virsh_options = "--live --verbose --copy-storage-inc"
                         - with_migrate_disks:
                             setup_nfs = "yes"
                             enable_virt_use_nfs = "yes"
@@ -531,12 +531,12 @@
                             config_libvirtd = "yes"
                             variants:
                                 - no_migrate_disks:
-                                    virsh_options = "--live --unsafe --verbose --copy-storage-all"
+                                    virsh_options = "--live --verbose --copy-storage-all"
                                 - all_non_shared_disks:
-                                    virsh_options = "--live --unsafe --verbose --copy-storage-all --migrate-disks vda,vdb"
+                                    virsh_options = "--live --verbose --copy-storage-all --migrate-disks vda,vdb"
                                 - part_non_shared_disks:
                                     status_error = "yes"
-                                    virsh_options = "--live --unsafe --verbose --copy-storage-all --migrate-disks vda"
+                                    virsh_options = "--live --verbose --copy-storage-all --migrate-disks vda"
                         - disk_ports:
                             nfs_mount_dir =
                             disk_port = "56789"
@@ -551,31 +551,31 @@
                     variants:
                         - stop_libvirtd_remotely:
                             stop_libvirtd_remotely = "yes"
-                            virsh_options = "--live --verbose --unsafe"
+                            virsh_options = "--live --verbose"
                         - disable_virt_use_nfs_remotely:
                             remote_boolean_value = "off"
-                            virsh_options = "--live --verbose --unsafe"
+                            virsh_options = "--live --verbose"
                         - noexist_xml:
-                            virsh_options = "--live --verbose --unsafe --xml no_exist.xml"
+                            virsh_options = "--live --verbose --xml no_exist.xml"
                         - unprivileged_user:
                             su_user = "bob"
                             adduser_cmd = "useradd ${su_user}"
                             deluser_cmd = "userdel -r ${su_user}"
                             uri_path = "/session"
-                            virsh_options = "--live --verbose --unsafe --xml no_exist_xml"
+                            virsh_options = "--live --verbose --xml no_exist_xml"
                         - same_host_uuid:
                             config_libvirtd = "yes"
                             host_uuid = "'00000000-0000-0000-0000-000000000001'"
-                            virsh_options = "--live --verbose --unsafe"
+                            virsh_options = "--live --verbose"
                         - invalid_listen_address:
                             listen_address = "01.2.3.4"
-                            virsh_options = "--live --verbose --unsafe --listen-address ${listen_address}"
+                            virsh_options = "--live --verbose --listen-address ${listen_address}"
                         - abort_job:
                             abort_job = "yes"
                             set_migration_speed = 1
                             run_migrate_cmd_in_front = "no"
                             run_migrate_cmd_in_back = "yes"
-                            virsh_options = "--live --verbose --unsafe"
+                            virsh_options = "--live --verbose"
                         - cancel_migration:
                             ctrl_c = "yes"
                             delay_time = 5
@@ -584,14 +584,14 @@
                             run_migrate_cmd_in_back = "yes"
                             check_domain_state = "yes"
                             expected_domain_state = "running"
-                            virsh_options = "--live --verbose --unsafe"
+                            virsh_options = "--live --verbose"
                         - restart_local_libvirtd:
                             set_migration_speed = 1
                             run_migrate_cmd_in_front = "no"
                             run_migrate_cmd_in_back = "yes"
                             restart_src_libvirtd = "yes"
                             restart_vm = "yes"
-                            virsh_options = "--live --verbose --unsafe"
+                            virsh_options = "--live --verbose"
                         - with_hugepages:
                             variants:
                                 - no_config_target:
@@ -627,7 +627,7 @@
                         - unreachable_destenation:
                             target_ip = "11.22.33.44"
                             setup_ssh = "no"
-                            virsh_options = "--live --p2p --verbose --unsafe"
+                            virsh_options = "--live --p2p --verbose"
                             variants:
                                 - with_ssh:
                                     uri_port = ":22"
@@ -645,7 +645,7 @@
                                     client_cn = "ENTER.YOUR.CLIENT_CN"
                         - invalid_listen_address:
                             listen_address = "1.2.3.4"
-                            virsh_options = "--live --p2p --verbose --unsafe --listen-address ${listen_address}"
+                            virsh_options = "--live --p2p --verbose --listen-address ${listen_address}"
                             variants:
                                 - with_ssh:
                                     uri_port = ":22"
@@ -664,7 +664,7 @@
                 - tunnelled_migration:
                     variants:
                         - restart_local_libvirtd:
-                            virsh_options = "--persistent --undefinesource --live --p2p --tunnelled --verbose --unsafe"
+                            virsh_options = "--persistent --undefinesource --live --p2p --tunnelled --verbose"
                             set_migration_speed = 1
                             run_migrate_cmd_in_front = "no"
                             run_migrate_cmd_in_back = "yes"
@@ -713,7 +713,7 @@
                     setup_nfs = "no"
                     enable_virt_use_nfs = "no"
                     nfs_mount_dir =
-                    virsh_options = "--live --verbose --unsafe --migrateuri rdma://${server_ip} --listen-address 0.0.0.0"
+                    virsh_options = "--live --verbose --migrateuri rdma://${server_ip} --listen-address 0.0.0.0"
                     variants:
                         - no_memory_hard_limit:
                             status_error = "no"
@@ -726,16 +726,16 @@
                             hard_limit_value = "2097152"
                             swap_hard_limit_value = "2097152"
                             memtune_options = "--hard-limit ${hard_limit_value} --swap-hard-limit ${swap_hard_limit_value} --config"
-                            virsh_options = "--live --verbose --unsafe --rdma-pin-all --migrateuri rdma://${server_ip} --listen-address 0.0.0.0"
+                            virsh_options = "--live --verbose --rdma-pin-all --migrateuri rdma://${server_ip} --listen-address 0.0.0.0"
                         - no_rdma_env_turn_off_rdma_pin_all:
                             hard_limit_value = "1048576"
                             swap_hard_limit_value = "1048576"
                             memtune_options = "--hard-limit ${hard_limit_value} --swap-hard-limit ${swap_hard_limit_value} --config"
-                            virsh_options = "--live --verbose --unsafe --rdma-pin-all --migrateuri rdma://${server_ip}"
+                            virsh_options = "--live --verbose --rdma-pin-all --migrateuri rdma://${server_ip}"
                 - cross_rhel_platform_migration:
                     # only work well on RHEL platform
                     migration_timeout = 600
-                    virsh_options = "--live --verbose --unsafe"
+                    virsh_options = "--live --verbose"
                     os_ver_from = "release 6"
                     os_ver_to = "release 7"
                     variants:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
@@ -458,7 +458,7 @@
             # Uni-direction migration with option --compressed.
             virsh_migrate_options = "--live --compressed"
         - there_seamless_migration_with_graphicsuri:
-            virsh_migrate_options = "--live --verbose --unsafe"
+            virsh_migrate_options = "--live --verbose"
             # The default spice port is 5900 for graphic configuration
             # <graphics type='spice' autoport='yes'/> in the guest XML.
             virsh_migrate_graphics_uri = "yes"

--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -1360,7 +1360,7 @@ def run(test, params, env):
         # Prepare to update VM first disk driver cache
         disk_name = test_dict.get("disk_driver_name")
         disk_type = test_dict.get("disk_driver_type")
-        disk_cache = test_dict.get("disk_driver_cache")
+        disk_cache = test_dict.get("disk_driver_cache", "none")
         if disk_name or disk_type or disk_cache:
             update_disk_driver(vm_name, disk_name, disk_type, disk_cache)
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_compcache.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_compcache.py
@@ -106,7 +106,7 @@ def run(test, params, env):
             vm.resume()
         vm.wait_for_login()
         # Do actual migration to verify compression cache of migrate jobs
-        command = ("virsh migrate %s %s --compressed --unsafe --verbose"
+        command = ("virsh migrate %s %s --compressed --verbose"
                    % (vm_name, remote_uri))
         logging.debug("Start migrating: %s", command)
         p = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE,

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_set_get_speed.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_set_get_speed.py
@@ -168,7 +168,7 @@ def run(test, params, env):
         delta = float(params.get("allowed_delta", "0.1"))
         virsh_migrate_timeout = int(params.get("virsh_migrate_timeout", "60"))
         # virsh migrate options
-        virsh_migrate_options = "--live --unsafe --timeout %s" % virsh_migrate_timeout
+        virsh_migrate_options = "--live --timeout %s" % virsh_migrate_timeout
         # Migrate vms to remote host
         mig_first = utlv.MigrationTest()
         virsh_dargs = {"debug": True}

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_setmaxdowntime.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_setmaxdowntime.py
@@ -45,7 +45,7 @@ def thread_func_live_migration(vm, dest_uri, dargs):
     Thread for virsh migrate command.
     """
     # Migrate the domain.
-    options = "--live --unsafe"
+    options = "--live"
     postcopy_options = dargs.get("postcopy_options")
     if postcopy_options:
         options = "%s %s" % (options, postcopy_options)

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_virtio_scsi.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_virtio_scsi.py
@@ -208,7 +208,7 @@ def run(test, params, env):
                           % vm.name)
             return vm_ip, vm_pwd
 
-        options = "--live --unsafe"
+        options = "--live"
         # Do migration before attaching new devices
         if migrate_in_advance:
             vm_ip, vm_pwd = start_check_vm(vm)
@@ -272,7 +272,7 @@ def run(test, params, env):
         logging.debug("Disks to be checked:\nBefore migration:%s\n"
                       "After migration:%s", disks_before, disks_after)
 
-        options = "--live --unsafe"
+        options = "--live"
         if not migrate_in_advance:
             cleanup_ssh_config(vm)
             mig.do_migration(vms, None, dsturi, "orderly", options, 120)

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_monitor_blockjob.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_monitor_blockjob.py
@@ -40,7 +40,7 @@ def copied_migration(test, vm, params, blockjob_type=None, block_target="vda"):
     username = params.get("remote_user")
     password = params.get("migrate_dest_pwd")
     timeout = int(params.get("thread_timeout", 1200))
-    options = "--live %s --unsafe" % copy_option
+    options = "--live %s" % copy_option
 
     # Get vm ip for remote checking
     if vm.is_dead():


### PR DESCRIPTION
Using "--unsafe" in live migration is not safe for vm, and may result in
leak of bugs. Remove "--unsafe" from virsh virsh options, and set disk
cache to "none" by default for a successful safe migration(except for
storage migration where disk cache can be anything for safe migration).

Signed-off-by: Fangge Jin <fjin@redhat.com>