### PR TITLE
virsh_migrate: Fix unsupported direct socket mode issue

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
@@ -1041,6 +1041,9 @@ def run(test, params, env):
             logging.debug("PID for process '%s': %s",
                           remote_viewer_executable, remote_viewer_pid)
 
+        remove_dict = {"do_search": '{"%s": "ssh:/"}' % dest_uri}
+        src_libvirt_file = libvirt_config.remove_key_for_modular_daemon(
+            remove_dict)
         # Case for option '--timeout --timeout-suspend'
         # 1. Start the guest
         # 2. Set migration speed to a small value. Ensure the migration
@@ -1087,9 +1090,6 @@ def run(test, params, env):
                 if libvirt_version.version_compare(5, 0, 0):
                     virsh.migrate_setspeed(vm_name, speed,
                                            extra=postcopy_options, **virsh_args)
-            remove_dict = {"do_search": '{"%s": "ssh:/"}' % dest_uri}
-            src_libvirt_file = libvirt_config.remove_key_for_modular_daemon(
-                remove_dict)
 
             logging.info("Starting migration in thread")
             try:


### PR DESCRIPTION
In previous code, the conf libvirt.conf was updated only for
migration cases with postcopy, so correct it to update the
configurations for all cases.

Signed-off-by: Yingshun Cui <yicui@redhat.com>