### PR TITLE
Delete vddk_libdir_src from tp-libvirt

### DIFF
--- a/v2v/tests/cfg/convert_vm_to_libvirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_libvirt.cfg
@@ -20,7 +20,6 @@
         - it_vddk:
             only source_esx
             input_transport = 'vddk'
-            vddk_libdir_src = MOUNT_SRC_VDDK_LIB_DIR_V2V_EXAMPLE
             # Set the real vddk_libdir/thumbprint or keep it commented
             #vddk_libdir = VDDK_LIB_DIR_EXAMPLE
             #vddk_thumbprint = VDDK_THUMBPRINT_EXAMPLE

--- a/v2v/tests/cfg/convert_vm_to_ovirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_ovirt.cfg
@@ -20,7 +20,6 @@
         - it_vddk:
             only source_esx
             input_transport = 'vddk'
-            vddk_libdir_src = MOUNT_SRC_VDDK_LIB_DIR_V2V_EXAMPLE
             # Set the real vddk_libdir/thumbprint or keep it commented
             #vddk_libdir = VDDK_LIB_DIR_EXAMPLE
             #vddk_thumbprint = VDDK_THUMBPRINT_EXAMPLE

--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -26,7 +26,6 @@
         - it_vddk:
             only source_esx
             input_transport = 'vddk'
-            vddk_libdir_src = MOUNT_SRC_VDDK_LIB_DIR_V2V_EXAMPLE
             # Set the real vddk_libdir/thumbprint or keep it commented
             #vddk_libdir = VDDK_LIB_DIR_EXAMPLE
             #vddk_thumbprint = VDDK_THUMBPRINT_EXAMPLE

--- a/v2v/tests/cfg/specific_kvm.cfg
+++ b/v2v/tests/cfg/specific_kvm.cfg
@@ -22,7 +22,6 @@
         - it_vddk:
             only source_esx
             input_transport = 'vddk'
-            vddk_libdir_src = MOUNT_SRC_VDDK_LIB_DIR_V2V_EXAMPLE
             # Set the real vddk_libdir/thumbprint or keep it commented
             #vddk_libdir = VDDK_LIB_DIR_EXAMPLE
             #vddk_thumbprint = VDDK_THUMBPRINT_EXAMPLE


### PR DESCRIPTION
The vddk_libdir_src settings are moved to avocado-vt.

avocado-vt:
backends/v2v/cfg/convert_source.cfg

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>