### PR TITLE
Change destination for v2v case84568 and source for v2v case12986

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -35,7 +35,7 @@
     variants:
         - libvirt:
             only dest_libvirt
-            only uefi, GPO_AV, special_name, copy_to_local, usr_partition, suse
+            only uefi, GPO_AV, special_name, copy_to_local, suse
         - rhev:
             only dest_rhev.NFS
             variants:
@@ -83,6 +83,12 @@
                     main_vm = 'PROGRAM_FILES_2_VM_NAME_V2V_EXAMPLE'
                     expect_msg = 'no'
                     msg_content = '.*case_sensitive_path: v2v: no file or directory.*'
+                - rhev_file:
+                    only esx_67
+                    no libvirt
+                    checkpoint = 'rhev_file'
+                    os_version = OS_VERSION_RHEV_FILE_V2V_EXAMPLE
+                    main_vm = RHEV_FILE_VM_NAME_V2V_EXAMPLE
         - with_cdrom:
             only esx_55
             main_vm = 'VM_NAME_ESX_CDROM_V2V_EXAMPLE'
@@ -211,7 +217,7 @@
             esx_https_proxy = HTTPS_PROXY_V2V_EXAMPLE
         - usr_partition:
             only esx_55
-            only libvirt
+            no libvirt
             main_vm = VM_NAME_USR_PARTITION_V2V_EXAMPLE
         - lvm_multiple_disks:
             only esx_65

--- a/v2v/tests/cfg/function_test_xen.cfg
+++ b/v2v/tests/cfg/function_test_xen.cfg
@@ -147,10 +147,6 @@
                     windows_root = 'WINDOWS_ROOT_V2V_EXAMPLE'
                     os_version = 'WINDOWS_ROOT_OS_VERSION_V2V_EXAMPLE'
                     main_vm = 'WINDOWS_ROOT_VM_NAME_V2V_EXAMPLE'
-                - rhev_file:
-                    checkpoint = 'rhev_file'
-                    os_version = 'OS_VERSION_RHEV_FILE_V2V_EXAMPLE'
-                    main_vm = 'RHEV_FILE_VM_NAME_V2V_EXAMPLE'
                 - virtio_win:
                     main_vm = 'XEN_VM_NAME_VIRTIO_WIN_V2V_EXAMPLE'
                     os_version = 'OS_VERSION_VIRTIO_WIN_V2V_EXAMPLE'
@@ -180,11 +176,11 @@
             no xen_vm_default
             variants:
                 - libvirt:
-                    only pool_uuid, windows.rhev_file, display, sound, virtio_win, with_vdsm
+                    only pool_uuid, display, sound, virtio_win, with_vdsm
                     only output_mode.libvirt
                     no encrypt_warning
                 - rhev:
-                    no pool_uuid, windows.rhev_file, display.vnc.encrypt, sound, virtio_win
+                    no pool_uuid, display.vnc.encrypt, sound, virtio_win
                     only output_mode.rhev
         - negative_test:
             status_error = 'yes'

--- a/v2v/tests/src/function_test_esx.py
+++ b/v2v/tests/src/function_test_esx.py
@@ -159,6 +159,21 @@ def run(test, params, env):
         if 'resume=/dev/vd' not in content:
             log_fail('Content of /proc/cmdline is not correct')
 
+    def check_rhev_file_exist(vmcheck):
+        """
+        Check if rhev files exist
+        """
+        file_path = {
+            'rhev-apt.exe': r'C:\rhev-apt.exe',
+            'rhsrvany.exe': r'"C:\Program Files\Guestfs\Firstboot\rhsrvany.exe"'
+        }
+        for key in file_path:
+            status = vmcheck.session.cmd_status('dir %s' % file_path[key])
+            if status == 0:
+                logging.info('%s exists' % key)
+            else:
+                log_fail('%s does not exist after convert to rhv' % key)
+
     def check_result(result, status_error):
         """
         Check virt-v2v command result
@@ -196,6 +211,8 @@ def run(test, params, env):
                 check_device_map(vmchecker.checker)
             if checkpoint == 'resume_swap':
                 check_resume_swap(vmchecker.checker)
+            if checkpoint == 'rhev_file':
+                check_rhev_file_exist(vmchecker.checker)
             # Merge 2 error lists
             error_list.extend(vmchecker.errors)
         log_check = utils_v2v.check_log(params, output)

--- a/v2v/tests/src/function_test_xen.py
+++ b/v2v/tests/src/function_test_xen.py
@@ -76,23 +76,6 @@ def run(test, params, env):
             graphic.set(key, param[key])
         vmxml.sync(virsh_instance=virsh_instance)
 
-    def check_rhev_file_exist(vmcheck):
-        """
-        Check if rhev files exist
-        """
-        file_path = {
-            'rhev-apt.exe': r'C:\rhev-apt.exe',
-            'rhsrvany.exe': r'"C:\program files\redhat\rhev\apt\rhsrvany.exe"'
-        }
-        fail = False
-        for key in file_path:
-            status = vmcheck.session.cmd_status('dir %s' % file_path[key])
-            if not status:
-                logging.error('%s exists' % key)
-                fail = True
-        if fail:
-            log_fail('RHEV file exists after convert to kvm')
-
     def check_grub_file(vmcheck, check):
         """
         Check grub file content
@@ -182,8 +165,6 @@ def run(test, params, env):
             if len(ret) == 0:
                 logging.info("All common checkpoints passed")
             # Check specific checkpoints
-            if checkpoint == 'rhev_file':
-                check_rhev_file_exist(vmchecker.checker)
             if checkpoint == 'console_xvc0':
                 check_grub_file(vmchecker.checker, 'console_xvc0')
             if checkpoint in ('vnc_autoport', 'vnc_encrypt'):


### PR DESCRIPTION
Change the destination of case84568 from libvirt to rhv, change
the source of case12986 from Xen to VMware and modify 
corresponding function of checkpoint as previous result is not 
expected.

Signed-off-by: mxie91 <mxie@redhat.com>