### PR TITLE
migrate_options_shared: Add migration cases

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -37,6 +37,7 @@
             postcopy_options = ""
     variants:
         - positive_test:
+            virsh_migrate_options = "--live --verbose"
             variants:
                 - compress_methods:
                     keepalive_interval= -1
@@ -58,13 +59,11 @@
                             virsh_migrate_extra = "--comp-methods xbzrle --comp-xbzrle-cache"
                 - timeout_postcopy:
                     only with_postcopy
-                    virsh_migrate_options = "--live --verbose"
                     timeout_postcopy = 10
                     virsh_migrate_extra = "--timeout ${timeout_postcopy} --timeout-postcopy"
                     stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M"
                     stress_in_vm = "yes"
                 - native_tls:
-                    virsh_migrate_options = "--live --verbose"
                     virsh_migrate_extra = "--tls"
                     custom_pki_path = "/etc/pki/qemu"
                     qemu_tls = "yes"
@@ -75,8 +74,6 @@
                     grep_str_remote_log = '"dir":"/etc/pki/qemu","endpoint":"server","verify-peer":true'
                     grep_str_local_log = '"dir":"/etc/pki/qemu","endpoint":"client","verify-peer":true'
                 - hpt_resize:
-                    virsh_migrate_options = "--live --verbose"
-                    virsh_migrate_extra = ""
                     dmesg_content = "Attempting to resize HPT to shift %d|HPT resize to shift %d complete"
                     qemu_check = 'resize-hpt='
                     guest_xml_check_after_mig = 'hpt resizing='
@@ -88,13 +85,9 @@
                         - disabled:
                             hpt_resize = "disabled"
                 - multiple_phbs:
-                    virsh_migrate_options = "--live --verbose"
-                    virsh_migrate_extra = ""
                     new_contrl_index = 5
                     guest_xml_check_after_mig = "controller type='pci' index='[0-${new_contrl_index}]' model='pci-root'"
                 - htm:
-                    virsh_migrate_options = "--live --verbose"
-                    virsh_migrate_extra = ""
                     qemu_check = 'cap-htm='
                     guest_xml_check_after_mig = 'htm state='
                     variants:
@@ -102,3 +95,40 @@
                             htm_state = "on"
                         - state_off:
                             htm_state = "off"
+                - cache_safe:
+                    variants:
+                        - none:
+                            cache = "none"
+                        - directsync:
+                            cache = "directsync"
+                - cache_unsafe:
+                    virsh_migrate_extra = '--unsafe'
+                    variants:
+                        - writeback:
+                            cache = "writeback"
+                        - unsafe:
+                            cache = "unsafe"
+                        - writethrough:
+                            cache = "writethrough"
+                        - default:
+                            cache = "default"
+                        - nonexistence:
+                            remove_cache = "yes"
+                - migrate_uri:
+                    virsh_migrate_extra = "--migrateuri tcp://${migrate_dest_host}"
+        - negative_test:
+            variants:
+                - cache_unsafe:
+                    # Without '--unsafe', migration will fail and throw an error message
+                    err_msg = "Unsafe migration: Migration may lead to data corruption"
+                    variants:
+                        - writeback:
+                            cache = "writeback"
+                        - unsafe:
+                            cache = "unsafe"
+                        - writethrough:
+                            cache = "writethrough"
+                        - default:
+                            cache = "default"
+                        - nonexistence:
+                            remove_cache = "yes"


### PR DESCRIPTION
- cache safe/unsafe test
Safe cache mode:
  none
  directsync
Unsafe cache mode(must add --unsafe in order to migrate successfully):
  writeback
  unsafe
  writethrough
  default
  without cache element in domain xml

- migrate-uri tcp:

Signed-off-by: Dan Zheng <dzheng@redhat.com>