### PR TITLE
remote_with_unix: Complete fix the regex issue of unix connection test

### DIFF
--- a/libvirt/tests/cfg/remote_access/remote_with_unix.cfg
+++ b/libvirt/tests/cfg/remote_access/remote_with_unix.cfg
@@ -70,7 +70,7 @@
                     deluser_cmd = "userdel -r ${su_user}"
                     main_vm = "avocado-vt-vm1"
                     virsh_cmd = "start"
-                    patterns_virsh_cmd = ".*Domain\s*${main_vm}\s*started\s*.*"
+                    patterns_virsh_cmd = ".*Domain\s*\'?${main_vm}\'?\s*started\s*.*"
                     polkit_pkla = "/etc/polkit-1/localauthority/50-local.d/polkit.pkla"
                     polkit_pkla_cxt = "[Allow ${su_user} libvirt management permissions]\nIdentity=unix-user:${su_user}\nAction=org.libvirt.unix.manage\nResultAny=yes\nResultInactive=yes\nResultActive=yes"
                     action_id = "org.libvirt.api.domain.start"
@@ -84,7 +84,7 @@
                     deluser_cmd = "userdel -r ${su_user}"
                     main_vm = "avocado-vt-vm1"
                     virsh_cmd = "start"
-                    patterns_virsh_cmd = ".*Domain\s*${main_vm}\s*started\s*.*"
+                    patterns_virsh_cmd = ".*Domain\s*\'?${main_vm}\'?\s*started\s*.*"
                     polkit_pkla = "/etc/polkit-1/localauthority/50-local.d/polkit.pkla"
                     polkit_pkla_cxt = "[Allow ${su_user} libvirt management permissions]\nIdentity=unix-user:${su_user}\nAction=org.libvirt.unix.manage\nResultAny=yes\nResultInactive=yes\nResultActive=yes"
         - negative_testing:
@@ -107,7 +107,7 @@
                     read_only = "-r"
                     virsh_cmd = "start"
                     main_vm = "avocado-vt-vm1"
-                    patterns_virsh_cmd = ".*Domain\s*${main_vm}\s*started\s*.*"
+                    patterns_virsh_cmd = ".*Domain\s\'?*${main_vm}\'?\s*started\s*.*"
                 - readonly_without_auth:
                     read_only = "-r"
                     virsh_cmd = "start"


### PR DESCRIPTION
The guest name returned by virsh cmds has been added with quote marks
now. Need to fix it to avoid regex failure.

Signed-off-by: Lily Zhu <lizhu@redhat.com>

