### PR TITLE
migrate_vm: Fix TLS setup

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_vm.cfg
+++ b/libvirt/tests/cfg/migration/migrate_vm.cfg
@@ -316,9 +316,9 @@
                         - with_tls:
                             transport = "tls"
                             uri_port = ":16514"
-                            listen_addr = "${ipv6_addr_des}"
-                            server_cn = "${ipv6_addr_des}"
-                            client_cn = "${ipv6_addr_src}"
+                            listen_addr = "0.0.0.0"
+                            server_cn = "ENTER.YOUR.SERVER_CN"
+                            client_cn = "ENTER.YOUR.CLIENT_CN"
                 - migration_with_devices:
                     variants:
                         - eject_cdrom_in_guest:

--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -1455,9 +1455,9 @@ def run(test, params, env):
 
         # generate remote IP
         if target_ip == "":
-            if config_ipv6 == "yes" and ipv6_addr_des:
+            if config_ipv6 == "yes" and ipv6_addr_des and not server_cn:
                 target_ip = "[%s]" % ipv6_addr_des
-            elif config_ipv6 != "yes" and server_cn:
+            elif server_cn:
                 target_ip = server_cn
             elif config_ipv6 != "yes" and ipv6_addr_des:
                 target_ip = "[%s]" % ipv6_addr_des


### PR DESCRIPTION
Set CN to hostname instead of IPV6 address to avoid of confused connection.

Signed-off-by: Dan Zheng <dzheng@redhat.com>