### PR TITLE
[nodedev-list] add support for dasd on s390x

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_list.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_list.cfg
@@ -14,6 +14,9 @@
                     tree_option = on
                 - one_cap_option:
                     cap_option = one
+                    comparison_mode = exact
+                    s390-virtio:
+                        comparison_mode = similar
                 - multi_cap_option:
                     cap_option = multi
                 - long_cap_option:


### PR DESCRIPTION
Use the partial comparison for s390x only
-----------------------------------------
A dasd block device identifier listed by nodedev-list
has a different format. Allow for non-exact comparison of
identifiers from sysfs and nodedev-list in order to avoid
reimplementing the identifier creation logic in the test.
For example, info from sysfs block_dasda will match
block_dasda_IBM_750000000FRB71_0230_0c.

Add css and ccw caps check
--------------------------
dasd block devices have ccw parents that hold important information
for passthrough configuration, e.g. driver and subchannel id.

ccw devices have css that hold information to check if a device
has already been assigned to passthrough driver or not.

Requires cio_ignore=all
--------------------------------
Tests might fail if subchannel io devices without actual devices attached
aren't blacklisted. cio_ignore=all should have been set accordingly
on the host. See cio_ignore manpage.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>