### PR TITLE
Fix typo in multifd tests

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -62,7 +62,7 @@
                                     only without_postcopy
                                     virsh_migrate_extra = "--parallel --parallel-connections"
                                     parallel_cn_nums = 255
-                        - defualt_connection:
+                        - default_connection:
                             stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M --timeout 70"
                             stress_in_vm = "yes"
                             asynch_migrate = "yes"
@@ -267,7 +267,7 @@
                                     stress_in_vm = "yes"
                                     asynch_migrate = "yes"
                                     actions_during_migration = "checkestablished"
-                                - defualt_connection:
+                                - default_connection:
                                     stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M --timeout 70"
                                     stress_in_vm = "yes"
                                     asynch_migrate = "yes"


### PR DESCRIPTION
The variant 'defualt_connection' should be 'default_connection'.

Signed-off-by: Yingshun Cui <yicui@redhat.com>