### PR TITLE
Handle controller address on s390x

### DIFF
--- a/libvirt/tests/cfg/controller/controller_functional.cfg
+++ b/libvirt/tests/cfg/controller/controller_functional.cfg
@@ -44,6 +44,10 @@
                     controller_index = 1
                     controller_address = 00:02.0
                     second_level_controller_num = 8
+                - virtio_serial_ccw:
+                      only s390-virtio
+                      controller_type = virtio-serial
+                      controller_bus = ccw
                 - virtio_serial:
                     no q35
                     controller_type = virtio-serial


### PR DESCRIPTION
On s390x default controller address type is ccw.

1. get_controller_addr:
 a. Use same pattern for addr_string to join values for ccw
 b. New parameter to determine which bus type to test for

2. check_controller_addr:
 a. New parameter to determine which bus type to test for
 b. Confirm virtio-ccw devices must
    have their cssid set to 0xfe.

3. check_guest:
 a. Extract method to improve readability
 b. Add method to cover bus type ccw on s390x

4. check_ccw_bus_type:
 a. Check that device is present in guest by its number using
    s390x specific lszdev command

Test run on s390x:
```bash
# avocado run --vt-type libvirt --vt-machine-type s390-virtio --vt-connect-uri qemu:///system controller.functional.positive_tests.virtio_serial_ccw
JOB ID     : 7262f676746f5e05deb8d90df25238ace435396e
JOB LOG    : /root/avocado/job-results/job-2019-12-04T06.58-7262f67/job.log
 (1/1) type_specific.io-github-autotest-libvirt.controller.functional.positive_tests.virtio_serial_ccw: PASS (54.91 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 56.55 s
```