### PR TITLE
Fix 'virsh migrate-postcopy' command failure

### DIFF
--- a/libvirt/tests/src/migration/migrate_options_shared.py
+++ b/libvirt/tests/src/migration/migrate_options_shared.py
@@ -410,8 +410,9 @@ def run(test, params, env):
         """
         Switch to postcopy during migration
         """
-        res = virsh.migrate_postcopy(vm_name)
-        logging.debug("Command output: %s", res)
+        if not utils_misc.wait_for(
+           lambda: not virsh.migrate_postcopy(vm_name, debug=True).exit_status, 5):
+            test.fail("Failed to set migration postcopy.")
 
         if not utils_misc.wait_for(
            lambda: libvirt.check_vm_state(vm_name, "paused",


### PR DESCRIPTION
Test failed with "Enable postcopy with migrate_set_capability
before the start of migration" even the state of vm was 'paused'.
It needs some time. So add wait_for to avoid this kind of failure.

Signed-off-by: Yingshun Cui <yicui@redhat.com>