### PR TITLE
Remove tests of input devices with ps2 bus from pseries tests

### DIFF
--- a/libvirt/tests/cfg/virtual_device/input_devices.cfg
+++ b/libvirt/tests/cfg/virtual_device/input_devices.cfg
@@ -33,7 +33,7 @@
         - bus_type_virtio:
             bus_type = virtio
         - bus_type_ps2:
-            no s390-virtio
+            no s390-virtio, pseries
             bus_type = ps2
     variants:
         - positive_test:


### PR DESCRIPTION
ps2 is not supported by pseries.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>