### PR TITLE
Avoid xattr left on image blocking all followed up cases

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockcommit.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockcommit.py
@@ -19,6 +19,105 @@ from virttest.utils_test import libvirt
 
 from provider import libvirt_version
 
+clean_shell = """
+#!/bin/bash
+
+function die {
+    echo $@ >&2
+    exit 1
+}
+
+function show_help {
+    cat << EOF
+Usage: ${0##*/} -[hqn] [PATH]
+
+Clear out any XATTRs set by libvirt on all files that have them.
+The idea is to reset refcounting, should it break.
+
+  -h    display this help and exit
+  -q    quiet (don't print which files are being fixed)
+  -n    dry run; don't remove any XATTR just report the file name
+
+PATH can be specified to refine search to only to given path
+instead of whole root ('/'), which is the default.
+EOF
+}
+
+QUIET=0
+DRY_RUN=0
+DIR="/"
+
+# So far only qemu and lxc drivers use security driver.
+URI=("qemu:///system"
+     "lxc:///system")
+
+# On Linux we use 'trusted' namespace, on FreeBSD we use 'system'
+# as there is no 'trusted'.
+LIBVIRT_XATTR_PREFIXES=("trusted.libvirt.security"
+                        "system.libvirt.security")
+
+if [ `whoami` != "root" ]; then
+    die "Must be run as root"
+fi
+
+while getopts hqn opt; do
+    case $opt in
+        h)
+            show_help
+            exit 0
+            ;;
+        q)
+            QUIET=1
+            ;;
+        n)
+            DRY_RUN=1
+            ;;
+        *)
+            show_help >&2
+            exit 1
+            ;;
+    esac
+done
+
+shift $((OPTIND - 1))
+if [ $# -gt 0 ]; then
+    DIR=$1
+fi
+
+if [ ${DRY_RUN} -eq 0 ]; then
+    for u in ${URI[*]} ; do
+        if [ -n "`virsh -q -c $u list 2>/dev/null`" ]; then
+            die "There are still some domains running for $u"
+        fi
+    done
+fi
+
+
+declare -a XATTRS
+for i in "dac" "selinux"; do
+    for p in ${LIBVIRT_XATTR_PREFIXES[@]}; do
+        XATTRS+=("$p.$i" "$p.ref_$i" "$p.timestamp_$i")
+    done
+done
+
+for p in ${LIBVIRT_XATTR_PREFIXES[*]}; do
+    for i in $(getfattr -R -d -m ${p} --absolute-names ${DIR} 2>/dev/null | grep "^# file:" | cut -d':' -f 2); do
+        echo $i;
+        if [ ${DRY_RUN} -ne 0 ]; then
+            getfattr -d -m $p --absolute-names $i | grep -v "^# file:"
+            continue
+        fi
+
+        if [ ${QUIET} -eq 0 ]; then
+            echo "Fixing $i";
+        fi
+        for x in ${XATTRS[*]}; do
+            setfattr -x $x $i
+        done
+    done
+done
+"""
+
 
 def check_chain_xml(disk_xml, chain_lst):
     """
@@ -560,6 +659,13 @@ def run(test, params, env):
             os.remove(ceph_cfg)
         if vm.is_alive():
             vm.destroy(gracefully=False)
+        # Check if image having xattr left even if vm destroyed
+        image_dirty = False
+        getfattr_result = process.run("getfattr -m trusted.libvirt.security -d "
+                                      "/var/lib/avocado/data/avocado-vt/images/jeos-27-x86_64.qcow2",
+                                      shell=True)
+        if "selinux" in getfattr_result.stdout_text:
+            image_dirty = True
         # Recover xml of vm.
         vmxml_backup.sync("--snapshots-metadata")
         # Clean ceph image if used in test
@@ -593,3 +699,10 @@ def run(test, params, env):
             restore_selinux = params.get('selinux_status_bak')
             libvirt.setup_or_cleanup_nfs(is_setup=False,
                                          restore_selinux=restore_selinux)
+        # Recover image xattr if having some
+        if image_dirty:
+            sh_path = os.path.join(tmp_dir, 'clean_xattr.sh')
+            with open(sh_path, 'w') as cleansh:
+                cleansh.write(clean_shell)
+            process.run("sh %s" % sh_path, shell=True)
+            test.fail("image having xattr left, getfattr output is:\n %s" % getfattr_result.stdout)


### PR DESCRIPTION
This is due to bz1741456. When image has xattr left after vm
destroyed, vm cannot be started anymore until we clear these
xattrs. This will block all followed up cases when happened.
This commit is to report the error and clear the xattr within
the problematic case, not blocking followed up cases.

Signed-off-by: Yi Sun <yisun@redhat.com>