### PR TITLE
virtual_disks: Apply wait_remove_event for disk hot unplug

### DIFF
--- a/libvirt/tests/src/virtual_disks/at_dt_iscsi_disk.py
+++ b/libvirt/tests/src/virtual_disks/at_dt_iscsi_disk.py
@@ -359,7 +359,7 @@ def run(test, params, env):
         find_attach_disk(not status_error)
 
         # Detach disk
-        cmd_result = virsh.detach_disk(vm_name, disk_target)
+        cmd_result = virsh.detach_disk(vm_name, disk_target, wait_remove_event=True)
         libvirt.check_exit_status(cmd_result, status_error)
 
         # Check disk inside the VM

--- a/libvirt/tests/src/virtual_disks/virtual_disks_ceph.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_ceph.py
@@ -945,13 +945,13 @@ def run(test, params, env):
         # Detach the device.
         if attach_device:
             xml_file = libvirt.create_disk_xml(params)
-            ret = virsh.detach_device(vm_name, xml_file)
+            ret = virsh.detach_device(vm_name, xml_file, wait_remove_event=True)
             libvirt.check_exit_status(ret)
             if additional_guest:
-                ret = virsh.detach_device(guest_name, xml_file)
+                ret = virsh.detach_device(guest_name, xml_file, wait_remove_event=True)
                 libvirt.check_exit_status(ret)
         elif attach_disk:
-            ret = virsh.detach_disk(vm_name, targetdev)
+            ret = virsh.detach_disk(vm_name, targetdev, wait_remove_event=True)
             libvirt.check_exit_status(ret)
 
         # Check disk in vm after detachment.

--- a/libvirt/tests/src/virtual_disks/virtual_disks_encryption.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_encryption.py
@@ -332,7 +332,7 @@ def run(test, params, env):
                     if not check_in_vm(vm, device_target, old_parts):
                         test.fail("Check encryption disk in VM failed")
                     result = virsh.detach_device(vm_name, disk_xml.xml,
-                                                 debug=True)
+                                                 debug=True, wait_remove_event=True)
                     libvirt.check_exit_status(result)
                 else:
                     if not check_in_vm(vm, device_target, old_parts):

--- a/libvirt/tests/src/virtual_disks/virtual_disks_gluster.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_gluster.py
@@ -262,7 +262,7 @@ def run(test, params, env):
         if start_vm and not default_pool:
             if gluster_disk:
                 ret = virsh.detach_device(vm_name, custom_disk.xml,
-                                          flagstr=attach_option, dargs=virsh_dargs)
+                                          flagstr=attach_option, dargs=virsh_dargs, wait_remove_event=True)
                 libvirt.check_exit_status(ret)
 
     finally:

--- a/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
@@ -1825,7 +1825,8 @@ def run(test, params, env):
                 if devices[i] == "cdrom":
                     dt_options = "--config"
                 ret = virsh.detach_disk(vm_name, device_targets[i],
-                                        dt_options, **virsh_dargs)
+                                        dt_options, wait_remove_event=True,
+                                        **virsh_dargs)
                 disk_detach_error = False
                 if len(device_attach_error) > i:
                     disk_detach_error = "yes" == device_attach_error[i]
@@ -1874,7 +1875,7 @@ def run(test, params, env):
                 for counter in range(0, iteration_times):
                     logging.info("Begin to execute attach or detach %d operations", counter)
                     ret = virsh.detach_device(vm_name, disks_xml[0].xml,
-                                              flagstr=attach_option, debug=True)
+                                              flagstr=attach_option, debug=True, wait_remove_event=True)
                     libvirt.check_exit_status(ret)
                     # Sleep 10 seconds to let VM really cleanup devices.
                     time.sleep(10)
@@ -1893,7 +1894,7 @@ def run(test, params, env):
                     if device_attach_error[i] == "yes":
                         continue
                 ret = virsh.detach_device(vm_name, disks_xml[i].xml,
-                                          flagstr=attach_option, **virsh_dargs)
+                                          flagstr=attach_option, wait_remove_event=True, **virsh_dargs)
                 os.remove(disks_xml[i].xml)
                 libvirt.check_exit_status(ret)
 

--- a/libvirt/tests/src/virtual_disks/virtual_disks_nbd.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_nbd.py
@@ -258,7 +258,7 @@ def run(test, params, env):
         # Unplug disk.
         if hotplug_disk:
             result = virsh.detach_device(vm_name, disk_xml.xml,
-                                         ignore_status=True, debug=True)
+                                         ignore_status=True, debug=True, wait_remove_event=True)
             libvirt.check_exit_status(result, status_error)
     finally:
         # Clean up backend storage and TLS

--- a/libvirt/tests/src/virtual_disks/virtual_disks_scsi3_persistent_reservation.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_scsi3_persistent_reservation.py
@@ -234,7 +234,7 @@ def run(test, params, env):
             new_part = new_parts[0]
             check_pr_cmds(vm, new_part)
             result = virsh.detach_device(vm_name, disk_xml.xml,
-                                         ignore_status=True, debug=True)
+                                         ignore_status=True, debug=True, wait_remove_event=True)
             libvirt.check_exit_status(result)
         except virt_vm.VMStartError as e:
             test.fail("VM failed to start."

--- a/libvirt/tests/src/virtual_disks/virtual_disks_usb.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_usb.py
@@ -231,7 +231,7 @@ def run(test, params, env):
         # Detach the disk from vm
         result = virsh.detach_device(vm_name, disk_xml.xml,
                                      flagstr=attach_options,
-                                     ignore_status=True, debug=True)
+                                     ignore_status=True, debug=True, wait_remove_event=True)
         libvirt.check_exit_status(result, status_error)
 
         # Check the detached disk in vm


### PR DESCRIPTION
The wait_remove_event, introduced from c4904fe6[1] of avocado-vt, will be
applied in detach_disk and detach_device. It will help to resolve the
false positive issues caused by the waiting for confirmation of pcie device[2]
detach and the asynchronicity of detach device API[3].

[1]: https://github.com/avocado-framework/avocado-vt/pull/2418
[2]:
https://lists.nongnu.org/archive/html/qemu-discuss/2019-04/msg00063.html
[3]:
https://gitlab.com/libvirt/libvirt/-/blob/master/src/libvirt-domain.c#L8350

Signed-off-by: Han Han <hhan@redhat.com>