### PR TITLE
Update guest for virt-v2v case84637 and case18973

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -117,20 +117,18 @@
             main_vm = VM_NAME_ESX_SNAPSHOT_V2V_EXAMPLE
             removed_file = ESX_REMOVED_FILE_V2V_EXAMPLE
         - uefi:
-            main_vm = VM_NAME_ESX_EFI_V2V_EXAMPLE
             only libvirt
             variants:
                 - ovmf:
                     variants:
                         - windows:
-                            only esx_60
-                            checkpoint = 'ovmf'
+                            only esx_67
+                            main_vm = VM_NAME_ESX_UEFI_WINDOWS_V2V_EXAMPLE
                             msg_content = 'virt-v2v: warning: fstrim on guest filesystem /dev/.*? failed.  Usually'
                             expect_msg = yes
-                        - rhel:
-                            only esx_55
-                            checkpoint = uefi_rhel
-                            main_vm = VM_NAME_ESX_UEFI_RHEL_V2V_EXAMPLE
+                        - rhel7:
+                            only esx_67
+                            main_vm = VM_NAME_ESX_UEFI_RHEL7_V2V_EXAMPLE
         - raid:
             only esx_60
             main_vm = VM_NAME_ESX_RAID_V2V_EXAMPLE

--- a/v2v/tests/src/function_test_esx.py
+++ b/v2v/tests/src/function_test_esx.py
@@ -6,7 +6,6 @@ from avocado.utils import process
 
 from virttest import data_dir
 from virttest import utils_misc
-from virttest import utils_package
 from virttest import utils_sasl
 from virttest import utils_v2v
 from virttest import virsh
@@ -180,7 +179,7 @@ def run(test, params, env):
             logging.info('Checking common checkpoints for v2v')
             vmchecker = VMChecker(test, params, env)
             params['vmchecker'] = vmchecker
-            if checkpoint not in ['GPO_AV', 'ovmf']:
+            if checkpoint != 'GPO_AV':
                 ret = vmchecker.run()
                 if len(ret) == 0:
                     logging.info("All common checkpoints passed")
@@ -277,8 +276,6 @@ def run(test, params, env):
         if output_mode == 'libvirt':
             pvt.pre_pool(pool_name, pool_type, pool_target, '')
 
-        if checkpoint == 'ovmf':
-            utils_package.package_install('OVMF')
         if checkpoint == 'root_ask':
             v2v_params['v2v_opts'] += ' --root ask'
             v2v_params['custom_inputs'] = params.get('choice', '2')


### PR DESCRIPTION
Use latest guests with secure boot to replace the old one and
there is no need to install OVMF by manual now.

Signed-off-by: mxie91 <mxie@redhat.com>