### PR TITLE
Fix 2 auto failed case

### DIFF
--- a/v2v/tests/cfg/v2v_options.cfg
+++ b/v2v/tests/cfg/v2v_options.cfg
@@ -249,7 +249,7 @@
                     checkpoint = vmx_ssh
                     main_vm = VM_NAME_VMX_SSH_V2V_EXAMPLE
                     output_format = qcow2
-                    vmx = ssh://root@${esx_ip}/vmfs/volumes/datastore1/${main_vm}/${main_vm}.vmx
+                    vmx = ssh://root@${esx_ip}/vmfs/volumes/esx6.5-function/${main_vm}/${main_vm}.vmx
                 - qemu_session:
                     only input_mode.libvirt.kvm.default
                     only output_mode.libvirt


### PR DESCRIPTION
1.RHV only support one special character；'_',so the case about specail_name only need to convert to libvirt.
2.Guest storage has been changed.

Signed-off-by: Zi Liu <zili@redhat.com>