### PR TITLE
Block rhv output for special_name case

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -121,6 +121,8 @@
             main_vm = 'VM_NAME_ESX_MULCPUS_V2V_EXAMPLE'
         - special_name:
             only esx_55
+            #rhv env does not allowed guest to have speical characters
+            only libvirt
             main_vm = 'VM_NAME_ESX_SPECIALNAME_V2V_EXAMPLE'
         - cloned_vm:
             only esx_55


### PR DESCRIPTION
The guest whose nanme contains special charecter can't be power on
rhv so skip rhv output for the case.

Signed-off-by: mxie91 <mxie@redhat.com>