### PR TITLE
Update migration cases that uses libvirt.MigrationTest

### DIFF
--- a/libvirt/tests/src/migration/migrate_ceph.py
+++ b/libvirt/tests/src/migration/migrate_ceph.py
@@ -9,6 +9,7 @@ from avocado.utils import process
 from virttest import ssh_key
 from virttest import data_dir
 from virttest import remote
+from virttest import migration
 from virttest import utils_package
 from virttest import utils_selinux
 from virttest import utils_package
@@ -148,12 +149,12 @@ def migrate_vm(test, params):
 
     logging.info("Prepare migrate %s", vm_name)
     global MIGRATE_RET
-    MIGRATE_RET, mig_output = libvirt.do_migration(vm_name, uri, extra,
-                                                   auth_pwd, auth_user,
-                                                   options,
-                                                   virsh_patterns,
-                                                   su_user, timeout,
-                                                   extra_opt)
+    MIGRATE_RET, mig_output = migration.do_migration(vm_name, uri, extra,
+                                                     auth_pwd, auth_user,
+                                                     options,
+                                                     virsh_patterns,
+                                                     su_user, timeout,
+                                                     extra_opt)
 
     if status_error == "no":
         if MIGRATE_RET:
@@ -495,7 +496,7 @@ def run(test, params, env):
     vmxml_backup = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
 
     # Setup migration context
-    migrate_setup = libvirt.MigrationTest()
+    migrate_setup = migration.MigrationTest()
     migrate_setup.migrate_pre_setup(test_dict["desuri"], params)
 
     # Install ceph-common on remote host machine.

--- a/libvirt/tests/src/migration/migrate_with_legacy_guest.py
+++ b/libvirt/tests/src/migration/migrate_with_legacy_guest.py
@@ -5,8 +5,8 @@ import re
 from avocado.utils import download
 
 from virttest import libvirt_vm
-from virttest import utils_test
 from virttest import defaults
+from virttest import migration
 from virttest import virsh
 from virttest import remote
 from virttest import utils_conn
@@ -16,86 +16,13 @@ from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 
 
-def check_parameters(test, params):
-    """
-    Make sure all of parameters are assigned a valid value
-
-    :param test: the test object
-    :param params: the parameters to be checked
-
-    :raise: test.cancel if invalid value exists
-    """
-    migrate_dest_host = params.get("migrate_dest_host")
-    migrate_dest_pwd = params.get("migrate_dest_pwd")
-    migrate_source_host = params.get("migrate_source_host")
-    migrate_source_pwd = params.get("migrate_source_pwd")
-
-    args_list = [migrate_dest_host,
-                 migrate_dest_pwd, migrate_source_host,
-                 migrate_source_pwd]
-
-    for arg in args_list:
-        if arg and arg.count("EXAMPLE"):
-            test.cancel("Please assign a value for %s!" % arg)
-
-
 def run(test, params, env):
     """
     Test virsh migrate command.
     """
 
-    def check_vm_network_accessed(session=None):
-        """
-        The operations to the VM need to be done before or after
-        migration happens
-
-        :param session: The session object to the host
-
-        :raise: test.error when ping fails
-        """
-        # Confirm local/remote VM can be accessed through network.
-        logging.info("Check VM network connectivity")
-        s_ping, _ = utils_test.ping(vm.get_address(),
-                                    count=10,
-                                    timeout=20,
-                                    output_func=logging.debug,
-                                    session=session)
-        if s_ping != 0:
-            if session:
-                session.close()
-            test.fail("%s did not respond after %d sec." % (vm.name, 20))
-
-    def check_migration_res(result):
-        """
-        Check if the migration result is as expected
-
-        :param result: the output of migration
-        :raise: test.fail if test is failed
-        """
-        if not result:
-            test.error("No migration result is returned.")
-
-        logging.info("Migration out: %s", result.stdout_text.strip())
-        logging.info("Migration error: %s", result.stderr_text.strip())
-
-        if status_error:  # Migration should fail
-            if err_msg:   # Special error messages are expected
-                if not re.search(err_msg, result.stderr_text.strip()):
-                    test.fail("Can not find the expected patterns '%s' in "
-                              "output '%s'" % (err_msg,
-                                               result.stderr_text.strip()))
-                else:
-                    logging.debug("It is the expected error message")
-            else:
-                if int(result.exit_status) != 0:
-                    logging.debug("Migration failure is expected result")
-                else:
-                    test.fail("Migration success is unexpected result")
-        else:
-            if int(result.exit_status) != 0:
-                test.fail(result.stderr_text.strip())
-
-    check_parameters(test, params)
+    migration_test = migration.MigrationTest()
+    migration_test.check_parameters(params)
 
     # Params for NFS shared storage
     shared_storage = params.get("migrate_shared_storage", "")
@@ -162,8 +89,6 @@ def run(test, params, env):
     if not libvirt_version.version_compare(5, 0, 0):
         test.cancel("This libvirt version doesn't support "
                     "virtio-transitional model.")
-    # Make sure all of parameters are assigned a valid value
-    check_parameters(test, params)
 
     # params for migration connection
     params["virsh_migrate_desturi"] = libvirt_vm.complete_uri(
@@ -181,7 +106,6 @@ def run(test, params, env):
     new_xml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     orig_config_xml = new_xml.copy()
 
-    migration_test = libvirt.MigrationTest()
     try:
         # Create a remote runner for later use
         runner_on_target = remote.RemoteRunner(host=server_ip,
@@ -224,7 +148,7 @@ def run(test, params, env):
 
         # Check local guest network connection before migration
         vm_session = vm.wait_for_login(restart_network=True)
-        check_vm_network_accessed()
+        migration_test.ping_vm(vm, params)
 
         # Execute migration process
         vms = [vm]
@@ -234,14 +158,10 @@ def run(test, params, env):
                                     extra_opts=extra)
         mig_result = migration_test.ret
 
-        check_migration_res(mig_result)
+        migration_test.check_result(mig_result, params)
 
         if int(mig_result.exit_status) == 0:
-            server_session = remote.wait_for_login('ssh', server_ip, '22',
-                                                   server_user, server_pwd,
-                                                   r"[\#\$]\s*$")
-            check_vm_network_accessed(server_session)
-            server_session.close()
+            migration_test.ping_vm(vm, params, dest_uri)
 
         if xml_check_after_mig:
             if not remote_virsh_session:
@@ -293,6 +213,8 @@ def run(test, params, env):
         # Clean VM on destination
         vm.connect_uri = ''
         migration_test.cleanup_dest_vm(vm, src_uri, dest_uri)
+        if vm.is_alive():
+            vm.destroy(gracefully=False)
 
         logging.info("Recovery VM XML configration")
         orig_config_xml.sync()

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domjobabort.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domjobabort.py
@@ -6,7 +6,7 @@ import locale
 
 from virttest import virsh
 from virttest import data_dir
-from virttest.utils_test import libvirt as utlv
+from virttest import migration
 from virttest import ssh_key
 
 
@@ -179,7 +179,7 @@ def run(test, params, env):
     if action == "migrate":
         # Recover migration speed
         virsh.migrate_setspeed(vm_name, original_speed)
-        utlv.MigrationTest().cleanup_dest_vm(vm, None, remote_uri)
+        migration.MigrationTest().cleanup_dest_vm(vm, None, remote_uri)
 
     # check status_error
     if status_error == "yes":

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
@@ -19,6 +19,7 @@ from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices import memory
 from virttest import utils_misc
 from virttest import cpu
+from virttest import migration
 from virttest.qemu_storage import QemuImg
 from virttest.utils_test import libvirt
 from virttest import test_setup
@@ -799,7 +800,7 @@ def run(test, params, env):
         # Change the disk of the vm to shared disk
         libvirt.set_vm_disk(vm, params)
 
-        migrate_setup = libvirt.MigrationTest()
+        migrate_setup = migration.MigrationTest()
 
         subdriver = utils_test.get_image_info(shared_storage)['format']
         extra_attach = ("--config --driver qemu --subdriver %s --cache %s"
@@ -1047,7 +1048,7 @@ def run(test, params, env):
             timeout = int(params.get("timeout_before_suspend", 5))
             logging.debug("Set migration speed to %sM", speed)
             virsh.migrate_setspeed(vm_name, speed, debug=True)
-            migration_test = libvirt.MigrationTest()
+            migration_test = migration.MigrationTest()
             migrate_options = "%s %s" % (options, extra)
             vms = [vm]
             migration_test.do_migration(vms, None, dest_uri, 'orderly',
@@ -1061,7 +1062,7 @@ def run(test, params, env):
             vms = []
             vms.append(vm)
             cmd = params.get("virsh_postcopy_cmd")
-            obj_migration = libvirt.MigrationTest()
+            obj_migration = migration.MigrationTest()
             migrate_options = "%s %s" % (options, extra)
             # start stress inside VM
             stress_tool = params.get("stress_package", "stress")

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_compcache.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_compcache.py
@@ -7,7 +7,7 @@ from avocado.utils import path as utils_path
 
 from virttest import virsh
 from virttest import ssh_key
-from virttest.utils_test import libvirt as utlv
+from virttest import migration
 
 
 def get_page_size():
@@ -140,7 +140,7 @@ def run(test, params, env):
                 pass
 
         # Cleanup in case of successful migration
-        utlv.MigrationTest().cleanup_dest_vm(vm, None, remote_uri)
+        migration.MigrationTest().cleanup_dest_vm(vm, None, remote_uri)
 
     # Shut down the VM to make sure the compcache setting cleared
     if vm.is_alive():

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_copy_storage.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_copy_storage.py
@@ -6,6 +6,7 @@ from avocado.core import exceptions
 from virttest import ssh_key
 from virttest import utils_test
 from virttest import libvirt_vm
+from virttest import migration
 from virttest.utils_test import libvirt as utlv
 from virttest.staging import lv_utils
 from virttest import virsh
@@ -116,7 +117,7 @@ def copied_migration(test, vms, params):
         vm.wait_for_login()
         vms_ip[vm.name] = vm.get_address()
 
-    cp_mig = utlv.MigrationTest()
+    cp_mig = migration.MigrationTest()
     cp_mig.do_migration(vms, None, dest_uri, "orderly", options, timeout,
                         ignore_status=True)
     check_ip_failures = []

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_multi_vms.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_multi_vms.py
@@ -9,6 +9,7 @@ from virttest import virsh
 from virttest import remote
 from virttest import utils_test
 from virttest import nfs
+from virttest import migration
 from virttest import ssh_key
 from virttest.libvirt_xml import vm_xml
 
@@ -122,7 +123,7 @@ def multi_migration(vm, src_uri, dest_uri, options, migrate_type,
     :rrunner: remote session instance
     """
 
-    obj_migration = utils_test.libvirt.MigrationTest()
+    obj_migration = migration.MigrationTest()
     if migrate_type.lower() == "simultaneous":
         logging.info("Migrate vms simultaneously.")
         try:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_set_get_speed.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_set_get_speed.py
@@ -3,8 +3,8 @@ import logging
 from virttest import ssh_key
 from virttest import virsh
 from virttest import libvirt_vm
+from virttest import migration
 from virttest import utils_test
-from virttest.utils_test import libvirt as utlv
 
 from provider import libvirt_version
 
@@ -170,7 +170,7 @@ def run(test, params, env):
         # virsh migrate options
         virsh_migrate_options = "--live --unsafe --timeout %s" % virsh_migrate_timeout
         # Migrate vms to remote host
-        mig_first = utlv.MigrationTest()
+        mig_first = migration.MigrationTest()
         virsh_dargs = {"debug": True}
         for vm in vms:
             set_get_speed(vm.name, bandwidth, virsh_dargs=virsh_dargs)
@@ -203,7 +203,7 @@ def run(test, params, env):
             vm.wait_for_login()
             set_get_speed(vm.name, second_bandwidth, virsh_dargs=virsh_dargs)
         utils_test.load_stress(stress_type, params=params, vms=vms)
-        mig_second = utlv.MigrationTest()
+        mig_second = migration.MigrationTest()
         mig_second.do_migration(vms, src_uri, dest_uri, migration_type,
                                 options=virsh_migrate_options, thread_timeout=thread_timeout)
         for vm in vms:
@@ -244,6 +244,6 @@ def run(test, params, env):
         virsh.migrate_setspeed(vm_name, orig_value)
         if twice_migration:
             for vm in env.get_all_vms():
-                utlv.MigrationTest().cleanup_dest_vm(vm, src_uri, dest_uri)
+                migration.MigrationTest().cleanup_dest_vm(vm, src_uri, dest_uri)
                 if vm.is_alive():
                     vm.destroy(gracefully=False)

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_stress.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_stress.py
@@ -1,6 +1,7 @@
 import logging
 
 from virttest import libvirt_vm
+from virttest import migration
 from virttest import utils_test
 from virttest import utils_misc
 from virttest import utils_package
@@ -40,7 +41,7 @@ def do_stress_migration(vms, srcuri, desturi, migration_type, test, params,
 
     :raise: test.fail if migration fails
     """
-    migrate_setup = utils_test.libvirt.MigrationTest()
+    migrate_setup = migration.MigrationTest()
     options = params.get("migrate_options")
     ping_count = int(params.get("ping_count", 10))
     migrate_times = 1
@@ -192,8 +193,7 @@ def run(test, params, env):
     finally:
         logging.debug("Cleanup vms...")
         for vm in vms:
-            utils_test.libvirt.MigrationTest().cleanup_dest_vm(vm, None,
-                                                               dest_uri)
+            migration.MigrationTest().cleanup_dest_vm(vm, None, dest_uri)
             # Try to start vms in source once vms in destination are
             # cleaned up
             if not vm.is_alive():

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_virtio_scsi.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_virtio_scsi.py
@@ -6,6 +6,7 @@ import time
 from avocado.utils import process
 from avocado.core import exceptions
 
+from virttest import migration
 from virttest import utils_test
 from virttest import virsh
 from virttest import utils_misc
@@ -161,7 +162,7 @@ def run(test, params, env):
     try:
         # For safety and easily reasons, we'd better define a new vm
         new_vm_name = "%s_vsmtest" % vm.name
-        mig = utlv.MigrationTest()
+        mig = migration.MigrationTest()
         if vm.is_alive():
             vm.destroy()
         utlv.define_new_vm(vm.name, new_vm_name)

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_vm_cfg.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_vm_cfg.py
@@ -5,6 +5,7 @@ import re
 from six import itervalues, string_types
 from avocado.utils import process
 
+from virttest import migration
 from virttest import utils_selinux
 from virttest import virsh
 from virttest import utils_package
@@ -136,7 +137,7 @@ def run(test, params, env):
     try:
         # Get a MigrationTest() Object
         logging.debug("Get a MigrationTest()  object")
-        obj_migration = libvirt.MigrationTest()
+        obj_migration = migration.MigrationTest()
 
         # Setup libvirtd remote connection TLS connection env
         if transport == "tls":

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migration.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migration.py
@@ -2,6 +2,7 @@ import logging
 import platform
 
 from virttest import libvirt_vm
+from virttest import migration
 from virttest import virsh
 from virttest.utils_test import libvirt
 from virttest import libvirt_xml
@@ -111,7 +112,7 @@ def run(test, params, env):
         logging.debug("Supported machine types that are common in  source and "
                       "target are: %s", ", ".join(map(str, machine_list)))
 
-    migrate_setup = libvirt.MigrationTest()
+    migrate_setup = migration.MigrationTest()
     # Perform migration with each machine type
     try:
         for vm in vm_list:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_monitor_blockjob.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_monitor_blockjob.py
@@ -5,6 +5,7 @@ import threading
 from avocado.utils import process
 from avocado.core import exceptions
 
+from virttest import migration
 from virttest import utils_test
 from virttest import libvirt_vm
 from virttest import virsh
@@ -59,7 +60,7 @@ def copied_migration(test, vm, params, blockjob_type=None, block_target="vda"):
     if stress_type is not None:
         utils_test.load_stress("stress_in_vms", params=params, vms=[vm])
 
-    cp_mig = utlv.MigrationTest()
+    cp_mig = migration.MigrationTest()
     migration_thread = threading.Thread(target=cp_mig.thread_func_migration,
                                         args=(vm, dest_uri, options))
     migration_thread.start()


### PR DESCRIPTION
change all the migration testcases that uses utils_test.libvirt
to migration.py for MigrationTest

depends on https://github.com/avocado-framework/avocado-vt/pull/1783
Signed-off-by: Yingshun Cui <yicui@redhat.com>