### PR TITLE
Fix libvirt_mem..discard

### DIFF
--- a/libvirt/tests/src/libvirt_mem.py
+++ b/libvirt/tests/src/libvirt_mem.py
@@ -462,7 +462,7 @@ def run(test, params, env):
         elif discard:
             vm.start()
             session = vm.wait_for_login()
-            check_qemu_cmd()
+            check_qemu_cmd(max_mem_rt, tg_size)
         dev_xml = None
 
         # To attach the memory device.


### PR DESCRIPTION
1. Missing parameters in function call:
   `ERROR: check_qemu_cmd() missing 2 required positional arguments: 'max_mem_rt' and 'tg_size'`
   Add params to function call.

Test run
```bash
JOB ID     : cc237c0963a7175bb982f50efde7aa1c958f2209
JOB LOG    : /root/avocado/job-results/job-2020-01-10T16.40-cc237c0/job.log
 (1/3) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.mem_basic.discard: PASS (42.28 s)
 (2/3) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.hugepages.no_numatune.discard: PASS (51.94 s)
 (3/3) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.hugepages.with_numatune.discard: PASS (47.40 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 143.12 s
```