### PR TITLE
auto_dump: Skip ISA model test on aarch64

### DIFF
--- a/libvirt/tests/cfg/conf_file/qemu_conf/auto_dump.cfg
+++ b/libvirt/tests/cfg/conf_file/qemu_conf/auto_dump.cfg
@@ -11,7 +11,7 @@
             auto_dump_bypass_cache = 0
     variants:
         - isa_model:
-            no s390-virtio
+            no s390-virtio, aarch64
             variants:
                 - model_only:
                     panic_model = 'isa'


### PR DESCRIPTION
qemu aarch64 doesn't support ISA panic device

E.g.
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio conf_file.qemu_conf.auto_dump.isa_model.model_only.default_bypass_cache
JOB ID     : e330aba6f2dc803a28660b5e092176910e22909b
JOB LOG    : /root/avocado/job-results/job-2021-03-01T03.09-e330aba/job.log
 (1/1) type_specific.io-github-autotest-libvirt.conf_file.qemu_conf.auto_dump.isa_model.model_only.default_bypass_cache: ERROR: Failed to define avocado-vt-vm1 for reason:\nerror: Failed to define domain from /tmp/xml_utils_temp_4bij0p3l.xml\nerror: unsupported configuration: the QEMU binary does not support the ISA panic device\n (8.92 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 9.57 s

```

