### PR TITLE
Wait for scsi_debug

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_multivms.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multivms.py
@@ -7,6 +7,7 @@ from virttest import data_dir
 from virttest import virt_vm
 from virttest import virsh
 from virttest import remote
+from virttest import utils_misc
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.disk import Disk
@@ -359,7 +360,8 @@ def run(test, params, env):
         for img in disks:
             if 'format' in img:
                 if img["format"] == "scsi":
-                    libvirt.delete_scsi_disk()
+                    utils_misc.wait_for(libvirt.delete_scsi_disk,
+                                        120, ignore_errors=True)
                 elif img["format"] == "iscsi":
                     libvirt.setup_or_cleanup_iscsi(is_setup=False)
             elif "source" in img:


### PR DESCRIPTION
Depends on https://github.com/avocado-framework/avocado-vt/pull/2565

During test teardown, scsi_debug module might still be in use when trying to delete it.

Tests fail due to issue in teardown with "RuntimeError: Module scsi_debug is still in use. Can not unload it."

Instead, retry deleting the scsi device until timeout.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>