### PR TITLE
virsh_boot: Update usb controller and loader path to the default

### DIFF
--- a/libvirt/tests/cfg/bios/virsh_boot.cfg
+++ b/libvirt/tests/cfg/bios/virsh_boot.cfg
@@ -171,7 +171,7 @@
                             check_prompt = "error:.*has invalid signature"
         - by_seabios:
             boot_type = "seabios"
-            loader = "/usr/share/seabios/bios.bin"
+            loader = "/usr/share/seabios/bios-256k.bin"
             loader_type = "rom"
             variants:
                 - positive_test:
@@ -208,7 +208,7 @@
                                                     source_protocol = "usb"
                                                     device_bus = "usb"
                                                     target_dev = "vda"
-                                                    usb_model = "ich9-ehci1,ich9-uhci1,ich9-uhci2,ich9-uhci3"
+                                                    usb_model = "qemu-xhci"
                                                     usb_index = "0"
                                                 - block_disk:
                                                     disk_type = "block"


### PR DESCRIPTION
virsh_boot: Update usb controller and loader path to the default

Signed-off-by: Meina Li <meili@redhat.com>