### PR TITLE
Update testing guests for V2V

### DIFF
--- a/provider/v2v_vmcheck_helper.py
+++ b/provider/v2v_vmcheck_helper.py
@@ -279,7 +279,8 @@ class VMChecker(object):
             expect_adapter = 'QXL'
         if self.os_version in ['win2003', 'win2008']:
             expect_adapter = 'Standard VGA Graphics Adapter'
-        if self.os_version in ['win8', 'win8.1', 'win10', 'win2012', 'win2012r2', 'win2016']:
+        bdd_list = ['win8', 'win8.1', 'win10', 'win2012', 'win2012r2', 'win2016', 'win2019']
+        if self.os_version in bdd_list:
             expect_adapter = 'Basic Display Driver'
         expect_drivers.append(expect_adapter)
         check_drivers = expect_drivers[:]

--- a/v2v/tests/cfg/convert_vm_to_libvirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_libvirt.cfg
@@ -18,11 +18,13 @@
 
     variants:
         - arch_i386:
-            no 7_LATEST7
+            no latest8
+            no latest7
             no win2008r2
             no win2012
             no win2012r2
             no win2016
+            no win2019
             vm_arch = "i386"
         - arch_x86_64:
             vm_arch = "x86_64"
@@ -32,10 +34,12 @@
             vm_user = ${username}
             vm_pwd = ${password}
             variants:
-                - 7_LATEST7:
-                    os_version = "rhel7.LATEST7"
-                - 6_LATEST6:
-                    os_version = "rhel6.LATEST6"
+                - latest8:
+                    os_version = "LATEST8"
+                - latest7:
+                    os_version = "LATEST7"
+                - latest6:
+                    os_version = "LATEST6"
                 - 5_11:
                     os_version = "rhel5.11"
         - windows:
@@ -82,7 +86,10 @@
                     os_version = "win10"
                 - win2016:
                     only esx
-                    os_version = win2016
+                    os_version = "win2016"
+                - win2019:
+                    only esx
+                    os_version = "win2019"
     variants:
         - xen:
             only source_xen
@@ -91,7 +98,8 @@
             v2v_opts = "-v -x"
             variants:
                 - pv:
-                    no 7_LATEST7
+                    no latest8
+                    no latest7
                     vir_mode = "pv"
                 - hvm:
                     vir_mode = "hvm"

--- a/v2v/tests/cfg/convert_vm_to_ovirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_ovirt.cfg
@@ -60,11 +60,13 @@
             output_format = "qcow2"
     variants:
         - arch_i386:
-            no 7_LATEST7
+            no latest8
+            no latest7
             no win2008r2
             no win2012
             no win2012r2
             no win2016
+            no win2019
             vm_arch = "i386"
         - arch_x86_64:
             vm_arch = "x86_64"
@@ -74,10 +76,12 @@
             vm_user = ${username}
             vm_pwd = "redhat"
             variants:
-                - 7_LATEST7:
-                    os_version = "rhel7.LATEST7"
-                - 6_LATEST6:
-                    os_version = "rhel6.LATEST6"
+                - latest8:
+                    os_version = "LATEST8"
+                - latest7:
+                    os_version = "LATEST7"
+                - latest6:
+                    os_version = "LATEST6"
                 - 5_11:
                     os_version = "rhel5.11"
         - windows:
@@ -124,7 +128,10 @@
                     os_version = "win10"
                 - win2016:
                     no xen
-                    os_version = win2016
+                    os_version = "win2016"
+                - win2019:
+                    no xen
+                    os_version = "win2019"
     variants:
         - kvm:
             only source_kvm
@@ -139,7 +146,8 @@
             v2v_opts = "-v -x"
             variants:
                 - pv:
-                    no 7_LATEST7
+                    no latest8
+                    no latest7
                     vir_mode = "pv"
                 - hvm:
                     vir_mode = "hvm"

--- a/v2v/tests/src/convert_vm_to_libvirt.py
+++ b/v2v/tests/src/convert_vm_to_libvirt.py
@@ -117,8 +117,9 @@ def run(test, params, env):
         vm = env.create_vm("libvirt", "libvirt", vm_name, params, test.bindir)
         # Win10 is not supported by some cpu model,
         # need to modify to 'host-model'
-        if params.get('os_version') in ['win10', 'win2016']:
-            logging.info('Set cpu mode to "host-model" for win10 and win2016')
+        unsupport_list = ['win10', 'win2016', 'win2019']
+        if params.get('os_version') in unsupport_list:
+            logging.info('Set cpu mode to "host-model" for %s.', unsupport_list)
             vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
             cpu_xml = vm_xml.VMCPUXML()
             cpu_xml.mode = 'host-model'

--- a/v2v/tests/src/convert_vm_to_ovirt.py
+++ b/v2v/tests/src/convert_vm_to_ovirt.py
@@ -173,8 +173,9 @@ def run(test, params, env):
             'win2012',
             'win2012r2',
             'win2008',
-            'win2016']
-        win_version = ['6.2', '6.3', '10.0', '6.2', '6.3', '6.0', '10.0']
+            'win2016',
+            'win2019']
+        win_version = ['6.2', '6.3', '10.0', '6.2', '6.3', '6.0', '10.0', '10.0']
         os_map = dict(list(zip(os_list, win_version)))
         vm_arch = params.get('vm_arch')
         os_ver = params.get('os_version')


### PR DESCRIPTION
1) Update rhel7 and rhel6 testing guests to latest version
2) Add win2019 guest support
3) Update cfg variant name for rhel7 and rhel6 to a fixed name,
   this can avoid case name changes when testing version changes.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>