### PR TITLE
Fix errors of virsh_event tests

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_event.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_event.cfg
@@ -76,6 +76,8 @@
                     strict_order = "yes"
                     q35:
                         device_target_bus = "scsi"
+                    pseries:
+                        device_target_bus = "scsi"
                 - rtc-change_event:
                     event_name = "rtc-change"
                     events_list = "hwclock"
@@ -86,6 +88,7 @@
                     metadata_key = "app"
                     metadata_value = "<app xmlns:foobar='http://foo.bar/'></app>"
                 - device-removal-failed_event:
+                    no pseries
                     event_name = "device-removal-failed"
                     events_list = "detach-dimm"
                     max_mem = 25600000

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
@@ -159,8 +159,8 @@ def run(test, params, env):
         numa_dict = {}
         numa_dict_list = []
         cpu_idx = 0
-        for each_node in host_numa_node_list:
-            numa_dict['id'] = str(each_node)
+        for index in range(numa_nodes):
+            numa_dict['id'] = str(index)
             numa_dict['memory'] = str(current_mem // numa_nodes)
             numa_dict['unit'] = mem_unit
             numa_dict['cpus'] = "%s-%s" % (str(cpu_idx), str(cpu_idx + 1))


### PR DESCRIPTION
- IDE is not supported by pseries, update to scsi
- Removal of dimm device should succeed on pseries
- The range of numa cells should be contiguous

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>