### PR TITLE
Filter out hypervisor-cpu-compare on s390x

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_hypervisor_cpu_compare.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_hypervisor_cpu_compare.cfg
@@ -66,6 +66,7 @@
                     cpu_mode = "host-passthrough"
                     msg_pattern = "superset"
         - capa_xml:
+            no s390-virtio
             compare_file_type = "capa_xml"
             status_error = "yes"
             msg_pattern = "incompatible"
@@ -76,6 +77,7 @@
                     compare_file_type = "domxml"
                     msg_pattern = "superset|identical"
                 - f_capa_xml:
+                    no s390-virtio
                     compare_file_type = "capa_xml"
                     status_error = "yes"
                     msg_pattern = "incompatible"


### PR DESCRIPTION
Using <cpu> node from 'virsh capabilities' is not supported on s390x,
s. https://bugzilla.redhat.com/show_bug.cgi?id=1850654

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>