### PR TITLE
Fix index range error

### DIFF
--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_edit.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_edit.py
@@ -116,7 +116,7 @@ def run(test, params, env):
         pre = pre_xml.split()
         after = after_xml.split()
 
-        for i in range(max(len(pre), len(after), count)):
+        for i in range(min(len(pre), len(after), count)):
             logging.debug("before xml=%s", pre[i].lstrip())
             logging.debug(" after xml=%s", after[i].lstrip())
 


### PR DESCRIPTION
Use `min` to avoid list index out of range.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>