### PR TITLE
memory_discard: Adapt memory_discard test on aarch64

### DIFF
--- a/libvirt/tests/cfg/memory/memory_discard.cfg
+++ b/libvirt/tests/cfg/memory/memory_discard.cfg
@@ -9,6 +9,8 @@
                 - numa_cell:
                     check = numa_cell
                     cpuxml_mode = host-model
+                    aarch64:
+                        cpuxml_mode = host-passthrough
                     cpuxml_check = partial
                     cpuxml_fallback = allow
                     cpuxml_numa_cell = [{'id': '0', 'cpus': '0-1', 'memory': '512', 'unit': 'MiB', 'discard': 'yes'}, {'id': '1', 'cpus': '2-3', 'memory': '512', 'unit': 'MiB'}]
@@ -44,6 +46,7 @@
                              mbxml_access_mode = 'shared'
                              mbxml_source_type = 'file'
                 - mem_dev:
+                    no aarch64
                     check = mem_dev
                     cpuxml_mode = host-model
                     cpuxml_check = partial
@@ -90,6 +93,7 @@
                              mbxml_access_mode = 'shared'
                              mbxml_source_type = 'file'
         - hot_plug:
+            no aarch64
             check = hot_plug
             dimmxml_mem_model = dimm
             dimmxml_mem_access = shared


### PR DESCRIPTION
1. aarch64 doesn't support host-model, set cpu mode host-passthrough for aarch64
2. Skip memory hotplug tests for aarch64

Signed-off-by: Liu Yiding <liuyd.fnst@cn.fujitsu.com>


## If the PR is bug cases
- [x] Bug descriptions or bug links
```
memory_discard.common.numa_cell.discard_yes

CmdError: Command '/bin/virsh start avocado-vt-vm1 ' failed.stdout: b'\n'stderr: b&quot;error: Failed to start domain 'avocado-vt-vm1'\nerror: unsupported configuration: CPU mode 'host-model' for aarch64 kvm domain on aarch64 host is not supported by hypervisor\n&quot;additional_info: None&#10;
```
- [x] Test results
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio memory_discard.common.numa_cell
JOB ID     : d71f18a7f9134aec98df21636c6b4f8ccd984b59
JOB LOG    : /root/avocado/job-results/job-2021-02-18T20.54-d71f18a/job.log
 (1/6) type_specific.io-github-autotest-libvirt.memory_discard.common.numa_cell.discard_yes: PASS (37.01 s)
 (2/6) type_specific.io-github-autotest-libvirt.memory_discard.common.numa_cell.shared_yes: PASS (37.53 s)
 (3/6) type_specific.io-github-autotest-libvirt.memory_discard.common.numa_cell.shared_no: PASS (37.37 s)
 (4/6) type_specific.io-github-autotest-libvirt.memory_discard.common.numa_cell.type_file: PASS (36.98 s)
 (5/6) type_specific.io-github-autotest-libvirt.memory_discard.common.numa_cell.type_anon: PASS (37.05 s)
 (6/6) type_specific.io-github-autotest-libvirt.memory_discard.common.numa_cell.discard_no: PASS (37.28 s)
RESULTS    : PASS 6 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 224.28 s
```

