### PR TITLE
v2v: Add new case for remote libvirt connection

### DIFF
--- a/v2v/tests/cfg/v2v_options.cfg
+++ b/v2v/tests/cfg/v2v_options.cfg
@@ -30,8 +30,7 @@
                     output_mode = "local"
                     output_storage = "/tmp"
                 - null:
-                    # No test yet
-                    output_mode = "null"
+                    only dest_null
                 - qemu:
                     # No test yet
                     output_mode = "qemu"
@@ -340,6 +339,12 @@
                         - default:
                             expect_msg = yes
                             msg_content = "disk \d+: \d+%total: \d+"
+                - remote_libvirt_conn:
+                    only output_mode.null
+                    only input_mode.libvirt.kvm.default
+                    checkpoint = 'remote_libvirt_conn'
+                    expect_msg = yes
+                    msg_content = "no support for remote libvirt connections"
         - negative_test:
             status_error = "yes"
             variants:


### PR DESCRIPTION
The new case is mainly test the following warning.

virt-v2v: warning: no support for remote libvirt connections to '-ic
qemu+ssh://localhost/system'.  The conversion may fail when it tries to
read the source disks.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>