### PR TITLE
vcpu_feature:Remove case unsupported by pseries

### DIFF
--- a/libvirt/tests/cfg/cpu/vcpu_feature.cfg
+++ b/libvirt/tests/cfg/cpu/vcpu_feature.cfg
@@ -22,6 +22,7 @@
             status_error = "yes"
             variants:
                 - host_without_cr8legacy:
+                    no pseries
                     only policy_require
                     host_supported_feature = "no"
                     feature_name = "cr8legacy"


### PR DESCRIPTION
Feature cr8legacy is not supported by pseries.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>