### PR TITLE
v2v: fix qemu-ga service not found on SUSE

### DIFF
--- a/v2v/tests/src/function_test_esx.py
+++ b/v2v/tests/src/function_test_esx.py
@@ -305,7 +305,7 @@ def run(test, params, env):
 
         # Check the service status of qemu-guest-agent in VM
         status_ptn = r'Active: active \(running\)|qemu-ga \(pid +[0-9]+\) is running'
-        cmd = 'service qemu-ga status;systemctl status qemu-guest-agent'
+        cmd = 'service qemu-ga* status;systemctl status qemu-guest-agent;systemctl status qemu-ga*'
         _, output = vmcheck.run_cmd(cmd)
 
         if not re.search(status_ptn, output):


### PR DESCRIPTION
The qemu-guest-agent service name is not 'qeme-guest-agent' or
'qemu-ga', it's "qemu-ga@virtio\x2dports-org.qemu.guest_agent.0.service".

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>