### PR TITLE
Update timeout to 60 to avoid channel not being connected

### DIFF
--- a/libvirt/tests/src/daemon/restart_consist.py
+++ b/libvirt/tests/src/daemon/restart_consist.py
@@ -31,7 +31,7 @@ def run(test, params, env):
 
     # Wait guest agent channel to be connected to avoid XML differ
     try:
-        if not utils_misc.wait_for(agent_connected, 30):
+        if not utils_misc.wait_for(agent_connected, 60):
             logging.warning('Agent channel not connected')
     except LibvirtXMLNotFoundError:
         pass


### PR DESCRIPTION
The original 30s is sometimes not enough for ppc machines.

Signed-off-by: haizhao <haizhao@redhat.com>