### PR TITLE
Fix the issue of local variable 'bt' referenced before assignment

### DIFF
--- a/libvirt/tests/src/libvirt_vcpu_plug_unplug.py
+++ b/libvirt/tests/src/libvirt_vcpu_plug_unplug.py
@@ -544,7 +544,7 @@ def run(test, params, env):
         if need_mkswap:
             vm.cleanup_swap()
         if with_stress:
-            if bt:
+            if "bt" in locals() and bt:
                 bt.join(ignore_status=True)
         vm.destroy()
         backup_xml.sync()


### PR DESCRIPTION
It reports UnboundLocalError: local variable 'bt' referenced
before assignment, so fixup this issue.

Signed-off-by: Yingshun Cui <yicui@redhat.com>