### PR TITLE
Add try-except to old test code

### DIFF
--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_start.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_start.py
@@ -44,54 +44,58 @@ def run(test, params, env):
     except KeyError:
         virsh_instance.close_session()
         test.cancel("Test requires default network to exist")
-    # To confirm default network is active
-    if not default_netxml.active:
-        default_netxml.active = True
+    try:
+        # To confirm default network is active
+        if not default_netxml.active:
+            default_netxml.active = True
 
-    # inactive default according test's need
-    if inactive_default:
-        logging.info("Stopped default network")
-        default_netxml.active = False
+        # inactive default according test's need
+        if inactive_default:
+            logging.info("Stopped default network")
+            default_netxml.active = False
 
-    # State before run command
-    origin_state = virsh_instance.net_state_dict()
-    logging.debug("Origin network(s) state: %s", origin_state)
+        # State before run command
+        origin_state = virsh_instance.net_state_dict()
+        logging.debug("Origin network(s) state: %s", origin_state)
 
-    if net_ref == "netname":
-        net_ref = default_netxml.name
-    elif net_ref == "netuuid":
-        net_ref = default_netxml.uuid
+        if net_ref == "netname":
+            net_ref = default_netxml.name
+        elif net_ref == "netuuid":
+            net_ref = default_netxml.uuid
 
-    if params.get('setup_libvirt_polkit') == 'yes':
-        virsh_dargs = {'uri': virsh_uri, 'unprivileged_user': unprivileged_user,
-                       'debug': False, 'ignore_status': True}
-    if params.get('net_start_readonly', 'no') == 'yes':
-        virsh_dargs = {'uri': uri, 'debug': True, 'readonly': True, 'ignore_status': True}
+        if params.get('setup_libvirt_polkit') == 'yes':
+            virsh_dargs = {'uri': virsh_uri, 'unprivileged_user': unprivileged_user,
+                           'debug': False, 'ignore_status': True}
+        if params.get('net_start_readonly', 'no') == 'yes':
+            virsh_dargs = {'uri': uri, 'debug': True, 'readonly': True, 'ignore_status': True}
 
-    # Run test case
-    result = virsh.net_start(net_ref, extra, **virsh_dargs)
-    logging.debug(result)
-    status = result.exit_status
-
-    # Get current net_stat_dict
-    current_state = virsh_instance.net_state_dict()
-    logging.debug("Current network(s) state: %s", current_state)
-    is_default_active = current_state['default']['active']
-
-    # Recover default state to active
-    if not is_default_active:
-        default_netxml.active = True
-
-    virsh_instance.close_session()
-
-    # Check status_error
-    if status_error:
-        if not status:
-            test.fail("Run successfully with wrong command!")
-    else:
-        if status:
-            test.fail("Run failed with right command")
+        # Run test case
+        if 'unprivileged_user' in virsh_dargs and status_error:
+            test_virsh = virsh.VirshPersistent(unprivileged_user=virsh_dargs['unprivileged_user'])
+            virsh_dargs.pop('unprivileged_user')
+            result = test_virsh.net_start(net_ref, extra, **virsh_dargs)
+            test_virsh.close_session()
         else:
-            if not is_default_active:
-                test.fail("Execute cmd successfully but "
-                          "default is inactive actually.")
+            result = virsh.net_start(net_ref, extra, **virsh_dargs)
+        logging.debug(result)
+        status = result.exit_status
+
+        # Get current net_stat_dict
+        current_state = virsh_instance.net_state_dict()
+        logging.debug("Current network(s) state: %s", current_state)
+        is_default_active = current_state['default']['active']
+
+        # Check status_error
+        if status_error:
+            if not status:
+                test.fail("Run successfully with wrong command!")
+        else:
+            if status:
+                test.fail("Run failed with right command")
+            else:
+                if not is_default_active:
+                    test.fail("Execute cmd successfully but "
+                              "default is inactive actually.")
+    finally:
+        virsh_instance.close_session()
+        virsh.net_start('default', debug=True, ignore_status=True)


### PR DESCRIPTION
To make sure 'default' network will be started after test executed
Update old way of executing virsh command with negative acl tests
to avoid polkit error

Signed-off-by: haizhao <haizhao@redhat.com>