### PR TITLE
Clean up checkpoints metadata before create new one

### DIFF
--- a/libvirt/tests/src/incremental_backup/incremental_backup_backing_chain.py
+++ b/libvirt/tests/src/incremental_backup/incremental_backup_backing_chain.py
@@ -194,6 +194,9 @@ def run(test, params, env):
         vm_name = params.get("main_vm")
         vm = env.get_vm(vm_name)
 
+        # Make sure there is no checkpoint metadata before test
+        utils_backup.clean_checkpoints(vm_name)
+
         # Backup vm xml
         vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
         vmxml_backup = vmxml.copy()

--- a/libvirt/tests/src/incremental_backup/incremental_backup_checkpoint_cmd.py
+++ b/libvirt/tests/src/incremental_backup/incremental_backup_checkpoint_cmd.py
@@ -8,6 +8,7 @@ from virttest import virsh
 from virttest import data_dir
 from virttest import libvirt_version
 from virttest import utils_disk
+from virttest import utils_backup
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import checkpoint_xml
 from virttest.utils_test import libvirt
@@ -53,6 +54,9 @@ def run(test, params, env):
     try:
         vm_name = params.get("main_vm")
         vm = env.get_vm(vm_name)
+
+        # Make sure there is no checkpoint metadata before test
+        utils_backup.clean_checkpoints(vm_name)
 
         # Backup vm xml
         vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)

--- a/libvirt/tests/src/incremental_backup/incremental_backup_multidisk.py
+++ b/libvirt/tests/src/incremental_backup/incremental_backup_multidisk.py
@@ -59,6 +59,9 @@ def run(test, params, env):
         vm_name = params.get("main_vm")
         vm = env.get_vm(vm_name)
 
+        # Make sure there is no checkpoint metadata before test
+        utils_backup.clean_checkpoints(vm_name)
+
         # Backup vm xml
         vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
         vmxml_backup = vmxml.copy()

--- a/libvirt/tests/src/incremental_backup/incremental_backup_pull_mode.py
+++ b/libvirt/tests/src/incremental_backup/incremental_backup_pull_mode.py
@@ -86,6 +86,9 @@ def run(test, params, env):
         vm_name = params.get("main_vm")
         vm = env.get_vm(vm_name)
 
+        # Make sure there is no checkpoint metadata before test
+        utils_backup.clean_checkpoints(vm_name)
+
         # Backup vm xml
         vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
         vmxml_backup = vmxml.copy()

--- a/libvirt/tests/src/incremental_backup/incremental_backup_push_mode.py
+++ b/libvirt/tests/src/incremental_backup/incremental_backup_push_mode.py
@@ -67,6 +67,9 @@ def run(test, params, env):
         vm_name = params.get("main_vm")
         vm = env.get_vm(vm_name)
 
+        # Make sure there is no checkpoint metadata before test
+        utils_backup.clean_checkpoints(vm_name)
+
         # Backup vm xml
         vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
         vmxml_backup = vmxml.copy()


### PR DESCRIPTION
Some failed cases may leave checkpoints metadata, and they will
block future test due to checkpoint name conflict. This patch
is to make sure to remove any existing checkpoits metadata before
test.

Signed-off-by: Yi Sun <yisun@redhat.com>