### PR TITLE
migration: add tls-destination related tests

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -308,7 +308,20 @@
                                     libvirtd_conf_dict = '{"keepalive_interval": "5", "keepalive_count": "5", "log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
                                     grep_str_not_in_local_log = "virKeepAliveTimerInternal.*countToDeath=4 idle=10"
                                     grep_str_remote_log = "virKeepAliveTimerInternal.*countToDeath=4 idle=10"
-                                    block_time = 10                                                        
+                                    block_time = 10
+                        - native_tls:
+                            virsh_migrate_extra = "--tls"
+                            custom_pki_path = "/etc/pki/qemu"
+                            qemu_tls = "yes"
+                            client_cn = "ENTER.YOUR.CLIENT_CN"
+                            disable_verify_peer = "no"
+                            qemu_conf_dict = '{"migrate_tls_x509_verify": "1"}'
+                            variants:
+                                - tls_destination:
+                                    only without_postcopy
+                                    check_tls_destination = "yes"
+                                    server_cn = "test.com.cn"
+                                    virsh_migrate_extra = "--tls --tls-destination ${server_cn}"                                                          
         - negative_test:
             virsh_migrate_options = "--live --verbose"
             # The variable indicates migration command should fail
@@ -395,6 +408,29 @@
                                 - without_parallel:
                                     parallel_cn_nums = 4
                                     err_msg = "error: invalid argument: Turn parallel migration on to tune it"
+                        - native_tls:
+                            custom_pki_path = "/etc/pki/qemu"
+                            qemu_tls = "yes"
+                            server_cn = "INCORRECT.SERVER_CN"
+                            client_cn = "ENTER.YOUR.CLIENT_CN"
+                            disable_verify_peer = "yes"
+                            variants:
+                                - tls_destination:
+                                    only without_postcopy
+                                    check_tls_destination = "yes"
+                                    variants:
+                                        - without_option:
+                                            virsh_migrate_extra = "--tls"
+                                            err_msg = "error: internal error: qemu unexpectedly closed the monitor"
+                                        - empty_str:
+                                            virsh_migrate_extra = "--tls --tls-destination ''"
+                                            err_msg = "error: Failed to get option 'tls-destination': Option argument is empty"
+                                        - without_tls:
+                                            virsh_migrate_extra = "--tls-destination ${server_cn}"
+                                            err_msg = "error: Option --tls is required by option --tls-destination"
+                                        - incorrect_hostname:
+                                            virsh_migrate_extra = "--tls --tls-destination fake${server_cn}"
+                                            err_msg = "error: internal error: qemu unexpectedly closed the monitor"
                 - tunnelled_migration:
                     only without_postcopy
                     virsh_migrate_options = "--live --p2p --tunnelled --verbose"

--- a/libvirt/tests/src/migration/migrate_options_shared.py
+++ b/libvirt/tests/src/migration/migrate_options_shared.py
@@ -884,6 +884,7 @@ def run(test, params, env):
     check_domjobinfo_results = "yes" == params.get("check_domjobinfo_results")
     check_log_interval = params.get("check_log_interval")
     check_event_output = params.get("check_event_output")
+    check_tls_destination = "yes" == params.get("check_tls_destination", "no")
     contrl_index = params.get("new_contrl_index", None)
     asynch_migration = "yes" == params.get("asynch_migrate", "no")
     grep_str_remote_log = params.get("grep_str_remote_log", "")
@@ -978,6 +979,10 @@ def run(test, params, env):
             if not libvirt_version.version_compare(5, 2, 0):
                 test.cancel("This libvirt version doesn't support "
                             "multifd feature.")
+        if check_tls_destination:
+            if not libvirt_version.version_compare(5, 6, 0):
+                test.cancel("This libvirt version doesn't support "
+                            "tls-destination option.")
 
         if vcpu_num:
             cmd = "grep -c processor /proc/cpuinfo"


### PR DESCRIPTION
This PR adds tests about tls-destination option which can
specific the hostname of destination server_cn in certificate
verification.

Signed-off-by: Yingshun Cui <yicui@redhat.com>