### PR TITLE
Set vcpu plug number larger for pseries

### DIFF
--- a/libvirt/tests/cfg/libvirt_vcpu_plug_unplug.cfg
+++ b/libvirt/tests/cfg/libvirt_vcpu_plug_unplug.cfg
@@ -107,6 +107,8 @@
             variants:
                 - greater_plug_number:
                     vcpu_plug_num = "8"
+                    pseries:
+                        vcpu_plug_num = "256"
                     vcpu_unplug = "no"
                     check_after_plug_fail = "yes"
                 - readonly_setvcpu:


### PR DESCRIPTION
pseries hosts usually have more cpus than x86 hosts, 8 is not large
enough to make this negative test case.

Signed-off-by: haizhao <haizhao@redhat.com>