### PR TITLE
Define parameters in clean-traffic nwfilter

### DIFF
--- a/libvirt/tests/cfg/nwfilter/nwfilter_vm_start.cfg
+++ b/libvirt/tests/cfg/nwfilter/nwfilter_vm_start.cfg
@@ -9,7 +9,6 @@
             filter_name = "testcase"
             variants:
                 - new_filter:
-                    filter_uuid = "11111111-b071-6127-b4ec-111111111111"
                     variants:
                         - variable_notation:
                             filter_chain = "root"
@@ -58,7 +57,6 @@
                             rule = "rule_action=accept rule_direction=inout rule_priority=-501 EOL"
                             check_cmd = "ebtables -t nat -L I-DEVNAME-${filter_chain}"
                             expect_match = "-j ACCEPT"
-                            bug_url = "https://bugzilla.redhat.com/show_bug.cgi?id=1072292"
                         - dhcpserver_variable:
                             filter_name = "disallow-dhcp-server"
                             filter_chain = "ipv4"
@@ -98,7 +96,7 @@
                             filterref_name_5 = "qemu-announce-self"
                             rule = "rule_action=accept rule_direction=out rule_priority=-650 protocol=mac protocolid=ipv4 EOL rule_action=accept rule_direction=inout rule_priority=-500 protocol=mac protocolid=arp"
                             check_cmd = "ebtables -t nat -L I-DEVNAME-ipv4-ip"
-                            expect_match = "-p IPv4 --ip-src 192.168\.\d{1,3}\.\d{1,3} -j RETURN"
+                            expect_match = "-p IPv4 --ip-src 192.168\S+ -j RETURN"
                         - allow_ipv6:
                             filter_name = "allow-ipv6"
                             filter_chain = "ipv6"
@@ -135,7 +133,7 @@
                         - no_mac_broadcast:
                             filter_name = "no-mac-broadcast"
                             exist_filter = "${filter_name}"
-                            filterref_name_0 = "${filter_name}"
+                            filterref_name = "${filter_name}"
                             check_cmd = "ebtables -t nat -L I-DEVNAME-ipv4"
                             expect_match = "-d Broadcast -j DROP"
                         - no_ip_spoofing:
@@ -183,6 +181,24 @@
                             parameter_value_1 = "MAC_of_virbr0"
                             dst_outside = "www.google.com"
                             ping_timeout = "5"
+                        - clean_traffic_with_params:
+                            filter_name = "clean-traffic"
+                            exist_filter = "${filter_name}"
+                            check_cmd = "ebtables -t nat -L I-DEVNAME-mac, ebtables -t nat -L I-DEVNAME-mac, ebtables -t nat -L I-DEVNAME-ipv4-ip, ebtables -t nat -L I-DEVNAME-ipv4-ip, ebtables -t nat -L I-DEVNAME-arp-mac, ebtables -t nat -L I-DEVNAME-arp-mac, ebtables -t nat -L I-DEVNAME-arp-ip, ebtables -t nat -L I-DEVNAME-arp-ip"
+                            expect_match = "-s 52:54:00:7b:35:94 -j RETURN, -s 52:54:00:7b:35:96 -j RETURN, -p IPv4 --ip-src 104.207.129.11 -j RETURN, -p IPv4 --ip-src 104.207.129.12 -j RETURN, -p ARP --arp-mac-src 52:54:00:7b:35:94 -j RETURN, -p ARP --arp-mac-src 52:54:00:7b:35:96 -j RETURN, -p ARP --arp-ip-src 104.207.129.11 -j RETURN, -p ARP --arp-ip-src 104.207.129.12 -j RETURN"
+                            parameter_name_0 = 'IP'
+                            parameter_value_0 = '104.207.129.11'
+                            parameter_name_1 = 'IP'
+                            parameter_value_1 = '104.207.129.12'
+                            parameter_name_2 = 'MAC'
+                            parameter_value_2 = '52:54:00:7b:35:94'
+                            parameter_name_3 = 'MAC'
+                            parameter_value_3 = '52:54:00:7b:35:96'
+                        - clean_traffic_without_params:
+                            filter_name = "clean-traffic"
+                            exist_filter = "${filter_name}"
+                            check_cmd = "ebtables -t nat -L I-DEVNAME-mac, ebtables -t nat -L I-DEVNAME-arp-mac"
+                            expect_match = "-s VMMAC -j RETURN, -p ARP --arp-mac-src VMMAC -j RETURN"
         - negative_test:
             status_error = "yes"
             variants:


### PR DESCRIPTION
Check the parameters defined in clean-traffic should take precedence. If
no parameters is defined, the mac and ip of the own interface will then
be used in the rules.

Signed-off-by: yalzhang <yalzhang@redhat.com>