### PR TITLE
virsh_detach_device: Don't use virtio bus for cdrom

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device.cfg
@@ -22,7 +22,7 @@
             dt_device_device_target = hdc
             dt_device_bus_type = ide
             machine_type == q35:
-                dt_device_bus_type = virtio
+                dt_device_bus_type = scsi
         - disk_test:
             dt_device_device = disk
             dt_device_device_target = vdb


### PR DESCRIPTION
Libvirt disabled virtio bus as cdrom device since v5.1.0(commit
5d884f3d3). Update tp-libvirt script accordingly.

Signed-off-by: Han Han <hhan@redhat.com>