### PR TITLE
Fix no pagesize on node

### DIFF
--- a/libvirt/tests/src/virsh_cmd/host/virsh_freepages.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_freepages.py
@@ -225,7 +225,9 @@ def run(test, params, env):
             if cell is not None and page is None and not status_error:
                 status_error = True
 
-            utlv.check_exit_status(result, status_error)
+            skip_errors = [r'page size.*is not available on node']
+            utlv.check_result(result, skip_if=skip_errors, any_error=status_error)
+
             expect_result_list = []
             # Check huge pages
             if not status_error:


### PR DESCRIPTION
When no pagesize is available on the host, we should skip the test
instead of raising errors.

The error is like ' page size 1048576 is not available on node 0'.

Signed-off-by: Dan Zheng <dzheng@redhat.com>