### PR TITLE
Add testcases for 'vnc_tls_x509_secret_uuid' in qemu.conf

### DIFF
--- a/libvirt/tests/cfg/graphics/graphics_functional.cfg
+++ b/libvirt/tests/cfg/graphics/graphics_functional.cfg
@@ -196,6 +196,17 @@
                             vnc_auto_unix_socket = 1
                         - vnc_auto_unix_socket_disabled:
                             vnc_auto_unix_socket = 0
+                        - vnc_tls_x509_secret_uuid:
+                             vnc_tls_x509_secret_uuid = 1
+                             variants:
+                                 - valid_secret_uuid:
+                                     vnc_tls = 1
+                                     vnc_secret_uuid = "valid"
+                                     secret_password_no_encoded = 'redhat'
+                                 - invalid_secret_uuid:
+                                     vnc_secret_uuid = "invalid"
+                                 - non_existing_vnc_secret_uuid:
+                                     vnc_secret_uuid = "non_exist"
                         - set_passwd:
                             remote_viewer_check = 'yes'
                             graphic_passwd = 'redhat'


### PR DESCRIPTION
3 cases added:
1. Set valid and existing 'vnc_tls_x509_secret_uuid' in qemu.conf;
2. Set invalid 'vnc_tls_x509_secret_uuid' in qemu.conf;
3. Set valid but non-existing 'vnc_tls_x509_secret_uuid' in qemu.conf;

Signed-off-by: Yan Fu <yafu@redhat.com>