### PR TITLE
[nodedev-dumpxml] add dasd support on s390x

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_dumpxml_chain.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_dumpxml_chain.cfg
@@ -1,0 +1,10 @@
+- virsh.nodedev_dumpxml_chain:
+    type = virsh_nodedev_dumpxml_chain
+    vms = ""
+    main_vm = ""
+    start_vm = "no"
+    variants:
+        - device_type_dasd:
+            only s390-virtio
+            checks = '[{"capability/block": r"/dev/dasd","capability/drive_type": r"dasd"},{"driver/name": r"dasd"},{"driver/name": r"(io_subchannel|vfio_ccw)"}]'
+            chain_start_device_pattern = "block_dasd"

--- a/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_dumpxml_chain.py
+++ b/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_dumpxml_chain.py
@@ -1,0 +1,79 @@
+import logging
+import re
+
+from virttest import virsh
+from virttest.libvirt_xml.base import LibvirtXMLBase
+
+
+def run(test, params, env):
+    """
+    Test properties of a chain of devices, starting at a given device
+    going up per parent.
+    """
+
+    chain_start_device_pattern = params.get("chain_start_device_pattern")
+    checks = eval(params.get("checks"))
+    result = virsh.nodedev_list(ignore_status=False)
+    selected_device = get_device(result.stdout_text.strip().splitlines(),
+                                 chain_start_device_pattern)
+    if not selected_device:
+        test.error("No suitable device found for test."
+                   "Pattern: %s. Available devices: %s." %
+                   (chain_start_device_pattern, result.stdout))
+
+    xml = get_nodedev_dumpxml(selected_device)
+    validate_nodedev_xml(test, xml)
+    for check in checks:
+        for xpath, pattern in check.items():
+            value = xml.xmltreefile.findtext(xpath)
+            value = value if value else ""
+            if not re.search(pattern, value):
+                test.fail("Unexpected value on xpath '%s':"
+                          " '%s' does not match '%s'" %
+                          (xpath, value, pattern))
+        xml = get_nodedev_dumpxml(xml.xmltreefile.findtext("parent"))
+        validate_nodedev_xml(test, xml)
+
+
+def validate_nodedev_xml(test, xml):
+    """
+    Validates the xml against nodedev schema
+
+    :param test: avocado test instance
+    :param xml: LibvirtXMLBase instance
+    """
+    result = xml.virt_xml_validate(xml.xml, "nodedev")
+    if result.exit_status:
+        test.fail("nodedev xml invalid: %s", xml.xml)
+
+
+def get_nodedev_dumpxml(selected_device):
+    """
+    Returns LibvirtXMLBase instance holding the nodedev xml.
+
+    :param selected_device: device identifier
+    :return: LibvirtXMLBase instance from nodedev-dumpxml output
+    """
+    result = virsh.nodedev_dumpxml(selected_device, ignore_status=False)
+    xml = LibvirtXMLBase()
+    xml.xml = result.stdout_text
+    logging.debug("nodedev-dumpxml for '%s': %s", selected_device,
+                  xml.xmltreefile)
+    return xml
+
+
+def get_device(nodedev_list, pattern):
+    """
+    Returns a device identifier from the nodedev-list output
+    based on a pattern.
+
+    :param nodedev_list: The list of device identifiers, e.g.
+        ["net_lo_00_00_00_00_00_00",
+         "block_sda_333333330000007d0"]
+    :param pattern: regex pattern to match at least one device
+    :return: The first device identifier matching 'pattern'
+    """
+    for dev_id in nodedev_list:
+        if re.search(pattern, dev_id):
+            return dev_id
+    return None


### PR DESCRIPTION
The dumpxml information is used to set up a vfio_ccw passthrough device.
The device hierarchy by cap is dasd -> ccw -> css. The css id is used to
configure the mdev.

Test minimally that the chain is valid and that the device are
of the right type for dasd passthrough.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>