### PR TITLE
fix volume test case vol_concurrent

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/volume/vol_concurrent.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/volume/vol_concurrent.cfg
@@ -3,11 +3,11 @@
     vms = ''
     main_vm = ''
     start_vm = no
-    volume_number = 100
+    volume_number = 10
     pool_name = "orign_pool"
     volume_name = "orign_volume"
-    volume_size = "16777216"
-    volume_format = "qcow2"
+    volume_size = "1677721600"
+    volume_format = "raw"
     emulated_image = "emulated-image"
     emulated_image_size = "20G"
     variants:


### PR DESCRIPTION
increase volume size and change volume type to give enough time for
the last working thread to make volume operation after the creation of volume

Signed-off-by: Jin Li <jil@redhat.com>