### PR TITLE
Need to cleanup vm on remote for migration test

### DIFF
--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -2727,6 +2727,10 @@ def run(test, params, env):
 
     finally:
         logging.info("Recovery test environment")
+
+        logging.debug("Removing vm on remote if it exists.")
+        virsh.remove_domain(vm.name, uri=uri)
+
         # Clean up of pre migration setup for local machine
         if migr_vm_back:
             migrate_setup.migrate_pre_setup(src_uri, params,


### PR DESCRIPTION
In finally block, it removed disk resource but not vm on remote.
Fix this issue in this PR.

Signed-off-by: Yingshun Cui <yicui@redhat.com>