### PR TITLE
Add case to validate disk cluster size set

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_disk.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_disk.cfg
@@ -32,6 +32,11 @@
                         - disk_only:
                             only memory_none
                             snapshot_options = "--disk-only"
+                        - disk_cluster_size_set:
+                            only no_delete..positive_test.no_pool..attach_img_qcow2..snapshot_from_xml..disk_external..disk_cluster_size_set..memory_none
+                            snapshot_options = "--disk-only"
+                            disk_cluster_size_set = "yes"
+                            image_cluster_size = "1024"
         - snapshot_default:
             snapshot_from_xml = "no"
             variants:


### PR DESCRIPTION
RHEL-196449:Snapshot and backing file share the same cluster size

Signed-off-by: chunfuwen <chwen@redhat.com>
