### PR TITLE
virsh_event: Enrich lifecycle events

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_event.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_event.cfg
@@ -21,8 +21,15 @@
                     mem_size = 512000
                 - lifecycle_events:
                     only loop
+                    only no_timeout
                     event_name = "lifecycle"
-                    events_list = "start,save,restore,destroy"
+                    variants:
+                        - general:
+                            events_list = "undefine,create,destroy,define,start,save,restore,suspend,resume,edit,shutdown"
+                        - shutdown_from_host:
+                            only test_events
+                            signal = 'SIGTERM'
+                            events_list = "shutdown"
                 - reboot_event:
                     event_name = "reboot"
                     events_list = "reset"
@@ -36,9 +43,10 @@
                     event_name = "balloon-change"
                     events_list = "setmem"
                     mem_size = 512000
-                - device-removed_event:
-                    event_name = "device-removed"
-                    events_list = "detach-disk"
+                - device-added-removed_event:
+                    only loop
+                    event_all_option = "yes"
+                    events_list = "device-added-removed"
             variants:
                 - virsh_event:
                     # Test virsh event
@@ -52,7 +60,6 @@
                         - test_events:
                             no other_option
                         - test_multiple_domains:
-                            only no_timeout 
                             only lifecycle_events
                             multi_vms = "yes" 
                 - qemu_monitor_event:


### PR DESCRIPTION
Enrich lifecycle events. And optimize the check_output function to
compare output with expected ones in order, to avoid matching
duplicated ones. Also remove timeout for lifecycle events, no need
to test it everywhere.

Signed-off-by: Yanqiu Zhang <yanqzhan@redhat.com>