### PR TITLE
enable specified gluster server in config file

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_gluster.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_gluster.cfg
@@ -6,6 +6,9 @@
     virt_disk_device = "disk"
     vol_name = "vol_virtual_disks_gluster"
     pool_name = "gluster-pool"
+    gluster_server_name = "EXAMPLE_GLUSTER_SERVER"
+    gluster_server_user = "root"
+    gluster_server_pwd = "redhat"
     variants:
         - test_dompmsuspend:
             only disk_qcow2

--- a/libvirt/tests/src/virtual_disks/virtual_disks_gluster.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_gluster.py
@@ -27,6 +27,10 @@ def run(test, params, env):
     vm_name = params.get("main_vm")
     vm = env.get_vm(vm_name)
     virsh_dargs = {'debug': True, 'ignore_status': True}
+    gluster_server_name = params.get("gluster_server_name")
+    # If gluster_server is specified from config file, just use this gluster server.
+    if 'EXAMPLE' not in gluster_server_name:
+        params.update({'gluster_server_ip': gluster_server_name})
 
     def prepare_gluster_disk(disk_img, disk_format):
         """


### PR DESCRIPTION
if third party gluster server is provisioned, this can be specified
in cfg file.

Signed-off-by: chunfuwen <chwen@redhat.com>