### PR TITLE
Add a migration test with XBZRLE compression

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -86,6 +86,15 @@
                             jobinfo_item = "Compression cache:"
                             diff_rate = '0'
                             virsh_migrate_extra = "--comp-methods xbzrle --comp-xbzrle-cache"
+                        - xbzrle_method_by_cmd:
+                            only without_postcopy
+                            libvirtd_conf_dict = '{"log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
+                            check_complete_job = "yes"
+                            virsh_migrate_extra = "--comp-methods xbzrle"
+                            comp_cache_size = 33554432
+                            compare_to_value = "32"
+                            jobinfo_item = "Compression cache:"
+                            grep_str_local_log = '"capability":"xbzrle","state":true'
                 - timeout_postcopy:
                     only with_postcopy
                     timeout_postcopy = 10


### PR DESCRIPTION
This PR adds a test about migration with memory compression -
XBZRLE compression.

Signed-off-by: Yingshun Cui <yicui@redhat.com>