### PR TITLE
Check mac address when attach interface with --live --config

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_hotplug.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_hotplug.cfg
@@ -83,6 +83,10 @@
                             attach_option = "--config --persistent"
                         - live_config_persistent:
                             attach_option = "--live --config --persistent"
+                        - check_mac:
+                            attach_option = "--live --config"
+                            check_mac = "yes"
+                            only at_device..active
                 - stress_test:
                     iface_num = '500'
                     stress_test = "yes" 


### PR DESCRIPTION
There is a bug that when attach-device with --live and --config but
no mac address for the interface, it will generate 2 different mac
address separately to live and inactive xml, which will cause the mac
changes after a vm destroy-start. Add the test scenario into the hotplug
tests.

Signed-off-by: yalzhang <yalzhang@redhat.com>