### PR TITLE
Fix the pool-autostart status failed

### DIFF
--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool_autostart.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool_autostart.py
@@ -190,6 +190,9 @@ def run(test, params, env):
             # Step(3)
             # Restart libvirtd and check pool status
             logging.info("Try to restart libvirtd")
+            # Remove the autostart management file
+            cmd = ("rm -rf /var/run/libvirt/storage/autostarted")
+            process.run(cmd, ignore_status=True, shell=True)
             libvirtd = utils_libvirtd.Libvirtd()
             libvirtd.restart()
             check_pool(pool_name, pool_type, checkpoint="State",


### PR DESCRIPTION
Remove the pool autostart management file so that we can test the status of pool without rebooting the host.

Signed-off-by: jgao <jgao@localhost.localdomain>