### PR TITLE
startup_policy: Set device bus to 'scsi' for aarch tests

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/startup_policy.cfg
+++ b/libvirt/tests/cfg/virtual_disks/startup_policy.cfg
@@ -62,6 +62,8 @@
                                 disk_target_bus = "scsi"
                             q35:
                                 disk_target_bus = "scsi"
+                            aarch64:
+                                disk_target_bus = "scsi"
                         - floppy:
                             device_type = "floppy"
                             target_dev = "fda"

--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_multivms.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_multivms.cfg
@@ -97,6 +97,8 @@
             image_size = "100M"
             s390-virtio:
                 virt_disk_bus = "scsi"
+            aarch64:
+                virt_disk_bus = "scsi"
     variants:
         - hotplug:
             virt_disk_vms_hotplug = "yes"


### PR DESCRIPTION
IDE controllers are unsupported for machine type 'aarch', therefore
change it to 'scsi'

Fix following tests:
startup_policy.startupPolicy.mandatory.device_type.cdrom.file.default
startup_policy.startupPolicy.mandatory.device_type.cdrom.file.update_policy.default.live
startup_policy.startupPolicy.mandatory.device_type.cdrom.file.update_policy.default.config
startup_policy.startupPolicy.mandatory.device_type.cdrom.file.update_policy.default.persistent
startup_policy.startupPolicy.mandatory.device_type.cdrom.file.update_policy.policy_and_source
startup_policy.startupPolicy.mandatory.device_type.cdrom.volume.dir_pool
startup_policy.startupPolicy.optional.device_type.cdrom.file.default
startup_policy.startupPolicy.optional.device_type.cdrom.file.update_policy.default.live
startup_policy.startupPolicy.optional.device_type.cdrom.file.update_policy.default.config
startup_policy.startupPolicy.optional.device_type.cdrom.file.update_policy.default.persistent
startup_policy.startupPolicy.optional.device_type.cdrom.file.update_policy.policy_and_source
startup_policy.startupPolicy.optional.device_type.cdrom.volume.dir_pool
startup_policy.startupPolicy.requisite.device_type.cdrom.file.default
startup_policy.startupPolicy.requisite.device_type.cdrom.file.update_policy.default.live
startup_policy.startupPolicy.requisite.device_type.cdrom.file.update_policy.default.config
startup_policy.startupPolicy.requisite.device_type.cdrom.file.update_policy.default.persistent
startup_policy.startupPolicy.requisite.device_type.cdrom.file.update_policy.policy_and_source
startup_policy.startupPolicy.requisite.device_type.cdrom.volume.dir_pool

Signed-off-by: Li Zhijian <lizhijian@cn.fujitsu.com>