### PR TITLE
Add the cases of ssh connection via ipv4

### DIFF
--- a/libvirt/tests/cfg/remote_access/remote_with_ssh.cfg
+++ b/libvirt/tests/cfg/remote_access/remote_with_ssh.cfg
@@ -23,6 +23,7 @@
                     # please change query command based on your
                     # Linux distribution
                     query_cmd = "rpm -q libvirt"
+                - ssh_ipv4:
                 - ssh_static_ipv6:
                     # no problem, the test codes will automatically
                     # clean up created static IPv6 configuration


### PR DESCRIPTION
Add the remote access case of ssh connection between two hosts with
the same libvirt version via ipv4

Signed-off-by: Lily Zhu <lizhu@redhat.com>