### PR TITLE
Add test cases for qcow2 volume with luks encryption

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_create.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_create.cfg
@@ -13,7 +13,7 @@
             status_error = "no"
             variants:
                 - luks_encryption:
-                    only logical_pool..normal_vol,disk_pool..vol_format_none,fs_like_pool..v_raw
+                    only logical_pool..normal_vol,disk_pool..vol_format_none,fs_like_pool..v_raw,fs_like_pool..v_qcow2
                     encryption_method = "luks"
                     encryption_secret_type = "passphrase"
                     action_lookup = "connect_driver:QEMU"


### PR DESCRIPTION
Add test cases for qcow2 volume with luks encryption
1. Create qcow2 volume with luks encryption
2. Start vm with this volume

Signed-off-by: Meina Li <meili@redhat.com>