### PR TITLE
Fix cdrom device bus type error on q35

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
@@ -41,6 +41,8 @@
                     s390-virtio:
                         virt_disk_device_target = "sdb sda"
                         virt_disk_device_bus = "scsi scsi"
+                    q35:
+                        virt_disk_device_bus = "scsi scsi"
                 - virtio_disks_duplicate_wwn_disk:
                     coldplug:
                         test_disk_option_cmd = "yes"
@@ -129,6 +131,8 @@
                     flopy_error_msg = "unsupported configuration: per-device boot elements cannot be used together"
                     cdrom_error_msg = "Operation not supported: cannot modify field 'boot order' of the disk"
                     disk_boot_seabios = "/usr/share/seabios/bios.bin"
+                    q35:
+                        virt_disk_device_bus = "scsi scsi"
                 - disks_bootorder_error_test:
                     only hotplug
                     virt_disk_with_boot_disk = "yes"
@@ -504,6 +508,9 @@
                     s390-virtio:
                         virt_disk_device_bus = "scsi"
                         virt_disk_device_target = "sda"
+                    q35:
+                        virt_disk_device_bus = "scsi"
+                        virt_disk_device_target = "sda"
                 - disk_readonly_nfs_raw:
                     virt_disk_device_test_readonly = "yes"
                     virt_disk_device_source = "disk"
@@ -545,6 +552,8 @@
                     s390-virtio:
                         virt_disk_device_bus = "scsi"
                         virt_disk_device_target = "sda"
+                    q35:
+                        virt_disk_device_bus = "scsi"
                     variants:
                         - coldplug_only_iso:
                             nfs_disk_type = "iso"
@@ -607,6 +616,9 @@
                             disks_attach_error = "no"
                             virt_disk_device_bus = "scsi"
                             virt_disk_device_target = "sda"
+                        q35:
+                            virt_disk_device_bus = "scsi"
+                            disks_attach_error = "no"
                 - disk_cdrom_update_boot_order:
                     only coldplug
                     iso_path = '/var/lib/libvirt/images/second.iso'
@@ -623,6 +635,8 @@
                     s390-virtio:
                         virt_disk_device_bus = "scsi"
                         virt_disk_device_target = "sda"
+                    q35:
+                        virt_disk_device_bus = "scsi"
                 - disk_floppy_update_boot_order:
                     only coldplug
                     floppy_path = '/var/lib/libvirt/images/fd2.img'
@@ -939,6 +953,7 @@
                     virtio_scsi_controller_driver = "queues=4,cmd_per_lun=10,max_sectors=512"
                 - disk_virtio_multi_ide_controller:
                     only coldplug
+                    no q35
                     status_error = "yes"
                     disk_virtio_multi_ide_controller = "yes"
                     virt_disk_device = "disk"


### PR DESCRIPTION
IDE device bus type is not applicable on q35 machine type
Signed-off-by: chunfuwen <chwen@redhat.com>