### PR TITLE
Fix local variable 'vm' referenced before assignment

### DIFF
--- a/libvirt/tests/src/memory/hmat.py
+++ b/libvirt/tests/src/memory/hmat.py
@@ -54,10 +54,10 @@ def run(test, params, env):
 
     chk_case = params.get('chk')
     try:
+        vm = env.get_vm(vm_name)
         if not libvirt_version.version_compare(6, 6, 0):
             test.cancel("Current version doesn't support the function")
 
-        vm = env.get_vm(vm_name)
         vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
 
         # Set cpu according to params


### PR DESCRIPTION
```
# avocado run --vt-type libvirt --vt-machine-type arm64-mmio hmat.hmat --vt-connect-uri qemu:///system
WARNING:root:No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
WARNING:root:No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : b35f4a8196b45bf8f596137717f1706ceb9da0de
JOB LOG    : /root/avocado/job-results/job-2021-01-25T21.04-b35f4a8/job.log
 (1/1) type_specific.io-github-autotest-libvirt.hmat.hmat: ERROR: local variable 'vm' referenced before assignment (6.56 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```
Signed-off-by: Li Zhijian <lizhijian@cn.fujitsu.com>