### PR TITLE
Fix virsh_attach_detach_interface s390x

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_interface.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_interface.cfg
@@ -17,12 +17,12 @@
                 - domid:
                     at_detach_iface_vm_ref = "domid"
                     at_detach_iface_model = "rtl8139"
-                    pseries:
+                    pseries, s390-virtio:
                         at_detach_iface_model = "virtio"
                 - domuuid:
                     at_detach_iface_vm_ref = "domuuid"
                     at_detach_iface_model = "e1000e"
-                    pseries:
+                    pseries, s390-virtio:
                         at_detach_iface_model = "virtio"
             variants:
                 - default_network:


### PR DESCRIPTION
Use virtio as only supported option in this case for s390x.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>