### PR TITLE
Fix disk order test on s390x

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
@@ -69,7 +69,7 @@ def run(test, params, env):
 
     def check_disk_order(targets_name):
         """
-        Check VM disk's order on pci bus.
+        Check VM disk's order on pci/ccw bus.
 
         :param targets_name. Disks target list.
         :return: True if check successfully.
@@ -78,12 +78,13 @@ def run(test, params, env):
         xml = vm_xml.VMXML.new_from_dumpxml(vm_name)
         disk_list = xml.devices.by_device_tag("disk")
         slot_dict = {}
-        # Get the disks pci slot.
+        # Get the disks order attribute's value.
         for disk in disk_list:
             if 'virtio' == disk.target['bus']:
+                selector = 'devno' if disk.address.attrs['type'] == 'ccw' else 'slot'
                 slot_dict[disk.target['dev']] = int(
-                    disk.address.attrs['slot'], base=16)
-        # Disk's order on pci bus should keep the same with disk target name.
+                    disk.address.attrs[selector], base=16)
+        # Disk's order should be the same with disk target name.
         s_dev = sorted(list(slot_dict.keys()))
         s_slot = sorted(list(slot_dict.values()))
         for i in range(len(s_dev)):


### PR DESCRIPTION
On s390x addresses are of type 'ccw'. The attribute
reflecting order of attachment is 'devno' instead

test run on s390x:
```bash
JOB ID     : 609085704e0aa5c339f7ebae2bb29fa1294524de
JOB LOG    : /root/avocado/job-results/job-2020-01-20T10.19-6090857/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_disks.multidisks.coldplug.multi_disks_test.virtio_disks_order: PASS (104.12 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 107.32 s
```