### PR TITLE
Fix the network issue in iface_bridge.py

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_bridge.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_bridge.cfg
@@ -5,7 +5,7 @@
     bridge_name = "test_br0"
     netdst_nic1 = ${bridge_name}
     # Replace remote_ip by a actual IP address
-    remote_ip = "www.baidu.com"
+    remote_ip = "www.google.com"
     ping_count = 3
     pint_timeout = 10
     filter_uuid = "11111111-b071-6127-b4ec-111111111111"


### PR DESCRIPTION
Use ip command to create bridge to replace the original iface-bridge
command as it is not stable. Execute the commands in tmux to avoid
breaking the host network. And newtork.service is not
recommended, replace it with NetworkManager service.

Signed-off-by: yalzhang <yalzhang@redhat.com>