### PR TITLE
virsh_reboot: acpi is not supported for PowerPC

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_reboot.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_reboot.cfg
@@ -6,7 +6,8 @@
     reboot_extra = ""
     reboot_mode = ""
     reboot_pre_domian_status = "running"
-    wait_time = 10
+    # provide sufficient time for vm reboot
+    wait_time = 60
     variants:
         - normal_test:
             status_error = "no"
@@ -14,6 +15,7 @@
                 - no_mode:
                 - acpi_mode:
                     reboot_mode = "acpi"
+                    no ppc64,ppc64le
                 - agent_mode:
                     no lxc
                     reboot_mode = "agent"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_reboot.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_reboot.py
@@ -2,15 +2,15 @@ import re
 import logging
 import aexpect
 
-from virttest.utils_test import libvirt
 from avocado.utils import process
+from avocado.utils import wait
 
 from virttest import libvirt_vm
 from virttest import virt_vm
 from virttest import virsh
 from virttest import remote
 from virttest import utils_libvirtd
-from virttest import utils_misc
+from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
 
 
@@ -112,8 +112,8 @@ def run(test, params, env):
                     domstate_status = cmdoutput.exit_status
                     output = "running" in cmdoutput.stdout
                     return not domstate_status and output
-                if not utils_misc.wait_for(_wait_for_vm_running,
-                                           timeout=wait_time, step=1):
+                if not wait.wait_for(_wait_for_vm_running,
+                                     timeout=wait_time, step=1):
                     test.fail("Cmd error: %s Error status: %s" %
                               (cmdoutput.stderr, cmdoutput.stdout))
             elif pre_domian_status != 'shutoff':


### PR DESCRIPTION
filter out acpi mode testcases for powerpc in virsh reboot
testcases, vm reboot time often varies each time so give
sufficient time of 60sec to check for vm domstate.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>