### PR TITLE
Reduce rng period per bug1205141

### DIFF
--- a/libvirt/tests/cfg/libvirt_rng.cfg
+++ b/libvirt/tests/cfg/libvirt_rng.cfg
@@ -20,7 +20,7 @@
             backend_protocol = "raw"
             test_qemu_cmd = "yes"
         - rng_rate:
-            rng_rate = "{'bytes':'5000','period':'2000'}"
+            rng_rate = "{'bytes':'5000','period':'1'}"
             test_qemu_cmd = "yes"
             test_guest = "yes"
             variants:


### PR DESCRIPTION
Encountered rate exceeds failure, reduce period to check more
accurate rng rate, since bug1205141 said rate exceeds is
acceptable when period is big.

Signed-off-by: Yanqiu Zhang <yanqzhan@redhat.com>