### PR TITLE
virsh_attach_detach_disk: change dist target

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_disk.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_disk.cfg
@@ -10,8 +10,6 @@
     at_dt_disk_test_twice = 'no'
     at_dt_disk_device = disk
     at_dt_disk_device_target = vdb
-    machine_type == s390-virtio:
-      at_dt_disk_device_target = sda
     at_dt_disk_bus_type = virtio
     at_dt_disk_device_source = "attach.img"
     at_dt_disk_device_source_format = "raw"
@@ -185,6 +183,8 @@
                     variants:
                         - raw_format:
                         - qcow2_format:
+                            s390-virtio:
+                              at_dt_disk_device_target = sda
                             at_dt_disk_device_source_format = "qcow2"
                 - only_attach_disk:
                     only attach_disk


### PR DESCRIPTION
Change disk target attached on s390x to make the case stable.

Signed-off-by: Dan Zheng <dzheng@redhat.com>