### PR TITLE
Replace win2003 guest with win2016

### DIFF
--- a/provider/v2v_vmcheck_helper.py
+++ b/provider/v2v_vmcheck_helper.py
@@ -243,8 +243,6 @@ class VMChecker(object):
         """
         Check windows guest after v2v convert.
         """
-        # Make sure windows boot up successfully first
-        self.checker.boot_windows()
         try:
             self.checker.create_session()
         except Exception as detail:

--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -29,7 +29,33 @@
             only source_esx.esx_55
         - esx_60:
             only source_esx.esx_60
+        - esx_67:
+            only source_esx.esx_67
     variants:
+        - windows:
+            os_type = 'windows'
+            shutdown_command = 'shutdown /s /f /t 0'
+            reboot_command = 'shutdown /r /f /t 0'
+            status_test_command = 'echo %errorlevel%'
+            shell_prompt = '^\w:\\.*>\s*$'
+            shell_linesep = '\r\n'
+            shell_client = 'nc'
+            shell_port = 10022
+            file_transfer_client = 'rss'
+            file_transfer_port = 10023
+            redirs += ' file_transfer'
+            guest_port_remote_shell = 10022
+            guest_port_file_transfer = 10023
+            rtc_base = 'localtime'
+            network_query = 'ipconfig /all'
+            restart_network = 'ipconfig /renew'
+            vm_user = 'Administrator'
+            vm_pwd = '123qweP'
+            variants:
+                - program_files_2:
+                    only esx_67
+                    os_version = 'PROGRAM_FILES_2_OS_VERSION_V2V_EXAMPLE'
+                    main_vm = 'PROGRAM_FILES_2_VM_NAME_V2V_EXAMPLE'
         - with_cdrom:
             only esx_55
             main_vm = 'VM_NAME_ESX_CDROM_V2V_EXAMPLE'

--- a/v2v/tests/cfg/function_test_xen.cfg
+++ b/v2v/tests/cfg/function_test_xen.cfg
@@ -123,7 +123,6 @@
             restart_network = 'ipconfig /renew'
             vm_user = 'Administrator'
             vm_pwd = '123qweP'
-            screenshots_for_match = 'WIN2003_SCREENSHOTS_V2V_EXAMPLE'
             variants:
                 - default_install:
                     windows_root = 'WINDOWS_ROOT_V2V_EXAMPLE'
@@ -133,9 +132,6 @@
                     checkpoint = 'rhev_file'
                     os_version = 'OS_VERSION_RHEV_FILE_V2V_EXAMPLE'
                     main_vm = 'RHEV_FILE_VM_NAME_V2V_EXAMPLE'
-                - program_files_2:
-                    os_version = 'PROGRAM_FILES_2_OS_VERSION_V2V_EXAMPLE'
-                    main_vm = 'PROGRAM_FILES_2_VM_NAME_V2V_EXAMPLE'
                 - virtio_win:
                     main_vm = 'XEN_VM_NAME_VIRTIO_WIN_V2V_EXAMPLE'
                     os_version = 'OS_VERSION_VIRTIO_WIN_V2V_EXAMPLE'


### PR DESCRIPTION
Since win2003 is out of service, the testing guest should be
updated.
Replace Auto-xen-win2003-2ProgramFiles with Auto-esx6.7-win2016-2ProgramFiles

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>