### PR TITLE
Check output of command "virsh pool-capability"

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/pool/virsh_pool_capabilities.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/pool/virsh_pool_capabilities.cfg
@@ -1,0 +1,11 @@
+- virsh.pool_capabilities:
+    type = virsh_pool_capabilities
+    vms = ''
+    start_vm = no
+    status_error = "no"
+    variants:
+        - no_option:
+            virsh_pool_cap_options = ""
+        - unexpect_option:
+            virsh_pool_cap_options = "xyz"
+            status_error = "yes"

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool_capabilities.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool_capabilities.py
@@ -1,0 +1,94 @@
+import logging
+
+from avocado.utils import process
+
+from virttest import libvirt_vm
+from virttest import virsh
+from virttest.libvirt_xml import pool_capability_xml
+
+from provider import libvirt_version
+
+
+def run(test, params, env):
+    """
+    Test the command virsh capabilities
+
+    (1) Call virsh pool-capabilities
+    (2) Call virsh pool-capabilities with an unexpected option
+    """
+    def compare_poolcapabilities_xml(source):
+        """
+        Compare new output of pool-capability with the standard one
+
+        (1) Dict the new pool capability XML
+        (2) Compare with the standard XML dict
+        """
+        cap_xml = pool_capability_xml.PoolcapabilityXML()
+        cap_xml.xml = source
+        connect_uri = libvirt_vm.normalize_connect_uri(params.get("connect_uri", 'default'))
+
+        # Check the pool capability xml
+        pool_capa = cap_xml.get_pool_capabilities()
+        logging.debug(pool_capa)
+        pool_type_list = ['dir', 'fs', 'netfs', 'logical', 'disk', 'iscsi', 'iscsi-direct',
+                          'scsi', 'mpath', 'rbd', 'sheepdog', 'gluster', 'zfs', 'vstorage']
+        for pooltype in pool_capa.keys():
+            if pooltype not in pool_type_list:
+                test.fail("'%s' is not expected in pool-capability" % (pooltype))
+        pool_type_info_dict = {'dir': {'pool_default_format_name': [],
+                                       'raw': ['none', 'raw', 'dir', 'bochs', 'cloop', 'dmg', 'iso', 'vpc', 'vdi',
+                                               'fat', 'vhd', 'ploop', 'cow', 'qcow', 'qcow2', 'qed', 'vmdk']},
+                               'fs': {'auto': ['auto', 'ext2', 'ext3', 'ext4', 'ufs', 'iso9660', 'udf', 'gfs', 'gfs2',
+                                               'vfat', 'hfs+', 'xfs', 'ocfs2'],
+                                      'raw': ['none', 'raw', 'dir', 'bochs', 'cloop', 'dmg', 'iso', 'vpc', 'vdi',
+                                              'fat', 'vhd', 'ploop', 'cow', 'qcow', 'qcow2', 'qed', 'vmdk']},
+                               'netfs': {'auto': ['auto', 'nfs', 'glusterfs', 'cifs'],
+                                         'raw': ['none', 'raw', 'dir', 'bochs', 'cloop', 'dmg', 'iso', 'vpc', 'vdi',
+                                                 'fat', 'vhd', 'ploop', 'cow', 'qcow', 'qcow2', 'qed', 'vmdk']},
+                               'logical': {'lvm2': ['unknown', 'lvm2'], 'vol_default_format_name': []},
+                               'disk': {'unknown': ['unknown', 'dos', 'dvh', 'gpt', 'mac', 'bsd', 'pc98', 'sun',
+                                                    'lvm2'],
+                                        'none': ['none', 'linux', 'fat16', 'fat32', 'linux-swap', 'linux-lvm',
+                                                 'linux-raid', 'extended']},
+                               'iscsi': {'pool_default_format_name': [], 'vol_default_format_name': []},
+                               'iscsi-direct': {'pool_default_format_name': [], 'vol_default_format_name': []},
+                               'scsi': {'pool_default_format_name': [], 'vol_default_format_name': []},
+                               'mpath': {'pool_default_format_name': [], 'vol_default_format_name': []},
+                               'rbd': {'pool_default_format_name': []},
+                               'sheepdog': {'pool_default_format_name': [], 'vol_default_format_name': []},
+                               'gluster': {'pool_default_format_name': [],
+                                           'raw': ['none', 'raw', 'dir', 'bochs', 'cloop', 'dmg', 'iso', 'vpc',
+                                                   'vdi', 'fat', 'vhd', 'ploop', 'cow', 'qcow', 'qcow2', 'qed',
+                                                   'vmdk']},
+                               'zfs': {'pool_default_format_name': [], 'vol_default_format_name': []},
+                               'vstorage': {'pool_default_format_name': [],
+                                            'raw': ['none', 'raw', 'dir', 'bochs', 'cloop', 'dmg', 'iso', 'vpc',
+                                                    'vdi', 'fat', 'vhd', 'ploop', 'cow', 'qcow', 'qcow2', 'qed',
+                                                    'vmdk']}}
+
+        #Check the pool capability information
+        if pool_capa != pool_type_info_dict:
+            test.fail('Unexpected pool information support occured,please check the information by manual')
+
+    # Run test case
+    option = params.get("virsh_pool_cap_options")
+    try:
+        output = virsh.pool_capabilities(option, ignore_status=False, debug=True)
+        status = 0   # good
+    except process.CmdError:
+        status = 1   # bad
+        output = ''
+    status_error = params.get("status_error")
+    if status_error == "yes":
+        if status == 0:
+            if not libvirt_version.version_compare(5, 0, 0):
+                test.fail("Command 'virsh pool-capabilities %s'"
+                          "doesn't support in this libvirt version" % option)
+            else:
+                test.fail("Command 'virsh pool-capabilities %s'"
+                          "succeeded (incorrect command)" % option)
+    elif status_error == "no":
+        compare_poolcapabilities_xml(output)
+        if status != 0:
+            test.fail("Command 'virsh capabilities %s' failed"
+                      "(correct command)" % option)


### PR DESCRIPTION
Check the pool capability information and execute with wrong option and libvirtd offline.
Signed-off-by: jgao12345 <jgao@redhat.com>

# avocado run --vt-type libvirt type_specific.io-github-autotest-libvirt.virsh.pool_capabilities
JOB ID     : 9c506b45ed13427723d4325032a56ea5b73c36a2
JOB LOG    : /root/avocado/job-results/job-2019-09-27T03.32-9c506b4/job.log
 (1/3) type_specific.io-github-autotest-libvirt.virsh.pool_capabilities.no_option: PASS (4.58 s)
 (2/3) type_specific.io-github-autotest-libvirt.virsh.pool_capabilities.unexpect_option: PASS (5.43 s)
 (3/3) type_specific.io-github-autotest-libvirt.virsh.pool_capabilities.with_libvirtd_stop: PASS (6.50 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 22.25 s