### PR TITLE
auto_dump: Move debug information

### DIFF
--- a/libvirt/tests/src/conf_file/qemu_conf/auto_dump.py
+++ b/libvirt/tests/src/conf_file/qemu_conf/auto_dump.py
@@ -106,6 +106,9 @@ def run(test, params, env):
                         flags = int(line.split()[1], 8)
                         logging.debug('file open flag is: %o', flags)
             result_dict['flags'] = flags
+            with open('/proc/%s/cmdline' % iohelper_pid) as cmdinfo:
+                cmdline = cmdinfo.readline()
+                logging.debug(cmdline.split())
 
         session = vm.wait_for_login()
         result_dict = multiprocessing.Manager().dict()
@@ -128,10 +131,6 @@ def run(test, params, env):
             child_process.kill()
         flags = result_dict['flags']
         iohelper_pid = result_dict['pid']
-
-        with open('/proc/%s/cmdline' % iohelper_pid) as cmdinfo:
-            cmdline = cmdinfo.readline()
-            logging.debug(cmdline.split())
 
         # Kill core dump process to speed up test
         try:


### PR DESCRIPTION
To avoid following error:

FileNotFoundError: [Errno 2] No such file or directory:
'/proc/145646/cmdline'

Signed-off-by: Liping Cheng <lcheng@redhat.com>