### PR TITLE
nvdimm:check minimum target size when defining vm

### DIFF
--- a/libvirt/tests/cfg/memory/nvdimm.cfg
+++ b/libvirt/tests/cfg/memory/nvdimm.cfg
@@ -56,7 +56,7 @@
                                     check = 'less_than_256'
                                     nvdimmxml_target_size = 255
                                     nvdimmxml_label_size = 128
-                                    error_msg = 'error: unsupported configuration: minimum target size for the NVDIMM must be 256MB plus the label size'
+                                    error_msg = 'minimum target size for the NVDIMM must be 256MB plus the label size'
                 - no_label:
                     check = back_file
                     cpuxml_topology = {'sockets': '2', 'cores': '1', 'threads': '1'}


### PR DESCRIPTION
The old behavior is throwing out error when starting vm. Currently
defining vm would fail. The case needs update to move the check
ahead to defining step.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>