### PR TITLE
 Debug the issue of the virsh_domfsinfo.py

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domfsinfo.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domfsinfo.py
@@ -191,9 +191,12 @@ def run(test, params, env):
             result = virsh.attach_disk(domain, source, target, "--live",
                                        ignore_status=False, debug=True)
         else:
-            session = vm.wait_for_login()
-            session.cmd("umount %s" %mount_dir)
-            session.close()
+            try:
+                session = vm.wait_for_login()
+                session.cmd("umount %s" % mount_dir)
+                session.close()
+            except:
+                test.fail("fail to unmount the disk before unpluging the disk")
             result = virsh.detach_disk(domain, target, "--live",
                                        ignore_status=False, debug=True)
         # It need more time for attachment to take effect

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domfsinfo.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domfsinfo.py
@@ -191,6 +191,9 @@ def run(test, params, env):
             result = virsh.attach_disk(domain, source, target, "--live",
                                        ignore_status=False, debug=True)
         else:
+            session = vm.wait_for_login()
+            session.cmd("umount %s" %mount_dir)
+            session.close()
             result = virsh.detach_disk(domain, target, "--live",
                                        ignore_status=False, debug=True)
         # It need more time for attachment to take effect
@@ -251,7 +254,7 @@ def run(test, params, env):
             check_output(cmd_output, mount_dir, test, expected=False)
         elif hotplug_unplug:
             blk_target = re.findall(r'[a-z]+', new_part)[0]
-            disk_pat = "%s\s+%s\s+%s\s+%s\s+" % (mount_dir, new_part, fs_type, blk_target)
+            disk_pat = "%s\s+%s\s+%s\s+%s" % (mount_dir, new_part, fs_type, blk_target)
             check_output(cmd_output, disk_pat, test, expected=True)
             # Unplug domain disk
             hotplug_domain_disk(vm_name, target=new_part, hotplug=False)


### PR DESCRIPTION
  Fix the attributeError "module 'locale' has no attribute
  ‘getpreferrencoding'“.

  Fix the error “expect matched pattern ‘/mnt\s+vdb\s+ext3\s+vdb\s+’
  did not match the virsh.domfsinfo input".

  Fix the error about failing to run virsh.domfsinfo after disk unplug.
  the error message are as followed:
  (1) Unable to get filesystem information”
  (2) unable to execute QEMU agent command 'guest-get-fsinfo':
  realpath("/sys/dev/block/252:16"): no such file or directory”