### PR TITLE
migration: Add 3 migration cases to check disks port option

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_storage.cfg
+++ b/libvirt/tests/cfg/migration/migrate_storage.cfg
@@ -35,3 +35,44 @@
                     server_info_ip = ""
                     virsh_migrate_extra = "--tls --migrateuri tcp://${migrate_dest_host}"
                     err_msg = "Certificate does not match the hostname"
+        - migrateuri:
+            only copy_storage_all
+            check_disks_port = "yes"
+            func_params_exists = "yes"
+            bandwidth_opt = "--bandwidth 200"
+            variants:
+                - @default:
+                    migrateuri_port = 49153
+                    variants:
+                        - ipv4:
+                            virsh_migrate_extra = "--migrateuri tcp://${migrate_dest_host}:${migrateuri_port} ${bandwidth_opt}"
+                        - ipv6:
+                            ipv6_config = "yes"
+                            ipv6_addr_src = "ENTER.YOUR.IPv6.SOURCE"
+                            ipv6_addr_des = "ENTER.YOUR.IPv6.DESTINATION"
+                            virsh_migrate_extra = "--migrateuri tcp://[${ipv6_addr_des}]:${migrateuri_port} ${bandwidth_opt}"
+                - disks_port:
+                    migrateuri_port = 49155
+                    port_to_check = 49158
+                    virsh_migrate_extra = "--migrateuri tcp://${migrate_dest_host}:${migrateuri_port} --disks-port ${port_to_check} ${bandwidth_opt}"
+                - disks_uri:
+                    virsh_migrate_options = "--live  --verbose  --p2p"
+                    func_supported_since_libvirt_ver = (6, 8, 0)
+                    unspported_err_msg = "This libvirt version doesn't support migration with --disks-uri option."
+                    ipv6_addr_des = "ENTER.YOUR.IPv6.DESTINATION"
+                    variants:
+                        - custom_port:
+                            port_to_check = 49157
+                            variants:
+                                - hostname:
+                                    virsh_migrate_extra = "--disks-uri  tcp://ENTER.DEST.HOSTNAME:${port_to_check} --listen-address ${migrate_dest_host} --migrateuri tcp://${migrate_dest_host} ${bandwidth_opt}"
+                                - ipv4_addr:
+                                    virsh_migrate_extra = "--disks-uri  tcp://${migrate_dest_host}:${port_to_check} --listen-address [${ipv6_addr_des}] --migrateuri tcp://[${ipv6_addr_des}] ${bandwidth_opt}"
+                                - ipv6_addr:
+                                    ipv6_config = "yes"
+                                    ipv6_addr_src = "ENTER.YOUR.IPv6.SOURCE"
+                                    virsh_migrate_extra = "--disks-uri  tcp://[${ipv6_addr_des}]:${port_to_check} --listen-address ${migrate_dest_host} --migrateuri tcp://${migrate_dest_host} ${bandwidth_opt}"
+                        - default_port:
+                            variants:
+                                - ipv4_addr:
+                                    virsh_migrate_extra = "--disks-uri  tcp://${migrate_dest_host} --listen-address [${ipv6_addr_des}] --migrateuri tcp://[${ipv6_addr_des}] ${bandwidth_opt}"


### PR DESCRIPTION
This PR adds 2 migration cases:

1. RHEL-196401: Migrate vm with copy storage over TCP transport - Specified IP
2. RHEL-196402: Migrate vm with copy storage over TCP transport - Specified IP+Port
3. RHEL-196392: [--disks-uri] Migrate vm with copy storage over  TCP transport - Specified IP+Port

depends on:
https://github.com/avocado-framework/avocado-vt/pull/2958
https://github.com/avocado-framework/avocado-vt/pull/2957

**Test results:**
```
# avocado run --vt-type libvirt --vt-machine-type q35 virsh.migrate_storage.migrateuri
WARNING:root:No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
WARNING:root:No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : 6bf0781ac4ed01231133bb84984585efcdc54ea8
JOB LOG    : /root/avocado/job-results/job-2021-03-17T05.01-6bf0781/job.log
 (1/7) type_specific.io-github-autotest-libvirt.virsh.migrate_storage.migrateuri.default.ipv4.copy_storage_all: PASS (156.52 s)
 (2/7) type_specific.io-github-autotest-libvirt.virsh.migrate_storage.migrateuri.default.ipv6.copy_storage_all: PASS (166.52 s)
 (3/7) type_specific.io-github-autotest-libvirt.virsh.migrate_storage.migrateuri.disks_port.copy_storage_all: PASS (179.71 s)
 (4/7) type_specific.io-github-autotest-libvirt.virsh.migrate_storage.migrateuri.disks_uri.custom_port.hostname.copy_storage_all: PASS (181.25 s)
 (5/7) type_specific.io-github-autotest-libvirt.virsh.migrate_storage.migrateuri.disks_uri.custom_port.ipv4_addr.copy_storage_all: PASS (183.93 s)
 (6/7) type_specific.io-github-autotest-libvirt.virsh.migrate_storage.migrateuri.disks_uri.custom_port.ipv6_addr.copy_storage_all: PASS (166.87 s)
 (7/7) type_specific.io-github-autotest-libvirt.virsh.migrate_storage.migrateuri.disks_uri.default_port.ipv4_addr.copy_storage_all: PASS (165.85 s)
RESULTS    : PASS 7 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 1205.15 s


```
