### PR TITLE
Set migrate_tls_x509_verify to '0' to disable peer verification

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -175,6 +175,7 @@
                                     stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M"
                                     stress_in_vm = "yes"
                         - no_verify_client:
+                            qemu_conf_dest_dict = '{r"migrate_tls_x509_verify\s*=.*": 'migrate_tls_x509_verify=0'}'
                             disable_verify_peer = "yes"
                             grep_str_remote_log = '"dir":"/etc/pki/qemu","endpoint":"server","verify-peer":false'
                 - hpt_resize:


### PR DESCRIPTION
The default value of migrate_tls_x509_verify was changed to '1',
so set it as '0' for native_tls.no_verify_client test.

Signed-off-by: Yingshun Cui <yicui@redhat.com>