### PR TITLE
Fix a looking for snapshot's path issue

### DIFF
--- a/libvirt/tests/src/backingchain/blockcommand.py
+++ b/libvirt/tests/src/backingchain/blockcommand.py
@@ -226,7 +226,7 @@ def run(test, params, env):
             # Get path of each snapshot file
             snaps = virsh.domblklist(vm_name, debug=True).stdout.splitlines()
             for line in snaps:
-                if line.startswith(('hd', 'sd', 'vd')):
+                if line.lstrip().startswith(('hd', 'sd', 'vd')):
                     file_to_del.append(line.split()[-1])
 
         qemu_img_cmd = 'qemu-img info --backing-chain %s' % snapshot_image_list[-1]


### PR DESCRIPTION
Some libvirt versions have extra space when listing snapshots. And the original
code not dealing with that, causing the snapshot path list being empty for all
the time, and leave snapshots file not deleted. Rest cases will be blocked with
reporting error "external snapshot file for disk vda already exists".

Signed-off-by: Yi Sun <yisun@redhat.com>