### PR TITLE
Fix the hostname not match issue

### DIFF
--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_update.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_update.py
@@ -833,7 +833,7 @@ def run(test, params, env):
                         else:
                             test.fail("getting ip %s is not same with setting %s"
                                       % (iface_ip, new_dhcp_host_ip))
-                        hostname = session.cmd_output("hostname").strip('\n')
+                        hostname = session.cmd_output("hostname -s").strip('\n')
                         if hostname == new_dhcp_host_name.split('.')[0]:
                             logging.info("getting hostname same with setting: %s", hostname)
                         else:


### PR DESCRIPTION
On rhel7.6 auto test, the hostname command on guest return the FDQN
(hostname+domain name), while on other releases, the "hostname" command
on guest return the only the hostname. The script only compare the hostname.
So update the string to only include the hostname.

Signed-off-by: yalzhang <yalzhang@redhat.com>