### PR TITLE
Delete v2v cases about parameter copy_to_local

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -35,7 +35,7 @@
     variants:
         - libvirt:
             only dest_libvirt
-            only uefi, GPO_AV, special_name, copy_to_local, suse
+            only uefi, GPO_AV, special_name, suse
         - rhev:
             only dest_rhev.NFS
             variants:
@@ -207,11 +207,6 @@
             main_vm = VM_NAME_ESX_FSTAB_SEPBY_COMMA
             msg_content = 'virt-v2v: warning: mount: mount exited with status 32: mount: .*? already mounted .*?\(ignored\)'
             expect_msg = yes
-        - copy_to_local:
-            only esx_60
-            only libvirt
-            checkpoint = copy_to_local
-            esx_password = 123qweP
         - with_proxy:
             only esx_60
             no libvirt

--- a/v2v/tests/src/function_test_esx.py
+++ b/v2v/tests/src/function_test_esx.py
@@ -2,9 +2,7 @@ import os
 import logging
 import re
 
-from avocado.utils import process
 
-from virttest import data_dir
 from virttest import utils_misc
 from virttest import utils_sasl
 from virttest import utils_v2v
@@ -314,19 +312,6 @@ def run(test, params, env):
         if checkpoint.startswith('root_') and checkpoint != 'root_ask':
             root_option = params.get('root_option')
             v2v_params['v2v_opts'] += ' --root %s' % root_option
-        if checkpoint == 'copy_to_local':
-            esx_password = params.get('esx_password')
-            esx_passwd_file = os.path.join(
-                data_dir.get_tmp_dir(), "esx_passwd")
-            logging.info('Prepare esx password file')
-            with open(esx_passwd_file, 'w') as pwd_f:
-                pwd_f.write(esx_password)
-            esx_uri = 'esx://root@%s/?no_verify=1' % esx_ip
-            copy_cmd = 'virt-v2v-copy-to-local -ic %s %s --password-file %s' %\
-                       (esx_uri, vm_name, esx_passwd_file)
-            process.run(copy_cmd)
-            v2v_params['input_mode'] = 'libvirtxml'
-            v2v_params['input_file'] = '%s.xml' % vm_name
         if checkpoint == 'with_proxy':
             http_proxy = params.get('esx_http_proxy')
             https_proxy = params.get('esx_https_proxy')


### PR DESCRIPTION
Because v2v code changed on 2018.11.01
https://github.com/libguestfs/virt-v2v/commit/c1c4ed4c16e83a83d6d2835e05d6adf97836db70#diff-31c097437346a8f33915e8de88c011d2
we need to delete related cases which use parameter copy_to_local to convert guest from ESXI.
