### PR TITLE
Define network with multiple ip/dhcp sections

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_define_undefine.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_define_undefine.cfg
@@ -19,6 +19,16 @@
                     net_define_undefine_net_name = "foobar"
                     variants:
                         - non_acl:
+                        - multi_ip:
+                            multi_ip = "yes"
+                            test_range = "no"
+                            address_v4 = "192.168.100.1"
+                            netmask = "255.255.255.0"
+                            address_v6_1 = "2001:db8:ca2:6::1"
+                            address_v6_2 = "2001:db8:ca3:6::1"
+                            dhcp_ranges_v6_start_1 = "2001:db8:ca2:6::100"
+                            dhcp_ranges_v6_end_1 = "2001:db8:ca2:6::1ff"
+                            prefix_v6 = "64"
                         - acl_test:
                             setup_libvirt_polkit = "yes"
                             action_id = "org.libvirt.api.network.write org.libvirt.api.network.save org.libvirt.api.network.start org.libvirt.api.network.stop org.libvirt.api.network.delete"
@@ -85,6 +95,24 @@
                                     dhcp_ranges_start = "192.168.110.2"
                                     dhcp_ranges_end = "192.168.110.100"
                                     net_define_undefine_err_msg = "not entirely within"
+                        - multi_dhcp:
+                            multi_ip = "yes"
+                            address_v4 = "192.168.100.1"
+                            netmask = "255.255.255.0"
+                            address_v6_1 = "2001:db8:ca2:7::1"
+                            address_v6_2 = "2001:db8:ca3:7::1"
+                            prefix_v6 = "64"
+                            variants:
+                                - v4:
+                                    dhcp_ranges_start = "192.168.100.5"
+                                    dhcp_ranges_end = "192.168.100.80"
+                                    net_define_undefine_err_msg = "Multiple IPv4 dhcp sections found"
+                                - v6:
+                                    dhcp_ranges_v6_start_1 = "2001:db8:ca2:7::100"
+                                    dhcp_ranges_v6_end_1 = "2001:db8:ca2:7::1ff"
+                                    dhcp_ranges_v6_start_2 = "2001:db8:ca3:7::100"
+                                    dhcp_ranges_v6_end_2 =   "2001:db8:ca3:7::1ff"
+                                    net_define_undefine_err_msg = "Multiple IPv6 dhcp sections found"
                 - acl_test:
                     variants:
                         - define_acl:


### PR DESCRIPTION
Define network with multiple ip sections including ipv4 and ipv6 is
accepted. And define network with multiple dhcp sections is not allowed.

Signed-off-by: yalzhang <yalzhang@redhat.com>