### PR TITLE
virtual_disks_multivms: Replace ide cdrom with sata cdrom

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_multivms.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_multivms.cfg
@@ -88,8 +88,8 @@
         - vms_readonly_test:
             only coldplug
             virt_disk_test_readonly = "yes"
-            virt_disk_bus = "ide"
-            virt_disk_target = "hdc"
+            virt_disk_bus = "sata"
+            virt_disk_target = "sdc"
             virt_disk_type = "file"
             virt_disk_device = "cdrom"
             virt_disk_vms_readonly = "readonly readonly"


### PR DESCRIPTION
Since q35 machine types do not support ide controller, use sata disk
instead.

Signed-off-by: Han Han <hhan@redhat.com>