### PR TITLE
Fix err caused by no "lsusb" cmd for hostdev cases

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
@@ -43,6 +43,7 @@ def run(test, params, env):
 
         :return: usb verndor and product id
         """
+        install_cmd = process.run("yum install usbutils* -y", shell=True)
         result = process.run("lsusb|awk '{print $6\":\"$2\":\"$4}'", shell=True)
         if not result.exit_status:
             return result.stdout_text.rstrip(':')


### PR DESCRIPTION
The following cases will be influenced:

- rhel.virsh.detach_device_alias.live.hostdev
- rhel.virsh.detach_device_alias.config.hostdev
- rhel.virsh.detach_device_alias.current.hostdev

Signed-off-by: Jing Yan <jiyan@redhat.com>