### PR TITLE
Fix libvirt_hugepage on s390x

### DIFF
--- a/libvirt/tests/cfg/libvirt_hugepage.cfg
+++ b/libvirt/tests/cfg/libvirt_hugepage.cfg
@@ -8,6 +8,8 @@
     contrast_enable = no
     test_type = ""
     delay_time = 10
+    setup_hugepages = yes
+    kvm_module_parameters = ''
     variants:
         # mount/umount hugetlbfs for host
         - mount_hugetlbfs:


### PR DESCRIPTION
Add parameters to assure kvm hugepage support can be activated by
setting `kvm_module_parameters = 'hpage=1'` if necessary.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>