### PR TITLE
Add a case for concurrent migration

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -418,6 +418,12 @@
                             stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M --timeout 70"
                             actions_during_migration = "setmigratepostcopy"
                             actions_after_migration = "checkdomstate"
+                        - cancel_concurrent_migration:
+                            only without_postcopy
+                            concurrent_migration = "yes"
+                            virsh_migrate_extra = "--bandwidth 5"
+                            asynch_migrate = "yes"
+                            actions_during_migration = "cancel_concurrent_migration"
                 - tunnelled_migration:
                     only without_postcopy
                     virsh_migrate_options = "--live --p2p --tunnelled --verbose"


### PR DESCRIPTION
This PR adds a migration case - cancel a concurrent migration.
In this case, a VM will be migrated concurrently. It will kill one
of the migration processes to check if the other is working well.

Signed-off-by: Yingshun Cui <yicui@redhat.com>