### PR TITLE
Fix a re pattern for virtual disk size

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockresize.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockresize.py
@@ -134,7 +134,7 @@ def run(test, params, env):
                 cmd += " -U"
             ret = process.run(cmd, allow_output_check='combined', shell=True)
             status, output = (ret.exit_status, ret.stdout_text.strip())
-            value_return_by_qemu_img = re.search(r'virtual size:\s+(\d+(\.\d+)?)+G', output).group(1)
+            value_return_by_qemu_img = re.search(r'virtual size:\s+(\d+(\.\d+)?)+\s?G', output).group(1)
             if value != int(float(value_return_by_qemu_img)):
                 test.fail("initial image size in config is not equals to value returned by qemu-img info")
         else:


### PR DESCRIPTION
The virtual size from output of qemu-img info changed from
"xxxG" to "xxx GiB", so the original re pattern failed to get the
size info.

Signed-off-by: Yi Sun <yisun@redhat.com>