### PR TITLE
virtual_disks_multidisks: Fix pci_bridge_controller error

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
@@ -986,6 +986,8 @@
                     virtio_scsi_controller_type = "pci"
                     virtio_scsi_controller_model = "pci-bridge"
                     virtio_scsi_controller_addr = "type=pci,bus=0x00,domain=0x0000,function=0x0,slot=0x0a"
+                    aarch64:
+                        new_iface_addr = "yes"
                 - disk_virtio_scsi_controller_multi_driver_sub_elements:
                     only coldplug
                     add_disk_driver = "virtio_scsi"


### PR DESCRIPTION
pci_bridge_controller failed due to below issue
```
XML error: Invalid PCI address 0000:01:00.0. slot must be >= 1
```

The root casue is the default iface still use slot 0x00
E.g.
```
    </controller><interface type="bridge">
      <mac address="52:54:00:dd:a8:1a" />
      <source bridge="virbr0" />
      <model type="virtio" />
      <address bus="0x01" domain="0x0000" function="0x0" slot="0x00" type="pci" />
    </interface><serial type="pty">
```

So when we test pci_bridge_controller, we need modify iface slot. Use
slot >= 1 to fix this error.

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Before this commit
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virtual_disks.multidisks.coldplug.single_disk_test.disk_virtio_pci_bridge_controller
JOB ID     : aa8eb84373e96b4741abf09e7a9336dde553ca03
JOB LOG    : /root/avocado/job-results/job-2021-03-24T21.31-aa8eb84/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_disks.multidisks.coldplug.single_disk_test.disk_virtio_pci_bridge_controller: FAIL: Failed to define VM:\nFailed to define avocado-vt-vm1 for reason:\nerror: Failed to define domain from /tmp/xml_utils_temp_0jjb3cnh.xml\nerror: XML error: Invalid PCI address 0000:01:00.0. slot must be >= 1\n (10.76 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 11.44 s
```
After this commit
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virtual_disks.multidisks.coldplug.single_disk_test.disk_virtio_pci_bridge_controller
JOB ID     : 3be325aaa17c9173c37d6c2dc207ca12cb701c43
JOB LOG    : /root/avocado/job-results/job-2021-03-24T22.11-3be325a/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_disks.multidisks.coldplug.single_disk_test.disk_virtio_pci_bridge_controller: PASS (50.61 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 51.35 s
```