### PR TITLE
github: Add a template for the new pull requests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+# Format of PR title < sub-system: summary >
+e.g
+*virsh_migrate: Fix unsupported direct socket mode issue*
+
+# Check lists by category
+## If the PR is new cases
+- [ ] Description of the cases
+- [ ] Links of libvirt features, libvirt bugs or case IDs
+- [ ] Test results
+
+## If the PR is bug cases
+- [ ] Bug descriptions or bug links
+- [ ] Test results
+
+## If the PR is a trivial fix
+It it is the fix of typos, comments or documents, the description of PR could be skipped.


### PR DESCRIPTION
Add the github a pull request template[1] for bug fixes, new cases, and tiny
fixes. They will help the contributors provide necessary information of their
pull requests.

[1]:
https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/creating-a-pull-request-template-for-your-repository

Signed-off-by: Han Han <hhan@redhat.com>