### PR TITLE
migrate_vm: Enable a port on remote host

### DIFF
--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -2364,9 +2364,10 @@ def run(test, params, env):
             status_error = "no"
             test_dict['err_msg'] = None
 
-        if transport in ('tcp', 'tls') and uri_port:
+        if (transport in ('tcp', 'tls') and uri_port) or disk_port:
+            port = disk_port if disk_port else uri_port[1:]
             migrate_setup.migrate_pre_setup("//%s/" % server_ip, test_dict,
-                                            cleanup=False, ports=uri_port[1:])
+                                            cleanup=False, ports=port)
         if run_migr_front:
             migrate_vm(test_dict)
 
@@ -2783,6 +2784,7 @@ def run(test, params, env):
         if objs_list and len(objs_list) > 0:
             logging.debug("Clean up the objects")
             cleanup(objs_list)
-        if transport in ('tcp', 'tls') and uri_port:
+        if (transport in ('tcp', 'tls') and uri_port) or disk_port:
+            port = disk_port if disk_port else uri_port[1:]
             migrate_setup.migrate_pre_setup("//%s/" % server_ip, test_dict,
-                                            cleanup=True, ports=uri_port[1:])
+                                            cleanup=True, ports=port)


### PR DESCRIPTION
This is required for migration with --disk-port option.

Signed-off-by: Dan Zheng <dzheng@redhat.com>