### PR TITLE
Fix err caused by "virsh setvcpu" with two threads running on X86_84

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_setvcpu.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_setvcpu.cfg
@@ -48,6 +48,7 @@
                             setvcpu_vm_ref = "uuid"
                     variants:
                         - with_2_threads:
+                            only ppc64le
                             setvcpu_current = '2'
                             topology_cores= '16'
                             topology_threads = '2'


### PR DESCRIPTION
Cases with 2_threads will be running only on PPC64.
The following cases will be influenced:
 rhel.virsh.setvcpu.normal_test.guest_on.with_comma.with_2_threads.id_option.option_enable_live
 rhel.virsh.setvcpu.normal_test.guest_on.with_comma.with_2_threads.id_option.option_enable
 rhel.virsh.setvcpu.normal_test.guest_on.with_comma.with_2_threads.id_option.option_enable_current
 rhel.virsh.setvcpu.normal_test.guest_on.with_comma.with_2_threads.id_option.option_disable_live
 rhel.virsh.setvcpu.normal_test.guest_on.with_comma.with_2_threads.id_option.option_disable
 rhel.virsh.setvcpu.normal_test.guest_on.with_comma.with_2_threads.id_option.option_disable_current
 rhel.virsh.setvcpu.normal_test.guest_on.with_comma.with_2_threads.name_option
 rhel.virsh.setvcpu.normal_test.guest_on.with_comma.with_2_threads.pause_option
 rhel.virsh.setvcpu.normal_test.guest_on.with_comma.with_2_threads.uuid_option
 rhel.virsh.setvcpu.normal_test.guest_on.with_hypen.with_2_threads.id_option.option_enable_live
 rhel.virsh.setvcpu.normal_test.guest_on.with_hypen.with_2_threads.id_option.option_enable
 rhel.virsh.setvcpu.normal_test.guest_on.with_hypen.with_2_threads.id_option.option_enable_current
 rhel.virsh.setvcpu.normal_test.guest_on.with_hypen.with_2_threads.id_option.option_disable_live
 rhel.virsh.setvcpu.normal_test.guest_on.with_hypen.with_2_threads.id_option.option_disable
 rhel.virsh.setvcpu.normal_test.guest_on.with_hypen.with_2_threads.id_option.option_disable_current
 rhel.virsh.setvcpu.normal_test.guest_on.with_hypen.with_2_threads.name_option
 rhel.virsh.setvcpu.normal_test.guest_on.with_hypen.with_2_threads.pause_option

Signed-off-by: Jing Yan <jiyan@redhat.com>