### PR TITLE
Fix pool autostart test step

### DIFF
--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool.py
@@ -292,6 +292,7 @@ def run(test, params, env):
 
             # Step (11)
             # Restart libvirtd and check the autostart pool
+            utils_libvirtd.unmark_storage_autostarted()
             utils_libvirtd.libvirtd_restart()
             option = "--autostart --persistent"
             check_pool_list(pool_name, option)

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool_autostart.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool_autostart.py
@@ -191,8 +191,7 @@ def run(test, params, env):
             # Restart libvirtd and check pool status
             logging.info("Try to restart libvirtd")
             # Remove the autostart management file
-            cmd = ("rm -rf /var/run/libvirt/storage/autostarted")
-            process.run(cmd, ignore_status=True, shell=True)
+            utils_libvirtd.unmark_storage_autostarted()
             libvirtd = utils_libvirtd.Libvirtd()
             libvirtd.restart()
             check_pool(pool_name, pool_type, checkpoint="State",


### PR DESCRIPTION
Depends on https://github.com/avocado-framework/avocado-vt/pull/2729
Is related to https://github.com/autotest/tp-libvirt/pull/2513

Objects are started only once since 5.9.

virsh_pool.py
Add test step to make sure daemon will start pool simulating
system boot behavior in order to avoid test failure
'FAIL: Expect pool 'virsh_pool_test' doesn't exist.'

virsh_pool_autostart.py
Use library function.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>