### PR TITLE
copy unattended_install from tp-qemu

### DIFF
--- a/generic/tests/cfg/unattended_install/unattended_install.cfg
+++ b/generic/tests/cfg/unattended_install/unattended_install.cfg
@@ -1,0 +1,223 @@
+- unattended_install:
+    virt_test_type = qemu libvirt
+    type = unattended_install
+    backup_image_after_testing_passed = yes
+    start_vm = no
+    kill_vm = yes
+    kill_vm_gracefully = yes
+    kill_vm_on_error = yes
+    shutdown_cleanly = yes
+    shutdown_cleanly_timeout = 120
+    force_create_image = yes
+    guest_port_unattended_install = 12323
+    kernel = vmlinuz
+    initrd = initrd.img
+    # Throw errors if guest screen is inactive
+    inactivity_watcher = error
+    # Inactivity treshold to error the test
+    inactivity_treshold = 1800
+    # Set migrate_background to yes to run migration in parallel
+    # migrate_background = yes
+    image_verify_bootable = no
+    # Copy boot image to results dir or not
+    # boot image will include the ks file or other files you need
+    # during install. Could be helpful to debug the install failed
+    # reasons.
+    # store_boot_disk = yes
+    #
+    # Backup images from nfs when install failed
+    image_copy_on_error = no
+    # images_good =
+    # Mount point for your back up images
+    # dst_dir =
+    #
+    # This value is setup for huge page set up.
+    # Lowest memory size for on vm to finish install test based on the
+    # anaconda memory check size. Tested it with RHEL, Windows and newest
+    # Fedora guests. For other guests like ubuntu if your install failed with
+    # don't have enough RAM error from anaconda, please enlarge this value.
+    lowest_mem = 512
+    # This value can be set to define time between each VM installation trigger
+    # in MultiVM environment
+    install_trigger_time = 0
+    # This value can be set to 'yes' if required to perform installation trigger
+    # random time in the range random.randint(0, install_trigger_time)
+    random_trigger = "no"
+    variants:
+        - aio_native:
+            image_aio = native
+        - aio_threads:
+            image_aio = threads
+    # Add some special types of installation
+    variants:
+        - default_install:
+            # Installation without any special configuration
+        - perf:
+            # configuration for performance test
+        - multi_disk_install:
+            no ide
+            only unattended_install..cdrom
+            serial_name = SYSTEM_DISK0
+            blk_extra_params_image1 = "serial=${serial_name}"
+            cmd_only_use_disk = "ignoredisk --only-use=disk/by-id/*${serial_name}"
+            images += " stg stg2 stg3 stg4 stg5 stg6 stg7 stg8 stg9 stg10 stg11 stg12 stg13 stg14 stg15 stg16 stg17 stg18 stg19 stg20 stg21 stg22 stg23 stg24"
+            image_name_stg = images/storage
+            image_name_stg2 = images/storage2
+            image_name_stg3 = images/storage3
+            image_name_stg4 = images/storage4
+            image_name_stg5 = images/storage5
+            image_name_stg6 = images/storage6
+            image_name_stg7 = images/storage7
+            image_name_stg8 = images/storage8
+            image_name_stg9 = images/storage9
+            image_name_stg10 = images/storage10
+            image_name_stg11 = images/storage11
+            image_name_stg12 = images/storage12
+            image_name_stg13 = images/storage13
+            image_name_stg14 = images/storage14
+            image_name_stg15 = images/storage15
+            image_name_stg16 = images/storage16
+            image_name_stg17 = images/storage17
+            image_name_stg18 = images/storage18
+            image_name_stg19 = images/storage19
+            image_name_stg20 = images/storage20
+            image_name_stg21 = images/storage21
+            image_name_stg22 = images/storage22
+            image_name_stg23 = images/storage23
+            image_name_stg24 = images/storage24
+            image_name_stg25 = images/storage25
+            image_size_equal = 1G
+            ahci:
+                images = "image1 stg stg2 stg3 stg4 stg5"
+        - large_image:
+            only unattended_install.cdrom
+            only qcow2 qcow2v3
+            install_timeout = 7200
+            image_size_image1 = 2300G
+            image_size = 2300G
+            RHEL.7:
+                image_size_image1 = 16300G
+                image_size = 16300G
+                images += " stg"
+                image_name_stg = images/storage
+                image_size_stg = 500000G
+            RHEL.8:
+                image_size_image1 = 16300G
+                image_size = 16300G
+                images += " stg"
+                image_name_stg = images/storage
+                image_size_stg = 1P
+            Windows:
+                image_size_image1 = 16300G
+                image_size = 16300G
+                images += " stg"
+                image_name_stg = images/storage
+                image_size_stg = 16000G
+        - 128g_image_512_cluster_size:
+            image_size_image1 = 128G
+            image_cluster_size = 512
+            install_timeout = 60000
+            no Host_RHEL.m5
+            only qcow2 qcow2v3
+        - with_migration:
+            migrate_background = yes
+        - setting_cluster_size:
+            # qemu-kvm bug 812705
+            no Host_RHEL.m5
+            image_cluster_size = 4096
+            install_timeout = 7200
+            only qcow2 qcow2v3
+    # Way of delivering ks file into the guest
+    variants:
+        # Additional iso with kickstart is attached into the guest
+        - extra_cdrom_ks:
+            no WinXP Win2000 Win2003 WinVista
+            unattended_delivery_method = cdrom
+            cdroms += " unattended"
+            Windows:
+                # FIXME: Guest could not be installed successfully without
+                # the serial option when using the blockdev option.
+                serial_name = SYSTEM_DISK0
+                blk_extra_params_image1 = "serial=${serial_name}"
+                i440fx:
+                    cd_format_unattended = ide
+                q35:
+                    cd_format_unattended = ahci
+            drive_index_unattended = 1
+            drive_index_cd1 = 2
+        # Kickstart is packed into the installation iso
+        - in_cdrom_ks:
+            only Linux, unattended_install.cdrom
+            unattended_delivery_method = integrated
+        # Autotest starts simple http server providing kickstart
+        - http_ks:
+            only Linux
+            unattended_delivery_method = url
+        # Image with kickstart is attached into the guest as floppy drive
+        - floppy_ks:
+            unattended_delivery_method = floppy
+            no q35
+            no pseries
+        # Only perform a libvirt import. No cdroms, no floppies, no nothing
+        - import:
+            virt_test_type = libvirt
+            no cdrom, url, nfs, remote_ks, pxe, kernel_initrd
+            backup_image_after_testing_passed = no
+            cdroms = ""
+            floppy = ""
+            install_timeout = 180
+    variants:
+        # Install guest from cdrom
+        - cdrom:
+
+            # set copy_to_local if you want copy files from nfs to local host before testing.
+            # local_dir: local folder used to save nfs file, kvm folder will be used by default.
+            # Both absolute path and relative path are supported in local_dir
+            # local_dir = /root/
+            # copy_to_local = cdrom_cd1 cdrom_winutils
+
+            # TODO: is this needed for both kvm and libvirt?
+            # This option is only used in windows installation case,
+            # since linux use kernel/initrd option of qemu.
+            Windows:
+                i440fx:
+                    cd_format_cd1 = ide
+                    cd_format_winutils = ide
+                q35:
+                    cd_format_cd1 = ahci
+                    cd_format_winutils = ahci
+            boot_once = d
+            medium = cdrom
+            redirs += " unattended_install"
+        # Install guest from http/ftp url
+        - url:
+            only Linux
+            medium = url
+            url = REPLACE_THIS_WITH_TREE_URL
+        # Install guest from nfs nfs_server:nfs_dir
+        - nfs:
+            only Linux
+            medium = nfs
+            nfs_server = REPLACE_THIS_WITH_NFS_SERVER
+            nfs_dir = REPLACE_THIS_WITH_NFS_DIRECTORY
+        # Install guest with a remote kickstart
+        - remote_ks:
+            only Linux
+            medium = url
+            # TODO: does kvm need to prefix this with '--append'?
+            extra_params = " ks=REPLACE_THIS_WITH_URL_OF_KS"
+            url = REPLACE_THIS_WITH_TREE_URL
+        # Install guest using pxe/tftp  (virt-install --pxe)
+        - pxe:
+            only Linux
+            medium = pxe
+        # Install guest using kernel/initrd pair from directory
+        - kernel_initrd:
+            only Linux
+            medium = kernel_initrd
+        - import:
+            virt_test_type = libvirt
+            no extra_cdrom_ks, in_cdrom_ks, http_ks, floppy_ks
+            medium = import
+            force_create_image = no
+            create_image = no

--- a/generic/tests/src/unattended_install/unattended_install.py
+++ b/generic/tests/src/unattended_install/unattended_install.py
@@ -1,0 +1,63 @@
+import logging
+import threading
+import time
+import random
+
+from virttest.tests import unattended_install
+
+error_flag = False
+
+
+def run(test, params, env):
+    """
+    Unattended install test:
+    1) Starts a VM with an appropriated setup to start an unattended OS install.
+    2) Wait until the install reports to the install watcher its end.
+
+    :param test: QEMU test object.
+    :param params: Dictionary with the test parameters.
+    :param env: Dictionary with test environment.
+    """
+    # use vm name to differentiate among single/multivm
+    vms = params.objects("vms")
+
+    if len(vms) < 2:
+        unattended_install.run(test, params, env)
+        return
+
+    def thread_func(vm):
+        """
+        Thread Method to trigger the unattended installation
+
+        :param vm: VM name
+        """
+        global error_flag
+        try:
+            vm_params = params.object_params(vm)
+            vm_params["main_vm"] = vm
+            unattended_install.run(test, vm_params, env)
+        except Exception as info:
+            logging.error(info)
+            error_flag = True
+
+    trigger_time = int(params.get("install_trigger_time", 0))
+    random_trigger = params.get("random_trigger", "no") == "yes"
+    install_threads = []
+
+    for vm in vms:
+        thread = threading.Thread(target=thread_func, args=(vm,))
+        install_threads.append(thread)
+
+    for thread in install_threads:
+        if trigger_time:
+            sleep_time = trigger_time
+            if random_trigger:
+                sleep_time = random.randint(0, trigger_time)
+            time.sleep(sleep_time)
+        thread.start()
+
+    for thread in install_threads:
+        thread.join()
+
+    if error_flag:
+        test.fail("Failed to perform unattended install")


### PR DESCRIPTION
To auto install windows guest via libvirt ci, copy scripts from
tp-qemu which has already automated windows installation.

Signed-off-by: Yingshun Cui <yicui@redhat.com>