### PR TITLE
Add cases for vtpm on ppc

### DIFF
--- a/libvirt/tests/cfg/virtual_device/tpm_device.cfg
+++ b/libvirt/tests/cfg/virtual_device/tpm_device.cfg
@@ -17,7 +17,7 @@
                             only default_model
                 - emulator:
                     backend_type = 'emulator'
-                    only tpm-crb_model
+                    only tpm-crb_model,tpm-spapr_model
                     backend_version = '2.0'
                     variants:
                         - basic:
@@ -57,9 +57,14 @@
                             prepare_secret = 'yes'
             variants:
                 - tpm-tis_model:
+                    only q35
                     tpm_model = 'tpm-tis'
                 - tpm-crb_model:
+                    only q35
                     tpm_model = 'tpm-crb'
+                - tpm-spapr_model:
+                    only pseries
+                    tpm_model = 'tpm-spapr'
                 - default_model:
         - negative_test:
             status_error = 'yes'
@@ -86,6 +91,8 @@
                 - emulator:
                     backend_type='emulator'
                     tpm_model = 'tpm-crb'
+                    pseries:
+                        tpm_model = 'tpm-spapr'
                     variants:
                         - backend_version:
                             xml_error = 'yes'


### PR DESCRIPTION
PPC only support one tpm model: tpm-spapr while other models are only supported on q35 for x86_64.
Signed-off-by: Dan Zheng <dzheng@redhat.com>