### PR TITLE
Add client private key encryption cases on nbd

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_nbd.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_nbd.cfg
@@ -38,6 +38,17 @@
     variants:
         - enable_tls:
             enable_tls = "yes"
+            variants:
+                - default:
+                - client_private_key_encryption:
+                    only coldplug..disable_export..lifecycle_operate
+                    virt_disk_device_format = "raw"
+                    deleteExisted = "no"
+                    virt_disk_check_partitions = "no"
+                    private_key_password = "redhat"
+                    enable_private_key_encryption = "yes"
+                    sec_usage = "tls"
+                    sec_private = "yes"
         - disable_tls:
             enable_tls = "no"
     variants:


### PR DESCRIPTION
After libvirt 6.6.0, client private key encryption is now supported

Signed-off-by: chunfuwen <chwen@redhat.com>