### PR TITLE
Fix for matching failure as '' added in output around vm name

### DIFF
--- a/libvirt/tests/src/virtual_device/tpm_device.py
+++ b/libvirt/tests/src/virtual_device/tpm_device.py
@@ -540,7 +540,7 @@ def run(test, params, env):
         ret = virsh.define(vm_xml.xml, ignore_status=True, debug=True)
         expected_match = ""
         if not err_msg:
-            expected_match = "Domain %s defined from %s" % (vm_name, vm_xml.xml)
+            expected_match = "Domain .*%s.* defined from %s" % (vm_name, vm_xml.xml)
         libvirt.check_result(ret, err_msg, "", False, expected_match)
         if err_msg:
             # Stop test when get expected failure


### PR DESCRIPTION
before 
Domain avocado-vt-vm1 defined from xxx
after
Domain 'avocado-vt-vm1' defined from xxx

Signed-off-by: Kyla Zhang <weizhan@redhat.com>