### PR TITLE
Fix result for auto case 'virtio_win.unset' of v2v case18974

### DIFF
--- a/provider/v2v_vmcheck_helper.py
+++ b/provider/v2v_vmcheck_helper.py
@@ -145,6 +145,10 @@ class VMChecker(object):
         # Video model will change to QXL for Windows2008r2 and windows7
         if self.os_version in ['win7', 'win2008r2']:
             video_model = 'qxl'
+            # video mode of windows guest will be cirrus if there is no virtio-win
+            # driver installed on host
+            if process.run('rpm -q virtio-win', ignore_status=True).exit_status != 0:
+                video_model = 'cirrus'
         return video_model
 
     def check_metadata_libosinfo(self):
@@ -266,7 +270,7 @@ class VMChecker(object):
             err_msg = "Fail to get OS distribution: %s" % e
             self.log_err(err_msg)
         if dist_major < 4:
-            logging.warn("Skip unspported distribution check")
+            logging.warning("Skip unsupported distribution check")
             return
         else:
             logging.info("PASS")

--- a/v2v/tests/cfg/function_test_xen.cfg
+++ b/v2v/tests/cfg/function_test_xen.cfg
@@ -160,7 +160,7 @@
                     variants:
                         - unset:
                             checkpoint += 'unset'
-                            missing = 'Red Hat VirtIO SCSI,Red Hat VirtIO Ethernet Adapte'
+                            missing = 'Red Hat VirtIO SCSI,Red Hat VirtIO Ethernet Adapte,QXL'
                         - custom:
                             checkpoint += 'custom'
                         - iso_mount:


### PR DESCRIPTION
The video driver is cirrus if virtio_win is unset during v2v
windows conversion.

Signed-off-by: mxie91 <mxie@redhat.com>