### PR TITLE
Replace the old windows guest for virt-v2v aws testing

### DIFF
--- a/v2v/tests/cfg/convert_from_file.cfg
+++ b/v2v/tests/cfg/convert_from_file.cfg
@@ -105,9 +105,9 @@
                             variants:
                                 - rhel7_2:
                                     ova_file = OVA_FILE_RHEL72_AWS_V2V_EXAMPLE
-                                - win2008r2:
-                                    ova_file = OVA_FILE_WIN2008R2_AWS_V2V_EXAMPLE
-                                    os_version = OS_VERSION_WIN2008R2_AWS_V2V_EXAMPLE
+                                - win2019:
+                                    ova_file = OVA_FILE_WIN2019_AWS_V2V_EXAMPLE
+                                    os_version = OS_VERSION_WIN2019_AWS_V2V_EXAMPLE
                                 - ec2:
                                     ova_file = OVA_FILE_EC2_V2V_EXAMPLE
                                 - Eaton:
@@ -121,7 +121,7 @@
             variants:
                 - linux:
                     only ova
-                    no win2008r2_ostk,aws.win2008r2
+                    no win2008r2_ostk,aws.win2019
                 - windows:
                     os_type = 'windows'
                     shutdown_command = 'shutdown /s /f /t 0'
@@ -141,4 +141,4 @@
                     restart_network = 'ipconfig /renew'
                     vm_user = 'Administrator'
                     vm_pwd = '123qweP'
-                    only win2008r2_ostk,aws.win2008r2
+                    only win2008r2_ostk,aws.win2019


### PR DESCRIPTION
As previous win2008r2 can't login after v2v conversion, use 
win2019 to replace it.

Signed-off-by: mxie91 <mxie@redhat.com>