### PR TITLE
Fix save vm login error

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_save.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_save.py
@@ -78,7 +78,9 @@ def run(test, params, env):
         utils_libvirtd.libvirtd_start()
 
     if savefile:
+        time.sleep(10) # extra seconds for guest to be ready
         virsh.restore(savefile, debug=True)
+        time.sleep(10) # extra seconds for guest to be ready
 
     # check status_error
     try:


### PR DESCRIPTION
VM save and restore need some seconds to make sure the guest is
fully ready, otherwise the guest may have some unexpected issue,
like can not login as below error:
 login timeout expired    (output: 'exceeded 240 s timeout')

Signed-off-by: Dan Zheng <dzheng@redhat.com>