### PR TITLE
Update conf of disk dev and bus to support q35 and pseries

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_change_media_matrix.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_change_media_matrix.cfg
@@ -6,6 +6,14 @@
     change_media_new_iso = "change_media_new.iso"
     change_media_source =
     change_media_init_iso = "change_media_old.iso"
+    change_media_target_bus = "ide"
+    change_media_target_device = "hdc"
+    q35:
+        change_media_target_bus = "scsi"
+        change_media_target_device = "sdc"
+    pseries:
+        change_media_target_bus = "scsi"
+        change_media_target_device = "sdc"
     kill_vm = yes
     variants:
         - action_twice:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_update_device_matrix.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_update_device_matrix.cfg
@@ -7,6 +7,12 @@
     disk_mode = "readonly"
     updatedevice_target_bus = "ide"
     updatedevice_target_dev = "hdc"
+    q35:
+        updatedevice_target_bus = "scsi"
+        updatedevice_target_dev = "sdc"
+    pseries:
+        updatedevice_target_bus = "scsi"
+        updatedevice_target_dev = "sdc"
     disk_type = "cdrom"
     variants:
         - dt_okay_at_okay:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_change_media_matrix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_change_media_matrix.py
@@ -168,6 +168,7 @@ def run(test, params, env):
     options = params.get("change_media_options")
     options_twice = params.get("change_media_options_twice", "")
     device_type = params.get("change_media_device_type", "cdrom")
+    target_bus = params.get("change_media_target_bus", "ide")
     target_device = params.get("change_media_target_device", "hdc")
     init_iso_name = params.get("change_media_init_iso")
     old_iso_name = params.get("change_media_old_iso")
@@ -211,7 +212,7 @@ def run(test, params, env):
             libvirt.create_local_disk("iso", init_iso)
             disk_params = {"disk_type": "file", "device_type": device_type,
                            "driver_name": "qemu", "driver_type": "raw",
-                           "target_bus": "ide", "readonly": "yes"}
+                           "target_bus": target_bus, "readonly": "yes"}
             libvirt.attach_additional_device(vm_name, target_device,
                                              init_iso, disk_params)
 


### PR DESCRIPTION
IDE is not supported by q35, update bus to SCSI which is supported.

Signed-off-by: haizhao <haizhao@redhat.com>