### PR TITLE
Update params setting of test out_of_range

### DIFF
--- a/libvirt/tests/cfg/cpu/iothread.cfg
+++ b/libvirt/tests/cfg/cpu/iothread.cfg
@@ -47,6 +47,8 @@
                             iothread_ids = "1"
                             iothread_num = "2"
                             iothreadpins = "2:100"
+                            pseries:
+                                iothreadpins = "2:300"
                             start_vm = "yes"
                             err_msg = "Numerical result out of range"
                         - no_matchs_iothread:


### PR DESCRIPTION
ppc hosts usually have more cpus, 100 is not enough to be out of
range

Signed-off-by: haizhao <haizhao@redhat.com>