### PR TITLE
Fix npiv_hostdev_passthrough.py session close error

### DIFF
--- a/libvirt/tests/src/npiv/npiv_hostdev_passthrough.py
+++ b/libvirt/tests/src/npiv/npiv_hostdev_passthrough.py
@@ -159,6 +159,8 @@ def run(test, params, env):
         result = virsh.detach_device(vm_name, new_hostdev_xml.xml)
         libvirt.check_exit_status(result, status_error)
         # login vm and check disk actually removed
+        if not vm.session:
+            session = vm.wait_for_login()
         parts_after_detach = utils_disk.get_parts_list(session)
         old_parts.sort()
         parts_after_detach.sort()


### PR DESCRIPTION
After attaching disk the VM session will be closed,so the partiton check
later will fail because of the session close.Add the detect of vm session
and start the session if session in closed status.

Signed-off-by: jgao <jgao@redhat.com>