### PR TITLE
Make sure the tmp file existing until used

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_interface.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_interface.py
@@ -255,8 +255,8 @@ def run(test, params, env):
             vm.destroy()
             vm.start()
             # Generate attached xml
-            xml_file_tmp = libvirt.modify_vm_iface(vm_name, "get_xml", iface_format)
             new_iface = Interface(type_name=iface_type)
+            xml_file_tmp = libvirt.modify_vm_iface(vm_name, "get_xml", iface_format)
             new_iface.xml = xml_file_tmp
             new_iface.del_address()
             xml_file = new_iface.xml


### PR DESCRIPTION
The the tmp xml file sometimes get lost before used. This fix is
to make sure the tmp filed used just after it's generated.

Signed-off-by: Yi Sun <yisun@redhat.com>