### PR TITLE
virtual_disks_ceph.py: hide redundant error

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_ceph.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_ceph.py
@@ -699,7 +699,7 @@ def run(test, params, env):
             first_disk = vm.get_first_disk_devices()
             blk_source = first_disk['source']
             # Convert the image to remote storage
-            disk_cmd = ("rbd -m %s %s info %s || qemu-img convert"
+            disk_cmd = ("rbd -m %s %s info %s 2> /dev/null|| qemu-img convert"
                         " -O %s %s %s" % (mon_host, key_opt,
                                           disk_src_name, disk_format,
                                           blk_source, disk_path))
@@ -718,7 +718,7 @@ def run(test, params, env):
                         (disk_format, img_file, img_file))
             process.run(disk_cmd, ignore_status=False, shell=True)
             # Convert the image to remote storage
-            disk_cmd = ("rbd -m %s %s info %s || qemu-img convert -O"
+            disk_cmd = ("rbd -m %s %s info %s 2> /dev/null|| qemu-img convert -O"
                         " %s %s %s" % (mon_host, key_opt, disk_src_name,
                                        disk_format, img_file, disk_path))
             process.run(disk_cmd, ignore_status=False, shell=True)


### PR DESCRIPTION
A 'rbd info attach.img' action before qemu-img convert is not a
checkpoint for function, and 'no such file' is as expected since
it will be removed in previous steps even it exists. So hide this
redundant error to avoid confusing testing result msgs.

Signed-off-by: Yanqiu Zhang <yanqzhan@redhat.com>