### PR TITLE
Fix 'host_device' issue because of enable -blockdev in virsh_boot.cfg

### DIFF
--- a/libvirt/tests/cfg/bios/virsh_boot.cfg
+++ b/libvirt/tests/cfg/bios/virsh_boot.cfg
@@ -197,7 +197,7 @@
                                                     target_dev = "hda"
                                                 - usb_disk:
                                                     no s390-virtio
-                                                    disk_type = "block"
+                                                    disk_type = "file"
                                                     source_protocol = "usb"
                                                     device_bus = "usb"
                                                     target_dev = "vda"


### PR DESCRIPTION
The purpose of these seabios cases is mainly testing usb bus of the disk to boot, so we can only change block disk to file disk in virsh_boot.cfg
Signed-off-by: Meina Li <meili@redhat.com>