### PR TITLE
virsh_attach_device_matrix: Wait longer time after vm resume

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device_matrix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device_matrix.py
@@ -197,6 +197,7 @@ def run(test, params, env):
     # Test.
     domid = vm.get_id()
     domuuid = vm.get_uuid()
+    wait_stable = 10
 
     # Confirm how to reference a VM.
     if vm_ref == "name":
@@ -235,7 +236,7 @@ def run(test, params, env):
             vm.wait_for_login().close()
 
         #Sleep a while for vm is stable
-        time.sleep(3)
+        time.sleep(wait_stable)
         if not ret.exit_status:
             check_result(device_source, device, device_target,
                          at_options)
@@ -255,7 +256,7 @@ def run(test, params, env):
             vm.wait_for_login().close()
 
         #Sleep a while for vm is stable
-        time.sleep(3)
+        time.sleep(wait_stable)
         if not ret.exit_status:
             check_result(device_source, device, device_target,
                          dt_options, False)


### PR DESCRIPTION
For this test case:
Detach a device from paused vm, then resume it, wait 3 seconds then
check the detach result.

3 seconds is not enough for qemu to finish the detach actions after
resume. Extend it to 10 seconds.

Signed-off-by: Han Han <hhan@redhat.com>