### PR TITLE
fix vhba fabirc not setting issue

### DIFF
--- a/libvirt/tests/src/npiv/npiv_restart_libvirtd.py
+++ b/libvirt/tests/src/npiv/npiv_restart_libvirtd.py
@@ -1,4 +1,5 @@
 import logging
+import time
 
 from avocado.utils import process
 
@@ -125,6 +126,7 @@ def run(test, params, env):
         if not utils_misc.wait_for(lambda: npiv.is_vhbas_added(old_vhbas),
                                    timeout=_TIMEOUT):
             test.fail("vhba not successfully created")
+        time.sleep(2)
         tmp_list = list(set(npiv.find_hbas("vhba")).difference(set(old_vhbas)))
         if len(tmp_list) != 1:
             test.fail("Not 1 vhba created, something wrong.")


### PR DESCRIPTION
The vhba created by echo command is not synced with virsh command.
So libvirt may not get its fabric name at once. Add a 2 seconds
sleep to avoid info missing. A waitfor method is not necessary
for such a short sleep.

Signed-off-by: Yi Sun <yisun@redhat.com>