### PR TITLE
Fix the file path issue

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_network.py
+++ b/libvirt/tests/src/virtual_network/iface_network.py
@@ -817,15 +817,10 @@ TIMEOUT 3"""
                 run_dnsmasq_default_test("dhcp-range", "192.168.122.2,192.168.122.254,255.255.252.0")
             # check the left part in dnsmasq conf
             run_dnsmasq_default_test("strict-order", name=net_name)
-            if os.path.exists("/run/libvirt/network/%s.pid" % net_name):
-                run_dnsmasq_default_test("pid-file",
-                                         "/run/libvirt/network/%s.pid" % net_name,
-                                         name=net_name)
+            if libvirt_version.version_compare(6, 0, 0):
+                run_dnsmasq_default_test("pid-file", "/run/libvirt/network/%s.pid" % net_name, name=net_name)
             else:
-                if libvirt_version.version_compare(6, 0, 0):
-                    run_dnsmasq_default_test("pid-file", "/run/libvirt/network/%s.pid" % net_name, name=net_name)
-                else:
-                    run_dnsmasq_default_test("pid-file", "/var/run/libvirt/network/%s.pid" % net_name, name=net_name)
+                run_dnsmasq_default_test("pid-file", "/var/run/libvirt/network/%s.pid" % net_name, name=net_name)
             run_dnsmasq_default_test("except-interface", "lo", name=net_name)
             run_dnsmasq_default_test("bind-dynamic", name=net_name)
             run_dnsmasq_default_test("dhcp-no-override", name=net_name)


### PR DESCRIPTION
Last attempt to fix the file path issue is wrong. As in both libvirt
version, the pid path of "/var/run/libvirt/network" and
"/run/libvirt/network" exists. And with libvirt > 6.0.0, the path in
config file changes. So we need to judge by libvirt version, not by
the existence of the file path.

Signed-off-by: yalzhang <yalzhang@redhat.com>