### PR TITLE
migration: Fix missing option issue

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -393,6 +393,7 @@
                             only without_postcopy
                             variants:
                                 - without_parallel:
+                                    virsh_migrate_extra = "--parallel-connections"
                                     parallel_cn_nums = 4
                                     err_msg = "error: invalid argument: Turn parallel migration on to tune it"
                 - tunnelled_migration:


### PR DESCRIPTION
The option "--parallel-connections" was missed from cfg file,
so fix it in this PR.

Signed-off-by: Yingshun Cui <yicui@redhat.com>