### PR TITLE
Check the netmask in network config file

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_network.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_network.cfg
@@ -52,6 +52,11 @@
                     net_dns_forwarders = "{'addr':'8.8.8.8'}"
                     net_dns_hostip = "2.2.2.2"
                     net_dns_hostnames = "test1.com test2.com"
+                - net_netmask:
+                    net_ip_netmask = "255.255.252.0"
+                    dhcp_start_ipv4 = "192.168.122.2"
+                    dhcp_end_ipv4 = "192.168.122.254"
+                    test_netmask = "yes"
         - qos_test:
             variants:
                 - qos_option_bandwidth:

--- a/libvirt/tests/src/virtual_network/iface_network.py
+++ b/libvirt/tests/src/virtual_network/iface_network.py
@@ -587,6 +587,7 @@ TIMEOUT 3"""
     password = params.get("password")
     forward = ast.literal_eval(params.get("net_forward", "{}"))
     boot_failure = "yes" == params.get("boot_failure", "no")
+    test_netmask = "yes" == params.get("test_netmask", "no")
     ipt_rules = []
     ipt6_rules = []
 
@@ -785,6 +786,8 @@ TIMEOUT 3"""
             if guest_name and guest_ipv4:
                 run_dnsmasq_host_test(iface_mac, guest_ipv4, guest_name)
 
+            if test_netmask and libvirt_version.version_compare(5, 1, 0):
+                run_dnsmasq_default_test("dhcp-range", "192.168.122.2,192.168.122.254,255.255.252.0")
             # check the left part in dnsmasq conf
             run_dnsmasq_default_test("strict-order", name=net_name)
             run_dnsmasq_default_test("pid-file",
@@ -902,7 +905,6 @@ TIMEOUT 3"""
                 # Check dnsmasq settings if take affect in guest
                 if guest_ipv4:
                     check_name_ip(session)
-
                 # Run bandwidth test for interface
                 if test_qos_bandwidth:
                     run_bandwidth_test(check_iface=True)


### PR DESCRIPTION
Libvirt has add the netmask to all ipv4 dhcp-range options since 5.1.
Check the netmask in dnsmasq config file.

Signed-off-by: yalzhang <yalzhang@redhat.com>