### PR TITLE
Add L3 cache cases

### DIFF
--- a/libvirt/tests/cfg/cpu/vcpu_cache.cfg
+++ b/libvirt/tests/cfg/cpu/vcpu_cache.cfg
@@ -1,0 +1,46 @@
+- vcpu_cache:
+    type = vcpu_cache
+    start_vm = "no"
+    cmd_in_vm = "lscpu |grep cache"
+    cmd_output_regex = "L3 cache:\s+\d+K"
+    status_error = "no"
+    variants:
+        - no_cpu_mode:
+        - host_model:
+            cpu_mode = "host-model"
+        - host_passthrough:
+            cpu_mode = "host-passthrough"
+    variants:
+        - positive_test:
+            variants:
+                - L3:
+                    cache_level = "3"
+                    cache_mode = "emulate"
+                    qemu_line = "l3-cache=on"
+                    string_in_cmd_output = "yes"
+                - passthrough:
+                    only host_passthrough
+                    cache_mode = "passthrough"
+                    qemu_line = "l3-cache=off"
+                    qemu_line_cacheinfo = "host-cache-info=on"
+                    cmd_output_regex = ""
+                - disable:
+                    cache_mode = "disable"
+                    qemu_line = "l3-cache=off"
+        - negative_test:
+            status_error = "yes"
+            variants:
+                - L3_with_disable_mode:
+                    only no_cpu_mode
+                    cache_level = "3"
+                    cache_mode = "disable"
+                    err_msg = "error: unsupported configuration: unsupported CPU cache level for mode 'disable'"
+                - L2_with_emulate_mode:
+                    only no_cpu_mode
+                    cache_level = "2"
+                    cache_mode = "emulate"
+                    err_msg = "error: unsupported configuration: CPU cache mode 'emulate' can only be used with level='3'"
+                - passthrough_with_host_model:
+                    only host_model
+                    cache_mode = "passthrough"
+                    err_msg = "error: unsupported configuration: CPU cache mode 'passthrough' can only be used with 'host-passthrough' CPUs"               

--- a/libvirt/tests/src/cpu/vcpu_cache.py
+++ b/libvirt/tests/src/cpu/vcpu_cache.py
@@ -1,0 +1,114 @@
+import logging
+import re
+
+from avocado.utils import process
+
+from virttest import virsh
+from virttest import virt_vm
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_test import libvirt
+
+
+def run(test, params, env):
+    """
+    Test virtual L3 cache as follows.
+    1) Start vm with virtual L3 cache and none cpu mode
+    2) Start vm with virtual L3 cache and host-passthrough cpu mode
+    3) Start vm with virtual L3 cache and host-model cpu mode
+    4) Invalid virtual L3 cache info for VM
+
+    :param test: test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+
+    def create_cpu_xml():
+        """
+        Create cpu xml
+
+        :return: cpu object
+        """
+        cpu_xml = vm_xml.VMCPUXML()
+        cache_attrs = {}
+        if cpu_mode:
+            cpu_xml.mode = cpu_mode
+        if cache_level:
+            cache_attrs.update({'level': cache_level})
+        if cache_mode:
+            cache_attrs.update({'mode': cache_mode})
+        cpu_xml.cache = cache_attrs
+        logging.debug(cpu_xml)
+        return cpu_xml
+
+    vm_name = params.get('main_vm')
+    vm = env.get_vm(vm_name)
+
+    cpu_mode = params.get('cpu_mode')
+    cache_level = params.get('cache_level')
+    cache_mode = params.get('cache_mode')
+    cmd_in_vm = params.get('cmd_in_vm')
+    qemu_line = params.get('qemu_line')
+    cmd_output_regex = params.get('cmd_output_regex')
+    string_in_cmd_output = "yes" == params.get("string_in_cmd_output", "no")
+    status_error = "yes" == params.get("status_error", "no")
+    err_msg = params.get("err_msg")
+
+    qemu_lines = []
+    if qemu_line:
+        qemu_lines.append(qemu_line)
+    bkxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+
+    try:
+        # Create cpu xml for test
+        cpu_xml = create_cpu_xml()
+
+        # Update vm's cpu
+        vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+        vmxml.cpu = cpu_xml
+
+        # Update for "passthrough" test
+        if cpu_mode == "host-passthrough":
+            qemu_line_cacheinfo = params.get("qemu_line_cacheinfo",
+                                             "host-cache-info=off")
+            qemu_lines.append(qemu_line_cacheinfo)
+            if cache_mode == "passthrough" and cmd_in_vm:
+                cmd_output_regex = process.run(cmd_in_vm, shell=True).stdout_text
+
+        if not status_error:
+            vmxml.sync()
+            vm_xml_cxt = virsh.dumpxml(vm_name).stdout_text.strip()
+            logging.debug("The VM XML with cpu cache: \n%s", vm_xml_cxt)
+
+            # Check if vm could start successfully
+            try:
+                result = virsh.start(vm_name, debug=True)
+                libvirt.check_exit_status(result)
+            except virt_vm.VMStartError as details:
+                test.fail('VM failed to start:\n%s' % details)
+
+            # Check qemu command line and other checkpoints
+            for qemuline in qemu_lines:
+                libvirt.check_qemu_cmd_line(qemuline)
+
+            if cmd_in_vm:
+                vm_session = vm.wait_for_login()
+                status, output = vm_session.cmd_status_output(cmd_in_vm)
+                if status != 0 or not output:
+                    test.fail("Failed to run command '%s'.status: [%s] output: "
+                              "[%s]" % (cmd_in_vm, status, output))
+                if cmd_output_regex:
+                    logging.debug("checking regex %s", cmd_output_regex)
+                    res = re.findall(cmd_output_regex, output.strip())
+                    if string_in_cmd_output != bool(len(res)):
+                        test.fail("The string '{}' {} included in {}"
+                                  .format(cmd_output_regex,
+                                          "is not" if string_in_cmd_output else "is",
+                                          output.strip()))
+        else:
+            result_need_check = virsh.define(vmxml.xml, debug=True)
+            libvirt.check_result(result_need_check, err_msg)
+
+    finally:
+        logging.debug("Recover test environment")
+        vm.destroy(gracefully=False)
+        bkxml.sync()


### PR DESCRIPTION
Add some virtual L3 cache tests in this PR.
1. L3 cache with host-model cpu mode
2. L3 cache with host-passthrough cpu mode
3. L3 cache with none cpu mode
4. invalid cache info

depends on https://github.com/avocado-framework/avocado-vt/pull/2303.

Signed-off-by: Yingshun Cui <yicui@redhat.com>