### PR TITLE
Fix a firewall-cmd error

### DIFF
--- a/libvirt/tests/src/migration/migrate_options_shared.py
+++ b/libvirt/tests/src/migration/migrate_options_shared.py
@@ -565,7 +565,8 @@ def run(test, params, env):
 
         if use_firewall_cmd:
             firewall_cmd.add_direct_rule(firewall_rule)
-            direct_rules = firewall_cmd.get(key="all-rules", is_direct=True)
+            direct_rules = firewall_cmd.get(key="all-rules", is_direct=True,
+                                            zone=None)
             cmdRes = re.findall(firewall_rule, direct_rules)
             if len(cmdRes) == 0:
                 test.error("Rule '%s' is not added" % firewall_rule)
@@ -577,7 +578,8 @@ def run(test, params, env):
 
         if use_firewall_cmd:
             firewall_cmd.remove_direct_rule(firewall_rule)
-            direct_rules = firewall_cmd.get(key="all-rules", is_direct=True)
+            direct_rules = firewall_cmd.get(key="all-rules", is_direct=True,
+                                            zone=None)
             cmdRes = re.findall(firewall_rule, direct_rules)
             if len(cmdRes):
                 test.error("Rule '%s' is not removed correctly" % firewall_rule)
@@ -1488,7 +1490,8 @@ def run(test, params, env):
                 if use_firewall_cmd:
                     logging.debug("cleanup firewall rule via firewall-cmd.")
                     direct_rules = firewall_cmd.get(key="all-rules",
-                                                    is_direct=True)
+                                                    is_direct=True,
+                                                    zone=None)
                     cmdRes = re.findall(firewall_rule, direct_rules)
                     if len(cmdRes):
                         firewall_cmd.remove_direct_rule(firewall_rule)


### PR DESCRIPTION
It fails to execute firewall-cmd in the latest firewalld version.
The option "--zone" is unsupported with "--direct" for now.
The value of 'zone' was set to 'public' by default when calling
Firewall_cmd.get(). And before deleting the firewalld direct
rules, it checked the rules via Firewall_cmd.get(), after that
the firewall-cmd command reported an error "--zone is an
invalid option with --direct". So the added rules were not removed.
Update 'zone' to None to make sure there is no '--zone' option in
this PR.

Signed-off-by: Yingshun Cui <yicui@redhat.com>