### PR TITLE
fix mem_align test scenario issue.

### DIFF
--- a/libvirt/tests/src/libvirt_mem.py
+++ b/libvirt/tests/src/libvirt_mem.py
@@ -522,7 +522,6 @@ def run(test, params, env):
 
         if mem_align:
             dom_mem = check_mem_align()
-            check_qemu_cmd(dom_mem['maxMemory'], dom_mem['attached_mem'])
             if hot_plug and params['delta'] != dom_mem['attached_mem']:
                 test.fail('Memory after attach not equal to original mem + attached mem')
 


### PR DESCRIPTION
mem_align does hotplug of memory and trys to check the qemu_cmd_line with out
setting the parameter  ``test_qemu_cmd`` in the config file. More over
test_qemu_cmd should be enbled only for the coldplug not for hotplug, hotplug
will not update the qemu command line.

Removed the check itself, because if  ``test_qemu_cmd`` is set the qemu command line
is verified in the generic flow. 

Signed-off-by: Hariharan T.S <hari@linux.vnet.ibm.com>