### PR TITLE
Fix getting hostname atest-guest is not same with setting: redhatipv4…

### DIFF
--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_update.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_update.py
@@ -822,8 +822,8 @@ def run(test, params, env):
                     if "ip-dhcp" in net_section:
                         dhclient_cmd = "(if pgrep dhclient;" \
                                        "then pkill dhclient; sleep 3; fi) " \
-                                       "&& dhclient -%s" % ip_version[-1]
-                        session.cmd(dhclient_cmd)
+                                       "&& dhclient -%s -lf /dev/stdout" % ip_version[-1]
+                        leases = session.cmd_output(dhclient_cmd)
                         iface_ip = utils_net.get_guest_ip_addr(session, mac,
                                                                ip_version=ip_version,
                                                                timeout=10)
@@ -841,8 +841,10 @@ def run(test, params, env):
                             test.fail("getting ip %s is not same with setting %s"
                                       % (iface_ip, new_dhcp_host_ip))
                         hostname = session.cmd_output("hostname -s").strip('\n')
-                        if hostname == new_dhcp_host_name.split('.')[0]:
-                            logging.info("getting hostname same with setting: %s", hostname)
+                        # option host-name "redhatipv4-2"
+                        dhcp_hostname = "option host-name \"%s\"" % new_dhcp_host_name.split('.')[0]
+                        if hostname == new_dhcp_host_name.split('.')[0] or dhcp_hostname in leases:
+                            logging.info("getting hostname same with setting: %s", new_dhcp_host_name.split('.')[0])
                         else:
                             test.fail("getting hostname %s is not same with "
                                       "setting: %s" % (hostname, new_dhcp_host_name))


### PR DESCRIPTION
…-2.redhat.com

Previously, we hope the guest set hostname according to the hostname
from the dhcp reply, however, this process only works when the guest
didn't have a static name(/etc/hostname) before that isn't a general
case in modern OSes.

And our purpose is just to verify if the dhcp server can reply the
hostname to the guest. so we can try to get this information from the
lease file on the guest.

the lease contents are like:
```
lease {
  interface "eth0";
  fixed-address 192.168.122.229;
  option subnet-mask 255.255.255.0;
  option routers 192.168.122.1;
  option dhcp-lease-time 3600;
  option dhcp-message-type 5;
  option domain-name-servers 192.168.122.1;
  option dhcp-server-identifier 192.168.122.1;
  option dhcp-renewal-time 1800;
  option broadcast-address 192.168.122.255;
  option dhcp-rebinding-time 3150;
  option host-name "centos75ga";
  renew 4 2020/10/29 04:17:16;
  rebind 4 2020/10/29 04:42:22;
  expire 4 2020/10/29 04:49:52;
}
```

after this patch:
avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio unattended_install.import.import.default_install.aio_native type_specific.io-github-autotest-libvirt.virsh.net_update.normal-test.add-first.ip_dhcp_host.ipv4_addr.net_active.options_no.ip_dhcp_opt.with_ip_dhcp.default_parent_index.use-in-guest --vt-extra-params mem=4096 smp=4
JOB ID     : 4d037ac1ea2e55acca71dba2368e18865fa4fab8
JOB LOG    : /root/avocado/job-results/job-2020-11-11T11.27-4d037ac/job.log
 (1/2) io-github-autotest-qemu.unattended_install.import.import.default_install.aio_native: PASS (49.48 s)
 (2/2) type_specific.io-github-autotest-libvirt.virsh.net_update.normal-test.add-first.ip_dhcp_host.ipv4_addr.net_active.options_no.ip_dhcp_opt.with_ip_dhcp.default_parent_index.use-in-guest: |
PASS (232.05 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 282.25 s

Signed-off-by: Li Zhijian <lizhijian@cn.fujitsu.com>