### PR TITLE
v2v: delete case function_test_xen..encryped

### DIFF
--- a/v2v/tests/cfg/function_test_xen.cfg
+++ b/v2v/tests/cfg/function_test_xen.cfg
@@ -114,8 +114,6 @@
             sasl_user = test
             sasl_pwd = GENERAL_GUEST_PASSWORD
             only libvirt
-        - encryped:
-            main_vm = VM_NAME_XEN_ENCRYPED_V2V_EXAMPLE
         - multidisk:
             main_vm = VM_NAME_XEN_MULTIDISK_V2V_EXAMPLE
             checkpoint = multidisk


### PR DESCRIPTION
function_test_xen..encryped is deprecated.
It is replaced with new case 'function_test_esx..luks'.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>