### PR TITLE
Fix the error test miss issue

### DIFF
--- a/libvirt/tests/cfg/sriov/sriov.cfg
+++ b/libvirt/tests/cfg/sriov/sriov.cfg
@@ -39,7 +39,7 @@
                                     managed = "yes"
                                 - managed_no:
                                     managed = "no"
-                                    only normal_test.guest_with_vf.hotplug.nop
+                                    only normal_test.guest_with_vf.hotplug.default.nop
                 - macvtap_network:
                     vf_type = "macvtap_network"
                 - macvtap_interface:
@@ -74,7 +74,7 @@
                         - default:
                         - persistent:
                             option = "--persistent"
-                            only guest_with_vf.hotplug.nop.vf_pool.vf_list
+                            only guest_with_vf.hotplug.default.nop.vf_pool.vf_list
                 - cold_plug:
                     attach = "yes"
                     option = "--config"
@@ -110,22 +110,22 @@
                         - duplicate_vf:
                             duplicate_vf = "yes"
                             error_msg = "can only be listed once in network"
-                            only guest_with_vf.hotplug.nop.vf_pool.vf_list
+                            only guest_with_vf.hotplug.default.nop.vf_pool.vf_list
                         - including_pf:
                             including_pf = "yes"
                             error_msg = "is not an SR-IOV Virtual Function"
-                            only guest_with_vf.hotplug.nop.vf_pool.vf_list
+                            only guest_with_vf.hotplug.default.nop.vf_pool.vf_list
                         - non_existing_pf:
                             non_existing_pf = "yes"
-                            only guest_with_vf.hotplug.nop.vf_pool.pf
+                            only guest_with_vf.hotplug.default.nop.vf_pool.pf
                 - inactive_pool:
                     inactive_pool = "yes"
                     hot_plug = "yes"
                     vf_type = "vf_pool"
                     network_status = "inactive"
                     error_msg = "is not active"
-                    only guest_with_vf.hotplug.nop.vf_pool.pf
+                    only guest_with_vf.hotplug.default.nop.vf_pool.pf
                 - domain_save:
                     attach = "yes"
                     operation = "save"
-                    only guest_with_vf.hotplug.nop.vf_pool.pf
+                    only guest_with_vf.hotplug.default.nop.vf_pool.pf


### PR DESCRIPTION
As the config file changes, the original pattern can not match any
test cases in the error test part. Update the pattern to fix it.

Signed-off-by: yalzhang <yalzhang@redhat.com>