### PR TITLE
Remove pv_eoi cases from pseries

### DIFF
--- a/libvirt/tests/cfg/libvirt_qemu_cmdline.cfg
+++ b/libvirt/tests/cfg/libvirt_qemu_cmdline.cfg
@@ -5,7 +5,7 @@
         - hypervisor_features:
             variants:
                 - pv_eoi:
-                    no s390-virtio
+                    no s390-virtio, pseries
                     test_feature = 'pv_eoi'
                     test_feature_attr = 'eoi_enable'
                     expect_start_vm_fail = 'no'


### PR DESCRIPTION
The 'eoi' attribute of the 'apic' feature is not supported for
architecture 'ppc64le' or machine type 'pseries-xxxxx'

Signed-off-by: haizhao <haizhao@redhat.com>