### PR TITLE
virtual_network: fix mtu UnboundLocalError

### DIFF
--- a/libvirt/tests/src/virtual_network/mtu.py
+++ b/libvirt/tests/src/virtual_network/mtu.py
@@ -173,8 +173,8 @@ def run(test, params, env):
         bk_netxml = NetworkXML.new_from_net_dumpxml(DEFAULT_NET)
         if add_pkg:
             add_pkg = add_pkg.split()
+            new_pkg = add_pkg.copy()
             if 'openvswitch' in add_pkg and shutil.which('ovs-vsctl'):
-                new_pkg = add_pkg.copy()
                 new_pkg.remove('openvswitch')
             utils_package.package_install(new_pkg)
         if 'openvswitch' in add_pkg:


### PR DESCRIPTION
Fix the following issue
```
2021-03-23 22:35:35,294 stacktrace       L0045 ERROR| Traceback (most recent call last):
2021-03-23 22:35:35,295 stacktrace       L0045 ERROR|   File "/var/lib/avocado/data/avocado-vt/virttest/test-providers.d/downloads/io-github-autotest-libvirt/libvirt/tests/src/virtual_networ
k/mtu.py", line 179, in run
2021-03-23 22:35:35,295 stacktrace       L0045 ERROR|     utils_package.package_install(new_pkg)
2021-03-23 22:35:35,295 stacktrace       L0045 ERROR| UnboundLocalError: local variable 'new_pkg' referenced before assignment
```
Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Before this fix
```
# avocado run --vt-type libvirt --vt-machine-type arm64-mmio virtual_network.mtu.positive_test.normal.ovswitch.iface
JOB ID     : 53814485585d082c888b7a86e75e478e50e912e9
JOB LOG    : /root/avocado/job-results/job-2021-03-23T23.55-5381448/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.mtu.positive_test.normal.ovswitch.iface: ERROR: local variable 'br' referenced before assignment (8.48 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 9.16 s

2021-03-23 23:55:19,687 stacktrace       L0045 ERROR| Traceback (most recent call last):
2021-03-23 23:55:19,687 stacktrace       L0045 ERROR|   File "/var/lib/avocado/data/avocado-vt/virttest/test-providers.d/downloads/io-github-autotest-libvirt/libvirt/tests/src/virtual_networ
k/mtu.py", line 179, in run
2021-03-23 23:55:19,687 stacktrace       L0045 ERROR|     utils_package.package_install(new_pkg)
2021-03-23 23:55:19,688 stacktrace       L0045 ERROR| UnboundLocalError: local variable 'new_pkg' referenced before assignment
```
After this fix
```
# avocado run --vt-type libvirt --vt-machine-type arm64-mmio virtual_network.mtu.positive_test.normal.ovswitch.iface
JOB ID     : 908c3a7f3d5da9a4c4f9ffc337bfb721625d0fe4
JOB LOG    : /root/avocado/job-results/job-2021-03-23T23.48-908c3a7/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.mtu.positive_test.normal.ovswitch.iface: PASS (57.65 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 58.30 s
```
