### PR TITLE
Fix test expectations when libvirtd is off

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domid.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domid.cfg
@@ -15,8 +15,6 @@
                 - shutoff_option:
                     start_vm = "no"
                     kill_vm_before_test = "yes"
-                - libvirtd_auto_restart:
-                    libvirtd = "off"
                 - remote:
                     domid_vm_ref = "remote"
         - error_test:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domjobinfo.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domjobinfo.cfg
@@ -28,11 +28,6 @@
                     domjobinfo_action = "save"
                 - managedsave_action:
                     domjobinfo_action = "managedsave"
-        - libvirtd_auto_restart:
-            status_error = "no"
-            libvirtd = "off"
-            domjobinfo_action = "dump"
-            dump_opt = "--crash"
         - error_test:
             status_error = "yes"
             variants:
@@ -55,3 +50,5 @@
                     kill_vm_before_test = "yes"
                 - with_libvirtd_stop:
                     libvirtd = "off"
+                    domjobinfo_action = "dump"
+                    dump_opt = "--crash"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domuuid.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domuuid.cfg
@@ -18,10 +18,6 @@
                 - vm_shutoff:
                     no valid_domid
                     domuuid_vm_state = "shutoff"
-        - libvirtd_auto_restart:
-            status_error = "no"
-            domuuid_vm_ref = "domid"
-            libvirtd = "off"
         - error_test:
             status_error = "yes"
             variants:
@@ -35,3 +31,4 @@
                     domuuid_vm_ref = ""
                 - libvirtd_off:
                     libvirtd = "off"
+                    domuuid_vm_ref = "domid"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domxml_to_native.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domxml_to_native.cfg
@@ -23,6 +23,7 @@
                     dtn_extra_param = "xyz"
                 - with_libvirtd_stop:
                     libvirtd = "off"
+                    dtn_extra = ""
                 - readonly_mode:
                     readonly = "yes"
         - positive_test:
@@ -41,5 +42,3 @@
                     dtn_vm_id = "name"
                     dtn_extra_param = "--domain "
                     dtn_file_xml = ""
-                - libvirtd_auto_restart:
-                    libvirtd = "off"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_managedsave.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_managedsave.cfg
@@ -69,9 +69,6 @@
                 - loop_cmd:
                     test_loop_cmd = "yes"
                     loop_range = "20"
-        - libvirtd_auto_restart:
-            status_error = "no"
-            libvirtd = "off"
         - status_error_yes:
             status_error = "yes"
             variants:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_restore.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_restore.cfg
@@ -41,6 +41,3 @@
             setup_libvirt_polkit = "yes"
             unprivileged_user = "EXAMPLE"
             virsh_uri = "qemu:///system"
-        - libvirtd_auto_restart:
-            libvirtd = "off"
-            status_error = "no"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_shutdown.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_shutdown.cfg
@@ -42,10 +42,6 @@
                     action_lookup = "connect_driver:QEMU domain_name:${main_vm}"
                     unprivileged_user = "EXAMPLE"
                     virsh_uri = "qemu:///system"
-        - libvirtd_auto_restart:
-            status_error = "no"
-            libvirtd = "off"
-            shutdown_mode = ""
         - error_test:
             status_error = "yes"
             variants:
@@ -67,6 +63,7 @@
                     reboot_pre_domian_status = "shutoff"
                 - with_libvirtd_stop:
                     libvirtd = "off"
+                    shutdown_mode = ""
                 - acl_test:
                     setup_libvirt_polkit = "yes"
                     unprivileged_user = "EXAMPLE"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_undefine.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_undefine.cfg
@@ -68,7 +68,7 @@
                     undefine_vm_ref = undefine_invalid_vm_name
                     undefine_invalid_vm_name = "\#"
                 - libvirtd_stop:
-                    libvirtd = off
+                    libvirtd = "off"
                 - invalid_vm_uuid:
                     undefine_vm_ref = undefine_invalid_vm_uuid
                     undefine_invalid_vm_uuid = "99999999-9999-9999-9999-999999999999"

--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_uri.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_uri.cfg
@@ -22,3 +22,4 @@
             virsh_uri_options = ""
             status_error = "yes"
             libvirtd = "off"
+            target_uri = "qemu:///system"

--- a/libvirt/tests/cfg/virsh_cmd/monitor/virsh_domstate.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/monitor/virsh_domstate.cfg
@@ -73,9 +73,6 @@
                                     dump_option = "--live"
                                 - dump_crash:
                                     dump_option = "--crash"
-        - libvirtd_auto_restart:
-            status_error = "no"
-            libvirtd = "off"
         - error_test:
             status_error = "yes"
             variants:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domid.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domid.py
@@ -1,3 +1,5 @@
+import logging
+
 from avocado.utils import process
 
 from virttest import libvirt_vm
@@ -5,6 +7,8 @@ from virttest import remote
 from virttest import virsh
 from virttest import utils_libvirtd
 from virttest import ssh_key
+
+from provider import libvirt_version
 
 
 def run(test, params, env):
@@ -96,7 +100,11 @@ def run(test, params, env):
     # check status_error
     if status_error == "yes":
         if status == 0 or err == "":
-            test.fail("Run successfully with wrong command!")
+            if libvirtd == "off" and libvirt_version.version_compare(5, 6, 0):
+                logging.info("From libvirt version 5.6.0 libvirtd is restarted "
+                             "and command should succeed")
+            else:
+                test.fail("Run successfully with wrong command!")
     elif status_error == "no":
         if status != 0 or output == "":
             test.fail("Run failed with right command")

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domjobinfo.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domjobinfo.py
@@ -205,7 +205,11 @@ def run(test, params, env):
     # Check status_error
     if status_error == "yes":
         if status == 0:
-            test.fail("Run successfully with wrong command!")
+            if libvirtd == "off" and libvirt_version.version_compare(5, 6, 0):
+                logging.info("From libvirt 5.6.0 libvirtd is restarted "
+                             "and command should succeed")
+            else:
+                test.fail("Run successfully with wrong command!")
     elif status_error == "no":
         if status != 0 or status_cmplt != 0:
             test.fail("Run failed with right command")

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domuuid.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domuuid.py
@@ -5,6 +5,8 @@ from virttest import libvirt_xml
 from virttest import utils_libvirtd
 from virttest.utils_test.libvirt import check_domuuid_compliant_with_rfc4122
 
+from provider import libvirt_version
+
 
 def run(test, params, env):
     """
@@ -57,7 +59,11 @@ def run(test, params, env):
     # Check status_error
     if status_error == "yes":
         if status == 0:
-            test.fail("Run successfully with wrong command!")
+            if libvirtd == "off" and libvirt_version.version_compare(5, 6, 0):
+                logging.info("From libvirt version 5.6.0 libvirtd is restarted "
+                             "and command should succeed")
+            else:
+                test.fail("Run successfully with wrong command!")
     elif status_error == "no":
         if not check_domuuid_compliant_with_rfc4122(output):
             test.fail("UUID is not compliant with RFC4122 format")

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_to_native.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_to_native.py
@@ -8,6 +8,8 @@ from virttest import virsh
 from virttest import utils_libvirtd
 from virttest.compat_52lts import decode_to_text as to_text
 
+from provider import libvirt_version
+
 
 def run(test, params, env):
     """
@@ -218,7 +220,11 @@ def run(test, params, env):
     # check status_error
     if status_error == "yes":
         if status == 0:
-            test.fail("Run successfully with wrong command!")
+            if libvirtd == "off" and libvirt_version.version_compare(5, 6, 0):
+                logging.info("From libvirt version 5.6.0 libvirtd is restarted "
+                             "and command should succeed")
+            else:
+                test.fail("Run successfully with wrong command!")
     elif status_error == "no":
         if status != 0:
             test.fail("Run failed with right command")

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_managedsave.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_managedsave.py
@@ -16,6 +16,8 @@ from virttest.utils_test import libvirt
 from virttest.staging.service import Factory
 from virttest.staging.utils_memory import drop_caches
 
+from provider import libvirt_version
+
 
 def run(test, params, env):
     """
@@ -463,7 +465,11 @@ def run(test, params, env):
 
             if status_error:
                 if not status:
-                    test.fail("Run successfully with wrong command!")
+                    if libvirtd_state == "off" and libvirt_version.version_compare(5, 6, 0):
+                        logging.info("From libvirt version 5.6.0 libvirtd is restarted "
+                                     "and command should succeed")
+                    else:
+                        test.fail("Run successfully with wrong command!")
             else:
                 if status:
                     test.fail("Run failed with right command")

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_restore.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_restore.py
@@ -1,5 +1,6 @@
 import re
 import os
+import logging
 
 from virttest import virsh
 from virttest import data_dir
@@ -87,7 +88,11 @@ def run(test, params, env):
     try:
         if status_error:
             if not status:
-                test.fail("Run successfully with wrong command!")
+                if libvirtd == "off" and libvirt_version.version_compare(5, 6, 0):
+                    logging.info("From libvirt version 5.6.0 libvirtd is restarted "
+                                 "and command should succeed")
+                else:
+                    test.fail("Run successfully with wrong command!")
         else:
             if status:
                 test.fail("Run failed with right command")

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_save.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_save.py
@@ -1,5 +1,6 @@
 import os
 import re
+import logging
 
 from virttest import virsh
 from virttest import data_dir
@@ -83,8 +84,12 @@ def run(test, params, env):
     try:
         if status_error:
             if not status:
-                test.fail("virsh run succeeded with an "
-                          "incorrect command")
+                if libvirtd == "off" and libvirt_version.version_compare(5, 6, 0):
+                    logging.info("From libvirt version 5.6.0 libvirtd is restarted "
+                                 "and command should succeed")
+                else:
+                    test.fail("virsh run succeeded with an "
+                              "incorrect command")
             if readonly:
                 if not re.search(expect_msg, err_msg):
                     test.fail("Fail to get expect err msg: %s" % expect_msg)

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_shutdown.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_shutdown.py
@@ -1,3 +1,5 @@
+import logging
+
 from avocado.utils import process
 
 from virttest import remote
@@ -117,7 +119,11 @@ def run(test, params, env):
         # check status_error
         if status_error:
             if not status:
-                test.fail("Run successfully with wrong command!")
+                if libvirtd == "off" and libvirt_version.version_compare(5, 6, 0):
+                    logging.info("From libvirt version 5.6.0 libvirtd is restarted "
+                                 "and command should succeed")
+                else:
+                    test.fail("Run successfully with wrong command!")
             if expect_msg:
                 libvirt.check_result(result, expect_msg.split(';'))
         else:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_undefine.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_undefine.py
@@ -260,7 +260,11 @@ def run(test, params, env):
     # Check results.
     if status_error:
         if not status:
-            test.fail("virsh undefine return unexpected result.")
+            if libvirtd_state == "off" and libvirt_version.version_compare(5, 6, 0):
+                logging.info("From libvirt version 5.6.0 libvirtd is restarted "
+                             "and command should succeed")
+            else:
+                test.fail("virsh undefine return unexpected result.")
         if params.get('setup_libvirt_polkit') == 'yes':
             if status3 == 0:
                 test.fail("virsh define with false acl permission" +

--- a/libvirt/tests/src/virsh_cmd/host/virsh_hostname.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_hostname.py
@@ -1,3 +1,5 @@
+import logging
+
 from avocado.utils import process
 
 from virttest import virsh
@@ -5,6 +7,8 @@ from virttest import ssh_key
 from virttest import utils_package
 from virttest import utils_libvirtd
 from virttest import remote
+
+from provider import libvirt_version
 
 
 def run(test, params, env):
@@ -71,8 +75,12 @@ def run(test, params, env):
     status_error = params.get("status_error")
     if status_error == "yes":
         if status == 0:
-            test.fail("Command 'virsh hostname %s' succeeded "
-                      "(incorrect command)" % option)
+            if libvirtd == "off" and libvirt_version.version_compare(5, 6, 0):
+                logging.info("From libvirt version 5.6.0 libvirtd is restarted "
+                             "and command should succeed.")
+            else:
+                test.fail("Command 'virsh hostname %s' succeeded "
+                          "(incorrect command)" % option)
     elif status_error == "no":
         if hostname != hostname_test:
             test.fail(

--- a/libvirt/tests/src/virsh_cmd/host/virsh_nodeinfo.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_nodeinfo.py
@@ -187,9 +187,9 @@ def run(test, params, env):
     status_error = params.get("status_error")
     if status_error == "yes":
         if status == 0:
-            if libvirtd == "off":
-                test.fail("Command 'virsh nodeinfo' succeeded "
-                          "with libvirtd service stopped, incorrect")
+            if libvirtd == "off" and libvirt_version.version_compare(5, 6, 0):
+                logging.info("From libvirt version 5.6.0 libvirtd is restarted "
+                             "and command should succeed")
             else:
                 test.fail("Command 'virsh nodeinfo %s' succeeded"
                           "(incorrect command)" % option)

--- a/libvirt/tests/src/virsh_cmd/host/virsh_uri.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_uri.py
@@ -8,6 +8,8 @@ from virttest import virsh
 from virttest import utils_libvirtd
 from virttest import ssh_key
 
+from provider import libvirt_version
+
 
 def run(test, params, env):
     """
@@ -74,8 +76,12 @@ def run(test, params, env):
     status_error = params.get("status_error")
     if status_error == "yes":
         if status == 0:
-            raise exceptions.TestFail("Command: %s  succeeded "
-                                      "(incorrect command)" % cmd)
+            if libvirtd == "off" and libvirt_version.version_compare(5, 6, 0):
+                logging.info("From libvirt version 5.6.0 libvirtd is restarted "
+                             "and command should succeed.")
+            else:
+                raise exceptions.TestFail("Command: %s  succeeded "
+                                          "(incorrect command)" % cmd)
         else:
             logging.info("command: %s is a expected error", cmd)
     elif status_error == "no":

--- a/libvirt/tests/src/virsh_cmd/host/virsh_version.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_version.py
@@ -1,6 +1,10 @@
+import logging
+
 from virttest import libvirt_vm
 from virttest import virsh
 from virttest import utils_libvirtd
+
+from provider import libvirt_version
 
 
 def run(test, params, env):
@@ -32,8 +36,12 @@ def run(test, params, env):
     # Check status_error
     if status_error:
         if not result.exit_status:
-            test.fail("Command 'virsh version %s' succeeded "
-                      "(incorrect command)" % option)
+            if libvirtd == "off" and libvirt_version.version_compare(5, 6, 0):
+                logging.info("From libvirt version 5.6.0 libvirtd is restarted "
+                             "and command should succeed.")
+            else:
+                test.fail("Command 'virsh version %s' succeeded "
+                          "(incorrect command)" % option)
     else:
         if result.exit_status:
             test.fail("Command 'virsh version %s' failed "

--- a/libvirt/tests/src/virsh_cmd/monitor/virsh_domstate.py
+++ b/libvirt/tests/src/virsh_cmd/monitor/virsh_domstate.py
@@ -21,6 +21,8 @@ from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.panic import Panic
 
+from provider import libvirt_version
+
 find_dump_file = False
 
 
@@ -254,7 +256,11 @@ def run(test, params, env):
         # check status_error
         if status_error:
             if not status:
-                test.fail("Run successfully with wrong command!")
+                if libvirtd_state == "off" and libvirt_version.version_compare(5, 6, 0):
+                    logging.info("From libvirt version 5.6.0 libvirtd is restarted "
+                                 "and command should succeed.")
+                else:
+                    test.fail("Run successfully with wrong command!")
         else:
             if status or not output:
                 test.fail("Run failed with right command")


### PR DESCRIPTION
libvirtd is restarted after issuing virsh commands from libvirt
version 5.6.0 on.

Removed separate libvirtd_auto_restart test definition from previous
PR.
Also, reviewed the libvirtd off test configuration has reasonable
parameters that should make the test pass if libvirtd is restarted
but should also pass if libvirtd is not restarted.

Tests now expect to pass if libvirtd was stopped but libvirt is at
least version 5.6.0 and before command was expected to fail.