### PR TITLE
libvirt_rng.py: wait_for_login bef attach_rng

### DIFF
--- a/libvirt/tests/src/libvirt_rng.py
+++ b/libvirt/tests/src/libvirt_rng.py
@@ -519,6 +519,7 @@ def run(test, params, env):
 
             vm.start()
             if attach_rng:
+                vm.wait_for_login(timeout=120)
                 ret = virsh.attach_device(vm_name, rng_xml.xml,
                                           flagstr=attach_options,
                                           debug=True, ignore_status=True)


### PR DESCRIPTION
Attach rng after guest os is fully up, otherwise may encounter
no rng found in guest os after attach.

Signed-off-by: Yanqiu Zhang <yanqzhan@redhat.com>