### PR TITLE
migration: Add 2 maxdowntime related cases

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -104,6 +104,20 @@
                     migrate_maxdowntime = '0.100000'
                     check_complete_job = "yes"
                     grep_str_local_log = '"execute":"migrate_set_downtime","arguments":{"value":${migrate_maxdowntime}}'
+                - default_maxdowntime_during_migrate:
+                    only without_postcopy
+                    asynch_migrate = "yes"
+                    low_speed = "40"
+                    diff_rate = "0.5"
+                    jobinfo_item = "Expected downtime:"
+                    compare_to_value = "300"
+                    check_default_maxdowntime = "${compare_to_value}"
+                    actions_during_migration = "domjobinfo"
+                    check_complete_job = "yes"
+                - set_get_maxdowntime_before_migrate:
+                    only without_postcopy
+                    set_maxdowntime_before_migration = "yes"
+                    migrate_maxdowntime = '0.100000'
                 - set_get_speed_during_migrate:
                     virsh_migrate_options = "--live --verbose"
                     asynch_migrate = "yes"


### PR DESCRIPTION
1. Check migraion with default maxdowntime
2. Set maxdowntime before migration

Signed-off-by: Yingshun Cui <yicui@redhat.com>