### PR TITLE
Fix issue of wrong usage cleanup function in VMChecker

### DIFF
--- a/v2v/tests/src/convert_vm_to_ovirt.py
+++ b/v2v/tests/src/convert_vm_to_ovirt.py
@@ -182,7 +182,7 @@ def run(test, params, env):
             test.error("Import VM failed")
 
         # Check all checkpoints after convert
-        vmchecker = VMChecker(test, params, env)
+        params['vmchecker'] = vmchecker = VMChecker(test, params, env)
         ret = vmchecker.run()
 
         # Other checks
@@ -232,8 +232,8 @@ def run(test, params, env):
         else:
             test.fail("%d checkpoints failed: %s" % (len(ret), ret))
     finally:
-        vmcheck = utils_v2v.VMCheck(test, params, env)
-        vmcheck.cleanup()
+        if params.get('vmchecker'):
+            params['vmchecker'].cleanup()
         if v2v_sasl:
             v2v_sasl.cleanup()
             v2v_sasl.close_session()

--- a/v2v/tests/src/function_test_xen.py
+++ b/v2v/tests/src/function_test_xen.py
@@ -58,6 +58,7 @@ def run(test, params, env):
         '/')[2] if params.get("ovirt_engine_url") else None
     ovirt_ca_file_path = params.get("ovirt_ca_file_path")
     local_ca_file_path = params.get("local_ca_file_path")
+    virsh_instance = None
 
     def log_fail(msg):
         """

--- a/v2v/tests/src/v2v_options.py
+++ b/v2v/tests/src/v2v_options.py
@@ -853,9 +853,8 @@ def run(test, params, env):
         if output_mode is None:
             pvt.cleanup_pool(pool_name, pool_type, pool_target, emulated_img)
         vmcheck_flag = params.get("vmcheck_flag")
-        if vmcheck_flag:
-            vmcheck = utils_v2v.VMCheck(test, params, env)
-            vmcheck.cleanup()
+        if vmcheck_flag and params.get('vmchecker'):
+            params['vmchecker'].cleanup()
         if new_v2v_user:
             process.system("userdel -f %s" % v2v_user)
         if backup_xml:


### PR DESCRIPTION
The original code created a new VMChecker instance to cleanup
the VM. But this way cannot close virsh session correclty.

The code should use the primary instance to cleanup.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>