### PR TITLE
Skip gluster rdma cases in blockpull tests

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockpull.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockpull.py
@@ -17,7 +17,7 @@ from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import snapshot_xml
 
-from provider import libvirt_version
+from virttest import libvirt_version
 
 
 def check_chain_xml(disk_xml, chain_lst):
@@ -257,6 +257,12 @@ def run(test, params, env):
     tmp_dir = data_dir.get_tmp_dir()
     pool_name = params.get("pool_name", "gluster-pool")
     brick_path = os.path.join(tmp_dir, pool_name)
+
+    # This is brought by new feature:block-dev
+    if (libvirt_version.version_compare(6, 0, 0) and
+       params.get("transport", "") == "rdma"):
+        test.cancel("If blockdev is enabled, the transport protocol 'rdma' is "
+                    "not yet supported.")
 
     # A backup of original vm
     vmxml_backup = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)


### PR DESCRIPTION
Transport protocol 'rdma' is not yet supported for now.

Signed-off-by: Yingshun Cui <yicui@redhat.com>