### PR TITLE
migration: move unsupported cases to negative_test

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_vm.cfg
+++ b/libvirt/tests/cfg/migration/migrate_vm.cfg
@@ -506,28 +506,6 @@
                             variants:
                                 - copy_storage_all:
                                     virsh_options = "--live --verbose --copy-storage-all"
-                                - copy_storage_inc:
-                                    virsh_options = "--live --verbose --copy-storage-inc"
-                        - backing_file_with_copy_storage_inc:
-                            create_target_image = "no"
-                            setup_nfs = "yes"
-                            enable_virt_use_nfs = "yes"
-                            target_image_format = "qcow2"
-                            target_image_path = "/var/lib/libvirt/images"
-                            target_image_name = "foo_bar_test.${target_image_format}"
-                            new_disk_source = "${target_image_path}/${target_image_name}"
-                            # create disk image based on ${nfs_mount_dir}/${image_name} both local and remote host
-                            create_local_disk_backfile_cmd = "qemu-img create ${new_disk_source} -f qcow2 -b ${nfs_mount_dir}/"
-                            create_remote_disk_backfile_cmd = "${create_local_disk_backfile_cmd}"
-                            # create disk image in the VM
-                            dd_image_count = 100000
-                            dd_image_bs = 1024
-                            dd_image_of = "/tmp/vr_test.raw"
-                            run_cmd_in_vm = "dd if=/dev/zero of=${dd_image_of} count=${dd_image_count} bs=${dd_image_bs}"
-                            check_image_size = "yes"
-                            check_disk_size_cmd = "qemu-img info ${new_disk_source}"
-                            local_image_source = "${new_disk_source}"
-                            virsh_options = "--live --verbose --copy-storage-inc"
                         - with_migrate_disks:
                             setup_nfs = "yes"
                             enable_virt_use_nfs = "yes"
@@ -679,7 +657,6 @@
                 - live_storage_migration:
                     setup_nfs = "no"
                     enable_virt_use_nfs = "no"
-                    nfs_mount_dir =
                     migration_timeout = 1800
                     target_pool_name = "precreation_pool"
                     target_pool_type = "dir"
@@ -687,6 +664,7 @@
                         - create_neither_target_pool_nor_image:
                             create_target_image = "no"
                             no_create_pool = "yes"
+                            nfs_mount_dir =
                             variants:
                                 - simple:
                                     virsh_options = "--live --verbose"
@@ -696,27 +674,65 @@
                             create_target_image = "yes"
                             no_create_pool = "yes"
                             target_image_format = "raw"
+                            nfs_mount_dir =
                             variants:
                                 - copy_storage_all:
                                     virsh_options = "--live --verbose --copy-storage-all"
                                 - copy_storage_inc:
                                     virsh_options = "--live --verbose --copy-storage-inc"
+                        - raw_to_raw_target_image_format:
+                            nfs_mount_dir =
+                            local_image_format = "raw"
+                            local_disk_image = ${nfs_mount_src}/virt_disk_test.img
+                            local_disk_size = 1.0G
+                            target_dev = "vdb"
+                            attach_disk_args = "--config --driver qemu --subdriver ${local_image_format} --cache none"
+                            check_disk_size_cmd = "qemu-img info ${local_disk_image} | grep "virtual size"|cut -d' ' -f3"
+                            variants:
+                                - copy_storage_inc:
+                                    virsh_options = "--live --verbose --copy-storage-inc"
+                                    err_msg = "error: Operation not supported: pre-creation of storage targets for incremental storage migration is not supported"
+                        - backing_file_with_copy_storage_inc:
+                            create_target_image = "no"
+                            setup_nfs = "yes"
+                            enable_virt_use_nfs = "yes"
+                            target_image_format = "qcow2"
+                            target_image_path = "/var/lib/libvirt/images"
+                            target_image_name = "foo_bar_test.${target_image_format}"
+                            new_disk_source = "${target_image_path}/${target_image_name}"
+                            # create disk image based on ${nfs_mount_dir}/${image_name} both local and remote host
+                            create_local_disk_backfile_cmd = "qemu-img create ${new_disk_source} -f qcow2 -b ${nfs_mount_dir}/"
+                            create_remote_disk_backfile_cmd = "${create_local_disk_backfile_cmd}"
+                            # create disk image in the VM
+                            dd_image_count = 100000
+                            dd_image_bs = 1024
+                            dd_image_of = "/tmp/vr_test.raw"
+                            run_cmd_in_vm = "dd if=/dev/zero of=${dd_image_of} count=${dd_image_count} bs=${dd_image_bs}"
+                            check_image_size = "yes"
+                            check_disk_size_cmd = "qemu-img info ${new_disk_source}"
+                            local_image_source = "${new_disk_source}"
+                            virsh_options = "--live --verbose --copy-storage-inc"
+                            err_msg = "error: Operation not supported: pre-creation of storage targets for incremental storage migration is not supported"
                         - mutually_exclusive_options:
                             create_target_image = "yes"
                             virsh_options = "--live --persistent --verbose --copy-storage-all --copy-storage-inc"
+                            nfs_mount_dir =
                         - cancel_migration:
-                            status_error = "no"
                             ctrl_c = "yes"
                             delay_time = 5
                             create_target_image = "yes"
                             check_job_info = "no"
                             run_migrate_cmd_in_back = "yes"
                             run_migrate_cmd_in_front = "yes"
+                            nfs_mount_dir =
                             variants:
                                 - copy_storage_all:
+                                    status_error = "no"
+                                    check_job_info = "yes"
                                     virsh_options = "--live --verbose --persistent --copy-storage-all"
                                 - copy_storage_inc:
                                     virsh_options = "--live --verbose --persistent --copy-storage-inc"
+                                    err_msg = "error: Operation not supported: pre-creation of storage targets for incremental storage migration is not supported"
                 - rdma_migration:
                     setup_nfs = "yes"
                     enable_virt_use_nfs = "yes"


### PR DESCRIPTION
There are 2 unsupported cases in positive testing category.
So move them to negative_test, and update error message pattern for
the cases which have similar scenario.

Signed-off-by: Yingshun Cui <yicui@redhat.com>