### PR TITLE
video_devices: Fix no_secondary_video.heads_test for aarch64

### DIFF
--- a/libvirt/tests/src/virtual_device/video_devices.py
+++ b/libvirt/tests/src/virtual_device/video_devices.py
@@ -126,6 +126,8 @@ def run(test, params, env):
         logging.debug("the cmdline is: %s" % cmdline)
         # s390x only supports virtio
         s390x_pattern = r"-device\svirtio-gpu-ccw\S+max_outputs=%s"
+        # aarch64 only supports virtio
+        aarch64_pattern = r"-device\svirtio-gpu-pci\S+max_outputs=%s"
 
         if is_primary or is_primary is None:
             model_heads = kwargs.get("model_heads", default_primary_heads)
@@ -133,6 +135,8 @@ def run(test, params, env):
                 pattern = r"-device\s%s-vga\S+max_outputs=%s" % (model_type, model_heads)
                 if guest_arch == 's390x':
                     pattern = s390x_pattern % model_heads
+                elif guest_arch == 'aarch64':
+                    pattern = aarch64_pattern % model_heads
                 if not re.search(pattern, cmdline):
                     test.fail("The heads number of the primary %s video device "
                               "in not correct." % model_type)


### PR DESCRIPTION
aarch64 only supports virtio

- [x] Bug descriptions or bug links
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virtual_devices.video_devices.positive_test.primary_video.virtio.no_secondary_video.heads_test.default_heads
JOB ID     : 6c2431b4d0842c3a42ca00e5b756cc29743e0eaa
JOB LOG    : /root/avocado/job-results/job-2021-02-23T03.51-6c2431b/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_devices.video_devices.positive_test.primary_video.virtio.no_secondary_video.heads_test.default_heads: FAIL: The heads number of the primary virtio video device in not correct. (10.64 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 11.28 s
```
- [x] Test results
After this fix
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virtual_devices.video_devices.positive_test.primary_video.virtio.no_secondary_video.heads_test.default_heads
JOB ID     : 4afe721a6cf31241ec6ed179d36f1e31998e348c
JOB LOG    : /root/avocado/job-results/job-2021-02-23T03.52-4afe721/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_devices.video_devices.positive_test.primary_video.virtio.no_secondary_video.heads_test.default_heads: PASS (9.59 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 10.24 s
```