### PR TITLE
Fix a logic error in add_disk_xml()

### DIFF
--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -316,7 +316,7 @@ def add_disk_xml(test, device_type, source_file,
     :prams disk_type: disk type for attaching
     :raise: test.cancel if device type is not supported
     """
-    if device_type != 'cdrom' or device_type != 'floppy':
+    if device_type != 'cdrom' and device_type != 'floppy':
         test.cancel("Only support 'cdrom' and 'floppy'"
                     " device type: %s" % device_type)
 


### PR DESCRIPTION
The logic is: if the device_type is neither cdrom nor floppy, test
should be cancelled. So the if expression should be:
  if device_type != 'cdrom' and device_type != 'floppy':

Signed-off-by: Fangge Jin <fjin@redhat.com>