### PR TITLE
migration: Fix pool issue

### DIFF
--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -1855,7 +1855,8 @@ def run(test, params, env):
         # and nbd-server, but need create a specific pool.
         no_create_pool = test_dict.get("no_create_pool", "no")
         try:
-            if (utils_misc.is_qemu_capability_supported("drive-mirror") and
+            if ((utils_misc.is_qemu_capability_supported("drive-mirror") or
+                 libvirt_version.version_compare(5, 3, 0)) and
                     utils_misc.is_qemu_capability_supported("nbd-server")):
                 support_precreation = True
         except exceptions.TestError as e:


### PR DESCRIPTION
QEMU_CAPS_DRIVE_MIRROR became default qemu caps from v5.3.0 and no
longer present in '/var/cache/libvirt/qemu/capabilities/xx.xml'.
So update the condition.

Signed-off-by: Yingshun Cui <yicui@redhat.com>