### PR TITLE
virsh_migrate_copy_storage: Add migration setup

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_copy_storage.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_copy_storage.cfg
@@ -1,6 +1,7 @@
 - virsh.migrate_copy_storage:
     type = virsh_migrate_copy_storage
     migrate_dest_uri = "qemu+ssh://${migrate_dest_host}/system"
+    migration_setup = "yes"
     thread_timeout = 1200
     start_vm = "no"
     precreation_pool_type = "dir"


### PR DESCRIPTION
Enable the parameter to use migration setup function in avocado-vt.
This parameter will help to setup and clean the required firewall port.

Signed-off-by: Dan Zheng <dzheng@redhat.com>