### PR TITLE
The output of maxvcpu is not consistent among multi-archs

### DIFF
--- a/libvirt/tests/cfg/cpu/max_vcpus.cfg
+++ b/libvirt/tests/cfg/cpu/max_vcpus.cfg
@@ -4,6 +4,7 @@
 
     variants:
         - virsh_maxvcpus:
+            no pseries, s390-virtio
             check = "virsh_maxvcpus"
             report_num = "240"
         - virsh_capabilities:


### PR DESCRIPTION
The maxvcpus depends on many factors and should not be a fixed value
for pseries or s390x.

Signed-off-by: haizhao <haizhao@redhat.com>