### PR TITLE
Fix virsh_boot on s390x

### DIFF
--- a/libvirt/tests/cfg/bios/virsh_boot.cfg
+++ b/libvirt/tests/cfg/bios/virsh_boot.cfg
@@ -20,6 +20,7 @@
             boot_ref = "order"
             boot_order = 1
             boot_loadparm = 2
+            boot_type = "ipl"
             start_vm = "yes"
             test_cmd = "lsreipl"
             expected_output = Loadparm:\s+"2"


### PR DESCRIPTION
The code tries to install unnavailable packages because `boot_type`
has default value `seabios` leading to test error
'seabios package install failed'

Set parameter explicitly to `ipl` on s390x to avoid any execution
conditional on `boot_type`.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>