### PR TITLE
Enable remote gluster management

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_disk.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_disk.cfg
@@ -5,6 +5,11 @@
     # and cause error messages
     take_regular_screendumps = "no"
     snapshot_options = ""
+    remote_gluster_manage = "yes"
+    remote_gluster = "no"
+    gluster_server_ip = "GLUSTER.SERVER.IP"
+    gluster_server_user = "GLUSTER.SERVER.USER"
+    gluster_server_pwd = "GLUSTER.SERVER.PWD"
     variants:
         - snapshot_from_xml:
             snapshot_from_xml = "yes"

--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_disk.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_disk.py
@@ -123,12 +123,7 @@ def run(test, params, env):
         if snapshot_with_pool:
             # Create dst pool for create attach vol img
             pvt = utlv.PoolVolumeTest(test, params)
-            kwargs = params.copy()
-            update_items = {"image_size": "1G", "emulated_image": emulated_image,
-                            "source_name": vol_name, "pre_disk_vol": ["20M"],
-                            "export_options": export_options}
-            kwargs.update(update_items)
-            kwargs.pop("vol_name")
+            kwargs = get_pre_pool_kwargs(emulated_image, export_options, params, vol_name)
             pvt.pre_pool(**kwargs)
 
             if pool_type in ["iscsi", "disk"]:
@@ -304,7 +299,7 @@ def run(test, params, env):
                     test.fail("Failed to create snapshot. Error:%s."
                               % snapshot_result.stderr.strip())
             snapshot_name = re.search(
-                "\d+", snapshot_result.stdout.strip()).group(0)
+                "\\d+", snapshot_result.stdout.strip()).group(0)
 
             if snapshot_current:
                 snap_xml = libvirt_xml.SnapshotXML()
@@ -368,7 +363,7 @@ def run(test, params, env):
                 # to external snapshot not supported yet" since d410e6f. Thus,
                 # let's check for that and handle as a SKIP for now. Check bug:
                 # https://bugzilla.redhat.com/show_bug.cgi?id=1071264
-                if re.search("revert to external \w* ?snapshot not supported yet",
+                if re.search("revert to external \\w* ?snapshot not supported yet",
                              revert_result.stderr):
                     test.cancel(revert_result.stderr.strip())
                 else:
@@ -454,3 +449,19 @@ def run(test, params, env):
             except exceptions.TestFail as detail:
                 libvirtd.restart()
                 logging.error(str(detail))
+
+
+def get_pre_pool_kwargs(emulated_image, export_options, params, vol_name):
+    kwargs = params.copy()
+    # avoid remote connection on remote ip
+    if params.get("remote_gluster", "no") == "no":
+        host_ip = ""
+    else:
+        host_ip = params.get("gluster_server_ip")
+    update_items = {"image_size": "1G", "emulated_image": emulated_image,
+                    "source_name": vol_name, "pre_disk_vol": ["20M"],
+                    "export_options": export_options,
+                    "gluster_server_ip": host_ip}
+    kwargs.update(update_items)
+    kwargs.pop("vol_name")
+    return kwargs


### PR DESCRIPTION
The script supports remote gluster management through root user. Currently,
gluster.py decides if to log in through ssh if gluster_server_ip is defined.

Default behavior is maintained as before, existing tests are not affected.

Added these variables explicitly to the configuration to be substituted if required.
Remote gluster management has to be enabled explicitly by setting config
parameter remote_gluster: If you want to run on a remote gluster server set
remote_gluster = "yes" and the additional gluster_server_X paramters to allow for
the test to access the remote server through ssh (root).

Added new variable to avoid test managing the gluster volume itself but rather
use a static gluster volume. Set remote_gluster_manage = "no" and only the
gluster_server_ip if you don't want to manage the gluster server in the test run.
This can help improve test performance and test doesn't need to know about ssh (root)
credentials.

The usage of variable remote_gluster_manage requires https://github.com/avocado-framework/avocado-vt/pull/2301

I executed the tests for both scenarios through CI

A) Have test manage gluster server:

08:18:32 AM (1/12) virsh.snapshot_disk.delete_test.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2.snapshot_from_xml.disk_internal.memory_internal Result: PASS 101.05 s
08:20:15 AM (2/12) virsh.snapshot_disk.delete_test.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2.snapshot_from_xml.disk_internal.memory_no Result: CANCEL: 73.08 s
08:21:31 AM (3/12) virsh.snapshot_disk.delete_test.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2.snapshot_from_xml.disk_internal.memory_none Result: PASS 89.08 s
08:23:02 AM (4/12) virsh.snapshot_disk.delete_test.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2.snapshot_default.current Result: PASS 88.50 s
08:24:33 AM (5/12) virsh.snapshot_disk.delete_test.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2.snapshot_default.no_current Result: PASS 90.68 s
08:26:06 AM (6/12) virsh.snapshot_disk.delete_test.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2.snapshot_default.revert_paused Result: PASS 92.02 s
08:27:40 AM (7/12) virsh.snapshot_disk.delete_test.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2v3.snapshot_from_xml.disk_internal.memory_internal Result: PASS 93.16 s
08:29:16 AM (8/12) virsh.snapshot_disk.delete_test.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2v3.snapshot_from_xml.disk_internal.memory_no Result: CANCEL: 73.74 s
08:30:32 AM (9/12) virsh.snapshot_disk.delete_test.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2v3.snapshot_from_xml.disk_internal.memory_none Result: PASS 91.99 s
08:32:06 AM (10/12) virsh.snapshot_disk.delete_test.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2v3.snapshot_default.current Result: PASS 93.54 s
08:33:42 AM (11/12) virsh.snapshot_disk.delete_test.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2v3.snapshot_default.no_current Result: PASS 89.80 s
08:35:14 AM (12/12) virsh.snapshot_disk.delete_test.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2v3.snapshot_default.revert_paused Result: PASS 89.67 s

B) Use static gluster volume
11:58:20 AM (1/12) virsh.snapshot_disk.delete_test.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2.snapshot_from_xml.disk_internal.memory_internal Result: PASS 101.38 s
12:00:03 PM (2/12) virsh.snapshot_disk.delete_test.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2.snapshot_from_xml.disk_internal.memory_no Result: CANCEL: 14.03 s
12:00:18 PM (3/12) virsh.snapshot_disk.delete_test.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2.snapshot_from_xml.disk_internal.memory_none Result: PASS 88.95 s
12:01:48 PM (4/12) virsh.snapshot_disk.delete_test.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2.snapshot_default.current Result: PASS 86.48 s
12:03:16 PM (5/12) virsh.snapshot_disk.delete_test.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2.snapshot_default.no_current Result: PASS 87.53 s
12:04:45 PM (6/12) virsh.snapshot_disk.delete_test.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2.snapshot_default.revert_paused Result: PASS 89.50 s
12:06:16 PM (7/12) virsh.snapshot_disk.delete_test.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2v3.snapshot_from_xml.disk_internal.memory_internal Result: PASS 89.75 s
12:07:47 PM (8/12) virsh.snapshot_disk.delete_test.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2v3.snapshot_from_xml.disk_internal.memory_no Result: CANCEL: 14.08 s
12:08:02 PM (9/12) virsh.snapshot_disk.delete_test.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2v3.snapshot_from_xml.disk_internal.memory_none Result: PASS 88.57 s
12:09:32 PM (10/12) virsh.snapshot_disk.delete_test.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2v3.snapshot_default.current Result: PASS 88.07 s
12:11:01 PM (11/12) virsh.snapshot_disk.delete_test.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2v3.snapshot_default.no_current Result: PASS 87.52 s
12:12:30 PM (12/12) virsh.snapshot_disk.delete_test.positive_test.pool_vol.netfs_gluster_pool.attach_img_qcow2.v_qcow2v3.snapshot_default.revert_paused Result: PASS 89.56 s