### PR TITLE
migration: Use a parameter in base.cfg to enable VM migration back

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_network.cfg
+++ b/libvirt/tests/cfg/migration/migrate_network.cfg
@@ -17,7 +17,7 @@
     virsh_migrate_options = "--live --p2p --verbose"
     # Local URI
     virsh_migrate_connect_uri = "qemu:///system"
-    migr_vm_back = "yes"
+    migrate_vm_back = "yes"
 
     variants:
         - with_postcopy:

--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -215,7 +215,7 @@
                             htm_state = "off"
                 - vcpu-number:
                     only without_postcopy
-                    migr_vm_back = "yes"
+                    migrate_vm_back = "yes"
                     guest_xml_check_after_mig = "<vcpu placement='static'>"
                     variants:
                         - vcpu_1:

--- a/libvirt/tests/src/migration/migrate_ceph.py
+++ b/libvirt/tests/src/migration/migrate_ceph.py
@@ -481,8 +481,8 @@ def run(test, params, env):
     #ssh_key.setup_ssh_key(server_ip, server_user, server_pwd, port=22)
 
     # Set up remote ssh key and remote /etc/hosts file for bi-direction migration
-    migr_vm_back = "yes" == test_dict.get("migrate_vm_back", "no")
-    if migr_vm_back:
+    migrate_vm_back = "yes" == test_dict.get("migrate_vm_back", "no")
+    if migrate_vm_back:
         ssh_key.setup_remote_ssh_key(server_ip, server_user, server_pwd)
         ssh_key.setup_remote_known_hosts_file(client_ip,
                                               server_ip,
@@ -561,7 +561,7 @@ def run(test, params, env):
         # Trigger migration
         migrate_vm(test, test_dict)
 
-        if migr_vm_back:
+        if migrate_vm_back:
             ssh_connection = utils_conn.SSHConnection(server_ip=client_ip,
                                                       server_pwd=client_pwd,
                                                       client_ip=server_ip,
@@ -587,7 +587,7 @@ def run(test, params, env):
     finally:
         logging.info("Recovery test environment")
         # Clean up of pre migration setup for local machine
-        if migr_vm_back:
+        if migrate_vm_back:
             migrate_setup.migrate_pre_setup(src_uri, params,
                                             cleanup=True)
         # Ensure VM can be cleaned up on remote host even migrating fail.

--- a/libvirt/tests/src/migration/migrate_gluster.py
+++ b/libvirt/tests/src/migration/migrate_gluster.py
@@ -75,7 +75,7 @@ def run(test, params, env):
     status_error = "yes" == params.get("status_error", "no")
     err_msg = params.get("err_msg")
     host_ip = params.get("gluster_server_ip", "")
-    migr_vm_back = params.get("migrate_vm_back", "no") == "yes"
+    migrate_vm_back = params.get("migrate_vm_back", "no") == "yes"
 
     selinux_local = params.get('set_sebool_local', 'yes') == "yes"
     selinux_remote = params.get('set_sebool_remote', 'no') == "yes"
@@ -198,7 +198,7 @@ def run(test, params, env):
         migrate_test.check_result(mig_result, params)
         migrate_test.ping_vm(vm, params, dest_uri)
 
-        if migr_vm_back:
+        if migrate_vm_back:
             ssh_connection = utils_conn.SSHConnection(server_ip=client_ip,
                                                       server_pwd=client_pwd,
                                                       client_ip=server_ip,
@@ -241,7 +241,7 @@ def run(test, params, env):
             del remote_libvirt_file
 
         # Clean up of pre migration setup for local machine
-        if migr_vm_back:
+        if migrate_vm_back:
             if 'ssh_connection' in locals():
                 ssh_connection.auto_recover = True
             migrate_test.migrate_pre_setup(src_uri, params,

--- a/libvirt/tests/src/migration/migrate_mem.py
+++ b/libvirt/tests/src/migration/migrate_mem.py
@@ -26,7 +26,7 @@ def run(test, params, env):
     :param params: Dictionary with the test parameters
     :param env: Dictionary with test environment.
     """
-    migr_vm_back = "yes" == params.get("migr_vm_back", "no")
+    migrate_vm_back = "yes" == params.get("migrate_vm_back", "no")
     remote_ip = params.get("remote_ip")
     remote_user = params.get("remote_user")
     remote_pwd = params.get("remote_pwd")
@@ -191,7 +191,7 @@ def run(test, params, env):
                 libvirt.check_qemu_cmd_line(qemu_check, False, params,
                                             runner_on_target)
 
-        if migr_vm_back:
+        if migrate_vm_back:
             ssh_connection = utils_conn.SSHConnection(server_ip=remote_ip,
                                                       server_pwd=remote_pwd,
                                                       client_ip=local_ip,

--- a/libvirt/tests/src/migration/migrate_network.py
+++ b/libvirt/tests/src/migration/migrate_network.py
@@ -154,7 +154,7 @@ def run(test, params, env):
     restart_dhclient = params.get("restart_dhclient", "dhclient -r; dhclient")
     ping_dest = params.get("ping_dest", "www.baidu.com")
     func_params_exists = "yes" == params.get("func_params_exists", "no")
-    migr_vm_back = "yes" == params.get("migr_vm_back", "no")
+    migrate_vm_back = "yes" == params.get("migrate_vm_back", "no")
 
     target_vm_name = params.get("target_vm_name")
     direct_mode = "yes" == params.get("direct_mode", "no")
@@ -339,7 +339,7 @@ def run(test, params, env):
                           " Actual: %s, Expected: %s. "
                           % (act_macvtap, exp_macvtap))
         # Execute migration from remote
-        if migr_vm_back:
+        if migrate_vm_back:
             ssh_connection = utils_conn.SSHConnection(server_ip=client_ip,
                                                       server_pwd=client_pwd,
                                                       client_ip=server_ip,
@@ -409,7 +409,7 @@ def run(test, params, env):
         if virsh_session_remote:
             virsh_session_remote.close_session()
 
-        if migr_vm_back:
+        if migrate_vm_back:
             if 'ssh_connection' in locals():
                 ssh_connection.auto_recover = True
             migration_test.migrate_pre_setup(src_uri, params,

--- a/libvirt/tests/src/migration/migrate_options_shared.py
+++ b/libvirt/tests/src/migration/migrate_options_shared.py
@@ -1037,7 +1037,7 @@ def run(test, params, env):
     status_error = "yes" == params.get("status_error", "no")
     stress_in_vm = "yes" == params.get("stress_in_vm", "no")
     low_speed = params.get("low_speed", None)
-    migr_vm_back = "yes" == params.get("migr_vm_back", "no")
+    migrate_vm_back = "yes" == params.get("migrate_vm_back", "no")
     timer_migration = "yes" == params.get("timer_migration", "no")
     concurrent_migration = "yes" == params.get("concurrent_migration", "no")
 
@@ -1581,7 +1581,7 @@ def run(test, params, env):
         if params.get("actions_after_migration"):
             do_actions_after_migrate(params)
 
-        if migr_vm_back:
+        if migrate_vm_back:
             ssh_connection = utils_conn.SSHConnection(server_ip=client_ip,
                                                       server_pwd=client_pwd,
                                                       client_ip=server_ip,
@@ -1655,7 +1655,7 @@ def run(test, params, env):
                 remote_session.close()
 
             # Clean up of pre migration setup for local machine
-            if migr_vm_back:
+            if migrate_vm_back:
                 if 'ssh_connection' in locals():
                     ssh_connection.auto_recover = True
                 if 'src_full_uri' in locals():

--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -1368,9 +1368,9 @@ def run(test, params, env):
 
     # Set up remote ssh key and remote /etc/hosts file for
     # bi-direction migration
-    migr_vm_back = "yes" == test_dict.get("migrate_vm_back", "no")
+    migrate_vm_back = "yes" == test_dict.get("migrate_vm_back", "no")
     remote_known_hosts_obj = None
-    if migr_vm_back:
+    if migrate_vm_back:
         ssh_key.setup_remote_ssh_key(server_ip, server_user, server_pwd)
         remote_known_hosts_obj = ssh_key.setup_remote_known_hosts_file(client_ip,
                                                                        server_ip,
@@ -2741,7 +2741,7 @@ def run(test, params, env):
             # Check the disks on VM can work correctly.
             check_vm_disk_after_migration(test, vm, test_dict)
 
-        if migr_vm_back:
+        if migrate_vm_back:
             # Pre migration setup for local machine
             migrate_setup.migrate_pre_setup(src_uri, params)
             remove_dict = {"do_search": ('{"%s": "ssh:/"}' % src_uri)}
@@ -2771,7 +2771,7 @@ def run(test, params, env):
         if remote_libvirt_file:
             del remote_libvirt_file
         # Clean up of pre migration setup for local machine
-        if migr_vm_back:
+        if migrate_vm_back:
             migrate_setup.migrate_pre_setup(src_uri, params,
                                             cleanup=True)
 

--- a/libvirt/tests/src/migration/migrate_with_legacy_guest.py
+++ b/libvirt/tests/src/migration/migrate_with_legacy_guest.py
@@ -72,7 +72,7 @@ def run(test, params, env):
     check_rng = "yes" == params.get("check_rng")
     rng_model = params.get("rng_model")
 
-    migr_vm_back = "yes" == params.get("migrate_vm_back", "no")
+    migrate_vm_back = "yes" == params.get("migrate_vm_back", "no")
     status_error = "yes" == params.get("status_error", "no")
     remote_virsh_dargs = {'remote_ip': server_ip, 'remote_user': server_user,
                           'remote_pwd': server_pwd, 'unprivileged_user': None,
@@ -196,7 +196,7 @@ def run(test, params, env):
             remote_virsh_session.close_session()
 
         # Execute migration from remote
-        if migr_vm_back:
+        if migrate_vm_back:
             ssh_connection = utils_conn.SSHConnection(server_ip=client_ip,
                                                       server_pwd=client_pwd,
                                                       client_ip=server_ip,
@@ -239,7 +239,7 @@ def run(test, params, env):
             del remote_libvirt_file
 
         # Clean up of pre migration setup for local machine
-        if migr_vm_back:
+        if migrate_vm_back:
             if 'ssh_connection' in locals():
                 ssh_connection.auto_recover = True
             migration_test.migrate_pre_setup(src_uri, params,


### PR DESCRIPTION
One of the migration jobs needs to enable VM migration back for all
cases, so update the parameter to migrate_vm_back that already
exists in base.cfg.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
