### PR TITLE
Split general lifecycle_events into groups

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_event.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_event.cfg
@@ -24,8 +24,18 @@
                     only no_timeout
                     event_name = "lifecycle"
                     variants:
-                        - general:
-                            events_list = "undefine,create,destroy,define,start,save,restore,suspend,resume,edit,shutdown"
+                        - create_destroy:
+                              events_list = "create,destroy"
+                        - suspend_resume:
+                              events_list = "suspend,resume"
+                        - edit:
+                              events_list = "edit"
+                        - save_restore:
+                              events_list = "save,restore"
+                        - undefine_define:
+                              events_list = "undefine,define"
+                        - start_stop:
+                              events_list = "start,shutdown"
                         - shutdown_from_host:
                             only test_events
                             signal = 'SIGTERM'


### PR DESCRIPTION
1. lifecycle_events.general:
 a. .general currently contains all lifecycle events. This leads to
    long test run and low test precision.
 b. Proposal is to test at most two related lifecycle events in the
    same test case to improve test precision.

2. wait_for_shutoff:
 a. If no_timeout test failed before vm actually had shut off. This
    took longer on z/VM. Added wait-for loop to avoid early failure.

Test run on s390x:
```bash
# avocado run --vt-type libvirt --vt-machine-type s390-virtio --vt-connect-uri qemu:///system virsh_event.test_events.lifecycle_events..no_timeout.loop
JOB ID     : c259599ce946ad26459467767b2932b678a563d9
JOB LOG    : /root/avocado/job-results/job-2019-12-03T06.25-c259599/job.log
 (1/8) type_specific.io-github-autotest-libvirt.virsh.event.positive_test.virsh_event.test_events.lifecycle_events.create_destroy.no_timeout.loop: PASS (19.21 s)
 (2/8) type_specific.io-github-autotest-libvirt.virsh.event.positive_test.virsh_event.test_events.lifecycle_events.suspend_resume.no_timeout.loop: PASS (106.22 s)
 (3/8) type_specific.io-github-autotest-libvirt.virsh.event.positive_test.virsh_event.test_events.lifecycle_events.edit.no_timeout.loop: PASS (89.83 s)
 (4/8) type_specific.io-github-autotest-libvirt.virsh.event.positive_test.virsh_event.test_events.lifecycle_events.save_restore.no_timeout.loop:PASS (139.15 s)
 (5/8) type_specific.io-github-autotest-libvirt.virsh.event.positive_test.virsh_event.test_events.lifecycle_events.undefine_define.no_timeout.loop: PASS (15.73 s)
 (6/8) type_specific.io-github-autotest-libvirt.virsh.event.positive_test.virsh_event.test_events.lifecycle_events.start_stop.no_timeout.loop: PASS (86.30 s)
 (7/8) type_specific.io-github-autotest-libvirt.virsh.event.positive_test.virsh_event.test_events.lifecycle_events.shutdown_from_host.no_timeout.loop: PASS (61.74 s)
 (8/8) type_specific.io-github-autotest-libvirt.virsh.event.positive_test.virsh_event.test_events.lifecycle_events.crash_panic.no_timeout.loop: PASS (197.94 s)
RESULTS    : PASS 8 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 725.58 s
```