### PR TITLE
Remove unsupported case from pseries tests

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
@@ -911,6 +911,7 @@
                                             define_error = "yes"
                                             virt_disk_addr_options = "type=driver,domain=0x0000,bus=0x00,slot=0x0a,function=0x0"
                                         - error_test4:
+                                            no pseries
                                             status_error = "yes"
                                             virt_disk_addr_options = "type=pci,domain=0x0000,bus=0x00,slot=0x09,function=0x0"
                                             usb_error_message = "unexpected address type for usb disk"


### PR DESCRIPTION
unsupported configuration: piix3-usb-uhci not supported in this QEMU binary

Signed-off-by: haizhao <haizhao@redhat.com>