### PR TITLE
controller_functional: fix vm define error

### DIFF
--- a/libvirt/tests/cfg/controller/controller_functional.cfg
+++ b/libvirt/tests/cfg/controller/controller_functional.cfg
@@ -8,7 +8,6 @@
     remove_contr = "yes"
     variants:
         - positive_tests:
-            remove_address = "yes"
             run_vm = "yes"
             controller_type = pci
             variants:
@@ -150,7 +149,7 @@
                     controller_type = scsi
                     controller_model = virtio-scsi
                     check_contr_addr = 'no'
-                    update_cntl_bus = 'yes'
+                    auto_bus = 'yes'
                     check_within_guest = "no"
                     add_contrl_list = "[{'type': 'scsi', 'model': 'virtio-scsi', 'bus': '%s', 'slot': '0x00', 'func': '0x0'},{'type': 'scsi', 'model': 'virtio-scsi', 'bus': '%s', 'slot': '0x00', 'func': '0x2'}]"
                     qemu_patterns = "[('-device', 'virtio-scsi-pci,.*multifunction=on,addr=0x0.*')]"
@@ -299,7 +298,10 @@
                            controller_model = 'root'
                            err_msg = ".*Unknown model type '${controller_model}'"
                 - invalid_chassisNr:
-                    controller_model = pci-bridge
+                    remove_contr = "no"
+                    remove_address = "no"
+                    auto_index = "yes"
+                    auto_slot = "yes"
                     variants:
                         - zero:
                             chassisNr = 0
@@ -310,3 +312,4 @@
                         - string:
                             chassisNr = 'abc'
                             err_msg = "Invalid chassisNr '${chassisNr}' in PCI controller"
+                    add_contrl_list = "[{'type': 'pci', 'model': 'pci-bridge', 'index': '%s', 'bus': '0x00', 'slot': '%s','chassisNr': '${chassisNr}'}]"


### PR DESCRIPTION
This is to fix a vm define error like below. This error happened due
to a new libvirt parsing behavior in 7.0.0-x. But the fix is compatible
to old libvirt versions.

```
XML error: The PCI controller with index='0' must be model='pcie-root'
for this machine type, but model='pci-bridge' was found instead
```

Signed-off-by: Dan Zheng <dzheng@redhat.com>
