### PR TITLE
Add timeout constant

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_metadata.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_metadata.py
@@ -9,6 +9,8 @@ from virttest.utils_test import libvirt as utlv
 from virttest.utils_libvirtd import Libvirtd
 from virttest.libvirt_xml import vm_xml
 
+CMD_TIMEOUT = 60
+
 
 def run(test, params, env):
     """
@@ -90,7 +92,7 @@ def run(test, params, env):
                     session.sendline(".")
                     session.send('ZZ')
                     remote.handle_prompts(session, None, None, r"[\#\$]\s*$",
-                                          debug=True)
+                                          debug=True, timeout=CMD_TIMEOUT)
                 except Exception as e:
                     logging.error("Error occured: %s", e)
                 session.close()


### PR DESCRIPTION
Overwrite timeout default value with constant to allow for slower
environments.

```bash
# avocado run --vt-type libvirt --vt-machine-type s390-virtio --vt-connect-uri qemu:///system virsh.metadata.positive_test.edit_option
JOB ID     : e1daf13f3722c76e1a6f9ef3cf23b9926ef2ff9d
JOB LOG    : /root/avocado/job-results/job-2020-03-03T12.31-e1daf13/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.metadata.positive_test.edit_option: WARN: Test passed but there were warnings during execution. Check the log for details. (50.64 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 1 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 71.62 s
```