### PR TITLE
virsh_sendkey: make kernel option set optional

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_sendkey.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_sendkey.cfg
@@ -2,6 +2,10 @@
     type = virsh_sendkey
     start_vm = "yes"
     take_regular_screendumps = "no"
+    # If the guest image in test is already text mode only installed, it is 
+    # better to set force_vm_boot_text_mode = "no" to avoid of potential
+    # failures.
+    force_vm_boot_text_mode = "yes"
     variants:
         - params_test:
             create_file_name = "/root/abc"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_sendkey.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_sendkey.py
@@ -42,6 +42,7 @@ def run(test, params, env):
     unprivileged_user = params.get('unprivileged_user')
     is_crash = ("yes" == params.get("is_crash", "no"))
     add_panic_device = ("yes" == params.get("add_panic_device", "yes"))
+    force_vm_boot_text_mode = ("yes" == params.get("force_vm_boot_text_mode", "yes"))
     crash_dir = "/var/crash"
     if unprivileged_user:
         if unprivileged_user.count('EXAMPLE'):
@@ -67,12 +68,13 @@ def run(test, params, env):
     vm.wait_for_login().close()
     vmxml_backup = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
 
-    # Boot the guest in text only mode so that send-key commands would succeed
-    # in creating a file
-    try:
-        utils_test.update_boot_option(vm, args_added="3", guest_arch_name=params.get('vm_arch_name'))
-    except Exception as info:
-        test.error(info)
+    if force_vm_boot_text_mode:
+        # Boot the guest in text only mode so that send-key commands would succeed
+        # in creating a file
+        try:
+            utils_test.update_boot_option(vm, args_added="3", guest_arch_name=params.get('vm_arch_name'))
+        except Exception as info:
+            test.error(info)
 
     session = vm.wait_for_login()
     if sysrq_test:


### PR DESCRIPTION
Original codes sets kernel option for guest image with graphic mode.
But if the guest image is already text mode installed, there is no
need to set this option. In addition, sometimes setting kernel option
will randomly fail with unclear reason. So the fix is to make the
setting kernel option optionally.

Signed-off-by: Dan Zheng <dzheng@redhat.com>