### PR TITLE
Fix virsh_attach_detach_disk

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk.py
@@ -160,7 +160,7 @@ def run(test, params, env):
     vg_name = params.get("at_dt_disk_vg", "vg_test_0")
     lv_name = params.get("at_dt_disk_lv", "lv_test_0")
     # Get additional lvm item names.
-    additional_lv_names = params.get("at_dt_disk_additional_lvs").split()
+    additional_lv_names = params.get("at_dt_disk_additional_lvs", "").split()
     serial = params.get("at_dt_disk_serial", "")
     address = params.get("at_dt_disk_address", "")
     address2 = params.get("at_dt_disk_address2", "")


### PR DESCRIPTION
Currently, tests fail when `at_dt_disk_additional_lvs` is not defined
in test cfg with message `AttributeError: 'NoneType' object has no attribute 'split'`

Define default value `""`.

Test run:
```bash
# avocado run --vt-type libvirt --vt-connect-uri qemu:///system virsh.attach_detach_disk --vt-only-filter virsh.attach_detach_disk.detach_disk.normal_test.host_block_vm_id,virsh.attach_detach_disk.detach_disk.error_test.no_vm_name
JOB ID     : 8b50cae645885ed0c867c1a383e5ace44cd4ab1e
JOB LOG    : /root/avocado/job-results/job-2020-01-09T14.07-8b50cae/job.log
 (1/2) type_specific.io-github-autotest-libvirt.virsh.attach_detach_disk.detach_disk.error_test.no_vm_name: PASS (38.34 s)
 (2/2) type_specific.io-github-autotest-libvirt.virsh.attach_detach_disk.detach_disk.normal_test.host_block_vm_id: PASS (29.49 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 69.20 s
```