### PR TITLE
Handle date output format change

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domtime.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domtime.py
@@ -109,22 +109,32 @@ def run(test, params, env):
         times['local_hw'] -= datetime.timedelta(seconds=delta)
 
         # Guest system local timezone time
-        output, _ = run_cmd(session, 'date')
-        # Strip timezone info from output
-        # e.g. 'Sun Feb 15 07:31:40 CST 2009' -> 'Sun Feb 15 07:31:40 2009'
-        time_str = re.sub(r'\S+ (?=\S+$)', '', output.strip())
-        times['local_sys'] = datetime.datetime.strptime(
-            time_str, r"%a %b %d %H:%M:%S %Y")
+        try:
+            output, _ = run_cmd(session, 'date')
+            # Strip timezone info from output
+            # e.g. 'Sun Feb 15 07:31:40 CST 2009' -> 'Sun Feb 15 07:31:40 2009'
+            time_str = re.sub(r'\S+ (?=\S+$)', '', output.strip())
+            times['local_sys'] = datetime.datetime.strptime(
+                    time_str, r"%a %b %d %H:%M:%S %Y")
+        except ValueError:
+            output, _ = run_cmd(session, 'date +"%a %b %d %H:%M:%S %Y"')
+            times['local_sys'] = datetime.datetime.strptime(
+                    output.strip(), r"%a %b %d %H:%M:%S %Y")
         delta = time.time() - get_begin
         times['local_sys'] -= datetime.timedelta(seconds=delta)
 
         # Guest system UTC timezone time
-        output, _ = run_cmd(session, 'date -u')
-        # Strip timezone info from output
-        # e.g. 'Sun Feb 15 07:31:40 CST 2009' -> 'Sun Feb 15 07:31:40 2009'
-        time_str = re.sub(r'\S+ (?=\S+$)', '', output.strip())
-        times['utc_sys'] = datetime.datetime.strptime(
-            time_str, r"%a %b %d %H:%M:%S %Y")
+        try:
+            output, _ = run_cmd(session, 'date -u')
+            # Strip timezone info from output
+            # e.g. 'Sun Feb 15 07:31:40 CST 2009' -> 'Sun Feb 15 07:31:40 2009'
+            time_str = re.sub(r'\S+ (?=\S+$)', '', output.strip())
+            times['utc_sys'] = datetime.datetime.strptime(
+                    time_str, r"%a %b %d %H:%M:%S %Y")
+        except ValueError:
+            output, _ = run_cmd(session, 'date -u +"%a %b %d %H:%M:%S %Y"')
+            times['utc_sys'] = datetime.datetime.strptime(
+                    output.strip(), r"%a %b %d %H:%M:%S %Y")
         delta = time.time() - get_begin
         times['utc_sys'] -= datetime.timedelta(seconds=delta)
 


### PR DESCRIPTION
Recent distributions like Ubuntu 20.04, date command
output format changed, hence the below error,

ValueError: time data 'Sat 08 Feb 2020 01:00:25 IST' does not match format '%a %b %d %H:%M:%S %Y

So let's handle it by forcing the date command output with
a format string, though this can be generic for all distributions,
there may be some old distributions might not support format string
with date command, so let's handle it in failure path not to break
tests in other environments.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>