### PR TITLE
migrate_vm: fix UnboundLocalError: host_ip

### DIFF
--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -2661,10 +2661,12 @@ def run(test, params, env):
             process.run("iptables -F", ignore_status=True, shell=True)
 
         # Disable ports 24007 and 49152:49216
-        if gluster_disk and host_ip == client_ip:
-            logging.debug("Disable 24007 and 49152:49216 in Firewall")
-            migrate_setup.migrate_pre_setup(src_uri, params, cleanup=True, ports="24007")
-            migrate_setup.migrate_pre_setup(src_uri, params, cleanup=True)
+        if gluster_disk and 'host_ip' in locals():
+            if host_ip == client_ip:
+                logging.debug("Disable 24007 and 49152:49216 in Firewall")
+                migrate_setup.migrate_pre_setup(src_uri, params, cleanup=True,
+                                                ports="24007")
+                migrate_setup.migrate_pre_setup(src_uri, params, cleanup=True)
 
         # Restore libvirtd conf and restart libvirtd
         if libvirtd_conf:


### PR DESCRIPTION
It reported error "UnboundLocalError: local variable 'host_ip'
referenced before assignment" if lost connection to gluster server
at beginning of test. Fix it in 'finally' block.

Signed-off-by: Yingshun Cui <yicui@redhat.com>