### PR TITLE
Fix test configuration

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_disk.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_disk.cfg
@@ -139,10 +139,10 @@
                     at_dt_disk_device_target = hdc
                     at_dt_disk_bus_type = ide
                     at_dt_disk_pre_vm_state = "shut off"
-                    machine_type == s390-ccw-virtio:
+                    s390-virtio:
                         at_dt_disk_device_target = sdb
                         at_dt_disk_bus_type = scsi
-                    machine_type == q35:
+                    q35:
                         at_dt_disk_device_target = sdb
                         at_dt_disk_bus_type = scsi
                 - cdrom_eject_control:
@@ -156,10 +156,10 @@
                     at_dt_disk_eject_cdrom = "yes"
                     at_dt_disk_save_vm = "yes"
                     time_sleep = "5"
-                    machine_type == s390-ccw-virtio:
+                    s390-virtio:
                         at_dt_disk_device_target = sdb
                         at_dt_disk_bus_type = scsi
-                    machine_type == q35:
+                    q35:
                         at_dt_disk_device_target = sdb
                         at_dt_disk_bus_type = scsi
                 - special_disk_name:

--- a/libvirt/tests/cfg/virtual_disks/startup_policy.cfg
+++ b/libvirt/tests/cfg/virtual_disks/startup_policy.cfg
@@ -58,7 +58,7 @@
                             target_dev = "hda"
                             disk_target_bus = "ide"
                             image_size = "100M"
-                            machine_type == s390-ccw-virtio:
+                            s390-virtio:
                                 disk_target_bus = "scsi"
                         - floppy:
                             device_type = "floppy"


### PR DESCRIPTION
The usage of `machine_type == X` has been found to have side effects,
s. https://github.com/autotest/tp-libvirt/pull/2523#discussion_r375134579
Fix as described.

Did not run tests because the change was tested on referenced PRs.