### PR TITLE
Remove gluster-related cases for pseries

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockcommand.cfg
+++ b/libvirt/tests/cfg/backingchain/blockcommand.cfg
@@ -10,6 +10,7 @@
                 - block_bk:
                     disk_src = 'iscsi'
                 - gluster_bk:
+                    no pseries
                     disk_src = 'gluster'
                     vol_name = 'vol_blockpull'
                     pool_name = 'pool_blockpull'


### PR DESCRIPTION
Gluster is Not supported on pseries.

Signed-off-by: haizhao <haizhao@redhat.com>