### PR TITLE
virsh_migrate: add --postcopy-after-precopy for postcopy tests

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
@@ -44,16 +44,16 @@
             no with_inactive_guest, there_vm_shutdown_live, there_vm_shutdown_online
             no there_offline.with_active_guest, with_HP_only, with_HP
             no with_numa_and_HP, with_HP_pin, there_online, there_online_with_numa
-            postcopy_options = "--postcopy"
-        - without_postcopy:
-            no postcopy_after_precopy, migrate_postcopy
+            no migrate_postcopy
+            postcopy_options = "--postcopy --postcopy-after-precopy"
+        - @default:
             postcopy_options = ""
     variants:
         - compat_migration:
             variants:
                 - ppc_compat_migration:
                     only ppc64le,ppc64
-                    only there_live,there_live_with_numa,there_and_back,there_and_back_with_numa,postcopy_after_precopy,migrate_postcopy
+                    only there_live,there_live_with_numa,there_and_back,there_and_back_with_numa
                     compat_mode = "yes"
                     power9_compat = "yes"
                     power9_compat_remote = "yes"
@@ -69,7 +69,7 @@
                 - non_compat_migration:
     variants:
         - with_cpu_hotplug:
-            only there_live,there_live_with_numa,there_and_back,there_and_back_with_numa,postcopy_after_precopy,migrate_postcopy
+            only there_live,there_live_with_numa,there_and_back,there_and_back_with_numa
             virsh_migrate_cpu_hotplug = "yes"
             variants:
                 - with_hotplug:
@@ -246,11 +246,9 @@
                         - memnode_with_preferred_strict:
                             memnode_mode_1 = "preferred"
                             memnode_mode_2 = "strict"
-        - postcopy_after_precopy:
-            virsh_migrate_options = "--live --postcopy-after-precopy"
         - migrate_postcopy:
             stress_args = "--cpu 8 --io 8 --vm 2 --vm-bytes 256M --timeout 60s"
-            virsh_migrate_options = "--live"
+            virsh_migrate_options = "--live --postcopy"
             virsh_postcopy_cmd = "migrate-postcopy"
             # migration thread timeout
             postcopy_migration_timeout = "200"


### PR DESCRIPTION
currently postcopy test will run with just enabling postcopy
flag but without actual postcopy migration. add option
`--postcopy-after-precopy` to perform postcopy migration.

Signed-off-by: Balamuruhan S <bala24@linux.ibm.com>