### PR TITLE
Improve multivm stress testcase

### DIFF
--- a/libvirt/tests/cfg/multivm_loadstress.cfg
+++ b/libvirt/tests/cfg/multivm_loadstress.cfg
@@ -7,52 +7,30 @@
     create_vm_import = yes
     ignore_status = no
     event_sleep_time = 5
+    stress_config = "mix"
     iface_model = "virtio"
     stress_duration = 20
-    server_clients = "vm1_vm2 vm1_vm3"
-    iptables_rule = "INPUT -p tcp -m multiport --dports 5000:65535 -j ACCEPT"
-    variants:
-         - uperf:
-              stress_type = "uperf"
-              stress_args = ""
-              download_url_uperf = "https://github.com/uperf/uperf.git"
-              download_type_uperf = "git"
-              nthreads = "40"
-              need_profile = 1
-              profile_pattern = "n_threads duration_secs proto_req"
-              make_cmds_uperf = "autoreconf -f -i && ./configure && make install"
-              uninstall_cmds_uperf = "./configure && make uninstall"
-              uperf_server_cmd = "uperf -s"
-              uperf_client_cmd = "uperf -m /home/%s -a"
-              variants:
-                   - TCP:
-                        uperf_protocol = "tcp"
-                   - UDP:
-                        uperf_protocol = "udp"
-                   - SCTP:
-                        uperf_protocol = "sctp"
-              variants:
-                   - iperf:
-                        client_profile_uperf = "shared/deps/uperf/iperf.xml"
-                   - netperf:
-                        client_profile_uperf = "shared/deps/uperf/netperf.xml"
-                   - packetstream:
-                        client_profile_uperf = "shared/deps/uperf/packet_stream.xml"
-         - netperf:
-              stress_type = "netperf"
-              stress_args = ""
-              download_url_netperf = "https://github.com/HewlettPackard/netperf.git"
-              download_type_netperf = "git"
-              nthreads = "40"
-              need_profile = 0
-              ports = "16604"
-              make_cmds_netperf = "./autogen.sh && ./configure && make install"
-              uninstall_cmds_netperf = "./configure && make uninstall"
-              netperf_server_cmd = "netserver -p {0}"
-              netperf_client_cmd = "netperf -H {0} -p {1} -l {2} -t {3}"
-              test_protocols = TCP_STREAM
-              variants:
-                   - TCP_STREAM:
-                        test_protocols = "TCP_STREAM"
-                   - UDP_STREAM:
-                        test_protocols = "UDP_STREAM"
+    vm_pair_server_clients = "vm1_vm2"
+    iptables_rule_server_clients = "INPUT -p tcp -m multiport --dports 5000:65535 -j ACCEPT"
+    stress_type_server_clients = "uperf"
+    stress_args_server_clients = ""
+    download_url_uperf_server_clients = "https://github.com/uperf/uperf.git"
+    download_type_uperf_server_clients = "git"
+    nthreads_server_clients = "40"
+    need_profile_server_clients = 1
+    profile_pattern_server_clients = "n_threads duration_secs proto_req"
+    make_cmds_uperf_server_clients = "autoreconf -f -i && ./configure && make install"
+    uninstall_cmds_uperf_server_clients = "./configure && make uninstall"
+    uperf_server_cmd_server_clients = "uperf -s"
+    uperf_client_cmd_server_clients = "uperf -m /home/%s -a"
+    uperf_protocol_server_clients = "tcp"
+    client_profile_uperf_server_clients = "shared/deps/uperf/iperf.xml"
+    stress_type_vm3 = "stress-ng"
+    stress_cmds_stress-ng_vm3 = "stress-ng"
+    make_cmds_stress-ng_vm3 = "rm -rf /usr/bin/stress-ng && make && cp stress-ng /usr/bin && rm -rf /tmp/stress-*"
+    uninstall_cmds_stress-ng_vm3 = "rm -rf /usr/bin/stress-ng && make clean"
+    download_url_stress-ng_vm3 = "https://github.com/ColinIanKing/stress-ng.git"
+    download_type_stress-ng_vm3 = "git"
+    stress-ng_args_vm3 = "--vm 4 --vm-bytes 75% --vm-keep --timeout 100"
+    stress_tool = "stress"
+    stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M -t 200"

--- a/libvirt/tests/src/multivm_loadstress.py
+++ b/libvirt/tests/src/multivm_loadstress.py
@@ -1,5 +1,6 @@
 import logging
 import time
+import re
 
 from avocado.core import exceptions
 from virttest import utils_test
@@ -9,31 +10,138 @@ def run(test, params, env):
     """
     :param params: Dictionary with the test parameters
     :param env:    Dictionary with test environment.
-    The test will
-    1. Create 'n' uperf server-client pairs,
-    2. Configure iptables in guest and install uperf
-    3. Kick start uperf run, wait for duration [customized given in uperf profile]
-    4. After run, test will check for errors and make sure all guests are reachable.
-    5. Cleanup temp files and iptable rules added before
+    The test, based on input params, will
+    1. Accepts pair of server-client guests and load mentioned stress in it.
+    2. Load standalone stress in other guests, if any.
+    3. Configure required steps such as iptable addition, if any given.
+    4. If host stress is considered, start host stress run.
+    5. Kick start stress runs, wait for duration
+    6. After run, test will check for errors
+    7. Cleanup temp files and iptable rules added before
     """
+    def clientserver_stress(server_client, opt_type):
+        """
+        This method would help load or unload given client server stress
+        test
+        """
+        if opt_type == "load":
+            if server_client.load_stress(server_clients_params):
+                return True
+        else:
+            if server_client.verify_unload_stress(server_clients_params):
+                return True
+        return False
+
+    def standalone_stress(stress_server, opt_type, server_vms):
+        """
+        This method would help load stress and unload,verify state of given vms
+        post standalone server stress test
+        """
+        error_state = False
+        if opt_type == "load":
+            try:
+                for vm in server_vms:
+                    stress_server[vm.name].load_stress_tool()
+            except exceptions.TestError as err_msg:
+                logging.error(err_msg)
+                return True
+        else:
+            for vm in server_vms:
+                try:
+                    s_ping, o_ping = utils_test.ping(
+                        vm.get_address(), count=5, timeout=20)
+                    if s_ping != 0:
+                        error_state = True
+                        logging.error(
+                            "%s seem to have gone out of network", vm.name)
+                        continue
+                    uptime = vm.uptime()
+                    if up_time[vm.name] > uptime:
+                        error_state = True
+                        logging.error(
+                            "%s seem to have rebooted during the stress run", vm.name)
+                    stress_server[vm.name].unload_stress()
+                    stress_server[vm.name].clean()
+                    vm.verify_dmesg()
+                except exceptions.TestError as err_msg:
+                    logging.error(err_msg)
+                    error_state = True
+
+        return error_state
 
     stress_duration = int(params.get("stress_duration", "20"))
-    stress_type = params.get("stress_type", "uperf")
+    stress_config = params.get("stress_config", "client_server")
     error = False
-    if stress_type == "uperf":
-        server_client = utils_test.UperfStressload(params, env)
-    elif stress_type == "netperf":
-        server_client = utils_test.NetperfStressload(params, env)
-    else:
-        logging.error("Client server stress tool %s not defined", stress_type)
-        exceptions.TestFail("%s run failed: see error messages above" % stress_type)
+    server_clients_params = params.object_params("server_clients")
+    stress_tool = params.get("stress_tool", "")
+    stress_args = params.get("%s_args" % stress_tool)
+    stress_server = {}
+    up_time = {}
+    server_vms = []
+    standalone_vms = []
 
-    if server_client.load_stress(params):
+    if stress_config in {"mix", "standalone"}:
+        if stress_config != "standalone":
+            server_clients_vms = re.split(
+                '_| ', server_clients_params.get("vm_pair"))
+            standalone_vms = [vm for vm in env.get_all_vms() if vm.name not in server_clients_vms]
+            for vm in standalone_vms:
+                server_vms.append(vm)
+        else:
+            server_vms = env.get_all_vms()
+        for vm in server_vms:
+            up_time[vm.name] = vm.uptime()
+            vm_params = params.object_params(vm.name)
+            stress_type = vm_params.get("stress_type", "stress-ng")
+            stress_server[vm.name] = utils_test.VMStress(
+                vm, stress_type, vm_params)
+
+    if stress_config in {"mix", "server_client"}:
+        if not server_clients_params:
+            logging.error("No server client params defined")
+            error = True
+        else:
+            stress_type = server_clients_params.get("stress_type", "uperf")
+            if stress_type == "uperf":
+                server_client = utils_test.UperfStressload(
+                    server_clients_params, env)
+            elif stress_type == "netperf":
+                server_client = utils_test.NetperfStressload(
+                    server_clients_params, env)
+            else:
+                logging.error(
+                    "Client server stress tool %s not defined", stress_type)
+                error = True
+            if standalone_vms:
+                server_client.vms = server_client.server_vms + server_client.client_vms
+
+    if stress_config == "mix" and not error:
+        error = clientserver_stress(server_client, "load")
+        if not error:
+            error = standalone_stress(stress_server, "load", server_vms)
+    elif stress_config == "standalone" and not error:
+        error = standalone_stress(stress_server, "load", server_vms)
+    elif stress_config == "server_client" and not error:
+        error = clientserver_stress(server_client, "load")
+    else:
+        logging.error("stress config undefined %s" % stress_config)
         error = True
+    if stress_tool and not error:
+        try:
+            host_stress = utils_test.HostStress(stress_tool, params)
+            host_stress.load_stress_tool()
+        except utils_test.StressError, info:
+            logging.error(info)
+            error = True
     if stress_duration and not error:
         time.sleep(stress_duration)
     if not error:
-        if server_client.verify_unload_stress(params):
-            error = True
+        if stress_config in {"mix", "server_client"}:
+            error = clientserver_stress(server_client, "unload")
+        if stress_config in {"mix", "standalone"}:
+            error = standalone_stress(stress_server, "unload", server_vms)
+        if stress_tool:
+            logging.info("unloading stress on host")
+            host_stress.unload_stress()
     if error:
-        raise exceptions.TestFail("%s run failed: see error messages above" % stress_type)
+        raise exceptions.TestFail("Run failed: see error messages above")


### PR DESCRIPTION
This commits improves current testcase by

1. Facilitating users to run stress tools in certain vms which are
server-client based and standalone stress tools in other vms parallely.
2. Option to load stress on host in parallel to running stress in vms.

Signed-off-by: Srikanth Aithal <sraithal@linux.vnet.ibm.com>