### PR TITLE
To support cross migration from 8.2 to 8.3, the qemu cmdline has some change

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_mem.cfg
+++ b/libvirt/tests/cfg/migration/migrate_mem.cfg
@@ -48,7 +48,8 @@
             memdev_tg_size = "512"
             memdev_tg_sizeunit = "MiB"
             memdev_tg_node = "0"
-            qemu_checks = "id=ram-node1,size=536870912`-numa node,nodeid=1,cpus=2-3,memdev=ram-node1`-object memory-backend-ram,id=memdimm0,size=536870912"
+            # migrate from 8.2 to 8.3.1, the qemu cmdline is "-numa node,nodeid=1,cpus=2-3,mem=1024 -object memory-backend-ram,id=memdimm0,size=536870912"
+            qemu_checks = "(id=ram-node1,size=536870912|)`-numa node,nodeid=1,cpus=2-3,mem(=1024|dev=ram-node1)`-object memory-backend-ram,id=memdimm0,size=536870912"
         - mem_balloon:
             check = "mem_balloon"
             ballooned_mem = "716800"


### PR DESCRIPTION
Since the qemu command changed from 8.2 to 8.3, the different comparation strings
is needed for 8.2 as the source of the migration.