### PR TITLE
Change the destination for v2v function_test_esx cases

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -35,7 +35,6 @@
     variants:
         - libvirt:
             only dest_libvirt
-            only uefi, GPO_AV, special_name, copy_to_local, suse
         - rhev:
             only dest_rhev.NFS
             variants:


### PR DESCRIPTION
Make every functional esx case except 'copy_to_local' case
has three destinations 'libvirt,rhv rhv-upload'.

Signed-off-by: mxie91 <mxie@redhat.com>