### PR TITLE
Fix hypervisor-cpu-compare on s390x

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_hypervisor_cpu_compare.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_hypervisor_cpu_compare.cfg
@@ -5,6 +5,8 @@
     hypv_cpu_compare_option = ""
     compare_file_type = "domcapa_xml"
     extract_mode = "no"
+    s390-virtio:
+        baseline_provider = hypervisor
     variants:
         - none_option:
         - virttype_option:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_hypervisor_cpu_compare.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_hypervisor_cpu_compare.py
@@ -81,6 +81,7 @@ def run(test, params, env):
     if not vm.is_alive():
         vm.start()
 
+    baseline_provider = params.get("baseline_provider", "libvirt")
     dom_xml = vm_xml.VMXML.new_from_dumpxml(vm_name)
     backup_xml = dom_xml.copy()
     compare_file = os.path.join(data_dir.get_tmp_dir(), "cpu.xml")
@@ -110,9 +111,12 @@ def run(test, params, env):
             domcapa_output = get_domcapa_output(test)
             with open(domcapa_file, "w+") as tmp_f:
                 tmp_f.write(domcapa_output)
-            ret = virsh.cpu_baseline(domcapa_file)
+            if "hypervisor" in baseline_provider:
+                ret = virsh.hypervisor_cpu_baseline(domcapa_file)
+            else:
+                ret = virsh.cpu_baseline(domcapa_file)
             if ret.exit_status:
-                test.fail("Fail to run virsh cpu-baseline: %s"
+                test.fail("Fail to run virsh (hypervisor-)cpu-baseline: %s"
                           % ret.stderr.strip())
             cpuxml.xml = ret.stdout.strip()
 


### PR DESCRIPTION
Depends on 

https://github.com/avocado-framework/avocado-vt/pull/2609
https://github.com/autotest/tp-libvirt/pull/2890

virsh_hypervisor_cpu_compare.py:
* on s390x only hypervisor-cpu-(compare|baseline) are supported
  use 'hypervisor-cpu-baseline' instead of plain 'cpu-baseline'

virsh_hypervisor_cpu_compare.cfg:
* set config value to use 'hypervisor' to provide baseline on s390x

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>