### PR TITLE
Extend the timeout for unprivilaged login

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_unprivileged.py
+++ b/libvirt/tests/src/virtual_network/iface_unprivileged.py
@@ -201,7 +201,7 @@ def run(test, params, env):
             session = aexpect.ShellSession(cmd)
             session.sendline()
             remote.handle_prompts(session, params.get("username"),
-                                  params.get("password"), r"[\#\$]\s*$", 30)
+                                  params.get("password"), r"[\#\$]\s*$", 60)
             logging.debug(session.cmd_output('ifconfig'))
             check_ping(remote_ip, 5, 10, session=session)
             session.close()


### PR DESCRIPTION
Before:
```
# avocado run --vt-type libvirt virtual_network.iface_unprivileged.precreated.host_macvtap
JOB ID     : 35dfd22071dd366a95f4a03883a2a56016ba5878
JOB LOG    : /root/avocado/job-results/job-2020-12-23T03.38-35dfd22/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.iface_unprivileged.precreated.host_macvtap: ERROR: Login timeout expired    (output: '\x1b[?25l\x1b[m\x1b[H\x1b[J\x1b[1;1H\x1b[20;7H\x1b[mUse the ^ and v keys to change the selection.                       \n      Press \'e\' to edit the selected item, or \'c\' for a command prompt.   \x1b[4;80H \x1b[7m\x... (85.14 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 87.16 s
```
After
```
# avocado run --vt-type libvirt virtual_network.iface_unprivileged.precreated.host_macvtap
JOB ID     : 18d65f29baf1cf527fa496f1a05e7523724a5b71
JOB LOG    : /root/avocado/job-results/job-2020-12-23T05.18-18d65f2/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.iface_unprivileged.precreated.host_macvtap: PASS (111.61 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 113.57 s
```


Signed-off-by: Kyla Zhang <weizhan@redhat.com>