### PR TITLE
virsh_change_media: Add readonly variants for floppy

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_change_media.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_change_media.cfg
@@ -107,3 +107,8 @@
             change_media_device_type = "floppy"
             change_media_target_device = "fda"
             device_target_bus = "fdc"
+            variants:
+                - read_write:
+                    readonly = no
+                - read_only:
+                    readonly = yes

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_change_media.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_change_media.py
@@ -91,9 +91,10 @@ def run(test, params, env):
             virsh.destroy(vm_name)
 
         device_target_bus = params.get("device_target_bus", "ide")
+        readonly = "--mode readonly" if params.get("readonly", True) else ""
         virsh.attach_disk(vm_name, init_source,
                           target_device,
-                          "--type %s --sourcetype file --targetbus %s --config" % (device_type, device_target_bus),
+                          "--type %s --sourcetype file --targetbus %s %s --config" % (device_type, device_target_bus, readonly),
                           debug=True)
 
     def update_device(vm_name, init_iso, options, start_vm):
@@ -110,15 +111,16 @@ def run(test, params, env):
         else:
             disk_alias_update = disk_alias
         device_target_bus = params.get("device_target_bus", "ide")
+        readonly = "<readonly/>" if params.get("readonly", True) else ""
         snippet = """
 <disk type='file' device='%s'>
 <driver name='qemu' type='raw'/>
 <source file='%s'/>
 <target dev='%s' bus='%s'/>
-<readonly/>
+%s
 <alias name='%s'/>
 </disk>
-""" % (device_type, init_iso, target_device, device_target_bus, disk_alias_update)
+""" % (device_type, init_iso, target_device, device_target_bus, readonly, disk_alias_update)
         logging.info("Update xml is %s", snippet)
         with open(update_iso_xml, "w") as update_iso_file:
             update_iso_file.write(snippet)


### PR DESCRIPTION
Floppy device can be emulated as RO or RW device. Add readonly variants
to make floopy RW or RO.

Signed-off-by: Han Han <hhan@redhat.com>