### PR TITLE
Fix for "IndexError: list index out of range" 

### DIFF
--- a/libvirt/tests/src/numa/guest_numa.py
+++ b/libvirt/tests/src/numa/guest_numa.py
@@ -69,9 +69,13 @@ def run(test, params, env):
             # 'node,nodeid=1,cpus=2-3,memdev=ram-node1'
             for cmd in cmdline_list:
                 line = cmd['cmdline']
-                node = line.split(',')[1][-1]
-                cmd['cmdline'] = line.replace('mem=512',
-                                              'memdev=ram-node{}'.format(node))
+                try:
+                    node = line.split(',')[1][-1]
+                    cmd['cmdline'] = line.replace('mem=512',
+                                                  'memdev=ram-node{}'.format(node))
+                # We can skip replacing, when the cmdline parameter is empty.
+                except IndexError:
+                    pass
 
         return cmdline_list
 


### PR DESCRIPTION
Issue, where automated tests were failing due to: _IndexError: list index out of range on libvirt/tests/src/numa/guest_numa.py", line 72, in replace_qemu_cmdline_ is fixed by this patch. The root cause is when the cmdline parameter is empty and the code is trying to parse it. This causes IndexError exception, that is now captured, and the code for replacing is skipped (there is no replacing needed, when the parameter is empty).