### PR TITLE
Add sleep time in the commands to avoid failure

### DIFF
--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_update.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_update.py
@@ -783,7 +783,7 @@ def run(test, params, env):
                     session = vm.wait_for_serial_login()
                     if "ip-dhcp" in net_section:
                         dhclient_cmd = "(if pgrep dhclient;" \
-                                       "then pkill dhclient; fi) " \
+                                       "then pkill dhclient; sleep 3; fi) " \
                                        "&& dhclient -%s" % ip_version[-1]
                         session.cmd(dhclient_cmd)
                         iface_ip = utils_net.get_guest_ip_addr(session, mac,


### PR DESCRIPTION
After pkill, the process may still exists in a short time. So add a
sleep time after the kill command.

Signed-off-by: yalzhang <yalzhang@redhat.com>