### PR TITLE
virsh_event: Multiple fixup for aarch64

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_event.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_event.cfg
@@ -40,6 +40,7 @@
                             signal = 'SIGTERM'
                             events_list = "shutdown"
                         - crash_panic:
+                            no aarch64
                             only test_events
                             events_list = "crash"
                             panic_model = 'isa'
@@ -77,6 +78,8 @@
                     q35:
                         device_target_bus = "scsi"
                     pseries:
+                        device_target_bus = "scsi"
+                    aarch64:
                         device_target_bus = "scsi"
                 - rtc-change_event:
                     event_name = "rtc-change"


### PR DESCRIPTION
a) Skip crash_panic test. qemu-kvm aarch64 doesn't support ISA panic device
b) Set device_target_bus scsi for aarch64

## For the b fixup
- [x] Bug descriptions or bug links
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virsh.event.positive_test.virsh_event.test_events.tray-change_event.no_timeout.loop
JOB ID     : deb3ef9dd525651968f9f9623a9dff2f49970847
JOB LOG    : /root/avocado/job-results/job-2021-03-01T06.46-deb3ef9/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.event.positive_test.virsh_event.test_events.tray-change_event.no_timeout.loop: ERROR: VM 'avocado-vt-vm1' failed to start: error: Failed to start domain 'avocado-vt-vm1'\nerror: unsupported configuration: IDE controllers are unsupported for this QEMU binary or machine type (41.47 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 42.12 s
```
- [x] Test results
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virsh.event.positive_test.qemu_monitor_event.pretty_option.tray-change_event.no_timeout.loop
JOB ID     : 4c424545b0751b838d49f1bd708bac7e96f88eac
JOB LOG    : /root/avocado/job-results/job-2021-03-01T06.42-4c42454/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.event.positive_test.qemu_monitor_event.pretty_option.tray-change_event.no_timeout.loop: PASS (69.49 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 70.15 s
```
