### PR TITLE
Remove spicevmc cases from pseries tests

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
@@ -17,6 +17,7 @@
             detach_redirdev_bus = "usb"
             detach_check_xml = "<redirdev"
         - channel:
+            no pseries
             detach_channel_type = "spicevmc"
             detach_channel_target = "{'target_type':'virtio', 'target_name':'com.redhat.spice.0'}"
             detach_check_xml = "<channel type='spicevmc'>"


### PR DESCRIPTION
spicevmc is not supported by pseries.

Signed-off-by: haizhao <haizhao@redhat.com>