### PR TITLE
Fix qemu_conf test on s390x

### DIFF
--- a/libvirt/tests/cfg/conf_file/qemu_conf/auto_dump.cfg
+++ b/libvirt/tests/cfg/conf_file/qemu_conf/auto_dump.cfg
@@ -10,6 +10,7 @@
             auto_dump_bypass_cache = 0
     variants:
         - isa_model:
+            no s390-virtio
             variants:
                 - model_only:
                     panic_model = 'isa'
@@ -23,3 +24,6 @@
         - pseries_model:
             only pseries
             panic_model = 'pseries'
+        - s390_model:
+            only s390-virtio
+            panic_model = 's390'

--- a/libvirt/tests/src/conf_file/qemu_conf/auto_dump.py
+++ b/libvirt/tests/src/conf_file/qemu_conf/auto_dump.py
@@ -124,25 +124,16 @@ def run(test, params, env):
 
         arch = platform.machine()
 
-        if arch == 'x86_64':
+        if arch in ['x86_64', 'ppc64le', 's390x']:
             # Check if bypass cache flag set or unset accordingly.
-            if (flags & 0o40000) and bypass_cache != '1':
-                test.fail('auto_dump_bypass_cache is %s but flags '
-                          'is %o' % (bypass_cache, flags))
-            if not (flags & 0o40000) and bypass_cache == '1':
-                test.fail('auto_dump_bypass_cache is %s but flags '
-                          'is %o' % (bypass_cache, flags))
-        elif arch == 'ppc64le':
-            # Check if bypass cache flag set or unset accordingly.
-            if (flags & 0o400000) and bypass_cache != '1':
-                test.fail('auto_dump_bypass_cache is %s but flags '
-                          'is %o' % (bypass_cache, flags))
-            if not (flags & 0o400000) and bypass_cache == '1':
+            cond1 = (flags & 0o40000) and bypass_cache != '1'
+            cond2 = not (flags & 0o40000) and bypass_cache == '1'
+            if cond1 or cond2:
                 test.fail('auto_dump_bypass_cache is %s but flags '
                           'is %o' % (bypass_cache, flags))
         else:
             test.cancel("Unknown Arch. Do the necessary changes to"
-                        "support")
+                        " support")
 
     finally:
         backup_xml.sync()


### PR DESCRIPTION
1. cfg:
 a. Define s390x specific model test and exclude from all others
    because this is the only valid panic model

2. py/run:
 a. Remove duplicated code
 b. Add s390x for same conditions

Run tests on s390x:
```bash
# avocado run --vt-type libvirt --vt-machine-type s390-virtio --vt-connect-uri qemu:///system conf_file.qemu_conf..s390_model
JOB ID     : 7ac39fe99119874e70e1449f2c8bf57415f934b1
JOB LOG    : /root/avocado/job-results/job-2019-12-04T11.01-7ac39fe/job.log
 (1/3) type_specific.io-github-autotest-libvirt.conf_file.qemu_conf.auto_dump.s390_model.default_bypass_cache: PASS (68.29 s)
 (2/3) type_specific.io-github-autotest-libvirt.conf_file.qemu_conf.auto_dump.s390_model.enable_bypass_cache: PASS (72.32 s)
 (3/3) type_specific.io-github-autotest-libvirt.conf_file.qemu_conf.auto_dump.s390_model.disable_bypass_cache: PASS (63.14 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 205.33 s
```