### PR TITLE
Attach usb controller into right pci endpoint

### DIFF
--- a/libvirt/tests/cfg/usb_device.cfg
+++ b/libvirt/tests/cfg/usb_device.cfg
@@ -6,6 +6,9 @@
     pkgs_host = "usbutils,usbredir-server"
     pkgs_guest = "usbutils"
     no s390-virtio
+    ctrl_addr_domain = "0x0000"
+    ctrl_addr_slot = "0x01"
+    ctrl_addr_function = "0x00"
     variants:
         # bus controller
         - pcie-root:
@@ -40,6 +43,7 @@
             only pcie-to-pci-bridge,pci-root
             usb_alias = "yes"
             usb_model = "ich9-ehci1,ich9-uhci1,ich9-uhci2,ich9-uhci3,nec-xhci,qemu-xhci,piix3-uhci,piix4-uhci,vt82c686b-uhci"
+            set_addr = "no"
     variants:
         # usb device
         - passthrough:


### PR DESCRIPTION
set the suitable addr for usb controller, to attach usb controller into right pci endpoint

Singed-off-by: ljmen <lmen@redhat.com>