### PR TITLE
vcpu_affinity: check cpu status before online cpu

### DIFF
--- a/libvirt/tests/src/cpu/vcpu_affinity.py
+++ b/libvirt/tests/src/cpu/vcpu_affinity.py
@@ -122,8 +122,9 @@ def run(test, params, env):
             test.cancel("The host should have at least 8 CPUs for this test.")
 
         # online all host cpus
+        online_cpus = cpuutil.cpu_online_list()
         for x in range(1, hostcpu_num):
-            if cpuutil.online(x):
+            if x not in online_cpus and cpuutil.online(x):
                 test.fail("fail to online cpu{}".format(x))
 
         # use vcpu cpuset or/and cputune cpuset to define xml


### PR DESCRIPTION
On avocado:82lts online(cpu) returns False if cpu is already online.
Therefore check whether a cpu is in online_list before online it.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>