### PR TITLE
Add copy function and rhev output for v2v ova cases

### DIFF
--- a/v2v/tests/cfg/convert_from_file.cfg
+++ b/v2v/tests/cfg/convert_from_file.cfg
@@ -52,49 +52,47 @@
                     only source_none
                     input_mode = "ova"
                     ova_dir = 'OVA_DIR_V2V_EXAMPLE'
+                    ova_copy_dir = 'OVA_DIR_COPY_V2V_EXAMPLE'
                     variants:
                         - normal:
                             only output_mode.libvirt,output_mode.rhev
                             variants:
                                 - ova_tar:
-                                    input_file = '${ova_dir}/OVA_TAR_FILE_V2V_EXAMPLE'
+                                    input_file = '${ova_copy_dir}/OVA_TAR_FILE_V2V_EXAMPLE'
                                 - ova_zip:
-                                    input_file = '${ova_dir}/OVA_ZIP_FILE_V2V_EXAMPLE'
+                                    input_file = '${ova_copy_dir}/OVA_ZIP_FILE_V2V_EXAMPLE'
                                 - ova_pigz:
-                                    input_file = '${ova_dir}/OVA_PIGZ_FILE_V2V_EXAMPLE'
+                                    input_file = '${ova_copy_dir}/OVA_PIGZ_FILE_V2V_EXAMPLE'
                                 - ova_xz:
-                                    input_file = '${ova_dir}/OVA_XZ_FILE_V2V_EXAMPLE'
+                                    input_file = '${ova_copy_dir}/OVA_XZ_FILE_V2V_EXAMPLE'
                                 - ova_relative_path:
-                                    input_file = 'OVA_RELATIVE_PATH_V2V_EXAMPLE'
+                                    input_file = '${ova_copy_dir}/OVA_RELATIVE_PATH_V2V_EXAMPLE'
                                     checkpoint = 'ova_relative_path'
                                 - ova_abs_path:
-                                    input_file = '${ova_dir}/OVA_RELATIVE_PATH_V2V_EXAMPLE'
+                                    input_file = '${ova_copy_dir}/OVA_RELATIVE_PATH_V2V_EXAMPLE'
                                 - ova_vmdk_gz_zip:
-                                    input_file = '${ova_dir}/OVA_VMDKGZ_ZIP_FILE_V2V_EXAMPLE'
+                                    input_file = '${ova_copy_dir}/OVA_VMDKGZ_ZIP_FILE_V2V_EXAMPLE'
                                 - ova_vmdk_gz_tar:
-                                    input_file = '${ova_dir}/OVA_VMDKGZ_TAR_FILE_V2V_EXAMPLE'
+                                    input_file = '${ova_copy_dir}/OVA_VMDKGZ_TAR_FILE_V2V_EXAMPLE'
                                 - permission:
-                                    only libvirt
-                                    input_file = '${ova_dir}/OVA_TAR_FILE_V2V_EXAMPLE'
+                                    input_file = '${ova_copy_dir}/OVA_TAR_FILE_V2V_EXAMPLE'
                                     checkpoint = permission
                                 - rhel6_5:
-                                    only libvirt
                                     ova_dir = OVA_DIR_RHEL65_V2V_EXAMPLE
-                                    input_file = ${ova_dir}/OVA_FILE_RHEL65_V2V_EXAMPLE
+                                    input_file = ${ova_copy_dir}/OVA_FILE_RHEL65_V2V_EXAMPLE
                         - special:
-                            only output_mode.libvirt
                             ova_dir = 'OVA_DIR_SPECIAL_V2V_EXAMPLE'
                             variants:
                                 - parent_ctrl:
                                     checkpoint = "parent_ctrl"
-                                    input_file = "${ova_dir}/OVA_FILE_BUG_1167302_V2V_EXAMPLE"
+                                    input_file = "${ova_copy_dir}/OVA_FILE_BUG_1167302_V2V_EXAMPLE"
                                 - win2008r2_ostk:
                                     checkpoint = "win2008r2_ostk"
                                     input_file = "${ova_dir}/OVA_FILE_BUG_1161333_V2V_EXAMPLE"
                                     image_to_match = "${ova_dir}/BSOD_IMAGE_V2V_EXAMPLE"
                                     v2v_timeout = 1800
+                                    only output_mode.libvirt
                         - parse:
-                            only output_mode.local
                             ova_dir = OVA_DIR_PARSE_V2V_EXAMPLE
                             skip_check = yes
                             variants:
@@ -133,7 +131,7 @@
                                 - Eaton:
                                     ova_file = OVA_FILE_EATON_V2V_EXAMPLE
                                     skip_vm_check = yes
-                            input_file = ${ova_dir}/${ova_file}
+                            input_file = ${ova_copy_dir}/${ova_file}
                 - vmx:
                     input_mode = "vmx"
                     hypervisor = 'esx'


### PR DESCRIPTION
Copy ova before converting to save time and add rhev output to
cover ova cases of convert_from_file in rhel8 AV and rhel7-rhev
jobs.

Signed-off-by: mxie91 <mxie@redhat.com>