### PR TITLE
add subcase inactive vcpu affinity check

### DIFF
--- a/libvirt/tests/cfg/cpu/vcpu_affinity.cfg
+++ b/libvirt/tests/cfg/cpu/vcpu_affinity.cfg
@@ -30,12 +30,21 @@
                     check = "cputune"
                     vcpu_cpuset = "0-1"
                     variants:
-                        - vcpu:
+                        - vcpu_affinity_xml:
+                            hotplug_vcpu = "yes"
                             config_xml = "cputune"
+                            vcpu = "7"
                             cputune_cpuset = "2-3"
+                            current_vcpu = "1"
+                            setvcpus_option = "8"
+                        - vcpu_affinity_active:
+                            hotplug_vcpu = "yes"
+                            vcpu = "7"
+                            cputune_cpuset = "3"
+                            current_vcpu = "1"
+                            setvcpus_option = "8"
                         - offline_hostcpu:
                             check = "cputune_offline_hostcpu"
-                            vm_down = "yes"
                             offline_hostcpus = "2,3"
                             cputune_cpuset = "3"
                         - vcpu_maxvcpu_minus:


### PR DESCRIPTION
This test case is based on bug
    https://bugzilla.redhat.com/show_bug.cgi?id=1306556

This case specify vcpu affinity for inactive vcpu and check result

Signed-off-by: Jin Li <jil@redhat.com>