### PR TITLE
Check cmdline for subexpression

### DIFF
--- a/libvirt/tests/cfg/vm_boot_with_kernel_param.cfg
+++ b/libvirt/tests/cfg/vm_boot_with_kernel_param.cfg
@@ -24,3 +24,6 @@
                     kernel_param = ""
                     kernel_param_remove = "disable_radix"
                     boot_log = "Using radix MMU under hypervisor"
+        - check_kernel_cmdline:
+            check_cmdline_only = yes
+            expect_in_cmdline = 'BOOT_IMAGE'


### PR DESCRIPTION
On s390x BOOT_IMAGE is not populated by qemu bootloader,
s. https://bugzilla.redhat.com/show_bug.cgi?id=1782026

1. cfg: Add test case. Expect to hold for all archs.
2. py: Add switch to check guest cmdline.

Test run on x86_64:
```bash
# avocado run --vt-type libvirt --vt-connect-uri qemu:///system vm_boot_with_kernel_param..check_kernel_cmdline
JOB ID     : 33e99a1f69c1977d77f5a8f7ac540a803fe7a754
JOB LOG    : /root/avocado/job-results/job-2019-12-12T16.39-33e99a1/job.log
 (1/1) type_specific.io-github-autotest-libvirt.vm_boot_with_kernel_param.check_kernel_cmdline: PASS (15.50 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 16.88 s
```

Test run on s390x (fails as expected due to bz):
```bash
# avocado run --vt-type libvirt --vt-machine-type s390-virtio --vt-connect-uri qemu:///system vm_boot_with_kernel_param..check_kernel_cmdline
JOB ID     : 67594feb217b73a73a5c97d81bcfc69a5ed75e77
JOB LOG    : /root/avocado/job-results/job-2019-12-12T10.49-67594fe/job.log
 (1/1) type_specific.io-github-autotest-libvirt.vm_boot_with_kernel_param.check_kernel_cmdline: ERROR: Couldn't find 'BOOT_IMAGE' in cmdline 'root=/dev/mapper/rhel-root console=tty0 console=ttyS0,115200 reboot=pci biosdevname=0 crashkernel=auto rd.lvm.lv=rhel/root rd.lvm.lv=rhel/swap\n' (253.99 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 276.29 s
```