### PR TITLE
Revert 'fixed type error: Added letter 'G' to image_size'

### DIFF
--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -1422,7 +1422,7 @@ def run(test, params, env):
             target = libvirt.setup_or_cleanup_iscsi(is_setup=True, is_login=False,
                                                     emulated_image=fileio_name,
                                                     portal_ip=portal_ip,
-                                                    image_size=str(img_vsize) + 'G')
+                                                    image_size=img_vsize)
             logging.debug("Created iscsi target: %s", target)
             host_ip = update_host_ip(client_ip, params.get("ipv6_addr_src"))
             redefine_vm_with_iscsi_target(host_ip, disk_format,


### PR DESCRIPTION
Reverting https://github.com/autotest/tp-libvirt/pull/2485
1. `get_virtual_size` always returns string, a match of `(\d+\w)` e.g. 10G
2. Currently, test fails:
```bash
JOB ID     : b561dadcdc32865e7e53416fb4f772fd96f400b9
JOB LOG    : /root/avocado/job-results/job-2020-01-08T02.57-b561dad/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_vm.positive_testing.live_migration.iscsi.ipv6.with_postcopy: ERROR: invalid literal for int() with base 10: '10G' (31.77 s)
```

Test run after reverting:
```bash
JOB ID     : 39efd349460c779c781273f1f69f00ab68fd9b2a
JOB LOG    : /root/avocado/job-results/job-2020-01-08T03.09-39efd34/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_vm.positive_testing.live_migration.iscsi.ipv6.with_postcopy: PASS (205.20 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 207.20 s
```