### PR TITLE
migrate_options_shared: Add auto converge mig cases

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -27,8 +27,7 @@
     # Local URI
     virsh_migrate_connect_uri = "qemu:///system"
 
-    # Default not to change libvirtd configuration
-    config_libvirtd = "no"
+    log_outputs = "/var/log/libvirt/libvirtd.log"
 
     variants:
         - with_postcopy:
@@ -45,8 +44,7 @@
                     variants:
                         - mt_method:
                             only without_postcopy
-                            config_libvirtd = "yes"
-                            log_level= 1
+                            libvirtd_conf_dict = '{"log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
                             level = 9
                             threads = 5
                             dthreads = 5
@@ -70,8 +68,7 @@
                     virsh_migrate_options = "--live --verbose"
                     asynch_migrate = "yes"
                     low_speed = "40"
-                    config_libvirtd = "yes"
-                    log_level= 1
+                    libvirtd_conf_dict = '{"log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
                     diff_rate = '0.5'
                     jobinfo_item = 'Total downtime:'
                     actions_during_migration = "setmaxdowntime"
@@ -82,8 +79,7 @@
                     virsh_migrate_options = "--live --verbose"
                     asynch_migrate = "yes"
                     low_speed = "1"
-                    config_libvirtd = "yes"
-                    log_level= 1
+                    libvirtd_conf_dict = '{"log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
                     diff_rate = '0.5'
                     jobinfo_item = 'Memory bandwidth:'
                     actions_during_migration = "setspeed,domjobinfo"
@@ -93,14 +89,14 @@
                     virsh_migrate_extra = "--tls"
                     custom_pki_path = "/etc/pki/qemu"
                     qemu_tls = "yes"
-                    config_libvirtd = "yes"
-                    log_level= 1
+                    libvirtd_conf_dict = '{"log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
                     server_cn = "ENTER.YOUR.SERVER_CN"
                     client_cn = "ENTER.YOUR.CLIENT_CN"
                     grep_str_local_log = '"dir":"/etc/pki/qemu","endpoint":"client","verify-peer":true'
                     variants:
                         - verify_client:
                             disable_verify_peer = "no"
+                            qemu_conf_dict = '{"migrate_tls_x509_verify": "1"}'
                             grep_str_remote_log = '"dir":"/etc/pki/qemu","endpoint":"server","verify-peer":true'
                             variants:
                                 - no_post_after_precopy:
@@ -147,6 +143,24 @@
                             htm_state = "on"
                         - state_off:
                             htm_state = "off"
+                - auto-converge:
+                    qemu_conf_dict = '{"keepalive_interval": "-1"}'
+                    libvirtd_conf_dict = '{"keepalive_interval": "-1", "log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
+                    stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M --timeout 70"
+                    actions_during_migration = "setmaxdowntime,converge"
+                    asynch_migrate = "yes"
+                    stress_in_vm = "yes"
+                    virsh_opt = ' -k0'
+                    low_speed = "50"
+                    migrate_maxdowntime = '0.100000'
+                    grep_str_local_log = '"execute":"migrate-set-capabilities".*"capability":"auto-converge","state":true'
+                    variants:
+                        - default:
+                            virsh_migrate_extra = "--auto-converge"
+                        - customized:
+                            initial = 30
+                            increment = 15
+                            virsh_migrate_extra = "--auto-converge --auto-converge-initial ${initial} --auto-converge-increment ${increment}"
                 - cache_safe:
                     variants:
                         - none:


### PR DESCRIPTION
The cases are to test '--auto-converge' option for migration:
- default -auto-converge
- specified with auto-converge-initial and auto-converge-increment

Signed-off-by: Dan Zheng <dzheng@redhat.com>