### PR TITLE
Add log info for disk attachment in block resize cases

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockresize.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockresize.py
@@ -57,7 +57,8 @@ def run(test, params, env):
 
     # Hotplug the image as disk device
     result = virsh.attach_disk(vm_name, source=image_path, target="vdd",
-                               extra=" --subdriver %s" % image_format)
+                               extra=" --subdriver %s" % image_format,
+                               **virsh_dargs)
     if result.exit_status:
         test.error("Failed to attach disk %s to VM: %s."
                    % (image_path, result.stderr.strip()))
@@ -148,7 +149,4 @@ def run(test, params, env):
                           "different from actual size from "
                           "'qemu-img info'")
     finally:
-        virsh.detach_disk(vm_name, target="vdd")
-
-        if os.path.exists(image_path):
-            os.remove(image_path)
+        virsh.detach_disk(vm_name, target="vdd", **virsh_dargs)


### PR DESCRIPTION
The disk attachment is a key step here. Without the info, it's
hard for debugger to manually check what happened according to
the log.

Signed-off-by: Yi Sun <yisun@redhat.com>