### PR TITLE
Fix virtual network pxe boot failure

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_network.py
+++ b/libvirt/tests/src/virtual_network/iface_network.py
@@ -56,6 +56,9 @@ def run(test, params, env):
         process.system("wget %s -O %s/vmlinuz" % (boot_vmlinuz, tftp_root))
         process.system("cp -f /usr/share/syslinux/pxelinux.0 {0};"
                        " mkdir -m 777 -p {0}/pxelinux.cfg".format(tftp_root), shell=True)
+        ldlinux_file = "/usr/share/syslinux/ldlinux.c32"
+        if os.path.exists(ldlinux_file):
+            process.system("cp -f {0} {1}".format(ldlinux_file, tftp_root), shell=True)
         pxe_file = "%s/pxelinux.cfg/default" % tftp_root
         boot_txt = """
 DISPLAY boot.txt
@@ -905,8 +908,6 @@ TIMEOUT 3"""
                     vm.serial_console.read_until_output_matches(
                         ["Loading vmlinuz", "Loading initrd.img"],
                         utils_misc.strip_console_codes)
-                    output = vm.serial_console.get_stripped_output()
-                    logging.debug("Boot messages: %s", output)
                 except ExpectTimeoutError as details:
                     if boot_failure:
                         logging.info("Fail to boot from pxe as expected")


### PR DESCRIPTION
Add this patch again as the previous code is change back by another pr by mistake(should be not rebase before submit)
Approved and merged pr before: https://github.com/autotest/tp-libvirt/pull/2583
Removed pr: https://github.com/autotest/tp-libvirt/pull/2594

1. Add missing step for ldlinux.c32 copy
2. Remove the failure of debug output
from get_stripped_output to avoid error
ERROR: [1S is not included in the known console codes list
which is caused in aexpect and not fixed now. please check
https://github.com/avocado-framework/aexpect/pull/48 for detailed info

Signed-off-by: Kylazhang <weizhan@redhat.com>