### PR TITLE
Fix hypervisor_cpu_compare

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_hypervisor_cpu_compare.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_hypervisor_cpu_compare.cfg
@@ -79,7 +79,7 @@
                     msg_pattern = "incompatible"
                 - f_domcapa_xml:
                     compare_file_type = "domcapa_xml"
-                    msg_pattern = "superset"
+                    msg_pattern = "identical"
                 - illegal_format:
                     status_error = "yes"
                     illegal_cpu_test = "yes"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_hypervisor_cpu_compare.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_hypervisor_cpu_compare.py
@@ -37,7 +37,8 @@ def get_cpu_definition(source_type, vm_name, test):
         cpu_xml = dom_xml.xmltreefile.get_element_string('/cpu')
     elif source_type == "domcapa_xml":
         domcapa_xml = domcapability_xml.DomCapabilityXML()
-        cpu_xml = domcapa_xml.xmltreefile.get_element_string('/cpu')
+        cpu_tmp = vm_xml.VMCPUXML.from_domcapabilities(domcapa_xml)
+        cpu_xml = cpu_tmp.xmltreefile.get_element_string('/')
     elif source_type == "capa_xml":
         capa_xml = capability_xml.CapabilityXML()
         cpu_xml = capa_xml.xmltreefile.get_element_string('/host/cpu')
@@ -95,7 +96,7 @@ def run(test, params, env):
         try:
             cpuxml = dom_xml.cpu
             if not action_mode and cpuxml.mode == cpu_mode:
-                return dom_xml.xmltreefile.get_element_string("/")
+                return dom_xml.xmltreefile.get_element_string("/cpu")
             else:
                 del dom_xml["cpu"]
         except LibvirtXMLNotFoundError:
@@ -123,7 +124,7 @@ def run(test, params, env):
         vm.start()
         # VM start will change domxml content
         v_xml = vm_xml.VMXML.new_from_dumpxml(vm_name)
-        return v_xml.xmltreefile.get_element_string("/")
+        return v_xml.xmltreefile.get_element_string("/cpu")
 
     def get_options(option_str):
         """


### PR DESCRIPTION
Depends on https://github.com/avocado-framework/avocado-vt/pull/2610

Test review revealed issue https://bugzilla.redhat.com/show_bug.cgi?id=1850614

Construct host cpu based on domcapabilities host-model info as expected behavior.
Use cpu element for guest cpu from dumpxml instead of the full domain xml.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>