### PR TITLE
remote_with_unix: Fix the regex issue of unix connection test

### DIFF
--- a/libvirt/tests/cfg/remote_access/remote_with_unix.cfg
+++ b/libvirt/tests/cfg/remote_access/remote_with_unix.cfg
@@ -28,7 +28,7 @@
                 - default_config_and_start_vm:
                     virsh_cmd = "start"
                     main_vm = "avocado-vt-vm1"
-                    patterns_virsh_cmd = ".*Domain\s*${main_vm}\s*started\s*.*"
+                    patterns_virsh_cmd = ".*Domain\s*\'?${main_vm}\'?\s*started\s*.*"
                 - allow_sasl_krb_user:
                     auth_unix_rw = "sasl"
                     sasl_type = "gssapi"


### PR DESCRIPTION
The guest name returned by virsh cmds has been added with quote marks
now. Need to fix it to avoid regex failure.

Signed-off-by: Lily Zhu <lizhu@redhat.com>