### PR TITLE
Fix err for 9 cases related to detach-device-alias

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
@@ -64,7 +64,7 @@ def run(test, params, env):
     if hostdev_type in ["usb", "scsi"]:
         if hostdev_type == "usb":
             pci_id = get_usb_info()
-        elif hostdev_type == "scsi":
+        else:
             source_disk = libvirt.create_scsi_disk(scsi_option="",
                                                    scsi_size="8")
             pci_id = get_scsi_info(source_disk)
@@ -72,9 +72,6 @@ def run(test, params, env):
                                                 dev_type=hostdev_type,
                                                 managed=hostdev_managed,
                                                 alias=device_alias)
-    else:
-        test.error("Hostdev type %s not handled by test."
-                   " Please check code." % hostdev_type)
     if contr_type:
         controllers = vmxml.get_controllers(contr_type)
         contr_index = len(controllers) + 1


### PR DESCRIPTION
The cases are as follows, previous logic will cause the err
"ERROR: Hostdev type  not handled by test. Please check code".
After deleting the unnecessary "else", the cases will pass.
- type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.controller
- type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.redirdev
- type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.channel
- type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.config.controller
- type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.config.redirdev
- type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.config.channel
- type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.current.controller
- type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.current.redirdev
- type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.current.channel

Signed-off-by: Jing Yan <jiyan@redhat.com>