### PR TITLE
Add watchdog for s390x

### DIFF
--- a/libvirt/tests/cfg/virtual_device/watchdog.cfg
+++ b/libvirt/tests/cfg/virtual_device/watchdog.cfg
@@ -4,7 +4,7 @@
     take_regular_screendumps = "no"
     variants:
         - model_i6300esb:
-            no pseries
+            no pseries, s390x
             model = "i6300esb"
             variants:
                 - model_test:
@@ -14,11 +14,15 @@
                 - hotunplug_test:
                     hotunplug_test = "yes"
         - model_ib700:
-            no pseries
+            no pseries, s390x
             model = "ib700"
             variants:
                 - model_test:
                     model_test = "yes"
+        - model_diag288:
+            only s390x
+            model = "diag288"
+            model_test = "yes"
     variants:
         - action_shutdown:
             action = "shutdown"


### PR DESCRIPTION
On s390x only watchdog model is diag288.

1. watchdog.cfg:
 a. diag288 only supported on s390x
 b. hotplugging watchdog device is not supported on s390x

2. watchdog.py:
 a. extract method to try load watchdog kernel module to be reusable
 b. diag288_wdt doesn't emit messages. Add output to test log but
    don't fail test if watchdog driver doesn't emit messages.
    Sample logged message: 
```bash
2019-10-30 17:43:59,080 watchdog         L0049 INFO | dmesg watchdog messages: [    2.061611] i6300esb: Intel 6300ESB WatchDog Timer Driver v0.05
[    2.069133] i6300esb: initialized (0xffffaf8c401fd000). heartbeat=30 sec (nowayout=0)
```

Tests on s390x
```bash
# avocado run --vt-type libvirt --vt-machine-type s390-virtio --vt-connect-uri qemu:///system watchdog
JOB ID     : 6251658b562704825caa982faac6fb7024bbf3f6
JOB LOG    : /root/avocado/job-results/job-2019-10-30T15.14-6251658/job.log
 (1/7) type_specific.io-github-autotest-libvirt.watchdog.action_shutdown.model_diag288: PASS (103.06 s)
 (2/7) type_specific.io-github-autotest-libvirt.watchdog.action_dump.normal_domain_name.model_diag288: PASS (55.94 s)
 (3/7) type_specific.io-github-autotest-libvirt.watchdog.action_none.model_diag288: PASS (230.80 s)
 (4/7) type_specific.io-github-autotest-libvirt.watchdog.action_poweroff.model_diag288: PASS (76.00 s)
 (5/7) type_specific.io-github-autotest-libvirt.watchdog.action_pause.model_diag288: PASS (77.39 s)
 (6/7) type_specific.io-github-autotest-libvirt.watchdog.action_reset.model_diag288: PASS (120.70 s)
 (7/7) type_specific.io-github-autotest-libvirt.watchdog.action_inject_nmi.model_diag288: PASS (79.52 s)
RESULTS    : PASS 7 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 745.79 s
```

Tests on x86_64
```bash
# avocado run --vt-type libvirt --vt-connect-uri qemu:///system watchdog
JOB ID     : 2860638fb6f343ee82879b7364027d2bd5f57a32
JOB LOG    : /root/avocado/job-results/job-2019-10-30T20.21-2860638/job.log
 (01/31) type_specific.io-github-autotest-libvirt.watchdog.action_shutdown.model_i6300esb.model_test: PASS (42.16 s)
 (02/31) type_specific.io-github-autotest-libvirt.watchdog.action_shutdown.model_i6300esb.hotplug_test: PASS (45.88 s)
 (03/31) type_specific.io-github-autotest-libvirt.watchdog.action_shutdown.model_i6300esb.hotunplug_test: PASS (12.78 s)
 (04/31) type_specific.io-github-autotest-libvirt.watchdog.action_shutdown.model_ib700.model_test: PASS (44.86 s)
 (05/31) type_specific.io-github-autotest-libvirt.watchdog.action_dump.long_domain_name.model_i6300esb.model_test: PASS (50.98 s)
 (06/31) type_specific.io-github-autotest-libvirt.watchdog.action_dump.long_domain_name.model_i6300esb.hotplug_test: PASS (46.83 s)
 (07/31) type_specific.io-github-autotest-libvirt.watchdog.action_dump.long_domain_name.model_i6300esb.hotunplug_test: PASS (13.26 s)
 (08/31) type_specific.io-github-autotest-libvirt.watchdog.action_dump.normal_domain_name.model_i6300esb.model_test: PASS (45.32 s)
 (09/31) type_specific.io-github-autotest-libvirt.watchdog.action_dump.normal_domain_name.model_i6300esb.hotplug_test: PASS (44.55 s)
 (10/31) type_specific.io-github-autotest-libvirt.watchdog.action_dump.normal_domain_name.model_i6300esb.hotunplug_test: PASS (12.92 s)
 (11/31) type_specific.io-github-autotest-libvirt.watchdog.action_dump.normal_domain_name.model_ib700.model_test: PASS (45.54 s)
 (12/31) type_specific.io-github-autotest-libvirt.watchdog.action_none.model_i6300esb.model_test: PASS (193.58 s)
 (13/31) type_specific.io-github-autotest-libvirt.watchdog.action_none.model_i6300esb.hotplug_test: PASS (196.03 s)
 (14/31) type_specific.io-github-autotest-libvirt.watchdog.action_none.model_i6300esb.hotunplug_test: PASS (12.93 s)
 (15/31) type_specific.io-github-autotest-libvirt.watchdog.action_none.model_ib700.model_test: PASS (194.94 s)
 (16/31) type_specific.io-github-autotest-libvirt.watchdog.action_poweroff.model_i6300esb.model_test: PASS (43.85 s)
 (17/31) type_specific.io-github-autotest-libvirt.watchdog.action_poweroff.model_i6300esb.hotplug_test: PASS (45.24 s)
 (18/31) type_specific.io-github-autotest-libvirt.watchdog.action_poweroff.model_i6300esb.hotunplug_test: PASS (12.85 s)
 (19/31) type_specific.io-github-autotest-libvirt.watchdog.action_poweroff.model_ib700.model_test: PASS (43.89 s)
 (20/31) type_specific.io-github-autotest-libvirt.watchdog.action_pause.model_i6300esb.model_test: PASS (42.12 s)
 (21/31) type_specific.io-github-autotest-libvirt.watchdog.action_pause.model_i6300esb.hotplug_test: PASS (45.51 s)
 (22/31) type_specific.io-github-autotest-libvirt.watchdog.action_pause.model_i6300esb.hotunplug_test: PASS (13.01 s)
 (23/31) type_specific.io-github-autotest-libvirt.watchdog.action_pause.model_ib700.model_test: PASS (44.72 s)
 (24/31) type_specific.io-github-autotest-libvirt.watchdog.action_reset.model_i6300esb.model_test: PASS (52.58 s)
 (25/31) type_specific.io-github-autotest-libvirt.watchdog.action_reset.model_i6300esb.hotplug_test: PASS (53.83 s)
 (26/31) type_specific.io-github-autotest-libvirt.watchdog.action_reset.model_i6300esb.hotunplug_test: PASS (13.68 s)
 (27/31) type_specific.io-github-autotest-libvirt.watchdog.action_reset.model_ib700.model_test: PASS (52.40 s)
 (28/31) type_specific.io-github-autotest-libvirt.watchdog.action_inject_nmi.model_i6300esb.model_test: PASS (44.43 s)
 (29/31) type_specific.io-github-autotest-libvirt.watchdog.action_inject_nmi.model_i6300esb.hotplug_test: PASS (45.54 s)
 (30/31) type_specific.io-github-autotest-libvirt.watchdog.action_inject_nmi.model_i6300esb.hotunplug_test: PASS (13.22 s)
 (31/31) type_specific.io-github-autotest-libvirt.watchdog.action_inject_nmi.model_ib700.model_test: PASS (45.10 s)
RESULTS    : PASS 31 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 1617.22 s
```