### PR TITLE
Fix the failure for nvdimm memory case as the qemu cmd line changed in the new version

### DIFF
--- a/libvirt/tests/cfg/memory/nvdimm.cfg
+++ b/libvirt/tests/cfg/memory/nvdimm.cfg
@@ -74,7 +74,7 @@
                     setvm_current_mem_unit = KiB
                     setvm_vcpu = 2
                     setvm_placement = static
-                    qemu_checks = nvdimm=on`-smp 2,sockets=2,cores=1,threads=1 -numa node,nodeid=0,cpus=0-1,mem=512`mem-path=${nvdimm_file},share=yes`node=0
+                    qemu_checks = nvdimm=on`-smp 2,sockets=2,dies=1,cores=1,threads=1`-numa node,nodeid=0,cpus=0-1,mem=512|-object memory-backend-ram,id=ram-node0,size=536870912 -numa node,nodeid=0,cpus=0-1,memdev=ram-node0`mem-path=${nvdimm_file},share=yes`node=0
                     pseries:
                         check = ppc_no_label
                         status_error = yes


### PR DESCRIPTION
```
# avocado run --vt-type libvirt nvdimm.back_file.no_label 
JOB ID     : 6f055a31ff8d0a011c4a28f10074e9819322301e
JOB LOG    : /root/avocado/job-results/job-2020-11-12T06.40-6f055a3/job.log
 (1/1) type_specific.io-github-autotest-libvirt.nvdimm.back_file.no_label: PASS (128.84 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 130.50 s
```


Signed-off-by: Kylazhang <weizhan@redhat.com>