### PR TITLE
Fix a vmx enabled issue

### DIFF
--- a/libvirt/tests/src/libvirt_mem.py
+++ b/libvirt/tests/src/libvirt_mem.py
@@ -323,6 +323,7 @@ def run(test, params, env):
             cpu_xml.xml = "<cpu><numa/></cpu>"
             cpu_mode = params.get("cpu_mode")
             model_fallback = params.get("model_fallback")
+            cpu_xml.add_feature('vmx', 'disable')
             if cpu_mode:
                 cpu_xml.mode = cpu_mode
             if model_fallback:


### PR DESCRIPTION
vmx is enabled by defult now, which will hit bz1559845.
So we need to disable it to bypass that bug.

Signed-off-by: Yi Sun <yisun@redhat.com>