### PR TITLE
Fix virsh numatune

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_numatune.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_numatune.cfg
@@ -54,8 +54,10 @@
                                     variants:
                                         - comma_list:
                                             numa_nodeset = 0,1
+                                            dynamic_nodeset = "yes"
                                         - ranges:
                                             numa_nodeset = 0-1
+                                            dynamic_nodeset = "yes"
                                         - excluding:
                                             numa_nodeset = 0-1,^1
                                         - single:


### PR DESCRIPTION
The tests working with numatune parameter may failed on setups with nodeset != 0,1. This fix is getting numa nodes with memory dynamically and therefore it allows to pass the tests with any setup with at least two numa nodes.