### PR TITLE
cpu: Add setvcpus cases

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_setvcpus.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_setvcpus.cfg
@@ -19,6 +19,22 @@
                             # less than setvcpus_max
                             setvcpus_count = "2"
                         -del:
+                        - @default:
+                            only name_option
+                            variants:
+                                - option_maxmum_config:
+                                    update_maxmum_config = "yes"
+                                    setvcpus_options = "--config"
+                                    setvcpus_count = "max_vcpu + 8"
+                                - restart_vm:
+                                    restart_vm = "yes"
+                                    variants:
+                                        - update_cur:
+                                            setvcpus_options = "--config"
+                                            setvcpus_count = "2"
+                                        - update_max:
+                                            setvcpus_options = "--maximum --config"
+                                            setvcpus_count = "1"
                     variants:
                         - id_option:
                             setvcpus_vm_ref = "id"
@@ -92,9 +108,19 @@
                             # With topology setvcpus api itself fails out
                             # https://bugzilla.redhat.com/show_bug.cgi?id=1426220
                             with_topology = "yes"
-                            setvcpus_pre_vm_state = "running"
                             setvcpus_count = "8"
                             setvcpus_max = "4"
                             setvcpus_options = "--maximum --config"
+                - maximum_option_with_topology:
+                    with_topology = "yes"
+                    setvcpus_count = "8"
+                    setvcpus_max = "4"
+                    setvcpus_options = "--maximum --config"
                 - maximum_option:
                     setvcpus_options = "--maximum --live"
+                - no_acpi:
+                    no_acpi = "yes"
+                    setvcpus_count = ${setvcpus_current}
+                    hot_unplug = "yes"
+                    hotplugin_count = "3"
+                    vm_reboot = "yes"


### PR DESCRIPTION
This PR adds setvcpus related cases.They are as follows:
1. Update "maximum/current" vcpus numbers by setvcpus
2. Hot-plug/unplug vCPU without <acpi> feature
3. Restart VM after changing inactive maxvcpu/current vcpus conf
4. Check maximum vcpus number with topology settings when guest is
shutdown/running
Signed-off-by: Yingshun Cui <yicui@redhat.com>