### PR TITLE
Do not test usb on s390x

### DIFF
--- a/libvirt/tests/cfg/bios/virsh_boot.cfg
+++ b/libvirt/tests/cfg/bios/virsh_boot.cfg
@@ -196,6 +196,7 @@
                                                     device_bus = "scsi"
                                                     target_dev = "hda"
                                                 - usb_disk:
+                                                    no s390-virtio
                                                     disk_type = "block"
                                                     source_protocol = "usb"
                                                     device_bus = "usb"

--- a/libvirt/tests/cfg/controller/controller_functional.cfg
+++ b/libvirt/tests/cfg/controller/controller_functional.cfg
@@ -53,6 +53,7 @@
                     controller_type = virtio-serial
                     controller_vectors = '0'
                 - usb_controller:
+                    no s390-virtio
                     controller_type = usb
                     variants:
                         # ehci and ich9-ehci1 are USB2.0 controller model

--- a/libvirt/tests/cfg/libvirt_bench/libvirt_bench_usb_hotplug.cfg
+++ b/libvirt/tests/cfg/libvirt_bench/libvirt_bench_usb_hotplug.cfg
@@ -7,6 +7,7 @@
     usb_hotplug_tablet = yes
     usb_hotplug_disk = yes
     attach_count = 1000
+    no s390-virtio
     variants:
         - keyboard:
             usb_hotplug_keyboard = yes

--- a/libvirt/tests/cfg/libvirt_usb_hotplug_controller.cfg
+++ b/libvirt/tests/cfg/libvirt_usb_hotplug_controller.cfg
@@ -1,6 +1,7 @@
 - libvirt_usb_hotplug_controller:
     type = libvirt_usb_hotplug_controller
     status_error = no
+    no s390-virtio
     variants:
         - guest_on:
             start_vm = yes

--- a/libvirt/tests/cfg/libvirt_usb_hotplug_device.cfg
+++ b/libvirt/tests/cfg/libvirt_usb_hotplug_device.cfg
@@ -4,6 +4,7 @@
     start_vm = yes
     model = "nec-xhci"
     index = "1"
+    no s390-virtio
     variants:
         - keyboard:
             usb_type = "kdb"

--- a/libvirt/tests/cfg/usb_device.cfg
+++ b/libvirt/tests/cfg/usb_device.cfg
@@ -5,6 +5,7 @@
     usb_index = "0"
     pkgs_host = "usbutils,usbredir-server"
     pkgs_guest = "usbutils"
+    no s390-virtio
     variants:
         # bus controller
         - pcie-root:

--- a/libvirt/tests/cfg/usb_passthrough.cfg
+++ b/libvirt/tests/cfg/usb_passthrough.cfg
@@ -1,5 +1,6 @@
 - usb_passthrough:
     type = usb_passthrough
+    no s390-virtio
     variants:
         - All:
             usb_device_label = "all"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_device.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_device.cfg
@@ -215,6 +215,7 @@
                     vadu_dev_obj_targetbus_VirtualDiskBasic = "virtio"
                     # 0th disk is /dev/vda
                 - single_usb_file:
+                    no s390-virtio
                     vadu_dev_obj_meg_VirtualDiskBasic = 10
                     vadu_dev_obj_devidx_VirtualDiskBasic = 0
                     vadu_dev_obj_targetbus_VirtualDiskBasic = "usb"

--- a/libvirt/tests/cfg/virtual_device/input_devices.cfg
+++ b/libvirt/tests/cfg/virtual_device/input_devices.cfg
@@ -22,10 +22,12 @@
                 only bus_type_ps2 bus_type_usb
     variants:
         - bus_type_usb:
+            no s390-virtio
             bus_type = usb
         - bus_type_virtio:
             bus_type = virtio
         - bus_type_ps2:
+            no s390-virtio
             bus_type = ps2
     variants:
         - positive_test:

--- a/libvirt/tests/cfg/virtual_disks/at_dt_iscsi_disk.cfg
+++ b/libvirt/tests/cfg/virtual_disks/at_dt_iscsi_disk.cfg
@@ -17,6 +17,7 @@
                 - ipv6_virtio_bus:
                     disk_source_host = "::1"
                 - usb_bus:
+                    no s390-virtio
                     disk_target = "sda"
                     disk_target_bus = "usb"
                 - readonly_mode:

--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
@@ -794,6 +794,7 @@
                                     driver_option = "type=raw"
                                     virt_disk_option_readonly = "yes"
                         - disk_bus_usb:
+                            no s390-virtio
                             driver_option = "type=raw,cache=none"
                             virt_disk_device_target = "sda"
                             virt_disk_device_bus = "usb"

--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_usb.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_usb.cfg
@@ -8,6 +8,7 @@
     virt_disk_device_target = "sdb"
     virt_disk_device_bus = "usb"
     status_error = "no"
+    no s390-virtio
     variants:
         - usb1_1:
             variants:


### PR DESCRIPTION
On s390x USB is not available. Adding filter to avoid running them
in the first place.