### PR TITLE
Make scheduler path configurable

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blkiotune.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blkiotune.cfg
@@ -2,6 +2,7 @@
     type = virsh_blkiotune
     libvirtd = "on"
     qemu_path = "/cgroup/blkio/libvirt/qemu/"
+    schedulerfd = "/sys/block/sda/queue/scheduler"
     variants:
         - positive:
             status_error = "no"


### PR DESCRIPTION
In d43a4a3b0b34ec0eb85709d1abe1ac508e74fa09 I stated that on s390x
the first disk device is /dev/dasda. This is not always true, a system
can also have SCSI and no DASD.

Therefore, make the path configurable and use /dev/sda like before as default.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>