### PR TITLE
Fixup: incorrect module import for python3

### DIFF
--- a/libvirt/tests/src/limit.py
+++ b/libvirt/tests/src/limit.py
@@ -1,5 +1,5 @@
 import logging
-from string import letters
+from string import ascii_letters as letters
 import os
 
 from avocado.utils import process


### PR DESCRIPTION
Seems letters from string module is deprecated in python3, so below error
ERROR: cannot import name 'letters' from 'string' (/usr/lib/python3.8/string.py)

Let's fix it by changing it to supported one.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>