### PR TITLE
input_devices: Skip ps2 tests for aarch64

### DIFF
--- a/libvirt/tests/cfg/virtual_device/input_devices.cfg
+++ b/libvirt/tests/cfg/virtual_device/input_devices.cfg
@@ -33,7 +33,7 @@
         - bus_type_virtio:
             bus_type = virtio
         - bus_type_ps2:
-            no s390-virtio, pseries
+            no s390-virtio, pseries, aarch64
             bus_type = ps2
     variants:
         - positive_test:


### PR DESCRIPTION
ps2 is not supported by aarch64, @chloerh. Thanks.