### PR TITLE
Fix missing return error by mistake

### DIFF
--- a/provider/v2v_vmcheck_helper.py
+++ b/provider/v2v_vmcheck_helper.py
@@ -163,6 +163,7 @@ class VMChecker(object):
             logging.info(
                 'Skip Checking metadata libosinfo parameters: %s' %
                 reason)
+            return
 
         # Checking if the feature is supported
         if not self.compare_version(FEATURE_SUPPORT['libosinfo']):


### PR DESCRIPTION
The return was removed by mistake in ea984489f06bc058b03a8bc6951328c989da1672.
We should add it back.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>