### PR TITLE
virtual_disks_multidisks: Remove volume_lun cases

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
@@ -784,20 +784,6 @@
                                     virtio_scsi_controller = "yes"
                                     virtio_scsi_controller_model = "virtio-scsi"
                                     driver_option = "type=raw,cache=none"
-                                - volume_lun:
-                                    hotplug:
-                                        test_bus_option_cmd = "no"
-                                        disks_attach_option = "--persistent"
-                                    disk_source_host = "127.0.0.1"
-                                    pool_name = "iscsi_pool"
-                                    pool_type = "iscsi"
-                                    pool_target = "/dev/disk/by-path"
-                                    pool_source_host = "127.0.0.1"
-                                    virt_disk_device_type = "volume"
-                                    virt_disk_device = "lun"
-                                    virt_disk_device_bus = "scsi"
-                                    virt_disk_device_target = "sda"
-                                    driver_option = "type=raw,cache=none"
                                 - volume_disk:
                                     disk_source_host = "127.0.0.1"
                                     pool_name = "iscsi_pool"


### PR DESCRIPTION
The device='lun' with block type source has been rejected since libvirt
v1.3.5-rc1 (commit bd9d7078). Remove these positive cases.

Signed-off-by: Han Han <hhan@redhat.com>