### PR TITLE
tpm_device: replace os and disk for vtpm

### DIFF
--- a/libvirt/tests/cfg/virtual_device/tpm_device.cfg
+++ b/libvirt/tests/cfg/virtual_device/tpm_device.cfg
@@ -1,6 +1,9 @@
 - virtual_devices.tpm_device:
     type = tpm_device
     start_vm = no
+    loader = "/usr/share/edk2/ovmf/OVMF_CODE.secboot.fd"
+    nvram = "/var/lib/libvirt/qemu/nvram/<VM_NAME>_VARS.fd"
+    uefi_disk_url = "EXAMPLE_UEFI_DISK_URL"
     variants:
         - normal_test:
             variants:


### PR DESCRIPTION
Vtpm only supports uefi firmware, so if default guest is on bios
without nvram, replace its os, features, disk image.

Signed-off-by: Yanqiu Zhang <yanqzhan@redhat.com>