### PR TITLE
Fix the nwfilter test cases as the feature changes

### DIFF
--- a/libvirt/tests/cfg/nwfilter/filter_aready_present_binding.cfg
+++ b/libvirt/tests/cfg/nwfilter/filter_aready_present_binding.cfg
@@ -6,7 +6,7 @@
     filter_name = "clean-traffic"
     filter_binding_name = "no-arp-mac-spoofing"
     expected_failed = "already exists"
-    target_dev = "vnet0"
+    target_dev = "new_tap"
     source_network = "default"
     source_bridge = "virbr0"
     alias_name = "net0"

--- a/libvirt/tests/cfg/nwfilter/nwfilter_binding_delete.cfg
+++ b/libvirt/tests/cfg/nwfilter/nwfilter_binding_delete.cfg
@@ -6,6 +6,7 @@
     filter_name = "clean-traffic"
     check_cmd = "ebtables -t nat -L"
     expected_not_match = "-j DROP"
+    target_name = "net_tap"
     variants:
         - variable_notation:
             parameters_name_0 = "IP"

--- a/libvirt/tests/src/nwfilter/nwfilter_binding_delete.py
+++ b/libvirt/tests/src/nwfilter/nwfilter_binding_delete.py
@@ -46,6 +46,7 @@ def run(test, params, env):
 
         new_filterref = new_iface.new_filterref(**filterref_dict)
         new_iface.filterref = new_filterref
+        new_iface.target = {'dev': params.get('target_name', 'net_tap')}
         logging.debug("new interface xml is: %s" % new_iface)
         vmxml.add_device(new_iface)
         vmxml.sync()

--- a/libvirt/tests/src/nwfilter/nwfilter_binding_dumpxml.py
+++ b/libvirt/tests/src/nwfilter/nwfilter_binding_dumpxml.py
@@ -24,8 +24,8 @@ def run(test, params, env):
     new_filter_1 = params.get("newfilter_1")
     new_filter_2 = params.get("newfilter_2")
     vmxml_backup = libvirt_xml.vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
-    vnet0_xml = os.path.join(data_dir.get_tmp_dir(), "vnet0.xml")
-    vnet1_xml = os.path.join(data_dir.get_tmp_dir(), "vnet1_xml")
+    new_net0_xml = os.path.join(data_dir.get_tmp_dir(), "new_net0.xml")
+    new_net1_xml = os.path.join(data_dir.get_tmp_dir(), "new_net1.xml")
     option = params.get("option")
     status_error = "yes" == params.get("status_error")
     alias_name = params.get("alias_name")
@@ -82,6 +82,8 @@ def run(test, params, env):
         new_iface_2.type_name = "network"
         new_iface_1.source = {'network': source_network}
         new_iface_2.source = {'network': source_network}
+        new_iface_1.target = {'dev': 'new_net0'}
+        new_iface_2.target = {'dev': 'new_net1'}
         new_filterref = new_iface_1.new_filterref(**filterref_dict_1)
         new_iface_1.filterref = new_filterref
         new_filterref = new_iface_2.new_filterref(**filterref_dict_2)
@@ -101,15 +103,15 @@ def run(test, params, env):
         ret = virsh.nwfilter_binding_list(debug=True)
         utlv.check_exit_status(ret, status_error)
         virsh.nwfilter_binding_dumpxml(new_iface_1.target['dev'],
-                                       to_file=vnet0_xml, debug=True)
+                                       to_file=new_net0_xml, debug=True)
         virsh.nwfilter_binding_dumpxml(new_iface_2.target['dev'],
-                                       to_file=vnet1_xml, debug=True)
+                                       to_file=new_net1_xml, debug=True)
         # check dump filterbinding can pass xml validate
-        vnet0_cmd = "virt-xml-validate %s" % vnet0_xml
-        vnet1_cmd = "virt-xml-validate %s" % vnet1_xml
-        valid_0 = process.run(vnet0_cmd, ignore_status=True,
+        new_net0_cmd = "virt-xml-validate %s" % new_net0_xml
+        new_net1_cmd = "virt-xml-validate %s" % new_net1_xml
+        valid_0 = process.run(new_net0_cmd, ignore_status=True,
                               shell=True).exit_status
-        valid_1 = process.run(vnet1_cmd, ignore_status=True,
+        valid_1 = process.run(new_net1_cmd, ignore_status=True,
                               shell=True).exit_status
         if valid_0 or valid_1:
             test.fail("the xml can not validate successfully")
@@ -128,9 +130,9 @@ def run(test, params, env):
                                   debug=True)
         utlv.check_exit_status(ret, status_error)
         ret_list = virsh.nwfilter_binding_list(debug=True)
-        utlv.check_result(ret_list, expected_match="vnet1")
+        utlv.check_result(ret_list, expected_match="new_net1")
 
-        ret_dump = virsh.nwfilter_binding_dumpxml('vnet0', debug=True)
+        ret_dump = virsh.nwfilter_binding_dumpxml('new_net0', debug=True)
         utlv.check_result(ret_dump, expected_match=new_filter_name)
 
     finally:

--- a/libvirt/tests/src/nwfilter/nwfilter_binding_list.py
+++ b/libvirt/tests/src/nwfilter/nwfilter_binding_list.py
@@ -112,8 +112,8 @@ def run(test, params, env):
         # list binding port dev
         logging.debug("check nwfilter binding for 2 interfaces")
         ret = virsh.nwfilter_binding_list(debug=True)
-        utlv.check_result(ret, expected_match=[r"vnet0\s+clean-traffic"])
-        utlv.check_result(ret, expected_match=[r"vnet1\s+allow-dhcp-server"])
+        utlv.check_result(ret, expected_match=[r"vnet\d+\s+clean-traffic"])
+        utlv.check_result(ret, expected_match=[r"vnet\d+\s+allow-dhcp-server"])
         # detach a interface
         option = "--type network" + " --mac " + new_iface_1.mac_address
         ret = virsh.detach_interface(vm_name, option, debug=True)
@@ -122,9 +122,9 @@ def run(test, params, env):
         logging.debug("check nwfilter binding after detach one interface:")
         time.sleep(3)
         ret = virsh.nwfilter_binding_list(debug=True)
-        if re.search(r'vnet0\s+clean-traffic.*', ret.stdout):
-            test.fail("vnet0 binding still exists after detach the interface!")
-        utlv.check_result(ret, expected_match=[r"vnet1\s+allow-dhcp-server"])
+        if re.search(r'vnet\d+\s+clean-traffic.*', ret.stdout):
+            test.fail("vnet binding clean-traffic still exists after detach the interface!")
+        utlv.check_result(ret, expected_match=[r"vnet\d+\s+allow-dhcp-server"])
 
         # update_device to delete the filter
         iface_dict = {'del_filter': True}
@@ -134,15 +134,15 @@ def run(test, params, env):
                             debug=True)
         logging.debug("check nwfilter-binding after delete the only interface")
         ret = virsh.nwfilter_binding_list(debug=True)
-        if re.search(r'vnet1\s+allow-dhcp-server.*', ret.stdout):
-            test.fail("vnet1 binding still exists after detach the interface!")
+        if re.search(r'vnet\d+\s+allow-dhcp-server.*', ret.stdout):
+            test.fail("vnet binding allow-dhcp-server still exists after detach the interface!")
         utlv.check_exit_status(ret, status_error)
 
         # attach new interface
         attach_new_device()
         ret = virsh.nwfilter_binding_list(debug=True)
         logging.debug("Check nwfilter-binding exists after attach device")
-        utlv.check_result(ret, expected_match=[r"vnet0\s+clean-traffic"])
+        utlv.check_result(ret, expected_match=[r"vnet\d+\s+clean-traffic"])
 
     finally:
         if vm.is_alive():


### PR DESCRIPTION
Libvirt patch 95089f481e003 now introduced 1 feature change to assign tap device
names using a monotonically increasing integer. For some cases, update the check
point to check 'vnet\d+' instead of 'vnet0'/'vnet1', for other cases, update the
target name from 'auto generate' to manually assigned. It will avoid the failure
and no impact for old libvirt version.

Signed-off-by: yalzhang <yalzhang@redhat.com>