### PR TITLE
Fix gluster failures due to qemu-cmd checking

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_gluster.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_gluster.py
@@ -12,6 +12,8 @@ from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.disk import Disk
 
+from virttest import libvirt_version
+
 
 def run(test, params, env):
     """
@@ -235,6 +237,11 @@ def run(test, params, env):
                 test.fail("failed to prepare agent: %s" % detail)
             # Run dompmsuspend command.
             test_pmsuspend(vm_name)
+
+        # After block-dev introduced in libvirt 6.0.0 afterwards, gluster+%s.*format information is not provided from qemu output
+        if libvirt_version.version_compare(6, 0, 0):
+            test_qemu_cmd = False
+
         if test_qemu_cmd:
             # Check qemu-kvm command line
             cmd = ("ps -ef | grep %s | grep -v grep " % vm_name)


### PR DESCRIPTION
After block-dev introduced, qemu-cmd doesn't output gluster.*=format information

Signed-off-by: chunfuwen <chwen@redhat.com>