### PR TITLE
Fix restore result no options

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_save_image_edit.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_save_image_edit.cfg
@@ -5,6 +5,7 @@
     take_regular_screendumps = "no"
     variants:
         - no_option:
+            restore_state = "running"
         - running:
             restore_state = "running"
         - paused:


### PR DESCRIPTION
By manpage "Normally, restoring a saved image will use the state recorded in the save image to decide  between  running  or  paused."
The `no_option` test currently fails because `restore_state` is not set.
Set 'running' as expected according to manpage.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>