### PR TITLE
Clusters may leak after the watchdog test.

### DIFF
--- a/libvirt/tests/cfg/virtual_device/watchdog.cfg
+++ b/libvirt/tests/cfg/virtual_device/watchdog.cfg
@@ -38,6 +38,7 @@
             action = "none"
         - action_poweroff:
             action = "poweroff"
+            skip_cluster_leak_warn = "yes"
         - action_pause:
             action = "pause"
         - action_reset:


### PR DESCRIPTION
Added new variable to configuration file which allows leaked clusters after the test. This is a safe option in a case, when the VM is closed unexpectedly(from QEMU perspective) by test and this is required by test. Also, when no data is harmed. Leaked clusters happen in 90% of executions of this test, but with no harm to data.

Signed-off-by: Kamil Varga <kvarga@redhat.com>