### PR TITLE
Delete virtioscsi_disk case in sepcific_kvm job

### DIFF
--- a/v2v/tests/cfg/specific_kvm.cfg
+++ b/v2v/tests/cfg/specific_kvm.cfg
@@ -69,9 +69,6 @@
             remote_host = ${xen_hostname}
     variants:
         - default:
-        - virtioscsi_disk:
-            only xen
-            main_vm = 'VM_VIRTIOSCSI_DISK_V2V_EXAMPLE'
         - sata_disk:
             only source_esx.esx_65
             main_vm = 'VM_SATA_DISK_V2V_EXAMPLE'


### PR DESCRIPTION
Case 'specific_kvm.positive_test.linux.virtioscsi_disk' is
duplicated with case 'function_test_xen.positive_test.rhev.
scsi_disk'

Signed-off-by: mxie91 <mxie@redhat.com>