### PR TITLE
Update libvirt_version imported module from provider to virttest

### DIFF
--- a/libvirt/tests/src/svirt/dac_start_destroy.py
+++ b/libvirt/tests/src/svirt/dac_start_destroy.py
@@ -10,8 +10,8 @@ from virttest import utils_selinux
 from virttest import virt_vm
 from virttest import utils_config
 from virttest import utils_libvirtd
+from virttest import libvirt_version
 from virttest.libvirt_xml.vm_xml import VMXML
-from provider import libvirt_version
 
 
 def check_qemu_grp_user(user, test):

--- a/libvirt/tests/src/svirt/dac_vm_per_image_start.py
+++ b/libvirt/tests/src/svirt/dac_vm_per_image_start.py
@@ -13,10 +13,9 @@ from virttest import gluster
 from virttest import utils_config
 from virttest import utils_libvirtd
 from virttest import data_dir
+from virttest import libvirt_version
 from virttest.utils_test import libvirt as utlv
 from virttest.libvirt_xml.vm_xml import VMXML
-
-from provider import libvirt_version
 
 
 def format_user_group_str(user, group):

--- a/libvirt/tests/src/svirt/svirt_attach_disk.py
+++ b/libvirt/tests/src/svirt/svirt_attach_disk.py
@@ -13,13 +13,12 @@ from virttest import libvirt_storage
 from virttest import libvirt_xml
 from virttest import utils_config
 from virttest import utils_libvirtd
+from virttest import libvirt_version
 from virttest.utils_test import libvirt as utlv
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml.vm_xml import VMXML
 from virttest.libvirt_xml.devices.disk import Disk
 from virttest.libvirt_xml.devices import seclabel
-
-from provider import libvirt_version
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk.py
@@ -17,8 +17,7 @@ from virttest.staging import lv_utils
 from virttest import utils_disk
 from virttest import utils_misc
 from virttest import data_dir
-
-from provider import libvirt_version
+from virttest import libvirt_version
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_destroy.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_destroy.py
@@ -7,8 +7,7 @@ from virttest import remote
 from virttest import virsh
 from virttest import utils_libvirtd
 from virttest import ssh_key
-
-from provider import libvirt_version
+from virttest import libvirt_version
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domfsfreeze.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domfsfreeze.py
@@ -2,10 +2,9 @@ import uuid
 import aexpect
 
 from virttest import virsh
+from virttest import libvirt_version
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
-
-from provider import libvirt_version
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domiftune.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domiftune.py
@@ -3,8 +3,8 @@ import re
 
 from virttest import virsh
 from virttest import utils_libvirtd
+from virttest import libvirt_version
 from virttest.libvirt_xml import vm_xml
-from provider import libvirt_version
 from virttest.utils_test import libvirt
 
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domjobinfo.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domjobinfo.py
@@ -7,8 +7,7 @@ import locale
 from virttest import virsh
 from virttest import data_dir
 from virttest import utils_libvirtd
-
-from provider import libvirt_version
+from virttest import libvirt_version
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_to_native.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_to_native.py
@@ -7,8 +7,7 @@ from avocado.utils import process
 from virttest import virsh
 from virttest import libvirt_version
 from virttest import utils_libvirtd
-
-from provider import libvirt_version
+from virttest import libvirt_version
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_dumpxml.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_dumpxml.py
@@ -4,12 +4,11 @@ import platform
 
 from virttest import virsh
 from virttest import cpu
+from virttest import libvirt_version
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import capability_xml
 from virttest.libvirt_xml import domcapability_xml
 from virttest.utils_test import libvirt as utlv
-
-from provider import libvirt_version
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
@@ -9,8 +9,7 @@ import shutil
 from aexpect import ShellTimeoutError
 from aexpect import ShellProcessTerminatedError
 
-from provider import libvirt_version
-
+from virttest import libvirt_version
 from virttest import virsh
 from virttest import data_dir
 from virttest import remote

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_managedsave.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_managedsave.py
@@ -11,12 +11,11 @@ from virttest import utils_libvirtd
 from virttest import utils_config
 from virttest import utils_misc
 from virttest import utils_libguestfs
+from virttest import libvirt_version
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 from virttest.staging.service import Factory
 from virttest.staging.utils_memory import drop_caches
-
-from provider import libvirt_version
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
@@ -20,13 +20,12 @@ from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices import memory
 from virttest import utils_misc
 from virttest import cpu
+from virttest import libvirt_version
 from virttest.qemu_storage import QemuImg
 from virttest.utils_test import libvirt
 from virttest import test_setup
 from virttest.staging import utils_memory
 from virttest.libvirt_xml.xcepts import LibvirtXMLNotFoundError
-
-from provider import libvirt_version
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_sendkey.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_sendkey.py
@@ -4,10 +4,9 @@ import time
 from virttest import virsh
 from virttest import utils_package
 from virttest import utils_test
+from virttest import libvirt_version
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
-
-from provider import libvirt_version
 
 from avocado.utils import wait
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_shutdown.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_shutdown.py
@@ -8,10 +8,9 @@ from virttest import virsh
 from virttest import utils_libvirtd
 from virttest import ssh_key
 from virttest import utils_misc
+from virttest import libvirt_version
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
-
-from provider import libvirt_version
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_start.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_start.py
@@ -5,8 +5,7 @@ from virttest import virsh
 from virttest import libvirt_xml
 from virttest import utils_libvirtd
 from virttest import ssh_key
-
-from provider import libvirt_version
+from virttest import libvirt_version
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_undefine.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_undefine.py
@@ -15,11 +15,10 @@ from virttest import remote
 from virttest import utils_libvirtd
 from virttest import libvirt_storage
 from virttest import ssh_key
+from virttest import libvirt_version
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.xcepts import LibvirtXMLError
 from virttest.utils_test import libvirt as utlv
-
-from provider import libvirt_version
 
 
 def run(test, params, env):


### PR DESCRIPTION
Those changes are part of efforts to maintain only one place libvirt_version across all python files

Signed-off-by: chunfuwen <chwen@redhat.com>