### PR TITLE
Skip checkpoint for v2v option_root.dev_sdx case

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -149,12 +149,15 @@
             checkpoint = 'GPO_AV'
             msg_content = 'virt-v2v: warning: this guest has Windows Group Policy Objects%virt-v2v: warning: this guest has Anti-Virus \(AV\) software'
             expect_msg = yes
+            skip_vm_check = yes
+            skip_reason = 'guest version is too old'
         - AV_WIN7:
             only esx_67
             main_vm = 'VM_NAME_AV_WIN7_V2V_EXAMPLE'
-            checkpoint = 'GPO_AV'
             msg_content = 'virt-v2v: warning: this guest has Anti-Virus \(AV\) software'
             expect_msg = yes
+            skip_vm_check = yes
+            skip_reason = 'guest version is too old'
         - vmtools:
             variants:
                 - pkgs:
@@ -180,7 +183,7 @@
             main_vm = VM_NAME_EMPTY_CDROM_V2V_EXAMPLE
             checkpoint = empty_cdrom
         - option_root:
-            only esx_55
+            only esx_67
             main_vm = VM_NAME_MULTIPLE_LINUX_V2V_EXAMPLE
             checkpoint = root
             v2v_timeout = '7200'
@@ -194,7 +197,9 @@
                     root_option = single
                     only negative_test
                 - dev_sdx:
-                    root_option = '/dev/sda2'
+                    root_option = '/dev/sda1'
+                    skip_vm_check = yes
+                    skip_reason = "/dev/sda1 belongs to the second OS which can't boot into os without selecting by user during booting after v2v conversion"
                 - dev_vglv:
                     root_option = '/dev/rhel/root'
             checkpoint += _${root_option}

--- a/v2v/tests/src/function_test_esx.py
+++ b/v2v/tests/src/function_test_esx.py
@@ -36,6 +36,8 @@ def run(test, params, env):
     status_error = 'yes' == params.get('status_error', 'no')
     address_cache = env.get('address_cache')
     checkpoint = params.get('checkpoint', '')
+    skip_vm_check = params.get('skip_vm_check', 'no')
+    skip_reason = params.get('skip_reason')
     error_list = []
     remote_host = vpx_hostname
     # For VDDK
@@ -277,10 +279,12 @@ def run(test, params, env):
             logging.info('Checking common checkpoints for v2v')
             vmchecker = VMChecker(test, params, env)
             params['vmchecker'] = vmchecker
-            if checkpoint != 'GPO_AV':
+            if skip_vm_check != 'yes':
                 ret = vmchecker.run()
                 if len(ret) == 0:
                     logging.info("All common checkpoints passed")
+            else:
+                logging.info('Skip checking vm after conversion: %s' % skip_reason)
             # Check specific checkpoints
             if checkpoint == 'cdrom':
                 virsh_session = utils_sasl.VirshSessionSASL(params)


### PR DESCRIPTION
For this case, guest can't boot into os without selecting by user
after v2v conversion, so skip checking guest

Signed-off-by: mxie91 <mxie@redhat.com>