### PR TITLE
Fix incorrect format

### DIFF
--- a/libvirt/tests/cfg/virtual_device/tpm_device.cfg
+++ b/libvirt/tests/cfg/virtual_device/tpm_device.cfg
@@ -105,7 +105,7 @@
                                     backend_version = '1.2'
                                     xml_errmsg = 'Unsupported interface tpm-crb for TPM 1.2'
                                     pseries:
-                                    xml_errmsg = 'TPM 1.2 is not supported with the SPAPR device mode'
+                                        xml_errmsg = 'TPM 1.2 is not supported with the SPAPR device mode'
                                 - version_2:
                                     backend_version = '2'
                                     xml_errmsg = "Unsupported TPM version '2'"


### PR DESCRIPTION
Incorrect format introduced by tp-libvirt 2977.
The incorrect format will make the xml_errmsg be 'TPM 1.2 is not supported with the SPAPR device mode' even on x86_64.

Signed-off-by: Dan Zheng <dzheng@redhat.com>