### PR TITLE
Add more mapping pattern as new libvirt version change the qemu cmd line

### DIFF
--- a/libvirt/tests/cfg/numa/guest_numa.cfg
+++ b/libvirt/tests/cfg/numa/guest_numa.cfg
@@ -73,7 +73,7 @@
                      vmpage_nodeset_0 = "0"
                      qemu_cmdline_numa_cell_0 = "node,nodeid=0,cpus=0-1,memdev=ram-node0"
                      qemu_cmdline_numa_cell_1 = "node,nodeid=1,cpus=2-3,memdev=ram-node1"
-                     qemu_cmdline_mem_backend_prealloc_0 = "(?:id=ram-node0),prealloc=yes,mem-path=\S+,size=\d+M?|prealloc=yes,mem-path=\S+,size=\d+M?,(?:id=ram-node0)"
+                     qemu_cmdline_mem_backend_prealloc_0 = "(?:id=ram-node0),mem-path=\S+,prealloc=yes,size=\d+M?|(?:id=ram-node0),prealloc=yes,mem-path=\S+,size=\d+M?|prealloc=yes,mem-path=\S+,size=\d+M?,(?:id=ram-node0)"
                      variants:
                          - per_node:
                              variants:


### PR DESCRIPTION
Signed-off-by: Kyla Zhang <weizhan@redhat.com>
Before
```
# avocado run --vt-type libvirt guest_numa.possitive_test.hugepage.per_node.2M.topology.numatune_memnode.m_strict.numatune_mem 
JOB ID     : ee6dfa5f59ea40535b1e1392f623ae8b2fe96403
JOB LOG    : /root/avocado/job-results/job-2020-12-10T06.06-ee6dfa5/job.log
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.2M.topology.numatune_memnode.m_strict.numatune_mem: FAIL: (?:id=ram-node0),prealloc=yes,mem-path=\S+,size=\d+M?|prealloc=yes,mem-path=\S+,size=\d+M?,(?:id=ram-node0) not found in vm qemu cmdline (42.17 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 43.59 s
```
After
```
# avocado run --vt-type libvirt guest_numa.possitive_test.hugepage.per_node.2M.topology.numatune_memnode.m_strict.numatune_mem 
JOB ID     : cd5fe3f71c0f542e150f6a5306d8455ad60acd6f
JOB LOG    : /root/avocado/job-results/job-2020-12-10T06.13-cd5fe3f/job.log
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.2M.topology.numatune_memnode.m_strict.numatune_mem: PASS (21.57 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 23.03 s
```