### PR TITLE
[virtual_device][filesystem_device] allow for shared memory without numa

### DIFF
--- a/libvirt/tests/cfg/virtual_device/filesystem_device.cfg
+++ b/libvirt/tests/cfg/virtual_device/filesystem_device.cfg
@@ -17,6 +17,8 @@
         vcpus_per_cell = 5
     aarch64:
         extra_hugepages = 0
+    s390-virtio:
+        with_numa = no
     variants:
         - fs_test:
             variants:

--- a/libvirt/tests/src/virtual_device/filesystem_device.py
+++ b/libvirt/tests/src/virtual_device/filesystem_device.py
@@ -105,6 +105,7 @@ def run(test, params, env):
     extra_hugepages = params.get_numeric("extra_hugepages")
     edit_start = params.get("edit_start", "no") == "yes"
     with_hugepages = params.get("with_hugepages", "yes") == "yes"
+    with_numa = params.get("with_numa", "yes") == "yes"
 
     fs_devs = []
     vms = []
@@ -155,7 +156,9 @@ def run(test, params, env):
                 utils_memory.set_num_huge_pages(huge_pages_num)
             vmxml.remove_all_device_by_type('filesystem')
             vmxml.sync()
-            numa_no = vmxml.vcpu // vcpus_per_cell if vmxml.vcpu != 1 else 1
+            numa_no = None
+            if with_numa:
+                numa_no = vmxml.vcpu // vcpus_per_cell if vmxml.vcpu != 1 else 1
             vm_xml.VMXML.set_vm_vcpus(vmxml.vm_name, vmxml.vcpu, numa_number=numa_no)
             vm_xml.VMXML.set_memoryBacking_tag(vmxml.vm_name, access_mode="shared",
                                                hpgs=with_hugepages)


### PR DESCRIPTION
NUMA is not available on s390x. Shared memory without NUMA has been fully
supported since libvirt commit bff2ad5d6b1f25da02802273934d2a519159fec7.

Skip NUMA configuration on s390x. The new config value defaults to "yes" to
maintain current behavior, that is, create NUMA configuration by default.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>