### PR TITLE
Skip virtio transitional cases if libvirt version < 5.0

### DIFF
--- a/libvirt/tests/src/virtio_transitional/virtio_transitional_blk.py
+++ b/libvirt/tests/src/virtio_transitional/virtio_transitional_blk.py
@@ -8,6 +8,8 @@ from virttest import virsh
 from virttest import data_dir
 from virttest import utils_misc
 from virttest import utils_package
+from virttest import libvirt_version
+
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import devices
 from virttest.utils_test import libvirt
@@ -212,6 +214,10 @@ def run(test, params, env):
     pci_bridge_index = None
     tmp_dir = data_dir.get_tmp_dir()
     guest_src_url = params.get("guest_src_url")
+
+    if not libvirt_version.version_compare(5, 0, 0):
+        test.cancel("This libvirt version doesn't support "
+                    "virtio-transitional model.")
 
     if guest_src_url:
 

--- a/libvirt/tests/src/virtio_transitional/virtio_transitional_blk_negative.py
+++ b/libvirt/tests/src/virtio_transitional/virtio_transitional_blk_negative.py
@@ -7,6 +7,8 @@ from avocado.utils import download
 from virttest import remote
 from virttest import data_dir
 from virttest import utils_misc
+from virttest import libvirt_version
+
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import xcepts
 from virttest.utils_test import libvirt
@@ -25,6 +27,11 @@ def run(test, params, env):
     guest_src_url = params["guest_src_url"]
     image_name = params['image_path']
     target_path = utils_misc.get_path(data_dir.get_data_dir(), image_name)
+
+    if not libvirt_version.version_compare(5, 0, 0):
+        test.cancel("This libvirt version doesn't support "
+                    "virtio-transitional model.")
+
     if not os.path.exists(target_path):
         download.get_file(guest_src_url, target_path)
         params["blk_source_name"] = target_path

--- a/libvirt/tests/src/virtio_transitional/virtio_transitional_mem_balloon.py
+++ b/libvirt/tests/src/virtio_transitional/virtio_transitional_mem_balloon.py
@@ -6,6 +6,8 @@ from avocado.utils import download
 from virttest import virsh
 from virttest import data_dir
 from virttest import utils_misc
+from virttest import libvirt_version
+
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 
@@ -35,6 +37,10 @@ def run(test, params, env):
     virtio_model = params['virtio_model']
     os_variant = params.get("os_variant", "")
     params["disk_model"] = virtio_model
+
+    if not libvirt_version.version_compare(5, 0, 0):
+        test.cancel("This libvirt version doesn't support "
+                    "virtio-transitional model.")
 
     # Download and replace image when guest_src_url provided
     if guest_src_url:

--- a/libvirt/tests/src/virtio_transitional/virtio_transitional_nic.py
+++ b/libvirt/tests/src/virtio_transitional/virtio_transitional_nic.py
@@ -11,6 +11,8 @@ from virttest import data_dir
 from virttest import utils_net
 from virttest import utils_test
 from virttest import utils_misc
+from virttest import libvirt_version
+
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.interface import Interface
@@ -261,6 +263,10 @@ def run(test, params, env):
     guest_src_url = params.get("guest_src_url")
     params['disk_model'] = params['virtio_model']
     guest_os_type = params['os_type']
+
+    if not libvirt_version.version_compare(5, 0, 0):
+        test.cancel("This libvirt version doesn't support "
+                    "virtio-transitional model.")
 
     # Download and replace image when guest_src_url provided
     if guest_src_url:

--- a/libvirt/tests/src/virtio_transitional/virtio_transitional_rng.py
+++ b/libvirt/tests/src/virtio_transitional/virtio_transitional_rng.py
@@ -7,6 +7,8 @@ from avocado.utils import process
 from virttest import data_dir
 from virttest import virsh
 from virttest import utils_misc
+from virttest import libvirt_version
+
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 
@@ -113,6 +115,10 @@ def run(test, params, env):
     hotplug = (params.get('hotplug', 'no') == 'yes')
     device_exists = (params.get('device_exists', 'yes') == 'yes')
     plug_to = params.get('plug_to', '')
+
+    if not libvirt_version.version_compare(5, 0, 0):
+        test.cancel("This libvirt version doesn't support "
+                    "virtio-transitional model.")
 
     # Download and update image if required
     if guest_src_url:

--- a/libvirt/tests/src/virtio_transitional/virtio_transitional_serial.py
+++ b/libvirt/tests/src/virtio_transitional/virtio_transitional_serial.py
@@ -5,6 +5,8 @@ from avocado.utils import download
 
 from virttest import data_dir
 from virttest import utils_misc
+from virttest import libvirt_version
+
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml.devices.channel import Channel
@@ -72,6 +74,10 @@ def run(test, params, env):
     add_pcie_to_pci_bridge = params.get("add_pcie_to_pci_bridge")
     guest_src_url = params.get("guest_src_url")
     virtio_model = params['virtio_model']
+
+    if not libvirt_version.version_compare(5, 0, 0):
+        test.cancel("This libvirt version doesn't support "
+                    "virtio-transitional model.")
 
     # Download and replace image when guest_src_url provided
     if guest_src_url:

--- a/libvirt/tests/src/virtio_transitional/virtio_transitional_vsock.py
+++ b/libvirt/tests/src/virtio_transitional/virtio_transitional_vsock.py
@@ -7,6 +7,8 @@ from avocado.utils import download
 from virttest import data_dir
 from virttest import virsh
 from virttest import utils_misc
+from virttest import libvirt_version
+
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 
@@ -32,6 +34,10 @@ def run(test, params, env):
     hotplug = (params.get('hotplug', 'no') == 'yes')
     addr_pattern = params['addr_pattern']
     device_pattern = params['device_pattern']
+
+    if not libvirt_version.version_compare(5, 0, 0):
+        test.cancel("This libvirt version doesn't support "
+                    "virtio-transitional model.")
 
     def check_vsock_inside_guest():
         """


### PR DESCRIPTION
This feature is introduced from 5.0.0.

Signed-off-by: Yingshun Cui <yicui@redhat.com>