### PR TITLE
fix vol_concurrent: change the number of new volumn to 100

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/volume/vol_concurrent.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/volume/vol_concurrent.cfg
@@ -3,7 +3,7 @@
     vms = ''
     main_vm = ''
     start_vm = no
-    volume_number = 5
+    volume_number = 100
     pool_name = "orign_pool"
     volume_name = "orign_volume"
     volume_size = "16777216"


### PR DESCRIPTION
test case vol_concurrent is designed to check whether libvirt throw
a error when there is simultaneous volume operations

This commit change the number of new volumn to be created during vol
deleting to 100 so that simultaneous volume operation will definitely
happen

Signed-off-by: Jin Li <jil@redhat.com>