### PR TITLE
Fix "TypeError: first argument must be string" failure in virtio console

### DIFF
--- a/libvirt/tests/src/serial/serial_functional.py
+++ b/libvirt/tests/src/serial/serial_functional.py
@@ -638,7 +638,7 @@ def run(test, params, env):
         if exp_ser_opt is not None and re.match(exp_ser_opt, ser_opt) is None:
             test.fail('Expect get qemu command serial option "%s", '
                       'but got "%s"' % (exp_ser_opt, ser_opt))
-        if re.match(exp_ser_dev, ser_dev) is None:
+        if exp_ser_dev is not None and ser_dev is not None and re.match(exp_ser_dev, ser_dev) is None:
             test.fail(
                 'Expect get qemu command serial device option "%s", '
                 'but got "%s"' % (exp_ser_dev, ser_dev))


### PR DESCRIPTION
Fix following error msg caused by two 'None' type variables
in re.match(exp_ser_dev, ser_dev) when testing virtio console
TypeError: first argument must be string or compiled pattern&#10;

Signed-off-by: jiyan <jiyan@redhat.com>