### PR TITLE
Add test cases for boot/loadparm

### DIFF
--- a/libvirt/tests/cfg/bios/virsh_boot.cfg
+++ b/libvirt/tests/cfg/bios/virsh_boot.cfg
@@ -15,6 +15,16 @@
     driver_type = "qcow2"
     os_version = "EXAMPLE_OS_VERSION"
     variants:
+        - loadparm:
+            only s390-virtio
+            boot_ref = "order"
+            boot_order = 1
+            boot_loadparm = 2
+            start_vm = "yes"
+            test_cmd = "lsreipl"
+            expected_output = Loadparm:\s+"2"
+            with_loader = "no"
+            with_boot = "yes"
         - by_ovmf:
             only q35
             boot_type = "ovmf"

--- a/libvirt/tests/src/bios/virsh_boot.py
+++ b/libvirt/tests/src/bios/virsh_boot.py
@@ -593,6 +593,7 @@ def set_boot_dev_or_boot_order(vmxml, **kwargs):
     boot_order = kwargs.get("boot_order", "1")
     target_dev = kwargs.get("target_dev", "vdb")
     two_same_boot_dev = kwargs.get("two_same_boot_dev", False)
+    boot_loadparm = kwargs.get("loadparm", None)
     if boot_ref == "dev":
         boot_list = []
         boot_list.append(boot_dev)
@@ -601,7 +602,8 @@ def set_boot_dev_or_boot_order(vmxml, **kwargs):
             boot_list.append(boot_dev)
         vmxml.set_os_attrs(**{"boots": boot_list})
     elif boot_ref == "order":
-        vmxml.set_boot_order_by_target_dev(target_dev, boot_order)
+        vmxml.set_boot_attrs_by_target_dev(target_dev, order=boot_order,
+                                           loadparm=boot_loadparm)
 
 
 def run(test, params, env):
@@ -621,6 +623,7 @@ def run(test, params, env):
     username = params.get("username", "root")
     password = params.get("password", "redhat")
     test_cmd = params.get("test_cmd", "")
+    expected_output = params.get("expected_output", "")
     check_point = params.get("checkpoint", "")
     status_error = "yes" == params.get("status_error", "no")
     boot_iso_file = os.path.join(data_dir.get_tmp_dir(), "boot.iso")
@@ -640,6 +643,7 @@ def run(test, params, env):
     vol_name = params.get("vol_name")
     brick_path = os.path.join(test.virtdir, "gluster-pool")
     boot_type = params.get("boot_type", "seabios")
+    boot_loadparm = params.get("boot_loadparm", None)
 
     # Prepare result checkpoint list
     check_points = []
@@ -664,7 +668,8 @@ def run(test, params, env):
             boot_kwargs = {"boot_ref": boot_ref,
                            "boot_dev": boot_dev,
                            "boot_order": boot_order,
-                           "target_dev": target_dev}
+                           "target_dev": target_dev,
+                           "loadparm": boot_loadparm}
             if "yes" == params.get("two_same_boot_dev", "no"):
                 boot_kwargs.update({"two_same_boot_dev": True})
             set_boot_dev_or_boot_order(vmxml, **boot_kwargs)
@@ -711,6 +716,11 @@ def run(test, params, env):
                 if test_cmd:
                     status, output = remote_session.cmd_status_output(test_cmd)
                     logging.debug("CMD '%s' running result is:\n%s", test_cmd, output)
+                    if expected_output:
+                        if not re.search(expected_output, output):
+                            test.fail("Expected '%s' to match '%s'"
+                                      " but failed." % (output,
+                                                        expected_output))
                     if status:
                         test.fail("Failed to boot %s from %s" % (vm_name, vmxml.xml))
                 remote_session.close()


### PR DESCRIPTION
Depends on https://github.com/avocado-framework/avocado-vt/pull/2653

On s390x, an optional `loadparm` can be passed to be used
when booting from disk. The parameter can be used to select
the boot entry.
Add a test that uses `lsreipl` to determine if the parameter
is passed correctly.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>