### PR TITLE
Memory size will automatically align to 256m on pseries

### DIFF
--- a/libvirt/tests/cfg/libvirt_mem.cfg
+++ b/libvirt/tests/cfg/libvirt_mem.cfg
@@ -190,6 +190,7 @@
                             attach_times = 4
                             attach_option = "--config"
                         - attach_invalid_size:
+                            no pseries
                             tg_size = 512001
                         - attach_gt_max:
                             test_qemu_cmd = "no"


### PR DESCRIPTION
According to Bug 1780506. This negative case is no longer aplicable
on pseries.

Signed-off-by: haizhao <haizhao@redhat.com>