### PR TITLE
Update to check output of vol-list

### DIFF
--- a/libvirt/tests/src/virsh_cmd/volume/virsh_vol_download_upload.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_vol_download_upload.py
@@ -227,6 +227,9 @@ def run(test, params, env):
         vol_list = virsh.vol_list(pool_name, debug=True).stdout.strip()
         # iscsi volume name is different from others
         if pool_type == "iscsi":
+            # Due to BZ 1843791, the volume cannot be obtained sometimes.
+            if len(vol_list.splitlines()) < 3:
+                test.fail("Failed to get iscsi type volume.")
             vol_name = vol_list.split('\n')[2].split()[0]
 
         vol_path = virsh.vol_path(vol_name, pool_name,


### PR DESCRIPTION
To avoid IndexError, update to check 'virsh vol-list' command's
output first.

Signed-off-by: Yingshun Cui <yicui@redhat.com>