### PR TITLE
Remove an unstable checking from virtio_transitional tests

### DIFF
--- a/libvirt/tests/src/virtio_transitional/virtio_transitional_blk_negative.py
+++ b/libvirt/tests/src/virtio_transitional/virtio_transitional_blk_negative.py
@@ -59,8 +59,5 @@ def run(test, params, env):
             test.fail("Vm is expected to fail on booting from disk"
                       " with wrong model, while login successfully.")
 
-        vm.serial_console.read_until_output_matches(['Kernel panic'],
-                                                    utils_misc.strip_console_codes)
-
     finally:
         backup_xml.sync()


### PR DESCRIPTION
The original checkpoint is "check if vm boot up failed".
It's already covered by wait_for_serial_login.
Remove "kernel panic" pattern checking because it's unstable in
CI env for now.

Signed-off-by: Yingshun Cui <yicui@redhat.com>