### PR TITLE
Do not set rebootTimeout to -1

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
@@ -1204,8 +1204,8 @@ def run(test, params, env):
                 if test_boot_console:
                     osxml.loader = "/usr/share/seabios/bios.bin"
                     osxml.bios_useserial = "yes"
-                    osxml.bios_reboot_timeout = "-1"
-
+                    if utils_misc.compare_qemu_version(4, 0, 0, False):
+                        osxml.bios_reboot_timeout = "-1"
                 del vmxml.os
                 vmxml.os = osxml
             driver_dict = {"name": disk.driver["name"],
@@ -1257,7 +1257,8 @@ def run(test, params, env):
                 if test_boot_console:
                     osxml.loader = params.get("disk_boot_seabios", "")
                     osxml.bios_useserial = "yes"
-                    osxml.bios_reboot_timeout = "-1"
+                    if utils_misc.compare_qemu_version(4, 0, 0, False):
+                        osxml.bios_reboot_timeout = "-1"
                 del vmxml.os
                 vmxml.os = osxml
             vmxml.sync()

--- a/libvirt/tests/src/virtual_network/iface_network.py
+++ b/libvirt/tests/src/virtual_network/iface_network.py
@@ -83,7 +83,8 @@ TIMEOUT 3"""
             osxml.machine = vmxml.os.machine
             osxml.loader = "/usr/share/seabios/bios.bin"
             osxml.bios_useserial = "yes"
-            osxml.bios_reboot_timeout = "-1"
+            if utils_misc.compare_qemu_version(4, 0, 0, False):
+                osxml.bios_reboot_timeout = "-1"
             osxml.boots = ['network']
             del vmxml.os
             vmxml.os = osxml


### PR DESCRIPTION
Since qemu v4.0.0(commit ee5d0f89de3), qemu disallows reboot-timeout set
beyond 0~0xffff. Because reboot-timeout is disabled by default, just
remove rebootTimeout for disabling.

Signed-off-by: Han Han <hhan@redhat.com>