### PR TITLE
Add testcase for virtiofs guest startup process

### DIFF
--- a/libvirt/tests/cfg/virtual_device/filesystem_device.cfg
+++ b/libvirt/tests/cfg/virtual_device/filesystem_device.cfg
@@ -66,6 +66,9 @@
             variants:
                 - suspend_resume:
                     suspend_resume = "yes"
+                - edit_start:
+                    edit_start = "yes"
+                    error_msg_start = "qemu-kvm: -foo: invalid option"
         - coldplug_coldunplug:
             only xattr_on.flock_on.lock_posix_on.cache_mode_none.one_fs
             coldplug = "yes"


### PR DESCRIPTION
1. Destroy a virtiofs guest
2. Modify guest domain, add invalid option '-foo' and start guest.
   Guest start failure is expected.
3. Correct guest domain and start guest.

Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1897105
This issue has been fixed in libvirt-6.10.0-1.el8.

Signed-off-by: Liu Yiding <liuyd.fnst@cn.fujitsu.com>