### PR TITLE
Update check for xive

### DIFF
--- a/libvirt/tests/src/cpu/ppccpucompat.py
+++ b/libvirt/tests/src/cpu/ppccpucompat.py
@@ -34,11 +34,9 @@ def run(test, params, env):
         if 'power8' in feature:
             cmd = 'lscpu|grep -i "Model name:.*power8"'
         elif 'xive' in feature:
-            # remove -v once guest xive support is available
-            # right now power9 guest supports only xics
-            cmd = "grep -v xive /sys/firmware/devicetree/base/interrupt-*/compatible"
+            cmd = "grep ivpe /sys/firmware/devicetree/base/interrupt-*/compatible"
         elif 'xics' in feature:
-            cmd = "grep -v xive /sys/firmware/devicetree/base/interrupt-*/compatible"
+            cmd = "grep -v ivpe /sys/firmware/devicetree/base/interrupt-*/compatible"
         elif 'power9' in feature:
             cmd = 'lscpu|grep -i "Model name:.*power9"'
         elif 'hpt' in feature:


### PR DESCRIPTION
Now that xive as interrupt controller
becomes default from Power9 processor and
all Distribution support the same has the
relevant Software, let's enable check for
xive.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>