### PR TITLE
Allow redefine checkpoint without domain XML

### DIFF
--- a/libvirt/tests/src/incremental_backup/incremental_backup_checkpoint_cmd.py
+++ b/libvirt/tests/src/incremental_backup/incremental_backup_checkpoint_cmd.py
@@ -110,6 +110,10 @@ def run(test, params, env):
                 cp_dumpxml_options = ""
                 if no_domain:
                     cp_dumpxml_options = "--no-domain"
+                    if libvirt_version.version_compare(6, 6, 0):
+                        # libvirt-6.6.0-9.el8 starts to allow redefine VM
+                        # backup checkpoint without the domain XML (bz1901830)
+                        status_error = False
                 checkpoint_redef = current_checkpoints[0]
                 cp_xml = checkpoint_xml.CheckpointXML.new_from_checkpoint_dumpxml(
                         vm_name, checkpoint_redef, cp_dumpxml_options)


### PR DESCRIPTION
Since libvirt-6.6.0-9.el8 (ref: bz1901830), libvirts starts to allow
redefine VM backup checkpoint without the domain XML. This will fail
our existing case, which expected a failure when dmoain XML not
provided. So update the script to align with the change.

Signed-off-by: Yi Sun <yisun@redhat.com>