### PR TITLE
Fix vsock tests on s390x

### DIFF
--- a/libvirt/tests/src/virtual_device/vsock.py
+++ b/libvirt/tests/src/virtual_device/vsock.py
@@ -1,8 +1,11 @@
+import os
 import re
 import random
-import string
-import threading
+import uuid
 import logging
+import time
+
+from threading import Thread
 
 from avocado.utils import process
 
@@ -13,6 +16,16 @@ from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.vsock import Vsock
 
+# Control the timeout of commands in guest globally
+CMD_TIMEOUT = 240.0
+
+# Constants for nc-vsock setup and usage
+NC_VSOCK_DIR = '/tmp/nc-vsock'
+NC_VSOCK_CMD = os.path.join(NC_VSOCK_DIR, 'nc-vsock')
+NC_VSOCK_SRV_OUT = os.path.join(NC_VSOCK_DIR, "server_out.txt")
+NC_VSOCK_CLI_TXT = os.path.join(NC_VSOCK_DIR, "client_in.txt")
+VSOCK_PORT = 1234
+
 
 def run(test, params, env):
     """
@@ -21,49 +34,145 @@ def run(test, params, env):
     1.Edit/start guest with vsock device.
     2.Hotplug/hotunplug vsock device.
     3.Coldplug/Coldunplug vsock device
+    4.Check if hotplugged vsock communicates.
     """
+
+    def remove_all_vsocks(vm, vmxml):
+        """
+        Removes all vsock devices from current domain
+        to avoid failures due to original domain definition
+        which must have been backed up earlier for correct
+        restore.
+
+        :param vm: the current test domain
+        :param vmxml: VMXML of the current test domain
+        :return: None
+        """
+
+        vmxml.remove_all_device_by_type('vsock')
+        was_alive = vm.is_alive()
+        vmxml.sync()
+        if was_alive:
+            vm.start()
+
     def env_setup():
+        """
+        1. Install build dependency for nc-vsock both on guest
+        and host.
+        2. Get nc-vsock code
+        3. Build nc-vsock on both guest and host.
+        :return: None
+        """
+
         session = vm.wait_for_login()
-        cmd = [
+        cmds = [
             'rpm -q lsof || yum -y install lsof',
             'rpm -q git || yum -y install git',
             'rpm -q make || yum -y install make',
             'rpm -q gcc && yum -y reinstall gcc || yum -y install gcc',
-            'rm -rf /tmp/nc-vsock',
-            'git clone %s /tmp/nc-vsock' % git_repo,
-            'cd /tmp/nc-vsock/ && make',
+            'rm -rf %s' % NC_VSOCK_DIR,
+            'git clone %s %s' % (git_repo, NC_VSOCK_DIR),
+            'cd %s && make' % NC_VSOCK_DIR,
         ]
-        for i in range(len(cmd)):
-            status1 = session.cmd_status(cmd[i])
-            logging.debug(status1)
-            status2 = process.run(cmd[i], shell=True).exit_status
-            logging.debug(status2)
-            if (status1 + status2) != 0:
-                test.cancel("Failed to install pkg %s" % cmd[i])
+        for cmd in cmds:
+            for where in ["guest", "host"]:
+                session_arg = session if where == "guest" else None
+                status, output = utils_misc.cmd_status_output(cmd, shell=True,
+                                                              timeout=CMD_TIMEOUT,
+                                                              session=session_arg)
+                cancel_if_failed(cmd, status, output, where)
+
         session.close()
 
+    def cancel_if_failed(cmd, status, output, where):
+        """
+        Cancel test execution as soon as command failed reporting output
+
+        :param cmd: Command that was executed
+        :param status: Exit status of command
+        :param output: Output of command
+        :param where: "guest" or "host"
+        :return:
+        """
+
+        if status:
+            test.cancel("Failed to run %s on %s output: %s" % (
+                cmd,
+                where,
+                output
+            ))
+
+    def write_from_host_to_guest():
+        """
+        1. Create file for stdin to nc-vsock
+        2. Invoke nc-vsock as client writing to guest cid
+        :return msg: The message sent to the server
+        """
+
+        msg = "message from client"
+        process.run('echo %s > %s' % (msg, NC_VSOCK_CLI_TXT), shell=True)
+        output = process.run("%s %d %s < %s" % (NC_VSOCK_CMD, int(cid),
+                                                VSOCK_PORT, NC_VSOCK_CLI_TXT),
+                             shell=True).stdout_text
+        logging.debug(output)
+        process.system_output('cat %s' % NC_VSOCK_CLI_TXT)
+        return msg
+
+    def wait_for_guest_to_receive(server):
+        """
+        nc-vsock server finishes as soon as it received data.
+        We report if it's still running.
+
+        :param server: The started server instance accepting requests
+        :return: Nothing
+        """
+
+        server.join(5)
+        if server.is_alive():
+            logging.debug("The server thread is still running in the guest.")
+
     def validate_data_transfer_by_vsock():
+        """
+        1. Setup nc-vsock on host and guest
+        2. Start vsock server on guest (wait a bit)
+        3. Send message from host to guest using correct cid
+        4. Get received message from vsock server
+        5. Verify message was sent
+        """
+
         env_setup()
 
-        def _vsock_server():
-            session.cmd("/tmp/nc-vsock/nc-vsock -l 1234 > /tmp/testfile")
-
-        server = threading.Thread(target=_vsock_server)
         session = vm.wait_for_login()
+
+        def _start_vsock_server_in_guest():
+            """
+            Starts the nc-vsock server to listen on VSOCK_PORT in the guest.
+            The server will stop as soon as it received message from host.
+            :return:
+            """
+
+            session.cmd("%s -l %s > %s" % (NC_VSOCK_CMD, VSOCK_PORT, NC_VSOCK_SRV_OUT))
+
+        server = Thread(target=_start_vsock_server_in_guest)
         server.start()
-        process.run('echo "test file" > /tmp/testfile', shell=True)
-        output = process.run("/tmp/nc-vsock/nc-vsock %d 1234 < /tmp/testfile" % int(cid), shell=True).stdout_text
-        logging.debug(output)
-        server.join(5)
-        data_host = process.run("sha256sum /tmp/testfile", shell=True).stdout_text
-        logging.debug(session.cmd_status_output("cat /tmp/testfile")[1])
-        data_guest = session.cmd_status_output("sha256sum /tmp/testfile")[1]
-        logging.debug(data_guest[1])
-        if data_guest != data_host:
-            test.fail("Data transfer error with vsock device\n")
+        time.sleep(5)
+
+        sent_data = write_from_host_to_guest()
+        wait_for_guest_to_receive(server)
+        received_data = session.cmd_output('cat %s' % NC_VSOCK_SRV_OUT).strip()
+
+        if not sent_data == received_data:
+            test.fail("Data transfer error with vsock device\n"
+                      "Sent: '%s'\n"
+                      "Received:'%s'" % (sent_data, received_data))
+
         session.close()
 
     def managedsave_restore():
+        """
+        Check that vm can be saved and restarted with current configuration
+        """
+
         result = virsh.managedsave(vm_name, debug=True)
         utils_test.libvirt.check_exit_status(result, expect_error=False)
         result = virsh.start(vm_name)
@@ -87,8 +196,9 @@ def run(test, params, env):
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     backup_xml = vmxml.copy()
 
-    # Add vsock device to domain
-    vmxml.remove_all_device_by_type('vsock')
+    remove_all_vsocks(vm, vmxml)
+
+    # Define vsock device xml
     vsock_dev = Vsock()
     vsock_dev.model_type = "virtio"
     if process.run("modprobe vhost_vsock").exit_status != 0:
@@ -98,12 +208,12 @@ def run(test, params, env):
     else:
         cid = random.randint(3, 10)
         vsock_dev.cid = {'auto': auto_cid, 'address': cid}
-        chars = string.ascii_letters + string.digits + '-_'
-        alias_name = 'ua-' + ''.join(random.choice(chars) for _ in list(range(64)))
-        vsock_dev.alias = {'name': alias_name}
+        vsock_dev.alias = {'name': str(uuid.uuid1())}
     logging.debug(vsock_dev)
+
     if start_vm == "no" and vm.is_alive():
         virsh.destroy()
+
     try:
         if edit_xml:
             edit_status1 = libvirt.exec_virsh_edit(


### PR DESCRIPTION
1. remove_all_vsocks:
 a. When domain xml already had <vsock> communication tests failed because
    originally <vsock> was only removed from xml but not from domain.

2. alias_name:
 a. Use uuid instead of string module to simplify code.

3. global variables:
 a. Setup in env_setup can take quite some time as it depends both
    on machine performance and connectivity. Avoid early timeouts by
    using CMD_TIMEOUT on all setup commands.
 b. nc-vsock:
    i.) use variables to build paths and commands for reusability and
        readability
    ii.) put input and output files below /tmp/nc-vsock to assure
         they are removed, too

4. env_setup:
 a. no need to use index to iterate over commands
 b. use status and output to fail early instead of executing all
 c. create/rename methods to make code more readable
 d. time.sleep: the thread needs for server to listen
 e. sent_data/received_data: the test intention is to check if
    communication from host to guest works (depending on different
    guest cids); simplify check ignoring implementation details from
    nc-vsock server usage and session.cmd commands

Tests on s390x:
```bash
# avocado run --vt-type libvirt --vt-machine-type s390-virtio --vt-connect-uri qemu:///system vsock
JOB ID     : 8da4ea8409bcfda9b88a453f5d0dbce94b444402
JOB LOG    : /root/avocado/job-results/job-2019-11-13T13.36-8da4ea8/job.log
 (01/14) type_specific.io-github-autotest-libvirt.vsock.normal_test.hotplug.nop.auto_cid: PASS (45.47 s)
 (02/14) type_specific.io-github-autotest-libvirt.vsock.normal_test.hotplug.nop.static_cid: PASS (50.91 s)
 (03/14) type_specific.io-github-autotest-libvirt.vsock.normal_test.hotplug.managedsave_with_vsock.auto_cid: WARN: Test passed but there were warnings during execution. Check the log for details. (98.93 s)
 (04/14) type_specific.io-github-autotest-libvirt.vsock.normal_test.hotplug.managedsave_with_vsock.static_cid: PASS (180.37 s)
 (05/14) type_specific.io-github-autotest-libvirt.vsock.normal_test.hotplug.managedsave_after_vsock.auto_cid: PASS (102.55 s)
 (06/14) type_specific.io-github-autotest-libvirt.vsock.normal_test.hotplug.managedsave_after_vsock.static_cid: PASS (98.15 s)
 (07/14) type_specific.io-github-autotest-libvirt.vsock.normal_test.hotplug.communication.auto_cid: PASS (545.70 s)
 (08/14) type_specific.io-github-autotest-libvirt.vsock.normal_test.hotplug.communication.static_cid: PASS (119.92 s)
 (09/14) type_specific.io-github-autotest-libvirt.vsock.normal_test.coldplug.auto_cid: PASS (47.95 s)
 (10/14) type_specific.io-github-autotest-libvirt.vsock.normal_test.coldplug.static_cid: PASS (48.72 s)
 (11/14) type_specific.io-github-autotest-libvirt.vsock.normal_test.edit_start.auto_cid: PASS (12.14 s)
 (12/14) type_specific.io-github-autotest-libvirt.vsock.normal_test.edit_start.static_cid: PASS (6.25 s)
 (13/14) type_specific.io-github-autotest-libvirt.vsock.negative_test.invalid_cid.static_cid: PASS (44.12 s)
 (14/14) type_specific.io-github-autotest-libvirt.vsock.negative_test.two_vsocks.static_cid: PASS (44.35 s)
RESULTS    : PASS 13 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 1 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 1450.03 s
```
The mentioned warning was due to ```virsh list``` not finishing in time with SIGTERM.