### PR TITLE
migration: new case to kill qemu process during migration

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -233,3 +233,16 @@
                             server_cn = "INCONSISTENT.SERVER_CN"
                             client_cn = "ENTER.YOUR.CLIENT_CN"
                             disable_verify_peer = "yes"
+                - p2p_migration:
+                    virsh_migrate_options = "--live --p2p --verbose"
+                    variants:
+                        - kill_qemu_target:
+                            only with_postcopy
+                            asynch_migrate = "yes"
+                            virsh_opt = ' -k0'
+                            low_speed = "10"
+                            stress_in_vm = "yes"
+                            stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M --timeout 70"
+                            actions_during_migration = "killqemutarget"
+                            err_msg = "error: internal error: qemu unexpectedly closed the monitor"
+


### PR DESCRIPTION
This patch adds one test that kill qemu process on target during
migration with postcopy

Signed-off-by: Yingshun Cui <yicui@redhat.com>