### PR TITLE
Fix some v2v problems

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -143,6 +143,7 @@
             only esx_55
             main_vm = VM_NAME_MULTIPLE_LINUX_V2V_EXAMPLE
             checkpoint = root
+            v2v_timeout = '7200'
             variants:
                 - ask:
                     root_option = ask

--- a/v2v/tests/cfg/v2v_options.cfg
+++ b/v2v/tests/cfg/v2v_options.cfg
@@ -100,7 +100,7 @@
                         - esx:
                             only source_esx
                             hypervisor = "esx"
-                            v2v_timeout = 2400
+                            v2v_timeout = 5400
                             variants:
                                 - esx_60:
                                     only source_esx.esx_60
@@ -202,7 +202,7 @@
                             oc_uri = "qemu:///system"
                         - unprivileged:
                             oc_uri = "qemu:///session"
-                            unprivileged_user = "USER._V2V_EXAMPLE"
+                            unprivileged_user = "USER_V2V_EXAMPLE"
                     v2v_options = "-oc ${oc_uri} -on ${new_vm_name}"
                 - option_vdsm:
                     # Set the output method to vdsm
@@ -251,7 +251,7 @@
                     only input_mode.libvirt.kvm.default
                     only output_mode.libvirt
                     ori_pool = ori_pool
-                    unprivileged_user = USER.V2V_EXAMPLE
+                    unprivileged_user = USER_V2V_EXAMPLE
                     sh_install_vm = /DISK_IMAGE_PATH_V2V_EXAMPLE/INSTALL_VM_SCRIPT_V2V_EXAMPLE
                     main_vm = vm_nonroot
                     new_vm_name = vm_test_ic

--- a/v2v/tests/src/v2v_options.py
+++ b/v2v/tests/src/v2v_options.py
@@ -420,12 +420,12 @@ def run(test, params, env):
                 if len(ret) == 0:
                     logging.info("All common checkpoints passed")
             if checkpoint == 'quiet':
-                if len(output.strip()) != 0:
+                if len(output.strip().splitlines()) > 10:
                     test.fail('Output is not empty in quiet mode')
             if checkpoint == 'dependency':
                 if 'libguestfs-winsupport' not in output:
                     test.fail('libguestfs-winsupport not in dependency')
-                if 'VMF' not in output:
+                if all(pkg_pattern not in output for pkg_pattern in ['VMF', 'edk2-ovmf']):
                     test.fail('OVMF/AAVMF not in dependency')
                 if 'qemu-kvm-rhev' in output:
                     test.fail('qemu-kvm-rhev is in dependency')


### PR DESCRIPTION
1) extend v2v_timeout value
2) Modify USER.V2V_EXAMPLE to USER_V2V_EXAMPLE
3) Modify the way of checking '-q' option, even if '-q' is used, warning
   or errors still can be printed.
4) Modify ovmf checking for rhel8

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>