### PR TITLE
Fix invalid cpu in iothread

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_iothreadadd.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_iothreadadd.cfg
@@ -5,9 +5,10 @@
     iothread_vm_ref = "name"
     iothread_extra_param = ""
     iothread_options = ""
-    iothreadids = "2 1 4"
+    iothreadids = "2 1"
     # The format of iothreadpins is IOTHEADID:CPUSET
-    iothreadpins = "2:3 1:0-4 3:3-4"
+    iothreadpins = "2:1 1:0-1"
+    iothreads = "2"
     iothread_id = "6"
     variants:
         - normal_test:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_iothreaddel.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_iothreaddel.cfg
@@ -5,9 +5,10 @@
     iothread_vm_ref = "name"
     iothread_extra_param = ""
     iothread_options = ""
-    iothreadids = "2 1 4"
+    iothreadids = "2 1"
     # The format of iothreadpins is IOTHEADID:CPUSET
-    iothreadpins = "2:3 1:0-4 3:3-4"
+    iothreads = "2"
+    iothreadpins = "2:1 1:0-1"
     iothread_id = "2"
     variants:
         - normal_test:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_iothreadinfo.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_iothreadinfo.cfg
@@ -5,9 +5,10 @@
     iothread_vm_ref = "name"
     iothread_extra_param = ""
     iothread_options = ""
-    iothreadids = "2 1 4"
+    iothreadids = "2 1"
     # The format of iothreadpins is IOTHEADID:CPUSET
-    iothreadpins = "2:3 1:0-4 3:3-4"
+    iothreads = "2"
+    iothreadpins = "2:1 1:0-1"
     variants:
         - normal_test:
             status_error = "no"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_iothreadpin.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_iothreadpin.cfg
@@ -5,9 +5,10 @@
     iothread_vm_ref = "name"
     iothread_extra_param = ""
     iothread_options = ""
-    iothreadids = "2 1 4"
+    iothreadids = "2 1"
     # The format of iothreadpins is IOTHEADID:CPUSET
-    iothreadpins = "2:3 1:0-4 3:3-4"
+    iothreads = "2"
+    iothreadpins = "2:1 1:0-1"
     iothread_id = "2"
     variants:
         - normal_test:


### PR DESCRIPTION
The original parameter value in cfg limited the host cpu number  must be not less
than 5. That limitation will cause the tests fail in some test machines. But the
limitation can be decreased to smaller value which will make the tests pass in
most test machines, and at same time, this change will not effect the test points.

Original failure message is like:
 ---  error: Invalid value '0-4' for 'cpuset.cpus': Invalid argument

Signed-off-by: Dan Zheng <dzheng@redhat.com>