### PR TITLE
Fixup: Modify cpu library functions

### DIFF
--- a/libvirt/tests/src/cpu/max_vcpus.py
+++ b/libvirt/tests/src/cpu/max_vcpus.py
@@ -3,6 +3,7 @@ import logging
 from virttest import virsh
 from virttest import libvirt_xml
 from virttest import utils_misc
+from virttest import cpu
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import capability_xml
 from virttest.libvirt_xml.devices.iommu import Iommu
@@ -35,7 +36,7 @@ def run(test, params, env):
         :param cpu_num: the num of online vcpus need to match
         """
         if not utils_misc.wait_for(
-                lambda: utils_misc.check_if_vm_vcpu_match(cpu_num, vm),
+                lambda: cpu.check_if_vm_vcpu_match(cpu_num, vm),
                 timeout=120, step=5, text="wait for vcpu online"):
             test.fail('Not all vcpus are online as expected.')
 

--- a/libvirt/tests/src/cpu/ppccpucompat.py
+++ b/libvirt/tests/src/cpu/ppccpucompat.py
@@ -8,7 +8,7 @@ from virttest import data_dir
 from virttest import virt_vm
 from virttest import virsh
 from virttest import libvirt_xml
-from virttest import utils_misc
+from virttest import cpu
 from virttest import utils_package
 from virttest import utils_test
 
@@ -108,7 +108,7 @@ def run(test, params, env):
         if max_vcpu:
             virsh.setvcpus(vm_name, int(max_vcpu), "--live",
                            ignore_status=False, debug=True)
-            if not utils_misc.check_if_vm_vcpu_match(int(max_vcpu), vm):
+            if not cpu.check_if_vm_vcpu_match(int(max_vcpu), vm):
                 test.fail("Vcpu hotplug failed")
         if not status_error:
             for feature in guest_features:

--- a/libvirt/tests/src/cpu/setvcpu.py
+++ b/libvirt/tests/src/cpu/setvcpu.py
@@ -2,7 +2,7 @@ import logging
 import collections
 
 from virttest import virsh
-from virttest import utils_misc
+from virttest import cpu
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 
@@ -71,7 +71,7 @@ def run(test, params, env):
 
         # login vm and check the number of online vcpu
         if check == "hotplug":
-            if not utils_misc.check_if_vm_vcpu_match(cpu_count + cpus_online_pre, vm):
+            if not cpu.check_if_vm_vcpu_match(cpu_count + cpus_online_pre, vm):
                 test.fail("vcpu status check fail")
 
     def get_vcpu_order(vmxml):
@@ -171,7 +171,7 @@ def run(test, params, env):
             for cpus, option in setvcpu_option.items():
                 result_to_check = virsh.setvcpu(vm_name, cpus, option, debug=True)
                 if not status_error:
-                    cpulist = libvirt.cpus_parser(cpus)
+                    cpulist = cpu.cpus_parser(cpus)
                     check_vcpu_status(cpulist, option)
 
         # start vm
@@ -197,7 +197,7 @@ def run(test, params, env):
                 cpus_online_pre = vm.get_cpu_count()
                 result_to_check = virsh.setvcpu(vm_name, cpus, option, debug=True)
                 if not status_error:
-                    cpulist = libvirt.cpus_parser(cpus)
+                    cpulist = cpu.cpus_parser(cpus)
                     check_vcpu_status(cpulist, option, cpus_online_pre)
                     # check vcpu order only when live status of vcpu is changed
                     if 'config' not in option:

--- a/libvirt/tests/src/cpu/vcpu_hotpluggable.py
+++ b/libvirt/tests/src/cpu/vcpu_hotpluggable.py
@@ -9,7 +9,9 @@ from avocado.utils import process
 from avocado.utils.software_manager import SoftwareManager
 
 from virttest import virsh
-from virttest import utils_config, utils_libvirtd, utils_misc
+from virttest import utils_config
+from virttest import utils_libvirtd
+from virttest import cpu
 from virttest import data_dir
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
@@ -194,7 +196,7 @@ def run(test, params, env):
                 test.fail("vcpuinfo is not correct.")
 
             # Check cpu in guest
-            if not utils_misc.check_if_vm_vcpu_match(vcpus_crt, vm):
+            if not cpu.check_if_vm_vcpu_match(vcpus_crt, vm):
                 test.fail("cpu number in VM is not correct, it should be %s cpus" % vcpus_crt)
 
             # Check VM xml change for cold-plug/cold-unplug

--- a/libvirt/tests/src/libvirt_bench/libvirt_bench_vcpu_hotplug.py
+++ b/libvirt/tests/src/libvirt_bench/libvirt_bench_vcpu_hotplug.py
@@ -7,8 +7,8 @@ from avocado.core import exceptions
 from virttest import libvirt_xml
 from virttest import libvirt_vm
 from virttest import utils_test
-from virttest.utils_test import libvirt
 from virttest import utils_misc
+from virttest import cpu
 
 
 def run(test, params, env):
@@ -62,9 +62,9 @@ def run(test, params, env):
         session.cmd("dmesg -c")
         for i in range(test_times):
             # 1. Add vcpu
-            add_result = libvirt.hotplug_domain_vcpu(vm,
-                                                     max_count,
-                                                     add_by_virsh)
+            add_result = cpu.hotplug_domain_vcpu(vm,
+                                                 max_count,
+                                                 add_by_virsh)
             add_status = add_result.exit_status
             # 1.1 check add status
             if add_status:
@@ -74,7 +74,7 @@ def run(test, params, env):
                                 % add_result.stderr.strip())
                 test.fail("Test failed for:\n %s"
                           % add_result.stderr.strip())
-            if not utils_misc.wait_for(lambda: utils_misc.check_if_vm_vcpu_match(max_count, vm),
+            if not utils_misc.wait_for(lambda: cpu.check_if_vm_vcpu_match(max_count, vm),
                                        hotplug_timeout,
                                        text="wait for vcpu online"):
                 test.fail("vcpu hotplug failed")
@@ -126,10 +126,10 @@ def run(test, params, env):
                 test.fail("Set cpu%d online failed!"
                           % (max_count - 1))
             # 2. Del vcpu
-            del_result = libvirt.hotplug_domain_vcpu(vm,
-                                                     min_count,
-                                                     del_by_virsh,
-                                                     hotplug=False)
+            del_result = cpu.hotplug_domain_vcpu(vm,
+                                                 min_count,
+                                                 del_by_virsh,
+                                                 hotplug=False)
             del_status = del_result.exit_status
             if del_status:
                 logging.info("del_result: %s" % del_result.stderr.strip())
@@ -153,7 +153,7 @@ def run(test, params, env):
                 # besides above, regard it failed
                 test.fail("Test fail for:\n %s"
                           % del_result.stderr.strip())
-            if not utils_misc.wait_for(lambda: utils_misc.check_if_vm_vcpu_match(min_count, vm),
+            if not utils_misc.wait_for(lambda: cpu.check_if_vm_vcpu_match(min_count, vm),
                                        hotplug_timeout,
                                        text="wait for vcpu offline"):
                 test.fail("vcpu hotunplug failed")

--- a/libvirt/tests/src/libvirt_vcpu_plug_unplug.py
+++ b/libvirt/tests/src/libvirt_vcpu_plug_unplug.py
@@ -9,11 +9,11 @@ from avocado.utils import cpu as cpu_util
 from virttest import virsh
 from virttest import data_dir
 from virttest import utils_misc
+from virttest import cpu
 from virttest import utils_libvirtd
 from virttest import utils_test
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml.vm_xml import VMXML
-from virttest import utils_hotplug
 
 vm_uptime_init = 0
 
@@ -321,7 +321,7 @@ def run(test, params, env):
 
         # Run test
         for _ in range(iterations):
-            if not utils_hotplug.check_vcpu_value(vm, expect_vcpu_num):
+            if not cpu.check_vcpu_value(vm, expect_vcpu_num):
                 logging.error("Expected vcpu check failed")
                 result_failed += 1
             # plug vcpu
@@ -347,7 +347,7 @@ def run(test, params, env):
                     expect_vcpu_num['cur_live'] = vcpu_plug_num
                     expect_vcpu_num['guest_live'] = vcpu_plug_num
                     if not status_error:
-                        if not utils_misc.wait_for(lambda: utils_misc.check_if_vm_vcpu_match(vcpu_plug_num, vm),
+                        if not utils_misc.wait_for(lambda: cpu.check_if_vm_vcpu_match(vcpu_plug_num, vm),
                                                    vcpu_max_timeout, text="wait for vcpu online") or not online_new_vcpu(vm, vcpu_plug_num):
                             test.fail("Fail to enable new added cpu")
 
@@ -359,7 +359,7 @@ def run(test, params, env):
                     expect_vcpupin = {pin_vcpu: pin_cpu_list}
 
                 if status_error and check_after_plug_fail:
-                    if not utils_hotplug.check_vcpu_value(vm, expect_vcpu_num_bk, {}, setvcpu_option):
+                    if not cpu.check_vcpu_value(vm, expect_vcpu_num_bk, {}, setvcpu_option):
                         logging.error("Expected vcpu check failed")
                         result_failed += 1
 
@@ -368,7 +368,7 @@ def run(test, params, env):
                         utils_libvirtd.libvirtd_restart()
 
                     # Check vcpu number and related commands
-                    if not utils_hotplug.check_vcpu_value(vm, expect_vcpu_num, expect_vcpupin, setvcpu_option):
+                    if not cpu.check_vcpu_value(vm, expect_vcpu_num, expect_vcpupin, setvcpu_option):
                         logging.error("Expected vcpu check failed")
                         result_failed += 1
 
@@ -377,7 +377,7 @@ def run(test, params, env):
 
                     if vm_operation != "null":
                         # Check vcpu number and related commands
-                        if not utils_hotplug.check_vcpu_value(vm, expect_vcpu_num, expect_vcpupin, setvcpu_option):
+                        if not cpu.check_vcpu_value(vm, expect_vcpu_num, expect_vcpupin, setvcpu_option):
                             logging.error("Expected vcpu check failed")
                             result_failed += 1
 
@@ -406,7 +406,7 @@ def run(test, params, env):
                             expect_vcpu_num['guest_live'] = vcpu_current_num
                     if vm_operation != "null":
                         # Check vcpu number and related commands
-                        if not utils_hotplug.check_vcpu_value(vm, expect_vcpu_num, expect_vcpupin, setvcpu_option):
+                        if not cpu.check_vcpu_value(vm, expect_vcpu_num, expect_vcpupin, setvcpu_option):
                             logging.error("Expected vcpu check failed")
                             result_failed += 1
 
@@ -446,7 +446,7 @@ def run(test, params, env):
                                         setvcpu_option,
                                         readonly=setvcpu_readonly,
                                         ignore_status=True, debug=True)
-                unsupport_str = utils_hotplug.vcpuhotunplug_unsupport_str()
+                unsupport_str = cpu.vcpuhotunplug_unsupport_str()
                 if unsupport_str and (unsupport_str in result.stderr):
                     test.cancel("Vcpu hotunplug is not supported in this host:"
                                 "\n%s" % result.stderr)
@@ -496,7 +496,7 @@ def run(test, params, env):
                         utils_libvirtd.libvirtd_restart()
 
                     # Check vcpu number and related commands
-                    if not utils_hotplug.check_vcpu_value(vm, expect_vcpu_num, expect_vcpupin, setvcpu_option):
+                    if not cpu.check_vcpu_value(vm, expect_vcpu_num, expect_vcpupin, setvcpu_option):
                         logging.error("Expected vcpu check failed")
                         result_failed += 1
 
@@ -505,7 +505,7 @@ def run(test, params, env):
 
                     if vm_operation != "null":
                         # Check vcpu number and related commands
-                        if not utils_hotplug.check_vcpu_value(vm, expect_vcpu_num, expect_vcpupin, setvcpu_option):
+                        if not cpu.check_vcpu_value(vm, expect_vcpu_num, expect_vcpupin, setvcpu_option):
                             logging.error("Expected vcpu check failed")
                             result_failed += 1
 
@@ -534,7 +534,7 @@ def run(test, params, env):
                             expect_vcpu_num['guest_live'] = vcpu_current_num
                     if vm_operation != "null":
                         # Check vcpu number and related commands
-                        if not utils_hotplug.check_vcpu_value(vm, expect_vcpu_num, expect_vcpupin, setvcpu_option):
+                        if not cpu.check_vcpu_value(vm, expect_vcpu_num, expect_vcpupin, setvcpu_option):
                             logging.error("Expected vcpu check failed")
                             result_failed += 1
         if vm.uptime() < vm_uptime_init:

--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -11,6 +11,7 @@ from subprocess import Popen
 
 from avocado.core import exceptions
 from avocado.utils import process
+from avocado.utils import cpu as cpuutil
 
 from virttest import ssh_key
 from virttest import data_dir
@@ -19,6 +20,7 @@ from virttest import remote
 from virttest import utils_config
 from virttest import utils_libvirtd
 from virttest import utils_misc
+from virttest import cpu
 from virttest import utils_netperf
 from virttest import utils_package
 from virttest import utils_selinux
@@ -492,7 +494,7 @@ def get_same_processor(test, server_ip, server_user, server_pwd, verbose):
     :param verbose: the flag to control whether or not to log messages
     :raise: test.fail if test fails
     """
-    local_processors = utils_misc.get_cpu_processors(verbose=verbose)
+    local_processors = cpuutil.cpu_online_list()
     cmd = "grep processor /proc/cpuinfo"
     status, output = run_remote_cmd(cmd, server_ip, server_user, server_pwd)
     if status:
@@ -1527,7 +1529,7 @@ def run(test, params, env):
         logging.debug("The final test dict:\n<%s>", test_dict)
 
         if diff_cpu_vendor:
-            local_vendor = utils_misc.get_cpu_vendor()
+            local_vendor = cpu.get_cpu_vendor()
             logging.info("Local CPU vendor: %s", local_vendor)
             local_cpu_xml = get_cpu_xml_from_virsh_caps(test)
             logging.debug("Local CPU XML: \n%s", local_cpu_xml)

--- a/libvirt/tests/src/numa/guest_numa.py
+++ b/libvirt/tests/src/numa/guest_numa.py
@@ -7,11 +7,11 @@ from avocado.utils import process
 from virttest import virt_vm
 from virttest import libvirt_xml
 from virttest import utils_misc
+from virttest import cpu
 from virttest import utils_config
 from virttest import utils_libvirtd
 from virttest import test_setup
 from virttest import utils_params
-from virttest.utils_test import libvirt as utlv
 
 from provider import libvirt_version
 
@@ -189,17 +189,17 @@ def run(test, params, env):
         logging.debug("host node list is %s", node_list)
         used_node = []
         if numa_memory.get('nodeset'):
-            used_node += utlv.cpus_parser(numa_memory['nodeset'])
+            used_node += cpu.cpus_parser(numa_memory['nodeset'])
         if numa_memnode:
             for i in numa_memnode:
-                used_node += utlv.cpus_parser(i['nodeset'])
+                used_node += cpu.cpus_parser(i['nodeset'])
         if page_list:
             host_page_tuple = ("hugepage_size", "page_num", "page_nodenum")
             h_list = handle_param(host_page_tuple, params)
             h_nodenum = [h_list[p_size]['nodenum']
                          for p_size in range(len(h_list))]
             for i in h_nodenum:
-                used_node += utlv.cpus_parser(i)
+                used_node += cpu.cpus_parser(i)
         if used_node and not status_error:
             logging.debug("set node list is %s", used_node)
             used_node = list(set(used_node))
@@ -326,7 +326,7 @@ def run(test, params, env):
                 for map_info in hugepage_info:
                     for (mem_mode, mem_num, cell_num, host_node_num,
                          vm_page_num) in re.findall(node_pattern, map_info):
-                        usage_dict[mem_mode] = utlv.cpus_parser(mem_num)
+                        usage_dict[mem_mode] = cpu.cpus_parser(mem_num)
                         usage_dict[host_node_num] = vm_page_num
                         map_dict[cell_num] = usage_dict.copy()
                 logging.debug("huagepage info in vm numa maps is %s",
@@ -335,7 +335,7 @@ def run(test, params, env):
                 usage_dict = {}
                 if numa_memnode:
                     for i in numa_memnode:
-                        node = utlv.cpus_parser(i['nodeset'])
+                        node = cpu.cpus_parser(i['nodeset'])
                         mode = mode_dict[i['mode']]
                         usage_dict[mode] = node
                         memnode_dict[i['cellid']] = usage_dict.copy()
@@ -363,7 +363,7 @@ def run(test, params, env):
                 test.fail("%s not found in vm qemu cmdline" % cmd['cmdline'])
 
         # vm inside check
-        vm_cpu_info = utils_misc.get_cpu_info(session)
+        vm_cpu_info = cpu.get_cpu_info(session)
         logging.debug("lscpu output dict in vm is %s", vm_cpu_info)
         session.close()
         node_num = int(vm_cpu_info["NUMA node(s)"])
@@ -371,8 +371,8 @@ def run(test, params, env):
             test.fail("node number %s in vm is not expected" % node_num)
         for i in range(len(numa_cell)):
             cpu_str = vm_cpu_info["NUMA node%s CPU(s)" % i]
-            vm_cpu_list = utlv.cpus_parser(cpu_str)
-            cpu_list = utlv.cpus_parser(numa_cell[i]["cpus"])
+            vm_cpu_list = cpu.cpus_parser(cpu_str)
+            cpu_list = cpu.cpus_parser(numa_cell[i]["cpus"])
             if vm_cpu_list != cpu_list:
                 test.fail("vm node %s cpu list %s not expected"
                           % (i, vm_cpu_list))

--- a/libvirt/tests/src/numa/numa_memory.py
+++ b/libvirt/tests/src/numa/numa_memory.py
@@ -10,6 +10,7 @@ from virttest import virt_vm
 from virttest import libvirt_xml
 from virttest import virsh
 from virttest import utils_misc
+from virttest import cpu
 from virttest import utils_test
 from virttest import utils_config
 from virttest import utils_libvirtd
@@ -176,7 +177,7 @@ def run(test, params, env):
         cpu_list = [int(i) for i in tmp_list]
 
         if numa_memory.get('nodeset'):
-            used_node = utils_test.libvirt.cpus_parser(numa_memory['nodeset'])
+            used_node = cpu.cpus_parser(numa_memory['nodeset'])
             logging.debug("set node list is %s", used_node)
             if not status_error:
                 if not set(used_node).issubset(node_list):
@@ -184,7 +185,7 @@ def run(test, params, env):
                                                    numa_memory['nodeset'])
 
         if vcpu_cpuset:
-            pre_cpuset = utils_test.libvirt.cpus_parser(vcpu_cpuset)
+            pre_cpuset = cpu.cpus_parser(vcpu_cpuset)
             logging.debug("Parsed cpuset list is %s", pre_cpuset)
             if not set(pre_cpuset).issubset(cpu_list):
                 raise exceptions.TestSkipError("cpuset %s out of range" %
@@ -280,7 +281,7 @@ def run(test, params, env):
                 logging.warning('numa cmd opt:\n%s\n' % numad_cmd_opt)
                 test.fail("numad command not expected in log")
             numad_ret = numad_log[1].split("numad: ")[-1]
-            numad_node = utils_test.libvirt.cpus_parser(numad_ret)
+            numad_node = cpu.cpus_parser(numad_ret)
             left_node = [node_list.index(i) for i in node_list if i not in numad_node]
             numad_node_seq = [node_list.index(i) for i in numad_node]
             logging.debug("numad nodes are %s", numad_node)

--- a/libvirt/tests/src/numa/numa_memory_migrate.py
+++ b/libvirt/tests/src/numa/numa_memory_migrate.py
@@ -9,6 +9,7 @@ from virttest import virt_vm
 from virttest import libvirt_xml
 from virttest import virsh
 from virttest import utils_misc
+from virttest import cpu
 from virttest import utils_test
 from virttest import utils_config
 from virttest import utils_libvirtd
@@ -95,7 +96,7 @@ def run(test, params, env):
             test.fail("Libvirtd hang after restarted")
 
         if numa_memory.get('nodeset'):
-            used_node = utils_test.libvirt.cpus_parser(numa_memory['nodeset'])
+            used_node = cpu.cpus_parser(numa_memory['nodeset'])
             logging.debug("set node list is %s", used_node)
             for i in used_node:
                 if i not in node_list:
@@ -121,7 +122,7 @@ def run(test, params, env):
                                           " log")
             logging.debug("numad log list is %s", numad_log)
             numad_ret = numad_log[1].split("numad: ")[-1]
-            used_node = utils_test.libvirt.cpus_parser(numad_ret)
+            used_node = cpu.cpus_parser(numad_ret)
             logging.debug("numad nodes are %s", used_node)
 
         left_node = [i for i in node_list if i not in used_node]

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_dumpxml.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_dumpxml.py
@@ -2,7 +2,7 @@ import re
 import logging
 
 from virttest import virsh
-from virttest import utils_misc
+from virttest import cpu
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import capability_xml
 from virttest.libvirt_xml import domcapability_xml
@@ -67,7 +67,7 @@ def run(test, params, env):
             for key, value in item.items():
                 if value == 'require':
                     features.append(key)
-        return list(set(features) | set(utils_misc.get_model_features(modelname)))
+        return list(set(features) | set(cpu.get_model_features(modelname)))
 
     def check_cpu(xml, cpu_match):
         """

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_emulatorpin.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_emulatorpin.py
@@ -6,7 +6,7 @@ from avocado.utils import cpu
 
 from virttest.libvirt_xml import vm_xml
 from virttest import utils_libvirtd, virsh
-from virttest.utils_test.libvirt import cpus_parser
+from virttest.cpu import cpus_parser
 from virttest.staging import utils_cgroup
 from virttest.virt_vm import VMStartError
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_guestvcpus.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_guestvcpus.py
@@ -1,6 +1,8 @@
 import logging
+
+
 from virttest import virsh
-from virttest import utils_misc
+from virttest import cpu as cpuutil
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
 
@@ -93,7 +95,7 @@ def run(test, params, env):
 
             # Check the cpu in guest
             session = vm.wait_for_login()
-            vm_cpu_info = utils_misc.get_cpu_info(session)
+            vm_cpu_info = cpuutil.get_cpu_info(session)
             session.close()
 
             if combine == "yes":

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
@@ -20,6 +20,7 @@ from virttest import utils_package
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices import memory
 from virttest import utils_misc
+from virttest import cpu
 from virttest.qemu_storage import QemuImg
 from virttest.utils_test import libvirt
 from virttest import test_setup
@@ -393,9 +394,9 @@ def run(test, params, env):
 
             logging.debug("Checking CPU number gets reflected from inside "
                           "guest")
-            if not utils_misc.wait_for(lambda: utils_misc.check_if_vm_vcpu_match(cpu_count,
-                                                                                 vm,
-                                                                                 connect_uri=uri),
+            if not utils_misc.wait_for(lambda: cpu.check_if_vm_vcpu_match(cpu_count,
+                                                                          vm,
+                                                                          connect_uri=uri),
                                        300, text="wait for vcpu online"):
                 test.fail("CPU %s failed" % operation)
 
@@ -636,7 +637,7 @@ def run(test, params, env):
     hotunplug_after_migrate = "yes" == params.get("virsh_hotunplug_cpu_after",
                                                   "no")
     compat_guest_migrate = (params.get("host_arch", "all_arch") in
-                            utils_misc.get_cpu_info()['Model name'])
+                            cpu.get_cpu_info()['Model name'])
     compat_mode = "yes" == params.get("compat_mode", "no")
 
     # Configurations for cpu compat guest to boot
@@ -651,7 +652,7 @@ def run(test, params, env):
                                       model=cpu_model)
             vm.start()
             session = vm.wait_for_login()
-            actual_cpu_model = utils_misc.get_cpu_info(session)['Model name']
+            actual_cpu_model = cpu.get_cpu_info(session)['Model name']
             if cpu_model not in actual_cpu_model.lower():
                 test.error("Failed to configure cpu model,\nexpected: %s but "
                            "actual cpu model: %s" % (cpu_model,

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_numatune.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_numatune.py
@@ -6,7 +6,7 @@ from virttest import libvirt_xml
 from virttest import virsh
 from virttest import utils_libvirtd
 from virttest import utils_misc
-from virttest.utils_test.libvirt import cpus_parser
+from virttest.cpu import cpus_parser
 from virttest.libvirt_xml.xcepts import LibvirtXMLAccessorError
 from virttest.staging import utils_cgroup
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_setvcpu.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_setvcpu.py
@@ -3,7 +3,7 @@ import logging
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
-from virttest import utils_hotplug
+from virttest import cpu
 
 
 def run(test, params, env):
@@ -208,7 +208,7 @@ def run(test, params, env):
                     status = virsh.setvcpu(
                         dom_option, vcpu_list_option, options,
                         ignore_status=True, debug=True)
-                    unsupport_str = utils_hotplug.vcpuhotunplug_unsupport_str()
+                    unsupport_str = cpu.vcpuhotunplug_unsupport_str()
                     if unsupport_str and (unsupport_str in status.stderr):
                         test.cancel("Vcpu hotunplug is not supported in this host:"
                                     "\n%s" % status.stderr)
@@ -248,8 +248,8 @@ def run(test, params, env):
 
             # Lets validate the result in positive cases
             if status_error != "yes":
-                result = utils_hotplug.check_vcpu_value(vm, exp_vcpu,
-                                                        option=options)
+                result = cpu.check_vcpu_value(vm, exp_vcpu,
+                                              option=options)
     finally:
         if pre_vm_state == "paused":
             virsh.resume(vm_name, ignore_status=True)

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_setvcpus.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_setvcpus.py
@@ -7,7 +7,7 @@ from virttest import data_dir
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml, xcepts
 from virttest.libvirt_xml.vm_xml import VMCPUXML
-from virttest import utils_hotplug
+from virttest import cpu
 
 
 def run(test, params, env):
@@ -149,7 +149,7 @@ def run(test, params, env):
         logging.debug("Pre-test xml is %s", vmxml.xmltreefile)
 
         # Get the number of cpus, current value if set, and machine type
-        cpu_xml_data = utils_hotplug.get_cpu_xmldata(vm, options)
+        cpu_xml_data = cpu.get_cpu_xmldata(vm, options)
         logging.debug("Before run setvcpus: cpu_count=%d, cpu_current=%d,"
                       " mtype=%s", cpu_xml_data['vcpu'],
                       cpu_xml_data['current_vcpu'], cpu_xml_data['mtype'])
@@ -195,13 +195,13 @@ def run(test, params, env):
                                     ignore_status=True, debug=True)
             if not status_error:
                 set_expected(vm, options)
-                result = utils_hotplug.check_vcpu_value(vm, exp_vcpu,
-                                                        option=options)
+                result = cpu.check_vcpu_value(vm, exp_vcpu,
+                                              option=options)
         setvcpu_exit_status = status.exit_status
         setvcpu_exit_stderr = status.stderr.strip()
 
     finally:
-        cpu_xml_data = utils_hotplug.get_cpu_xmldata(vm, options)
+        cpu_xml_data = cpu.get_cpu_xmldata(vm, options)
         logging.debug("After run setvcpus: cpu_count=%d, cpu_current=%d,"
                       " mtype=%s", cpu_xml_data['vcpu'],
                       cpu_xml_data['current_vcpu'], cpu_xml_data['mtype'])

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_vcpupin.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_vcpupin.py
@@ -6,6 +6,7 @@ from avocado.utils import process
 from avocado.utils import cpu as cpuutils
 
 from virttest import virsh
+from virttest import cpu
 from virttest import utils_test
 from virttest import utils_misc
 from virttest.libvirt_xml import vm_xml
@@ -53,7 +54,7 @@ def run(test, params, env):
             if ':' in item:
                 split_key = ':'
             vcpus_affinity[item.split(split_key)[0].strip()] = item.split(split_key)[-1].strip()
-        return utils_test.libvirt.cpus_string_to_affinity_list(
+        return cpu.cpus_string_to_affinity_list(
             vcpus_affinity[str(vcpu)], int(total_cpu))
 
     def check_vcpupin(vm_name, vcpu, cpu_list, pid, vcpu_pid):
@@ -70,7 +71,7 @@ def run(test, params, env):
 
         total_cpu = process.run("ls -d /sys/devices/system/cpu/cpu[0-9]* |wc -l", shell=True).stdout_text.strip()
         logging.debug("Debug: cpulist %s", cpu_list)
-        expected_output = utils_test.libvirt.cpus_string_to_affinity_list(
+        expected_output = cpu.cpus_string_to_affinity_list(
             cpu_list,
             int(total_cpu))
         logging.debug("Expected affinity: %s", expected_output)
@@ -99,7 +100,7 @@ def run(test, params, env):
             return
         # Get the actual cpu affinity value in the proc entry
         output = utils_test.libvirt.cpu_allowed_list_by_task(pid, vcpu_pid)
-        actual_output_proc = utils_test.libvirt.cpus_string_to_affinity_list(
+        actual_output_proc = cpu.cpus_string_to_affinity_list(
             output,
             int(total_cpu))
         logging.debug("Actual affinity in guest proc: %s", actual_output_proc)
@@ -271,14 +272,14 @@ def run(test, params, env):
                         if cpu_itrs == 0:
                             cpu_itrs = 2
                 for _ in range(cpu_itrs):
-                    cpu = random.choice(cpus_list)
-                    left_cpus = "0-%s,^%s" % (online_cpu_max, cpu)
+                    cpuid = random.choice(cpus_list)
+                    left_cpus = "0-%s,^%s" % (online_cpu_max, cpuid)
                     if offline_pin:
-                        offline_pin_and_check(vm, vcpu, str(cpu))
+                        offline_pin_and_check(vm, vcpu, str(cpuid))
                         if multi_dom:
                             offline_pin_and_check(vm2, vcpu, left_cpus)
                     else:
-                        run_and_check_vcpupin(vm, vm_ref, vcpu, str(cpu),
+                        run_and_check_vcpupin(vm, vm_ref, vcpu, str(cpuid),
                                               options)
                         if multi_dom:
                             run_and_check_vcpupin(vm2, "name", vcpu, left_cpus,

--- a/libvirt/tests/src/virsh_cmd/host/virsh_nodecpustats.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_nodecpustats.py
@@ -1,8 +1,9 @@
 import re
 
+from avocado.utils import cpu as cpuutil
+
 from virttest import virsh
 from virttest import utils_libvirtd
-from virttest import utils_misc
 
 
 def run(test, params, env):
@@ -170,7 +171,7 @@ def run(test, params, env):
         utils_libvirtd.libvirtd_stop()
 
     # Get the host cpu list
-    host_cpus_list = utils_misc.get_cpu_processors()
+    host_cpus_list = cpuutil.cpu_online_list()
 
     # Run test case for 5 iterations default can be changed in subtests.cfg
     # file

--- a/libvirt/tests/src/virsh_cmd/host/virsh_nodeinfo.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_nodeinfo.py
@@ -8,6 +8,7 @@ from avocado.utils import process
 from virttest import virsh
 from virttest import utils_libvirtd
 from virttest import utils_misc
+from virttest import cpu
 from virttest.libvirt_xml import capability_xml
 from virttest.staging import utils_memory
 
@@ -122,7 +123,7 @@ def run(test, params, env):
         spec_numa = False
         if not re.match(cores_per_socket_nodeinfo, cores_per_socket_os):
             # for spec NUMA arch, the output of nodeinfo is in a spec format
-            cpus_os = utils_misc.get_cpu_info().get("CPU(s)")
+            cpus_os = cpu.get_cpu_info().get("CPU(s)")
             numa_cells_nodeinfo = _check_nodeinfo(
                 nodeinfo_output, 'NUMA cell(s)', 3)
             if (re.match(cores_per_socket_nodeinfo, cpus_os) and

--- a/libvirt/tests/src/vm_boot_with_kernel_param.py
+++ b/libvirt/tests/src/vm_boot_with_kernel_param.py
@@ -2,7 +2,7 @@ import logging
 
 from virttest.libvirt_xml import vm_xml
 from virttest import utils_test
-from virttest import utils_misc
+from virttest import cpu
 
 
 def run(test, params, env):
@@ -30,7 +30,7 @@ def run(test, params, env):
     vm_list = env.get_all_vms()
     # To ensure host that doesn't support Radix MMU gets skipped
     if cpu_check:
-        cpu_model = utils_misc.get_cpu_info()['Model name'].upper()
+        cpu_model = cpu.get_cpu_info()['Model name'].upper()
         if cpu_check not in cpu_model:
             logging.info("This test will work for %s", cpu_check)
             test.skip("Test is not applicable for %s" % cpu_model)


### PR DESCRIPTION
Let's modify the cpu library functions used in the
tests to match the re-order and grouping of library functions
addressed by below Patch(PR).
https://github.com/avocado-framework/avocado-vt/pull/2150

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>