### PR TITLE
[virtio-transitional][s390x] add no filter on s390x

### DIFF
--- a/libvirt/tests/cfg/virtio_transitional/virtio_transitional_blk.cfg
+++ b/libvirt/tests/cfg/virtio_transitional/virtio_transitional_blk.cfg
@@ -10,9 +10,11 @@
             virtio_model = "virtio"
             controller_model = "virtio-scsi"
         - virtio_transitional:
+            no s390-virtio
             virtio_model = "virtio-transitional"
             controller_model = ${virtio_model}
         - virtio_non_transitional:
+            no s390-virtio
             virtio_model = "virtio-non-transitional"
     variants:
         - boot_test:

--- a/libvirt/tests/cfg/virtio_transitional/virtio_transitional_blk_negative.cfg
+++ b/libvirt/tests/cfg/virtio_transitional/virtio_transitional_blk_negative.cfg
@@ -10,6 +10,7 @@
                 - virtio:
                     disk_model = "virtio"
                 - virtio_non_transitional:
+                    no s390-virtio
                     disk_model = "virtio-non-transitional"
                 - invalid_model:
                     status_error = undefinable
@@ -24,6 +25,7 @@
                 - virtio_scsi_model:
                     controller_model = "virtio-scsi"
                 - virtio_non_transitional:
+                    no s390-virtio
                     controller_model = "virtio-non-transitional"
                 - invalid_model:
                     status_error = undefinable

--- a/libvirt/tests/cfg/virtio_transitional/virtio_transitional_mem_balloon.cfg
+++ b/libvirt/tests/cfg/virtio_transitional/virtio_transitional_mem_balloon.cfg
@@ -6,8 +6,10 @@
         - virtio:
             virtio_model = "virtio"
         - virtio_transitional:
+            no s390-virtio
             virtio_model = "virtio-transitional"
         - virtio_non_transitional:
+            no s390-virtio
             virtio_model = "virtio-non-transitional"
     variants:
         - @default:

--- a/libvirt/tests/cfg/virtio_transitional/virtio_transitional_nic.cfg
+++ b/libvirt/tests/cfg/virtio_transitional/virtio_transitional_nic.cfg
@@ -19,8 +19,10 @@
         - virtio:
             virtio_model = "virtio"
         - virtio_transitional:
+            no s390-virtio
             virtio_model = "virtio-transitional"
         - virtio_non_transitional:
+            no s390-virtio
             virtio_model = "virtio-non-transitional"
     variants:
         - @default:

--- a/libvirt/tests/cfg/virtio_transitional/virtio_transitional_rng.cfg
+++ b/libvirt/tests/cfg/virtio_transitional/virtio_transitional_rng.cfg
@@ -6,8 +6,10 @@
         - virtio:
             virtio_model = "virtio"
         - virtio_transitional:
+            no s390-virtio
             virtio_model = "virtio-transitional"
         - virtio_non_transitional:
+            no s390-virtio
             virtio_model = "virtio-non-transitional"
     variants:
         - boot_test:

--- a/libvirt/tests/cfg/virtio_transitional/virtio_transitional_serial.cfg
+++ b/libvirt/tests/cfg/virtio_transitional/virtio_transitional_serial.cfg
@@ -15,4 +15,5 @@
         - virtio:
             virtio_model = "virtio"
         - virtio_transitional:
+            no s390-virtio
             virtio_model = "virtio-transitional"

--- a/libvirt/tests/cfg/virtio_transitional/virtio_transitional_vsock.cfg
+++ b/libvirt/tests/cfg/virtio_transitional/virtio_transitional_vsock.cfg
@@ -8,8 +8,10 @@
         - virtio:
             virtio_model = "virtio"
         - virtio_transitional:
+            no s390-virtio
             virtio_model = "virtio-transitional"
         - virtio_non_transitional:
+            no s390-virtio
             virtio_model = "virtio-non-transitional"
     variants:
         - boot_test:


### PR DESCRIPTION
On s390x all disks (and more generally most devices) are
attached not as PCI but as CCW. Virtio (non-)transitional is PCI-only.

Therefore, filter out those test cases for s390x.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>
