### PR TITLE
Fix some checking issues in public checkpoint

### DIFF
--- a/v2v/tests/cfg/convert_from_file.cfg
+++ b/v2v/tests/cfg/convert_from_file.cfg
@@ -10,7 +10,7 @@
     input_mode = 'libvirt'
     hypervisor = 'kvm'
     username = 'root'
-    password = 'redhat'
+    password = GENERAL_GUEST_PASSWORD
     vms = ''
 
     # Shell paramters

--- a/v2v/tests/cfg/convert_vm_to_libvirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_libvirt.cfg
@@ -8,7 +8,7 @@
     only dest_libvirt
 
     username = "root"
-    password = "redhat"
+    password = GENERAL_GUEST_PASSWORD
 
     # Prepare libvirt network as convert output network
     network = "v2v_net_0"

--- a/v2v/tests/cfg/convert_vm_to_ovirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_ovirt.cfg
@@ -6,7 +6,7 @@
     vms = ""
     start_vm = "no"
     username = "root"
-    password = "redhat"
+    password = GENERAL_GUEST_PASSWORD
     remote_preprocess = yes
     remote_node_user = "root"
     remote_node_password = "RHV_NODE_PASSWORD"
@@ -78,7 +78,7 @@
         - linux:
             os_type = "linux"
             vm_user = ${username}
-            vm_pwd = "redhat"
+            vm_pwd = GENERAL_GUEST_PASSWORD
             variants:
                 - latest8:
                     os_version = "LATEST8"

--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -11,7 +11,7 @@
     main_vm = VM_NAME_ESX_DEFAULT_V2V_EXAMPLE
     os_type = 'linux'
     username = 'root'
-    password = 'redhat'
+    password = GENERAL_GUEST_PASSWORD
 
     # Standard shell parameters
     remote_shell_client = 'ssh'

--- a/v2v/tests/cfg/function_test_xen.cfg
+++ b/v2v/tests/cfg/function_test_xen.cfg
@@ -15,7 +15,7 @@
     os_type = 'linux'
     main_vm = 'XEN_VM_NAME_V2V_EXAMPLE'
     username = 'root'
-    password = 'redhat'
+    password = GENERAL_GUEST_PASSWORD
     os_version = 'XEN_VM_OS_VERSION_V2V_EXAMPLE'
 
     # Standard shell parameters
@@ -72,7 +72,7 @@
                             checkpoint = 'vnc_autoport'
                         - encrypt:
                             checkpoint = 'vnc_encrypt'
-                            vnc_passwd = 'redhat'
+                            vnc_passwd = GENERAL_GUEST_PASSWORD
                         - encrypt_warning:
                             checkpoint = 'vnc_encrypt_warning'
                             msg_content = 'virt-v2v: warning: This guest required a password for connection to its display, but this is not supported by RHV.  Therefore the converted guest.s display will not require a separate password to connect.'
@@ -111,7 +111,7 @@
             sasl_server_user = root
             sasl_server_passwd = SERVER_PASSWORD_V2V_EXAMPLE
             sasl_user = test
-            sasl_pwd = redhat
+            sasl_pwd = GENERAL_GUEST_PASSWORD
             only libvirt
         - encryped:
             main_vm = VM_NAME_XEN_ENCRYPED_V2V_EXAMPLE
@@ -120,12 +120,6 @@
             checkpoint = multidisk
         - rhel6_2:
             main_vm = VM_NAME_XEN_RHEL62_V2V_EXAMPLE
-        - suse:
-            variants:
-                - sles11sp4:
-                    main_vm = VM_NAME_XEN_SLES11SP4_V2V_EXAMPLE
-                - sles12sp1:
-                    main_vm = VM_NAME_XEN_SLES12SP1_V2V_EXAMPLE
         - windows:
             os_type = 'windows'
             shutdown_command = 'shutdown /s /f /t 0'

--- a/v2v/tests/cfg/specific_kvm.cfg
+++ b/v2v/tests/cfg/specific_kvm.cfg
@@ -10,7 +10,7 @@
     v2v_timeout = '3600'
     os_type = 'linux'
     username = 'root'
-    password = 'redhat'
+    password = GENERAL_GUEST_PASSWORD
 
     # Shell paramters
     remote_shell_client = 'ssh'
@@ -82,7 +82,7 @@
                     os_type = 'linux'
                     checkpoint = 'multi_disks'
                     vm_user = 'root'
-                    vm_pwd = 'redhat'
+                    vm_pwd = GENERAL_GUEST_PASSWORD
                     main_vm = "VM_MULTI_DISKS_V2V_EXAMPLE"
                 - windows:
                     os_type = 'windows'
@@ -182,7 +182,7 @@
                     checkpoint = 'spice'
                 - spice_encrypt:
                     checkpoint = 'spice_encrypt'
-                    spice_passwd = 'redhat'
+                    spice_passwd = GENERAL_GUEST_PASSWORD
                 - mix:
                     only libvirt
                     skip_vm_check = yes

--- a/v2v/tests/cfg/v2v_options.cfg
+++ b/v2v/tests/cfg/v2v_options.cfg
@@ -12,7 +12,7 @@
     output_bridge = "virbr0"
     os_type = "linux"
     username = 'root'
-    password = 'redhat'
+    password = GENERAL_GUEST_PASSWORD
     v2v_timeout = 10800
     # Full types input disks
     variants:


### PR DESCRIPTION
1) Changed the way of checking video module
2) Fixed checking RNG device fail problem on old RHEL guests
3) Hidden guest password from cfg files.
4) Delete sles from xen cases, sles11 has very low priority,
   sles12 has been covered in matrix testing

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>