### PR TITLE
use utils_misc.cmd_status_output to catch exception output

### DIFF
--- a/libvirt/tests/src/libvirt_rng.py
+++ b/libvirt/tests/src/libvirt_rng.py
@@ -349,8 +349,9 @@ def run(test, params, env):
                 logging.info("dd cmd failed as expected")
             elif ret:
                 test.fail("Failed to read the random device")
-        except aexpect.exceptions.ShellTimeoutError:
+        except aexpect.exceptions.ShellTimeoutError as stderr:
             logging.info("dd cmd timeout")
+            output = stderr
             # Close session as the current session still hang on last cmd
             session.close()
             session = vm.wait_for_login()


### PR DESCRIPTION
the test failed "UnboundLocalError: local variable 'output'
referenced before assignment" due to the output of dd is missed
when the dd command timeout.
the exception output of dd command should be saved and checked
via utils_misc.cmd_status_output

Signed-off-by: jil <jil@redhat.com>