### PR TITLE
Add new case for copy_on_read attach disk

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
@@ -372,22 +372,30 @@
                             virt_disk_device_target = "fda"
                             virt_disk_device_bus = "fdc"
                 - disk_driver_option:
-                    only coldplug
                     test_disk_option_cmd = "yes"
                     virt_disk_device_target = "vdb"
                     virt_disk_device_type = "file"
                     virt_disk_device_format = "raw"
                     variants:
                         - option_discard_unmap:
+                            only coldplug
                             driver_option = "discard=unmap"
                         - option_discard_ignore:
+                            only coldplug
                             driver_option = "discard=ignore"
                         - option_copy_on_read_off:
+                            only coldplug
                             virt_disk_device_format = "qcow2"
                             driver_option = "copy_on_read=off"
                         - option_copy_on_read_on:
+                            hotplug:
+                                test_disk_option_cmd = "no"
+                                virt_disk_at_dt_disk = "yes"
+                            coldplug:
+                                virt_disk_cold_dt = "yes"
                             virt_disk_device_format = "qcow2"
-                            driver_option = "copy_on_read=on"
+                            disks_attach_option = "--subdriver qcow2"
+                            driver_option = "copy_on_read=on,type=qcow2"
                 - disk_option_serial_wwn:
                     only coldplug
                     test_disk_option_cmd = "yes"


### PR DESCRIPTION
This implements two scenarios:
1. Coldplug/cold-unplug a disk with copy_on_read=on
2. Hotplug/hotunplug a disk with copy_on_read=on

Signed-off-by: Dan Zheng <dzheng@redhat.com>