### PR TITLE
Fix console device nodes for s390x

### DIFF
--- a/libvirt/tests/cfg/serial/serial_functional.cfg
+++ b/libvirt/tests/cfg/serial/serial_functional.cfg
@@ -8,10 +8,13 @@
             serial_dev_type = dev
             serial_sources = path:/dev/ttyS0
             target_type = isa-serial
+            s390-virtio:
+                serial_sources = path:/dev/ttysclp0
+                target_type = sclp-serial
         - type_dev_sclplm:
             only s390-virtio
             serial_dev_type = dev
-            serial_sources = path:/dev/ttyS0
+            serial_sources = path:/dev/sclp_line0
             target_type = sclp-serial
             target_model = sclplmconsole
         - type_file:


### PR DESCRIPTION
Device nodes for passthrough updated according to https://www.ibm.com/support/knowledgecenter/en/linuxonibm/com.ibm.linux.z.lgdd/lgdd_r_console_assure_nodes.html
Tests passed previously a) because they were run on z/VM (ttyS0 available) and b) tests don't check console type/driver.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>