### PR TITLE
Retry scsi_debug unload on tear down

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
@@ -2004,7 +2004,8 @@ def run(test, params, env):
                 del img["disk_dev"]
             else:
                 if img["format"] == "scsi":
-                    libvirt.delete_scsi_disk()
+                    utils_misc.wait_for(libvirt.delete_scsi_disk,
+                                        120, ignore_errors=True)
                 elif img["format"] == "iscsi" or network_iscsi_baseimg:
                     libvirt.setup_or_cleanup_iscsi(is_setup=False)
                     # Clean up secret


### PR DESCRIPTION
scsi_debug module might still be in use when trying to unload for
the first time in test tear down.
Wait for it like shown in commit 6f2bbce4374c9e6c8b7cb7e3afe5af930a0ed943

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>