### PR TITLE
Add 'vms' to vcpupin..multi_dom

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_vcpupin.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_vcpupin.cfg
@@ -42,6 +42,7 @@
                 - multi_dom:
                     no ppc64, ppc64le
                     multi_dom_pin = "yes"
+                    vms = "ENTER.YOUR.VM1 ENTER.YOUR.VM2"
                 - initial_check:
                     only online
                     kill_vm_before_test = yes


### PR DESCRIPTION
To avoid misconfiguration issues, add 'vms' to subtest cfg.

Signed-off-by: Yingshun Cui <yicui@redhat.com>