### PR TITLE
Add auto generate port id when hotplug channel device

### DIFF
--- a/libvirt/tests/cfg/channel/channel_functional.cfg
+++ b/libvirt/tests/cfg/channel/channel_functional.cfg
@@ -28,6 +28,14 @@
                     channel_target_address = '10.0.2.1'
                     channel_target_port = '4600'
                     channel_source_path = '/var/lib/libvirt/qemu/virt-test.test-channel'
+                - auto_gen_port:
+                    no unix_type
+                    auto_gen_port = 'yes' 
+                    channel_target_type = 'virtio'
+                    channel_target_state = 'disconnected'
+                    channel_address_type = 'virtio-serial'
+                    channel_address_controller = '0'
+                    channel_address_bus = '0'
         - negative_tests:
             variants:
                 - target_not_set:


### PR DESCRIPTION
It's to test if a port id is not given when hotplug a channel, port id can
be generated automatically

Signed-off-by: qijing <jinqi@redhat.com>