### PR TITLE
virtual_network: multiple fixup for aarch64

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_network.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_network.cfg
@@ -203,13 +203,13 @@
                         - virtio:
                             iface_model = "virtio"
                         - e1000:
-                            no s390-virtio
+                            no s390-virtio, aarch64
                             iface_model = "e1000"
                         - rtl8139:
-                            no s390-virtio
+                            no s390-virtio, aarch64
                             iface_model = "rtl8139"
                         - e1000e:
-                            no s390-virtio
+                            no s390-virtio, aarch64
                             iface_model = "e1000e"
         - net_guest:
             test_guest_libvirt = "yes"
@@ -253,6 +253,8 @@
                             iface_source = "{'dev':'eno1','mode':'bridge'}"
                             iface_type = "direct"
                             iface_model = "rtl8139"
+                            aarch64:
+                                iface_model = "virtio"
                         - exist_macvtap:
                             net_forward = "{'dev':'eno1','mode':'bridge'}"
                             define_macvtap = "yes"
@@ -294,16 +296,22 @@
                     change_iface_option = "yes"
                     iface_source = "{'network':'nettest'}"
                     iface_model = "rtl8139"
+                    aarch64:
+                        iface_model = "virtio"
                     test_dhcp_range = "yes"
                 - specific_portgroup:
                     change_iface_option = "yes"
                     iface_source = "{'network':'nettest','portgroup':'sales'}"
                     iface_model = "rtl8139"
+                    aarch64:
+                        iface_model = "virtio"
                     test_dhcp_range = "yes"
                 - overwriting_bandwidth:
                     change_iface_option = "yes"
                     iface_source = "{'network':'nettest','portgroup':'sales'}"
                     iface_model = "rtl8139"
+                    aarch64:
+                        iface_model = "virtio"
                     test_dhcp_range = "yes"
                     iface_bandwidth_inbound = "{'average':'1000','peak':'5000','burst':'1024'}"
                     iface_bandwidth_outbound = "{'average':'128','peak':'256','burst':'256'}"

--- a/libvirt/tests/src/virtual_network/iface_bridge.py
+++ b/libvirt/tests/src/virtual_network/iface_bridge.py
@@ -47,7 +47,9 @@ def run(test, params, env):
             test.cancel("The bridge %s already exist" % br_name)
 
         # Create bridge
-        utils_package.package_install('tmux')
+        if not utils_package.package_install(["tmux", "iproute",
+                                              "dhclient", "net-tools"]):
+            test.fail("Failed to install specified pkgs in host OS.")
         cmd = 'tmux -c "ip link add name {0} type bridge; ip link set {1} up;' \
               ' ip link set {1} master {0}; ip link set {0} up;' \
               ' pkill dhclient; sleep 6; dhclient {0}; ifconfig {1} 0"'.format(br_name, iface_name)

--- a/libvirt/tests/src/virtual_network/iface_unprivileged.py
+++ b/libvirt/tests/src/virtual_network/iface_unprivileged.py
@@ -28,7 +28,9 @@ def run(test, params, env):
             test.cancel("The bridge %s already exist" % br_name)
 
         # Create bridge
-        utils_package.package_install('tmux')
+        if not utils_package.package_install(["tmux", "iproute",
+                                              "dhclient", "net-tools"]):
+            test.fail("Failed to install specified pkgs in host OS.")
         cmd = 'tmux -c "ip link add name {0} type bridge; ip link set {1} up;' \
               ' ip link set {1} master {0}; ip link set {0} up; pkill dhclient; ' \
               'sleep 6; dhclient {0}; ifconfig {1} 0"'.format(br_name, iface_name)

--- a/libvirt/tests/src/virtual_network/virtual_network_multivms.py
+++ b/libvirt/tests/src/virtual_network/virtual_network_multivms.py
@@ -13,7 +13,7 @@ from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices import interface
 
 
-def create_bridge(br_name, iface_name):
+def create_bridge(test, br_name, iface_name):
     """
     Create bridge attached to physical interface
 
@@ -26,7 +26,9 @@ def create_bridge(br_name, iface_name):
         return
 
     # Create bridge using commands
-    utils_package.package_install('tmux')
+    if not utils_package.package_install(["tmux", "iproute",
+                                          "dhclient", "net-tools"]):
+        test.fail("Failed to install specified pkgs in host OS.")
     cmd = 'tmux -c "ip link add name {0} type bridge; ip link set {1} up;' \
           ' ip link set {1} master {0}; ip link set {0} up; pkill dhclient; ' \
           'sleep 6; dhclient {0}; ifconfig {1} 0"'.format(br_name, iface_name)
@@ -120,7 +122,7 @@ def run(test, params, env):
                             ' > 6.2.0 to support port isolated')
 
             if case.startswith('set_iface'):
-                create_bridge(bridge_name, iface_name)
+                create_bridge(test, bridge_name, iface_name)
                 bridge_created = True
                 iface_type = case.split('_')[-1]
                 if iface_type == 'network':


### PR DESCRIPTION
1. Fix virtual_network.iface_bridge.multiqueues.hotplug_device.shared_physical_network, test failed due to missing cmd.
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virtual_network.iface_bridge.multiqueues.hotplug_device.shared_physical_network
JOB ID     : 86212d35af650ee8a35d4a36ecd9cff9a9f47a2c
JOB LOG    : /root/avocado/job-results/job-2021-02-24T03.21-86212d3/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.iface_bridge.multiqueues.hotplug_device.shared_physical_network: ERROR: Command 'tmux -c "ip link add name test_br0 type bridge; ip link set eno1 up; ip link set eno1 master test_br0; ip link set test_br0 up; pkill dhclient; sleep 6; dhclient test_br0; ifconfig eno1 0"' failed.\nstdout: b''\nstderr: b'bash: ifconfig: command no... (30.94 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 31.79 s

```
After fixup
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virtual_network.iface_bridge.multiqueues.hotplug_device.shared_physical_network
JOB ID     : fde47c557a65c9f7c5669fe2edc9097216904b85
JOB LOG    : /root/avocado/job-results/job-2021-02-24T03.13-fde47c5/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.iface_bridge.multiqueues.hotplug_device.shared_physical_network: PASS (84.59 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 85.43 s
```
2. Skip e1000 rtl8139 e1000e on aarch64
3. Replace default iface_model rtl8139 with virtio on aarch64
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virtual_network.iface_network.net_portgroup.specific_portgroup
JOB ID     : c15b4b005c5fff2e0172a0c5555efae6e92570f7
JOB LOG    : /root/avocado/job-results/job-2021-02-24T03.24-c15b4b0/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.net_portgroup.specific_portgroup: FAIL: VM failed to start:\nVM 'avocado-vt-vm1' failed to start: error: Failed to start domain 'avocado-vt-vm1'\nerror: internal error: qemu unexpectedly closed the monitor: 2021-02-24T08:24:54.145671Z qemu-kvm: -device rtl8139,netdev=hostnet0,id=net0,mac=52:54:00... (15.90 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 16.58 s
```
After fixup
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virtual_network.iface_network.net_portgroup.specific_portgroup
JOB ID     : a0381dbccd661127df7ed569bb5b393b58d208e6
JOB LOG    : /root/avocado/job-results/job-2021-02-24T03.19-a0381db/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.net_portgroup.specific_portgroup: PASS (41.92 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 42.61 s
```