### PR TITLE
migration: Add missing settings

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -341,6 +341,8 @@
                                     # Set conf type to the value in modular daemon mode, it will be converted to the\
                                     # value in monolithic daemon mode automatically according to the test env
                                     log_conf_type = "virtqemud"
+                                    log_conf_dest_dict = '{r"log_level\s*=.*": 'log_level=1', r"log_outputs\s*=.*": 'log_outputs="1:file:${log_outputs}"'}'
+                                    log_conf_type_dest = "virtqemud"
                                     level = 9
                                     threads = 5
                                     dthreads = 5


### PR DESCRIPTION
Two settings for remote libvirtd log configuration were missing
in previous code.

Signed-off-by: Yingshun Cui <yicui@redhat.com>