### PR TITLE
Update scripts which call setup_or_cleanup_gluster or get_host_ipv4_addr

### DIFF
--- a/libvirt/tests/src/bios/virsh_boot.py
+++ b/libvirt/tests/src/bios/virsh_boot.py
@@ -9,13 +9,15 @@ from avocado.utils import process
 from virttest import remote
 from virttest import virsh
 from virttest import utils_package
-from virttest.libvirt_xml import vm_xml
-from virttest.libvirt_xml.devices.disk import Disk
-from virttest.utils_test import libvirt as utlv
 from virttest import utils_misc
 from virttest import data_dir
 from virttest import ceph
+from virttest import gluster
+
+from virttest.utils_test import libvirt as utlv
 from virttest.libvirt_xml.devices.controller import Controller
+from virttest.libvirt_xml import vm_xml
+from virttest.libvirt_xml.devices.disk import Disk
 
 from provider import libvirt_version
 
@@ -425,7 +427,7 @@ def prepare_gluster_disk(blk_source, test, **kwargs):
     brick_path = kwargs.get("brick_path")
     disk_img = kwargs.get("disk_img")
     disk_format = kwargs.get("disk_format")
-    host_ip = utlv.setup_or_cleanup_gluster(True, **kwargs)
+    host_ip = gluster.setup_or_cleanup_gluster(True, **kwargs)
     logging.debug("host ip: %s ", host_ip)
     # Copy the domain disk image to gluster disk path
     image_info = utils_misc.get_image_info(blk_source)
@@ -698,7 +700,7 @@ def run(test, params, env):
         vmxml_backup.sync(options="--nvram")
         if cleanup_gluster:
             process.run("umount /mnt", ignore_status=True, shell=True)
-            utlv.setup_or_cleanup_gluster(False, brick_path=brick_path, **params)
+            gluster.setup_or_cleanup_gluster(False, brick_path=brick_path, **params)
         if cleanup_iscsi:
             utlv.setup_or_cleanup_iscsi(False)
         if cleanup_iso_file:

--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -15,6 +15,7 @@ from avocado.utils import process
 from virttest import ssh_key
 from virttest import data_dir
 from virttest import nfs
+from virttest import gluster
 from virttest import remote
 from virttest import utils_config
 from virttest import utils_libvirtd
@@ -372,7 +373,7 @@ def prepare_gluster_disk(params):
                                 image_name + '.' + image_format)
 
     # Setup gluster.
-    host_ip = libvirt.setup_or_cleanup_gluster(True, **params)
+    host_ip = gluster.setup_or_cleanup_gluster(True, **params)
     logging.debug("host ip: %s ", host_ip)
     image_info = utils_misc.get_image_info(image_source)
     if image_info["format"] == disk_format:
@@ -2737,7 +2738,7 @@ def run(test, params, env):
 
         libvirtd = utils_libvirtd.Libvirtd()
         if disk_src_protocol == "gluster":
-            libvirt.setup_or_cleanup_gluster(False, **test_dict)
+            gluster.setup_or_cleanup_gluster(False, **test_dict)
             libvirtd.restart()
 
         if disk_src_protocol == "iscsi":

--- a/libvirt/tests/src/svirt/dac_vm_per_image_start.py
+++ b/libvirt/tests/src/svirt/dac_vm_per_image_start.py
@@ -8,6 +8,7 @@ from avocado.utils import process
 
 from virttest import utils_selinux
 from virttest import virt_vm
+from virttest import gluster
 from virttest import utils_config
 from virttest import utils_libvirtd
 from virttest import data_dir
@@ -202,7 +203,7 @@ def run(test, params, env):
         if disk_src_protocol == 'iscsi':
             utlv.setup_or_cleanup_iscsi(is_setup=False)
         elif disk_src_protocol == 'gluster':
-            utlv.setup_or_cleanup_gluster(False, brick_path=brick_path, **params)
+            gluster.setup_or_cleanup_gluster(False, brick_path=brick_path, **params)
             libvirtd.restart()
         elif disk_src_protocol == 'netfs':
             utlv.setup_or_cleanup_nfs(is_setup=False,

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockcommit.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockcommit.py
@@ -13,6 +13,7 @@ from virttest import utils_libvirtd
 from virttest import utils_package
 from virttest import libvirt_storage
 from virttest import ceph
+from virttest import gluster
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 
@@ -585,7 +586,7 @@ def run(test, params, env):
             libvirt.setup_or_cleanup_iscsi(is_setup=False,
                                            restart_tgtd=restart_tgtd)
         elif disk_src_protocol == 'gluster':
-            libvirt.setup_or_cleanup_gluster(False, brick_path=brick_path, **params)
+            gluster.setup_or_cleanup_gluster(False, brick_path=brick_path, **params)
             libvirtd = utils_libvirtd.Libvirtd()
             libvirtd.restart()
         elif disk_src_protocol == 'netfs':

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockpull.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockpull.py
@@ -11,6 +11,8 @@ from virttest import utils_libvirtd
 from virttest import utils_package
 from virttest import libvirt_storage
 from virttest import ceph
+from virttest import gluster
+
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import snapshot_xml
@@ -496,7 +498,7 @@ def run(test, params, env):
                                            restart_tgtd=restart_tgtd)
         elif disk_src_protocol == 'gluster':
             logging.info("clean gluster env")
-            libvirt.setup_or_cleanup_gluster(False, brick_path=brick_path, **params)
+            gluster.setup_or_cleanup_gluster(False, brick_path=brick_path, **params)
             libvirtd.restart()
         elif disk_src_protocol == 'netfs':
             restore_selinux = params.get('selinux_status_bak')

--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_create_as.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_create_as.py
@@ -12,6 +12,7 @@ from virttest import utils_misc
 from virttest import xml_utils
 from virttest import utils_config
 from virttest import utils_libvirtd
+from virttest import gluster
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import xcepts
@@ -596,7 +597,7 @@ def run(test, params, env):
             test.fail("Still can find snapshot metadata")
 
         if disk_src_protocol == 'gluster':
-            libvirt.setup_or_cleanup_gluster(False, brick_path=brick_path, **params)
+            gluster.setup_or_cleanup_gluster(False, brick_path=brick_path, **params)
             libvirtd.restart()
 
         if disk_src_protocol == 'iscsi':

--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_disk.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_disk.py
@@ -12,6 +12,7 @@ from virttest import data_dir
 from virttest import libvirt_xml
 from virttest import libvirt_storage
 from virttest import utils_libvirtd
+from virttest import gluster
 from virttest.utils_test import libvirt as utlv
 
 from provider import libvirt_version
@@ -436,12 +437,12 @@ def run(test, params, env):
 
         libvirtd = utils_libvirtd.Libvirtd()
         if disk_source_protocol == 'gluster':
-            utlv.setup_or_cleanup_gluster(False, brick_path=brick_path, **params)
+            gluster.setup_or_cleanup_gluster(False, brick_path=brick_path, **params)
             if multi_gluster_disks:
                 brick_path = os.path.join(tmp_dir, "gluster-pool2")
                 mul_kwargs = params.copy()
                 mul_kwargs.update({"vol_name": "gluster-vol2"})
-                utlv.setup_or_cleanup_gluster(False, brick_path=brick_path, **mul_kwargs)
+                gluster.setup_or_cleanup_gluster(False, brick_path=brick_path, **mul_kwargs)
             libvirtd.restart()
 
         if snapshot_xml_path:

--- a/libvirt/tests/src/virsh_cmd/volume/virsh_volume.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_volume.py
@@ -9,6 +9,8 @@ from virttest import utils_misc
 from virttest import data_dir
 from virttest import virsh
 from virttest import libvirt_storage
+from virttest import utils_net
+
 from virttest.libvirt_xml import vol_xml
 from virttest.utils_test import libvirt as utlv
 from virttest.staging import service
@@ -465,7 +467,7 @@ def run(test, params, env):
                 if gluster_server_ip:
                     ip_addr = gluster_server_ip
                 else:
-                    ip_addr = utlv.get_host_ipv4_addr()
+                    ip_addr = utils_net.get_host_ip_address()
                 expected_vol['path'] = "gluster://%s/%s/%s" % (ip_addr,
                                                                source_name,
                                                                volume_name)

--- a/libvirt/tests/src/virtual_disks/virtual_disks_gluster.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_gluster.py
@@ -5,6 +5,7 @@ from avocado.utils import process
 
 from virttest import virsh
 from virttest import data_dir
+from virttest import gluster
 from virttest import utils_misc
 from virttest import virt_vm, remote
 from virttest.utils_test import libvirt
@@ -35,7 +36,7 @@ def run(test, params, env):
         image_source = vm.get_first_disk_devices()['source']
 
         # Setup gluster
-        host_ip = libvirt.setup_or_cleanup_gluster(True, brick_path=brick_path,  **params)
+        host_ip = gluster.setup_or_cleanup_gluster(True, brick_path=brick_path,  **params)
         logging.debug("host ip: %s ", host_ip)
         image_info = utils_misc.get_image_info(image_source)
         image_dest = "/mnt/%s" % disk_img
@@ -260,4 +261,4 @@ def run(test, params, env):
                         ignore_status=True, shell=True)
 
         if gluster_disk:
-            libvirt.setup_or_cleanup_gluster(False, brick_path=brick_path, **params)
+            gluster.setup_or_cleanup_gluster(False, brick_path=brick_path, **params)

--- a/libvirt/tests/src/virtual_disks/virtual_disks_luks.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_luks.py
@@ -12,6 +12,7 @@ from virttest import virt_vm
 from virttest import virsh
 from virttest import utils_package
 from virttest import ceph
+from virttest import gluster
 from virttest import utils_disk
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
@@ -340,9 +341,9 @@ def run(test, params, env):
 
         # Clean up backend storage
         if backend_storage_type == "iscsi":
-            libvirt.setup_or_cleanup_iscsi(is_setup=False)
+            gluster.setup_or_cleanup_iscsi(is_setup=False)
         elif backend_storage_type == "gluster":
-            libvirt.setup_or_cleanup_gluster(is_setup=False,
+            gluster.setup_or_cleanup_gluster(is_setup=False,
                                              vol_name=gluster_vol_name,
                                              pool_name=gluster_pool_name,
                                              **params)


### PR DESCRIPTION
The function get_host_ipv4_addr and setup_or_cleanup_gluster are moved
from utils_test/libvirt, so update related scripts.

Signed-off-by: Yingshun Cui <yicui@redhat.com>