### PR TITLE
Fixed trying checking drivers only once time problem and spell error

### DIFF
--- a/provider/v2v_vmcheck_helper.py
+++ b/provider/v2v_vmcheck_helper.py
@@ -403,9 +403,11 @@ class VMChecker(object):
         check_drivers = expect_drivers[:]
         for check_times in range(5):
             logging.info('Check drivers for the %dth time', check_times + 1)
-            win_dirves = self.checker.get_driver_info()
+            win_dirvers = self.checker.get_driver_info()
+            if not win_dirvers:
+                continue
             for driver in expect_drivers:
-                if driver in win_dirves:
+                if driver in win_dirvers:
                     logging.info("Driver %s found", driver)
                     check_drivers.remove(driver)
                 else:


### PR DESCRIPTION
The code means to try to check drivers multiple times, but when getting driver info
failed, the script exits and will not try to check again.

In the debug logs, you only can find below debug log once instead of multiple times.
2019-07-14 01:56:00,248 v2v_vmcheck_help L0404 INFO | Check drivers for the 1th time

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>