### PR TITLE
Shutdown vm before libvirtd exit

### DIFF
--- a/libvirt/tests/src/numa/numa_memory_migrate.py
+++ b/libvirt/tests/src/numa/numa_memory_migrate.py
@@ -171,11 +171,11 @@ def run(test, params, env):
             process.run('systemctl restart virtlogd.socket', ignore_status=True, shell=True)
         except path.CmdNotFoundError:
             pass
+        if vm.is_alive():
+            vm.destroy(gracefully=False)
         libvirtd.exit()
         if config_path:
             config.restore()
             if os.path.exists(config_path):
                 os.remove(config_path)
-        if vm.is_alive():
-            vm.destroy(gracefully=False)
         backup_xml.sync()


### PR DESCRIPTION
In case cannot get vm state correctly and qemu thread will continue
to exist which will effect future tests.

Signed-off-by: haizhao <haizhao@redhat.com>