### PR TITLE
Remove duplicated nvram option

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
@@ -512,7 +512,7 @@ def run(test, params, env):
 
         # Prepare transient/persistent vm
         if persistent_vm == "no" and vm.is_persistent():
-            vm.undefine("--nvram")
+            vm.undefine()
         elif persistent_vm == "yes" and not vm.is_persistent():
             new_xml.define()
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockjob.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockjob.py
@@ -91,7 +91,7 @@ def run(test, params, env):
     # Prepare transient/persistent vm
     original_xml = vm.backup_xml()
     if not persistent_vm and vm.is_persistent():
-        vm.undefine("--nvram")
+        vm.undefine()
     elif persistent_vm and not vm.is_persistent():
         vm.define(original_xml)
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_create.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_create.py
@@ -1,5 +1,4 @@
 import logging
-import platform
 
 import aexpect
 
@@ -51,10 +50,7 @@ def run(test, params, env):
         if not options or "--validate" in options:
             xml_backup = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
             xmlfile = xmlfile_with_extra_attibute(xml_backup)
-        nvram_o = None
-        if platform.machine() == 'aarch64':
-            nvram_o = " --nvram"
-        vm.undefine(nvram_o)
+        vm.undefine()
     else:
         xmlfile = params.get("create_domain_xmlfile")
         if xmlfile is None:


### PR DESCRIPTION
As of now, nvram option will be automatically added in vm.undefine if
needed.

Signed-off-by: Liu Yiding <liuyd.fnst@cn.fujitsu.com>