### PR TITLE
v2v: Fix VMChecker initialization problem when converting to ovirt

### DIFF
--- a/v2v/tests/cfg/convert_from_file.cfg
+++ b/v2v/tests/cfg/convert_from_file.cfg
@@ -3,7 +3,7 @@
     vm_type = 'libvirt'
     start_vm = 'no'
     take_regular_screendumps = no
-    v2v_timeout = '3600'
+    v2v_timeout = '7200'
     v2v_debug = on
 
     # Regular kvm guest parameters

--- a/v2v/tests/cfg/convert_vm_to_ovirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_ovirt.cfg
@@ -14,7 +14,7 @@
     remote_shell_port = 22
     remote_shell_prompt = "^\w:\\.*>\s*$|^\[.*\][\#\$]\s*$"
     status_test_command = "echo $?"
-    v2v_timeout = '3600'
+    v2v_timeout = '7200'
     v2v_debug = on
 
     variants:

--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -3,7 +3,7 @@
     vm_type = 'libvirt'
     start_vm = 'no'
     take_regular_screendumps = no
-    v2v_timeout = '3600'
+    v2v_timeout = '7200'
     default_output_format = 'qcow2'
     vpx_passwd_file = "/tmp/v2v_vpx_passwd"
     v2v_debug = on

--- a/v2v/tests/cfg/function_test_xen.cfg
+++ b/v2v/tests/cfg/function_test_xen.cfg
@@ -3,7 +3,7 @@
     vm_type = 'libvirt'
     start_vm = 'no'
     take_regular_screendumps = no
-    v2v_timeout = '3600'
+    v2v_timeout = '7200'
     v2v_debug = on
 
     # Xen host info

--- a/v2v/tests/cfg/specific_kvm.cfg
+++ b/v2v/tests/cfg/specific_kvm.cfg
@@ -7,7 +7,7 @@
     type = 'specific_kvm'
     start_vm = 'no'
     take_regular_screendumps = no
-    v2v_timeout = '3600'
+    v2v_timeout = '7200'
     os_type = 'linux'
     username = 'root'
     password = GENERAL_GUEST_PASSWORD

--- a/v2v/tests/cfg/v2v_options.cfg
+++ b/v2v/tests/cfg/v2v_options.cfg
@@ -13,6 +13,7 @@
     os_type = "linux"
     username = 'root'
     password = GENERAL_GUEST_PASSWORD
+    # v2v cmd running time
     v2v_timeout = 10800
     # Full types input disks
     variants:

--- a/v2v/tests/src/convert_from_file.py
+++ b/v2v/tests/src/convert_from_file.py
@@ -125,14 +125,14 @@ def run(test, params, env):
         libvirt.check_exit_status(result, status_error)
         output = result.stdout_text + result.stderr_text
         if not status_error:
-            if output_mode == 'rhev':
-                if not utils_v2v.import_vm_to_ovirt(params, address_cache,
-                                                    timeout=v2v_timeout):
-                    test.fail('Import VM failed')
             # Create vmchecker before virsh.start so that the vm can be undefined
             # if started failed.
             vmchecker = VMChecker(test, params, env)
             params['vmchecker'] = vmchecker
+            if output_mode == 'rhev':
+                if not utils_v2v.import_vm_to_ovirt(params, address_cache,
+                                                    timeout=v2v_timeout):
+                    test.fail('Import VM failed')
             if output_mode == 'libvirt':
                 try:
                     virsh.start(vm_name, debug=True, ignore_status=False)

--- a/v2v/tests/src/convert_vm_to_ovirt.py
+++ b/v2v/tests/src/convert_vm_to_ovirt.py
@@ -180,13 +180,13 @@ def run(test, params, env):
         params['main_vm'] = v2v_params['new_name']
 
         logging.info("output_method is %s" % output_method)
+        # Check all checkpoints after convert
+        params['vmchecker'] = vmchecker = VMChecker(test, params, env)
         # Import the VM to oVirt Data Center from export domain, and start it
         if not utils_v2v.import_vm_to_ovirt(params, address_cache,
                                             timeout=v2v_timeout):
             test.error("Import VM failed")
 
-        # Check all checkpoints after convert
-        params['vmchecker'] = vmchecker = VMChecker(test, params, env)
         ret = vmchecker.run()
 
         # Other checks

--- a/v2v/tests/src/function_test_esx.py
+++ b/v2v/tests/src/function_test_esx.py
@@ -417,6 +417,8 @@ def run(test, params, env):
             if status_error:
                 log_fail('Virsh dumpxml failed for empty cdrom image')
         elif not status_error:
+            vmchecker = VMChecker(test, params, env)
+            params['vmchecker'] = vmchecker
             if output_mode == 'rhev':
                 if not utils_v2v.import_vm_to_ovirt(params, address_cache,
                                                     timeout=v2v_timeout):
@@ -425,8 +427,6 @@ def run(test, params, env):
                 virsh.start(vm_name, debug=True)
             # Check guest following the checkpoint document after convertion
             logging.info('Checking common checkpoints for v2v')
-            vmchecker = VMChecker(test, params, env)
-            params['vmchecker'] = vmchecker
             if skip_vm_check != 'yes':
                 ret = vmchecker.run()
                 if len(ret) == 0:

--- a/v2v/tests/src/function_test_xen.py
+++ b/v2v/tests/src/function_test_xen.py
@@ -162,6 +162,8 @@ def run(test, params, env):
         libvirt.check_exit_status(result, status_error)
         output = result.stdout_text + result.stderr_text
         if not status_error and checkpoint != 'vdsm':
+            vmchecker = VMChecker(test, params, env)
+            params['vmchecker'] = vmchecker
             if output_mode == 'rhev':
                 if not utils_v2v.import_vm_to_ovirt(params, address_cache,
                                                     timeout=v2v_timeout):
@@ -173,8 +175,6 @@ def run(test, params, env):
                     test.fail('Start vm failed: %s', str(e))
             # Check guest following the checkpoint document after convertion
             logging.info('Checking common checkpoints for v2v')
-            vmchecker = VMChecker(test, params, env)
-            params['vmchecker'] = vmchecker
             if params.get('skip_vm_check') != 'yes':
                 ret = vmchecker.run()
                 if len(ret) == 0:

--- a/v2v/tests/src/specific_kvm.py
+++ b/v2v/tests/src/specific_kvm.py
@@ -578,6 +578,8 @@ def run(test, params, env):
         utlv.check_exit_status(result, status_error)
         output = result.stdout_text + result.stderr_text
         if not status_error:
+            vmchecker = VMChecker(test, params, env)
+            params['vmchecker'] = vmchecker
             if output_mode == 'rhev':
                 if not utils_v2v.import_vm_to_ovirt(params, address_cache,
                                                     timeout=v2v_timeout):
@@ -588,8 +590,6 @@ def run(test, params, env):
                 except Exception as e:
                     test.fail('Start vm failed: %s' % str(e))
             # Check guest following the checkpoint document after convertion
-            vmchecker = VMChecker(test, params, env)
-            params['vmchecker'] = vmchecker
             if params.get('skip_vm_check') != 'yes':
                 ret = vmchecker.run()
                 if len(ret) == 0:


### PR DESCRIPTION
1) When vm starts failed on rhv, the vm cannot be cleaned up.
This is because VMChecker is initialized after import_vm_to_ovirt.
But if import_vm_to_ovirt failed, VMChecker will have no chance
to run, and if put VMChecker ahead of import_vm_to_ovirt, the
VMChecker will fail at virsh.dumpxml in __init__. Because the VM
only can be seen when it's started on rhv, so it must be put after
import_vm_to_ovirt.
This patch breaks the dead loop of above relationship. Now the
VMChecker can be initialized at anywhere, so the vm can be cleaned
up at the end of the script.

2) Set import_vm_to_ovirt timeout to -1 which means no timeout.
When it's timeout, it doesn't mean import_vm_to_ovirt failed. If
the script is interupted forcely, the vm will be left on rhv and
may cause upcoming scripts fail.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>