### PR TITLE
add usb device sub case - start vm with usb controller alias configured

### DIFF
--- a/libvirt/tests/cfg/usb_device.cfg
+++ b/libvirt/tests/cfg/usb_device.cfg
@@ -21,17 +21,22 @@
             bus_controller = "pci-root,pci-bridge"
     variants:
         # usb controller
-        - usb30_controller:
+        - usb3_0:
             variants:
-                - nec_xhci_model_hub:
+                - nec_xhci_hub:
                     usb_hub = "yes"
                     usb_model = "nec-xhci"
-                - qemu_xhci_model:
+                - qemu_xhci:
                     usb_model = "qemu-xhci"
-        - usb20_controller:
+        - usb2_0:
             variants:
-                - companion_model:
+                - companion:
                     usb_model = "ich9-ehci1,ich9-uhci1,ich9-uhci2,ich9-uhci3"
+        - usb_all:
+            only bus_dev
+            only pcie-to-pci-bridge
+            usb_alias = "yes"
+            usb_model = "ich9-ehci1,ich9-uhci1,ich9-uhci2,ich9-uhci3,nec-xhci,qemu-xhci,piix3-uhci,piix4-uhci,vt82c686b-uhci"
     variants:
         # usb device
         - passthrough:


### PR DESCRIPTION
this case is based on bug
	https://bugzilla.redhat.com/show_bug.cgi?id=1552127

configure usb controllers with alias and check the name of controller,
masterbus and device id

Signed-off-by: Jin Li <jil@redhat.com>