### PR TITLE
video_devices: Fix no_secondary_video.model_test for aarch64

### DIFF
--- a/libvirt/tests/src/virtual_device/video_devices.py
+++ b/libvirt/tests/src/virtual_device/video_devices.py
@@ -89,6 +89,8 @@ def run(test, params, env):
         logging.debug("the cmdline is: %s" % cmdline)
         # s390x only supports virtio
         s390x_pattern = r"-device\svirtio-gpu-ccw"
+        # aarch64 only supports virtio
+        aarch64_pattern = r"-device\svirtio-gpu-pci"
 
         if is_primary or is_primary is None:
             if model_type == "vga":
@@ -97,6 +99,8 @@ def run(test, params, env):
                 pattern = r"-device\s%s-vga" % model_type
             if guest_arch == 's390x':
                 pattern = s390x_pattern
+            elif guest_arch == 'aarch64':
+                pattern = aarch64_pattern
             if not re.search(pattern, cmdline):
                 test.fail("Can not find the primary %s video device "
                           "in qemu cmd line." % model_type)


### PR DESCRIPTION
- [x] Bug descriptions or bug links
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virtual_devices.video_devices.positive_test.primary_video.virtio.no_secondary_video.model_test.with_packed_on
JOB ID     : 7ad4be11d1911d0a65c9b6c2fe91adf89ec6bd19
JOB LOG    : /root/avocado/job-results/job-2021-02-22T03.26-7ad4be1/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_devices.video_devices.positive_test.primary_video.virtio.no_secondary_video.model_test.with_packed_on: FAIL: Can not find the primary virtio video device in qemu cmd line. (10.49 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 11.19 s
```
aarch64 only supports virtio-gpu-pci
- [x] Test results
After this fix
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virtual_devices.video_devices.positive_test.primary_video.virtio.no_secondary_video.model_test.with_packed_on
JOB ID     : 99fda55010733c69b99af5d4b1fc001b063b53c7
JOB LOG    : /root/avocado/job-results/job-2021-02-22T03.41-99fda55/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_devices.video_devices.positive_test.primary_video.virtio.no_secondary_video.model_test.with_packed_on: PASS (9.39 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 10.09 s
```
