### PR TITLE
Virsh blkdeviotune:Fix the matrix error of slice test

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blkdeviotune.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blkdeviotune.cfg
@@ -390,7 +390,7 @@
                             target_bus = "scsi"
                             device_type = "disk"
                         - not_slice_test:
-                            disk_slice = no
+                            disk_slice_enabled = no
                     variants:
                         - hotplug:
                             attach_before_start = no


### PR DESCRIPTION
Modify the parameter 'disk_slice' to 'disk_slice_enabled' which has not used now.

Signed-off-by: Jianan Gao <jgao@redhat.com>

# avocado run --vt-type libvirt --vt-machine-type q35 virsh.blkdeviotune.positive_testing.attach_disk --vt-connect-uri qemu:///system
JOB ID     : 882ff2560bb6a0169729b7d85b8a06952c81dba0
JOB LOG    : /root/avocado/job-results/job-2020-10-10T02.50-882ff25/job.log
 (01/10) type_specific.io-github-autotest-libvirt.virsh.blkdeviotune.positive_testing.attach_disk.hotplug.slice_test: PASS (191.56 s)
 (02/10) type_specific.io-github-autotest-libvirt.virsh.blkdeviotune.positive_testing.attach_disk.hotplug.not_slice_test: PASS (17.97 s)
 (03/10) type_specific.io-github-autotest-libvirt.virsh.blkdeviotune.positive_testing.attach_disk.coldplug.with_alias.bus_virtio.slice_test: PASS (211.23 s)
 (04/10) type_specific.io-github-autotest-libvirt.virsh.blkdeviotune.positive_testing.attach_disk.coldplug.with_alias.bus_virtio.not_slice_test: PASS (51.80 s)
 (05/10) type_specific.io-github-autotest-libvirt.virsh.blkdeviotune.positive_testing.attach_disk.coldplug.with_alias.bus_scsi.slice_test: PASS (79.71 s)
 (06/10) type_specific.io-github-autotest-libvirt.virsh.blkdeviotune.positive_testing.attach_disk.coldplug.with_alias.bus_scsi.not_slice_test: PASS (51.14 s)
 (07/10) type_specific.io-github-autotest-libvirt.virsh.blkdeviotune.positive_testing.attach_disk.coldplug.without_alias.bus_virtio.slice_test: PASS (78.81 s)
 (08/10) type_specific.io-github-autotest-libvirt.virsh.blkdeviotune.positive_testing.attach_disk.coldplug.without_alias.bus_virtio.not_slice_test: PASS (51.19 s)
 (09/10) type_specific.io-github-autotest-libvirt.virsh.blkdeviotune.positive_testing.attach_disk.coldplug.without_alias.bus_scsi.slice_test: PASS (78.57 s)
 (10/10) type_specific.io-github-autotest-libvirt.virsh.blkdeviotune.positive_testing.attach_disk.coldplug.without_alias.bus_scsi.not_slice_test: PASS (51.03 s)
RESULTS    : PASS 10 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 867.98 s
