### PR TITLE
Update ceph_disk_name to EXAMPLE_DISK_NAME

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/pool/virsh_pool_auth.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/pool/virsh_pool_auth.cfg
@@ -27,7 +27,7 @@
             secret_description = "rbd secret"
             secret_usage_type = "ceph"
             auth_type = "ceph"
-            ceph_disk_name = "avocado-vt-pool/secret.img"
+            ceph_disk_name = "EXAMPLE_DISK_NAME"
             ceph_host_ip = "EXAMPLE_HOSTS_AUTHX"
             ceph_mon_ip = "EXAMPLE_MON_HOST_AUTHX"
             ceph_client_name = "EXAMPLE_CLIENT_NAME"


### PR DESCRIPTION
Ceph settings will be updated in ci, so update the value of
ceph_disk_name to EXAMPLE_DISK_NAME which will be replaced by ci.

Signed-off-by: Yingshun Cui <yicui@redhat.com>