### PR TITLE
Update bridge type interface with network type xml

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_bridge.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_bridge.cfg
@@ -24,6 +24,13 @@
             iface_alias = "ua-abcdabcd-abcd-abcd-abcd-abcdabcdabcd"
             hotplug = "yes"
             iface_type = "bridge"
+        - update_with_diff_type:
+            hotplug = "yes"
+            update_with_diff_type = "yes"
+            iface_type = "network"
+            create_network = "yes"
+            iface_source = "{'network':'host_bridge'}"
+            iface_alias = "ua-ad4acfc8-2ed4-43d4-9481-18a7d8e11b4f"
         - multiqueues:
             iface_driver = '{"queues": "4", "rx_queue_size": "1024", "tx_queue_size": "512", "name": "vhost" }'
             iface_model = "virtio"


### PR DESCRIPTION
When update an <interface>, and the interface type changed from type='network'
where the network was an unmanaged bridge (so actualType == bridge) to type='bridge'
(i.e. actualType also == bridge), the update without the recently fix would fail
due to the perceived change in type. Add the test case about updating bridge type
interface with network type xml.

Signed-off-by: Yalan Zhang <yalzhang@redhat.com>