### PR TITLE
fix update device matrix

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_update_device_matrix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_update_device_matrix.py
@@ -304,7 +304,7 @@ def run(test, params, env):
         if check_rhel_version('rhel6', session):
             guest_rhel6 = True
         session.close()
-        vm.destroy(gracefully=False)
+    vm.destroy(gracefully=False)
 
     try:
         # Prepare the disk first.


### PR DESCRIPTION
https://github.com/autotest/tp-libvirt/pull/2607 introduced an optimization
However, originally the guest was always destroyed; therefore the attach
disk operation was always run on a shutoff machine and the disk available
on the guest in any state that was established later (`pre_vm_state`).

Make sure vm is always destroyed before test setup is started.
No exception handling required (just as before) because `vm.destroy`
doesn't raise even if executed on dead machine.