### PR TITLE
Update the config file to keep consistence

### DIFF
--- a/libvirt/tests/cfg/sriov/sriov.cfg
+++ b/libvirt/tests/cfg/sriov/sriov.cfg
@@ -15,7 +15,7 @@
                     driver = mlx4_core
                 - enic:
                     driver = enic
-                - x710:
+                - i40e:
                     driver = i40e
     variants:
         - guest_with_vf:


### PR DESCRIPTION
The x710 is the device model name, and i40e is the driver name.
To keep the naming rules to be consistent, update the name accordingly.

Signed-off-by: yalzhang <yalzhang@redhat.com>