### PR TITLE
Add negative test for define nat network

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_define_undefine.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_define_undefine.cfg
@@ -65,6 +65,26 @@
                         - invalid_name_with_slash:
                             net_define_undefine_net_name = "b/r2"
                             net_define_undefine_err_msg = "invalid char in name: /"
+                        - invalid_setting:
+                            edit_xml = "yes"
+                            address_v4 = "192.168.100.1"
+                            netmask = "255.255.255.0"
+                            dhcp_ranges_start = "192.168.100.30"
+                            dhcp_ranges_end = "192.168.100.100"
+                            variants:
+                                - reverse_range:
+                                    dhcp_ranges_start = "192.168.100.100"
+                                    dhcp_ranges_end = "192.168.100.30"
+                                    net_define_undefine_err_msg = "is reversed"
+                                - reverse_port:
+                                    test_port = "yes"
+                                    nat_port_start = "65535"
+                                    nat_port_end = "1024"
+                                    net_define_undefine_err_msg = "Missing or invalid 'end' attribute"
+                                - not_within_range:
+                                    dhcp_ranges_start = "192.168.110.2"
+                                    dhcp_ranges_end = "192.168.110.100"
+                                    net_define_undefine_err_msg = "not entirely within"
                 - acl_test:
                     variants:
                         - define_acl:

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_define_undefine.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_define_undefine.py
@@ -62,6 +62,16 @@ def run(test, params, env):
     net_active = "yes" == params.get("net_active")
     expect_msg = params.get("net_define_undefine_err_msg")
 
+    # Edit net xml forward/ip part then define/start to check invalid setting
+    edit_xml = "yes" == params.get("edit_xml", "no")
+    address_v4 = params.get("address_v4")
+    netmask = params.get("netmask")
+    dhcp_ranges_start = params.get("dhcp_ranges_start")
+    dhcp_ranges_end = params.get("dhcp_ranges_end")
+    nat_port_start = params.get("nat_port_start")
+    nat_port_end = params.get("nat_port_end")
+    test_port = "yes" == params.get("test_port", "no")
+
     virsh_dargs = {'uri': uri, 'debug': False, 'ignore_status': True}
     virsh_instance = virsh.VirshPersistent(**virsh_dargs)
 
@@ -128,6 +138,17 @@ def run(test, params, env):
         virsh_dargs = {'uri': uri, 'debug': False, 'ignore_status': True,
                        'readonly': True}
     try:
+        if edit_xml:
+            ipxml_v4 = network_xml.IPXML()
+            ipxml_v4.address = address_v4
+            ipxml_v4.netmask = netmask
+            ipxml_v4.dhcp_ranges = {"start": dhcp_ranges_start, "end": dhcp_ranges_end}
+            testnet_xml.del_ip()
+            testnet_xml.set_ip(ipxml_v4)
+            if test_port:
+                nat_port = {"start": nat_port_start, "end": nat_port_end}
+                testnet_xml.nat_port = nat_port
+            testnet_xml.debug_xml()
         # Run test case
         define_result = virsh.net_define(define_options, define_extra,
                                          **virsh_dargs)


### PR DESCRIPTION
Define nat network should check the nat port, and the dhcp range. The
address should in the same subnet of the dhcp range and the sequence of
the dhcp range and port range should also be checked.

Signed-off-by: yalzhang <yalzhang@redhat.com>