### PR TITLE
virsh_sendkey: sendkey fails to create file if VM boots in GUI

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_sendkey.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_sendkey.py
@@ -3,6 +3,7 @@ import time
 
 from virttest import virsh
 from virttest import utils_package
+from virttest import utils_test
 
 from provider import libvirt_version
 
@@ -55,8 +56,16 @@ def run(test, params, env):
                       ignore_status=False)
 
     vm = env.get_vm(vm_name)
-    session = vm.wait_for_login()
+    vm.wait_for_login().close()
 
+    # Boot the guest in text only mode so that send-key commands would succeed
+    # in creating a file
+    try:
+        utils_test.update_boot_option(vm, args_added="3")
+    except Exception as info:
+        test.error(info)
+
+    session = vm.wait_for_login()
     if sysrq_test:
         # In postprocess of previous testcase would pause and resume the VM
         # that would change the domstate to running (unpaused) and cause


### PR DESCRIPTION
Ensure VM boots in text only mode, so that sendkey keystrokes
succeed to create a file and validate it accordingly.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>