### PR TITLE
Fix environment recovery issue for remote_access

### DIFF
--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -839,7 +839,7 @@ def cleanup(objs_list):
     # recovery test environment
     for obj in objs_list:
         obj.auto_recover = True
-        del obj
+        obj.__del__()
 
 
 def check_vm_disk_after_migration(test, vm, params):

--- a/libvirt/tests/src/remote_access/remote_access.py
+++ b/libvirt/tests/src/remote_access/remote_access.py
@@ -40,9 +40,10 @@ def remote_access(params, test):
     log_level = params.get("log_level", "LIBVIRT_DEBUG=3")
 
     status_error = params.get("status_error", "no")
-    ret = connect_libvirtd(uri, read_only, virsh_cmd, auth_user,
-                           auth_pwd, vm_name, status_error, extra_env,
-                           log_level, su_user, virsh_patterns, patterns_extra_dict)
+    ret, output = connect_libvirtd(uri, read_only, virsh_cmd, auth_user,
+                                   auth_pwd, vm_name, status_error, extra_env,
+                                   log_level, su_user, virsh_patterns,
+                                   patterns_extra_dict)
 
     if status_error == "no":
         if ret:
@@ -54,12 +55,13 @@ def remote_access(params, test):
                 fp.close()
             logging.info("Succeed to connect libvirt daemon.")
         else:
-            test.fail("Failed to connect libvirt daemon!!")
+            test.fail("Failed to connect libvirt daemon!!output: {}"
+                      .format(output))
     else:
         if not ret:
             logging.info("It's an expected error!!")
         else:
-            test.fail("Unexpected return result")
+            test.fail("Unexpected return result: {}".format(output))
 
 
 def check_parameters(params, test):
@@ -119,7 +121,7 @@ def cleanup(objs_list):
     objs_list.reverse()
     for obj in objs_list:
         obj.auto_recover = True
-        del obj
+        obj.__del__()
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_vm_cfg.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_vm_cfg.py
@@ -528,7 +528,7 @@ def run(test, params, env):
             logging.debug("Clean up test env: SSH, TCP, TLS, etc")
             for obj in objs_list:
                 obj.auto_recover = True
-                del obj
+                obj.__del__()
 
         # Disable libvirtd remote connection transport port
         obj_migration.migrate_pre_setup(dest_uri, params, cleanup=True, ports=transport_port)


### PR DESCRIPTION
TLS/TCP configurations cannot be recovered correctly before,
fix in this PR.
BTW, the error message is not clear in these tests,
so update it also.

Signed-off-by: Yingshun Cui <yicui@redhat.com>