### PR TITLE
Add cases to check secret-set-value --file and --interactive 

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/secret/virsh_secret_set_get.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/secret/virsh_secret_set_get.cfg
@@ -1,7 +1,5 @@
 - virsh.secret_set_get:
     type = virsh_secret_set_get
-    main_vm = ""
-    vms = ""
     start_vm = no
     take_regular_screendumps = no
     secret_usage_volume = "/var/lib/libvirt/images/foo-bar.secret"
@@ -12,11 +10,13 @@
     secret_base64_no_encoded = "~!@#$%^\-=[]{}|_+":;'`,>"
     variants:
         - public_secret:
-            secret_private = "yes"
-        - private_secret:
             secret_private = "no"
+        - private_secret:
+            secret_private = "yes"
     variants:
         - negative_testing:
+            main_vm = ""
+            vms = ""
             status_error = "yes"
             variants:
                 - get_secret_value:
@@ -35,4 +35,28 @@
                         - invalid_options:
                             set_secret_options = "--invalid"
         - positive_testing:
+            main_vm = ""
+            vms = ""
             status_error = "no"
+        - misc_testing:
+            status_error = "no"
+            secret_base64_no_encoded = "my_secret"
+            variants:
+                - set_secret_value:
+                    only public_secret
+                    variants:
+                        - file:
+                            secret_file = "yes"
+                            main_vm = ""
+                            vms = ""
+                        - file_plain:
+                            test_vm_start = "yes"
+                            secret_file = "yes"
+                            secret_string_base64_encode = "no"
+                            set_secret_options = "plain"
+                            get_secret_options = "plain"
+                        - interactive:
+                            test_vm_start = "yes"
+                            secret_string_base64_encode = "no"
+                            set_secret_options = "interactive"
+                            get_secret_options = "plain"

--- a/libvirt/tests/src/virsh_cmd/secret/virsh_secret_set_get.py
+++ b/libvirt/tests/src/virsh_cmd/secret/virsh_secret_set_get.py
@@ -3,11 +3,18 @@ import re
 import base64
 import logging
 import locale
+import time
 from tempfile import mktemp
 
 from avocado.utils import process
 
+from virttest import data_dir
 from virttest import virsh
+from virttest import libvirt_version
+from virttest import virt_vm
+
+from virttest.utils_test import libvirt
+from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.secret_xml import SecretXML
 
 _VIRT_SECRETS_PATH = "/etc/libvirt/secrets"
@@ -23,17 +30,21 @@ def check_secret(params):
 
     uuid = params.get("secret_ref")
     secret_string = params.get("secret_base64_no_encoded")
+    secret_encode = "yes" == params.get("secret_string_base64_encode", "yes")
 
     base64_file = os.path.join(_VIRT_SECRETS_PATH, "%s.base64" % uuid)
 
-    if os.access(base64_file, os.R_OK):
-        with open(base64_file, 'rb') as base64file:
-            base64_encoded_string = base64file.read().strip()
-        secret_decoded_string = base64.b64decode(base64_encoded_string).decode(locale.getpreferredencoding())
+    if secret_encode:
+        if os.access(base64_file, os.R_OK):
+            with open(base64_file, 'rb') as base64file:
+                base64_encoded_string = base64file.read().strip()
+            secret_decoded_string = base64.b64decode(base64_encoded_string)\
+                .decode(locale.getpreferredencoding())
+        else:
+            logging.error("Did not find base64_file: %s", base64_file)
+            return False
     else:
-        logging.error("Did not find base64_file: %s", base64_file)
-        return False
-
+        secret_decoded_string = secret_string
     if secret_string and secret_string != secret_decoded_string:
         logging.error("To expect %s value is %s",
                       secret_string, secret_decoded_string)
@@ -88,7 +99,7 @@ def get_secret_value(test, params):
     options = params.get("get_secret_options")
     status_error = params.get("status_error", "no")
 
-    result = virsh.secret_get_value(uuid, options)
+    result = virsh.secret_get_value(uuid, options, debug=True)
     status = result.exit_status
 
     # Get secret XML by UUID
@@ -137,13 +148,27 @@ def set_secret_value(test, params):
     options = params.get("set_secret_options")
     status_error = params.get("status_error", "no")
     secret_string = params.get("secret_base64_no_encoded")
+    secret_encode = "yes" == params.get("secret_string_base64_encode", "yes")
+    secret_file = "yes" == params.get("secret_file", "no")
 
-    # Encode secret string if it exists
-    if secret_string:
-        encoding = locale.getpreferredencoding()
-        secret_string = base64.b64encode(secret_string.encode(encoding)).decode(encoding)
-
-    result = virsh.secret_set_value(uuid, secret_string, options)
+    if options and "interactive" in options:
+        cmd = "secret-set-value %s --%s" % (uuid, options)
+        virsh_session = virsh.VirshSession(virsh_exec=virsh.VIRSH_EXEC,
+                                           auto_close=True)
+        virsh_session.sendline(cmd)
+        # Wait for 5s
+        time.sleep(5)
+        virsh_session.sendline(secret_string)
+        # Wait for 5s to get stripped output
+        time.sleep(5)
+        output = virsh_session.get_stripped_output()
+        exit_status = 0 if "Secret value set" in output else 1
+        result = process.CmdResult(cmd, output, output, exit_status)
+    else:
+        result = virsh.secret_set_value(uuid, secret_string, options=options,
+                                        encode=secret_encode,
+                                        use_file=secret_file,
+                                        debug=True)
     status = result.exit_status
 
     # Don't check result if we don't need to.
@@ -176,6 +201,7 @@ def cleanup(test, params):
     """
     uuid = params.get("secret_uuid")
     usage_volume = params.get("secret_usage_volume")
+    vm_name = params.get("main_vm", "")
 
     os.unlink(usage_volume)
 
@@ -184,6 +210,10 @@ def cleanup(test, params):
         status = result.exit_status
         if status:
             test.fail(result.stderr)
+    if vm_name:
+        virsh.destroy(vm_name, debug=True, ignore_status=True)
+    if params.get("orig_config_xml"):
+        params.get("orig_config_xml").sync()
 
 
 def run(test, params, env):
@@ -193,20 +223,69 @@ def run(test, params, env):
     1) Positive testing
        1.1) set the private or public secret value
        1.2) get the public secret value
+       1.3) set secret value with --file option
+       1.4) set secret value with --file and --plain option
+       1.5) set secret value with --interactive
     2) Negative testing
        2.1) get private secret
        2.2) get secret without setting secret value
        2.3) get or set secret with invalid options
        2.4) set secret with doesn't exist UUID
     """
+    def attach_disk_secret(params):
+        """
+        Attach a disk with secret to VM
+
+        :params: the parameter dictionary
+        :raise: test.fail when disk cannot be attached
+        """
+        secret_string = params.get("secret_base64_no_encoded")
+        target_dev = params.get("target_dev", "vdb")
+        uuid = params.get("secret_uuid")
+        # TODO: support encoded data
+        extra = "--object secret,id=sec0,data=%s -o key-secret=sec0" % secret_string
+        tmp_dir = data_dir.get_tmp_dir()
+        disk_path = os.path.join(tmp_dir, "test.img")
+        libvirt.create_local_disk("file", disk_format="luks",
+                                  path=disk_path, size="1", extra=extra)
+        new_disk_dict = {}
+        new_disk_dict.update(
+            {"source_encryption_dict": {"encryption": 'luks',
+             "secret": {"type": "passphrase", "uuid": uuid}}})
+
+        result = libvirt.attach_additional_device(vm_name, target_dev,
+                                                  disk_path, new_disk_dict)
+        if result.exit_status:
+            raise test.fail("Attach device %s failed." % target_dev)
+
+    def check_vm_start(params):
+        """
+        Start a guest with a secret
+
+        :params: the parameter dictionary
+        :raise: test.fail when VM cannot be started
+        """
+        attach_disk_secret(params)
+
+        if not vm.is_alive():
+            try:
+                vm.start()
+            except virt_vm.VMStartError as err:
+                test.fail("Failed to start VM: %s" % err)
 
     # Run test case
     uuid = ""
+    vm_name = params.get("main_vm")
+    if vm_name:
+        vm = env.get_vm(vm_name)
+        vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+        params["orig_config_xml"] = vmxml.copy()
 
     usage_volume = params.get("secret_usage_volume",
                               "/var/lib/libvirt/images/foo-bar.secret")
     set_secret = params.get("set_secret", "yes")
     get_secret = params.get("get_secret", "yes")
+    test_vm_start = params.get("test_vm_start", "no")
 
     # If storage volume doesn't exist then create it
     if not os.path.isfile(usage_volume):
@@ -236,11 +315,22 @@ def run(test, params, env):
     if not params.get('secret_ref'):
         params['secret_ref'] = uuid
 
+    if set_secret == "yes":
+        if not libvirt_version.version_compare(6, 2, 0):
+            if params.get("secret_file", "no") == "yes":
+                test.cancel("Current libvirt version doesn't support "
+                            "'--file' for virsh secret-set-value.")
+            if "interactive" in params.get("set_secret_options", ""):
+                test.cancel("Current libvirt version doesn't support "
+                            "'--interactive' for virsh secret-set-value.")
+
     # positive and negative testing #########
     try:
         if set_secret == "yes":
             set_secret_value(test, params)
         if get_secret == "yes":
             get_secret_value(test, params)
+        if test_vm_start == "yes":
+            check_vm_start(params)
     finally:
         cleanup(test, params)


### PR DESCRIPTION
This PR adds 3 cases:
1) Set a secret value with --file option.
2) Set a secret value with --file and --plain option.
3) Set a secret value with --interactive option.

depends on 
https://github.com/avocado-framework/avocado-vt/pull/2832
https://github.com/avocado-framework/avocado-vt/pull/2833

Signed-off-by: Yingshun Cui <yicui@redhat.com>