### PR TITLE
Skip some pseries/aarch64 unsupported tests

### DIFF
--- a/libvirt/tests/cfg/cpu/vm_features.cfg
+++ b/libvirt/tests/cfg/cpu/vm_features.cfg
@@ -34,6 +34,7 @@
                         - disable:
                             pvspinlock_attr={'pvspinlock_state': 'off'}
                 - kvm_poll_control:
+                    no pseries, aarch64
                     variants:
                         - enable:
                             kvm_poll_control_attr = {'kvm_poll_control': 'on'}

--- a/libvirt/tests/cfg/virtual_device/input_devices.cfg
+++ b/libvirt/tests/cfg/virtual_device/input_devices.cfg
@@ -33,7 +33,7 @@
         - bus_type_virtio:
             bus_type = virtio
         - bus_type_ps2:
-            no s390-virtio, pseries
+            no s390-virtio, pseries, aarch64
             bus_type = ps2
     variants:
         - positive_test:

--- a/libvirt/tests/cfg/virtual_device/sound_device.cfg
+++ b/libvirt/tests/cfg/virtual_device/sound_device.cfg
@@ -11,13 +11,13 @@
             codec_type = micro
     variants:
         - sound_model_ac97:
-            no pseries
+            no pseries, aarch64
             sound_model = ac97
         - sound_model_ich6:
-            no pseries
+            no pseries, aarch64
             sound_model = ich6
         - sound_model_ich9:
-            no pseries
+            no pseries, aarch64
             sound_model = ich9
     variants:
         - positive_test:

--- a/libvirt/tests/cfg/virtual_device/watchdog.cfg
+++ b/libvirt/tests/cfg/virtual_device/watchdog.cfg
@@ -4,7 +4,7 @@
     take_regular_screendumps = "no"
     variants:
         - model_i6300esb:
-            no pseries, s390x
+            no pseries, s390x, aarch64
             model = "i6300esb"
             variants:
                 - model_test:


### PR DESCRIPTION
a) Skip kvm_poll_control on pseries/aarch64

b) Skip bus_type_ps2, model_i6300esb sound_model ac97 ich6 ich9 on aarch64

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>