### PR TITLE
Update test params for blockcopy

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcopy.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcopy.cfg
@@ -101,9 +101,6 @@
                 - block_disk:
                     replace_vm_disk = "yes"
                     disk_source_protocol = "iscsi"
-                    disk_target = "vda"
-                    disk_target_bus = "virtio"
-                    disk_format = "qcow2"
                     image_size = "10G"
                     emulated_image = "emulated-iscsi"
                     variants:
@@ -120,8 +117,14 @@
                         - lun_t:
                             no volume_type, no_blockdev, shallow
                             disk_device = 'lun'
+                            disk_format = "raw"
+                            disk_target = "sda"
+                            disk_target_bus = "scsi"
                         - disk_t:
                             disk_device = 'disk'
+                            disk_format = "qcow2"
+                            disk_target = "vda"
+                            disk_target_bus = "virtio"
             variants:
                 - non_acl:
                 - acl_test:


### PR DESCRIPTION
change the block+lun test scenaro mapping from qcow2+virtio to raw+scsi as it do not supported with the old mapping

Signed-off-by: Kyla Zhang <weizhan@redhat.com>