### PR TITLE
Update max value of cpu quota

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_schedinfo_qemu_posix.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_schedinfo_qemu_posix.cfg
@@ -102,8 +102,11 @@
                                     schedinfo_set_value = 1000
                                     schedinfo_set_value_expected = 1000
                                 - value_max:
-                                    schedinfo_set_value = 18446744073709551
-                                    schedinfo_set_value_expected = 18446744073709551
+                                    schedinfo_set_value = 17592186044415
+                                    schedinfo_set_value_expected = 17592186044415
+                                    libvirt_ver_function_changed = [6, 0, 0]
+                                    schedinfo_set_value_bk = 18446744073709551
+                                    schedinfo_set_value_expected_bk = 18446744073709551
         # TODO: to support more parameters
         - error_test:
             status_error = yes

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_schedinfo_qemu_posix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_schedinfo_qemu_posix.py
@@ -3,6 +3,7 @@ import logging
 import os
 
 from virttest import virsh
+from virttest import libvirt_version
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import xcepts
 
@@ -107,12 +108,20 @@ def run(test, params, env):
     set_value = params.get("schedinfo_set_value", "")
     set_method = params.get("schedinfo_set_method", "cmd")
     set_value_expected = params.get("schedinfo_set_value_expected", "")
+    # Libvirt version where function begins to change
+    libvirt_ver_function_changed = eval(params.get(
+        "libvirt_ver_function_changed", '[]'))
     # The default scheduler on qemu/kvm is posix
     scheduler_value = "posix"
     status_error = params.get("status_error", "no")
     start_vm = ("yes" == params.get("start_vm"))
     readonly = ("yes" == params.get("schedinfo_readonly", "no"))
     expect_msg = params.get("schedinfo_err_msg", "")
+
+    if libvirt_ver_function_changed:
+        if not libvirt_version.version_compare(*libvirt_ver_function_changed):
+            set_value = params.get("schedinfo_set_value_bk")
+            set_value_expected = params.get("schedinfo_set_value_expected_bk")
 
     # Prepare vm test environment
     vm_name = params.get("main_vm")


### PR DESCRIPTION
The max value of cpu quota has changed to 17592186044415 since libvirt 6.0,
so update the script accordingly.

Signed-off-by: Yingshun Cui <yicui@redhat.com>