### PR TITLE
Add test cases for network leases

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_dhcp_leases.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_dhcp_leases.cfg
@@ -17,6 +17,45 @@
                 - attach_interface_after_vm_start:
                     hotplug_interface = "yes"
                     filter_by_mac = "yes"
+                - lease:
+                    prepare_net = "yes"
+                    hotplug_interface = "no"
+                    variants:
+                        - hours:
+                            variants:
+                                - host:
+                                    host = "{'mac': '52:54:00:67:51:85', 'ip': '192.168.110.50'}"
+                                    host_lease = "{'expiry': '2', 'unit': 'hours'}"
+                                - range:
+                                    range_lease = "{'expiry': '5', 'unit': 'hours'}"
+                        - minutes:
+                            variants:
+                                - host:
+                                    host = "{'mac': '52:54:00:67:51:85', 'ip': '192.168.110.50'}"
+                                    host_lease = "{'expiry': '300', 'unit': 'minutes'}"
+                                - range:
+                                    range_lease = "{'expiry': '400', 'unit': 'minutes'}"
+                        - seconds:
+                            variants:
+                                - host:
+                                    host = "{'mac': '52:54:00:67:51:85', 'ip': '192.168.110.50'}"
+                                    host_lease = "{'expiry': '600', 'unit': 'seconds'}"
+                                - range:
+                                    range_lease = "{'expiry': '700', 'unit': 'seconds'}"
+                        - infinite:
+                            variants:
+                                - host:
+                                    host_lease = "{'expiry': '0'}"
+                                    host = "{'mac': '52:54:00:67:51:85', 'ip': '192.168.110.50'}"
+                                - range:
+                                    range_lease = "{'expiry': '0'}"
+                        - default:
+                            variants:
+                                - host:
+                                    host_lease = "{'expiry': '8'}"
+                                    host = "{'mac': '52:54:00:67:51:85', 'ip': '192.168.110.50'}"
+                                - range:
+                                    range_lease = "{'expiry': '8'}"
         - negative_test:
             status_error = "yes"
             variants:
@@ -34,3 +73,11 @@
                 - blank_mac:
                     net_option = "--mac ' '"
                     leases_err_msg = "invalid MAC address"
+                - invalid_lease:
+                    invalid_lease = "yes"
+                    range_lease = "{'expiry': '1', 'unit': 'minutes'}"
+                    leases_err_msg = "The minimum lease time should be greater than 2 minutes"
+                - blank_lease:
+                    invalid_lease = "yes"
+                    range_lease = "{'expiry': ''}"
+                    leases_err_msg = "An error occurred, but the cause is unknown"

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_dhcp_leases.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_dhcp_leases.py
@@ -9,6 +9,7 @@ from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import network_xml
 from virttest.utils_test import libvirt as utlv
 from avocado.utils import process
+from datetime import datetime, timedelta
 
 from virttest import libvirt_version
 
@@ -32,6 +33,10 @@ def run(test, params, env):
     filter_by_mac = "yes" == params.get("filter_by_mac", "no")
     invalid_mac = "yes" == params.get("invalid_mac", "no")
     expect_msg = params.get("leases_err_msg")
+    range_lease = eval(params.get("range_lease", "None"))
+    host_lease = eval(params.get("host_lease", "None"))
+    host = eval(params.get("host", "None"))
+    invalid_lease = "yes" == params.get("invalid_lease", "no")
     # Generate a random string as the MAC address
     nic_mac = None
     if invalid_mac:
@@ -53,10 +58,19 @@ def run(test, params, env):
         netxml = network_xml.NetworkXML()
         netxml.name = net_name
         netxml.forward = {'mode': "nat"}
+        range = network_xml.RangeXML()
+        range.attrs = {'start': net_dhcp_start, "end": net_dhcp_end}
         ipxml = network_xml.IPXML()
+        if range_lease:
+            range.lease_attrs = range_lease
         ipxml.address = net_ip_addr
         ipxml.netmask = net_ip_netmask
-        ipxml.dhcp_ranges = {'start': net_dhcp_start, "end": net_dhcp_end}
+        ipxml.dhcp_ranges = range
+        if host:
+            new_host = network_xml.DhcpHostXML()
+            new_host.attrs = host
+            new_host.lease_attrs = host_lease
+            ipxml.hosts = [new_host]
         netxml.set_ip(ipxml)
         netxml.create()
 
@@ -77,6 +91,42 @@ def run(test, params, env):
             return leases
         except Exception:
             test.error("Fail to parse output: %s" % output)
+
+    def check_lease_time(ex_time, duration):
+        """
+        Compare the expiry time from the virsh cmd output and the setting
+        :param ex_time: text, the expiry time get from the net-dhcp-lease output
+        :param duration: dict, the configured expiry time
+        """
+        now_time = datetime.now()
+        # convert the lease time from str to the datetime structure
+        # lease is in format like: 2021-01-18 02:15:35
+        get_ex_time = datetime.strptime(ex_time, '%Y-%m-%d %H:%M:%S')
+        if duration['expiry'] == '0':
+            if get_ex_time > now_time:
+                test.fail("The expiry time is not correct!!")
+        if 'unit' not in duration:
+            duration['unit'] = 'minutes'
+        else:
+            if duration['unit'] == 'seconds':
+                dur_sec = int(duration['expiry'])
+            elif duration['unit'] == 'hours':
+                dur_sec = int(duration['expiry']) * 3600
+            else:
+                dur_sec = int(duration['expiry']) * 60
+
+            delta = get_ex_time - now_time
+            logging.debug("The get_ex_time is %s, the now_time is %s, "
+                          "duration is %s" % (get_ex_time, now_time, duration))
+            if delta > timedelta(seconds=dur_sec):
+                test.fail("Get expiry time %s longer than the setting %s!!"
+                          % (delta, timedelta(seconds=dur_sec)))
+            elif delta < timedelta(seconds=(dur_sec-30)):
+                test.fail("Get expiry time %s shorter than the setting %s"
+                          % (delta, timedelta(seconds=dur_sec)))
+            else:
+                logging.info("Get expected lease info.")
+        return None
 
     def get_ip_by_mac(mac_addr, try_dhclint=False, timeout=120):
         """
@@ -121,6 +171,7 @@ def run(test, params, env):
         for net_lease in net_leases:
             net_mac = net_lease['MAC address']
             net_ip = net_lease['IP address'][:-3]
+            expiry_time = net_lease['Expiry Time']
             if vm_xml.VMXML.get_iface_by_mac(vm_name, net_mac):
                 find_mac = True
                 logging.debug("Find '%s' in domain XML", net_mac)
@@ -130,6 +181,12 @@ def run(test, params, env):
             iface_ip = get_ip_by_mac(net_mac)
             if iface_ip and iface_ip != net_ip:
                 test.fail("Address '%s' is not expected" % iface_ip)
+            #check if lease time is correct
+            if libvirt_version.version_compare(6, 2, 0):
+                if host_lease and net_mac == host['mac']:
+                    check_lease_time(expiry_time, host_lease)
+                elif range_lease:
+                    check_lease_time(expiry_time, range_lease)
         if expected_find and not find_mac:
             test.fail("No matched MAC address")
 
@@ -153,14 +210,18 @@ def run(test, params, env):
     logging.debug(pid_list)
     for pid in pid_list:
         utils_misc.safe_kill(pid, signal.SIGKILL)
-    # Create new network
-    if prepare_net:
-        create_network()
-    nets = virsh.net_state_dict()
-    if net_name not in list(nets.keys()) and not status_error:
-        test.error("Not find network '%s'" % net_name)
-    expected_find = False
     try:
+        # Create new network
+        if prepare_net:
+            nets_old = virsh.net_state_dict()
+            if net_name in list(nets_old.keys()):
+                virsh.net_destroy(net_name)
+                virsh.net_undefine(net_name)
+            create_network()
+        nets = virsh.net_state_dict()
+        if net_name not in list(nets.keys()) and not status_error:
+            test.error("Not find network '%s'" % net_name)
+        expected_find = False
         result = virsh.net_dhcp_leases(net_name,
                                        mac=nic_mac,
                                        options=net_option,
@@ -170,7 +231,10 @@ def run(test, params, env):
         lease = get_net_dhcp_leases(result.stdout.strip())
         check_net_lease(lease, expected_find)
         if not status_error:
-            iface_mac = utils_net.generate_mac_address_simple()
+            if host:
+                iface_mac = host['mac']
+            else:
+                iface_mac = utils_net.generate_mac_address_simple()
             if filter_by_mac:
                 nic_mac = iface_mac
             op = "--type network --model virtio --source %s --mac %s" \
@@ -198,8 +262,6 @@ def run(test, params, env):
                 login_timeout = 10
             new_interface_ip = get_ip_by_mac(iface_mac, try_dhclint=True,
                                              timeout=login_timeout)
-            # Allocate IP address for the new interface may fail, so only
-            # check the result if get new IP address
             if new_interface_ip:
                 expected_find = True
             result = virsh.net_dhcp_leases(net_name, mac=nic_mac,
@@ -210,6 +272,12 @@ def run(test, params, env):
         else:
             if expect_msg:
                 utlv.check_result(result, expect_msg.split(';'))
+    except Exception as e:
+        if status_error and invalid_lease:
+            if expect_msg not in e.details:
+                test.fail("Network create fail unexpected: %s", e.details)
+            else:
+                logging.debug("Network create fail expected: %s", e.details)
     finally:
         # Delete the new attached interface
         if new_nic_index > 0:


### PR DESCRIPTION
Support set lease info in network definition

lease is supported for ip/dhcp/range and ip/dhcp/host since
libvirt-6.2. Add the test cases for network leases.

Signed-off-by: Yalan Zhang <yalzhang@redhat.com>