### PR TITLE
Enable nfs setup for RDMA migration

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_vm.cfg
+++ b/libvirt/tests/cfg/migration/migrate_vm.cfg
@@ -717,9 +717,8 @@
                                 - copy_storage_inc:
                                     virsh_options = "--live --verbose --persistent --copy-storage-inc"
                 - rdma_migration:
-                    setup_nfs = "no"
-                    enable_virt_use_nfs = "no"
-                    nfs_mount_dir =
+                    setup_nfs = "yes"
+                    enable_virt_use_nfs = "yes"
                     virsh_options = "--live --verbose --migrateuri rdma://${server_ip} --listen-address 0.0.0.0"
                     variants:
                         - no_memory_hard_limit:
@@ -729,16 +728,19 @@
                             hard_limit_value = "1048576"
                             swap_hard_limit_value = "2097152"
                             memtune_options = "--hard-limit ${hard_limit_value} --swap-hard-limit ${swap_hard_limit_value} --config"
+                            err_msg = "unable to execute QEMU command 'migrate-incoming': RDMA ERROR: could not create rdma event channel"
                         - no_rdma_env_rdma_pin_all:
                             hard_limit_value = "2097152"
                             swap_hard_limit_value = "2097152"
                             memtune_options = "--hard-limit ${hard_limit_value} --swap-hard-limit ${swap_hard_limit_value} --config"
                             virsh_options = "--live --verbose --rdma-pin-all --migrateuri rdma://${server_ip} --listen-address 0.0.0.0"
+                            err_msg = "unable to execute QEMU command 'migrate-incoming': RDMA ERROR: could not create rdma event channel"
                         - no_rdma_env_turn_off_rdma_pin_all:
                             hard_limit_value = "1048576"
                             swap_hard_limit_value = "1048576"
                             memtune_options = "--hard-limit ${hard_limit_value} --swap-hard-limit ${swap_hard_limit_value} --config"
                             virsh_options = "--live --verbose --rdma-pin-all --migrateuri rdma://${server_ip}"
+                            err_msg = "unable to execute QEMU command 'migrate-incoming': RDMA ERROR: could not create rdma event channel"
                 - cross_rhel_platform_migration:
                     # only work well on RHEL platform
                     migration_timeout = 600

--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -147,9 +147,13 @@ def check_output(test, output_msg, params):
                           with some conditions satisfied
     """
     err_msg = params.get("err_msg", None)
-    if err_msg and err_msg in output_msg:
-        logging.debug("Expected error '%s' was found", err_msg)
-        return
+    status_error = params.get("status_error", "no")
+    if status_error == "yes" and err_msg:
+        if err_msg in output_msg:
+            logging.debug("Expected error '%s' was found", err_msg)
+            return
+        else:
+            test.fail("The expected error '%s' was not found in output '%s'" % (err_msg, output_msg))
 
     ERR_MSGDICT = {"Bug 1249587": "error: Operation not supported: " +
                    "pre-creation of storage targets for incremental " +


### PR DESCRIPTION
If nfs setup is not enable for RDMA migration, it will reports:
"Unsafe migration: Migration without shared storage is unsafe"

Signed-off-by: Fangge Jin <fjin@redhat.com>