### PR TITLE
Fix the schedinfo_valid_domid cases by getting right domid

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_schedinfo_qemu_posix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_schedinfo_qemu_posix.py
@@ -191,6 +191,7 @@ def run(test, params, env):
 
             vm.destroy()
             vm.start()
+            vm_ref = vm.get_id()
 
         if set_ref:
             start_current_value = get_current_value()


### PR DESCRIPTION
when restarting VM after setting schedinfo with --config

- rhel.virsh.schedinfo_qemu_posix.normal_test.set_cpu_param.set_cpu_shares
  - value_negative.set_by_cmd.config.valid_domid.running_guest
  - value_zero.set_by_cmd.config.valid_domid.running_guest
  - value_normal.set_by_cmd.config.valid_domid.running_guest
  - value_maximum.set_by_cmd.config.valid_domid.running_guest
  - value_exceed.set_by_cmd.config.valid_domid.running_guest

Signed-off-by: Jing Yan <jiyan@redhat.com>