### PR TITLE
migrate_bandwidth: Run the stress tool to slow down migration process

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_bandwidth.cfg
+++ b/libvirt/tests/cfg/migration/migrate_bandwidth.cfg
@@ -26,6 +26,7 @@
             postcopy_options = "--postcopy"
             variants:
                 - postcopy_bandwidth_opt:
+                    stress_package = "stress"
                     virsh_migrate_extra = "--postcopy-bandwidth 5"
                     exp_migrate_speed = "{'precopy_speed': '8796093022207', 'postcopy_speed': '5'}"
                     variants:
@@ -40,6 +41,7 @@
                     migrate_postcopy_cmd = "no"
                     exp_migrate_speed = "{'precopy_speed': '5', 'postcopy_speed': '0'}"      
                 - postcopy_bandwith_cmd:
+                    stress_package = "stress"
                     variants:
                         - postcopy_phase:
                             set_postcopy_in_postcopy_phase = "6"

--- a/libvirt/tests/src/migration/migrate_bandwidth.py
+++ b/libvirt/tests/src/migration/migrate_bandwidth.py
@@ -129,6 +129,7 @@ def run(test, params, env):
     set_postcopy_speed_before_mig = params.get("set_postcopy_speed_before_mig")
     set_precopy_speed_before_mig = params.get("set_precopy_speed_before_mig")
     set_precopy_speed_before_vm_start = params.get("set_precopy_speed_before_vm_start")
+    stress_package = params.get("stress_package")
     exp_migrate_speed = eval(params.get('exp_migrate_speed', '{}'))
     func_params_exists = "yes" == params.get("func_params_exists", "yes")
     log_file = params.get("log_outputs", "/var/log/libvirt/libvirt_daemons.log")
@@ -211,6 +212,9 @@ def run(test, params, env):
                 virsh.migrate_setspeed(vm_name, set_postcopy_speed_before_mig,
                                        "--postcopy", **virsh_args)
             get_speed(exp_migrate_speed)
+
+        if stress_package:
+            migration_test.run_stress_in_vm(vm, params)
 
         # Execute migration process
         vms = [vm]


### PR DESCRIPTION
To perform some operations during migration, need to make it slow,
so update to load stress in VM.

depends on https://github.com/avocado-framework/avocado-vt/pull/2918
Signed-off-by: Yingshun Cui <yicui@redhat.com>