### PR TITLE
Fix vtpm default version

### DIFF
--- a/libvirt/tests/cfg/virtual_device/tpm_device.cfg
+++ b/libvirt/tests/cfg/virtual_device/tpm_device.cfg
@@ -21,6 +21,9 @@
                     backend_version = '2.0'
                     variants:
                         - basic:
+                        - version_default:
+                            only plain
+                            backend_version = 'none'
                         - multi_vms:
                             multi_vms = 'yes'
                         - test_suite:
@@ -97,12 +100,12 @@
                         tpm_model = 'tpm-spapr'
                     variants:
                         - backend_version:
-                            xml_errmsg = 'Unsupported interface tpm-crb for TPM 1.2'
                             variants:
-                                - version_default:
-                                    backend_version = 'none'
                                 - version_1.2:
                                     backend_version = '1.2'
+                                    xml_errmsg = 'Unsupported interface tpm-crb for TPM 1.2'
+                                    pseries:
+                                    xml_errmsg = 'TPM 1.2 is not supported with the SPAPR device mode'
                                 - version_2:
                                     backend_version = '2'
                                     xml_errmsg = "Unsupported TPM version '2'"

--- a/libvirt/tests/src/virtual_device/tpm_device.py
+++ b/libvirt/tests/src/virtual_device/tpm_device.py
@@ -201,10 +201,11 @@ def run(test, params, env):
                       "in the guest xml file." % backend_type)
         # Check backend version
         if backend_version:
-            pattern = '"emulator" version="%s"' % backend_version
+            check_ver = backend_version if backend_version != 'none' else '2.0'
+            pattern = '"emulator" version="%s"' % check_ver
             if pattern not in astring.to_text(xml_after_adding_device):
                 test.fail("Can not find the %s backend version xml for tpm dev "
-                          "in the guest xml file." % backend_version)
+                          "in the guest xml file." % check_ver)
         # Check device path
         if backend_type == "passthrough":
             pattern = '<device path="/dev/tpm0"'


### PR DESCRIPTION
1. When no version is provided, the default version 2.0 for crb and spapr will be created now
instead of returning an error.
2. if version is set to 1.2 for spapr, an error will be returned now instead of being accepted
in libvirt, but not supported in qemu-kvm SLOF layer.

Signed-off-by: Dan Zheng <dzheng@redhat.com>