### PR TITLE
Fix missing libvirtd log issue when enable modular libvirt daemon

### DIFF
--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_create_as.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_create_as.py
@@ -13,6 +13,7 @@ from virttest import xml_utils
 from virttest import utils_config
 from virttest import utils_libvirtd
 from virttest import gluster
+from virttest import utils_split_daemons
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import xcepts
@@ -454,8 +455,11 @@ def run(test, params, env):
             process.run("chmod 500 %s" % disk_path, shell=True)
 
     qemu_conf = None
-    libvirtd_conf = None
+    libvirtd_conf_dict = {}
     libvirtd_log_path = None
+    conf_type = "libvirtd"
+    if utils_split_daemons.is_modular_daemon():
+        conf_type = "virtqemud"
     libvirtd = utils_libvirtd.Libvirtd()
     try:
         # Config "snapshot_image_format" option in qemu.conf
@@ -466,11 +470,12 @@ def run(test, params, env):
             libvirtd.restart()
 
         if check_json_no_savevm:
-            libvirtd_conf = utils_config.LibvirtdConfig()
-            libvirtd_conf["log_level"] = '1'
-            libvirtd_conf["log_filters"] = '"1:json 3:remote 4:event"'
+            libvirtd_conf_dict["log_level"] = '1'
+            libvirtd_conf_dict["log_filters"] = '"1:json 3:remote 4:event"'
             libvirtd_log_path = os.path.join(data_dir.get_tmp_dir(), "libvirtd.log")
-            libvirtd_conf["log_outputs"] = '"1:file:%s"' % libvirtd_log_path
+            libvirtd_conf_dict["log_outputs"] = '"1:file:%s"' % libvirtd_log_path
+            libvirtd_conf = libvirt.customize_libvirt_config(libvirtd_conf_dict,
+                                                             conf_type,)
             logging.debug("the libvirtd config file content is:\n %s" %
                           libvirtd_conf)
             libvirtd.restart()


### PR DESCRIPTION
When modular daemon enabled, we need to config virtqemud instead of
libvirtd.

Signed-off-by: Yi Sun <yisun@redhat.com>