### PR TITLE
virsh_change_media_matrix: Set device bus to 'scsi' for aarch tests

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_change_media_matrix.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_change_media_matrix.cfg
@@ -14,6 +14,9 @@
     pseries:
         change_media_target_bus = "scsi"
         change_media_target_device = "sdc"
+    aarch64:
+        change_media_target_bus = "scsi"
+        change_media_target_device = "sdc"
     kill_vm = yes
     variants:
         - action_twice:


### PR DESCRIPTION
IDE controllers are unsupported for machine type 'aarch', therefore
change it to 'scsi'

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>