### PR TITLE
Fix interface hotplug

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_hotplug.py
+++ b/libvirt/tests/src/virtual_network/iface_hotplug.py
@@ -150,7 +150,7 @@ def run(test, params, env):
                         logging.debug("options %s are mutually exclusive" % attach_option)
                         if not ("--current" in sep_options and len(sep_options) > 1):
                             test.fail("return mutualy exclusive, but it is unexpected")
-                    elif err_msg_rom in ret.stderr:
+                    elif err_msg_rom and err_msg_rom in ret.stderr:
                         logging.debug("Attach failed with expect err msg: %s" % err_msg_rom)
                     else:
                         test.fail("Failed to attach-interface: %s" % ret.stderr.strip())


### PR DESCRIPTION
Non-negative tests are failing with message "TypeError: 'in <string>' requires string as left operand, not NoneType".
`err_msg_rom` doesn't need to be checked for non-negative test cases, s. 9c92eb66444c3a5247d07c8449e3fc11869cfb2f
Only check it if defined.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>