### PR TITLE
Change the default value to avoid failure

### DIFF
--- a/libvirt/tests/src/virtual_device/watchdog.py
+++ b/libvirt/tests/src/virtual_device/watchdog.py
@@ -91,7 +91,7 @@ def run(test, params, env):
         def _booting_completed():
             session = vm.wait_for_login()
             status = None
-            second_boot_time = None
+            second_boot_time = ""
             try:
                 status, second_boot_time = session.cmd_status_output("uptime --since")
                 logging.debug("The second boot time is %s", second_boot_time)


### PR DESCRIPTION
Fix the failure 
```
TypeError: '&gt;' not supported between instances of 'NoneType' and 'str'&#10;
```
when running code
```
return second_boot_time > first_boot_time
```
As when get value failed, it will compare the first_boot_time(str) with second_boot_time(None) which cause this error

Signed-off-by: kylazhang <weizhan@redhat.com>