### PR TITLE
Make tests fail if vm cannot be started

### DIFF
--- a/libvirt/tests/src/virtual_device/sound_device.py
+++ b/libvirt/tests/src/virtual_device/sound_device.py
@@ -110,7 +110,7 @@ def run(test, params, env):
             sound_dev.codec_type = codec_type
         vm_xml.add_device(sound_dev)
         vm_xml.sync()
-        virsh.start(vm_name)
+        virsh.start(vm_name, ignore_status=False)
         check_dumpxml()
         check_qemu_cmd_line()
     finally:


### PR DESCRIPTION
Original error message would inform "VM pid file missing."
New behavior is to not continue test if vm cannot be started.