### PR TITLE
tsc timer is not supported on pseries

### DIFF
--- a/libvirt/tests/cfg/timer_management.cfg
+++ b/libvirt/tests/cfg/timer_management.cfg
@@ -104,6 +104,8 @@
                     # Support hypervisor: libxml,qemu
                     timer_name = "tsc"
                     no present_no         #Temporary does not work according to feature testing
+                    present_yes:
+                        no pseries
                 - platform:
                     no pseries
                     # currently unsupported


### PR DESCRIPTION
Remove tsc cases for pseries.
Configuring the 'tsc' timer is not supported for virtType=kvm
arch=ppc64le machine=pseries-rhelx.x.x guests.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>