### PR TITLE
Fix dumpxml default value for s390x

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_dumpxml.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_dumpxml.cfg
@@ -2,7 +2,7 @@
     type = virsh_dumpxml
     start_vm = "yes"
     s390-virtio:
-        cpu_mode=exact
+        cpu_match = exact
     variants:
         - normal_test:
             status_error = "no"


### PR DESCRIPTION
Set correct variable to fix 235fc4a0b1afd3ca238fc15f9e136318b82fae2d.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>