### PR TITLE
Update value assignment of hpt of vm features

### DIFF
--- a/libvirt/tests/src/migration/migrate_options_shared.py
+++ b/libvirt/tests/src/migration/migrate_options_shared.py
@@ -82,7 +82,9 @@ def run(test, params, env):
         """
         features_xml = vm_xml.VMFeaturesXML()
         if feature == 'hpt':
-            features_xml.hpt_resizing = value
+            hpt_xml = vm_xml.VMFeaturesHptXML()
+            hpt_xml.resizing = value
+            features_xml.hpt = hpt_xml
         elif feature == 'htm':
             features_xml.htm = value
         vmxml.features = features_xml


### PR DESCRIPTION
Hpt of vm features is now put as an xml object instead of just one
value(resizing). Update the value assignment in migration test code
to keep correct.

Signed-off-by: haizhao <haizhao@redhat.com>

based on: https://github.com/avocado-framework/avocado-vt/pull/2045