### PR TITLE
virsh_shutdown: acpi is not supported in PowerPC

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_shutdown.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_shutdown.cfg
@@ -15,6 +15,7 @@
                     shutdown_mode = ""
                 - acpi_mode:
                     no lxc
+                    no ppc64,ppc64le
                     shutdown_mode = "acpi"
                 - agent_mode:
                     no lxc

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_shutdown.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_shutdown.py
@@ -5,6 +5,7 @@ from virttest import libvirt_vm
 from virttest import virsh
 from virttest import utils_libvirtd
 from virttest import ssh_key
+from virttest import utils_misc
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 
@@ -123,6 +124,7 @@ def run(test, params, env):
             if status:
                 test.fail("Run failed with right command")
             if not vm.wait_for_shutdown(timeout):
-                test.fail("Failed to shutdown in timeout %s", timeout)
+                test.fail("Failed to shutdown in timeout %s" % timeout)
     finally:
-        xml_backup.sync()
+        if utils_misc.wait_for(utils_libvirtd.libvirtd_is_running, 60):
+            xml_backup.sync()


### PR DESCRIPTION
    filter out acpi mode test for PowerPC and fix argument error for
    fail(),
    
    ```
    ERROR: fail() takes at most 2 arguments (3 given)
    ```
    
    xml sync() in finally block fails due to timing issue, so ensure
    libvirtd is in running status and the sync the xml.
    
    ```
    018-12-07 01:06:46,995 vm_xml           L0637 DEBUG| Failed to backup virt-tests-vm1.
    2018-12-07 01:06:47,026 virsh            L1434 WARNI| VM virt-tests-vm1 does not exist
    2018-12-07 01:06:47,027 virsh            L1381 DEBUG| Define VM from /var/tmp/xml_utils_temp_ZLJFNT.xml
    2018-12-07 01:06:47,058 vm_xml           L0627 DEBUG| Define virt-tests-vm1 failed.
    Detail: error: failed to connect to the hypervisor
    error: Failed to connect socket to '/var/run/libvirt/libvirt-sock': Connection refused
    .
    2018-12-07 01:06:47,166 stacktrace       L0041 ERROR|
    2018-12-07 01:06:47,166 stacktrace       L0044 ERROR| Reproduced traceback from: /usr/lib/python2.7/site-packages/avocado_plugins_vt-66.0-py2.7.egg/avocado_vt/test.py:435
    2018-12-07 01:06:47,167 stacktrace       L0047 ERROR| Traceback (most recent call last):
    2018-12-07 01:06:47,167 stacktrace       L0047 ERROR|   File "/home/workspace/runAvocadoFVTTest/avocado-fvt-wrapper/data/avocado-vt/test-providers.d/downloads/powerkvm-libvirt/libvirt/tests/src/virsh_cmd/domain/virsh_shutdown.py", line 128, in run
    2018-12-07 01:06:47,167 stacktrace       L0047 ERROR|     xml_backup.sync()
    2018-12-07 01:06:47,168 stacktrace       L0047 ERROR|   File "/usr/lib/python2.7/site-packages/avocado_plugins_vt-66.0-py2.7.egg/virttest/libvirt_xml/vm_xml.py", line 647, in sync
    2018-12-07 01:06:47,168 stacktrace       L0047 ERROR|     % (self.vm_name, self.xmltreefile))
    2018-12-07 01:06:47,168 stacktrace       L0047 ERROR| LibvirtXMLError: Failed to define virt-tests-vm1 from xml:
    
    ```


Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>