### PR TITLE
virsh_undefine: check for virsh attach-disk return value

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_undefine.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_undefine.py
@@ -141,7 +141,10 @@ def run(test, params, env):
                 test.fail("Creation of volume %s failed." % vol_name)
             volumes = new_pool.list_volumes()
             volume = volumes[vol_name]
-            virsh.attach_disk(vm_name, volume, disk_target, "--config")
+            ret = virsh.attach_disk(vm_name, volume, disk_target, "--config",
+                                    debug=True)
+            if ret.exit_status != 0:
+                test.error("Attach disk failed: %s" % ret.stderr)
 
         # Turn libvirtd into certain state.
         if libvirtd_state == "off":


### PR DESCRIPTION
when `attach-disk` fails then subsequent virsh undefine with
`--remove-storage` will not work/remove the storage as it not
attached to VM. This will fail the test without proper reason,
so check the return status for virsh attach-disk and error out
appropriately.

Signed-off-by: Balamuruhan S <bala24@linux.ibm.com>