### PR TITLE
Update cases which call get_parts_list

### DIFF
--- a/libvirt/tests/src/npiv/npiv_hostdev_passthrough.py
+++ b/libvirt/tests/src/npiv/npiv_hostdev_passthrough.py
@@ -9,6 +9,7 @@ from virttest import remote
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
 from virttest import utils_npiv
+from virttest import utils_disk
 from virttest import utils_misc
 
 
@@ -37,7 +38,7 @@ def run(test, params, env):
        """
         try:
             session = vm.wait_for_login()
-            new_parts = libvirt.get_parts_list(session)
+            new_parts = utils_disk.get_parts_list(session)
             added_parts = list(set(new_parts).difference(set(old_parts)))
             logging.info("Added parts:%s", added_parts)
             if len(added_parts) != 1:
@@ -91,7 +92,7 @@ def run(test, params, env):
         if vm.is_dead():
             vm.start()
         session = vm.wait_for_login()
-        old_parts = libvirt.get_parts_list(session)
+        old_parts = utils_disk.get_parts_list(session)
         # find first online hba
         online_hbas = []
         online_hbas = utils_npiv.find_hbas("hba")
@@ -152,7 +153,7 @@ def run(test, params, env):
         result = virsh.detach_device(vm_name, new_hostdev_xml.xml)
         libvirt.check_exit_status(result, status_error)
         # login vm and check disk actually removed
-        parts_after_detach = libvirt.get_parts_list(session)
+        parts_after_detach = utils_disk.get_parts_list(session)
         old_parts.sort()
         parts_after_detach.sort()
         if parts_after_detach == old_parts:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk.py
@@ -14,6 +14,7 @@ from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 from virttest.staging.service import Factory
 from virttest.staging import lv_utils
+from virttest import utils_disk
 from virttest import utils_misc
 from virttest import data_dir
 
@@ -47,7 +48,7 @@ def run(test, params, env):
             attached = False
             if os_type == "linux":
                 session = vm.wait_for_login()
-                new_parts = libvirt.get_parts_list(session)
+                new_parts = utils_disk.get_parts_list(session)
                 added_parts = list(set(new_parts).difference(set(old_parts)))
                 logging.debug("Added parts: %s" % added_parts)
                 for i in range(len(added_parts)):
@@ -184,7 +185,7 @@ def run(test, params, env):
     if vm.is_dead():
         vm.start()
     session = vm.wait_for_login()
-    old_parts = libvirt.get_parts_list(session)
+    old_parts = utils_disk.get_parts_list(session)
     session.close()
     vm.destroy(gracefully=False)
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domfsinfo.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domfsinfo.py
@@ -8,6 +8,7 @@ from avocado.utils import process
 
 from virttest import virsh
 from virttest import data_dir
+from virttest import utils_disk
 from virttest.libvirt_xml import vm_xml
 from virttest.staging import lv_utils
 from virttest.utils_test import libvirt
@@ -217,9 +218,9 @@ def run(test, params, env):
         if hotplug_unplug:
             session = vm.wait_for_login()
             new_device = libvirt.create_local_disk("file", path=disk_path, size="1")
-            parts_list_before_attach = libvirt.get_parts_list(session)
+            parts_list_before_attach = utils_disk.get_parts_list(session)
             hotplug_domain_disk(vm_name, disk_target, new_device)
-            parts_list_after_attach = libvirt.get_parts_list(session)
+            parts_list_after_attach = utils_disk.get_parts_list(session)
             new_part = list(set(parts_list_after_attach).difference(set(parts_list_before_attach)))[0]
             logging.debug("The new partition is %s", new_part)
             libvirt.mkfs("/dev/%s" % new_part, fs_type, session=session)

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_agent_command_fs.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_agent_command_fs.py
@@ -4,6 +4,7 @@ import logging
 
 from virttest import virsh
 from virttest import data_dir
+from virttest import utils_disk
 from virttest import utils_misc
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
@@ -63,12 +64,12 @@ def run(test, params, env):
         tmp_file = "/mnt/test.file"
         try:
             # Create extra image and attach to guest, then mount
-            old_parts = libvirt.get_parts_list(session)
+            old_parts = utils_disk.get_parts_list(session)
             ret = virsh.attach_disk(vm_name, device_source, "vdd")
             if ret.exit_status:
                 test.fail("Attaching device failed before testing agent:%s" % ret.stdout.strip())
             time.sleep(1)
-            new_parts = libvirt.get_parts_list(session)
+            new_parts = utils_disk.get_parts_list(session)
             added_part = list(set(new_parts).difference(set(old_parts)))
             session.cmd("mkfs.ext3 -F /dev/{0} && mount /dev/{0} /mnt".format(added_part[0]))
 

--- a/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_event.py
+++ b/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_event.py
@@ -178,7 +178,6 @@ def run(test, params, env):
             if nodedev_event_timestamp:
                 timestamp = time.strftime("%Y-%m-%d")
                 if timestamp in ret_output:
-                    print ("print the output with timestamp")
                     check_event_output(ret_output, expected_event_list)
             else:
                 check_event_output(ret_output, expected_event_list)

--- a/libvirt/tests/src/virtual_disks/startup_policy.py
+++ b/libvirt/tests/src/virtual_disks/startup_policy.py
@@ -9,6 +9,7 @@ from avocado.utils import process
 
 from virttest import virsh
 from virttest import data_dir
+from virttest import utils_disk
 from virttest import utils_misc
 from virttest import virt_vm, remote
 from virttest.libvirt_xml import vm_xml
@@ -168,7 +169,7 @@ def run(test, params, env):
         """
         try:
             session = vm.wait_for_login()
-            new_parts = libvirt.get_parts_list(session)
+            new_parts = utils_disk.get_parts_list(session)
             logging.debug("new parted:%s", new_parts)
             added_parts = list(set(new_parts).difference(set(old_parts)))
             logging.info("Added parts:%s", added_parts)
@@ -336,7 +337,7 @@ def run(test, params, env):
     if vm.is_dead():
         vm.start()
     session = vm.wait_for_login()
-    old_parts = libvirt.get_parts_list(session)
+    old_parts = utils_disk.get_parts_list(session)
     session.close()
     vm.destroy(gracefully=False)
 

--- a/libvirt/tests/src/virtual_disks/virtual_disks_ceph.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_ceph.py
@@ -11,6 +11,7 @@ from avocado.utils import process
 
 from virttest import virsh
 from virttest import utils_libvirtd
+from virttest import utils_disk
 from virttest import utils_misc
 from virttest import utils_package
 from virttest import virt_vm, remote
@@ -346,7 +347,7 @@ def run(test, params, env):
         """
         try:
             session = vm_obj.wait_for_login()
-            new_parts = libvirt.get_parts_list(session)
+            new_parts = utils_disk.get_parts_list(session)
             added_parts = list(set(new_parts).difference(set(old_parts)))
             logging.info("Added parts:%s", added_parts)
             if len(added_parts) != 1:
@@ -527,7 +528,7 @@ def run(test, params, env):
     if vm.is_dead():
         vm.start()
     session = vm.wait_for_login()
-    old_parts = libvirt.get_parts_list(session)
+    old_parts = utils_disk.get_parts_list(session)
     session.close()
     vm.destroy(gracefully=False)
     if additional_guest:
@@ -867,7 +868,7 @@ def run(test, params, env):
         # Check disk in vm after detachment.
         if attach_device or attach_disk:
             session = vm.wait_for_login()
-            new_parts = libvirt.get_parts_list(session)
+            new_parts = utils_disk.get_parts_list(session)
             if len(new_parts) != len(old_parts):
                 test.fail("Disk still exists in vm"
                           " after detachment")

--- a/libvirt/tests/src/virtual_disks/virtual_disks_encryption.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_encryption.py
@@ -11,6 +11,7 @@ from avocado.utils import process
 from virttest import remote
 from virttest import virt_vm
 from virttest import virsh
+from virttest import utils_disk
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import vol_xml
@@ -123,7 +124,7 @@ def run(test, params, env):
                 test.fail("Failed to query/install parted, make sure"
                           " that you have usable repo in guest")
 
-            new_parts = libvirt.get_parts_list(session)
+            new_parts = utils_disk.get_parts_list(session)
             added_parts = list(set(new_parts).difference(set(old_parts)))
             logging.info("Added parts:%s", added_parts)
             if len(added_parts) != 1:
@@ -197,7 +198,7 @@ def run(test, params, env):
     if vm.is_dead():
         vm.start()
     session = vm.wait_for_login()
-    old_parts = libvirt.get_parts_list(session)
+    old_parts = utils_disk.get_parts_list(session)
     session.close()
     vm.destroy(gracefully=False)
 

--- a/libvirt/tests/src/virtual_disks/virtual_disks_iscsi.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_iscsi.py
@@ -12,6 +12,7 @@ from virttest import remote
 from virttest import data_dir
 from virttest import virt_vm
 from virttest import virsh
+from virttest import utils_disk
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml, xcepts
 from virttest.libvirt_xml import secret_xml
@@ -79,7 +80,7 @@ def run(test, params, env):
         """
         try:
             session = vm.wait_for_login()
-            new_parts = libvirt.get_parts_list(session)
+            new_parts = utils_disk.get_parts_list(session)
             added_parts = list(set(new_parts).difference(set(old_parts)))
             logging.info("Added parts:%s", added_parts)
             if len(added_parts) != 1:
@@ -173,7 +174,7 @@ def run(test, params, env):
     if vm.is_dead():
         vm.start()
     session = vm.wait_for_login()
-    old_parts = libvirt.get_parts_list(session)
+    old_parts = utils_disk.get_parts_list(session)
     session.close()
     vm.destroy(gracefully=False)
 

--- a/libvirt/tests/src/virtual_disks/virtual_disks_luks.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_luks.py
@@ -12,6 +12,7 @@ from virttest import virt_vm
 from virttest import virsh
 from virttest import utils_package
 from virttest import ceph
+from virttest import utils_disk
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.disk import Disk
@@ -84,7 +85,7 @@ def run(test, params, env):
             session = vm.wait_for_login()
             if platform.platform().count('ppc64'):
                 time.sleep(10)
-            new_parts = libvirt.get_parts_list(session)
+            new_parts = utils_disk.get_parts_list(session)
             added_parts = list(set(new_parts).difference(set(old_parts)))
             logging.info("Added parts:%s", added_parts)
             if len(added_parts) != 1:
@@ -150,7 +151,7 @@ def run(test, params, env):
     if vm.is_dead():
         vm.start()
     session = vm.wait_for_login()
-    old_parts = libvirt.get_parts_list(session)
+    old_parts = utils_disk.get_parts_list(session)
     session.close()
     vm.destroy(gracefully=False)
 

--- a/libvirt/tests/src/virtual_disks/virtual_disks_multipath.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multipath.py
@@ -8,6 +8,7 @@ import shutil
 from virttest import remote
 from virttest import virt_vm
 from virttest import virsh
+from virttest import utils_disk
 from virttest import utils_npiv as mpath
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
@@ -73,7 +74,7 @@ def run(test, params, env):
             session = vm.wait_for_login()
             if platform.platform().count('ppc64'):
                 time.sleep(10)
-            new_parts = libvirt.get_parts_list(session)
+            new_parts = utils_disk.get_parts_list(session)
             added_parts = list(set(new_parts).difference(set(old_parts)))
             logging.info("Added parts:%s", added_parts)
             if len(added_parts) != 1:
@@ -98,7 +99,7 @@ def run(test, params, env):
     if vm.is_dead():
         vm.start()
     session = vm.wait_for_login()
-    old_parts = libvirt.get_parts_list(session)
+    old_parts = utils_disk.get_parts_list(session)
     session.close()
     vmxml_backup = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)

--- a/libvirt/tests/src/virtual_disks/virtual_disks_usb.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_usb.py
@@ -5,6 +5,7 @@ import platform
 import aexpect
 
 from virttest import virsh
+from virttest import utils_disk
 from virttest import utils_misc
 from virttest import virt_vm, remote
 from virttest.utils_test import libvirt
@@ -40,7 +41,7 @@ def run(test, params, env):
             session = vm.wait_for_login()
             if platform.platform().count('ppc64'):
                 time.sleep(10)
-            new_partitions = libvirt.get_parts_list(session)
+            new_partitions = utils_disk.get_parts_list(session)
             added_partitions = list(set(new_partitions).difference(set(old_partitions)))
             if not added_partitions:
                 logging.debug("No new partitions found in vm.")
@@ -188,7 +189,7 @@ def run(test, params, env):
     if vm.is_dead():
         vm.start()
     session = vm.wait_for_login()
-    old_partitions = libvirt.get_parts_list(session)
+    old_partitions = utils_disk.get_parts_list(session)
     session.close()
     vm.destroy(gracefully=False)
 


### PR DESCRIPTION
The method get_parts_list() is moved from virttest/utils_test/libvirt.py
to virttest/utils_disk.py. Hence updating accordingly.

Signed-off-by: Yingshun Cui <yicui@redhat.com>