### PR TITLE
Update error message for future debugging

### DIFF
--- a/libvirt/tests/src/remote_access/remote_access.py
+++ b/libvirt/tests/src/remote_access/remote_access.py
@@ -210,7 +210,9 @@ def run(test, params, env):
         logging.debug("start libvirt on remote")
         res = remote_libvirtd.start()
         if not res:
-            test.error("Failed to start libvirtd on remote")
+            status, output = server_session.cmd_status_output("journalctl -xe")
+            test.error("Failed to start libvirtd on remote. [status]: %s "
+                       "[output]: %s." % (status, output))
     server_session.close()
 
     # only simply connect libvirt daemon then return


### PR DESCRIPTION
Libvirtd on remote is failed to startup sometimes.
It's hard to reproduce in local environment. So add output of
'journalctl -xe' for future debugging.

Signed-off-by: Yingshun Cui <yicui@redhat.com>