### PR TITLE
Fix variable missing issue in snapshot_create_as

### DIFF
--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_create_as.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_create_as.py
@@ -455,6 +455,7 @@ def run(test, params, env):
             process.run("chmod 500 %s" % disk_path, shell=True)
 
     qemu_conf = None
+    libvirtd_conf = None
     libvirtd_conf_dict = {}
     libvirtd_log_path = None
     conf_type = "libvirtd"


### PR DESCRIPTION
This is a regression issue of tp-libvirt PR3012.
The 'libvirtd_conf' used in 'finally' part, but it's not defined
in some scenarios, so put this line back to file.

Signed-off-by: Yi Sun <yisun@redhat.com>