### PR TITLE
Dynamic Numa nodes usage added into freepages function

### DIFF
--- a/libvirt/tests/src/virsh_cmd/host/virsh_freepages.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_freepages.py
@@ -164,7 +164,7 @@ def run(test, params, env):
     pagesize = params.get("freepages_pagesize")
 
     host_numa_node = utils_misc.NumaInfo()
-    node_list = host_numa_node.online_nodes
+    node_list = host_numa_node.get_online_nodes_withmem()
     oth_node = []
 
     hp_cl = test_setup.HugePageConfig(params)


### PR DESCRIPTION
Since there are setups, where the NUMA nodes with memory can be assigned
in other than linear order, test must support these setups as well.
Therefore, this fix is comming with an assignmnent of NUMA nodes with
memory to the list for checking.

Since there is an existing bug which prevents from execution tests on
setups with other than linear order, this fix adds part for canceling
tests that would not work until the bug is fixed.

Signed-off-by: Kamil Varga <kvarga@localhost.localdomain>