### PR TITLE
Add expect serial info of aarch64.

### DIFF
--- a/libvirt/tests/src/serial/serial_functional.py
+++ b/libvirt/tests/src/serial/serial_functional.py
@@ -646,6 +646,8 @@ def run(test, params, env):
                 dev_type = target_model
             exp_ser_devs = [dev_type, 'chardev=charserial0',
                             'id=serial0']
+        elif "aarch64" in arch:
+            exp_ser_devs = ['chardev:charserial0']
         else:
             logging.debug('target_type: %s', target_type)
             if target_type == 'pci-serial':


### PR DESCRIPTION
This test parses qemu cmd line to get serial option and diff it with
expect serial info.
Add expect serial info of aarch64.

I use below cmd to start a aarch64 guest, then check qemu cmdline to get default
serial info.
------
avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio \
unattended_install.import.import.default_install.aio_native
------

Signed-off-by: Liu Yiding <liuyd.fnst@cn.fujitsu.com>