### PR TITLE
libvirt_vm:set different page number to power8 and power9

### DIFF
--- a/libvirt/tests/src/libvirt_mem.py
+++ b/libvirt/tests/src/libvirt_mem.py
@@ -444,8 +444,10 @@ def run(test, params, env):
         cpu_arch = cpu_util.get_cpu_arch()
         if cpu_arch == 'power8':
             pg_size = '16384'
+            huge_page_num = 200
         elif cpu_arch == 'power9':
             pg_size = '2048'
+            huge_page_num = 2000
         [x.update({'size': pg_size}) for x in huge_pages]
         setup_hugepages(int(pg_size), shp_num=huge_page_num)
 
@@ -474,6 +476,8 @@ def run(test, params, env):
         if vm.is_alive():
             vm.destroy(gracefully=False)
         modify_domain_xml()
+        numa_info = utils_misc.NumaInfo()
+        logging.debug(numa_info.get_all_node_meminfo())
 
         # Start the domain any way if attach memory device
         old_mem_total = None


### PR DESCRIPTION
- Power8 and power9 have different pagesize, page numbers need
to be different when power8 machines have small total memory
power9 machines don't have this kind of problems.
- Print numa info before starting vm

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>