### PR TITLE
Fix gating failure in OSP

### DIFF
--- a/provider/v2v_vmcheck_helper.py
+++ b/provider/v2v_vmcheck_helper.py
@@ -115,9 +115,12 @@ class VMChecker(object):
         """
         Compare version against given version.
 
-        :param compare_version: The least version to compare
+        :param compare_version: The minumum version to be compared
         :param real_version: The real version to compare
         :param cmd: the command to get the real version
+
+        :return: If the real_version is greater equal than minumum version,
+                return True, others return False
         """
         if not real_version:
             if not cmd:

--- a/v2v/tests/cfg/convert_from_file.cfg
+++ b/v2v/tests/cfg/convert_from_file.cfg
@@ -157,6 +157,14 @@
                             vmx_nfs_src = NFS_ESX67_VMX_V2V_EXAMPLE
                             # Do not skip vm checking by default
                             skip_vm_check = no
+                            # By default, v2v will try to connect to source hypervisor
+                            # to get vm information, like disk path in esx, etc.
+                            # But in some testing envrionment, it don't have source
+                            # hypervisor, such as gating envrionment, we need to skip
+                            # the step of connecting to the hypervisor.
+                            #
+                            # The default is 'no'.
+                            skip_virsh_pre_conn = no
                             variants:
                                 - win2012r2:
                                     only esx_55

--- a/v2v/tests/src/convert_from_file.py
+++ b/v2v/tests/src/convert_from_file.py
@@ -41,6 +41,7 @@ def run(test, params, env):
     v2v_timeout = int(params.get('v2v_timeout', 1200))
     status_error = 'yes' == params.get('status_error', 'no')
     skip_vm_check = params.get('skip_vm_check', 'no')
+    skip_virsh_pre_conn = params.get('skip_virsh_pre_conn', 'no')
     pool_name = params.get('pool_name', 'v2v_test')
     pool_type = params.get('pool_type', 'dir')
     pool_target = params.get('pool_target_path', 'v2v_pool')
@@ -172,7 +173,8 @@ def run(test, params, env):
                  'hypervisor': hypervisor,
                  'vpx_dc': vpx_dc,
                  'password': vpx_password if src_uri_type != 'esx' else esxi_password,
-                 'hostname': vpx_hostname})
+                 'hostname': vpx_hostname,
+                 'skip_virsh_pre_conn': skip_virsh_pre_conn})
         # copy ova from nfs storage before v2v conversion
         if input_mode == 'ova':
             src_dir = params.get('ova_dir')


### PR DESCRIPTION
By default, v2v will try to connect to source hypervisor
to get vm information, like disk path in esx, etc.
But in some testing envrionment, it don't have source
hypervisor, such as gating envrionment, we need to skip
the step of connecting to the hypervisor.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>