### PR TITLE
Change attach_times to 255 from 256 for the max_slots

### DIFF
--- a/libvirt/tests/cfg/libvirt_mem.cfg
+++ b/libvirt/tests/cfg/libvirt_mem.cfg
@@ -51,7 +51,7 @@
                         - max_slots:
                             max_mem_rt = 138412032
                             max_mem_slots = 256
-                            attach_times = 256
+                            attach_times = 255
                             variants:
                                 - without_reboot:
                                 # Do not enable hot_reboot until unless it has to be tested.
@@ -195,7 +195,7 @@
                             test_qemu_cmd = "no"
                             max_mem_rt = 138412032
                             max_mem_slots = 256
-                            attach_times = 255
+                            attach_times = 257
                 - detach_error:
                     add_mem_device = "no"
                     attach_device = "no"


### PR DESCRIPTION
Signed-off-by: qijing <jinqi@redhat.com>

For there is a cold plugged memory device, change attach_times to 255 from 256.
Restore the attach_gt_max to 257 from a mistake change.

Signed-off-by: qijing <jinqi@redhat.com>