### PR TITLE
Blacklist RDMA migration on s390x

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_vm.cfg
+++ b/libvirt/tests/cfg/migration/migrate_vm.cfg
@@ -289,6 +289,7 @@
                             migrate_vm_back = "yes"
                             migration_source_uri = "qemu+ssh://${client_ip}/system"
                         - rdma:
+                            no s390-virtio
                             virsh_options = "--live --verbose"
                             gluster_transport = "rdma"
                             migration_timeout = 300


### PR DESCRIPTION
On s390x RoCE works differently, e.g. no udp package transfer.
Migration is not supported currently.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>