### PR TITLE
Fix the cases of watchdog

### DIFF
--- a/libvirt/tests/src/virtual_device/watchdog.py
+++ b/libvirt/tests/src/virtual_device/watchdog.py
@@ -48,7 +48,7 @@ def run(test, params, env):
                 except aexpect.ShellCmdError:
                     session.close()
                     test.fail("Failed to load module ib700wdt")
-            session.cmd("dmesg | grep %s && lsmod | grep %s" % (model, model))
+            session.cmd("dmesg | grep -i %s && lsmod | grep %s" % (model, model))
             session.cmd("echo 1 > /dev/watchdog")
         except aexpect.ShellCmdError:
             session.close()
@@ -60,9 +60,8 @@ def run(test, params, env):
         """
         def _booting_completed():
             session = vm.wait_for_login()
-            output = session.cmd_status_output("last reboot")
-            second_boot_time = output[1].strip().split("\n")[0].split()[-4]
-            logging.debug(second_boot_time)
+            status, second_boot_time = session.cmd_status_output("uptime --since")
+            logging.debug("The second boot time is %s", second_boot_time)
             session.close()
             return second_boot_time > first_boot_time
 
@@ -152,8 +151,7 @@ def run(test, params, env):
         vm.start()
         session = vm.wait_for_login()
         if action == "reset":
-            output = session.cmd_status_output("last reboot")
-            first_boot_time = output[1].strip().split("\n")[0].split()[-4]
+            status, first_boot_time = session.cmd_status_output("uptime --since")
             logging.info("The first boot time is %s\n", first_boot_time)
         if action == "inject-nmi":
             virsh_session = virsh.VirshSession(virsh_exec=virsh.VIRSH_EXEC, auto_close=True)


### PR DESCRIPTION
Fix in two aspect:
1) The name of i6300esb watchdog in dmesg has been changed to "i6300ESB", so
ignore case distinctions for grep patterns by adding the option "-i"
2) Change the method of getting the last reboot time. Since the original
method was to get the day of the last reboot time, it will always be the
same with the ones of last reboot time.

Signed-off-by: Lily Zhu <lizhu@redhat.com>