### PR TITLE
Add parameter explicitly to test config

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/pool/virsh_pool_autostart.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/pool/virsh_pool_autostart.cfg
@@ -62,6 +62,7 @@
                             source_format = "nfs"
                         - source_format_glusterfs:
                             source_format = "glusterfs"
+                            pool_source_name = "gluster-vol1"
                 - pool_type_iscsi:
                     pool_type = "iscsi"
                     pool_target = "/dev/disk/by-path"


### PR DESCRIPTION
I need to use a fixed 'pool_source_name' for usage with a static gluster server.
Add parameter explicitly to test configuration (with default value) in order to easily replace
'pool_source_name' to existing name.

Executed tests:
```bash
# avocado run --vt-type libvirt --vt-machine-type s390-virtio --vt-connect-uri qemu:///system virsh.pool_autostart --vt-only-filter virsh..source_format_glusterfs,virsh..pool_type_gluster
JOB ID     : 0ecb6a12b63fb08f8fe6e9f0a11600217f739293
JOB LOG    : /root/avocado/job-results/job-2019-12-18T12.39-0ecb6a1/job.log
 (1/4) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_netfs.source_format_glusterfs: PASS (6.69 s)
 (2/4) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_gluster: PASS (7.88 s)
 (3/4) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.uuid_option.pool_type_netfs.source_format_glusterfs: PASS (6.95 s)
 (4/4) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.uuid_option.pool_type_gluster: PASS (8.04 s)
RESULTS    : PASS 4 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 31.10 s
```