### PR TITLE
Add UEFI checkpoint for v2v

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -89,6 +89,14 @@
                     checkpoint = 'rhev_file'
                     os_version = OS_VERSION_RHEV_FILE_V2V_EXAMPLE
                     main_vm = RHEV_FILE_VM_NAME_V2V_EXAMPLE
+                - uefi:
+                    boottype = 3
+                    variants:
+                        - win2019:
+                            only esx_67
+                            main_vm = VM_NAME_ESX_UEFI_WINDOWS_V2V_EXAMPLE
+                            msg_content = 'virt-v2v: warning: fstrim on guest filesystem /dev/.*? failed.  Usually'
+                            expect_msg = yes
         - with_cdrom:
             only esx_55
             main_vm = 'VM_NAME_ESX_CDROM_V2V_EXAMPLE'
@@ -123,15 +131,10 @@
             main_vm = VM_NAME_ESX_SNAPSHOT_V2V_EXAMPLE
             removed_file = ESX_REMOVED_FILE_V2V_EXAMPLE
         - uefi:
-            only libvirt
+            boottype = 3
             variants:
                 - ovmf:
                     variants:
-                        - windows:
-                            only esx_67
-                            main_vm = VM_NAME_ESX_UEFI_WINDOWS_V2V_EXAMPLE
-                            msg_content = 'virt-v2v: warning: fstrim on guest filesystem /dev/.*? failed.  Usually'
-                            expect_msg = yes
                         - rhel7:
                             only esx_67
                             main_vm = VM_NAME_ESX_UEFI_RHEL7_V2V_EXAMPLE


### PR DESCRIPTION
Users can set a checkpoint for UEFI guest by biostype in cfg files.
It has value 0-3. 0 is default now. In futrue, after v2v supports
converting all guest to q35 by default, The default value can be
updated to 1 for adapting the change.

All possible values of 'biostype' can be set by users:
    0: ['i440fx', 'bios', False]
    1: ['q35', 'bios', False]
    2: ['q35', 'uefi', False]
    3: ['q35', 'uefi', True]

The checking for biostype.
    - check chipset and boot type in vm xml
    - check if guest boots with uefi if boot type is UEFI

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>