### PR TITLE
hpt:Fix failed cases on x86

### DIFF
--- a/libvirt/tests/cfg/papr_hpt.cfg
+++ b/libvirt/tests/cfg/papr_hpt.cfg
@@ -10,7 +10,7 @@
                 - disabled:
                     hpt_attrs = "{'resizing': 'disabled'}"
                     qemu_check = 'resize-hpt=disabled'
-                    error_msg = 'echo: write error: No such device'
+                    error_msg = ['echo: write error: No such device']
                 - enabled:
                     hpt_attrs = "{'resizing': 'enabled'}"
                     qemu_check = 'resize-hpt=enabled'
@@ -45,7 +45,7 @@
 
         - negative_test:
             status_error = yes
-            error_msg = error: unsupported configuration: HPT tuning is only supported for pSeries guests
+            error_msg = ["error: unsupported configuration: The 'hpt' feature is not supported for architecture", "error: unsupported configuration: HPT tuning is only supported for pSeries guests"]
             variants:
                 - not_ppc:
                     no pseries
@@ -69,4 +69,4 @@
                             maxpagesize = 16384
                             hpt_attrs = "{'resizing': 'required', 'maxpagesize_unit': 'KiB', 'maxpagesize': 16384}"
                             cpu_attrs = "{'mode': 'host-model', 'check': 'partial', 'fallback': 'forbid', 'model': 'power8'}"
-                            error_msg = 'qemu-kvm: Can't support 16384 kiB guest pages with .*? kiB host pages with this KVM implementation'
+                            error_msg = ["qemu-kvm: Can't support 16384 kiB guest pages with .*? kiB host pages with this KVM implementation"]

--- a/libvirt/tests/src/papr_hpt.py
+++ b/libvirt/tests/src/papr_hpt.py
@@ -22,7 +22,7 @@ def run(test, params, env):
     vm_name = params.get('main_vm')
     vm = env.get_vm(vm_name)
     status_error = 'yes' == params.get('status_error', 'no')
-    error_msg = params.get('error_msg', '')
+    error_msg = eval(params.get('error_msg', '[]'))
 
     hpt_attrs = eval(params.get('hpt_attrs', '{}'))
     hpt_order_path = params.get('hpt_order_path', '')
@@ -100,7 +100,7 @@ def run(test, params, env):
             result = process.CmdResult(stderr=cmd_result[1],
                                        exit_status=cmd_result[0])
             libvirt.check_exit_status(result, True)
-            libvirt.check_result(result, [error_msg])
+            libvirt.check_result(result, error_msg)
         return hpt_order
 
     def check_hp_in_vm(session, page_size):
@@ -228,10 +228,10 @@ def run(test, params, env):
 
         # Test on non-ppc64le hosts
         else:
-            set_hpt(vmxml, attrs=hpt_attrs, sync=False)
+            set_hpt(vmxml, sync=False, **hpt_attrs)
             result = virsh.define(vmxml.xml)
             libvirt.check_exit_status(result, status_error)
-            libvirt.check_result(result, [error_msg])
+            libvirt.check_result(result, error_msg)
 
     finally:
         bk_xml.sync()


### PR DESCRIPTION
- Fix that passing the wrong params to function:set_hpt.
- Update expected error message since the actual error message is
changed.

Signed-off-by: haizhao <haizhao@redhat.com>