### PR TITLE
Add a case to migrate VM with direct type interface

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_network.cfg
+++ b/libvirt/tests/cfg/migration/migrate_network.cfg
@@ -17,6 +17,7 @@
     virsh_migrate_options = "--live --p2p --verbose"
     # Local URI
     virsh_migrate_connect_uri = "qemu:///system"
+    migr_vm_back = "yes"
 
     variants:
         - with_postcopy:
@@ -26,7 +27,17 @@
     variants:
         - ovs_br:
             only without_postcopy
-            migr_vm_back = "yes"
             ovs_bridge_name = "ovsbr0"
             network_dict = {"net_name": "ovs-net", "net_forward": '{"mode": "bridge"}',"net_bridge": '{"name": "${ovs_bridge_name}"}', "net_virtualport": "openvswitch"}
             iface_dict = {"type": "network", "source": "{'network': 'ovs-net'}","model": "virtio"}
+        - direct:
+            direct_mode = "yes"
+            target_vm_name = "avocado-vt-remote-vm1"
+            network_dict = {"net_name": "direct-macvtap", "net_forward": '{"mode": "bridge"}'}
+            iface_dict = {"type": "network", "source": "{'network': 'direct-macvtap'}","model": "virtio"}
+            macvtap_cmd = "ip l |grep macvtap |sed 's/.*macvtap\([0-9]\+\).*.*/\1/'"
+            target_vm_ip_cmd = "arp -a | grep  %s | sed 's/.*(\(.*\)).*/\1/g'"
+            variants:
+                - macvtap_exists_dest:
+                    modify_target_vm = "yes"
+                    check_macvtap_exists = "yes"

--- a/libvirt/tests/src/migration/migrate_network.py
+++ b/libvirt/tests/src/migration/migrate_network.py
@@ -20,6 +20,8 @@ def run(test, params, env):
     """
     Test migration with special network settings
     1) migrate guest with bridge type interface connected to ovs bridge
+    2) migrate guest with direct type interface when a macvtap device name
+        exists on dest host
 
     :param test: test object
     :param params: Dictionary with the test parameters
@@ -44,21 +46,83 @@ def run(test, params, env):
         if status != 0:
             test.fail("Ping failed, status: %s, output: %s" % (status, output))
 
-    def update_iface_xml(vm_name, iface_dict):
+    def vm_sync(vmxml, vm_name=None, virsh_instance=virsh):
+        """
+        A wrapper to sync vm xml on localhost and remote host
+
+        :param vmxml: domain VMXML instance
+        :param vm_name: The name of VM
+        :param virsh_instance: virsh instance object
+        """
+        if vm_name and virsh_instance != virsh:
+            remote.scp_to_remote(server_ip, '22', server_user,
+                                 server_pwd,
+                                 vmxml.xml, vmxml.xml)
+            if virsh_instance.domain_exists(vm_name):
+                if virsh_instance.is_alive(vm_name):
+                    virsh_instance.destroy(vm_name, ignore_status=True)
+                virsh_instance.undefine(vmxml.xml, ignore_status=True)
+            virsh_instance.define(vmxml.xml, debug=True)
+        else:
+            vmxml.sync()
+
+    def update_iface_xml(vm_name, iface_dict, virsh_instance=virsh):
         """
         Update interfaces for guest
 
         :param vm_name: The name of VM
         :param iface_dict: The interface configurations params
+        :param virsh_instance: virsh instance object
         """
         logging.debug("update iface xml")
-        vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+        vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(
+            vm_name, virsh_instance=virsh_instance)
         vmxml.remove_all_device_by_type('interface')
-        vmxml.sync()
-
+        vm_sync(vmxml, vm_name, virsh_instance=virsh_instance)
         iface = interface.Interface('network')
-        iface.xml = libvirt.modify_vm_iface(vm.name, "get_xml", iface_dict)
-        libvirt.add_vm_device(vmxml, iface)
+        iface.xml = libvirt.modify_vm_iface(vm_name, "get_xml", iface_dict,
+                                            virsh_instance=virsh_instance)
+        vmxml.add_device(iface)
+        vmxml.xmltreefile.write()
+        vm_sync(vmxml, vm_name, virsh_instance=virsh_instance)
+        logging.debug("VM XML after updating interface: %s" % vmxml)
+
+    def update_net_dict(net_dict, runner=utils_net.local_runner):
+        """
+        Update network dict
+
+        :param net_dict: The network dict to be updated
+        :param runner: Command runner
+        :return: Updated network dict
+        """
+        if net_dict.get("net_name", "") == "direct-macvtap":
+            logging.info("Updating network iface name")
+            iface_name = utils_net.get_net_if(runner=runner, state="UP")[0]
+            net_dict.update({"forward_iface": iface_name})
+        else:
+            # TODO: support other types
+            logging.info("No need to update net_dict. We only support to "
+                         "update direct-macvtap type for now.")
+        logging.debug("net_dict is %s" % net_dict)
+        return net_dict
+
+    def get_remote_direct_mode_vm_mac(vm_name, uri):
+        """
+        Get mac of remote direct mode VM
+
+        :param vm_name: The name of VM
+        :param uri: The uri on destination
+        :return: mac
+        :raise: test.fail when the result of virsh domiflist is incorrect
+        """
+        vm_mac = None
+        res = virsh.domiflist(
+            vm_name, uri=uri, ignore_status=False).stdout_text.strip().split("\n")
+        if len(res) < 2:
+            test.fail("Unable to get remote VM's mac: %s" % res)
+        else:
+            vm_mac = res[-1].split()[-1]
+        return vm_mac
 
     migration_test = migration.MigrationTest()
     migration_test.check_parameters(params)
@@ -87,18 +151,33 @@ def run(test, params, env):
     virsh_options = params.get("virsh_options", "")
     extra = params.get("virsh_migrate_extra")
     options = params.get("virsh_migrate_options", "--live --p2p --verbose")
+    restart_dhclient = params.get("restart_dhclient", "dhclient -r; dhclient")
+    ping_dest = params.get("ping_dest", "www.baidu.com")
     func_params_exists = "yes" == params.get("func_params_exists", "no")
     migr_vm_back = "yes" == params.get("migr_vm_back", "no")
 
+    target_vm_name = params.get("target_vm_name")
+    direct_mode = "yes" == params.get("direct_mode", "no")
+    check_macvtap_exists = "yes" == params.get("check_macvtap_exists", "no")
+    macvtap_cmd = params.get("macvtap_cmd")
+    modify_target_vm = "yes" == params.get("modify_target_vm", "no")
     ovs_bridge_name = params.get("ovs_bridge_name")
     network_dict = eval(params.get("network_dict", '{}'))
     iface_dict = eval(params.get("iface_dict", '{}'))
     remote_virsh_dargs = {'remote_ip': server_ip, 'remote_user': server_user,
                           'remote_pwd': server_pwd, 'unprivileged_user': None,
                           'ssh_remote_auth': True}
+    cmd_parms = {'server_ip': server_ip, 'server_user': server_user,
+                 'server_pwd': server_pwd}
+
+    virsh_session_remote = None
     func_name = None
     libvirtd_conf = None
     mig_result = None
+    target_org_xml = None
+    target_vm_session = None
+    target_vm = None
+    exp_macvtap = []
 
     # params for migration connection
     params["virsh_migrate_desturi"] = libvirt_vm.complete_uri(
@@ -111,6 +190,7 @@ def run(test, params, env):
     vm_name = params.get("migrate_main_vm")
     vm = env.get_vm(vm_name)
     vm.verify_alive()
+    bk_uri = vm.connect_uri
 
     extra_args = {}
     if func_params_exists:
@@ -132,6 +212,24 @@ def run(test, params, env):
         remote_session = remote.remote_login("ssh", server_ip, "22",
                                              server_user, server_pwd,
                                              r'[$#%]')
+        virsh_session_remote = virsh.VirshPersistent(**remote_virsh_dargs)
+
+        if target_vm_name:
+            target_vm = libvirt_vm.VM(target_vm_name, params, vm.root_dir,
+                                      vm.address_cache)
+            target_vm.connect_uri = dest_uri
+            if not virsh_session_remote.domain_exists(target_vm_name):
+                test.error("VM %s should be installed on %s."
+                           % (target_vm_name, server_ip))
+            # Backup guest's xml on remote
+            target_org_xml = vm_xml.VMXML.new_from_inactive_dumpxml(
+                target_vm_name, virsh_instance=virsh_session_remote)
+            # Scp original xml to remote for restoration
+            remote.scp_to_remote(server_ip, '22', server_user,
+                                 server_pwd,
+                                 target_org_xml.xml, target_org_xml.xml)
+            logging.debug("target xml is %s" % target_org_xml)
+
         if ovs_bridge_name:
             status, stdout = utils_net.create_ovs_bridge(ovs_bridge_name)
             if status:
@@ -143,9 +241,30 @@ def run(test, params, env):
                 test.fail("Failed to create ovs bridge on remote. Status: %s"
                           "Stdout: %s" % (status, stdout))
         if network_dict:
+            update_net_dict(network_dict, runner=remote_session.cmd)
             libvirt_network.create_or_del_network(
                 network_dict, remote_args=remote_virsh_dargs)
+            logging.info("dest: network created")
+            update_net_dict(network_dict)
             libvirt_network.create_or_del_network(network_dict)
+            logging.info("localhost: network created")
+
+        if target_vm_name:
+            if modify_target_vm and iface_dict:
+                logging.info("Updating remote VM's interface")
+                update_iface_xml(target_vm_name, iface_dict,
+                                 virsh_instance=virsh_session_remote)
+            target_vm.start()
+            target_vm_session = target_vm.wait_for_serial_login(timeout=240)
+            check_vm_network_accessed(ping_dest, session=target_vm_session)
+            if check_macvtap_exists and macvtap_cmd:
+                # Get macvtap device's index on remote after target_vm started
+                idx = remote_session.cmd_output(macvtap_cmd).strip()
+                if not idx:
+                    test.fail("Unable to get macvtap index using %s."
+                              % macvtap_cmd)
+                # Generate the expected macvtap devices' index list
+                exp_macvtap = ['macvtap'+idx, 'macvtap'+str(int(idx)+1)]
 
         remote_session.close()
         # Change domain network xml
@@ -179,7 +298,10 @@ def run(test, params, env):
         vm_ip = utils_net.get_guest_ip_addr(vm_session, mac)
         logging.debug("VM IP Addr: %s", vm_ip)
 
-        check_vm_network_accessed(vm_ip)
+        if direct_mode:
+            check_vm_network_accessed(ping_dest, session=vm_session)
+        else:
+            check_vm_network_accessed(vm_ip)
 
         # Execute migration process
         vms = [vm]
@@ -193,13 +315,29 @@ def run(test, params, env):
         mig_result = migration_test.ret
         migration_test.check_result(mig_result, params)
 
+        # Check network accessibility after migration
         if int(mig_result.exit_status) == 0:
+            vm.connect_uri = dest_uri
+            if vm.serial_console is not None:
+                vm.cleanup_serial_console()
+            vm.create_serial_console()
+            vm_session_after_mig = vm.wait_for_serial_login(timeout=240)
+            vm_session_after_mig.cmd(restart_dhclient)
+            check_vm_network_accessed(ping_dest, session=vm_session_after_mig)
+            if target_vm_session:
+                check_vm_network_accessed(ping_dest, session=target_vm_session)
+
+        if check_macvtap_exists and macvtap_cmd:
             remote_session = remote.remote_login("ssh", server_ip, "22",
                                                  server_user, server_pwd,
                                                  r'[$#%]')
-            check_vm_network_accessed(vm_ip, session=remote_session)
-            remote_session.close()
-
+            # Check macvtap devices' index after migration
+            idx = remote_session.cmd_output(macvtap_cmd)
+            act_macvtap = ['macvtap'+i for i in idx.strip().split("\n")]
+            if act_macvtap != exp_macvtap:
+                test.fail("macvtap devices after migration are incorrect!"
+                          " Actual: %s, Expected: %s. "
+                          % (act_macvtap, exp_macvtap))
         # Execute migration from remote
         if migr_vm_back:
             ssh_connection = utils_conn.SSHConnection(server_ip=client_ip,
@@ -222,9 +360,17 @@ def run(test, params, env):
             if cmd_result.exit_status:
                 test.fail("Failed to run '%s' on remote: %s" % (cmd, cmd_result))
             logging.debug("VM is migrated back.")
-            check_vm_network_accessed(vm_ip)
+
+            vm.connect_uri = bk_uri
+            if vm.serial_console is not None:
+                vm.cleanup_serial_console()
+            vm.create_serial_console()
+            vm_session_after_mig_bak = vm.wait_for_serial_login(timeout=240)
+            vm_session_after_mig_bak.cmd(restart_dhclient)
+            check_vm_network_accessed(ping_dest, vm_session_after_mig_bak)
     finally:
         logging.debug("Recover test environment")
+        vm.connect_uri = bk_uri
         # Clean VM on destination and source
         try:
             migration_test.cleanup_dest_vm(vm, vm.connect_uri, dest_uri)
@@ -238,6 +384,16 @@ def run(test, params, env):
         remote_session = remote.remote_login("ssh", server_ip, "22",
                                              server_user, server_pwd,
                                              r'[$#%]')
+        if target_vm and target_vm.is_alive():
+            target_vm.destroy(gracefully=False)
+
+        if target_org_xml and target_vm_name:
+            logging.info("Recovery XML configration for %s.", target_vm_name)
+            virsh_session_remote = virsh.VirshPersistent(**remote_virsh_dargs)
+            vm_sync(target_org_xml, vm_name=target_vm_name,
+                    virsh_instance=virsh_session_remote)
+            virsh_session_remote.close_session()
+
         if network_dict:
             libvirt_network.create_or_del_network(
                 network_dict, is_del=True, remote_args=remote_virsh_dargs)
@@ -247,6 +403,12 @@ def run(test, params, env):
             utils_net.delete_ovs_bridge(ovs_bridge_name, session=remote_session)
 
         remote_session.close()
+        if target_vm_session:
+            target_vm_session.close()
+
+        if virsh_session_remote:
+            virsh_session_remote.close_session()
+
         if migr_vm_back:
             if 'ssh_connection' in locals():
                 ssh_connection.auto_recover = True


### PR DESCRIPTION
This PR adds a case as below:
1. check if a VM with direct type interface assigned from
virtual network can be migrated correctly.
(auto-generated macvtap device name + macvtap device name already
exists on dest host)

depends on https://github.com/avocado-framework/avocado-vt/pull/2842
Signed-off-by: Yingshun Cui <yicui@redhat.com>