### PR TITLE
Delete invalid scenarios for virtio releated cases

### DIFF
--- a/v2v/tests/cfg/specific_kvm.cfg
+++ b/v2v/tests/cfg/specific_kvm.cfg
@@ -57,27 +57,6 @@
         - multi_kernel:
             checkpoint = 'multi_kernel'
             main_vm = 'VM_MULTI_KERNEL_V2V_EXAMPLE'
-        - virtio:
-            variants:
-                - windows:
-                    variants:
-                        - enable:
-                            checkpoint = 'ctemp'
-                            os_version = 'win2008'
-                            main_vm = 'VM_WIN_VIRTIO_ON_V2V_EXAMPLE'
-                            expect_msg = 'no'
-                            msg_content = '.*case_sensitive_path: v2v: no file or directory.*'
-                        - disable:
-                            checkpoint = 'virtio_off_win'
-                            os_version = 'OS_VERSION_WIN_V2V_EXAMPLE'
-                            main_vm = 'VM_WIN_V2V_EXAMPLE'
-                - linux:
-                    os_type = 'linux'
-                    variants:
-                        - enable:
-                            checkpoint = 'virtio_on'
-                        - disable:
-                            checkpoint = 'virtio_off'
         - noyumrepo-rhn:
             checkpoint = 'noyumrepo-rhn'
             main_vm = 'VM_NOYUMREPO_V2V_EXAMPLE'
@@ -105,10 +84,6 @@
                 - uuid:
                     checkpoint = 'fstab_uuid'
                     msg_content = 'unknown filesystem UUID.*'
-                    expect_msg = 'no'
-                - virtio:
-                    checkpoint = 'fstab_virtio'
-                    msg_content = 'unknown filesystem /dev/vd.*'
                     expect_msg = 'no'
                 - sr0:
                     checkpoint = fstab_sr0
@@ -139,8 +114,6 @@
             variants:
                 - multi_netcards:
                     checkpoint = 'multi_netcards'
-                - virtio:
-                    checkpoint = 'network_virtio'
                 - rtl8139:
                     checkpoint = 'network_rtl8139'
                 - e1000:
@@ -222,7 +195,6 @@
                 - linux:
                     no default
                     no unclean_fs
-                    no virtio.windows
                     no multi_disks.windows
                     no fstab.invalid
                     no display.mix
@@ -247,9 +219,6 @@
                     vm_user = 'Administrator'
                     vm_pwd = '123qweP'
                     variants:
-                        - virtio:
-                            only virtio.windows
-                            only output_mode.rhev
                         - multi_disks:
                             only multi_disks.windows
                             only output_mode.rhev


### PR DESCRIPTION
Virtio is only supported by redhat VM, it's not a valid scenario
for converting a virtio guest to rhv or other redhat systems.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>