### PR TITLE
Fix startup_policy on s390x

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/startup_policy.cfg
+++ b/libvirt/tests/cfg/virtual_disks/startup_policy.cfg
@@ -58,6 +58,8 @@
                             target_dev = "hda"
                             disk_target_bus = "ide"
                             image_size = "100M"
+                            machine_type == s390-ccw-virtio:
+                                disk_target_bus = "scsi"
                         - floppy:
                             device_type = "floppy"
                             target_dev = "fda"


### PR DESCRIPTION
On s390x cdrom are attached through 'scsi' bus.

Tests run
```bash
JOB ID     : 8d08c48f6ef56454a046616f3a9e9ee573d83138
JOB LOG    : /root/avocado/job-results/job-2020-01-21T09.47-8d08c48/job.log
 (1/7) type_specific.io-github-autotest-libvirt.startup_policy.startupPolicy.mandatory.device_type.cdrom.file.default: PASS (178.19 s)
 (2/7) type_specific.io-github-autotest-libvirt.startup_policy.startupPolicy.mandatory.device_type.cdrom.file.update_policy.default.live: PASS (102.72 s)
 (3/7) type_specific.io-github-autotest-libvirt.startup_policy.startupPolicy.mandatory.device_type.cdrom.file.update_policy.default.config: PASS (89.12 s)
 (4/7) type_specific.io-github-autotest-libvirt.startup_policy.startupPolicy.mandatory.device_type.cdrom.file.update_policy.default.persistent: PASS (98.22 s)
 (5/7) type_specific.io-github-autotest-libvirt.startup_policy.startupPolicy.mandatory.device_type.cdrom.file.update_policy.policy_and_source: PASS (105.38 s)
 (6/7) type_specific.io-github-autotest-libvirt.startup_policy.startupPolicy.mandatory.device_type.cdrom.volume.iscsi_pool: PASS (287.83 s)
 (7/7) type_specific.io-github-autotest-libvirt.startup_policy.startupPolicy.mandatory.device_type.cdrom.volume.dir_pool: PASS (299.76 s)
RESULTS    : PASS 7 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 1164.34 s
```