### PR TITLE
Update guest for virt-v2v case84637 and case18973

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -117,20 +117,18 @@
             main_vm = VM_NAME_ESX_SNAPSHOT_V2V_EXAMPLE
             removed_file = ESX_REMOVED_FILE_V2V_EXAMPLE
         - uefi:
-            main_vm = VM_NAME_ESX_EFI_V2V_EXAMPLE
             only libvirt
             variants:
                 - ovmf:
                     variants:
                         - windows:
-                            only esx_60
-                            checkpoint = 'ovmf'
+                            only esx_67
+                            main_vm = VM_NAME_ESX_UEFI_WINDOWS_V2V_EXAMPLE
                             msg_content = 'virt-v2v: warning: fstrim on guest filesystem /dev/.*? failed.  Usually'
                             expect_msg = yes
                         - rhel:
-                            only esx_55
-                            checkpoint = uefi_rhel
-                            main_vm = VM_NAME_ESX_UEFI_RHEL_V2V_EXAMPLE
+                            only esx_67
+                            main_vm = VM_NAME_ESX_UEFI_RHEL7_V2V_EXAMPLE
         - raid:
             only esx_60
             main_vm = VM_NAME_ESX_RAID_V2V_EXAMPLE

--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -38,6 +38,15 @@
             only uefi, GPO_AV, special_name, copy_to_local, usr_partition, suse
         - rhev:
             only dest_rhev.NFS
+            variants:
+                - rhv_upload:
+                    output_method = "rhv_upload"
+                    rhv_upload_passwd = ${ovirt_engine_password}
+                    rhv_upload_passwd_file = "/tmp/rhv_upload_passwd_file"
+                    rhv_upload_opts = "-oc ${ovirt_engine_url} -op ${rhv_upload_passwd_file} -oo rhv-cafile=${local_ca_file_path} -oo rhv-cluster=${cluster_name}"
+                    rhv_upload_opts = "${rhv_upload_opts} -oo rhv-direct"
+                - rhv:
+                    output_method = "rhev"
     variants:
         - esx_55:
             only source_esx.esx_55

--- a/v2v/tests/cfg/function_test_xen.cfg
+++ b/v2v/tests/cfg/function_test_xen.cfg
@@ -33,6 +33,15 @@
                     only dest_libvirt
                 - rhev:
                     only dest_rhev.NFS
+                    variants:
+                        - rhv_upload:
+                            output_method = "rhv_upload"
+                            rhv_upload_passwd = ${ovirt_engine_password}
+                            rhv_upload_passwd_file = "/tmp/rhv_upload_passwd_file"
+                            rhv_upload_opts = "-oc ${ovirt_engine_url} -op ${rhv_upload_passwd_file} -oo rhv-cafile=${local_ca_file_path} -oo rhv-cluster=${cluster_name}"
+                            rhv_upload_opts = "${rhv_upload_opts} -oo rhv-direct"
+                        - rhv:
+                            output_method = "rhev"
     variants:
         - xen_vm_default:
         - multiconsole:

--- a/v2v/tests/cfg/specific_kvm.cfg
+++ b/v2v/tests/cfg/specific_kvm.cfg
@@ -19,6 +19,15 @@
     status_test_command = 'echo $?'
 
     variants:
+        - it_vddk:
+            only source_esx
+            input_transport = 'vddk'
+            vddk_libdir_src = MOUNT_SRC_VDDK_LIB_DIR_V2V_EXAMPLE
+            # Set the real vddk_libdir/thumbprint or keep it commented
+            #vddk_libdir = VDDK_LIB_DIR_EXAMPLE
+            #vddk_thumbprint = VDDK_THUMBPRINT_EXAMPLE
+        - it_default:
+    variants:
         - output_mode:
             variants:
                 - local:
@@ -27,6 +36,15 @@
                     target = ${output_mode}
                 - rhev:
                     only dest_rhev.NFS
+                    variants:
+                        - rhv_upload:
+                            output_method = "rhv_upload"
+                            rhv_upload_passwd = ${ovirt_engine_password}
+                            rhv_upload_passwd_file = "/tmp/rhv_upload_passwd_file"
+                            rhv_upload_opts = "-oc ${ovirt_engine_url} -op ${rhv_upload_passwd_file} -oo rhv-cafile=${local_ca_file_path} -oo rhv-cluster=${cluster_name}"
+                            rhv_upload_opts = "${rhv_upload_opts} -oo rhv-direct"
+                        - rhv:
+                            output_method = "rhev"
                 - libvirt:
                     only dest_libvirt
     variants:

--- a/v2v/tests/src/function_test_esx.py
+++ b/v2v/tests/src/function_test_esx.py
@@ -180,7 +180,7 @@ def run(test, params, env):
             logging.info('Checking common checkpoints for v2v')
             vmchecker = VMChecker(test, params, env)
             params['vmchecker'] = vmchecker
-            if checkpoint not in ['GPO_AV', 'ovmf']:
+            if checkpoint != 'GPO_AV':
                 ret = vmchecker.run()
                 if len(ret) == 0:
                     logging.info("All common checkpoints passed")
@@ -277,8 +277,6 @@ def run(test, params, env):
         if output_mode == 'libvirt':
             pvt.pre_pool(pool_name, pool_type, pool_target, '')
 
-        if checkpoint == 'ovmf':
-            utils_package.package_install('OVMF')
         if checkpoint == 'root_ask':
             v2v_params['v2v_opts'] += ' --root ask'
             v2v_params['custom_inputs'] = params.get('choice', '2')


### PR DESCRIPTION
Use latest guests with secure boot to replace the old one and
there is no need to install OVMF by manual now.

Signed-off-by: mxie91 <mxie@redhat.com>