### PR TITLE
Fix the unplug failure

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_bridge.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_bridge.cfg
@@ -39,6 +39,7 @@
                 - hotplug_device:
                     hotplug = "yes"
                     iface_type = "bridge"
+                    iface_alias = "ua-cb8914ab-82d9-453e-bf4f-d2e90ca19abd"
 
 
 


### PR DESCRIPTION
As there is a patch recently to add the alias into account when detach
an interface device. The original detach device will fail as it has
alias set as 'None', which can pass in the old libvirt which do not
care about the alias, but fail in current libvirt version. Add a customer
alias into the cfg file to fix the issue. It should pass both in old and
latest libvirt.

Signed-off-by: Yalan Zhang <yalzhang@redhat.com>