### PR TITLE
Add --live hotplug option to the test and fixed debug messages.

### DIFF
--- a/libvirt/tests/cfg/libvirt_mem.cfg
+++ b/libvirt/tests/cfg/libvirt_mem.cfg
@@ -55,7 +55,7 @@
                            detach_device = "yes"
                     variants:
                        - hot:
-                           attach_option = ""
+                           attach_option = "--live"
                        - cold:
                            attach_option = "--config"
                 - no_attach:

--- a/libvirt/tests/src/libvirt_mem.py
+++ b/libvirt/tests/src/libvirt_mem.py
@@ -447,8 +447,9 @@ def run(test, params, env):
                                                    tg_sizeunit, pg_unit, tg_node,
                                                    node_mask, mem_model)
             randvar = 0
-            rand_value = random.randint(15, 25)
-            logging.debug("reboots at %s", rand_value)
+            if rand_reboot:
+                rand_value = random.randint(15, 25)
+                logging.debug("reboots at %s", rand_value)
             for x in xrange(at_times):
                 # If any error excepted, command error status should be
                 # checked in the last time
@@ -462,11 +463,11 @@ def run(test, params, env):
                     vm.reboot()
                     vm.wait_for_login()
                 if rand_reboot and randvar == rand_value:
+                    vm.reboot()
+                    vm.wait_for_login()
                     randvar = 0
                     rand_value = random.randint(15, 25)
                     logging.debug("reboots at %s", rand_value)
-                    vm.reboot()
-                    vm.wait_for_login()
 
         # Check domain xml after attach device.
         if test_dom_xml:


### PR DESCRIPTION
Initially hotplug was performed without  --live in test, added
--live explicitly.

Random reboot was displayed for normal tests too, fixed the same.

Signed-off-by: Hariharan T.S <hari@linux.vnet.ibm.com>