### PR TITLE
Use v2v_setup_ssh_key in utils_v2v instead of customized function

### DIFF
--- a/v2v/tests/cfg/convert_from_file.cfg
+++ b/v2v/tests/cfg/convert_from_file.cfg
@@ -223,5 +223,5 @@
                     network_query = 'ipconfig /all'
                     restart_network = 'ipconfig /renew'
                     vm_user = 'Administrator'
-                    vm_pwd = '123qweP'
+                    vm_pwd = DEFAULT_WIN_VM_PASSWORD
                     only win2008r2_ostk,aws.win2019,win2019,win10,win2012r2

--- a/v2v/tests/cfg/convert_vm_to_libvirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_libvirt.cfg
@@ -88,7 +88,7 @@
             network_query = "ipconfig /all"
             restart_network = "ipconfig /renew"
             vm_user = "Administrator"
-            vm_pwd = "123qweP"
+            vm_pwd = DEFAULT_WIN_VM_PASSWORD
             variants:
                 - win2008:
                     os_version = "win2008"

--- a/v2v/tests/cfg/convert_vm_to_ovirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_ovirt.cfg
@@ -125,7 +125,7 @@
             network_query = "ipconfig /all"
             restart_network = "ipconfig /renew"
             vm_user = "Administrator"
-            vm_pwd = "123qweP"
+            vm_pwd = DEFAULT_WIN_VM_PASSWORD
             variants:
                 - win2008:
                     os_version = "win2008"

--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -78,7 +78,7 @@
             network_query = 'ipconfig /all'
             restart_network = 'ipconfig /renew'
             vm_user = 'Administrator'
-            vm_pwd = '123qweP'
+            vm_pwd = DEFAULT_WIN_VM_PASSWORD
             variants:
                 - program_files_2:
                     only esx_67

--- a/v2v/tests/cfg/function_test_xen.cfg
+++ b/v2v/tests/cfg/function_test_xen.cfg
@@ -144,7 +144,7 @@
             network_query = 'ipconfig /all'
             restart_network = 'ipconfig /renew'
             vm_user = 'Administrator'
-            vm_pwd = '123qweP'
+            vm_pwd = DEFAULT_WIN_VM_PASSWORD
             variants:
                 - default_install:
                     windows_root = 'WINDOWS_ROOT_V2V_EXAMPLE'

--- a/v2v/tests/cfg/specific_kvm.cfg
+++ b/v2v/tests/cfg/specific_kvm.cfg
@@ -287,7 +287,7 @@
                     network_query = 'ipconfig /all'
                     restart_network = 'ipconfig /renew'
                     vm_user = 'Administrator'
-                    vm_pwd = '123qweP'
+                    vm_pwd = DEFAULT_WIN_VM_PASSWORD
                     only output_mode.rhev
                     variants:
                         - multi_disks:

--- a/v2v/tests/cfg/v2v_options.cfg
+++ b/v2v/tests/cfg/v2v_options.cfg
@@ -13,7 +13,7 @@
     os_type = "linux"
     username = 'root'
     password = 'redhat'
-    v2v_timeout = "3600"
+    v2v_timeout = 10800
     # Full types input disks
     variants:
         - output_mode:
@@ -100,7 +100,6 @@
                         - esx:
                             only source_esx
                             hypervisor = "esx"
-                            v2v_timeout = 5400
                             remote_host = ${vpx_hostname}
                             vpx_dc = ${vpx_dc}
                             esx_ip = ${esx_hostname}
@@ -246,7 +245,7 @@
                     only output_mode.libvirt
                     esx_ip = ESX_65_HOSTNAME_V2V_EXAMPLE
                     esx_host_user = "root"
-                    esx_host_passwd = "123qweP"
+                    esx_host_passwd = RHV_NODE_PASSWORD
                     checkpoint = vmx_ssh
                     main_vm = VM_NAME_VMX_SSH_V2V_EXAMPLE
                     output_format = qcow2


### PR DESCRIPTION
1) Remove customized ssh_key setup function and use v2v_setup_ssh_key
in utils_v2v instead.
2) Remove all plain passwords in cfg files.
3) Some code formats changes by autopep8

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>