### PR TITLE
tpm_device: adapt to new tpm2-tools, add fixes

### DIFF
--- a/libvirt/tests/cfg/virtual_device/tpm_device.cfg
+++ b/libvirt/tests/cfg/virtual_device/tpm_device.cfg
@@ -70,14 +70,16 @@
             status_error = 'yes'
             variants:
                 - other_backend:
-                    xml_error = 'yes'
                     variants:
                         - no_backend:
                             no_backend = 'yes'
+                            xml_errmsg = 'missing TPM device backend'
                         - none_backendtype:
                             backend_type = 'none'
+                            xml_errmsg = 'missing TPM device backend type'
                         - invalid_backendtype:
                             backend_type = 'invalid'
+                            xml_errmsg = "Unknown TPM backend type 'invalid'"
                 - passthrough:
                     backend_type='passthrough'
                     variants:
@@ -86,8 +88,8 @@
                             tpm_model = 'tpm-tis'
                             device_path = '/dev/tpm0'
                         - multi_passthrgh_tpm:
-                            xml_error = 'yes'
                             tpm_num = 2
+                            xml_errmsg = 'only a single TPM non-proxy device is supported'
                 - emulator:
                     backend_type='emulator'
                     tpm_model = 'tpm-crb'
@@ -95,7 +97,7 @@
                         tpm_model = 'tpm-spapr'
                     variants:
                         - backend_version:
-                            xml_error = 'yes'
+                            xml_errmsg = 'Unsupported interface tpm-crb for TPM 1.2'
                             variants:
                                 - version_default:
                                     backend_version = 'none'
@@ -103,13 +105,14 @@
                                     backend_version = '1.2'
                                 - version_2:
                                     backend_version = '2'
+                                    xml_errmsg = "Unsupported TPM version '2'"
                         - encrypt_secret:
                             backend_version = '2.0'
                             variants:
                                 - invalid_secret:
                                     prepare_secret = 'yes'
-                                    xml_error = 'yes'
                                     secret_uuid = 'invalid'
+                                    xml_errmsg = 'Unable to parse secret uuid'
                                 - nonexist_secret:
                                     secret_uuid = 'nonexist'
                         - encryption_test:


### PR DESCRIPTION
From tpm2-tools-4.0, tpm2_getrandom needs -T to specify /dev/tpm0
as file for TCTI device. And its output changed to be binary, so
needs --hex for readable. Second, replace vm_xml.sync() with
virsh.define to better show the failure msg. Finally, add a step
to clean the decompressed dir /root/linux-* in guest os.

Signed-off-by: Yanqiu Zhang <yanqzhan@redhat.com>