### PR TITLE
Fix cdrom device on s390x

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_disk.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_disk.cfg
@@ -139,6 +139,9 @@
                     at_dt_disk_device_target = hdc
                     at_dt_disk_bus_type = ide
                     at_dt_disk_pre_vm_state = "shut off"
+                    machine_type == s390-ccw-virtio:
+                        at_dt_disk_device_target = sdb
+                        at_dt_disk_bus_type = scsi
                     machine_type == q35:
                         at_dt_disk_device_target = sdb
                         at_dt_disk_bus_type = scsi
@@ -153,6 +156,9 @@
                     at_dt_disk_eject_cdrom = "yes"
                     at_dt_disk_save_vm = "yes"
                     time_sleep = "5"
+                    machine_type == s390-ccw-virtio:
+                        at_dt_disk_device_target = sdb
+                        at_dt_disk_bus_type = scsi
                     machine_type == q35:
                         at_dt_disk_device_target = sdb
                         at_dt_disk_bus_type = scsi


### PR DESCRIPTION
On s390x cdrom are connected via SCSI, IDE is not available.

test run on s390x:
```bash
JOB ID     : 816b99f0e06073549782f942e024437d5a6a2ddb
JOB LOG    : /root/avocado/job-results/job-2020-01-20T13.00-816b99f/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.attach_detach_disk.attach_disk.normal_test.cdrom_eject_control: PASS (210.90 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 212.42 s
JOB ID     : 29c27ecc04f6141256781ec43f1cb32bac1db98e
JOB LOG    : /root/avocado/job-results/job-2020-01-20T13.09-29c27ec/job.log
 (1/2) type_specific.io-github-autotest-libvirt.virsh.attach_detach_disk.attach_disk.normal_test.cdrom: PASS (202.53 s)
 (2/2) type_specific.io-github-autotest-libvirt.virsh.attach_detach_disk.detach_disk.normal_test.cdrom: PASS (210.83 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 415.87 s
```