### PR TITLE
Update error message for max_vcpus.negative_test.ioapic_iommu

### DIFF
--- a/libvirt/tests/cfg/cpu/max_vcpus.cfg
+++ b/libvirt/tests/cfg/cpu/max_vcpus.cfg
@@ -58,4 +58,4 @@
                     only q35
                     check = "ioapic_iommu_ne"
                     guest_vcpu = "385"
-                    err_msg = "unsupported configuration: Maximum CPUs greater than specified machine type limit"
+                    err_msg = "unsupported configuration: Maximum CPUs greater than specified machine type limit|exceeds the maximum cpus supported"

--- a/libvirt/tests/src/cpu/max_vcpus.py
+++ b/libvirt/tests/src/cpu/max_vcpus.py
@@ -156,7 +156,8 @@ def run(test, params, env):
 
             if status_error:
                 if start_fail:
-                    if libvirt_version.version_compare(5, 6, 0):
+                    if (libvirt_version.version_compare(5, 6, 0) and
+                       not libvirt_version.version_compare(6, 6, 0)):
                         result_need_check = virsh.define(vmxml.xml, debug=True)
                     else:
                         vmxml.sync()


### PR DESCRIPTION
It reports error when the vm starts with 384 max cpus since
libvirt 6.6.0-6. And the error message is updated.

Signed-off-by: Yingshun Cui <yicui@redhat.com>