### PR TITLE
Attach cdrom device to scsi controller instead of IDE controller

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_vm.cfg
+++ b/libvirt/tests/cfg/migration/migrate_vm.cfg
@@ -328,7 +328,7 @@
                             local_disk_image = "${nfs_mount_dir}/virt_iso.img"
                             local_image_format = "raw"
                             local_disk_size = "10M"
-                            target_dev = "hdc"
+                            target_dev = "sdb"
                             attach_disk_args = "--config --driver qemu --subdriver ${local_image_format} --cache none --type cdrom --mode readonly"
                         - startup_policy:
                             variants:

--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -307,7 +307,7 @@ def add_disk_xml(device_type, source_file,
         exceptions.TestSkipError("Only support 'cdrom' and 'floppy'"
                                  " device type: %s" % device_type)
 
-    dev_dict = {'cdrom': {'bus': 'ide', 'dev': 'hdc'},
+    dev_dict = {'cdrom': {'bus': 'scsi', 'dev': 'sdb'},
                 'floppy': {'bus': 'fdc', 'dev': 'fda'}}
     if image_size:
         cmd = "qemu-img create %s %s" % (source_file, image_size)


### PR DESCRIPTION
IDE controller is deprecated for q35 machine type; while scsi
controoler is available for both i440fx and q35 machine type.

Signed-off-by: Fangge Jin <fjin@redhat.com>