### PR TITLE
Skip gluster rdma cases in snapshot function

### DIFF
--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_create_as.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_create_as.py
@@ -352,6 +352,7 @@ def run(test, params, env):
     tmp_dir = data_dir.get_tmp_dir()
     pool_name = params.get("pool_name", "gluster-pool")
     brick_path = os.path.join(tmp_dir, pool_name)
+    transport = params.get("transport", "")
 
     uri = params.get("virsh_uri")
     usr = params.get('unprivileged_user')
@@ -390,6 +391,10 @@ def run(test, params, env):
             logging.info("--no-metadata and --print-xml can be used together "
                          "in this libvirt version. Not expecting a failure.")
             status_error = "no"
+
+    # This is brought by new feature:block-dev
+    if libvirt_version.version_compare(6, 0, 0) and transport == "rdma":
+        test.cancel("transport protocol 'rdma' is not yet supported")
 
     opt_names = locals()
     if memspec_opts is not None:

--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_disk.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_disk.py
@@ -47,6 +47,7 @@ def run(test, params, env):
     pool_name = params.get("pool_name", "gluster-pool")
     brick_path = os.path.join(tmp_dir, pool_name)
     multi_gluster_disks = "yes" == params.get("multi_gluster_disks", "no")
+    transport = params.get("transport", "")
 
     # Pool variables.
     snapshot_with_pool = "yes" == params.get("snapshot_with_pool", "no")
@@ -99,6 +100,10 @@ def run(test, params, env):
                         "current version. Check more info with "
                         "https://bugzilla.redhat.com/buglist.cgi?"
                         "bug_id=1017289,1032370")
+
+    # This is brought by new feature:block-dev
+    if libvirt_version.version_compare(6, 0, 0) and transport == "rdma":
+        test.cancel("transport protocol 'rdma' is not yet supported")
 
     # Init snapshot_name
     snapshot_name = None


### PR DESCRIPTION
We do not support rdma with libvirt and qemu for now.

Signed-off-by: Yi Sun <yisun@redhat.com>