### PR TITLE
migrate_vm: Add test matrix for normal live_migration with ssh/tcp/tls

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_vm.cfg
+++ b/libvirt/tests/cfg/migration/migrate_vm.cfg
@@ -41,6 +41,21 @@
             variants:
                 - live_migration:
                     variants:
+                        - basic:
+                            virsh_options = "--live --verbose"
+                            variants:
+                                - with_ssh:
+                                    uri_port = ":22"
+                                    transport = "ssh"
+                                - with_tcp:
+                                    transport = "tcp"
+                                    uri_port = ":16509"
+                                - with_tls:
+                                    transport = "tls"
+                                    uri_port = ":16514"
+                                    # please change these with your hostname
+                                    server_cn = "ENTER.YOUR.SERVER_CN"
+                                    client_cn = "ENTER.YOUR.CLIENT_CN"
                         - pause_vm:
                             pause_vm = "yes"
                         - reboot_vm:


### PR DESCRIPTION
The auto script for p2p/tunnelled migration with ssh/tcp/tls is already
there, and can be re-used for normal live migration with ssh/tcp/tls.

Signed-off-by: Fangge Jin <fjin@redhat.com>