### PR TITLE
Fix the pid type error issue

### DIFF
--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_dhcp_leases.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_dhcp_leases.py
@@ -152,7 +152,9 @@ def run(test, params, env):
     cmd = "ps aux|grep dnsmasq|grep -v grep | grep -v default | awk '{print $2}'"
     pid_list = results_stdout_52lts(process.run(cmd, shell=True)).strip().split('\n')
     for pid in pid_list:
-        utils_misc.safe_kill(pid, signal.SIGKILL)
+        if pid:
+            pid_n = int(pid)
+            utils_misc.safe_kill(pid_n, signal.SIGKILL)
     # Create new network
     if prepare_net:
         create_network()


### PR DESCRIPTION
virsh_net_dhcp_leases.py: after destroy the network, the dnsmasq
processes should be killed, the original script is to make sure all the
dnsmasq processes are killed except the default ones. But the "ps"
command return pid as str type in some system, which will cause the script fail.

Signed-off-by: yalzhang <yalzhang@redhat.com>