### PR TITLE
Fix blkdeviotune slice test error

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blkdeviotune.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blkdeviotune.cfg
@@ -383,7 +383,7 @@
                     blkdevio_group_name = libvirt_iotune_group1
                     variants:
                         - slice_test:
-                            disk_slice = yes
+                            disk_slice_enabled = yes
                             test_size = "10"
                             type_name = "file"
                             target_dev = "vdb"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blkdeviotune.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blkdeviotune.py
@@ -168,7 +168,7 @@ def run(test, params, env):
     disk_bus = params.get("disk_bus", 'virtio')
     disk_alias = params.get("disk_alias")
     attach_options = params.get("attach_options")
-    slice_test = "yes" == params.get("disk_slice", "yes")
+    slice_test = "yes" == params.get("disk_slice_enabled", "yes")
     test_size = params.get("test_size", "1")
 
     original_vm_xml = libvirt_xml.VMXML.new_from_inactive_dumpxml(vm_name)
@@ -183,6 +183,7 @@ def run(test, params, env):
 
     disk_source = tempfile.mktemp(dir=data_dir.get_tmp_dir())
     params["input_source_file"] = disk_source
+    params["disk_slice"] = {"slice_test": "yes"}
     if attach_disk and not slice_test:
         libvirt.create_local_disk(disk_type, path=disk_source, size='1',
                                   disk_format=disk_format)


### PR DESCRIPTION
Modify the variable 'disk_slice' to 'disk_slice_enabled' and add
a new dict param 'disk_slice' to match avocado-vt patch 2952.

# avocado  run --vt-type libvirt --vt-machine-type q35 virsh.blkdeviotune.positive_testing.attach_disk..slice_test 
/root/.libvirt-ci-venv-ci-runtest-jZYIZh/lib/python3.6/site-packages/avocado_framework-80.0-py3.6.egg/avocado/plugins/run.py:292: FutureWarning: The following arguments will be changed to boolean soon: sysinfo, output-check, failfast and keep-tmp. 
  FutureWarning)
JOB ID     : c76eb0df70d4a53216ab0714a0f6a563cf409e54
JOB LOG    : /root/avocado/job-results/job-2020-07-15T05.23-c76eb0d/job.log
 (1/5) type_specific.io-github-autotest-libvirt.virsh.blkdeviotune.positive_testing.attach_disk.hotplug.slice_test: PASS (109.52 s)
 (2/5) type_specific.io-github-autotest-libvirt.virsh.blkdeviotune.positive_testing.attach_disk.coldplug.with_alias.bus_virtio.slice_test: PASS (143.11 s)
 (3/5) type_specific.io-github-autotest-libvirt.virsh.blkdeviotune.positive_testing.attach_disk.coldplug.with_alias.bus_scsi.slice_test: PASS (152.27 s)
 (4/5) type_specific.io-github-autotest-libvirt.virsh.blkdeviotune.positive_testing.attach_disk.coldplug.without_alias.bus_virtio.slice_test: PASS (145.86 s)
 (5/5) type_specific.io-github-autotest-libvirt.virsh.blkdeviotune.positive_testing.attach_disk.coldplug.without_alias.bus_scsi.slice_test: PASS (79.71 s)
RESULTS    : PASS 5 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 633.60 s

Signed-off-by: root <root@localhost.localdomain>