### PR TITLE
Fix local variable 'gic_version' referenced before assignment

### DIFF
--- a/libvirt/tests/src/virsh_cmd/host/virsh_maxvcpus.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_maxvcpus.py
@@ -104,6 +104,7 @@ def run(test, params, env):
                                       "%s\n Details: %s" % (connect_uri, details))
 
     is_arm = "aarch" in platform.machine()
+    gic_version = ''
     if is_arm:
         for gic_enum in domcap.DomCapabilityXML()['features']['gic_enums']:
             if gic_enum['name'] == "version":


### PR DESCRIPTION

initialize gic_version to empty first

errors appear when running type_specific.io-github-autotest-libvirt.virsh.domblkerror.undefinded_error on aarch64

Signed-off-by: Li Zhijian <lizhijian@cn.fujitsu.com>