### PR TITLE
add migration case with disabled keepalive in source

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -296,13 +296,19 @@
                                     libvirtd_conf_dict = '{"keepalive_interval": "5", "keepalive_count": "5", "log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
                                     block_time = 40
                                 - on_target:
-                                    qemu_conf_dest_dict = '{r"keepalive_interval\s*=.*": 'keepalive_interval=5', r"keepalive_count\s*=.*": 'keepalive_count=5'}'
                                     libvirtd_conf_dest_dict ='{r"keepalive_interval\s*=.*": 'keepalive_interval=-1', r"log_level\s*=.*": 'log_level=1', r"log_outputs\s*=.*": 'log_outputs="1:file:${log_outputs}"'}'
                                     qemu_conf_dict = '{"keepalive_interval": "5", "keepalive_count": "5"}'
                                     libvirtd_conf_dict = '{"keepalive_interval": "5", "keepalive_count": "5", "log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
                                     grep_str_local_log = "virKeepAliveTimerInternal.*countToDeath=4 idle=10"
                                     grep_str_not_in_remote_log = "virKeepAliveTimerInternal"
-                                    block_time = 10                               
+                                    block_time = 10
+                                - on_source:
+                                    qemu_conf_dest_dict = '{r"keepalive_interval\s*=.*": 'keepalive_interval=5', r"keepalive_count\s*=.*": 'keepalive_count=5'}'
+                                    qemu_conf_dict = '{"keepalive_interval": "-1"}'
+                                    libvirtd_conf_dict = '{"keepalive_interval": "5", "keepalive_count": "5", "log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
+                                    grep_str_not_in_local_log = "virKeepAliveTimerInternal.*countToDeath=4 idle=10"
+                                    grep_str_remote_log = "virKeepAliveTimerInternal.*countToDeath=4 idle=10"
+                                    block_time = 10                                                        
         - negative_test:
             virsh_migrate_options = "--live --verbose"
             # The variable indicates migration command should fail
@@ -360,22 +366,29 @@
                             err_msg = "error: internal error: qemu unexpectedly closed the monitor|error: operation failed: domain is not running"
                         - disable_keepalive:
                             only without_postcopy
+                            break_network_connection = "yes"
+                            asynch_migrate = "yes"
+                            low_speed = "10"
+                            stress_in_vm = "yes"
+                            stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M --timeout 70"
+                            actions_during_migration= "drop_network_connection"
+                            block_time = 40
                             variants:
                                 - on_target:
-                                    break_network_connection = "yes"
-                                    asynch_migrate = "yes"
-                                    low_speed = "10"
-                                    stress_in_vm = "yes"
-                                    stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M --timeout 70"
-                                    actions_during_migration= "drop_network_connection"
                                     libvirtd_conf_dest_dict = '{r".*keepalive_interval.*=.*": 'keepalive_interval=-1'}'
                                     qemu_conf_dict = '{"keepalive_interval": "5", "keepalive_count": "5"}'
                                     libvirtd_conf_dict = '{"keepalive_interval": "5", "keepalive_count": "5", "log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
                                     grep_str_local_log = "No response from client .* after .* keepalive messages in .* seconds"
                                     grep_str_local_log_1 = "virKeepAliveTimerInternal.*countToDeath=0 idle=30"
                                     grep_str_not_in_remote_log = "virKeepAliveTimerInternal"
-                                    block_time = 40
                                     err_msg = "error: operation failed: Lost connection to destination host"
+                                - on_source:
+                                    qemu_conf_dest_dict = '{r"keepalive_interval\s*=.*": 'keepalive_interval=5', r"keepalive_count\s*=.*": 'keepalive_count=5'}'
+                                    qemu_conf_dict = '{"keepalive_interval": "-1"}'
+                                    libvirtd_conf_dict = '{"keepalive_interval": "5", "keepalive_count": "5", "log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
+                                    grep_str_not_in_local_log = "virKeepAliveTimerInternal.*countToDeath=4 idle=10"
+                                    grep_str_remote_log = "internal error: connection closed due to keepalive timeout"
+                                    err_msg = "error: operation failed: migration out job: unexpectedly failed"
                         - multifd:
                             only without_postcopy
                             variants:

--- a/libvirt/tests/src/migration/migrate_options_shared.py
+++ b/libvirt/tests/src/migration/migrate_options_shared.py
@@ -888,6 +888,7 @@ def run(test, params, env):
     asynch_migration = "yes" == params.get("asynch_migrate", "no")
     grep_str_remote_log = params.get("grep_str_remote_log", "")
     grep_str_not_in_remote_log = params.get("grep_str_not_in_remote_log", "")
+    grep_str_not_in_local_log = params.get("grep_str_not_in_local_log", "")
     grep_str_local_log = params.get("grep_str_local_log", "")
     grep_str_local_log_1 = params.get("grep_str_local_log_1", "")
     disable_verify_peer = "yes" == params.get("disable_verify_peer", "no")
@@ -1239,6 +1240,8 @@ def run(test, params, env):
         for grep_str in [grep_str_local_log, grep_str_local_log_1]:
             if grep_str:
                 libvirt.check_logfile(grep_str, log_file)
+        if grep_str_not_in_local_log:
+            libvirt.check_logfile(grep_str_not_in_local_log, log_file, False)
         if grep_str_remote_log:
             libvirt.check_logfile(grep_str_remote_log, log_file, True, cmd_parms,
                                   runner_on_target)


### PR DESCRIPTION
This patch adds below cases:
1. positive_test: break network during migration and recovers it
                  before keepalive timeout
2. negative_test: break network during migration and recovers it
                  after keepalive timeout

Signed-off-by: Yingshun Cui <yicui@redhat.com>