### PR TITLE
Fix the issue in the final clean up steps

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_bridge.py
+++ b/libvirt/tests/src/virtual_network/iface_bridge.py
@@ -350,5 +350,5 @@ def run(test, params, env):
         # recover NetworkManager
         if NM_status is True:
             NM_service.start()
-        if iface_source["network"] in virsh.net_state_dict():
+        if 'network' in iface_source and iface_source["network"] in virsh.net_state_dict():
             virsh.net_destroy(iface_source["network"], ignore_status=False)


### PR DESCRIPTION
In 5ceba88, I have added 2 negative cases with 1 clean up step. But
the clean up step is not suitable for the existing cases, which will
cause no key error. Fix it by adding one condition.

Signed-off-by: Yalan Zhang <yalzhang@redhat.com>