### PR TITLE
Add configuration parameter to serial functional

### DIFF
--- a/libvirt/tests/cfg/serial/serial_functional.cfg
+++ b/libvirt/tests/cfg/serial/serial_functional.cfg
@@ -2,6 +2,7 @@
     type = serial_functional
     start_vm = no
     local_ip_address = "127.0.0.1"
+    remove_devices = "serial,console"
     variants:
         - type_dev:
             serial_dev_type = dev
@@ -54,9 +55,11 @@
             serial_dev_type = nmdm
             serial_sources = master:/dev/nmdm0A,slave:/dev/nmdm0B
         - console_target_type_virtio:
+            remove_devices = ""
             serial_dev_type = pty
             console_target_type = virtio
         - test_only_first_console_be_serial:
+            remove_devices = ""
             serial_dev_type = pty
             console_target_type = virtio
             second_serial_console = yes

--- a/libvirt/tests/src/serial/serial_functional.py
+++ b/libvirt/tests/src/serial/serial_functional.py
@@ -744,6 +744,7 @@ def run(test, params, env):
     client_pwd = params.get('client_pwd', None)
     server_pwd = params.get('server_pwd', None)
     machine_type = params.get('machine_type', '')
+    remove_devices = params.get('remove_devices', 'serial,console').split(',')
 
     args_list = [client_pwd, server_pwd]
 
@@ -760,9 +761,8 @@ def run(test, params, env):
     vm_xml = VMXML.new_from_inactive_dumpxml(vm_name)
     vm_xml_backup = vm_xml.copy()
     try:
-        if console_target_type != 'virtio':
-            vm_xml.remove_all_device_by_type('serial')
-            vm_xml.remove_all_device_by_type('console')
+        for device_type in remove_devices:
+            vm_xml.remove_all_device_by_type(device_type)
         if serial_type == "tls":
             test_dict = dict(params)
             tls_obj = TLSConnection(test_dict)


### PR DESCRIPTION
If the domain xml already defines a console of target type virtio,
the test correctly fails.
Allow for explicit removal of console devices from configuration, instead.
This way, in case of an existing virtio console we can have the test remove
it before continuing making the test pass.

No impact on existing tests.

```bash
# avocado run --vt-type libvirt --vt-machine-type s390-virtio --vt-connect-uri qemu:///system serial.functional.console_target_type_virtio,serial.functional.type_pty,serial.functional.test_only_first_console_be_serial
JOB ID     : 066ed731a847e5d5a13fc921126aa5f7b0a650cf
JOB LOG    : /root/avocado/job-results/job-2020-02-03T11.36-066ed73/job.log
 (1/3) type_specific.io-github-autotest-libvirt.serial.functional.type_pty: PASS (5.96 s)
 (2/3) type_specific.io-github-autotest-libvirt.serial.functional.console_target_type_virtio: PASS (5.44 s)
 (3/3) type_specific.io-github-autotest-libvirt.serial.functional.test_only_first_console_be_serial: PASS (4.60 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 19.17 s
```