### PR TITLE
Do not check the mtu in vm if no mtu in interface

### DIFF
--- a/libvirt/tests/src/virtual_network/mtu.py
+++ b/libvirt/tests/src/virtual_network/mtu.py
@@ -233,8 +233,9 @@ def run(test, params, env):
 
             # Check in both host and vm
             check_mtu(mtu_size, check_qemu)
-            check_mtu_in_vm(vm_login, mtu_size)
-            vm_login(timeout=60).close()
+            if mtu_type == 'interface' or with_iface:
+                check_mtu_in_vm(vm_login, mtu_size)
+                vm_login(timeout=60).close()
 
             if check == 'hotplug_save':
                 virsh.detach_interface(vm_name, 'network %s' % params['mac'], debug=True)


### PR DESCRIPTION
If mtu is only set in network, it will not take effect in the vm. If we
want vm to get the setting, the only way is to set it in device. Update
the script to avoid check mtu in vm if no mtu in interface.

Signed-off-by: yalzhang <yalzhang@redhat.com>