### PR TITLE
Ignore channel index in qemu command

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -134,7 +134,7 @@
                     cmd_run_in_remote_host = "cat %s > ${remote_cat_file} &"
                     cmd_run_in_remote_host_1 = "cat ${remote_cat_file}|grep '${message_sent}'"
                     cmd_run_in_remote_host_2 = "rm -f ${remote_cat_file}"
-                    qemu_check = "-chardev pty,id=charchannel1.*-device virtserialport.*chardev=charchannel1.*name=${target_name}"
+                    qemu_check = "-chardev pty,id=charchannel.*-device virtserialport.*chardev=charchannel.*name=${target_name}"
                 - htm:
                     qemu_check = 'cap-htm='
                     guest_xml_check_after_mig = 'htm state='


### PR DESCRIPTION
migrate_options_shared.cfg: The actual charchannel index depends on the
domain xml. With s390-virtio domain xml channel index is 0. I couldn't find a
reason why this index should be pass/fail criterion, therefore, using less restrictive
regular expression for qemu cmd check.

Tests on s390x:
```bash
# avocado run --vt-type libvirt --vt-machine-type s390-virtio --vt-connect-uri qemu:///system virsh.migrate_options_shared.positive_test.pty_channel
JOB ID     : 3faac2a63bf0545fcfaccfb8357dd0f7b355344b
JOB LOG    : /root/avocado/job-results/job-2019-11-04T16.50-3faac2a/job.log
 (1/2) type_specific.io-github-autotest-libvirt.virsh.migrate_options_shared.positive_test.pty_channel.with_postcopy: PASS (200.68 s)
 (2/2) type_specific.io-github-autotest-libvirt.virsh.migrate_options_shared.positive_test.pty_channel.without_postcopy: PASS (214.47 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 416.80 s
```