### PR TITLE
Fix AttributeError for remote_access

### DIFF
--- a/libvirt/tests/src/remote_access/remote_access.py
+++ b/libvirt/tests/src/remote_access/remote_access.py
@@ -122,6 +122,7 @@ def cleanup(objs_list):
     for obj in objs_list:
         obj.auto_recover = True
         obj.__del__()
+        obj.auto_recover = False
 
 
 def run(test, params, env):


### PR DESCRIPTION
It reports error AttributeError at end of execution even it passed.
The objects need to be removed dirrectly in finally block for remote
access cases, so update to skip cleanup in GC.

Signed-off-by: Yingshun Cui <yicui@redhat.com>