### PR TITLE
Fix hostdev detach device by alias on s390x

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
@@ -5,6 +5,8 @@
             detach_hostdev_type = "usb"
             detach_hostdev_managed = "no"
             detach_check_xml = "<hostdev"
+            s390-virtio:
+                detach_hostdev_type = "scsi"
         - controller:
             detach_controller_type = "scsi"
             detach_controller_mode = "virtio-scsi"


### PR DESCRIPTION
On s390x there are not usb devices, update test to work with scsi using scsi_debug device.

Depends on https://github.com/avocado-framework/avocado-vt/pull/2443

Executed test:
```bash
# avocado run --vt-type libvirt --vt-machine-type s390-virtio --vt-connect-uri qemu:///system virsh.detach_device_alias.live.hostdev
JOB ID     : e91fd4f92c0f58940f872b64721c1cb721306283
JOB LOG    : /root/avocado/job-results/job-2020-02-24T12.15-e91fd4f/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.hostdev: PASS (76.82 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 78.88 s
```