### PR TITLE
fix a typo in cpuset_vcpupin cfg file

### DIFF
--- a/libvirt/tests/cfg/cpu/guestpin.cfg
+++ b/libvirt/tests/cfg/cpu/guestpin.cfg
@@ -56,9 +56,9 @@
                     limit_vcpu_sockets = 1
     variants:
         - randompin:
-            pin_type = "random"
+            pintype = "random"
         - sequential:
-            pin_type = "sequential"
+            pintype = "sequential"
     variants:
         - without_emulatorpin:
             emulatorpin = "no"


### PR DESCRIPTION
fix a typo in cpuset_vcpupin cfg file

pin_type --> pintype

Signed-off-by: Jin Li <jil@redhat.com>