### PR TITLE
Add pkg dependency list to powerpc_hmi and guestpin stress tests

### DIFF
--- a/libvirt/tests/cfg/cpu/guestpin.cfg
+++ b/libvirt/tests/cfg/cpu/guestpin.cfg
@@ -31,6 +31,7 @@
                     itr = 10
                 - with_stress:
                     condn = "stress"
+                    stress_dependency_packages_list = ['gcc', 'make']
                     variants:
                         - guestcpu:
                             stress_args = '--cpu 8'

--- a/libvirt/tests/cfg/cpu/powerpc_hmi.cfg
+++ b/libvirt/tests/cfg/cpu/powerpc_hmi.cfg
@@ -10,6 +10,7 @@
     ppchmi_threads = 1
     hmi_iterations = 1
     condn = vcpupin,stress
+    stress_dependency_packages_list = ['gcc', 'make']
     variants:
         - positive:
             variants:


### PR DESCRIPTION
Stress tests requires stress test tool installed which requies
pkgs 'gcc, make' installed inside vms.

Signed-off-by: haizhao <haizhao@redhat.com>