### PR TITLE
Fix the 'clean-traffic' nwfilter missing issue

### DIFF
--- a/libvirt/tests/src/nwfilter/nwfilter_vm_start.py
+++ b/libvirt/tests/src/nwfilter/nwfilter_vm_start.py
@@ -134,10 +134,6 @@ def run(test, params, env):
         rule = params.get("rule")
         if rule:
             # Create new filter xml
-            cmd_result = virsh.nwfilter_list(options="",
-                                             ignore_status=True, debug=True).stdout_text
-            if filter_name in cmd_result:
-                virsh.nwfilter_undefine(filter_name, debug=True)
             filterxml = utlv.create_nwfilter_xml(params)
             # Define filter xml
             virsh.nwfilter_define(filterxml.xml, debug=True)


### PR DESCRIPTION
There is a negative test which undefine the clean-traffic nwfilter,
which will cause the 'clean-traffic' nwfilter missing. This will cause
many case needs 'clean-traffic' fail. Fix the issue by not undefine it.

Signed-off-by: yalzhang <yalzhang@redhat.com>