### PR TITLE
Fix errors in migrate_options_shared.cfg and sriov_migrate.cfg

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -274,10 +274,7 @@
                     src_secret_value = "sec value test"
                     dst_secret_value = ${src_secret_value}
                     cmd_in_vm_after_migration = "tpm2_getrandom 10"
-                    vtpm_without_postcopy:
-                        only without_postcopy
-                    vtpm_with_postcopy:
-                        only with_postcopy
+                    with_postcopy:
                         low_speed = "10"
                         stress_in_vm = "yes"
                         stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M --timeout 70"

--- a/libvirt/tests/cfg/migration/sriov_migrate.cfg
+++ b/libvirt/tests/cfg/migration/sriov_migrate.cfg
@@ -35,10 +35,7 @@
             cmd_during_mig =  "> ${vm_tmp_file} ;ping www.baidu.com > ${vm_tmp_file} 2>&1 &"
             variants:
                 - normal_test:
-                    postcopy:
-                        only with_postcopy
-                    precopy:
-                        only without_postcopy
+                    without_postcopy:
                         migrate_vm_back = "yes"
                 - cancel_migration:
                     only without_postcopy


### PR DESCRIPTION
The variables "vtpm_without/with_postcopy" and "pre/postcopy"
are not available in these two cfg files. So fix them in this PR.

Signed-off-by: Yingshun Cui <yicui@redhat.com>