### PR TITLE
Fix: update unsupported case from skip to pass

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_update.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_update.cfg
@@ -120,8 +120,12 @@
                     network_section = "portgroup"
                 - bridge_t:
                     network_section = "bridge"
+                    status_error = "yes"
+                    error_type = "not-support"
                 - forward:
                     network_section = "forward"
+                    status_error = "yes"
+                    error_type = "not-support"
                 - forward_interface:
                     network_section = "forward-interface"
                     variants:
@@ -134,6 +138,8 @@
                             guest_iface_num = 4
                 - ip:
                     network_section = "ip"
+                    status_error = "yes"
+                    error_type = "not-support"
                 - ip_dhcp_range:
                     network_section = "ip-dhcp-range"
                     variants:
@@ -168,6 +174,11 @@
                     update_command = "modify"
                     variants:
                         - default:
+                            only portgroup.net_active, ip-dhcp-host.net_active
+                        - no_modify:
+                            only ip-dhcp-range, forward-interface
+                            status_error = "yes"
+                            error_type = "modify"
                         - ipv4_oper:
                             only ip_dhcp_host.ipv4_addr.net_active.options_no
                             variants:
@@ -308,10 +319,12 @@
                             variants:
                                 - modify:
                                     update_command = "modify"
+                                    error_type = "modify"
                                 - dns_disable:
                                     without_dns_txt = "yes"
                                     without_dns_srv = "yes"
                                     without_dns_host = "yes"
+                                    without_dns_forwarder = "yes"
                                     dns_enable = "no"
                                     error_type = "dns-disable"
                 - ip_dhcp_oper:
@@ -536,3 +549,18 @@
                                     update_command = "delete"
                                     update_sec = "ip"
                                     without_sec = "id"
+                - not_support:
+                    error_type = "not-support"
+                    update_command = "delete"
+                    variants:
+                        - domain:
+                            network_section = "domain"
+                        - dns:
+                            network_section = "dns"
+                            error_type = "unrecognized"
+                        - dns-forwarder:
+                            network_section = "dns-forwarder"
+                            error_type = "unrecognized"
+                        - mtu:
+                            network_section = "mtu"
+                            error_type = "unrecognized"


### PR DESCRIPTION
net_update.py: some network section do not support live update, so the
update command will report error. These cases were skipped before, update
the test resule to be pass. And add several negative cases.

Signed-off-by: yalzhang <yalzhang@redhat.com>