### PR TITLE
Update filter expression for some negative cases of v2v

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -246,7 +246,7 @@
             checkpoint = file_architecture
         - invalid_rhv_pem:
             only esx_67
-            only negative_test, rhev.rhv_upload
+            only negative_test..rhev.rhv_upload
             main_vm = VM_NAME_RHEL7_V2V_EXAMPLE
             checkpoint = 'invalid_pem'
             rhv_upload_opts = "${rhv_upload_opts} -oo rhv-verifypeer=true"

--- a/v2v/tests/cfg/v2v_options.cfg
+++ b/v2v/tests/cfg/v2v_options.cfg
@@ -465,7 +465,7 @@
                         - no-copy:
                             v2v_options = "-o glance --no-copy"
                 - custom:
-                    only input_mode.none, output_mode.none
+                    only input_mode.none..output_mode.none
                     variants:
                         - no_verifypeer_without_ca:
                             # Means version >= libguestfs-1.40.2-15


### PR DESCRIPTION
Some unreasonable cases was listed by wrong cartesian filter, this
patch fixes the problem.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>