### PR TITLE
virsh_edit: set vim as $EDITOR in os.environ to use its regex

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_edit.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_edit.py
@@ -1,8 +1,12 @@
 import logging
+import os
+
+from avocado.utils import path
 
 from virttest import virsh
 from virttest import utils_libvirtd
 from virttest import utils_misc
+from virttest import utils_package
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 
@@ -32,6 +36,19 @@ def run(test, params, env):
 
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     libvirtd = utils_libvirtd.Libvirtd()
+    # check whether vim editor is set as $EDITOR in environment
+    try:
+        vim = path.find_command("vim")
+    except path.path.CmdNotFoundError:
+        if not utils_package.package_install("vim"):
+            test.cancel("virsh edit need vim editor for using regex to edit "
+                        "vmxml")
+        vim = path.find_command("vim")
+    try:
+        if vim not in os.environ["EDITOR"]:
+            os.environ["EDITOR"] = vim
+    except KeyError:
+        os.environ["EDITOR"] = vim
 
     def edit_vcpu(source):
         """


### PR DESCRIPTION
virsh edit test cases uses vi editor regex to edit vmxml
if editor is not configured or if virsh uses other editor
like nano, all the tests fails.

Signed-off-by: Balamuruhan S <bala24@linux.ibm.com>