### PR TITLE
Fix test.cancel was not thrown

### DIFF
--- a/libvirt/tests/src/migration/migrate_options_shared.py
+++ b/libvirt/tests/src/migration/migrate_options_shared.py
@@ -1576,7 +1576,8 @@ def run(test, params, env):
 
             logging.info("Remove local NFS image")
             source_file = params.get("source_file")
-            libvirt.delete_local_disk("file", path=source_file)
+            if source_file:
+                libvirt.delete_local_disk("file", path=source_file)
 
             if objs_list:
                 for obj in objs_list:


### PR DESCRIPTION
Original test.cancel was not thrown by the avocado framework which is
because another invalid file removing in final cleanup phase fails. So
this is to avoid of that invalid removing step in order to throw the
original exception.

Signed-off-by: Dan Zheng <dzheng@redhat.com>