### PR TITLE
Revert "Pass vm_arch_name to ensure zipl is called on s390x guest"

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_sendkey.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_sendkey.py
@@ -66,7 +66,7 @@ def run(test, params, env):
     # Boot the guest in text only mode so that send-key commands would succeed
     # in creating a file
     try:
-        utils_test.update_boot_option(vm, args_added="3", guest_arch_name=params.get('vm_arch_name'))
+        utils_test.update_boot_option(vm, args_added="3")
     except Exception as info:
         test.error(info)
 


### PR DESCRIPTION
Reverts autotest/tp-libvirt#2394
Depends on avocado-vt 2312