### PR TITLE
Check migration result after do_migration

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_option_mix.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_option_mix.cfg
@@ -1,6 +1,6 @@
-- virsh.migrate_vm_cfg:
+- virsh.migrate_option_mix:
     # Migrate persistent/transient/active/inactive vm with --persistent
-    type = virsh_migrate_vm_cfg
+    type = virsh_migrate_option_mix
     # Transport protocol to connect to remote hypervisor: SSH, TCP, TLS, etc
     transport = 'tls'
     # The port used to connect to remote hypervisor. Default values:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_option_mix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_option_mix.py
@@ -321,10 +321,12 @@ def run(test, params, env):
             obj_migration.do_migration(vms, src_uri, dest_uri, "orderly",
                                        options="",
                                        thread_timeout=postcopy_timeout,
-                                       ignore_status=False,
+                                       ignore_status=True,
                                        func=virsh.migrate_postcopy,
                                        extra_opts=extra_options,
                                        shell=True)
+            # Check migration result
+            obj_migration.check_result(obj_migration.ret, params)
 
             # Check "postcopy-active" event after postcopy migration
             logging.debug("Check postcopy-active event after postcopy migration")
@@ -341,8 +343,10 @@ def run(test, params, env):
             logging.debug("Start to do precopy migration")
             obj_migration.do_migration(vms, src_uri, dest_uri, "orderly",
                                        options="",
-                                       ignore_status=False,
+                                       ignore_status=True,
                                        extra_opts=extra_options)
+            # Check migration result
+            obj_migration.check_result(obj_migration.ret, params)
 
         """
         # Check src vm after migration


### PR DESCRIPTION
So the virsh command error message can be throwed out which is
convenient for debugging
Also changed the cfg and py file name to avoid confusion.

Signed-off-by: Fangge Jin <fjin@redhat.com>