### PR TITLE
clean device address when the address type of device is pci

### DIFF
--- a/libvirt/tests/src/usb_device.py
+++ b/libvirt/tests/src/usb_device.py
@@ -200,6 +200,12 @@ def run(test, params, env):
             if dev.type == "usb" or dev.type == "pci":
                 vmxml.del_device(dev)
 
+        # clean device address when the address type of device is pci
+        for element in vmxml.xmltreefile.findall("/devices/*/address"):
+            if element.get('type') == "pci":
+                vmxml.xmltreefile.remove(element)
+        vmxml.xmltreefile.write()
+
         hubs = vmxml.get_devices(device_type="hub")
         for hub in hubs:
             if hub.type_name == "usb":


### PR DESCRIPTION
In libvirt usb test, the existing pci bus controller will be replaced
by the one configured in cfg file and the device which use these pci
bus may have conflict with the new pci bus in the following scenario:

pci bus_controller = "pcie-root,pcie-root-port,pcie-to-pci-bridge,pci-bridge"

<controller type='virtio-serial' index='0'>
  <address type='pci' domain='0x0000' bus='0x03' slot='0x00' function='0x0'/>
</controller>

Therefore, the device address should be cleaned when the address type of device
is pci. The device address will be allocated automaticly when the vm is defined

Signed-off-by: Jin Li <jil@redhat.com>