### PR TITLE
Fix the virsh.blkiotune usage in case

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blkiotune.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blkiotune.py
@@ -194,7 +194,7 @@ def set_blkio_parameter(test, params, cgstop):
     device_weights = params.get("blkio_device_weights")
     options = params.get("options")
 
-    result = virsh.blkiotune(vm_name, weight, device_weights, options)
+    result = virsh.blkiotune(vm_name, weight, device_weights, options=options)
     status = result.exit_status
 
     # Check status_error


### PR DESCRIPTION
There are more parameters for virsh.blkiotune now.

Signed-off-by: Yi Sun <yisun@redhat.com>