### PR TITLE
migration: Fix domjobinfo command failure in auto-converge case

### DIFF
--- a/libvirt/tests/src/migration/migrate_options_shared.py
+++ b/libvirt/tests/src/migration/migrate_options_shared.py
@@ -411,7 +411,16 @@ def run(test, params, env):
                                           ignore_status=True)
             if cmd_result.exit_status:
                 logging.debug(cmd_result.stderr)
-                test.error("Failed to get domjobinfo: %s" % cmd_result.stderr)
+                # Check if migration is completed
+                if "domain is not running" in cmd_result.stderr:
+                    args = vm_name + " --completed"
+                    cmd_result = virsh.domjobinfo(args, debug=True,
+                                                  ignore_status=True)
+                    if cmd_result.exit_status:
+                        test.error("Failed to get domjobinfo and domjobinfo "
+                                   "--completed: %s" % cmd_result.stderr)
+                else:
+                    test.error("Failed to get domjobinfo: %s" % cmd_result.stderr)
             jobinfo = cmd_result.stdout
             for line in jobinfo.splitlines():
                 key = line.split(':')[0]


### PR DESCRIPTION
In auto-converge case, it checks "Auto converge throttle" in
domjobinfo's output during migration. The problem is that command
"virsh domjobinfo" reports error "Requested operation is not valid:
domain is not running" if run it after migration completed. In this
case, need execute "virsh domjobinfo --completed" to see if
migration is done.

Signed-off-by: Yingshun Cui <yicui@redhat.com>