### PR TITLE
migrate_vm: Add one parameter for setup

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_vm.cfg
+++ b/libvirt/tests/cfg/migration/migrate_vm.cfg
@@ -2,6 +2,7 @@
     type = migrate_vm
     take_regular_screendumps = no
     ssh_timeout = 60
+    migration_setup = "yes"
     # please replace your configuration
     server_ip = "${migrate_dest_host}"
     server_user = "root"


### PR DESCRIPTION
The parameter can provide the migration setup which help control
firewalld ports before and after migration.

Signed-off-by: Dan Zheng <dzheng@redhat.com>