### PR TITLE
Pass vm_arch_name to ensure zipl is called on s390x guest

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_sendkey.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_sendkey.py
@@ -66,7 +66,7 @@ def run(test, params, env):
     # Boot the guest in text only mode so that send-key commands would succeed
     # in creating a file
     try:
-        utils_test.update_boot_option(vm, args_added="3")
+        utils_test.update_boot_option(vm, args_added="3", guest_arch_name=params.get('vm_arch_name'))
     except Exception as info:
         test.error(info)
 


### PR DESCRIPTION
This fix requires https://github.com/avocado-framework/avocado-vt/pull/2312

On s390x running zipl command is required after updating boot loader entries
(with grubby), see https://bugzilla.redhat.com/show_bug.cgi?id=1764306#c2
In other words, running grubby and then rebooting without zipl won't change
cmdline.