### PR TITLE
Drop code of dmesg checking for hpt tests

### DIFF
--- a/libvirt/tests/cfg/papr_hpt.cfg
+++ b/libvirt/tests/cfg/papr_hpt.cfg
@@ -24,7 +24,6 @@
                             mem_node = 0
                             mem_model = dimm
                             numa_cell = [{'id':'0','cpus':'0-1','memory':'524288','unit':'KiB'}, {'id':'1','cpus':'2-3','memory':'524288','unit':'KiB'}]
-                            dmesg_content = Attempting to resize HPT to shift %d|HPT resize to shift %d complete
                 - maxpagesize:
                     cpu_attrs = "{'mode': 'host-model', 'check': 'partial', 'fallback': 'forbid', 'model': 'power8'}"
                     check_hp = 'yes'

--- a/libvirt/tests/src/papr_hpt.py
+++ b/libvirt/tests/src/papr_hpt.py
@@ -227,16 +227,6 @@ def run(test, params, env):
                     if not re.search(pattern, str(xml_after_attach.xmltreefile)):
                         test.fail('Missing memory alias: %s' % pattern)
 
-                # Log in the guest and check dmesg
-                dmesg = session.cmd('dmesg')
-                logging.debug(dmesg)
-                dmesg_content = params.get('dmesg_content', '').split('|')
-                for order in range(1, 3):
-                    order += hpt_order
-                    for content in dmesg_content:
-                        if content % order not in dmesg:
-                            test.fail('Missing dmesg: %s' % (content % order))
-
         # Test on non-ppc64le hosts
         else:
             set_hpt(vmxml, sync=False, **hpt_attrs)


### PR DESCRIPTION
Content of dmesg output is not constant, dmesg checking could be
dropped.

Signed-off-by: haizhao <haizhao@redhat.com>