### PR TITLE
virsh.cpu_compare: Handle libvirt error message check

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_compare.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_compare.py
@@ -123,48 +123,48 @@ def run(test, params, env):
             logging.debug("CPU description XML:\n%s", cpu_compare_xml_f.read())
 
         # Expected possible result msg patterns and exit status
-        msg_patterns = ""
+        msg_patterns = []
         if not mode:
             if target == "host":
-                msg_patterns = "identical"
+                msg_patterns = ["identical"]
             else:
                 # As we don't know the <cpu> element in domain,
                 # so just check command exit status
                 pass
         elif mode == "delete":
             if cpu_match == "strict":
-                msg_patterns = "incompatible"
+                msg_patterns = ["incompatible"]
             else:
-                msg_patterns = "superset"
+                msg_patterns = ["superset"]
         elif mode == "modify":
             if modify_target == "mode":
                 if modify_invalid:
-                    msg_patterns = "Invalid mode"
+                    msg_patterns = ["Invalid mode"]
             elif modify_target == "model":
                 if modify_invalid:
-                    msg_patterns = "Unknown CPU model"
+                    msg_patterns = ["Unknown CPU model"]
             elif modify_target == "vendor":
                 if modify_invalid:
-                    msg_patterns = "incompatible"
+                    msg_patterns = ["incompatible"]
             elif modify_target == "feature_name":
                 if modify_value == "REPEAT":
-                    msg_patterns = "more than once"
+                    msg_patterns = ["more than once"]
                 elif modify_value == "ia64":
-                    msg_patterns = "incompatible"
+                    msg_patterns = ["incompatible"]
                 elif modify_invalid:
-                    msg_patterns = "Unknown"
+                    msg_patterns = ["Unknown"]
             elif modify_target == "feature_policy":
                 if modify_value == "forbid":
-                    msg_patterns = "incompatible"
+                    msg_patterns = ["incompatible"]
                 else:
-                    msg_patterns = "identical"
+                    msg_patterns = ["identical"]
             else:
                 test.cancel("Unsupport modify target %s in this "
                             "test" % mode)
         elif mode == "clear":
-            msg_patterns = "empty"
+            msg_patterns = ["empty", "does not contain any"]
         elif mode == "invalid_test":
-            msg_patterns = ""
+            msg_patterns = []
         else:
             test.cancel("Unsupport modify mode %s in this "
                         "test" % mode)
@@ -176,7 +176,7 @@ def run(test, params, env):
         else:
             # If exit status is not specified in cfg, using msg_patterns
             # to get expect exit status
-            if msg_patterns in ['identical', 'superset']:
+            if [item for item in msg_patterns if item in ['identical', 'superset']]:
                 expected_status = 0
             else:
                 expected_status = 1
@@ -204,7 +204,8 @@ def run(test, params, env):
                 output = result.stdout.strip()
             else:
                 output = result.stderr.strip()
-            if not output.count(msg_patterns):
+
+            if not [item for item in msg_patterns if output.count(item)]:
                 test.fail("Not find expect key word in command output")
 
         # Check VM for cpu 'mode' related cases


### PR DESCRIPTION
Libvirt error message has been changed in newer libvirt
versions, so let's handle all possible error message strings.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>