### PR TITLE
Fix domain not found error when converting to RHV

### DIFF
--- a/v2v/tests/src/function_test_esx.py
+++ b/v2v/tests/src/function_test_esx.py
@@ -279,8 +279,6 @@ def run(test, params, env):
             if status_error:
                 log_fail('Virsh dumpxml failed for empty cdrom image')
         elif not status_error:
-            vmchecker = VMChecker(test, params, env)
-            params['vmchecker'] = vmchecker
             if output_mode == 'rhev':
                 if not utils_v2v.import_vm_to_ovirt(params, address_cache,
                                                     timeout=v2v_timeout):
@@ -289,6 +287,8 @@ def run(test, params, env):
                 virsh.start(vm_name, debug=True)
             # Check guest following the checkpoint document after convertion
             logging.info('Checking common checkpoints for v2v')
+            vmchecker = VMChecker(test, params, env)
+            params['vmchecker'] = vmchecker
             if skip_vm_check != 'yes':
                 ret = vmchecker.run()
                 if len(ret) == 0:


### PR DESCRIPTION
In VMChecker, it tries to get the xml of the VM, but when the VM
is on rhv host, it must be started up first, or the VM cannot be
found. And the startup is done in utils_v2v.import_vm_to_ovirt.

By current design of VMChecker, it cannot be placed before
utils_v2v.import_vm_to_ovirt.

In order to fix the VM residual problem when utils_v2v.import_vm_to_ovirt timeout,
the VMChecker or utils_v2v.import_vm_to_ovirt timeout needs to be redesigned in future.

This patch just fixes the block execution for cases to RHV.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>