### PR TITLE
Update the dhcp/range as the definition changes

### DIFF
--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_define_undefine.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_define_undefine.py
@@ -48,7 +48,9 @@ def set_ip_section(testnet_xml, addr, ipv6=False, **dargs):
     if "dhcp_ranges_start" in dargs and dargs["dhcp_ranges_start"] is not None:
         dhcp_ranges_start = dargs["dhcp_ranges_start"]
         dhcp_ranges_end = dargs["dhcp_ranges_end"]
-        ipxml.dhcp_ranges = {"start": dhcp_ranges_start, "end": dhcp_ranges_end}
+        ran = network_xml.RangeXML()
+        ran.attrs = {"start": dhcp_ranges_start, "end": dhcp_ranges_end}
+        ipxml.dhcp_ranges = ran
     testnet_xml.set_ip(ipxml)
 
 
@@ -173,7 +175,9 @@ def run(test, params, env):
             ipxml_v4 = network_xml.IPXML()
             ipxml_v4.address = address_v4
             ipxml_v4.netmask = netmask
-            ipxml_v4.dhcp_ranges = {"start": dhcp_ranges_start, "end": dhcp_ranges_end}
+            range_4 = network_xml.RangeXML()
+            range_4.attrs = {"start": dhcp_ranges_start, "end": dhcp_ranges_end}
+            ipxml_v4.dhcp_ranges = range_4
             testnet_xml.del_ip()
             testnet_xml.set_ip(ipxml_v4)
             if test_port:

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_start.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_start.py
@@ -71,7 +71,9 @@ def run(test, params, env):
             test_xml.forward = {'mode': 'nat'}
             test_xml.routes = [{'address': '192.168.122.0', 'prefix': '24', 'gateway': '192.168.100.1'}]
             ipxml = IPXML(address='192.168.100.1', netmask='255.255.255.0')
-            ipxml.dhcp_ranges = {'start': '192.168.100.2', 'end': '192.168.100.254'}
+            range_4 = network_xml.RangeXML()
+            range_4.attrs = {'start': '192.168.100.2', 'end': '192.168.100.254'}
+            ipxml.dhcp_ranges = range_4
             test_xml.ip = ipxml
             test_xml.define()
             virsh.net_start("def")


### PR DESCRIPTION
Recently the dhcp/range has added a element expiry time, so the
definition change from dict to a class. Update some network
define functions in libvirt.py file accordingly.

Signed-off-by: Yalan Zhang <yalzhang@redhat.com>