### PR TITLE
Fix 'v2v_dir' pool problem and skip positive_test.invalid_rhv_pem

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -273,6 +273,7 @@
     variants:
         - positive_test:
             status_error = 'no'
+            no invalid_rhv_pem
         - negative_test:
             status_error = 'yes'
             only option_root.single, invalid_rhv_pem

--- a/v2v/tests/cfg/v2v_options.cfg
+++ b/v2v/tests/cfg/v2v_options.cfg
@@ -206,6 +206,8 @@
                         - unprivileged:
                             oc_uri = "qemu:///session"
                             unprivileged_user = "USER_V2V_EXAMPLE"
+                            session_pool = src_pool
+                            session_pool_target = v2v_src_pool
                     v2v_options = "-oc ${oc_uri} -on ${new_vm_name}"
                 - option_vdsm:
                     # Set the output method to vdsm

--- a/v2v/tests/src/v2v_options.py
+++ b/v2v/tests/src/v2v_options.py
@@ -82,6 +82,8 @@ def run(test, params, env):
         Create libvirt pool as the output storage
         """
         if output_uri == "qemu:///session" or user_pool:
+            pool_name = params.get('session_pool')
+            pool_target = params.get('session_pool_target')
             target_path = os.path.join("/home", v2v_user, pool_target)
             cmd = su_cmd + "'mkdir -p %s'" % target_path
             process.system(cmd, verbose=True)
@@ -99,6 +101,8 @@ def run(test, params, env):
         Clean up libvirt pool
         """
         if output_uri == "qemu:///session" or user_pool:
+            pool_name = params.get('session_pool')
+            pool_target = params.get('session_pool_target')
             cmd = su_cmd + "'virsh pool-destroy %s'" % pool_name
             process.system(cmd, verbose=True)
             target_path = os.path.join("/home", v2v_user, pool_target)
@@ -641,7 +645,7 @@ def run(test, params, env):
             output_option = "-o %s -os %s" % (output_mode, output_storage)
             if checkpoint == 'rhv':
                 output_option = output_option.replace('rhev', 'rhv')
-            if checkpoint in ['with_ic', 'without_ic']:
+            if checkpoint in ['with_ic', 'without_ic'] or output_uri == "qemu:///session":
                 output_option = output_option.replace('v2v_dir', 'src_pool')
         output_format = params.get("output_format")
         if output_format and output_format != input_format:


### PR DESCRIPTION
1. As v2v_dir pool also will be created in qemu:///system, should
change pool name in qemu:///session in case can't find v2v_dir
pool in qemu:///session mode.

2. Block invalid_rhv_pem case in positive_test as it's a negative
case.

Signed-off-by: mxie91 <mxie@redhat.com>