### PR TITLE
Fix virsh_edit case failure by removing noise dmesg checking

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_edit.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_edit.cfg
@@ -3,6 +3,7 @@
     take_regular_screendumps = no
     edit_vm_ref = "name"
     edit_extra_param = ""
+    verify_guest_dmesg = no
     variants:
         - edit_vcpu:
             edit_element = "vcpu"


### PR DESCRIPTION
Noise guest dmesg checking will leads to cases failures

Signed-off-by: chunfuwen <chwen@redhat.com>