### PR TITLE
replace the deprecated exception TestNAError with TestCancel

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_interface.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_interface.py
@@ -202,7 +202,7 @@ def run(test, params, env):
     if iface_type == "direct":
         iface_source = utils_net.get_net_if(state="UP")[0]
     # Get a bridge name for test if iface_type is bridge.
-    # If there is no bridge other than virbr0, raise TestNAError
+    # If there is no bridge other than virbr0, raise TestCancel
     if iface_type == "bridge":
         host_bridge = utils_net.Bridge()
         bridge_list = host_bridge.list_br()

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_copy_storage.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_copy_storage.py
@@ -73,7 +73,7 @@ def check_output(test, output_msg, params):
     :param output_msg: the given output messages
     :param params: the dictionary including necessary parameters
 
-    :raise TestNAError: raised if the known error is found together
+    :raise TestCancel: raised if the known error is found together
                         with some conditions satisfied
     """
     ERR_MSGDICT = {"Bug 1249587": "error: Operation not supported: " +

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_agent_command.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_agent_command.py
@@ -107,7 +107,7 @@ def run(test, params, env):
     # Prepare domain
     try:
         reset_domain(test, vm, vm_state, needs_agent, guest_cpu_busy, password)
-    except exceptions.TestNAError as details:
+    except exceptions.TestCancel as details:
         reset_env(vm_name, xml_file)
         test.cancel(details)
     except Exception as details:


### PR DESCRIPTION
fix runtime error as follows:
AttributeError: module 'avocado.core.exceptions' has no
attribute 'TestNAError'

Signed-off-by: Jin Li <jil@redhat.com>