### PR TITLE
Check whether 'result' is None before referencing it.

### DIFF
--- a/libvirt/tests/src/migration/migrate_options_shared.py
+++ b/libvirt/tests/src/migration/migrate_options_shared.py
@@ -714,6 +714,9 @@ def run(test, params, env):
         :param result: the output of migration
         :raise: test.fail if test is failed
         """
+        if not result:
+            test.error("No migration result is returned.")
+
         logging.info("Migration out: %s", results_stdout_52lts(result).strip())
         logging.info("Migration error: %s", results_stderr_52lts(result).strip())
 


### PR DESCRIPTION
Sometimes, migration result is still not returned when the code
starts to check the result.

Signed-off-by: Fangge Jin <fjin@redhat.com>