### PR TITLE
 libvirt_pci_passthrough: refactor tests to use `host_pf_filter` for device pass-through.

### DIFF
--- a/libvirt/tests/cfg/libvirt_pci_passthrough.cfg
+++ b/libvirt/tests/cfg/libvirt_pci_passthrough.cfg
@@ -5,6 +5,10 @@
             libvirt_pci_SRIOV = no
         - SRIOV:
             libvirt_pci_SRIOV = yes
+            vf_filter = "Virtual Function"
+            # Enter the no.of Virtual Function's to be created
+            # for each Physical Function.
+            number_vfs = 4
     variants:
         - NIC:
             libvirt_pci_device_type = "NIC"
@@ -12,8 +16,8 @@
             # a network device. We will attach this
             # device to guest. Then this network device
             # will be unavailable on host.
-            # E.g: pci_0000_05_00_0
-            libvirt_pci_net_dev_label = "ENTER.YOUR.PCI.LABEL"
+            # E.g: 0000:05:00.0
+            pf_filter = "ENTER.YOUR.PCI.LABEL"
             # Please enter the ip what is used by the device
             # you are going to attach to guest.
             libvirt_pci_net_ip = "ENTER.YOUR.IP"
@@ -21,7 +25,6 @@
             # We need to ping it after attaching pci device
             # to guest to verify this device works well in guest.
             libvirt_pci_server_ip = "ENTER.YOUR.SERVER.IP"
-            libvirt_pci_net_dev_name = "ENTER.YOUR.DEVICE.NAME"
             # Enter netmask in CIDR notation
             libvirt_pci_net_mask = "ENTER.YOUR.NETMASK"
         - STORAGE:


### PR DESCRIPTION
The PciAssignable class uses the "host_pf_filter" for the PCI Devices
to be pass-through'ed, and the same can be used in the test-case.
Now the user also have the flexibilty to create the desired no.of Virtual Functions,
for each Physical Function incase of SR-IOV.

Removed the device_name params for comparision of the PCI devices
before/after passthrough.

Signed-off-by: Santwana Samantray <santwana@linux.vnet.ibm.com>