### PR TITLE
Add cases of qcow2 image with native luks encryption

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_luks.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_luks.cfg
@@ -100,6 +100,13 @@
             virt_disk_device_type = "file"
             virt_disk_check_partitions = "yes"
             sec_volume = "/var/lib/libvirt/images/luks/luks_1.img"
+            virt_disk_check_partitions = "yes"
+            luks_extra_elements = "--object secret,id=sec0,data=`printf password | base64`,format=base64 -o encrypt.format=luks,encrypt.key-secret=sec0"
+            variants:
+                - target_format_raw:
+                    target_format = "raw"
+                - target_format_qcow2:
+                    target_format = "qcow2"
     variants:
         - device_disk:
             virt_disk_device = "disk"


### PR DESCRIPTION
Add tests of qcow2 image with native luks encryption
```

# avocado run --vt-type libvirt type_specific.io-github-autotest-libvirt.virtual_disks.luks.positive_test.coldplug.device_disk.dir_pool_test.target_format_qcow2
JOB ID     : 8891b73993fd0d83260f0b9866c43ed1100c5734
JOB LOG    : /root/avocado/job-results/job-2020-04-02T22.38-8891b73/job.log
 (1/2) type_specific.io-github-autotest-libvirt.virtual_disks.luks.positive_test.coldplug.device_disk.dir_pool_test.target_format_qcow2.encryption_in_source: PASS (101.63 s)
 (2/2) type_specific.io-github-autotest-libvirt.virtual_disks.luks.positive_test.coldplug.device_disk.dir_pool_test.target_format_qcow2.encryption_out_source: PASS (184.83 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 289.04 s
[root@jgao-test1 ~]# avocado run --vt-type libvirt type_specific.io-github-autotest-libvirt.virtual_disks.luks.negative_test.duplicated_encryption.coldplug.device_disk.dir_pool_test.target_format_qcow2
JOB ID     : 795bf478085fb0f74fb3cea03174c3e22b2ccbf7
JOB LOG    : /root/avocado/job-results/job-2020-04-02T22.47-795bf47/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_disks.luks.negative_test.duplicated_encryption.coldplug.device_disk.dir_pool_test.target_format_qcow2.encryption_in_source: PASS (121.96 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 124.30 s
[root@jgao-test1 ~]# avocado run --vt-type libvirt type_specific.io-github-autotest-libvirt.virtual_disks.luks.negative_test.wrong_password.coldplug.device_disk.dir_pool_test.target_format_qcow2
JOB ID     : b4fcbcd526f2205e74329b9e4b0c75358fdee988
JOB LOG    : /root/avocado/job-results/job-2020-04-02T22.57-b4fcbcd/job.log
 (1/2) type_specific.io-github-autotest-libvirt.virtual_disks.luks.negative_test.wrong_password.coldplug.device_disk.dir_pool_test.target_format_qcow2.encryption_in_source: PASS (164.87 s)
 (2/2) type_specific.io-github-autotest-libvirt.virtual_disks.luks.negative_test.wrong_password.coldplug.device_disk.dir_pool_test.target_format_qcow2.encryption_out_source: PASS (184.63 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 352.12 s

```
Signed-off-by: jgao <jgao@localhost.localdomain>