### PR TITLE
Add checkpoint for disk selinux context after guest started

### DIFF
--- a/libvirt/tests/cfg/svirt/svirt_attach_disk.cfg
+++ b/libvirt/tests/cfg/svirt/svirt_attach_disk.cfg
@@ -46,6 +46,17 @@
                     virt_use_nfs = "on"
                 - virt_use_nfs_off:
                     virt_use_nfs = "off"
+        - disk_pool:
+            with_pool_vol = 'yes'
+            pool_name = "svirt_test_pool"
+            only sec_type_dynamic..sec_relabel_yes..disk_label_svirt_image_MCS1
+            pool_type = "disk"
+            pool_target = "/dev"
+            emulated_image = "disk-pool"
+            variants:
+                - enable_namespace:
+                    enable_namespace = 'yes'
+                - disable_namespace:
         - cap_rawio:
             check_cap_rawio = "yes"
             with_pool_vol = 'yes'
@@ -56,10 +67,6 @@
                     pool_type = "iscsi"
                     pool_target = "/dev/disk/by-path"
                     emulated_image = "iscsi-pool"
-                - disk_pool:
-                    pool_type = "disk"
-                    pool_target = "/dev"
-                    emulated_image = "disk-pool"
     variants:
         - positive_test:
             status_error = no


### PR DESCRIPTION
Add checkpoint for disk selinux context after guest started:
1.Enable namespaces(default setting) and check；
2.Disable namespaces and check;

Signed-off-by: Yan Fu <yafu@redhat.com>