### PR TITLE
guest_numa: Fix incorrect qemu cmd line

### DIFF
--- a/libvirt/tests/src/numa/guest_numa.py
+++ b/libvirt/tests/src/numa/guest_numa.py
@@ -50,6 +50,31 @@ def run(test, params, env):
     """
     Test guest numa setting
     """
+
+    def replace_qemu_cmdline(cmdline_list):
+        """
+        Replace the expected qemu command line for new machine type
+
+        :param cmdline_list: The list for expected qemu command lines
+        :return: The list contains the updated qemu command lines if any
+        """
+        os_xml = getattr(vmxml, "os")
+        machine_ver = getattr(os_xml, 'machine')
+        if (machine_ver.startswith("pc-q35-rhel") and
+                machine_ver > 'pc-q35-rhel8.2.0' and
+                libvirt_version.version_compare(6, 4, 0)):
+            # Replace 'node,nodeid=0,cpus=0-1,mem=512' with
+            # 'node,nodeid=0,cpus=0-1,memdev=ram-node0'
+            # Replace 'node,nodeid=1,cpus=2-3,mem=512' with
+            # 'node,nodeid=1,cpus=2-3,memdev=ram-node1'
+            for cmd in cmdline_list:
+                line = cmd['cmdline']
+                node = line.split(',')[1][-1]
+                cmd['cmdline'] = line.replace('mem=512',
+                                              'memdev=ram-node{}'.format(node))
+
+        return cmdline_list
+
     host_numa_node = utils_misc.NumaInfo()
     node_list = host_numa_node.online_nodes
     arch = platform.machine()
@@ -347,6 +372,7 @@ def run(test, params, env):
         with open("/proc/%s/cmdline" % vm_pid) as f_cmdline:
             q_cmdline_list = f_cmdline.read().split("\x00")
         logging.debug("vm qemu cmdline list is %s" % q_cmdline_list)
+        cmdline_list = replace_qemu_cmdline(cmdline_list)
         for cmd in cmdline_list:
             logging.debug("checking '%s' in qemu cmdline", cmd['cmdline'])
             p_found = False


### PR DESCRIPTION
Since machine type pc-q35-rhel8.3.0, the expected qemu command line
was changed for no numatune setting. So this is to introduce the new
qemu command line checking.

Signed-off-by: Dan Zheng <dzheng@redhat.com>