### PR TITLE
Fix IDE related tests on aarch64

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_change_media.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_change_media.cfg
@@ -95,6 +95,7 @@
             change_media_device_type = "cdrom"
             variants:
                 - ide_:
+                    no aarch64
                     change_media_target_device = "hdc"
                     device_target_bus = "ide"
                     q35:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device.cfg
@@ -30,6 +30,8 @@
                 dt_device_bus_type = scsi
             s390-virtio:
                 dt_device_bus_type = scsi
+            aarch64:
+                dt_device_bus_type = scsi
         - disk_test:
             dt_device_device = disk
             dt_device_device_target = vdb

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_update_device.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_update_device.cfg
@@ -11,6 +11,7 @@
             variants:
                 - ide_option:
                     no s390-virtio
+                    no aarch64
                     updatedevice_target_bus = "ide"
                     updatedevice_target_dev = "hdc"
                     disk_type = "cdrom"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_update_device_matrix.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_update_device_matrix.cfg
@@ -10,6 +10,9 @@
     q35:
         updatedevice_target_bus = "scsi"
         updatedevice_target_dev = "sdc"
+    aarch64:
+        updatedevice_target_bus = "scsi"
+        updatedevice_target_dev = "sdc"
     pseries:
         updatedevice_target_bus = "scsi"
         updatedevice_target_dev = "sdc"


### PR DESCRIPTION
IDE controllers are unsupported for aarch64.
a) Skip IDE option tests on aarch64
b) Replace IDE device with SCSI

Signed-off-by: Liu Yiding <liuyd.fnst@cn.fujitsu.com>