### PR TITLE
kill_started: wait a little longer for SIGABRT and SIGSEGV

### DIFF
--- a/libvirt/tests/cfg/daemon/kill_started.cfg
+++ b/libvirt/tests/cfg/daemon/kill_started.cfg
@@ -19,11 +19,13 @@
         - sigabrt:
             signal = 'SIGABRT'
             expect_restart = yes
+            restart_timeout = 3
         - sigkill:
             signal = 'SIGKILL'
             expect_restart = yes
         - sigsegv:
             signal = 'SIGSEGV'
+            restart_timeout = 3
             expect_restart = yes
             sysconfig = 'DAEMON_COREFILE_LIMIT=unlimited'
             check_dmesg = 'code=dumped, status=11/SEGV'

--- a/libvirt/tests/src/daemon/kill_started.py
+++ b/libvirt/tests/src/daemon/kill_started.py
@@ -50,6 +50,7 @@ def run(test, params, env):
     message_dest_file = '/tmp/messages_tmp'
     signal_name = params.get("signal", "SIGTERM")
     should_restart = params.get("expect_restart", "yes") == "yes"
+    timeout = int(params.get("restart_timeout", 1))
     pid_should_change = params.get("expect_pid_change", "yes") == "yes"
     sysconfig = params.get("sysconfig", None)
     check_dmesg = params.get("check_dmesg", None)
@@ -72,7 +73,7 @@ def run(test, params, env):
         send_signal(pid, signal_name)
 
         # Wait for libvirtd to restart or reload
-        time.sleep(1)
+        time.sleep(timeout)
 
         if libvirtd.is_running():
             if not should_restart:


### PR DESCRIPTION
During the testing on aarch64, we found that it takes more than 1 second to
finish the libvirtd restarting with signal SIGABRT and SIGSEGV

Signed-off-by: Li Zhijian <lizhijian@cn.fujitsu.com>