### PR TITLE
Add new case of pcie

### DIFF
--- a/libvirt/tests/cfg/controller/pcibridge.cfg
+++ b/libvirt/tests/cfg/controller/pcibridge.cfg
@@ -2,13 +2,15 @@
     type = 'pcibridge'
     start_vm = 'no'
 
+    iface_model = 'rtl8139'
+    iface_source = "{'network': 'default'}"
+
     variants:
         - positive_test:
             variants:
                 - hotplug:
                     hotplug = 'yes'
-                    iface_model = 'rtl8139'
-                    iface_source = "{'network': 'default'}"
+                    need_pci_br = 'yes'
                     variants:
                         - with_device:
                             pci_br_has_device = 'yes'
@@ -25,3 +27,84 @@
                             no q35
                             pci_model ='pci-bridge'
                             pci_model_name = 'pci-bridge'
+                - max_slots:
+                    only q35
+                    case = max_slots
+                    pci_model ='pcie-to-pci-bridge'
+                    pci_model_name = 'pcie-pci-bridge'
+                    max_slots = 31
+                    need_pci_br = 'yes'
+                    err_msg = "internal error: No more available PCI slots;XML error: Invalid PCI address slot='0x20', must be <= 0x1F"
+                    iface_kwargs = {'address': "{'type': 'pci', 'domain': '0x0000', 'bus': '%s', 'slot': '%s', 'function': '0x0'}"}
+                - vm_with_pcie_br:
+                    only q35
+                    case = 'vm_with_pcie_br_'
+                    pci_model ='pcie-to-pci-bridge'
+                    pci_model_name = 'pcie-pci-bridge'
+                    sound_dev_model_type = 'ich6'
+                    sound_dev_address = "{'type': 'pci', 'domain': '0x0000', 'bus': '0x0%s', 'slot': '0x02', 'function': '0x0'}"
+                    variants:
+                        - 1_br:
+                            case += '1_br'
+                            need_pci_br = 'yes'
+                            pci_br_has_device = 'yes'
+                        - multi_br:
+                            case += 'multi_br'
+                            pcie_br_count = 3
+                            pci_br_kwargs = {'address': "{'type': 'pci', 'domain': '0x0000', 'bus': '%s', 'slot': '0x00', 'function': '0x0'}"}
+                        - no_br:
+                            case += 'no_br'
+                            need_pci_br = 'no'
+                            iface_kwargs = {'address': "{'type': 'pci', 'domain': '0x0000', 'bus': '0x09', 'slot': '${slot}', 'function': '0x0'}"}
+
+        - negative_test:
+            status_error = 'yes'
+            pci_model ='pcie-to-pci-bridge'
+            pci_model_name = 'pcie-pci-bridge'
+            variants:
+                - wrong_model_name:
+                    only q35
+                    case = 'wrong_model_name'
+                    pci_model_name = 'pci-bridge'
+                    err_msg = "unsupported configuration: Option 'modelName' has invalid value for PCI controller with index '.*?', model 'pcie-to-pci-bridge' and modelName '.*?'"
+                - invalid_index:
+                    only q35
+                    case = 'invalid_index'
+                    variants:
+                        - i_0:
+                            pci_br_index = 0
+                            err_msg = "Multiple 'pci' controllers with index '0'"
+                        - i_256:
+                            pci_br_index = 256
+                            err_msg = "internal error: a PCI slot is needed to connect a PCI controller"
+                        - i_str:
+                            pci_br_index = 'abc'
+                            err_msg = "internal error: Cannot parse controller index ${pci_br_index}"
+                    pci_br_kwargs = "{'index': '${pci_br_index}'}"
+                - attach_with_invalid_slot:
+                    only q35
+                    case = 'attach_with_invalid_slot'
+                    need_pci_br = 'yes'
+                    variants:
+                        - s_0:
+                            slot = '0x00'
+                            err_msg = "XML error: Invalid PCI address .*? slot must be >= 1"
+                        - s_20:
+                            slot = '0x20'
+                            err_msg = "XML error: Invalid PCI address slot='.*?', must be <= 0x1F"
+                        - s_str:
+                            slot = 'haha'
+                            err_msg = "internal error: Cannot parse <address> 'slot' attribute"
+                    pci_br_kwargs = "{'index': '9'}"
+                    iface_kwargs = {'address': "{'type': 'pci', 'domain': '0x0000', 'bus': '0x09', 'slot': '${slot}', 'function': '0x0'}"}
+                - index_v_bus:
+                    only q35
+                    case = 'index_v_bus_'
+                    pci_br_kwargs = {'address': "{'type': 'pci', 'domain': '0x0000', 'bus': '%s', 'slot': '0x02', 'function': '0x0'}"}
+                    variants:
+                        - less_than:
+                            case += 'less_than'
+                            err_msg = "internal error: Cannot automatically add a new PCI bus for a device with connect flags 800;XML error: The device at PCI address .*? cannot be plugged into the PCI controller with index='.*?'. It requires a controller that accepts a pcie-to-pci-bridge;qemu-kvm: -device pcie-pci-bridge,id=pci.*?,bus=pci.*?,addr=.*?: Bus 'pci.*?' not found"
+                        - equal_to:
+                            case += 'equal_to'
+                            err_msg = "XML error: The device at PCI address .*? cannot be plugged into the PCI controller with index='.*?'. It requires a controller that accepts a pcie-to-pci-bridge"

--- a/libvirt/tests/src/controller/pcibridge.py
+++ b/libvirt/tests/src/controller/pcibridge.py
@@ -17,17 +17,76 @@ def run(test, params, env):
     Hotplug interface to pci/pcie-to-pci bridge, then check xml and
     inside vm.
     Hotunplug interface, then check xml and inside vm
+    Other test scenarios of pci/pcie-to-pci bridge
     """
+
+    def create_pci_device(pci_model, pci_model_name, **kwargs):
+        """
+        Create a pci/pcie bridge
+
+        :param pci_model: model of pci controller device
+        :param pci_model_name: model name of pci controller device
+        :param kwargs: other k-w args that needed to create device
+        :return: the newly created device object
+        """
+        pci_bridge = Controller('pci')
+        pci_bridge.model = pci_model
+        pci_bridge.model_name = {'name': pci_model_name}
+        if 'index' in kwargs:
+            pci_bridge.index = kwargs['index']
+        if 'address' in kwargs:
+            pci_bridge.address = pci_bridge.new_controller_address(
+                attrs=eval(kwargs['address']))
+
+        logging.debug('pci_bridge: %s', pci_bridge)
+        return pci_bridge
+
+    def create_iface(iface_model, iface_source, **kwargs):
+        """
+        Create an interface to be attached to vm
+
+        :param iface_model: model of the interface device
+        :param iface_source: source of the interface device
+        :param kwargs: other k-w args that needed to create device
+        :return: the newly created interface object
+        """
+        iface = Interface('network')
+        iface.model = iface_model
+        iface.source = eval(iface_source)
+
+        if 'mac' in kwargs:
+            iface.mac_address = kwargs['mac']
+        else:
+            mac = utils_net.generate_mac_address_simple()
+            iface.mac_address = mac
+
+        if 'address' in kwargs:
+            iface.address = iface.new_iface_address(attrs=eval(kwargs['address']))
+
+        logging.debug('iface: %s', iface)
+        return iface
+
     vm_name = params.get('main_vm')
-    pci_model = params.get('pci_model', 'pci')
+    status_error = 'yes' == params.get('status_error', 'no')
+    err_msg = params.get('err_msg', '').split(';')
+    case = params.get('case', '')
     hotplug = 'yes' == params.get('hotplug', 'no')
 
+    need_pci_br = 'yes' == params.get('need_pci_br', 'no')
+    pci_model = params.get('pci_model', 'pci')
     pci_model_name = params.get('pci_model_name')
+    pci_br_kwargs = eval(params.get('pci_br_kwargs', '{}'))
+
     pci_br_has_device = 'yes' == params.get('pci_br_has_device', 'no')
     sound_dev_model_type = params.get('sound_dev_model_type', '')
     sound_dev_address = params.get('sound_dev_address', '')
+
     iface_model = params.get('iface_model', '')
     iface_source = params.get('iface_source', '')
+    iface_kwargs = eval(params.get('iface_kwargs', '{}'))
+
+    max_slots = int(params.get('max_slots', 31))
+    pcie_br_count = int(params.get('pcie_br_count', 3))
 
     vmxml = VMXML.new_from_inactive_dumpxml(vm_name)
     bkxml = vmxml.copy()
@@ -40,39 +99,38 @@ def run(test, params, env):
         ori_pci_br = [dev for dev in vmxml.get_devices('controller')
                       if dev.type == 'pci' and dev.model == pci_model]
 
-        # If there is not a pci/pcie-to-pci bridge to test,
-        # create one and add to vm
-        if not ori_pci_br:
-            logging.info('No %s on vm, create one', pci_model)
-            pci_bridge = Controller('pci')
-            pci_bridge.model = pci_model
-            pci_bridge.model_name = {'name': pci_model_name}
+        if need_pci_br:
+            # If there is not a pci/pcie-to-pci bridge to test,
+            # create one and add to vm
+            if not ori_pci_br:
+                logging.info('No %s on vm, create one', pci_model)
+                pci_bridge = create_pci_device(pci_model, pci_model_name)
+                vmxml.add_device(pci_bridge)
+                vmxml.sync()
+                logging.debug(virsh.dumpxml(vm_name))
 
-            vmxml.add_device(pci_bridge)
-            vmxml.sync()
-            logging.debug(virsh.dumpxml(vm_name))
+            # Check if pci/pcie-to-pci bridge is successfully added
+            vmxml = VMXML.new_from_inactive_dumpxml(vm_name)
+            cur_pci_br = [dev for dev in vmxml.get_devices('controller')
+                          if dev.type == 'pci' and dev.model == pci_model]
+            if not cur_pci_br:
+                test.error('Failed to add %s controller to vm xml' % pci_model)
 
-        # Check if pci/pcie-to-pci bridge is successfully added
-        vmxml = VMXML.new_from_inactive_dumpxml(vm_name)
-        cur_pci_br = [dev for dev in vmxml.get_devices('controller')
-                      if dev.type == 'pci' and dev.model == pci_model]
-        if not cur_pci_br:
-            test.error('Failed to add %s controller to vm xml' % pci_model)
-
-        pci_br = cur_pci_br[0]
-        logging.debug(pci_br)
-        pci_br_index = pci_br.index
+            pci_br = cur_pci_br[0]
+            logging.debug('pci_br: %s', pci_br)
+            pci_br_index = pci_br.index
 
         # If test scenario requires another pci device on pci/pcie-to-pci
         # bridge before hotplug, add a sound device and make sure
         # the 'bus' is same with pci bridge index
-        if pci_br_has_device:
+        if need_pci_br and pci_br_has_device:
             sound_dev = Sound()
             sound_dev.model_type = sound_dev_model_type
             sound_dev.address = eval(sound_dev_address % pci_br_index)
-            logging.debug(sound_dev.address)
+            logging.debug('sound_dev.address: %s', sound_dev.address)
             vmxml.add_device(sound_dev)
-            vmxml.sync()
+            if case != 'vm_with_pcie_br_1_br':
+                vmxml.sync()
 
         # Test hotplug scenario
         if hotplug:
@@ -81,12 +139,8 @@ def run(test, params, env):
 
             # Create interface to be hotplugged
             logging.info('Create interface to be hotplugged')
-            iface = Interface('network')
-            iface.model = iface_model
-            iface.source = eval(iface_source)
-            mac = utils_net.generate_mac_address_simple()
-            iface.mac_address = mac
-            logging.debug(iface)
+            iface = create_iface(iface_model, iface_source)
+            mac = iface.mac_address
 
             result = virsh.attach_device(vm_name, iface.xml, debug=True)
             libvirt.check_exit_status(result)
@@ -94,10 +148,12 @@ def run(test, params, env):
             xml_after_attach = VMXML.new_from_dumpxml(vm_name)
             logging.debug(virsh.dumpxml(vm_name))
 
-            # Check if the iface with given mac address is successfully attached
+            # Check if the iface with given mac address is successfully
+            # attached with address bus equal to pcie/pci bridge's index
             iface_list = [
                 iface for iface in xml_after_attach.get_devices('interface')
-                if iface.mac_address == mac
+                if iface.mac_address == mac and
+                int(iface.address['attrs']['bus'], 16) == int(pci_br_index, 16)
             ]
 
             logging.debug('iface list after attach: %s', iface_list)
@@ -107,7 +163,7 @@ def run(test, params, env):
             # Check inside vm
             def check_inside_vm(session, expect=True):
                 ip_output = session.cmd('ip a')
-                logging.debug(ip_output)
+                logging.debug('output of "ip a": %s', ip_output)
 
                 return expect if mac in ip_output else not expect
 
@@ -145,6 +201,161 @@ def run(test, params, env):
                           'interface not successfully detached:'
                           'found mac address %s' % mac)
             session.close()
+
+        # Other test scenarios of pci/pcie
+        if case:
+            logging.debug('iface_kwargs: %s', iface_kwargs)
+
+            # Setting pcie-to-pci-bridge model name !=pcie-pci-bridge.
+            # or Invalid controller index for pcie-to-pci-bridge.
+            if case in ('wrong_model_name', 'invalid_index'):
+                pci_bridge = create_pci_device(pci_model, pci_model_name,
+                                               **pci_br_kwargs)
+                vmxml.add_device(pci_bridge)
+                result_to_check = virsh.define(vmxml.xml, debug=True)
+
+            # Attach device with invalid slot to pcie-to-pci-bridge
+            if case == 'attach_with_invalid_slot':
+                iface = create_iface(iface_model, iface_source, **iface_kwargs)
+                vmxml.add_device(iface)
+                result_to_check = virsh.define(vmxml.xml, debug=True)
+
+            # Test that pcie-to-pci-bridge has 31 available slots
+            if case == 'max_slots':
+                target_bus = cur_pci_br[0].index
+                target_bus = hex(int(target_bus))
+                logging.debug('target_bus: %s', target_bus)
+
+                # Attach 32 interfaces
+                for i in range(max_slots + 1):
+                    logging.debug('address: %s', iface_kwargs['address'])
+                    new_iface_kwargs = {'address': iface_kwargs['address']
+                                        % (target_bus, hex(i + 1))}
+                    iface = create_iface(iface_model, iface_source,
+                                         **new_iface_kwargs)
+                    logging.info('Attaching the %d th interface', i + 1)
+                    result_in_loop = virsh.attach_device(
+                        vm_name, iface.xml, flagstr='--config', debug=True)
+
+                    # Attaching the 32rd interfaces will fail
+                    if i == max_slots:
+                        status_error = True
+                    libvirt.check_exit_status(result_in_loop,
+                                              expect_error=status_error)
+                logging.debug(virsh.dumpxml(vm_name))
+
+                # Get all devices on pcie-to-pci-bridge from new xml
+                # Test if it matches with value of max_slots
+                new_xml = VMXML.new_from_dumpxml(vm_name)
+                device_on_pci_br = [
+                    dev for dev in new_xml.get_devices('interface')
+                    if dev.address['type_name'] == 'pci' and
+                    int(dev.address['attrs']['bus'], 16) == int(target_bus, 16)
+                ]
+
+                logging.info('All slots of pcie-to-pci-bridge is %d',
+                             len(device_on_pci_br))
+                if len(device_on_pci_br) != max_slots:
+                    test.fail('Max slots is %d instead of %d' %
+                              (len(device_on_pci_br), max_slots))
+
+            # Define a guest with pcie-to-pci-bridge controller's index <=bus
+            if case.startswith('index_v_bus'):
+                last_pci_index = max([
+                    int(dev.index) for dev in vmxml.get_devices('controller')
+                    if dev.type == 'pci'])
+
+                # New index of new pcie-bridge should be +1
+                new_index = last_pci_index + 1
+                if case.endswith('less_than'):
+                    new_bus = new_index + 1
+                elif case.endswith('equal_to'):
+                    new_bus = new_index
+                else:
+                    test.error('Invalid test: %s' % case)
+
+                pci_br_kwargs['index'] = new_index
+                pci_br_kwargs['address'] = pci_br_kwargs['address'] % (new_bus)
+                logging.debug('pci_br_kwargs: %s', pci_br_kwargs)
+
+                pcie_br = create_pci_device(pci_model, pci_model_name, **pci_br_kwargs)
+                vmxml.add_device(pcie_br)
+                result_to_check = virsh.define(vmxml.xml, debug=True)
+
+            # Test define & start an VM with/without pcie-to-pci-bridge
+            if case.startswith('vm_with_pcie_br'):
+                if case.endswith('1_br'):
+                    pass
+                elif case.endswith('multi_br'):
+                    # Add $pcie_br_count pcie-root-port to vm
+                    for i in range(pcie_br_count):
+                        temp_xml = VMXML.new_from_inactive_dumpxml(vm_name)
+                        port = create_pci_device('pcie-root-port', 'pcie-root-port')
+                        temp_xml.add_device(port)
+                        temp_xml.sync()
+
+                    vmxml = VMXML.new_from_inactive_dumpxml(vm_name)
+                    pci_root_ports = [dev for dev in vmxml.get_devices('controller')
+                                      if dev.type == 'pci' and
+                                      dev.model == 'pcie-root-port']
+                    indexs = sorted([hex(int(dev.index)) for dev in pci_root_ports])
+                    logging.debug('indexs: %s', indexs)
+
+                    # Add $pcie_br_count pcie-to-pci-bridge to vm,
+                    # on separated pcie-root-port
+                    for i in range(pcie_br_count):
+                        new_kwargs = {
+                            'address': pci_br_kwargs['address'] % indexs[-i - 1]}
+                        pcie_br = create_pci_device(pci_model, pci_model_name,
+                                                    **new_kwargs)
+                        vmxml.add_device(pcie_br)
+
+                elif case.endswith('no_br'):
+                    # Delete all pcie-to-pci-bridge
+                    for dev in ori_pci_br:
+                        vmxml.del_device(dev)
+                    vmxml.sync()
+
+                    # Add an pci device(rtl8139 nic)
+                    iface = create_iface(iface_model, iface_source)
+                    vmxml.add_device(iface)
+                else:
+                    test.error('Invalid test: %s' % case)
+
+                # Test define and start vm with new xml settings
+                result_define_vm = virsh.define(vmxml.xml, debug=True)
+                libvirt.check_exit_status(result_define_vm)
+                result_start_vm = virsh.start(vm_name, debug=True)
+                libvirt.check_exit_status(result_start_vm)
+
+                # Login to make sure vm is actually started
+                vm.create_serial_console()
+                vm.wait_for_serial_login().close()
+
+                logging.debug(virsh.dumpxml(vm_name))
+
+                # Get all pcie-to-pci-bridge after test operations
+                new_vmxml = VMXML.new_from_inactive_dumpxml(vm_name)
+                cur_pci_br = [dev for dev in new_vmxml.get_devices('controller')
+                              if dev.type == 'pci' and dev.model == pci_model]
+                logging.debug('cur_pci_br: %s', cur_pci_br)
+
+                if case.endswith('multi_br'):
+                    # Check whether all new pcie-to-pci-br are successfullly added
+                    if len(cur_pci_br) - len(ori_pci_br) != pcie_br_count:
+                        test.fail('Not all pcie-to-pci-br successfully added.'
+                                  'Should be %d, actually is %d' %
+                                  (pcie_br_count, len(cur_pci_br) - len(ori_pci_br)))
+
+                elif case.endswith('no_br'):
+                    # Check if a pcie-to-pci-br will be automatically created
+                    if len(cur_pci_br) == 0:
+                        test.fail('No new pcie-to-pci-bridge automatically created')
+
+            # Check command result if there is a result to be checked
+            if 'result_to_check' in locals():
+                libvirt.check_exit_status(result_to_check, expect_error=status_error)
+                libvirt.check_result(result_to_check, expected_fails=err_msg)
 
     finally:
         bkxml.sync()


### PR DESCRIPTION
- pcie-to-pci-bridge has 31 available slots
- [Negative]Attach device with invalid slot to pcie-to-pci-bridge
- [negative] Define a guest by setting pcie-to-pci-bridge model name
 !=pcie-pci-bridge.
- [Negative] Invalid controller index for pcie-to-pci-bridge
- [negative] Define a guest with pcie-to-pci-bridge controller's
index <=bus
- Define & start an VM with/without pcie-to-pci-bridge

Signed-off-by: haizhao <haizhao@redhat.com>