### PR TITLE
Fix numa issue in guest_numa.cfg

### DIFF
--- a/libvirt/tests/cfg/numa/guest_numa.cfg
+++ b/libvirt/tests/cfg/numa/guest_numa.cfg
@@ -20,7 +20,7 @@
                      memory_placement = "static"
                      memory_nodeset = "0-1"
                      memory_mode = "strict"
-                     qemu_cmdline_mem_backend_1 = "memory-backend-ram,.*?id=ram-node1,.*?host-nodes=[0-9,],policy=bind"
+                     qemu_cmdline_mem_backend_1 = "memory-backend-ram,.*?id=ram-node1,.*?host-nodes=\d-\d,policy=bind"
                      pseries:
                          memory_nodeset = "0"
                          qemu_cmdline_mem_backend_1 = "memory-backend-ram,.*?id=ram-node1,.*?host-nodes=0,policy=bind"


### PR DESCRIPTION
Fix numa issue in guest_numa.cfg: 
TestFail: ...host-nodes=[0-9,],policy=bind not found in vm qemu cmdline

Signed-off-by: Meina Li <meili@redhat.com>