### PR TITLE
controller_functional: remove multifunction test case for s390x

### DIFF
--- a/libvirt/tests/cfg/controller/controller_functional.cfg
+++ b/libvirt/tests/cfg/controller/controller_functional.cfg
@@ -146,6 +146,7 @@
                     cmd_in_guest = "[{'cat /sys/devices/pci0000\:64/**/numa_node': '1'},{'cat /sys/devices/pci0000\:c8/**/numa_node': '0'}]"
                 - scsi_multifunc:
                     no i440fx
+                    no s390-virtio
                     remove_contr = "no"
                     controller_type = scsi
                     controller_model = virtio-scsi


### PR DESCRIPTION
Multifunction is PCI related. On s390x SCSI works over channel system
that doesn't have this concept. Filter those test cases out.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>