### PR TITLE
Workaround a disk attaching issue

### DIFF
--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_disk.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_disk.py
@@ -109,6 +109,9 @@ def run(test, params, env):
     # Get a tmp dir
     snap_cfg_path = "/var/lib/libvirt/qemu/snapshot/%s/" % vm_name
     try:
+        if vm.is_dead():
+            vm.start()
+        vm.wait_for_login().close()
         if replace_vm_disk:
             utlv.set_vm_disk(vm, params, tmp_dir)
             if multi_gluster_disks:


### PR DESCRIPTION
In rhel8, when attach a disk during vm booting process, the disk
could not be used in vm, this is a potential bug. Change the code
to bypass it.

Signed-off-by: Yi Sun <yisun@redhat.com>