### PR TITLE
Update mapping pattern for bios cases

### DIFF
--- a/libvirt/tests/src/bios/boot_integration.py
+++ b/libvirt/tests/src/bios/boot_integration.py
@@ -166,21 +166,21 @@ def run(test, params, env):
         else:
             # Start test and check result
             ret = virsh.define(vmxml.xml, **virsh_dargs)
-            stdout_patt = "Domain %s defined from %s" % (vm_name, vmxml.xml)
+            stdout_patt = "Domain .*%s.* defined from %s" % (vm_name, vmxml.xml)
             utlv.check_result(ret, expected_match=[stdout_patt])
 
             ret = virsh.start(vm_name, **virsh_dargs)
-            stdout_patt = "Domain %s started" % vm_name
+            stdout_patt = "Domain .*%s.* started" % vm_name
             utlv.check_result(ret, expected_match=[stdout_patt])
             vm.wait_for_login()
 
             ret = virsh.destroy(vm_name, **virsh_dargs)
-            stdout_patt = "Domain %s destroyed" % vm_name
+            stdout_patt = "Domain .*%s.* destroyed" % vm_name
             utlv.check_result(ret, expected_match=[stdout_patt])
 
             vm.start()
             ret = virsh.save(vm_name, save_file, **virsh_dargs)
-            stdout_patt = "Domain %s saved to %s" % (vm_name, save_file)
+            stdout_patt = "Domain .*%s.* saved to %s" % (vm_name, save_file)
             utlv.check_result(ret, expected_match=[stdout_patt])
 
             ret = virsh.restore(save_file, **virsh_dargs)
@@ -188,7 +188,7 @@ def run(test, params, env):
             utlv.check_result(ret, expected_match=[stdout_patt])
 
             ret = virsh.undefine(vm_name, options="--nvram", **virsh_dargs)
-            stdout_patt = "Domain %s has been undefined" % vm_name
+            stdout_patt = "Domain .*%s.* has been undefined" % vm_name
             utlv.check_result(ret, expected_match=[stdout_patt])
             if boot_type == "ovmf":
                 if os.path.exists(nvram_file):


### PR DESCRIPTION
```
# avocado run --vt-type libvirt --vt-machine-type q35 boot_integration.by_ovmf.boot_dev.define_start_destroy_save_restore_undefine
JOB ID     : e91974da8e2d3afa3582443d66b8a43bc9655165
JOB LOG    : /root/avocado/job-results/job-2021-01-28T01.33-e91974d/job.log
 (1/1) type_specific.io-github-autotest-libvirt.boot_integration.by_ovmf.boot_dev.define_start_destroy_save_restore_undefine: PASS (60.45 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 61.61 s
(.libvirt-ci-venv-ci-runtest-PyWYH0) [root@dell-per730-66 tp-libvirt]# avocado run --vt-type libvirt --vt-machine-type q35 boot_integration.by_ovmf.boot_order.define_start_destroy_save_restore_undefine
JOB ID     : 1a1a3a6688f211c6e06011daec3a82070f336a59
JOB LOG    : /root/avocado/job-results/job-2021-01-28T01.36-1a1a3a6/job.log
 (1/1) type_specific.io-github-autotest-libvirt.boot_integration.by_ovmf.boot_order.define_start_destroy_save_restore_undefine: PASS (68.81 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 69.95 s

```

Signed-off-by: Kyla Zhang <weizhan@redhat.com>