### PR TITLE
virtual_disks_multidisks: skip disk_virtio_pci_bridge_controller test on aarch64

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
@@ -973,6 +973,7 @@
                 - disk_virtio_pci_bridge_controller:
                     no q35
                     no s390-virtio
+                    no aarch64
                     virt_disk_device = "disk"
                     virt_disk_check_pci_bridge = "yes"
                     virt_disk_device_source = "disk1"


### PR DESCRIPTION
Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

disk_virtio_pci_bridge_controller is too old and has already been skipped on s390 and q35.
Skip it on aarch64 too. 
