### PR TITLE
Add test cases for keywrap support on s390x

### DIFF
--- a/libvirt/tests/cfg/svirt/libvirt_keywrap.cfg
+++ b/libvirt/tests/cfg/svirt/libvirt_keywrap.cfg
@@ -1,0 +1,16 @@
+- libvirt_keywrap:
+    type = libvirt_keywrap
+    start_vm = no
+    only s390-virtio
+    variants:
+        - default:
+            default = yes
+            expect_token = yes
+            name = aes
+            state = on
+        - aes_off:
+            default = no
+            name = aes
+            state = off
+            expect_token = no
+

--- a/libvirt/tests/src/svirt/libvirt_keywrap.py
+++ b/libvirt/tests/src/svirt/libvirt_keywrap.py
@@ -1,0 +1,45 @@
+from virttest.libvirt_xml.vm_xml import VMXML, VMKeywrapXML
+from virttest.utils_libvirt.libvirt_keywrap import ProtectedKeyHelper
+
+
+def run(test, params, env):
+    """
+    Test keywrap handling for s390x guests
+
+    :param test: test instance
+    :param params: test parameters
+    :param env: test environment
+    :return: None
+    """
+    default = params.get("default", "yes") == "yes"
+    vm_name = params.get("main_vm")
+    expect_token = params.get("expect_token", "yes") == "yes"
+    name = params.get("keyname", None)
+    state = params.get("keystate", None)
+
+    vm = env.get_vm(vm_name)
+
+    vmxml_backup = VMXML.new_from_inactive_dumpxml(vm_name)
+    vmxml = VMXML.new_from_inactive_dumpxml(vm_name)
+
+    try:
+        if default:
+            vmxml.del_keywrap()
+        else:
+            kw = VMKeywrapXML()
+            kw.set_cipher(name, state)
+            vm.set_keywrap(kw)
+
+        vm.sync()
+        vm.start()
+        session = vm.wait_for_login()
+
+        pkey_helper = ProtectedKeyHelper(session)
+        pkey_helper.load_module()
+
+        if expect_token:
+            if pkey_helper.get_some_aes_key_token() is None:
+                test.fail("Didn't receive expected key token."
+                          " Please check debug log.")
+    finally:
+        vmxml_backup.sync()


### PR DESCRIPTION
Depends on https://github.com/avocado-framework/avocado-vt/pull/2772

On s390x, QEMU supports control of dea/aes wrapping.
Per default they are enabled. Linux guests can generate
protected key tokens through the pkey kernel module if
the wrapping key is enabled.

Add test cases to minimally confirm that protected keys of
some aes type can be generated if wrapping key is available.

This way, we can confirm that disabling the wrapping key works.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>