### PR TITLE
Update the period for rng rate test

### DIFF
--- a/libvirt/tests/cfg/libvirt_rng.cfg
+++ b/libvirt/tests/cfg/libvirt_rng.cfg
@@ -62,14 +62,14 @@
                     backend_source = "{'mode':'bind','host':'localhost','service':'1024'}"
                     test_guest_dump = "yes"
         - rng_rate:
-            rng_rate = "{'bytes':'5000','period':'1'}"
             test_qemu_cmd = "yes"
             test_guest = "yes"
-            timeout = 30
             variants:
                 - back_rdm:
+                    rng_rate = "{'bytes':'5000','period':'2000'}"
                     backend_dev = "/dev/random"
                 - back_tcp:
+                    rng_rate = "{'bytes':'5000','period':'10'}"
                     backend_model = "egd"
                     backend_type = "tcp"
                     backend_source = "{'mode':'connect','host':'localhost','service':'1024'}"


### PR DESCRIPTION
Also remove the timeout as default is 600s and 30s may
not enough for the cmd return

Signed-off-by: Kylazhang <weizhan@redhat.com>