### PR TITLE
Fixup: Add testlist params to avocado tests method

### DIFF
--- a/libvirt/tests/cfg/cpu/guestpin.cfg
+++ b/libvirt/tests/cfg/cpu/guestpin.cfg
@@ -17,10 +17,13 @@
                     # only power9
                     condn = "host_smt"
                 - with_guest_smt:
+                    current_vcpu = 8
+                    limit_vcpu_cores = 1
+                    limit_vcpu_threads = 8
                     only ppc64le,ppc64
                     # guest cpu hotplug
-                    condn = "avocadotest"
-                    avocado_test = "cpu/ppc64_cpu_test.py"
+                    condn = "avocado_test"
+                    avocadotest = "cpu/ppc64_cpu_test.py"
                 - with_save:
                     condn = "save"
                 - with_managedsave:

--- a/libvirt/tests/cfg/cpu/ppccpucompat.cfg
+++ b/libvirt/tests/cfg/cpu/ppccpucompat.cfg
@@ -45,16 +45,16 @@
                                             guest_features = ""
                                             variants:
                                                 - guestcpu:
-                                                    avocado_test = "perf/stress.py"
+                                                    avocadotest = "generic/stress.py"
                                                 - guestmem:
-                                                    avocado_test = "memory/memhotplug.py"
+                                                    avocadotest = "memory/memory_api.py"
                                                 - with_vcpu_hotplug:
                                                     cpucompat_vcpu_cur = "1"
                                                     cpucompat_vcpu_max = "2"
                                                     topology_sockets='1'
                                                     topology_cores= '2'
                                                     topology_threads= '1'
-                                                    avocado_test = "cpu/ebizzy.py"
+                                                    avocadotest = "cpu/ebizzy.py"
                                         - with_save:
                                             condn = "save"
                                             guest_features = ""

--- a/libvirt/tests/cfg/libvirt_vcpu_plug_unplug.cfg
+++ b/libvirt/tests/cfg/libvirt_vcpu_plug_unplug.cfg
@@ -78,7 +78,7 @@
                             only live
                             test_itr = 4
                             run_stress = "yes"
-                            avocado_test = "cpu/ebizzy.py"
+                            avocadotest = "cpu/ebizzy.py"
                         - with_iteration:
                             only live
                             test_itr = 12

--- a/libvirt/tests/src/cpu/guestpin.py
+++ b/libvirt/tests/src/cpu/guestpin.py
@@ -37,8 +37,9 @@ def run(test, params, env):
         """
         bt = None
         if not reset:
-            if condn == "avocadotest":
-                bt = utils_test.run_avocado_bg(vm, params, test)
+            if condn == "avocado_test":
+                testlist = utils_test.get_avocadotestlist(params)
+                bt = utils_test.run_avocado_bg(vm, params, test, testlist)
                 if not bt:
                     test.cancel("guest stress failed to start")
                 # Allow stress to start
@@ -93,8 +94,8 @@ def run(test, params, env):
             elif condn == "suspend":
                 result = virsh.resume(vm_name, ignore_status=True, debug=True)
                 libvirt.check_exit_status(result)
-            elif condn == "avocadotest":
-                guestbt.join(ignore_status=True)
+            elif condn == "avocado_test":
+                guestbt.join()
             elif condn == "stress":
                 utils_test.unload_stress("stress_in_vms", params=params, vms=[vm])
             elif condn == "hotplug":

--- a/libvirt/tests/src/cpu/ppccpucompat.py
+++ b/libvirt/tests/src/cpu/ppccpucompat.py
@@ -116,9 +116,11 @@ def run(test, params, env):
         if condn == "filetrans":
             utils_test.run_file_transfer(test, params, env)
         elif condn == "stress":
-            bt = utils_test.run_avocado_bg(vm, params, test)
+            testlist = utils_test.get_avocadotestlist(params)
+            bt = utils_test.run_avocado_bg(vm, params, test, testlist)
             if not bt:
                 test.cancel("guest stress failed to start")
+            bt.join()
         elif condn == "save":
             save_file = os.path.join(data_dir.get_tmp_dir(), vm_name + ".save")
             result = virsh.save(vm_name, save_file, ignore_status=True,

--- a/libvirt/tests/src/libvirt_vcpu_plug_unplug.py
+++ b/libvirt/tests/src/libvirt_vcpu_plug_unplug.py
@@ -301,7 +301,8 @@ def run(test, params, env):
         vm.start()
         vm_uptime_init = vm.uptime()
         if with_stress:
-            bt = utils_test.run_avocado_bg(vm, params, test)
+            testlist = utils_test.get_avocadotestlist(params)
+            bt = utils_test.run_avocado_bg(vm, params, test, testlist)
             if not bt:
                 test.cancel("guest stress failed to start")
         # Create swap partition/file if nessesary
@@ -545,7 +546,7 @@ def run(test, params, env):
             vm.cleanup_swap()
         if with_stress:
             if "bt" in locals() and bt:
-                bt.join(ignore_status=True)
+                bt.join()
         vm.destroy()
         backup_xml.sync()
 


### PR DESCRIPTION
Commit bb8c86a introduces additional mandatory
function argument testlist for run_avocado_bg()
method, let's update it.

Depends on: https://github.com/avocado-framework/avocado-vt/pull/2580

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>