### PR TITLE
Fix a timeout issue for blockcommit with ceph storage

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcommit.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcommit.cfg
@@ -96,6 +96,7 @@
                             driver_type = "raw"
                             driver_cache = "none"
                             image_convert = "yes"
+                            cmd_timeout = "10"
                 - block_disk:
                     no base, notimeout, no_ga
                     replace_vm_disk = "yes"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockcommit.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockcommit.py
@@ -243,6 +243,7 @@ def run(test, params, env):
     replace_vm_disk = "yes" == params.get("replace_vm_disk", "no")
     top_inactive = ("yes" == params.get("top_inactive"))
     with_timeout = ("yes" == params.get("with_timeout_option", "no"))
+    cmd_timeout = params.get("cmd_timeout", "1")
     status_error = ("yes" == params.get("status_error", "no"))
     base_option = params.get("base_option", "none")
     middle_base = "yes" == params.get("middle_base", "no")
@@ -423,7 +424,7 @@ def run(test, params, env):
         blockcommit_options = "--wait --verbose"
 
         if with_timeout:
-            blockcommit_options += " --timeout 1"
+            blockcommit_options += " --timeout %s" % cmd_timeout
 
         if base_option == "shallow":
             blockcommit_options += " --shallow"


### PR DESCRIPTION
Ceph server is not prepared locally on the test machine, so the
timeout=1 will easily trigger a blockjob abort, and cause some
random failures for ceph cases. Set timeout=10 for ceph cases
will avoid the failures.

Signed-off-by: Yi Sun <yisun@redhat.com>