### PR TITLE
Fix the err msg mapping for new release

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_coalesce.py
+++ b/libvirt/tests/src/virtual_network/iface_coalesce.py
@@ -375,9 +375,9 @@ def run(test, params, env):
             out = process.run('ethtool -c %s' % newinterface, ignore_status=True)
             if network_type == 'macvtap':
                 # Currently, output coalesce for macvtap is not supported
-                err_msg = "Cannot get device coalesce settings: Operation not supported"
-                std_msg = "Coalesce parameters for %s:" % newinterface
-                if err_msg not in out.stderr_text or std_msg not in out.stdout_text:
+                err_msg = "Operation not supported"
+                logging.info("err_msg is %s, out.stderr_text is %s" % (err_msg, out.stderr_text))
+                if err_msg not in out.stderr_text:
                     test.fail("coalesce setting on %s failed." % network_type)
             else:
                 # Get coalesce value and check it is true


### PR DESCRIPTION
old version:
```
 # ethtool -c macvtap0
Coalesce parameters for macvtap0:
Cannot get device coalesce settings: Operation not supported
```
New version:
```
 # ethtool -c macvtap0
netlink error: Operation not supported
```
Test result:
```
# avocado run --vt-type libvirt virtual_network.iface_coalesce.positive_testing.net_macvtap.iface-network
JOB ID     : 3b17ff42c282894aa443bbf6b0ac58d89f0c19fe
JOB LOG    : /root/avocado/job-results/job-2021-01-28T01.00-3b17ff4/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.iface_coalesce.positive_testing.net_macvtap.iface-network: PASS (6.73 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 8.16 s
```

Signed-off-by: Kyla Zhang <weizhan@redhat.com>