### PR TITLE
Add v2v new case 'check selinux type mls'

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -104,9 +104,6 @@
             only esx_55
             main_vm = 'VM_NAME_ESX_CDROM_V2V_EXAMPLE'
             checkpoint = 'cdrom'
-        - selinux_type:
-            only esx_60
-            main_vm = 'VM_NAME_ESX_SELINUX_TYPE_V2V_EXAMPLE'
         - migrated_vm:
             only esx_55
             main_vm = 'VM_NAME_ESX_MIGRATED_V2V_EXAMPLE'

--- a/v2v/tests/cfg/specific_kvm.cfg
+++ b/v2v/tests/cfg/specific_kvm.cfg
@@ -216,9 +216,13 @@
             only esx.esx_65
             variants:
                 - min:
+                    checkpoint = 'check_selinuxtype'
                     main_vm = 'VM_SELINUXTYPE_MIN_V2V_EXAMPLE'
                 - missing:
                     main_vm = 'VM_SELINUXTYPE_NONE_V2V_EXAMPLE'
+                - mls:
+                    checkpoint = 'check_selinuxtype'
+                    main_vm = 'VM_SELINUXTYPE_MLS_V2V_EXAMPLE'
         - firewalld:
             only source_kvm
             variants:

--- a/v2v/tests/src/specific_kvm.py
+++ b/v2v/tests/src/specific_kvm.py
@@ -627,6 +627,13 @@ def run(test, params, env):
                 logging.info('Selinux status after v2v:%s', status)
                 if status != checkpoint[8:]:
                     log_fail('Selinux status not match')
+            if checkpoint == 'check_selinuxtype':
+                expect_output = vmchecker.checker.session.cmd('cat /etc/selinux/config')
+                expect_selinuxtype = re.search(r'^SELINUXTYPE=\s*(\S+)$', expect_output, re.MULTILINE).group(1)
+                actual_output = vmchecker.checker.session.cmd('sestatus')
+                actual_selinuxtype = re.search(r'^Loaded policy name:\s*(\S+)$', actual_output, re.MULTILINE).group(1)
+                if actual_selinuxtype != expect_selinuxtype:
+                    log_fail('Seliunx type not match')
             if checkpoint == 'guest_firewalld_status':
                 check_firewalld_status(vmchecker.checker, params[checkpoint])
             if checkpoint in ['ntpd_on', 'sync_ntp']:


### PR DESCRIPTION
1.Add scenario to check selinux type mls
2.Can't find the manual case for selinux_type case of
function_test_esx job and related guest has no setting about selinux
type, so delete the case.

Signed-off-by: mxie91 <mxie@redhat.com>