### PR TITLE
Remove 52lts compatiblity layer dependences

### DIFF
--- a/libvirt/tests/src/limit.py
+++ b/libvirt/tests/src/limit.py
@@ -13,7 +13,6 @@ from virttest import libvirt_xml
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml.devices.interface import Interface
 from virttest.libvirt_xml.devices.disk import Disk
-from virttest.compat_52lts import decode_to_text as to_text
 
 
 def run(test, params, env):
@@ -69,7 +68,7 @@ def run(test, params, env):
                 test.cancel("block partition is not given")
             # Check if valid partition or raise
             cmd = "blkid /dev/%s|awk -F" " '{print $2}'" % blk_partition
-            output = to_text(process.system_output(cmd, shell=True))
+            output = process.run(cmd, shell=True).stdout_text
             if "UUID" not in output:
                 test.cancel("Not a valid partition given for swap creation")
             # Create swap partition

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_dhcp_leases.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_dhcp_leases.py
@@ -8,7 +8,6 @@ from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import network_xml
 from virttest.utils_test import libvirt as utlv
-from virttest.compat_52lts import results_stdout_52lts
 from avocado.utils import process
 
 from provider import libvirt_version
@@ -150,7 +149,7 @@ def run(test, params, env):
             virsh.net_destroy(net)
             virsh.net_undefine(net)
     cmd = "ps aux|grep dnsmasq|grep -v grep | grep -v default | awk '{print $2}'"
-    pid_list = results_stdout_52lts(process.run(cmd, shell=True)).strip().splitlines()
+    pid_list = process.run(cmd, shell=True).stdout_text.strip().splitlines()
     logging.debug(pid_list)
     for pid in pid_list:
         utils_misc.safe_kill(pid, signal.SIGKILL)

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_update.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_update.py
@@ -12,7 +12,6 @@ from virttest import remote
 from virttest.libvirt_xml import network_xml
 from virttest.libvirt_xml import xcepts
 from virttest.libvirt_xml import vm_xml
-from virttest.compat_52lts import results_stdout_52lts
 from avocado.utils import process
 
 
@@ -509,7 +508,7 @@ def run(test, params, env):
                              net_state == "active" and options != "--config")
             if check_dnsmasq:
                 cmd = "ps aux|grep dnsmasq|grep -v grep|grep %s|awk '{print $2}'" % net_name
-                pid_list_bef = results_stdout_52lts(process.run(cmd, shell=True)).strip().split('\n')
+                pid_list_bef = process.run(cmd, shell=True).stdout_text.strip().split('\n')
 
             if parent_index:
                 options += " --parent-index %s" % parent_index
@@ -625,7 +624,7 @@ def run(test, params, env):
 
             # Get dnsmasq pid after update
             if check_dnsmasq:
-                pid_list_aft = results_stdout_52lts(process.run(cmd, shell=True)).strip().split('\n')
+                pid_list_aft = process.run(cmd, shell=True).stdout_text.strip().split('\n')
                 for pid in pid_list_aft:
                     if pid in pid_list_bef:
                         test.fail("dnsmasq do not updated")

--- a/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_event.py
+++ b/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_event.py
@@ -6,7 +6,6 @@ from avocado.utils import process
 from virttest import virsh
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import nodedev_xml
-from virttest.compat_52lts import results_stdout_52lts
 
 
 def run(test, params, env):
@@ -97,7 +96,7 @@ def run(test, params, env):
         net_lists = net_list.stdout.strip().splitlines()
         device_check = False
         route_cmd = " route | grep default"
-        route_default = results_stdout_52lts(process.run(route_cmd, shell=True)).strip().split(' ')
+        route_default = process.run(route_cmd, shell=True).stdout_text.strip().split(' ')
         ip_default = route_default[-1]
 
         for net_device_name in net_lists:

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_find_storage_pool_sources.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_find_storage_pool_sources.py
@@ -7,7 +7,6 @@ from virttest import xml_utils
 from virttest import utils_test
 from virttest import virsh
 from virttest.staging import lv_utils
-from virttest.compat_52lts import decode_to_text as to_text
 
 from provider import libvirt_version
 
@@ -113,7 +112,7 @@ def run(test, params, env):
         # Clean up
         if cleanup_logical:
             cmd = "pvs |grep %s |awk '{print $1}'" % vg_name
-            pv_name = to_text(process.system_output(cmd, shell=True))
+            pv_name = process.run(cmd, shell=True).stdout_text
             lv_utils.vg_remove(vg_name)
             process.run("pvremove %s" % pv_name)
         if cleanup_iscsi:

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_find_storage_pool_sources_as.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_find_storage_pool_sources_as.py
@@ -6,7 +6,6 @@ from avocado.core import exceptions
 from virttest import virsh
 from virttest import utils_test
 from virttest.staging import lv_utils
-from virttest.compat_52lts import decode_to_text as to_text
 
 from provider import libvirt_version
 
@@ -82,7 +81,7 @@ def run(test, params, env):
         # Clean up
         if cleanup_logical:
             cmd = "pvs |grep %s |awk '{print $1}'" % vg_name
-            pv_name = to_text(process.system_output(cmd, shell=True))
+            pv_name = process.run(cmd, shell=True).stdout_text
             lv_utils.vg_remove(vg_name)
             process.run("pvremove %s" % pv_name)
         if cleanup_iscsi:

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool_acl.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool_acl.py
@@ -9,7 +9,6 @@ from virttest import data_dir
 from virttest import virsh
 from virttest.staging import lv_utils
 from virttest.utils_test import libvirt as utlv
-from virttest.compat_52lts import decode_to_text as to_text
 
 from provider import libvirt_version
 
@@ -272,7 +271,7 @@ def run(test, params, env):
             logging.error("Can't delete pool: %s", pool_name)
         if cleanup_env[2]:
             cmd = "pvs |grep %s |awk '{print $1}'" % vg_name
-            pv_name = to_text(process.system_output(cmd, shell=True))
+            pv_name = process.run(cmd, shell=True).stdout_text
             lv_utils.vg_remove(vg_name)
             process.run("pvremove %s" % pv_name, shell=True)
         if cleanup_env[1]:

--- a/libvirt/tests/src/virtual_disks/virtual_disks_ceph.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_ceph.py
@@ -29,7 +29,6 @@ from virttest.libvirt_xml import pool_xml
 from virttest.libvirt_xml import secret_xml
 from virttest.libvirt_xml.devices.lease import Lease
 from virttest import data_dir
-from virttest.compat_52lts import results_stdout_52lts
 
 from provider import libvirt_version
 
@@ -462,7 +461,7 @@ def run(test, params, env):
         """
         logging.info("Get secret list ...")
         secret_list_result = virsh.secret_list()
-        secret_list = results_stdout_52lts(secret_list_result).strip().splitlines()
+        secret_list = secret_list_result.stdout_text.strip().splitlines()
         # First two lines contain table header followed by entries
         # for each secret, such as:
         #


### PR DESCRIPTION
Remove any reference to results_stdout_52lts,results_stderr_52lts,decode_to_text from
compat_52lts.py under avocado-vt

Signed-off-by: chunfuwen <chwen@redhat.com>