### PR TITLE
Add new cases for multiple File Descriptor support

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -38,6 +38,35 @@
         - positive_test:
             virsh_migrate_options = "--live --verbose"
             variants:
+                - multifd:
+                    virsh_migrate_extra = "--parallel"
+                    variants:
+                        - customized_connection:
+                            variants:
+                                - set_minus:
+                                    only without_postcopy
+                                    virsh_migrate_extra = "--parallel --parallel-connections"
+                                    parallel_cn_nums = -1
+                                - set_min:
+                                    only without_postcopy
+                                    virsh_migrate_extra = "--parallel --parallel-connections"
+                                    parallel_cn_nums = 1
+                                - set_normal:
+                                    virsh_migrate_extra = "--parallel --parallel-connections"
+                                    parallel_cn_nums = 4
+                                    stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M --timeout 70"
+                                    stress_in_vm = "yes"
+                                    asynch_migrate = "yes"
+                                    actions_during_migration = "checkestablished"
+                                - set_max:
+                                    only without_postcopy
+                                    virsh_migrate_extra = "--parallel --parallel-connections"
+                                    parallel_cn_nums = 255
+                        - defualt_connection:
+                            stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M --timeout 70"
+                            stress_in_vm = "yes"
+                            asynch_migrate = "yes"
+                            actions_during_migration = "checkestablished"
                 - compress_methods:
                     keepalive_interval= -1
                     virsh_migrate_options = "--live --verbose --compressed"
@@ -215,6 +244,21 @@
                 - p2p_migration:
                     virsh_migrate_options = "--live --p2p --verbose"
                     variants:
+                        - multifd:
+                            virsh_migrate_extra = "--parallel"
+                            variants:
+                                - customized_connection:
+                                    virsh_migrate_extra = "--parallel --parallel-connections"
+                                    parallel_cn_nums = 4
+                                    stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M --timeout 70"
+                                    stress_in_vm = "yes"
+                                    asynch_migrate = "yes"
+                                    actions_during_migration = "checkestablished"
+                                - defualt_connection:
+                                    stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M --timeout 70"
+                                    stress_in_vm = "yes"
+                                    asynch_migrate = "yes"
+                                    actions_during_migration = "checkestablished"
                         - check_domstats:
                             asynch_migrate = "yes"
                             virsh_opt = ' -k0'
@@ -250,6 +294,21 @@
             # The variable indicates migration command should fail
             status_error = 'yes'
             variants:
+                - multifd:
+                    only without_postcopy
+                    variants:
+                        - without_parallel:
+                            virsh_migrate_extra = "--parallel-connections"
+                            parallel_cn_nums = 4
+                            err_msg = "error: invalid argument: Turn parallel migration on to tune it"
+                        - inavalid_connect_num:
+                            virsh_migrate_extra = "--parallel --parallel-connections"
+                            err_msg = "error: internal error: unable to execute QEMU command 'migrate-set-parameters': Parameter 'multifd_channels' expects is invalid, it should be in the range of 1 to 255"
+                            variants:
+                                - set_zero:
+                                    parallel_cn_nums = 0
+                                - set_cross_border:
+                                    parallel_cn_nums = 256
                 - cache_unsafe:
                     # Without '--unsafe', migration will fail and throw an error message
                     err_msg = "Unsafe migration: Migration may lead to data corruption"
@@ -302,4 +361,18 @@
                                     grep_str_not_in_remote_log = "virKeepAliveTimerInternal"
                                     block_time = 40
                                     err_msg = "error: operation failed: Lost connection to destination host"
+                        - multifd:
+                            only without_postcopy
+                            variants:
+                                - without_parallel:
+                                    parallel_cn_nums = 4
+                                    err_msg = "error: invalid argument: Turn parallel migration on to tune it"
+                - tunnelled_migration:
+                    only without_postcopy
+                    virsh_migrate_options = "--live --p2p --tunnelled --verbose"
+                    variants:
+                        - multifd:
+                            virsh_migrate_extra = "--parallel"
+                            # TODO: Need to update error message once BZ 1726937 got fixed
+                            err_msg = "unsupport"
 


### PR DESCRIPTION
This PR covers below cases:
live migration with parallel network connections:
    a. default network connections
    b. specified connection number
    c. boundary values of connection number
    d. without enabling parallel capability

Signed-off-by: Yingshun Cui <yicui@redhat.com>