### PR TITLE
virsh_migrate: check hotplug vcpu using wait_for()

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
@@ -394,26 +394,10 @@ def run(test, params, env):
 
             logging.debug("Checking CPU number gets reflected from inside "
                           "guest")
-            cmd = "lscpu | grep \"^CPU(s):\""
-            # vcpu count gets reflected step by step gradually, so we check
-            # vcpu and compare with previous count by taking 5 seconds, if
-            # there is no change in vpcu count we break the loop.
-            prev_output = -1
-            while True:
-                ret, output = session.cmd_status_output(cmd)
-                if ret:
-                    test.fail("CPU %s failed - %s" % (operation, output))
-                output = filter(str.isdigit, str(output.split(":")[-1].strip()))
+            if not utils_misc.wait_for(lambda: utils_misc.check_if_vm_vcpu_match(cpu_count, vm),
+                                       300, text="wait for vcpu online"):
+                test.fail("CPU %s failed" % operation)
 
-                if int(prev_output) == int(output):
-                    break
-                prev_output = output
-                time.sleep(5)
-            logging.debug("CPUs available from inside guest after %s - %s",
-                          operation, output)
-            if int(output) != cpu_count:
-                test.fail("CPU %s failed as cpus are not "
-                          "reflected from inside guest" % operation)
             logging.debug("CPU %s successful !!!", operation)
         except Exception as info:
             test.fail("CPU %s failed - %s" % (operation, info))


### PR DESCRIPTION
virsh console session is used to take vcpu count after guest is migrated
to target host, so other dmesg printed on console due to cpu hotplug event
is taken along with lscpu value cause validation to fail. use wait_for()
to avoid while loop and check the vcpu count after 5 sec of hotplug event
so that appropriate value is considered for validation.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>