### PR TITLE
Fix a wrong setting of status error in npiv hostdev case

### DIFF
--- a/libvirt/tests/cfg/npiv/npiv_hostdev_passthrough.cfg
+++ b/libvirt/tests/cfg/npiv/npiv_hostdev_passthrough.cfg
@@ -12,7 +12,7 @@
     kill_unresponsive_vms = "no"
     variants:
         - positive_testing:
-            status_error = "yes"
+            status_error = "no"
             variants:
                 - hot_attach_hot_detach_hostdev:
                     create_number = 1


### PR DESCRIPTION
Should set status_error as 'no' for positive cases.

Signed-off-by: Yi Sun <yisun@redhat.com>