### PR TITLE
Fix hostdev not handled err

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
@@ -61,20 +61,21 @@ def run(test, params, env):
     # wait for vm start successfully
     vm.wait_for_login()
 
-    if hostdev_type in ["usb", "scsi"]:
-        if hostdev_type == "usb":
-            pci_id = get_usb_info()
-        elif hostdev_type == "scsi":
-            source_disk = libvirt.create_scsi_disk(scsi_option="",
-                                                   scsi_size="8")
-            pci_id = get_scsi_info(source_disk)
-        device_xml = libvirt.create_hostdev_xml(pci_id=pci_id,
-                                                dev_type=hostdev_type,
-                                                managed=hostdev_managed,
-                                                alias=device_alias)
-    else:
-        test.error("Hostdev type %s not handled by test."
-                   " Please check code." % hostdev_type)
+    if hostdev_type:
+        if hostdev_type in ["usb", "scsi"]:
+            if hostdev_type == "usb":
+                pci_id = get_usb_info()
+            elif hostdev_type == "scsi":
+                source_disk = libvirt.create_scsi_disk(scsi_option="",
+                                                       scsi_size="8")
+                pci_id = get_scsi_info(source_disk)
+            device_xml = libvirt.create_hostdev_xml(pci_id=pci_id,
+                                                    dev_type=hostdev_type,
+                                                    managed=hostdev_managed,
+                                                    alias=device_alias)
+        else:
+            test.error("Hostdev type %s not handled by test."
+                       " Please check code." % hostdev_type)
     if contr_type:
         controllers = vmxml.get_controllers(contr_type)
         contr_index = len(controllers) + 1


### PR DESCRIPTION
PR 2566 causes other cases except hostdev cases are failed.
This is to recover the original case structure of original design.

Signed-off-by: Dan Zheng <dzheng@redhat.com>