### PR TITLE
Update travis setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,11 @@
 language: python
 python:
     - "2.7"
-    - "3.4"
+    - "3.6"
 
 branches:
     only:
         - master
-
-matrix:
-    allow_failures:
-        - python: "3.4"
 
 sudo: false
 

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,9 +1,7 @@
-coverage==3.6
+coverage==5.1
 nose==1.3.0
 nosexcover==1.0.8
 tox==1.5.0
 virtualenv==1.9.1
 simplejson==3.8.1
-MySQL-python==1.2.5
-inspektor==0.4.5
-autotest==0.16.2
+inspektor==0.5.2


### PR DESCRIPTION
- Update travis requirements, remove outdated ones, and make a few
version upgrades
- Set checking version from python 3.4 to 3.6
- Set ignore python version from 3.4 to None

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>