### PR TITLE
Filter out hypervisor-cpu-compare on aarch64

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_hypervisor_cpu_compare.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_hypervisor_cpu_compare.cfg
@@ -68,7 +68,7 @@
                     s390-virtio:
                         msg_pattern = "identical"
         - capa_xml:
-            no s390-virtio
+            no s390-virtio, aarch64
             compare_file_type = "capa_xml"
             status_error = "yes"
             msg_pattern = "incompatible"
@@ -79,7 +79,7 @@
                     compare_file_type = "domxml"
                     msg_pattern = "superset|identical"
                 - f_capa_xml:
-                    no s390-virtio
+                    no s390-virtio, aarch64
                     compare_file_type = "capa_xml"
                     status_error = "yes"
                     msg_pattern = "incompatible"


### PR DESCRIPTION
https://www.redhat.com/archives/libvir-list/2020-October/msg00696.html
------
On some architectures, e.g. aarch64 and s390x, the output of
`virsh capabilities` is not suitable for use in
`virsh hypervisor-cpu-baseline`. 
------

Signed-off-by: Liu Yiding <liuyd.fnst@cn.fujitsu.com>