### PR TITLE
Apply an old patch of pseries settings of numa tests

### DIFF
--- a/libvirt/tests/cfg/numa/guest_numa.cfg
+++ b/libvirt/tests/cfg/numa/guest_numa.cfg
@@ -20,6 +20,9 @@
                      memory_nodeset = "0-1"
                      memory_mode = "strict"
                      qemu_cmdline_mem_backend_1 = "memory-backend-ram,.*?id=ram-node1,.*?host-nodes=0-1,policy=bind"
+                     pseries:
+                         memory_nodeset = "0"
+                         qemu_cmdline_mem_backend_1 = "memory-backend-ram,.*?id=ram-node1,.*?host-nodes=0,policy=bind"
                  - no_numatune_mem:
              variants:
                  - no_numatune_memnode:
@@ -27,6 +30,8 @@
                      qemu_cmdline_numa_cell_1 = "node,nodeid=1,cpus=2-3,mem=512"
                  - numatune_memnode:
                      memnode_nodeset_0 = 1
+                     pseries:
+                        memnode_nodeset_0 = 0
                      memnode_cellid_0 = 0
                      qemu_cmdline_numa_cell_0 = "node,nodeid=0,cpus=0-1,memdev=ram-node0"
                      qemu_cmdline_numa_cell_1 = "node,nodeid=1,cpus=2-3,memdev=ram-node1"
@@ -35,12 +40,18 @@
                              memnode_mode_0 = "strict"
                              kernel_hp_file = "/sys/devices/system/node/node1/hugepages/hugepages-2048kB/nr_hugepages"
                              qemu_cmdline_mem_backend_0 = "id=ram-node0,.*?host-nodes=1,policy=bind"
+                             pseries:
+                                qemu_cmdline_mem_backend_0 = "id=ram-node0,.*?host-nodes=0,policy=bind"
                          - m_preferred:
                              memnode_mode_0 = "preferred"
                              qemu_cmdline_mem_backend_0 = "id=ram-node0,.*?host-nodes=1,policy=preferred"
+                             pseries:
+                                qemu_cmdline_mem_backend_0 = "id=ram-node0,.*?host-nodes=0,policy=preferred"
                          - m_interleave:
                              memnode_mode_0 = "interleave"
                              qemu_cmdline_mem_backend_0 = "id=ram-node0,.*?host-nodes=1,policy=interleave"
+                             pseries:
+                                qemu_cmdline_mem_backend_0 = "id=ram-node0,.*?host-nodes=0,policy=interleave"
              variants:
                  - topology:
                      sockets = "2"
@@ -70,6 +81,8 @@
                                      hugepage_size_0 = "2048"
                                      page_num_0 = "256"
                                      page_nodenum_0 = "1"
+                                     pseries:
+                                        page_nodenum_0 = "0"
                                  - 1G:
                                      max_mem = "2097152"
                                      cell_memory_0 = "1048576"
@@ -78,6 +91,8 @@
                                      hugepage_size_0 = "1048576"
                                      page_num_0 = "1"
                                      page_nodenum_0 = "1"
+                                     pseries:
+                                        page_nodenum_0 = "0"
                                  - 16M:
                                      max_mem = "2097152"
                                      cell_memory_0 = "1048576"
@@ -86,6 +101,8 @@
                                      hugepage_size_0 = "16384"
                                      page_num_0 = "65"
                                      page_nodenum_0 = "1"
+                                     pseries:
+                                        page_nodenum_0 = "0"
                          - host_total:
                              nr_pagesize_total = "1024"
         - negative_test:


### PR DESCRIPTION
    guest_numa: update test with only use node 0

    To avoid empty node and not skip testing, use only node 0 for
    it's with most chance as memory not empty.

    Signed-off-by: Wayne Sun <gsun@redhat.com>

Signed-off-by: haizhao <haizhao@redhat.com>