### PR TITLE
Fix the check_qemu_cmd function issue

### DIFF
--- a/libvirt/tests/cfg/libvirt_mem.cfg
+++ b/libvirt/tests/cfg/libvirt_mem.cfg
@@ -33,6 +33,7 @@
                     numa_cells = "{'id':'0','cpus':'0-1','memory':'1024000','unit':'KiB'} {'id':'1','cpus':'2-3','memory':'512000','unit':'KiB'}"
                     variants:
                         - default:
+                            test_qemu_cmd = "no"
                         - cold_plug_discard:
                             cold_plug_discard = "yes"
                             test_qemu_cmd = "yes"


### PR DESCRIPTION
Fix checking the memory-backing-file for non-file memory device issue and attach  devices more than one time with unique alias issue.
Signed-off-by: qijing <jinqi@redhat.com>