### PR TITLE
Add cases to check image having correct bitmap when redefine checkpoint

### DIFF
--- a/libvirt/tests/cfg/incremental_backup/incremental_backup_checkpoint_cmd.cfg
+++ b/libvirt/tests/cfg/incremental_backup/incremental_backup_checkpoint_cmd.cfg
@@ -9,6 +9,14 @@
                 - redefine:
                     flag = "--redefine"
                     variants:
+                        - redefine_validate:
+                            extra_flag = "--redefine-validate"
+                            variants:
+                                - image_with_bitmap:
+                                    image_with_bitmap = "yes"
+                                - image_without_bitmap:
+                        - not_redefine_validate:
+                    variants:
                         - xml_with_domain:
                             no_domain = "no"
                         - xml_without_domain:


### PR DESCRIPTION
Since bz1874846, libvirt starts to support checking if image has correct
bitmaps when redefine libvirt checkpoint. This is to make sure the
libvirt's checkpoint metadata and qcow2 image have exactly same bitmap
info.

Signed-off-by: Yi Sun <yisun@redhat.com>