### PR TITLE
max_vcpus: Update the maxCpus value of pc-q35-rhel8.3.0

### DIFF
--- a/libvirt/tests/cfg/cpu/max_vcpus.cfg
+++ b/libvirt/tests/cfg/cpu/max_vcpus.cfg
@@ -12,6 +12,7 @@
             report_num_pc_7 = "240"
             report_num_q35_73 = "255"
             report_num_q35_7_8 = "384"
+            report_num_q35_8_3 = "512"
         - positive_test:
             status_error = "no"
             variants:

--- a/libvirt/tests/src/cpu/max_vcpus.py
+++ b/libvirt/tests/src/cpu/max_vcpus.py
@@ -71,6 +71,7 @@ def run(test, params, env):
             report_num_pc_7 = params.get('report_num_pc_7', '')
             report_num_q35_73 = params.get('report_num_q35_73', '')
             report_num_q35_7_8 = params.get('report_num_q35_7_8', '')
+            report_num_q35_8_3 = params.get('report_num_q35_8_3', '')
             logging.info('Check the output of virsh capabilities')
             xmltreefile = capability_xml.CapabilityXML().xmltreefile
             machtype_vcpunum_dict = {}
@@ -85,14 +86,29 @@ def run(test, params, env):
                 logging.info("%s : %s", key, machtype_vcpunum_dict[key])
                 if key.startswith('pc-i440fx') or key.startswith('rhel') or key == 'pc':
                     if machtype_vcpunum_dict[key] != report_num_pc_7:
-                        test.fail('Test failed as i440fx_max_vcpus_num in virsh_capa is wrong.')
+                        test.fail('Test failed as i440fx_max_vcpus_num in '
+                                  'virsh_capa is wrong. Expected: {} '
+                                  'Actual: {}.'
+                                  .format(report_num_pc_7,
+                                          machtype_vcpunum_dict[key]))
                 if key.startswith('pc-q35') or key == 'q35':
                     if key == "pc-q35-rhel7.3.0":
                         if machtype_vcpunum_dict[key] != report_num_q35_73:
-                            test.fail('Test failed as q35_rhel73_max_vcpus_num in virsh_capa is wrong.')
+                            test.fail('Test failed as q35_rhel73_max_vcpus_num '
+                                      'in virsh_capa is wrong. Expected: {} '
+                                      'Actual: {}.'
+                                      .format(report_num_q35_73,
+                                              machtype_vcpunum_dict[key]))
                     else:
-                        if machtype_vcpunum_dict[key] != report_num_q35_7_8:
-                            test.fail('Test failed as the q35_max_vcpus_num in virsh_capa is wrong.')
+                        exp_val = report_num_q35_7_8
+                        if libvirt_version.version_compare(6, 6, 0):
+                            exp_val = report_num_q35_8_3
+                        if machtype_vcpunum_dict[key] != exp_val:
+                            test.fail('Test failed as the q35_max_vcpus_num in '
+                                      'virsh_capa is wrong. Expected: {} '
+                                      'Actual: {}.'
+                                      .format(exp_val,
+                                              machtype_vcpunum_dict[key]))
 
         # Test i440fx VM starts with 240(positive)/241(negative) vcpus and hot-plugs vcpus to 240
         if check.startswith('i440fx_test'):


### PR DESCRIPTION
There is an update in the latest libvirt's version, so update the
script accordingly.

Signed-off-by: Yingshun Cui <yicui@redhat.com>