### PR TITLE
Enable transient disk feature on file based backend

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
@@ -757,7 +757,7 @@
                             variants:
                                 - default:
                                 - enable_transient_on_disk:
-                                    only coldplug
+                                    only coldplug..file_disk
                                     disk_transient = "yes"
                                     status_error = "yes"
                             variants:
@@ -768,6 +768,12 @@
                                     virtio_scsi_controller = "yes"
                                     virtio_scsi_controller_model = "virtio-scsi"
                                     driver_option = "type=raw,cache=none"
+                                - file_disk:
+                                    virt_disk_device = "disk"
+                                    virt_disk_device_type = "file"
+                                    virt_disk_device_format = "qcow2"
+                                    status_error = "no"
+                                    driver_option = "type=qcow2,cache=none"
                                 - device_disk:
                                     virt_disk_device = "disk"
                                 - network_lun:


### PR DESCRIPTION
transient disk feature is brought back after libvirt version 6.8.0
but only file-based backend is supported

Signed-off-by: chunfuwen <chwen@redhat.com>