### PR TITLE
Add cases for luks enabled pull-mode backup

### DIFF
--- a/libvirt/tests/cfg/incremental_backup/incremental_backup_pull_mode.cfg
+++ b/libvirt/tests/cfg/incremental_backup/incremental_backup_pull_mode.cfg
@@ -8,6 +8,12 @@
     local_user_name = "ENTER.YOUR.USER.NAME"
     local_user_password = "ENTER.YOUR.USER.PASSWORD"
     variants:
+        - scratch_luks_encrypted:
+            only custom_exportname..custom_exportbitmap..hotplug_disk..original_disk_local
+            scratch_luks_encrypted = "yes"
+            luks_passphrase = "password"
+        - scratch_not_encrypted:
+    variants:
         - custom_exportname:
             set_exportname = "yes"
         - default_exportname:
@@ -22,6 +28,7 @@
             scratch_type = "file"
             variants:
                 - reuse_scratch_file:
+                    only scratch_not_encrypted
                     reuse_scratch_file = "yes"
                     prepare_scratch_file = "yes"
                     variants:


### PR DESCRIPTION
Now libvirt supports to encrypt scratch data of pull-mode backup.
This patch adds cases to cover luks encryption scenarios.

Signed-off-by: Yi Sun <yisun@redhat.com>