### PR TITLE
Add test for rng-builtin

### DIFF
--- a/libvirt/tests/cfg/libvirt_rng.cfg
+++ b/libvirt/tests/cfg/libvirt_rng.cfg
@@ -5,7 +5,7 @@
     status_error = no
     variants:
         - hotplug_unplug:
-            only backend_rdm.default, backend_tcp, backend_udp
+            only backend_rdm.default, backend_tcp, backend_udp, backend_builtin
             rng_attach_device = "yes"
             variants:
                 - positive:
@@ -23,6 +23,11 @@
         - device_assign:
             rng_attach_device = "no"
     variants:
+        - backend_builtin:
+            backend_model = "builtin"
+            test_guest = "yes"
+            test_qemu_cmd = "yes"
+            test_guest_dump = "yes"
         - backend_rdm:
             test_host = "yes"
             test_guest = "yes"

--- a/libvirt/tests/src/libvirt_rng.py
+++ b/libvirt/tests/src/libvirt_rng.py
@@ -13,12 +13,11 @@ from avocado.utils import process
 from virttest import virt_vm, virsh
 from virttest import utils_package
 from virttest import utils_misc
+from virttest import libvirt_version
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import xcepts
 from virttest.libvirt_xml.devices import rng
-
-from virttest import libvirt_version
 
 
 def run(test, params, env):
@@ -199,6 +198,7 @@ def run(test, params, env):
         rng_model = dparams.get("rng_model", "virtio")
         rng_rate = dparams.get("rng_rate")
         backend_type = dparams.get("backend_type")
+        backend_model = dparams.get("backend_model")
         backend_source_list = dparams.get("backend_source",
                                           "").split()
         cmd = ("ps -ef | grep %s | grep -v grep" % vm_name)
@@ -213,6 +213,8 @@ def run(test, params, env):
                 src_host = source['host']
                 src_port = source['service']
 
+        if backend_model == "builtin":
+            cmd += (" | grep rng-builtin")
         if chardev and src_host and src_port:
             cmd += (" | grep 'chardev %s,.*host=%s,port=%s'"
                     % (chardev, src_host, src_port))
@@ -307,7 +309,7 @@ def run(test, params, env):
         """
         check_cmd = "hexdump /dev/hwrng"
         try:
-            status = session.cmd_status(check_cmd, 5)
+            status = session.cmd_status(check_cmd, 3)
 
             if status != 0 and exists:
                 test.fail("Fail to check hexdump in guest")


### PR DESCRIPTION
```
# avocado run --vt-type libvirt libvirt_rng.backend_builtin
JOB ID     : 6452c6a8c0722959e6ac1cf115f8e8185bd1df8a
JOB LOG    : /root/avocado/job-results/job-2020-07-21T15.16-6452c6a/job.log
 (1/3) type_specific.io-github-autotest-libvirt.libvirt_rng.backend_builtin.hotplug_unplug.positive.no_options: PASS (62.64 s)
 (2/3) type_specific.io-github-autotest-libvirt.libvirt_rng.backend_builtin.hotplug_unplug.positive.persistent: PASS (65.06 s)
 (3/3) type_specific.io-github-autotest-libvirt.libvirt_rng.backend_builtin.device_assign: PASS (55.66 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 190.54 s
```