### PR TITLE
Install gcc to build stress tool

### DIFF
--- a/libvirt/tests/src/cpu/guestpin.py
+++ b/libvirt/tests/src/cpu/guestpin.py
@@ -12,6 +12,7 @@ from virttest import virt_vm
 from virttest import data_dir
 from virttest import utils_test
 from virttest import libvirt_xml
+from virttest import utils_package
 from virttest.utils_test import libvirt
 from virttest.staging import utils_cgroup
 
@@ -46,6 +47,10 @@ def run(test, params, env):
                 time.sleep(condn_sleep_sec)
                 return bt
             elif condn == "stress":
+                session = vm.wait_for_login()
+                if not utils_package.package_install("gcc", session):
+                    test.fail("Failed to install gcc in guest")
+                session.close()
                 utils_test.load_stress("stress_in_vms", params=params, vms=[vm])
             elif condn in ["save", "managedsave"]:
                 # No action


### PR DESCRIPTION
Fix the following issue
------
2021-01-26 09:16:26,300 stacktrace       L0045 ERROR| checking for gcc... no
2021-01-26 09:16:26,300 stacktrace       L0045 ERROR| checking for cc... no
2021-01-26 09:16:26,300 stacktrace       L0045 ERROR| checking for cl.exe... no
2021-01-26 09:16:26,301 stacktrace       L0045 ERROR| configure: error: in `/home/stress-1.0.4':
2021-01-26 09:16:26,301 stacktrace       L0045 ERROR| configure: error: no acceptable C compiler found in $PATH
------

Signed-off-by: Liu Yiding <liuyd.fnst@cn.fujitsu.com>