### PR TITLE
Extend exit timeout for pseries

### DIFF
--- a/libvirt/tests/cfg/daemon/daemon_functional.cfg
+++ b/libvirt/tests/cfg/daemon/daemon_functional.cfg
@@ -4,6 +4,8 @@
     check_image = no
     take_regular_screendumps = no
     exit_time_tolerance = 1
+    pseries:
+        exit_time_tolerance = 2
     variants:
         - no_opt:
         - opt_help:


### PR DESCRIPTION
It usually cost more time than x86

Signed-off-by: haizhao <haizhao@redhat.com>