### PR TITLE
Update pci_lable_from_address func name

### DIFF
--- a/libvirt/tests/src/libvirt_pci_passthrough.py
+++ b/libvirt/tests/src/libvirt_pci_passthrough.py
@@ -145,8 +145,8 @@ def run(test, params, env):
                 if not virt_functions:
                     test.fail("No Virtual Functions found.")
                 for val in virt_functions:
-                    pci_dev = utils_test.libvirt.pci_label_from_address(val,
-                                                                        radix=16)
+                    pci_dev = utils_test.libvirt.pci_info_from_address(val,
+                                                                       radix=16)
                     pci_xml = NodedevXML.new_from_dumpxml(pci_dev)
                     pci_address = pci_xml.cap.get_address_dict()
                     vmxml.add_hostdev(pci_address)


### PR DESCRIPTION
Changed the usage and name of pci_lable_from_address in avocado-vt.
Update accordingly.

depends on https://github.com/avocado-framework/avocado-vt/pull/2529
Signed-off-by: Yingshun Cui <yicui@redhat.com>