### PR TITLE
Fix 3 failures caused by short timeout; hotplugging vcpus performancec and err msg pattern

### DIFF
--- a/libvirt/tests/cfg/cpu/max_vcpus.cfg
+++ b/libvirt/tests/cfg/cpu/max_vcpus.cfg
@@ -22,7 +22,8 @@
                             guest_vcpu = "240"
                         - hotplug:
                             check = "i440fx_test_hotplug"
-                            current_vcpu = "50"
+                            current_vcpu = "2"
+                            target_vcpu = "50"
                             guest_vcpu = "240"
                 - ioapic_iommu:
                     guest_vcpu = "50"

--- a/libvirt/tests/cfg/cpu/vcpu_affinity.cfg
+++ b/libvirt/tests/cfg/cpu/vcpu_affinity.cfg
@@ -5,7 +5,7 @@
     maxvcpu = "8"
     current_vcpu = "3"
     vcpu = "0"
-    start_timeout = "60"
+    start_timeout = "180"
     machine_cpuset_path = "/sys/fs/cgroup/cpuset/machine.slice/cpuset.cpus"
     variants:
         - positive_test:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_guestvcpus.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_guestvcpus.cfg
@@ -34,7 +34,7 @@
                     variants:
                         - no_dom:
                             domain_name = ""
-                            error_msg = "error: command 'guestvcpus' requires <domain> option"
+                            error_msg = "expected syntax: --domain <string>"
                         - err_dom:
                             domain_name = "\#"
                             error_msg = "error: failed to get domain"

--- a/libvirt/tests/src/cpu/max_vcpus.py
+++ b/libvirt/tests/src/cpu/max_vcpus.py
@@ -94,6 +94,7 @@ def run(test, params, env):
         # Test i440fx VM starts with 240(positive)/241(negative) vcpus and hot-plugs vcpus to 240
         if check.startswith('i440fx_test'):
             current_vcpu = params.get('current_vcpu')
+            target_vcpu = params.get('target_vcpu')
             if 'hotplug' not in check:
                 vmxml.vcpu = int(guest_vcpu)
                 vmxml.sync()
@@ -108,14 +109,15 @@ def run(test, params, env):
             else:
                 vmxml.vcpu = int(guest_vcpu)
                 vmxml.current_vcpu = int(current_vcpu)
+                target_vcpu = int(target_vcpu)
                 vmxml.sync()
                 vm.start()
                 logging.info(libvirt_xml.VMXML.new_from_dumpxml(vm_name))
                 vm.wait_for_login(timeout=boot_timeout).close()
                 check_onlinevcpus(vm, int(current_vcpu))
-                res = virsh.setvcpus(vm_name, guest_vcpu, debug=True)
+                res = virsh.setvcpus(vm_name, target_vcpu, debug=True)
                 libvirt.check_exit_status(res)
-                check_onlinevcpus(vm, int(guest_vcpu))
+                check_onlinevcpus(vm, int(target_vcpu))
 
         # Configure a guest vcpu > 255 without iommu device for q35 VM
         if check == 'no_iommu':

--- a/libvirt/tests/src/cpu/vcpu_affinity.py
+++ b/libvirt/tests/src/cpu/vcpu_affinity.py
@@ -78,7 +78,7 @@ def run(test, params, env):
     cputune_cpuset = params.get("cputune_cpuset", "")
     vcpu_placement = params.get("vcpu_placement", "static")
     err_msg = params.get("err_msg", "")
-    start_timeout = int(params.get("start_timeout", "60"))
+    start_timeout = int(params.get("start_timeout", "180"))
     offline_hostcpus = params.get("offline_hostcpus", "")
     machine_cpuset_path = params.get("machine_cpuset_path", "")
 


### PR DESCRIPTION
1: Changing timeout from 60 to 180 for "vm.wait_for_login(timeout=start_timeout).close()"
to avoid some timeout expiring err in  vcpu_affinity.py and  vcpu_affinity.cfg file.
2: Changing max_vcpus.positive_test.i440fx_test.hotplug case as kernel performance:
Hot-plugging vcpus to 50 to VM after starting VM with 2 current vcpus and 240 total vcpus
3: For "# virsh guestvcpus --domain" negative cmd; the checking msg is wrong; so modify it
for case "virsh.guestvcpus.error_test.invalid_dom.no_dom"

Signed-off-by: JingYan <jiyan@redhat.com>