### PR TITLE
Add paramter explicitly to test config

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/pool/virsh_pool.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/pool/virsh_pool.cfg
@@ -69,6 +69,7 @@
                                     source_protocol_ver = "no"
                         - source_format_glusterfs:
                             source_format = "glusterfs"
+                            pool_source_name = "gluster-vol1"
                 - pool_type_iscsi:
                     pool_type = "iscsi"
                     pool_target = "/dev/disk/by-path"


### PR DESCRIPTION
I need to use fixed 'pool_source-name' for usage with a static gluster server.
Add parameter explicitly (with default value) to test configuration in order
to easily replace 'pool_source_name' to existing name.

Executed test:
```bash
JOB ID     : 3fdd87d5e4f523e3b1e35e15151cd316b2f5b215
JOB LOG    : /root/avocado/job-results/job-2019-12-18T15.55-3fdd87d/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.pool.positive_test.pool_type_netfs.source_format_glusterfs: PASS (9.51 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 11.11 s
```