### PR TITLE
Update checkpoint for device.map if converting from KVM

### DIFF
--- a/provider/v2v_vmcheck_helper.py
+++ b/provider/v2v_vmcheck_helper.py
@@ -218,7 +218,17 @@ class VMChecker(object):
             logging.info("The guest is uefi mode,skip the checkpoint")
         elif not self.checker.get_grub_device():
             err_msg = "Not find vd? in disk partition"
-            self.log_err(err_msg)
+            if self.hypervisor != 'kvm':
+                self.log_err(err_msg)
+            else:
+                # Just warning the err if converting from KVM. It may
+                # happen that disk's bus type in xml is not the real bus
+                # type be used when preparing the image. Ex, if the image
+                # is installed with IDE, then you import the image with
+                # bus virtio, the device.map file will be inconsistent with
+                # the xml.
+                # V2V doesn't modify device.map file for this scenario.
+                logging.warning(err_msg)
         else:
             logging.info("PASS")
 


### PR DESCRIPTION
If the image's OS system is installed with bus=IDE, the device.map
will be '(hd0) /dev/sda'. Then if users create a new vm by this image,
and specify the bus to virtio, and after converting by virt-v2v,
v2v will give a warning and doesn't update /dev/sda to /dev/vda in
device.map.
This is a scenario only occurs when converting from KVM. Let's update
the checkpoint and just give a warning instead of fail the case for
this scenario.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>