### PR TITLE
Update image type to raw for lun tests

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcopy.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcopy.cfg
@@ -169,7 +169,7 @@
                     disk_device = 'lun'
                     disk_target = "vda"
                     disk_target_bus = "virtio"
-                    disk_format = "qcow2"
+                    disk_format = "raw"
                     image_size = "10G"
                     emulated_image = "emulated-iscsi"
                     variants:


### PR DESCRIPTION
Based on change on libvirt:
qemu: Forbid non-raw images for disk type='lun' with vitio-blk frontend
https://gitlab.com/libvirt/libvirt/-/commit/b40ec75296769884ba873d2a72cdda01c2c03c24

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>