### PR TITLE
Fix "UnicodeDecodeError: 'utf-8'..." failure in tcp_server and unix serial

### DIFF
--- a/libvirt/tests/src/serial/serial_functional.py
+++ b/libvirt/tests/src/serial/serial_functional.py
@@ -148,7 +148,7 @@ class Console(aexpect.ShellSession):
                 if self.console_type in ['tcp', 'unix']:
                     new_data = self.socket.recv(
                         1024, socket.MSG_DONTWAIT)
-                    data += astring.to_text(new_data)
+                    data += astring.to_text(new_data, errors='ignore')
                     return data
                 elif self.console_type == 'udp':
                     new_data, self.peer_addr = self.socket.recvfrom(


### PR DESCRIPTION
Computing 'string' type variable and 'bytes' type varible,
when testing console_type is 'tcp' or 'unix'.

Signed-off-by: jiyan <jiyan@redhat.com>