### PR TITLE
Add new case for testing vnc encrypt guest to rhv

### DIFF
--- a/v2v/tests/cfg/function_test_xen.cfg
+++ b/v2v/tests/cfg/function_test_xen.cfg
@@ -62,6 +62,10 @@
                         - encrypt:
                             checkpoint = 'vnc_encrypt'
                             vnc_passwd = 'redhat'
+                        - encrypt_warning:
+                            checkpoint = 'vnc_encrypt_warning'
+                            msg_content = 'This guest required a password for connection to its display, but this is not supported by RHV.  Therefore the converted guest’s display will not require a separate password to connect.'
+                            expect_msg = yes
                 - sdl:
                     os_version = 'rhel6'
                     main_vm = 'SDL_VM_NAME_V2V_EXAMPLE'
@@ -163,8 +167,9 @@
                 - libvirt:
                     only pool_uuid, windows.rhev_file, display, sound, virtio_win, with_vdsm
                     only output_mode.libvirt
+                    no encrypt_warning
                 - rhev:
-                    no pool_uuid, windows.rhev_file, display.vnc, sound, virtio_win
+                    no pool_uuid, windows.rhev_file, display.vnc.encrypt, sound, virtio_win
                     only output_mode.rhev
         - negative_test:
             status_error = 'yes'

--- a/v2v/tests/src/function_test_xen.py
+++ b/v2v/tests/src/function_test_xen.py
@@ -43,7 +43,7 @@ def run(test, params, env):
     pvt = libvirt.PoolVolumeTest(test, params)
     address_cache = env.get('address_cache')
     checkpoint = params.get('checkpoint', '')
-    bk_list = ['vnc_autoport', 'vnc_encrypt']
+    bk_list = ['vnc_autoport', 'vnc_encrypt', 'vnc_encrypt_warning']
     error_list = []
 
     def log_fail(msg):
@@ -290,7 +290,7 @@ def run(test, params, env):
                 params[checkpoint] = {'autoport': 'yes'}
                 vm_xml.VMXML.set_graphics_attr(vm_name, params[checkpoint],
                                                virsh_instance=virsh_instance)
-            elif checkpoint == 'vnc_encrypt':
+            elif checkpoint in ['vnc_encrypt', 'vnc_encrypt_warning']:
                 params[checkpoint] = {'passwd': params.get('vnc_passwd', 'redhat')}
                 vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(
                         vm_name, virsh_instance=virsh_instance)


### PR DESCRIPTION
when importing a guest which has vnc authentication password to rhv,
there will be a warning message (see below example) in v2v and the
guest can be imported successfully.

virt-v2v: warning: This guest required a password for connection to its
display, but this is not supported by RHV.  Therefore the converted
guest’s display will not require a separate password to connect.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>