### PR TITLE
Add test scenario of define macvtap network with duplicate dev

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_network.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_network.cfg
@@ -219,6 +219,10 @@
                             dhcp_end_ipv4 = "192.168.130.254"
                             net_bridge = "{'name':'virbr3'}"
                             define_error = "yes"
+                        - duplicate_dev:
+                            forward_iface = "eno1 eno2 eno1"
+                            net_forward = "{'mode':'bridge'}"
+                            define_error = "yes"
                 - net_bridge:
                     change_iface_option = "yes"
                     iface_source = "{'network':'nettest'}"


### PR DESCRIPTION
Add negative test scenario: define macvtap network with duplicate
dev will fail as expeced.

Signed-off-by: yalzhang <yalzhang@redhat.com>