### PR TITLE
Fix svirt.virt_install on aarch64

### DIFF
--- a/libvirt/tests/cfg/svirt/svirt_virt_install.cfg
+++ b/libvirt/tests/cfg/svirt/svirt_virt_install.cfg
@@ -5,6 +5,10 @@
     main_vm = "svirt_vm"
     start_vm = no
     svirt_install_vm_sec_label = system_u:system_r:svirt_t:s0:c87,c520
+    video_model = 'vga'
+    aarch64:
+        video_model = 'virtio'
+        nvram_o = '--nvram'
     variants:
         - host_selinux_enforcing:
             host_selinux = enforcing

--- a/libvirt/tests/src/svirt/svirt_virt_install.py
+++ b/libvirt/tests/src/svirt/svirt_virt_install.py
@@ -28,6 +28,8 @@ def run(test, params, env):
     # Get general variables.
     status_error = ('yes' == params.get("status_error", 'no'))
     host_sestatus = params.get("host_selinux", "enforcing")
+    video_model = params.get('video_model', 'vga')
+    nvram_o = params.get('nvram_o', None)
     # Get variables about seclabel for VM.
     sec_type = params.get("svirt_install_vm_sec_type", "dynamic")
     sec_model = params.get("svirt_install_vm_sec_model", "selinux")
@@ -46,7 +48,7 @@ def run(test, params, env):
     real_data_path = os.path.realpath(data_path)
     image_path = os.path.join(real_data_path, "svirt_image")
     if virsh.domain_exists(vm_name):
-        virsh.remove_domain(vm_name)
+        virsh.remove_domain(vm_name, nvram_o)
     if not os.path.exists(image_path):
         utils_test.libvirt.create_local_disk("file", path=image_path)
 
@@ -67,7 +69,7 @@ def run(test, params, env):
         if sec_relabel is not None:
             cmd += ",relabel=%s" % sec_relabel
 
-        cmd += " --noautoconsole --graphics vnc --video vga"
+        cmd += " --noautoconsole --graphics vnc --video %s" % video_model
         process.run(cmd, timeout=600, ignore_status=True)
 
         def _vm_alive():
@@ -82,6 +84,6 @@ def run(test, params, env):
         # cleanup
         utils_selinux.set_status(backup_sestatus)
         if virsh.domain_exists(vm_name):
-            virsh.remove_domain(vm_name)
+            virsh.remove_domain(vm_name, nvram_o)
         if not os.path.exists(image_path):
             utils_test.libvirt.delete_local_disk("file", path=image_path)


### PR DESCRIPTION
a) virt-install model vga is unsupported on aarch64, use virtio
b) set undefine nvram option on aarch64

Signed-off-by: Liu Yiding <liuyd.fnst@cn.fujitsu.com>