### PR TITLE
BIOS: fix ide bus issue and CDROM issue in seabios option

### DIFF
--- a/libvirt/tests/cfg/bios/boot_integration.cfg
+++ b/libvirt/tests/cfg/bios/boot_integration.cfg
@@ -30,4 +30,4 @@
             bios_useserial = "yes"
             bios_reboot_timeout = "1000"
             disk_target_dev = 'hda'
-            disk_target_bus = 'ide'
+            disk_target_bus = 'scsi'

--- a/libvirt/tests/cfg/bios/virsh_boot.cfg
+++ b/libvirt/tests/cfg/bios/virsh_boot.cfg
@@ -185,7 +185,7 @@
                                             variants:
                                                 - file_disk:
                                                     disk_type = "file"
-                                                    device_bus = "ide"
+                                                    device_bus = "scsi"
                                                     target_dev = "hda"
                                                 - usb_disk:
                                                     disk_type = "block"

--- a/libvirt/tests/src/bios/virsh_boot.py
+++ b/libvirt/tests/src/bios/virsh_boot.py
@@ -313,6 +313,8 @@ def apply_boot_options(vmxml, params):
         logging.debug("Enable bios serial console in OS XML")
         dict_os_attrs.update({"bios_useserial": "yes"})
         dict_os_attrs.update({"bios_reboot_timeout": "0"})
+        dict_os_attrs.update({"bootmenu_enable": "yes"})
+        dict_os_attrs.update({"bootmenu_timeout": "3000"})
 
     # Set attributes of nvram of VMOSXML
     if with_nvram:


### PR DESCRIPTION
1. Change ide bus to scsi bus in cfg to support seabios-q35
2. Add bootmenu in os element to make sure case can get CDROM prompt

Signed-off-by: meinaLi <meili@redhat.com>