### PR TITLE
Catch Shell*Error exception when waiting for vm rebooting

### DIFF
--- a/libvirt/tests/src/virtual_device/watchdog.py
+++ b/libvirt/tests/src/virtual_device/watchdog.py
@@ -60,8 +60,14 @@ def run(test, params, env):
         """
         def _booting_completed():
             session = vm.wait_for_login()
-            status, second_boot_time = session.cmd_status_output("uptime --since")
-            logging.debug("The second boot time is %s", second_boot_time)
+            status = None
+            second_boot_time = None
+            try:
+                status, second_boot_time = session.cmd_status_output("uptime --since")
+                logging.debug("The second boot time is %s", second_boot_time)
+            except (aexpect.ShellStatusError, aexpect.ShellProcessTerminatedError) as e:
+                logging.error("Exception caught:%s", e)
+
             session.close()
             return second_boot_time > first_boot_time
 


### PR DESCRIPTION
When waiting for vm rebooting, it has a chance for Shell*Error
exception to happen. The exception needs to be caught, or the
test case will fail.

Signed-off-by: Fangge Jin <fjin@redhat.com>