### PR TITLE
virtual_disks_multidisks: Do not check ide-cd

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
@@ -1680,10 +1680,6 @@ def run(test, params, env):
                 dev_id = vm_xml.VMXML.get_disk_attr(vm_name, device_targets[0],
                                                     "alias", "name")
             if device_bus[0] == "ide":
-                check_cmd = "/usr/libexec/qemu-kvm -device ? 2>&1 |grep -E 'ide-cd|ide-hd'"
-                if process.system(check_cmd, ignore_status=False, shell=True):
-                    test.cancel("ide-cd/ide-hd not supported by this qemu-kvm")
-
                 if devices[0] == "cdrom":
                     device_option = "ide-cd"
                 else:


### PR DESCRIPTION
The device ide-cd is introduced very early at qemu v0.15.0(commit 1f56e32a).
And no build configration to disable it. We can think it is defaultly
supported.

Signed-off-by: Han Han <hhan@redhat.com>