### PR TITLE
Fix the mem failure to decode stdout

### DIFF
--- a/libvirt/tests/src/virsh_cmd/host/virsh_node_memtune.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_node_memtune.py
@@ -86,7 +86,7 @@ def get_node_memtune_parameter(test, params):
 
     _params = {}
 
-    for i in result.stdout.strip().split('\n\t')[1:]:
+    for i in result.stdout_text.strip().split('\n\t')[1:]:
         _params[i.split(' ')[0]] = i.split(' ')[-1]
 
     logging.debug(_params)


### PR DESCRIPTION
Signed-off-by: Kyla Zhang <weizhan@redhat.com>

Before:
```
# avocado run --vt-type libvirt virsh.node_memtune.negative_testing.get_node_memory_parameter
JOB ID     : d576d8604f6fa806a7e90a8a0b073b0c1a474efa
JOB LOG    : /root/avocado/job-results/job-2020-06-30T23.00-d576d86/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.node_memtune.negative_testing.get_node_memory_parameter: ERROR: a bytes-like object is required, not 'str' (2.64 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 3.84 s
```
After:
```
# avocado run --vt-type libvirt virsh.node_memtune.negative_testing.get_node_memory_parameter
JOB ID     : 7c3300d4a5fb32150bc8e44e8b3aa8d75f98a5a0
JOB LOG    : /root/avocado/job-results/job-2020-06-30T23.01-7c3300d/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.node_memtune.negative_testing.get_node_memory_parameter: PASS (2.72 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 3.94 s
```