### PR TITLE
virsh_domrename: rename vm with autostart set

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domrename.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domrename.cfg
@@ -6,7 +6,6 @@
     domrename_vm_state = "shutoff"
     variants:
         - normal_test:
-            status_error = "no"
             variants:
                 - vm_name:
                 - vm_uuid:
@@ -19,6 +18,10 @@
                 - no_dom_opt:
                 - with_dom_opt:
                     dom_opt = "--domain"
+        - special_test:
+            variants:
+                - autostart_set:
+                    domrename_vm_state = "autostart"
         - error_test:
             status_error = "yes"
             variants:


### PR DESCRIPTION
Rename a domain that configured as autostart. Make sure new
symlink is created, and domain can be autostarted well.

Signed-off-by: Yanqiu Zhang <yanqzhan@redhat.com>