### PR TITLE
Fix change media failure cases on q35 machine type

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_change_media.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_change_media.cfg
@@ -96,8 +96,14 @@
             variants:
                 - ide_:
                     change_media_target_device = "hdc"
+                    device_target_bus = "ide"
+                    machine_type == q35:
+                        device_target_bus = "sata"
+                        change_media_target_device = "sdc"
                 - scsi_:
                     change_media_target_device = "sdc"
+                    device_target_bus = "scsi"
         - floppy_test:
             change_media_device_type = "floppy"
             change_media_target_device = "fda"
+            device_target_bus = "fdc"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_change_media.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_change_media.py
@@ -90,9 +90,10 @@ def run(test, params, env):
         if vm.is_alive():
             virsh.destroy(vm_name)
 
+        device_target_bus = params.get("device_target_bus", "ide")
         virsh.attach_disk(vm_name, init_source,
                           target_device,
-                          "--type %s --sourcetype file --config" % device_type,
+                          "--type %s --sourcetype file --targetbus %s --config" % (device_type, device_target_bus),
                           debug=True)
 
     def update_device(vm_name, init_iso, options, start_vm):
@@ -108,15 +109,16 @@ def run(test, params, env):
             disk_alias_update = ""
         else:
             disk_alias_update = disk_alias
+        device_target_bus = params.get("device_target_bus", "ide")
         snippet = """
 <disk type='file' device='%s'>
 <driver name='qemu' type='raw'/>
 <source file='%s'/>
-<target dev='%s'/>
+<target dev='%s' bus='%s'/>
 <readonly/>
 <alias name='%s'/>
 </disk>
-""" % (device_type, init_iso, target_device, disk_alias_update)
+""" % (device_type, init_iso, target_device, device_target_bus, disk_alias_update)
         logging.info("Update xml is %s", snippet)
         with open(update_iso_xml, "w") as update_iso_file:
             update_iso_file.write(snippet)


### PR DESCRIPTION
IDE controller is not supported on q35,and sata and scsi are preferred.

Signed-off-by: chunfuwen <chwen@redhat.com>