### PR TITLE
Delete the created binding after test

### DIFF
--- a/libvirt/tests/src/nwfilter/nwfilter_binding_create.py
+++ b/libvirt/tests/src/nwfilter/nwfilter_binding_create.py
@@ -48,7 +48,7 @@ def run(test, params, env):
         new_iface.source = {'network': "default", 'bridge': "virbr0"}
         alias_dict = {'name': "net0"}
         new_iface.alias = alias_dict
-        target_dict = {'dev': "vnet0"}
+        target_dict = {'dev': "tar"}
         new_iface.target = target_dict
         logging.debug("new interface xml is : %s" % new_iface)
         vmxml.add_device(new_iface)
@@ -60,7 +60,7 @@ def run(test, params, env):
         binding = nwfilter_binding.NwfilterBinding()
         binding.owner = binding.new_owner(vm_name, vmxml.uuid)
         binding.mac_address = new_iface.mac_address
-        portdev = "vnet0"
+        portdev = "tar"
         binding.portdev = portdev
         param_dict['name'] = "MAC"
         param_dict['value'] = new_iface.mac_address
@@ -97,10 +97,15 @@ def run(test, params, env):
         ret = virsh.nwfilter_binding_list(debug=True)
         utlv.check_exit_status(ret, status_error)
 
-        ret = virsh.nwfilter_binding_dumpxml("vnet0", debug=True)
+        ret = virsh.nwfilter_binding_dumpxml("tar", debug=True)
         utlv.check_exit_status(ret, status_error)
 
     finally:
         if vm.is_alive():
             vm.destroy(gracefully=False)
         vmxml_backup.sync()
+        # delete the created binding
+        ret = virsh.nwfilter_binding_list(debug=True)
+        if "tar" in ret.stdout_text:
+            re = virsh.nwfilter_binding_delete("tar", debug=True)
+            utlv.check_exit_status(re, status_error)


### PR DESCRIPTION
The nwfilter binding should be deleted after the test to avoid the issue
in flowing test.

Signed-off-by: yalzhang <yalzhang@redhat.com>