### PR TITLE
Add libvirt version checking for scsi packed feature case

### DIFF
--- a/libvirt/tests/src/virtual_disks/at_dt_iscsi_disk.py
+++ b/libvirt/tests/src/virtual_disks/at_dt_iscsi_disk.py
@@ -98,7 +98,7 @@ def run(test, params, env):
         if not libvirt_version.version_compare(4, 7, 0):
             test.cancel("iscsi-direct pool is not supported in"
                         " current libvirt version.")
-    if disk_packed and not libvirt_version.version_compare(6, 3, 0):
+    if ((disk_packed or scsi_packed) and not libvirt_version.version_compare(6, 3, 0)):
         test.cancel("The virtio packed attribute is not supported in"
                     " current libvirt version.")
     # Back VM XML


### PR DESCRIPTION
scsi packed feature is supported after libvirt 6.3.0 afterwards

Signed-off-by: chunfuwen <chwen@redhat.com>
