### PR TITLE
virsh_attach_detach_disk:

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_disk.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_disk.cfg
@@ -10,6 +10,8 @@
     at_dt_disk_test_twice = 'no'
     at_dt_disk_device = disk
     at_dt_disk_device_target = vdb
+    machine_type == s390-virtio:
+      at_dt_disk_device_target = sda
     at_dt_disk_bus_type = virtio
     at_dt_disk_device_source = "attach.img"
     at_dt_disk_device_source_format = "raw"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk.py
@@ -237,10 +237,11 @@ def run(test, params, env):
             s_at_options += " --mode shareable"
 
         s_attach = virsh.attach_disk(vm_name, device_source, device_target,
-                                     s_at_options).exit_status
+                                     s_at_options, debug=True).exit_status
         if s_attach != 0:
             logging.error("Attaching device failed before testing detach-disk")
-
+        else:
+            logging.debug("Attaching device succeeded before testing detach-disk")
         if test_twice:
             device_target2 = params.get("at_dt_disk_device_target2",
                                         device_target)


### PR DESCRIPTION
- Add debug info for attaching disk
- Replace virtio bus with scsi bus for attaching/detaching disk on s390x
      Sometimes after cold pluging a disk, the disk names in guest may
      change either when booting up or hotunpluging that disk, for
      example, before cold pluging, the disk names are 'vda', 'vda1',
      'vda2', 'dm-0', 'dm-1', and after coldpluging and hotunpluging the
      same disk, the disk names are 'vdb', 'vdb1', 'vdb2', 'dm-0',
      'dm-1'. So this fix is intending to avoid of using same bus
      'virtio' and the unexpected changes on s390x.

Signed-off-by: Dan Zheng <dzheng@redhat.com>