### PR TITLE
Set different hugepage number other than 2000 on ppc hosts

### DIFF
--- a/libvirt/tests/cfg/libvirt_mem.cfg
+++ b/libvirt/tests/cfg/libvirt_mem.cfg
@@ -87,6 +87,9 @@
                     test_qemu_cmd = "no"
                     test_mem_binding = "no"
                     setup_hugepages = "yes"
+                    huge_page_num = 2000
+                    pseries:
+                        huge_page_num = 200
                     max_mem_rt = 25600000
                     max_mem = "2609152"
                     current_mem = "2609152"

--- a/libvirt/tests/src/libvirt_mem.py
+++ b/libvirt/tests/src/libvirt_mem.py
@@ -428,6 +428,7 @@ def run(test, params, env):
     tg_node = params.get("tg_node", 0)
     pg_size = params.get("page_size")
     pg_unit = params.get("page_unit", "KiB")
+    huge_page_num = int(params.get('huge_page_num', 2000))
     node_mask = params.get("node_mask", "0")
     mem_addr = ast.literal_eval(params.get("memory_addr", "{}"))
     huge_pages = [ast.literal_eval(x)
@@ -446,7 +447,7 @@ def run(test, params, env):
         elif cpu_arch == 'power9':
             pg_size = '2048'
         [x.update({'size': pg_size}) for x in huge_pages]
-        setup_hugepages(int(pg_size))
+        setup_hugepages(int(pg_size), shp_num=huge_page_num)
 
     # Back up xml file.
     vmxml_backup = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)


### PR DESCRIPTION
PPC hosts have different hugepage size from x86, therefore the number
of hugepages on ppc should not be fixed to 2000 as x86. Set to a
smaller number to avoid memory size exceeds.

Signed-off-by: haizhao <haizhao@redhat.com>