### PR TITLE
migration: Re-set storage_type to "tp-libvirt" in <test>.cfg

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_ceph.cfg
+++ b/libvirt/tests/cfg/migration/migrate_ceph.cfg
@@ -17,6 +17,8 @@
     start_vm = "no"
     ssh_port = "${port}"
     migration_timeout = 300
+    # Set storage_type to "tp-libvirt" to avoid the storage setup in preprocess
+    storage_type = "tp-libvirt"
     variants:
         - with_postcopy:
             postcopy_options = "--postcopy"

--- a/libvirt/tests/cfg/migration/migrate_gluster.cfg
+++ b/libvirt/tests/cfg/migration/migrate_gluster.cfg
@@ -12,6 +12,8 @@
     image_size = "10G"
     vol_name = "vol_migrate_vm"
     pool_name = "glusterfs"
+    # Set storage_type to "tp-libvirt" to avoid the storage setup in preprocess
+    storage_type = "tp-libvirt"
 
     # enable virt_use_glusterd SELinux boolean
     local_boolean_varible = "virt_use_glusterd"

--- a/libvirt/tests/cfg/migration/migrate_storage.cfg
+++ b/libvirt/tests/cfg/migration/migrate_storage.cfg
@@ -2,6 +2,8 @@
     type = migrate_storage
     migration_setup = "yes"
     log_outputs = "/var/log/libvirt/libvirt_daemons.log"
+    # Set storage_type to "tp-libvirt" to avoid the storage setup in preprocess
+    storage_type = "tp-libvirt"
     variants:
         - copy_storage_inc:
             copy_storage_option = "--copy-storage-inc"

--- a/libvirt/tests/cfg/migration/migrate_vm.cfg
+++ b/libvirt/tests/cfg/migration/migrate_vm.cfg
@@ -16,6 +16,8 @@
     client = "ssh"
     start_vm = "no"
     ssh_port = "${port}"
+    # Set storage_type to "tp-libvirt" to avoid the storage setup in preprocess
+    storage_type = "tp-libvirt"
     # setup NFS test environment
     nfs_client_ip = "${server_ip}"
     nfs_server_ip = "${client_ip}"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_copy_storage.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_copy_storage.cfg
@@ -6,6 +6,8 @@
     start_vm = "no"
     precreation_pool_type = "dir"
     precreation_pool_name = "precreation_pool"
+    # Set storage_type to "tp-libvirt" to avoid the storage setup in preprocess
+    storage_type = "tp-libvirt"
     variants:
         - file_image:
             copy_storage_type = "file"


### PR DESCRIPTION
In some test modules, vm storage is setup in tp-libvirt instead of
in the env_process of avocado-vt. So storage_type needs to be reset
in each <test>.cfg to avoid the storage setup by env_process.

Signed-off-by: Fangge Jin <fjin@redhat.com>