### PR TITLE
Restrict interface model on s390x

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_coalesce.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_coalesce.cfg
@@ -46,10 +46,13 @@
                     hotplug_iface = 'yes'
                     coalesce = '-25'
                 - model_type_e1000:
+                    no s390-virtio
                     iface_model = "e1000"
                 - model_type_e1000e:
+                    no s390-virtio
                     iface_model = "e1000e"
                 - model_type_rtl8139:
+                    no s390-virtio
                     iface_model = "rtl8139"
                 - boudary_negative:
                     coalesce = '-1'

--- a/libvirt/tests/cfg/virtual_network/iface_hotplug.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_hotplug.cfg
@@ -109,12 +109,15 @@
                             status_error = "yes"
             variants:
                 - model_e1000:
+                    no s390-virtio
                     iface_model = "e1000"
                 - model_rtl8139:
+                    no s390-virtio
                     iface_model = "rtl8139"
                 - model_virtio:
                     iface_model = "virtio"
                 - model_e1000e:
+                    no s390-virtio
                     iface_model = "e1000e"
     variants:
         - at_device:


### PR DESCRIPTION
On s390x only interface model available is 'virtio'.