### PR TITLE
Fix: slow down migration process to do other operations

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
@@ -252,6 +252,7 @@
             # migration thread timeout
             postcopy_migration_timeout = "200"
             migration_start_timeout = "50"
+            migrate_speed = 10
         - there_p2p:
             # Uni-direction migration with option --p2p.
             virsh_migrate_options = "--live --p2p"


### PR DESCRIPTION
Sometimes, postcopy migration finished before switch to postcopy
or other checks. To do other operations during migration, need
to make it slow.

Signed-off-by: Yingshun Cui <yicui@redhat.com>