### PR TITLE
Fix error message matching problem when converting a running guest

### DIFF
--- a/v2v/tests/cfg/specific_kvm.cfg
+++ b/v2v/tests/cfg/specific_kvm.cfg
@@ -307,7 +307,7 @@
                 - not_shutdown:
                     only default.kvm
                     only output_mode.local
-                    msg_content = '.*is running or paused.*%virt-v2v: error: internal error: invalid argument:.*'
+                    msg_content = 'virt-v2v: error:.*is running or paused.*must be shut down'
                     expect_msg = 'yes'
                     variants:
                         - running:


### PR DESCRIPTION
Before rhel8.2, it's like:
virt-v2v: error: internal error: invalid argument: libvirt domain
‘avocado-vt-vm1’ is running or paused.  It must be shut down in order
to perform virt-v2v conversion

In rhel8.3, it's like:
virt-v2v: error: libvirt domain ‘avocado-vt-vm1’ is running or paused.
It must be shut down in order to perform virt-v2v conversion

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>