### PR TITLE
Fix libvirt_mem cold_plug on s390x

### DIFF
--- a/libvirt/tests/cfg/libvirt_mem.cfg
+++ b/libvirt/tests/cfg/libvirt_mem.cfg
@@ -91,10 +91,10 @@
                     model_fallback = "forbid"
                     tg_size = 524288
                     tg_node = 0
-                    page_size = 2048
+                    page_size = USE.HOST.SIZE
                     page_unit = "KiB"
                     node_mask = 0
-                    huge_pages = "{'size':'2048','unit':'KiB','nodeset':'0'}"
+                    huge_pages = "{'size':'USE.HOST.SIZE','unit':'KiB','nodeset':'0'}"
                     hugepage_force_allocate = "yes"
                     variants:
                         - hot_plug:
@@ -108,9 +108,27 @@
                             detach_device = "yes"
                         - cold_plug:
                             test_qemu_cmd = "yes"
+                            variants:
+                                - with_mem_with_numa:
+                                - only_hugepage:
+                                    only no_numatune
+                                    tg_size = ""
+                                    numa_cells = ""
+                                    huge_pages = "{'size':'USE.HOST.SIZE','unit':'KiB'}"
+                                    add_mem_device = "no"
+                                    max_mem_rt = ""
                         - cold_plug_discard:
                             cold_plug_discard = "yes"
                             test_qemu_cmd = "yes"
+                            variants:
+                                - with_mem_with_numa:
+                                - only_hugepage:
+                                    only no_numatune
+                                    tg_size = ""
+                                    numa_cells = ""
+                                    huge_pages = "{'size':'USE.HOST.SIZE','unit':'KiB'}"
+                                    add_mem_device = "no"
+                                    max_mem_rt = ""
                         - discard:
                             numa_cells = "{'id':'0','cpus':'0-1','memory':'1048576','unit':'KiB','discard':'yes'} {'id':'1','cpus':'2-3','memory':'1048576','unit':'KiB','discard':'no'}"
                             discard = "yes"


### PR DESCRIPTION
This PR requires https://github.com/avocado-framework/avocado-vt/pull/2304

1. Added placeholder variable for page_size: On s390x the default hugepage
size is 1024KiB, 2048KiB is not available. If the placeholder is used the
page_size value is read from cat /proc/meminfo.

2. Moved code to cancel_run_early function: After adding more conditions
that qualify for cancelling a test run on s390x, moved to method to maintain
readability.
 a. s390x doesn't support NUMA
 b. s390x doesn't support maxMemory
 c. s390x doesn't support (NV)DIMM, therefore memory device is not allowed

3. Renamed mount_hugepages: The function really toogles the mount status.

4. Split hugepages..cold_plug into two subcases: On s390x memory cannot be
attached, maxMemory is not allowed either. Therefore, added a minimal test
regarding hugepage memory backend and qemu check, while the old cold_plug
test is equivalent to cold_plug.with_mem_with_numa.

5. check_qemu_cmd:
 a. Added argument to check cmd if hugepages are assigned.
 b. Added qemu-kvm command line to log for easier debugging.

6. Safeguarded test of max_mem_rt usage: For s390-virtio the maxMemory
element is not allowed as it implies memory hotplug which is not supported.

7. Simplified list creation for readability.

8. Changed escape sequence as requested by inspektor W605 invalid escape
sequence. Test passed. Also tried not escaping but then test fails.

9. setup_hugepages and restore_hugepages now calls new functions in
virttest/utils_memory: On s390x kvm hugepage support has to be explicitly
enabled on RHEL 8. This works, too if it was enabled already.
The new functions are in https://github.com/avocado-framework/avocado-vt/pull/2304