### PR TITLE
Fix some script issue in mtu.py

### DIFF
--- a/libvirt/tests/cfg/virtual_network/mtu.cfg
+++ b/libvirt/tests/cfg/virtual_network/mtu.cfg
@@ -2,6 +2,7 @@
     type = mtu
     start_vm = no
     mtu_size = 6000
+    model = virtio
     variants:
         - positive_test:
             variants:


### PR DESCRIPTION
As mtu is only supported by virtio model type, so add the model type in
the interface xml setting. And delete the openvswitch bridge after test.
And sleep for 5s after detach, then check to avoid the check failure.

Signed-off-by: yalzhang <yalzhang@redhat.com>