### PR TITLE
Remove unsupported cases from pseries tests

### DIFF
--- a/libvirt/tests/cfg/virtual_device/sound_device.cfg
+++ b/libvirt/tests/cfg/virtual_device/sound_device.cfg
@@ -11,10 +11,13 @@
             codec_type = micro
     variants:
         - sound_model_ac97:
+            no pseries
             sound_model = ac97
         - sound_model_ich6:
+            no pseries
             sound_model = ich6
         - sound_model_ich9:
+            no pseries
             sound_model = ich9
     variants:
         - positive_test:

--- a/libvirt/tests/cfg/virtual_device/watchdog.cfg
+++ b/libvirt/tests/cfg/virtual_device/watchdog.cfg
@@ -4,8 +4,10 @@
     take_regular_screendumps = "no"
     variants:
         - model_i6300esb:
+            no pseries
             model = "i6300esb"
         - model_ib700:
+            no pseries
             model = "ib700"
     variants:
         - action_shutdown:


### PR DESCRIPTION
Devices are not supported by pseries

Signed-off-by: haizhao <haizhao@redhat.com>