### PR TITLE
v2v: fix incorrect parameter counts in test.error

### DIFF
--- a/v2v/tests/src/function_test_xen.py
+++ b/v2v/tests/src/function_test_xen.py
@@ -303,7 +303,7 @@ def run(test, params, env):
         virsh_instance = utils_v2v.wait_for(virsh.VirshPersistent, **virsh_dargs)
         logging.debug('A new virsh session %s was created', virsh_instance)
         if not utils_v2v.wait_for(virsh_instance.domain_exists, name=vm_name):
-            test.error('VM %s not exists', vm_name)
+            test.error('VM %s not exists' % vm_name)
 
         if checkpoint in bk_list:
             bk_xml = vm_xml.VMXML.new_from_inactive_dumpxml(

--- a/v2v/tests/src/specific_kvm.py
+++ b/v2v/tests/src/specific_kvm.py
@@ -569,7 +569,7 @@ def run(test, params, env):
             vm.shutdown()
             logging.info('%s is down' % vm_name)
         except Exception as e:
-            test.error('Bootup guest and login failed: %s', str(e))
+            test.error('Bootup guest and login failed: %s' % str(e))
 
     def check_result(result, status_error):
         """


### PR DESCRIPTION
The ',' should be '%' in test.error.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>