### PR TITLE
Add some cases to check migration over unix socket

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_over_unix.cfg
+++ b/libvirt/tests/cfg/migration/migrate_over_unix.cfg
@@ -1,0 +1,92 @@
+- virsh.migrate_over_unix:
+    type = migrate_over_unix
+    # Console output can only be monitored via virsh console output
+    only_pty = True
+    take_regular_screendumps = no
+    # Extra options to pass after <domain> <desturi>
+    virsh_migrate_extra = ""
+    # SSH connection time out
+    ssh_timeout = 60
+    virsh_migrate_dest_state = running
+    virsh_migrate_src_state = running
+    # Local URI
+    virsh_migrate_connect_uri = "qemu:///system"
+    # Sockets' path
+    desturi_socket_path = "/tmp/desturi-socket"
+    migrateuri_socket_path = "/var/lib/libvirt/qemu/migrateuri-socket"
+    disks_uri_socket_path = "/var/lib/libvirt/qemu/disks-uri-socket"
+    # URIs to use for Virsh migrate command line's options
+    virsh_migrate_desturi = "qemu+unix:///system?socket=${desturi_socket_path}"
+    virsh_migrate_migrateuri = "unix://${migrateuri_socket_path}"
+    virsh_migrate_disks_uri = "unix://${disks_uri_socket_path}"
+
+    variants:
+        - with_postcopy:
+            postcopy_options = "--postcopy"
+        - without_postcopy:
+            postcopy_options = ""
+    variants:
+        - p2p_live_migration:
+            virsh_migrate_options = "--live --p2p --verbose"
+        - live_migration:
+            virsh_migrate_options = "--live --verbose"
+    variants:
+        - positive_testing:
+            status_error = "no"
+            variants:
+                - without_copy_storage:
+                    migration_setup = "yes"
+                    storage_type = 'nfs'
+                    setup_local_nfs = 'yes'
+                    variants:
+                        - migrate_uri:
+                            no live_migration.with_postcopy
+                            virsh_migrate_extra = "--migrateuri ${virsh_migrate_migrateuri} --bandwidth 50"
+                            action_during_mig = "check_socket"
+                            func_params_exists = "yes"
+                        - multifd:
+                            only without_postcopy
+                            only p2p_live_migration                    
+                            virsh_migrate_extra = "--migrateuri ${virsh_migrate_migrateuri} --bandwidth 50 --parallel --parallel-connections 4"
+                            action_during_mig = "check_socket"
+                            func_params_exists = "yes"
+                            expected_socket_num = "6"
+                        - tunnelled:
+                            only without_postcopy
+                            only p2p_live_migration
+                            virsh_migrate_extra = "--tunnelled"
+                - with_copy_storage:
+                    only without_postcopy
+                    virsh_migrate_extra = "--migrateuri ${virsh_migrate_migrateuri} --copy-storage-all --disks-uri ${virsh_migrate_disks_uri}"
+                    variants:
+                        - single_disk:
+                            disk_num = 1                   
+                        - multi_disks:
+                            only p2p_live_migration
+                            disk_num = 3
+                    variants:
+                        - @default:
+                        - multifd:
+                            only multi_disks
+                            virsh_migrate_extra = "--migrateuri ${virsh_migrate_migrateuri} --copy-storage-all --disks-uri ${virsh_migrate_disks_uri} --parallel --parallel-connections 4"
+        - negative_test:
+            status_error = "yes"
+            variants:
+                - domjobabort:
+                    only p2p_live_migration
+                    only without_postcopy
+                    action_during_mig = "virsh.domjobabort"
+                    func_params_exists = "yes"
+                    func_params = "'%s' % vm_name"
+                    migrate_again = "yes"
+                    migrate_again_status_error = "no"
+                    migrate_again_clear_func = "yes"
+                    variants:
+                        - normal_migration:
+                            virsh_migrate_extra = "--migrateuri ${virsh_migrate_migrateuri} --bandwidth 50"
+                            migration_setup = "yes"
+                            storage_type = 'nfs'
+                            setup_local_nfs = 'yes'
+                        - storage_migration:
+                            virsh_migrate_extra = "--migrateuri ${virsh_migrate_migrateuri} --bandwidth 100 --copy-storage-all --disks-uri ${virsh_migrate_disks_uri}"
+                            disk_num = 3

--- a/libvirt/tests/src/migration/migrate_over_unix.py
+++ b/libvirt/tests/src/migration/migrate_over_unix.py
@@ -1,0 +1,263 @@
+import os
+import logging
+import time
+
+from avocado.utils import process
+
+from virttest import libvirt_vm
+from virttest import defaults
+from virttest import virsh
+from virttest import migration
+from virttest import remote
+from virttest import utils_disk
+from virttest import utils_conn
+from virttest import utils_misc
+from virttest import libvirt_version
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_test import libvirt
+from virttest.utils_libvirt import libvirt_disk
+
+
+def run(test, params, env):
+    """
+    Test migration over unix socket.
+    1) Migrate vm over unix socket
+    2) Migrate vm over unix socket - libvirt tunnelled(--tunnelled)
+    3) Migrate vm over unix socket - enable multifd(--parallel)
+    4) Migrate vm with copy storage over unix socket - one disk
+    5) Migrate vm with copy storage over unix socket - multiple disks
+    6) Abort migration over unix socket and migrate again
+    7) Abort migration with copy storage over unix socket, and migrate again
+    8) Migrate vm with copy storage over unix socket - multiple disks
+        - enable multifd(--parallel)
+
+    :param test: test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    def update_disk(vm, params):
+        """
+        Update disk for testing.
+
+        :param vm: vm object.
+        :param params: the parameters used.
+        :return: updated images.
+        """
+        local_image_list = []
+        remote_image_list = []
+        vm_did_list = []
+        # Change the disk of the vm
+        if storage_type == "nfs":
+            libvirt.set_vm_disk(vm, params)
+        else:
+            disk_format = params.get("disk_format", "qcow2")
+            disk_num = eval(params.get("disk_num", "1"))
+            blk_source = vm.get_first_disk_devices()['source']
+            vsize = utils_misc.get_image_info(blk_source).get("vsize")
+            remote_session = remote.remote_login("ssh", server_ip, "22",
+                                                 server_user, server_pwd,
+                                                 r'[$#%]')
+            # Create disk on remote host
+            utils_misc.make_dirs(os.path.dirname(blk_source), remote_session)
+            libvirt_disk.create_disk("file", disk_format=disk_format,
+                                     path=blk_source, size=vsize,
+                                     session=remote_session)
+            remote_image_list.append(blk_source)
+
+            for idx in range(2, disk_num+1):
+                disk_path = os.path.join(os.path.dirname(blk_source),
+                                         "test%s.img" % str(idx))
+                # Create disk on local
+                libvirt_disk.create_disk("file", disk_format=disk_format,
+                                         path=disk_path)
+                local_image_list.append(disk_path)
+
+                target_dev = 'vd' + chr(idx + ord('a') - 1)
+                new_disk_dict = {"driver_type": disk_format}
+                result = libvirt.attach_additional_device(vm_name, target_dev,
+                                                          disk_path,
+                                                          new_disk_dict, False)
+                libvirt.check_exit_status(result)
+
+                libvirt_disk.create_disk("file", disk_format=disk_format,
+                                         path=disk_path,
+                                         session=remote_session)
+
+                remote_image_list.append(disk_path)
+                vm_did_list.append(target_dev)
+
+            remote_session.close()
+        return local_image_list, remote_image_list, vm_did_list
+
+    def check_socket(params):
+        """
+        Check sockets' number
+
+        :param params: the parameters used
+        :raise: test.fail when command fails
+        """
+        postcopy_options = params.get("postcopy_options")
+        vm_name = params.get("migrate_main_vm")
+        exp_num = params.get("expected_socket_num", "2")
+        if postcopy_options:
+            migration_test.set_migratepostcopy(vm_name)
+        cmd = ("netstat -xanp|grep -E \"CONNECTED"
+               ".*(desturi-socket|migrateuri-socket)\" | wc -l")
+        res = process.run(cmd, shell=True).stdout_text.strip()
+        if res != exp_num:
+            test.fail("There should be {} connected unix sockets, "
+                      "but found {} sockets.".format(exp_num, res))
+
+    migration_test = migration.MigrationTest()
+    migration_test.check_parameters(params)
+
+    # Local variables
+    virsh_args = {"debug": True}
+    server_ip = params["server_ip"] = params.get("remote_ip")
+    server_user = params["server_user"] = params.get("remote_user", "root")
+    server_pwd = params["server_pwd"] = params.get("remote_pwd")
+    client_ip = params["client_ip"] = params.get("local_ip")
+    client_pwd = params["client_pwd"] = params.get("local_pwd")
+    virsh_options = params.get("virsh_options", "")
+    extra = params.get("virsh_migrate_extra")
+    options = params.get("virsh_migrate_options", "--live --p2p --verbose")
+    storage_type = params.get("storage_type")
+    disk_num = params.get("disk_num")
+    desturi_port = params.get("desturi_port", "22222")
+    migrateuri_port = params.get("migrateuri_port", "33333")
+    disks_uri_port = params.get("disks_uri_port", "44444")
+    migrate_again = "yes" == params.get("migrate_again", "no")
+    func_params_exists = "yes" == params.get("func_params_exists", "no")
+    func_name = params.get("action_during_mig")
+    if func_name:
+        func_name = eval(func_name)
+
+    mig_result = None
+    local_image_list = []
+    remote_image_list = []
+    vm_did_list = []
+
+    if not libvirt_version.version_compare(6, 6, 0):
+        test.cancel("This libvirt version doesn't support "
+                    "migration over unix.")
+
+    if storage_type == "nfs":
+        # Params for NFS shared storage
+        shared_storage = params.get("migrate_shared_storage", "")
+        if shared_storage == "":
+            default_guest_asset = defaults.get_default_guest_os_info()['asset']
+            default_guest_asset = "%s.qcow2" % default_guest_asset
+            shared_storage = os.path.join(params.get("nfs_mount_dir"),
+                                          default_guest_asset)
+            logging.debug("shared_storage:%s", shared_storage)
+
+        # Params to update disk using shared storage
+        params["disk_type"] = "file"
+        params["disk_source_protocol"] = "netfs"
+        params["mnt_path_name"] = params.get("nfs_mount_dir")
+
+    # params for migration connection
+    params["virsh_migrate_connect_uri"] = libvirt_vm.complete_uri(
+        params.get("migrate_source_host"))
+    src_uri = params.get("virsh_migrate_connect_uri")
+    dest_uri = params.get("virsh_migrate_desturi")
+    dest_uri_ssh = libvirt_vm.complete_uri(params.get("migrate_dest_host"))
+
+    unix_obj = None
+
+    vm_name = params.get("migrate_main_vm")
+    vm = env.get_vm(vm_name)
+    vm.verify_alive()
+    bk_uri = vm.connect_uri
+
+    extra_args = {}
+    if func_params_exists:
+        if params.get("func_params"):
+            extra_args.update({'func_params': eval(params.get("func_params"))})
+        else:
+            extra_args.update({'func_params': params})
+    postcopy_options = params.get("postcopy_options")
+    if postcopy_options:
+        extra = "%s %s" % (extra, postcopy_options)
+
+    # For safety reasons, we'd better back up  xmlfile.
+    new_xml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    orig_config_xml = new_xml.copy()
+
+    try:
+        unix_obj = utils_conn.UNIXSocketConnection(params)
+        unix_obj.conn_setup()
+        unix_obj.auto_recover = True
+
+        local_image_list, remote_image_list, vm_did_list = update_disk(vm, params)
+
+        if not vm.is_alive():
+            vm.start()
+
+        logging.debug("Guest xml after starting:\n%s",
+                      vm_xml.VMXML.new_from_dumpxml(vm_name))
+
+        vm_session = vm.wait_for_login()
+
+        for did in vm_did_list:
+            utils_disk.linux_disk_check(vm_session, did)
+
+        # Execute migration process
+        vms = [vm]
+
+        migration_test.do_migration(vms, None, dest_uri, 'orderly',
+                                    options, thread_timeout=600,
+                                    ignore_status=True, virsh_opt=virsh_options,
+                                    func=func_name, extra_opts=extra,
+                                    **extra_args)
+
+        mig_result = migration_test.ret
+        migration_test.check_result(mig_result, params)
+
+        if migrate_again:
+            logging.debug("Sleeping 10 seconds before rerunning the migration.")
+            time.sleep(10)
+            if params.get("migrate_again_clear_func", "yes") == "yes":
+                func_name = None
+            params["status_error"] = params.get(
+                "migrate_again_status_error", "no")
+            migration_test.do_migration(vms, None, dest_uri, 'orderly',
+                                        options, thread_timeout=900,
+                                        ignore_status=True,
+                                        virsh_opt=virsh_options,
+                                        extra_opts=extra, func=func_name,
+                                        **extra_args)
+
+            mig_result = migration_test.ret
+            migration_test.check_result(mig_result, params)
+
+        if int(mig_result.exit_status) == 0:
+            vm.connect_uri = dest_uri_ssh
+            if not utils_misc.wait_for(
+               lambda: virsh.is_alive(vm_name, uri=dest_uri_ssh,
+                                      debug=True), 60):
+                test.fail("The migrated VM should be alive!")
+            if vm_did_list:
+                vm_session_after_mig = vm.wait_for_serial_login(timeout=240)
+                for did in vm_did_list:
+                    vm_session_after_mig.cmd(
+                        "echo mytest >> /mnt/%s1/mytest" % did)
+    finally:
+        logging.info("Recover test environment")
+        vm.connect_uri = bk_uri
+        # Clean VM on destination and source
+        try:
+            migration_test.cleanup_dest_vm(vm, bk_uri, dest_uri_ssh)
+        except Exception as err:
+            logging.error(err)
+        if vm.is_alive():
+            vm.destroy(gracefully=False)
+
+        orig_config_xml.sync()
+
+        # Remove image files
+        for source_file in local_image_list:
+            libvirt.delete_local_disk("file", path=source_file)
+        for img in remote_image_list:
+            remote.run_remote_cmd("rm -rf %s" % img, params)


### PR DESCRIPTION
This PR adds below cases:
    1) Migrate vm over unix socket
    2) Migrate vm over unix socket - libvirt tunnelled(--tunnelled)
    3) Migrate vm over unix socket - enable multifd(--parallel)
    4) Migrate vm with copy storage over unix socket - one disk
    5) Migrate vm with copy storage over unix socket - multiple disks
    6) Abort migration over unix socket and migrate again
    7) Abort migration with copy storage over unix socket, and migrate again
    8) Migrate vm with copy storage over unix socket - multiple disks
        - enable multifd(--parallel)

depends on: 
https://github.com/avocado-framework/avocado-vt/pull/2891
https://github.com/avocado-framework/avocado-vt/pull/2892
https://github.com/avocado-framework/avocado-vt/pull/2894
https://github.com/avocado-framework/avocado-vt/pull/2915

Signed-off-by: Yingshun Cui <yicui@redhat.com>