### PR TITLE
virsh_autostart:  rm a file to make vm autostart

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_autostart.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_autostart.py
@@ -2,6 +2,7 @@ import logging
 import os
 
 from virttest import virsh, utils_libvirtd
+from virttest import libvirt_version
 
 
 def run(test, params, env):
@@ -60,6 +61,9 @@ def run(test, params, env):
                                      debug=True, readonly=ro_flag)
         err = cmd_result.stderr.strip()
         status = cmd_result.exit_status
+        # rhbz#1755303
+        if libvirt_version.version_compare(5, 6, 0):
+            os.remove("/run/libvirt/qemu/autostarted")
         # Restart libvirtd and sleep 2
         utils_libvirtd.libvirtd_restart()
         if not status_error:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domrename.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domrename.py
@@ -11,6 +11,7 @@ from virttest import libvirt_xml
 from virttest import utils_libguestfs
 from virttest import utils_package
 from virttest import utils_libvirtd
+from virttest import libvirt_version
 
 
 def run(test, params, env):
@@ -115,6 +116,9 @@ def run(test, params, env):
                 # Try to start vm with the new name
                 new_vm.start()
             else:
+                # rhbz#1755303
+                if libvirt_version.version_compare(5, 6, 0):
+                    os.remove("/run/libvirt/qemu/autostarted")
                 utils_libvirtd.libvirtd_restart()
                 list_autostart = virsh.dom_list("--autostart", debug=True).stdout
                 logging.debug("files under '/etc/libvirt/qemu/autostart/' are %s",


### PR DESCRIPTION
From libvirt-5.6.0, libvirtd can be auto started by systemd socket
activation, which makes vm autostart work unexpectedly. A fix in
rhbz#1755303 resolves this, "/run/libvirt/qemu/autostarted" can
make sure vm autostart only once when host reboot. Here, remove
this file before start libvirtd, to achieve vm autostart without
host reboot.

Signed-off-by: Yanqiu Zhang <yanqzhan@redhat.com>