### PR TITLE
Fix randomly getting ip address failure problem

### DIFF
--- a/v2v/tests/src/specific_kvm.py
+++ b/v2v/tests/src/specific_kvm.py
@@ -877,12 +877,10 @@ def run(test, params, env):
             logging.info('Attach network')
             virsh.attach_interface(
                 vm_name, 'network default --current', debug=True)
-            v2v_params.pop('bridge')
         if checkpoint == 'only_br':
             logging.info('Attatch bridge')
             virsh.attach_interface(
                 vm_name, 'bridge virbr0 --current', debug=True)
-            v2v_params.pop('network')
         if checkpoint == 'no_libguestfs_backend':
             os.environ.pop('LIBGUESTFS_BACKEND')
         if checkpoint == 'file_image':


### PR DESCRIPTION
Sometimes the --mac argument cannot be set correctly. This is because
the bridge or network parameter is deleted from params dictionay
object before passing to v2v_cmd function. Then when composing
--mac option, if the deleted net type is chosed, the value will be
None, then following wrong parameter will be set.

wrong setting:
--mac 52:54:00:b9:9b:db:network:None

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>