### PR TITLE
migration: adopt utils_test.libvirt to migration

### DIFF
--- a/libvirt/tests/src/migration/migrate_ceph.py
+++ b/libvirt/tests/src/migration/migrate_ceph.py
@@ -15,6 +15,7 @@ from virttest import utils_package
 from virttest import utils_conn
 from virttest import virsh
 from virttest import virt_vm
+from virttest import migration
 
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import secret_xml
@@ -495,7 +496,7 @@ def run(test, params, env):
     vmxml_backup = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
 
     # Setup migration context
-    migrate_setup = libvirt.MigrationTest()
+    migrate_setup = migration.MigrationTest()
     migrate_setup.migrate_pre_setup(test_dict["desuri"], params)
 
     # Install ceph-common on remote host machine.

--- a/libvirt/tests/src/migration/migrate_gluster.py
+++ b/libvirt/tests/src/migration/migrate_gluster.py
@@ -10,6 +10,7 @@ from virttest import utils_misc
 from virttest import utils_package
 from virttest import utils_conn
 from virttest import gluster
+from virttest import migration
 
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
@@ -195,7 +196,7 @@ def run(test, params, env):
     new_xml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     orig_config_xml = new_xml.copy()
 
-    migrate_setup = libvirt.MigrationTest()
+    migrate_setup = migration.MigrationTest()
     try:
         # Create a remote runner for later use
         runner_on_target = remote.RemoteRunner(host=server_ip,

--- a/libvirt/tests/src/migration/migrate_options_shared.py
+++ b/libvirt/tests/src/migration/migrate_options_shared.py
@@ -28,6 +28,7 @@ from virttest import utils_package
 from virttest import utils_iptables
 from virttest import utils_conn
 from virttest import xml_utils
+from virttest import migration
 
 from virttest.utils_iptables import Iptables
 from virttest.libvirt_xml import vm_xml
@@ -1257,7 +1258,7 @@ def run(test, params, env):
         if not asynch_migration:
             mig_result = do_migration(vm, dest_uri, options, extra)
         else:
-            migration_test = libvirt.MigrationTest()
+            migration_test = migration.MigrationTest()
 
             logging.debug("vm.connect_uri=%s", vm.connect_uri)
             vms = [vm]
@@ -1426,7 +1427,7 @@ def run(test, params, env):
                 ssh_connection.conn_setup()
                 ssh_connection.conn_check()
 
-            migrate_setup = libvirt.MigrationTest()
+            migrate_setup = migration.MigrationTest()
             # Pre migration setup for local machine
             src_full_uri = libvirt_vm.complete_uri(
                         params.get("migrate_source_host"))
@@ -1498,7 +1499,7 @@ def run(test, params, env):
             if migr_vm_back:
                 if 'ssh_connection' in locals():
                     ssh_connection.auto_recover = True
-                migrate_setup = libvirt.MigrationTest()
+                migrate_setup = migration.MigrationTest()
                 if 'src_full_uri' in locals():
                     migrate_setup.migrate_pre_setup(src_full_uri, params,
                                                     cleanup=True)

--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -30,6 +30,7 @@ from virttest import utils_selinux
 from virttest import utils_test
 from virttest import virsh
 from virttest import virt_vm
+from virttest import migration
 
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import pool_xml
@@ -1421,7 +1422,7 @@ def run(test, params, env):
     remote_virsh_dargs = {'remote_ip': server_ip, 'remote_user': server_user,
                           'remote_pwd': server_pwd, 'unprivileged_user': None,
                           'ssh_remote_auth': True}
-    migrate_setup = libvirt.MigrationTest()
+    migrate_setup = migration.MigrationTest()
     dest_uri = libvirt_vm.complete_uri(server_ip)
     migrate_setup.cleanup_dest_vm(vm, src_uri, dest_uri)
     try:
@@ -2388,7 +2389,7 @@ def run(test, params, env):
 
         if disk_port:
             # Run migration command on a seperate thread
-            migration_test = libvirt.MigrationTest()
+            migration_test = migration.MigrationTest()
             vms = [vm]
             func_dict = {"disk_port": disk_port, "server_ip": server_ip,
                          "server_user": server_user, "server_pwd": server_pwd,

--- a/libvirt/tests/src/migration/migrate_with_legacy_guest.py
+++ b/libvirt/tests/src/migration/migrate_with_legacy_guest.py
@@ -10,6 +10,7 @@ from virttest import defaults
 from virttest import virsh
 from virttest import remote
 from virttest import utils_conn
+from virttest import migration
 from virttest import libvirt_version
 
 from virttest.libvirt_xml import vm_xml
@@ -181,7 +182,7 @@ def run(test, params, env):
     new_xml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     orig_config_xml = new_xml.copy()
 
-    migration_test = libvirt.MigrationTest()
+    migration_test = migration.MigrationTest()
     try:
         # Create a remote runner for later use
         runner_on_target = remote.RemoteRunner(host=server_ip,

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domjobabort.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domjobabort.py
@@ -6,7 +6,7 @@ import locale
 
 from virttest import virsh
 from virttest import data_dir
-from virttest.utils_test import libvirt as utlv
+from virttest import migration
 from virttest import ssh_key
 
 
@@ -179,7 +179,7 @@ def run(test, params, env):
     if action == "migrate":
         # Recover migration speed
         virsh.migrate_setspeed(vm_name, original_speed)
-        utlv.MigrationTest().cleanup_dest_vm(vm, None, remote_uri)
+        migration.MigrationTest().cleanup_dest_vm(vm, None, remote_uri)
 
     # check status_error
     if status_error == "yes":

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
@@ -15,6 +15,7 @@ from virttest import virsh
 from virttest import utils_libvirtd
 from virttest import data_dir
 from virttest import libvirt_vm
+from virttest import migration
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices import memory
 from virttest import utils_misc
@@ -799,7 +800,7 @@ def run(test, params, env):
         # Change the disk of the vm to shared disk
         libvirt.set_vm_disk(vm, params)
 
-        migrate_setup = libvirt.MigrationTest()
+        migrate_setup = migration.MigrationTest()
 
         subdriver = utils_test.get_image_info(shared_storage)['format']
         extra_attach = ("--config --driver qemu --subdriver %s --cache %s"
@@ -1047,7 +1048,7 @@ def run(test, params, env):
             timeout = int(params.get("timeout_before_suspend", 5))
             logging.debug("Set migration speed to %sM", speed)
             virsh.migrate_setspeed(vm_name, speed, debug=True)
-            migration_test = libvirt.MigrationTest()
+            migration_test = migration.MigrationTest()
             migrate_options = "%s %s" % (options, extra)
             vms = [vm]
             migration_test.do_migration(vms, None, dest_uri, 'orderly',
@@ -1061,7 +1062,7 @@ def run(test, params, env):
             vms = []
             vms.append(vm)
             cmd = params.get("virsh_postcopy_cmd")
-            obj_migration = libvirt.MigrationTest()
+            obj_migration = migration.MigrationTest()
             migrate_options = "%s %s" % (options, extra)
             # start stress inside VM
             stress_tool = params.get("stress_package", "stress")

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_compcache.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_compcache.py
@@ -7,7 +7,7 @@ from avocado.utils import path as utils_path
 
 from virttest import virsh
 from virttest import ssh_key
-from virttest.utils_test import libvirt as utlv
+from virttest import migration
 
 
 def get_page_size():
@@ -140,7 +140,7 @@ def run(test, params, env):
                 pass
 
         # Cleanup in case of successful migration
-        utlv.MigrationTest().cleanup_dest_vm(vm, None, remote_uri)
+        migration.MigrationTest().cleanup_dest_vm(vm, None, remote_uri)
 
     # Shut down the VM to make sure the compcache setting cleared
     if vm.is_alive():

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_copy_storage.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_copy_storage.py
@@ -6,6 +6,7 @@ from avocado.core import exceptions
 from virttest import ssh_key
 from virttest import utils_test
 from virttest import libvirt_vm
+from virttest import migration
 from virttest.utils_test import libvirt as utlv
 from virttest.staging import lv_utils
 from virttest import virsh
@@ -116,7 +117,7 @@ def copied_migration(test, vms, params):
         vm.wait_for_login()
         vms_ip[vm.name] = vm.get_address()
 
-    cp_mig = utlv.MigrationTest()
+    cp_mig = migration.MigrationTest()
     cp_mig.do_migration(vms, None, dest_uri, "orderly", options, timeout,
                         ignore_status=True)
     check_ip_failures = []

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_multi_vms.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_multi_vms.py
@@ -10,6 +10,7 @@ from virttest import remote
 from virttest import utils_test
 from virttest import nfs
 from virttest import ssh_key
+from virttest import migration
 from virttest.libvirt_xml import vm_xml
 
 
@@ -122,7 +123,7 @@ def multi_migration(vm, src_uri, dest_uri, options, migrate_type,
     :rrunner: remote session instance
     """
 
-    obj_migration = utils_test.libvirt.MigrationTest()
+    obj_migration = migration.MigrationTest()
     if migrate_type.lower() == "simultaneous":
         logging.info("Migrate vms simultaneously.")
         try:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_set_get_speed.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_set_get_speed.py
@@ -4,7 +4,7 @@ from virttest import ssh_key
 from virttest import virsh
 from virttest import libvirt_vm
 from virttest import utils_test
-from virttest.utils_test import libvirt as utlv
+from virttest import migration
 
 from provider import libvirt_version
 
@@ -170,7 +170,7 @@ def run(test, params, env):
         # virsh migrate options
         virsh_migrate_options = "--live --unsafe --timeout %s" % virsh_migrate_timeout
         # Migrate vms to remote host
-        mig_first = utlv.MigrationTest()
+        mig_first = migration.MigrationTest()
         virsh_dargs = {"debug": True}
         for vm in vms:
             set_get_speed(vm.name, bandwidth, virsh_dargs=virsh_dargs)
@@ -203,7 +203,7 @@ def run(test, params, env):
             vm.wait_for_login()
             set_get_speed(vm.name, second_bandwidth, virsh_dargs=virsh_dargs)
         utils_test.load_stress(stress_type, params=params, vms=vms)
-        mig_second = utlv.MigrationTest()
+        mig_second = migration.MigrationTest()
         mig_second.do_migration(vms, src_uri, dest_uri, migration_type,
                                 options=virsh_migrate_options, thread_timeout=thread_timeout)
         for vm in vms:
@@ -244,6 +244,6 @@ def run(test, params, env):
         virsh.migrate_setspeed(vm_name, orig_value)
         if twice_migration:
             for vm in env.get_all_vms():
-                utlv.MigrationTest().cleanup_dest_vm(vm, src_uri, dest_uri)
+                migration.MigrationTest().cleanup_dest_vm(vm, src_uri, dest_uri)
                 if vm.is_alive():
                     vm.destroy(gracefully=False)

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_stress.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_stress.py
@@ -4,6 +4,7 @@ from virttest import libvirt_vm
 from virttest import utils_test
 from virttest import utils_misc
 from virttest import utils_package
+from virttest import migration
 from virttest import remote
 from virttest.libvirt_xml import vm_xml
 from virttest.staging import utils_memory
@@ -40,7 +41,7 @@ def do_stress_migration(vms, srcuri, desturi, migration_type, test, params,
 
     :raise: test.fail if migration fails
     """
-    migrate_setup = utils_test.libvirt.MigrationTest()
+    migrate_setup = migration.MigrationTest()
     options = params.get("migrate_options")
     ping_count = int(params.get("ping_count", 10))
     migrate_times = 1
@@ -192,8 +193,7 @@ def run(test, params, env):
     finally:
         logging.debug("Cleanup vms...")
         for vm in vms:
-            utils_test.libvirt.MigrationTest().cleanup_dest_vm(vm, None,
-                                                               dest_uri)
+            migration.MigrationTest().cleanup_dest_vm(vm, None, dest_uri)
             # Try to start vms in source once vms in destination are
             # cleaned up
             if not vm.is_alive():

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_virtio_scsi.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_virtio_scsi.py
@@ -13,6 +13,7 @@ from virttest import libvirt_vm
 from virttest import virt_vm
 from virttest import remote
 from virttest import ssh_key
+from virttest import migration
 from virttest.utils_test import libvirt as utlv
 
 
@@ -161,7 +162,7 @@ def run(test, params, env):
     try:
         # For safety and easily reasons, we'd better define a new vm
         new_vm_name = "%s_vsmtest" % vm.name
-        mig = utlv.MigrationTest()
+        mig = migration.MigrationTest()
         if vm.is_alive():
             vm.destroy()
         utlv.define_new_vm(vm.name, new_vm_name)

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_vm_cfg.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_vm_cfg.py
@@ -8,6 +8,7 @@ from avocado.utils import process
 from virttest import utils_selinux
 from virttest import virsh
 from virttest import utils_package
+from virttest import migration
 from virttest.utils_conn import TLSConnection
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
@@ -136,7 +137,7 @@ def run(test, params, env):
     try:
         # Get a MigrationTest() Object
         logging.debug("Get a MigrationTest()  object")
-        obj_migration = libvirt.MigrationTest()
+        obj_migration = migration.MigrationTest()
 
         # Setup libvirtd remote connection TLS connection env
         if transport == "tls":

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migration.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migration.py
@@ -3,6 +3,7 @@ import platform
 
 from virttest import libvirt_vm
 from virttest import virsh
+from virttest import migration
 from virttest.utils_test import libvirt
 from virttest import libvirt_xml
 
@@ -111,7 +112,7 @@ def run(test, params, env):
         logging.debug("Supported machine types that are common in  source and "
                       "target are: %s", ", ".join(map(str, machine_list)))
 
-    migrate_setup = libvirt.MigrationTest()
+    migrate_setup = migration.MigrationTest()
     # Perform migration with each machine type
     try:
         for vm in vm_list:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_monitor_blockjob.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_monitor_blockjob.py
@@ -9,6 +9,7 @@ from virttest import utils_test
 from virttest import libvirt_vm
 from virttest import virsh
 from virttest import ssh_key
+from virttest import migration
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt as utlv
 
@@ -59,7 +60,7 @@ def copied_migration(test, vm, params, blockjob_type=None, block_target="vda"):
     if stress_type is not None:
         utils_test.load_stress("stress_in_vms", params=params, vms=[vm])
 
-    cp_mig = utlv.MigrationTest()
+    cp_mig = migration.MigrationTest()
     migration_thread = threading.Thread(target=cp_mig.thread_func_migration,
                                         args=(vm, dest_uri, options))
     migration_thread.start()


### PR DESCRIPTION
change all the migration testcases that uses utils_test.libvirt
to migration.py for `MigrationTest`.

Signed-off-by: Balamuruhan S <bala24@linux.ibm.com>