### PR TITLE
add subcase enable/disable vcpu 0

### DIFF
--- a/libvirt/tests/cfg/cpu/setvcpu.cfg
+++ b/libvirt/tests/cfg/cpu/setvcpu.cfg
@@ -1,4 +1,4 @@
-- setvcpu:
+- cpu.setvcpu:
     type = setvcpu
     start_vm = "no"
     vcpu_placement = "static"
@@ -42,32 +42,49 @@
         - negative_test:
             status_error = "yes"
             variants:
-                - hotplug_duplicate_vcpu:
+                - disable:
+                    setvcpu_action = "--disable"
+                - enable:
+                    setvcpu_action = "--enable"
+            variants:
+                - hotplug:
                     check = "hotplug"
-                    runtime_fail = "yes"
                     variants:
-                        - enable:
-                            vcpus_enabled = "{0}"
-                            setvcpu_option = "{'2-3':'--enable'}"
+                        - duplicate_vcpu:
+                            enable:
+                                vcpus_enabled = "{0}"
+                            disable:
+                                vcpus_enabled = "{0,2,3}"
+                            setvcpu_option = "'2-3'"
                             err_msg = "only one hotpluggable entity can be selected"
-                        - disable:
-                            vcpus_enabled = "{0,2,3}"
-                            setvcpu_option = "{'2-3':'--disable'}"
-                            err_msg = "only one hotpluggable entity can be selected"
-                - hotplug_invalid_vcpu:
-                    check = "hotplug"
-                    runtime_fail = "yes"
-                    variants:
-                        - disable_online_vcpu:
+                        - online_vcpu:
+                            only disable
                             vcpus_enabled = "{0,1}"
                             vcpus_hotpluggable = "{2,3,4,5,6,7}"
-                            setvcpu_option = "{'1':'--disable'}"
+                            setvcpu_option = "'1'"
                             err_msg = "Operation not supported: vcpu '1' can't be unplugged"
-                        - enable_noexist_vcpu:
+                        - noexist_vcpu:
+                            only enable
                             vcpus_enabled = "{0,1,2,3}"
-                            setvcpu_option = "{'9':'--enable'}"
+                            setvcpu_option = "'9'"
                             err_msg = "invalid argument: vcpu 9 is not present in live config"
-                        - disable_offline_vcpu:
+                        - offline_vcpu:
+                            only disable
                             vcpus_enabled = "{0,1}"
-                            setvcpu_option = "{'3':'--disable'}"
+                            setvcpu_option = "'3'"
                             err_msg = "vcpu '3' is already in requested state"
+                        - vcpu0:
+                            vcpus_enabled = "{0}"
+                            setvcpu_option = "'0'"
+                            enable:
+                                err_msg = "error: invalid argument: vcpu '0' is already in requested state"
+                            disable:
+                                err_msg = "error: Operation not supported: vcpu '0' can't be unplugged"
+                - coldplug:
+                    check = "coldplug"
+                    variants:
+                        - invalid_vcpu:
+                            vcpus_enabled = "{0}"
+                            setvcpu_option = "'0'"
+                            err_msg = "error: invalid argument: vCPU '0' can't be modified"
+


### PR DESCRIPTION
This subcase is based on bug
https://bugzilla.redhat.com/show_bug.cgi?id=1459785

enable/disable vcpu0 when vm is active/inactive and check error

Signed-off-by: Jin Li <jil@redhat.com>