### PR TITLE
Wait some time before doing managedsave/save for pseries vms

### DIFF
--- a/libvirt/tests/cfg/libvirt_mem.cfg
+++ b/libvirt/tests/cfg/libvirt_mem.cfg
@@ -9,6 +9,9 @@
     guest_known_unplug_errors = "'pseries-hotplug-mem: Memory indexed-count-remove failed, adding any removed LMBs'"
     host_known_unplug_errors = "'Memory unplug already in progress for device dimm'"
     vcpu = 4
+    wait_before_save_secs = 0
+    pseries:
+        wait_before_save_secs = 10
     variants:
         - positive_test:
             max_mem_rt = 2560000

--- a/libvirt/tests/src/libvirt_mem.py
+++ b/libvirt/tests/src/libvirt_mem.py
@@ -5,6 +5,7 @@ import uuid
 import logging
 import platform
 import tempfile
+import time
 import random
 
 from six.moves import xrange
@@ -380,6 +381,7 @@ def run(test, params, env):
     maxmem_error = "yes" == params.get("maxmem_error", "no")
     attach_option = params.get("attach_option", "")
     test_qemu_cmd = "yes" == params.get("test_qemu_cmd", "no")
+    wait_before_save_secs = int(params.get("wait_before_save_secs", 0))
     test_managedsave = "yes" == params.get("test_managedsave", "no")
     test_save_restore = "yes" == params.get("test_save_restore", "no")
     test_mem_binding = "yes" == params.get("test_mem_binding", "no")
@@ -587,6 +589,8 @@ def run(test, params, env):
 
         # Run managedsave command to check domain xml.
         if test_managedsave:
+            # Wait 10s for vm to be ready before managedsave
+            time.sleep(wait_before_save_secs)
             ret = virsh.managedsave(vm_name, **virsh_dargs)
             libvirt.check_exit_status(ret)
             vm.start()
@@ -596,6 +600,8 @@ def run(test, params, env):
 
         # Run save and restore command to check domain xml
         if test_save_restore:
+            # Wait 10s for vm to be ready before save
+            time.sleep(wait_before_save_secs)
             check_save_restore()
             if test_dom_xml:
                 check_dom_xml(at_mem=attach_device)


### PR DESCRIPTION
In some cases, doing managedsave/save too soon will cause failures
after restoring.

Signed-off-by: haizhao <haizhao@redhat.com>