### PR TITLE
migration: Add 2 domjobinfo cases

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -182,6 +182,18 @@
                             remove_cache = "yes"
                 - migrate_uri:
                     virsh_migrate_extra = "--migrateuri tcp://${migrate_dest_host}"
+                - check_domjobinfo:
+                    qemu_conf_dict = '{"keepalive_interval": "-1"}'
+                    libvirtd_conf_dict = '{"keepalive_interval": "-1", "log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
+                    asynch_migrate = "yes"
+                    virsh_opt = ' -k0'
+                    low_speed = "10"
+                    stress_in_vm = "yes"
+                    stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M --timeout 70"
+                    migrate_maxdowntime = '0.100000'
+                    check_complete_job = "yes"
+                    check_domjobinfo_results = "yes"
+                    actions_during_migration = "setmaxdowntime,domjobinfo_output_all"
         - negative_test:
             virsh_migrate_options = "--live --verbose"
             # The variable indicates migration command should fail


### PR DESCRIPTION
This patch adds 2 tests that could check domjobinfo output during and
after migration.

Signed-off-by: Yingshun Cui <yicui@redhat.com>