### PR TITLE
migrate_vm: Remove case *.source_hugemem_less_than_vm_mem.*

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_vm.cfg
+++ b/libvirt/tests/cfg/migration/migrate_vm.cfg
@@ -612,14 +612,6 @@
                                 - no_config_target:
                                     setup_hugepages = "yes"
                                     mb_enable = "yes"
-                                - source_hugemem_less_than_vm_mem:
-                                    setup_hugepages = "yes"
-                                    target_hugepages = 10
-                                    mb_enable = "yes"
-                                    config_remote_hugepages = "yes"
-                                    remote_target_hugepages = ${target_hugepages}
-                                    remote_hugetlbfs_path = "/dev/hugepages"
-                                    restart_libvirtd_remotely = "yes"
                                 - target_hugemem_less_than_vm_mem:
                                     setup_hugepages = "yes"
                                     mb_enable = "yes"


### PR DESCRIPTION
This case doesn't make sense. When hugemem on src host is less than
vm mem, vm will fail to start in the first place, migration can't
be performed at all.

Signed-off-by: Fangge Jin <fjin@redhat.com>