### PR TITLE
migrate_options_shared: Update the conf file logic for modular daemon

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -73,7 +73,10 @@
                     variants:
                         - mt_method:
                             only without_postcopy
-                            libvirtd_conf_dict = '{"log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
+                            libvirtd_conf_dest_dict = '{"log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
+                            # Set conf type to the value in modular daemon mode, it will be converted to the\
+                            # value in monolithic daemon mode automatically according to the test env
+                            libvirtd_conf_type_dest = "virtqemud"
                             level = 9
                             threads = 5
                             dthreads = 5
@@ -89,6 +92,9 @@
                         - xbzrle_method_by_cmd:
                             only without_postcopy
                             libvirtd_conf_dict = '{"log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
+                            # Set conf type to the value in modular daemon mode, it will be converted to the\
+                            # value in monolithic daemon mode automatically according to the test env
+                            libvirtd_conf_type = "virtqemud"
                             check_complete_job = "yes"
                             virsh_migrate_extra = "--comp-methods xbzrle"
                             comp_cache_size = 33554432
@@ -107,6 +113,9 @@
                     asynch_migrate = "yes"
                     low_speed = "40"
                     libvirtd_conf_dict = '{"log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
+                    # Set conf type to the value in modular daemon mode, it will be converted to the\
+                    # value in monolithic daemon mode automatically according to the test env
+                    libvirtd_conf_type = "virtqemud"
                     diff_rate = '0.5'
                     jobinfo_item = 'Total downtime:'
                     actions_during_migration = "setmaxdowntime"
@@ -131,7 +140,10 @@
                     virsh_migrate_options = "--live --verbose"
                     asynch_migrate = "yes"
                     low_speed = "1"
-                    libvirtd_conf_dict = '{"log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
+                    log_conf_dict = '{"log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
+                    # Set conf type to the value in modular daemon mode, it will be converted to the\
+                    # value in monolithic daemon mode automatically according to the test env
+                    log_conf_type = "virtqemud"
                     diff_rate = '0.5'
                     jobinfo_item = 'Memory bandwidth:'
                     actions_during_migration = "setspeed,domjobinfo"
@@ -141,14 +153,17 @@
                     virsh_migrate_extra = "--tls"
                     custom_pki_path = "/etc/pki/qemu"
                     qemu_tls = "yes"
-                    libvirtd_conf_dict = '{"log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
+                    log_conf_dest_dict = '{"log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
+                    # Set conf type to the value in modular daemon mode, it will be converted to the\
+                    # value in monolithic daemon mode automatically according to the test env
+                    log_conf_type_dest = "virtqemud"
                     server_cn = "ENTER.YOUR.SERVER_CN"
                     client_cn = "ENTER.YOUR.CLIENT_CN"
                     grep_str_local_log = '"dir":"/etc/pki/qemu","endpoint":"client","verify-peer":true'
                     variants:
                         - verify_client:
                             disable_verify_peer = "no"
-                            qemu_conf_dict = '{"migrate_tls_x509_verify": "1"}'
+                            qemu_conf_dest_dict = '{"migrate_tls_x509_verify": "1"}'
                             grep_str_remote_log = '"dir":"/etc/pki/qemu","endpoint":"server","verify-peer":true'
                             variants:
                                 - no_post_after_precopy:
@@ -209,8 +224,12 @@
                         - vcpu_16:
                             vcpu_num = 16
                 - auto-converge:
-                    qemu_conf_dict = '{"keepalive_interval": "-1"}'
-                    libvirtd_conf_dict = '{"keepalive_interval": "-1", "log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
+                    libvirtd_conf_dict = '{"keepalive_interval": "-1"}'
+                    # Set conf type to the value in modular daemon mode, it will be converted to the\
+                    # value in monolithic daemon mode automatically according to the test env
+                    libvirtd_conf_type = "virtproxyd"
+                    libvirtd_conf_dest_dict = '{"keepalive_interval": "-1"}'
+                    libvirtd_conf_type_dest = "virtproxyd"
                     stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M --timeout 70"
                     actions_during_migration = "setmaxdowntime,converge"
                     asynch_migrate = "yes"
@@ -245,8 +264,12 @@
                 - migrate_uri:
                     virsh_migrate_extra = "--migrateuri tcp://${migrate_dest_host}"
                 - check_domjobinfo:
-                    qemu_conf_dict = '{"keepalive_interval": "-1"}'
-                    libvirtd_conf_dict = '{"keepalive_interval": "-1", "log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
+                    libvirtd_conf_dict = '{"keepalive_interval": "-1"}'
+                    # Set conf type to the value in modular daemon mode, it will be converted to the\
+                    # value in monolithic daemon mode automatically according to the test env
+                    libvirtd_conf_type = "virtproxyd"
+                    libvirtd_conf_dest_dict = '{"keepalive_interval": "-1"}'
+                    libvirtd_conf_type_dest = "virtproxyd"
                     asynch_migrate = "yes"
                     virsh_opt = ' -k0'
                     low_speed = "10"
@@ -260,7 +283,16 @@
                     check_event_output = "yes"
                     grep_str_local_log = 'qemuProcessHandleMigrationStatus'
                     grep_str_remote_log = 'qemuProcessHandleMigrationStatus'
-                    libvirtd_conf_dict = '{"keepalive_interval": "-1", "log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
+                    libvirtd_conf_dict = '{"keepalive_interval": "-1"}'
+                    # Set conf type to the value in modular daemon mode, it will be converted to the\
+                    # value in monolithic daemon mode automatically according to the test env
+                    libvirtd_conf_type = "virtproxyd"
+                    libvirtd_conf_dest_dict = '{"keepalive_interval": "-1"}'
+                    libvirtd_conf_type_dest = "virtproxyd"
+                    log_conf_dict = '{"log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
+                    log_conf_type = "virtqemud"
+                    log_conf_dest_dict = '{"log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
+                    log_conf_type_dest = "virtqemud"
                     check_log_interval = "yes"
                     variants:
                         - event_without_postcopy:
@@ -301,7 +333,10 @@
                             variants:
                                 - mt_method:
                                     only without_postcopy
-                                    libvirtd_conf_dict = '{"log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
+                                    log_conf_dict = '{"log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
+                                    # Set conf type to the value in modular daemon mode, it will be converted to the\
+                                    # value in monolithic daemon mode automatically according to the test env
+                                    log_conf_type = "virtqemud"
                                     level = 9
                                     threads = 5
                                     dthreads = 5
@@ -316,7 +351,10 @@
                                     virsh_migrate_extra = "--comp-methods xbzrle --comp-xbzrle-cache"
                                 - xbzrle_method_by_cmd:
                                     only without_postcopy
-                                    libvirtd_conf_dict = '{"log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
+                                    log_conf_dict = '{"log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
+                                    # Set conf type to the value in modular daemon mode, it will be converted to the\
+                                    # value in monolithic daemon mode automatically according to the test env
+                                    log_conf_type = "virtqemud"
                                     check_complete_job = "yes"
                                     virsh_migrate_extra = "--comp-methods xbzrle"
                                     comp_cache_size = 33554432
@@ -361,24 +399,27 @@
                             stress_in_vm = "yes"
                             stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M --timeout 70"
                             actions_during_migration = "drop_network_connection"
+                            # Set conf type to the value in modular daemon mode, it will be converted to the\
+                            # value in monolithic daemon mode automatically according to the test env
+                            libvirtd_conf_type_dest = "virtproxyd"
+                            log_conf_dict = '{"log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
+                            log_conf_type = "virtqemud"
+                            log_conf_dest_dict = '{r"log_level\s*=.*": 'log_level=1', r"log_outputs\s*=.*": 'log_outputs="1:file:${log_outputs}"'}'
+                            log_conf_type_dest = "virtproxyd"
                             variants:
                                 - on_both:
-                                    qemu_conf_dest_dict = '{r"keepalive_interval\s*=.*": 'keepalive_interval=5', r"keepalive_count\s*=.*": 'keepalive_count=5'}'
-                                    libvirtd_conf_dest_dict ='{r"keepalive_interval\s*=.*": 'keepalive_interval=-1', r"log_level\s*=.*": 'log_level=1', r"log_outputs\s*=.*": 'log_outputs="1:file:${log_outputs}"'}'
                                     qemu_conf_dict = '{"keepalive_interval": "-1"}'
-                                    libvirtd_conf_dict = '{"keepalive_interval": "5", "keepalive_count": "5", "log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
+                                    libvirtd_conf_dest_dict ='{r"keepalive_interval\s*=.*": 'keepalive_interval=-1', }'
                                     block_time = 40
                                 - on_target:
-                                    libvirtd_conf_dest_dict ='{r"keepalive_interval\s*=.*": 'keepalive_interval=-1', r"log_level\s*=.*": 'log_level=1', r"log_outputs\s*=.*": 'log_outputs="1:file:${log_outputs}"'}'
                                     qemu_conf_dict = '{"keepalive_interval": "5", "keepalive_count": "5"}'
-                                    libvirtd_conf_dict = '{"keepalive_interval": "5", "keepalive_count": "5", "log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
+                                    libvirtd_conf_dest_dict ='{r"keepalive_interval\s*=.*": 'keepalive_interval=-1'}'
                                     grep_str_local_log = "virKeepAliveTimerInternal.*countToDeath=4 idle=10"
                                     grep_str_not_in_remote_log = "virKeepAliveTimerInternal"
                                     block_time = 10
                                 - on_source:
-                                    qemu_conf_dest_dict = '{r"keepalive_interval\s*=.*": 'keepalive_interval=5', r"keepalive_count\s*=.*": 'keepalive_count=5'}'
                                     qemu_conf_dict = '{"keepalive_interval": "-1"}'
-                                    libvirtd_conf_dict = '{"keepalive_interval": "5", "keepalive_count": "5", "log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
+                                    libvirtd_conf_dest_dict = '{r"keepalive_interval\s*=.*": 'keepalive_interval=5', r"keepalive_count\s*=.*": 'keepalive_count=5'}'
                                     grep_str_not_in_local_log = "virKeepAliveTimerInternal.*countToDeath=4 idle=10"
                                     grep_str_remote_log = "virKeepAliveTimerInternal.*countToDeath=4 idle=10"
                                     block_time = 10
@@ -389,6 +430,7 @@
                             client_cn = "ENTER.YOUR.CLIENT_CN"
                             disable_verify_peer = "no"
                             qemu_conf_dict = '{"migrate_tls_x509_verify": "1"}'
+                            qemu_conf_dest_dict = '{"migrate_tls_x509_verify": "1"}'
                             variants:
                                 - tls_destination:
                                     only without_postcopy
@@ -507,19 +549,22 @@
                             stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M --timeout 70"
                             actions_during_migration= "drop_network_connection"
                             block_time = 40
+                            libvirtd_conf_type_dest = "virtproxyd"
+                            log_conf_dict = '{"log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
+                            log_conf_type = "virtqemud"
+                            log_conf_dest_dict = '{r"log_level\s*=.*": 'log_level=1', r"log_outputs\s*=.*": 'log_outputs="1:file:${log_outputs}"'}'
+                            log_conf_type_dest = "virtproxyd"
                             variants:
                                 - on_target:
-                                    libvirtd_conf_dest_dict = '{r".*keepalive_interval.*=.*": 'keepalive_interval=-1'}'
                                     qemu_conf_dict = '{"keepalive_interval": "5", "keepalive_count": "5"}'
-                                    libvirtd_conf_dict = '{"keepalive_interval": "5", "keepalive_count": "5", "log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
+                                    libvirtd_conf_dest_dict ='{r"keepalive_interval\s*=.*": 'keepalive_interval=-1'}'
                                     grep_str_local_log = "No response from client .* after .* keepalive messages in .* seconds"
                                     grep_str_local_log_1 = "virKeepAliveTimerInternal.*countToDeath=0 idle=30"
                                     grep_str_not_in_remote_log = "virKeepAliveTimerInternal"
                                     err_msg = "error: operation failed: Lost connection to destination host|client socket is closed"
                                 - on_source:
-                                    qemu_conf_dest_dict = '{r"keepalive_interval\s*=.*": 'keepalive_interval=5', r"keepalive_count\s*=.*": 'keepalive_count=5'}'
                                     qemu_conf_dict = '{"keepalive_interval": "-1"}'
-                                    libvirtd_conf_dict = '{"keepalive_interval": "5", "keepalive_count": "5", "log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
+                                    libvirtd_conf_dest_dict = '{r"keepalive_interval\s*=.*": 'keepalive_interval=5', r"keepalive_count\s*=.*": 'keepalive_count=5'}'
                                     grep_str_not_in_local_log = "virKeepAliveTimerInternal.*countToDeath=4 idle=10"
                                     grep_str_remote_log = "internal error: connection closed due to keepalive timeout"
                                     err_msg = "error: operation failed: migration out job:|client socket is closed"

--- a/libvirt/tests/src/migration/migrate_options_shared.py
+++ b/libvirt/tests/src/migration/migrate_options_shared.py
@@ -17,6 +17,7 @@ from avocado.core import exceptions
 
 from virttest import libvirt_vm
 from virttest import utils_misc
+from virttest import utils_split_daemons
 from virttest import defaults
 from virttest import data_dir
 from virttest import virsh
@@ -26,6 +27,7 @@ from virttest import remote
 from virttest import utils_package
 from virttest import utils_iptables
 from virttest import utils_conn
+from virttest import utils_config
 from virttest import xml_utils
 from virttest import migration
 
@@ -812,24 +814,134 @@ def run(test, params, env):
                       "is power of 2", item, pagesize)
         return item
 
-    def update_config_file(config_type, new_conf, remote_host=True,
-                           params=None):
+    def update_qemu_conf_on_local_and_remote():
+        """
+        Update qemu.conf on both local and remote hosts
+        """
+
+        conf_dict = eval(params.get("qemu_conf_dict", '{}'))
+        conf_dest_dict = params.get("qemu_conf_dest_dict", '{}')
+
+        update_conf_on_local_and_remote("qemu", "qemu",
+                                        conf_dict, conf_dest_dict)
+
+    def update_libvirtd_conf_on_local_and_remote():
+        """
+        Update libvirtd conf file on both local and remote hosts
+        """
+
+        conf_dict = eval(params.get("libvirtd_conf_dict", '{}'))
+        conf_dest_dict = params.get("libvirtd_conf_dest_dict", '{}')
+        conf_type = params.get("libvirtd_conf_type")
+        conf_type_dest = params.get("libvirtd_conf_type_dest")
+
+        update_conf_on_local_and_remote(conf_type, conf_type_dest,
+                                        conf_dict, conf_dest_dict)
+
+    def update_log_conf_on_local_and_remote():
+        """
+        Update log conf file on both local and remote hosts
+        """
+
+        conf_dict = eval(params.get("log_conf_dict", '{}'))
+        conf_dest_dict = params.get("log_conf_dest_dict", '{}')
+        conf_type = params.get("log_conf_type")
+        conf_type_dest = params.get("log_conf_type_dest")
+
+        update_conf_on_local_and_remote(conf_type, conf_type_dest,
+                                        conf_dict, conf_dest_dict)
+
+    def update_conf_on_local_and_remote(conf_type, conf_type_dest,
+                                        conf_dict, conf_dest_dict):
+        """
+        Update libvirt related conf files on both local and remote hosts
+
+        :param conf_type: String type, conf type on local host
+        :param conf_dict: Dict of parameters to set on local host
+        :param conf_type_dest: String type, conf type on remote host
+        :param conf_dest_dict: String type that contains dict of parameters
+                               to be set on remote host
+        """
+
+        if conf_dict:
+            logging.info("Update conf on local host")
+            updated_conf_local = update_config_file(
+                conf_type, conf_dict, remote=False, remote_params=None
+                )
+            local_conf_obj_list.append(updated_conf_local)
+
+        if eval(conf_dest_dict):
+            logging.info("Update conf on remote host")
+            updated_conf_remote = update_config_file(
+                conf_type_dest, conf_dest_dict, remote=True,
+                remote_params=params
+                )
+            remote_conf_obj_list.append(updated_conf_remote)
+
+    def get_conf_type(conf_type):
+        """
+        Convert the configred conf_type to the actual conf_type\
+        according to test env.
+        Note: The conf_type configured in <test>.cfg is always set to the value
+              in modular daemon mode. Need to convert it to the actual value
+              according to the test env.
+
+        :param conf_type: Configured conf_type, String type
+                          like virtlogd, virtproxyd, etc
+        :return conf_type: Actual conf_type, String type,
+                           like virtlogd, virtproxyd, etc
+        """
+
+        if (not utils_split_daemons.is_modular_daemon() and
+            conf_type in ["virtqemud", "virtproxyd", "virtnetworkd",
+                          "virtstoraged", "virtinterfaced", "virtnodedevd",
+                          "virtnwfilterd", "virtsecretd"]):
+            return "libvirtd"
+        else:
+            return conf_type
+
+    def get_conf_file_path(conf_type):
+        """
+        Get conf file path by the conf type
+
+        :param conf_type: conf type, like libvirtd, qemu, virtproxyd, etc
+        :return conf file path
+        """
+
+        return utils_config.get_conf_obj(conf_type).conf_path
+
+    def update_config_file(conf_type, conf_dict, remote=False,
+                           remote_params=None):
         """
         Update the specified configuration file with dict
 
-        :param config_type: Like libvirtd, qemu
-        :param new_conf: The str including new configuration
-        :param remote_host: True to also update in remote host
-        :param params: The dict including parameters to connect remote host
-        :return: utils_config.LibvirtConfigCommon object
+        :param conf_type: String type, conf type
+        :param conf_dict: Dict of parameters to set
+        :param remote: True to update only remote
+                       False to update only local
+        :param remote_params: Dict of remote host parameters, which should
+                              include: server_ip, server_user, server_pwd
+        :return: utils_config.LibvirtConfigCommon object if remote is False, or
+                 remote.RemoteFile objects if remote is True
         """
-        logging.debug("Update configuration file")
-        cleanup_libvirtd_log(log_file)
-        config_dict = eval(new_conf)
-        updated_conf = libvirt.customize_libvirt_config(config_dict,
-                                                        config_type=config_type,
-                                                        remote_host=remote_host,
-                                                        extra_params=params)
+
+        updated_conf = None
+
+        if not remote:
+            logging.debug("Update local conf, conf type is %s, dict is %s",
+                          conf_type, conf_dict)
+            updated_conf = libvirt.customize_libvirt_config(
+                conf_dict, config_type=conf_type,
+                remote_host=False, extra_params=None
+                )
+        else:
+            logging.debug("Update remote conf, conf type is %s, dict is %s",
+                          conf_type, conf_dict)
+            actual_conf_type = get_conf_type(conf_type)
+            file_path = get_conf_file_path(actual_conf_type)
+            updated_conf = libvirt_remote.update_remote_file(
+                remote_params, conf_dict, file_path)
+
         return updated_conf
 
     def time_diff_between_vm_host(localvm=True):
@@ -976,6 +1088,8 @@ def run(test, params, env):
     is_TestCancel = False
 
     # Objects to be cleaned up in the end
+    local_conf_obj_list = []
+    remote_conf_obj_list = []
     objs_list = []
     tls_obj = None
 
@@ -1039,33 +1153,13 @@ def run(test, params, env):
                 tls_obj.auto_recover = True
                 tls_obj.conn_setup()
 
-        # Setup qemu.conf
-        qemu_conf_dict = params.get("qemu_conf_dict")
-        qemu_conf_dest_dict = params.get("qemu_conf_dest_dict")
-        update_remote = not bool(qemu_conf_dest_dict)
-        if qemu_conf_dict:
-            qemu_conf = update_config_file('qemu',
-                                           qemu_conf_dict,
-                                           remote_host=update_remote,
-                                           params=params)
-            # Setup qemu.conf on target only
-            if qemu_conf_dest_dict:
-                qemuDestConf = libvirt_remote.update_remote_file(params,
-                                                                 qemu_conf_dest_dict,
-                                                                 '/etc/libvirt/qemu.conf')
-        # Setup libvirtd
-        libvirtd_conf_dict = params.get("libvirtd_conf_dict")
-        libvirtd_conf_dest_dict = params.get("libvirtd_conf_dest_dict")
-        update_remote = not bool(libvirtd_conf_dest_dict)
-        if libvirtd_conf_dict:
-            libvirtd_conf = update_config_file('libvirtd',
-                                               libvirtd_conf_dict,
-                                               remote_host=update_remote,
-                                               params=params)
-            # Setup libvirtd on dest
-            if libvirtd_conf_dest_dict:
-                libvirtDestConf = libvirt_remote.update_remote_file(params,
-                                                                    libvirtd_conf_dest_dict)
+        # Clean up existing libvirtd log
+        cleanup_libvirtd_log(log_file)
+
+        # Setup libvirt related conf files
+        update_qemu_conf_on_local_and_remote()
+        update_libvirtd_conf_on_local_and_remote()
+        update_log_conf_on_local_and_remote()
 
         # Prepare required guest xml before starting guest
         if contrl_index:
@@ -1561,14 +1655,19 @@ def run(test, params, env):
                                                  is_recover=True,
                                                  config_object=qemu_conf)
 
-            for update_conf in [libvirtd_conf, qemu_conf]:
-                if update_conf:
-                    logging.debug("Recover the configurations")
-                    libvirt.customize_libvirt_config(None,
-                                                     remote_host=True,
-                                                     extra_params=params,
-                                                     is_recover=True,
-                                                     config_object=update_conf)
+            local_conf_obj_list.reverse()
+            for conf in local_conf_obj_list:
+                logging.info("Recover the conf files on local host")
+                libvirt.customize_libvirt_config(None,
+                                                 remote_host=False,
+                                                 is_recover=True,
+                                                 config_object=conf)
+
+            remote_conf_obj_list.reverse()
+            for conf in remote_conf_obj_list:
+                logging.info("Recover the conf files on remote host")
+                del conf
+
             if src_libvirt_file:
                 src_libvirt_file.restore()
             if remote_libvirt_file:


### PR DESCRIPTION
Translation of conf_type from monolithic daemon mode to modular daemon
mode is complex and depends on the parameter to be configured heavily,
while the reverse translation is much more simple by tranlating all the
conf_type of modular daemon mode to "libvirtd". This commit sets the
conf_type to the value of modular daemon mode in <test>.cfg and the
<test>.py or avocado-vt utils will translate to "libvirtd" if test env
is monolithic daemon mode.

Signed-off-by: Fangge Jin <fjin@redhat.com>