### PR TITLE
v2v: add a new positive --mac static ip case

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -152,6 +152,11 @@
                     virtio_win_path = '/usr/share/virtio-win/virtio-win.iso'
                     main_vm = VM_NAME_WIN2019_V2V_EXAMPLE
                     os_version = "win2019"
+                - mac_ip:
+                    only esx_67
+                    checkpoint = 'mac_ip'
+                    main_vm = VM_NAME_WIN_STATIC_IP_V2V_EXAMPLE
+                    v2v_opts = VM_NAME_WIN_STATIC_IP_MAC_CONF_V2V_EXAMPLE
         - with_cdrom:
             only esx_55
             main_vm = 'VM_NAME_ESX_CDROM_V2V_EXAMPLE'
@@ -501,16 +506,15 @@
         - invalid_mac_ip:
             only esx_67
             only negative_test
-            checkpoint = 'mac_ip'
             version_requried = "[virt-v2v-1.42.0-6,)"
             main_vm = VM_NAME_RHEL8_V2V_EXAMPLE
             variants:
                 - addr:
-                    mac_value = '00:50:56:ac:cd:56:ip:invalid_ip_addr'
+                    v2v_opts = '--mac 00:50:56:ac:cd:56:ip:invalid_ip_addr'
                     expect_msg = 'yes'
                     msg_content = 'cannot parse --mac ip .*?: doesn’t look like .*? is an IP address'
                 - prefix:
-                    mac_value = '00:50:56:ac:cd:56:ip:00:50:56:ac:cd:56:ip:192.168.1.1,192.168.1.2,129,10.1.1.1'
+                    v2v_opts = '--mac 00:50:56:ac:cd:56:ip:00:50:56:ac:cd:56:ip:192.168.1.1,192.168.1.2,129,10.1.1.1'
                     expect_msg = 'yes'
                     msg_content = 'virt-v2v: error: --mac ip prefix length field is out of range'
     variants:


### PR DESCRIPTION
1) Add a new postive case for --mac xxx:ip:xxx option.
Notes: This case requires the guest has at least two interfaces
in order to connect to the VM normally.
2) Update the way of passing paramters for invalid_mac_ip case

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>