### PR TITLE
 Fix disk device 'lun' issue in blockcopy job

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcopy.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcopy.cfg
@@ -119,6 +119,9 @@
                     variants:
                         - lun_t:
                             no volume_type, no_blockdev, shallow
+                            disk_format = "raw"
+                            disk_target_bus = "scsi"
+                            disk_target = "sda"
                             disk_device = 'lun'
                         - disk_t:
                             disk_device = 'disk'


### PR DESCRIPTION
Fix error "unsupported configuration: disk device 'lun' must use 'raw' format" in blockcopy job: it's better to use 'raw' format and 'scsi' bus to test lun disk

Signed-off-by: Meina Li <meili@redhat.com>