### PR TITLE
Fixup: python3: TypeError: a bytes-like object is required, not 'str'

### DIFF
--- a/libvirt/tests/src/cpu/powerpc_hmi.py
+++ b/libvirt/tests/src/cpu/powerpc_hmi.py
@@ -10,6 +10,7 @@ from virttest import data_dir
 from virttest import virsh
 from virttest import libvirt_xml
 from virttest import utils_test
+from virttest.compat_52lts import decode_to_text
 
 
 def run(test, params, env):
@@ -128,7 +129,7 @@ def run(test, params, env):
         process.run(hmi_cmd)
 
         # Check host and guest dmesg
-        host_dmesg = process.system_output("dmesg -c", verbose=False)
+        host_dmesg = decode_to_text(process.system_output("dmesg -c", verbose=False))
         guest_dmesg = session.cmd_output("dmesg")
         if "Unrecovered" in host_dmesg:
             test.fail("Unrecovered host hmi\n%s", host_dmesg)


### PR DESCRIPTION
Let's decode the dmesg output as text before using because
python3 complains the same.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>