### PR TITLE
Reduce loop times from 100 to 50

### DIFF
--- a/libvirt/tests/cfg/sriov/sriov.cfg
+++ b/libvirt/tests/cfg/sriov/sriov.cfg
@@ -85,7 +85,7 @@
                     attach = 'yes'
                     variants:
                         - multiple_times:
-                            loop_times = 100
+                            loop_times = 50
                         - max_vfs:
                             max_vfs_attached = "yes"
         - info_check:


### PR DESCRIPTION
Current timeout is 2h and sometimes it's still not enough, that's
when one loop costs 90s. Therefore cut the number to 50.

Signed-off-by: haizhao <haizhao@redhat.com>