### PR TITLE
virsh_snapshot_disk: modified the test case status from CANCEL to ERROR

### DIFF
--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_disk.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_disk.py
@@ -189,8 +189,8 @@ def run(test, params, env):
             result = virsh.attach_disk(vm_name, source=img_path, target="vdf",
                                        extra=extra, debug=True)
             if result.exit_status:
-                test.cancel("Failed to attach disk %s to VM."
-                            "Detail: %s." % (img_path, result.stderr))
+                test.error("Failed to attach disk %s to VM."
+                           "Detail: %s." % (img_path, result.stderr))
 
         # Create snapshot.
         if snapshot_from_xml:


### PR DESCRIPTION
when test case is trying to attach the disk to the VM, it got cancelled.
Actually it should throw the error if it is not able to attach it.
So this test case code has modified from CANCEL to ERROR.

Suggested-by: Balamuruhan S <bala24@linux.ibm.com>
Signed-off-by: Kalaiarasan Panneerselvam <panneer1@in.ibm.com>