### PR TITLE
virtual_disks_multidisks: fix incorrect device target on aarch64

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
@@ -595,7 +595,6 @@
                         virt_disk_device_bus = "scsi"
                     aarch64:
                         virt_disk_device_bus = "scsi"
-                        virt_disk_device_target = "sda"
                     variants:
                         - coldplug_only_iso:
                             nfs_disk_type = "iso"


### PR DESCRIPTION
check_readonly() in virtual_disks_multidisks treats device target 'hdc' as a cdrom

```
$ avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio $tests
WARNING:root:No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
WARNING:root:No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : f37ff4462ab0dea0803ac9ec5fd66d704d619d9c
JOB LOG    : /root/avocado/job-results/job-2021-01-26T21.53-f37ff44/job.log
 (1/3) type_specific.io-github-autotest-libvirt.virtual_disks.multidisks.coldplug.single_disk_test.disk_readonly_nfs_cdrom.coldplug_only_iso: PASS (46.93 s)
 (2/3) type_specific.io-github-autotest-libvirt.virtual_disks.multidisks.coldplug.single_disk_test.disk_readonly_nfs_cdrom.coldplug_only_raw: PASS (51.19 s)
 (3/3) type_specific.io-github-autotest-libvirt.virtual_disks.multidisks.coldplug.single_disk_test.disk_readonly_nfs_cdrom.coldplug_with_at_dt_disk: PASS (56.90 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 155.80 s
```

Fixes: 233fe5c9cd13 ("virtual_disks_multidisks: Set device bus to 'scsi' for aarch tests")
Signed-off-by: Li Zhijian <lizhijian@cn.fujitsu.com>