### PR TITLE
[virsh.attach_device] Allow for chardev removal globally

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_device.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_device.cfg
@@ -8,6 +8,7 @@
     # serial device file path
     # on power architecture serail_dir specify as /var/tmp
     serial_dir = ""
+    remove_all_chardev = no
     variants:
         - domain_positional:
             vadu_domain_positional = "yes"
@@ -124,14 +125,12 @@
                 - sclp_twice:
                     only s390-virtio, virsh..single_serial.without_alias..file_argument.domain_argument
                     no controller, block, multiple, normal_test.hot_attach_hot_vm, normal_test.hot_attach_hot_vm_current
-                    remove_all_chardev = yes
                     vadu_dev_objs = "SerialPipe"
                     vadu_dev_objs_models = "sclpconsole sclpconsole"
                     vadu_dev_objs_count_SerialPipe = 2
                 - sclplm_twice:
                     only s390-virtio, virsh..single_serial.without_alias..file_argument.domain_argument
                     no controller, block, multiple, normal_test.hot_attach_hot_vm, normal_test.hot_attach_hot_vm_current
-                    remove_all_chardev = yes
                     vadu_dev_objs = "SerialFile"
                     vadu_dev_objs_models = "sclplmconsole sclplmconsole"
                     vadu_dev_objs_count_SerialFile = 2
@@ -182,7 +181,6 @@
                     no normal_test.hot_attach_hot_vm, normal_test.hot_attach_hot_vm_current
                     # Only two serial target types are available and
                     # must be different
-                    remove_all_chardev = yes
                     variants:
                         - single_serial:
                             # SerialFile is name of class in test-module


### PR DESCRIPTION
The configuration option `remove_all_chardev` has been used to remove
all chardevs from vm before running test. The need to remove all chardevs
before running test however, is not arch-dependent but depends on the
domain definition before starting the test. Let's move this option to global
scope to allow for removal for all test cases. The default value is `no`
as before (s. corresponding script `virsh_attach_device.py`)

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>