### PR TITLE
Start guest with direct type interface

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_network.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_network.cfg
@@ -201,6 +201,13 @@
                             iface_source = "{'dev':'eno1','mode':'bridge'}"
                             iface_type = "direct"
                             iface_model = "rtl8139"
+                        - exist_macvtap:
+                            net_forward = "{'dev':'eno1','mode':'bridge'}"
+                            define_macvtap = "yes"
+                            iface_model = "virtio"
+                            iface_type = "network"
+                            attach_iface = "yes"
+                            iface_num = 4
                 - net_passthrough:
                     net_forward = "{'dev':'eno1','mode':'passthrough'}"
                     change_iface_option = "yes"

--- a/libvirt/tests/src/virtual_network/iface_network.py
+++ b/libvirt/tests/src/virtual_network/iface_network.py
@@ -555,6 +555,7 @@ TIMEOUT 3"""
     boot_failure = "yes" == params.get("boot_failure", "no")
     ipt_rules = []
     ipt6_rules = []
+    define_macvtap = "yes" == params.get("define_macvtap", "no")
 
     # Destroy VM first
     if vm.is_alive():
@@ -606,6 +607,11 @@ TIMEOUT 3"""
                              forward['dev'], net_ifs[0])
                 forward['dev'] = net_ifs[0]
                 params["net_forward"] = str(forward)
+            if define_macvtap:
+                for i in [0, 2, 4]:
+                    cmd = "ip l add li %s macvtap%s type macvtap" % (forward['dev'], i)
+                    process.run(cmd, shell=True, verbose=True)
+                process.run("ip l", shell=True, verbose=True)
             forward_iface = params.get("forward_iface")
             if forward_iface:
                 interface = [x for x in forward_iface.split()]
@@ -798,6 +804,15 @@ TIMEOUT 3"""
             vm.start()
             if start_error:
                 test.fail("VM started unexpectedly")
+            if define_macvtap:
+                cmd = "ls /sys/devices/virtual/net"
+                output = process.run(cmd, shell=True, verbose=True).stdout_text
+                macvtap_list = re.findall(r'macvtap0|macvtap1|macvtap2|macvtap3'
+                                          r'|macvtap4|macvtap5|macvtap6|macvtap7',
+                                          output)
+                logging.debug("The macvtap_list is %s" % macvtap_list)
+                if set(macvtap_list) != set(['macvtap' + str(x) for x in range(8)]):
+                    test.fail("Existing macvtap device %s is not expected! should be macvtap(0-7)" % macvtap_list)
             if pxe_boot:
                 # Just check network boot messages here
                 try:
@@ -951,3 +966,6 @@ TIMEOUT 3"""
 
         if test_ipv6_address and original_accept_ra != '2':
             process.system(sysctl_cmd + "=%s" % original_accept_ra)
+        if define_macvtap:
+            cmd = "ip l del macvtap0; ip l del macvtap2; ip l del macvtap4"
+            process.run(cmd, shell=True, verbose=True)


### PR DESCRIPTION
Start guest with direct type interface when there are existing macvtap
devices created by other than libvirt.

Signed-off-by: yalzhang <yalzhang@redhat.com>