### PR TITLE
Add cases about cpu vendor_id

### DIFF
--- a/libvirt/tests/cfg/cpu/vcpu_misc.cfg
+++ b/libvirt/tests/cfg/cpu/vcpu_misc.cfg
@@ -10,3 +10,12 @@
                     test_operations = "do_snapshot"
                     expected_str_before_startup = ${cpu_mode}
                     expected_str_after_startup = 'mode="custom"'
+                - vendor_id:
+                    cpu_mode = "host-model"
+                    variants:
+                        - AuthenticAMD:
+                            vendor_id = 'AuthenticAMD'
+                        - GenuineIntel:
+                            vendor_id = 'GenuineIntel'
+                    expected_qemuline = "vendor=${vendor_id}"
+                    cmd_in_guest = "cat /proc/cpuinfo | grep vendor_id | grep ${vendor_id}"


### PR DESCRIPTION
This PR adds 2 cpu vendor_id cases -
Start VM with AuthenticAMD/GenuineIntel vendor_id attribute.

depends on https://github.com/avocado-framework/avocado-vt/pull/2350

Signed-off-by: Yingshun Cui <yicui@redhat.com>