### PR TITLE
Fix virsh_attach_device on s390x

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_device.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_device.cfg
@@ -289,6 +289,7 @@
         - multiple:
             variants:
                 - VirtualDiskBasic_SerialFile_SerialPipe:
+                    no s390-virtio
                     # Hot attach serial not supported (ISA bus limitation)
                     no normal_test.hot_attach_hot_vm
                     no normal_test.hot_attach_hot_vm_current
@@ -296,6 +297,19 @@
                     vadu_dev_obj_count_VirtualDiskBasic = 3
                     vadu_dev_obj_count_SerialFile = 2
                     vadu_dev_obj_count_SerialPipe = 1
+                    vadu_dev_obj_meg_VirtualDiskBasic = 100
+                    vadu_dev_obj_devidx_VirtualDiskBasic = 1
+                    vadu_dev_obj_targetbus_VirtualDiskBasic = "virtio"
+                - VirtualDiskBasic_ConsoleFile_ConsolePipe:
+                    only s390-virtio
+                    no normal_test.hot_attach_hot_vm
+                    no normal_test.hot_attach_hot_vm_current
+                    vadu_dev_objs = "VirtualDiskBasic ConsoleFile ConsolePipe"
+                    vadu_dev_obj_count_VirtualDiskBasic = 3
+                    vadu_dev_obj_count_ConsoleFile = 2
+                    vadu_dev_obj_count_ConsolePipe = 1
+                    vadu_dev_obj_targettype_ConsoleFile = "virtio"
+                    vadu_dev_obj_targettype_ConsolePipe = "virtio"
                     vadu_dev_obj_meg_VirtualDiskBasic = 100
                     vadu_dev_obj_devidx_VirtualDiskBasic = 1
                     vadu_dev_obj_targetbus_VirtualDiskBasic = "virtio"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
@@ -483,6 +483,39 @@ class Console(AttachDeviceBase):
         return not self.test_params.status_error
 
 
+def _init_device_Serial2Console(self, index):
+    """
+    Helper function to merge init_device from two parent
+    classes SerialFile/Pipe and Console.
+
+    :param self: instance of ConsoleFile/Pipe
+    :param index: device index
+    """
+
+    self.type = self.type_name
+    console_device = Console.init_device(self, index)
+    filepath = self.make_filepath(index)
+    self.make_source(filepath)
+    console_device.add_source(path=filepath)
+    return console_device
+
+
+class ConsoleFile(Console, SerialFile):
+    """
+    Simplistic pipe-backed console
+    """
+    def init_device(self, index):
+        return _init_device_Serial2Console(self, index)
+
+
+class ConsolePipe(Console, SerialPipe):
+    """
+    Simplistic file-backed console
+    """
+    def init_device(self, index):
+        return _init_device_Serial2Console(self, index)
+
+
 class Channel(AttachDeviceBase):
 
     """
@@ -955,6 +988,7 @@ def run(test, params, env):
             test_params.main_vm.destroy(gracefully=True,
                                         free_mac_addresses=False)
         try:
+            logging.debug("vmxml %s", VMXML.new_from_inactive_dumpxml(vm_name))
             test_params.main_vm.start()
         except virt_vm.VMStartError as details:
             test.fail('VM Failed to start for some reason!: %s' % details)


### PR DESCRIPTION
On s390x, maximally two serial consoles can be present and they must
be different (covered by virsh.attach_device..serial_s390x).
Therefore, virsh.attach_device..VirtualDiskBasic_SerialFile_SerialPipe
fails with 'Multiple VT220 operator consoles are not supported'.

On this arch, attach the consoles with <console> and target type 'virtio'
instead while using the same type (file, pipe).

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>