### PR TITLE
Pass vm_arch_name to ensure zipl is called on s390x guest

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_sendkey.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_sendkey.py
@@ -61,7 +61,7 @@ def run(test, params, env):
     # Boot the guest in text only mode so that send-key commands would succeed
     # in creating a file
     try:
-        utils_test.update_boot_option(vm, args_added="3")
+        utils_test.update_boot_option(vm, args_added="3", guest_arch_name=params.get('vm_arch_name'))
     except Exception as info:
         test.error(info)
 


### PR DESCRIPTION
This fix requires https://github.com/avocado-framework/avocado-vt/pull/2312

On s390x running zipl command is required after updating boot loader entries
(with grubby), see https://bugzilla.redhat.com/show_bug.cgi?id=1764306#c2
In other words, running grubby and then rebooting without zipl won't change
cmdline.

Tests on s390x, libvirt 4.5/qemu-kvm 2.12
```bash
# avocado run --vt-type libvirt --vt-machine-type s390-virtio --vt-connect-uri qemu:///system virsh.sendkey
JOB ID     : 41da65922c8a2ca09e86429b87bc15002d9fd28a
JOB LOG    : /root/avocado/job-results/job-2019-10-28T12.54-41da659/job.log
 (01/30) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.non_acl.without_codeset: PASS (164.55 s)
 (02/30) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.non_acl.linux_keycode: PASS (128.51 s)
 (03/30) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.non_acl.at_set1_keycode: PASS (114.24 s)
 (04/30) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.non_acl.at_set2_keycode: PASS (104.36 s)
 (05/30) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.non_acl.at_set3_keycode: PASS (111.36 s)
 (06/30) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.non_acl.xt_keycode: PASS (128.43 s)
 (07/30) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.non_acl.xt_kbd_keycode: PASS (111.71 s)
 (08/30) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.non_acl.usb_keycode: PASS (108.45 s)
 (09/30) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.non_acl.rfb_keycode: PASS (98.93 s)
 (10/30) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.non_acl.default_name: PASS (99.88 s)
 (11/30) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.acl_test.without_codeset: PASS (129.00 s)
 (12/30) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.acl_test.linux_keycode: PASS (104.58 s)
 (13/30) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.acl_test.at_set1_keycode: PASS (111.36 s)
 (14/30) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.acl_test.at_set2_keycode: PASS (133.36 s)
 (15/30) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.acl_test.at_set3_keycode: PASS (105.39 s)
 (16/30) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.acl_test.xt_keycode: PASS (117.83 s)
 (17/30) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.acl_test.xt_kbd_keycode: PASS (104.43 s)
 (18/30) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.acl_test.usb_keycode: PASS (120.49 s)
 (19/30) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.acl_test.rfb_keycode: PASS (122.59 s)
 (20/30) type_specific.io-github-autotest-libvirt.virsh.sendkey.params_test.acl_test.default_name: PASS (114.71 s)
 (21/30) type_specific.io-github-autotest-libvirt.virsh.sendkey.sysrq.non_acl.help: PASS (320.41 s)
 (22/30) type_specific.io-github-autotest-libvirt.virsh.sendkey.sysrq.non_acl.show_memory_usage: PASS (107.53 s)
 (23/30) type_specific.io-github-autotest-libvirt.virsh.sendkey.sysrq.non_acl.show_task_status: PASS (111.52 s)
 (24/30) type_specific.io-github-autotest-libvirt.virsh.sendkey.sysrq.non_acl.reboot_guest: PASS (139.41 s)
 (25/30) type_specific.io-github-autotest-libvirt.virsh.sendkey.sysrq.acl_test.help: PASS (108.52 s)
 (26/30) type_specific.io-github-autotest-libvirt.virsh.sendkey.sysrq.acl_test.show_memory_usage: PASS (113.93 s)
 (27/30) type_specific.io-github-autotest-libvirt.virsh.sendkey.sysrq.acl_test.show_task_status: PASS (114.99 s)
 (28/30) type_specific.io-github-autotest-libvirt.virsh.sendkey.sysrq.acl_test.reboot_guest: PASS (143.51 s)
 (29/30) type_specific.io-github-autotest-libvirt.virsh.sendkey.readonly: PASS (108.60 s)
 (30/30) type_specific.io-github-autotest-libvirt.virsh.sendkey.negative_test.acl_test: PASS (100.51 s)
RESULTS    : PASS 30 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 3705.39 s
```