### PR TITLE
Allow for double check of edit results

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_edit.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_edit.cfg
@@ -3,6 +3,7 @@
     take_regular_screendumps = "no"
     snapshot_edit_description = "new-desc"
     snapshot_edit_newname = "new-name"
+    double_check = "no"
     variants:
         - negative_tests:
             status_error = "yes"


### PR DESCRIPTION
Snapshot edition might finish in the background while
the test already checks the result, leading to
"FAIL: After rename, snapshot snap1 still exist"

Instead, extract the checks and re-run them if `double_check = "yes"`
has been set after waiting for 1 sec.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>