### PR TITLE
Fix the case for domrename guest with snapshots

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domrename.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domrename.cfg
@@ -22,6 +22,8 @@
             variants:
                 - autostart_set:
                     domrename_vm_state = "autostart"
+                - with_snapshot:
+                    domrename_vm_state = "with_snapshot"
         - error_test:
             status_error = "yes"
             variants:
@@ -33,8 +35,6 @@
                             domrename_vm_state = "paused"
                         - vm_managed_saved:
                             domrename_vm_state = "managed_saved"
-                        - with_snapshot:
-                            domrename_vm_state = "with_snapshot"
                 - invalid_dom_name:
                     domrename_vm_ref = "invalid"
                 - invalid_new_name:


### PR DESCRIPTION
domrename guest with snapshots is supported after
libvirt-6.10.0.

Signed-off-by: Lily Zhu <lizhu@redhat.com>