### PR TITLE
Add nvdimm cases of ppc

### DIFF
--- a/libvirt/tests/cfg/memory/nvdimm.cfg
+++ b/libvirt/tests/cfg/memory/nvdimm.cfg
@@ -29,7 +29,9 @@
                     setvm_current_mem_unit = M
                     setvm_vcpu = 4
                     setvm_placement = static
-                    qemu_checks = -numa node,nodeid=1,cpus=2-3,mem=512`mem-path=${nvdimm_file},share=yes,size=536870912`label-size=262144
+                    qemu_checks = -numa node,nodeid=1,cpus=2-3`mem-path=${nvdimm_file},share=yes,size=536870912`label-size=262144
+                    pseries:
+                        qemu_checks = nvdimm=on`mem-path=${nvdimm_file},share=yes`-device nvdimm,node=1,label-size=262144
                     variants:
                         - default:
                         - check_life_cycle:
@@ -39,6 +41,22 @@
                             nvdimmxml_discard = yes
                             status_error = yes
                             error_msg = 'discard is not supported for nvdimms'
+                        - with_uuid:
+                            only pseries
+                            nvdimmxml_uuid = '8ec948ec-8898-46af-889c-470b50297999'
+                            variants:
+                                - access_private:
+                                    nvdimmxml_mem_access = 'private'
+                                    qemu_checks = nvdimm=on`mem-path=${nvdimm_file},share=no`-device nvdimm,node=1,label-size=262144,uuid=${nvdimmxml_uuid}
+                        - invalid_target_size:
+                            only pseries
+                            status_error = yes
+                            variants:
+                                - less_than_256:
+                                    check = 'less_than_256'
+                                    nvdimmxml_target_size = 255
+                                    nvdimmxml_label_size = 128
+                                    error_msg = 'error: unsupported configuration: minimum target size for the NVDIMM must be 256MB plus the label size'
                 - no_label:
                     check = back_file
                     cpuxml_topology = {'sockets': '2', 'cores': '1', 'threads': '1'}
@@ -78,6 +96,8 @@
             nvdimmxml2_mem_access = shared
             nvdimmxml2_source_path = ${nvdimm_file_2}
             nvdimmxml2_target_size = 256
+            pseries:
+                nvdimmxml2_target_size = 512
             nvdimmxml2_target_size_unit = M
             nvdimmxml2_target_node = 1
             nvdimmxml2_label_size = 128


### PR DESCRIPTION
- Support file backed nvdimm with label size + access shared
- Define a vm with file backed nvdimm device with an uuid specified
and access private
- Define a vm with file backed nvdimm device with target_size smaller
than 256MiB + label_size

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>