### PR TITLE
Fix xml error for blockcommit multiple_chain tests

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockcommit.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockcommit.py
@@ -354,6 +354,13 @@ def run(test, params, env):
             vmxml.del_device(disk_xml)
             disk_dict = {'attrs': {'file': snap_top}}
             disk_xml.source = disk_xml.new_disk_source(**disk_dict)
+            bs_source = {'file': blk_source}
+            bs_dict = {"type": params.get("disk_type", "file"),
+                       "format": {'type': params.get("disk_format", "qcow2")}}
+
+            new_bs = disk_xml.new_backingstore(**bs_dict)
+            new_bs["source"] = disk_xml.backingstore.new_source(**bs_source)
+            disk_xml.backingstore = new_bs
             vmxml.add_device(disk_xml)
             vmxml.sync()
             vm.start()


### PR DESCRIPTION
It reports "Permission denied" when vm start up.
Fixup this error in this PR.

depends on https://github.com/avocado-framework/avocado-vt/pull/2512
Signed-off-by: Yingshun Cui <yicui@redhat.com>