### PR TITLE
[watchdog] Fix virsh command line

### DIFF
--- a/libvirt/tests/src/virtual_device/watchdog.py
+++ b/libvirt/tests/src/virtual_device/watchdog.py
@@ -258,7 +258,7 @@ def run(test, params, env):
             logging.info("The first boot time is %s\n", first_boot_time)
         if action == "inject-nmi":
             virsh_session = virsh.VirshSession(virsh_exec=virsh.VIRSH_EXEC, auto_close=True)
-            event_cmd = "event --event watchdog --all --loop"
+            event_cmd = "event --all --loop"
             virsh_session.sendline(event_cmd)
         trigger_watchdog(model)
         confirm_guest_status()


### PR DESCRIPTION
The test listens to events with the 'virsh event' command.
libvirt accepted passing both '--all' and '--event' but will now report
"Options --all and --event are mutually exclusive" and not start.

The test code uses 'aexpect.client.sendline' which can't report on error.
Therefore the test fails the command silently leading to later test failure.

As watchdog events are a subset of all events use only '--all'.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>