### PR TITLE
Replace 'warn' with 'cancel' of libvirt_vcpu_plug_unplug

### DIFF
--- a/libvirt/tests/src/libvirt_vcpu_plug_unplug.py
+++ b/libvirt/tests/src/libvirt_vcpu_plug_unplug.py
@@ -390,8 +390,8 @@ def run(test, params, env):
                     try:
                         vm.wait_for_login(timeout=600)
                     except Exception as e:
-                        test.warn("Skip remaining test steps as domain"
-                                  " not resume in 10 mins: %s" % e)
+                        test.cancel("Skip remaining test steps as domain"
+                                    " not resume in 10 mins: %s" % e)
                     # For hotplug/unplug vcpu without '--config flag, after
                     # suspend domain to disk(shut off) and re-start it, the
                     # current live vcpu number will recover to orinial value
@@ -518,8 +518,8 @@ def run(test, params, env):
                     try:
                         vm.wait_for_login(timeout=600)
                     except Exception as e:
-                        test.warn("Skip remaining test steps as domain"
-                                  " not resume in 10 mins: %s" % e)
+                        test.cancel("Skip remaining test steps as domain"
+                                    " not resume in 10 mins: %s" % e)
                     # For hotplug/unplug vcpu without '--config flag, after
                     # suspend domain to disk(shut off) and re-start it, the
                     # current live vcpu number will recover to orinial value


### PR DESCRIPTION
test.warn is undefined from avocado and according to comments of
this piece of code, we could replace 'warn' with 'cancel'

Signed-off-by: haizhao <haizhao@redhat.com>