### PR TITLE
Fix login timeout error after saving on pseries

### DIFF
--- a/libvirt/tests/cfg/virtual_network/mtu.cfg
+++ b/libvirt/tests/cfg/virtual_network/mtu.cfg
@@ -3,6 +3,10 @@
     start_vm = no
     mtu_size = 6000
     model = virtio
+    timeout = 240
+    pseries:
+        timeout = 480
+        wait_for_up = 30
     variants:
         - positive_test:
             variants:


### PR DESCRIPTION
Extend waiting time for pseries during login.
Extend waiting time after boot up, before login, to wait for services
of network fully started.

Signed-off-by: haizhao <haizhao@redhat.com>