### PR TITLE
Fix "Cannot grow device files" error

### DIFF
--- a/libvirt/tests/src/virsh_cmd/volume/virsh_vol_create_from.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_vol_create_from.py
@@ -55,7 +55,7 @@ def run(test, params, env):
         if src_pool_type != dest_pool_type:
             pvt.pre_pool(dest_pool_name, dest_pool_type, dest_pool_target,
                          dest_emulated_image, image_size="100M",
-                         pre_disk_vol=["1M"])
+                         pre_disk_vol=["2M"])
 
         # Print current pools for debugging
         logging.debug("Current pools:%s",


### PR DESCRIPTION
The original item in pre_disk_vol is too small, so update to 2M.

Signed-off-by: Yingshun Cui <yicui@redhat.com>