### PR TITLE
Update incorrect param

### DIFF
--- a/libvirt/tests/cfg/virt_cmd/virt_xml_validate.cfg
+++ b/libvirt/tests/cfg/virt_cmd/virt_xml_validate.cfg
@@ -5,7 +5,7 @@
     start_vm = "no"
     kill_vm_before_test = "yes"
     net_dumpxml_name = "default"
-    pool_dumpxml_name = "default"
+    pool_dumpxml_name = "images"
     variants:
         - domain:
             schema = "domain"


### PR DESCRIPTION
The pool name was set incorrectly. This is to fix it by setting correct
default libvirt pool name.