### PR TITLE
Add 2 cases about pvspinlock and relaxed feature

### DIFF
--- a/libvirt/tests/cfg/cpu/vm_features.cfg
+++ b/libvirt/tests/cfg/cpu/vm_features.cfg
@@ -8,15 +8,31 @@
                     no pseries
                     variants:
                         - tlbflush:
-                            hyperv_attr = {'tlbflush': 'on'}
+                            hyperv_attr = {'relaxed': 'on', 'vapic': 'on', 'vpindex': 'on', 'tlbflush': 'on'}
                         - frequencies:
                             hyperv_attr = {'relaxed': 'on', 'vapic': 'on', 'vpindex': 'on', 'frequencies': 'on'}
                         - reenlightenment:
                             hyperv_attr = {'reenlightenment': 'on'}
+                        - relaxed:
+                            variants:
+                                - enable:
+                                    hyperv_attr={'relaxed': 'on'}
+                                - disable:
+                                    hyperv_attr={'relaxed': 'off'}
+                          
                 - pmu:
                     variants:
                         - enable:
                             pmu_attr={'pmu': 'on'}
                         - disable:
                             pmu_attr={'pmu': 'off'}
+                - pvspinlock:
+                    no pseries
+                    variants:
+                        - enable:
+                            pvspinlock_attr={'pvspinlock_state': 'on'}
+                        - disable:
+                            pvspinlock_attr={'pvspinlock_state': 'off'}
+                                  
+
 


### PR DESCRIPTION
Automated below 2 cases in this PR:
1. start VM with/without pvspinlock feature
2. start VM with/without relaxed feature

Since some of qemu command line changed from libvirt 5.x,
updated expected pattern for hyperv feature accordingly.

Signed-off-by: Yingshun Cui <yicui@redhat.com>