### PR TITLE
Blacklist APIC test case on s390x

### DIFF
--- a/libvirt/tests/cfg/libvirt_qemu_cmdline.cfg
+++ b/libvirt/tests/cfg/libvirt_qemu_cmdline.cfg
@@ -5,6 +5,7 @@
         - hypervisor_features:
             variants:
                 - pv_eoi:
+                    no s390-virtio
                     test_feature = 'pv_eoi'
                     test_feature_attr = 'eoi_enable'
                     expect_start_vm_fail = 'no'


### PR DESCRIPTION
EOI requires APIC; not available on s390x.
Blacklist test case.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>