### PR TITLE
Fixup a migration case that kills by signal.SIGINT

### DIFF
--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -2255,7 +2255,7 @@ def run(test, params, env):
             if ctrl_c:
                 if p.pid:
                     logging.info("Send SIGINT signal to cancel migration.")
-                    if utils_misc.safe_kill(p.pid, signal.SIGINT):
+                    if utils_misc.safe_kill(p.pid, signal.SIGKILL):
                         logging.info("Succeed to cancel migration:"
                                      " [%s].", p.pid)
                         time.sleep(delay)


### PR DESCRIPTION
The signal SIGINT can not stop migration process correctly, so
modify it to SIGKILL.

Signed-off-by: Yingshun Cui <yicui@redhat.com>