### PR TITLE
Align the tests to memory common lib

### DIFF
--- a/libvirt/tests/src/libvirt_mem.py
+++ b/libvirt/tests/src/libvirt_mem.py
@@ -15,7 +15,7 @@ from virttest import utils_libvirtd
 from virttest import utils_misc
 from virttest import utils_config
 from virttest import utils_numeric
-from virttest import utils_hotplug
+from virttest import utils_mem
 from virttest import virt_vm
 from virttest import data_dir
 from virttest.utils_test import libvirt
@@ -443,9 +443,9 @@ def run(test, params, env):
         # To attach the memory device.
         if add_mem_device and not hot_plug:
             at_times = int(params.get("attach_times", 1))
-            dev_xml = utils_hotplug.create_mem_xml(tg_size, pg_size, mem_addr,
-                                                   tg_sizeunit, pg_unit, tg_node,
-                                                   node_mask, mem_model)
+            dev_xml = utils_mem.create_mem_xml(tg_size, pg_size, mem_addr,
+                                               tg_sizeunit, pg_unit, tg_node,
+                                               node_mask, mem_model)
             randvar = 0
             if rand_reboot:
                 rand_value = random.randint(15, 25)
@@ -509,10 +509,10 @@ def run(test, params, env):
             process.run('ps -ef|grep qemu', shell=True, verbose=True)
             session = vm.wait_for_login()
             original_mem = vm.get_totalmem_sys()
-            dev_xml = utils_hotplug.create_mem_xml(tg_size, pg_size,
-                                                   mem_addr, tg_sizeunit,
-                                                   pg_unit, tg_node,
-                                                   node_mask, mem_model)
+            dev_xml = utils_mem.create_mem_xml(tg_size, pg_size,
+                                               mem_addr, tg_sizeunit,
+                                               pg_unit, tg_node,
+                                               node_mask, mem_model)
             add_device(dev_xml, True)
             mem_after = vm.get_totalmem_sys()
             params['delta'] = mem_after - original_mem
@@ -575,10 +575,10 @@ def run(test, params, env):
         unplug_failed_with_known_error = False
         if detach_device:
             if not dev_xml:
-                dev_xml = utils_hotplug.create_mem_xml(tg_size, pg_size,
-                                                       mem_addr, tg_sizeunit,
-                                                       pg_unit, tg_node,
-                                                       node_mask, mem_model)
+                dev_xml = utils_mem.create_mem_xml(tg_size, pg_size,
+                                                   mem_addr, tg_sizeunit,
+                                                   pg_unit, tg_node,
+                                                   node_mask, mem_model)
             for x in xrange(at_times):
                 ret = virsh.detach_device(vm_name, dev_xml.xml,
                                           flagstr=attach_option)

--- a/libvirt/tests/src/memory/nvdimm.py
+++ b/libvirt/tests/src/memory/nvdimm.py
@@ -5,7 +5,7 @@ import time
 from avocado.utils import process
 
 from virttest import virsh
-from virttest import utils_hotplug
+from virttest import utils_mem
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices import memory
 from virttest.utils_test import libvirt
@@ -77,7 +77,7 @@ def run(test, params, env):
         """
         Create xml of nvdimm memory device
         """
-        mem_xml = utils_hotplug.create_mem_xml(
+        mem_xml = utils_mem.create_mem_xml(
             tg_size=mem_param['target_size'],
             mem_addr={'slot': mem_param['address_slot']},
             tg_sizeunit=mem_param['target_size_unit'],

--- a/libvirt/tests/src/papr_hpt.py
+++ b/libvirt/tests/src/papr_hpt.py
@@ -7,7 +7,7 @@ from avocado.utils import cpu
 from avocado.utils import process
 
 from virttest import virsh
-from virttest import utils_hotplug
+from virttest import utils_mem
 from virttest import utils_libvirtd
 from virttest import utils_misc
 from virttest.libvirt_xml import vm_xml
@@ -192,7 +192,7 @@ def run(test, params, env):
                 check_hp_in_vm(session, maxpagesize * 1024)
 
             if resizing == 'enabled':
-                mem_xml = utils_hotplug.create_mem_xml(
+                mem_xml = utils_mem.create_mem_xml(
                     tg_size=int(params.get('mem_size', 2048000)),
                     tg_sizeunit=params.get('size_unit', 'KiB'),
                     tg_node=int(params.get('mem_node', 0)),


### PR DESCRIPTION
Some of the function moved to common libary in avocado-vt,
hence aliging the tests to call funtions from new memory
library.

Signed-off-by: Hariharan T.S <hari@linux.vnet.ibm.com>