### PR TITLE
v2v: fix incorrect disk count problem when vm has cdrom disk

### DIFF
--- a/v2v/tests/src/function_test_xen.py
+++ b/v2v/tests/src/function_test_xen.py
@@ -420,12 +420,11 @@ def run(test, params, env):
             xml = vm_xml.VMXML.new_from_inactive_dumpxml(
                 vm_name, virsh_instance=virsh_instance)
             logging.debug(xml.xmltreefile)
-            disks = xml.get_disk_all()
+            disks = xml.get_disk_all_by_attr(device='cdrom')
             logging.debug('Disks: %r', disks)
             for disk in list(disks.values()):
                 # Check if vm has cdrom attached
-                if disk.get('device') == 'cdrom' and disk.find(
-                        'source') is None:
+                if disk.find('source') is None:
                     test.error('No CDROM image attached')
         if checkpoint == 'vdsm':
             extra_pkg = params.get('extra_pkg')

--- a/v2v/tests/src/specific_kvm.py
+++ b/v2v/tests/src/specific_kvm.py
@@ -280,7 +280,7 @@ def run(test, params, env):
         dev_table = dict(list(zip(bus_list, dev_prefix)))
         logging.info('Change disk bus to %s' % dest)
         vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
-        disks = vmxml.get_disk_all()
+        disks = vmxml.get_disk_all_by_attr(device='disk')
         index = 0
         for disk in list(disks.values()):
             if disk.get('device') != 'disk':
@@ -736,10 +736,7 @@ def run(test, params, env):
         if checkpoint == 'multi_disks':
             new_xml = vm_xml.VMXML.new_from_inactive_dumpxml(
                 vm_name, virsh_instance=v2v_virsh)
-            disk_count = 0
-            for disk in list(new_xml.get_disk_all().values()):
-                if disk.get('device') == 'disk':
-                    disk_count += 1
+            disk_count = len(new_xml.get_disk_all_by_attr(device='disk'))
             if disk_count <= 1:
                 test.error('Not enough disk devices')
             params['ori_disks'] = disk_count

--- a/v2v/tests/src/v2v_options.py
+++ b/v2v/tests/src/v2v_options.py
@@ -333,7 +333,7 @@ def run(test, params, env):
                 fail.append(key)
 
         # Check disk info
-        disk = list(xml.get_disk_all().values())[0]
+        disk = list(xml.get_disk_all_by_attr(device='disk').values())[0]
 
         def _get_disk_subelement_attr_value(obj, attr, subattr):
             if obj.find(attr) is not None:


### PR DESCRIPTION
When VM has cdrom disk, the xml may be as following:

    <disk type='file' device='disk'>
      <source file='[esx6.7-matrix] xxx/xxx-xxx.vmdk'/>
      <target dev='sda' bus='scsi'/>
      <address type='drive' controller='0' bus='0' target='0' unit='0'/>
    </disk>
    <disk type='file' device='cdrom'>
      <target dev='sda' bus='sata'/>
      <address type='drive' controller='0' bus='0' target='0' unit='0'/>
    </disk>

Above xml may not work when calling get_disk_all function, this patch
fixes the problem by specifying the device value to only return desired
disks.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>