### PR TITLE
Add rhv-verifypeer=true cases and one invalid pem case

### DIFF
--- a/v2v/tests/cfg/convert_vm_to_ovirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_ovirt.cfg
@@ -40,10 +40,9 @@
                     only dest_rhev.NFS
             variants:
                 - rhv_verifypeer:
-                    rhv_upload_opts = "${rhv_upload_opts} -oo rhv-verifypeer"
+                    rhv_upload_opts = "${rhv_upload_opts} -oo rhv-verifypeer=true"
                 - rhv_noverifypeer:
-                    # do not test now
-                    no rhv_noverifypeer
+                    rhv_upload_opts = "${rhv_upload_opts} -oo rhv-verifypeer=false"
             variants:
                 - rhv_direct:
                     rhv_upload_opts = "${rhv_upload_opts} -oo rhv-direct"

--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -244,6 +244,15 @@
             only esx_67
             main_vm = 'VM_NAME_NO_FILE_ARCHITECTURE_V2V_EXAMPLE'
             checkpoint = file_architecture
+        - invalid_rhv_pem:
+            only esx_67
+            only negative_test
+            only rhev.rhv_upload
+            main_vm = VM_NAME_RHEL7_V2V_EXAMPLE
+            checkpoint = 'invalid_pem'
+            rhv_upload_opts = "${rhv_upload_opts} -oo rhv-verifypeer=true"
+            msg_content = 'virt-v2v: error: failed server prechecks, see earlier errors'
+            expect_msg = yes
         # ovirt-guest-agent-common
         - OGAC:
             only esx_67
@@ -266,4 +275,4 @@
             status_error = 'no'
         - negative_test:
             status_error = 'yes'
-            only option_root.single
+            only option_root.single, invalid_rhv_pem

--- a/v2v/tests/src/function_test_esx.py
+++ b/v2v/tests/src/function_test_esx.py
@@ -407,6 +407,16 @@ def run(test, params, env):
             if not os.path.isfile(os.getenv('VIRTIO_WIN')):
                 test.fail('%s does not exist' % os.getenv('VIRTIO_WIN'))
 
+        if checkpoint == 'invalid_pem':
+            # simply change the 2nd line to lowercase to get an invalid pem
+            with open(local_ca_file_path, 'r+') as fd:
+                for i in range(2):
+                    pos = fd.tell()
+                    res = fd.readline()
+                fd.seek(pos)
+                fd.write(res.lower())
+                fd.flush()
+
         if checkpoint == 'empty_cdrom':
             virsh_dargs = {'uri': remote_uri, 'remote_ip': remote_host,
                            'remote_user': 'root', 'remote_pwd': vpx_passwd,


### PR DESCRIPTION
1) The default value of rhv-verifypeer is false, explicitly add cases
for rhv-verifypeer=true.
2) Add one case when rhv-verifypeer=true but rhv-cafile is an invalid
ca file.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>