### PR TITLE
Fix the attach interface issue

### DIFF
--- a/libvirt/tests/cfg/nwfilter/nwfilter_binding_dumpxml.cfg
+++ b/libvirt/tests/cfg/nwfilter/nwfilter_binding_dumpxml.cfg
@@ -3,7 +3,7 @@
     start_vm = "yes"
     status_error = "no"
     kill_vm = "yes"
-    option = "--type network --source default"
+    option = "--type network --source default --persistent --model virtio"
     newfilter_1 = "clean-traffic"
     newfilter_2 = "allow-dhcp-server"
     alias_name = "net0"


### PR DESCRIPTION
In set_env() function, there is attach_interface operation to prepare
the env, but it fails sometimes as no available pci slots. Add the model
option to attach virtio device will avoid this error.

Signed-off-by: yalzhang <yalzhang@redhat.com>