### PR TITLE
Fix xml error when setting numa_cell to vmcpuxml

### DIFF
--- a/libvirt/tests/src/controller/multiple_controller_ppc.py
+++ b/libvirt/tests/src/controller/multiple_controller_ppc.py
@@ -11,6 +11,7 @@ from virttest import virt_vm
 from virttest import virsh
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml.vm_xml import VMXML
+from virttest.libvirt_xml.vm_xml import VMCPUXML
 from virttest.libvirt_xml.devices.controller import Controller
 from virttest.libvirt_xml.devices.disk import Disk
 from virttest.libvirt_xml.devices.interface import Interface
@@ -475,7 +476,13 @@ def run(test, params, env):
                 virsh.destroy(vm_name)
         spe_device = False
         if numa:
-            vmcpuxml = vm_xml.xmltreefile.find('/cpu')
+            if vm_xml.xmltreefile.find('/cpu'):
+                vmcpuxml = vm_xml.cpu
+                if not vmcpuxml.xmltreefile.find('numa'):
+                    vmcpuxml.xmltreefile.create_by_xpath('numa')
+            else:
+                vmcpuxml = VMCPUXML()
+                vmcpuxml.xml = '<cpu><numa/></cpu>'
             vmcpuxml.numa_cell = vmcpuxml.dicts_to_cells(
                 [{'id': '0', 'cpus': '0', 'memory': '1048576'},
                  {'id': '1', 'cpus': '1', 'memory': '1048576'}])


### PR DESCRIPTION
The original way is to get an xml element object, which is not an
object of VMCPUXML. The new way is to create new cpu xml if cannot
find one in vmxml, then set numa_cells

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>