### PR TITLE
Remove incorrect skip aarch64 cases

### DIFF
--- a/libvirt/tests/cfg/virtual_device/sound_device.cfg
+++ b/libvirt/tests/cfg/virtual_device/sound_device.cfg
@@ -11,13 +11,13 @@
             codec_type = micro
     variants:
         - sound_model_ac97:
-            no pseries, aarch64
+            no pseries
             sound_model = ac97
         - sound_model_ich6:
-            no pseries, aarch64
+            no pseries
             sound_model = ich6
         - sound_model_ich9:
-            no pseries, aarch64
+            no pseries
             sound_model = ich9
     variants:
         - positive_test:

--- a/libvirt/tests/cfg/virtual_device/watchdog.cfg
+++ b/libvirt/tests/cfg/virtual_device/watchdog.cfg
@@ -4,7 +4,7 @@
     take_regular_screendumps = "no"
     variants:
         - model_i6300esb:
-            no pseries, s390x, aarch64
+            no pseries, s390x
             model = "i6300esb"
             variants:
                 - model_test:


### PR DESCRIPTION
Some virtual devices are not supported by RHEL qemu-kvm but upstream
qemu-system-aarch64 (I checked on qemu-4.2.0-7.fc32) supports them.

So skip these cases on tp-libvirt upstream is incorrect, remove these
incorrect skip cases.

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>
