### PR TITLE
v2v: add a new case about vmx file without fileName

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -439,6 +439,9 @@
             main_vm = VM_NAME_RHEL7_V2V_EXAMPLE
             cmd_has_ip = 'no'
             interaction_run = 'yes'
+        - vmx_filename:
+            only esx_67
+            main_vm = VM_NAME_VMX_FILENAME_OPTIONAL_V2V_EXAMPLE
         - luks:
             only esx_67
             interaction_run = 'yes'


### PR DESCRIPTION
Add a new case about vmware vmx file without fileName setting.
See: bz#1815269

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>