### PR TITLE
Fix wrong usage of getting cpu arch/family

### DIFF
--- a/libvirt/tests/src/cpu/powerpc_hmi.py
+++ b/libvirt/tests/src/cpu/powerpc_hmi.py
@@ -70,7 +70,9 @@ def run(test, params, env):
     hmi_name = params.get("hmi_name", "")
     hmi_iterations = int(params.get("hmi_iterations", 1))
 
-    if host_version not in cpu.get_cpu_arch():
+    cpu_arch = cpu.get_family() if hasattr(cpu, 'get_family')\
+        else cpu.get_cpu_arch()
+    if host_version not in cpu_arch:
         test.cancel("Unsupported Host cpu version")
 
     vm_name = params.get("main_vm")

--- a/libvirt/tests/src/cpu/ppccpucompat.py
+++ b/libvirt/tests/src/cpu/ppccpucompat.py
@@ -80,7 +80,9 @@ def run(test, params, env):
         guest_features = guest_features.split(',')
         if guest_version:
             guest_features.append(guest_version)
-    if host_version not in cpu_util.get_cpu_arch():
+    cpu_arch = cpu_util.get_family() if hasattr(cpu_util, 'get_family')\
+        else cpu_util.get_cpu_arch()
+    if host_version not in cpu_arch:
         test.cancel("Unsupported Host cpu version")
 
     vmxml = libvirt_xml.VMXML.new_from_inactive_dumpxml(vm_name)

--- a/libvirt/tests/src/libvirt_mem.py
+++ b/libvirt/tests/src/libvirt_mem.py
@@ -441,10 +441,13 @@ def run(test, params, env):
     config = utils_config.LibvirtQemuConfig()
     setup_hugepages_flag = params.get("setup_hugepages")
     if (setup_hugepages_flag == "yes"):
-        cpu_arch = cpu_util.get_cpu_arch()
+        cpu_arch = cpu_util.get_family() if hasattr(cpu_util, 'get_family')\
+            else cpu_util.get_cpu_arch()
         if cpu_arch == 'power8':
+            logging.debug('Set page size to 16M for Power8')
             pg_size = '16384'
         elif cpu_arch == 'power9':
+            logging.debug('Set page size to 2M for Power9')
             pg_size = '2048'
         [x.update({'size': pg_size}) for x in huge_pages]
         setup_hugepages(int(pg_size), shp_num=huge_page_num)

--- a/libvirt/tests/src/papr_hpt.py
+++ b/libvirt/tests/src/papr_hpt.py
@@ -145,7 +145,7 @@ def run(test, params, env):
 
         # Test on ppc64le hosts
         if arch.lower() == 'ppc64le':
-            cpu_arch = cpu.get_cpu_arch()
+            cpu_arch = cpu.get_family() if hasattr(cpu, 'get_family') else cpu.get_cpu_arch()
             logging.debug('cpu_arch is: %s', cpu_arch)
             if skip_p8 and cpu_arch == 'power8':
                 test.cancel('This case is not for POWER8')


### PR DESCRIPTION
The function get_cpu_arch is now deprecated on latest version of
avocado. We need to use get_family if we want to get the info like
'power8'.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>