### PR TITLE
fix brokenpipeerror when close socket

### DIFF
--- a/libvirt/tests/src/serial/serial_functional.py
+++ b/libvirt/tests/src/serial/serial_functional.py
@@ -83,6 +83,7 @@ class Console(aexpect.ShellSession):
                 obj.stdin.write('\n')
                 time.sleep(50)
                 obj.stdin.write('\n')
+                time.sleep(50)
                 obj.stdin.close()
             self.process = obj
         elif console_type == 'tcp':


### PR DESCRIPTION
This might be happening when a client program doesn't wait
till all the data from the server is received and simply closes a socket

Signed-off-by: chunfuwen <chwen@redhat.com>