### PR TITLE
Add exception detection when trying to unload a linux module

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domfstrim.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domfstrim.py
@@ -220,4 +220,8 @@ def run(test, params, env):
         # Do domain recovery
         vm.shutdown()
         xml_backup.sync()
-        linux_modules.unload_module("scsi_debug")
+
+        def _unload():
+            linux_modules.unload_module("scsi_debug")
+            return True
+        utils_misc.wait_for(_unload, timeout=30, ignore_errors=True)


### PR DESCRIPTION
To avoid throwing out RuntimeError

Signed-off-by: haizhao <haizhao@redhat.com>