### PR TITLE
libvirt_vcpu_plug_unplug: Check if var 'bt' is None before calling

### DIFF
--- a/libvirt/tests/src/libvirt_vcpu_plug_unplug.py
+++ b/libvirt/tests/src/libvirt_vcpu_plug_unplug.py
@@ -541,7 +541,8 @@ def run(test, params, env):
         if need_mkswap:
             vm.cleanup_swap()
         if with_stress:
-            bt.join(ignore_status=True)
+            if bt:
+                bt.join(ignore_status=True)
         vm.destroy()
         backup_xml.sync()
 


### PR DESCRIPTION
To avoid NoneType errors.

Signed-off-by: haizhao <haizhao@redhat.com>