### PR TITLE
Virsh_update_device:Fix slice test with sharable error

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_update_device.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_update_device.py
@@ -32,6 +32,10 @@ def create_disk(params, test, vm_name, orig_iso, disk_type, target_dev, disk_for
             params["input_source_file"] = orig_iso
             params["disk_slice"] = {"slice": "yes"}
             params["target_dev"] = "sdc"
+            if mode == 'readonly':
+                params["readonly"] = "yes"
+            elif mode == "shareable":
+                params["shareable"] = "yes"
             disk_xml = libvirt.create_disk_xml(params)
         else:
             with open(orig_iso, 'wb') as _file:


### PR DESCRIPTION
Add attribute of "readonly" or "shareable" when create disk xml with "slice".

Signed-off-by: root <root@localhost.localdomain>

Test result:
# avocado run --vt-type libvirt --vt-machine-type q35 virsh.update_device.normal_test.id_option..scsi_option. --vt-connect-uri qemu:///system
JOB ID     : 27120a9ea15e0fe6f2153c33af5a8495b9929946
JOB LOG    : /root/avocado/job-results/job-2020-09-23T03.56-27120a9/job.log
 (01/27) type_specific.io-github-autotest-libvirt.virsh.update_device.normal_test.id_option.no_option.scsi_option.slice_test_qcow2: PASS (113.33 s)
 (02/27) type_specific.io-github-autotest-libvirt.virsh.update_device.normal_test.id_option.no_option.scsi_option.slice_test_raw: PASS (119.16 s)
 (03/27) type_specific.io-github-autotest-libvirt.virsh.update_device.normal_test.id_option.no_option.scsi_option.not_slice_test: PASS (37.90 s)
 (04/27) type_specific.io-github-autotest-libvirt.virsh.update_device.normal_test.id_option.force_option.scsi_option.slice_test_qcow2: PASS (116.25 s)
 (05/27) type_specific.io-github-autotest-libvirt.virsh.update_device.normal_test.id_option.force_option.scsi_option.slice_test_raw: PASS (119.38 s)
 (06/27) type_specific.io-github-autotest-libvirt.virsh.update_device.normal_test.id_option.force_option.scsi_option.not_slice_test: PASS (37.81 s)
 (07/27) type_specific.io-github-autotest-libvirt.virsh.update_device.normal_test.id_option.force_live_option.scsi_option.slice_test_qcow2: PASS (119.27 s)
 (08/27) type_specific.io-github-autotest-libvirt.virsh.update_device.normal_test.id_option.force_live_option.scsi_option.slice_test_raw: PASS (119.07 s)
 (09/27) type_specific.io-github-autotest-libvirt.virsh.update_device.normal_test.id_option.force_live_option.scsi_option.not_slice_test: PASS (37.51 s)
 (10/27) type_specific.io-github-autotest-libvirt.virsh.update_device.normal_test.id_option.force_current_option.scsi_option.slice_test_qcow2: PASS (119.66 s)
 (11/27) type_specific.io-github-autotest-libvirt.virsh.update_device.normal_test.id_option.force_current_option.scsi_option.slice_test_raw: PASS (119.89 s)
 (12/27) type_specific.io-github-autotest-libvirt.virsh.update_device.normal_test.id_option.force_current_option.scsi_option.not_slice_test: PASS (37.73 s)
 (13/27) type_specific.io-github-autotest-libvirt.virsh.update_device.normal_test.id_option.live_option.scsi_option.slice_test_qcow2: PASS (118.84 s)
 (14/27) type_specific.io-github-autotest-libvirt.virsh.update_device.normal_test.id_option.live_option.scsi_option.slice_test_raw: PASS (118.59 s)
 (15/27) type_specific.io-github-autotest-libvirt.virsh.update_device.normal_test.id_option.live_option.scsi_option.not_slice_test: PASS (37.61 s)
 (16/27) type_specific.io-github-autotest-libvirt.virsh.update_device.normal_test.id_option.current_option.scsi_option.slice_test_qcow2: PASS (123.47 s)
 (17/27) type_specific.io-github-autotest-libvirt.virsh.update_device.normal_test.id_option.current_option.scsi_option.slice_test_raw: PASS (119.09 s)
 (18/27) type_specific.io-github-autotest-libvirt.virsh.update_device.normal_test.id_option.current_option.scsi_option.not_slice_test: PASS (38.06 s)
 (19/27) type_specific.io-github-autotest-libvirt.virsh.update_device.normal_test.id_option.config_option.scsi_option.slice_test_qcow2:PASS (118.10 s)
 (20/27) type_specific.io-github-autotest-libvirt.virsh.update_device.normal_test.id_option.config_option.scsi_option.slice_test_raw: PASS (118.86 s)
 (21/27) type_specific.io-github-autotest-libvirt.virsh.update_device.normal_test.id_option.config_option.scsi_option.not_slice_test: PASS (36.24 s)
 (22/27) type_specific.io-github-autotest-libvirt.virsh.update_device.normal_test.id_option.diff_iso_option.scsi_option.slice_test_qcow2: PASS (119.07 s)
 (23/27) type_specific.io-github-autotest-libvirt.virsh.update_device.normal_test.id_option.diff_iso_option.scsi_option.slice_test_raw:PASS (119.28 s)
 (24/27) type_specific.io-github-autotest-libvirt.virsh.update_device.normal_test.id_option.diff_iso_option.scsi_option.not_slice_test:PASS (38.40 s)
 (25/27) type_specific.io-github-autotest-libvirt.virsh.update_device.normal_test.id_option.shareable_disk.scsi_option.slice_test_qcow2: PASS (118.96 s)
 (26/27) type_specific.io-github-autotest-libvirt.virsh.update_device.normal_test.id_option.shareable_disk.scsi_option.slice_test_raw: PASS (119.40 s)
 (27/27) type_specific.io-github-autotest-libvirt.virsh.update_device.normal_test.id_option.shareable_disk.scsi_option.not_slice_test: PASS (37.38 s)
RESULTS    : PASS 27 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 2480.62 s
