### PR TITLE
Add vms config into cfg file itself instead of dependence on base.cfg

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_multivms.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_multivms.cfg
@@ -2,6 +2,7 @@
     type = virtual_disks_multivms
     virt_disk_vm_ref = "name"
     take_regular_screendumps = "no"
+    vms = avocado-vt-vm1 vm1
     status_error = "yes yes"
     variants:
         - vms_sgio_share_normal_test:


### PR DESCRIPTION
Those cases need two VMs, bring that config back to it's self cfg file

Signed-off-by: chunfuwen <chwen@redhat.com>