### PR TITLE
Rename result in case the name being used in other ways

### DIFF
--- a/libvirt/tests/src/cpu/max_vcpus.py
+++ b/libvirt/tests/src/cpu/max_vcpus.py
@@ -43,14 +43,14 @@ def run(test, params, env):
         if check == 'no_iommu':
             logging.info('Set vcpu to %s', guest_vcpu)
             vmxml.vcpu = int(guest_vcpu)
-            result = virsh.define(vmxml.xml, debug=True)
+            result_need_check = virsh.define(vmxml.xml, debug=True)
 
         # Set iommu device but not set ioapci in features
         if check == 'with_iommu':
             logging.info('Set vcpu to %s', guest_vcpu)
             vmxml.vcpu = int(guest_vcpu)
             set_iommu(vmxml)
-            result = virsh.define(vmxml.xml, debug=True)
+            result_need_check = virsh.define(vmxml.xml, debug=True)
 
         # Add ioapic and iommu device in xml
         if check.startswith('ioapic_iommu'):
@@ -76,7 +76,7 @@ def run(test, params, env):
 
             if status_error:
                 if start_fail:
-                    result = virsh.start(vm_name, debug=True)
+                    result_need_check = virsh.start(vm_name, debug=True)
 
             else:
                 # Login guest and check guest cpu number
@@ -96,8 +96,8 @@ def run(test, params, env):
                     test.fail('Not all CPU(s) are online')
 
         # Check result if there's result to check
-        if 'result' in locals():
-            libvirt.check_result(result, err_msg)
+        if 'result_need_check' in locals():
+            libvirt.check_result(result_need_check, err_msg)
 
     finally:
         bkxml.sync()

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_managedsave_extra.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_managedsave_extra.py
@@ -52,8 +52,9 @@ def run(test, params, env):
                                      % save_img_xml, **virsh_dargs)
             virsh.managedsave_dumpxml(vm_name, ' > %s' % managed_save_xml,
                                       **virsh_dargs)
-            result = process.run('diff %s %s' % (save_img_xml, managed_save_xml),
-                                 shell=True, verbose=True)
+            result_need_check = process.run('diff %s %s' %
+                                            (save_img_xml, managed_save_xml),
+                                            shell=True, verbose=True)
         if checkpoint == 'secure_info':
             # Check managedsave-dumpxml with option --security-info
             vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
@@ -120,18 +121,24 @@ def run(test, params, env):
         if params.get('check_cmd_error', '') == 'yes':
             ms_command = params.get('ms_command', '')
             if ms_command == 'edit':
-                result = virsh.managedsave_edit(vm_name, ms_extra_options, debug=True)
+                result_need_check = virsh.managedsave_edit(vm_name,
+                                                           ms_extra_options,
+                                                           debug=True)
             if ms_command == 'dumpxml':
-                result = virsh.managedsave_dumpxml(vm_name, ms_extra_options, debug=True)
+                result_need_check = virsh.managedsave_dumpxml(vm_name,
+                                                              ms_extra_options,
+                                                              debug=True)
             if ms_command == 'define':
-                result = virsh.managedsave_define(vm_name, bkxml.xml, ms_extra_options,
-                                                  debug=True)
+                result_need_check = virsh.managedsave_define(vm_name,
+                                                             bkxml.xml,
+                                                             ms_extra_options,
+                                                             debug=True)
         # If needs to check result, check it
-        if 'result' in locals():
+        if 'result_need_check' in locals():
             logging.info('Check command result.')
-            libvirt.check_exit_status(result, status_error)
+            libvirt.check_exit_status(result_need_check, status_error)
             if error_msg:
-                libvirt.check_result(result, [error_msg])
+                libvirt.check_result(result_need_check, [error_msg])
 
     finally:
         if params.get('clean_managed_save'):


### PR DESCRIPTION
The purpose of using the expression "if 'result' in locals()" is
to check 'result' only if there is a 'result' to be checked. But
the var name 'result' is too common, too much risk to be used in
another way, being another var and not need to be checked.
Therefore, we rename this var to make it unique.

Signed-off-by: haizhao <haizhao@redhat.com>