### PR TITLE
attach_detach_disk: Wait for few seconds after resume

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk.py
@@ -329,6 +329,7 @@ def run(test, params, env):
     # been a bug. The change in xml file is done after the guest is resumed.
     if pre_vm_state == "paused":
         vm.resume()
+        time.sleep(5)
 
     # Check audit log
     check_audit_after_cmd = True


### PR DESCRIPTION
For detach disk when vm is suspend, vm needs some time to clean the
detached disk after resume. Add waiting code for that.

Signed-off-by: Han Han <hhan@redhat.com>