### PR TITLE
papr_hpt:use new func 'get_family()' provided by avocado:82

### DIFF
--- a/libvirt/tests/src/papr_hpt.py
+++ b/libvirt/tests/src/papr_hpt.py
@@ -145,7 +145,7 @@ def run(test, params, env):
 
         # Test on ppc64le hosts
         if arch.lower() == 'ppc64le':
-            cpu_arch = cpu.get_cpu_arch()
+            cpu_arch = cpu.get_family() if hasattr(cpu, 'get_family') else cpu.get_cpu_arch()
             logging.debug('cpu_arch is: %s', cpu_arch)
             if skip_p8 and cpu_arch == 'power8':
                 test.cancel('This case is not for POWER8')


### PR DESCRIPTION
The function 'get_cpu_arch()' is changed on avocado:82. To adapt to
the change and keep 69lts working, we call new function if it's
available.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>