### PR TITLE
Fix nodedev_dumpxml on s390x

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_dumpxml.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_dumpxml.cfg
@@ -12,6 +12,7 @@
             status_error = "no"
             variants:
                 - device_type_pci:
+                    no s390-virtio
                     device_type = 'pci'
                 - device_type_net:
                     device_type = 'net'


### PR DESCRIPTION
Device type pci is not available on s390x.