### PR TITLE
Add test for checking xattr added by libvirt

### DIFF
--- a/libvirt/tests/cfg/svirt/svirt_start_destroy.cfg
+++ b/libvirt/tests/cfg/svirt/svirt_start_destroy.cfg
@@ -65,6 +65,8 @@
     variants:
         - off_destroy:
             svirt_start_destroy_vm_poweroff = "destroy"
+            d_svirt_img_s0.no_baselabel.relabel_yes.st_dynamic.default_model.without_qemu_conf:
+                xattr_check = "yes"
         - off_shutdown:
             no no_model, st_none, with_qemu_conf, with_baselabel
             svirt_start_destroy_vm_poweroff = "shutdown"


### PR DESCRIPTION
1.Start 2 guests using the same disk image;
2.The xattr should be the same after trying starting the second guest;
3.The xattr should be cleaned after guest shutoff;

Signed-off-by: Yan Fu <yafu@redhat.com>