### PR TITLE
pcie_controllers:fix incorrect quote

### DIFF
--- a/libvirt/tests/cfg/controller/pcie_controllers.cfg
+++ b/libvirt/tests/cfg/controller/pcie_controllers.cfg
@@ -36,7 +36,7 @@
                 - multiple_hotplug:
                     hotplug = 'yes'
                     hotplug_counts = 5
-                    err_msg = '"No more available PCI slots"'
+                    err_msg = "No more available PCI slots"
                     attach_extra = '--subdriver qcow2'
                     check_within_guest = "no"
                     check_disk_xml = "no"
@@ -53,11 +53,11 @@
             variants:
                 - hotplug:
                     hotplug = 'yes'
-                    err_msg = '"PCI controller with index='%s' doesn't support hotplug"'
+                    err_msg = "PCI controller with index='%s' doesn't support hotplug"
                 - hotunplug:
                     hotplug = 'no'
                     attach_extra = '--address pci:${disk_addr} --subdriver qcow2 --config'
-                    err_msg = '"cannot hot unplug.*device with PCI.*address: 0000:0%s:00.0.*not allowed by controller"'
+                    err_msg = "cannot hot unplug.*device with PCI.*address: 0000:0%s:00.0.*not allowed by controller"
                 - double_addr:
                     err_msg = "Attempted double use of PCI Address"
                     hotplug_off:


### PR DESCRIPTION
Extra quote caused the string match failed. This fix is to remove those quote.

Signed-off-by: Dan Zheng <dzheng@redhat.com>