### PR TITLE
Fix update device matrix on s390x

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_update_device_matrix.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_update_device_matrix.cfg
@@ -13,6 +13,10 @@
     pseries:
         updatedevice_target_bus = "scsi"
         updatedevice_target_dev = "sdc"
+    s390-virtio:
+        updatedevice_target_bus = "scsi"
+        updatedevice_target_dev = "sdc"
+        skip_release_check = "yes"
     disk_type = "cdrom"
     variants:
         - dt_okay_at_okay:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_update_device_matrix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_update_device_matrix.py
@@ -294,15 +294,17 @@ def run(test, params, env):
     test_iso = os.path.join(data_dir.get_tmp_dir(), "test.iso")
 
     # Check the version first.
-    host_rhel6 = check_rhel_version('rhel6')
+    host_rhel6 = False
     guest_rhel6 = False
-    if not vm.is_alive():
-        vm.start()
-    session = vm.wait_for_login()
-    if check_rhel_version('rhel6', session):
-        guest_rhel6 = True
-    session.close()
-    vm.destroy(gracefully=False)
+    if not params.get("skip_release_check", "no") == "yes":
+        host_rhel6 = check_rhel_version('rhel6')
+        if not vm.is_alive():
+            vm.start()
+        session = vm.wait_for_login()
+        if check_rhel_version('rhel6', session):
+            guest_rhel6 = True
+        session.close()
+        vm.destroy(gracefully=False)
 
     try:
         # Prepare the disk first.


### PR DESCRIPTION
1. On s390x, IDE is not available. Use SCSI instead.
2. skip_release_check: allow for skipping the release check to
   speed up testing; specifically, s390x wasn't supported on RHEL
   before version 7.

```bash
# avocado run --vt-type libvirt --vt-machine-type s390-virtio --vt-connect-uri qemu:///system virsh.update_device_matrix.pre_vm_state_running.dt_option_live.at_option_live.dt_okay_at_okay
JOB ID     : f8fc0cca6947142df9e2d7374bf8852153156adc
JOB LOG    : /root/avocado/job-results/job-2020-03-20T11.45-f8fc0cc/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.update_device_matrix.pre_vm_state_running.dt_option_live.at_option_live.dt_okay_at_okay: PASS (220.31 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 222.93 s
```

```bash
# avocado run --vt-type libvirt --vt-machine-type s390-virtio --vt-connect-uri qemu:///system virsh.update_device_matrix.pre_vm_state_shutoff.dt_option_live.at_option_live.dt_error_at_error,virsh.update_device_matrix.pre_vm_state_shutoff.dt_option_live.at_option_config.dt_error_at_okay
JOB ID     : d0e5c1e00706ebbb797bdaf08f56575375b91ed7
JOB LOG    : /root/avocado/job-results/job-2020-03-22T12.52-d0e5c1e/job.log
 (1/2) type_specific.io-github-autotest-libvirt.virsh.update_device_matrix.pre_vm_state_shutoff.dt_option_live.at_option_live.dt_error_at_error: PASS (55.98 s)
 (2/2) type_specific.io-github-autotest-libvirt.virsh.update_device_matrix.pre_vm_state_shutoff.dt_option_live.at_option_config.dt_error_at_okay: PASS (73.87 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 131.38 s
```