### PR TITLE
Add case to support dot(.) in vm name

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_create.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_create.cfg
@@ -5,6 +5,9 @@
     variants:
         - none:
             create_options = ""
+        - dot_name:
+            new_name = "vm1."
+            create_options = ""
         - console:
             create_options = "--console"
         - console_autodestroy:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_define.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_define.cfg
@@ -15,6 +15,8 @@
                     new_name = "-_-"
                 - option_none:
                     is_defined_from_xml = "yes"
+                - dot_name:
+                    new_name = "vm1."
         - negative_test:
             status_error = "yes"
             variants:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domrename.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domrename.cfg
@@ -24,6 +24,8 @@
                     domrename_vm_state = "autostart"
                 - with_snapshot:
                     domrename_vm_state = "with_snapshot"
+        - dot_name:
+            vm_new_name = "vm_dot"
         - error_test:
             status_error = "yes"
             variants:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domrename.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domrename.py
@@ -50,6 +50,9 @@ def run(test, params, env):
     if new_name == "vm2_name":
         vm2_name = ("%s" % vm_name[:-1])+"2"
         new_name = vm2_name
+    elif new_name == "vm_dot":
+        vm2_name = vm_name + "."
+        new_name = vm2_name
 
     # Build input params
     dom_param = ' '.join([domain_option, vm_ref])


### PR DESCRIPTION
New automated test cases added to check if the virsh utility is able to create, define and domrename the VM with a dot(.) in the name.

Signed-off-by: Kamil Varga <kvarga@redhat.com>