### PR TITLE
Adjust checkpoints for linux guests

### DIFF
--- a/v2v/tests/cfg/function_test_xen.cfg
+++ b/v2v/tests/cfg/function_test_xen.cfg
@@ -4,7 +4,6 @@
     start_vm = 'no'
     take_regular_screendumps = no
     v2v_timeout = '3600'
-    default_output_format = 'qcow2'
 
     # Xen host info
     only source_xen
@@ -24,6 +23,9 @@
     remote_shell_port = 22
     remote_shell_prompt = '^\w:\\.*>\s*$|^\[.*\][\#\$]\s*$'
     status_test_command = 'echo $?'
+
+    # vms is not need for XEN guests
+    vms = ''
 
     # Full types input disks
     variants:
@@ -91,6 +93,7 @@
             main_vm = 'VM_NAME_PV_WITH_REGULAR_KERNEL_V2V_EXAMPLE'
         - format_convert:
             checkpoint = 'format_convert'
+            output_format = 'qcow2'
         - sound:
             checkpoint = 'sound'
             variants:

--- a/v2v/tests/src/function_test_esx.py
+++ b/v2v/tests/src/function_test_esx.py
@@ -414,8 +414,8 @@ def run(test, params, env):
         check_result(v2v_result, status_error)
 
     finally:
-        if checkpoint == 'ogac':
-            if os.path.exists(params['tmp_mount_point']):
+        if checkpoint == 'ogac' and params.get('tmp_mount_point'):
+            if os.path.exists(params.get('tmp_mount_point')):
                 utils_misc.umount(
                     os.getenv('VIRTIO_WIN'),
                     params['tmp_mount_point'],

--- a/v2v/tests/src/function_test_xen.py
+++ b/v2v/tests/src/function_test_xen.py
@@ -234,6 +234,8 @@ def run(test, params, env):
 
         # Build rhev related options
         if output_mode == 'rhev':
+            # To RHV doesn't support 'qcow2' right now
+            v2v_params['output_format'] = 'raw'
             # create different sasl_user name for different job
             params.update({'sasl_user': params.get("sasl_user") +
                            utils_misc.generate_random_string(3)})
@@ -281,7 +283,7 @@ def run(test, params, env):
             blklist = virsh.domblklist(vm_name, uri=uri).stdout.split('\n')
             logging.debug('domblklist %s:\n%s', vm_name, blklist)
             for line in blklist:
-                if line.startswith(('hda', 'vda', 'sda', 'xvda')):
+                if line.strip().startswith(('hda', 'vda', 'sda', 'xvda')):
                     params['remote_disk_image'] = line.split()[-1]
                     break
             # Local path of disk image
@@ -337,8 +339,6 @@ def run(test, params, env):
                                                 params['img_path'], xml_file)
                 process.run(cmd)
                 logging.debug(process.run('cat %s' % xml_file).stdout_text)
-            if checkpoint == 'format_convert':
-                v2v_params['output_format'] = 'qcow2'
         if checkpoint == 'ssh_banner':
             session = remote.remote_login("ssh", xen_host, "22", "root",
                                           xen_host_passwd, "#")


### PR DESCRIPTION
1) Add checking for Suse and Debian based systems
2) Add memory and rng device checking for all targets
3) Remove Xorg log checking, only check video by lspci
4) A fix to format_convert
5) Replace params[x] with params.get(x) to avoid exception

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>