### PR TITLE
Update for libvirt_hooks case

### DIFF
--- a/libvirt/tests/src/libvirt_hooks.py
+++ b/libvirt/tests/src/libvirt_hooks.py
@@ -300,12 +300,16 @@ def run(test, params, env):
         sta, pid = process.getstatusoutput("pgrep qemu-kvm")
         if not pid:
             test.fail("Cannot get pid of qemu command")
-        ret = virsh.qemu_attach(pid, **virsh_dargs)
-        if ret.exit_status:
+        try:
+            ret = virsh.qemu_attach(pid, **virsh_dargs)
+            if ret.exit_status:
+                utils_misc.kill_process_tree(pid)
+                test.fail("Cannot attach qemu process")
+            else:
+                virsh.destroy(vm_test)
+        except Exception as detail:
             utils_misc.kill_process_tree(pid)
-            test.fail("Cannot attach qemu process")
-        else:
-            virsh.destroy(vm_test)
+            test.fail("Failed to attach qemu process: %s" % str(detail))
         hook_str = hook_file + " " + vm_test + " attach begin -"
         if not check_hooks(hook_str):
             test.fail("Failed to check attach hooks")


### PR DESCRIPTION
When failed to attach qemu process, we need to clean 'qemu-kvm'
process to avoid following cases failed.

Signed-off-by: Liping Cheng <lcheng@redhat.com>