### PR TITLE
migrate_options_shared: add tls migration cases

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -71,8 +71,21 @@
                     log_level= 1
                     server_cn = "ENTER.YOUR.SERVER_CN"
                     client_cn = "ENTER.YOUR.CLIENT_CN"
-                    grep_str_remote_log = '"dir":"/etc/pki/qemu","endpoint":"server","verify-peer":true'
                     grep_str_local_log = '"dir":"/etc/pki/qemu","endpoint":"client","verify-peer":true'
+                    variants:
+                        - verify_client:
+                            disable_verify_peer = "no"
+                            grep_str_remote_log = '"dir":"/etc/pki/qemu","endpoint":"server","verify-peer":true'
+                            variants:
+                                - no_post_after_precopy:
+                                - post_after_precopy:
+                                    only with_postcopy
+                                    virsh_migrate_extra = "--tls --postcopy-after-precopy"
+                                    stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M"
+                                    stress_in_vm = "yes"
+                        - no_verify_client:
+                            disable_verify_peer = "yes"
+                            grep_str_remote_log = '"dir":"/etc/pki/qemu","endpoint":"server","verify-peer":false'
                 - hpt_resize:
                     dmesg_content = "Attempting to resize HPT to shift %d|HPT resize to shift %d complete"
                     qemu_check = 'resize-hpt='
@@ -117,6 +130,9 @@
                 - migrate_uri:
                     virsh_migrate_extra = "--migrateuri tcp://${migrate_dest_host}"
         - negative_test:
+            virsh_migrate_options = "--live --verbose"
+            # The variable indicates migration command should fail
+            status_error = 'yes'
             variants:
                 - cache_unsafe:
                     # Without '--unsafe', migration will fail and throw an error message
@@ -132,3 +148,12 @@
                             cache = "default"
                         - nonexistence:
                             remove_cache = "yes"
+                - native_tls:
+                    variants:
+                        - inconsistent_cn_server:
+                            virsh_migrate_extra = "--tls"
+                            custom_pki_path = "/etc/pki/qemu"
+                            qemu_tls = "yes"
+                            server_cn = "INCONSISTENT.SERVER_CN"
+                            client_cn = "ENTER.YOUR.CLIENT_CN"
+                            disable_verify_peer = "yes"


### PR DESCRIPTION
Add some native tls migration cases

- not verify client
- inconsistent server_cn and server host name
- verify client + postcopy-after-precopy

Signed-off-by: Dan Zheng <dzheng@redhat.com>