### PR TITLE
virtual_disks_multidisks: rm the cases of usb bus together with devic…

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
@@ -864,14 +864,6 @@
                             virt_disk_device_target = "sda"
                             virt_disk_device_bus = "usb"
                             variants:
-                                - device_lun:
-                                    status_error = "yes"
-                                    virt_disk_device_type = "block"
-                                    virt_disk_device_source = "test"
-                                    virt_disk_device = "lun"
-                                    virtio_scsi_controller = "yes"
-                                    virtio_scsi_controller_model = "virtio-scsi"
-                                    virt_disk_device_format = "scsi"
                                 - device_disk:
                                     virt_disk_check_partitions = "no"
                                     add_usb_device = "yes"


### PR DESCRIPTION
…e lun

According to the libvirt validation function
qemuValidateDomainDeviceDefDiskFrontend[1], the deivce lun is only
valid with virtio or scsi bus.

[1]: https://gitlab.com/libvirt/libvirt/-/raw/master/src/qemu/qemu_validate.c

Signed-off-by: Han Han <hhan@redhat.com>