### PR TITLE
Extract timeout variable

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_console.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_console.py
@@ -10,6 +10,8 @@ from virttest.libvirt_xml import vm_xml
 
 from provider import libvirt_version
 
+CMD_TIMEOUT = 30
+
 
 def xml_console_config(vm_name, serial_type='pty',
                        serial_port='0', serial_path=None):
@@ -87,7 +89,7 @@ def check_duplicated_console(command, force_command, status_error, login_user,
     session = aexpect.ShellSession(command)
     if not status_error:
         # Test duplicated console session
-        res = process.run(command, timeout=10, ignore_status=True, shell=True)
+        res = process.run(command, timeout=CMD_TIMEOUT, ignore_status=True, shell=True)
         logging.debug(res)
         if res.exit_status == 0:
             test.fail("Duplicated console session should fail. "
@@ -96,7 +98,7 @@ def check_duplicated_console(command, force_command, status_error, login_user,
         # Test duplicated console session with force option
         force_session = aexpect.ShellSession(force_command)
         force_status = utils_test.libvirt.verify_virsh_console(
-            force_session, login_user, login_passwd, timeout=10, debug=True)
+            force_session, login_user, login_passwd, timeout=CMD_TIMEOUT, debug=True)
         if not force_status:
             test.fail("Expect force console session should succeed, "
                       "but failed.")
@@ -244,7 +246,7 @@ def run(test, params, env):
         console_session = aexpect.ShellSession(command)
 
         status = utils_test.libvirt.verify_virsh_console(
-            console_session, login_user, login_passwd, timeout=10, debug=True)
+            console_session, login_user, login_passwd, timeout=CMD_TIMEOUT, debug=True)
         console_session.close()
 
         check_duplicated_console(command, force_command, status_error,


### PR DESCRIPTION
In order to ease timeout tuning on slow environments
1. extract command timeout value
2. increase hard coded value

```bash
# avocado run --vt-type libvirt --vt-machine-type s390-virtio --vt-connect-uri qemu:///system virsh.console.normal_test.non_acl.valid_domname
JOB ID     : b7494845bbacdcbda2bd844f766724a875782cd9
JOB LOG    : /root/avocado/job-results/job-2020-02-17T07.47-b749484/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.console.normal_test.non_acl.valid_domname: PASS (357.30 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 376.60 s
```