### PR TITLE
Use recommended 'virtio' model for interface

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_interface.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_interface.cfg
@@ -4,6 +4,8 @@
     at_detach_iface_options_suffix = ""
     # Create a mac address with autotest codes
     at_detach_iface_mac = "created"
+    machine_type == q35:
+        at_detach_iface_model = "virtio"
     variants:
         - normal_test:
             status_error = "no"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_interface.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_interface.py
@@ -196,7 +196,7 @@ def run(test, params, env):
     save_restore = params.get("save_restore", "no")
     restart_libvirtd = params.get("restart_libvirtd", "no")
     attach_cmd = params.get("attach_cmd", "attach-interface")
-    virsh_dargs = {'ignore_status': True, 'uri': uri}
+    virsh_dargs = {'ignore_status': True, 'debug': True, 'uri': uri}
 
     # Get iface name if iface_type is direct
     if iface_type == "direct":
@@ -296,7 +296,7 @@ def run(test, params, env):
                 attach_result = virsh.attach_interface(vm_ref, options, **virsh_dargs)
             elif attach_cmd == "attach-device":
                 attach_result = virsh.attach_device(vm_name, xml_file,
-                                                    ignore_status=True)
+                                                    ignore_status=True, debug=True)
         attach_status = attach_result.exit_status
         logging.debug(attach_result)
 


### PR DESCRIPTION
When attach interface, use recommended 'virtio' model instead of
the default rtl8139. Also it can avoid rtl8139 not working for q35
machine type.

Signed-off-by: Yanqiu Zhang <yanqzhan@redhat.com>