### PR TITLE
Safeguard debug logging

### DIFF
--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_edit.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_edit.py
@@ -104,6 +104,22 @@ def run(test, params, env):
                                       aft_line.lstrip().strip())
             test.fail("Failed xml before/after comparison")
 
+    def log_first_lines(pre_xml, after_xml, count=15):
+        """
+        Print only first lines of xml info
+
+        :param pre_xml: snapshot xml before edit
+        :param after_xml: snapshot xml after edit
+        :param count: number of lines to be printed at most
+        """
+
+        pre = pre_xml.split()
+        after = after_xml.split()
+
+        for i in range(max(len(pre), len(after), count)):
+            logging.debug("before xml=%s", pre[i].lstrip())
+            logging.debug(" after xml=%s", after[i].lstrip())
+
     snapshot_oldlist = None
     try:
         # Create disk snapshot before all to make the origin image clean
@@ -171,11 +187,8 @@ def run(test, params, env):
             if snap_desc:
                 logging.debug("Failed to edit snapshot edit_opts=%s, match=%s",
                               edit_opts, match_str)
-                # Only print first 15 lines - they are most relevant
-                for i in range(15):
-                    logging.debug("before xml=%s", pre_xml.split()[i].lstrip())
-                    logging.debug(" after xml=%s",
-                                  after_xml.split()[i].lstrip())
+                log_first_lines(pre_xml, after_xml)
+
                 test.fail("Failed to edit snapshot description")
 
         # Check edit options --clone


### PR DESCRIPTION
1. Got index error from debug logging; avoid this by making index access safe.

Originally, due to environment issue I got 
```bash
2020-01-31 10:57:40,872 stacktrace       L0047 ERROR|   File "/var/lib/avocado/data/avocado-vt/test-providers.d/downloads/io-github-autotest-libvirt/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_edit.py", line 178, in run
2020-01-31 10:57:40,872 stacktrace       L0047 ERROR|     after_xml.split()[i].lstrip())
2020-01-31 10:57:40,872 stacktrace       L0047 ERROR| IndexError: list index out of range
```
During test execution. But test passes now; however, the code should avoid `IndexError` in the future.

Test execution s390x
```bash
# avocado run --vt-type libvirt --vt-machine-type s390-virtio --vt-connect-uri qemu:///system virsh.snapshot_edit.positive_tests.edit_option_rename.edit_option_current_and_snapname.mem_snapshot.disk_snapshot
JOB ID     : 90a0bfa34b46c2752222946523f18f09d29c2cf4
JOB LOG    : /root/avocado/job-results/job-2020-01-31T11.22-90a0bfa/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.snapshot_edit.positive_tests.edit_option_rename.edit_option_current_and_snapname.mem_snapshot.disk_snapshot: PASS (133.29 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 150.32 s
```