### PR TITLE
Fix two lun types failure cases

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
@@ -798,6 +798,7 @@
                                     virt_disk_device_bus = "scsi"
                                     virt_disk_device_target = "sda"
                                     driver_option = "type=raw,cache=none"
+                                    disk_bus_volume_lun = "yes"
                                 - volume_disk:
                                     disk_source_host = "127.0.0.1"
                                     pool_name = "iscsi_pool"

--- a/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
@@ -971,6 +971,12 @@ def run(test, params, env):
         test.cancel("ccsid values are unrestricted in this"
                     " qemu version")
 
+    if libvirt_version.version_compare(6, 6, 0):
+        disk_bus_volume_lun = "yes" == params.get("disk_bus_volume_lun", "no")
+        disk_bus_usb_lun = (device_bus[0] == "usb" and device_types[0] == "block")
+        if disk_bus_volume_lun or disk_bus_usb_lun:
+            test.cancel("disk device='lun' is only valid for block type disk source")
+
     # Backup selinux_mode and virt_use_nfs status
     virt_use_nfs_off = "yes" == params.get("virt_use_nfs_off", "no")
     if virt_use_nfs_off:


### PR DESCRIPTION
After libvirt version 6.6.0, disk device='lun' is only valid for block type disk source
so skip those 2 cases

Signed-off-by: chunfuwen <chwen@redhat.com>