### PR TITLE
Add migration with local filesystem backed disk cases

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_vm.cfg
+++ b/libvirt/tests/cfg/migration/migrate_vm.cfg
@@ -528,6 +528,13 @@
                             run_migrate_cmd_in_front = "no"
                             create_target_image = "yes"
                             virsh_options = "--live --verbose --copy-storage-all --disks-port ${disk_port}"
+                        - local_fs_with_unsafe_option:
+                            only without_postcopy
+                            nfs_mount_dir =
+                            no_create_pool = "yes"
+                            create_target_image = "yes"
+                            virsh_options = "--live --verbose --unsafe"
+                            target_image_format = "qcow2"
         - negative_testing:
             status_error = "yes"
             stop_remote_guest = "no"
@@ -734,6 +741,34 @@
                                 - copy_storage_inc:
                                     virsh_options = "--live --verbose --persistent --copy-storage-inc"
                                     err_msg = "error: Operation not supported: pre-creation of storage targets for incremental storage migration is not supported"
+                        - cache_mode:
+                            only without_postcopy
+                            nfs_mount_dir =
+                            no_create_pool = "yes"
+                            create_target_image = "no"
+                            virsh_options = "--live --verbose"
+                            err_msg = "error: Unsafe migration: Migration without shared storage is unsafe"
+                            variants:
+                                - without_shareable:
+                                    disk_format = "qcow2"
+                                    disk_shareable = "no"
+                                    variants:
+                                        - copy_img_to_target:
+                                            create_target_image = "yes"
+                                            target_image_format = ${disk_format}
+                                        - default:
+                                - with_shareable:
+                                    target_image_format = "raw"
+                                    disk_driver_type = "raw"
+                                    disk_format = "raw"
+                                    disk_shareable = "yes"
+                                    new_disk_source = "/var/lib/libvirt/images/guest.img"
+                                    update_disk_source = "yes"
+                                    variants:
+                                        - none_cache:
+                                            disk_driver_cache = "none"
+                                        - directsync:
+                                            disk_driver_cache = "directsync"
                 - rdma_migration:
                     setup_nfs = "yes"
                     enable_virt_use_nfs = "yes"


### PR DESCRIPTION
Below cases are included in this PR:
1. negative testing:
    1) migration vm without shareable/cache when target image is/isn't present on target host
    2) migration vm with shareable and none/directsync cache when target image is/isn't present on target host
2. positive testing:
    1) migration vm with --unsafe option when target image is present on target host.

Signed-off-by: Yingshun Cui <yicui@redhat.com>