### PR TITLE
Update pv_eoi cases for pseries

### DIFF
--- a/libvirt/tests/cfg/libvirt_qemu_cmdline.cfg
+++ b/libvirt/tests/cfg/libvirt_qemu_cmdline.cfg
@@ -5,10 +5,14 @@
         - hypervisor_features:
             variants:
                 - pv_eoi:
-                    no s390-virtio, pseries
+                    no s390-virtio
                     test_feature = 'pv_eoi'
                     test_feature_attr = 'eoi_enable'
+                    expect_define_vm_fail = 'no'
                     expect_start_vm_fail = 'no'
+                    pseries:
+                        expect_define_vm_fail = 'yes'
+                        expected_msg = "unsupported configuration: The 'eoi' attribute of the 'apic' feature is not supported"
                     variants:
                         - enable:
                             test_feature_valu = 'on'

--- a/libvirt/tests/src/libvirt_qemu_cmdline.py
+++ b/libvirt/tests/src/libvirt_qemu_cmdline.py
@@ -4,6 +4,7 @@ BTW it not limited to hypervisors CPU/machine features.
 """
 import re
 import logging
+import platform
 
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
@@ -48,16 +49,22 @@ def config_feature_pv_eoi(test, vmxml, **kwargs):
         else:
             test.fail("Can not decide the expected qemu cmd line because of no expected hostos version")
 
-    try:
-        vmxml_feature = vmxml.features
-        if vmxml_feature.has_feature('apic'):
-            vmxml_feature.remove_feature('apic')
-        vmxml_feature.add_feature('apic', 'eoi', eoi_enable)
-        vmxml.features = vmxml_feature
-        logging.debug("Update VM XML:\n%s", vmxml)
-        vmxml.sync()
-    except Exception as detail:
-        logging.error("Update VM XML fail: %s", detail)
+    # Create features tag if not existed
+    if not vmxml.xmltreefile.find('features'):
+        vmxml.features = vm_xml.VMFeaturesXML()
+    vmxml_feature = vmxml.features
+    if vmxml_feature.has_feature('apic'):
+        vmxml_feature.remove_feature('apic')
+    vmxml_feature.add_feature('apic', 'eoi', eoi_enable)
+    vmxml.features = vmxml_feature
+    logging.debug("Update VM XML:\n%s", vmxml)
+    expect_fail = False if 'expect_define_vm_fail' not in kwargs \
+        else kwargs['expect_define_vm_fail']
+    result = virsh.define(vmxml.xml, debug=True)
+    libvirt.check_exit_status(result, expect_fail)
+    if expect_fail:
+        libvirt.check_result(result, kwargs.get('expected_msg'))
+        return
     return qemu_flags
 
 
@@ -113,6 +120,7 @@ def run(test, params, env):
     vm_name = params.get("main_vm", "avocado-vt-vm1")
     vm = env.get_vm(vm_name)
     expect_fail = "yes" == params.get("expect_start_vm_fail", "no")
+    expect_define_vm_fail = 'yes' == params.get('expect_define_vm_fail', 'no')
     test_feature = params.get("test_feature")
     # All test case Function start with 'test_feature' prefix
     testcase = globals()['config_feature_%s' % test_feature]
@@ -122,14 +130,23 @@ def run(test, params, env):
     if len(test_feature_attr) != len(test_feature_valu):
         test.error("Attribute number not match with value number")
     test_dargs = dict(list(zip(test_feature_attr, test_feature_valu)))
+    if expect_define_vm_fail:
+        test_dargs.update({'expect_define_vm_fail': expect_define_vm_fail,
+                           'expected_msg': params.get('expected_msg', '')})
     if vm.is_alive():
         vm.destroy()
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     vmxml_backup = vmxml.copy()
     virsh_dargs = {'debug': True, 'ignore_status': False}
+
+    if 'ppc64le' in platform.machine().lower() and test_feature == 'pv_eoi':
+        if not libvirt_version.version_compare(6, 2, 0):
+            test.cancel('Feature %s is supported since version 6.2.0' % test_feature)
     try:
         # Run test case
         qemu_flags = testcase(test, vmxml, **test_dargs)
+        if not qemu_flags and expect_define_vm_fail:
+            return
         result = virsh.start(vm_name, **virsh_dargs)
         libvirt.check_exit_status(result, expect_fail)
 


### PR DESCRIPTION
There has been an error message update on this feature, which is
the test focuses on.
Unlike x86, eoi is not supported by pseries, the result of virsh
define command should reflect this info.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>