### PR TITLE
migrate_vm: Add timeout for migration

### DIFF
--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -2591,7 +2591,7 @@ def run(test, params, env):
                                               virsh_options, src_uri)
             logging.debug("Start migrating: %s", cmd)
             status, output = run_remote_cmd(cmd, server_ip, server_user,
-                                            server_pwd)
+                                            server_pwd, timeout=300)
             logging.info(output)
 
             if status:


### PR DESCRIPTION
Default timeout 60 seconds is not practical sometimes in migration. This
is to allow more seconds for migration to finish from target host to
source host.

Signed-off-by: Dan Zheng <dzheng@redhat.com>