### PR TITLE
Add clear failure message when no newly mpath dev found

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_multipath.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multipath.py
@@ -112,6 +112,8 @@ def run(test, params, env):
         cur_mpath_devs = mpath.find_mpath_devs()
         new_mpath_devs = list(set(cur_mpath_devs).difference(
             set(old_mpath_devs)))
+        if not new_mpath_devs:
+            test.fail("No newly added multipath devices found.")
         logging.debug("newly added mpath devs are: %s", new_mpath_devs)
         # Prepare disk xml
         disk_params = {}


### PR DESCRIPTION
If multipath devs not created without this message, case will be
failed with error "IndexError: list index out of range" which will
cause the failure report merged into other failures with same error
message.

Signed-off-by: Yi Sun <yisun@redhat.com>