### PR TITLE
[virtual_devices][filesystem_device] add variant file backed

### DIFF
--- a/libvirt/tests/cfg/virtual_device/filesystem_device.cfg
+++ b/libvirt/tests/cfg/virtual_device/filesystem_device.cfg
@@ -75,6 +75,11 @@
     variants:
         - positive_test:
             status_error = "no"
+            variants:
+                - hugepages_backed:
+                      with_hugepages = yes
+                - file_backed:
+                      with_hugepages = no
         - negative_test:
             only nop.fs_test.xattr_on.flock_on.lock_posix_on.cache_mode_none.one_fs.one_guest
             status_error = "yes"


### PR DESCRIPTION
virtio-fs requires memory backing in one of the following ways:
1. by hugepages
2. by file

The current test suite only covers 1.

For 2. no hugepages must be configured. The qemu.conf value `memory_backing_dir` has a valid default value,
e.g. on RHEL `/var/lib/libvirt/qemu/ram`.

More details on https://libvirt.org/kbase/virtiofs.html.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>