### PR TITLE
Fix pool destory failure in volume_application

### DIFF
--- a/libvirt/tests/src/virsh_cmd/volume/virsh_volume_application.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_volume_application.py
@@ -8,6 +8,7 @@ from virttest import libvirt_storage
 from virttest import virsh
 from virttest import data_dir
 from virttest import utils_selinux
+from virttest import utils_misc
 from virttest.utils_test import libvirt as utlv
 from virttest.tests import unattended_install
 
@@ -145,6 +146,8 @@ def run(test, params, env):
                     virsh.remove_domain(vm_name)
             elif application == "attach":
                 virsh.detach_disk(vm_name, disk_target)
+                utils_misc.wait_for(
+                   lambda: not utlv.device_exists(vm, disk_target), 10)
         finally:
             pvtest.cleanup_pool(pool_name, pool_type,
                                 pool_target, emulated_img,


### PR DESCRIPTION
It reports "target is busy" when the pool is destroyed directly
after the disk is detached. It needs some time to detach disk
correctly.

Signed-off-by: Yingshun Cui <yicui@redhat.com>