### PR TITLE
Cancel virsh_dumpxml with_cpu tests on unsupported platform

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_dumpxml.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_dumpxml.py
@@ -80,7 +80,7 @@ def run(test, params, env):
                                   "msa2": "force",
                                   "edat": "disable",
                                   "vmx": "forbid"}
-        else:
+        elif arch == "x86_64":
             return "Penryn", {"xtpr": "optional",
                               "tm2": "disable",
                               "est": "force",
@@ -88,6 +88,9 @@ def run(test, params, env):
                               # Unsupported feature 'ia64'
                               "ia64": "optional",
                               "vme": "optional"}
+        else:
+            test.cancel("This test currently only supports s390x and x86_64, "
+                        "%s requires special customization" % arch)
 
     def is_supported_on_host_func(host_capa):
         """


### PR DESCRIPTION
with_cpu test will customize cpu. Different platforms require special
customization.

Currently only s390 and x86_64 have added customized info. So cancel
with_cpu tests on unsupported platform.

Signed-off-by: Liu Yiding <liuyd.fnst@cn.fujitsu.com>