### PR TITLE
Modular daemon: Fix kill_starting cases error

### DIFF
--- a/libvirt/tests/src/daemon/kill_starting.py
+++ b/libvirt/tests/src/daemon/kill_starting.py
@@ -30,9 +30,23 @@ def run(test, params, env):
         gdb.send_signal(signal_name)
         gdb.cont()
 
+    def get_service(send_signal_at):
+        """
+        Get the name of the service
+
+        :param send_signal_at: The function to set breakpoint
+        :return: Service name
+        """
+        return {
+            'netcfStateInitialize': 'virtinterfaced',
+            'networkStateInitialize': 'virtnetworkd',
+            'nwfilterStateInitialize': 'virtnwfilterd'
+        }.get(send_signal_at)
+
+    serv_name = get_service(send_signal_at)
     bundle = {'recieved': False}
 
-    libvirtd = LibvirtdSession(gdb=True)
+    libvirtd = LibvirtdSession(service_name=serv_name, gdb=True)
     try:
         libvirtd.set_callback('break', _break_callback)
         libvirtd.set_callback('signal', _signal_callback, bundle)


### PR DESCRIPTION
Some cases need to create a LibvirtdSession() object with the
service virtnetworkd, virtinterfaced and so on when the modular
daemon is enabled, so update the case accordingly.

Signed-off-by: Yingshun Cui <yicui@redhat.com>