### PR TITLE
Fix wrong genid is created when the hex length of vm.genid is less th…

### DIFF
--- a/provider/v2v_vmcheck_helper.py
+++ b/provider/v2v_vmcheck_helper.py
@@ -673,6 +673,11 @@ class VMChecker(object):
                     map(lambda x: hex(int(x) & ((1 << 64) - 1)), [vm_genid, vm_genidX])):
                 # Remove 'L' suffix for python2
                 val = val.rstrip('L')
+                # if length of val is not equal 18, we must fill the length
+                # to 18 with 0.
+                if len(val) < 18:
+                    zero_pad = 18 - len(val)
+                    val = '0x' + '0' * zero_pad + val[2:]
                 if index == 0:
                     gen_id = '-'.join([val[n:] if n == -8 else val[n:n + 4]
                                        for n in range(-8, -17, -4)])
@@ -683,6 +688,7 @@ class VMChecker(object):
             return gen_id + '-' + gen_idX
 
         has_genid = self.params.get('has_genid')
+        # Return if not set has_genid
         if not has_genid:
             return
 

--- a/v2v/tests/cfg/convert_from_file.cfg
+++ b/v2v/tests/cfg/convert_from_file.cfg
@@ -189,7 +189,7 @@
                                     only esx_67
                                     only windows
                                     os_version = 'win10'
-                                    has_genid = 'no'
+                                    has_genid = 'yes'
                                     main_vm = 'VM_NAME_GENID_WIN10_V2V_EXAMPLE'
                                     vmx_nfs_src = NFS_ESX67_VMX_V2V_EXAMPLE
                                     # genid only supports libvirt, local, qemu


### PR DESCRIPTION
…an 18

When vm.genid is too small, the hex length will be less than 18. it will
cause an incorrect expected genid.

The hex string should be left zero padded when it happened.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>