### PR TITLE
Add tests of slice luks with different disk format

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_encryption.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_encryption.cfg
@@ -43,6 +43,14 @@
             target_encypt = "luks"
             virt_disk_qcow2_format = 'no'
     variants:
+        - slice_test:
+            slice_test = "yes"
+            target_encypt = "luks"
+            test_size = "10"
+            extra_parameter = "--object secret,data=redhat,id=sec -o encrypt.format=luks,encrypt.key-secret=sec,preallocation=full"
+        - not_slice_test:
+            slice_test = "no"
+    variants:
         - hotplug:
             virt_disk_device_hotplug = "yes"
         - coldplug:


### PR DESCRIPTION
Add tests of slice luks with different disk format
```
# avocado run --vt-type libvirt type_specific.io-github-autotest-libvirt.virtual_disks.encryption.hotplug.slice_test.qcow2_internal.normal_test.encryption_out_source
JOB ID     : aeee0693b46eb9cdaa538624309f0f955428be67
JOB LOG    : /root/avocado/job-results/job-2020-04-24T00.20-aeee069/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_disks.encryption.hotplug.slice_test.qcow2_internal.normal_test.encryption_out_source: PASS (87.58 s)

# avocado run --vt-type libvirt type_specific.io-github-autotest-libvirt.virtual_disks.encryption.hotplug.slice_test.raw_luks.normal_test.encryption_in_source
JOB ID     : ead446774b88d016a1cae1d1bf8c5749bb76fd10
JOB LOG    : /root/avocado/job-results/job-2020-04-24T00.24-ead4467/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_disks.encryption.hotplug.slice_test.raw_luks.normal_test.encryption_in_source: PASS (68.86 s)

 avocado run --vt-type libvirt type_specific.io-github-autotest-libvirt.virtual_disks.encryption.hotplug.slice_test.qcow2_internal.error_test.encryption_in_source
JOB ID     : a049f30b20d865d953678f025e77c6b8cd60a6b5
JOB LOG    : /root/avocado/job-results/job-2020-04-24T00.26-a049f30/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_disks.encryption.hotplug.slice_test.qcow2_internal.error_test.encryption_in_source: PASS (74.34 s)
```


