### PR TITLE
Add cases for starting guest without usb cotroller in guest xml

### DIFF
--- a/libvirt/tests/cfg/usb_device.cfg
+++ b/libvirt/tests/cfg/usb_device.cfg
@@ -48,6 +48,10 @@
             usb_alias = "yes"
             usb_model = "ich9-ehci1,ich9-uhci1,ich9-uhci2,ich9-uhci3,nec-xhci,qemu-xhci,piix3-uhci,piix4-uhci,vt82c686b-uhci"
             set_addr = "no"
+        - usb_none:
+            only pcie-to-pci-bridge
+            only bus_dev
+            usb_model = "none"
     variants:
         # usb device
         - passthrough:


### PR DESCRIPTION
Start guest without usb cotroller in guest xml. The default usb controller will be added into xml automatically.
For q35 guest, will add usb3.
Check if the controller is added as expected.

Singed-off-by: ljmen <lmen@redhat.com>