### PR TITLE
Fix parameters that are static and may differ from default system setup (CPUs, Numa nodes)

### DIFF
--- a/libvirt/tests/cfg/numa/numa_memory.cfg
+++ b/libvirt/tests/cfg/numa/numa_memory.cfg
@@ -22,9 +22,11 @@
                          - node1:
                              no interleave
                              memory_nodeset = "0"
+                             can_be_dynamic = "yes"
                          - node2:
                              no preferred
                              memory_nodeset = "0-1"
+                             can_be_dynamic = "yes"
              variants:
                  - no_vcpu:
                  - vcpu:
@@ -34,6 +36,7 @@
                          - vcpu_static:
                              vcpu_placement = "static"
                              vcpu_cpuset = "2,4"
+                             can_be_dynamic = "yes"
         - negative_test:
              status_error = "yes"
              memory_placement = "static"
@@ -50,3 +53,4 @@
                  - preferred_multi:
                      memory_nodeset = "0-1"
                      memory_mode = "preferred"
+                     can_be_dynamic = "yes"


### PR DESCRIPTION
This fix introduced a possibility to update numa nodes and cpu sets dynamically per setup. This should fix failing cases on setups, that differ from default (0,1..). Cpus are choosen randomly based on a number of available cpu cores, numa nodes per index of available nodes.

Signed-off-by: Kamil Varga <kvarga@redhat.com>