### PR TITLE
Fix "failed to remove tty related kernel cmd line" issue

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_console.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_console.cfg
@@ -9,6 +9,7 @@
     console_login_user = "root"
     # Only useful when console_login_user is not 'root'
     console_password_not_root = ""
+    update_console = "yes"
     console_device = "ttyS0"
     console_speed = "115200"
     variants:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_console.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_console.py
@@ -187,6 +187,7 @@ def run(test, params, env):
     if 'ppc64' in platform.machine():
         params["console_device"] = 'hvc0'
 
+    update_console = params.get("update_console", "yes")
     console_dev = params.get("console_device", "ttyS0")
     console_speed = params.get("console_speed", "115200")
     if unprivileged_user:
@@ -207,9 +208,10 @@ def run(test, params, env):
 
     try:
         # Guarantee cleanup after config vm console failed.
-        if vm.is_qemu():
-            vm_console_config(vm, test, device=console_dev,
-                              speed=console_speed)
+        if update_console == "yes":
+            if vm.is_qemu():
+                vm_console_config(vm, test, device=console_dev,
+                                  speed=console_speed)
 
         # Prepare vm state for test
         if vm_state != "shutoff":
@@ -258,7 +260,8 @@ def run(test, params, env):
         if not vm.is_alive():
             vm.start()
             vm.wait_for_login()
-        vm.set_kernel_console(console_dev, console_speed, remove=True)
+        if update_console == "yes":
+            vm.set_kernel_console(console_dev, console_speed, remove=True)
 
         # Recover vm
         if vm.is_alive():


### PR DESCRIPTION
Adding 'guest kernel option console=ttyS0,115200' is not necessary
when these options are already in VM image file
Deleting these parameters also causes problems
Failing to remove guest kernel option occurs occasionally
Besides, the later auto jobs demanded 'virsh console' usage
can not succeed once removing guest kernel option successfully.

Signed-off-by: Jing Yan <jiyan@redhat.com>