### PR TITLE
remove fsid=0 for nfs prepare

### DIFF
--- a/libvirt/tests/cfg/svirt/dac_nfs_disk.cfg
+++ b/libvirt/tests/cfg/svirt/dac_nfs_disk.cfg
@@ -21,11 +21,11 @@
     img_mode = 438
     variants:
         - root_squash:
-            export_options= "rw,root_squash,fsid=0"
+            export_options= "rw,root_squash"
         - no_root_squash:
-            export_options= "rw,no_root_squash,sync,fsid=0"
+            export_options= "rw,no_root_squash,sync"
         - readonly:
-            export_options= "ro,no_root_squash,sync,fsid=0"
+            export_options= "ro,no_root_squash,sync"
     variants:
         - dynamic_ownership_on:
             dynamic_ownership = "yes"

--- a/libvirt/tests/cfg/svirt/dac_vm_per_image_start.cfg
+++ b/libvirt/tests/cfg/svirt/dac_vm_per_image_start.cfg
@@ -42,7 +42,7 @@
                 - nfs:
                     no invalid_per_img_label
                     disk_source_protocol = "netfs"
-                    export_options = "rw,no_root_squash,fsid=0"
+                    export_options = "rw,no_root_squash"
                     disk_type = "file"
                     disk_target = "vda"
                     disk_target_bus = "virtio"

--- a/libvirt/tests/src/svirt/dac_nfs_disk.py
+++ b/libvirt/tests/src/svirt/dac_nfs_disk.py
@@ -57,7 +57,7 @@ def run(test, params, env):
     pool_type = params.get("pool_type")
     pool_target = params.get("pool_target")
     export_options = params.get("export_options",
-                                "rw,async,no_root_squash,fsid=0")
+                                "rw,async,no_root_squash")
     emulated_image = params.get("emulated_image")
     vol_name = params.get("vol_name")
     vol_format = params.get("vol_format")

--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_disk.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_disk.py
@@ -56,7 +56,7 @@ def run(test, params, env):
     vol_format = params.get("vol_format")
     lazy_refcounts = "yes" == params.get("lazy_refcounts")
     options = params.get("snapshot_options", "")
-    export_options = params.get("export_options", "rw,no_root_squash,fsid=0")
+    export_options = params.get("export_options", "rw,no_root_squash")
 
     # Set volume xml attribute dictionary, extract all params start with 'vol_'
     # which are for setting volume xml, except 'lazy_refcounts'.


### PR DESCRIPTION
fsid=0 misused here, in nfsv4, the path to the export dir will be
missing with current code. Cause a access denied error.

Signed-off-by: Yi Sun <yisun@redhat.com>