### PR TITLE
virtual_network: Fix iface_network for aarch64

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_network.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_network.cfg
@@ -253,6 +253,8 @@
                             iface_source = "{'dev':'eno1','mode':'bridge'}"
                             iface_type = "direct"
                             iface_model = "rtl8139"
+                            aarch64:
+                                iface_model = "virtio"
                         - exist_macvtap:
                             net_forward = "{'dev':'eno1','mode':'bridge'}"
                             define_macvtap = "yes"
@@ -289,21 +291,21 @@
             test_portgroup_bandwidth = "yes"
             portgroup_bandwidth_inbound = "{'average':'1000','peak':'5000','burst':'5120'} {'average':'500','peak':'2000','burst':'2560'}"
             portgroup_bandwidth_outbound = "{'average':'1000','peak':'5000','burst':'5120'} {'average':'128','peak':'256','burst':'256'}"
+            iface_model = "rtl8139"
+            aarch64:
+                iface_model = "virtio"
             variants:
                 - default_portgroup:
                     change_iface_option = "yes"
                     iface_source = "{'network':'nettest'}"
-                    iface_model = "rtl8139"
                     test_dhcp_range = "yes"
                 - specific_portgroup:
                     change_iface_option = "yes"
                     iface_source = "{'network':'nettest','portgroup':'sales'}"
-                    iface_model = "rtl8139"
                     test_dhcp_range = "yes"
                 - overwriting_bandwidth:
                     change_iface_option = "yes"
                     iface_source = "{'network':'nettest','portgroup':'sales'}"
-                    iface_model = "rtl8139"
                     test_dhcp_range = "yes"
                     iface_bandwidth_inbound = "{'average':'1000','peak':'5000','burst':'1024'}"
                     iface_bandwidth_outbound = "{'average':'128','peak':'256','burst':'256'}"


### PR DESCRIPTION
RHEL qemu-kvm doesn't support rtl8139, replace default iface_model rtl8139 with virtio on aarch64
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio \
> virtual_network.iface_network.net_portgroup.default_portgroup \
> virtual_network.iface_network.net_portgroup.specific_portgroup \
> virtual_network.iface_network.net_portgroup.overwriting_bandwidth
JOB ID     : 4f1223696f35056360b2ebab8d04d82d1dc73b6b
JOB LOG    : /root/avocado/job-results/job-2021-02-25T03.07-4f12236/job.log
 (1/3) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.net_portgroup.default_portgroup: FAIL: VM failed to start:\nVM 'avocado-vt-vm1' failed to start: error: Failed to start domain 'avocado-vt-vm1'\nerror: internal error: process exited while connecting to monitor: 2021-02-25T08:07:21.528305Z qemu-kvm: -device rtl8139,netdev=hostnet0,id=net0,mac=52... (15.94 s)
 (2/3) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.net_portgroup.specific_portgroup: FAIL: VM failed to start:\nVM 'avocado-vt-vm1' failed to start: error: Failed to start domain 'avocado-vt-vm1'\nerror: internal error: qemu unexpectedly closed the monitor: 2021-02-25T08:07:37.525284Z qemu-kvm: -device rtl8139,netdev=hostnet0,id=net0,mac=52:54:00... (16.05 s)
 (3/3) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.net_portgroup.overwriting_bandwidth: FAIL: VM failed to start:\nVM 'avocado-vt-vm1' failed to start: error: Failed to start domain 'avocado-vt-vm1'\nerror: internal error: qemu unexpectedly closed the monitor: 2021-02-25T08:07:53.716400Z qemu-kvm: -device rtl8139,netdev=hostnet0,id=net0,mac=52:54:00... (16.05 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 3 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 49.00 s
```
After fixup
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio \
> virtual_network.iface_network.net_portgroup.default_portgroup \
> virtual_network.iface_network.net_portgroup.specific_portgroup \
> virtual_network.iface_network.net_portgroup.overwriting_bandwidth
JOB ID     : d04a6cb78baa71bbbb8d7ac114a5714a7972278a
JOB LOG    : /root/avocado/job-results/job-2021-02-25T03.03-d04a6cb/job.log
 (1/3) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.net_portgroup.default_portgroup: PASS (41.71 s)
 (2/3) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.net_portgroup.specific_portgroup: PASS (41.95 s)
 (3/3) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.net_portgroup.overwriting_bandwidth: PASS (42.20 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 126.62 s
```
