### PR TITLE
migrate_vm: update default compression case

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_vm.cfg
+++ b/libvirt/tests/cfg/migration/migrate_vm.cfg
@@ -73,7 +73,11 @@
                             run_migrate_cmd_in_back = "yes"
                             set_migration_speed = 10
                             check_job_info = "yes"
+                            check_complete_job = "yes"
+                            config_libvirtd = "yes"
                             virsh_options = "--live --verbose --compressed"
+                            default_cache = "64.000 MiB"
+                            grep_str_from_local_libvirt_log = '"capability":"xbzrle","state":true'
                         - set_cache_size:
                             set_migrate_compcache_size = 640000000
                             set_migration_speed = 15

--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -83,7 +83,7 @@ def destroy_active_pool_on_remote(params):
     return ret
 
 
-def create_destroy_pool_on_remote(action, params):
+def create_destroy_pool_on_remote(test, action, params):
     """
     This is to create or destroy a specified pool on remote host.
     :param action: "create" or "destory"
@@ -125,8 +125,8 @@ def create_destroy_pool_on_remote(action, params):
         session.close()
         if status:
             new_session.close_session()
-            raise exceptions.TestFail("Run command '%s' on remote host '%s'"
-                                      "failed: %s." % (cmd, remote_ip, output))
+            test.fail("Run command '%s' on remote host '%s'"
+                      "failed: %s." % (cmd, remote_ip, output))
         ret = new_session.pool_create_as(pool_name, pool_type, pool_target)
     else:  # suppose it is to destroy
         ret = new_session.pool_destroy(pool_name)
@@ -135,10 +135,11 @@ def create_destroy_pool_on_remote(action, params):
     return ret
 
 
-def check_output(output_msg, params):
+def check_output(test, output_msg, params):
     """
     Check if known messages exist in the given output messages.
 
+    :param test: the test object
     :param output_msg: the given output messages
     :param params: the dictionary including necessary parameters
 
@@ -179,20 +180,18 @@ def check_output(output_msg, params):
             logging.debug("The expected error '%s' was found", expect_msg)
             return
         else:
-            raise exceptions.TestFail("The actual output:\n%s\n"
-                                      "The expected error '%s' "
-                                      "was not found",
-                                      output_msg, expect_msg)
+            test.fail("The actual output:\n%s\n"
+                      "The expected error '%s' was not found",
+                      output_msg, expect_msg)
 
     if params.get("target_vm_name"):
         if output_msg.find(ERR_MSGDICT['ERROR 3']) >= 0:
             logging.debug("The expected error is found: %s", ERR_MSGDICT['ERROR 3'])
             return
         else:
-            raise exceptions.TestFail("The actual output:\n%s\n"
-                                      "The expected error '%s' "
-                                      "was not found",
-                                      output_msg, ERR_MSGDICT['ERROR 3'])
+            test.fail("The actual output:\n%s\n"
+                      "The expected error '%s' was not found",
+                      output_msg, ERR_MSGDICT['ERROR 3'])
 
     for (key, value) in ERR_MSGDICT.items():
         if output_msg.find(value) >= 0:
@@ -203,13 +202,17 @@ def check_output(output_msg, params):
             else:
                 logging.debug("The known error was found: %s --- %s",
                               key, value)
-                raise exceptions.TestSkipError("Known error: %s --- %s in %s" %
-                                               (key, value, output_msg))
+                test.cancel("Known error: %s --- %s in %s"
+                            % (key, value, output_msg))
 
 
-def migrate_vm(params):
+def migrate_vm(test, params):
     """
     Connect libvirt daemon
+
+    :param test: the test object
+    :param params: parameters used
+    :raise: test.fail if migration does not get expected result
     """
     vm_name = params.get("vm_name_to_migrate")
     if vm_name is None:
@@ -227,7 +230,7 @@ def migrate_vm(params):
 
     for option in options.split():
         if option.startswith("--"):
-            check_virsh_command_and_option("migrate", option)
+            check_virsh_command_and_option(test, "migrate", option)
 
     logging.info("Prepare migrate %s", vm_name)
     global MIGRATE_RET
@@ -242,21 +245,24 @@ def migrate_vm(params):
         if MIGRATE_RET:
             logging.info("Get an expected migration result:\n%s" % mig_output)
         else:
-            check_output(mig_output, params)
-            raise exceptions.TestFail("Can't get an expected migration "
-                                      "result:\n%s" % mig_output)
+            check_output(test, mig_output, params)
+            test.fail("Can't get an expected migration result:\n%s"
+                      % mig_output)
     else:
         if not MIGRATE_RET:
-            check_output(mig_output, params)
+            check_output(test, mig_output, params)
             logging.info("It's an expected error:\n%s" % mig_output)
         else:
-            raise exceptions.TestFail("Unexpected return result:\n%s"
-                                      % mig_output)
+            test.fail("Unexpected return result:\n%s" % mig_output)
 
 
-def check_parameters(params):
+def check_parameters(test, params):
     """
     Make sure all of parameters are assigned a valid value
+
+    :param test: the test object
+    :param params: parameters used
+    :raise: test.cancel if not enough parameters are specified
     """
     client_ip = params.get("client_ip")
     server_ip = params.get("server_ip")
@@ -273,8 +279,7 @@ def check_parameters(params):
 
     for arg in args_list:
         if arg and arg.count("ENTER.YOUR."):
-            raise exceptions.TestSkipError("Please assign a value for %s!"
-                                           % arg)
+            test.cancel("Please assign a value for %s!" % arg)
 
 
 def config_libvirt(params):
@@ -293,19 +298,23 @@ def config_libvirt(params):
     return libvirtd_conf
 
 
-def add_disk_xml(device_type, source_file,
+def add_disk_xml(test, device_type, source_file,
                  image_size, policy,
                  disk_type="file"):
     """
     Create a disk xml file for attaching to a guest.
 
-    :prams xml_file: path/file to save the disk XML
-    :source_file: disk's source file
-    :device_type: CD-ROM or floppy
+    :param test: the test object
+    :param device_type: CD-ROM or floppy
+    :param source_file: disk's source file
+    :param image_size: the size of disk
+    :param policy: the policy for attaching disk
+    :prams disk_type: disk type for attaching
+    :raise: test.cancel if device type is not supported
     """
     if device_type != 'cdrom' or device_type != 'floppy':
-        exceptions.TestSkipError("Only support 'cdrom' and 'floppy'"
-                                 " device type: %s" % device_type)
+        test.cancel("Only support 'cdrom' and 'floppy'"
+                    " device type: %s" % device_type)
 
     dev_dict = {'cdrom': {'bus': 'scsi', 'dev': 'sdb'},
                 'floppy': {'bus': 'fdc', 'dev': 'fda'}}
@@ -420,9 +429,13 @@ def build_disk_xml(vm_name, disk_format, host_ip, disk_src_protocol,
     vmxml.sync()
 
 
-def get_cpu_xml_from_virsh_caps(runner=None):
+def get_cpu_xml_from_virsh_caps(test, runner=None):
     """
     Get CPU XML from virsh capabilities output
+
+    :param test: test object
+    :param runner: the runner object to execute commands
+    :raise: test.fail if test fails
     """
     cmd = "virsh capabilities | awk '/<cpu>/,/<\/cpu>/'"
     out = ""
@@ -432,14 +445,19 @@ def get_cpu_xml_from_virsh_caps(runner=None):
         out = runner(cmd)
 
     if not re.search('cpu', out):
-        raise exceptions.TestFail("Failed to get cpu XML: %s" % out)
+        test.fail("Failed to get cpu XML: %s" % out)
 
     return out
 
 
-def compute_cpu_baseline(cpu_xml, status_error="no"):
+def compute_cpu_baseline(test, cpu_xml, status_error="no"):
     """
     Compute CPU baseline
+
+    :param test: test object
+    :param cpu_xml: the cpu xml used for computing
+    :param status_error: yes to not raise an exception on failure
+    :raise: test.fail if test fails
     """
     result = virsh.cpu_baseline(cpu_xml, ignore_status=True, debug=True)
     status = result.exit_status
@@ -447,35 +465,35 @@ def compute_cpu_baseline(cpu_xml, status_error="no"):
     err = result.stderr.strip()
     if status_error == "no":
         if status:
-            raise exceptions.TestFail("Failed to compute baseline CPU: %s"
-                                      % err)
+            test.fail("Failed to compute baseline CPU: %s" % err)
         else:
             logging.info("Succeed to compute baseline CPU: %s", output)
     else:
         if status:
             logging.info("It's an expected %s", err)
         else:
-            raise exceptions.TestFail("Unexpected return result: %s" % output)
+            test.fail("Unexpected return result: %s" % output)
 
     return output
 
 
-def get_same_processor(server_ip, server_user, server_pwd, verbose):
+def get_same_processor(test, server_ip, server_user, server_pwd, verbose):
     """
     Return the same processor between local and remote host.
     Otherwise, raise a TestSkipError.
 
+    :param test: test object
     :param server_ip: the address of remote host
     :param server_user: the user id to log on remote host
     :param server_pwd: the password for server_user
     :param verbose: the flag to control whether or not to log messages
+    :raise: test.fail if test fails
     """
     local_processors = utils_misc.get_cpu_processors(verbose=verbose)
     cmd = "grep processor /proc/cpuinfo"
     status, output = run_remote_cmd(cmd, server_ip, server_user, server_pwd)
     if status:
-        raise exceptions.TestFail("Failed to run '%s' on the remote: %s"
-                                  % (cmd, output))
+        test.fail("Failed to run '%s' on the remote: %s" % (cmd, output))
     remote_processors = re.findall('processor\s+: (\d+)', output)
     if verbose:
         logging.debug("Local processors: %s", local_processors)
@@ -495,8 +513,8 @@ def get_same_processor(server_ip, server_user, server_pwd, verbose):
             continue
         break
     if not matched:
-        raise exceptions.TestSkipError("There is no same processor "
-                                       "between local and remote host.")
+        test.cancel("There is no same processor "
+                    "between local and remote host.")
     return local_processor
 
 
@@ -704,18 +722,22 @@ def update_interface_xml(vm_name, iface_address, iface_model=None,
     vmxml.sync()
 
 
-def check_virsh_command_and_option(command, option=None):
+def check_virsh_command_and_option(test, command, option=None):
     """
     Check if virsh command exists
+
+    :param test: test object
+    :param command: the command to validate
+    :param option: the option for the command
+    :raise: test.cancel if commmand is not supported
     """
     msg = "This version of libvirt does not support "
     if not virsh.has_help_command(command):
-        raise exceptions.TestSkipError(msg + "virsh command '%s'" % command)
+        test.cancel(msg + "virsh command '%s'" % command)
 
     if option and not virsh.has_command_help_match(command, option):
-        raise exceptions.TestSkipError(msg +
-                                       "virsh command '%s' with option '%s'"
-                                       % (command, option))
+        test.cancel(msg + "virsh command '%s' with option '%s'"
+                    % (command, option))
 
 
 def run_remote_cmd(command, server_ip, server_user, server_pwd,
@@ -815,7 +837,15 @@ def cleanup(objs_list):
         del obj
 
 
-def check_vm_disk_after_migration(vm, params):
+def check_vm_disk_after_migration(test, vm, params):
+    """
+    Check the disk work well after migration on target host
+
+    :param test: test object
+    :param vm: the guest object to migrate
+    :param params: parameters used
+    :raise: test.fail if command execution fails
+    """
     cmd = "fdisk -l|grep '^Disk /dev'|cut -d: -f1|cut -d' ' -f2"
     vm_ip = vm.get_address()
     vm_pwd = params.get("password", "redhat")
@@ -828,7 +858,7 @@ def check_vm_disk_after_migration(vm, params):
     remote_vm_obj.setup_ssh_auth(vm_ip, vm_pwd, timeout=60)
     cmdres = remote_vm_obj.run_command(vm_ip, cmd, ignore_status=True)
     if cmdres.exit_status:
-        raise exceptions.TestFail("Command '%s' result: %s\n", cmd, cmdres)
+        test.fail("Command '%s' result: %s\n", cmd, cmdres)
     disks = cmdres.stdout.strip().split("\n")
     logging.debug("Get disks in remote VM: %s", disks)
     for disk in disks:
@@ -846,7 +876,7 @@ def check_vm_disk_after_migration(vm, params):
             logging.debug("Execute command on remote VM: %s", cmd)
             cmdres = remote_vm_obj.run_command(vm_ip, cmd, ignore_status=True)
             if cmdres.exit_status:
-                raise exceptions.TestFail("Command '%s' result: %s\n", cmd, cmdres)
+                test.fail("Command '%s' result: %s\n", cmd, cmdres)
 
 
 def check_migration_disk_port(params):
@@ -862,6 +892,7 @@ def check_migration_disk_port(params):
     server_user = params.get("server_user")
     server_pwd = params.get("server_pwd")
     client_ip = params.get("client_ip")
+    test = params.get("test_object")
     # Here need to wait for several seconds before checking the port on
     # remote host because the storage migration needs some time (about 5s)
     # to start working actually. The whole period for the storage migration
@@ -871,16 +902,15 @@ def check_migration_disk_port(params):
     cmd = "netstat -tunap|grep %s" % disk_port
     status, output = run_remote_cmd(cmd, server_ip, server_user, server_pwd)
     if status:
-        raise exceptions.TestFail("Failed to run '%s' on the remote: %s"
-                                  % (cmd, output))
+        test.fail("Failed to run '%s' on the remote: %s" % (cmd, output))
     pattern1 = r".*:::%s.*LISTEN.*qemu-kvm.*" % disk_port
     pattern2 = r".*%s:%s.*%s.*ESTABLISHED.*qemu-kvm.*" % (server_ip,
                                                           disk_port,
                                                           client_ip)
     logging.debug("Check the disk port specified is in use")
     if not re.search(pattern1, output) or not re.search(pattern2, output):
-        raise exceptions.TestFail("Can not find the expected patterns"
-                                  " '%s, %s' in output '%s'")
+        test.fail("Can not find the expected patterns"
+                  " '%s, %s' in output '%s'")
 
 
 def update_disk_driver_with_iothread(vm_name, iothread):
@@ -903,8 +933,16 @@ def update_disk_driver_with_iothread(vm_name, iothread):
     vmxml.sync()
 
 
-def check_iothread_after_migration(vm_name, params, iothread):
-    """ Check iothread by qemu-monitor-command on remote host."""
+def check_iothread_after_migration(test, vm_name, params, iothread):
+    """
+    Check iothread by qemu-monitor-command on remote host.
+
+    :param test: test object
+    :param vm_name: the guest name for migration
+    :param params: parameters used
+    :param iothread: the iothread value to check
+    :raise: test.fail if checking fails
+    """
     remote_virsh = virsh.VirshPersistent(**params)
     try:
         ret = remote_virsh.qemu_monitor_command(vm_name,
@@ -912,7 +950,7 @@ def check_iothread_after_migration(vm_name, params, iothread):
                                                 "--pretty")
         libvirt.check_exit_status(ret)
         if ret.stdout.strip().count("thread-id") != int(iothread):
-            raise exceptions.TestFail("Failed to check domain iothreads")
+            test.fail("Failed to check domain iothreads")
     finally:
         remote_virsh.close_session()
 
@@ -950,6 +988,7 @@ def check_domjobinfo_on_complete(test, source_jobinfo, target_jobinfo):
     :param test: avocado.core.test.Test object
     :param local_jobinfo: The domjobinfo output on source host
     :param remote_jobinfo: The domjobinfo output on target host
+    :raise: test.fail if checking fails
     """
     source_info = read_domjobinfo(test, source_jobinfo)
     target_info = read_domjobinfo(test, target_jobinfo)
@@ -980,7 +1019,7 @@ def read_domjobinfo(test, domjobinfo):
 
     :param test: avocado.core.test.Test object
     :param domjobinfo: The domjobinfo command output
-
+    :raise: test.fail if checking fails
     :return: A dict contains the domjobinfo
     """
     jobinfo_dict = {}
@@ -1181,7 +1220,7 @@ def run(test, params, env):
     attach_disk = False
 
     # Make sure all of parameters are assigned a valid value
-    check_parameters(test_dict)
+    check_parameters(test, test_dict)
 
     # Check for some skip situations
     os_ver_from = test_dict.get("os_ver_from")
@@ -1191,23 +1230,21 @@ def run(test, params, env):
     if os_ver_from:
         curr_os_ver = to_text(process.system_output(os_ver_cmd, shell=True))
         if os_ver_from not in curr_os_ver:
-            raise exceptions.TestSkipError("The current OS is %s"
-                                           % curr_os_ver)
+            test.cancel("The current OS is %s" % curr_os_ver)
 
     if os_ver_to:
         status, curr_os_ver = run_remote_cmd(os_ver_cmd, server_ip,
                                              server_user, server_pwd)
         if os_ver_to not in curr_os_ver:
-            raise exceptions.TestSkipError("The current OS is %s"
-                                           % curr_os_ver)
+            test.cancel("The current OS is %s" % curr_os_ver)
 
     speed = test_dict.get("set_migration_speed")
     if speed:
         cmd = "migrate-setspeed"
         if not virsh.has_help_command(cmd):
-            raise exceptions.TestSkipError("This version of libvirt "
-                                           "does not support virsh "
-                                           "command %s" % cmd)
+            test.cancel("This version of libvirt "
+                        "does not support virsh "
+                        "command %s" % cmd)
 
     # Set up SSH key
     ssh_key.setup_ssh_key(server_ip, server_user, server_pwd, 22)
@@ -1358,13 +1395,13 @@ def run(test, params, env):
             logging.debug("Make sure %s exists both local and remote", nfs_mount_dir)
             output = to_text(process.system_output(cmd, shell=True))
             if output:
-                raise exceptions.TestFail("Failed to run '%s' on the local : %s"
-                                          % (cmd, output))
+                test.fail("Failed to run '%s' on the local : %s"
+                          % (cmd, output))
 
             status, output = run_remote_cmd(cmd, server_ip, server_user, server_pwd)
             if status:
-                raise exceptions.TestFail("Failed to run '%s' on the remote: %s"
-                                          % (cmd, output))
+                test.fail("Failed to run '%s' on the remote: %s"
+                          % (cmd, output))
             cmd = "mount | grep -E '.*%s.*%s.*'" % (client_ip + ':' + nfs_mount_src,
                                                     nfs_mount_dir)
             status, out = run_remote_cmd(cmd, server_ip, server_user, server_pwd)
@@ -1415,9 +1452,8 @@ def run(test, params, env):
         if cmd:
             status, output = run_remote_cmd(cmd, server_ip, server_user, server_pwd)
             if status:
-                raise exceptions.TestFail("Failed to run '%s' "
-                                          "on the remote: %s"
-                                          % (cmd, output))
+                test.fail("Failed to run '%s' on the remote: %s"
+                          % (cmd, output))
 
             remote_image_list.append(target_disk_image)
 
@@ -1439,8 +1475,7 @@ def run(test, params, env):
             cmd = "setenforce permissive"
             status, output = run_remote_cmd(cmd, server_ip, server_user, server_pwd)
             if status:
-                raise exceptions.TestSkipError("Failed to set SELinux "
-                                               "in permissive mode")
+                test.cancel("Failed to set SELinux in permissive mode")
 
             REMOTE_SELINUX_ENFORCING = False
 
@@ -1477,7 +1512,7 @@ def run(test, params, env):
         if diff_cpu_vendor:
             local_vendor = utils_misc.get_cpu_vendor()
             logging.info("Local CPU vendor: %s", local_vendor)
-            local_cpu_xml = get_cpu_xml_from_virsh_caps()
+            local_cpu_xml = get_cpu_xml_from_virsh_caps(test)
             logging.debug("Local CPU XML: \n%s", local_cpu_xml)
 
             cmd = "grep %s /proc/cpuinfo" % local_vendor
@@ -1486,15 +1521,14 @@ def run(test, params, env):
                                                      ret_session_status_output=True)
             try:
                 if not status:
-                    raise exceptions.TestSkipError("The CPU model is "
-                                                   "the same between local "
-                                                   "and remote host %s:%s"
-                                                   % (local_vendor, output))
+                    test.cancel("The CPU model is the same between local "
+                                "and remote host %s:%s"
+                                % (local_vendor, output))
                 if not session:
-                    raise exceptions.TestFail("The session is dead")
+                    test.fail("The session is dead")
 
                 runner = session.cmd_output
-                remote_cpu_xml = get_cpu_xml_from_virsh_caps(runner)
+                remote_cpu_xml = get_cpu_xml_from_virsh_caps(test, runner)
                 session.close()
                 logging.debug("Remote CPU XML: \n%s", remote_cpu_xml)
                 cpu_xml = os.path.join(data_dir.get_tmp_dir(), 'cpu.xml')
@@ -1509,7 +1543,7 @@ def run(test, params, env):
                 process.system(cmd, shell=True)
                 cpu_xml_cxt = to_text(process.system_output("cat %s" % cpu_xml, shell=True))
                 logging.debug("The current CPU XML contents: \n%s", cpu_xml_cxt)
-                output = compute_cpu_baseline(cpu_xml, status_error)
+                output = compute_cpu_baseline(test, cpu_xml, status_error)
                 logging.debug("The baseline CPU XML: \n%s", output)
                 output = output.replace("\n", "")
                 vm_new_xml = os.path.join(data_dir.get_tmp_dir(), 'vm_new.xml')
@@ -1533,7 +1567,7 @@ def run(test, params, env):
                 logging.debug("The current VM XML:\n%s", vmxml_backup.xmltreefile)
 
         if cpu_set:
-            vcpu_cpuset = get_same_processor(server_ip, server_user, server_pwd,
+            vcpu_cpuset = get_same_processor(test, server_ip, server_user, server_pwd,
                                              verbose=True)
             vcpu_args = ""
             if vcpu_cpuset:
@@ -1607,8 +1641,8 @@ def run(test, params, env):
             status, output = run_remote_cmd(cmd, server_ip, server_user,
                                             server_pwd)
             if status:
-                raise exceptions.TestFail("Failed to run '%s' on the remote: %s"
-                                          % (cmd, output))
+                test.fail("Failed to run '%s' on the remote: %s"
+                          % (cmd, output))
 
             libvirtd_conf = config_libvirt(libvirtd_conf_dict)
 
@@ -1654,17 +1688,15 @@ def run(test, params, env):
                 status, output = run_remote_cmd(cmd, server_ip, server_user,
                                                 server_pwd)
                 if status:
-                    raise exceptions.TestFail("Failed to run '%s' "
-                                              "on the remote: %s"
-                                              % (cmd, output))
+                    test.fail("Failed to run '%s' on the remote: %s"
+                              % (cmd, output))
             HUGETLBFS_MOUNT = True
 
         if create_disk_src_backing_file:
             cmd = create_disk_src_backing_file + orig_image_name
             out = to_text(process.system_output(cmd, ignore_status=True, shell=True))
             if not out:
-                raise exceptions.TestFail("Failed to create backing file: %s"
-                                          % cmd)
+                test.fail("Failed to create backing file: %s" % cmd)
             logging.info(out)
             local_image_list.append(new_disk_source)
 
@@ -1673,16 +1705,16 @@ def run(test, params, env):
             status, output = run_remote_cmd(cmd, server_ip, server_user,
                                             server_pwd)
             if status:
-                raise exceptions.TestFail("Failed to run '%s' on remote: %s"
-                                          % (cmd, output))
+                test.fail("Failed to run '%s' on remote: %s"
+                          % (cmd, output))
 
         if remote_hugetlbfs_path:
             cmd = "ls %s" % remote_hugetlbfs_path
             status, output = run_remote_cmd(cmd, server_ip, server_user,
                                             server_pwd)
             if status:
-                raise exceptions.TestFail("Failed to run '%s' on remote: %s"
-                                          % (cmd, output))
+                test.fail("Failed to run '%s' on remote: %s"
+                          % (cmd, output))
 
         if memtune_options:
             virsh.memtune_set(vm_name, memtune_options)
@@ -1719,11 +1751,11 @@ def run(test, params, env):
                     image_size = floppy_image_size
                 if image_size:
                     local_image_list.append(source_file)
-                    disk_xml = add_disk_xml(dev_type, source_file,
+                    disk_xml = add_disk_xml(test, dev_type, source_file,
                                             image_size, policy)
                 else:
                     cdrom_disk_type = test_dict.get("cdrom_disk_type")
-                    disk_xml = add_disk_xml(dev_type, source_file,
+                    disk_xml = add_disk_xml(test, dev_type, source_file,
                                             image_size, policy,
                                             cdrom_disk_type)
 
@@ -1758,8 +1790,8 @@ def run(test, params, env):
                 status, output = run_remote_cmd(setup_loop_cmd, server_ip,
                                                 server_user, server_pwd)
                 if status:
-                    raise exceptions.TestFail("Failed to run '%s' on remote: %s"
-                                              % (setup_loop_cmd, output))
+                    test.fail("Failed to run '%s' on remote: %s"
+                              % (setup_loop_cmd, output))
 
             if attach_args:
                 logging.info("Prepare to attach disk to guest")
@@ -1789,11 +1821,11 @@ def run(test, params, env):
                 logging.debug("The current VM XML:\n%s", vmxml_backup.xmltreefile)
                 if start_filter_string:
                     if re.search(start_filter_string, str(e)):
-                        raise exceptions.TestSkipError("Failed to start VM: %s" % e)
+                        test.cancel("Failed to start VM: %s" % e)
                     else:
-                        raise exceptions.TestFail("Failed to start VM: %s" % e)
+                        test.fail("Failed to start VM: %s" % e)
                 else:
-                    raise exceptions.TestFail("Failed to start VM: %s" % e)
+                    test.fail("Failed to start VM: %s" % e)
 
             if disk_src_protocol != "iscsi":
                 vm_session = vm.wait_for_login()
@@ -1804,8 +1836,8 @@ def run(test, params, env):
             logging.debug("To run '%s' in VM: status=<%s>, output=<%s>",
                           guest_cmd, status, output)
             if status:
-                raise exceptions.TestFail("Failed to run '%s' : %s"
-                                          % (guest_cmd, output))
+                test.fail("Failed to run '%s' : %s"
+                          % (guest_cmd, output))
             logging.info(output)
 
         target_image_source = test_dict.get("target_image_source", disk_source)
@@ -1825,10 +1857,10 @@ def run(test, params, env):
                 create_target_pool = True
         if target_pool_name and create_target_pool:
             create_target_image = False
-            pool_created = create_destroy_pool_on_remote("create", test_dict)
+            pool_created = create_destroy_pool_on_remote(test, "create", test_dict)
             if not pool_created:
-                raise exceptions.TestError("Create pool on remote host '%s' "
-                                           "failed." % server_ip)
+                test.error("Create pool on remote host '%s' "
+                           "failed." % server_ip)
             remote_image_list.append(target_image_source)
         elif target_pool_name and not create_target_pool:
             pool_destroyed = destroy_active_pool_on_remote(test_dict)
@@ -1850,8 +1882,8 @@ def run(test, params, env):
                 status, output = run_remote_cmd(cmd, server_ip,
                                                 server_user, server_pwd)
                 if status:
-                    raise exceptions.TestFail("Failed to run '%s' on remote: %s"
-                                              % (cmd, output))
+                    test.fail("Failed to run '%s' on remote: %s"
+                              % (cmd, output))
 
                 remote_image_list.append(target_image_source)
         # Below cases are to test option "--migrate-disks" with mix of storage and
@@ -1898,14 +1930,13 @@ def run(test, params, env):
                 status, output = run_remote_cmd(cmd, server_ip,
                                                 server_user, server_pwd)
                 if status:
-                    raise exceptions.TestFail("Failed to run '%s' on remote: %s"
-                                              % (cmd, output))
+                    test.fail("Failed to run '%s' on remote: %s"
+                              % (cmd, output))
             remote_image_list.append(new_disk_source)
         if pause_vm:
             if not vm.pause():
-                raise exceptions.TestFail("Guest state should be "
-                                          "paused after started "
-                                          "because of init guest state")
+                test.fail("Guest state should be paused after started "
+                          "because of init guest state")
         if reboot_vm:
             vm.reboot()
 
@@ -1914,11 +1945,11 @@ def run(test, params, env):
             status, output = run_remote_cmd(cmd, server_ip, server_user,
                                             server_pwd)
             if status:
-                raise exceptions.TestFail("Failed to run '%s' on remote: %s"
-                                          % (cmd, output))
+                test.fail("Failed to run '%s' on remote: %s"
+                          % (cmd, output))
 
         if get_migr_cache:
-            check_virsh_command_and_option("migrate-compcache")
+            check_virsh_command_and_option(test, "migrate-compcache")
             result = virsh.migrate_compcache(vm_name)
             logging.debug(result)
 
@@ -1935,16 +1966,14 @@ def run(test, params, env):
             logging.info("Execute command <%s> in the VM", cmd)
             status, output = vm_session.cmd_status_output(cmd, timeout=600)
             if status:
-                raise exceptions.TestFail("Failed to run %s in VM: %s"
-                                          % (cmd, output))
+                test.fail("Failed to run %s in VM: %s" % (cmd, output))
             logging.debug(output)
 
             cmd = test_dict.get("memhog_install_pkg")
             logging.info("Execute command <%s> in the VM", cmd)
             status, output = vm_session.cmd_status_output(cmd, timeout=600)
             if status:
-                raise exceptions.TestFail("Failed to run %s in VM: %s"
-                                          % (cmd, output))
+                test.fail("Failed to run %s in VM: %s" % (cmd, output))
             logging.debug(output)
 
             # memory size should be less than VM's physical memory
@@ -1953,8 +1982,7 @@ def run(test, params, env):
             logging.info("Execute command <%s> in the VM", cmd)
             status, output = vm_session.cmd_status_output(cmd, timeout=600)
             if status:
-                raise exceptions.TestFail("Failed to run %s in VM: %s"
-                                          % (cmd, output))
+                test.fail("Failed to run %s in VM: %s" % (cmd, output))
             logging.debug(output)
 
         run_cmd_in_vm = test_dict.get("run_cmd_in_vm")
@@ -1962,8 +1990,8 @@ def run(test, params, env):
             logging.info("Execute command <%s> in the VM", run_cmd_in_vm)
             status, output = vm_session.cmd_status_output(run_cmd_in_vm)
             if status:
-                raise exceptions.TestFail("Failed to run %s in VM: %s"
-                                          % (run_cmd_in_vm, output))
+                test.fail("Failed to run %s in VM: %s"
+                          % (run_cmd_in_vm, output))
             logging.debug(output)
 
         if enable_stress_test and stress_args and stress_type:
@@ -1971,15 +1999,15 @@ def run(test, params, env):
 
             if s_list and s_list[-1] == "vms":
                 if not vm_session:
-                    raise exceptions.TestFail("The VM session is inactive")
+                    test.fail("The VM session is inactive")
                 else:
                     cmd = "yum install patch -y"
                     logging.info("Run '%s' in VM", cmd)
                     status, output = vm_session.cmd_status_output(cmd,
                                                                   timeout=600)
                     if status:
-                        raise exceptions.TestFail("Failed to run %s in VM: %s"
-                                                  % (cmd, output))
+                        test.fail("Failed to run %s in VM: %s"
+                                  % (cmd, output))
                     logging.debug(output)
 
             elif s_list and s_list[-1] == "host":
@@ -1989,15 +2017,14 @@ def run(test, params, env):
                 err_msg = utils_test.load_stress(stress_type,
                                                  test_dict, [vm])
                 if len(err_msg):
-                    raise exceptions.TestFail("Add stress for migration failed:%s"
-                                              % err_msg[0])
+                    test.fail("Add stress for migration failed:%s"
+                              % err_msg[0])
             else:
-                raise exceptions.TestFail("The stress type looks like "
-                                          "'stress_in_vms, iozone_in_vms, "
-                                          "stress_on_host'")
+                test.fail("The stress type looks like "
+                          "'stress_in_vms, iozone_in_vms, stress_on_host'")
 
         if set_migr_cache_size:
-            check_virsh_command_and_option("migrate-compcache")
+            check_virsh_command_and_option(test, "migrate-compcache")
             result = virsh.migrate_compcache(vm_name, size=set_migr_cache_size)
             logging.debug(result)
 
@@ -2017,8 +2044,7 @@ def run(test, params, env):
 
             ret, n_client_c, n_server_c = setup_netsever_and_launch_netperf(test_dict)
             if not ret:
-                raise exceptions.TestError("Can not start netperf on %s"
-                                           % client_ip)
+                test.error("Can not start netperf on %s" % client_ip)
 
             new_args_dict = dict(test_dict)
             new_args_dict["server_ip"] = client_ip
@@ -2036,16 +2062,14 @@ def run(test, params, env):
 
             ret, n_client_s, n_server_s = setup_netsever_and_launch_netperf(new_args_dict)
             if not ret:
-                raise exceptions.TestError("Can not start netperf on %s"
-                                           % client_ip)
+                test.error("Can not start netperf on %s" % client_ip)
 
         speed = test_dict.get("set_migration_speed")
         if speed:
             cmd = "migrate-setspeed"
             if not virsh.has_help_command(cmd):
-                raise exceptions.TestSkipError("This version of libvirt "
-                                               "does not support "
-                                               "virsh command %s" % cmd)
+                test.cancel("This version of libvirt does not support "
+                            "virsh command %s" % cmd)
 
             logging.debug("Set migration speed to %s", speed)
             virsh.migrate_setspeed(vm_name, speed)
@@ -2065,7 +2089,7 @@ def run(test, params, env):
                     else:
                         logging.error("Command output %s" %
                                       ret.stdout.strip())
-                        raise exceptions.TestFail("Failed to attach-interface")
+                        test.fail("Failed to attach-interface")
             vm_xml_cxt = to_text(process.system_output("virsh dumpxml %s" % vm_name, shell=True))
             logging.debug("The VM XML with attached interface: \n%s",
                           vm_xml_cxt)
@@ -2117,18 +2141,16 @@ def run(test, params, env):
                                      " [%s].", p.pid)
                         time.sleep(delay)
                     else:
-                        raise exceptions.TestError("Fail to cancel"
-                                                   " migration: [%s]", p.pid)
+                        test.error("Fail to cancel migration: [%s]", p.pid)
                 else:
                     p.kill()
-                    raise exceptions.TestFail("Migration process is dead")
+                    test.fail("Migration process is dead")
 
             if check_domain_state:
                 domain_state = virsh.domstate(vm_name, debug=True).stdout.strip()
                 if expected_domain_state != domain_state:
-                    raise exceptions.TestFail("The domain state is not "
-                                              "expected: %s"
-                                              % domain_state)
+                    test.fail("The domain state is not expected: %s"
+                              % domain_state)
 
             # Give enough time for starting job
             t = 0
@@ -2157,17 +2179,24 @@ def run(test, params, env):
                     logging.info("stdout:[%s], stderr:[%s]", stdout, stderr)
                     opts = "--completed"
                     args = vm_name + " " + opts
-                    check_virsh_command_and_option("domjobinfo", opts)
+                    check_virsh_command_and_option(test, "domjobinfo", opts)
                     jobinfo = virsh.domjobinfo(args, debug=True,
                                                ignore_status=True).stdout
-                    logging.debug("Local job info:\n%s", jobinfo)
+                    default_cache = params.get("default_cache")
+                    if (default_cache and
+                       "Compression cache: {}".format(default_cache) in jobinfo):
+                        logging.debug("Find the default "
+                                      "compression cache: %s", default_cache)
+                    else:
+                        test.fail("Failed to find "
+                                  "default compression cache %s", default_cache)
                     cmd = "virsh domjobinfo %s %s" % (vm_name, opts)
                     logging.debug("Get remote job info")
                     status, output = run_remote_cmd(cmd, server_ip, server_user,
                                                     server_pwd)
                     if status:
-                        raise exceptions.TestFail("Failed to run '%s' on remote"
-                                                  ": %s" % (cmd, output))
+                        test.fail("Failed to run '%s' on remote: %s"
+                                  % (cmd, output))
                     else:
                         check_domjobinfo_on_complete(test, jobinfo, output)
 
@@ -2181,15 +2210,13 @@ def run(test, params, env):
             if abort_job and jobtype != "None":
                 job_ret = virsh.domjobabort(vm_name, debug=True)
                 if job_ret.exit_status:
-                    raise exceptions.TestError("Failed to abort active "
-                                               "domain job.")
+                    test.error("Failed to abort active domain job.")
                 else:
                     stderr = p.communicate()[1]
                     logging.debug(stderr)
                     err_str = ".*error.*migration.*job: canceled by client"
                     if not re.search(err_str, stderr):
-                        raise exceptions.TestFail("Can't find error: %s."
-                                                  % (err_str))
+                        test.fail("Can't find error: %s." % (err_str))
                     else:
                         logging.info("Find error: %s.", err_str)
 
@@ -2216,7 +2243,7 @@ def run(test, params, env):
                 stdout, stderr = p.communicate()
                 logging.info("stdout:<%s> , stderr:<%s>", stdout, stderr)
                 if stderr:
-                    raise exceptions.TestFail("Can't finish VM migration")
+                    test.fail("Can't finish VM migration")
 
             if p.poll():
                 try:
@@ -2247,7 +2274,7 @@ def run(test, params, env):
             vms = [vm]
             func_dict = {"disk_port": disk_port, "server_ip": server_ip,
                          "server_user": server_user, "server_pwd": server_pwd,
-                         "client_ip": client_ip}
+                         "client_ip": client_ip, "test_object": test}
             migration_test.do_migration(vms, None, uri, 'orderly',
                                         virsh_options,
                                         thread_timeout=900,
@@ -2260,8 +2287,8 @@ def run(test, params, env):
                                                  server_pwd,
                                                  shell_prompt=r"[\#\$]\s*$")
             else:
-                check_output(str(migration_test.ret), test_dict)
-                raise exceptions.TestFail("The migration with disks port failed")
+                check_output(test, str(migration_test.ret), test_dict)
+                test.fail("The migration with disks port failed")
 
         # For TLS reverse migration
         # This case do following steps:
@@ -2284,17 +2311,16 @@ def run(test, params, env):
                 remote_virsh_session = virsh.VirshPersistent(**remote_virsh_dargs)
                 logging.debug("Check if remote guest exists")
                 if remote_virsh_session.domain_exists(target_vm_name) is False:
-                    raise exceptions.TestSkipError("The guest '%s' on remote "
-                                                   "'%s' should be "
-                                                   "installed before the test."
-                                                   % (target_vm_name, server_ip))
+                    test.cancel("The guest '%s' on remote '%s' should be "
+                                "installed before the test."
+                                % (target_vm_name, server_ip))
                 # Check the prepared guest state on remote host.
                 # 'shut off' is expected.
                 logging.debug("Check if remote guest is in shutoff")
                 if remote_virsh_session.is_alive(target_vm_name):
-                    raise exceptions.TestError("The guest '%s' on remote "
-                                               "'%s' should not be alive."
-                                               % (target_vm_name, server_ip))
+                    test.error("The guest '%s' on remote "
+                               "'%s' should not be alive."
+                               % (target_vm_name, server_ip))
 
                 # Replace the disk of the remote guest
                 logging.debug("Replace guest image with nfs image")
@@ -2389,8 +2415,7 @@ def run(test, params, env):
                           "Check it...")
             libvirtd = utils_libvirtd.Libvirtd()
             if not libvirtd.is_running():
-                raise exceptions.TestFail("Local libvirtd service is"
-                                          " crashed unexpectedly.")
+                test.fail("Local libvirtd service is crashed unexpectedly.")
             session = None
             remote_session = None
             try:
@@ -2401,15 +2426,15 @@ def run(test, params, env):
                                                 r"[\#\$]\s*$")
                 libvirtd = utils_libvirtd.Libvirtd(session=session)
                 if not libvirtd.is_running():
-                    raise exceptions.TestFail("Remote libvirtd service is"
-                                              " crashed unexpectedly.")
+                    test.fail("Remote libvirtd service is"
+                              " crashed unexpectedly.")
 
                 logging.debug("Guest '%s' should not exist locally. "
                               "Check it...",
                               target_vm_name)
                 if virsh.domain_exists(target_vm_name) is True:
-                    raise exceptions.TestFail("Guest '%s' should not exist "
-                                              "locally" % target_vm_name)
+                    test.fail("Guest '%s' should not exist locally"
+                              % target_vm_name)
 
                 logging.debug("Guest '%s' should be running remotely. "
                               "Check it...",
@@ -2419,14 +2444,13 @@ def run(test, params, env):
                 logging.debug("Guest '%s' on remote host is '%s'",
                               target_vm_name, domstate.stdout.strip())
                 if domstate.stdout.strip() != "running":
-                    raise exceptions.TestFail("Guest '%s' on remote host "
-                                              "is not running."
-                                              % target_vm_name)
+                    test.fail("Guest '%s' on remote host is not running."
+                              % target_vm_name)
 
             except (remote.LoginError, aexpect.ShellError) as detail:
-                raise exceptions.TestError(detail)
+                test.error(detail)
             except (process.CmdError, remote.SCPError) as detail:
-                raise exceptions.TestError(detail)
+                test.error(detail)
             finally:
                 if session:
                     session.close()
@@ -2443,16 +2467,16 @@ def run(test, params, env):
                 status, output = run_remote_cmd(cmd, server_ip, server_user,
                                                 server_pwd)
                 if status:
-                    raise exceptions.TestFail("Failed to run '%s' on remote: %s"
-                                              % (cmd, output))
+                    test.fail("Failed to run '%s' on remote: %s"
+                              % (cmd, output))
                 time.sleep(state_delay)
                 if tgt == "mem" and set_tgt_pm_wakeup:
                     cmd = "virsh dompmwakeup %s" % vm_name
                     status, output = run_remote_cmd(cmd, server_ip, server_user,
                                                     server_pwd)
                     if status:
-                        raise exceptions.TestFail("Failed to run '%s' on the "
-                                                  "remote: %s" % (cmd, output))
+                        test.fail("Failed to run '%s' on the remote: %s"
+                                  % (cmd, output))
 
         run_cmd_in_vm = test_dict.get("run_cmd_in_vm_after_migration")
         if run_cmd_in_vm:
@@ -2478,24 +2502,24 @@ def run(test, params, env):
                                                 password=server_pwd)
             cmdResult = remote_runner.run(cmd, ignore_status=True)
             if cmdResult.exit_status:
-                raise exceptions.TestError("Failed to run '%s' on remote: %s"
-                                           % (cmd, cmdResult))
+                test.error("Failed to run '%s' on remote: %s"
+                           % (cmd, cmdResult))
             local_disk_size = test_dict.get("local_disk_size")
             if cmdResult.stdout.strip() != local_disk_size:
-                raise exceptions.TestFail("Image location: %s \n"
-                                          "The image sizes are not equal.\n"
-                                          "Remote size is %s\n"
-                                          "Local size is %s"
-                                          % (local_disk_image,
-                                             cmdResult.stdout.strip(),
-                                             local_disk_size))
+                test.fail("Image location: %s \n"
+                          "The image sizes are not equal.\n"
+                          "Remote size is %s\n"
+                          "Local size is %s"
+                          % (local_disk_image,
+                             cmdResult.stdout.strip(),
+                             local_disk_size))
 
         if cmd and check_image_size and not support_precreation:
             status, output = run_remote_cmd(cmd, server_ip, server_user,
                                             server_pwd)
             if status:
-                raise exceptions.TestFail("Failed to run '%s' on remote: %s"
-                                          % (cmd, output))
+                test.fail("Failed to run '%s' on remote: %s"
+                          % (cmd, output))
             logging.debug("Remote disk image info: %s", output)
 
         cmd = test_dict.get("target_qemu_filter")
@@ -2503,8 +2527,8 @@ def run(test, params, env):
             status, output = run_remote_cmd(cmd, server_ip, server_user,
                                             server_pwd)
             if status:
-                raise exceptions.TestFail("Failed to run '%s' on remote: %s"
-                                          % (cmd, output))
+                test.fail("Failed to run '%s' on remote: %s"
+                          % (cmd, output))
             logging.debug("The filtered result:\n%s", output)
 
         if restart_libvirtd == "yes":
@@ -2521,12 +2545,12 @@ def run(test, params, env):
             status, output = run_remote_cmd(cmd, server_ip, server_user,
                                             server_pwd)
             if status or not re.search("paused", output):
-                raise exceptions.TestFail("Failed to run '%s' on remote: %s"
-                                          % (cmd, output))
+                test.fail("Failed to run '%s' on remote: %s"
+                          % (cmd, output))
 
         # Check iothread after migration.
         if driver_iothread:
-            check_iothread_after_migration(vm_name, remote_virsh_dargs, driver_iothread)
+            check_iothread_after_migration(test, vm_name, remote_virsh_dargs, driver_iothread)
 
         grep_str_local = test_dict.get("grep_str_from_local_libvirt_log")
         if config_libvirtd == "yes" and grep_str_local:
@@ -2540,8 +2564,7 @@ def run(test, params, env):
                                             server_pwd)
             logging.debug("The command result: %s", output)
             if status:
-                raise exceptions.TestFail("Failed to run '%s' on remote: %s"
-                                          % (cmd, output))
+                test.fail("Failed to run '%s' on remote: %s" % (cmd, output))
         # Check points for --migrate-disk cases.
         if migrate_disks and status_error == "no":
             # Check the libvirtd.log
@@ -2550,16 +2573,14 @@ def run(test, params, env):
             status, output = run_remote_cmd(cmd, server_ip, server_user,
                                             server_pwd)
             if status:
-                raise exceptions.TestFail("Can not find expected log '%s' "
-                                          "on remote host '%s'"
-                                          % (grep_from_remote,
-                                             server_ip))
+                test.fail("Can not find expected log '%s' on remote host '%s'"
+                          % (grep_from_remote, server_ip))
             if (re.search(r".*drive-virtio-disk0.*", output) is None or
                     re.search(r".*drive-virtio-disk1.*", output) is None):
-                raise exceptions.TestFail("The actual output:\n%s\n"
-                                          "Can not find 'disk0' or 'disk1' "
-                                          "in the log on remote host '%s'"
-                                          % (output, server_ip))
+                test.fail("The actual output:\n%s\n"
+                          "Can not find 'disk0' or 'disk1' "
+                          "in the log on remote host '%s'"
+                          % (output, server_ip))
             if re.search(r".*drive-virtio-disk2.*", output) is None:
                 if virsh_options.find("--migrate-disks") >= 0:
                     # This is expected as shared image should not be
@@ -2567,10 +2588,10 @@ def run(test, params, env):
                     logging.debug("The shared image is not copied when "
                                   " '--migrate-disks' option")
                 else:
-                    raise exceptions.TestFail("The actual output:\n%s\n"
-                                              "Can not find expected log "
-                                              "'disk2' on remote host '%s'"
-                                              % (output, server_ip))
+                    test.fail("The actual output:\n%s\n"
+                              "Can not find expected log "
+                              "'disk2' on remote host '%s'"
+                              % (output, server_ip))
             else:
                 if virsh_options.find("--migrate-disks") < 0:
                     # This is expected as shared image should be
@@ -2578,12 +2599,12 @@ def run(test, params, env):
                     logging.debug("The shared image is copied when "
                                   "no '--migrate-disks' option")
                 else:
-                    raise exceptions.TestFail("The actual output:\n%s\n"
-                                              "Find unexpected log "
-                                              "'disk2' on remote host '%s'"
-                                              % (output, server_ip))
+                    test.fail("The actual output:\n%s\n"
+                              "Find unexpected log "
+                              "'disk2' on remote host '%s'"
+                              % (output, server_ip))
             # Check the disks on VM can work correctly.
-            check_vm_disk_after_migration(vm, test_dict)
+            check_vm_disk_after_migration(test, vm, test_dict)
 
         if migr_vm_back:
             # Pre migration setup for local machine
@@ -2599,8 +2620,8 @@ def run(test, params, env):
                 destroy_cmd = "virsh destroy %s" % vm_name
                 run_remote_cmd(destroy_cmd, server_ip,
                                server_user, server_pwd)
-                raise exceptions.TestFail("Failed to run '%s' on remote: %s"
-                                          % (cmd, output))
+                test.fail("Failed to run '%s' on remote: %s"
+                          % (cmd, output))
 
     finally:
         logging.info("Recovery test environment")
@@ -2625,9 +2646,8 @@ def run(test, params, env):
             status, output = run_remote_cmd(cmd, server_ip, server_user,
                                             server_pwd)
             if status:
-                raise exceptions.TestSkipError("Failed to set SELinux "
-                                               "in enforcing mode, %s"
-                                               % output)
+                test.cancel("Failed to set SELinux "
+                            "in enforcing mode, %s" % output)
 
         # Delete all rules in chain or all chains
         if add_iptables_rules:
@@ -2666,9 +2686,8 @@ def run(test, params, env):
                 status, output = run_remote_cmd(cmd, server_ip, server_user,
                                                 server_pwd)
                 if status:
-                    raise exceptions.TestFail("Failed to run '%s' "
-                                              "on the remote: %s"
-                                              % (cmd, output))
+                    test.fail("Failed to run '%s' on the remote: %s"
+                              % (cmd, output))
         # Recovery remotely libvirt service
         if stop_libvirtd_remotely:
             libvirt.remotely_control_libvirtd(server_ip, server_user,
@@ -2685,8 +2704,8 @@ def run(test, params, env):
                 status, output = run_remote_cmd(cmd, server_ip, server_user,
                                                 server_pwd)
                 if status:
-                    raise exceptions.TestFail("Failed to run '%s' on remote: %s"
-                                              % (cmd, output))
+                    test.fail("Failed to run '%s' on remote: %s"
+                              % (cmd, output))
 
             if not status and re.search("--persistent", virsh_options):
                 cmd = "virsh undefine %s" % vm_name
@@ -2694,8 +2713,8 @@ def run(test, params, env):
                 status, output = run_remote_cmd(cmd, server_ip, server_user,
                                                 server_pwd)
                 if status or not re.search(match_string, output):
-                    raise exceptions.TestFail("Failed to run '%s' on the remote: %s"
-                                              % (cmd, output))
+                    test.fail("Failed to run '%s' on the remote: %s"
+                              % (cmd, output))
             vm.connect_uri = "qemu:///system"
 
         libvirtd = utils_libvirtd.Libvirtd()
@@ -2724,7 +2743,7 @@ def run(test, params, env):
                 logging.debug("Recover remote guest xml")
                 remote_virsh_session.define(xml_path)
             except (process.CmdError, remote.SCPError) as detail:
-                raise exceptions.TestError(detail)
+                test.error(detail)
             finally:
                 remote_virsh_session.close_session()
 
@@ -2748,8 +2767,8 @@ def run(test, params, env):
                 status, output = run_remote_cmd(cmd, server_ip, server_user,
                                                 server_pwd)
                 if status:
-                    raise exceptions.TestFail("Failed to run '%s' on remote: %s"
-                                              % (cmd, output))
+                    test.fail("Failed to run '%s' on remote: %s"
+                              % (cmd, output))
 
         # vms will be shutdown, so no need to do this cleanup
         # And migrated vms may be not login if the network is local lan
@@ -2765,13 +2784,13 @@ def run(test, params, env):
                 status, output = run_remote_cmd(cmd, server_ip, server_user,
                                                 server_pwd)
                 if status:
-                    raise exceptions.TestFail("Failed to run '%s' on remote: %s"
-                                              % (cmd, output))
+                    test.fail("Failed to run '%s' on remote: %s"
+                              % (cmd, output))
         if pool_created:
-            pool_destroyed = create_destroy_pool_on_remote("destroy", test_dict)
+            pool_destroyed = create_destroy_pool_on_remote(test, "destroy", test_dict)
             if not pool_destroyed:
-                raise exceptions.TestError("Destroy pool on remote '%s' failed."
-                                           % server_ip)
+                test.error("Destroy pool on remote '%s' failed."
+                           % server_ip)
 
         if nfs_mount_dir:
             logging.info("To remove '%s' on remote host ...", nfs_mount_dir)
@@ -2779,8 +2798,8 @@ def run(test, params, env):
             status, output = run_remote_cmd(cmd, server_ip, server_user,
                                             server_pwd)
             if status:
-                raise exceptions.TestFail("Failed to run '%s' on the remote: %s"
-                                          % (cmd, output))
+                test.fail("Failed to run '%s' on the remote: %s"
+                          % (cmd, output))
 
         # Stop netserver service and clean up netperf package
         if n_server_c:


### PR DESCRIPTION
Add some new checking points to the case, such as
- Checking domjobinfo with --completion option to find default cache
- Checking the libvirtd.log with desired string

Replace exceptions.Test* with test.* according to the strategy

Signed-off-by: Dan Zheng <dzheng@redhat.com>