### PR TITLE
Update the expected result as libvirt feature changes

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_options.py
+++ b/libvirt/tests/src/virtual_network/iface_options.py
@@ -247,10 +247,9 @@ def run(test, params, env):
         # 3. Other scenarios, the target dev should be set successfully.
         if test_target:
             if target_dev != iface.target["dev"]:
-                if target_dev.startswith("vnet") or \
-                        (iface_type == "direct" and
-                         (target_dev.startswith("macvtap") or
-                          target_dev.startswith("macvlan"))):
+                if target_dev.startswith("vnet")\
+                        or target_dev.startswith("macvtap")\
+                        or target_dev.startswith("macvlan"):
                     logging.debug("target dev %s is override" % target_dev)
                 else:
                     test.fail("Failed to set target dev to %s", target_dev)


### PR DESCRIPTION
Libvirt now has a feature change that the traget dev name with prefix
of "macvtap" and "macvlan" will be ignored even with network type. As it
is also backported, so the version check is not needed.

Signed-off-by: yalzhang <yalzhang@redhat.com>