### PR TITLE
migrate_vm: Update to set migration speed

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_vm.cfg
+++ b/libvirt/tests/cfg/migration/migrate_vm.cfg
@@ -548,6 +548,7 @@
                                     virsh_options = "--live --verbose --copy-storage-all --migrate-disks vda"
                         - disk_ports:
                             nfs_mount_dir =
+                            set_migration_speed = 100
                             disk_port = "56789"
                             run_migrate_cmd_in_front = "no"
                             create_target_image = "yes"


### PR DESCRIPTION
Make the migration process longer by setting migration's speed to
have enough time to perform other checks.

Signed-off-by: Yingshun Cui <yicui@redhat.com>