### PR TITLE
Fix snapshot_create_as device_lun on s390-ccw-virtio

### DIFF
--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_create_as.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_create_as.py
@@ -324,6 +324,8 @@ def run(test, params, env):
 
     vm_name = params.get("main_vm")
     status_error = params.get("status_error", "no")
+    machine_type = params.get("machine_type", "")
+    disk_device = params.get("disk_device", "")
     options = params.get("snap_createas_opts")
     multi_num = params.get("multi_num", "1")
     diskspec_num = params.get("diskspec_num", "1")
@@ -356,6 +358,11 @@ def run(test, params, env):
     if usr:
         if usr.count('EXAMPLE'):
             usr = 'testacl'
+
+    if disk_device == 'lun' and machine_type == 's390-ccw-virtio':
+        params['disk_target_bus'] = 'scsi'
+        logging.debug("Setting target bus scsi because machine type has virtio 1.0."
+                      " See https://bugzilla.redhat.com/show_bug.cgi?id=1365823")
 
     if disk_src_protocol == 'iscsi':
         if not libvirt_version.version_compare(1, 0, 4):


### PR DESCRIPTION
1. s390-ccw-virtio uses virtio 1.0 per default in QEMU. This means
   if disk device is 'lun' the target bus must be 'scsi' instead of
   'virtio', see https://bugzilla.redhat.com/show_bug.cgi?id=1365823


test run on s390x:
```bash
# avocado run --vt-type libvirt --vt-machine-type s390-virtio --vt-connect-uri qemu:///system virsh.snapshot_create_as.negative_tests.network_disk.iscsi.device_lun
JOB ID     : ffdf2e262e43e96b5c5c1cbd21354182afddfc69
JOB LOG    : /root/avocado/job-results/job-2019-12-23T05.54-ffdf2e2/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.snapshot_create_as.negative_tests.network_disk.iscsi.device_lun: PASS (173.22 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 174.82 s
```