### PR TITLE
virsh_event: Add tray-change event and fix issues

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_event.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_event.cfg
@@ -47,6 +47,10 @@
                     only loop
                     event_all_option = "yes"
                     events_list = "device-added-removed"
+                - tray-change_event:
+                    only loop
+                    event_name = "tray-change"
+                    events_list = "change-media"
             variants:
                 - virsh_event:
                     # Test virsh event


### PR DESCRIPTION
Add 'tray-change' event. Modify 'edit' with act on 'description',
to avoid cpu topology error when edit vcpu. Fix 'shutdown' event
order issue due to time delay by adding time sleep.

Signed-off-by: Yanqiu Zhang <yanqzhan@redhat.com>