### PR TITLE
Skip check when source tag has no 'file' attr

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_change_media_matrix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_change_media_matrix.py
@@ -1,6 +1,7 @@
 import os
 import time
 import logging
+import platform
 from virttest import virsh
 from virttest import data_dir
 from virttest.libvirt_xml import vm_xml
@@ -36,7 +37,9 @@ def run(test, params, env):
                 continue
             if disk.target['dev'] != target_dev:
                 continue
-            if disk.xmltreefile.find('source') is not None:
+            if disk.xmltreefile.find('source') is not None and \
+                    not ('ppc64le' in platform.machine()
+                         and 'file' not in disk.source.attrs):
                 if disk.source.attrs['file'] != source_file:
                     continue
             else:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_update_device_matrix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_update_device_matrix.py
@@ -2,6 +2,7 @@ import os
 import time
 import shutil
 import logging
+import platform
 from avocado.core import exceptions
 from avocado.utils import process
 from virttest import virsh
@@ -62,6 +63,7 @@ def create_attach_xml(update_xmlfile, disk_type, target_bus,
         disk.alias = dict(name=disk_alias)
     disk.xmltreefile.write()
     shutil.copyfile(disk.xml, update_xmlfile)
+    logging.debug('Disk xml created: \n %s', disk)
 
 
 def run(test, params, env):
@@ -97,7 +99,9 @@ def run(test, params, env):
                 continue
             if disk.target['dev'] != target_dev:
                 continue
-            if disk.xmltreefile.find('source') is not None:
+            if disk.xmltreefile.find('source') is not None and \
+                    not ('ppc64le' in platform.machine()
+                         and 'file' not in disk.source.attrs):
                 if disk.source.attrs['file'] != source_file:
                     continue
             else:


### PR DESCRIPTION
Currently this only happens to ppc. Xml usually does not have 'source'
tag if the source file is not specified. But now a tag like
<source index='3' /> is being created, which is affecting test.
Therefore skip check if this happens.

Signed-off-by: haizhao <haizhao@redhat.com>