### PR TITLE
Remove source esx5.5 from v2v functional jobs

### DIFF
--- a/v2v/tests/cfg/convert_from_file.cfg
+++ b/v2v/tests/cfg/convert_from_file.cfg
@@ -166,12 +166,12 @@
                             skip_virsh_pre_conn = no
                             variants:
                                 - win2012r2:
-                                    only esx_55
+                                    only esx_60
                                     only windows
                                     os_version = 'win2012r2'
                                     has_genid = 'no'
                                     main_vm = 'VM_NAME_GENID_WIN2012R2_V2V_EXAMPLE'
-                                    vmx_nfs_src = NFS_ESX55_VMX_V2V_EXAMPLE
+                                    vmx_nfs_src = NFS_ESX60_VMX_V2V_EXAMPLE
                                     # genid only supports libvirt, local, qemu
                                     only output_mode.libvirt
                                 - win2019:

--- a/v2v/tests/cfg/convert_vm_to_libvirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_libvirt.cfg
@@ -150,9 +150,6 @@
                 - 6_0:
                     only source_esx.esx_60
                     esx_version = "esx6.0"
-                - 5_5:
-                    only source_esx.esx_55
-                    esx_version = "esx5.5"
             hostname = ${esx_hostname}
             variants:
                 - vm:

--- a/v2v/tests/cfg/convert_vm_to_ovirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_ovirt.cfg
@@ -191,9 +191,6 @@
                 - 6_0:
                     only source_esx.esx_60
                     esx_version = "esx6.0"
-                - 5_5:
-                    only source_esx.esx_55
-                    esx_version = "esx5.5"
             hostname = ${vpx_hostname}
             variants:
                 - vm:

--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -45,7 +45,7 @@
                     json_disk_pattern = '%%{GuestName}-%{GuestName}-%{DiskDeviceName}-%{DiskNo}'
         - libvirt:
             only dest_libvirt
-            only uefi, GPO_AV, special_name, suse
+            only uefi, GPO_AV, special_name, suse, local_storage
         - rhev:
             only dest_rhev.NFS
             variants:
@@ -58,8 +58,6 @@
                 - rhv:
                     output_method = "rhev"
     variants:
-        - esx_55:
-            only source_esx.esx_55
         - esx_60:
             only source_esx.esx_60
         - esx_65:
@@ -156,31 +154,34 @@
                     main_vm = VM_NAME_WIN_STATIC_IP_V2V_EXAMPLE
                     v2v_opts = VM_NAME_WIN_STATIC_IP_MAC_CONF_V2V_EXAMPLE
         - with_cdrom:
-            only esx_55
+            only esx_70
             main_vm = 'VM_NAME_ESX_CDROM_V2V_EXAMPLE'
             checkpoint = 'cdrom'
         - migrated_vm:
             only esx_67
             main_vm = 'VM_NAME_ESX_MIGRATED_V2V_EXAMPLE'
         - local_storage:
-            only esx_55
-            main_vm = 'VM_NAME_ESX_LOCALSTORAGE_V2V_EXAMPLE'
+            only esx_70
+            boottype = 3
+            main_vm = "VM_NAME_ESX_LOCALSTORAGE_V2V_EXAMPLE"
         - multiple_disks:
-            only esx_55
+            only esx_70
             main_vm = 'VM_NAME_ESX_MULDISKS_V2V_EXAMPLE'
         - multiple_cpus:
-            only esx_55
+            only esx_70
             main_vm = 'VM_NAME_ESX_MULCPUS_V2V_EXAMPLE'
         - special_name:
-            only esx_55
+            only esx_70
             #rhv env does not allowed guest to have speical characters
             only libvirt
-            main_vm = 'VM_NAME_ESX_SPECIALNAME_V2V_EXAMPLE'
+            main_vm = "VM_NAME_ESX_SPECIALNAME_V2V_EXAMPLE"
         - cloned_vm:
-            only esx_55
+            only esx_70
+            boottype = 3
             main_vm = 'VM_NAME_ESX_CLONED_V2V_EXAMPLE'
         - esx_template:
-            only esx_55
+            only esx_70
+            boottype = 3
             main_vm = 'VM_NAME_ESX_TEMPLATE_V2V_EXAMPLE'
         - esx_snapshot:
             only esx_65
@@ -239,7 +240,7 @@
             checkpoint = modprobe
             cfg_content = 'alias eth0 virtio_net'
         - passthru:
-            only esx_55
+            only esx_70
             main_vm = VM_NAME_DEVICE_PASSTHRU_V2V_EXAMPLE
         - empty_cdrom:
             only esx_60
@@ -290,7 +291,7 @@
             esx_http_proxy = HTTP_PROXY_V2V_EXAMPLE
             esx_https_proxy = HTTPS_PROXY_V2V_EXAMPLE
         - usr_partition:
-            only esx_55
+            only esx_70
             no libvirt
             main_vm = VM_NAME_USR_PARTITION_V2V_EXAMPLE
         - lvm_multiple_disks:


### PR DESCRIPTION
As esx5.5 is not supported by v2v now, move source esxi5.5 from
v2v jobs and use the other vmware source to replace it.

Signed-off-by: mxie91 <mxie@redhat.com>

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [ ] Description of the cases
- [ ] Links of libvirt features, libvirt bugs or case IDs
- [ ] Test results

## If the PR is bug cases
- [ ] Bug descriptions or bug links
- [ ] Test results

## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
