### PR TITLE
Add the missing configuration for virsh_restore test

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_restore.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_restore.cfg
@@ -28,6 +28,7 @@
                     setup_nfs = "yes"
                     nfs_mount_dir = "/var/lib/libvirt/restore_nfs"
                     export_dir = "/var/lib/avocado/data/avocado-vt/images"
+                    export_options = "rw,no_root_squash"
                     sec_model = "dac"
                     disk_source_protocol = 'netfs'
                     relabel = 'no'


### PR DESCRIPTION
If you mount an NFS without "rw,no_root_squash" option, an error
is reported.

Signed-off-by: Yingshun Cui <yicui@redhat.com>