### PR TITLE
Fix an issue in virsh_migrate

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
@@ -53,7 +53,7 @@ def run(test, params, env):
         """
         actual_state = ""
         if uri:
-            actual_state = virsh.domstate(vm.name, uri=uri).stdout.strip()
+            actual_state = virsh.domstate(vm.name, uri=uri).stdout_text.strip()
         else:
             actual_state = vm.state()
         if actual_state != state:


### PR DESCRIPTION
It reports error like "The VM state is expected 'paused',
but 'b'paused'' found", fixup it in this PR.

Signed-off-by: Yingshun Cui <yicui@redhat.com>