### PR TITLE
Update the parameter passed to check_vm_state()

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_stress.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_stress.py
@@ -50,7 +50,7 @@ def post_migration_check(vms, uptime, test, params, uri=None):
                      vm_uptime)
         if vm_uptime < uptime[vm.name]:
             test.fail("vm went for a reboot during migration")
-        if not migrate_setup.check_vm_state(vm, vm_state, uri):
+        if not migrate_setup.check_vm_state(vm.name, vm_state, uri):
             test.fail("Migrated VMs failed to be in %s state at "
                       "destination" % vm_state)
         logging.info("Guest state is '%s' at destination is as expected",

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migration.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migration.py
@@ -52,7 +52,7 @@ def run(test, params, env):
         except Exception as info:
             test.fail(info)
         for vm in vm_list:
-            if not migrate_setup.check_vm_state(vm, vm_state, dest_uri):
+            if not migrate_setup.check_vm_state(vm.name, vm_state, dest_uri):
                 test.fail("Migrated VMs failed to be in %s state at "
                           "destination" % vm_state)
             logging.info("Guest state is '%s' at destination is as expected",


### PR DESCRIPTION
We need to update the parameter passed to check_vm_state() accordingly
after the defination changed in avocado-vt

Signed-off-by: Fangge Jin <fjin@redhat.com>