### PR TITLE
virtual_disks_gluster: Cancel all gluster rdma tests

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_gluster.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_gluster.py
@@ -167,7 +167,7 @@ def run(test, params, env):
     mnt_src = ""
 
     # This is brought by new feature:block-dev
-    if libvirt_version.version_compare(6, 0, 0) and transport == "rdma":
+    if transport == "rdma":
         test.cancel("transport protocol 'rdma' is not yet supported")
     try:
         # Build new vm xml.


### PR DESCRIPTION
In QEMU[1], gluster+rdma scheme will be regarded as tcp tranport. That
has been duplicated to gluster tcp cases. The cancel will be revoked after
gluster rdma are really supported in QEMU.

[1]:
https://github.com/qemu/qemu/blob/762fa6d79aa30e1a713444da0399739423f8d00e/block/gluster.c#L375

Signed-off-by: Han Han <hhan@redhat.com>