### PR TITLE
minorfix: fix firewall_port UnboundLocalError

### DIFF
--- a/libvirt/tests/src/remote_access/remote_access.py
+++ b/libvirt/tests/src/remote_access/remote_access.py
@@ -409,7 +409,7 @@ def run(test, params, env):
             if vm and vm.is_alive():
                 vm.destroy(gracefully=False)
 
-        if transport in ["tcp", "tls"]:
+        if transport in ["tcp", "tls"] and 'firewalld_port' in locals():
             server_session = remote.wait_for_login('ssh', server_ip, '22',
                                                    server_user, server_pwd,
                                                    r"[\#\$]\s*$")


### PR DESCRIPTION
In remote acess testing, it reports "ERROR: local variable
'firewalld_port' referenced before assignment" once it fails to setup
ipv6 enviroment. The error message is unclear. So update it.

Signed-off-by: Yingshun Cui <yicui@redhat.com>