### PR TITLE
Add --nvram option for undefine

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_create.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_create.py
@@ -1,4 +1,5 @@
 import logging
+import platform
 
 import aexpect
 
@@ -50,7 +51,10 @@ def run(test, params, env):
         if not options or "--validate" in options:
             xml_backup = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
             xmlfile = xmlfile_with_extra_attibute(xml_backup)
-        vm.undefine()
+        nvram_o = None
+        if platform.machine() == 'aarch64':
+            nvram_o = " --nvram"
+        vm.undefine(nvram_o)
     else:
         xmlfile = params.get("create_domain_xmlfile")
         if xmlfile is None:


### PR DESCRIPTION
Some vm_create tests trigger met since undefine failed.
The guest uses UEFI to boot, --nvram is required to undefine.

Signed-off-by: Liu Yiding <liuyd.fnst@cn.fujitsu.com>