### PR TITLE
Fix IDE controller which is not supported in q35 machine type issues

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_update_device.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_update_device.cfg
@@ -14,6 +14,9 @@
                     updatedevice_target_bus = "ide"
                     updatedevice_target_dev = "hdc"
                     disk_type = "cdrom"
+                    q35:
+                        updatedevice_target_bus = "scsi"
+                        updatedevice_target_dev = "sdc"
                 - scsi_option:
                     updatedevice_target_bus = "scsi"
                     updatedevice_target_dev = "sdc"
@@ -82,6 +85,10 @@
 
         - error_test:
             status_error = "yes"
+            q35:
+                updatedevice_target_bus = "scsi"
+                updatedevice_target_dev = "sdc"
+                disk_type = "cdrom"
             s390-virtio:
                 updatedevice_target_bus = "scsi"
                 updatedevice_target_dev = "sdc"

--- a/libvirt/tests/cfg/virtual_disks/startup_policy.cfg
+++ b/libvirt/tests/cfg/virtual_disks/startup_policy.cfg
@@ -60,6 +60,8 @@
                             image_size = "100M"
                             s390-virtio:
                                 disk_target_bus = "scsi"
+                            q35:
+                                disk_target_bus = "scsi"
                         - floppy:
                             device_type = "floppy"
                             target_dev = "fda"

--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
@@ -364,6 +364,7 @@
                     status_error = "yes"
                     variants:
                         - disk_bus_ide:
+                            no q35
                             no s390-virtio
                             virt_disk_device_target = "hda"
                             virt_disk_device_bus = "ide"
@@ -396,6 +397,7 @@
                     variants:
                         - disk_bus_ide:
                             no s390-virtio
+                            no q35
                             only test_serial_wwn
                             virt_disk_device_target = "hda"
                             virt_disk_device_format = "qcow2"
@@ -667,6 +669,7 @@
                     driver_option = "type=raw"
                 - disk_ide_place_correct_boot_order:
                     only coldplug
+                    no q35
                     virt_disk_with_source = "yes"
                     virt_disk_device = "disk"
                     virt_disk_device_source = "ide1"
@@ -713,6 +716,7 @@
                             driver_option = "type=qcow2,cache=none"
                         - disk_bus_ide:
                             no s390-virtio
+                            no q35
                             only coldplug
                             virt_disk_device_bus = "ide"
                             virt_disk_device_type = "block"
@@ -789,6 +793,7 @@
                                     restart_libvird = "yes"
                         - disk_bus_ide:
                             no s390-virtio
+                            no q35
                             virt_disk_device_bus = "ide"
                             virt_disk_device_type = "file"
                             virt_disk_device_source = "test"


### PR DESCRIPTION
Fix the  IDE controller which is not supported in q35 machine type issues

Signed-off-by: Meina Li <meili@redhat.com>