### PR TITLE
Fix expect message for rhv-verifypeer option because of bug1791240

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -45,7 +45,7 @@
                     output_method = "rhv_upload"
                     rhv_upload_passwd = ${ovirt_engine_password}
                     rhv_upload_passwd_file = "/tmp/rhv_upload_passwd_file"
-                    rhv_upload_opts = "-oc ${ovirt_engine_url} -op ${rhv_upload_passwd_file} -oo rhv-cafile=${local_ca_file_path} -oo rhv-cluster=${cluster_name}"
+                    rhv_upload_opts = "-oc ${ovirt_engine_url} -op ${rhv_upload_passwd_file} -oo rhv-cluster=${cluster_name}"
                     rhv_upload_opts = "${rhv_upload_opts} -oo rhv-direct"
                 - rhv:
                     output_method = "rhev"
@@ -246,11 +246,12 @@
             checkpoint = file_architecture
         - invalid_rhv_pem:
             only esx_67
-            only negative_test, rhev.rhv_upload
+            only negative_test
+            only rhev.rhv_upload
             main_vm = VM_NAME_RHEL7_V2V_EXAMPLE
             checkpoint = 'invalid_pem'
-            rhv_upload_opts = "${rhv_upload_opts} -oo rhv-verifypeer=true"
-            msg_content = 'virt-v2v: error: failed server prechecks, see earlier errors'
+            rhv_upload_opts = "${rhv_upload_opts} -oo rhv-cafile=${local_ca_file_path} -oo rhv-verifypeer=true"
+            msg_content = 'ovirtsdk4.Error: Error while sending HTTP request.*? CApath: none'
             expect_msg = yes
         # ovirt-guest-agent-common
         - OGAC:
@@ -269,9 +270,23 @@
                   main_vm = VM_NAME_SLES_V2V_EXAMPLE
                 - opensuse:
                   main_vm = VM_NAME_OPENSUSE_V2V_EXAMPLE
+        - verifypeer_ca:
+            only esx_67
+            only rhev.rhv_upload
+            main_vm = VM_NAME_RHEL7_V2V_EXAMPLE
+            variants:
+                - verifypeer_false_with_ca:
+                    rhv_upload_opts = "${rhv_upload_opts} -oo rhv-cafile=${local_ca_file_path}  -oo rhv-verifypeer=false"
+                - verifypeer_true_without_ca:
+                    only negative_test
+                    # Means version >= libguestfs-1.40.2-21
+                    version_requried = "[libguestfs-1.40.2-21,)"
+                    rhv_upload_opts = "${rhv_upload_opts} -oo rhv-verifypeer=true"
+                    msg_content = "virt-v2v: error: -o rhv-upload: must use .-oo rhv-cafile. .*? oVirt or RHV"
+                    expect_msg = no
     variants:
         - positive_test:
             status_error = 'no'
         - negative_test:
             status_error = 'yes'
-            only option_root.single, invalid_rhv_pem
+            only option_root.single, invalid_rhv_pem, verifypeer_true_without_ca

--- a/v2v/tests/cfg/v2v_options.cfg
+++ b/v2v/tests/cfg/v2v_options.cfg
@@ -464,17 +464,4 @@
                             v2v_options = "-o null -os default"
                         - no-copy:
                             v2v_options = "-o glance --no-copy"
-                - custom:
-                    only input_mode.none, output_mode.none
-                    variants:
-                        - no_verifypeer_without_ca:
-                            # Means version >= libguestfs-1.40.2-15
-                            version_requried = "[libguestfs-1.40.2-15,)"
-                            v2v_options = "-o rhv-upload -oo rhv-verifypeer=false"
-                            msg_content = "virt-v2v: error: expecting a libvirt guest name on the command line"
-                            expect_msg = yes
-                        - verifypeer_without_ca:
-                            v2v_options = "-o rhv-upload -oo rhv-verifypeer=true"
-                            msg_content = "virt-v2v: error: -o rhv-upload: must use .-oo rhv-cafile. .*? oVirt or RHV"
-                            expect_msg = yes
 


### PR DESCRIPTION
The origin info shouldn't be shown after fixing bug1791240.

Signed-off-by: mxie91 <mxie@redhat.com>