### PR TITLE
Add another command to check video device of sles guest

### DIFF
--- a/provider/v2v_vmcheck_helper.py
+++ b/provider/v2v_vmcheck_helper.py
@@ -336,8 +336,8 @@ class VMChecker(object):
         :param dev_id: the ID of the video device
         :return: log error will be recored if not found, else return nothing
         """
-        # Check by 'lspci' or 'lshw'
-        cmd = ["lspci", "lshw"]
+        # Check by 'lspci' or 'lshw' or 'hwinfo --gfxcard'
+        cmd = ["lspci", "lshw", "hwinfo --gfxcard"]
         if self.checker.vm_general_search(
             cmd,
             video_type,


### PR DESCRIPTION
SLES15SP1 guest which is installed minimal OS doesn't support
'lspci' and 'lshw' command, so add command 'hwinfo --gfxcard' to
check the video device of guest.

Signed-off-by: mxie91 <mxie@redhat.com>