### PR TITLE
Mark inject-nmi stress test case invalid on s390x

### DIFF
--- a/libvirt/tests/cfg/timer_management.cfg
+++ b/libvirt/tests/cfg/timer_management.cfg
@@ -37,6 +37,7 @@
                 - vm_operations:
                     variants:
                         - inject_nmi:
+                            no s390-virtio
                             stress_type = "inject_nmi"
                             inject_times = 10
                         - dump:


### PR DESCRIPTION
On s390x 'inject-nmi' causes restart and kernel dump. Therefore,
'inject-nmi' can't be used to put stress on guest because it cannot
be run more than once immediately one after another.

Don't run test case on s390x.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>