### PR TITLE
Change the destination for v2v function_test_xen cases

### DIFF
--- a/v2v/tests/cfg/function_test_xen.cfg
+++ b/v2v/tests/cfg/function_test_xen.cfg
@@ -109,7 +109,6 @@
             sasl_server_passwd = SERVER_PASSWORD_V2V_EXAMPLE
             sasl_user = test
             sasl_pwd = redhat
-            only libvirt
         - encryped:
             main_vm = VM_NAME_XEN_ENCRYPED_V2V_EXAMPLE
         - multidisk:
@@ -178,16 +177,13 @@
             no xen_vm_default
             variants:
                 - libvirt:
-                    only pool_uuid, display, sound, virtio_win, with_vdsm
                     only output_mode.libvirt
-                    no encrypt_warning
                 - rhev:
-                    no pool_uuid, display.vnc.encrypt, sound, virtio_win
+                    no pool_uuid
                     only output_mode.rhev
         - negative_test:
             status_error = 'yes'
             only xen_vm_default
-            only output_mode.libvirt
             variants:
                 - libguestfs_backend_empty:
                     checkpoint = 'libguestfs_backend_empty'


### PR DESCRIPTION
Make every functional xen case except with_vdsm and pool_uuid case
has three destinations 'libvirt,rhv rhv-upload'.

Signed-off-by: mxie91 <mxie@redhat.com>