### PR TITLE
Fix channel detach on s390x

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
@@ -21,6 +21,10 @@
             detach_channel_type = "spicevmc"
             detach_channel_target = "{'target_type':'virtio', 'target_name':'com.redhat.spice.0'}"
             detach_check_xml = "<channel type='spicevmc'>"
+            s390-virtio:
+                detach_channel_type = "pty"
+                detach_channel_target = "{'target_type':'virtio', 'target_name':'some.virtio.serial.port.name'}"
+                detach_check_xml = "<channel type='pty'>"
     variants:
         - live:
             detach_alias_options = "--live"


### PR DESCRIPTION
'spicevmc' is not available on s390x. Use 'pty' instead.

Signed-off-by: root <root@ibm-z-107.rhts.eng.bos.redhat.com>