### PR TITLE
Update the value of guest's vcpus for ioapic_iommu test

### DIFF
--- a/libvirt/tests/cfg/cpu/max_vcpus.cfg
+++ b/libvirt/tests/cfg/cpu/max_vcpus.cfg
@@ -58,5 +58,5 @@
                 - ioapic_iommu:
                     only q35
                     check = "ioapic_iommu_ne"
-                    guest_vcpu = "385"
+                    guest_vcpu = "513"
                     err_msg = "unsupported configuration: Maximum CPUs greater than specified machine type limit|exceeds the maximum cpus supported"

--- a/libvirt/tests/src/cpu/max_vcpus.py
+++ b/libvirt/tests/src/cpu/max_vcpus.py
@@ -172,8 +172,7 @@ def run(test, params, env):
 
             if status_error:
                 if start_fail:
-                    if (libvirt_version.version_compare(5, 6, 0) and
-                       not libvirt_version.version_compare(6, 6, 0)):
+                    if libvirt_version.version_compare(5, 6, 0):
                         result_need_check = virsh.define(vmxml.xml, debug=True)
                     else:
                         vmxml.sync()


### PR DESCRIPTION
Maximum CPUs changed from 384 to 512, so update VM vcpus accordingly.

Signed-off-by: Yingshun Cui <yicui@redhat.com>