### PR TITLE
Move rhv-verifypeer case to esx job and fix the some expected msg

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -46,7 +46,7 @@
                     output_method = "rhv_upload"
                     rhv_upload_passwd = ${ovirt_engine_password}
                     rhv_upload_passwd_file = "/tmp/rhv_upload_passwd_file"
-                    rhv_upload_opts = "-oc ${ovirt_engine_url} -op ${rhv_upload_passwd_file} -oo rhv-cafile=${local_ca_file_path} -oo rhv-cluster=${cluster_name}"
+                    rhv_upload_opts = "-oc ${ovirt_engine_url} -op ${rhv_upload_passwd_file} -oo rhv-cluster=${cluster_name}"
                     rhv_upload_opts = "${rhv_upload_opts} -oo rhv-direct"
                 - rhv:
                     output_method = "rhev"
@@ -252,9 +252,23 @@
             only negative_test..rhev.rhv_upload
             main_vm = VM_NAME_RHEL7_V2V_EXAMPLE
             checkpoint = 'invalid_pem'
-            rhv_upload_opts = "${rhv_upload_opts} -oo rhv-verifypeer=true"
-            msg_content = 'virt-v2v: error: failed server prechecks, see earlier errors'
+            rhv_upload_opts = "${rhv_upload_opts} -oo rhv-cafile=${local_ca_file_path} -oo rhv-verifypeer=true"
+            msg_content = 'ovirtsdk4.Error: Error while sending HTTP request.*? CApath: none'
             expect_msg = yes
+        - verifypeer_ca:
+            only esx_67
+            only rhev.rhv_upload
+            main_vm = VM_NAME_RHEL7_V2V_EXAMPLE
+            variants:
+                - verifypeer_false_with_ca:
+                    rhv_upload_opts = "${rhv_upload_opts} -oo rhv-cafile=${local_ca_file_path}  -oo rhv-verifypeer=false"
+                - verifypeer_true_without_ca:
+                    only negative_test
+                    # Means version >= libguestfs-1.40.2-21
+                    version_requried = "[libguestfs-1.40.2-21,)"
+                    rhv_upload_opts = "${rhv_upload_opts} -oo rhv-verifypeer=true"
+                    msg_content = "virt-v2v: error: -o rhv-upload: must use .-oo rhv-cafile. .*? oVirt or RHV"
+                    expect_msg = no
         - no-copy-illegal:
             only esx_67
             main_vm = VM_NAME_RHEL7_V2V_EXAMPLE
@@ -317,4 +331,4 @@
             status_error = 'no'
         - negative_test:
             status_error = 'yes'
-            only option_root.single, invalid_rhv_pem, no-copy-illegal
+            only option_root.single, invalid_rhv_pem, no-copy-illegal, verifypeer_true_without_ca

--- a/v2v/tests/cfg/v2v_options.cfg
+++ b/v2v/tests/cfg/v2v_options.cfg
@@ -465,17 +465,4 @@
                             v2v_options = "-o null -os default"
                         - no-copy:
                             v2v_options = "-o glance --no-copy"
-                - custom:
-                    only input_mode.none..output_mode.none
-                    variants:
-                        - no_verifypeer_without_ca:
-                            # Means version >= libguestfs-1.40.2-15
-                            version_requried = "[libguestfs-1.40.2-15,)"
-                            v2v_options = "-o rhv-upload -oo rhv-verifypeer=false"
-                            msg_content = "virt-v2v: error: expecting a libvirt guest name on the command line"
-                            expect_msg = yes
-                        - verifypeer_without_ca:
-                            v2v_options = "-o rhv-upload -oo rhv-verifypeer=true"
-                            msg_content = "virt-v2v: error: -o rhv-upload: must use .-oo rhv-cafile. .*? oVirt or RHV"
-                            expect_msg = yes
 


### PR DESCRIPTION
1.Must convert a guest with related rhv-upload options to
test rhv-verifypeer option, or the case is invaild, so move the
rhv-verifypeer case from v2v_option job to function_test_esx.

2.Fix the expected message for case invaild_rhv_pem, which is the
actual message we want to test.

Signed-off-by: mxie91 <mxie@redhat.com>