### PR TITLE
Add set threshold for disk mirroring node BZ1807741 cases

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domblkthreshold.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domblkthreshold.cfg
@@ -9,6 +9,7 @@
     virt_disk_device_format = "raw"
     virt_disk_device_bus = "virtio"
     block_threshold_timeout = "60"
+    block_threshold_value = "100M"
     block_threshold_option = "--loop"
     event_type = "block-threshold"
     variants:
@@ -17,6 +18,18 @@
             virt_disk_device_type = "file"
             image_filename = "disk.img"
             virt_disk_device_format = "qcow2"
+            variants:
+                - default:
+                    default_snapshot_test = "yes"
+                - mirror_mode_blockcommit:
+                    mirror_mode_blockcommit = "yes"
+                    block_threshold_value = "1024M"
+                    block_threshold_timeout = "120"
+                - mirror_mode_blockcopy:
+                    mirror_mode_blockcopy = "yes"
+                    dest_path = "/var/lib/libvirt/images/new-clone1"
+                    block_threshold_value = "1024M"
+                    block_threshold_timeout = "120"
         - luks_test:
             backend_storage_type = "luks"
             virt_disk_device_type = "file"


### PR DESCRIPTION
Test under mirroring of blockcommit and blockcopy, threshold setting
can work normally

Signed-off-by: chunfuwen <chwen@redhat.com>