### PR TITLE
Fix the hotplug interface failure

### DIFF
--- a/libvirt/tests/src/nwfilter/nwfilter_vm_attach.py
+++ b/libvirt/tests/src/nwfilter/nwfilter_vm_attach.py
@@ -51,6 +51,7 @@ def run(test, params, env):
         new_iface.target = {'dev': iface_target}
         new_filterref = new_iface.new_filterref(**filterref_dict)
         new_iface.filterref = new_filterref
+        new_iface.model = "virtio"
         logging.debug("new interface xml is: %s" % new_iface)
 
         # Attach interface to vm


### PR DESCRIPTION
When hotplug interface, the default model type is rtl8139 which is a pci
device not a pcie device. This will cause "no pcie slots" issue on q35
machine type. And virtio model has higher priority than rtl8139.

Signed-off-by: yalzhang <yalzhang@redhat.com>