### PR TITLE
Fix issue of adding pci-bridge incorrectly

### DIFF
--- a/libvirt/tests/src/sriov/sriov.py
+++ b/libvirt/tests/src/sriov/sriov.py
@@ -608,7 +608,8 @@ def run(test, params, env):
         pci_bridge_controllers = []
         for device in controller_devices:
             logging.debug(device)
-            if device.type == 'pci' and device.model == "pci-bridge":
+            if device.type == 'pci' and device.model in (
+                    "pci-bridge", "pcie-root-port"):
                 pci_bridge_controllers.append(device)
         if not pci_bridge_controllers:
             pci_bridge_controller = Controller("controller")


### PR DESCRIPTION
When there's pcie-root-port, no longer add pci-bridge

Signed-off-by: haizhao <haizhao@redhat.com>