### PR TITLE
virsh_event.py: fix 'edit' condition

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
@@ -111,7 +111,7 @@ def run(test, params, env):
 
         try:
             for event in events_list:
-                if event in ['start', 'restore', 'create', 'define', 'undefine', 'edit', 'crash']:
+                if event in ['start', 'restore', 'create', 'define', 'undefine', 'crash']:
                     if dom.is_alive():
                         dom.destroy()
                         if event in ['create', 'define']:


### PR DESCRIPTION
Do not destroy vm when 'edit', otherwise later 'shutdown' action
can not be executed.

Signed-off-by: Yanqiu Zhang <yanqzhan@redhat.com>