### PR TITLE
vcpu_affinity sub case - check vcpu affinity after cold-unpluging vcpu

### DIFF
--- a/libvirt/tests/cfg/cpu/vcpu_affinity.cfg
+++ b/libvirt/tests/cfg/cpu/vcpu_affinity.cfg
@@ -36,13 +36,21 @@
                             vcpu = "7"
                             cputune_cpuset = "2-3"
                             current_vcpu = "1"
-                            setvcpus_option = "8"
+                            setvcpus_count = "8"
                         - vcpu_affinity_active:
                             hotplug_vcpu = "yes"
                             vcpu = "7"
                             cputune_cpuset = "3"
                             current_vcpu = "1"
-                            setvcpus_option = "8"
+                            setvcpus_count = "8"
+                        - vcpu_affinity_config:
+                            hotplug_vcpu = "yes"
+                            vcpu = "3"
+                            cputune_cpuset = "3"
+                            current_vcpu = "4"
+                            setvcpus_count = "3"
+                            setvcpus_option = "--config"
+                            vcpupin_option = "--config"
                         - offline_hostcpu:
                             check = "cputune_offline_hostcpu"
                             offline_hostcpus = "2,3"


### PR DESCRIPTION
this case is based on bug
    https://bugzilla.redhat.com/show_bug.cgi?id=1316371
this bug report that libvirt auto remove the vcpu affinity config
when unplug vcpu with "setvcpus --config"(cold-unplug)

Signed-off-by: Jin Li <jil@redhat.com>