### PR TITLE
v2v: add a new checkpoint for vmx -it ssh (-T)

### DIFF
--- a/v2v/tests/cfg/convert_from_file.cfg
+++ b/v2v/tests/cfg/convert_from_file.cfg
@@ -143,8 +143,11 @@
                             input_transport = 'ssh'
                             variants:
                                 - latest8:
+                                    v2v_debug = force_on
                                     only esx_67
                                     main_vm = 'VM_NAME_RHEL8_V2V_EXAMPLE'
+                                    msg_content = 'scp -T'
+                                    expect_msg = yes
                                 - latest7:
                                     only esx_67
                                     main_vm = 'VM_NAME_RHEL7_V2V_EXAMPLE'

--- a/v2v/tests/src/convert_from_file.py
+++ b/v2v/tests/src/convert_from_file.py
@@ -71,7 +71,8 @@ def run(test, params, env):
     vpx_hostname = params.get("vpx_hostname")
     vpx_password = params.get("vpx_password")
     src_uri_type = params.get('src_uri_type')
-    v2v_opts = '-v -x' if params.get('v2v_debug', 'on') == 'on' else ''
+    v2v_opts = '-v -x' if params.get('v2v_debug',
+                                     'on') in ['on', 'force_on'] else ''
     if params.get('v2v_opts'):
         # Add a blank by force
         v2v_opts += ' ' + params.get("v2v_opts")


### PR DESCRIPTION
Add a new checkpoint for '-i vmx -it ssh', verify '-T' option is enabled.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>