### PR TITLE
pcie_controllers: support auto index

### DIFF
--- a/libvirt/tests/cfg/controller/pcie_controllers.cfg
+++ b/libvirt/tests/cfg/controller/pcie_controllers.cfg
@@ -5,9 +5,8 @@
     check_within_guest = "yes"
     check_disk_xml = "yes"
     controller_model = 'pcie-root-port'
-    contr_index = 6
     target_dev = 'vdb'
-    disk_addr = '0x0000.0x06.0x00.0x0'
+    disk_addr = '0x0000.0x%s.0x00.0x0'
     attach_extra = '--address pci:${disk_addr}'
     only q35
     variants:
@@ -43,11 +42,11 @@
             variants:
                 - hotplug:
                     hotplug = 'yes'
-                    err_msg = "PCI controller with index='${contr_index}' doesn't support hotplug"
+                    err_msg = "PCI controller with index='%s' doesn't support hotplug"
                 - hotunplug:
                     hotplug = 'no'
                     attach_extra = '--address pci:${disk_addr} --subdriver qcow2 --config'
-                    err_msg = "cannot hot unplug.*device with PCI.*address: 0000:0${contr_index}:00.0.*not allowed by controller"
+                    err_msg = "cannot hot unplug.*device with PCI.*address: 0000:0%s:00.0.*not allowed by controller"
                 - multiple_hotplug:
                     hotplug = 'yes'
                     hotplug_counts = 5


### PR DESCRIPTION
This is to support the newly added controller can be detected with
an index automatically instead of defining a fix number for its index
in order to avoid of below error in future when vm xml is changed.

 error: XML error: Attempted double use of PCI Address 0000:06:00.0"

Signed-off-by: Dan Zheng <dzheng@redhat.com>