### PR TITLE
virsh_guestinfo: Test cleanup fix

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_guestinfo.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_guestinfo.py
@@ -154,6 +154,9 @@ def run(test, params, env):
         test.cancel("Guestinfo command is not supported before version libvirt-6.0.0 ")
     import dateutil.parser
 
+    added_user_session = None
+    root_session = None
+
     try:
         vm = env.get_vm(vm_name)
         if start_ga and prepare_channel:
@@ -201,7 +204,9 @@ def run(test, params, env):
                                   "is not correct." % option[2:])
     finally:
         if "user" in option:
-            added_user_session.close()
-            root_session.cmd('userdel -f %s' % added_user_name)
-            root_session.close()
+            if added_user_session:
+                added_user_session.close()
+            if root_session:
+                root_session.cmd('userdel -f %s' % added_user_name)
+                root_session.close()
         vm.destroy()


### PR DESCRIPTION
When the test failed during the execution of test, some variables might remain
unreferenced and therefore this fix is adding their initialization prior the
try, except finally statement to make sure they are existing during cleanup.

Signed-off-by: Kamil Varga <kvarga@redhat.com>