### PR TITLE
Modify waiting time of ppc64le tests

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_reboot.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_reboot.cfg
@@ -6,6 +6,7 @@
     reboot_extra = ""
     reboot_mode = ""
     reboot_pre_domian_status = "running"
+    wait_time = 10
     variants:
         - normal_test:
             status_error = "no"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_reboot.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_reboot.py
@@ -1,7 +1,6 @@
 import re
 import logging
 import aexpect
-import time
 
 from virttest.utils_test import libvirt
 from avocado.utils import process
@@ -11,6 +10,7 @@ from virttest import virt_vm
 from virttest import virsh
 from virttest import remote
 from virttest import utils_libvirtd
+from virttest import utils_misc
 from virttest.libvirt_xml import vm_xml
 
 
@@ -41,6 +41,7 @@ def run(test, params, env):
     mode = params.get("reboot_mode", "")
     pre_domian_status = params.get("reboot_pre_domian_status", "running")
     reboot_readonly = "yes" == params.get("reboot_readonly", "no")
+    wait_time = int(params.get('wait_time', 5))
     xml_backup = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     try:
         # Add or remove qemu-agent from guest before test
@@ -101,14 +102,18 @@ def run(test, params, env):
                 if not virsh.has_command_help_match('reboot', '\s+--mode\s+'):
                     # old libvirt doesn't support reboot
                     status = -2
-            time.sleep(5)
             # avoid the check if it is negative test
             if not status_error:
-                cmdoutput = virsh.domstate(vm_ref, '--reason',
-                                           ignore_status=True, debug=True)
-                domstate_status = cmdoutput.exit_status
-                output = "running" in cmdoutput.stdout
-                if domstate_status or (not output):
+                cmdoutput = ''
+
+                def _wait_for_vm_running():
+                    cmdoutput = virsh.domstate(vm_ref, '--reason',
+                                               ignore_status=True, debug=True)
+                    domstate_status = cmdoutput.exit_status
+                    output = "running" in cmdoutput.stdout
+                    return not domstate_status and output
+                if not utils_misc.wait_for(_wait_for_vm_running,
+                                           timeout=wait_time, step=1):
                     test.fail("Cmd error: %s Error status: %s" %
                               (cmdoutput.stderr, cmdoutput.stdout))
             elif pre_domian_status != 'shutoff':


### PR DESCRIPTION
Extend waiting time to 10s. Use 'wait_for' to handle waiting operation
instead of time.sleep()