### PR TITLE
[libvirt_rng] Fix brittle test

### DIFF
--- a/libvirt/tests/src/libvirt_rng.py
+++ b/libvirt/tests/src/libvirt_rng.py
@@ -307,9 +307,9 @@ def run(test, params, env):
         :param session: ssh session to guest
         :param exists: check rng device exists/not exists
         """
-        check_cmd = "hexdump /dev/hwrng"
+        check_cmd = "hexdump /dev/hwrng -n 100"
         try:
-            status = session.cmd_status(check_cmd, 3)
+            status = session.cmd_status(check_cmd, 60)
 
             if status != 0 and exists:
                 test.fail("Fail to check hexdump in guest")


### PR DESCRIPTION
The test code timed out the command reading entropy wiht hexdump after
3 seconds. This led to the test never ending on my environments, possibly
because of the created load of reading with hexdump endlessly.

Instead, only read 100 bytes to confirm virtio device delivers entropy.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>