### PR TITLE
Fix travis-ci failures in python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
 sudo: false
 
 install:
-    - pip install sphinx${SPHINX_VERSION:+==$SPHINX_VERSION}
+    - pip install Sphinx==1.3b1
     - pip install -r requirements-travis.txt
 
 script:

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,3 +1,4 @@
+Sphinx==1.3b1
 coverage==3.6
 nose==1.3.0
 nosexcover==1.0.8


### PR DESCRIPTION
Fix it by fixing sphinx version to 1.8.5

Signed-off-by: chunfuwen <chwen@redhat.com>