### PR TITLE
Add fwcfg type of sysinfo element test cases

### DIFF
--- a/libvirt/tests/cfg/bios/virsh_boot_sysinfo.cfg
+++ b/libvirt/tests/cfg/bios/virsh_boot_sysinfo.cfg
@@ -1,0 +1,47 @@
+- virsh.boot_sysinfo:
+    type = virsh_boot_sysinfo
+    start_vm = "no"
+    variants:
+        - sysinfo_fwcfg:
+            sysinfo_type = "fwcfg"
+            value_string = "example value"
+            variants:
+                - positive_test:
+                    status_error = "no"
+                    variants:
+                        - entry_value:
+                            with_value = "yes"
+                            entry_name = "opt/com.example/name"
+                        - entry_file:
+                            entry_name = "opt/com.cores/config"
+                            with_file = "yes"
+                - negative_test:
+                    status_error = "yes"
+                    variants:
+                        - entry_value:
+                            variants:
+                                - without_name:
+                                    without_name = "yes"
+                                    error_msg = "Firmware entry is missing 'name' attribute"
+                                - without_prefix_opt:
+                                    with_value = "yes"
+                                    entry_name = "/tmp/com.example/name"
+                                    error_msg = "Invalid firmware name"
+                        - entry_file:
+                            with_file = "yes"
+                            variants:
+                                - with_exist_name:
+                                    entry_name = "opt/org.qemu/"
+                                    error_msg = "That firmware name is reserved"
+                                - without_file:
+                                    with_file = "no"
+                                    entry_name = "opt/com.cores/config"
+                                    error_msg = "Firmware entry must have either value or 'file' attribute"
+    variants:
+        - by_seabios:
+            boot_type = "seabios"
+        - by_ovmf:
+            only q35
+            boot_type = "ovmf"
+            loader_type = "pflash"
+            loader = "/usr/share/OVMF/OVMF_CODE.secboot.fd"

--- a/libvirt/tests/src/bios/virsh_boot_sysinfo.py
+++ b/libvirt/tests/src/bios/virsh_boot_sysinfo.py
@@ -1,0 +1,140 @@
+import logging
+import os
+
+from virttest import virsh
+from virttest import utils_package
+from virttest import libvirt_version
+from virttest import data_dir
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_test import libvirt
+
+
+def check_in_vm(test, vm, **kwargs):
+    """
+    Check the output of fwcfg and smbios info in guest
+    """
+    sysinfo_type = kwargs.get("sysinfo_type")
+    value_string = kwargs.get("value_string")
+    entry_name = kwargs.get("entry_name")
+    session = vm.wait_for_login()
+    if sysinfo_type == "fwcfg":
+        test_cmd = ("grep \"%s\" /sys/firmware/qemu_fw_cfg/by_name/%s/raw"
+                    % (value_string, entry_name))
+    status, output = session.cmd_status_output(test_cmd)
+    logging.debug("CMD '%s' running result is:\n%s", test_cmd, output)
+    if status:
+        test.fail(output)
+    if not output:
+        test.fail("Gan't get correct sysinfo value in guest")
+    session.close()
+    return output
+
+
+def run(test, params, env):
+    """
+    Test sysinfo in guest
+    <sysinfo type='fwcfg'>...</sysinfo>
+    <sysinfo type='smbios'>...</sysinfo>
+
+    Steps:
+    1) Edit VM XML for sysinfo element
+    2) Verify if guest can boot as expected
+    3) Check if the sysinfo is correct
+    """
+
+    vm_name = params.get("main_vm", "")
+    vm = env.get_vm(vm_name)
+    boot_type = params.get("boot_type", "")
+    loader_type = params.get("loader_type")
+    loader = params.get("loader")
+    sysinfo_type = params.get("sysinfo_type", "")
+    entry_name = params.get("entry_name")
+    value_string = params.get("value_string")
+    with_file = ("yes" == params.get("with_file", "no"))
+    with_value = ("yes" == params.get("with_value", "no"))
+    entry_file = os.path.join(data_dir.get_tmp_dir(), "provision.ign")
+    err_msg = params.get("error_msg", "")
+    status_error = ("yes" == params.get("status_error", "no"))
+    without_name = ("yes" == params.get("without_name", "no"))
+
+    if not libvirt_version.version_compare(6, 5, 0):
+        test.cancel("FWCFG sysinfo is not supported in "
+                    "current libvirt version")
+
+    if (boot_type == "seabios" and
+            not utils_package.package_install('seabios-bin')):
+        test.cancel("Failed to install Seabios")
+
+    if (boot_type == "ovmf" and
+            not utils_package.package_install('OVMF')):
+        test.cancel("Failed to install OVMF")
+
+    # Back VM XML
+    vmxml_backup = vm_xml.VMXML.new_from_dumpxml(vm_name)
+    vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+
+    try:
+        # Specify boot loader for OVMF
+        if boot_type == "ovmf":
+            os_xml = vmxml.os
+            os_xml.loader_type = loader_type
+            os_xml.loader = loader
+            os_xml.loader_readonly = "yes"
+            vmxml.os = os_xml
+
+        # Set attributes of fwcfg sysinfo in VMSysinfoXML
+        if sysinfo_type == "fwcfg":
+            sysinfo_xml = vm_xml.VMSysinfoXML()
+            sysinfo_xml.type = sysinfo_type
+
+            # Test with entry value in text
+            if with_value:
+                sysinfo_xml.entry_name = entry_name
+                sysinfo_xml.entry = value_string
+
+            # Test with entry file
+            if with_file:
+                with open('%s' % entry_file, 'w+') as f:
+                    f.write('%s' % value_string)
+                sysinfo_xml.entry_name = entry_name
+                sysinfo_xml.entry_file = entry_file
+            # Negative test without entry name
+            elif without_name:
+                sysinfo_xml.entry = value_string
+            # Negative test without file in entry
+            else:
+                sysinfo_xml.entry_name = entry_name
+
+        vmxml.sysinfo = sysinfo_xml
+        logging.debug("New VM XML is:\n%s" % vmxml)
+        ret = virsh.define(vmxml.xml)
+        libvirt.check_result(ret, expected_fails=err_msg)
+        result = virsh.start(vm_name, debug=True)
+        libvirt.check_exit_status(result)
+
+        if not status_error:
+            # Check result in dumpxml and qemu cmdline
+            if with_file:
+                expect_xml_line = "<entry file=\"%s\" name=\"%s\" />" % (entry_file, entry_name)
+                expect_qemu_line = "-fw_cfg name=%s,file=%s" % (entry_name, entry_file)
+            if with_value:
+                expect_xml_line = "<entry name=\"%s\">%s</entry>" % (entry_name, value_string)
+                expect_qemu_line = "-fw_cfg name=%s,string=%s" % (entry_name, value_string)
+            libvirt.check_dumpxml(vm, expect_xml_line)
+            libvirt.check_qemu_cmd_line(expect_qemu_line)
+
+            # Check result in guest
+            kwargs = {"sysinfo_type": sysinfo_type,
+                      "value_string": value_string,
+                      "entry_name": entry_name}
+            check_in_vm(test, vm, **kwargs)
+
+    finally:
+        logging.debug("Start to cleanup")
+        if vm.is_alive():
+            vm.destroy()
+        logging.debug("Restore the VM XML")
+        vmxml_backup.sync(options="--nvram")
+        # Remove tmp file
+        if os.path.exists(entry_file):
+            os.remove(entry_file)


### PR DESCRIPTION
Add fwcfg type of sysinfo element test cases
1) Define/start guest with fw_cfg sysinfo
2) Define/start guest with invaild entry value for fw_cfg type sysinfo

Signed-off-by: Meina Li <meili@redhat.com>