### PR TITLE
Fix polkit policy

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_restore.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_restore.cfg
@@ -25,6 +25,7 @@
                     setup_libvirt_polkit = "yes"
                     action_id = "org.libvirt.api.domain.start org.libvirt.api.domain.write"
                     action_lookup = "connect_driver:QEMU domain_name:${main_vm}"
+                    action_matrix = "[{'action_id': 'org.libvirt.api.domain.start', 'action_lookup': '["connect_driver:QEMU", "domain_name:${main_vm}"]', 'lookup_oper': '&&'},{'action_id': 'org.libvirt.api.domain.write', 'action_lookup': '["connect_driver:QEMU", "domain_name:${main_vm}"]', 'lookup_oper': '&&'},{'action_id': 'org.libvirt.api.network.read', 'action_lookup': '["connect_driver:network"]'},{'action_id': 'org.libvirt.api.network-port.create', 'action_lookup': '["connect_driver:network"]'},{'action_id': 'org.libvirt.api.network-port.read', 'action_lookup': '["connect_driver:network"]'},{'action_id': 'org.libvirt.api.connect.getattr', 'action_lookup': '["connect_driver:QEMU", "connect_driver:network"]', 'lookup_oper': '||'},{'action_id': 'org.libvirt.api.network.getattr', 'action_lookup': '["connect_driver:network"]'}]"
                     unprivileged_user = "EXAMPLE"
                     virsh_uri = "qemu:///system"
         - no_option:


### PR DESCRIPTION
After libvirt-5.6.0, more polkit rules are needed which are already
support in avocado-vt. Here we only need to add a new parameter to
configure it.

Signed-off-by: Dan Zheng <dzheng@redhat.com>