### PR TITLE
Modify v2v case12993 and change destinations for some function xen cases

### DIFF
--- a/v2v/tests/cfg/function_test_xen.cfg
+++ b/v2v/tests/cfg/function_test_xen.cfg
@@ -60,6 +60,7 @@
             checkpoint = 'guest_uuid'
         - pool_uuid:
             checkpoint = 'pool_uuid'
+            only libvirt
         - display:
             main_vm = 'DISPLAY_VM_NAME_V2V_EXAMPLE'
             os_version = 'DISPLAY_OS_VERSION_V2V_EXAMPLE'
@@ -178,16 +179,15 @@
             no xen_vm_default
             variants:
                 - libvirt:
-                    only pool_uuid, display, sound, virtio_win, with_vdsm
+                    only pool_uuid, with_vdsm
                     only output_mode.libvirt
-                    no encrypt_warning
                 - rhev:
-                    no pool_uuid, display.vnc.encrypt, sound, virtio_win
+                    no pool_uuid, with_vdsm
                     only output_mode.rhev
         - negative_test:
             status_error = 'yes'
             only xen_vm_default
-            only output_mode.libvirt
+            no libvirt
             variants:
                 - libguestfs_backend_empty:
                     checkpoint = 'libguestfs_backend_empty'

--- a/v2v/tests/src/function_test_xen.py
+++ b/v2v/tests/src/function_test_xen.py
@@ -280,13 +280,14 @@ def run(test, params, env):
             blklist = virsh.domblklist(vm_name, uri=uri).stdout.split('\n')
             logging.debug('domblklist %s:\n%s', vm_name, blklist)
             for line in blklist:
-                if line.startswith(('hda', 'vda', 'sda')):
+                if line.startswith(('hda', 'vda', 'sda', 'xvda')):
                     params['remote_disk_image'] = line.split()[-1]
                     break
             # Local path of disk image
             params['img_path'] = data_dir.get_tmp_dir() + '/%s.img' % vm_name
             if checkpoint == 'xvda_disk':
                 v2v_params['input_mode'] = 'disk'
+                v2v_params['hypervisor'] = 'kvm'
                 v2v_params.update({'input_file': params['img_path']})
             # Copy remote image to local with scp
             remote.scp_from_remote(xen_host, 22, xen_host_user,


### PR DESCRIPTION
Auto xen case xvda_disk will be failed with error "parameter 'remote_disk_image'
is missing" so fix it, all negative tests of funcition xen test would be
skipped in rhel8.1 av due to only convert cases to libvirt, so change the
destinations to cover the cases in both rhel8.1 slow and fast stream.

Signed-off-by: mxie91 <mxie@redhat.com>