### PR TITLE
virsh_domdisplay.py: fix 'r' mod for *-key.pem

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domdisplay.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domdisplay.py
@@ -54,7 +54,7 @@ def run(test, params, env):
 
     def clean_ssl_env():
         """
-        Do prepare for ssl spice connection
+        Clean ssl spice connection firstly
         """
         # modify qemu.conf
         with open(qemu_conf, "r") as f_obj:
@@ -71,7 +71,7 @@ def run(test, params, env):
 
     def prepare_ssl_env():
         """
-        Clean ssl spice connection firstly
+        Do prepare for ssl spice connection
         """
         # modify qemu.conf
         clean_ssl_env()
@@ -85,6 +85,8 @@ def run(test, params, env):
                                    "/C=IL/L=Raanana/O=Red Hat/CN=my CA",
                                    "/C=IL/L=Raanana/O=Red Hat/CN=my server",
                                    passwd)
+        os.chmod('/etc/pki/libvirt-spice/server-key.pem', 0o644)
+        os.chmod('/etc/pki/libvirt-spice/ca-key.pem', 0o644)
 
     try:
         graphic_count = len(vmxml_backup.get_graphics_devices())


### PR DESCRIPTION
on rhel8, the server-key.pem and ca-key.pem generated by default
only have 600 file permission. Here change them to 644 to avoid
test failures. And exchange the function description between
clean_ssl_env() and prepare_ssl_env().

Signed-off-by: Yanqiu Zhang <yanqzhan@redhat.com>