### PR TITLE
Fix address check attach disk s390x

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_disk.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_disk.cfg
@@ -91,6 +91,8 @@
                     at_dt_disk_at_options = "--driver qemu --subdriver raw --config"
                     at_dt_disk_dt_options = "--config"
                     at_dt_disk_pre_vm_state = "shut off"
+                    s390-virtio:
+                        at_dt_disk_address = "ccw:0xfe.0x0.0x0010"
                 - vm_shutdown_serial_config:
                     only attach_disk
                     at_dt_disk_serial = "test"
@@ -118,6 +120,9 @@
                     at_dt_disk_test_twice = 'yes'
                     at_dt_disk_device_target2 = vdx
                     at_dt_disk_pre_vm_state = "shut off"
+                    s390-virtio:
+                        at_dt_disk_address = "ccw:0xfe.0x0.0x0010"
+                        at_dt_disk_address2 = "ccw:0xfe.0x0.0x0011"
                 - twice_diff_target_with_shareable:
                     at_with_shareable = 'yes'
                     at_dt_disk_test_twice = 'yes'
@@ -131,6 +136,9 @@
                     at_dt_disk_test_twice = 'yes'
                     at_dt_disk_device_target2 = vdx
                     at_dt_disk_pre_vm_state = "shut off"
+                    s390-virtio:
+                        at_dt_disk_address = "ccw:0xfe.0x0.0x0010"
+                        at_dt_disk_address2 = "ccw:0xfe.0x0.0x0011"
                 - cdrom:
                     at_dt_disk_at_options = "--type cdrom --driver qemu --config"
                     at_dt_disk_dt_options = "--config"


### PR DESCRIPTION
Depends on https://github.com/avocado-framework/avocado-vt/pull/2427
On s390x disks are attached per default as ccw.

test execution on s390x
```bash
# avocado run --vt-type libvirt --vt-machine-type s390-virtio --vt-connect-uri qemu:///system virsh.attach_detach_disk.attach_disk.normal_test.vm_shutdown_config,virsh.attach_detach_disk.attach_disk.normal_test.twice_multifunction,virsh.attach_detach_disk.attach_disk.normal_test.twice_multifunction_with_shareable
JOB ID     : c4e4cda240df20b5db1fbe63b4e1047e59a22983
JOB LOG    : /root/avocado/job-results/job-2020-02-10T14.11-c4e4cda/job.log
 (1/3) type_specific.io-github-autotest-libvirt.virsh.attach_detach_disk.attach_disk.normal_test.vm_shutdown_config: PASS (632.01 s)
 (2/3) type_specific.io-github-autotest-libvirt.virsh.attach_detach_disk.attach_disk.normal_test.twice_multifunction: PASS (671.05 s)
 (3/3) type_specific.io-github-autotest-libvirt.virsh.attach_detach_disk.attach_disk.normal_test.twice_multifunction_with_shareable: PASS (625.14 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 1950.83 s
```