### PR TITLE
Fix 'virsh vcpupin' initial checking failure

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_vcpupin.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_vcpupin.py
@@ -221,7 +221,7 @@ def run(test, params, env):
             for vcpu in range(int(guest_vcpu_count)):
                 vcpu_pid = vm.get_vcpus_pid()[vcpu]
                 # Check the result of vcpupin command.
-                check_vcpupin(vm.name, vcpu, str(','.join(cpus_list)), pid, vcpu_pid)
+                check_vcpupin(vm.name, vcpu, str(','.join(list(map(str, cpuutils.cpu_online_list())))), pid, vcpu_pid)
             return
 
         if multi_dom:


### PR DESCRIPTION
"Shorten the cpus_list if it's too long" commit caused this failure
For the initial vcpupin checking, should use all active host cpus

Signed-off-by: Jing Yan <jiyan@redhat.com>