### PR TITLE
Restrict gluster management

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_disk.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_disk.cfg
@@ -5,6 +5,7 @@
     # and cause error messages
     take_regular_screendumps = "no"
     snapshot_options = ""
+    gluster_is_remote = "no"
     variants:
         - snapshot_from_xml:
             snapshot_from_xml = "yes"


### PR DESCRIPTION
Currently, per default the script manages a local gluster server instance and
if gluster_server_ip is given it manages a remote gluster server instance.

This change introduces new variables to restrict test to only use but not
manage the gluster server instance. Management of gluster server instance
i. requires ssh (root) access to remote server which is a security risk if
   credentials are shared in test code
ii. slows test down
Instead, a permanent gluster server (locally or remote) can be set up and only
used by the test as storage in the pool.

Default behavior is maintained as before, existing tests are not affected.

1. cfg:
 a. new variable: `gluster_is_remote` must be set to `"yes"` to use external gluster server
 b. additional configuration for gluster usage and management are defined in
    avocado_vt/shared/cfg/base.cfg, s. https://github.com/avocado-framework/avocado-vt/pull/2375
2. py:
 a. encapsulate dictionary creation for pre_pool call for improved readibility
 b. get_pre_pool_kwargs: use gluster_server_ip only if test explicitly sets new variable
    `gluster_is_remote` to avoid placeholder to trigger remote gluster management down the
    call stack.