### PR TITLE
Add cases for pci/pcie devices

### DIFF
--- a/libvirt/tests/cfg/controller/controller_functional.cfg
+++ b/libvirt/tests/cfg/controller/controller_functional.cfg
@@ -4,6 +4,7 @@
     setup_controller = "yes"
     check_qemu = "yes"
     check_within_guest = "yes"
+    check_contr_addr = "yes"
     variants:
         - positive_tests:
             remove_address = "yes"
@@ -48,6 +49,98 @@
                       only s390-virtio
                       controller_type = virtio-serial
                       controller_bus = ccw
+                - controller_alias:
+                    only i440fx
+                    add_contrl_list = "[{'model': 'pci-root', 'index': '0', 'alias': 'ua-PCI_ROOT'},{'model': 'pci-bridge', 'alias': 'ua-PCI_BRIDGE'}, {'model': 'pci-expander-bus', 'alias': 'ua-PCI_EXPANDER_BUS'}]"
+                    qemu_patterns = "[('-device', 'pci-bridge,.*,id=ua-PCI_BRIDGE'), ('-device', 'pxb,.*,id=ua-PCI_EXPANDER_BUS')]"
+                    check_contr_addr = "no"
+                    check_within_guest = "no"
+                - pcie_root_port_model:
+                    only q35
+                    run_vm = "yes"
+                    check_contr_addr = "no"
+                    new_model = pcie-root-port
+                    old_model = ioh3420
+                    attach_option = "--address pci:0000.06.00.0"
+                    qemu_patterns = "[('-device', 'pcie-root-port,.*,id=pci.6,bus=pcie.0,.*addr=0x2.*')]"
+                    guest_patterns = "['00:.* PCI bridge: Red Hat']"
+                    add_contrl_list = "[{'model': 'pcie-root-port', 'index': '6', 'bus': '0x00', 'slot': '0x02'}]"
+                - pcie_pci_bridge_autoadd:
+                    only q35
+                    setup_controller = "no"
+                    check_qemu = "no"
+                    run_vm = "yes"
+                    check_contr_addr = "no"
+                    check_within_guest = "no"
+                    # This sound device is often used as pci device on x86_64
+                    sound_dict = "{'model': 'ich6'}"
+                    check_cntrls_list = "[{'model': 'pcie-to-pci-bridge'}, {'type': 'pci', 'model': 'pcie-root-port'}]"
+                - pcie_root_children:
+                    only q35
+                    run_vm = "yes"
+                    check_within_guest = "no"
+                    add_contrl_list = "[{'model': 'dmi-to-pci-bridge', 'index': '1', 'bus': '0x00', 'slot': '0x1e'},{'model': 'pcie-root-port', 'index': '3', 'bus': '0x00', 'slot': '0x02'},{'model': 'pcie-expander-bus', 'index': '7', 'bus': '0x00', 'slot': '0x03'}]"
+                    qemu_patterns = "[('-device', 'i82801b11-bridge,id=pci.1,bus=pcie.0,addr=0x1e'), ('-device', 'pcie-root-port,.*,id=pci.3,bus=pcie.0,.*,addr=0x2'), ('-device', 'pxb-pcie,.*,id=pci.7,bus=pcie.0,addr=0x3')]"
+                - pcie_expander_bus_child:
+                    only q35
+                    run_vm = "yes"
+                    check_contr_addr = "no"
+                    add_contrl_list = "[{'model': 'pcie-expander-bus', 'index': '7', 'busNr': '100'},{'model': 'pcie-root-port', 'index': '8','bus': '0x07', 'slot': '0x01'},{'model': 'dmi-to-pci-bridge', 'index': '9', 'bus': '0x07', 'slot': '0x03'}]"
+                    # The controller attached to pcie-expander-bus should be 64:XX.X since busNr is 100(hex 64).
+                    guest_patterns = "['64:.* PCI bridge: Red Hat', '64:.* PCI bridge: Intel.*82801']"
+                - pcie_expander_bus_busNr:
+                    only q35
+                    run_vm = "no"
+                    check_contr_addr = "no"
+                    check_within_guest = "no"
+                    check_qemu = "no"
+                    variants:
+                      - default_busNr:
+                          add_contrl_list = "[{'model': 'pcie-expander-bus', 'index': '8'}]"
+                          check_cntrls_list = "[{'model': 'pcie-expander-bus', 'index': '8', 'modelname': 'pxb-pcie', 'busNr': '254'}]"
+                      - special_busNr:
+                          add_contrl_list = "[{'model': 'pcie-expander-bus', 'busNr': '100', 'index': '8'},{'model': 'pcie-expander-bus', 'busNr': '120', 'index': '9'},{'model': 'pcie-expander-bus', 'index': '10'}]"
+                          # When pcie-expander-bus controller exists, the new pcie-expander-bus
+                          # controller's busNr should be equal to (minimum of existing-busNr - 2)
+                          check_cntrls_list = "[{'model': 'pcie-expander-bus', 'index': '10', 'modelname': 'pxb-pcie', 'busNr': '98'}]"
+                - e1000e_default_assign:
+                    only q35
+                    run_vm = "no"
+                    check_qemu = "no"
+                    check_within_guest = "no"
+                    attach_count = 4
+                    check_contr_addr = "no"
+                    setup_controller = "no"
+                    attach_dev_type = "interface"
+                    remove_nic = "yes"
+                    attach_option = "network default --model e1000e --config"
+                - pci_root_plug_child:
+                    no q35
+                    check_contr_addr = "no"
+                    setup_controller = "no"
+                    check_qemu = "no"
+                    variants:
+                      - nic:
+                          attach_dev_type = "interface"
+                          check_dev_bus = "yes"
+                          expect_bus = "0x00"
+                          nic_type = "network"
+                          nic_mac = "44:37:e6:cc:92:94"
+                          attach_option = "${nic_type} default --model virtio --mac ${nic_mac}"
+                          detach_option = "${nic_type} --mac ${nic_mac}"
+                          qemu_monitor_cmd = "info network"
+                          qemu_monitor_pattern = "macaddr=${nic_mac}"
+                          cmd_in_guest = "['ip a |grep ${nic_mac}']"
+                - pcie_expander_bus_numa:
+                    only q35
+                    check_contr_addr = "no"
+                    check_qemu = "no"
+                    vcpu_count = "4"
+                    sound_dict = "{'model': 'ich9', 'bus': '0x04', 'slot': '0x00'}"
+                    balloon_dict = "{'model': 'virtio', 'bus': '0x08', 'slot': '0x00'}"
+                    add_contrl_list = "[{'model': 'pcie-expander-bus', 'index': '3', 'busNr': '100', 'node': '1'},{'model': 'pcie-root-port', 'index': '4','bus': '0x03', 'slot': '0x01'},{'model': 'pcie-expander-bus', 'index': '7', 'busNr': '200', 'node': '0'},{'model': 'pcie-root-port', 'index': '8','bus': '0x07', 'slot': '0x01'}]"
+                    cpu_numa_cells = "[{'id': '0', 'cpus': '0-1', 'memory': '512', 'unit': 'M'}, {'id': '1', 'cpus': '2-3', 'memory': '512', 'unit': 'M'}]"
+                    cmd_in_guest = "[{'cat /sys/devices/pci0000\:64/**/numa_node': '1'},{'cat /sys/devices/pci0000\:c8/**/numa_node': '0'}]"
                 - virtio_serial:
                     no q35
                     controller_type = virtio-serial


### PR DESCRIPTION
These cases include below scenarios:
- Set custom alias in pci controllers of pc machine type
- [PCI] Hot-plug/Hot-unplug an device to pci-root
- Start VM with pcie-root-port/dmi-to-pci-bridge/pcie-expander-bus attached to pcie-root
- Generic PCIe Root Ports support BZ1408808
- Use generic PCIe Root Ports by default when available
- Attach dmi-to-pci-bridge/pcie-root-port to pcie-expander-bus
- Assign valid numa node to pcie-expander-bus
- Q35 machine will automatically fill pci/pcie controllers
- Auto assign busNr and model to pcie-expander-bus
- Assign e1000e NIC to pcie controllers by default

Signed-off-by: Dan Zheng <dzheng@redhat.com>