### PR TITLE
Fix keywrap test

### DIFF
--- a/libvirt/tests/cfg/svirt/libvirt_keywrap.cfg
+++ b/libvirt/tests/cfg/svirt/libvirt_keywrap.cfg
@@ -6,11 +6,9 @@
         - default:
             default = yes
             expect_token = yes
-            name = aes
-            state = on
         - aes_off:
             default = no
-            name = aes
-            state = off
+            keyname = aes
+            keystate = off
             expect_token = no
 

--- a/libvirt/tests/src/svirt/libvirt_keywrap.py
+++ b/libvirt/tests/src/svirt/libvirt_keywrap.py
@@ -28,18 +28,21 @@ def run(test, params, env):
         else:
             kw = VMKeywrapXML()
             kw.set_cipher(name, state)
-            vm.set_keywrap(kw)
+            vmxml.set_keywrap(kw)
 
-        vm.sync()
+        vmxml.sync()
         vm.start()
         session = vm.wait_for_login()
 
         pkey_helper = ProtectedKeyHelper(session)
         pkey_helper.load_module()
 
-        if expect_token:
-            if pkey_helper.get_some_aes_key_token() is None:
-                test.fail("Didn't receive expected key token."
-                          " Please check debug log.")
+        token = pkey_helper.get_some_aes_key_token()
+        if expect_token and token is None:
+            test.fail("Didn't receive expected key token."
+                      " Please check debug log.")
+        elif not expect_token and token is not None:
+            test.fail("Received key token though none expected."
+                      " Please check debug log.")
     finally:
         vmxml_backup.sync()


### PR DESCRIPTION
Depends on https://github.com/avocado-framework/avocado-vt/pull/2836

Tests from 42a00e3b32258d64900997ee1b4628f9a68ffc1d passed
because all commands were executed on host.
It also looks like there was a regression introduced by
force pushing local changes to remote before merge.

1. Use the VMXML instance to manipulate the domain xml.
2. Use correct test parameter names.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>