### PR TITLE
Fix for libvirt new configure CPU 'dies'

### DIFF
--- a/libvirt/tests/cfg/numa/guest_numa.cfg
+++ b/libvirt/tests/cfg/numa/guest_numa.cfg
@@ -45,7 +45,7 @@
                      sockets = "2"
                      cores = "2"
                      threads = "1"
-                     qemu_cmdline_topo = "4,sockets=2,cores=2,threads=1"
+                     qemu_cmdline_topo = "4,sockets=2.*?,cores=2,threads=1"
                  - no_topo:
              variants:
                  - no_hugepage:


### PR DESCRIPTION
Now the qemu cmd line changed from
4,sockets=2,cores=2,threads=1
to
4,sockets=2,dies=1,cores=2,threads=1

Signed-off-by: Kylazhang <weizhan@redhat.com>