### PR TITLE
v2v: fix getting qemu-ga service failure in rhel6 guest

### DIFF
--- a/v2v/tests/src/function_test_esx.py
+++ b/v2v/tests/src/function_test_esx.py
@@ -335,7 +335,7 @@ def run(test, params, env):
 
         # Check the service status of qemu-guest-agent in VM
         status_ptn = r'Active: active \(running\)|qemu-ga \(pid +[0-9]+\) is running'
-        cmd = 'service qemu-ga* status;systemctl status qemu-guest-agent;systemctl status qemu-ga*'
+        cmd = 'service qemu-ga status;systemctl status qemu-guest-agent;systemctl status qemu-ga*'
         _, output = vmcheck.run_cmd(cmd)
 
         if not re.search(status_ptn, output):


### PR DESCRIPTION
In rhel6, the service name must not include wildcard, such as
'service qemu-ga* status', it will not work.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>