### PR TITLE
Skip pci_bridge_auto_add cases for q35 machine type

### DIFF
--- a/libvirt/tests/cfg/controller/controller_functional.cfg
+++ b/libvirt/tests/cfg/controller/controller_functional.cfg
@@ -5,20 +5,13 @@
     check_qemu = "yes"
     check_within_guest = "yes"
     variants:
-        - machine_i440fx:
-            os_machine = 'pc'
-        - machine_pseries:
-            os_machine = 'pseries'
-        - machine_q35:
-            os_machine = 'q35'
-    variants:
         - positive_tests:
             remove_address = "yes"
             run_vm = "yes"
             controller_type = pci
             variants:
                 - pci_bridge_auto_add:
-                    only machine_i440fx
+                    only i440fx 
                     remove_address = "no"
                     variants:
                         - no_pci_controller:
@@ -37,26 +30,26 @@
                             controller_index = 3
                             controller_index_second = 5
                 - pci_root:
-                    only machine_i440fx
+                    only i440fx
                     controller_type = pci
                     controller_model = pci-root
                     controller_pcihole64 = 1024
                 - pcie_root:
-                    only machine_q35
+                    only q35
                     controller_type = pci
                     controller_model = pcie-root
                 - second_level_bridge:
-                    only machine_i440fx
+                    only i440fx
                     controller_model = pci-bridge
                     controller_index = 1
                     controller_address = 00:02.0
                     second_level_controller_num = 8
                 - virtio_serial:
-                    no machine_q35
+                    no q35
                     controller_type = virtio-serial
                     controller_vectors = '1'
                 - virtio_serial_0_vectors:
-                    no machine_q35
+                    no q35
                     controller_type = virtio-serial
                     controller_vectors = '0'
                 - usb_controller:
@@ -64,10 +57,10 @@
                     variants:
                         # ehci and ich9-ehci1 are USB2.0 controller model
                         - ehci_model:
-                            no machine_pseries
+                            no pseries
                             controller_model = ehci
                         - ich9_ehci1_model:
-                            no machine_pseries
+                            no pseries
                             controller_model = ich9-ehci1
                             companion_controller_model = ich9-uhci
                             companion_controller_num = 3
@@ -75,15 +68,15 @@
                             controller_index = 0
                         # nec-xhci and qemu-xhci are USB3.0 controller model
                         - nec_xhci_model:
-                            no machine_pseries
+                            no pseries
                             controller_model = nec-xhci
                         - qemu_xhci_model:
                             variants:
                                 - non_pseries_machine:
-                                    no machine_pseries
+                                    no pseries
                                     controller_model = qemu-xhci
                                 - pseries_machine:
-                                    only machine_pseries
+                                    only pseries
                                     setup_controller = "no"
                     variants:
                         - auto_addr:
@@ -101,10 +94,10 @@
                             err_msg = 'XML error: pci-root and pcie-root controllers should have index 0'
                             variants:
                                 - pci_root:
-                                    only machine_i440fx
+                                    only i440fx
                                     controller_model = pci-root
                                 - pcie_root:
-                                    only machine_q35
+                                    only q35
                                     controller_model = pcie-root
                         - negative:
                             controller_index = -1
@@ -113,7 +106,7 @@
                                     controller_model = pci-bridge
                                     err_msg = "Cannot parse controller index ${controller_index}"
                                 - pcie_root:
-                                    only machine_q35
+                                    only q35
                                     err_msg = 'Cannot parse controller index ${controller_index}'
                                     controller_model = pcie-root
                         - zero:
@@ -123,26 +116,26 @@
                                     controller_model = pci-bridge
                             variants:
                                 - i440fx_machine:
-                                    only machine_i440fx
+                                    only i440fx
                                     err_msg = "The PCI controller with index='0' must be model='pci-root'"
                                 - pseries_machine:
-                                    only machine_pseries
+                                    only pseries
                                     err_msg = "The PCI controller with index='0' must be model='pci-root'"
                                 - q35_machine:
-                                    only machine_q35
+                                    only q35
                                     err_msg = "The PCI controller with index='0' must be model='pcie-root'"
                         - exceed_max:
-                            no machine_pseries
+                            no pseries
                             controller_index = 256
                             variants:
                                 - pci_bridge:
                                     controller_model = pci-bridge
                             variants:
                                 - i440fx_machine:
-                                    only machine_i440fx
+                                    only i440fx
                                     err_msg = ".*PCI controller index ${controller_index} too high, maximum is 255"
                                 - q35_machine:
-                                    only machine_q35
+                                    only q35
                                     err_msg = ".*PCI slot is needed to connect a PCI controller model='pcie-root-port'"
                         - string_inx:
                             controller_index = 'abc'
@@ -158,13 +151,13 @@
                                     controller_model = pci-bridge
                                     err_msg = ".*index must be larger than bus"
                                 - pci_expander_bus:
-                                    only machine_i440fx
+                                    only i440fx
                                     controller_model = 'pci-expander-bus'
                                     err_msg = "cannot be plugged into the PCI controller with index='${controller_index}'"
                         - index_less_bus:
                             controller_index = 2
                             controller_address = 03:01.0
-                            only machine_i440fx
+                            only i440fx
                             variants:
                                 - pci_bridge:
                                     controller_model = pci-bridge
@@ -184,11 +177,11 @@
                     controller_index = 0
                     variants:
                         - pcie_root_model:
-                            only machine_i440fx
+                            only i440fx
                             controller_model = 'pcie-root'
                             err_msg = "The PCI controller.*index='0' must be model='pci-root'"
                         - pci_root_model:
-                            only machine_q35
+                            only q35
                             controller_model = 'pci-root'
                             err_msg = "The PCI controller.*index='0' must be model='pcie-root'"
                         - other_model:

--- a/libvirt/tests/src/controller/controller_functional.py
+++ b/libvirt/tests/src/controller/controller_functional.py
@@ -446,7 +446,7 @@ def run(test, params, env):
                 test.fail("Can't find target pci device"
                           " '%s' on guest " % addr_str)
 
-    os_machine = params.get('os_machine', None)
+    os_machine = params.get('machine_type', None)
     libvirt.check_machine_type_arch(os_machine)
     cntlr_type = params.get('controller_type', None)
     model = params.get('controller_model', None)


### PR DESCRIPTION
These cases are 'only i440fx',and get an error 'Invalid PCI address 0000:04:00.0. slot must be >= 1 ' if run with q35 machine type.
Hence skip there cases for q35.

Signed-off-by: Yingshun Cui <yicui@redhat.com>