### PR TITLE
max_vcpus: Fix an issue in negative_test.ioapic_iommu

### DIFF
--- a/libvirt/tests/cfg/cpu/max_vcpus.cfg
+++ b/libvirt/tests/cfg/cpu/max_vcpus.cfg
@@ -58,5 +58,5 @@
                 - ioapic_iommu:
                     only q35
                     check = "ioapic_iommu_ne"
-                    guest_vcpu = "513"
+                    guest_vcpu = "711"
                     err_msg = "unsupported configuration: Maximum CPUs greater than specified machine type limit|exceeds the maximum cpus supported"


### PR DESCRIPTION
The max vcpu was changed, so the guest vcpu setting should be
updated.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
