### PR TITLE
Add cases for pull mode backup with tls enabled

### DIFF
--- a/libvirt/tests/cfg/incremental_backup/incremental_backup_pull_mode.cfg
+++ b/libvirt/tests/cfg/incremental_backup/incremental_backup_pull_mode.cfg
@@ -3,6 +3,10 @@
     start_vm = "no"
     original_disk_size = "100M"
     backup_data_size = "1M"
+    local_hostname = "ENTER.YOUR.HOSTNAME"
+    local_ip = "ENTER.YOUR.IPV4ADDR"
+    local_user_name = "ENTER.YOUR.USER.NAME"
+    local_user_password = "ENTER.YOUR.USER.PASSWORD"
     variants:
         - custom_exportname:
             set_exportname = "yes"
@@ -67,3 +71,26 @@
             original_disk_type = "iscsi"
         - original_disk_local:
             original_disk_type = "local"
+    variants:
+        - tls_enabled:
+            only custom_exportname..custom_exportbitmap..nbd_tcp..scratch_to_file..not_reuse_scratch_file..original_disk_local
+            tls_enabled = "yes"
+            variants:
+                - verify_client_cert:
+                    tls_x509_verify = "yes"
+                    variants:
+                        - negative_test:
+                            only incremental_backup.pull_mode.tls_enabled.default_pki_path.verify_client_cert.negative_test.no_client_cert.original_disk_local.coldplug_disk
+                            variants:
+                                - no_client_cert:
+                                    tls_provide_client_cert = "no"
+                                    tls_error = "yes"
+                        - positive_test:
+                            tls_provide_client_cert = "yes"
+                - not_verify_client_cert:
+                    tls_x509_verify = "no"
+            variants:
+                - default_pki_path:
+                - custom_pki_path:
+                    custom_pki_path = "yes"
+        - tls_disabled:


### PR DESCRIPTION
Since libvirt-6.6.0-1.el8(bz1822631), libvirt starts to support pull mode
backup with tls enbaled. This patch is to add related test cases.

Signed-off-by: Yi Sun <yisun@redhat.com>