### PR TITLE
Fix a problem to check network connectivity correctly after migaration

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
@@ -1093,10 +1093,7 @@ def run(test, params, env):
             except Exception as info:
                 test.fail(info)
             if obj_migration.RET_MIGRATION:
-                utils_test.check_dest_vm_network(vm, vm.get_address(),
-                                                 server_ip, server_user,
-                                                 server_pwd,
-                                                 shell_prompt=r"[\#\$]\s*$")
+                remote.VMManager(params).check_network(vm_ip)
                 ret_migrate = True
             else:
                 ret_migrate = False


### PR DESCRIPTION
It fails to get VM's IP address via get_address() without 'remote
session' after migration, and the IP address of VM will not change
during the migration process, so updte to use the value that obtained
in the previous step directly.

Signed-off-by: Yingshun Cui <yicui@redhat.com>