### PR TITLE
Add timeout to config

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_shutdown.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_shutdown.cfg
@@ -1,6 +1,7 @@
 - virsh.shutdown:
     type = virsh_shutdown
     shutdown_vm_ref = "name"
+    shutdown_timeout = 60
     shutdown_extra = ""
     libvirtd = "on"
     start_vm = "no"


### PR DESCRIPTION
Add timeout parameter explicitly to config in order to easily
substitute on slower systems