### PR TITLE
Add virtio packed test cases in disk and scsi controller

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/at_dt_iscsi_disk.cfg
+++ b/libvirt/tests/cfg/virtual_disks/at_dt_iscsi_disk.cfg
@@ -67,6 +67,19 @@
                 - lvm_disk_attach:
                     virt_disk_vg_name = "vg"
                     virt_disk_lv_name = "lv"
+                - with_packed:
+                    only cold_plug
+                    disk_packed = "yes"
+                    domain_operation = "start_with_packed"
+                    variants:
+                        - packed_on:
+                            driver_packed = "on"
+                        - packed_off:
+                            driver_packed = "off"
+                        - in_scsi_controller:
+                            scsi_packed = "yes"
+                            disk_packed = "no"
+                            driver_packed = "on"
     variants:
         - hot_plug:
             start_vm = "yes"


### PR DESCRIPTION
1. Add packed attribute test in virtio disk driver
2. Add packed attribute test in virtio-scsi controller

Signed-off-by: Meina Li <meili@redhat.com>