### PR TITLE
Fix TypoError while printing numa nodes.

### DIFF
--- a/libvirt/tests/src/numa/numa_memory.py
+++ b/libvirt/tests/src/numa/numa_memory.py
@@ -113,7 +113,7 @@ def run(test, params, env):
     # Get host numa node list
     host_numa_node = utils_misc.NumaInfo()
     node_list = host_numa_node.online_nodes_withmem
-    logging.debug("host node list is %s", " ".join(node_list))
+    logging.debug("host node list is %s", " ".join(map(str, node_list)))
 
     # Prepare numatune memory parameter dict
     mem_tuple = ('memory_mode', 'memory_placement', 'memory_nodeset')


### PR DESCRIPTION
Numa nodes list has node numbers in int, while printing the same
it has TypoError, Hence before printing coverting it to string.

Signed-off-by: Hariharan T.S <hari@linux.vnet.ibm.com>