### PR TITLE
Fix: hotplug interface with virtio model type

### DIFF
--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_dhcp_leases.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_dhcp_leases.py
@@ -173,7 +173,8 @@ def run(test, params, env):
             iface_mac = utils_net.generate_mac_address_simple()
             if filter_by_mac:
                 nic_mac = iface_mac
-            op = "--type network --source %s --mac %s" % (net_name, iface_mac)
+            op = "--type network --model virtio --source %s --mac %s" \
+                 % (net_name, iface_mac)
             nic_params = {'mac': iface_mac, 'nettype': 'bridge',
                           'ip_version': 'ipv4'}
             login_timeout = 120


### PR DESCRIPTION
virtio model type is higher priority than other types. If not specified,
it will use rtl8139 model type, which will be attached to pci slot not
pcie slot, the case will be failed on q35 machine type as no enough pci
slots.

Signed-off-by: yalzhang <yalzhang@redhat.com>