### PR TITLE
migrate_vm: Remove steps of setting selinux mode to permissive

### DIFF
--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -1598,18 +1598,6 @@ def run(test, params, env):
             test_dict['brick_path'] = os.path.join(test.virtdir, pool_name)
 
         if gluster_disk:
-            logging.info("Put local SELinux in permissive mode")
-            utils_selinux.set_status("permissive")
-            LOCAL_SELINUX_ENFORCING = False
-
-            logging.info("Put remote SELinux in permissive mode")
-            cmd = "setenforce permissive"
-            status, output = run_remote_cmd(cmd, server_ip, server_user, server_pwd)
-            if status:
-                test.cancel("Failed to set SELinux in permissive mode")
-
-            REMOTE_SELINUX_ENFORCING = False
-
             # Setup glusterfs and disk xml.
             disk_img = "gluster.%s" % disk_format
             test_dict['disk_img'] = disk_img


### PR DESCRIPTION
We should always do testing with selinux mode set to enforcing, or
we may miss bugs related to libvirt sVirt or selinux-policy.

Signed-off-by: Fangge Jin <fjin@redhat.com>