### PR TITLE
Shorten the cpus_list if it's too long

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_vcpupin.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_vcpupin.py
@@ -200,6 +200,15 @@ def run(test, params, env):
     cpus_list = list(map(str, cpuutils.cpu_online_list()))
     logging.info("Active cpus in host are %s", cpus_list)
 
+    # If the cpus_list has too many cpus, then only test the
+    # cpus of the head, middle and tail part
+    lenght = len(cpus_list)
+    if lenght > 30:
+        cpus_list = cpus_list[:10] + \
+                    cpus_list[lenght//2 - 5: lenght//2 + 5] + \
+                    cpus_list[lenght - 10:]
+        logging.info('Will run test on cpus: %s', cpus_list)
+
     try:
         # Control multi domain vcpu affinity
         multi_dom = ("yes" == params.get("multi_dom_pin", "no"))


### PR DESCRIPTION
If the cpus_list has too many cpus, then only test the
cpus of the head, middle and tail part

Signed-off-by: haizhao <haizhao@redhat.com>