### PR TITLE
Check the target dev set in the interface xml

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_options.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_options.cfg
@@ -221,3 +221,28 @@
                 - error_test:
                     start_error = "yes"
                     iface_backend = "{'tap':'/dev/net/mytap','vhost':'/dev/myvhost-net'}"
+        - iface_target_prefix:
+            test_target = "yes"
+            variants:
+                - network:
+                    iface_type = "network"
+                    iface_source = "{'network':'default'}"
+                - direct:
+                    iface_type = "direct"
+                    iface_source = "{'dev':'eno1','mode':'bridge'}"
+                    serial_login = "yes"
+            variants:
+                - vnet:
+                    target_dev = "vnet30"
+                - macvtap:
+                    target_dev = "macvtap40"
+                - vif:
+                    target_dev = "vif50"
+                - macvlan:
+                    target_dev = "macvlan60"
+                - test:
+                    target_dev = "test123"
+                - duplicate:
+                    target_dev = "dup_target"
+                    start_error = "yes"
+                    attach_iface_device = "config"


### PR DESCRIPTION
Target dev can set in the guest interface xml including direct type and
network type interface. The name with prefix as "vnet" or "macvtap" may
be override.

Signed-off-by: yalzhang <yalzhang@redhat.com>