### PR TITLE
Fixed Get wrong disk0 name sda issue

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_create_as.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_create_as.cfg
@@ -91,7 +91,7 @@
                     snap_createas_opts = "a--a a--a--snap1"
                 - disk_only_spec:
                     snap_createas_opts = "--disk-only"
-                    diskspec_opts = "vda,snapshot=external,driver=qcow2,file=disk-snap.img"
+                    diskspec_opts = "sda,snapshot=external,driver=qcow2,file=disk-snap.img"
                 - check_libvirtd_log:
                     check_json_no_savevm = "yes"
                     snap_createas_opts = "--disk-only"
@@ -107,7 +107,7 @@
                 - live_memspec:
                     snap_createas_opts = "--live"
                     memspec_opts = "live_memspec.img"
-                    diskspec_opts = "vda,snapshot=external,file=external_disk0"
+                    diskspec_opts = "sda,snapshot=external,file=external_disk0"
                     variants:
                         - compress_default:
                         - compress_format:
@@ -154,8 +154,8 @@
                 - multi_disk_external:
                     diskspec_num = 2
                     snap_createas_opts = "--name tt --description hello --disk-only"
-                    diskspec_opts1 = "vda,snapshot=external,driver=qcow2,file=test1.img"
-                    diskspec_opts2 = "vdb,snapshot=external,driver=qcow2,file=test2.img"
+                    diskspec_opts1 = "sda,snapshot=external,driver=qcow2,file=test1.img"
+                    diskspec_opts2 = "sdb,snapshot=external,driver=qcow2,file=test2.img"
                 - multi_diskspec_no_snapshot:
                     # for more than 1 diskspec diskspec_num must be given and second one with snapshot=no
                     diskspec_num = 2
@@ -174,7 +174,7 @@
                     only disk_only_spec, with_diskspec, compress_default, multi_disk_external
                     replace_vm_disk = "yes"
                     disk_type = "network"
-                    disk_target = "vda"
+                    disk_target = "sda"
                     disk_target_bus = "virtio"
                     disk_format = "raw"
                     image_size = "10G"

--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_create_as.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_create_as.py
@@ -525,8 +525,9 @@ def run(test, params, env):
             for i in range(1, dnum):
                 disk_path = os.path.join(data_dir.get_tmp_dir(), 'disk%s.qcow2' % i)
                 process.run("qemu-img create -f qcow2 %s 200M" % disk_path, shell=True)
+                adisk = list((opt_names["diskopts_%s" % str(i + 1)]).split(","))
                 virsh.attach_disk(vm_name, disk_path,
-                                  'vd%s' % list(string.ascii_lowercase)[i],
+                                  adisk[0],
                                   debug=True)
 
         # Run virsh command


### PR DESCRIPTION
disk_only_spec, compress_default and multi_disk_external tests creates VM with sda as the disk and snapshot is created with vda. Later check_snapslist() is called to compare dname that fails due to mismatch(FAIL: Get wrong disk0 name sda).

So, config & test code is changed to take this disk name correctly.

Signed-off-by : Kumuda G <kumuda@linux.vnet.ibm.com>