### PR TITLE
Update expected log output for virsh_migrate_setmaxdowntime

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_setmaxdowntime.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_setmaxdowntime.cfg
@@ -9,7 +9,7 @@
     virsh_migrate_src_uri = "qemu:///system"
     take_regular_screendumps = "no"
     delay_time = 1
-    grep_str_from_local_libvirt_log = "migrate_set_downtime.*${migrate_maxdowntime}"
+    grep_str_from_local_libvirt_log = "migrate_set_downtime.*${migrate_maxdowntime}|downtime-limit.:1000"
     # Disk cache mode must be "none" or "directsync" for a safe
     # migration without copy storage 
     driver_cache = "none"


### PR DESCRIPTION
The expected output was changed from migrate_set_downtime to
downtime-limit in latest libvirt version.

Signed-off-by: Yingshun Cui <yicui@redhat.com>