### PR TITLE
Modify the directory path of network pid

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_network.py
+++ b/libvirt/tests/src/virtual_network/iface_network.py
@@ -819,9 +819,10 @@ TIMEOUT 3"""
                                          "/run/libvirt/network/%s.pid" % net_name,
                                          name=net_name)
             else:
-                run_dnsmasq_default_test("pid-file",
-                                         "/var/run/libvirt/network/%s.pid" % net_name,
-                                         name=net_name)
+                if libvirt_version.version_compare(6, 0, 0):
+                    run_dnsmasq_default_test("pid-file", "/run/libvirt/network/%s.pid" % net_name, name=net_name)
+                else:
+                    run_dnsmasq_default_test("pid-file", "/var/run/libvirt/network/%s.pid" % net_name, name=net_name)
             run_dnsmasq_default_test("except-interface", "lo", name=net_name)
             run_dnsmasq_default_test("bind-dynamic", name=net_name)
             run_dnsmasq_default_test("dhcp-no-override", name=net_name)


### PR DESCRIPTION
After libvirt 6.0.0, the directory path of the network pid changes
from "/var/run/..." to "/run/...".

Signed-off-by: Yalan Zhang <yalzhang@redhat.com>