### PR TITLE
migration: Add virtio transitional model tests for rng/mem

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_with_legacy_guest.cfg
+++ b/libvirt/tests/cfg/migration/migrate_with_legacy_guest.cfg
@@ -24,7 +24,6 @@
     virsh_migrate_src_state = running
     virsh_migrate_libvirtd_state = 'on'
     virsh_migrate_options = "--live --verbose"
-    guest_xml_check_after_mig = "yes"
     # Local URI
     virsh_migrate_connect_uri = "qemu:///system"
 
@@ -82,3 +81,30 @@
                     only disk_qcow2
                     disk_model = ${virtio_model}
                     guest_xml_check_after_mig = "disk type='file' device='disk' model="
+        - test_memballoon:
+            only q35
+            no unspecified_model
+            check_memballoon = "yes"
+            membal_model = ${virtio_model}
+            guest_xml_check_after_mig = "<memballoon model="
+            variants:
+                - rhel6_guest:
+                    only virtio_transitional
+                    guest_src_url = ${rhel6_url}
+                    iface_model = "virtio-transitional"
+                - @default:
+                    no virtio_transitional
+        - test_rng:
+            only q35
+            no unspecified_model
+            check_rng = "yes"
+            rng_model = ${virtio_model}
+            guest_xml_check_after_mig = "<rng model="
+            variants:
+                - rhel6_guest:
+                    only virtio_transitional
+                    guest_src_url = ${rhel6_url}
+                    iface_model = "virtio-transitional"
+                - @default:
+                    no virtio_transitional
+


### PR DESCRIPTION
This PR adds migration tests for rng/mem balloom virtio
transitional model.

depends on https://github.com/avocado-framework/avocado-vt/pull/2310

Signed-off-by: Yingshun Cui <yicui@redhat.com>