### PR TITLE
Fix hypervisor-cpu-compare for host-processor on s390x

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_hypervisor_cpu_compare.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_hypervisor_cpu_compare.cfg
@@ -65,6 +65,8 @@
                 - host_passthrough:
                     cpu_mode = "host-passthrough"
                     msg_pattern = "superset"
+                    s390-virtio:
+                        msg_pattern = "identical"
         - capa_xml:
             compare_file_type = "capa_xml"
             status_error = "yes"


### PR DESCRIPTION
On s390x, the expected comparison result is
"CPU described in <cpu-xml-filename> is identical to the CPU provided by hypervisor on the host",
s. https://bugzilla.redhat.com/show_bug.cgi?id=1850680

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>