### PR TITLE
Fix setvcpus error_test shut_off error option with topology case fail

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_setvcpus.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_setvcpus.cfg
@@ -91,6 +91,7 @@
                         - with_topology:
                             # With topology setvcpus api itself fails out
                             # https://bugzilla.redhat.com/show_bug.cgi?id=1426220
+                            with_topology = "yes"
                             setvcpus_pre_vm_state = "running"
                             setvcpus_count = "8"
                             setvcpus_max = "4"


### PR DESCRIPTION
The precondition for this case is to have one topology element in vmxml,
Therefore, by adding one topology element before executing any further action

Signed-off-by: chunfuwen <chwen@redhat.com>