### PR TITLE
Don't check blockcopy job finishes with minimal bandwidth

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcopy.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcopy.cfg
@@ -26,6 +26,7 @@
                     only non_acl.local_disk.no_blockdev.no_shallow
                     variants:
                         - min:
+                            check_finish_job = "no"
                             blockcopy_bandwidth = "1"
                             variants:
                                 - byte:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
@@ -254,6 +254,7 @@ def run(test, params, env):
     active_snap = "yes" == params.get("active_snap", "no")
     active_save = "yes" == params.get("active_save", "no")
     check_state_lock = "yes" == params.get("check_state_lock", "no")
+    check_finish_job = "yes" == params.get("check_finish_job", "yes")
     with_shallow = "yes" == params.get("with_shallow", "no")
     with_blockdev = "yes" == params.get("with_blockdev", "no")
     setup_libvirt_polkit = "yes" == params.get('setup_libvirt_polkit')
@@ -565,7 +566,7 @@ def run(test, params, env):
                 val = options.count("--pivot") + options.count("--finish")
                 # Don't wait for job finish when using --byte option
                 val += options.count('--bytes')
-                if val == 0:
+                if val == 0 and check_finish_job:
                     try:
                         finish_job(vm_name, target, timeout)
                     except JobTimeout as excpt:


### PR DESCRIPTION
Don't test that the blockcopy job finishes when bandwidth is set minimal.
Setting it minimal is mainly useful for debugging scenarios but
doing so leads to a long running test case that most probably will timeout.

Considering that all other tests with 'val=0', i.e. '..bandwidth.max',
'..finish_async_option', '..finish_option' et al. already cover that job finishes
this check can be safely removed.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>