### PR TITLE
timer type 'platform' is not supported by pseries

### DIFF
--- a/libvirt/tests/cfg/timer_management.cfg
+++ b/libvirt/tests/cfg/timer_management.cfg
@@ -104,6 +104,7 @@
                     timer_name = "tsc"
                     no present_no         #Temporary does not work according to feature testing
                 - platform:
+                    no pseries
                     # currently unsupported
                     timer_name = "platform"
                     timer_start_error = "yes"


### PR DESCRIPTION
Signed-off-by: haizhao <haizhao@redhat.com>