### PR TITLE
Fix the ramdom failure for libvirt_mem.positive_test.hugepages

### DIFF
--- a/libvirt/tests/cfg/libvirt_mem.cfg
+++ b/libvirt/tests/cfg/libvirt_mem.cfg
@@ -68,7 +68,7 @@
                     memory_addr = "{'type':'dimm','slot':'1','base':'0x11f000000'}"
                 - hugepages:
                     test_qemu_cmd = "no"
-                    test_mem_binding = "yes"
+                    test_mem_binding = "no"
                     setup_hugepages = "yes"
                     max_mem_rt = 25600000
                     max_mem = "2609152"


### PR DESCRIPTION
The test binding method is not fit for hugepages cases since the memory
is binded when it is startup

Signed-off-by: qijing <jinqi@redhat.com>