### PR TITLE
Add 2 more scenarios about offloads

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_options.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_options.cfg
@@ -128,6 +128,16 @@
                 - update_iface:
                     status_error = "yes"
                     update_iface_device = "yes"
+                - disable_udp:
+                    iface_driver_host = "{'gso':'off', 'ufo':'off'}"
+                    iface_driver_guest = "{'ufo':'off'}"
+                    test_option_offloads = "yes"
+                    attach_iface_device = "live"
+                - disable_tcp:
+                    iface_driver_host = "{'gso':'off','tso4':'off','tso6':'off','ecn':'off'}"
+                    iface_driver_guest = "{'tso4':'off','tso6':'off','ecn':'off'}"
+                    test_option_offloads = "yes"
+                    attach_iface_device = "live"
         - iface_type:
             variants:
                 - type_user:

--- a/libvirt/tests/src/virtual_network/iface_options.py
+++ b/libvirt/tests/src/virtual_network/iface_options.py
@@ -180,7 +180,6 @@ def run(test, params, env):
         Check interface offloads by ethtool output
         """
         offloads = {"csum": "tx-checksumming",
-                    "gso": "generic-segmentation-offload",
                     "tso4": "tcp-segmentation-offload",
                     "tso6": "tx-tcp6-segmentation",
                     "ecn": "tx-tcp-ecn-segmentation",


### PR DESCRIPTION
Add 2 more scenarios about disable offloads: disable tcp and disable
udp. And refer to
https://bugzilla.redhat.com/show_bug.cgi?id=1387477#c6, as tso and ufo
depends on gso, to disable tso and ufo, we need to disable gso as well.

Signed-off-by: yalzhang <yalzhang@redhat.com>