### PR TITLE
migration: set start_vm to yes in some <test>.cfg files

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_bandwidth.cfg
+++ b/libvirt/tests/cfg/migration/migrate_bandwidth.cfg
@@ -17,6 +17,8 @@
     virsh_migrate_options = "--live --p2p --verbose"
     # Local URI
     virsh_migrate_connect_uri = "qemu:///system"
+    # Start vm in env_process before test
+    start_vm = "yes"
 
     log_outputs = "/var/log/libvirt/libvirt_daemons.log"
     diff_rate = '0.5'

--- a/libvirt/tests/cfg/migration/migrate_gluster.cfg
+++ b/libvirt/tests/cfg/migration/migrate_gluster.cfg
@@ -12,6 +12,8 @@
     image_size = "10G"
     vol_name = "vol_migrate_vm"
     pool_name = "glusterfs"
+    # Start vm in env_process before test
+    start_vm = "yes"
 
     # enable virt_use_glusterd SELinux boolean
     local_boolean_varible = "virt_use_glusterd"

--- a/libvirt/tests/cfg/migration/migrate_network.cfg
+++ b/libvirt/tests/cfg/migration/migrate_network.cfg
@@ -17,6 +17,8 @@
     virsh_migrate_options = "--live --p2p --verbose"
     # Local URI
     virsh_migrate_connect_uri = "qemu:///system"
+    # Start vm in env_process before test
+    start_vm = "yes"
 
     variants:
         - with_postcopy:

--- a/libvirt/tests/cfg/migration/migrate_storage.cfg
+++ b/libvirt/tests/cfg/migration/migrate_storage.cfg
@@ -1,6 +1,8 @@
 - virsh.migrate_storage:
     type = migrate_storage
     migration_setup = "yes"
+    # Start vm in env_process before test
+    start_vm = "yes"
     log_outputs = "/var/log/libvirt/libvirt_daemons.log"
     variants:
         - copy_storage_inc:


### PR DESCRIPTION
Some test modules require that vm is started during env_process before
test, it is better to set start_vm to yes in each <test>.cfg rather
than replying on base.cfg.

Signed-off-by: Fangge Jin <fjin@redhat.com>