### PR TITLE
libvirt_pci_passthrough: Implemented the GPU pass-through for guests.

### DIFF
--- a/libvirt/tests/cfg/libvirt_pci_passthrough.cfg
+++ b/libvirt/tests/cfg/libvirt_pci_passthrough.cfg
@@ -1,5 +1,6 @@
 - libvirt_pci_passthrough:
     type = libvirt_pci_passthrough
+    ignore_status = yes
     variants:
         - Normal_passthrough:
             libvirt_pci_SRIOV = no
@@ -34,3 +35,15 @@
             # device to guest.
             # E.g: pci_0000_0d_00_0
             libvirt_pci_storage_dev_label = "ENTER.YOUR.PCI.LABEL"
+        - GPU:
+            libvirt_pci_device_type = "GPU"
+            # E.g: 0030:00:00.0
+            pf_filter = "ENTER.YOUR.PCI.LABEL"
+            no SRIOV
+            stress_type = "stress-ng"
+            stress_cmds_stress-ng = "stress-ng"
+            make_cmds_stress-ng = "rm -rf /usr/bin/stress-ng && make && cp stress-ng /usr/bin && rm -rf /tmp/stress-*"
+            uninstall_cmds_stress-ng = "rm -rf /usr/bin/stress-ng && make clean"
+            download_url_stress-ng = "https://github.com/ColinIanKing/stress-ng.git"
+            download_type_stress-ng = "git"
+            stress-ng_args = "--cpu 8 --io 8 --vm 2 --vm-bytes 256M --timeout 200s"


### PR DESCRIPTION
libvirt_pci_passthrough: Implemented the GPU pass-through for guests.
Currently the libvirt_pci_passthrough has the provision for pass-through
of NIC and Storage.
Implemented the pass-through of GPU's for the guest, along with parallel
execution of "gpu-burn" and "stress-test" post the GPU pass-through.

Signed-off-by: Santwana Samantray <santwana@linux.vnet.ibm.com>