### PR TITLE
Detach interface by different match

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_hotplug.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_hotplug.cfg
@@ -3,6 +3,7 @@
     take_regular_screendumps = "no"
     start_vm = "yes"
     poll_timeout = 10
+    status_error = "no"
     variants:
         - iface_attach:
             iface_num = '1'
@@ -85,6 +86,27 @@
                 - stress_test:
                     iface_num = '500'
                     stress_test = "yes" 
+                - detach_match_test:
+                    only at_device
+                    only model_virtio
+                    detach_device = "yes"
+                    variants:
+                        - by_pci:
+                            del_mac = "yes"
+                            del_pci = "no"
+                        - by_mac_pci:
+                            del_mac = "no"
+                            del_pci = "no"
+                        - by_mac:
+                            del_mac = "no"
+                            del_pci = "yes"
+                        - by_wrong_mac:
+                            set_mac = "yes"
+                            status_error = "yes"
+                        - by_wrong_pci:
+                            set_pci = "yes"
+                            pci = {'slot': '0x0b', 'bus': '0x00', 'domain': '0x0000', 'type': 'pci', 'function': '0x6'}
+                            status_error = "yes"
             variants:
                 - model_e1000:
                     iface_model = "e1000"


### PR DESCRIPTION
Detach interface device can match by mac address or pci address, if both
are specified, both will be checked.

Signed-off-by: yalzhang <yalzhang@redhat.com>