### PR TITLE
auto_dump: replace process.kill with process.terminate

### DIFF
--- a/libvirt/tests/src/conf_file/qemu_conf/auto_dump.py
+++ b/libvirt/tests/src/conf_file/qemu_conf/auto_dump.py
@@ -128,7 +128,7 @@ def run(test, params, env):
 
         child_process.join(10)
         if child_process.is_alive():
-            child_process.kill()
+            child_process.terminate()
         flags = result_dict['flags']
         iohelper_pid = result_dict['pid']
 


### PR DESCRIPTION
func 'kill' of multiprocessing.Process was brought in from python3.7
therefore not availabe on python3.6. Replacing with 'terminate' could
allow test running on python3.6 without throwing out error like:
`AttributeError: 'Process' object has no attribute 'kill'`

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>