### PR TITLE
Fix the IDE controller which is not supported on aarch64

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_update_device.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_update_device.cfg
@@ -107,6 +107,10 @@
                 updatedevice_target_bus = "scsi"
                 updatedevice_target_dev = "sdc"
                 disk_type = "cdrom"
+            aarch64:
+                updatedevice_target_bus = "scsi"
+                updatedevice_target_dev = "sdc"
+                disk_type = "cdrom"
             variants:
                 - no_option:
                     updatedevice_vm_ref = ""


### PR DESCRIPTION
Signed-off-by: Liu Yiding <liuyd.fnst@cn.fujitsu.com>