### PR TITLE
Fix virtual_disks multivms on s390x

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_multivms.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_multivms.cfg
@@ -94,6 +94,8 @@
             virt_disk_device = "cdrom"
             virt_disk_vms_readonly = "readonly readonly"
             image_size = "100M"
+            s390-virtio:
+                virt_disk_bus = "scsi"
     variants:
         - hotplug:
             virt_disk_vms_hotplug = "yes"


### PR DESCRIPTION
On s390x cdrom is connected through scsi.

Test run:
```bash
# avocado run --vt-type libvirt --vt-machine-type s390-virtio --vt-connect-uri qemu:///system virtual_disks.multivms.coldplug.vms_readonly_test 
JOB ID     : 90b3bbed49169840834b2edd90332d11c0fd4ab1
JOB LOG    : /root/avocado/job-results/job-2020-01-22T11.50-90b3bbe/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_disks.multivms.coldplug.vms_readonly_test: PASS (267.95 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 270.28 s
```