### PR TITLE
Fix attach disk pci issues on s390x

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_disk.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_disk.cfg
@@ -17,6 +17,8 @@
     at_dt_disk_serial = ""
     at_dt_disk_address = ""
     at_dt_disk_create_image = "yes"
+    s390-virtio:
+        add_more_pci_controllers = "no"
     variants:
         - error_test:
             status_error = 'yes'

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk.py
@@ -276,17 +276,20 @@ def run(test, params, env):
             device_source = libvirt.create_local_disk(
                 "file", path=device_source_path,
                 size="1", disk_format=device_source_format)
-            vm_dump_xml.remove_all_device_by_type('controller')
-            machine_list = vm_dump_xml.os.machine.split("-")
-            vm_dump_xml.set_os_attrs(**{"machine": machine_list[0] + "-q35-" + machine_list[2]})
-            q35_pcie_dict0 = {'controller_model': 'pcie-root', 'controller_type': 'pci', 'controller_index': 0}
-            q35_pcie_dict1 = {'controller_model': 'pcie-root-port', 'controller_type': 'pci'}
-            vm_dump_xml.add_device(libvirt.create_controller_xml(q35_pcie_dict0))
-            # Add enough controllers to match multiple times disk attaching requirements
-            for i in list(range(1, 15)):
-                q35_pcie_dict1.update({'controller_index': "%d" % i})
-                vm_dump_xml.add_device(libvirt.create_controller_xml(q35_pcie_dict1))
-            vm_dump_xml.sync()
+
+            if params.get("add_more_pci_controllers", "yes") == "yes":
+                vm_dump_xml.remove_all_device_by_type('controller')
+                machine_list = vm_dump_xml.os.machine.split("-")
+                vm_dump_xml.set_os_attrs(**{"machine": machine_list[0] + "-q35-" + machine_list[2]})
+                q35_pcie_dict0 = {'controller_model': 'pcie-root', 'controller_type': 'pci', 'controller_index': 0}
+                q35_pcie_dict1 = {'controller_model': 'pcie-root-port', 'controller_type': 'pci'}
+                vm_dump_xml.add_device(libvirt.create_controller_xml(q35_pcie_dict0))
+                # Add enough controllers to match multiple times disk attaching requirements
+                for i in list(range(1, 15)):
+                    q35_pcie_dict1.update({'controller_index': "%d" % i})
+                    vm_dump_xml.add_device(libvirt.create_controller_xml(q35_pcie_dict1))
+                vm_dump_xml.sync()
+
             s_attach = virsh.attach_disk(vm_name, device_source, device_target2,
                                          s_at_options).exit_status
             if s_attach != 0:


### PR DESCRIPTION
Commit 00d0c03d568174510c691fe01e62d4b92d61399d added code to add pci controllers.
On s390x, this doesn't apply.
Add a configuration parameter for s390-virtio to switch this behavior off.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>