### PR TITLE
Change the destination for some v2v cases

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -35,7 +35,7 @@
     variants:
         - libvirt:
             only dest_libvirt
-            only uefi, GPO_AV, special_name, copy_to_local, usr_partition, suse
+            only uefi, copy_to_local, usr_partition, suse
         - rhev:
             only dest_rhev.NFS
             variants:
@@ -104,6 +104,7 @@
             main_vm = 'VM_NAME_ESX_MULCPUS_V2V_EXAMPLE'
         - special_name:
             only esx_55
+            no libvirt
             main_vm = 'VM_NAME_ESX_SPECIALNAME_V2V_EXAMPLE'
         - cloned_vm:
             only esx_55
@@ -134,6 +135,7 @@
             main_vm = VM_NAME_ESX_RAID_V2V_EXAMPLE
         - GPO_AV:
             only esx_60
+            no libvirt
             main_vm = 'VM_NAME_GPO_AV_V2V_EXAMPLE'
             checkpoint = 'GPO_AV'
             msg_content = 'virt-v2v: warning: this guest has Windows Group Policy Objects%virt-v2v: warning: this guest has Anti-Virus \(AV\) software'
@@ -222,6 +224,7 @@
             main_vm = VM_NAME_RESUME_SWAP_V2V_EXAMPLE
         - suse:
             only source_esx.esx_67
+            only libvirt
             variants:
                 - sles15:
                     main_vm = VM_NAME_SLES15_V2V_EXAMPLE


### PR DESCRIPTION
Previous code forgot to define ‘only libvirt’ in case 'suse',so
fix it, meanwhile change the destination for case'GPO_AV'and
'special_name' from libvirt to rhv .

Signed-off-by: mxie91 <mxie@redhat.com>