### PR TITLE
Fix issues in virtio_transitional_blk/rng/serial

### DIFF
--- a/libvirt/tests/src/virtio_transitional/virtio_transitional_blk.py
+++ b/libvirt/tests/src/virtio_transitional/virtio_transitional_blk.py
@@ -226,19 +226,21 @@ def run(test, params, env):
             download.get_file(guest_src_url, target_path)
         params["blk_source_name"] = target_path
 
-    if add_pcie_to_pci_bridge:
-        pci_controllers = vmxml.get_controllers('pci')
-        for controller in pci_controllers:
-            if controller.get('model') == 'pcie-to-pci-bridge':
-                pci_bridge = controller
-                break
-        else:
-            contr_dict = {'controller_type': 'pci',
-                          'controller_model': 'pcie-to-pci-bridge'}
-            pci_bridge = libvirt.create_controller_xml(contr_dict)
-            libvirt.add_controller(vm_name, pci_bridge)
-        pci_bridge_index = '%0#4x' % int(pci_bridge.get("index"))
     try:
+        if add_pcie_to_pci_bridge:
+            pci_controllers = vmxml.get_controllers('pci')
+            for controller in pci_controllers:
+                if controller.get('model') == 'pcie-to-pci-bridge':
+                    pci_bridge = controller
+                    break
+            else:
+                contr_dict = {'controller_type': 'pci',
+                              'controller_model': 'pcie-to-pci-bridge'}
+                pci_bridge = libvirt.create_controller_xml(contr_dict)
+                libvirt.add_controller(vm_name, pci_bridge)
+                pci_bridge = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)\
+                    .get_controllers('pci', 'pcie-to-pci-bridge')[0]
+            pci_bridge_index = '%0#4x' % int(pci_bridge.get("index"))
         if (params["os_variant"] == 'rhel6' or
                 'rhel6' in params.get("shortname")):
             iface_params = {'model': 'virtio-transitional'}
@@ -272,3 +274,5 @@ def run(test, params, env):
         vm.destroy()
         libvirt.clean_up_snapshots(vm_name)
         backup_xml.sync()
+        if guest_src_url and target_path:
+            libvirt.delete_local_disk("file", path=target_path)

--- a/libvirt/tests/src/virtio_transitional/virtio_transitional_rng.py
+++ b/libvirt/tests/src/virtio_transitional/virtio_transitional_rng.py
@@ -128,20 +128,22 @@ def run(test, params, env):
             download.get_file(guest_src_url, target_path)
         params["blk_source_name"] = target_path
 
-    # Add 'pcie-to-pci-bridge' if there is no one
-    pci_controllers = vmxml.get_controllers('pci')
-    for controller in pci_controllers:
-        if controller.get('model') == 'pcie-to-pci-bridge':
-            pci_bridge = controller
-            break
-    else:
-        contr_dict = {'controller_type': 'pci',
-                      'controller_model': 'pcie-to-pci-bridge'}
-        pci_bridge = libvirt.create_controller_xml(contr_dict)
-        libvirt.add_controller(vm_name, pci_bridge)
-    pci_bridge_index = '%0#4x' % int(pci_bridge.get("index"))
-
     try:
+        # Add 'pcie-to-pci-bridge' if there is no one
+        pci_controllers = vmxml.get_controllers('pci')
+        for controller in pci_controllers:
+            if controller.get('model') == 'pcie-to-pci-bridge':
+                pci_bridge = controller
+                break
+        else:
+            contr_dict = {'controller_type': 'pci',
+                          'controller_model': 'pcie-to-pci-bridge'}
+            pci_bridge = libvirt.create_controller_xml(contr_dict)
+            libvirt.add_controller(vm_name, pci_bridge)
+            pci_bridge = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)\
+                .get_controllers('pci', 'pcie-to-pci-bridge')[0]
+        pci_bridge_index = '%0#4x' % int(pci_bridge.get("index"))
+
         # Update nic and vm disks
         if (params["os_variant"] == 'rhel6' or
                 'rhel6' in params.get("shortname")):
@@ -206,3 +208,6 @@ def run(test, params, env):
     finally:
         vm.destroy()
         backup_xml.sync()
+
+        if guest_src_url and target_path:
+            libvirt.delete_local_disk("file", path=target_path)

--- a/libvirt/tests/src/virtio_transitional/virtio_transitional_serial.py
+++ b/libvirt/tests/src/virtio_transitional/virtio_transitional_serial.py
@@ -87,21 +87,23 @@ def run(test, params, env):
             download.get_file(guest_src_url, target_path)
         params["blk_source_name"] = target_path
 
-    # Add pcie-to-pci-bridge when it is required
-    if add_pcie_to_pci_bridge:
-        pci_controllers = vmxml.get_controllers('pci')
-        for controller in pci_controllers:
-            if controller.get('model') == 'pcie-to-pci-bridge':
-                pci_bridge = controller
-                break
-        else:
-            contr_dict = {'controller_type': 'pci',
-                          'controller_model': 'pcie-to-pci-bridge'}
-            pci_bridge = libvirt.create_controller_xml(contr_dict)
-            libvirt.add_controller(vm_name, pci_bridge)
-        pci_bridge_index = '%0#4x' % int(pci_bridge.get("index"))
-
     try:
+        # Add pcie-to-pci-bridge when it is required
+        if add_pcie_to_pci_bridge:
+            pci_controllers = vmxml.get_controllers('pci')
+            for controller in pci_controllers:
+                if controller.get('model') == 'pcie-to-pci-bridge':
+                    pci_bridge = controller
+                    break
+            else:
+                contr_dict = {'controller_type': 'pci',
+                              'controller_model': 'pcie-to-pci-bridge'}
+                pci_bridge = libvirt.create_controller_xml(contr_dict)
+                libvirt.add_controller(vm_name, pci_bridge)
+                pci_bridge = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)\
+                    .get_controllers('pci', 'pcie-to-pci-bridge')[0]
+            pci_bridge_index = '%0#4x' % int(pci_bridge.get("index"))
+
         # Update interface to virtio-transitional mode for
         # rhel6 guest to make it works for login
         iface_params = {'model': 'virtio-transitional'}
@@ -157,3 +159,6 @@ def run(test, params, env):
     finally:
         vm.destroy()
         backup_xml.sync()
+
+        if guest_src_url and target_path:
+            libvirt.delete_local_disk("file", path=target_path)


### PR DESCRIPTION
This PR fixes below issues:
1. make adjustment for the newly introduced libvirt.add_controller()
2. xml cannot be recovered if there is a problem getting the index
   of the newly added controller
3. network was unreachable in some cases

Signed-off-by: Yingshun Cui <yicui@redhat.com>