### PR TITLE
Fix the rom path issue

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_hotplug.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_hotplug.cfg
@@ -32,7 +32,7 @@
                     detach_device = "yes"
                 - rom_enable_yes:
                     only at_device
-                    iface_rom = "{'enabled':'yes','file':'/usr/share/qemu-kvm/pxe-virtio.rom','bar':'on'}"
+                    iface_rom = "{'enabled':'yes','file':'/usr/share/ipxe/1af41000.rom','bar':'on'}"
                     detach_device = "yes"
                 - large_scale:
                     iface_num = '32'


### PR DESCRIPTION
There is no qemu-kvm-rhev package on rhel8 any more, so the file
"/usr/share/qemu-kvm/pxe-virtio.rom" which is a symbol link for
"/usr/share/ipxe/1af41000.rom" will not exists. Update the rom
path to "/usr/share/ipxe/1af41000.rom" to avoid the file not found
issue.

Signed-off-by: yalzhang <yalzhang@redhat.com>