### PR TITLE
Handle automatic libvirtd start while running virsh commands

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_vcpuinfo.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_vcpuinfo.py
@@ -6,6 +6,8 @@ from virttest import virsh
 from virttest import utils_libvirtd
 from virttest import ssh_key
 
+from provider import libvirt_version
+
 
 def run(test, params, env):
     """
@@ -98,10 +100,14 @@ def run(test, params, env):
     # check status_error
     if status_error == "yes":
         if not status:
-            logging.debug(result)
-            test.fail("Run successfully with wrong command!")
+            if libvirtd == "off" and libvirt_version.version_compare(5, 6, 0):
+                logging.debug("From libvirt version 5.6.0 libvirtd is restarted "
+                              "and command should succeed")
+            else:
+                logging.debug(result)
+                test.fail("Run successfully with wrong command!")
         # Check the error message in negative case.
-        if not err:
+        if not err and not libvirt_version.version_compare(5, 6, 0):
             logging.debug(result)
             logging.debug("Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=889276 "
                           "is helpful for tracing this bug.")

--- a/libvirt/tests/src/virsh_cmd/host/virsh_nodecpustats.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_nodecpustats.py
@@ -1,9 +1,12 @@
 import re
+import logging
 
 from avocado.utils import cpu as cpuutil
 
 from virttest import virsh
 from virttest import utils_libvirtd
+
+from provider import libvirt_version
 
 
 def run(test, params, env):
@@ -185,10 +188,14 @@ def run(test, params, env):
 
             if status == 0:
                 if libvirtd == "off":
-                    utils_libvirtd.libvirtd_start()
-                    test.fail("Command 'virsh nodecpustats' "
-                              "succeeded with libvirtd service "
-                              "stopped, incorrect")
+                    if libvirt_version.version_compare(5, 6, 0):
+                        logging.debug("From libvirt version 5.6.0 libvirtd is restarted"
+                                      " and command should succeed")
+                    else:
+                        utils_libvirtd.libvirtd_start()
+                        test.fail("Command 'virsh nodecpustats' "
+                                  "succeeded with libvirtd service "
+                                  "stopped, incorrect")
                 else:
                     test.fail("Command 'virsh nodecpustats %s' "
                               "succeeded (incorrect command)" % option)


### PR DESCRIPTION
From libvirt version 5.6.0 libvirt service will start even
if the service is stopped while running virsh commands, let's
handle it for the negative tests which expects the command
failure when libvirt service is stopped.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>