### PR TITLE
Fix virtual disk attach failures due to uninitialized variable value

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
@@ -1030,37 +1030,43 @@
                     virt_disk_device_type = "file"
                     virt_disk_at_dt_disk = "yes"
                     disk_attach_driver_option = "--driver qemu --subdriver raw --type disk"
-                    disks_attach_option = "${disk_attach_bus_option}"
                     only hotplug
                     variants:
                         - attach_disk:
                             disks_attach_error = "yes"
                             virt_disk_check_partitions = "no"
                             disk_attach_bus_option = "--io native"
+                            disks_attach_option = "${disk_attach_bus_option}"
                         - attach_disk_with_none_cache:
                             check_disk_cache_mode = "yes"
                             disk_cache_mode = "none"
+                            disk_attach_bus_option = "--cache none"
                             disks_attach_option = "${disk_attach_bus_option}"
                         - attach_disk_with_directsync_cache:
                             check_disk_cache_mode = "yes"
                             disk_cache_mode = "directsync"
                             disk_attach_bus_option = "--io native --cache directsync"
+                            disks_attach_option = "${disk_attach_bus_option}"
                         - attach_disk_with_default_cache:
                             disks_attach_error = "yes"
                             virt_disk_check_partitions = "no"
                             disk_attach_bus_option = "--io native --cache default"
+                            disks_attach_option = "${disk_attach_bus_option}"
                         - attach_disk_with_writethrough_cache:
                             disks_attach_error = "yes"
                             virt_disk_check_partitions = "no"
                             disk_attach_bus_option = "--io native --cache writethrough"
+                            disks_attach_option = "${disk_attach_bus_option}"
                         - attach_disk_with_writeback_cache:
                             disks_attach_error = "yes"
                             virt_disk_check_partitions = "no"
                             disk_attach_bus_option = "--io native --cache writeback"
+                            disks_attach_option = "${disk_attach_bus_option}"
                         - attach_disk_with_unsafe_cache:
                             disks_attach_error = "yes"
                             virt_disk_check_partitions = "no"
                             disk_attach_bus_option = "--io native --cache unsafe"
+                            disks_attach_option = "${disk_attach_bus_option}"
     variants:
         - hotplug:
             virt_disk_device_hotplug = "yes"


### PR DESCRIPTION
disks_attach_option is not initialized correctly in the cfg file,
which leads to wrong attach option

Signed-off-by: chunfuwen <chwen@redhat.com>