### PR TITLE
Fix ceph image issue for blockpull/blockcommit cases

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockpull.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockpull.py
@@ -8,6 +8,7 @@ from avocado.utils import process
 from virttest import virsh
 from virttest import data_dir
 from virttest import utils_libvirtd
+from virttest import utils_package
 from virttest import libvirt_storage
 from virttest import ceph
 from virttest.utils_test import libvirt
@@ -468,6 +469,16 @@ def run(test, params, env):
             vm.destroy(gracefully=False)
         # Recover xml of vm.
         vmxml_backup.sync("--snapshots-metadata")
+        # Clean ceph image if used in test
+        if 'mon_host' in locals():
+            if utils_package.package_install(["ceph-common"]):
+                disk_source_name = params.get("disk_source_name")
+                cmd = ("rbd -m {0} info {1} && rbd -m {0} rm "
+                       "{1}".format(mon_host, disk_source_name))
+                cmd_result = process.run(cmd, ignore_status=True, shell=True)
+                logging.debug("result of rbd removal: %s", cmd_result)
+            else:
+                logging.debug('Failed to install ceph-common to clean ceph.')
 
         if not disk_src_protocol or disk_src_protocol != 'gluster':
             for disk in snapshot_external_disks:


### PR DESCRIPTION
Previoulsy, the script didn't remove the ceph image it created.
This will casue a 'error rbd create: File exists' error when execute
next case.

Signed-off-by: Yi Sun <yisun@redhat.com>