### PR TITLE
Use new target and scratch param structure for incremental backup

### DIFF
--- a/libvirt/tests/src/incremental_backup/incremental_backup_backing_chain.py
+++ b/libvirt/tests/src/incremental_backup/incremental_backup_backing_chain.py
@@ -326,10 +326,10 @@ def run(test, params, env):
                     backup_disk_params["disk_type"] = scratch_type
 
                     # Prepare nbd scratch file/dev params
-                    scratch_params = {}
+                    scratch_params = {"attrs": {}}
                     scratch_file_name = "scratch_file_%s" % backup_index
                     scratch_file_path = os.path.join(tmp_dir, scratch_file_name)
-                    scratch_params["file"] = scratch_file_path
+                    scratch_params["attrs"]["file"] = scratch_file_path
                     logging.debug("scratch_params: %s", scratch_params)
                     backup_disk_params["backup_scratch"] = scratch_params
                 backup_disk_xml = utils_backup.create_backup_disk_xml(

--- a/libvirt/tests/src/incremental_backup/incremental_backup_multidisk.py
+++ b/libvirt/tests/src/incremental_backup/incremental_backup_multidisk.py
@@ -170,11 +170,11 @@ def run(test, params, env):
                         nbd_bitmap_name = vm_disk + "_custom_bitmap"
                         backup_disk_params["exportbitmap"] = nbd_bitmap_name
                     # Prepare nbd scratch file params
-                    scratch_params = {}
+                    scratch_params = {"attrs": {}}
                     if scratch_type == "file":
                         scratch_file_name = "scratch_file_%s" % vm_disk
                         scratch_file_path = os.path.join(tmp_dir, scratch_file_name)
-                        scratch_params["file"] = scratch_file_path
+                        scratch_params["attrs"]["file"] = scratch_file_path
                         logging.debug("scratch_params: %s", scratch_params)
                     else:
                         test.cancel("We only use local file scratch for now.")

--- a/libvirt/tests/src/incremental_backup/incremental_backup_push_mode.py
+++ b/libvirt/tests/src/incremental_backup/incremental_backup_push_mode.py
@@ -206,25 +206,25 @@ def run(test, params, env):
                 else:
                     backup_disk_params["enable_backup"] = "yes"
                     backup_disk_params["disk_type"] = target_type
-                    target_params = {}
+                    target_params = {"attrs": {}}
                     if target_type == "file":
                         target_file_name = "target_file_%s" % backup_index
                         target_file_path = os.path.join(tmp_dir, target_file_name)
                         if prepare_target_file:
                             libvirt.create_local_disk("file", target_file_path,
                                                       original_disk_size, target_driver)
-                        target_params["file"] = target_file_path
-                        logging.debug("target_params: %s", target_params)
+                        target_params["attrs"]["file"] = target_file_path
                         backup_path_list.append(target_file_path)
                     elif target_type == "block":
                         if prepare_target_blkdev:
                             target_blkdev_path = libvirt.setup_or_cleanup_iscsi(
                                     is_setup=True, image_size=target_blkdev_size)
-                        target_params["dev"] = target_blkdev_path
+                        target_params["attrs"]["dev"] = target_blkdev_path
                         backup_path_list.append(target_blkdev_path)
                     else:
                         test.fail("We do not support backup target type: '%s'"
                                   % target_type)
+                    logging.debug("target params: %s", target_params)
                     backup_disk_params["backup_target"] = target_params
                     driver_params = {"type": target_driver}
                     backup_disk_params["backup_driver"] = driver_params


### PR DESCRIPTION
This is to align with avocado-vt PR2852. Now the 'target' and
'scratch' tag can have subelement 'encryption'.

Signed-off-by: Yi Sun <yisun@redhat.com>