### PR TITLE
Use enable_inc_backup_for_vm method to make code clean

### DIFF
--- a/libvirt/tests/src/incremental_backup/incremental_backup_multidisk.py
+++ b/libvirt/tests/src/incremental_backup/incremental_backup_multidisk.py
@@ -1,12 +1,9 @@
 import os
 import logging
 
-import xml.etree.ElementTree as ET
-
 from virttest import virsh
 from virttest import data_dir
 from virttest import utils_backup
-from virttest import utils_misc
 from virttest import libvirt_version
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
@@ -65,29 +62,7 @@ def run(test, params, env):
         # Backup vm xml
         vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
         vmxml_backup = vmxml.copy()
-
-        if not utils_misc.is_qemu_capability_supported("incremental-backup"):
-            # Enable vm incremental backup capability. This is only a workaround
-            # to make sure incremental backup can work for the vm. Code needs to
-            # be removded immediately when the function enabled by default, which
-            # is tracked by bz1799015
-            tree = ET.parse(vmxml.xml)
-            root = tree.getroot()
-            for elem in root.iter('domain'):
-                elem.set('xmlns:qemu', 'http://libvirt.org/schemas/domain/qemu/1.0')
-                qemu_cap = ET.Element("qemu:capabilities")
-                elem.insert(-1, qemu_cap)
-                incbackup_cap = ET.Element("qemu:add")
-                incbackup_cap.set('capability', 'incremental-backup')
-                qemu_cap.insert(1, incbackup_cap)
-            vmxml.undefine()
-            tmp_vm_xml = os.path.join(tmp_dir, "tmp_vm.xml")
-            tree.write(tmp_vm_xml)
-            virsh.define(tmp_vm_xml)
-            vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
-            logging.debug("Script insert xml elements to make sure vm can support "
-                          "incremental backup. This should be removded when "
-                          "bz 1799015 fixed.")
+        utils_backup.enable_inc_backup_for_vm(vm)
 
         # Prepare a dict to save the disks' info to be attached and backuped.
         # This will generate a dict as:

--- a/libvirt/tests/src/incremental_backup/incremental_backup_pull_mode.py
+++ b/libvirt/tests/src/incremental_backup/incremental_backup_pull_mode.py
@@ -2,8 +2,6 @@ import os
 import re
 import logging
 
-import xml.etree.ElementTree as ET
-
 from avocado.utils import process
 
 from virttest import virsh
@@ -92,28 +90,7 @@ def run(test, params, env):
         # Backup vm xml
         vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
         vmxml_backup = vmxml.copy()
-
-        # Enable vm incremental backup capability. This is only a workaround
-        # to make sure incremental backup can work for the vm. Code needs to
-        # be removded immediately when the function enabled by default, which
-        # is tracked by bz1799015
-        tree = ET.parse(vmxml.xml)
-        root = tree.getroot()
-        for elem in root.iter('domain'):
-            elem.set('xmlns:qemu', 'http://libvirt.org/schemas/domain/qemu/1.0')
-            qemu_cap = ET.Element("qemu:capabilities")
-            elem.insert(-1, qemu_cap)
-            incbackup_cap = ET.Element("qemu:add")
-            incbackup_cap.set('capability', 'incremental-backup')
-            qemu_cap.insert(1, incbackup_cap)
-        vmxml.undefine()
-        tmp_vm_xml = os.path.join(tmp_dir, "tmp_vm.xml")
-        tree.write(tmp_vm_xml)
-        virsh.define(tmp_vm_xml)
-        vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
-        logging.debug("Script insert xml elements to make sure vm can support "
-                      "incremental backup. This should be removded when "
-                      "bz 1799015 fixed.")
+        utils_backup.enable_inc_backup_for_vm(vm)
 
         # Prepare tls env
         if tls_enabled:

--- a/libvirt/tests/src/incremental_backup/incremental_backup_push_mode.py
+++ b/libvirt/tests/src/incremental_backup/incremental_backup_push_mode.py
@@ -1,6 +1,5 @@
 import os
 import logging
-import xml.etree.ElementTree as ET
 
 from avocado.utils import process
 
@@ -73,28 +72,7 @@ def run(test, params, env):
         # Backup vm xml
         vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
         vmxml_backup = vmxml.copy()
-
-        # Enable vm incremental backup capability. This is only a workaround
-        # to make sure incremental backup can work for the vm. Code needs to
-        # be removded immediately when the function enabled by default, which
-        # is tracked by bz1799015
-        tree = ET.parse(vmxml.xml)
-        root = tree.getroot()
-        for elem in root.iter('domain'):
-            elem.set('xmlns:qemu', 'http://libvirt.org/schemas/domain/qemu/1.0')
-            qemu_cap = ET.Element("qemu:capabilities")
-            elem.insert(-1, qemu_cap)
-            incbackup_cap = ET.Element("qemu:add")
-            incbackup_cap.set('capability', 'incremental-backup')
-            qemu_cap.insert(1, incbackup_cap)
-        vmxml.undefine()
-        tmp_vm_xml = os.path.join(tmp_dir, "tmp_vm.xml")
-        tree.write(tmp_vm_xml)
-        virsh.define(tmp_vm_xml)
-        vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
-        logging.debug("Script insert xml elements to make sure vm can support "
-                      "incremental backup. This should be removded when "
-                      "bz 1799015 fixed.")
+        utils_backup.enable_inc_backup_for_vm(vm)
 
         # Prepare the disk to be backuped.
         disk_params = {}


### PR DESCRIPTION
enable_inc_backup_for_vm() added in avocado-vt/virttest/utils_backup.py.
Use it to make code clean.

Signed-off-by: Yi Sun <yisun@redhat.com>