### PR TITLE
Attach cdrom device to scsi

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_disk.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_disk.cfg
@@ -139,6 +139,9 @@
                     at_dt_disk_device_target = hdc
                     at_dt_disk_bus_type = ide
                     at_dt_disk_pre_vm_state = "shut off"
+                    machine_type == q35:
+                        at_dt_disk_device_target = sdb
+                        at_dt_disk_bus_type = scsi
                 - cdrom_eject_control:
                     only attach_disk
                     at_dt_disk_at_options = "--type cdrom --sourcetype file --config"
@@ -150,6 +153,9 @@
                     at_dt_disk_eject_cdrom = "yes"
                     at_dt_disk_save_vm = "yes"
                     time_sleep = "5"
+                    machine_type == q35:
+                        at_dt_disk_device_target = sdb
+                        at_dt_disk_bus_type = scsi
                 - special_disk_name:
                     only detach_disk
                     variants:


### PR DESCRIPTION
IDE controllers are unsupported for q35,update it to scsi.

Signed-off-by: Yingshun Cui <yicui@redhat.com>