### PR TITLE
Add version switch for domxml_to_native

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_to_native.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_to_native.py
@@ -5,6 +5,7 @@ import logging
 from avocado.utils import process
 
 from virttest import virsh
+from virttest import libvirt_version
 from virttest import utils_libvirtd
 from virttest.compat_52lts import decode_to_text as to_text
 
@@ -110,11 +111,22 @@ def run(test, params, env):
         :return: cmdline prepended by expected environment variable values
         """
         expected_env_vars = [
-                'LC_ALL', 'PATH', 'QEMU_AUDIO_DRV', 'HOME',
-                'XDG_DATA_HOME', 'XDG_CACHE_HOME', 'XDG_CONFIG_HOME',
-                ]
+            'LC_ALL',
+            'PATH',
+            'QEMU_AUDIO_DRV',
+            ]
+        if libvirt_version.version_compare(5, 2, 0):
+            expected_env_vars += [
+                'HOME',
+                'XDG_DATA_HOME',
+                'XDG_CACHE_HOME',
+                'XDG_CONFIG_HOME',
+            ]
+
         valmatcher = '.[^\\s]+\\s'
+
         def matchf(x): return re.search(x + valmatcher, conv_arg).group(0)
+
         return "".join(map(matchf, expected_env_vars)) + cmdline
 
     def compare(conv_arg):


### PR DESCRIPTION
https://github.com/libvirt/libvirt/commit/2d69af29073aa3dc2dc5b79afcecaa703b81125a introduced new variables from 5.2.0.
https://github.com/autotest/tp-libvirt/pull/2338 made tests fail on older versions.

Added libvirt version switch to make pass in both versions.

Executed tests:
libvirt 4.5/qemu-kvm 2.12
```bash
# avocado run --vt-type libvirt --vt-connect-uri qemu:///system virsh.domxml_to_native.positive_test
JOB ID     : 09d7eaadf15d2c7ab582449b8c98a8c1feacf1e0
JOB LOG    : /root/avocado/job-results/job-2019-10-23T20.22-09d7eaa/job.log
 (1/3) type_specific.io-github-autotest-libvirt.virsh.domxml_to_native.positive_test.id_option: PASS (26.31 s)
 (2/3) type_specific.io-github-autotest-libvirt.virsh.domxml_to_native.positive_test.uuid_option: PASS (35.28 s)
 (3/3) type_specific.io-github-autotest-libvirt.virsh.domxml_to_native.positive_test.name_option: PASS (33.91 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 96.76 s
```
libvirt 5.6/qemu-kvm 4.1
```bash
# avocado run --vt-type libvirt --vt-connect-uri qemu:///system virsh.domxml_to_native.positive_test
JOB ID     : 85c2c521b41347131ffadaad8faa31fcadf84eae
JOB LOG    : /root/avocado/job-results/job-2019-10-23T21.00-85c2c52/job.log
 (1/3) type_specific.io-github-autotest-libvirt.virsh.domxml_to_native.positive_test.id_option: PASS (33.86 s)
 (2/3) type_specific.io-github-autotest-libvirt.virsh.domxml_to_native.positive_test.uuid_option: PASS (34.39 s)
 (3/3) type_specific.io-github-autotest-libvirt.virsh.domxml_to_native.positive_test.name_option: PASS (34.78 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 104.42 s
```