### PR TITLE
Add custom stress event test and skip uptime check for reboot test

### DIFF
--- a/libvirt/tests/cfg/multivm_stress/multivm_cpustress.cfg
+++ b/libvirt/tests/cfg/multivm_stress/multivm_cpustress.cfg
@@ -18,6 +18,9 @@
     vcpu_sockets = 1
     smp = 32
     variants:
+        - custom_vm_events:
+            stress_events = "vcpupin,suspend"
+            stress_itrs = 50
         - stress_vcpupin:
             stress_events = "vcpupin"
             stress_itrs = 100
@@ -42,6 +45,10 @@
             stress_boot = yes
             stress_itrs = 50
     variants:
+        - custom_host_events:
+            only custom_vm_events
+            host_stress = "no"
+            host_stress_events = ""
         - without_hoststress:
             host_stress = "no"
         - with_hoststress:

--- a/libvirt/tests/src/multivm_stress/multivm_stress.py
+++ b/libvirt/tests/src/multivm_stress/multivm_stress.py
@@ -15,10 +15,12 @@ def run(test, params, env):
 
     guest_stress = params.get("guest_stress", "no") == "yes"
     host_stress = params.get("host_stress", "no") == "yes"
+    stress_events = params.get("stress_events", "reboot")
     vms = env.get_all_vms()
     vms_uptime_init = {}
-    for vm in vms:
-        vms_uptime_init[vm.name] = vm.uptime()
+    if "reboot" not in stress_events:
+        for vm in vms:
+            vms_uptime_init[vm.name] = vm.uptime()
     stress_event = utils_stress.VMStressEvents(params, env)
     if guest_stress:
         try:
@@ -40,10 +42,11 @@ def run(test, params, env):
             utils_test.unload_stress("stress_in_vms", params=params, vms=vms)
         if host_stress:
             utils_test.unload_stress("stress_on_host", params=params)
-        fail = False
-        for vm in vms:
-            if vm.uptime() < vms_uptime_init[vm.name]:
-                logging.error("Unexpected reboot of VM: %s between test", vm.name)
-                fail = True
-        if fail:
-            test.fail("Unexpected VM reboot detected")
+        if "reboot" not in stress_events:
+            fail = False
+            for vm in vms:
+                if vm.uptime() < vms_uptime_init[vm.name]:
+                    logging.error("Unexpected reboot of VM: %s between test", vm.name)
+                    fail = True
+            if fail:
+                test.fail("Unexpected VM reboot detected")


### PR DESCRIPTION
Added a custom stress event subtest to have custom user defined
guest and host events, it would help user not to mislead when
we want override the default param setting for a test, and let's
skip uptime check for guest reboot test.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>