### PR TITLE
Fix failures caused by libvirt is activated automatically

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_capabilities.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_capabilities.cfg
@@ -6,12 +6,6 @@
         - no_option:
             virsh_cap_options = ""
             status_error = "no"
-            libvirtd = "on"
         - unexpect_option:
             virsh_cap_options = "xyz"
             status_error = "yes"
-            libvirtd = "on"
-        - with_libvirtd_stop:
-            virsh_cap_options = ""
-            status_error = "yes"
-            libvirtd = "off"

--- a/libvirt/tests/src/virsh_cmd/host/virsh_capabilities.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_capabilities.py
@@ -7,7 +7,6 @@ from avocado.utils import process
 
 from virttest import libvirt_vm
 from virttest import virsh
-from virttest import utils_libvirtd
 from virttest.libvirt_xml import capability_xml
 
 
@@ -103,13 +102,6 @@ def run(test, params, env):
 
     connect_uri = libvirt_vm.normalize_connect_uri(params.get("connect_uri",
                                                               "default"))
-
-    # Prepare libvirtd service
-    if "libvirtd" in params:
-        libvirtd = params.get("libvirtd")
-        if libvirtd == "off":
-            utils_libvirtd.libvirtd_stop()
-
     # Run test case
     option = params.get("virsh_cap_options")
     try:
@@ -120,21 +112,11 @@ def run(test, params, env):
         status = 1  # bad
         output = ''
 
-    # Recover libvirtd service start
-    if libvirtd == "off":
-        utils_libvirtd.libvirtd_start()
-
     # Check status_error
     status_error = params.get("status_error")
     if status_error == "yes":
         if status == 0:
-            if libvirtd == "off":
-                test.fail("Command 'virsh capabilities' succeeded "
-                          "with libvirtd service stopped, "
-                          "incorrect")
-            else:
-                test.fail("Command 'virsh capabilities %s' "
-                          "succeeded (incorrect command)" % option)
+            test.fail("Command virsh capabilities %s succeeded (incorrect command)" % option)
     elif status_error == "no":
         compare_capabilities_xml(output)
         if status != 0:


### PR DESCRIPTION
This problem is introduced since RHEL-8.1AV; Running any virsh cmd will activate libvirtd service automatically on RHEL-8, so it is not possible to get expected result that virsh cmd will fail
after stop libvirtd.
After checking with libvirtd feature owner; manual cases will be added and this kind of auto case (check virsh cmd after stopping libvirtd) should be deleted.

Signed-off-by: JingYan <jiyan@redhat.com>