### PR TITLE
Fix multidisks..with_minimal_xml

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
@@ -987,13 +987,15 @@ def run(test, params, env):
         first_disk = vm.get_first_disk_devices()
         first_disk_source = first_disk['source']
         minimal_vm_xml_file = minimal_vm_xml.xml
+        arch = params.get("vm_arch_name", "x86_64")
+        machine = params.get("machine_type", "pc")
         minimal_xml_content = """<domain type='kvm'>
         <name>%s</name>
         <memory unit='KiB'>1048576</memory>
         <currentMemory unit='KiB'>1048576</currentMemory>
         <vcpu placement='static'>1</vcpu>
         <os>
-          <type arch='x86_64' machine='pc'>hvm</type>
+          <type arch='%s' machine='%s'>hvm</type>
           <boot dev='hd'/>
         </os>
         <devices>
@@ -1004,7 +1006,7 @@ def run(test, params, env):
             <target dev='vda' bus='virtio'/>
           </disk>
         </devices>
-        </domain>""" % (vm_name, first_disk_source)
+        </domain>""" % (vm_name, arch, machine, first_disk_source)
         with open(minimal_vm_xml_file, 'w') as xml_file:
             xml_file.seek(0)
             xml_file.truncate()


### PR DESCRIPTION
Currently, hard-coded domain xml refers to x86_64 arch and pc machine type.
Read these values from params dictionary instead.

Test run on s390x:
```bash
# avocado run --vt-type libvirt --vt-machine-type s390-virtio --vt-connect-uri qemu:///system virtual_disks.multidisks.coldplug.single_disk_test.disk_attach_with_minimal_xml
JOB ID     : 414ca12b5f9eadab439ca7ceedce1a45e21b0d4d
JOB LOG    : /root/avocado/job-results/job-2020-01-22T07.30-414ca12/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_disks.multidisks.coldplug.single_disk_test.disk_attach_with_minimal_xml: PASS (11.44 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 14.31 s
```