### PR TITLE
Revert "acpi is not supported by pseries"

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_setvcpus.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_setvcpus.cfg
@@ -119,7 +119,6 @@
                 - maximum_option:
                     setvcpus_options = "--maximum --live"
                 - no_acpi:
-                    no pseries
                     no_acpi = "yes"
                     setvcpus_count = ${setvcpus_current}
                     hot_unplug = "yes"


### PR DESCRIPTION
Reverts autotest/tp-libvirt#2855