### PR TITLE
migrate_vm: Update conf config to include split daemon

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_vm.cfg
+++ b/libvirt/tests/cfg/migration/migrate_vm.cfg
@@ -138,7 +138,7 @@
                                             run_migrate_cmd_in_back = "yes"
                                             check_job_info = "yes"
                                             config_libvirtd = "yes"
-                                            grep_str_from_local_libvirt_log = "migrate_set_downtime.*${max_down_time}|downtime-limit.:100"
+                                            grep_str_from_local_libvirt_log = "migrate_set_downtime"
                                             virsh_options = "--live --verbose"
                                         - memhog_memory_without_swap:
                                             no_swap = "yes"


### PR DESCRIPTION
Also updated "grep_str_from_local_libvirt_log" to adapt the
change about migrate-set-downtime in libvirt-6.5.0.

Signed-off-by: Fangge Jin <fjin@redhat.com>