### PR TITLE
Safeguard Model name access on s390x

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
@@ -636,8 +636,7 @@ def run(test, params, env):
                                                 "no")
     hotunplug_after_migrate = "yes" == params.get("virsh_hotunplug_cpu_after",
                                                   "no")
-    compat_guest_migrate = (params.get("host_arch", "all_arch") in
-                            cpu.get_cpu_info()['Model name'])
+    compat_guest_migrate = get_compat_guest_migrate(params)
     compat_mode = "yes" == params.get("compat_mode", "no")
 
     # Configurations for cpu compat guest to boot
@@ -1362,3 +1361,12 @@ def run(test, params, env):
         logging.info("Remove the NFS image...")
         source_file = params.get("source_file")
         libvirt.delete_local_disk("file", path=source_file)
+
+
+def get_compat_guest_migrate(params):
+    # lscpu doesn't have 'Model name' on s390x
+    if platform.machine() == 's390x':
+        return False
+    compat_guest_migrate = (params.get("host_arch", "all_arch") in
+                            cpu.get_cpu_info()['Model name'])
+    return compat_guest_migrate


### PR DESCRIPTION
On s390x 'Model name' is not defined in lscpu. Set test to not support
compat_guest_migrate on s390x.

Test still fails on s390x with libvirt 5.4, qemu-kvm 2.12 but not due to change:
JOB ID     : 4771dd11927d42fe9efb8c5c15f0ee771dfdd690
JOB LOG    : /root/avocado/job-results/job-2019-10-16T05.11-4771dd1/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate.migrate_postcopy.without_cpu_hotplug.compat_migration.non_compat_migration.with_postcopy: ERROR: Command '/usr/bin/virsh migrate-setspeed avocado-vt-vm1 10 --postcopy' failed.\nstdout: b'\n'\nstderr: b"error: internal error: unable to execute QEMU command 'migrate-set-parameters': Parameter 'max-postcopy-bandwidth' is unexpected\n"\nadditional_info: Non... (374.39 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 375.96 s
