### PR TITLE
virtual_disks_multidisks: Fix: unsupported configuration: ACPI requires UEFI on this architecture

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
@@ -1333,6 +1333,14 @@ def run(test, params, env):
                     osxml.bios_useserial = "yes"
                     if utils_misc.compare_qemu_version(4, 0, 0, False):
                         osxml.bios_reboot_timeout = "-1"
+
+                if vmxml.xmltreefile.find('features'):
+                    vmxml_feature = vmxml.features
+                    if vmxml_feature.has_feature('acpi') and 'aarch64' in arch:
+                        osxml.loader = vmxml.os.loader
+                        osxml.loader_readonly = vmxml.os.loader_readonly
+                        osxml.loader_type = vmxml.os.loader_type
+
                 del vmxml.os
                 vmxml.os = osxml
             driver_dict = {"name": disk.driver["name"],


### PR DESCRIPTION


keep the origin loader/loader_readonly/loader_type if vmx has acpi
feature

Signed-off-by: Li Zhijian <lizhijian@fujitsu.com>

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [ ] Description of the cases
- [ ] Links of libvirt features, libvirt bugs or case IDs
- [ ] Test results

## If the PR is bug cases
- [ ] Bug descriptions or bug links
- [ ] Test results

## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
