### PR TITLE
[diagnose_data] update supported vcpu number

### DIFF
--- a/libvirt/tests/cfg/cpu/diagnose_data.cfg
+++ b/libvirt/tests/cfg/cpu/diagnose_data.cfg
@@ -3,12 +3,13 @@
     only s390-virtio
     variants:
         - with_diag318:
-            final_number_of_vcpus = 241
             els = require
             diag318 = require
             check_stat = yes
     variants:
         - hotplug:
+            final_number_of_vcpus = 248
             plug = hot
         - coldplug:
+            final_number_of_vcpus = 248
             plug = cold

--- a/libvirt/tests/src/cpu/diagnose_data.py
+++ b/libvirt/tests/src/cpu/diagnose_data.py
@@ -35,7 +35,7 @@ def run(test, params, env):
         if check_stat:
             raise_if_only_zero_entries(session)
     except Exception as e:
-        test.fail("Test failed: %s" % e.message)
+        test.fail("Test failed: %s" % e)
     finally:
         vmxml_backup.sync()
 


### PR DESCRIPTION
Check debug_stats is now available for a higher number of cpus.

AssertionError doesn't have field message. Use exception directly.
In case of failure the result will be reported as
"FAIL: Test failed: Expected counters to be none zero, got: diag 318 [...]"

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>