### PR TITLE
Fix serial_functional on s390x

### DIFF
--- a/libvirt/tests/cfg/serial/serial_functional.cfg
+++ b/libvirt/tests/cfg/serial/serial_functional.cfg
@@ -7,6 +7,12 @@
             serial_dev_type = dev
             serial_sources = path:/dev/ttyS0
             target_type = isa-serial
+        - type_dev_sclplm:
+            only s390-virtio
+            serial_dev_type = dev
+            serial_sources = path:/dev/ttyS0
+            target_type = sclp-serial
+            target_model = sclplmconsole
         - type_file:
             serial_dev_type = file
             serial_sources = path:/var/log/libvirt/virt-test
@@ -35,6 +41,7 @@
             serial_dev_type = pty
             target_type = isa-serial
         - type_pty_pci_serial:
+            no s390-virtio
             serial_dev_type = pty
             target_type = pci-serial
         - type_spicevmc:


### PR DESCRIPTION
1. cfg:
 a. type_dev_sclplm: add case to test line mode console
 b. type_pty_pci_serial: pci-serial not supported on arch
 c. type_spiceport: spice not supported on arch

2. py:
 a. set_targets: set default target, use target_model to test
    line mode console explicitly
 b. check_qemu_cmdline: provide test expectations on platform for
    sclp-serial
 c. new locals to hold value for new test case

4. fixed escape sequences issues for W605

Test run on s390x
```bash
# avocado run --vt-type libvirt --vt-machine-type s390-virtio --vt-connect-uri qemu:///system serial.functional
JOB ID     : 9c63a1ce0245be03259c3dfafd5ebb1f140d1092
JOB LOG    : /root/avocado/job-results/job-2019-11-06T09.21-9c63a1c/job.log
 (01/18) type_specific.io-github-autotest-libvirt.serial.functional.type_dev: PASS (6.39 s)
 (02/18) type_specific.io-github-autotest-libvirt.serial.functional.type_dev_sclplm: PASS (6.55 s)
 (03/18) type_specific.io-github-autotest-libvirt.serial.functional.type_file: PASS (88.10 s)
 (04/18) type_specific.io-github-autotest-libvirt.serial.functional.type_pipe: PASS (28.45 s)
 (05/18) type_specific.io-github-autotest-libvirt.serial.functional.type_unix: PASS (154.08 s)
 (06/18) type_specific.io-github-autotest-libvirt.serial.functional.type_tcp_server: PASS (100.28 s)
 (07/18) type_specific.io-github-autotest-libvirt.serial.functional.type_tcp_client: PASS (26.70 s)
 (08/18) type_specific.io-github-autotest-libvirt.serial.functional.type_udp_client: PASS (102.63 s)
 (09/18) type_specific.io-github-autotest-libvirt.serial.functional.type_null: PASS (24.71 s)
 (10/18) type_specific.io-github-autotest-libvirt.serial.functional.type_stdio: PASS (66.86 s)
 (11/18) type_specific.io-github-autotest-libvirt.serial.functional.type_vc: PASS (26.10 s)
 (12/18) type_specific.io-github-autotest-libvirt.serial.functional.type_pty: PASS (92.93 s)
 (13/18) type_specific.io-github-autotest-libvirt.serial.functional.type_spicevmc: PASS (4.76 s)
 (14/18) type_specific.io-github-autotest-libvirt.serial.functional.type_nmdm: PASS (5.26 s)
 (15/18) type_specific.io-github-autotest-libvirt.serial.functional.console_target_type_virtio: PASS (24.80 s)
 (16/18) type_specific.io-github-autotest-libvirt.serial.functional.test_only_first_console_be_serial: PASS (5.79 s)
 (17/18) type_specific.io-github-autotest-libvirt.serial.functional.type_tls_server: -*** Fatal error: Error in the certificate.
PASS (245.84 s)
 (18/18) type_specific.io-github-autotest-libvirt.serial.functional.type_tls_client: /Echo Server listening on IPv4 0.0.0.0 port 5556...done
Echo Server listening on IPv6 :: port 5556...done
Error while receiving data
Error: The TLS connection was non-properly terminated.
|Exiting via signal 15
PASS (137.92 s)
RESULTS    : PASS 18 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 1151.48 s
```
Notes on test run: 
1. type_tls_server "Fatal error: Error in the certificate" is solved by https://github.com/avocado-framework/avocado-vt/pull/1980 (error in certificate is non-trusted without it).
2. type_tls_client shows errors but those come from the way the test script closes client connection. I have not been able to fix this. There are no errors in the stdout file /tmp/gnutls.out.

type_tls_client run with https://github.com/avocado-framework/avocado-vt/pull/1980
```bash
# avocado run --vt-type libvirt --vt-machine-type s390-virtio --vt-connect-uri qemu:///system serial.functional --vt-only-filter serial.functional.type_tls_client
JOB ID     : 7252344bad7ae69d059a81bff28ddd7b102f311a
JOB LOG    : /root/avocado/job-results/job-2019-11-06T09.17-7252344/job.log
 (1/1) type_specific.io-github-autotest-libvirt.serial.functional.type_tls_client: -Echo Server listening on IPv4 0.0.0.0 port 5556...done
Echo Server listening on IPv6 :: port 5556...done
\received cmd: LOADPARM=[        ]

*** Processing 20 bytes command: LOADPARM=[        ]

received cmd: Using virtio-blk.

*** Processing 18 bytes command: Using virtio-blk.

received cmd: Using SCSI scheme.

*** Processing 19 bytes command: Using SCSI scheme.

received cmd: .......

*** Processing 8 bytes command: .......

Error while receiving data
Error: The TLS connection was non-properly terminated.
\Exiting via signal 15
PASS (140.92 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 143.90 s
```