### PR TITLE
Fix the issue when run as split daemon

### DIFF
--- a/libvirt/tests/src/nwfilter/nwfilter_vm_attach.py
+++ b/libvirt/tests/src/nwfilter/nwfilter_vm_attach.py
@@ -42,8 +42,7 @@ def run(test, params, env):
 
     # backup vm xml
     vmxml_backup = libvirt_xml.VMXML.new_from_inactive_dumpxml(vm_name)
-    libvirtd = utils_libvirtd.Libvirtd()
-
+    daemon_serv = utils_libvirtd.Libvirtd("virtqemud")
     try:
         # Prepare interface xml for attach
         new_iface = interface.Interface(type_name=iface_type)
@@ -68,8 +67,8 @@ def run(test, params, env):
                                       ignore_status=True)
             utlv.check_exit_status(ret, status_error)
 
-        if not libvirtd.is_running():
-            test.fail("libvirtd not running after attach "
+        if not daemon_serv.is_running():
+            test.fail("daemon not running after attach "
                       "interface.")
 
         # Check iptables or ebtables on host
@@ -90,7 +89,7 @@ def run(test, params, env):
 
     finally:
         if attach_twice_invalid:
-            libvirtd.restart()
+            daemon_serv.restart()
         # Clean env
         if vm.is_alive():
             vm.destroy(gracefully=False)

--- a/libvirt/tests/src/nwfilter/nwfilter_vm_start.py
+++ b/libvirt/tests/src/nwfilter/nwfilter_vm_start.py
@@ -13,7 +13,6 @@ from virttest import utils_misc
 from virttest import utils_package
 from virttest.utils_test import libvirt as utlv
 from virttest.libvirt_xml.devices import interface
-
 from virttest import libvirt_version
 
 
@@ -60,7 +59,7 @@ def run(test, params, env):
     # backup vm xml
     vmxml_backup = libvirt_xml.VMXML.new_from_inactive_dumpxml(vm_name)
 
-    libvirtd = utils_libvirtd.Libvirtd()
+    libvirtd = utils_libvirtd.Libvirtd("virtqemud")
     device_name = None
 
     def clean_up_dirty_nwfilter_binding():
@@ -165,7 +164,9 @@ def run(test, params, env):
                           " %s\n%s" % (e, bug_url))
 
         if kill_libvirtd:
-            cmd = "kill -s TERM `pidof libvirtd`"
+            daemon_name = libvirtd.service_name
+            pid = process.run('pidof %s' % daemon_name, shell=True).stdout_text.strip()
+            cmd = "kill -s TERM %s" % pid
             process.run(cmd, shell=True)
             ret = utils_misc.wait_for(lambda: not libvirtd.is_running(),
                                       timeout=30)


### PR DESCRIPTION
There is checkpoint to check libvirtd status after attach interface,
update the daemon name to be compatible with split daemon. And for
the test case to kill libvirtd with specific signal, skip the case.

Signed-off-by: yalzhang <yalzhang@redhat.com>