### PR TITLE
Remove fsid=0 for nfs export

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcommit.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcommit.cfg
@@ -45,7 +45,7 @@
                             no base, notimeout, no_ga
                             replace_vm_disk = "yes"
                             disk_source_protocol = "netfs"
-                            export_options = "rw,no_root_squash,fsid=0"
+                            export_options = "rw,no_root_squash"
                             disk_type = "file"
                             disk_target = "vda"
                             disk_target_bus = "virtio"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcopy.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcopy.cfg
@@ -66,7 +66,7 @@
                     no mirror_state_lock, blockdev
                     replace_vm_disk = "yes"
                     disk_source_protocol = "netfs"
-                    export_options = "rw,no_root_squash,fsid=0"
+                    export_options = "rw,no_root_squash"
                     mnt_path_name = "nfs-mount"
                     disk_type = "file"
                     disk_target = ${target_disk}

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockpull.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockpull.cfg
@@ -40,7 +40,7 @@
                             no timeout, no_async, with_bandwidth
                             replace_vm_disk = "yes"
                             disk_source_protocol = "netfs"
-                            export_options = "rw,no_root_squash,fsid=0"
+                            export_options = "rw,no_root_squash"
                             disk_type = "file"
                             disk_target = "vda"
                             disk_target_bus = "virtio"

--- a/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_disk.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_disk.cfg
@@ -111,7 +111,7 @@
                     pool_target = "nfs-mount"
                     nfs_server_dir = "nfs-server"
                     source_host = "localhost"
-                    export_options="rw,no_root_squash,fsid=0"
+                    export_options="rw,no_root_squash"
                 - logical_pool:
                     no v_qcow2v3
                     pool_type = "logical"


### PR DESCRIPTION
We'll meet bz1656306 if we still use the fsid=0, so remove it
from current cases.

Signed-off-by: Yi Sun <yisun@redhat.com>