### PR TITLE
virsh_migrate: Don't ignore status of virsh define

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
@@ -978,7 +978,7 @@ def run(test, params, env):
             vmxml.vm_name = extra.split()[1].strip()
             del vmxml.uuid
             # Define a new vm on destination for --dname
-            virsh.define(vmxml.xml, uri=dest_uri)
+            virsh.define(vmxml.xml, uri=dest_uri, ignore_status=False)
 
         # Prepare for --xml.
         xml_option = params.get("xml_option", "no")


### PR DESCRIPTION
If the status of virsh define is ignored and the auto case fail in
the following test steps, it will be much harder for us to locate
the problem.

Signed-off-by: Fangge Jin <fjin@redhat.com>