### PR TITLE
Fix blockcommand test for block device

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockcommand.cfg
+++ b/libvirt/tests/cfg/backingchain/blockcommand.cfg
@@ -15,6 +15,7 @@
                     pool_name = 'pool_blockpull'
         - block_disk:
             disk_type = 'block'
+            driver_type = 'raw'
             variants:
                 - block_bk:
                     disk_src = 'lvm'


### PR DESCRIPTION
Introduction of `-blockdev` has unmasked a failure in the test script.
The backing chain that was created originally for `disk_type=block` consisted
only of files instead of block devices. This didn't lead to issues before
introduction of `-blockdev` because of https://bugzilla.redhat.com/show_bug.cgi?id=1821663

The test intention is to use block devices (volumes) for all snapshots.

Therefore, create volumes for all files in the chain beforehand to make
sure snapshots are created to block device with backing file another block
device, that is
`/dev/HostVG/vol1 <-- /dev/HostVG/vol2 <-- ... <-- /dev/HostVG/vol5`
for 4 snapshots, attaching `vol1` as base.

The test case should use `vol1` as `raw`.

`.py`:
1. `vol_size`: introduce variable for reuse
2. `driver_type`: introduce variable in order to allow for raw block
   device to be attached, use previous value as default to maintain
   legacy behavior
3. `check_backingchain`: in case of a block device we start the backing
   chain directly with `/dev/HostVG/vol1`; therefore, the chain is shorter
   than in the case of `file_disk` variants because `vol1` won't have a
   backing file, e.g. there is no element `img[i + 1]` for the last
   element `i` in the list
4. `cmd_create_img`: remove unused definition; it's overwritten further
   down
5. create all volumes: in case of lvm volumes, create all volumes
   for snapshots beforehand and use the `vol1` as first image; don't
   remove `src_vol` from code as this can be used to configure a test
   case of type `file` with `lvm` source volume as first backing file
6. `cmd_create_img`: skip device formatting for raw block devices
7. `bc_chain`: there's no backing file for `vol1`

`.cfg`:
1. `driver_type`: set `raw` for `vol1` to be attached as raw block device

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>