### PR TITLE
Add vlan tag into the interface xml

### DIFF
--- a/libvirt/tests/cfg/sriov/sriov.cfg
+++ b/libvirt/tests/cfg/sriov/sriov.cfg
@@ -35,6 +35,14 @@
                             managed = "no"
                         - managed_yes:
                             managed = "yes"
+                - vf_vlan:
+                    vf_type = "vf"
+                    vlan_id = "{'trunk': 'no', 'tags': [{'id': '42'}]}"
+                    variants:
+                        - managed_no:
+                            managed = "no"
+                        - managed_yes:
+                            managed = "yes"
                 - vf_pool:
                     vf_type = "vf_pool"
                     variants:
@@ -48,10 +56,30 @@
                                 - managed_no:
                                     managed = "no"
                                     only normal_test.guest_with_vf.hotplug.default.nop
+                - vf_pool_vlan:
+                    vf_type = "vf_pool"
+                    vlan_id = "{'trunk': 'no', 'tags': [{'id': '45'}]}"
+                    variants:
+                        - vf_list:
+                            vf_pool_source = "vf_list"
+                        - pf:
+                            vf_pool_source = "pf"
+                            variants:
+                                - managed_yes:
+                                    managed = "yes"
+                                - managed_no:
+                                    managed = "no"
+                                    only normal_test.guest_with_vf.hotplug.default.nop
                 - macvtap_network:
                     vf_type = "macvtap_network"
+                - macvtap_network_vlan:
+                    vf_type = "macvtap_network"
+                    vlan_id = "{'trunk': 'no', 'tags': [{'id': '33'}]}"
                 - macvtap_interface:
                     vf_type = "macvtap"
+                - macvtap_interface_vlan:
+                    vf_type = "macvtap"
+                    vlan_id = "{'trunk': 'no', 'tags': [{'id': '35'}]}"
             variants:
                 - resume_suspend:
                     operation = "resume_suspend"
@@ -132,7 +160,7 @@
                             only guest_with_vf.hotplug.default.nop.vf_pool.pf
                 - inactive_pool:
                     inactive_pool = "yes"
-                    hot_plug = "yes"
+                    attach = "yes"
                     vf_type = "vf_pool"
                     network_status = "inactive"
                     error_msg = "is not active"
@@ -141,3 +169,9 @@
                     attach = "yes"
                     operation = "save"
                     only guest_with_vf.hotplug.default.nop.vf_pool.pf
+                - vlan_trunk:
+                    trunk = "yes"
+                    attach = "yes"
+                    error_msg = "vlan trunking is not supported"
+                    vlan_id = "{'trunk': 'yes', 'tags': [{'id': '35'}, {'id': '123', 'nativeMode': 'untagged'}]}"
+                    only guest_with_vf.hotplug.default.nop.vf_pool.vf_list, guest_with_vf.hotplug.default.nop.macvtap_network


### PR DESCRIPTION
As hostdev interface supports vlan tag, add vlan tag configuration. This is depends on https://github.com/avocado-framework/avocado-vt/pull/2597

Signed-off-by: yalzhang <yalzhang@redhat.com>