### PR TITLE
Add tests of update device for cdrom slice test

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_update_device.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_update_device.cfg
@@ -18,6 +18,19 @@
                     updatedevice_target_bus = "scsi"
                     updatedevice_target_dev = "sdc"
                     disk_type = "cdrom"
+                    variants:
+                        - slice_test_qcow2:
+                            disk_slice = "yes"
+                            driver_type = "qcow2"
+                            device_type = "cdrom"
+                            target_bus = "scsi"
+                        - slice_test_raw:
+                            disk_slice = "yes"
+                            driver_type = "raw"
+                            device_type = "cdrom"
+                            target_bus = "scsi"
+                        - not_slice_test:
+                            disk_slice = "False"
                 - floppy_option:
                     updatedevice_target_bus = "fdc"
                     updatedevice_target_dev = "fda"


### PR DESCRIPTION
```
# avocado run --vt-type libvirt type_specific.io-github-autotest-libvirt.virsh.update_device.normal_test..scsi_option
JOB ID     : c5b228e0f4e00488f75d86ee49cf2ea551a2a750
JOB LOG    : /root/avocado/job-results/job-2020-04-29T23.08-c5b228e/job.log
 (01/34) type_specific.io-github-autotest-libvirt.virsh.update_device.normal_test.id_option.no_option.scsi_option.slice_test: PASS (195.26 s)
 (02/34) type_specific.io-github-autotest-libvirt.virsh.update_device.normal_test.id_option.no_option.scsi_option.not_slice_test: PASS (37.92 s)
 (03/34) type_specific.io-github-autotest-libvirt.virsh.update_device.normal_test.id_option.force_option.scsi_option.slice_test: PASS (203.78 s)
 (04/34) type_specific.io-github-autotest-libvirt.virsh.update_device.normal_test.id_option.force_option.scsi_option.not_slice_test: PASS (40.77 s)
 (05/34) type_specific.io-github-autotest-libvirt.virsh.update_device.normal_test.id_option.force_live_option.scsi_option.slice_test: PASS (204.96 s)
 (06/34) type_specific.io-github-autotest-libvirt.virsh.update_device.normal_test.id_option.force_live_option.scsi_option.not_slice_test: PASS (36.59 s)
 (07/34) type_specific.io-github-autotest-libvirt.virsh.update_device.normal_test.id_option.force_current_option.scsi_option.slice_test: PASS (210.08 s)
 (08/34) type_specific.io-github-autotest-libvirt.virsh.update_device.normal_test.id_option.force_current_option.scsi_option.not_slice_test: PASS (36.56 s)
 (09/34) type_specific.io-github-autotest-libvirt.virsh.update_device.normal_test.id_option.live_option.scsi_option.slice_test: PASS (206.91 s)
 (10/34) type_specific.io-github-autotest-libvirt.virsh.update_device.normal_test.id_option.live_option.scsi_option.not_slice_test: PASS (37.96 s)
....
```
All can pass by local test
Signed-off-by: jgao <jgao@localhost.localdomain>
