### PR TITLE
[nodedev-dumpxml] Remove kernel-dependent check for dasd

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_dumpxml_chain.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_dumpxml_chain.cfg
@@ -6,5 +6,5 @@
     variants:
         - device_type_dasd:
             only s390-virtio
-            checks = '[{"capability/block": r"/dev/dasd","capability/drive_type": r"dasd"},{"driver/name": r"dasd"},{"driver/name": r"(io_subchannel|vfio_ccw)"}]'
+            checks = '[{"capability/block": r"/dev/dasd"},{"driver/name": r"dasd"},{"driver/name": r"(io_subchannel|vfio_ccw)"}]'
             chain_start_device_pattern = "block_dasd"


### PR DESCRIPTION
Depending on the kernel, the output of commands `nodedev-list` and
`nodedev-dumpxml` is slightly different but equivalent.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>