### PR TITLE
Add 99% progress checking before finish for finish_job

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
@@ -166,11 +166,19 @@ def finish_job(vm_name, target, timeout):
     :param timeout: Timeout value of this function
     """
     job_time = 0
+    progress = 0
     while job_time < timeout:
         # As BZ#1359679, blockjob may disappear during the process,
         # so we need check it all the time
         if utl.check_blockjob(vm_name, target, 'none', '0'):
-            raise exceptions.TestFail("No blockjob find for '%s'" % target)
+            if progress == 99:
+                logging.debug("Blockjob finished without 100% progress show")
+                break
+            else:
+                raise exceptions.TestFail("No blockjob find for '%s'" % target)
+
+        if utl.check_blockjob(vm_name, target, "progress", "99"):
+            progress = 99
 
         if utl.check_blockjob(vm_name, target, "progress", "100"):
             logging.debug("Block job progress up to 100%")


### PR DESCRIPTION
When met the issues that "virsh blockjob avocado-vt-vm1 vda --info" can not get "Block Copy: [ 100 %]", which means that from "Block Copy: [ 99 %]" to finish, it just means the job finished but should not raise error

Signed-off-by: Kyla Zhang <weizhan@redhat.com>

