### PR TITLE
Add timeout for serial login

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_network.py
+++ b/libvirt/tests/src/virtual_network/iface_network.py
@@ -915,7 +915,8 @@ TIMEOUT 3"""
             else:
                 if serial_login:
                     session = vm.wait_for_serial_login(username=username,
-                                                       password=password)
+                                                       password=password,
+                                                       timeout=120)
                 else:
                     session = vm.wait_for_login()
 


### PR DESCRIPTION
Sometimes the default time is not enough
previous fail with
```
(1/1) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.net_forward.net_route: ERROR: Unknown error occurred while looking for patterns ['[Aa]re you sure', '[Pp]assword:\\s*', '\\(or (press|type) Control-D to continue\\):\\s*$', '[Gg]ive.*[Ll]ogin:\\s*$', '(?<![Ll]ast )[Ll]ogin:\\s*$', '[Cc]onnection.*closed', '[Cc]onnection.*refused', '[P... (47.82 s)
```
Now pass
```
# avocado run --vt-type libvirt --vt-machine-type q35 virtual_network.iface_network.net_forward.net_route
JOB ID     : 8ef47c07c2806a5143443d6ee1f2880fa420be80
JOB LOG    : /root/avocado/job-results/job-2020-04-09T07.34-8ef47c0/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.net_forward.net_route: PASS (67.03 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 68.57 s
```

Signed-off-by: Kylazhang <weizhan@redhat.com>