### PR TITLE
Add 5 scenarios about max_vcpus

### DIFF
--- a/libvirt/tests/cfg/cpu/max_vcpus.cfg
+++ b/libvirt/tests/cfg/cpu/max_vcpus.cfg
@@ -1,14 +1,32 @@
 - max_vcpus:
     type = "max_vcpus"
     start_vm = "no"
-    only q35
 
     variants:
+        - virsh_maxvcpus:
+            check = "virsh_maxvcpus"
+            report_num = "240"
+        - virsh_capabilities:
+            check = "virsh_capabilities"
+            report_num_pc_7 = "240"
+            report_num_q35_73 = "255"
+            report_num_q35_7_8 = "384"
         - positive_test:
             status_error = "no"
             variants:
+                - i440fx_test:
+                    only i440fx
+                    variants:
+                        - default:
+                            check = "i440fx_test_default"
+                            guest_vcpu = "240"
+                        - hotplug:
+                            check = "i440fx_test_hotplug"
+                            current_vcpu = "50"
+                            guest_vcpu = "240"
                 - ioapic_iommu:
                     guest_vcpu = "50"
+                    only q35
                     variants:
                         - default:
                             check = "ioapic_iommu"
@@ -19,17 +37,23 @@
             status_error = "yes"
             start_fail = "yes"
             variants:
+                - i440fx_test:
+                    only i440fx
+                    check = "i440fx_test_negative"
+                    guest_vcpu = "241"
+                    err_msg = "unsupported configuration: Maximum CPUs greater than specified machine type limit"
                 - no_iommu:
+                    only q35
                     check = "no_iommu"
                     guest_vcpu = "256"
                     err_msg = "unsupported configuration: more than 255 vCPUs require extended interrupt mode enabled on the iommu device"
                 - with_iommu:
+                    only q35
                     check = "with_iommu"
                     guest_vcpu = "256"
-                    err_msg = "IOMMU interrupt remapping requires split I/O APIC (ioapic driver='qemu')"
-                - greater:
-                    variants:
-                        - ioapic_iommu:
-                            check = "ioapic_iommu_ne"
-                            guest_vcpu = "385"
-                            err_msg = "unsupported configuration: Maximum CPUs greater than specified machine type limit"
+                    err_msg = "IOMMU interrupt remapping requires split I/O APIC \(ioapic driver='qemu'\)"
+                - ioapic_iommu:
+                    only q35
+                    check = "ioapic_iommu_ne"
+                    guest_vcpu = "385"
+                    err_msg = "unsupported configuration: Maximum CPUs greater than specified machine type limit"

--- a/libvirt/tests/src/cpu/max_vcpus.py
+++ b/libvirt/tests/src/cpu/max_vcpus.py
@@ -4,6 +4,7 @@ from virttest import virsh
 from virttest import libvirt_xml
 from virttest import utils_misc
 from virttest.utils_test import libvirt
+from virttest.libvirt_xml import capability_xml
 from virttest.libvirt_xml.devices.iommu import Iommu
 
 
@@ -23,6 +24,19 @@ def run(test, params, env):
     vmxml = libvirt_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     bkxml = vmxml.copy()
 
+    def check_onlinevcpus(vm, cpu_num):
+        """
+
+        Check whether all vcpus are online as expected.
+
+        :param vm: the exact VM need to check
+        :param cpu_num: the num of online vcpus need to match
+        """
+        if not utils_misc.wait_for(
+                lambda: utils_misc.check_if_vm_vcpu_match(cpu_num, vm),
+                timeout=120, step=5, text="wait for vcpu online"):
+            test.fail('Not all vcpus are online as expected.')
+
     def set_iommu(vmxml, **dargs):
         """
 
@@ -39,20 +53,84 @@ def run(test, params, env):
         vmxml.add_device(iommu_device)
 
     try:
-        # Configure a guest vcpu > 255 without iommu device
+        # Check the output of "virsh maxvcpus" for both i440fx and q35 VM
+        if check == 'virsh_maxvcpus':
+            report_num = params.get('report_num', '')
+            logging.info('Check the output of virsh maxvcpus')
+            cmd_result = virsh.maxvcpus(debug=True)
+            if cmd_result.exit_status == 0 and cmd_result.stdout.strip() == report_num:
+                logging.debug('Test passed as the reported max vcpu num is %s', report_num)
+            else:
+                test.fail('Test failed as the reported max vcpu num is not as expected.')
+
+        # Check the output of "virsh capabilities" for both i440fx and q35 VM
+        if check == "virsh_capabilities":
+            report_num_pc_7 = params.get('report_num_pc_7', '')
+            report_num_q35_73 = params.get('report_num_q35_73', '')
+            report_num_q35_7_8 = params.get('report_num_q35_7_8', '')
+            logging.info('Check the output of virsh capabilities')
+            xmltreefile = capability_xml.CapabilityXML().xmltreefile
+            machtype_vcpunum_dict = {}
+            for guest in xmltreefile.findall('guest'):
+                for arch in guest.findall('arch'):
+                    if arch.get('name') == "x86_64":
+                        for machine in arch.findall('machine'):
+                            machine_text = machine.text
+                            vcpunum = machine.get('maxCpus')
+                            machtype_vcpunum_dict[machine_text] = vcpunum
+            for key in machtype_vcpunum_dict:
+                logging.info("%s : %s", key, machtype_vcpunum_dict[key])
+                if key.startswith('pc-i440fx') or key.startswith('rhel') or key == 'pc':
+                    if machtype_vcpunum_dict[key] != report_num_pc_7:
+                        test.fail('Test failed as i440fx_max_vcpus_num in virsh_capa is wrong.')
+                if key.startswith('pc-q35') or key == 'q35':
+                    if key == "pc-q35-rhel7.3.0":
+                        if machtype_vcpunum_dict[key] != report_num_q35_73:
+                            test.fail('Test failed as q35_rhel73_max_vcpus_num in virsh_capa is wrong.')
+                    else:
+                        if machtype_vcpunum_dict[key] != report_num_q35_7_8:
+                            test.fail('Test failed as the q35_max_vcpus_num in virsh_capa is wrong.')
+
+        # Test i440fx VM starts with 240(positive)/241(negative) vcpus and hot-plugs vcpus to 240
+        if check.startswith('i440fx_test'):
+            current_vcpu = params.get('current_vcpu')
+            if 'hotplug' not in check:
+                vmxml.vcpu = int(guest_vcpu)
+                vmxml.sync()
+                if status_error:
+                    if start_fail:
+                        result_need_check = virsh.start(vm_name, debug=True)
+                else:
+                    vm.start()
+                    logging.info(libvirt_xml.VMXML.new_from_dumpxml(vm_name))
+                    vm.wait_for_login(timeout=boot_timeout).close()
+                    check_onlinevcpus(vm, int(guest_vcpu))
+            else:
+                vmxml.vcpu = int(guest_vcpu)
+                vmxml.current_vcpu = int(current_vcpu)
+                vmxml.sync()
+                vm.start()
+                logging.info(libvirt_xml.VMXML.new_from_dumpxml(vm_name))
+                vm.wait_for_login(timeout=boot_timeout).close()
+                check_onlinevcpus(vm, int(current_vcpu))
+                res = virsh.setvcpus(vm_name, guest_vcpu, debug=True)
+                libvirt.check_exit_status(res)
+                check_onlinevcpus(vm, int(guest_vcpu))
+
+        # Configure a guest vcpu > 255 without iommu device for q35 VM
         if check == 'no_iommu':
             logging.info('Set vcpu to %s', guest_vcpu)
             vmxml.vcpu = int(guest_vcpu)
             result_need_check = virsh.define(vmxml.xml, debug=True)
 
-        # Set iommu device but not set ioapci in features
+        # Set iommu device but not set ioapci in features for q35 VM
         if check == 'with_iommu':
             logging.info('Set vcpu to %s', guest_vcpu)
             vmxml.vcpu = int(guest_vcpu)
             set_iommu(vmxml)
             result_need_check = virsh.define(vmxml.xml, debug=True)
 
-        # Add ioapic and iommu device in xml
+        # Add ioapic and iommu device in xml for q35 VM
         if check.startswith('ioapic_iommu'):
             logging.info('Modify features')
             vm_features = vmxml.features
@@ -80,7 +158,7 @@ def run(test, params, env):
 
             else:
                 # Login guest and check guest cpu number
-                virsh.start(vm_name, debug=True)
+                vm.start()
                 session = vm.wait_for_login(timeout=boot_timeout)
                 logging.debug(session.cmd('lscpu -e'))
 
@@ -90,10 +168,7 @@ def run(test, params, env):
                     libvirt.check_exit_status(res)
 
                 # Check if vcpu(s) are online
-                if not utils_misc.wait_for(
-                        lambda: utils_misc.check_if_vm_vcpu_match(int(guest_vcpu), vm),
-                        timeout=60, step=5, text="wait for vcpu online"):
-                    test.fail('Not all CPU(s) are online')
+                check_onlinevcpus(vm, int(guest_vcpu))
 
         # Check result if there's result to check
         if 'result_need_check' in locals():


### PR DESCRIPTION
1> Check the output of 'virsh maxvcpus'
2> Check the output of 'virsh capabilities' about vcpus_num and machine_type
3> Start i440fx VM with 240 vcpus
4> Hot-plug vcpus to i440fx VM until the num of online vcpus is 240
5> Start i440fx VM with more than 240 vcpus (Negative)

Signed-off-by: Jing Yan <jiyan@redhat.com>