### PR TITLE
Fix the hotplug issue in pci bridge controller

### DIFF
--- a/libvirt/tests/cfg/controller/pcibridge.cfg
+++ b/libvirt/tests/cfg/controller/pcibridge.cfg
@@ -16,7 +16,9 @@
                             pci_br_has_device = 'yes'
                             sound_dev_model_type = 'ich6'
                             sound_dev_address = "{'type': 'pci', 'domain': '0x0000', 'bus': '0x0%s', 'slot': '0x02', 'function': '0x0'}"
+                            iface_kwargs = {'address': "{'type': 'pci', 'domain': '0x0000', 'bus':'%s', 'slot': '0x05', 'function': '0x0'}"}
                         - no_device:
+                            iface_kwargs = {'address': "{'type': 'pci', 'domain': '0x0000', 'bus':'%s', 'slot': '0x05', 'function': '0x0'}"}
 
                     variants:
                         - pcie_to_pci_br:

--- a/libvirt/tests/src/controller/pcibridge.py
+++ b/libvirt/tests/src/controller/pcibridge.py
@@ -139,7 +139,13 @@ def run(test, params, env):
 
             # Create interface to be hotplugged
             logging.info('Create interface to be hotplugged')
-            iface = create_iface(iface_model, iface_source)
+            target_bus = cur_pci_br[0].index
+            target_bus = hex(int(target_bus))
+            logging.debug('target_bus: %s', target_bus)
+
+            new_iface_kwargs = {'address': iface_kwargs['address'] % target_bus}
+            logging.debug('address: %s', new_iface_kwargs['address'])
+            iface = create_iface(iface_model, iface_source, **new_iface_kwargs)
             mac = iface.mac_address
 
             result = virsh.attach_device(vm_name, iface.xml, debug=True)


### PR DESCRIPTION
Specify a fixed pci address to pci bridge controller: the pci device was hotplugged to the pci-root controller by default but not pci-bridge when we didn't assign the fixed pci address. So it will attach device failed when it judge whether the device is hotplugged to pci bridge.
Signed-off-by: MeinaLi <meili@redhat.com>