### PR TITLE
max_vcpus: Update q35_max_vcpus_num in virsh_capa

### DIFF
--- a/libvirt/tests/cfg/cpu/max_vcpus.cfg
+++ b/libvirt/tests/cfg/cpu/max_vcpus.cfg
@@ -13,6 +13,7 @@
             report_num_q35_73 = "255"
             report_num_q35_7_8 = "384"
             report_num_q35_8_3 = "512"
+            report_num_q35_8_4 = "710"
         - positive_test:
             status_error = "no"
             variants:

--- a/libvirt/tests/src/cpu/max_vcpus.py
+++ b/libvirt/tests/src/cpu/max_vcpus.py
@@ -72,6 +72,7 @@ def run(test, params, env):
             report_num_q35_73 = params.get('report_num_q35_73', '')
             report_num_q35_7_8 = params.get('report_num_q35_7_8', '')
             report_num_q35_8_3 = params.get('report_num_q35_8_3', '')
+            report_num_q35_8_4 = params.get('report_num_q35_8_4', '')
             logging.info('Check the output of virsh capabilities')
             xmltreefile = capability_xml.CapabilityXML().xmltreefile
             machtype_vcpunum_dict = {}
@@ -101,7 +102,9 @@ def run(test, params, env):
                                               machtype_vcpunum_dict[key]))
                     else:
                         exp_val = report_num_q35_7_8
-                        if libvirt_version.version_compare(6, 6, 0):
+                        if libvirt_version.version_compare(7, 0, 0):
+                            exp_val = report_num_q35_8_4
+                        elif libvirt_version.version_compare(6, 6, 0):
                             exp_val = report_num_q35_8_3
                         if machtype_vcpunum_dict[key] != exp_val:
                             test.fail('Test failed as the q35_max_vcpus_num in '


### PR DESCRIPTION
This PR is to add The maxCpus value of pc-q35-rhel8.4.0.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
