### PR TITLE
Add an sub-attribute to fix error

### DIFF
--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool_capabilities.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool_capabilities.py
@@ -39,7 +39,7 @@ def run(test, params, env):
                                        'raw': ['none', 'raw', 'dir', 'bochs', 'cloop', 'dmg', 'iso', 'vpc', 'vdi',
                                                'fat', 'vhd', 'ploop', 'cow', 'qcow', 'qcow2', 'qed', 'vmdk']},
                                'fs': {'auto': ['auto', 'ext2', 'ext3', 'ext4', 'ufs', 'iso9660', 'udf', 'gfs', 'gfs2',
-                                               'vfat', 'hfs+', 'xfs', 'ocfs2'],
+                                               'vfat', 'hfs+', 'xfs', 'ocfs2', 'vmfs'],
                                       'raw': ['none', 'raw', 'dir', 'bochs', 'cloop', 'dmg', 'iso', 'vpc', 'vdi',
                                               'fat', 'vhd', 'ploop', 'cow', 'qcow', 'qcow2', 'qed', 'vmdk']},
                                'netfs': {'auto': ['auto', 'nfs', 'glusterfs', 'cifs'],


### PR DESCRIPTION
Now virsh pool-capabilities for fs type storage we have a new sub-attribute "vmfs",
add it to the dict.


]# avocado run --vt-type libvirt type_specific.io-github-autotest-libvirt.virsh.pool_capabilities                  
JOB ID     : 7812d6c9779823bccd8233d19bc1840e36610d7d                                                                                    
JOB LOG    : /root/avocado/job-results/job-2020-09-02T03.17-7812d6c/job.log                                                              
 (1/2) type_specific.io-github-autotest-libvirt.virsh.pool_capabilities.no_option: PASS (4.32 s)                                         
 (2/2) type_specific.io-github-autotest-libvirt.virsh.pool_capabilities.unexpect_option: PASS (7.95 s)                                   
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0                                                        
JOB TIME   : 15.99 s     

Signed-off-by: jgao <jgao@redhat.com>