### PR TITLE
Adjust the test topology of OVMF feature

### DIFF
--- a/libvirt/tests/cfg/bios/virsh_boot.cfg
+++ b/libvirt/tests/cfg/bios/virsh_boot.cfg
@@ -27,33 +27,34 @@
             uefi_custom_codes = "\[\=3h"
             with_nvram = "yes"
             with_nvram_template = "yes"
-            secure_boot_mode = "no"
             os_firmware = "efi"
             variants:
                 - positive_test:
                     variants:
                         - options:
                             variants:
-                                - no_os_loader:
+                                - secure_boot:
                                     with_loader = "no"
+                                    with_nvram = "no"
+                                    test_cmd = "dmesg|grep -i secure"
+                                    release_os_url = "EXAMPLE_RELEASED_OS_URL"
                                     variants:
-                                        - without_secure:
-                                            with_secure = "no"
-                                        - with_secure:
+                                        - without_secure_option:
+                                        - with_secure_option:
                                             with_secure = "yes"
                                 - os_loader:
                                     variants:
                                         - valid_readonly:
                                     variants:
                                         - valid_loader_type:
-                            variants:
-                                - os_nvram:
                                     variants:
-                                        - valid_template:
-                                        - no_template:
-                                            with_nvram_template = "no"
-                                - no_os_nvram:
-                                    with_nvram = "no"
+                                        - os_nvram:
+                                            variants:
+                                                - valid_template:
+                                                - no_template:
+                                                    with_nvram_template = "no"
+                                        - no_os_nvram:
+                                            with_nvram = "no"
                             variants:
                                 - boot:
                                     variants:
@@ -107,11 +108,6 @@
                                     only valid_loader_type
                                     only valid_template
                                     with_boot = "no"
-                        - secure_boot_enabled:
-                            secure_boot_mode = "yes"
-                            test_cmd = "dmesg|grep -i secure"
-                            uefi_device_bus = "sata"
-                            uefi_target_dev = "sda"
                         - invalid_nvram:
                             nvram = "noexist"
                         - boot_order_big_integer:
@@ -158,7 +154,7 @@
                             checkpoint = "could not load PC BIOS"
                         - non_released_version:
                             non_release_os_url = "EXAMPLE_NON_RELEASED_OS_URL"
-                            secure_boot_mode = "yes"
+                            template = "/usr/share/OVMF/OVMF_VARS.secboot.fd"
                             uefi_device_bus = "sata"
                             uefi_target_dev = "sda"
                             check_prompt = "error:.*has invalid signature"


### PR DESCRIPTION
Adjust the test topology of OVMF feature
1. Add cases to start ovmf guest with released version and secure boot enabling
2. Adjust the test step to start guest with non-released version
3. Fix failures in virsh.boot.by_ovmf.negative_test.non_released_version

Signed-off-by: Meina Li <meili@redhat.com>