### PR TITLE
[libvirt_ap_passthrough] Unload module at teardown

### DIFF
--- a/libvirt/tests/src/svirt/libvirt_ap_passthrough.py
+++ b/libvirt/tests/src/svirt/libvirt_ap_passthrough.py
@@ -16,7 +16,7 @@ import logging
 
 from virttest import virsh
 from virttest.utils_zcrypt import CryptoDeviceInfoBuilder, \
-    APMaskHelper, MatrixDevice, load_vfio_ap
+    APMaskHelper, MatrixDevice, load_vfio_ap, unload_vfio_ap
 from virttest.libvirt_xml.vm_xml import VMXML
 from virttest.libvirt_xml.devices import hostdev
 from virttest.utils_misc import wait_for
@@ -97,3 +97,4 @@ def run(test, params, env):
             matrix_dev.unassign_all()
         if mask_helper:
             mask_helper.return_to_host_all()
+        unload_vfio_ap()


### PR DESCRIPTION
Depends on https://github.com/avocado-framework/avocado-vt/pull/2925

The test case loads the vfio_ap module. This would block
reloading the kvm module later.

Unload the vfio_ap module at teardown.

Tested via:
1. lsmod|grep vfio_ap >> empty
2. avocado run --vt-type libvirt --vt-machine-type s390-virtio libvirt_ap_passthrough.hotplug --vt-connect-uri qemu:///system
3. lsmod|grep vfio_ap >> empty

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>
