### PR TITLE
Update cache mode related migration cases

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -161,15 +161,12 @@
                             initial = 30
                             increment = 15
                             virsh_migrate_extra = "--auto-converge --auto-converge-initial ${initial} --auto-converge-increment ${increment}"
-                - cache_safe:
+                - cache_mode:
                     variants:
                         - none:
                             cache = "none"
                         - directsync:
                             cache = "directsync"
-                - cache_unsafe:
-                    virsh_migrate_extra = '--unsafe'
-                    variants:
                         - writeback:
                             cache = "writeback"
                         - unsafe:

--- a/libvirt/tests/src/migration/migrate_options_shared.py
+++ b/libvirt/tests/src/migration/migrate_options_shared.py
@@ -1077,6 +1077,18 @@ def run(test, params, env):
         if postcopy_options:
             extra = "%s %s" % (extra, postcopy_options)
 
+        if remove_cache or (cache and cache not in ["none", "directsync"]):
+            if not status_error:
+                if not (libvirt_version.version_compare(5, 6, 0) and
+                   utils_misc.compare_qemu_version(4, 0, 0, False)):
+                    extra = "%s %s" % (extra, "--unsafe")
+            else:
+                if (libvirt_version.version_compare(5, 6, 0) and
+                   utils_misc.compare_qemu_version(4, 0, 0, False)):
+                    test.cancel("All the cache modes are safe on "
+                                "current libvirtd & qemu version,"
+                                "skip negative tests.")
+
         if low_speed:
             control_migrate_speed(int(low_speed))
             if postcopy_options and libvirt_version.version_compare(5, 0, 0):


### PR DESCRIPTION
All the cache modes are safe since libvirt 5.6.0-2 + qemu-kvm-4.0.0.
So update cases accordingly.

Signed-off-by: Yingshun Cui <yicui@redhat.com>