### PR TITLE
Fix the clean-traffic nwfilter missing issue

### DIFF
--- a/libvirt/tests/cfg/nwfilter/nwfilter_vm_start.cfg
+++ b/libvirt/tests/cfg/nwfilter/nwfilter_vm_start.cfg
@@ -37,6 +37,7 @@
                         - ip_learning:
                             filter_chain = "root"
                             filter_name = "clean-traffic"
+                            exist_filter = "${filter_name}"
                             filterref_name_0 = "no-mac-spoofing"
                             filterref_name_1 = "no-ip-spoofing"
                             filterref_name_2 = "allow-incoming-ipv4"
@@ -88,6 +89,7 @@
                         - clean_traffic:
                             filter_chain = "root"
                             filter_name = "clean-traffic"
+                            exist_filter = "${filter_name}"
                             filterref_name_0 = "no-mac-spoofing"
                             filterref_name_1 = "no-ip-spoofing"
                             filterref_name_2 = "allow-incoming-ipv4"
@@ -175,6 +177,7 @@
                     filter_uuid = "11111111-b071-6127-b4ec-111111111111"
                     filter_chain = "root"
                     filter_name = "clean-traffic"
+                    exist_filter = "${filter_name}"
                     filterref_name_0 = "no-mac-spoofing"
                     filterref_name_1 = "no-ip-spoofing"
                     filterref_name_2 = "allow-incoming-ipv4"


### PR DESCRIPTION
The clean-traffic nwfilter is a built-in network filter.
It should not be undefined during test.

Signed-off-by: yalzhang <yalzhang@redhat.com>