### PR TITLE
SRIOV: correct pci driver directory path for SRIOV pci devices

### DIFF
--- a/libvirt/tests/src/sriov/sriov.py
+++ b/libvirt/tests/src/sriov/sriov.py
@@ -631,7 +631,7 @@ def run(test, params, env):
         if not vm.is_dead():
             vm.destroy()
     driver_dir = "/sys/bus/pci/drivers/%s" % driver
-    pci_dirs = glob.glob("%s/0000*" % driver_dir)
+    pci_dirs = glob.glob("%s/000*" % driver_dir)
     pci_device_dir = "/sys/bus/pci/devices"
     pci_address = ""
     net_name = "test-net"


### PR DESCRIPTION
Correcting pci directory path to allow more than one root complex

Signed-off-by: Vishnu Pajjuri <vishnu.pajjuri@amperecomputing.com>