### PR TITLE
virsh_iface_bridge: Fix Interface 'HOST_INTERFACE' not exists

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/interface/virsh_iface_bridge.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/interface/virsh_iface_bridge.cfg
@@ -9,7 +9,7 @@
     bridge_name = "br_virt_0"
     # Replace ping_ip by a actual IP address
     # Skip ping test if ping_ip = ""
-    ping_ip = "ENTER.THE.REMOTE.IP"
+    ping_ip = "www.baidu.com"
     ping_count = 3
     pint_timeout = 5
     create_bridge = "yes"


### PR DESCRIPTION
The script required to manually configure the iface_name in cfg file,
but it's hard when CI running, cos the iface_name is varied from servers,
so it's better to get the iface_name by script instead of manual configuration.
besides fix some other issues during this PR testing, as this script never
been successfully executed

Signed-off-by: Yan Li <yannli@redhat.com>