### PR TITLE
Fix the hot unplug max slots memory device can't find issue

### DIFF
--- a/libvirt/tests/cfg/libvirt_mem.cfg
+++ b/libvirt/tests/cfg/libvirt_mem.cfg
@@ -195,7 +195,7 @@
                             test_qemu_cmd = "no"
                             max_mem_rt = 138412032
                             max_mem_slots = 256
-                            attach_times = 257
+                            attach_times = 255
                 - detach_error:
                     add_mem_device = "no"
                     attach_device = "no"

--- a/libvirt/tests/src/libvirt_mem.py
+++ b/libvirt/tests/src/libvirt_mem.py
@@ -616,12 +616,11 @@ def run(test, params, env):
         # Detach the memory device
         unplug_failed_with_known_error = False
         if detach_device:
-            if not dev_xml:
-                dev_xml = utils_hotplug.create_mem_xml(tg_size, pg_size,
-                                                       mem_addr, tg_sizeunit,
-                                                       pg_unit, tg_node,
-                                                       node_mask, mem_model,
-                                                       mem_discard)
+            dev_xml = utils_hotplug.create_mem_xml(tg_size, pg_size,
+                                                   mem_addr, tg_sizeunit,
+                                                   pg_unit, tg_node,
+                                                   node_mask, mem_model,
+                                                   mem_discard)
             for x in xrange(at_times):
                 if not detach_alias:
                     ret = virsh.detach_device(vm_name, dev_xml.xml,


### PR DESCRIPTION
Signed-off-by: qijing <jinqi@redhat.com>

The memory device xml should not include the alias, so remove it and the number for max
 hotplug memory should be 255 since there is a cold plug memory device also.