### PR TITLE
virsh_snapshot_disk: use log not cancel

### DIFF
--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_disk.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_disk.py
@@ -297,8 +297,9 @@ def run(test, params, env):
                         if re.search("internal snapshot of a running VM" +
                                      " must include the memory state",
                                      out_err):
-                            test.cancel("Check Bug #1083345, %s" %
-                                        out_err)
+                            logging.warning("Got expected error. Please check "
+                                            "Bug #1083345, %s" % out_err)
+                            return
 
                     test.fail("Failed to create snapshot. Error:%s."
                               % out_err)


### PR DESCRIPTION
The bug 1083345 said this error output was expected. So we'd better to
log the information instead of raising an exception.

Signed-off-by: Dan Zheng <dzheng@redhat.com>