### PR TITLE
Fix attach_devices serial on s390x

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_device.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_device.cfg
@@ -121,6 +121,20 @@
                 - unsupport_sata_bus:
                     only single_file
                     vadu_dev_obj_targetbus_VirtualDiskBasic = "sata"
+                - sclp_twice:
+                    only s390-virtio, virsh..single_serial.without_alias..file_argument.domain_argument
+                    no controller, block, multiple, normal_test.hot_attach_hot_vm, normal_test.hot_attach_hot_vm_current
+                    remove_all_chardev = yes
+                    vadu_dev_objs = "SerialPipe"
+                    vadu_dev_objs_models = "sclpconsole sclpconsole"
+                    vadu_dev_objs_count_SerialPipe = 2
+                - sclplm_twice:
+                    only s390-virtio, virsh..single_serial.without_alias..file_argument.domain_argument
+                    no controller, block, multiple, normal_test.hot_attach_hot_vm, normal_test.hot_attach_hot_vm_current
+                    remove_all_chardev = yes
+                    vadu_dev_objs = "SerialFile"
+                    vadu_dev_objs_models = "sclplmconsole sclplmconsole"
+                    vadu_dev_objs_count_SerialFile = 2
 
     ########## Device type and parameter specification #########
     # Arbitrary attributes can be passed in to class instances #
@@ -140,8 +154,7 @@
             variants:
                 - serial:
                     # Hot attach serial not supported (ISA bus limitation)
-                    no normal_test.hot_attach_hot_vm
-                    no normal_test.hot_attach_hot_vm_current
+                    no s390-virtio, normal_test.hot_attach_hot_vm, normal_test.hot_attach_hot_vm_current
                     variants:
                         - single_serial:
                             # SerialFile is name of class in test-module
@@ -163,6 +176,46 @@
                             vadu_dev_obj_count_SerialFile = 1
                             # vadu_dev_obj_source_sfile ingerited as file
                             vadu_dev_obj_count_SerialPipe = 2
+                - serial_s390x:
+                    # Hot attach serial not supported
+                    only s390-virtio
+                    no normal_test.hot_attach_hot_vm, normal_test.hot_attach_hot_vm_current
+                    # Only two serial target types are available and
+                    # must be different
+                    remove_all_chardev = yes
+                    variants:
+                        - single_serial:
+                            # SerialFile is name of class in test-module
+                            vadu_dev_objs = "SerialPipe"
+                            # vadu_dev_obj_count_SerialPipe inherited as 1
+                            variants:
+                                - without_alias:
+                                - with_alias:
+                                    vadu_dev_obj_alias_SerialPipe = "ua-serial"
+                        - single_serial_lm:
+                            # SerialFile is name of class in test-module
+                            vadu_dev_objs = "SerialPipe"
+                            vadu_dev_obj_models = "sclplmconsole"
+                            # vadu_dev_obj_count_SerialPipe inherited as 1
+                            variants:
+                                - without_alias:
+                                - with_alias:
+                                    vadu_dev_obj_alias_SerialPipe = "ua-serial"
+                        - multi_serial:
+                            vadu_dev_objs = "SerialFile"
+                            vadu_dev_obj_count_SerialFile = 2
+                            vadu_dev_obj_models = "sclpconsole sclplmconsole"
+                            variants:
+                                - without_alias:
+                                - with_alias:File
+                                    vadu_dev_obj_alias_SerialFile = "ua-serial"
+                        - multi_type:
+                            vadu_dev_objs = "SerialFile SerialPipe"
+                            vadu_dev_obj_models_SerialFile = "sclpconsole"
+                            vadu_dev_obj_count_SerialFile = 1
+                            # vadu_dev_obj_source_sfile ingerited as file
+                            vadu_dev_obj_models_SerialPipe = "sclplmconsole"
+                            vadu_dev_obj_count_SerialPipe = 1
                 - console:
                     vadu_dev_objs = "Console"
                     variants:


### PR DESCRIPTION
On s390x only one single serial is allowed per model (sclpconsole|sclplmconsole).
If the domain xml already has a serial of that type defined a second one cannot
be attached.

1. serial, no s390-virtio:
 a. Skip default test cases in favor of specific tests for s390-virtio (s. below)

2. serial_s390x, sclp_twice, sclplm_twice:
 a. Implemenet new arch specific test cases:
|First device target model|Second device target model|Expected result|
|-------------------------|--------------------------|---------------|
|no device|sclpconsole|OK - attach and start|
|no device|sclplmconsole|OK - attach and start|
|sclpconsole|sclpconsole|ERROR "Multiple VT220 operator consoles are not supported"|
|sclplmconsole|sclplmconsole|ERROR "Multiple line-mode operator consoles are not supported"|
|sclpconsole|sclplmconsole|OK - attach and start|
|sclplmconsole|slcpconsole|OK - attach and start|

3. remove_non_disks:
 a. Move to method for readability

3. remove_all_chardevs:
 a. Removes serial and console elements to set preconditions on s390x
 b. Needs to remove elements and re-define because virsh.detach_device
    might fail (e.g. removing serial console not allowed)

4. SerialFile.init_device:
 a. Handle new class attribute "models" if defined in test configuration:
  i) davu_dev_objs_models: Defines list of target models for type "sclp-serial"
     for both SerialFile and SerialPipe, list separator " "
  ii) davu_dev_objs_models_Serial(Pipe|File): Defines list of target models for
      type "sclp-serial" for SerialFile and SerialPipe separately.

5. test_params.cleanup:
 a. try/except to assure domain xml is synced

Test run on CI s390x:
```bash
10:36:38 AM (1/17) virsh.attach_device.character.serial_s390x.single_serial.without_alias.normal_test.cold_attach_cold_vm.persistent.name_ref.file_argument.domain_argument Result: PASS 71.60 s
10:37:51 AM (2/17) virsh.attach_device.character.serial_s390x.single_serial.without_alias.normal_test.cold_attach_hot_vm.name_ref.file_argument.domain_argument Result: PASS 115.93 s
10:39:49 AM (3/17) virsh.attach_device.character.serial_s390x.single_serial.without_alias.error_test.sclp_twice.file_argument.domain_argument Result: PASS 144.22 s
10:42:14 AM (4/17) virsh.attach_device.character.serial_s390x.single_serial.without_alias.error_test.sclplm_twice.file_argument.domain_argument Result: PASS 159.16 s
10:44:55 AM (5/17) virsh.attach_device.character.serial_s390x.single_serial.with_alias.normal_test.cold_attach_cold_vm.config.name_ref.file_argument.domain_argument Result: PASS 63.87 s
10:46:00 AM (6/17) virsh.attach_device.character.serial_s390x.single_serial.with_alias.normal_test.cold_attach_hot_vm.name_ref.file_argument.domain_argument Result: PASS 152.33 s
10:48:34 AM (7/17) virsh.attach_device.character.serial_s390x.single_serial_lm.without_alias.normal_test.cold_attach_cold_vm.config.name_ref.file_argument.domain_argument Result: PASS 61.02 s
10:49:37 AM (8/17) virsh.attach_device.character.serial_s390x.single_serial_lm.with_alias.normal_test.cold_attach_cold_vm.persistent.name_ref.file_argument.domain_argument Result: PASS 57.78 s
10:50:36 AM (9/17) virsh.attach_device.character.serial_s390x.multi_serial.without_alias.normal_test.cold_attach_cold_vm.persistent.name_ref.file_argument.domain_argument Result: PASS 68.41 s
10:51:46 AM (10/17) virsh.attach_device.character.serial_s390x.multi_serial.without_alias.normal_test.cold_attach_cold_vm.config.name_ref.file_argument.domain_argument Result: PASS 59.37 s
10:52:46 AM (11/17) virsh.attach_device.character.serial_s390x.multi_serial.without_alias.normal_test.cold_attach_hot_vm.name_ref.file_argument.domain_argument Result: PASS 131.79 s
10:55:00 AM (12/17) virsh.attach_device.character.serial_s390x.multi_serial.with_alias.normal_test.cold_attach_cold_vm.persistent.name_ref.file_argument.domain_argument Result: PASS 54.74 s
10:55:56 AM (13/17) virsh.attach_device.character.serial_s390x.multi_serial.with_alias.normal_test.cold_attach_cold_vm.config.name_ref.file_argument.domain_argument Result: PASS 53.25 s
10:56:52 AM (14/17) virsh.attach_device.character.serial_s390x.multi_serial.with_alias.normal_test.cold_attach_hot_vm.name_ref.file_argument.domain_argument Result: PASS 138.39 s
10:59:12 AM (15/17) virsh.attach_device.character.serial_s390x.multi_type.normal_test.cold_attach_cold_vm.persistent.name_ref.file_argument.domain_argument Result: PASS 68.04 s
11:00:22 AM (16/17) virsh.attach_device.character.serial_s390x.multi_type.normal_test.cold_attach_cold_vm.config.name_ref.file_argument.domain_argument Result: PASS 67.91 s
11:01:33 AM (17/17) virsh.attach_device.character.serial_s390x.multi_type.normal_test.cold_attach_hot_vm.name_ref.file_argument.domain_argument Result: PASS 140.01 s
```
Equivalent avocado cmd:
```bash
# avocado run --vt-type libvirt --vt-machine-type s390-virtio --vt-connect-uri qemu:///system virsh.attach_device --vt-only-filter virsh.attach_device.character.serial_s390x.single_serial.without_alias.normal_test.cold_attach_cold_vm.persistent.name_ref.file_argument.domain_argument,virsh.attach_device.character.serial_s390x.single_serial_lm.without_alias.normal_test.cold_attach_cold_vm.config.name_ref.file_argument.domain_argument,virsh.attach_device.character.serial_s390x.single_serial.without_alias.normal_test.cold_attach_hot_vm.name_ref.file_argument.domain_argument,virsh.attach_device.character.serial_s390x.single_serial_lm.with_alias.normal_test.cold_attach_cold_vm.persistent.name_ref.file_argument.domain_argument,virsh.attach_device.character.serial_s390x.single_serial.with_alias.normal_test.cold_attach_cold_vm.config.name_ref.file_argument.domain_argument,virsh.attach_device.character.serial_s390x.single_serial.with_alias.normal_test.cold_attach_hot_vm.name_ref.file_argument.domain_argument,virsh.attach_device.character.serial_s390x.multi_serial.without_alias.normal_test.cold_attach_cold_vm.persistent.name_ref.file_argument.domain_argument,virsh.attach_device.character.serial_s390x.multi_serial.without_alias.normal_test.cold_attach_cold_vm.config.name_ref.file_argument.domain_argument,virsh.attach_device.character.serial_s390x.multi_serial.without_alias.normal_test.cold_attach_hot_vm.name_ref.file_argument.domain_argument,virsh.attach_device.character.serial_s390x.multi_serial.with_alias.normal_test.cold_attach_cold_vm.persistent.name_ref.file_argument.domain_argument,virsh.attach_device.character.serial_s390x.multi_serial.with_alias.normal_test.cold_attach_cold_vm.config.name_ref.file_argument.domain_argument,virsh.attach_device.character.serial_s390x.multi_serial.with_alias.normal_test.cold_attach_hot_vm.name_ref.file_argument.domain_argument,virsh.attach_device.character.serial_s390x.multi_type.normal_test.cold_attach_cold_vm.persistent.name_ref.file_argument.domain_argument,virsh.attach_device.character.serial_s390x.multi_type.normal_test.cold_attach_cold_vm.config.name_ref.file_argument.domain_argument,virsh.attach_device.character.serial_s390x.multi_type.normal_test.cold_attach_hot_vm.name_ref.file_argument.domain_argument,virsh..sclp_twice,virsh..sclplm_twice
```