### PR TITLE
Skip check when source tag has no 'file' attr

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_change_media_matrix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_change_media_matrix.py
@@ -36,7 +36,8 @@ def run(test, params, env):
                 continue
             if disk.target['dev'] != target_dev:
                 continue
-            if disk.xmltreefile.find('source') is not None:
+            if disk.xmltreefile.find('source') is not None and \
+                    'file' in disk.source.attrs:
                 if disk.source.attrs['file'] != source_file:
                     continue
             else:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_update_device_matrix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_update_device_matrix.py
@@ -62,6 +62,7 @@ def create_attach_xml(update_xmlfile, disk_type, target_bus,
         disk.alias = dict(name=disk_alias)
     disk.xmltreefile.write()
     shutil.copyfile(disk.xml, update_xmlfile)
+    logging.debug('Disk xml created: \n %s', disk)
 
 
 def run(test, params, env):
@@ -97,7 +98,8 @@ def run(test, params, env):
                 continue
             if disk.target['dev'] != target_dev:
                 continue
-            if disk.xmltreefile.find('source') is not None:
+            if disk.xmltreefile.find('source') is not None and \
+                    'file' in disk.source.attrs:
                 if disk.source.attrs['file'] != source_file:
                     continue
             else:


### PR DESCRIPTION
Xml usually does not have 'source' tag if the source file is not specified.
But now a tag like <source index='3' /> is being created, which is affecting test.
Therefore skip check if this happens.

Signed-off-by: haizhao <haizhao@redhat.com>