### PR TITLE
Add tests of qcow2 image with native luks encryption

### DIFF
--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/tp-libvirt.iml" filepath="$PROJECT_DIR$/.idea/tp-libvirt.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/tp-libvirt.iml
+++ b/.idea/tp-libvirt.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ChangeListManager">
+    <list default="true" id="2c2610a1-d52b-452f-b2a3-4991ed596939" name="Default Changelist" comment="" />
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="ProjectId" id="1Zxv3ZH115Brbv8iX5eMupVa917" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showExcludedFiles" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent">
+    <property name="RunOnceActivity.ShowReadmeOnStart" value="true" />
+    <property name="last_opened_file_path" value="$PROJECT_DIR$/.." />
+  </component>
+  <component name="SvnConfiguration">
+    <configuration />
+  </component>
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="2c2610a1-d52b-452f-b2a3-4991ed596939" name="Default Changelist" comment="" />
+      <created>1585793360655</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1585793360655</updated>
+    </task>
+    <servers />
+  </component>
+  <component name="WindowStateProjectService">
+    <state x="743" y="311" width="424" height="491" key="FileChooserDialogImpl" timestamp="1585793385147">
+      <screen x="0" y="27" width="1920" height="1053" />
+    </state>
+    <state x="743" y="311" width="424" height="491" key="FileChooserDialogImpl/0.27.1920.1053@0.27.1920.1053" timestamp="1585793385147" />
+    <state x="620" y="381" key="com.intellij.ide.util.TipDialog" timestamp="1585793365112">
+      <screen x="0" y="27" width="1920" height="1053" />
+    </state>
+    <state x="620" y="381" key="com.intellij.ide.util.TipDialog/0.27.1920.1053@0.27.1920.1053" timestamp="1585793365112" />
+  </component>
+</project>

--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_luks.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_luks.cfg
@@ -10,6 +10,7 @@
     virt_disk_device_target = "vdb"
     virt_disk_device_format = "raw"
     virt_disk_device_bus = "virtio"
+
     variants:
         - encryption_in_source:
             encryption_in_source = "yes"
@@ -93,12 +94,15 @@
             vol_cap_unit = "M"
             vol_cap = "100"
             dir_image_name = "luks_1.img"
-            target_format = "raw"
             target_label = "virt_image_t"
             target_encypt = "luks"
             virt_disk_device_type = "file"
             virt_disk_check_partitions = "yes"
-            sec_volume = "/var/lib/libvirt/images/luks/luks_1.img"
+            variants:
+                - target_format_raw:
+                    target_format = "raw"
+                - target_format_qcow2:
+                    target_format = "qcow2"
     variants:
         - device_disk:
             virt_disk_device = "disk"


### PR DESCRIPTION
Add tests of qcow2 image with native luks encryption

# avocado run --vt-type libvirt type_specific.io-github-autotest-libvirt.virtual_disks.luks.positive_test.coldplug.device_disk.dir_pool_test.target_format_qcow2
JOB ID     : 8891b73993fd0d83260f0b9866c43ed1100c5734
JOB LOG    : /root/avocado/job-results/job-2020-04-02T22.38-8891b73/job.log
 (1/2) type_specific.io-github-autotest-libvirt.virtual_disks.luks.positive_test.coldplug.device_disk.dir_pool_test.target_format_qcow2.encryption_in_source: PASS (101.63 s)
 (2/2) type_specific.io-github-autotest-libvirt.virtual_disks.luks.positive_test.coldplug.device_disk.dir_pool_test.target_format_qcow2.encryption_out_source: PASS (184.83 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 289.04 s
[root@jgao-test1 ~]# avocado run --vt-type libvirt type_specific.io-github-autotest-libvirt.virtual_disks.luks.negative_test.duplicated_encryption.coldplug.device_disk.dir_pool_test.target_format_qcow2
JOB ID     : 795bf478085fb0f74fb3cea03174c3e22b2ccbf7
JOB LOG    : /root/avocado/job-results/job-2020-04-02T22.47-795bf47/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_disks.luks.negative_test.duplicated_encryption.coldplug.device_disk.dir_pool_test.target_format_qcow2.encryption_in_source: PASS (121.96 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 124.30 s
[root@jgao-test1 ~]# avocado run --vt-type libvirt type_specific.io-github-autotest-libvirt.virtual_disks.luks.negative_test.wrong_password.coldplug.device_disk.dir_pool_test.target_format_qcow2
JOB ID     : b4fcbcd526f2205e74329b9e4b0c75358fdee988
JOB LOG    : /root/avocado/job-results/job-2020-04-02T22.57-b4fcbcd/job.log
 (1/2) type_specific.io-github-autotest-libvirt.virtual_disks.luks.negative_test.wrong_password.coldplug.device_disk.dir_pool_test.target_format_qcow2.encryption_in_source: PASS (164.87 s)
 (2/2) type_specific.io-github-autotest-libvirt.virtual_disks.luks.negative_test.wrong_password.coldplug.device_disk.dir_pool_test.target_format_qcow2.encryption_out_source: PASS (184.63 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 352.12 s

Signed-off-by: jgao <jgao@localhost.localdomain>