### PR TITLE
Fix using wrong xml as a checking source

### DIFF
--- a/provider/v2v_vmcheck_helper.py
+++ b/provider/v2v_vmcheck_helper.py
@@ -55,6 +55,9 @@ class VMChecker(object):
         self.vmxml = virsh.dumpxml(
             self.vm_name,
             session_id=self.virsh_session_id).stdout.strip()
+        self.xmltree = None
+        if self.vmxml:
+            self.xmltree = xml_utils.XMLTreeFile(self.vmxml)
         # Save NFS mount records like {0:(src, dst, fstype)}
         self.mount_records = {}
 

--- a/v2v/tests/src/specific_kvm.py
+++ b/v2v/tests/src/specific_kvm.py
@@ -610,11 +610,11 @@ def run(test, params, env):
                 else:
                     graph_type = checkpoint.split('_')[0]
                     vmchecker.check_graphics({'type': graph_type})
-                    video_type = vmxml.get_devices('video')[0].model_type
+                    video_type = vmchecker.xmltree.find('./devices/video/model').get('type')
                     if video_type.lower() != 'qxl':
                         log_fail('Video expect QXL, actual %s' % video_type)
             if checkpoint.startswith('listen'):
-                listen_type = vmxml.get_devices('graphics')[0].listen_type
+                listen_type = vmchecker.xmltree.find('./devices/graphics/listen').get('type')
                 logging.info('listen type is: %s', listen_type)
                 if listen_type != checkpoint.split('_')[-1]:
                     log_fail('listen type changed after conversion')


### PR DESCRIPTION
In commit 22f08263986429f7376b5ca1ecf5c1e236cfd021, vmxml was removed.
But some lines still use it and the lines were forgot to be modified.
so the wrong global vmxml variant was used.

This patch fixes the error.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>