### PR TITLE
Fix the virsh event issues

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
@@ -149,7 +149,6 @@ def run(test, params, env):
         vmxml.current_mem = current_mem
         vmxml.current_mem_unit = mem_unit
         vmxml.memory = int(params.get("memory"))
-        vmxml.sync()
         # Prepare numa settings in <cpu>
         host_numa_node = utils_misc.NumaInfo()
         host_numa_node_list = host_numa_node.online_nodes
@@ -544,7 +543,7 @@ def run(test, params, env):
             if re.search("block-threshold", event):
                 event_str = "block-threshold"
             else:
-                event_str = "event " + event % ("domain %s" % dom_name)
+                event_str = "event " + event % ("domain '%s'" % dom_name)
             logging.info("Expected event: %s", event_str)
             match = re.search(event_str, output[event_idx:])
             if match:


### PR DESCRIPTION
1) The guest name returned by virsh cmds has been added with quote marks
now. Need to fix it to avoid regex failure.

2) The guest with only memory hotplug enabled xml snippet can not be
defined. Need to config the numa node before defining the guest now.

Signed-off-by: Lily Zhu <lizhu@redhat.com>