### PR TITLE
migration: Cleanup vm on dest host before migration

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_option_mix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_option_mix.py
@@ -280,8 +280,7 @@ def run(test, params, env):
         logging.debug("Clean up vm on dest host before migration")
         if dname:
             cleanup_vm(vm, dname, dest_uri)
-        else:
-            cleanup_vm(vm, vm.name, dest_uri)
+        cleanup_vm(vm, vm.name, dest_uri)
 
         # Prepare host env: set selinux state before migration
         logging.debug("Set selinux to enforcing before migration")


### PR DESCRIPTION
If vm with same uuid exists on dest host, migration will fail. Previous
code only considered the situation when vm with same name exists on dest
host.

Signed-off-by: Fangge Jin <fjin@redhat.com>