### PR TITLE
Fix insuffient mem pages

### DIFF
--- a/libvirt/tests/cfg/numa/guest_numa.cfg
+++ b/libvirt/tests/cfg/numa/guest_numa.cfg
@@ -33,6 +33,7 @@
                      variants:
                          - m_strict:
                              memnode_mode_0 = "strict"
+                             kernel_hp_file = "/sys/devices/system/node/node1/hugepages/hugepages-2048kB/nr_hugepages"
                              qemu_cmdline_mem_backend_0 = "id=ram-node0,.*?host-nodes=1,policy=bind"
                          - m_preferred:
                              memnode_mode_0 = "preferred"

--- a/libvirt/tests/src/numa/guest_numa.py
+++ b/libvirt/tests/src/numa/guest_numa.py
@@ -149,8 +149,6 @@ def run(test, params, env):
     page_list = handle_param(page_tuple, params)
     nr_pagesize_total = params.get("nr_pagesize_total")
     deallocate = False
-    default_nr_hugepages_path = "/sys/kernel/mm/hugepages/hugepages-2048kB/"
-    default_nr_hugepages_path += "nr_hugepages"
 
     if page_list:
         if not libvirt_version.version_compare(1, 2, 5):
@@ -220,7 +218,6 @@ def run(test, params, env):
             # Only set total 2M size huge page number as total 1G size runtime
             # update not supported now.
             deallocate = True
-            hp_cl.kernel_hp_file = default_nr_hugepages_path
             hp_cl.target_hugepages = int(nr_pagesize_total)
             hp_cl.set_hugepages()
         if page_list:


### PR DESCRIPTION
When we set memnode attached to one node using strict mode, the memory
pages may not be enough for the guest RAM. So this is to allocate all
huge pages on the host numa node which is attached to which can avoid
of below error when starting the guest.

`Insufficient free host memory pages available to allocate guest RAM.`

Signed-off-by: Dan Zheng <dzheng@redhat.com>