### PR TITLE
Fix detach device with alias failure issues

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device.py
@@ -250,7 +250,7 @@ def run(test, params, env):
             vm_ref = ""
 
         if detach_alias:
-            status = virsh.detach_device_alias(vm_ref, device_alias, dt_options, readonly=readonly,
+            status = virsh.detach_device_alias(vm_ref, device_alias, dt_options, True, 7, readonly=readonly,
                                                debug=True).exit_status
         else:
             status = virsh.detach_device(vm_ref, device_xml, readonly=readonly, flagstr=dt_options,


### PR DESCRIPTION
By allowing for certain time to waiting for event,then check the detach result

Signed-off-by: chunfuwen <chwen@redhat.com>