### PR TITLE
v2v: fix error comparing string in xen cfg file

### DIFF
--- a/v2v/tests/cfg/function_test_xen.cfg
+++ b/v2v/tests/cfg/function_test_xen.cfg
@@ -154,7 +154,7 @@
                     variants:
                         - unset:
                             checkpoint += 'unset'
-                            missing = 'Red Hat VirtIO SCSI,Red Hat VirtIO Ethernet Adapte,QXL'
+                            missing = 'Red Hat VirtIO SCSI,Red Hat VirtIO Ethernet Adapte,Red Hat QXL GPU'
                         - custom:
                             checkpoint += 'custom'
                         - iso_mount:


### PR DESCRIPTION
The matching string in expected result should be updated in
case function_test_xen..unset.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>
