### PR TITLE
Fix some format error in cfg file

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -29,7 +29,7 @@
             only source_esx.esx_55
         - esx_60:
             only source_esx.esx_60
-        - esx_65
+        - esx_65:
             only source_esx.esx_65
         - esx_67:
             only source_esx.esx_67
@@ -184,7 +184,7 @@
             only esx_55
             only libvirt
             main_vm = VM_NAME_USR_PARTITION_V2V_EXAMPLE
-        - lvm_multiple_disks
+        - lvm_multiple_disks:
             only esx_65
             main_vm = VM_NAME_LVM_MULTIPLE_DISKS_V2V_EXAMPLE
     variants:


### PR DESCRIPTION
In 3306b3b93436209a2c86ea98abdcb74dc107b2c6, some format error was
involed. This patch fixes the error.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>