### PR TITLE
virsh_migrate_stress: perform migration with macvtap hotplug/coldplug

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_stress.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_stress.cfg
@@ -28,14 +28,31 @@
     virsh_migrate_back = "yes"
     virsh_migrated_state = "running"
     variants:
-        - set_vcpu_1:
-            smp = 2
-        - set_vcpu_2:
-            smp = 4
-        - set_memory_1:
-            mem = 2048
-        - set_memory_2:
-            mem = 4096
+        - @normal:
+        - with_macvtap:
+            host_pf_filter = "Mellanox Technologies MT28800 Family \[ConnectX-5 Ex\]"
+            host_vf_filter = "Mellanox Technologies MT28800 Family \[ConnectX-5 Ex Virtual Function\]"
+            vm_macvtap_interfaces_per_pf = 1
+            variants:
+                - hotplug:
+                    plug_operation = "hotplug"
+                - coldplug:
+                    plug_operation = "coldplug"
+            variants:
+                - plug_before_unplug_before_migration:
+                    virsh_plug_before = "yes"
+                    virsh_unplug_before = "yes"
+                - plug_before_unplug_after_migration:
+                    virsh_plug_before = "yes"
+                    virsh_unplug_after = "yes"
+                - plug_after_unplug_after_migration:
+                    virsh_plug_after = "yes"
+                    virsh_unplug_after = "yes"
+                - unplug_before_hotplug_unplug_after:
+                    virsh_plug_before = "yes"
+                    virsh_unplug_before = "yes"
+                    virsh_plug_after = "yes"
+                    virsh_unplug_after = "yes"
     variants:
         - precopy:
             # In precopy it takes more time to converge, so let it suspend after 30min and


### PR DESCRIPTION
This patch adds tests that could perform migration with macvtap
interface attached to VMs. pre-requisite is to have physical cards
attached in the same slots in source and target host so that the
Virtual Functions(VFs) created out of Physical Functions(PFs) will
be identical for VMs migrate.


This patch removes couple of trivial scenarios that can be tested
by overriding the `smp` and `mem` params from config instead.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>