### PR TITLE
Add new variables to expected output for domxml-to-native

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_to_native.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_to_native.py
@@ -98,6 +98,23 @@ def run(test, params, env):
 
         return retlist
 
+    def prepend_expected_env_vars(conv_arg, cmdline):
+        """
+        Prepend the various environment variables that will be in
+        the conv_arg, but not in the actual command
+
+        :param conv_arg : Converted information
+        :param cmdline: Command line qemu has been called with
+        :return: cmdline prepended by expected environment variable values
+        """
+        expected_env_vars = [
+                'LC_ALL', 'PATH', 'QEMU_AUDIO_DRV', 'HOME',
+                'XDG_DATA_HOME', 'XDG_CACHE_HOME', 'XDG_CONFIG_HOME',
+                ]
+        valmatcher = '.[^\\s]+\\s'
+        def matchf(x): return re.search(x + valmatcher, conv_arg).group(0)
+        return "".join(map(matchf, expected_env_vars)) + cmdline
+
     def compare(conv_arg):
         """
         Compare converted information with vm's information.
@@ -135,12 +152,7 @@ def run(test, params, env):
             logging.warning("qemu-kvm binary is not identified: '%s'",
                             qemu_kvm_bin)
 
-        # Now prepend the various environment variables that will be in
-        # the conv_arg, but not in the actual command
-        tmp = re.search('LC_ALL.[^\s]\s', conv_arg).group(0) +\
-            re.search('PATH.[^\s]+\s', conv_arg).group(0) +\
-            re.search('QEMU_AUDIO_DRV.[^\s]+\s', conv_arg).group(0)
-        qemu_arg = tmp + cmdline
+        qemu_arg = prepend_expected_env_vars(conv_arg, cmdline)
 
         conv_arg_lines = buildcmd(conv_arg)
         qemu_arg_lines = buildcmd(qemu_arg)


### PR DESCRIPTION
LIBVIRTAT-5329,LIBVIRTAT-4626 New variables have been added to
domxml_to_native command. See
[libvirt][PATCH 0/3] Define XDG variables
https://www.redhat.com/archives/libvir-list/2019-March/msg00323.html

Test run output after this fix:
JOB ID     : 3616337bdc07ad1ae7e4963c170f229d104b6481
JOB LOG    : /var/lib/libvirt/qemu/domain--1-avocado-vt-vm1/avocado/job-results/job-2019-09-24T08.00-3616337/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.domxml_to_native.negative_test.expected_option: PASS (95.14 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 96.68 s
JOB ID     : ca2dce59af362ac57f4386fec9d85313f6c36db4
JOB LOG    : /var/lib/libvirt/qemu/domain--1-avocado-vt-vm1/avocado/job-results/job-2019-09-24T08.02-ca2dce5/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.domxml_to_native.positive_test.libvirtd_auto_restart: PASS (95.30 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 96.86 s
JOB ID     : 286ee844962361a8b0d2a534a3a88f21bd706c2d
JOB LOG    : /var/lib/libvirt/qemu/domain--1-avocado-vt-vm1/avocado/job-results/job-2019-09-24T08.03-286ee84/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.domxml_to_native.positive_test.id_option: PASS (94.54 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 96.15 s
JOB ID     : 35533737f3c1c3c0302b8721baf56beacec5da7d
JOB LOG    : /var/lib/libvirt/qemu/domain--1-avocado-vt-vm1/avocado/job-results/job-2019-09-24T08.05-3553373/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.domxml_to_native.positive_test.uuid_option: PASS (96.41 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 97.97 s
JOB ID     : 65b1ca54448f962ff84543c43d72e91b8f9fc267
JOB LOG    : /var/lib/libvirt/qemu/domain--1-avocado-vt-vm1/avocado/job-results/job-2019-09-24T08.07-65b1ca5/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.domxml_to_native.positive_test.name_option: PASS (101.04 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 103.24 s
