### PR TITLE
Update for failed to restart rsyslog

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_sendkey.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_sendkey.py
@@ -111,11 +111,9 @@ def run(test, params, env):
         # check the result of restart rsyslog
         status, output = session.cmd_status_output("service rsyslog restart")
         if status:
-            # if rsyslog.service is empty, need to reinstall rsyslog
-            out = session.cmd_output("file /usr/lib/systemd/system/rsyslog.service")
-            if "empty" in out:
-                utils_package.package_remove("rsyslog", session)
-                utils_package.package_install("rsyslog", session)
+            # To avoid 'Exec format error'
+            utils_package.package_remove("rsyslog", session)
+            utils_package.package_install("rsyslog", session)
             # if rsyslog.service is masked, need to unmask rsyslog
             if "Unit rsyslog.service is masked" in output:
                 session.cmd("systemctl unmask rsyslog")


### PR DESCRIPTION
To avoid following error:
  Jul 13 16:09:30 localhost.localdomain systemd[921]: rsyslog.service: Failed to execute command: Exec format error
  Jul 13 16:09:30 localhost.localdomain systemd[921]: rsyslog.service: Failed at step EXEC spawning /usr/sbin/rsyslogd: Exec format error
  -- Subject: Process /usr/sbin/rsyslogd could not be executed

Signed-off-by: Liping Cheng <lcheng@redhat.com>