### PR TITLE
Fix domblkthreshold mirror mode blockcommit cases

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domblkthreshold.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domblkthreshold.cfg
@@ -23,7 +23,7 @@
                     default_snapshot_test = "yes"
                 - mirror_mode_blockcommit:
                     mirror_mode_blockcommit = "yes"
-                    block_threshold_value = "1024M"
+                    block_threshold_value = "512M"
                     block_threshold_timeout = "120"
                 - mirror_mode_blockcopy:
                     mirror_mode_blockcopy = "yes"


### PR DESCRIPTION
block_threshold value need to be less than image size filled up

Signed-off-by: chunfuwen <chwen@redhat.com>