### PR TITLE
Add more genid and libosinfo cases for v2v

### DIFF
--- a/provider/v2v_vmcheck_helper.py
+++ b/provider/v2v_vmcheck_helper.py
@@ -511,7 +511,7 @@ class VMChecker(object):
                     genid_list)
                 # genid will not be in vmxml
                 if re.search(r'genid', self.vmxml):
-                    self.log_err('Unexpected genid in xml:\n%s' % self.vmxml)
+                    self.log_err('Unexpected genid in xml')
                 return
 
             genid_str = _compose_genid(*genid_list)
@@ -521,4 +521,4 @@ class VMChecker(object):
                 self.log_err('Not find genid or genid is incorrect')
         elif has_genid == 'no':
             if re.search(r'genid', self.vmxml):
-                self.log_err('Unexpected genid in xml:\n%s' % self.vmxml)
+                self.log_err('Unexpected genid in xml')

--- a/v2v/tests/cfg/convert_from_file.cfg
+++ b/v2v/tests/cfg/convert_from_file.cfg
@@ -159,6 +159,15 @@
                             # Do not skip vm checking by default
                             skip_vm_check = no
                             variants:
+                                - win2012r2:
+                                    only esx_55
+                                    only windows
+                                    os_version = 'win2012r2'
+                                    has_genid = 'no'
+                                    main_vm = 'VM_NAME_GENID_WIN2012R2_V2V_EXAMPLE'
+                                    vmx_nfs_src = NFS_ESX55_VMX_V2V_EXAMPLE
+                                    # genid only supports libvirt, local, qemu
+                                    only output_mode.libvirt
                                 - win2019:
                                     only esx_67
                                     only windows
@@ -216,4 +225,4 @@
                     restart_network = 'ipconfig /renew'
                     vm_user = 'Administrator'
                     vm_pwd = '123qweP'
-                    only win2008r2_ostk,aws.win2019,win2019,win10
+                    only win2008r2_ostk,aws.win2019,win2019,win10,win2012r2

--- a/v2v/tests/cfg/convert_vm_to_libvirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_libvirt.cfg
@@ -29,6 +29,9 @@
         - arch_i386:
             no latest8
             no latest7
+            no debian9_8
+            no ubuntu18_04
+            no sles12sp4
             no win2008r2
             no win2012
             no win2012r2
@@ -47,11 +50,24 @@
                     os_short_id = "RHEL8_SHORT_ID"
                     os_version = "LATEST8"
                 - latest7:
+                    os_short_id = "RHEL7_SHORT_ID"
                     os_version = "LATEST7"
                 - latest6:
                     os_version = "LATEST6"
                 - 5_11:
                     os_version = "rhel5.11"
+                - debian9_8:
+                    only source_esx
+                    os_short_id = "debian9"
+                    os_version = "debian9.8"
+                - ubuntu18_04:
+                    only source_esx
+                    os_short_id = "ubuntu18.04"
+                    os_version = "ubuntu18.04"
+                - sles12sp4:
+                    only source_esx
+                    os_short_id = "sles12sp4"
+                    os_version = "sles12sp4"
         - windows:
             no pv
             os_type = "windows"


### PR DESCRIPTION
1) Remove vmxml info in log_err that will make a long error log
2) Add more guests for genid and libosinfo

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>