### PR TITLE
migration: fix remote libvirtd service startup failure

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -73,7 +73,7 @@
                     variants:
                         - mt_method:
                             only without_postcopy
-                            libvirtd_conf_dest_dict = '{"log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
+                            libvirtd_conf_dest_dict = '{r"log_level\s*=.*": 'log_level=1', r"log_outputs\s*=.*": 'log_outputs="1:file:${log_outputs}"'}'
                             # Set conf type to the value in modular daemon mode, it will be converted to the\
                             # value in monolithic daemon mode automatically according to the test env
                             libvirtd_conf_type_dest = "virtqemud"
@@ -153,7 +153,9 @@
                     virsh_migrate_extra = "--tls"
                     custom_pki_path = "/etc/pki/qemu"
                     qemu_tls = "yes"
-                    log_conf_dest_dict = '{"log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
+                    log_conf_dict = '{"log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
+                    log_conf_type = "virtqemud"
+                    log_conf_dest_dict = '{r"log_level\s*=.*": 'log_level=1', r"log_outputs\s*=.*": 'log_outputs="1:file:${log_outputs}"'}'
                     # Set conf type to the value in modular daemon mode, it will be converted to the\
                     # value in monolithic daemon mode automatically according to the test env
                     log_conf_type_dest = "virtqemud"
@@ -163,7 +165,7 @@
                     variants:
                         - verify_client:
                             disable_verify_peer = "no"
-                            qemu_conf_dest_dict = '{"migrate_tls_x509_verify": "1"}'
+                            qemu_conf_dest_dict = '{r"migrate_tls_x509_verify\s*=.*": 'migrate_tls_x509_verify=1'}'
                             grep_str_remote_log = '"dir":"/etc/pki/qemu","endpoint":"server","verify-peer":true'
                             variants:
                                 - no_post_after_precopy:
@@ -224,11 +226,13 @@
                         - vcpu_16:
                             vcpu_num = 16
                 - auto-converge:
+                    log_conf_dict = '{"log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
+                    log_conf_type = "virtqemud"
                     libvirtd_conf_dict = '{"keepalive_interval": "-1"}'
                     # Set conf type to the value in modular daemon mode, it will be converted to the\
                     # value in monolithic daemon mode automatically according to the test env
                     libvirtd_conf_type = "virtproxyd"
-                    libvirtd_conf_dest_dict = '{"keepalive_interval": "-1"}'
+                    libvirtd_conf_dest_dict = '{r"keepalive_interval\s*=.*": 'keepalive_interval=-1', }'
                     libvirtd_conf_type_dest = "virtproxyd"
                     stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M --timeout 70"
                     actions_during_migration = "setmaxdowntime,converge"
@@ -268,7 +272,7 @@
                     # Set conf type to the value in modular daemon mode, it will be converted to the\
                     # value in monolithic daemon mode automatically according to the test env
                     libvirtd_conf_type = "virtproxyd"
-                    libvirtd_conf_dest_dict = '{"keepalive_interval": "-1"}'
+                    libvirtd_conf_dest_dict = '{r"keepalive_interval\s*=.*": 'keepalive_interval=-1', }'
                     libvirtd_conf_type_dest = "virtproxyd"
                     asynch_migrate = "yes"
                     virsh_opt = ' -k0'
@@ -287,11 +291,11 @@
                     # Set conf type to the value in modular daemon mode, it will be converted to the\
                     # value in monolithic daemon mode automatically according to the test env
                     libvirtd_conf_type = "virtproxyd"
-                    libvirtd_conf_dest_dict = '{"keepalive_interval": "-1"}'
+                    libvirtd_conf_dest_dict = '{r"keepalive_interval\s*=.*": 'keepalive_interval=-1', }'
                     libvirtd_conf_type_dest = "virtproxyd"
                     log_conf_dict = '{"log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
                     log_conf_type = "virtqemud"
-                    log_conf_dest_dict = '{"log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
+                    log_conf_dest_dict = '{r"log_level\s*=.*": 'log_level=1', r"log_outputs\s*=.*": 'log_outputs="1:file:${log_outputs}"'}'
                     log_conf_type_dest = "virtqemud"
                     check_log_interval = "yes"
                     variants:
@@ -430,7 +434,7 @@
                             client_cn = "ENTER.YOUR.CLIENT_CN"
                             disable_verify_peer = "no"
                             qemu_conf_dict = '{"migrate_tls_x509_verify": "1"}'
-                            qemu_conf_dest_dict = '{"migrate_tls_x509_verify": "1"}'
+                            qemu_conf_dest_dict = '{r"migrate_tls_x509_verify\s*=.*": 'migrate_tls_x509_verify=1'}'
                             variants:
                                 - tls_destination:
                                     only without_postcopy


### PR DESCRIPTION
It was introduced by 8a7d92931a5232a.
The values of remote libvirtd configuration should be updated.

Signed-off-by: Yingshun Cui <yicui@redhat.com>