### PR TITLE
Add cases to test that libvirtd is automatically started

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domid.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domid.cfg
@@ -15,6 +15,8 @@
                 - shutoff_option:
                     start_vm = "no"
                     kill_vm_before_test = "yes"
+                - libvirtd_auto_restart:
+                    libvirtd = "off"
                 - remote:
                     domid_vm_ref = "remote"
         - error_test:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domjobinfo.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domjobinfo.cfg
@@ -28,6 +28,11 @@
                     domjobinfo_action = "save"
                 - managedsave_action:
                     domjobinfo_action = "managedsave"
+        - libvirtd_auto_restart:
+            status_error = "no"
+            libvirtd = "off"
+            domjobinfo_action = "dump"
+            dump_opt = "--crash"
         - error_test:
             status_error = "yes"
             variants:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domuuid.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domuuid.cfg
@@ -18,6 +18,10 @@
                 - vm_shutoff:
                     no valid_domid
                     domuuid_vm_state = "shutoff"
+        - livirtd_auto_restart:
+            status_error = "no"
+            domuuid_vm_ref = "domid"
+            libvirtd = "off"
         - error_test:
             status_error = "yes"
             variants:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domxml_to_native.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domxml_to_native.cfg
@@ -41,3 +41,5 @@
                     dtn_vm_id = "name"
                     dtn_extra_param = "--domain "
                     dtn_file_xml = ""
+                - libvirtd_auto_restart:
+                    libvirtd = "off"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_managedsave.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_managedsave.cfg
@@ -69,6 +69,9 @@
                 - loop_cmd:
                     test_loop_cmd = "yes"
                     loop_range = "20"
+        - libvirtd_auto_restart:
+            status_error = "no"
+            libvirtd = "off"
         - status_error_yes:
             status_error = "yes"
             variants:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_restore.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_restore.cfg
@@ -41,3 +41,6 @@
             setup_libvirt_polkit = "yes"
             unprivileged_user = "EXAMPLE"
             virsh_uri = "qemu:///system"
+        - libvirtd_auto_restart:
+            libvirtd = "off"
+            status_error = "no"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_shutdown.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_shutdown.cfg
@@ -42,6 +42,10 @@
                     action_lookup = "connect_driver:QEMU domain_name:${main_vm}"
                     unprivileged_user = "EXAMPLE"
                     virsh_uri = "qemu:///system"
+        - libvirtd_auto_restart:
+            status_error = "no"
+            libvirtd = "off"
+            shutdown_mode = ""
         - error_test:
             status_error = "yes"
             variants:

--- a/libvirt/tests/cfg/virsh_cmd/monitor/virsh_domstate.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/monitor/virsh_domstate.cfg
@@ -73,6 +73,9 @@
                                     dump_option = "--live"
                                 - dump_crash:
                                     dump_option = "--crash"
+        - libvirtd_auto_restart:
+            status_error = "no"
+            libvirtd = "off"
         - error_test:
             status_error = "yes"
             variants:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domjobinfo.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domjobinfo.py
@@ -210,7 +210,8 @@ def run(test, params, env):
         if status != 0 or status_cmplt != 0:
             test.fail("Run failed with right command")
 
-    if status_error == "no":
+    # if libvirtd wasn't running the jobinfo is exepected to be empty
+    if status_error == "no" and not libvirtd == "off":
         # The 'managedsave' Operation will be shown as 'Save' in domjobinfo
         if actions == "managedsave":
             actions = "save"


### PR DESCRIPTION
From libvirt 5.6.0 on issuing these commands won't result in error but succeed if the
rest of the paramters are valid. Blacklisting in CI will filter out those applicable
to each libvirt version.

This change must not be merged before blacklisting is set up.

Manual avocado runs showed that tests will pass. Will add CI run to PR comment.