### PR TITLE
Set start_time to 240s for pseries to fix ip missing issue

### DIFF
--- a/libvirt/tests/cfg/cpu/setvcpu.cfg
+++ b/libvirt/tests/cfg/cpu/setvcpu.cfg
@@ -5,6 +5,8 @@
     vcpu_current = "1"
     maxvcpu = "8"
     start_timeout = "60"
+    pseries:
+        start_timeout = '240'
     vcpus_hotpluggable = "{1,2,3,4,5,6,7}"
     variants:
         - positive_test:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_interface.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_interface.cfg
@@ -17,12 +17,12 @@
                 - domid:
                     at_detach_iface_vm_ref = "domid"
                     at_detach_iface_model = "rtl8139"
-                    machine_type == pseries:
+                    pseries:
                         at_detach_iface_model = "virtio"
                 - domuuid:
                     at_detach_iface_vm_ref = "domuuid"
                     at_detach_iface_model = "e1000e"
-                    machine_type == pseries:
+                    pseries:
                         at_detach_iface_model = "virtio"
             variants:
                 - default_network:


### PR DESCRIPTION
The original start_time was set to 60s which might be sufficient
for x86 vms but not pseries vms. In 60s ppc vms might not finish
booting up yet. Setting timeout to 240s could easily fix this
problem

Signed-off-by: haizhao <haizhao@redhat.com>