### PR TITLE
CPU cache specification is not supported for 'ppc64le' architecture

### DIFF
--- a/libvirt/tests/cfg/cpu/vcpu_cache.cfg
+++ b/libvirt/tests/cfg/cpu/vcpu_cache.cfg
@@ -4,6 +4,7 @@
     cmd_in_vm = "lscpu |grep cache"
     cmd_output_regex = "L3 cache:\s+\d+K"
     status_error = "no"
+    no pseries
     variants:
         - no_cpu_mode:
         - host_model:


### PR DESCRIPTION
Signed-off-by: haizhao <haizhao@redhat.com>