### PR TITLE
Correct version of eoi support to 6.0.0

### DIFF
--- a/libvirt/tests/src/libvirt_qemu_cmdline.py
+++ b/libvirt/tests/src/libvirt_qemu_cmdline.py
@@ -140,8 +140,8 @@ def run(test, params, env):
     virsh_dargs = {'debug': True, 'ignore_status': False}
 
     if 'ppc64le' in platform.machine().lower() and test_feature == 'pv_eoi':
-        if not libvirt_version.version_compare(6, 2, 0):
-            test.cancel('Feature %s is supported since version 6.2.0' % test_feature)
+        if not libvirt_version.version_compare(6, 0, 0):
+            test.cancel('Feature %s is supported since version 6.0.0' % test_feature)
     try:
         # Run test case
         qemu_flags = testcase(test, vmxml, **test_dargs)


### PR DESCRIPTION
The old version of 6.2.0 is not correct.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>