### PR TITLE
RFE: Add migration cases about vtpm device

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -254,6 +254,22 @@
                             asynch_migrate = "yes"
                             migrate_maxdowntime = '0.100000'
                             actions_during_migration = "setmaxdowntime,setmigratepostcopy"
+                - vtpm_emulator:
+                    tpm_args = "{"tpm_model": "tpm-crb", "backend_type": "emulator", "backend_version": "2.0"}"
+                    update_tpm_secret = yes
+                    src_secret_value = "sec value test"
+                    dst_secret_value = ${src_secret_value}
+                    cmd_in_vm_after_migration = "tpm2_getrandom 10"
+                    vtpm_without_postcopy:
+                        only without_postcopy
+                    vtpm_with_postcopy:
+                        only with_postcopy
+                        low_speed = "10"
+                        stress_in_vm = "yes"
+                        stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M --timeout 70"
+                        asynch_migrate = "yes"
+                        migrate_maxdowntime = '0.100000'
+                        actions_during_migration = "setmaxdowntime,setmigratepostcopy"
                 - p2p_migration:
                     virsh_migrate_options = "--live --p2p --verbose"
                     variants:
@@ -321,7 +337,24 @@
                                     only without_postcopy
                                     check_tls_destination = "yes"
                                     server_cn = "test.com.cn"
-                                    virsh_migrate_extra = "--tls --tls-destination ${server_cn}"                                                          
+                                    virsh_migrate_extra = "--tls --tls-destination ${server_cn}"
+                        - vtpm_emulator:
+                            only without_postcopy
+                            tpm_args = "{"tpm_model": "tpm-crb", "backend_type": "emulator", "backend_version": "2.0"}"
+                            update_tpm_secret = yes
+                            src_secret_value = "sec value test"
+                            dst_secret_value = ${src_secret_value}
+                            cmd_in_vm_after_migration = "tpm2_getrandom 10"  
+                - tunnelled_migration:
+                    only without_postcopy
+                    virsh_migrate_options = "--live --p2p --tunnelled --verbose"
+                    variants:
+                        - vtpm_emulator:
+                            tpm_args = "{"tpm_model": "tpm-crb", "backend_type": "emulator", "backend_version": "2.0"}"
+                            update_tpm_secret = yes
+                            src_secret_value = "sec value test"
+                            dst_secret_value = ${src_secret_value}
+                            cmd_in_vm_after_migration = "tpm2_getrandom 10"                                                   
         - negative_test:
             virsh_migrate_options = "--live --verbose"
             # The variable indicates migration command should fail
@@ -365,6 +398,13 @@
                             server_cn = "INCONSISTENT.SERVER_CN"
                             client_cn = "ENTER.YOUR.CLIENT_CN"
                             disable_verify_peer = "yes"
+                - vtpm_emulator:
+                    only without_postcopy
+                    tpm_args = "{"tpm_model": "tpm-crb", "backend_type": "emulator", "backend_version": "2.0"}"
+                    update_tpm_secret = yes
+                    src_secret_value = "sec value test"
+                    dst_secret_value = "sec value diff"
+                    err_msg = "qemu-kvm: tpm-emulator: Setting the stateblob \(type 1\) failed with a TPM error 0x21 decryption error"
                 - p2p_migration:
                     virsh_migrate_options = "--live --p2p --verbose"
                     variants:

--- a/libvirt/tests/src/migration/migrate_options_shared.py
+++ b/libvirt/tests/src/migration/migrate_options_shared.py
@@ -160,6 +160,20 @@ def run(test, params, env):
             vm_xml.add_device(newcontroller)
         vm_xml.sync()
 
+    def add_tpm(vm, tpm_args):
+        """
+        Add tpm device to vm
+
+        :param vm: The guest
+        :param tpm_args: Parameters for tpm device
+        """
+        vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm.name)
+        vmxml.remove_all_device_by_type('tpm')
+        tpm_dev = libvirt.create_tpm_dev(tpm_args)
+        logging.debug("tpm xml is %s", tpm_dev)
+        vmxml.add_device(tpm_dev)
+        vmxml.sync()
+
     def do_migration(vm, dest_uri, options, extra):
         """
         Execute the migration with given parameters
@@ -907,7 +921,10 @@ def run(test, params, env):
     vcpu_num = params.get("vcpu_num")
     block_time = params.get("block_time", 30)
     parallel_cn_nums = params.get("parallel_cn_nums")
-
+    tpm_args = eval(params.get("tpm_args", '{}'))
+    src_secret_value = params.get("src_secret_value")
+    dst_secret_value = params.get("dst_secret_value")
+    update_tpm_secret = "yes" == params.get("update_tpm_secret", "no")
     break_network_connection = "yes" == params.get("break_network_connection",
                                                    "no")
 
@@ -921,6 +938,7 @@ def run(test, params, env):
     cmd_run_in_remote_host = params.get("cmd_run_in_remote_host", None)
     cmd_run_in_remote_host_1 = params.get("cmd_run_in_remote_host_1", None)
     cmd_run_in_remote_host_2 = params.get("cmd_run_in_remote_host_2", None)
+    cmd_in_vm_after_migration = params.get("cmd_in_vm_after_migration")
 
     # For qemu command line checking
     qemu_check = params.get("qemu_check", None)
@@ -962,6 +980,9 @@ def run(test, params, env):
     tls_obj = None
 
     expConnNum = 0
+    tpm_sec_uuid = None
+    dest_tmp_sec_uuid = None
+
     # Local variables
     vm_name = params.get("migrate_main_vm")
     vm = env.get_vm(vm_name)
@@ -982,7 +1003,11 @@ def run(test, params, env):
             if not libvirt_version.version_compare(5, 6, 0):
                 test.cancel("This libvirt version doesn't support "
                             "tls-destination option.")
-
+        # only emulator backend type in migration for now
+        if tpm_args and tpm_args.get("backend_type") == "emulator":
+            if not utils_misc.compare_qemu_version(4, 0, 0, is_rhev=False):
+                test.cancel("This qemu version doesn't support "
+                            "vtpm emulator backend.")
         if vcpu_num:
             cmd = "grep -c processor /proc/cpuinfo"
             remote_session = remote.remote_login("ssh", server_ip, "22",
@@ -1076,6 +1101,48 @@ def run(test, params, env):
         if remove_cache:
             params["enable_cache"] = "no"
 
+        if tpm_args:
+            if update_tpm_secret:
+                auth_sec_dict = {"sec_ephemeral": "no",
+                                 "sec_private": "yes",
+                                 "sec_desc": "sample vTPM secret",
+                                 "sec_usage": "vtpm",
+                                 "sec_name": "VTPM_example"}
+                tpm_sec_uuid = libvirt.create_secret(auth_sec_dict)
+                logging.debug("tpm sec uuid on source: %s", tpm_sec_uuid)
+                tpm_args.update({"encryption_secret": tpm_sec_uuid})
+                add_tpm(vm, tpm_args)
+                if src_secret_value:
+                    virsh.secret_set_value(tpm_sec_uuid, src_secret_value,
+                                           encode=True, debug=True)
+
+                logging.debug("create secret on target")
+                auth_sec_dict.update({"sec_uuid": tpm_sec_uuid})
+                dest_tmp_sec_uuid = libvirt.create_secret(auth_sec_dict,
+                                                          remote_virsh_dargs)
+                logging.debug("tpm sec uuid on target: %s", dest_tmp_sec_uuid)
+                if dst_secret_value:
+                    if not remote_virsh_session:
+                        remote_virsh_session = virsh.VirshPersistent(**remote_virsh_dargs)
+
+                    remote_virsh_session.secret_set_value(dest_tmp_sec_uuid,
+                                                          dst_secret_value,
+                                                          encode=True,
+                                                          debug=True)
+                    remote_virsh_session.close_session()
+
+            remote_session = remote.remote_login("ssh", server_ip, "22",
+                                                 server_user, server_pwd,
+                                                 r'[$#%]')
+            for loc in ['source', 'target']:
+                session = None
+                if loc == 'target':
+                    session = remote_session
+                if not utils_package.package_install(["swtpm", "swtpm-tools"], session):
+                    test.error("Failed to install swtpm packages on {} host."
+                               .format(loc))
+            remote_session.close()
+
         # Change the disk of the vm to shared disk and then start VM
         libvirt.set_vm_disk(vm, params)
 
@@ -1113,6 +1180,10 @@ def run(test, params, env):
         # Preparation for the running guest before migration
         if hpt_resize and hpt_resize != 'disabled':
             trigger_hpt_resize(vm_session)
+
+        if tpm_args:
+            if not utils_package.package_install("tpm2-tools", vm_session):
+                test.error("Failed to install tpm2-tools in vm")
 
         if stress_in_vm:
             pkg_name = 'stress'
@@ -1315,7 +1386,19 @@ def run(test, params, env):
                                                    r"[\#\$]\s*$")
             check_vm_network_accessed(server_session)
             server_session.close()
-        # Execute migration from remote
+
+            if cmd_in_vm_after_migration:
+                vm_after_mig = utils_test.RemoteVMManager(cmd_parms)
+                vm_after_mig.setup_ssh_auth(vm.get_address(),
+                                            params.get("password"),
+                                            timeout=60)
+                cmd_result = vm_after_mig.run_command(vm.get_address(),
+                                                      cmd_in_vm_after_migration)
+                logging.debug("cmd_result is %s", cmd_result)
+                if cmd_result.exit_status:
+                    test.fail("Failed to run '{}' in vm. Result: {}"
+                              .format(cmd_in_vm_after_migration, cmd_result))
+
         if migr_vm_back:
             ssh_connection = utils_conn.SSHConnection(server_ip=client_ip,
                                                       server_pwd=client_pwd,
@@ -1379,6 +1462,15 @@ def run(test, params, env):
             logging.info("Recovery VM XML configration")
             orig_config_xml.sync()
             logging.debug("The current VM XML:\n%s", orig_config_xml.xmltreefile)
+
+            # cleanup secret uuid
+            if tpm_sec_uuid:
+                virsh.secret_undefine(tpm_sec_uuid, debug=True,
+                                      ignore_status=True)
+
+            if dest_tmp_sec_uuid:
+                cmd = "virsh secret-undefine %s" % dest_tmp_sec_uuid
+                remote.run_remote_cmd(cmd, params, runner_on_target)
 
             if remote_virsh_session:
                 remote_virsh_session.close_session()


### PR DESCRIPTION
This PR adds migration cases about vtpm device.
1. Migrate[p2p/tunnelled/postcopy] a guest with vtpm device
2. Migrate guest with encrypted vtpm to target host with different
  secret value set

depends on https://github.com/avocado-framework/avocado-vt/pull/2480 and https://github.com/avocado-framework/avocado-vt/pull/2481
Signed-off-by: Yingshun Cui <yicui@redhat.com>