### PR TITLE
Fix virsh event case failures due to unsupported IDE controller on q35

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_event.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_event.cfg
@@ -51,6 +51,9 @@
                     only loop
                     event_name = "tray-change"
                     events_list = "change-media"
+                    device_target_bus = "ide"
+                    machine_type == q35:
+                        device_target_bus = "scsi"
             variants:
                 - virsh_event:
                     # Test virsh event


### PR DESCRIPTION
On q35 machine type, IDE controller type is not supported, and
scsi or sata are preferred.
Moreover, some hardcarded string match is removed with self adapted parameter

Signed-off-by: chunfuwen <chwen@redhat.com>