### PR TITLE
Fix dmesg errors at teardown

### DIFF
--- a/libvirt/tests/src/virsh_cmd/volume/virsh_volume_application.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_volume_application.py
@@ -96,6 +96,7 @@ def run(test, params, env):
             if output != test_message:
                 test.fail("%s cannot be used normally!"
                           % vm_attach_device)
+            session.cmd("umount /mnt")
         elif application == "install":
             # Get a nonexist domain name anyway
             while virsh.domain_exists(vm_name):


### PR DESCRIPTION
'attach' tests will detach the volume. If this happens while the
 fs is still working in the background there will be errors, e.g.

[Thu Aug 27 00:04:20 2020] EXT4-fs error (device vdb1): ext4_journal_check_start:61: Detected aborted journal
[Thu Aug 27 00:04:20 2020] EXT4-fs (vdb1): Remounting filesystem read-only

Avoid these errors by properly unmounting the partition before
detaching the volume.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>