### PR TITLE
Fix cpu vendor_id case skipping issue

### DIFF
--- a/libvirt/tests/cfg/cpu/vcpu_misc.cfg
+++ b/libvirt/tests/cfg/cpu/vcpu_misc.cfg
@@ -11,11 +11,6 @@
                     expected_str_before_startup = ${cpu_mode}
                     expected_str_after_startup = 'mode="custom"'
                 - vendor_id:
+                    no pseries, s390x
                     cpu_mode = "host-model"
-                    variants:
-                        - AuthenticAMD:
-                            vendor_id = 'AuthenticAMD'
-                        - GenuineIntel:
-                            vendor_id = 'GenuineIntel'
-                    expected_qemuline = "vendor=${vendor_id}"
-                    cmd_in_guest = "cat /proc/cpuinfo | grep vendor_id | grep ${vendor_id}"
+                    check_vendor_id = "yes"


### PR DESCRIPTION
One case in vendor_id must be skipped due to compatibility problem
in previous code. Fix it to set vendor_id according to host info.

Signed-off-by: Yingshun Cui <yicui@redhat.com>