### PR TITLE
migrate_vm: Fix domain define failure

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_vm.cfg
+++ b/libvirt/tests/cfg/migration/migrate_vm.cfg
@@ -383,7 +383,7 @@
                     variants:
                         - vm_without_video:
                             del_vm_video_dev = "yes"
-                            iface_address = "type=pci,domain=0x0000,bus=0x00,slot=0x02,function=0x0"
+                            iface_address = "type=pci,domain=0x0000,bus=0x00,slot=0x03,function=0x0"
                         - with_io_throttling:
                             blkdevio_device = "vda"
                             variants:


### PR DESCRIPTION
Failed to define domain in migration vm_without_video test.
The reason is that same PCI address used in XML file.
Provide a free slot for interface attached.

Signed-off-by: Yingshun Cui <yicui@redhat.com>