### PR TITLE
migration: Update to set firewall for special cases only

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -269,11 +269,12 @@
                             actions_during_migration = "setmaxdowntime,checkdomstats"
                         - disable_keepalive:
                             only without_postcopy
+                            break_network_connection = "yes"
                             asynch_migrate = "yes"
                             low_speed = "10"
                             stress_in_vm = "yes"
                             stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M --timeout 70"
-                            actions_during_migration = "drop_network_connetion"
+                            actions_during_migration = "drop_network_connection"
                             variants:
                                 - on_both:
                                     qemu_conf_dest_dict = '{r"keepalive_interval\s*=.*": 'keepalive_interval=5', r"keepalive_count\s*=.*": 'keepalive_count=5'}'
@@ -348,11 +349,12 @@
                             only without_postcopy
                             variants:
                                 - on_target:
+                                    break_network_connection = "yes"
                                     asynch_migrate = "yes"
                                     low_speed = "10"
                                     stress_in_vm = "yes"
                                     stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M --timeout 70"
-                                    actions_during_migration= "drop_network_connetion"
+                                    actions_during_migration= "drop_network_connection"
                                     libvirtd_conf_dest_dict = '{r".*keepalive_interval.*=.*": 'keepalive_interval=-1'}'
                                     qemu_conf_dict = '{"keepalive_interval": "5", "keepalive_count": "5"}'
                                     libvirtd_conf_dict = '{"keepalive_interval": "5", "keepalive_count": "5", "log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'


### PR DESCRIPTION
So far, firewall cleanup part will be executed by every cases in
migrate_options_shared, which is redundancy. So fix up this issue
in this PR.

Signed-off-by: Yingshun Cui <yicui@redhat.com>