### PR TITLE
Add new cases for mixed detach disk

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device.cfg
@@ -12,6 +12,11 @@
             no cdrom_test,file_type
             only vm_running_config,vm_running_live,vm_running_current
             dt_device_alias = "yes"
+        - detach_mixed:
+            only normal_test..vm_running_live..disk_test..file_type..detach_mixed
+            dt_device_alias = "yes"
+            detach_times = 2
+            detach_mixed = "yes"
     variants:
         - cdrom_test:
             dt_device_pre_vm_state = "shut off"


### PR DESCRIPTION
Since libvirt detach device APIs(detach-device, detach-device-alias)
works asynchronously, that means every call returns before the detach
operation returns.This patch is to test multiple continuous detach to
make sure a detach call will not be interrupted by other calls.

Signed-off-by: Dan Zheng <dzheng@redhat.com>