### PR TITLE
Add dependency pkgs to libvirt_bench stress tests

### DIFF
--- a/libvirt/tests/cfg/libvirt_bench/libvirt_bench_vcpu_hotplug.cfg
+++ b/libvirt/tests/cfg/libvirt_bench/libvirt_bench_vcpu_hotplug.cfg
@@ -37,9 +37,12 @@
         - memory_stress:
             stress_type = "memory"
             stress_param = "-m 1 --vm-bytes 1G"
+            stress_dependency_packages_list = ['gcc', 'make']
         - cpu_stress:
             stress_type = "cpu"
             stress_param = "-c 1"
+            stress_dependency_packages_list = ['gcc', 'make']
         - io_stress:
             stress_type = "io"
             stress_param = "-a -n 512m -g 4g -i 0 -i 1 -i 5 -f /mnt/iozone -Rb ./iozone.xls"
+            stress_dependency_packages_list = ['gcc', 'make']


### PR DESCRIPTION
These pkgs are necessary for these test, they should be installed
inside vm before test.

Signed-off-by: haizhao <haizhao@redhat.com>