### PR TITLE
Fix remote_mode issue that is not supported for SSH

### DIFF
--- a/libvirt/tests/src/migration/migrate_options_shared.py
+++ b/libvirt/tests/src/migration/migrate_options_shared.py
@@ -34,6 +34,7 @@ from virttest.utils_iptables import Iptables
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 from virttest.utils_conn import TLSConnection
+from virttest.utils_libvirt import libvirt_config
 from virttest.libvirt_xml.devices.controller import Controller
 
 
@@ -934,6 +935,9 @@ def run(test, params, env):
     cmd_run_in_remote_host_1 = params.get("cmd_run_in_remote_host_1", None)
     cmd_run_in_remote_host_2 = params.get("cmd_run_in_remote_host_2", None)
     cmd_in_vm_after_migration = params.get("cmd_in_vm_after_migration")
+    remote_dargs = {'server_ip': server_ip, 'server_user': server_user,
+                    'server_pwd': server_pwd,
+                    'file_path': "/etc/libvirt/libvirt.conf"}
 
     # For qemu command line checking
     qemu_check = params.get("qemu_check", None)
@@ -977,6 +981,9 @@ def run(test, params, env):
     expConnNum = 0
     tpm_sec_uuid = None
     dest_tmp_sec_uuid = None
+    remove_dict = {}
+    remote_libvirt_file = None
+    src_libvirt_file = None
 
     # Local variables
     vm_name = params.get("migrate_main_vm")
@@ -1249,6 +1256,10 @@ def run(test, params, env):
         if pause_vm_before_mig:
             suspend_vm(vm)
 
+        remove_dict = {"do_search": '{"%s": "ssh:/"}' % dest_uri}
+        src_libvirt_file = libvirt_config.remove_key_for_modular_daemon(
+            remove_dict)
+
         # Execute migration process
         if not asynch_migration:
             mig_result = do_migration(vm, dest_uri, options, extra)
@@ -1458,8 +1469,12 @@ def run(test, params, env):
             src_full_uri = libvirt_vm.complete_uri(
                         params.get("migrate_source_host"))
             migration_test.migrate_pre_setup(src_full_uri, params)
+            remove_dict = {"do_search": ('{"%s": "ssh:/"}' % src_full_uri)}
+            remote_libvirt_file = libvirt_config\
+                .remove_key_for_modular_daemon(remove_dict, remote_dargs)
+
             cmd = "virsh migrate %s %s %s" % (vm_name,
-                                              virsh_opt, src_full_uri)
+                                              options, src_full_uri)
             logging.debug("Start migration: %s", cmd)
             cmd_result = remote.run_remote_cmd(cmd, params, runner_on_target)
             logging.info(cmd_result)
@@ -1559,6 +1574,10 @@ def run(test, params, env):
                                                      extra_params=params,
                                                      is_recover=True,
                                                      config_object=update_conf)
+            if src_libvirt_file:
+                src_libvirt_file.restore()
+            if remote_libvirt_file:
+                del remote_libvirt_file
 
             logging.info("Remove local NFS image")
             source_file = params.get("source_file")

--- a/libvirt/tests/src/migration/sriov_migrate.py
+++ b/libvirt/tests/src/migration/sriov_migrate.py
@@ -20,6 +20,7 @@ from virttest import libvirt_version
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices import interface
 from virttest.utils_test import libvirt
+from virttest.utils_libvirt import libvirt_config
 
 
 def run(test, params, env):
@@ -247,6 +248,10 @@ def run(test, params, env):
     remote_virsh_dargs = {'remote_ip': server_ip, 'remote_user': server_user,
                           'remote_pwd': server_pwd, 'unprivileged_user': None,
                           'ssh_remote_auth': True}
+    remote_dargs = {'server_ip': server_ip, 'server_user': server_user,
+                    'server_pwd': server_pwd,
+                    'file_path': "/etc/libvirt/libvirt.conf"}
+
     destparams_dict = copy.deepcopy(params)
 
     remote_virsh_session = None
@@ -259,6 +264,9 @@ def run(test, params, env):
     default_dest_vf = 0
     default_src_rp_filter = 1
     default_dest_rp_filer = 1
+    remove_dict = {}
+    remote_libvirt_file = None
+    src_libvirt_file = None
 
     if not libvirt_version.version_compare(6, 0, 0):
         test.cancel("This libvirt version doesn't support migration with "
@@ -384,6 +392,10 @@ def run(test, params, env):
         if cancel_migration:
             func_name = migration_test.do_cancel
 
+        remove_dict = {"do_search": '{"%s": "ssh:/"}' % dest_uri}
+        src_libvirt_file = libvirt_config.remove_key_for_modular_daemon(
+            remove_dict)
+
         # Execute migration process
         vms = [vm]
 
@@ -444,9 +456,12 @@ def run(test, params, env):
 
                 # Pre migration setup for local machine
                 migration_test.migrate_pre_setup(src_uri, params)
+                remove_dict = {"do_search": ('{"%s": "ssh:/"}' % src_uri)}
+                remote_libvirt_file = libvirt_config\
+                    .remove_key_for_modular_daemon(remove_dict, remote_dargs)
 
                 cmd = "virsh migrate %s %s %s" % (vm_name,
-                                                  virsh_options, src_uri)
+                                                  options, src_uri)
                 logging.debug("Start migration: %s", cmd)
                 cmd_result = remote.run_remote_cmd(cmd, params, runner_on_target)
                 logging.info(cmd_result)
@@ -479,6 +494,11 @@ def run(test, params, env):
         logging.info("Recovery VM XML configration")
         orig_config_xml.sync()
         logging.debug("The current VM XML:\n%s", orig_config_xml.xmltreefile)
+
+        if src_libvirt_file:
+            src_libvirt_file.restore()
+        if remote_libvirt_file:
+            del remote_libvirt_file
 
         server_session = remote.wait_for_login('ssh', server_ip, '22',
                                                server_user, server_pwd,


### PR DESCRIPTION
If the modular daemon is enabled, direct remote_mode is not
supported for SSH transport.

I just updated migration cases which are executed by ci and ssh related.
depends on https://github.com/avocado-framework/avocado-vt/pull/2736
Signed-off-by: Yingshun Cui <yicui@redhat.com>