### PR TITLE
Skip vcpu_affinity test if the host has less than 8 CPUs

### DIFF
--- a/libvirt/tests/src/cpu/vcpu_affinity.py
+++ b/libvirt/tests/src/cpu/vcpu_affinity.py
@@ -118,6 +118,8 @@ def run(test, params, env):
 
     try:
         hostcpu_num = int(cpuutil.total_cpus_count())
+        if hostcpu_num < 8:
+            test.cancel("The host should have at least 8 CPUs for this test.")
 
         # online all host cpus
         for x in range(1, hostcpu_num):


### PR DESCRIPTION
It makes some cases fail if the host has less than 8 CPUs.
There will be some limitations in picking up proper machines in CI,
but still add codes in script.

Signed-off-by: Yingshun Cui <yicui@redhat.com>