### PR TITLE
RPL: Add migration cases about net failover

### DIFF
--- a/libvirt/tests/cfg/migration/sriov_migrate.cfg
+++ b/libvirt/tests/cfg/migration/sriov_migrate.cfg
@@ -1,0 +1,46 @@
+- virsh.sriov_migrate:
+    type = sriov_migrate
+    # Migrating non-started VM causes undefined behavior
+    start_vm = yes
+    # Console output can only be monitored via virsh console output
+    only_pty = True
+    take_regular_screendumps = no
+    # Options to pass to virsh migrate command before <domain> <desturi>
+    virsh_migrate_options = ""
+    # Extra options to pass after <domain> <desturi>
+    virsh_migrate_extra = ""
+    # SSH connection time out
+    ssh_timeout = 60
+    migration_setup = "yes"
+    storage_type = 'nfs'
+    setup_local_nfs = 'yes'
+    virsh_migrate_dest_state = running
+    virsh_migrate_src_state = running
+    virsh_migrate_options = "--live --verbose --bandwidth 10"
+    # Local URI
+    virsh_migrate_connect_uri = "qemu:///system"
+    only x86_64
+
+    variants:
+        - with_postcopy:
+            virsh_migrate_extra = "--postcopy"
+        - without_postcopy:
+            virsh_migrate_extra = ""
+    variants:
+        - net_failover:
+            net_failover_test = "yes"
+            iface_type = "network"
+            bridge_name = "br0"
+            vm_tmp_file = "/tmp/test.txt"
+            cmd_during_mig =  "> ${vm_tmp_file} ;ping www.baidu.com > ${vm_tmp_file} 2>&1 &"
+            variants:
+                - normal_test:
+                    postcopy:
+                        only with_postcopy
+                    precopy:
+                        only without_postcopy
+                        migrate_vm_back = "yes"
+                - cancel_migration:
+                    only without_postcopy
+                    status_error = 'yes'
+                    cancel_migration = 'yes'

--- a/libvirt/tests/src/migration/sriov_migrate.py
+++ b/libvirt/tests/src/migration/sriov_migrate.py
@@ -1,0 +1,522 @@
+import os
+import copy
+import logging
+import re
+
+from avocado.utils import process
+
+from virttest import libvirt_vm
+from virttest import utils_test
+from virttest import utils_misc
+from virttest import utils_net
+from virttest import defaults
+from virttest import migration
+from virttest import virsh
+from virttest import utils_sriov
+from virttest import remote
+from virttest import utils_conn
+from virttest import libvirt_version
+
+from virttest.libvirt_xml import vm_xml
+from virttest.libvirt_xml.devices import interface
+from virttest.utils_test import libvirt
+
+
+def run(test, params, env):
+    """
+    Test virsh migrate command.
+    """
+
+    def check_vm_network_accessed(session=None, ping_dest="www.baidu.com"):
+        """
+        The operations to the VM need to be done before or after
+        migration happens
+
+        :param session: The session object to the host
+        :param ping_dest: The destination to be ping
+
+        :raise: test.fail when ping fails
+        """
+        # Confirm local/remote VM can be accessed through network.
+        logging.info("Check VM network connectivity")
+        status, output = utils_test.ping(ping_dest,
+                                         count=10,
+                                         timeout=20,
+                                         output_func=logging.debug,
+                                         session=session)
+        if status != 0:
+            test.fail("Ping failed, status: %s,"
+                      " output: %s" % (status, output))
+
+    def get_vm_ifaces(session=None):
+        """
+        Get interfaces of vm
+
+        :param session: The session object to the host
+        :return: interfaces
+        """
+        p_iface, v_iface = utils_net.get_remote_host_net_ifs(session)
+
+        return p_iface
+
+    def check_vm_iface_num(iface_list, exp_num=3):
+        """
+        Check he number of interfaces
+
+        :param iface_list: The interface list
+        :param exp_num: The expected number
+        :raise: test.fail when interfaces' number is not equal to exp_num
+        """
+        if len(iface_list) != exp_num:
+            test.fail("%d interfaces should be found on the vm, "
+                      "but find %s." % (exp_num, iface_list))
+
+    def create_or_del_networks(pf_name, params, remote_virsh_session=None,
+                               is_del=False):
+        """
+        Create or delete network on local or remote
+
+        :param params: Dictionary with the test parameters
+        :param pf_name: The name of PF
+        :param remote_virsh_session: The virsh session object to the remote host
+        :param is_del: Whether the networks should be deleted
+        :raise: test.fail when fails to define/start network
+        """
+        net_hostdev_name = params.get("net_hostdev_name", "hostdev-net")
+        net_hostdev_fwd = params.get("net_hostdev_fwd",
+                                     '{"mode": "hostdev", "managed": "yes"}')
+        net_bridge_name = params.get("net_bridge_name", "host-bridge")
+        net_bridge_fwd = params.get("net_bridge_fwd", '{"mode": "bridge"}')
+        bridge_name = params.get("bridge_name", "br0")
+
+        net_dict = {"net_name": net_hostdev_name,
+                    "net_forward": net_hostdev_fwd,
+                    "net_forward_pf": '{"dev": "%s"}' % pf_name}
+        bridge_dict = {"net_name": net_bridge_name,
+                       "net_forward": net_bridge_fwd,
+                       "net_bridge": '{"name": "%s"}' % bridge_name}
+
+        if not is_del:
+            for net_params in (net_dict, bridge_dict):
+                net_dev = libvirt.create_net_xml(net_params.get("net_name"),
+                                                 net_params)
+                if not remote_virsh_session:
+                    if net_dev.get_active():
+                        net_dev.undefine()
+                    net_dev.define()
+                    net_dev.start()
+                else:
+                    remote.scp_to_remote(server_ip, '22', server_user, server_pwd,
+                                         net_dev.xml, net_dev.xml, limit="",
+                                         log_filename=None, timeout=600,
+                                         interface=None)
+                    remote_virsh_session.net_define(net_dev.xml, **virsh_args)
+                    remote_virsh_session.net_start(net_params.get("net_name"),
+                                                   **virsh_args)
+
+        else:
+            virsh_session = virsh
+            if remote_virsh_session:
+                virsh_session = remote_virsh_session
+            for nname in (net_hostdev_name, net_bridge_name):
+                if nname not in virsh_session.net_state_dict():
+                    continue
+                virsh_session.net_destroy(nname, debug=True, ignore_status=True)
+                virsh_session.net_undefine(nname, debug=True, ignore_status=True)
+
+    def check_vm_network_connection(net_name, expected_conn=0):
+        """
+        Check network connections in network xml
+
+        :param net_name: The network to be checked
+        :param expected_conn: The expected value
+        :raise: test.fail when fails
+        """
+        output = virsh.net_dumpxml(net_name, debug=True).stdout_text
+        if expected_conn == 0:
+            reg_pattern = r"<network>"
+        else:
+            reg_pattern = r"<network connections='(\d)'>"
+        res = re.findall(reg_pattern, output, re.I)
+        if not res:
+            test.fail("Unable to find expected connection in %s." % net_name)
+        if expected_conn != 0:
+            if expected_conn != int(res[0]):
+                test.fail("Unable to get expected connection number."
+                          "Expected: %s, Actual %s" % (expected_conn, int(res[0])))
+
+    def get_hostdev_addr_from_xml():
+        """
+        Get VM hostdev address
+
+        :return: pci driver id
+        """
+        address_dict = {}
+        for ifac in vm_xml.VMXML.new_from_dumpxml(vm_name).devices.by_device_tag("interface"):
+            if ifac.type_name == "hostdev":
+                address_dict = ifac.hostdev_address.attrs
+
+        return libvirt.pci_info_from_address(address_dict, 16, "id")
+
+    def check_vfio_pci(pci_path, status_error=False):
+        """
+        Check if vf driver is vfio-pci
+
+        :param pci_path: The absolute path of pci device
+        :param status_error: Whether the driver should be vfio-pci
+        """
+        cmd = "readlink %s/driver | awk -F '/' '{print $NF}'" % pci_path
+        output = process.run(cmd, shell=True, verbose=True).stdout_text.strip()
+        if (output == "vfio-pci") == status_error:
+            test.fail("Get incorrect dirver %s, it should%s be vfio-pci."
+                      % (output, ' not' if status_error else ''))
+
+    def update_iface_xml(vmxml):
+        """
+        Update interfaces for guest
+
+        :param vmxml: vm_xml.VMXML object
+        """
+        vmxml.remove_all_device_by_type('interface')
+        vmxml.sync()
+
+        iface_dict = {"type": "network", "source": "{'network': 'host-bridge'}",
+                      "mac": mac_addr, "model": "virtio",
+                      "teaming": '{"type":"persistent"}',
+                      "alias": '{"name": "ua-backup0"}',
+                      "inbound": '{"average":"5"}',
+                      "outbound": '{"average":"5"}'}
+
+        iface_dict2 = {"type": "network", "source": "{'network': 'hostdev-net'}",
+                       "mac": mac_addr, "model": "virtio",
+                       "teaming": '{"type":"transient", "persistent": "ua-backup0"}'}
+
+        iface = interface.Interface('network')
+        for ifc in (iface_dict, iface_dict2):
+            iface.xml = libvirt.modify_vm_iface(vm.name, "get_xml", ifc)
+            vmxml.add_device(iface)
+        vmxml.sync()
+
+    migration_test = migration.MigrationTest()
+    migration_test.check_parameters(params)
+
+    # Params for NFS shared storage
+    shared_storage = params.get("migrate_shared_storage", "")
+    if shared_storage == "":
+        default_guest_asset = defaults.get_default_guest_os_info()['asset']
+        default_guest_asset = "%s.qcow2" % default_guest_asset
+        shared_storage = os.path.join(params.get("nfs_mount_dir"),
+                                      default_guest_asset)
+        logging.debug("shared_storage:%s", shared_storage)
+
+    # Params to update disk using shared storage
+    params["disk_type"] = "file"
+    params["disk_source_protocol"] = "netfs"
+    params["mnt_path_name"] = params.get("nfs_mount_dir")
+
+    # Local variables
+    virsh_args = {"debug": True}
+    virsh_options = params.get("virsh_options", "")
+
+    server_ip = params.get("server_ip")
+    server_user = params.get("server_user", "root")
+    server_pwd = params.get("server_pwd")
+    client_ip = params.get("client_ip")
+    client_pwd = params.get("client_pwd")
+    extra = params.get("virsh_migrate_extra")
+    options = params.get("virsh_migrate_options")
+
+    bridge_name = params.get("bridge_name", "br0")
+    net_hostdev_name = params.get("net_hostdev_name", "hostdev-net")
+    net_bridge_name = params.get("net_bridge_name", "host-bridge")
+    driver = params.get("driver", "ixgbe")
+    vm_tmp_file = params.get("vm_tmp_file", "/tmp/test.txt")
+    cmd_during_mig = params.get("cmd_during_mig")
+    net_failover_test = "yes" == params.get("net_failover_test", "no")
+    cancel_migration = "yes" == params.get("cancel_migration", "no")
+    try:
+        vf_no = int(params.get("vf_no", "4"))
+    except ValueError as e:
+        test.error(e)
+
+    migr_vm_back = "yes" == params.get("migrate_vm_back", "no")
+    err_msg = params.get("err_msg")
+    status_error = "yes" == params.get("status_error", "no")
+    cmd_parms = {'server_ip': server_ip, 'server_user': server_user,
+                 'server_pwd': server_pwd}
+    remote_virsh_dargs = {'remote_ip': server_ip, 'remote_user': server_user,
+                          'remote_pwd': server_pwd, 'unprivileged_user': None,
+                          'ssh_remote_auth': True}
+    destparams_dict = copy.deepcopy(params)
+
+    remote_virsh_session = None
+    vm_session = None
+    vm = None
+    mig_result = None
+    func_name = None
+    extra_args = {}
+    default_src_vf = 0
+    default_dest_vf = 0
+    default_src_rp_filter = 1
+    default_dest_rp_filer = 1
+
+    if not libvirt_version.version_compare(6, 0, 0):
+        test.cancel("This libvirt version doesn't support migration with "
+                    "net failover devices.")
+
+    # params for migration connection
+    params["virsh_migrate_desturi"] = libvirt_vm.complete_uri(
+                                       params.get("migrate_dest_host"))
+    params["virsh_migrate_connect_uri"] = libvirt_vm.complete_uri(
+                                       params.get("migrate_source_host"))
+    src_uri = params.get("virsh_migrate_connect_uri")
+    dest_uri = params.get("virsh_migrate_desturi")
+
+    vm_name = params.get("migrate_main_vm")
+    vm = env.get_vm(vm_name)
+    vm.verify_alive()
+
+    # For safety reasons, we'd better back up  xmlfile.
+    new_xml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    orig_config_xml = new_xml.copy()
+
+    try:
+        # Create a remote runner for later use
+        runner_on_target = remote.RemoteRunner(host=server_ip,
+                                               username=server_user,
+                                               password=server_pwd)
+
+        server_session = remote.wait_for_login('ssh', server_ip, '22',
+                                               server_user, server_pwd,
+                                               r"[\#\$]\s*$")
+        if net_failover_test:
+            src_pf, src_pf_pci = utils_sriov.find_pf(driver)
+            logging.debug("src_pf is %s. src_pf_pci: %s", src_pf, src_pf_pci)
+            params['pf_name'] = src_pf
+            dest_pf, dest_pf_pci = utils_sriov.find_pf(driver, server_session)
+            logging.debug("dest_pf is %s. dest_pf_pci: %s", dest_pf, dest_pf_pci)
+            destparams_dict['pf_name'] = dest_pf
+
+            src_pf_pci_path = utils_misc.get_pci_path(src_pf_pci)
+            dest_pf_pci_path = utils_misc.get_pci_path(dest_pf_pci, server_session)
+
+            cmd = "cat %s/sriov_numvfs" % (src_pf_pci_path)
+            default_src_vf = process.run(cmd, shell=True,
+                                         verbose=True).stdout_text
+
+            cmd = "cat %s/sriov_numvfs" % (dest_pf_pci_path)
+            status, default_dest_vf = utils_misc.cmd_status_output(cmd,
+                                                                   shell=True,
+                                                                   session=server_session)
+            if status:
+                test.error("Unable to get default sriov_numvfs on target!"
+                           "status: %s, output: %s" % (status, default_dest_vf))
+
+            if not utils_sriov.set_vf(src_pf_pci_path, vf_no):
+                test.error("Failed to set vf on source.")
+
+            if not utils_sriov.set_vf(dest_pf_pci_path, vf_no, session=server_session):
+                test.error("Failed to set vf on target.")
+
+            # Create PF and bridge connection on source and target host
+            cmd = 'cat /proc/sys/net/ipv4/conf/all/rp_filter'
+            default_src_rp_filter = process.run(cmd, shell=True,
+                                                verbose=True).stdout_text
+            status, default_dest_rp_filter = utils_misc.cmd_status_output(cmd,
+                                                                          shell=True,
+                                                                          session=server_session)
+            if status:
+                test.error("Unable to get default rp_filter on target!"
+                           "status: %s, output: %s" % (status, default_dest_rp_filter))
+            cmd = 'echo 0 >/proc/sys/net/ipv4/conf/all/rp_filter'
+            process.run(cmd, shell=True, verbose=True)
+            utils_misc.cmd_status_output(cmd, shell=True, session=server_session)
+            utils_sriov.add_or_del_connection(params, is_del=False)
+            utils_sriov.add_or_del_connection(destparams_dict, is_del=False,
+                                              session=server_session)
+
+            if not remote_virsh_session:
+                remote_virsh_session = virsh.VirshPersistent(**remote_virsh_dargs)
+            create_or_del_networks(dest_pf, params,
+                                   remote_virsh_session=remote_virsh_session)
+            remote_virsh_session.close_session()
+            create_or_del_networks(src_pf, params)
+            # Change network interface xml
+            mac_addr = utils_net.generate_mac_address_simple()
+            update_iface_xml(new_xml)
+
+        # Change the disk of the vm
+        libvirt.set_vm_disk(vm, params)
+
+        if not vm.is_alive():
+            vm.start()
+
+        # Check local guest network connection before migration
+        if vm.serial_console is not None:
+            vm.cleanup_serial_console()
+        vm.create_serial_console()
+        vm_session = vm.wait_for_serial_login(timeout=240)
+
+        if net_failover_test:
+            utils_net.restart_guest_network(vm_session)
+        iface_list = get_vm_ifaces(vm_session)
+
+        vm_ipv4, vm_ipv6 = utils_net.get_linux_ipaddr(vm_session, iface_list[0])
+        check_vm_network_accessed(ping_dest=vm_ipv4)
+
+        if net_failover_test:
+            check_vm_iface_num(iface_list)
+            check_vm_network_connection(net_hostdev_name, 1)
+            check_vm_network_connection(net_bridge_name, 1)
+
+            hostdev_pci_id = get_hostdev_addr_from_xml()
+            vf_path = utils_misc.get_pci_path(hostdev_pci_id)
+            check_vfio_pci(vf_path)
+            if cmd_during_mig:
+                s, o = utils_misc.cmd_status_output(cmd_during_mig, shell=True,
+                                                    session=vm_session)
+                if s:
+                    test.fail("Failed to run %s in vm." % cmd_during_mig)
+
+        if extra.count("--postcopy"):
+            func_name = virsh.migrate_postcopy
+            extra_args.update({'func_params': params})
+        if cancel_migration:
+            func_name = migration_test.do_cancel
+
+        # Execute migration process
+        vms = [vm]
+
+        migration_test.do_migration(vms, None, dest_uri, 'orderly',
+                                    options, thread_timeout=900,
+                                    ignore_status=True, virsh_opt=virsh_options,
+                                    func=func_name, extra_opts=extra,
+                                    **extra_args)
+        mig_result = migration_test.ret
+
+        migration_test.check_result(mig_result, params)
+
+        if int(mig_result.exit_status) == 0:
+            server_session = remote.wait_for_login('ssh', server_ip, '22',
+                                                   server_user, server_pwd,
+                                                   r"[\#\$]\s*$")
+            check_vm_network_accessed(server_session, vm_ipv4)
+            server_session.close()
+            if net_failover_test:
+                # Check network connection
+                check_vm_network_connection(net_hostdev_name)
+                check_vm_network_connection(net_bridge_name)
+                # VF driver should not be vfio-pci
+                check_vfio_pci(vf_path, True)
+
+                vm_after_mig = utils_test.RemoteVMManager(cmd_parms)
+                vm_after_mig.setup_ssh_auth(vm_ipv4,
+                                            params.get("password"),
+                                            timeout=60)
+                cmd = "ip link"
+                cmd_result = vm_after_mig.run_command(vm_ipv4, cmd)
+                libvirt.check_result(cmd_result)
+                p_iface = re.findall(r"\d+:\s+(\w+):\s+.*", cmd_result.stdout_text)
+                p_iface = [x for x in p_iface if x != 'lo']
+                check_vm_iface_num(p_iface)
+
+                # Check the output of ping command
+                cmd = 'cat %s' % vm_tmp_file
+                cmd_result = vm_after_mig.run_command(vm_ipv4, cmd)
+                libvirt.check_result(cmd_result)
+
+                if re.findall('Destination Host Unreachable', cmd_result.stdout_text, re.M):
+                    test.fail("The network does not work well during "
+                              "the migration peirod. ping output: %s"
+                              % cmd_result.stdout_text)
+
+            # Execute migration from remote
+            if migr_vm_back:
+                ssh_connection = utils_conn.SSHConnection(server_ip=client_ip,
+                                                          server_pwd=client_pwd,
+                                                          client_ip=server_ip,
+                                                          client_pwd=server_pwd)
+                try:
+                    ssh_connection.conn_check()
+                except utils_conn.ConnectionError:
+                    ssh_connection.conn_setup()
+                    ssh_connection.conn_check()
+
+                # Pre migration setup for local machine
+                migration_test.migrate_pre_setup(src_uri, params)
+
+                cmd = "virsh migrate %s %s %s" % (vm_name,
+                                                  virsh_options, src_uri)
+                logging.debug("Start migration: %s", cmd)
+                cmd_result = remote.run_remote_cmd(cmd, params, runner_on_target)
+                logging.info(cmd_result)
+                if cmd_result.exit_status:
+                    test.fail("Failed to run '%s' on remote: %s"
+                              % (cmd, cmd_result))
+                logging.debug("migration back done")
+                check_vm_network_accessed(ping_dest=vm_ipv4)
+                if net_failover_test:
+                    if vm_session:
+                        vm_session.close()
+                    vm_session = vm.wait_for_login()
+                    iface_list = get_vm_ifaces(vm_session)
+                    check_vm_iface_num(iface_list)
+
+        else:
+            check_vm_network_accessed(ping_dest=vm_ipv4)
+            if net_failover_test:
+                iface_list = get_vm_ifaces(vm_session)
+                check_vm_iface_num(iface_list)
+
+    finally:
+        logging.debug("Recover test environment")
+        # Clean VM on destination
+        migration_test.cleanup_dest_vm(vm, vm.connect_uri, dest_uri)
+
+        if vm.is_alive():
+            vm.destroy(gracefully=False)
+
+        logging.info("Recovery VM XML configration")
+        orig_config_xml.sync()
+        logging.debug("The current VM XML:\n%s", orig_config_xml.xmltreefile)
+
+        server_session = remote.wait_for_login('ssh', server_ip, '22',
+                                               server_user, server_pwd,
+                                               r"[\#\$]\s*$")
+        if 'src_pf' in locals():
+            cmd = 'echo %s  >/proc/sys/net/ipv4/conf/all/rp_filter' % default_src_rp_filter
+            process.run(cmd, shell=True, verbose=True)
+            utils_sriov.add_or_del_connection(params, is_del=True)
+            create_or_del_networks(src_pf, params, is_del=True)
+
+        if 'dest_pf' in locals():
+            cmd = 'echo %s  >/proc/sys/net/ipv4/conf/all/rp_filter' % default_dest_rp_filter
+            utils_misc.cmd_status_output(cmd, shell=True, session=server_session)
+            utils_sriov.add_or_del_connection(destparams_dict, session=server_session,
+                                              is_del=True)
+            remote_virsh_session = virsh.VirshPersistent(**remote_virsh_dargs)
+            create_or_del_networks(dest_pf, params,
+                                   remote_virsh_session,
+                                   is_del=True)
+            remote_virsh_session.close_session()
+
+        if 'dest_pf_pci_path' in locals() and default_dest_vf != vf_no:
+            utils_sriov.set_vf(dest_pf_pci_path, default_dest_vf, server_session)
+        if 'src_pf_pci_path' in locals() and default_src_vf != vf_no:
+            utils_sriov.set_vf(src_pf_pci_path, default_src_vf)
+
+        # Clean up of pre migration setup for local machine
+        if migr_vm_back:
+            if 'ssh_connection' in locals():
+                ssh_connection.auto_recover = True
+            migration_test.migrate_pre_setup(src_uri, params,
+                                             cleanup=True)
+
+        server_session.close()
+        if remote_virsh_session:
+            remote_virsh_session.close_session()
+
+        logging.info("Remove local NFS image")
+        source_file = params.get("source_file")
+        if source_file:
+            libvirt.delete_local_disk("file", path=source_file)


### PR DESCRIPTION
This PR adds below migration cases:
1. migrate vm with hostdev type interface
2. postcopy migrate vm with hostdev type interface
3. cancel during miration with hostdev type interface

depends on 
https://github.com/avocado-framework/avocado-vt/pull/2555
https://github.com/avocado-framework/avocado-vt/pull/2530
https://github.com/avocado-framework/avocado-vt/pull/2510
https://github.com/avocado-framework/avocado-vt/pull/2529
https://github.com/avocado-framework/avocado-vt/pull/2526
https://github.com/avocado-framework/avocado-vt/pull/1783
Signed-off-by: Yingshun Cui <yicui@redhat.com>