### PR TITLE
Add virt-v2v test case RHEL-149829

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -341,6 +341,11 @@
                     checkpoint = "system_rhv_pem_unset"
                     msg_content = "virt-v2v: error: -o rhv-upload: must use .-oo rhv-cafile. .*? oVirt or RHV"
                     expect_msg = no
+        - without_default_net:
+            only esx_67
+            main_vm = VM_NAME_RHEL7_V2V_EXAMPLE
+            checkpoint = "without_default_net"
+
     variants:
         - positive_test:
             status_error = 'no'


### PR DESCRIPTION
Add virt-v2v new test case RHEL-149829 - [Network]v2v can convert guest on rhel8 when v2v conversion server doesn't have bridge ' virbr0'

Signed-off-by: Zi Liu <zili@redhat.com>