### PR TITLE
Add source esx7.0 and change source of v2v tier2 guests to esx7.0

### DIFF
--- a/v2v/tests/cfg/convert_vm_to_libvirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_libvirt.cfg
@@ -48,26 +48,26 @@
                 - 5_11:
                     os_version = "rhel5.11"
                 - debian:
-                    only source_esx.esx_67
+                    only source_esx.esx_67, source_esx.esx_70
                     #os_short_id = "DEBIAN_SHORT_ID"
                     os_version = "DEBIAN_VERSION"
                 - ubuntu_lts:
-                    only source_esx.esx_67
+                    only source_esx.esx_67, source_esx.esx_70
                     os_short_id = "ubuntu18.04"
                     os_version = "UBUNTU_LTS_VERSION"
                 - sles12sp4:
-                    only source_esx.esx_67
+                    only source_esx.esx_67, source_esx.esx_70
                     os_short_id = "sles12sp4"
                     os_version = "sles12sp4"
                 - sles_latest:
-                    only source_esx.esx_67
+                    only source_esx.esx_67, source_esx.esx_70
                     os_version = "SLES_LATEST_VERSION"
                 - opensuse_latest:
-                    only source_esx.esx_67
+                    only source_esx.esx_67, source_esx.esx_70
                     os_short_id = "OPENSUSE_LATEST_SHORT_ID"
                     os_version = "OPENSUSE_LATEST_VERSION"
                 - opensuse15_1:
-                    only source_esx.esx_67
+                    only source_esx.esx_67, source_esx.esx_70
                     os_version = "opensuse15.1"
         - windows:
             no pv
@@ -140,6 +140,9 @@
             vpx_passwd_file = "/tmp/v2v_vpx_passwd"
             v2v_opts = " -ip ${vpx_passwd_file}"
             variants:
+                - 7_0:
+                    only source_esx.esx_70
+                    esx_version = "esx7.0"
                 - 6_7:
                     only source_esx.esx_67
                     esx_version = "esx6.7"

--- a/v2v/tests/cfg/convert_vm_to_ovirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_ovirt.cfg
@@ -88,22 +88,22 @@
                 - 5_11:
                     os_version = "rhel5.11"
                 - debian:
-                    only source_esx.esx_67
+                    only source_esx.esx_67, source_esx.esx_70
                     os_version = "DEBIAN_VERSION"
                 - ubuntu_lts:
-                    only source_esx.esx_67
+                    only source_esx.esx_67, source_esx.esx_70
                     os_version = "UBUNTU_LTS_VERSION"
                 - sles12sp4:
-                    only source_esx.esx_67
+                    only source_esx.esx_67, source_esx.esx_70
                     os_version = "sles12sp4"
                 - sles_latest:
-                    only source_esx.esx_67
+                    only source_esx.esx_67, source_esx.esx_70
                     os_version = "SLES_LATEST_VERSION"
                 - opensuse_latest:
-                    only source_esx.esx_67
+                    only source_esx.esx_67, source_esx.esx_70
                     os_version = "OPENSUSE_LATEST_VERSION"
                 - opensuse15_1:
-                    only source_esx.esx_67
+                    only source_esx.esx_67, source_esx.esx_70
                     os_version = "opensuse15.1"
         - windows:
             no pv
@@ -180,6 +180,9 @@
             vpx_passwd_file = "/tmp/v2v_vpx_passwd"
             v2v_opts = " -ip ${vpx_passwd_file}"
             variants:
+                - 7_0:
+                    only source_esx.esx_70
+                    esx_version = "esx7.0"
                 - 6_7:
                     only source_esx.esx_67
                     esx_version = "esx6.7"


### PR DESCRIPTION
V2V only need to convert tier2 guests from latest ESXi host

Signed-off-by: mxie91 <mxie@redhat.com>