### PR TITLE
virsh_attach_detach_interface: wait for detach event to finish cmd

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_interface.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_interface.py
@@ -445,7 +445,8 @@ def run(test, params, env):
         # Start detach-interface test
         if save_restore == "yes" and vm_ref == dom_id:
             vm_ref = vm_name
-        detach_result = virsh.detach_interface(vm_ref, options, **virsh_dargs)
+        detach_result = virsh.detach_interface(
+            vm_ref, options, wait_remove_event=True, **virsh_dargs)
         detach_status = detach_result.exit_status
         detach_msg = detach_result.stderr.strip()
 


### PR DESCRIPTION
Tests sometimes fail with 'Detach Failed: xml still exist after detach'
which should be fixed after waiting for detach event to check vm xml.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>