### PR TITLE
Fix virtual_network for s390x

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_network.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_network.cfg
@@ -188,10 +188,13 @@
                         - virtio:
                             iface_model = "virtio"
                         - e1000:
+                            no s390-virtio
                             iface_model = "e1000"
                         - rtl8139:
+                            no s390-virtio
                             iface_model = "rtl8139"
                         - e1000e:
+                            no s390-virtio
                             iface_model = "e1000e"
         - net_guest:
             test_guest_libvirt = "yes"


### PR DESCRIPTION
1. iface_network.cfg:
 a. Exclude test cases where not supported by machine-type s390-virtio

2. iface_network.py:
 a. Delegate value retrieval for iface_model to new function using
    default value "virtio" for machine-type s390-virtio. Log this side
    effect in case future test cases use e.g. virtio-transitional.


Test run
```bash
# avocado run --vt-type libvirt --vt-machine-type s390-virtio --vt-connect-uri qemu:///system virtual_network --vt-only-filter virtual_network.iface_network.net_portgroup.default_portgroup,virtual_network.iface_network.net_portgroup.specific_portgroup,virtual_network.iface_network.net_portgroup.overwriting_bandwidth
JOB ID     : a2a554eaa0f94ea9d713f29f7bcc367c858febb5
JOB LOG    : /root/avocado/job-results/job-2019-12-17T11.45-a2a554e/job.log
 (1/3) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.net_portgroup.default_portgroup: PASS (92.25 s)
 (2/3) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.net_portgroup.specific_portgroup: PASS (68.61 s)
 (3/3) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.net_portgroup.overwriting_bandwidth: PASS (64.41 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 228.10 s
```