### PR TITLE
Remove vcpu_cache test for s390x

### DIFF
--- a/libvirt/tests/cfg/cpu/vcpu_cache.cfg
+++ b/libvirt/tests/cfg/cpu/vcpu_cache.cfg
@@ -4,7 +4,7 @@
     cmd_in_vm = "lscpu |grep cache"
     cmd_output_regex = "L3 cache:\s+\d+K"
     status_error = "no"
-    no pseries
+    no pseries, s390-virtio
     variants:
         - no_cpu_mode:
         - host_model:


### PR DESCRIPTION
CPU cache specification is not supported for 's390x' architecture