### PR TITLE
Add a setvcpu case

### DIFF
--- a/libvirt/tests/cfg/cpu/setvcpu.cfg
+++ b/libvirt/tests/cfg/cpu/setvcpu.cfg
@@ -82,6 +82,20 @@
                                 err_msg = "error: invalid argument: vcpu '0' is already in requested state"
                             disable:
                                 err_msg = "error: Operation not supported: vcpu '0' can't be unplugged"
+                - hotplug_config:
+                    check = "hotplug_config"
+                    enable:
+                        setvcpu_action = "--enable --config"
+                    disable:
+                        setvcpu_action = "--disable --config"
+                    variants:
+                        - online_vcpu:
+                            modify_non_hotpluggable_online = "yes"
+                            vcpu_current = "7"
+                            vcpus_enabled = "{0,1,2,3,4,5,6}"
+                            vcpus_hotpluggable = "{7}"
+                            setvcpu_option = "'1'"
+                            err_msg = "vcpu '1' can't be modified as it is followed by non-hotpluggable online vcpus"
                 - coldplug:
                     check = "coldplug"
                     variants:

--- a/libvirt/tests/src/cpu/setvcpu.py
+++ b/libvirt/tests/src/cpu/setvcpu.py
@@ -3,6 +3,7 @@ import collections
 
 from virttest import virsh
 from virttest import cpu
+from virttest import libvirt_version
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 
@@ -33,12 +34,18 @@ def run(test, params, env):
     setvcpu_option = eval(params.get("setvcpu_option", "{}"))
     setvcpu_action = params.get("setvcpu_action", "")
     start_timeout = int(params.get("start_timeout", "60"))
+    modify_non_hp_ol_vcpus = params.get("modify_non_hotpluggable_online", "no")
     check = params.get("check", "")
     err_msg = params.get("err_msg", "")
     status_error = "yes" == params.get("status_error", "no")
 
     vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
     vmxml_backup = vmxml.copy()
+
+    if (modify_non_hp_ol_vcpus == "yes" and
+       not libvirt_version.version_compare(6, 2, 0)):
+        test.cancel("This Libvirt version doesn't initialize 'firstcpu' "
+                    "variable properly.")
 
     def check_vcpu_status(cpulist, cpu_option, vcpus_online_pre=1):
         """


### PR DESCRIPTION
This PR adds a case - Disable/Enable vCPU which is followed by
non-hotpluggable online vcpus with "virsh setvcpu --config" cmd.

Signed-off-by: Yingshun Cui <yicui@redhat.com>