### PR TITLE
Change guest name for virt-v2v acceptance gating test

### DIFF
--- a/v2v/tests/cfg/convert_vm_to_ovirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_ovirt.cfg
@@ -72,6 +72,7 @@
         - arch_i386:
             no latest8
             no latest7
+            no gate_vm
             no win2008r2
             no win2012
             no win2012r2
@@ -96,6 +97,7 @@
                     os_version = "rhel5.11"
         - windows:
             no pv
+            no gate_vm
             os_type = "windows"
             shutdown_command = "shutdown /s /f /t 0"
             reboot_command = "shutdown /r /f /t 0"
@@ -158,6 +160,7 @@
                 - pv:
                     no latest8
                     no latest7
+                    no gate_vm
                     vir_mode = "pv"
                 - hvm:
                     vir_mode = "hvm"
@@ -188,6 +191,8 @@
                 - vm:
                     # main_vm = ${esx_version}-${os_version}-${vm_arch}
                     main_vm = "ESX_VM_NAME_V2V_EXAMPLE"
+                - gate_vm:
+                    main_vm = "GATE_VM_NAME_V2V_EXAMPLE"
     # rhv_upload only supports raw format now.
     qcow2_f..rhv_upload:
     output_format = "raw"


### PR DESCRIPTION
Because previous guest can't be deleted successfully on rhv env
sometimes after converting by the other tests,change guest to
avoid mac duplicated failure

Signed-off-by: mxie91 <mxie@redhat.com>