### PR TITLE
Difference the expected result of storage migration per qemu version

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_vm.cfg
+++ b/libvirt/tests/cfg/migration/migrate_vm.cfg
@@ -537,6 +537,7 @@
                             config_libvirtd = "yes"
                             variants:
                                 - no_migrate_disks:
+                                    err_msg = "error: internal error: unable to execute QEMU command 'nbd-server-add': Block node is read-only"
                                     virsh_options = "--live --verbose --copy-storage-all"
                                 - all_non_shared_disks:
                                     virsh_options = "--live --verbose --copy-storage-all --migrate-disks vda,vdb"


### PR DESCRIPTION
For qemu-kvm>=2.10.0, storage migration with shared storage can succeed;
For qemu-kvm<2.10.0, storage migration with shared storage will fail.

Signed-off-by: Fangge Jin <fjin@redhat.com>