### PR TITLE
Fix dumpxml default value for s390x

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_dumpxml.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_dumpxml.cfg
@@ -1,6 +1,8 @@
 - virsh.dumpxml:
     type = virsh_dumpxml
     start_vm = "yes"
+    s390-virtio:
+        cpu_mode=exact
     variants:
         - normal_test:
             status_error = "no"


### PR DESCRIPTION
On s390x cpu match "minimum" is not supported.
Set default "exact" if not subtest "with_cpu" to avoid tests being skipped.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>