### PR TITLE
Fix virsh_sendkey on s390x

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_sendkey.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_sendkey.cfg
@@ -82,11 +82,17 @@
                     sendkey = "KEY_LEFTALT KEY_SYSRQ KEY_B"
                 - crash_guest:
                     is_crash = "yes"
+                    add_panic_device = "yes"
                     sendkey = "KEY_LEFTALT KEY_SYSRQ KEY_C"
+                    s390-virtio:
+                        add_panic_device = "no"
                 - usb_keycode:
                     is_crash = "yes"
+                    add_panic_device = "yes"
                     codeset = "usb"
                     sendkey = "230 70 6"
+                    s390-virtio:
+                        add_panic_device = "no"
             variants:
                 - non_acl:
                 - acl_test:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_sendkey.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_sendkey.py
@@ -38,6 +38,7 @@ def run(test, params, env):
     simultaneous = params.get("sendkey_simultaneous", "yes") == "yes"
     unprivileged_user = params.get('unprivileged_user')
     is_crash = ("yes" == params.get("is_crash", "no"))
+    add_panic_device = ("yes" == params.get("add_panic_device", "yes"))
     crash_dir = "/var/crash"
     if unprivileged_user:
         if unprivileged_user.count('EXAMPLE'):
@@ -85,7 +86,8 @@ def run(test, params, env):
         if is_crash:
             session.cmd("rm -rf {0}; mkdir {0}".format(crash_dir))
             libvirt.update_on_crash(vm_name, "destroy")
-            libvirt.add_panic_device(vm_name)
+            if add_panic_device:
+                libvirt.add_panic_device(vm_name)
             if not vm.is_alive():
                 vm.start()
             session = vm.wait_for_login()


### PR DESCRIPTION
1. On s390x panic device is automatically added. Avoid adding device.

```bash
(.libvirt-ci-venv-ci-runtest-50xirU) [root@ibm-z-101 tp-libvirt]# avocado run --vt-type libvirt --vt-machine-type s390-virtio --vt-connect-uri qemu:///system virsh.sendkey.sysrq.non_acl.crash_guest
JOB ID     : 7772a889c5427d38d09ec34b3d00e69dc14025ca
JOB LOG    : /root/avocado/job-results/job-2020-01-21T10.53-7772a88/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.sendkey.sysrq.non_acl.crash_guest: PASS (478.88 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 483.69 s
(.libvirt-ci-venv-ci-runtest-50xirU) [root@ibm-z-101 tp-libvirt]# avocado run --vt-type libvirt --vt-machine-type s390-virtio --vt-connect-uri qemu:///system virsh.sendkey.sysrq.acl_test.crash_guest,virsh.sendkey.sysrq..usb_keycode
JOB ID     : 4e4b5883a3083d8c7b8c52dda9894accb5b3fec2
JOB LOG    : /root/avocado/job-results/job-2020-01-21T11.02-4e4b588/job.log
 (1/3) type_specific.io-github-autotest-libvirt.virsh.sendkey.sysrq.non_acl.usb_keycode: PASS (177.67 s)
 (2/3) type_specific.io-github-autotest-libvirt.virsh.sendkey.sysrq.acl_test.crash_guest: PASS (182.43 s)
 (3/3) type_specific.io-github-autotest-libvirt.virsh.sendkey.sysrq.acl_test.usb_keycode: PASS (253.29 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 616.28 s
```