### PR TITLE
libvirt_hooks: Wait for a few seconds to get log

### DIFF
--- a/libvirt/tests/src/libvirt_hooks.py
+++ b/libvirt/tests/src/libvirt_hooks.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import logging
 import platform
+import time
 
 from avocado.utils import process
 
@@ -187,6 +188,7 @@ def run(test, params, env):
         """
         prepare_hook_file(hook_script % (vm_name, hook_log))
         hook_para = "%s %s" % (hook_file, vm_name)
+        time.sleep(2)
         libvirtd.restart()
         try:
             hook_str = hook_para + " reconnect begin -"


### PR DESCRIPTION
To avoid following error:
    "Log file doesn't exist"

Signed-off-by: Liping Cheng <lcheng@redhat.com>