### PR TITLE
Add support for multiple error messages

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_guestvcpus.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_guestvcpus.cfg
@@ -10,7 +10,7 @@
     vcpus_placement = "static"
     option = ""
     combine = ""
-    error_msg = ""
+    error_msg = []
     invalid_domain = ""
     domain_name = ""
     invalid_cpulist = ""
@@ -34,16 +34,16 @@
                     variants:
                         - no_dom:
                             domain_name = ""
-                            error_msg = "expected syntax: --domain <string>"
+                            error_msg = ["error: command 'guestvcpus' requires <domain> option", "error: expected syntax: --domain <string>"]
                         - err_dom:
                             domain_name = "\#"
-                            error_msg = "error: failed to get domain"
+                            error_msg = ["error: failed to get domain"]
                 - invalid_cpulist:
                     invalid_cpulist = "yes"
                     variants:
                         - enable:
                             option = "--enable"
-                            error_msg = "error: invalid argument: guest is missing vCPUs"
+                            error_msg = ["error: invalid argument: guest is missing vCPUs"]
                         - disable:
                             option = "--disable"
-                            error_msg = "error: internal error: unable to execute QEMU agent command 'guest-set-vcpus'"
+                            error_msg = ["error: internal error: unable to execute QEMU agent command 'guest-set-vcpus'"]

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_guestvcpus.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_guestvcpus.py
@@ -27,7 +27,7 @@ def run(test, params, env):
     domain_name = params.get("domain_name", "")
     invalid_cpulist = params.get("invalid_cpulist", "")
     status_error = params.get("status_error", "no")
-    error_msg = params.get("error_msg", "no")
+    error_msg = eval(params.get('error_msg', '[]'))
     vcpus_list = ""
     offline_vcpus = ""
 


### PR DESCRIPTION
Error messages can be different at times
based on the additional commandline options or
libvirt version, let's add it in list to
handle multiple error messages.

in this case `nodomain name` testcase can have two error
messages based on domain option is passed or not.

```
error: command 'guestvcpus' requires <domain> option

error: expected syntax: --domain <string>
```

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>