### PR TITLE
Modify initial check for non-pinned cpu-stats

### DIFF
--- a/libvirt/tests/cfg/cpu/guestpin.cfg
+++ b/libvirt/tests/cfg/cpu/guestpin.cfg
@@ -45,6 +45,10 @@
                     limit_vcpu_sockets = 1
                     condn = "hotplug"
                 - with_load_switch:
+                    # VM needs sometime to get correct pinned cpustats
+                    # Refer: https://www.redhat.com/archives/libvir-list/2020-April/msg00543.html
+                    # time in seconds
+                    cpustats_settle_time = 2
                     only randompin..with_emualorpin
                     condn = "stress"
                     stress_args = '--cpu 8'


### PR DESCRIPTION
Test was validating the initial cpu-stats value
on a non-pinned cpus during the initial guest boot time
and it was always asserting to failure, it looks to be
a behaviour due to a bug another fix and this behaviour
will not be fixed, more details can be found
https://www.redhat.com/archives/libvir-list/2020-April/msg00543.html

In order to accommodate such behaviour during very initial
guest boot time but still validating the testcase, taking
cpu-stats value two times within user configured(2 seconds bydefault)
interval and checking if there is no further increase in cpu-stats value
in non-pinned cpus.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>