### PR TITLE
Rename 'serial_type' to 'serial_dev_type' to avoid conflict

### DIFF
--- a/libvirt/tests/cfg/serial/serial_functional.cfg
+++ b/libvirt/tests/cfg/serial/serial_functional.cfg
@@ -4,56 +4,56 @@
     local_ip_address = "127.0.0.1"
     variants:
         - type_dev:
-            serial_type = dev
+            serial_dev_type = dev
             serial_sources = path:/dev/ttyS0
             target_type = isa-serial
         - type_file:
-            serial_type = file
+            serial_dev_type = file
             serial_sources = path:/var/log/libvirt/virt-test
         - type_pipe:
-            serial_type = pipe
+            serial_dev_type = pipe
             serial_sources = path:/tmp/virt-test
         - type_unix:
-            serial_type = unix
+            serial_dev_type = unix
             serial_sources = mode:bind,path:/var/lib/libvirt/qemu/virt-test
         - type_tcp_server:
-            serial_type = tcp
+            serial_dev_type = tcp
             serial_sources = mode:bind,host:0.0.0.0,service:2445
         - type_tcp_client:
-            serial_type = tcp
+            serial_dev_type = tcp
             serial_sources = mode:connect,host:0.0.0.0,service:2445
         - type_udp_client:
-            serial_type = udp
+            serial_dev_type = udp
             serial_sources = mode:connect,host:0.0.0.0,service:2445
         - type_null:
-            serial_type = null
+            serial_dev_type = null
         - type_stdio:
-            serial_type = stdio
+            serial_dev_type = stdio
         - type_vc:
-            serial_type = vc
+            serial_dev_type = vc
         - type_pty:
-            serial_type = pty
+            serial_dev_type = pty
             target_type = isa-serial
         - type_pty_pci_serial:
-            serial_type = pty
+            serial_dev_type = pty
             target_type = pci-serial
         - type_spicevmc:
-            serial_type = spicevmc
+            serial_dev_type = spicevmc
         - type_spiceport:
-            serial_type = spiceport
+            serial_dev_type = spiceport
             serial_sources = channel:org.qemu.console.serial.0
         - type_nmdm:
-            serial_type = nmdm
+            serial_dev_type = nmdm
             serial_sources = master:/dev/nmdm0A,slave:/dev/nmdm0B
         - console_target_type_virtio:
-            serial_type = pty
+            serial_dev_type = pty
             console_target_type = virtio
         - test_only_first_console_be_serial:
-            serial_type = pty
+            serial_dev_type = pty
             console_target_type = virtio
             second_serial_console = yes
         - type_tls_server:
-            serial_type = tls
+            serial_dev_type = tls
             serial_sources = mode:bind,host:${local_ip_address},service:5556,tls:yes
             server_ip = ${local_ip_address}
             server_user = "root"
@@ -69,7 +69,7 @@
             auto_recover = "yes"
             restart_libvirtd = "yes"
         - type_tls_client:
-            serial_type = tls
+            serial_dev_type = tls
             serial_sources = mode:connect,host:${local_ip_address},service:5556,tls:yes
             server_ip = ${local_ip_address}
             server_user = "root"

--- a/libvirt/tests/src/serial/serial_functional.py
+++ b/libvirt/tests/src/serial/serial_functional.py
@@ -717,7 +717,7 @@ def run(test, params, env):
         elif serial_type in ['pipe']:
             return 'server'
 
-    serial_type = params.get('serial_type', 'pty')
+    serial_type = params.get('serial_dev_type', 'pty')
     sources_str = params.get('serial_sources', '')
     username = params.get('username')
     password = params.get('password')


### PR DESCRIPTION
To avoid conflict with another var named 'serial_type'

Signed-off-by: haizhao <haizhao@redhat.com>