### PR TITLE
travis: Update python version of allow failures to 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ branches:
 
 matrix:
     allow_failures:
-        - python: "3.4"
+        - python: "2.7"
 
 sudo: false
 


### PR DESCRIPTION
Since python 2.7 is not maintained after 2020, it is time to update the
version of allow failures.

Signed-off-by: Han Han <hhan@redhat.com>