### PR TITLE
vcpu_feature: Remove case unsupported by aarch64

### DIFF
--- a/libvirt/tests/cfg/cpu/vcpu_feature.cfg
+++ b/libvirt/tests/cfg/cpu/vcpu_feature.cfg
@@ -22,7 +22,7 @@
             status_error = "yes"
             variants:
                 - host_without_cr8legacy:
-                    no pseries
+                    no pseries, aarch64
                     only policy_require
                     host_supported_feature = "no"
                     feature_name = "cr8legacy"


### PR DESCRIPTION
Feature cr8legacy is not supported by aarch64.

Signed-off-by: Liu Yiding <liuyd.fnst@cn.fujitsu.com>