### PR TITLE
Ignore numa node for non-numa systems

### DIFF
--- a/libvirt/tests/cfg/libvirt_mem.cfg
+++ b/libvirt/tests/cfg/libvirt_mem.cfg
@@ -103,8 +103,9 @@
                             memory_addr = "{'type':'dimm','slot':'0','base':'0x100000000'}"
                             node_mask = 0
                 - without_numa_save_restore:
-                    # max_mem_rt = 20971520
+                    max_mem_rt = 20971520
                     numa_cells = ""
+                    tg_node = ""
                 - align_256m:
                     max_mem_rt = 10000000
                     memory_val = 1000000


### PR DESCRIPTION
Hotplug xml will have node tag by default, due to which the test
fails to hotplug on non numa systems. Patch will not add node tag
for non numa systems.

Signed-off-by: Hariharan T.S <hari@linux.vnet.ibm.com>