### PR TITLE
Fix update device on s390x

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_update_device.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_update_device.cfg
@@ -10,6 +10,7 @@
             status_error = "no"
             variants:
                 - ide_option:
+                    no s390-virtio
                     updatedevice_target_bus = "ide"
                     updatedevice_target_dev = "hdc"
                     disk_type = "cdrom"
@@ -32,11 +33,9 @@
                         - force_live_option:
                             updatedevice_flag = "--force --live"
                             updatedevice_twice = "yes"
-                            updatedevice_twice = "yes"
                             updatedevice_diff_iso = "yes"
                         - force_current_option:
                             updatedevice_flag = "--force --current"
-                            updatedevice_twice = "yes"
                             updatedevice_twice = "yes"
                             updatedevice_diff_iso = "yes"
                         - live_option:
@@ -83,6 +82,10 @@
 
         - error_test:
             status_error = "yes"
+            s390-virtio:
+                updatedevice_target_bus = "scsi"
+                updatedevice_target_dev = "sdc"
+                disk_type = "cdrom"
             variants:
                 - no_option:
                     updatedevice_vm_ref = ""


### PR DESCRIPTION
1. error_test: on s390x use scsi bus
2. updatedevice_twice: remove unnecessary value assignment