### PR TITLE
[detach_device][cdrom] fix test for s390x

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device.cfg
@@ -28,6 +28,8 @@
             dt_device_bus_type = ide
             q35:
                 dt_device_bus_type = scsi
+            s390-virtio:
+                dt_device_bus_type = scsi
         - disk_test:
             dt_device_device = disk
             dt_device_device_target = vdb


### PR DESCRIPTION
On s390x, cdrom is attached through scsi. Fix test configuration.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>