### PR TITLE
Fix err caused by no wait time for "virsh detach-alias" cmd

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
@@ -1,4 +1,5 @@
 import uuid
+import time
 import logging
 
 from virttest import virsh
@@ -97,6 +98,7 @@ def run(test, params, env):
 
         # Detach xml with alias
         result = virsh.detach_device_alias(vm_name, device_alias, detach_options, debug=True)
+        time.sleep(10)
         libvirt.check_exit_status(result)
         domxml_dt = virsh.dumpxml(vm_name, dump_option, debug=True).stdout.strip()
         if detach_check_xml in domxml_dt:


### PR DESCRIPTION
The cmd "detach-device-alias" will return "Device detach request sent successfully" immediately,
which may cause that the related device info will not take effect in the dumpxml/guest os that fast.
So add some wait time for this cmd.

The following two cases will be influenced:
- virsh.detach_device_alias.current.controller
- virsh.detach_device_alias.live.controller

Signed-off-by: Jing Yan <jiyan@redhat.com>