### PR TITLE
Fix incorrect param name

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate.cfg
@@ -247,7 +247,7 @@
                             memnode_mode_1 = "preferred"
                             memnode_mode_2 = "strict"
         - migrate_postcopy:
-            stress_tool = "stress"
+            stress_package = "stress"
             make_cmds_stress = "./configure && make install"
             stress_args = "--cpu 8 --io 8 --vm 2 --vm-bytes 256M --timeout 60s"
             virsh_migrate_options = "--live --postcopy"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
@@ -1064,7 +1064,7 @@ def run(test, params, env):
             obj_migration = libvirt.MigrationTest()
             migrate_options = "%s %s" % (options, extra)
             # start stress inside VM
-            stress_tool = params.get("stress_tool", "stress")
+            stress_tool = params.get("stress_package", "stress")
             try:
                 vm_stress = utils_test.VMStress(vm, stress_tool, params)
                 vm_stress.load_stress_tool()


### PR DESCRIPTION
When stress_install_from_repo = yes, the stress package should be installed from repo. But it also requires 'stress_package' parameter. This parameter is missed in the case.

Signed-off-by: Dan Zheng <dzheng@redhat.com>