### PR TITLE
Fix hugepage migration

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_vm.cfg
+++ b/libvirt/tests/cfg/migration/migrate_vm.cfg
@@ -105,10 +105,8 @@
                             virsh_options = "--live --verbose --compressed"
                         - with_hugepages:
                             setup_hugepages = "yes"
-                            target_hugepages = 600
                             mb_enable = "yes"
                             config_remote_hugepages = "yes"
-                            remote_target_hugepages = ${target_hugepages}
                             remote_hugetlbfs_path = "/dev/hugepages"
                             restart_libvirtd_remotely = "yes"
                         - bi_directional:
@@ -613,7 +611,6 @@
                             variants:
                                 - no_config_target:
                                     setup_hugepages = "yes"
-                                    target_hugepages = 600
                                     mb_enable = "yes"
                                 - source_hugemem_less_than_vm_mem:
                                     setup_hugepages = "yes"
@@ -625,18 +622,15 @@
                                     restart_libvirtd_remotely = "yes"
                                 - target_hugemem_less_than_vm_mem:
                                     setup_hugepages = "yes"
-                                    target_hugepages = 600
                                     mb_enable = "yes"
                                     config_remote_hugepages = "yes"
-                                    remote_target_hugepages = 10
+                                    remote_target_hugepages = -100
                                     remote_hugetlbfs_path = "/dev/hugepages"
                                     restart_libvirtd_remotely = "yes"
                                 - no_restart_target_libvirtd:
                                     setup_hugepages = "yes"
-                                    target_hugepages = 600
                                     mb_enable = "yes"
                                     config_remote_hugepages = "yes"
-                                    remote_target_hugepages = ${target_hugepages}
                                     remote_hugetlbfs_path = "/dev/hugepages"
                                     restart_libvirtd_remotely = "no"
                 - p2p_migration:


### PR DESCRIPTION
The original hardcoded hugepage number is based on vm memory 1024M's assumption.
But when more vm memory is used, the defined hugepage number does not meet the
requirement which causes vm fails to start due to insufficient allocated memory.

Signed-off-by: Dan Zheng <dzheng@redhat.com>