### PR TITLE
virtual_disks_multidisks: expect to attach successfully on aarch64

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
@@ -671,6 +671,7 @@
                             virt_disk_device_bus = "scsi"
                             disks_attach_error = "no"
                         aarch64:
+                            disks_attach_error = "no"
                             virt_disk_device_bus = "scsi"
                             virt_disk_device_target = "sda"
                 - disk_cdrom_update_boot_order:


### PR DESCRIPTION
Signed-off-by: Li Zhijian <lizhijian@fujitsu.com>

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [ ] Description of the cases
- [ ] Links of libvirt features, libvirt bugs or case IDs
- [ ] Test results

## If the PR is bug cases
- [ ] Bug descriptions or bug links
- [x] Test results

## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
