### PR TITLE
Skip checkpoint for v2v option_root.first case

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -194,13 +194,15 @@
                     choice = 2
                 - first:
                     root_option = first
+                    skip_vm_check = yes
+                    skip_reason = "Can't boot into first os  without selecting by user during booting after v2v conversion"
                 - single:
                     root_option = single
                     only negative_test
                 - dev_sdx:
                     root_option = '/dev/sda1'
                     skip_vm_check = yes
-                    skip_reason = "/dev/sda1 belongs to the second OS which can't boot into os without selecting by user during booting after v2v conversion"
+                    skip_reason = "/dev/sda1 belongs to the first OS which can't boot into without selecting by user during booting after v2v conversion"
                 - dev_vglv:
                     root_option = '/dev/rhel/root'
             checkpoint += _${root_option}


### PR DESCRIPTION
Guest can't boot into first os without selecting by user after
v2v conversion, so skip checking guesit.

Signed-off-by: mxie91 <mxie@redhat.com>