### PR TITLE
[migrate_options_shared] reboot guest on dest

### DIFF
--- a/libvirt/tests/src/migration/migrate_options_shared.py
+++ b/libvirt/tests/src/migration/migrate_options_shared.py
@@ -1461,6 +1461,9 @@ def run(test, params, env):
             remote_virsh_session.close_session()
 
         if int(mig_result.exit_status) == 0:
+            if not remote_virsh_session:
+                remote_virsh_session = virsh.VirshPersistent(**remote_virsh_dargs)
+                remote_virsh_session.reboot(vm_name)
             migration_test.ping_vm(vm, params, dest_uri)
 
             if cmd_in_vm_after_migration:


### PR DESCRIPTION
Networking is not guaranteed to work after migration of NAT setup without reboot.
Reboot the vm before pinging it.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>