### PR TITLE
migration: Add a tls related case

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_storage.cfg
+++ b/libvirt/tests/cfg/migration/migrate_storage.cfg
@@ -29,4 +29,9 @@
                     cancel_migration = "yes"
                     status_error = "yes"
                     migrate_again = "yes"
-
+                - inconsistent_cn_server:
+                    only copy_storage_all
+                    status_error = "yes"
+                    server_info_ip = ""
+                    virsh_migrate_extra = "--tls --migrateuri tcp://${migrate_dest_host}"
+                    err_msg = "Certificate does not match the hostname"

--- a/libvirt/tests/src/migration/migrate_storage.py
+++ b/libvirt/tests/src/migration/migrate_storage.py
@@ -22,6 +22,8 @@ def run(test, params, env):
     TLS encryption - NBD transport
     2) Cancel storage migration with TLS encryption
     3) Copy only the top image for storage migration with backing chain
+    4) Migrate vm with copy storage - Native TLS(--tls) - inconsistent CN and
+        server hostname
 
     :param test: test object
     :param params: Dictionary with the test parameters


### PR DESCRIPTION
This PR adds below case:
RHEL-196406 - Migrate vm with copy storage - Native TLS(--tls)
- inconsistent CN and server hostname

depends on: https://github.com/avocado-framework/avocado-vt/pull/2941

Signed-off-by: Yingshun Cui <yicui@redhat.com>
