### PR TITLE
migration: remove SUSPENDED_POSTCOPY event on the destination

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -247,7 +247,7 @@
                         - event_with_postcopy:
                             only with_postcopy
                             expectedEventSrc = ["event 'migration-iteration'", "event 'lifecycle' for domain.*: Suspended Migrated", "event 'lifecycle' for domain .*: Suspended Post-copy", "event 'lifecycle' for domain.*: Stopped Migrated", "event 'job-completed' for domain"]
-                            expectedEventTarget = ["event 'lifecycle' for domain.*Started Migrated", "event 'lifecycle' for domain .*: Suspended Post-copy", "event 'lifecycle' for domain.*: Resumed Post-copy", "event 'lifecycle' for domain.*: Resumed Migrated"]
+                            expectedEventTarget = ["event 'lifecycle' for domain.*Started Migrated", "event 'lifecycle' for domain.*: Resumed Post-copy", "event 'lifecycle' for domain.*: Resumed Migrated"]
                             low_speed = "10"
                             stress_in_vm = "yes"
                             stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M --timeout 70"


### PR DESCRIPTION
In previous libvirt code, VIR_DOMAIN_EVENT_SUSPENDED_POSTCOPY
event was wrongly added on the destination host. It got fixed
recently, so update in migration test accordingly.

Signed-off-by: Yingshun Cui <yicui@redhat.com>