### PR TITLE
Blacklist hyperv feature tests on s390x

### DIFF
--- a/libvirt/tests/cfg/cpu/vm_features.cfg
+++ b/libvirt/tests/cfg/cpu/vm_features.cfg
@@ -5,7 +5,7 @@
         - positive_test:
             variants:
                 - hyperv:
-                    no pseries
+                    no pseries, s390-virtio
                     variants:
                         - tlbflush:
                             hyperv_attr = {'relaxed': 'on', 'vapic': 'on', 'vpindex': 'on', 'tlbflush': 'on'}
@@ -21,14 +21,14 @@
                                     hyperv_attr={'relaxed': 'off'}
                           
                 - pmu:
-                    no pseries
+                    no pseries, s390-virtio
                     variants:
                         - enable:
                             pmu_attr={'pmu': 'on'}
                         - disable:
                             pmu_attr={'pmu': 'off'}
                 - pvspinlock:
-                    no pseries
+                    no pseries, s390-virtio
                     variants:
                         - enable:
                             pvspinlock_attr={'pvspinlock_state': 'on'}


### PR DESCRIPTION
Listed features are not available on s390x.
Blacklist test cases.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>