### PR TITLE
libvirt autotest vnc ipv6 series case failed

### DIFF
--- a/libvirt/tests/src/graphics/graphics_functional.py
+++ b/libvirt/tests/src/graphics/graphics_functional.py
@@ -185,7 +185,7 @@ class EnvState(object):
         if vnc_listen == 'not_set':
             del self.qemu_config.vnc_listen
         elif vnc_listen in ['valid_ipv4', 'valid_ipv6']:
-            expected_ip = str(expected_result['vnc_ips'][0])
+            expected_ip = str(expected_result['vnc_ips'][0].addr)
             self.qemu_config.vnc_listen = expected_ip
         else:
             self.qemu_config.vnc_listen = vnc_listen
@@ -701,7 +701,7 @@ def get_expected_vnc_options(params, networks, expected_result):
             vnc_listen = params.get("vnc_listen", "127.0.0.1")
 
         if vnc_listen in ['valid_ipv4', 'valid_ipv6']:
-            listen_address = str(expected_result['vnc_ips'][0])
+            listen_address = str(expected_result['vnc_ips'][0].addr)
         else:
             listen_address = vnc_listen
 


### PR DESCRIPTION
rally defect LIBVIRTAT-3267

test case failed with strange syntax error as follows:

ValueError: invalid interpolation syntax in
'0000:0000:0000:0000:0000:0000:0000:0001%1' at position 39&#10;

expected_result is a list of IPAddress which has a addr attribute.
Therefore, it is correct to use .addr to get correct ipv6 address.

Signed-off-by: Jin Li <jil@redhat.com>