### PR TITLE
Remove redirdev test for s390x

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
@@ -10,6 +10,7 @@
             detach_controller_mode = "virtio-scsi"
             detach_check_xml = "<controller type='scsi' index='%s' model='virtio-scsi'>"
         - redirdev:
+            no s390-virtio
             detach_redirdev_type = "spicevmc"
             detach_redirdev_bus = "usb"
             detach_check_xml = "<redirdev"


### PR DESCRIPTION
On s390x there's no USB. Redirdev is only for USB device.