### PR TITLE
Fix err msg pattern and hostcpu 0 operation for vcpu_affinity case

### DIFF
--- a/libvirt/tests/cfg/cpu/vcpu_affinity.cfg
+++ b/libvirt/tests/cfg/cpu/vcpu_affinity.cfg
@@ -108,7 +108,7 @@
                             runtime_fail = "yes"
                             offline_hostcpus = "2,3"
                             cputune_cpuset = "3"
-                            err_msg = "error: cannot set CPU affinity"
+                            err_msg = "error: Invalid value '3' for 'cpuset.cpus'"
                         - none_exist_vcpu:
                             check = "cputune_none_exist_vcpu"
                             runtime_fail = "yes"

--- a/libvirt/tests/src/cpu/vcpu_affinity.py
+++ b/libvirt/tests/src/cpu/vcpu_affinity.py
@@ -120,7 +120,7 @@ def run(test, params, env):
         hostcpu_num = int(cpu.total_cpus_count())
 
         # online all host cpus
-        for x in range(hostcpu_num):
+        for x in range(1, hostcpu_num):
             if cpu.online(x):
                 test.fail("fail to online cpu{}".format(x))
 
@@ -207,7 +207,7 @@ def run(test, params, env):
         vmxml_backup.sync()
 
         # recovery the host cpu env
-        for x in range(hostcpu_num):
+        for x in range(1, hostcpu_num):
             cpu.online(x)
         cmd = "echo '0-{}' > {}".format(hostcpu_num-1, machine_cpuset_path)
         process.run(cmd, shell=True)


### PR DESCRIPTION
There are 2 failures for the following test case:
vcpu_affinity.negative_test.cputune.offline_hostcpu
1> For some machines; can not operate host cpu0; which will cause unexpected err msg
2> For negatively set vcpu affinity; the err msg has changed for both RHEL-7 and 8

Signed-off-by: JingYan <jiyan@redhat.com>