### PR TITLE
virsh_event: Extend timeout value

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_event.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_event.cfg
@@ -11,7 +11,7 @@
             variants:
                 - no_timeout:
                 - timeout:
-                    event_timeout = "60"
+                    event_timeout = "90"
             variants:
                 - other_option:
                 - all_events:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
@@ -252,7 +252,7 @@ def run(test, params, env):
                     session.cmd("echo 1 > /proc/sys/kernel/sysrq")
                     try:
                         # Crash the guest
-                        session.cmd("echo c > /proc/sysrq-trigger", timeout=60)
+                        session.cmd("echo c > /proc/sysrq-trigger", timeout=90)
                     except (ShellTimeoutError, ShellProcessTerminatedError) as details:
                         logging.info(details)
                     session.close()


### PR DESCRIPTION
To avoid following error:

TestFail: Not find expected event:event 'lifecycle' for domain
 avocado-vt-vm1: Resumed Unpaused. Is your guest too slow to
get started in Nones?

Signed-off-by: Liping Cheng <lcheng@redhat.com>