### PR TITLE
migration: Add a case for a paused VM postcopy migration

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -408,6 +408,14 @@
                                 actions_during_migration = "suspendvm"
                             with_postcopy:
                                 actions_during_migration = "suspendvm,setmigratepostcopy"
+                        - pause_vm_before_migration:
+                            only with_postcopy
+                            pause_vm_before_migration = "yes"
+                            asynch_migrate = "yes"
+                            stress_in_vm = "yes"
+                            stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M --timeout 70"
+                            actions_during_migration = "setmigratepostcopy"
+                            actions_after_migration = "checkdomstate"
                 - tunnelled_migration:
                     only without_postcopy
                     virsh_migrate_options = "--live --p2p --tunnelled --verbose"


### PR DESCRIPTION
This PR adds a case - Do live postcopy migration for a paused VM.

Signed-off-by: Yingshun Cui <yicui@redhat.com>