### PR TITLE
Remove the clone_status_error=True when disk is luks format

### DIFF
--- a/libvirt/tests/src/virsh_cmd/volume/virsh_vol_clone_wipe.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_vol_clone_wipe.py
@@ -201,7 +201,6 @@ def run(test, params, env):
         if vol_info["Type"] == "block" and clone_option.count("prealloc-metadata"):
             clone_status_error = True
         if b_luks_encrypted:
-            clone_status_error = True
             wipe_old_vol = True
 
         if pool_type == "disk":


### PR DESCRIPTION
Previously the vol-clone expects failure for luks image, since
it was not supported. But this function is supported in latest
libvirt, so remove the clone_status_error=True and use blacklist
to filter it out in unsupported libvirt version.

Signed-off-by: Yi Sun <yisun@redhat.com>