### PR TITLE
max_vcpus: Skip virsh_maxvcpus on aarch64

### DIFF
--- a/libvirt/tests/cfg/cpu/max_vcpus.cfg
+++ b/libvirt/tests/cfg/cpu/max_vcpus.cfg
@@ -4,7 +4,7 @@
 
     variants:
         - virsh_maxvcpus:
-            no pseries, s390-virtio
+            no pseries, s390-virtio, aarch64
             check = "virsh_maxvcpus"
             report_num = "240"
         - virsh_capabilities:


### PR DESCRIPTION
libvirt gets the maximum from the kernel, so the output of maxvcpu is
not consistent among multi-archs.

Skip maxvcpus tests on aarch64 since the default report_num is
incorrect for aarch64.

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>