### PR TITLE
add cases:Add slice test with different disk format

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_encryption.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_encryption.cfg
@@ -22,6 +22,15 @@
     extra_parameter_qcow2 = "--object secret,data=${secret_password_no_encoded},id=sec -o encrypt.format=luks,encrypt.key-secret=sec"
     extra_parameter_raw = "--object secret,data=${secret_password_no_encoded},id=sec -o key-secret=sec"
     variants:
+        - slice_test:
+            only encryption_in_source
+            slice_test = "yes"
+            target_encypt = "luks"
+            test_size = "10"
+            extra_parameter = "--object secret,data=${secret_password_no_encoded},id=sec -o encrypt.format=luks,encrypt.key-secret=sec,preallocation=full"
+        - not_slice_test:
+            slice_test = "no"    
+    variants:
         - encryption_in_source:
             encryption_in_source = "yes"
         - encryption_out_source:


### PR DESCRIPTION
Add slice attribute to disk xml to add slice test for different
disk format.

Signed-off-by: jgao <jgao@redhat.com>

]# avocado run --vt-type libvirt type_specific.io-github-autotest-libvirt.virtual_disks.encryption
JOB ID     : 6a65a5f17ac62855f73da50bc103c25fa964f96b
JOB LOG    : /root/avocado/job-results/job-2020-09-23T21.46-6a65a5f/job.log
 (01/16) type_specific.io-github-autotest-libvirt.virtual_disks.encryption.hotplug.slice_test.qcow2_internal.normal_test.encryption_in_source: PASS (86.76 s)
 (02/16) type_specific.io-github-autotest-libvirt.virtual_disks.encryption.hotplug.slice_test.qcow2_internal.normal_test.encryption_out_source: PASS (98.59 s)
 (03/16) type_specific.io-github-autotest-libvirt.virtual_disks.encryption.hotplug.slice_test.raw_luks.normal_test.encryption_in_source: PASS (81.90 s)
 (04/16) type_specific.io-github-autotest-libvirt.virtual_disks.encryption.hotplug.slice_test.raw_luks.normal_test.encryption_out_source: PASS (81.26 s)
 (05/16) type_specific.io-github-autotest-libvirt.virtual_disks.encryption.hotplug.not_slice_test.qcow2_internal.normal_test.encryption_in_source: PASS (79.78 s)
 (06/16) type_specific.io-github-autotest-libvirt.virtual_disks.encryption.hotplug.not_slice_test.qcow2_internal.normal_test.encryption_out_source: PASS (80.63 s)
 (07/16) type_specific.io-github-autotest-libvirt.virtual_disks.encryption.hotplug.not_slice_test.raw_luks.normal_test.encryption_in_source: PASS (79.18 s)
 (08/16) type_specific.io-github-autotest-libvirt.virtual_disks.encryption.hotplug.not_slice_test.raw_luks.normal_test.encryption_out_source: PASS (81.87 s)
 (09/16) type_specific.io-github-autotest-libvirt.virtual_disks.encryption.coldplug.slice_test.qcow2_internal.normal_test.encryption_in_source: PASS (91.17 s)
 (10/16) type_specific.io-github-autotest-libvirt.virtual_disks.encryption.coldplug.slice_test.qcow2_internal.normal_test.encryption_out_source: PASS (91.68 s)
 (11/16) type_specific.io-github-autotest-libvirt.virtual_disks.encryption.coldplug.slice_test.raw_luks.normal_test.encryption_in_source: PASS (74.51 s)
 (12/16) type_specific.io-github-autotest-libvirt.virtual_disks.encryption.coldplug.slice_test.raw_luks.normal_test.encryption_out_source: PASS (74.78 s)
 (13/16) type_specific.io-github-autotest-libvirt.virtual_disks.encryption.coldplug.not_slice_test.qcow2_internal.normal_test.encryption_in_source: PASS (74.45 s)
 (14/16) type_specific.io-github-autotest-libvirt.virtual_disks.encryption.coldplug.not_slice_test.qcow2_internal.normal_test.encryption_out_source: PASS (74.74 s)
 (15/16) type_specific.io-github-autotest-libvirt.virtual_disks.encryption.coldplug.not_slice_test.raw_luks.normal_test.encryption_in_source: PASS (76.16 s)
 (16/16) type_specific.io-github-autotest-libvirt.virtual_disks.encryption.coldplug.not_slice_test.raw_luks.normal_test.encryption_out_source: PASS (76.26 s)
RESULTS    : PASS 16 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 1307.98 s
