### PR TITLE
Fix IndexError for virsh schedinfo tests

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_schedinfo_qemu_posix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_schedinfo_qemu_posix.py
@@ -244,7 +244,7 @@ def run(test, params, env):
                 if not re.search(expect_msg, result.stderr.strip()):
                     test.fail("Fail to get expect err msg: %s" % expect_msg)
     finally:
-        if set_ref:
+        if set_ref and bef_current_value:
             for j in range(0, len(set_ref.split(','))):
                 virsh.schedinfo(vm_ref, "--set %s=%s" % (set_ref.split(',')[j], bef_current_value[j]),
                                 ignore_status=True, debug=True)


### PR DESCRIPTION
For some negative tests, it tries to get non-existing items from
schedinfo's output. In this case, an empty list will be returned,
so checking the list is necessary in finally block.

Signed-off-by: Yingshun Cui <yicui@redhat.com>