### PR TITLE
Fix the FileNotFoundError:No such file or directory:'/usr/share/libvi…

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_dumpxml.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_dumpxml.py
@@ -67,7 +67,7 @@ def run(test, params, env):
             for key, value in item.items():
                 if value == 'require':
                     features.append(key)
-        return list(set(features) | set(utils_misc.get_model_features(modelname)))
+        return list(set(features))
 
     def check_cpu(xml, cpu_match):
         """


### PR DESCRIPTION
The FileNotFoundError is caused by a calling to  utils_misc.get_model_features()
This function is to get features of one specific model from /usr/share/libvirt/cpu_map.xml.
But there is no /usr/share/libvirt/cpu_map.xml file on the RHEL8.0 system.
