### PR TITLE
migrate_options_shared: Fix an error introduced by 8a7d929

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -337,10 +337,10 @@
                             variants:
                                 - mt_method:
                                     only without_postcopy
-                                    log_conf_dict = '{"log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
+                                    log_conf_dest_dict = '{r"log_level\s*=.*": 'log_level=1', r"log_outputs\s*=.*": 'log_outputs="1:file:${log_outputs}"'}'
                                     # Set conf type to the value in modular daemon mode, it will be converted to the\
                                     # value in monolithic daemon mode automatically according to the test env
-                                    log_conf_type = "virtqemud"
+                                    log_conf_type_dest = "virtqemud"
                                     level = 9
                                     threads = 5
                                     dthreads = 5


### PR DESCRIPTION
Dest conf file instead of local one should be updated.

Signed-off-by: Fangge Jin <fjin@redhat.com>