### PR TITLE
Correct dd_data_to_vm usage

### DIFF
--- a/libvirt/tests/src/incremental_backup/incremental_backup_backing_chain.py
+++ b/libvirt/tests/src/incremental_backup/incremental_backup_backing_chain.py
@@ -369,8 +369,10 @@ def run(test, params, env):
             dd_count = "1"
             dd_seek = str(backup_index * 10 + 10)
             dd_bs = "1M"
-            utils_disk.dd_data_to_vm_disk(vm, test_disk_in_vm, dd_bs,
+            session = vm.wait_for_login()
+            utils_disk.dd_data_to_vm_disk(session, test_disk_in_vm, dd_bs,
                                           dd_seek, dd_count)
+            session.close()
 
             backup_result = virsh.backup_begin(vm_name, backup_options,
                                                debug=True)

--- a/libvirt/tests/src/incremental_backup/incremental_backup_pull_mode.py
+++ b/libvirt/tests/src/incremental_backup/incremental_backup_pull_mode.py
@@ -261,8 +261,10 @@ def run(test, params, env):
             dd_count = "1"
             dd_seek = str(backup_index * 10 + 10)
             dd_bs = "1M"
-            utils_backup.dd_data_to_vm_disk(vm, test_disk_in_vm, dd_bs,
-                                            dd_seek, dd_count)
+            session = vm.wait_for_login()
+            utils_disk.dd_data_to_vm_disk(session, test_disk_in_vm, dd_bs,
+                                          dd_seek, dd_count)
+            session.close()
 
             if reuse_scratch_file:
                 backup_options += " --reuse-external"

--- a/libvirt/tests/src/incremental_backup/incremental_backup_push_mode.py
+++ b/libvirt/tests/src/incremental_backup/incremental_backup_push_mode.py
@@ -264,8 +264,10 @@ def run(test, params, env):
             dd_count = "1"
             dd_seek = str(backup_index * 10 + 10)
             dd_bs = "1M"
-            utils_backup.dd_data_to_vm_disk(vm, test_disk_in_vm, dd_bs,
-                                            dd_seek, dd_count)
+            session = vm.wait_for_login()
+            utils_disk.dd_data_to_vm_disk(session, test_disk_in_vm, dd_bs,
+                                          dd_seek, dd_count)
+            session.close()
 
             if reuse_target_file:
                 backup_options += " --reuse-external"


### PR DESCRIPTION
Data generation method changed in avocado-vt, also need to
update it here.


Signed-off-by: Yi Sun <yisun@redhat.com>