### PR TITLE
v2v: clean vms variant for v2v_options job

### DIFF
--- a/v2v/tests/cfg/v2v_options.cfg
+++ b/v2v/tests/cfg/v2v_options.cfg
@@ -15,6 +15,7 @@
     password = GENERAL_GUEST_PASSWORD
     # v2v cmd running time
     v2v_timeout = 10800
+    vms = ''
     # Full types input disks
     variants:
         - output_mode:


### PR DESCRIPTION
The vms requires guest 'avocado-vt-vm1' which is not used by v2v.
It's annoying when running it on local host manually.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>