### PR TITLE
Add cases of blkdeviotune test with slice image

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blkdeviotune.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blkdeviotune.cfg
@@ -382,6 +382,16 @@
                     blkdevio_total_iops_sec_max = 11000
                     blkdevio_group_name = libvirt_iotune_group1
                     variants:
+                        - slice_test:
+                            disk_slice = yes
+                            test_size = "10"
+                            type_name = "file"
+                            target_dev = "vdb"
+                            target_bus = "scsi"
+                            device_type = "disk"
+                        - not_slice_test:
+                            disk_slice = no
+                    variants:
                         - hotplug:
                             attach_before_start = no
                         - coldplug:


### PR DESCRIPTION
```
# avocado run --vt-type libvirt type_specific.io-github-autotest-libvirt.virsh.blkdeviotune.positive_testing.attach_disk
JOB ID     : f9da567336e78ed9c0f27dd5cd33d575a2ca6042
JOB LOG    : /root/avocado/job-results/job-2020-05-13T23.21-f9da567/job.log
 (01/10) type_specific.io-github-autotest-libvirt.virsh.blkdeviotune.positive_testing.attach_disk.hotplug.slice_test: PASS (22.98 s)
 (02/10) type_specific.io-github-autotest-libvirt.virsh.blkdeviotune.positive_testing.attach_disk.hotplug.not_slice_test: PASS (15.54 s)
 (03/10) type_specific.io-github-autotest-libvirt.virsh.blkdeviotune.positive_testing.attach_disk.coldplug.with_alias.bus_virtio.slice_test: PASS (61.37 s)
 (04/10) type_specific.io-github-autotest-libvirt.virsh.blkdeviotune.positive_testing.attach_disk.coldplug.with_alias.bus_virtio.not_slice_test: PASS (45.85 s)
 (05/10) type_specific.io-github-autotest-libvirt.virsh.blkdeviotune.positive_testing.attach_disk.coldplug.with_alias.bus_scsi.slice_test: PASS (61.60 s)
 (06/10) type_specific.io-github-autotest-libvirt.virsh.blkdeviotune.positive_testing.attach_disk.coldplug.with_alias.bus_scsi.not_slice_test: PASS (45.16 s)
 (07/10) type_specific.io-github-autotest-libvirt.virsh.blkdeviotune.positive_testing.attach_disk.coldplug.without_alias.bus_virtio.slice_test: PASS (62.24 s)
 (08/10) type_specific.io-github-autotest-libvirt.virsh.blkdeviotune.positive_testing.attach_disk.coldplug.without_alias.bus_virtio.not_slice_test: PASS (46.08 s)
 (09/10) type_specific.io-github-autotest-libvirt.virsh.blkdeviotune.positive_testing.attach_disk.coldplug.without_alias.bus_scsi.slice_test: PASS (67.51 s)
 (10/10) type_specific.io-github-autotest-libvirt.virsh.blkdeviotune.positive_testing.attach_disk.coldplug.without_alias.bus_scsi.not_slice_test: PASS (45.20 s)
RESULTS    : PASS 10 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 477.01 s

Signed-off-by: jgao <jgao@localhost.localdomain>
```