### PR TITLE
Add cases to test that libvirtd is automatically started

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_hostname.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_hostname.cfg
@@ -14,6 +14,10 @@
             virsh_hostname_options = ""
             status_error = "yes"
             libvirtd = "off"
+        - libvirtd_auto_restart:
+            virsh_hostname_options = ""
+            status_error = "no"
+            libvirtd = "off"
         - remote_connect:
             start_vm = yes
             virsh_hostname_options = ""

--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_nodeinfo.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_nodeinfo.cfg
@@ -15,3 +15,7 @@
             virsh_node_options = ""
             status_error = "yes"
             libvirtd = "off"
+        - libvirtd_auto_restart:
+            virsh_node_options = ""
+            status_error = "no"
+            libvirtd = "off"

--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_uri.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_uri.cfg
@@ -22,3 +22,8 @@
             virsh_uri_options = ""
             status_error = "yes"
             libvirtd = "off"
+        - libvirtd_auto_restart:
+            virsh_uri_options = ""
+            status_error = "no"
+            libvirtd = "off"
+            target_uri = "qemu:///system"

--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_version.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_version.cfg
@@ -12,5 +12,9 @@
         - with_libvirtd_stop:
             status_error = "yes"
             libvirtd = "off"
+        - libvirtd_auto_restart:
+            status_error = "no"
+            libvirtd = "off"
         - daemon_option:
             virsh_version_options = "--daemon"
+


### PR DESCRIPTION
From libvirt 5.6.0 on issuing these commands won't result in error but
succeed if the rest of the parameters are valid. Blacklisting in CI
will filter out those applicable to each libvirt version.

This change must not be merged before blacklisting is set up.

All tests but the one on nodeinfo pass. However, as running virsh.nodeinfo.no_option
fails with the same issue, I believe this should be fixed in another PR.

JOB ID     : adfd0fc62bfa9a5ac22834761fbe8037b45dd2b6
JOB LOG    : /root/avocado/job-results/job-2019-09-23T15.06-adfd0fc/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.version.libvirtd_auto_restart: PASS (4.73 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 6.20 s
JOB ID     : 6c9f566a366daba43bb909c4bfc96bc715e2fe40
JOB LOG    : /root/avocado/job-results/job-2019-09-23T15.06-6c9f566/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.hostname.libvirtd_auto_restart: PASS (4.54 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 5.98 s
JOB ID     : d26809906683d5b9835f2032e28b985cb5fd3640
JOB LOG    : /root/avocado/job-results/job-2019-09-23T15.06-d268099/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.uri.libvirtd_auto_restart: PASS (4.61 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 6.07 s
JOB ID     : 799bb4c088fb27efc6777babb7f14f6215cdcc67
JOB LOG    : /root/avocado/job-results/job-2019-09-23T15.06-799bb4c/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.nodeinfo.libvirtd_auto_restart: ERROR: cannot import name 'cpu' (0.10 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 1.54 s
JOB ID     : da125439ae0b7f464be301004e75fa2d7bfc0af2
JOB LOG    : /root/avocado/job-results/job-2019-09-23T15.06-da12543/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.nodeinfo.no_option: ERROR: cannot import name 'cpu' (0.10 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 1.54 s