### PR TITLE
Check qemu lock for blockresize cases

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockresize.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockresize.py
@@ -7,6 +7,7 @@ from avocado.utils import process
 from virttest import virsh
 from virttest import data_dir
 from virttest import utils_misc
+from virttest import libvirt_storage
 
 from provider import libvirt_version
 
@@ -129,6 +130,8 @@ def run(test, params, env):
             value = int(resize_value[:-1])
             expected_size = value * 1024 * 1024 * 1024
             cmd = "qemu-img info %s" % image_path
+            if libvirt_storage.check_qemu_image_lock_support():
+                cmd += " -U"
             ret = process.run(cmd, allow_output_check='combined', shell=True)
             status, output = (ret.exit_status, ret.stdout_text.strip())
             value_return_by_qemu_img = re.search(r'virtual size:\s+(\d+(\.\d+)?)+G', output).group(1)


### PR DESCRIPTION
When qemu supports lock, the 'qemu-img info' cmd will be failed.
So fix it.

Signed-off-by: Yi Sun <yisun@redhat.com>