### PR TITLE
Fix error of mem cases

### DIFF
--- a/libvirt/tests/cfg/libvirt_mem.cfg
+++ b/libvirt/tests/cfg/libvirt_mem.cfg
@@ -7,7 +7,7 @@
     # If align_to_value is not given then '65536' will be taken as default.
     align_mem_values = "no"
     guest_known_unplug_errors = "'pseries-hotplug-mem: Memory indexed-count-remove failed, adding any removed LMBs'"
-    host_known_unplug_errors = "'Memory unplug already in progress for device dimm'"
+    host_known_unplug_errors = "'Memory unplug already in progress for device'"
     vcpu = 4
     wait_before_save_secs = 0
     pseries:


### PR DESCRIPTION
- The time that vm's log file being released could be later than
vm being shutdown, starting vm before log file released could face
errors. Wait for some time and retry several times on starting vm
- host_known_unplug_errors updated

Signed-off-by: haizhao <haizhao@redhat.com>