### PR TITLE
Fix cpu xml attrs missing

### DIFF
--- a/libvirt/tests/src/papr_hpt.py
+++ b/libvirt/tests/src/papr_hpt.py
@@ -62,9 +62,12 @@ def run(test, params, env):
         :param vmxml: xml of vm to be manipulated
         :param attrs: attrs to set to cpu xml
         """
-        cpu = vm_xml.VMCPUXML()
+        if vmxml.xmltreefile.find('cpu'):
+            cpu = vmxml.cpu
+        else:
+            cpu = vm_xml.VMCPUXML()
         if 'numa_cell' in attrs:
-            cpu.xml = "<cpu><numa/></cpu>"
+            cpu.xmltreefile.create_by_xpath('/numa')
             cpu.numa_cell = attrs['numa_cell']
         for key in attrs:
             setattr(cpu, key, attrs[key])


### PR DESCRIPTION
The original code is to create new cpu xml then set hpt/numa info
which could lead to info missing from original cpu xml. Now modify
to update original cpu xml which should fix the problem.

Signed-off-by: haizhao <haizhao@redhat.com>