### PR TITLE
Add cases for schedinfo

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_schedinfo_qemu_posix.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_schedinfo_qemu_posix.cfg
@@ -14,99 +14,136 @@
             variants:
                 - valid_domname:
                     schedinfo_vm_ref = domname
-                - valid_domid:
-                    schedinfo_vm_ref = domid
                 - valid_domuuid:
+                    only set_cpu_shares,show_schedinfo
                     schedinfo_vm_ref = domuuid
+            variants:
+                - set_by_self:
+                - set_by_cmd:
+                    schedinfo_set_method = 'cmd'
+                    variants:
+                        - config:
+                            only set_cpu_shares..set_by_cmd
+                            schedinfo_options_suffix = "--config"
+                        - live:
+                            schedinfo_options_suffix = "--live"
+                - set_by_xml:
+                    schedinfo_set_method = 'xml'
+            variants:
+                - for_show:
+                - for_multi:
+                - for_quota:
+                    variants:
+                        - value_negative:
+                            schedinfo_set_value = -1
+                            schedinfo_set_value_expected = -1
+                        - value_zero:
+                            schedinfo_set_value = 0
+                            schedinfo_set_value_expected = -1
+                        - value_min:
+                            schedinfo_set_value = 1000
+                            schedinfo_set_value_expected = 1000
+                        - value_normal:
+                            schedinfo_set_value = 80000
+                            schedinfo_set_value_expected = 80000
+                        - value_max:
+                            schedinfo_set_value = 17592186044415
+                            schedinfo_set_value_expected = 17592186044415
+                            libvirt_ver_function_changed = [6, 0, 0]
+                            schedinfo_set_value_bk = 18446744073709551
+                            schedinfo_set_value_expected_bk = 18446744073709551
+                - for_period:
+                    variants:
+                        - value_zero:
+                            schedinfo_set_value = 0
+                            schedinfo_set_value_expected = 100000
+                        - value_min:
+                            schedinfo_set_value = 1000
+                            schedinfo_set_value_expected = 1000
+                        - value_normal:
+                            schedinfo_set_value = 10000
+                            schedinfo_set_value_expected = 10000
+                        - value_max:
+                            schedinfo_set_value = 1000000
+                            schedinfo_set_value_expected = 1000000
+                - for_cpushare:
+                    variants:
+                        - value_min:
+                            schedinfo_set_value = 2
+                            schedinfo_set_value_expected = 2
+                        - value_normal:
+                            schedinfo_set_value = 512
+                            schedinfo_set_value_expected = 512
+                        - value_maximum:
+                            schedinfo_set_value = 262144
+                            schedinfo_set_value_expected = 262144
             variants:
                 # Do not set, just show the parameters
                 - show_schedinfo:
+                    only set_by_self..for_show
                 - set_multi_params:
                     only valid_domname
+                    only set_by_self..for_multi
                     schedinfo_set_ref = "vcpu_quota,vcpu_period,emulator_period,emulator_quota"
                     schedinfo_set_method = 'cmd'
                     schedinfo_set_value = "-1,100001,900002,-1"
                     schedinfo_set_value_expected = "-1,100001,900002,-1"
                 - set_cpu_param:
-                    variants:
-                        - set_by_cmd:
-                            schedinfo_set_method = 'cmd'
-                            variants:
-                                - config:
-                                    schedinfo_options_suffix = "--config"
-                                - live:
-                                    schedinfo_options_suffix = "--live"
-                                - current:
-                                    schedinfo_options_suffix = "--current"
-                        - set_by_xml:
-                            # When set 'shares' to 0 by XML, the tests will FAIL if
-                            # tested version of libvirt don't have a fix for a known bug:
-                            # https://bugzilla.redhat.com/show_bug.cgi?id=1040784
-                            schedinfo_set_method = 'xml'
+                    no set_by_self
                     schedinfo_param = "vcpu"
                     variants:
-                        # The cpu_shares parameter has a valid value range of 0-262144.
-                        # Negative values are wrapped to positive,
-                        # and larger values are capped at the maximum.
-                        # Therefore -1 is a useful shorthand for 262144.
-                        # On the Linux kernel, the values 0 and 1 are automatically
-                        # converted to a minimal value of 2.
                         - set_cpu_shares:
+                            only for_cpushare
                             schedinfo_set_ref = cpu_shares
                             # The filename in cgroup for cpu_shares
                             schedinfo_cgroup_ref = cpu.shares
-                            variants:
-                                - value_negative:
-                                    schedinfo_set_value = -1
-                                    schedinfo_set_value_expected = 262144
-                                - value_zero:
-                                    schedinfo_set_value = 0
-                                    schedinfo_set_value_expected = 2
-                                - value_normal:
-                                    schedinfo_set_value = 512
-                                    schedinfo_set_value_expected = 512
-                                - value_maximum:
-                                    schedinfo_set_value = 262144
-                                    schedinfo_set_value_expected = 262144
-                                - value_exceed:
-                                    schedinfo_set_value = 262145
-                                    schedinfo_set_value_expected = 262144
+                        - set_vcpu_period:
+                            only for_period
+                            schedinfo_set_ref = vcpu_period
+                            # The filename in cgroup for vcpu_period
+                            schedinfo_cgroup_ref = cpu.cfs_period_us
+                        - set_vcpu_quota:
+                            only for_quota
+                            schedinfo_set_ref = vcpu_quota
+                            schedinfo_cgroup_ref = cpu.cfs_quota_us
                 - set_emulator_param:
                     no lxc
+                    no set_by_self
                     schedinfo_param = "emulator"
                     variants:
                         - set_emulator_period:
+                            only for_period
                             schedinfo_set_ref = "emulator_period"
                             schedinfo_cgroup_ref = "cpu.cfs_period_us"
-                            variants:
-                                - value_normal:
-                                    schedinfo_set_value = 10000
-                                    schedinfo_set_value_expected = 10000
-                                - value_min:
-                                    schedinfo_set_value = 1000
-                                    schedinfo_set_value_expected = 1000
-                                - value_max:
-                                    schedinfo_set_value = 1000000
-                                    schedinfo_set_value_expected = 1000000
                         - set_emulator_quota:
+                            only for_quota
                             schedinfo_set_ref = "emulator_quota"
                             schedinfo_cgroup_ref = "cpu.cfs_quota_us"
-                            variants:
-                                - value_negative:
-                                    schedinfo_set_value = -1
-                                    schedinfo_set_value_expected = -1
-                                - value_normal:
-                                    schedinfo_set_value = 10000
-                                    schedinfo_set_value_expected = 10000
-                                - value_min:
-                                    schedinfo_set_value = 1000
-                                    schedinfo_set_value_expected = 1000
-                                - value_max:
-                                    schedinfo_set_value = 17592186044415
-                                    schedinfo_set_value_expected = 17592186044415
-                                    libvirt_ver_function_changed = [6, 0, 0]
-                                    schedinfo_set_value_bk = 18446744073709551
-                                    schedinfo_set_value_expected_bk = 18446744073709551
+                - set_global_param:
+                    no set_by_self
+                    schedinfo_param = "global"
+                    variants:
+                        - set_global_period:
+                            only for_period
+                            schedinfo_set_ref = "global_period"
+                            schedinfo_cgroup_ref = "cpu.cfs_period_us"
+                        - set_global_quota:
+                            only for_quota
+                            schedinfo_set_ref = "global_quota"
+                            schedinfo_cgroup_ref = "cpu.cfs_quota_us"
+                - set_iothread_param:
+                    no set_by_self
+                    schedinfo_param = "iothread"
+                    variants:
+                        - set_iothread_period:
+                            only for_period
+                            schedinfo_set_ref = "iothread_period"
+                            schedinfo_cgroup_ref = "cpu.cfs_period_us"
+                        - set_iothread_quota:
+                            only for_quota
+                            schedinfo_set_ref = "iothread_quota"
+                            schedinfo_cgroup_ref = "cpu.cfs_quota_us"
+
         # TODO: to support more parameters
         - error_test:
             status_error = yes


### PR DESCRIPTION
This is to verify 'virsh schedinfo vm <options>' using below options and different values and
compare to cgroup files.

- vcpu_period/vcpu_quota
- emulator_period/emulator_quota
- global_period/global_quota
- iothread_period/iothread_quota
Case ID:  RHEL-114504 RHEL-115015

And this patch also removes some unnecessary test cases after confirming with feature owner,
such as
 - cpu.share will not accept 0 and negative value any more
 - --current cases
 - domid cases

Signed-off-by: Dan Zheng <dzheng@redhat.com>