### PR TITLE
Dynamic numa guest nodes fix

### DIFF
--- a/libvirt/tests/cfg/numa/guest_numa.cfg
+++ b/libvirt/tests/cfg/numa/guest_numa.cfg
@@ -6,6 +6,7 @@
     vcpu_num = 4
     max_mem = 1048576
     hugepage_force_allocate = "yes"
+    numa_cells_with_memory_required = 2
     variants:
         - possitive_test:
              cell_id_0 = "0"
@@ -19,7 +20,7 @@
                      memory_placement = "static"
                      memory_nodeset = "0-1"
                      memory_mode = "strict"
-                     qemu_cmdline_mem_backend_1 = "memory-backend-ram,.*?id=ram-node1,.*?host-nodes=0-1,policy=bind"
+                     qemu_cmdline_mem_backend_1 = "memory-backend-ram,.*?id=ram-node1,.*?host-nodes=[0-9,],policy=bind"
                      pseries:
                          memory_nodeset = "0"
                          qemu_cmdline_mem_backend_1 = "memory-backend-ram,.*?id=ram-node1,.*?host-nodes=0,policy=bind"
@@ -39,17 +40,17 @@
                          - m_strict:
                              memnode_mode_0 = "strict"
                              kernel_hp_file = "/sys/devices/system/node/node1/hugepages/hugepages-2048kB/nr_hugepages"
-                             qemu_cmdline_mem_backend_0 = "id=ram-node0,.*?host-nodes=1,policy=bind"
+                             qemu_cmdline_mem_backend_0 = "id=ram-node0,.*?host-nodes=\d,policy=bind"
                              pseries:
                                 qemu_cmdline_mem_backend_0 = "id=ram-node0,.*?host-nodes=0,policy=bind"
                          - m_preferred:
                              memnode_mode_0 = "preferred"
-                             qemu_cmdline_mem_backend_0 = "id=ram-node0,.*?host-nodes=1,policy=preferred"
+                             qemu_cmdline_mem_backend_0 = "id=ram-node0,.*?host-nodes=\d,policy=preferred"
                              pseries:
                                 qemu_cmdline_mem_backend_0 = "id=ram-node0,.*?host-nodes=0,policy=preferred"
                          - m_interleave:
                              memnode_mode_0 = "interleave"
-                             qemu_cmdline_mem_backend_0 = "id=ram-node0,.*?host-nodes=1,policy=interleave"
+                             qemu_cmdline_mem_backend_0 = "id=ram-node0,.*?host-nodes=\d,policy=interleave"
                              pseries:
                                 qemu_cmdline_mem_backend_0 = "id=ram-node0,.*?host-nodes=0,policy=interleave"
              variants:
@@ -73,7 +74,7 @@
                      vmpage_nodeset_0 = "0"
                      qemu_cmdline_numa_cell_0 = "node,nodeid=0,cpus=0-1,memdev=ram-node0"
                      qemu_cmdline_numa_cell_1 = "node,nodeid=1,cpus=2-3,memdev=ram-node1"
-                     qemu_cmdline_mem_backend_prealloc_0 = "(?:id=ram-node0),mem-path=\S+,prealloc=yes,size=\d+M?|(?:id=ram-node0),prealloc=yes,mem-path=\S+,size=\d+M?|prealloc=yes,mem-path=\S+,size=\d+M?,(?:id=ram-node0)"
+                     qemu_cmdline_mem_backend_prealloc_0 = "(?:id=ram-node0),prealloc=yes,mem-path=\S+,size=\d+M?|prealloc=yes,mem-path=\S+,size=\d+M?,(?:id=ram-node0)"
                      variants:
                          - per_node:
                              variants:


### PR DESCRIPTION
The numa guest tests were failing on some setups, where the numa memory nodes were not allocated to nodes 0 and 1. This update make this test more robust to different setups and update it's config dynamically per current setup.