### PR TITLE
Add a migration case about xbzrle comp method and parallel

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -330,19 +330,19 @@
                             asynch_migrate = "yes"
                         - multifd:
                             virsh_migrate_extra = "--parallel"
+                            stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M --timeout 70"
+                            stress_in_vm = "yes"
+                            asynch_migrate = "yes"
+                            actions_during_migration = "checkestablished"
                             variants:
                                 - customized_connection:
                                     virsh_migrate_extra = "--parallel --parallel-connections"
                                     parallel_cn_nums = 4
-                                    stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M --timeout 70"
-                                    stress_in_vm = "yes"
-                                    asynch_migrate = "yes"
-                                    actions_during_migration = "checkestablished"
                                 - default_connection:
-                                    stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M --timeout 70"
-                                    stress_in_vm = "yes"
-                                    asynch_migrate = "yes"
-                                    actions_during_migration = "checkestablished"
+                                - with_xbzrle_method:
+                                    only without_postcopy
+                                    virsh_migrate_extra = "--comp-methods xbzrle --parallel --parallel-connections"
+                                    parallel_cn_nums = 4
                         - check_domstats:
                             asynch_migrate = "yes"
                             virsh_opt = ' -k0'


### PR DESCRIPTION
This PR adds a case - Do live migration with mixed options
--p2p --comp-methods xbzrle --parallel --parallel-connections

Signed-off-by: Yingshun Cui <yicui@redhat.com>