### PR TITLE
add usb redirdev device test case

### DIFF
--- a/libvirt/tests/cfg/usb_device.cfg
+++ b/libvirt/tests/cfg/usb_device.cfg
@@ -3,6 +3,8 @@
     start_vm = "no"
     start_timeout = "60"
     usb_index = "0"
+    pkgs_host = "usbutils,usbredir-server"
+    pkgs_guest = "usbutils"
     variants:
         # bus controller
         - pcie-root:
@@ -40,7 +42,9 @@
     variants:
         # usb device
         - passthrough:
-            passthrough = "yes"
+            device_name = "hostdev"
+            device_type = "usb"
+            device_mode = "subsystem"
             variants:
                 - vid_pid:
                     vid_pid = "yes"
@@ -48,3 +52,16 @@
                 - bus_dev:
                     bus_dev = "yes"
                     coldunplug = "yes"
+        - redirdev:
+            only companion
+            only pcie-to-pci-bridge
+            device_name = "redirdev"
+            variants:
+                - spicevmc:
+                    device_type = "spicevmc"
+                    hotplug = "yes"
+                - tcp:
+                    device_mode = "connect"
+                    device_type = "tcp"
+                    port = "6000"
+                    redirdev_alias = "yes"

--- a/libvirt/tests/src/usb_device.py
+++ b/libvirt/tests/src/usb_device.py
@@ -33,10 +33,13 @@ def run(test, params, env):
         ich9-ehci1,ich9-uhci1,ich9-uhci2,ich9-uhci3
 
     Test scenarios:
-    1. by default, cold-plug/hot-unplug usb host device to/from vm
+    1. by default, cold-plug/hot-unplug usb host device to/from guest
     2. passthrough usb host device with vid/pid or bus/device hostdev
-    3. cold-plug/unplug usb host device to/from vm
-    4. hot-plug/unplug usb host device to/from vm
+    3. cold-plug/unplug usb host device to/from guest
+    4. hot-plug/unplug usb host device to/from guest
+    5. by default, cold-plug/hot-unplug usb redirdev device to/from guest
+    6. add usb redirdev device by type spicevm or tcp
+    7. hot-plug/unplug usb redirdev device to/from guest
     """
 
     vm_name = params.get("main_vm")
@@ -45,14 +48,20 @@ def run(test, params, env):
     bus_controller = params.get("bus_controller", "")
     usb_model = params.get("usb_model", "")
     start_timeout = int(params.get("start_timeout", "60"))
+    device_name = params.get("device_name", "")
+    device_type = params.get("device_type", "")
+    device_mode = params.get("device_mode", "")
+    port = params.get("port", "")
+    pkgs_host = params.get("pkgs_host", "")
+    pkgs_guest = params.get("pkgs_guest", "")
     usb_hub = "yes" == params.get("usb_hub", "no")
     status_error = "yes" == params.get("status_error", "no")
-    passthrough = "yes" == params.get("passthrough", "no")
     vid_pid = "yes" == params.get("vid_pid", "no")
     bus_dev = "yes" == params.get("bus_dev", "no")
     hotplug = "yes" == params.get("hotplug", "no")
     coldunplug = "yes" == params.get("coldunplug", "no")
     usb_alias = "yes" == params.get("usb_alias", "no")
+    redirdev_alias = "yes" == params.get("redirdev_alias", "no")
 
     vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
     vmxml_backup = vmxml.copy()
@@ -94,12 +103,12 @@ def run(test, params, env):
         src['product'] = product_list
         return src
 
-    def usb_disk_check(session, src_guest=None):
+    def usb_disk_check(session, src_guest):
         """
         check usb storage disks passed from host with dd operation and product id
 
-        :param session: a console session of vm
-        :param src_guest: a dict of the source xml of usb device from vm
+        :param session: a console session of guest
+        :param src_guest: a dict of the source xml of usb device from guest
         """
 
         # check and write the usb disk
@@ -109,37 +118,42 @@ def run(test, params, env):
         if session.cmd_status("dd if=/dev/zero of=/dev/sda bs=1M count=100", timeout=300):
             test.fail("usb storage device write fail")
 
-        # check whether passthrough the right usb device
-        if passthrough and src_guest:
-            output = output.strip().splitlines()
-            for guest in src_guest['product']:
-                pattern = "ID_MODEL_ID={}".format(guest['product_id'].lstrip("0x"))
-                for line in output:
-                    if pattern in line:
-                        return
-            test.fail("passthrough the wrong usb device")
+        # check whether the guest got the right usb device
+        output = output.strip().splitlines()
+        for guest in src_guest['product']:
+            pattern = "ID_MODEL_ID={}".format(guest['product_id'].lstrip("0x"))
+            for line in output:
+                if pattern in line:
+                    return
+        test.fail("usb device {} is NOT found in output {}".format
+                  (src_guest['product'], output))
 
-    def usb_device_check(session, src_host=None):
+    def usb_device_check(session, src_host):
+
         """
         check usb devices passed from host with xml file, output of lsusb, and
         usb storage disk.
 
-        :param session: a console session of vm
+        :param session: a console session of guest
         :param src_host: a dict of the source xml of usb device from host
         """
-        if passthrough:
-            # check usb device xml
-            for addr in src_host['source']:
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        output = session.get_command_output("lsusb")
+
+        # check usb device xml
+        for addr in src_host['source']:
+            if device_name == "redirdev":
+                pattern = 'redirdev bus="usb" type="{}"'.format(device_type)
+            if device_name == "hostdev":
                 if vid_pid:
                     pattern = 'product id="{}"'.format(addr['product_id'])
                 if bus_dev:
                     pattern = 'address bus="{}" device="{}"'.format(int(addr['bus']), int(addr['device']))
-                vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
-                if pattern not in str(vmxml):
-                    test.fail("the xml check of usb device fails")
+            if pattern not in str(vmxml):
+                test.fail("the xml check of usb device fails")
 
-            # check the pid and vid of usb passthrough device in vm
-            output = session.get_command_output("lsusb")
+        if device_name == "hostdev" or device_type == "tcp":
+            # check the pid and vid of usb passthrough device in guest
             src_guest = get_usb_source(output.strip().splitlines())
             for host in src_host['product']:
                 flag = False
@@ -149,29 +163,35 @@ def run(test, params, env):
                         flag = True
                         break
                 if not flag:
-                    test.fail("usb passthrough device check fail")
+                    test.fail("the check of usb device in guest fails")
 
-        # check usb disk /dev/sda
-        if passthrough:
-            usb_disk_check(session, src_guest)
+            # check usb disk /dev/sda
+                usb_disk_check(session, src_guest)
 
-    def check_controller_alias(alias):
+    def check_alias(device_alias):
         """
         check usb controller alias from qemu command line with xml config file
 
-        :param alias: a {model:alias} dict of the usb controller
+        :param device_alias: a {model:alias} dict of the usb controller or
+                             a {port:alias} dict of the usb redirdev device
         """
         output = process.run("ps -ef | grep {}".format(vm_name), shell=True).stdout_text
         logging.debug('"ps -ef | grep {}" output {}'.format(vm_name, output))
-        for model in usb_model.split(','):
-            device = (model if model == "qemu-xhci" else
-                      ('-').join([model.split('-')[0], "usb", model.split('-')[1]]))
-            pattern = ("masterbus={}".format(alias['ich9-ehci1'])
-                       if "ich9-uhci" in model else "id={}".format(alias[model]))
-            pattern = "-device {},".format(device) + pattern
-            logging.debug("usb controller model {}, pattern {}".format(model, pattern))
-            if not re.search(pattern, output):
-                test.fail("controller alias check fail")
+        if usb_alias:
+            for model in usb_model.split(','):
+                device = (model if model == "qemu-xhci" else
+                          ('-').join([model.split('-')[0], "usb", model.split('-')[1]]))
+                pattern = ("masterbus={}".format(device_alias['ich9-ehci1'])
+                           if "ich9-uhci" in model else "id={}".format(device_alias[model]))
+                pattern = "-device {},".format(device) + pattern
+                logging.debug("usb controller model {}, pattern {}".format(model, pattern))
+                if not re.search(pattern, output):
+                    test.fail("the check of controller alias fails")
+        if redirdev_alias:
+            for alias in device_alias.values():
+                pattern = "-device usb-redir,chardev=char{0},id={0}".format(alias)
+                if not re.search(pattern, output):
+                    test.fail("the check of controller alias fails")
 
     try:
         # remove usb controller/device from xml
@@ -192,7 +212,7 @@ def run(test, params, env):
             pci_bridge.model = model
             vmxml.add_device(pci_bridge)
 
-        controller_alias = {}
+        device_alias = {}
         random_id = process.run("uuidgen").stdout_text.strip()
         # assemble the xml of usb controller
         for i, model in enumerate(usb_model.split(',')):
@@ -202,7 +222,7 @@ def run(test, params, env):
             controller.model = model
             if usb_alias:
                 alias_str = "ua-usb" + str(i) + random_id
-                controller_alias[model] = alias_str
+                device_alias[model] = alias_str
                 alias = {"name": alias_str}
                 if "ich9" not in model:
                     controller.index = i
@@ -214,95 +234,132 @@ def run(test, params, env):
             vmxml.add_device(hub)
 
         # install essential package usbutils in host
-        pkg = 'usbutils'
-        if not utils_package.package_install(pkg):
-            test.fail("package usbutils installation fail")
+        for pkg in pkgs_host.split(','):
+            if not utils_package.package_install(pkg):
+                test.fail("package {} installation fail".format(pkg))
+
+        # prepare to assemble the xml of usb device
+        devs = vmxml.get_devices(device_name)
+        for dev in devs:
+            if dev.type == device_type:
+                vmxml.del_device(dev)
+        lsusb_list = process.run('lsusb').stdout_text.splitlines()
+        src_host = get_usb_source(lsusb_list)
+        dev_list = []
 
         # assemble the xml of usb passthrough device
-        hostdev_list = []
-        if passthrough:
-            hostdevs = vmxml.get_devices(device_type="hostdev")
-            for dev in hostdevs:
-                vmxml.del_device(dev)
-            lsusb_list = process.run('lsusb').stdout_text.splitlines()
-            src_host = get_usb_source(lsusb_list)
+        if device_name == "hostdev":
             for addr in src_host['source']:
-                dev = vmxml.get_device_class('hostdev')()
-                source_xml = dev.Source()
-                dev.mode = 'subsystem'
-                dev.type = 'usb'
-                dev.managed = 'no'
+                device_xml = vmxml.get_device_class(device_name)()
+                device_xml.type = device_type
+                source_xml = device_xml.Source()
+                device_xml.mode = device_mode
+                device_xml.managed = 'no'
                 if vid_pid:
                     source_xml.vendor_id = addr['vendor_id']
                     source_xml.product_id = addr['product_id']
                 if bus_dev:
                     source_xml.untyped_address = source_xml.new_untyped_address(**addr)
-                dev.source = source_xml
+                device_xml.source = source_xml
                 if hotplug:
-                    hostdev_list.append(dev)
+                    dev_list.append(device_xml)
                 else:
-                    vmxml.add_device(dev)
+                    vmxml.add_device(device_xml)
 
-        # start vm
+        # assemble the xml of usb redirdev device
+        if device_name == "redirdev":
+            for i, addr in enumerate(src_host['product']):
+                device_xml = vmxml.get_device_class(device_name)()
+                device_xml.type = device_type
+                device_xml.bus = "usb"
+                if device_type == "tcp":
+                    source_xml = device_xml.Source()
+                    source_xml.mode = device_mode
+                    source_xml.host = "localhost"
+                    port = str(int(port)+i)
+                    source_xml.service = port
+                    source_xml.tls = "no"
+                    device_xml.source = source_xml
+                    # start usbredirserver
+                    vendor_id = addr['vendor_id'].lstrip("0x")
+                    product_id = addr['product_id'].lstrip("0x")
+                    ps = process.SubProcess("usbredirserver -p {} {}:{}".format
+                                            (port, vendor_id, product_id),
+                                            shell=True)
+                    server_id = ps.start()
+                if redirdev_alias:
+                    alias_str = "ua-redir" + str(i) + random_id
+                    device_alias[port] = alias_str
+                    alias = {"name": alias_str}
+                    device_xml.alias = alias
+                if hotplug:
+                    dev_list.append(device_xml)
+                else:
+                    vmxml.add_device(device_xml)
+
+        # start guest
         vmxml.sync()
         vm.start()
         session = vm.wait_for_login(timeout=start_timeout)
         vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
         logging.debug("vm xml after starting up {}".format(vmxml))
 
-        # check usb controller in vm
+        # check usb controller in guest
         for model_type in usb_model.split(','):
             model_type = model_type.split('-')[-1].rstrip("1,2,3")
-            logging.debug("check usb controller {} in vm".format(model_type))
+            logging.debug("check usb controller {} in guest".format(model_type))
             if session.cmd_status("dmesg | grep {}".format(model_type)):
                 test.fail("usb controller check fail")
-        if usb_alias:
-            check_controller_alias(controller_alias)
+        if usb_alias or redirdev_alias:
+            check_alias(device_alias)
 
-        # install package usbutils in vm
-        if not utils_package.package_install(pkg, session):
-            test.fail("package usbutils installation fails")
+        # install package usbutils in guest
+        for pkg in pkgs_guest.split(','):
+            if not utils_package.package_install(pkg, session):
+                test.fail("package {} installation fails in guest".format(pkg))
 
-        # hotplug usb passthrough device
-        if passthrough and hotplug:
-            for hostdev in hostdev_list:
-                virsh.attach_device(vm_name, hostdev.xml, flagstr="--live",
+        # hotplug usb device
+        if hotplug:
+            for dev in dev_list:
+                virsh.attach_device(vm_name, dev.xml, flagstr="--live",
                                     debug=True, ignore_status=False)
-                utils_misc.wait_for(lambda: not session.cmd_status(
-                                     "lsusb | grep {}".format(hostdev.source.product_id)), 10)
+                if device_name == "hostdev":
+                    utils_misc.wait_for(lambda: not session.cmd_status(
+                                        "lsusb | grep {}".format(dev.source.product_id)), 10)
             vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
             logging.debug("vmxml after attaching {}".format(vmxml))
 
         # check usb device
         usb_device_check(session, src_host)
 
-        if passthrough:
-            # detach usb passthrough device from vm
-            hostdevs = vmxml.get_devices('hostdev')
-            if coldunplug:
-                vm.destroy()
+        # detach usb device from guest
+        devs = vmxml.get_devices(device_name)
+        if coldunplug:
+            vm.destroy()
 
-            for dev in hostdevs:
-                if dev.type == "usb":
-                    logging.debug("detach usb device {}".format(dev.source))
-                    if coldunplug:
-                        vmxml.del_device(dev)
-                    else:
-                        virsh.detach_device(vm_name, dev.xml, flagstr="--live", debug=True, ignore_status=False)
+        for dev in devs:
+            if dev.type == device_type:
+                if coldunplug:
+                    vmxml.del_device(dev)
+                else:
+                    virsh.detach_device(vm_name, dev.xml, flagstr="--live",
+                                        debug=True, ignore_status=False)
 
-            # check the hostdev element in xml after detaching
-            if coldunplug:
-                vmxml.sync()
-                vm.start()
-                vm.wait_for_login(timeout=start_timeout).close()
-            vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
-            hostdevs = vmxml.get_devices('hostdev')
-            logging.debug("hostdevs: {}".format(hostdevs))
-            for dev in hostdevs:
-                if dev.type == "usb":
-                    test.fail("detach usb device fail")
+        # check the usb device element in xml after detaching
+        if coldunplug:
+            vmxml.sync()
+            vm.start()
+            vm.wait_for_login(timeout=start_timeout).close()
+
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        devs = vmxml.get_devices(device_name)
+        for dev in devs:
+            if dev.type == device_type:
+                test.fail("detach usb device fail")
 
     finally:
         if 'session' in locals():
             session.close()
+        if 'server_id' in locals():
+            process.run("killall usbredirserver")
         vmxml_backup.sync()


### PR DESCRIPTION
 - by default, cold-plug/hot-unplug usb redirdev device to/from guest
 - add usb redirdev device by type spicevm or tcp
 - hot-plug/unplug usb redirdev device to/from guest

Signed-off-by: Jin Li <jil@redhat.com>