### PR TITLE
Add host vendor/revision filter support

### DIFF
--- a/libvirt/tests/cfg/cpu/guestpin.cfg
+++ b/libvirt/tests/cfg/cpu/guestpin.cfg
@@ -13,8 +13,8 @@
             itr = 1
             variants:
                 - with_host_smt:
+                    only HostCpuFamily.power9
                     only ppc64le,ppc64
-                    # only power9
                     condn = "host_smt"
                 - with_guest_smt:
                     current_vcpu = 8

--- a/libvirt/tests/cfg/cpu/powerpc_hmi.cfg
+++ b/libvirt/tests/cfg/cpu/powerpc_hmi.cfg
@@ -21,10 +21,12 @@
                     inject_code = 0002080000000000
                     hmi_name = "TFMR HDEC parity error"
             variants:
-                - power8:
+                - p8:
+                    only HostCpuFamily.power8
                     host_version = 'power8'
                     scom_base = '0x10013281'
-                - power9:
+                - p9:
+                    only HostCpuFamily.power9
                     host_version = 'power9'
                     scom_base = '0x20010A84'
             variants:
@@ -33,6 +35,8 @@
                     condn += ,save
                 - with_suspend:
                     condn += ,suspend
-                - power8_compatguest:
-                    no positive..power8
+                - p8_compatguest:
+                    no positive..p8
+                    # no compat guest support
+                    no HostCpuFamily.power9.2.1
                     guest_version = "power8"

--- a/libvirt/tests/cfg/cpu/ppc_cpu_mode.cfg
+++ b/libvirt/tests/cfg/cpu/ppc_cpu_mode.cfg
@@ -24,8 +24,10 @@
                             negative_test..power7:
                             error_msg = "the CPU is incompatible with host CPU: host CPU model does not match required CPU model"
                         - power8:
+                            no HostCpuFamily.power7
                             model = "power8"
                         - power9:
+                            no HostCpuFamily.power7,HostCpuFamily.power8
                             model = "power9"
     variants:
         - match:

--- a/libvirt/tests/cfg/cpu/ppccpucompat.cfg
+++ b/libvirt/tests/cfg/cpu/ppccpucompat.cfg
@@ -6,14 +6,15 @@
     variants:
         - host:
             variants:
-                - power9:
+                - p9:
+                    only HostCpuFamily.power9
                     host_version = "power9"
                     power9_compat = "yes"
                     restore_smt = "yes"
                     variants:
                         - guest:
                             variants:
-                                - power9:
+                                - p9:
                                     guest_features = "xive,rpt,isa3.0"
                                     guest_version = "power9"
                                     variants:
@@ -25,7 +26,7 @@
                                             topology_cores= '2'
                                             topology_threads= '1'
                                             guest_features = "isa3.0"
-                                - power8:
+                                - p8:
                                     guest_features = "xics,hpt,isa2.7"
                                     guest_version = "power8"
                                     variants:
@@ -62,13 +63,14 @@
                                             condn = "suspend"
                                             guest_features = ""
 
-                - power8:
+                - p8:
+                    only HostCpuFamily.power8
                     host_version = "power8"
                     variants:
                         - guest:
                             variants:
-                                - power9:
+                                - p9:
                                     status_error = "yes"
-                                - power8:
+                                - p8:
                                     guest_features = "xics,hpt,isa2.7"
                                     guest_version = "power8"

--- a/libvirt/tests/src/cpu/guestpin.py
+++ b/libvirt/tests/src/cpu/guestpin.py
@@ -63,10 +63,7 @@ def run(test, params, env):
                 result = cpu.check_vcpu_value(vm, exp_vcpu,
                                               option="--live")
             elif condn == "host_smt":
-                if cpuutil.get_cpu_vendor_name() == 'power9':
-                    result = process.run("ppc64_cpu --smt=4", shell=True)
-                else:
-                    test.cancel("Host SMT changes not allowed during guest live")
+                result = process.run("ppc64_cpu --smt=4", shell=True)
             else:
                 logging.debug("No operation for the domain")
 


### PR DESCRIPTION
Let's adopt tests with host vendor filter support,
this would help us pick only relevant tests for
particular host vendor/revision.
Reference: https://github.com/avocado-framework/avocado-vt/pull/2225

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>