### PR TITLE
Fix detach_device cdrom test cases

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device.cfg
@@ -15,6 +15,8 @@
             dt_device_device_source = "attach.iso"
             dt_device_device_target = hdc
             dt_device_bus_type = ide
+            machine_type == q35:
+                dt_device_bus_type = virtio
         - disk_test:
             dt_device_device = disk
             dt_device_device_target = vdb


### PR DESCRIPTION
On q35 machine type, only virtio bus can be supported

Signed-off-by: chunfuwen <chwen@redhat.com>