### PR TITLE
v2v: update checkpoint for windows guests

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -141,6 +141,7 @@
                             os_version = "win10"
                             main_vm = VM_NAME_WIN10_V2V_EXAMPLE
                         - win2016:
+                            checkpoint = "${checkpoint},signature"
                             main_vm = VM_NAME_WIN2016_V2V_EXAMPLE
                             os_version = "win2016"
                         - win2019:
@@ -233,7 +234,7 @@
                 - service:
                     only esx_60
                     main_vm = VM_NAME_VMTOOLS_SERVICE_V2V_EXAMPLE
-                    checkpoint = vmtools_service
+                    checkpoint = "vmtools,service
                     service_name = vmware-tools
         - modprobe:
             only esx_60
@@ -272,7 +273,7 @@
                     skip_reason = "/dev/sda1 belongs to the first OS which can't boot into without selecting by user during booting after v2v conversion"
                 - dev_vglv:
                     root_option = '/dev/rhel/root'
-            checkpoint += _${root_option}
+            checkpoint += ,${root_option}
         - device_map:
             only esx_67
             checkpoint = device_map
@@ -416,10 +417,10 @@
             rhv_upload_opts = "${rhv_upload_opts} -oo rhv-verifypeer=true"
             variants:
                 - set:
-                    checkpoint = "system_rhv_pem_set"
+                    checkpoint = "system_rhv_pem,set"
                 - unset:
                     only negative_test
-                    checkpoint = "system_rhv_pem_unset"
+                    checkpoint = "system_rhv_pem,unset"
                     msg_content = "virt-v2v: error: -o rhv-upload: must use .-oo rhv-cafile. .*? oVirt or RHV"
                     expect_msg = no
         - without_default_net:
@@ -502,7 +503,7 @@
                             expect_msg = 'yes'
                             msg_content = 'virt-v2v: could not find key to open LUKS encrypted'
                         - pwd_file:
-                            checkpoint = 'luks_dev_keys_invalid_pwd_file'
+                            checkpoint = 'luks_dev_keys,invalid_pwd_file'
                             luks_keys = LUkS_DEV_INVALID_KEYS_FILE
                             expect_msg = 'yes'
                             msg_content = 'virt-v2v: fopen: \S+: No such file or directory'


### PR DESCRIPTION
1) Improve checkpoint usage, so mutiple checkpoint can be used easily.
2) Add spice-ga and rhev-apt checkpoint.
3) Add signature checkpoint for rhev-apt.exe in windows guest.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>