### PR TITLE
Hotpulg differnet Memory size

### DIFF
--- a/libvirt/tests/cfg/libvirt_mem.cfg
+++ b/libvirt/tests/cfg/libvirt_mem.cfg
@@ -59,6 +59,13 @@
                        - cold:
                            attach_option = "--config"
                 - no_attach:
+                - diff_size:
+                    test_qemu_cmd = "no"
+                    max_mem_rt = 138412032
+                    max_mem_slots = 256
+                    attach_times = 7
+                    tg_sizeunit = "GiB"
+                    diff_tg_size = [1, 2, 4, 8, 16, 32, 64]
                 - with_source:
                     tg_size = 524288
                     tg_node = 0


### PR DESCRIPTION
The patch hotplugs memory of different size as listed
[1, 2, 4, 8, 16, 32, 64] all size in GiB.

Signed-off-by: Hariharan T.S <hari@linux.vnet.ibm.com>