### PR TITLE
Update error message for invalid case of virsh_cpu_compare_xml

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_cpu_compare_xml.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_cpu_compare_xml.cfg
@@ -44,5 +44,5 @@
                     status_error = "yes"
                     cpu_compare_mode = "invalid_test"
                     compare_file_type = "domxml"
-                    msg_pattern = "not a valid"
+                    msg_pattern = "does not contain any <cpu> element or valid domain XML, host capabilities XML, or domain capabilities XML"
 


### PR DESCRIPTION
Incorrect error message makes automation case failed. Update it.

Signed-off-by: Yingshun Cui <yicui@redhat.com>