### PR TITLE
Check whether pkg is successfully installed

### DIFF
--- a/libvirt/tests/src/memory/nvdimm.py
+++ b/libvirt/tests/src/memory/nvdimm.py
@@ -189,7 +189,8 @@ def run(test, params, env):
 
         # ppc test requires ndctl
         if IS_PPC_TEST:
-            utils_package.package_install('ndctl', session=vm_session)
+            if not utils_package.package_install('ndctl', session=vm_session):
+                test.error('Cannot install ndctl to vm')
             logging.debug(vm_session.cmd_output(
                 'ndctl create-namespace --mode=fsdax --region=region0'))
 


### PR DESCRIPTION
ppc tests requires pkg ndctl. The installation of the pkg might
fail sometimes. Stop testing if pkg cannot be installed.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>