### PR TITLE
Fix virtual_disk device_lun on s390x

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_iscsi.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_iscsi.cfg
@@ -75,6 +75,8 @@
                             controller_model = "virtio-scsi"
                             controller_index = 0
                             controller_addr_options = "bus=0x00,slot=0x08,function=0x0,domain=0x0000,type=pci"
+                            s390-virtio:
+                                controller_addr_options = ""
                         - device_disk:
                             virt_disk_device = "disk"
                 - error_test:

--- a/libvirt/tests/src/virtual_disks/virtual_disks_iscsi.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_iscsi.py
@@ -283,12 +283,13 @@ def run(test, params, env):
                 ctrl.model = cntlr_model
             if cntlr_index is not None:
                 ctrl.index = cntlr_index
-            ctrl_addr_dict = {}
-            for addr_option in controller_addr_options.split(','):
-                if addr_option != "":
-                    addr_part = addr_option.split('=')
-                    ctrl_addr_dict.update({addr_part[0].strip(): addr_part[1].strip()})
-            ctrl.address = ctrl.new_controller_address(attrs=ctrl_addr_dict)
+            if controller_addr_options:
+                ctrl_addr_dict = {}
+                for addr_option in controller_addr_options.split(','):
+                    if addr_option != "":
+                        addr_part = addr_option.split('=')
+                        ctrl_addr_dict.update({addr_part[0].strip(): addr_part[1].strip()})
+                ctrl.address = ctrl.new_controller_address(attrs=ctrl_addr_dict)
 
             # If driver_iothread is true, need add iothread attribute in controller.
             if driver_iothread:


### PR DESCRIPTION
On s390x addresses are type ccw by default and don't allow for partial definition.
The test uses `controller_addr_options` exclusively for valid controller
definition, i.e. it's not a test condition.

Therefore, on s390x allow libvirt to add valid address by not setting any.

Test run on s390x:
```bash
JOB ID     : ae1b4ef61c019c1d70b04a01c57f0864a5310b02
JOB LOG    : /root/avocado/job-results/job-2020-01-21T11.22-ae1b4ef/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_disks.iscsi.iscsi_test.normal_test.device_lun.auth_uuid.auth_place_in_source: PASS (309.37 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 312.89 s
```