### PR TITLE
virsh_attach_detach_disk: Fix unsupported controllers for aarch64

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_disk.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_disk.cfg
@@ -155,6 +155,9 @@
                     q35:
                         at_dt_disk_device_target = sdb
                         at_dt_disk_bus_type = scsi
+                    aarch64:
+                        at_dt_disk_device_target = sdb
+                        at_dt_disk_bus_type = scsi
                 - cdrom_eject_control:
                     only attach_disk
                     at_dt_disk_at_options = "--type cdrom --sourcetype file --config"
@@ -170,6 +173,9 @@
                         at_dt_disk_device_target = sdb
                         at_dt_disk_bus_type = scsi
                     q35:
+                        at_dt_disk_device_target = sdb
+                        at_dt_disk_bus_type = scsi
+                    aarch64:
                         at_dt_disk_device_target = sdb
                         at_dt_disk_bus_type = scsi
                 - special_disk_name:


### PR DESCRIPTION
aarch64 doesn't support IDE, replace it with SCSI.

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

- [x] Bug descriptions or bug links
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virsh.attach_detach_disk.attach_disk.normal_test.cdrom_eject_control
JOB ID     : 5c33be83c5e98d04551cfe30d87469b0f52d56c3
JOB LOG    : /root/avocado/job-results/job-2021-02-23T08.32-5c33be8/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.attach_detach_disk.attach_disk.normal_test.cdrom_eject_control: ERROR: VM 'avocado-vt-vm1' failed to start: error: Failed to start domain 'avocado-vt-vm1'\nerror: unsupported configuration: IDE controllers are unsupported for this QEMU binary or machine type (62.32 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 62.98 s
```
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virsh.attach_detach_disk.attach_disk.normal_test.cdrom
JOB ID     : 0c8701136efd50390748b281337e9d1ee325bc83
JOB LOG    : /root/avocado/job-results/job-2021-02-23T08.36-0c87011/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.attach_detach_disk.attach_disk.normal_test.cdrom: ERROR: VM 'avocado-vt-vm1' failed to start: error: Failed to start domain 'avocado-vt-vm1'\nerror: unsupported configuration: IDE controllers are unsupported for this QEMU binary or machine type (6.80 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 7.47 s
```
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virsh.attach_detach_disk.detach_disk.normal_test.cdrom
JOB ID     : 6f594bab263953a610fca4b050d75a7a0d879c8e
JOB LOG    : /root/avocado/job-results/job-2021-02-23T08.37-6f594ba/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.attach_detach_disk.detach_disk.normal_test.cdrom: ERROR: VM 'avocado-vt-vm1' failed to start: error: Failed to start domain 'avocado-vt-vm1'\nerror: unsupported configuration: IDE controllers are unsupported for this QEMU binary or machine type (6.82 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 7.48 s
```
- [x] Test results
After this fix
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virsh.attach_detach_disk.attach_disk.normal_test.cdrom_eject_control
JOB ID     : 05bd37c00ae5420699c52ab11845c6c90af7ed4c
JOB LOG    : /root/avocado/job-results/job-2021-02-23T08.25-05bd37c/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.attach_detach_disk.attach_disk.normal_test.cdrom_eject_control: PASS (93.08 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 93.76 s
```
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio  virsh.attach_detach_disk.detach_disk.normal_test.cdrom
JOB ID     : 94e732791cd547295213d84452653456fff985ec
JOB LOG    : /root/avocado/job-results/job-2021-02-23T08.20-94e7327/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.attach_detach_disk.detach_disk.normal_test.cdrom: PASS (79.05 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 79.72 s
```
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virsh.attach_detach_disk.attach_disk.normal_test.cdrom_eject_control
JOB ID     : 05bd37c00ae5420699c52ab11845c6c90af7ed4c
JOB LOG    : /root/avocado/job-results/job-2021-02-23T08.25-05bd37c/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.attach_detach_disk.attach_disk.normal_test.cdrom_eject_control: PASS (93.08 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 93.76 s
```