### PR TITLE
Check libvirtd should not crash during net-update

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_update.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_update.cfg
@@ -273,6 +273,10 @@
             update_command = "add"
             net_state = "active"
             variants:
+                - portgroup_err:
+                    network_section = "portgroup"
+                    update_command = "modify"
+                    error_type = "XML error"
                 - interface_duplicate:
                     network_section = "forward-interface"
                     forward_mode = "bridge"


### PR DESCRIPTION
Check libvirtd should not crash during net_update even in negative test
with XML error.

Signed-off-by: yalzhang <yalzhang@redhat.com>