### PR TITLE
v2v: delete 'ipconfig /renew' operation for windows checking

### DIFF
--- a/provider/v2v_vmcheck_helper.py
+++ b/provider/v2v_vmcheck_helper.py
@@ -661,12 +661,6 @@ class VMChecker(object):
         if self.compare_version(V2V_7_3_VERSION):
             self.check_vm_xml()
 
-        # Renew network
-        logging.info("Renew network for windows guest")
-        if not self.checker.get_network_restart():
-            err_msg = "Renew network failed"
-            self.log_err(err_msg)
-
     def check_graphics(self, param):
         """
         Check if graphics attributes value in vm xml match with given param.


### PR DESCRIPTION
The 'ipconfig /renew' might change the IP address of the VM and
cause shell session disconnect.

The error is like below.
aexpect.exceptions.ShellProcessTerminatedError: Shell process terminated
while waiting for command to complete: 'ipconfig /renew'    (status: 1,
output: '\nWindows IP Configuration\n\nNcat: Connection reset by peer.\n')

Because not every ip renew will change the IP address, the problem may
happens occasionally. IMHO, this checkpoint is not necessary. The VM
has IP address and can be connected have already proved the network driver
is working well.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>