### PR TITLE
Add one more scenario about network autostart

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_autostart.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_autostart.cfg
@@ -18,6 +18,9 @@
             variants:
                 - set_autostart:
                     net_autostart_disable = "no"
+                - autostart_no_reboot:
+                    net_autostart_disable = "no"
+                    sim_reboot = "no"
                 - set_disable:
                     net_autostart_disable = "yes"
         - error_test:


### PR DESCRIPTION
Restarting libvirtd without host reboot will not turn the
autostart network status from inactive to active.

Signed-off-by: Yalan Zhang <yalzhang@redhat.com>