### PR TITLE
Add libvirt-guests cases for nfs backend image guest

### DIFF
--- a/libvirt/tests/cfg/conf_file/sysconfig_libvirt_guests/libvirt_guests.cfg
+++ b/libvirt/tests/cfg/conf_file/sysconfig_libvirt_guests/libvirt_guests.cfg
@@ -13,6 +13,14 @@
             variants:
                 - suspend_on_shutdown:
                     on_shutdown = "suspend"
+                    variants:
+                        - default_vol:
+                            nfs_vol = "no"
+                        - nfs_vol:
+                            only start_on_boot
+                            only no_parallel_shutdown
+                            nfs_vol = "yes"
+                            virt_use_nfs = "on"
                 - shutdown_on_shutdown:
                     on_shutdown = "shutdown"
             variants:

--- a/libvirt/tests/src/conf_file/sysconfig_libvirt_guests/libvirt_guests.py
+++ b/libvirt/tests/src/conf_file/sysconfig_libvirt_guests/libvirt_guests.py
@@ -3,6 +3,7 @@ import logging
 import re
 import aexpect
 import time
+import shutil
 
 from avocado.utils import path as utils_path
 from avocado.utils import process
@@ -12,6 +13,8 @@ from virttest import data_dir
 from virttest import utils_misc
 from virttest import virsh
 from virttest import utils_config
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_test import libvirt
 from virttest.staging import service
 
 
@@ -196,11 +199,49 @@ def run(test, params, env):
             session.close()
         return booting_time
 
+    def setup_nfs_backend_guest(vmxml_backup):
+        # nfs_server setup
+        nfs_server = libvirt.setup_or_cleanup_nfs(True)
+        nfs_export_dir = nfs_server['export_dir']
+        logging.debug("nfs dir is %s", nfs_export_dir)
+
+        # change the orignal xml and image path
+        for dom in vms:
+            vmxml = vm_xml.VMXML.new_from_dumpxml(dom.name)
+            vmxml_backup.append(vmxml.copy())
+            disk_xml = vmxml.get_devices(device_type="disk")[0]
+            orig_image_path_name = disk_xml.source.attrs['file']
+
+            libvirt.update_vm_disk_source(dom.name, nfs_export_dir)
+            shutil.copy(orig_image_path_name, nfs_export_dir)
+
+        # set the selinux bool
+        if virt_use_nfs:
+            result = process.run("setsebool virt_use_nfs 1",
+                                 shell=True, verbose=True)
+            if result.exit_status:
+                logging.error("Failed to set virt_use_nfs on")
+
+    def cleanup_nfs_backend_guest(vmxml_backup):
+        if virt_use_nfs:
+            result = process.run("setsebool virt_use_nfs 0",
+                                 shell=True, verbose=True)
+            if result.exit_status:
+                logging.error("Failed to set virt_use_nfs off")
+
+        # recover the guest xml
+        for xml_backup in vmxml_backup:
+            xml_backup.sync()
+
+        nfs_server = libvirt.setup_or_cleanup_nfs(False)
+
     main_vm_name = params.get("main_vm")
     main_vm = env.get_vm(main_vm_name)
 
     on_boot = params.get("on_boot")
     on_shutdown = params.get("on_shutdown")
+    nfs_vol = params.get("nfs_vol") == "yes"
+    virt_use_nfs = params.get("virt_use_nfs") == "on"
     parallel_shutdown = params.get("parallel_shutdown")
     additional_vms = int(params.get("additional_vms", "0"))
     status_error = params.get("status_error")
@@ -231,6 +272,11 @@ def run(test, params, env):
                                         True, timeout=360)
         vms.append(main_vm.clone(guest_name))
         logging.debug("Now the vms is: %s", [dom.name for dom in vms])
+
+    if nfs_vol:
+        # info collected for clear env finally
+        vmxml_backup = []
+        setup_nfs_backend_guest(vmxml_backup)
 
     for dom in vms:
         if not dom.is_alive():
@@ -282,3 +328,6 @@ def run(test, params, env):
 
         if not libvirt_guests_service.status():
             libvirt_guests_service.start()
+
+        if nfs_vol:
+            cleanup_nfs_backend_guest(vmxml_backup)


### PR DESCRIPTION
Test whether the nfs backend image guest can be suspended on shutdown,
and can be started on next reboot.

Signed-off-by: Lily Zhu <lizhu@redhat.com>