### PR TITLE
Fix ceph cases false warning error message issue by creating /etc/cep…

### DIFF
--- a/libvirt/tests/src/bios/virsh_boot.py
+++ b/libvirt/tests/src/bios/virsh_boot.py
@@ -594,6 +594,12 @@ def run(test, params, env):
     vmxml_backup = vm_xml.VMXML.new_from_dumpxml(vm_name)
     vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
     try:
+        # Create /etc/ceph/ceph.conf file to suppress false warning error message.
+        process.run("mkdir -p /etc/ceph", ignore_status=True, shell=True)
+        cmd = ("echo 'mon_host = {0}' >/etc/ceph/ceph.conf"
+               .format(params.get("mon_host")))
+        process.run(cmd, ignore_status=True, shell=True)
+
         setup_test_env(params, test)
         apply_boot_options(vmxml, params)
         blk_source = vm.get_first_disk_devices()['source']
@@ -658,6 +664,9 @@ def run(test, params, env):
                 remote_session.close()
         logging.debug("Succeed to boot %s" % vm_name)
     finally:
+        # Remove /etc/ceph/ceph.conf file if exists.
+        if os.path.exists('/etc/ceph/ceph.conf'):
+            os.remove('/etc/ceph/ceph.conf')
         logging.debug("Start to cleanup")
         if vm.is_alive:
             vm.destroy()

--- a/libvirt/tests/src/virtual_disks/virtual_disks_ceph.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_ceph.py
@@ -515,6 +515,12 @@ def run(test, params, env):
     test_json_pseudo_protocol = "yes" == params.get("json_pseudo_protocol", "no")
     disk_snapshot_with_sanlock = "yes" == params.get("disk_internal_with_sanlock", "no")
 
+    # Create /etc/ceph/ceph.conf file to suppress false warning error message.
+    process.run("mkdir -p /etc/ceph", ignore_status=True, shell=True)
+    cmd = ("echo 'mon_host = {0}' >/etc/ceph/ceph.conf"
+           .format(mon_host))
+    process.run(cmd, ignore_status=True, shell=True)
+
     # Start vm and get all partions in vm.
     if vm.is_dead():
         vm.start()
@@ -866,6 +872,9 @@ def run(test, params, env):
             test.fail("VM failed to start."
                       "Error: %s" % str(details))
     finally:
+        # Remove /etc/ceph/ceph.conf file if exists.
+        if os.path.exists('/etc/ceph/ceph.conf'):
+            os.remove('/etc/ceph/ceph.conf')
         # Delete snapshots.
         snapshot_lists = virsh.snapshot_list(vm_name)
         if len(snapshot_lists) > 0:


### PR DESCRIPTION
…h/ceph.conf

ceph rbd will firstly check /etc/ceph/ceph.conf, if not exist, it
will throw some false warning information.

Signed-off-by: chunfuwen <chwen@redhat.com>