### PR TITLE
Add case to pin all cpu

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_emulatorpin.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_emulatorpin.cfg
@@ -67,6 +67,11 @@
                                         - ranges:
                                             no ppc64, ppc64le
                                             emulatorpin_cpulist = "x-y"
+                                            variants:
+                                                - @default:
+                                                - all_cpus:
+                                                    only live
+                                                    all_cpuset = "yes"
                                         - excluding:
                                             no ppc64, ppc64le
                                             emulatorpin_cpulist = "x-y,^z"
@@ -118,7 +123,13 @@
                                         - single:
                                             emulatorpin_cpulist = x
                                         - noexist:
-                                            emulatorpin_cpulist = 0-123456
+                                            emulatorpin_cpulist = "noexist"
+                                            variants:
+                                                - set_by_cmd:
+                                                    err_msg = 'CPU.*in cpulist.*exceed the maxcpu'
+                                                - set_by_xml:
+                                                    set_emulatorpin_by_xml = "yes"
+                                                    err_msg = 'cannot set CPU affinity on process.*: Invalid argument'
                                     variants:
                                         - emulatorpin_options:
                                             variants:


### PR DESCRIPTION

    Test case: RHEL-114425
    Test scenario:
    - Set emulatorpin to subset of host cpus
    - Check the emulatorpin result and cgroup result
    - Set emulatorpin to all of host cpus
    - Check result again
    
    Test case: RHEL7-63519
    Test scenario:
    - Set emulatorpin to non-exist host cpu via virsh command
    - Set emulatorpin to non-exist host cpu via vm xml
    

Signed-off-by: Dan Zheng <dzheng@redhat.com>