### PR TITLE
Fix disk virtio bootorder snapshot issue

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
@@ -80,6 +80,7 @@
                     virt_disk_serial = "aaaabbbbccccdddd aaaabbbbccccdddd"
                 - disks_bootorder:
                     no s390-virtio
+                    no q35
                     only coldplug
                     virt_disk_with_boot_disk = "yes"
                     virt_disk_device_boot_console = "yes"
@@ -415,6 +416,8 @@
                             s390-virtio:
                                 virt_disk_bootdisk_bus = "scsi"
                                 virt_disk_device_target = "sda"
+                            q35:
+                                virt_disk_bootdisk_bus = "scsi"
                         - disk_virtio_driver_options:
                             test_disk_option_cmd = "yes"
                             variants:


### PR DESCRIPTION
And filter one case where Device isa-fdc is not supported with machine type pc-q35-rhel8.2.0

Signed-off-by: chunfuwen <chwen@redhat.com>