### PR TITLE
virtual_disks_ceph: Wait os boot before hot-plug disk

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_ceph.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_ceph.py
@@ -739,10 +739,12 @@ def run(test, params, env):
                             (json_str, front_end_img_file))
                 disk_path = front_end_img_file
                 process.run(disk_cmd, ignore_status=False, shell=True)
-        # If hot plug, start VM first, otherwise stop VM if running.
+        # If hot plug, start VM first, and then wait the OS boot.
+        # Otherwise stop VM if running.
         if start_vm:
             if vm.is_dead():
                 vm.start()
+            vm.wait_for_login().close()
         else:
             if not vm.is_dead():
                 vm.destroy()
@@ -773,6 +775,7 @@ def run(test, params, env):
                 # Make sure the additional VM is running
                 if additional_vm.is_dead():
                     additional_vm.start()
+                    additional_vm.wait_for_login().close()
                 ret = virsh.attach_device(guest_name, additional_xml_file,
                                           "", debug=True)
                 libvirt.check_result(ret, skip_if=unsupported_err)


### PR DESCRIPTION
When guest OS is not initialized sufficiently, it is likely that
hot-plug will return success but nothing attached. To avoid this known
issue, wait for OS boot before hot-plug.

The known issue reference:
https://www.redhat.com/archives/libvirt-users/2019-March/msg00008.html

Signed-off-by: Han Han <hhan@redhat.com>