### PR TITLE
Add wait for writing file success before return

### DIFF
--- a/libvirt/tests/src/virtual_network/mtu.py
+++ b/libvirt/tests/src/virtual_network/mtu.py
@@ -108,6 +108,7 @@ def run(test, params, env):
         if 'mtu' in kwargs:
             m_net.mtu = kwargs['mtu']
         logging.debug(m_net)
+        libvirt.wait_for_file_over("</network>", m_net.xml)
         return m_net.xml
 
     def create_iface(iface_type, **kwargs):


### PR DESCRIPTION
Signed-off-by: Kyla Zhang <weizhan@redhat.com>

depends on https://github.com/avocado-framework/avocado-vt/pull/2973
```
# avocado run --vt-type libvirt virtual_network.mtu.negative_test.not_support.network.net_define.macvtap_type
JOB ID     : 09ddbd90e9fe39f807850e241e0f9b53336709af
JOB LOG    : /root/avocado/job-results/job-2021-03-24T07.57-09ddbd9/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.mtu.negative_test.not_support.network.net_define.macvtap_type: PASS (6.07 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 7.58 s

# avocado run --vt-type libvirt virtual_network.mtu.negative_test.not_support.network.net_create.bridge_type
JOB ID     : 7809efd6fd3ae7db857cc850644c36c4ca632751
JOB LOG    : /root/avocado/job-results/job-2021-03-24T08.03-7809efd/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.mtu.negative_test.not_support.network.net_create.bridge_type: PASS (5.05 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 6.59 s
```
