### PR TITLE
Use class level timeout for serial login

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_network.py
+++ b/libvirt/tests/src/virtual_network/iface_network.py
@@ -916,8 +916,7 @@ TIMEOUT 3"""
             else:
                 if serial_login:
                     session = vm.wait_for_serial_login(username=username,
-                                                       password=password,
-                                                       timeout=120)
+                                                       password=password)
                 else:
                     session = vm.wait_for_login()
 


### PR DESCRIPTION
The explicitly set timeout might be too small.
Remove hard coded value in order to use class default value
for more consistent value configuration.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>