### PR TITLE
Fix vm cleanup issue when skip checking

### DIFF
--- a/v2v/tests/cfg/convert_from_file.cfg
+++ b/v2v/tests/cfg/convert_from_file.cfg
@@ -94,7 +94,7 @@
                                     only output_mode.libvirt
                         - parse:
                             ova_dir = OVA_DIR_PARSE_V2V_EXAMPLE
-                            skip_check = yes
+                            skip_vm_check = yes
                             variants:
                                 - SHA1:
                                     ova_file = OVA_FILE_SHA1_V2V_EXAMPLE

--- a/v2v/tests/cfg/function_test_xen.cfg
+++ b/v2v/tests/cfg/function_test_xen.cfg
@@ -147,7 +147,7 @@
                     windows_root = 'WINDOWS_ROOT_V2V_EXAMPLE'
                     os_version = 'WINDOWS_ROOT_OS_VERSION_V2V_EXAMPLE'
                     main_vm = 'WINDOWS_ROOT_VM_NAME_V2V_EXAMPLE'
-                    skip_check = yes
+                    skip_vm_check = yes
                     skip_reason = 'there is no virtio driver for win2003 guest'
                 - virtio_win:
                     main_vm = 'XEN_VM_NAME_VIRTIO_WIN_V2V_EXAMPLE'

--- a/v2v/tests/cfg/specific_kvm.cfg
+++ b/v2v/tests/cfg/specific_kvm.cfg
@@ -133,7 +133,7 @@
                     main_vm = 'VM_FSTAB_WITH_SR0_V2V_EXAMPLE'
                     msg_content = 'virt-v2v: warning: /files/etc/fstab/.*? references unknown device "sr"'
                     expect_msg = no
-                    skip_check = yes
+                    skip_vm_check = yes
                 - invalid:
                     only source_esx.esx_67
                     msg_content = 'virt-v2v: error: libguestfs error: inspect_os: .*?: augeas parse failure:'
@@ -185,7 +185,7 @@
                     spice_passwd = 'redhat'
                 - mix:
                     only libvirt
-                    skip_check = yes
+                    skip_vm_check = yes
                     variants:
                         - spice:
                             checkpoint = spice

--- a/v2v/tests/src/convert_from_file.py
+++ b/v2v/tests/src/convert_from_file.py
@@ -40,7 +40,7 @@ def run(test, params, env):
     address_cache = env.get('address_cache')
     v2v_timeout = int(params.get('v2v_timeout', 1200))
     status_error = 'yes' == params.get('status_error', 'no')
-    skip_check = 'yes' == params.get('skip_check', 'no')
+    skip_vm_check = params.get('skip_vm_check', 'no')
     pool_name = params.get('pool_name', 'v2v_test')
     pool_type = params.get('pool_type', 'dir')
     pool_target = params.get('pool_target_path', 'v2v_pool')
@@ -119,9 +119,7 @@ def run(test, params, env):
         """
         libvirt.check_exit_status(result, status_error)
         output = result.stdout + result.stderr
-        if skip_check:
-            logging.info('Skip checking vm after conversion')
-        elif not status_error:
+        if not status_error:
             if output_mode == 'rhev':
                 if not utils_v2v.import_vm_to_ovirt(params, address_cache,
                                                     timeout=v2v_timeout):

--- a/v2v/tests/src/specific_kvm.py
+++ b/v2v/tests/src/specific_kvm.py
@@ -53,7 +53,7 @@ def run(test, params, env):
     pvt = utlv.PoolVolumeTest(test, params)
     v2v_opts = params.get('v2v_opts', '-v -x')
     v2v_timeout = int(params.get('v2v_timeout', 3600))
-    skip_check = 'yes' == params.get('skip_check', 'no')
+    skip_vm_check = params.get('skip_vm_check', 'no')
     status_error = 'yes' == params.get('status_error', 'no')
     checkpoint = params.get('checkpoint', '')
     debug_kernel = 'debug_kernel' == checkpoint
@@ -538,9 +538,7 @@ def run(test, params, env):
         """
         utlv.check_exit_status(result, status_error)
         output = result.stdout + result.stderr
-        if skip_check:
-            logging.info('Skip checking vm after conversion')
-        elif not status_error:
+        if not status_error:
             if output_mode == 'rhev':
                 if not utils_v2v.import_vm_to_ovirt(params, address_cache,
                                                     timeout=v2v_timeout):
@@ -553,7 +551,7 @@ def run(test, params, env):
             # Check guest following the checkpoint document after convertion
             vmchecker = VMChecker(test, params, env)
             params['vmchecker'] = vmchecker
-            if params.get('skip_check') != 'yes':
+            if params.get('skip_vm_check') != 'yes':
                 ret = vmchecker.run()
                 if len(ret) == 0:
                     logging.info("All common checkpoints passed")


### PR DESCRIPTION
1) If skip_check is set, VM will not be cleaned from ovirt server.
This patch fixed it.
2) Update skip_check to skip_vm_check

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>