### PR TITLE
Remove 52lts dependency for some case

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blkiotune.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blkiotune.py
@@ -7,7 +7,6 @@ from avocado.utils import process
 from virttest import libvirt_xml, utils_libvirtd, virsh
 from virttest.staging import utils_cgroup
 from virttest.utils_misc import get_dev_major_minor
-from virttest.compat_52lts import results_stdout_52lts
 
 # By default path to first I/O scheduler is this. The value is
 # platform dependent and is updated through update_schedulerfd(arch).
@@ -265,7 +264,7 @@ def prepare_scheduler(params, test, vm):
     test_dict['vm'] = vm
 
     cmd = "cat " + schedulerfd
-    iosche = results_stdout_52lts(process.run(cmd, shell=True))
+    iosche = process.run(cmd, shell=True).stdout_text
     logging.debug("iosche value is:%s", iosche)
     test_dict['oldmode'] = re.findall(r"\[(.*?)\]", iosche)[0]
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
@@ -21,7 +21,6 @@ from virttest import utils_misc
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import snapshot_xml
 from virttest.utils_test import libvirt as utl
-from virttest.compat_52lts import results_stdout_52lts
 
 from provider import libvirt_version
 
@@ -200,7 +199,7 @@ def kill_blockcopy_process():
     Kill running blockcopy process
     """
     kill_cmd = "ps aux|grep -i 'blockcopy'|grep -v grep|grep -v transient_job|awk '{print $2}'"
-    pid_list = results_stdout_52lts(process.run(kill_cmd, shell=True)).strip().split('\n')
+    pid_list = process.run(kill_cmd, shell=True).stdout_text.strip().split('\n')
     for pid in pid_list:
         utils_misc.safe_kill(pid, signal.SIGKILL)
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domblklist.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domblklist.py
@@ -8,7 +8,6 @@ from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices import disk
 from virttest import element_tree as ElementTree
-from virttest.compat_52lts import results_stdout_52lts
 
 SOURCE_LIST = ['file', 'dev', 'dir', 'name']
 
@@ -147,7 +146,7 @@ def run(test, params, env):
             cmd = "virsh domblkinfo %s %s %s" % (vm_ref, target_disks[0], info_options)
             ret2 = process.run(cmd, shell=True, ignore_status=True)
         for check in check_list:
-            if not re.search(check, results_stdout_52lts(ret2)):
+            if not re.search(check, ret2.stdout_text):
                 test.fail("Cmd domblkinfo run failed")
 
     if status_error == "no":

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_to_native.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_to_native.py
@@ -7,7 +7,6 @@ from avocado.utils import process
 from virttest import virsh
 from virttest import libvirt_version
 from virttest import utils_libvirtd
-from virttest.compat_52lts import decode_to_text as to_text
 
 from provider import libvirt_version
 
@@ -138,7 +137,7 @@ def run(test, params, env):
                  vm's information.
         """
         pid = vm.get_pid()
-        cmdline_tmp = to_text(process.system_output("cat -v /proc/%d/cmdline" % pid, shell=True))
+        cmdline_tmp = process.run("cat -v /proc/%d/cmdline" % pid, shell=True).stdout_text
 
         # Output has a trailing '^@' which gets converted into an empty
         # element when spliting by '\x20', so strip it on the end.

--- a/libvirt/tests/src/virsh_cmd/monitor/virsh_domifstat.py
+++ b/libvirt/tests/src/virsh_cmd/monitor/virsh_domifstat.py
@@ -4,7 +4,6 @@ from avocado.utils import process
 
 from virttest import virsh
 from virttest import utils_libvirtd
-from virttest.compat_52lts import decode_to_text as to_text
 
 
 def run(test, params, env):
@@ -30,7 +29,7 @@ def run(test, params, env):
         :return: interface device of VM.
         """
         interface = ""
-        domxml = to_text(process.system_output("virsh dumpxml %s" % guest_name, shell=True))
+        domxml = process.run("virsh dumpxml %s" % guest_name, shell=True).stdout_text
         dom = parseString(domxml)
         root = dom.documentElement
         array = root.getElementsByTagName("interface")

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_define_undefine.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_define_undefine.py
@@ -8,7 +8,6 @@ from virttest import xml_utils
 from virttest import utils_libvirtd
 from virttest.libvirt_xml import network_xml
 from virttest.utils_test import libvirt
-from virttest.compat_52lts import decode_to_text as to_text
 
 from provider import libvirt_version
 
@@ -185,8 +184,7 @@ def run(test, params, env):
             # Enabling IPv6 forwarding with RA routes without accept_ra set to 2
             # is likely to cause routes loss
             sysctl_cmd = 'sysctl net.ipv6.conf.all.accept_ra'
-            original_accept_ra = to_text(
-                process.system_output(sysctl_cmd + ' -n'))
+            original_accept_ra = process.run(sysctl_cmd + ' -n').stdout_text
             if original_accept_ra != '2':
                 process.system(sysctl_cmd + '=2')
             # add another ipv4 address and dhcp range


### PR DESCRIPTION
libvirt/tests/src/virsh_cmd/domain/virsh_blkiotune.py
libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
libvirt/tests/src/virsh_cmd/domain/virsh_domblklist.py
libvirt/tests/src/virsh_cmd/domain/virsh_domxml_to_native.py
libvirt/tests/src/virsh_cmd/monitor/virsh_domifstat.py
libvirt/tests/src/virsh_cmd/network/virsh_net_define_undefine.py

```
# avocado run --vt-type libvirt virsh.blkiotune.positive.get_blkio_parameter.running_guest.options.none
JOB ID     : d9700a309c0f2be206927ee513d237656760eacf
JOB LOG    : /root/avocado/job-results/job-2020-03-23T14.49-d9700a3/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.blkiotune.positive.get_blkio_parameter.running_guest.options.none: PASS (14.07 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 23.83 s

# avocado run --vt-type libvirt virsh.blockcopy.positive_test.non_acl.local_disk.no_blockdev.no_shallow.transient_job_option
JOB ID     : 82fadab9df7794d3e593957e4050a35423b6f2e3
JOB LOG    : /root/avocado/job-results/job-2020-03-23T14.57-82fadab/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.blockcopy.positive_test.non_acl.local_disk.no_blockdev.no_shallow.transient_job_option: PASS (18.71 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 25.57 s

# avocado run --vt-type libvirt virsh.domblklist.normal_test.domblkinfo
JOB ID     : 4b4a6871baf68379393c0d6a55bf37d6b6ef4faf
JOB LOG    : /root/avocado/job-results/job-2020-03-23T15.04-4b4a687/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.domblklist.normal_test.domblkinfo: PASS (50.32 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 55.45 s

# avocado run --vt-type libvirt domxml_to_native.positive_test.name_option
JOB ID     : f7a0fe34633066bc410d142ad23f68f244daecc6
JOB LOG    : /root/avocado/job-results/job-2020-03-23T15.09-f7a0fe3/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.domxml_to_native.positive_test.name_option: PASS (77.15 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 85.97 s

# avocado run --vt-type libvirt domifstat.normal_test.id_option
JOB ID     : d5a1220fa0eff12fe5f55539365e996b50574952
JOB LOG    : /root/avocado/job-results/job-2020-03-23T15.15-d5a1220/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.domifstat.normal_test.id_option: PASS (47.60 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 55.35 s

# avocado run --vt-type libvirt virsh.net_define_undefine.normal_test.new_network.multi_ip
JOB ID     : e8ecc0d6dfe812d8b9f42229e05a64c2e8b7b91b
JOB LOG    : /root/avocado/job-results/job-2020-03-23T15.20-e8ecc0d/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.net_define_undefine.normal_test.new_network.multi_ip: PASS (25.56 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 31.42 s

```

Signed-off-by: Kylazhang <weizhan@redhat.com>