### PR TITLE
Fix multidisks on s390x

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
@@ -38,6 +38,9 @@
                     virt_disk_device_type = "file block"
                     driver_option = "type=raw type=raw,cache=none"
                     virt_disk_wwn = "5000c50015ea71aa 5000c50015ea71aa"
+                    s390-virtio:
+                        virt_disk_device_target = "sdb sda"
+                        virt_disk_device_bus = "scsi scsi"
                 - virtio_disks_duplicate_wwn_disk:
                     coldplug:
                         test_disk_option_cmd = "yes"
@@ -74,6 +77,7 @@
                     virt_disk_device_type = "file file"
                     virt_disk_serial = "aaaabbbbccccdddd aaaabbbbccccdddd"
                 - disks_bootorder:
+                    no s390-virtio
                     only coldplug
                     virt_disk_with_boot_disk = "yes"
                     virt_disk_device_boot_console = "yes"
@@ -94,6 +98,7 @@
                     disk_bootorder = "3"
                     disk_boot_seabios = "/usr/share/seabios/bios.bin"
                 - disks_boot_nfs_pool:
+                    no s390-virtio
                     only coldplug
                     disk_bootorder = "2"
                     virt_disk_with_boot_nfs_pool = "yes"
@@ -342,6 +347,7 @@
                     status_error = "yes"
                     variants:
                         - disk_bus_ide:
+                            no s390-virtio
                             virt_disk_device_target = "hda"
                             virt_disk_device_bus = "ide"
                         - disk_bus_fdc:
@@ -372,6 +378,7 @@
                     virt_disk_device_source = "disk"
                     variants:
                         - disk_bus_ide:
+                            no s390-virtio
                             only test_serial_wwn
                             virt_disk_device_target = "hda"
                             virt_disk_device_format = "qcow2"
@@ -401,6 +408,9 @@
                             disk_bootorder = "1"
                             virt_disk_bootdisk_target = "hda"
                             virt_disk_bootdisk_bus = "ide"
+                            s390-virtio:
+                                virt_disk_bootdisk_bus = "scsi"
+                                virt_disk_device_target = "sda"
                         - disk_virtio_driver_options:
                             test_disk_option_cmd = "yes"
                             variants:
@@ -491,6 +501,9 @@
                     virt_disk_device_bus = "ide"
                     virt_disk_device_format = "raw"
                     test_disk_option_cmd = "yes"
+                    s390-virtio:
+                        virt_disk_device_bus = "scsi"
+                        virt_disk_device_target = "sda"
                 - disk_readonly_nfs_raw:
                     virt_disk_device_test_readonly = "yes"
                     virt_disk_device_source = "disk"
@@ -529,6 +542,9 @@
                     virt_disk_device_format = "nfs"
                     virt_disk_option_readonly = "yes"
                     virt_disk_device_test_readonly = "yes"
+                    s390-virtio:
+                        virt_disk_device_bus = "scsi"
+                        virt_disk_device_target = "sda"
                     variants:
                         - coldplug_only_iso:
                             nfs_disk_type = "iso"
@@ -587,6 +603,10 @@
                         disks_attach_option = "--type cdrom --mode readonly"
                         virt_disk_option_readonly = "yes"
                         virt_disk_check_partitions_hotunplug = "no"
+                        s390-virtio:
+                            disks_attach_error = "no"
+                            virt_disk_device_bus = "scsi"
+                            virt_disk_device_target = "sda"
                 - disk_cdrom_update_boot_order:
                     only coldplug
                     iso_path = '/var/lib/libvirt/images/second.iso'
@@ -600,6 +620,9 @@
                     virt_disk_device_bus = "ide"
                     virt_disk_device_format = "raw"
                     driver_option = "type=raw"
+                    s390-virtio:
+                        virt_disk_device_bus = "scsi"
+                        virt_disk_device_target = "sda"
                 - disk_floppy_update_boot_order:
                     only coldplug
                     floppy_path = '/var/lib/libvirt/images/fd2.img'
@@ -660,6 +683,7 @@
                             virt_disk_device_format = "qcow2"
                             driver_option = "type=qcow2,cache=none"
                         - disk_bus_ide:
+                            no s390-virtio
                             only coldplug
                             virt_disk_device_bus = "ide"
                             virt_disk_device_type = "block"
@@ -735,6 +759,7 @@
                                     driver_option = "type=raw,cache=none"
                                     restart_libvird = "yes"
                         - disk_bus_ide:
+                            no s390-virtio
                             virt_disk_device_bus = "ide"
                             virt_disk_device_type = "file"
                             virt_disk_device_source = "test"
@@ -763,6 +788,7 @@
                                     image_size = "2G"
                                     virt_disk_device = "disk"
                         - disk_bus_sata:
+                            no s390-virtio
                             virt_disk_device_bus = "sata"
                             virt_disk_device_type = "file"
                             virt_disk_device_source = "test"
@@ -884,6 +910,7 @@
                     virtio_scsi_controller_model = "virtio-scsi"
                 - disk_virtio_pci_bridge_controller:
                     no q35
+                    no s390-virtio
                     virt_disk_device = "disk"
                     virt_disk_check_pci_bridge = "yes"
                     virt_disk_device_source = "disk1"


### PR DESCRIPTION
Depends on https://github.com/avocado-framework/avocado-vt/pull/2415

1. .py:
 a. minimal_xml: Currently, hard-coded domain xml refers to x86_64 arch
    and pc machine type. Read these values from params dictionary instead.
 b. test_bus_device_option: Construct cmd differently when address type ccw.
    Note that by default "libvirt will assign a free bus address with cssid=0xfe and ssid=0"
    https://libvirt.org/formatdomain.html#elementsAddress
    Therefore `dev_id_prefix` is taken here to be constant.
 c. ccw_address expected failure: Since qemu 2.12 ccsid values are unrestricted,
    s. https://wiki.qemu.org/Features/Channel_I/O_Passthrough#QEMU_.28since_2.12.29
 d. check_readonly:
    i. If IDE is not available (e.g. q35, s390x) cdrom is mounted as scsi
       which normally should start with 'sd'.
    ii. Add check for warning in output: the current command
        '(mount XXX /mnt && ls /mnt || exit 1) && (echo 'test' > /mnt/test || umount /mnt)'
        will always be true (s == 0), if mount succeeded: either writing fails and
        unmounting succeeds or writing succeeds and no unmounting will happen ('||').
        Therefore, check additionally if the warning is in the output of the command.
        (The full output with bash is '-bash: /mnt/test: Read-only file system')
        We could also, alternatively, avoid executing the write command because 'mount'
        already emits warning 'mount: /mnt: WARNING: device write-protected, mounted read-only.'
        if we trust 'mount'/the kernel not to allow write to read-only mount.
  e. virtio-net-pci: use different driver on s390x
  f. set_kernel_console: pass architecture to cause zipl to be run, required for updating
     boot parameters on s390x - depends on https://github.com/avocado-framework/avocado-vt/pull/2415
  g. logging.debug: There's no sleeping in the code at this area of code,
     log the vmxml instead to assist debugging.
2. .cfg:
 a. cdroms on s390x are attached through scsi
 b. disk_bus_sata/ide: IDE/SATA not available on s390x
 c. disks can't be attached on pci bus on s390x
 d. disks_bootorder,disks_boot_nfs_pool: no BIOS on s390x.

Test execution on s390x:
```bash
# avocado run --vt-type libvirt --vt-machine-type s390-virtio --vt-connect-uri qemu:///system virtual_disks.multidisks.coldplug.single_disk_test.disk_option_bootdisk.disk_virtio_bootorder_snapshot,virtual_disks.multidisks.coldplug.single_disk_test.disk_source_file_name,virtual_disks.multidisks.coldplug.single_disk_test.disk_readonly_nfs_cdrom.coldplug_only_iso,virtual_disks.multidisks.coldplug.single_disk_test.disk_readonly_nfs_cdrom.coldplug_only_raw,virtual_disks.multidisks.coldplug.single_disk_test.disk_readonly_nfs_cdrom.coldplug_with_at_dt_disk,virtual_disks.multidisks.coldplug.single_disk_test.disk_cdrom_update_boot_order,virtual_disks.multidisks.coldplug.single_disk_test.disk_attach_with_minimal_xml,virtual_disks.multidisks.coldplug.single_disk_test.disk_bus_device_option.disk_bus_virtio.device_disk.default
JOB ID     : 5c549ebe35c471fc122e22da47c7de510540417d
JOB LOG    : /root/avocado/job-results/job-2020-01-23T08.00-5c549eb/job.log
 (1/8) type_specific.io-github-autotest-libvirt.virtual_disks.multidisks.coldplug.single_disk_test.disk_option_bootdisk.disk_virtio_bootorder_snapshot: PASS (136.87 s)
 (2/8) type_specific.io-github-autotest-libvirt.virtual_disks.multidisks.coldplug.single_disk_test.disk_source_file_name: PASS (97.13 s)
 (3/8) type_specific.io-github-autotest-libvirt.virtual_disks.multidisks.coldplug.single_disk_test.disk_readonly_nfs_cdrom.coldplug_only_iso: PASS (136.49 s)
 (4/8) type_specific.io-github-autotest-libvirt.virtual_disks.multidisks.coldplug.single_disk_test.disk_readonly_nfs_cdrom.coldplug_only_raw: PASS (106.39 s)
 (5/8) type_specific.io-github-autotest-libvirt.virtual_disks.multidisks.coldplug.single_disk_test.disk_readonly_nfs_cdrom.coldplug_with_at_dt_disk: PASS (104.66 s)
 (6/8) type_specific.io-github-autotest-libvirt.virtual_disks.multidisks.coldplug.single_disk_test.disk_cdrom_update_boot_order: PASS (91.30 s)
 (7/8) type_specific.io-github-autotest-libvirt.virtual_disks.multidisks.coldplug.single_disk_test.disk_bus_device_option.disk_bus_virtio.device_disk.default: PASS (144.09 s)
 (8/8) type_specific.io-github-autotest-libvirt.virtual_disks.multidisks.coldplug.single_disk_test.disk_attach_with_minimal_xml: PASS (30.95 s)
RESULTS    : PASS 8 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 850.88 s
```
```bash
# avocado run --vt-type libvirt --vt-machine-type s390-virtio --vt-connect-uri qemu:///system virtual_disks.multidisks.hotplug.single_disk_test.disk_attach_ccw_address_at_dt_disk
JOB ID     : 240dc54e0070fbb7c1cdd743162d6421afaec3d9
JOB LOG    : /root/avocado/job-results/job-2020-01-23T10.10-240dc54/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_disks.multidisks.hotplug.single_disk_test.disk_attach_ccw_address_at_dt_disk: CANCEL: ccsid values are unrestricted in this qemu version (4.18 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 1
JOB TIME   : 5.87 s
```
```bash
# avocado run --vt-type libvirt --vt-machine-type s390-virtio --vt-connect-uri qemu:///system virtual_disks.multidisks.coldplug.single_disk_test..disk_iface_option1,virtual_disks.multidisks..disk_iface_option2,virtual_disks.multidisks..disk_iface_option3,virtual_disks.multidisks..disk_iface_option4
JOB ID     : 265c361ffdcd86109a95d0d1a687d647416915d9
JOB LOG    : /root/avocado/job-results/job-2020-01-23T10.34-265c361/job.log
 (1/4) type_specific.io-github-autotest-libvirt.virtual_disks.multidisks.coldplug.single_disk_test.disk_option_bootdisk.disk_virtio_driver_with_iface.disk_iface_option1: PASS (88.17 s)
 (2/4) type_specific.io-github-autotest-libvirt.virtual_disks.multidisks.coldplug.single_disk_test.disk_option_bootdisk.disk_virtio_driver_with_iface.disk_iface_option2: PASS (83.61 s)
 (3/4) type_specific.io-github-autotest-libvirt.virtual_disks.multidisks.coldplug.single_disk_test.disk_option_bootdisk.disk_virtio_driver_with_iface.disk_iface_option3: PASS (82.96 s)
 (4/4) type_specific.io-github-autotest-libvirt.virtual_disks.multidisks.coldplug.single_disk_test.disk_option_bootdisk.disk_virtio_driver_with_iface.disk_iface_option4: PASS (90.06 s)
RESULTS    : PASS 4 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 346.50 s
```
```bash
# avocado run --vt-type libvirt --vt-machine-type s390-virtio --vt-connect-uri qemu:///system virtual_disks.multidisks.coldplug.single_disk_test.disk_virtio_scsi_cdrom_multi_queue
JOB ID     : 260c7b7ccb736e250479d5215ce190ea378ba2a6
JOB LOG    : /root/avocado/job-results/job-2020-01-30T10.07-260c7b7/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_disks.multidisks.coldplug.single_disk_test.disk_virtio_scsi_cdrom_multi_queue: PASS (116.10 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 117.76 s
```
```bash
# avocado run --vt-type libvirt --vt-machine-type s390-virtio --vt-connect-uri qemu:///system virtual_disks.multidisks.coldplug.single_disk_test.disk_bus_device_option.disk_bus_virtio.device_lun.default,virtual_disks.multidisks.coldplug.single_disk_test.disk_bus_device_option.disk_bus_virtio.network_lun.default,virtual_disks.multidisks.coldplug.single_disk_test.disk_bus_device_option.disk_bus_virtio.volume_lun.default
JOB ID     : 5c98cc4fd83589cc89e7222cd393a98644fbcfcd
JOB LOG    : /root/avocado/job-results/job-2020-01-30T11.52-5c98cc4/job.log
 (1/3) type_specific.io-github-autotest-libvirt.virtual_disks.multidisks.coldplug.single_disk_test.disk_bus_device_option.disk_bus_virtio.device_lun.default: PASS (172.84 s)
 (2/3) type_specific.io-github-autotest-libvirt.virtual_disks.multidisks.coldplug.single_disk_test.disk_bus_device_option.disk_bus_virtio.network_lun.default: PASS (169.53 s)
 (3/3) type_specific.io-github-autotest-libvirt.virtual_disks.multidisks.coldplug.single_disk_test.disk_bus_device_option.disk_bus_virtio.volume_lun.default: PASS (148.18 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 496.10 s
```
```bash
# avocado run --vt-type libvirt --vt-machine-type s390-virtio --vt-connect-uri qemu:///system virtual_disks.multidisks.coldplug.multi_disks_test.virtio_disks_duplicate_wwn_cdrom
JOB ID     : be0b4cf7e648c7af3f45747467d7fcbea7f89037
JOB LOG    : /root/avocado/job-results/job-2020-01-30T14.24-be0b4cf/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_disks.multidisks.coldplug.multi_disks_test.virtio_disks_duplicate_wwn_cdrom: PASS (270.01 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 293.45 s
```
```bash
# avocado run --vt-type libvirt --vt-machine-type s390-virtio --vt-connect-uri qemu:///system virtual_disks.multidisks.coldplug.single_disk_test.disk_readonly_nfs_raw.attach_device
JOB ID     : ff5d20739c7df2585cb724b588487539a6a864ca
JOB LOG    : /root/avocado/job-results/job-2020-02-04T07.04-ff5d207/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_disks.multidisks.coldplug.single_disk_test.disk_readonly_nfs_raw.attach_device: PASS (179.11 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 182.70 s
```