### PR TITLE
Add cases for hotplug_option

### DIFF
--- a/libvirt/tests/cfg/controller/pcie_controllers.cfg
+++ b/libvirt/tests/cfg/controller/pcie_controllers.cfg
@@ -36,21 +36,34 @@
                 - multiple_hotplug:
                     hotplug = 'yes'
                     hotplug_counts = 5
-                    err_msg = 'No more available PCI slots'
+                    err_msg = '"No more available PCI slots"'
                     attach_extra = '--subdriver qcow2'
                     check_within_guest = "no"
                     check_disk_xml = "no"
         - negative_tests:
             status_error = "yes"
             variants:
+                - hotplug_on:
+                    only double_addr
+                    hotplug_option = 'on'
+                    controller_target = "{'hotplug':'${hotplug_option}'}"
                 - hotplug_off:
                     hotplug_option = 'off'
                     controller_target = "{'hotplug':'${hotplug_option}'}"
             variants:
                 - hotplug:
                     hotplug = 'yes'
-                    err_msg = "PCI controller with index='%s' doesn't support hotplug"
+                    err_msg = '"PCI controller with index='%s' doesn't support hotplug"'
                 - hotunplug:
                     hotplug = 'no'
                     attach_extra = '--address pci:${disk_addr} --subdriver qcow2 --config'
-                    err_msg = "cannot hot unplug.*device with PCI.*address: 0000:0%s:00.0.*not allowed by controller"
+                    err_msg = '"cannot hot unplug.*device with PCI.*address: 0000:0%s:00.0.*not allowed by controller"'
+                - double_addr:
+                    err_msg = "Attempted double use of PCI Address"
+                    hotplug_off:
+                        err_msg = ".*controller with index=\'%s\' doesn\'t support hotplug"
+                    hotplug = 'yes'
+                    addr_twice = 'yes'
+                    hotplug_counts = 2
+                    check_within_guest = "no"
+                    check_disk_xml = "no"

--- a/libvirt/tests/src/controller/pcie_controllers.py
+++ b/libvirt/tests/src/controller/pcie_controllers.py
@@ -205,6 +205,7 @@ def run(test, params, env):
     restart_daemon = params.get("restart_daemon", "no") == 'yes'
     save_restore = params.get("save_restore", "no") == 'yes'
     hotplug_counts = params.get("hotplug_counts")
+    addr_twice = params.get("addr_twice", 'no') == 'yes'
     contr_index = None
 
     virsh_options = {'debug': True, 'ignore_status': False}
@@ -242,7 +243,6 @@ def run(test, params, env):
             attach_extra = attach_extra % ("%02x" % int(contr_index))
         if err_msg and err_msg.count('%s'):
             err_msg = err_msg % contr_index
-
         if not save_restore:
             disk_max = int(hotplug_counts) if hotplug_counts else 1
             for disk_inx in range(0, disk_max):
@@ -287,7 +287,7 @@ def run(test, params, env):
                     ret = virsh.attach_disk(vm_name, image_path_list[attach_inx], disk_dev,
                                             extra=attach_extra,
                                             **virsh_options)
-                    if ret.exit_status:
+                    if ret.exit_status and not addr_twice:
                         break
                 libvirt.check_result(ret, expected_fails=err_msg)
         if not hotplug and check_within_guest:
@@ -300,7 +300,7 @@ def run(test, params, env):
             check_guest_disks(hotplug)
         if check_cntl_xml:
             check_guest_contr()
-        if hotplug_counts:
+        if hotplug_counts and not addr_twice:
             check_multi_attach(get_disk_bus())
         if check_within_guest:
             check_inside_guest(hotplug)


### PR DESCRIPTION
This is to add new cases for hotplug_option by attaching disk device twice
with specified same pci address for both hotplug_option=on and off.

Signed-off-by: Dan Zheng <dzheng@redhat.com>