### PR TITLE
remote_access:New case added for invalid transportation parameter.

### DIFF
--- a/libvirt/tests/cfg/remote_access/remote_with_ssh.cfg
+++ b/libvirt/tests/cfg/remote_access/remote_with_ssh.cfg
@@ -84,6 +84,9 @@
                     transport = "libssh2"
                 - ssh_no_uri_path:
                     uri_path = ""
+                - invalid_transport:
+                    inv_transport = "abc"
+                    error_pattern = "transport in URL not recognised"
                 - ssh_read_only_mode:
                     read_only = "-r"
                     virsh_cmd = "start"


### PR DESCRIPTION
New case added for invalid transportation parameter.
Case_description:
    Connect to the hypervisor over an invalid transportations, error tip should be properly given.
Introduced in:
    https://libvirt.org/uri.html
    https://libvirt.org/remote.html
Case_ID: 
    RHEL-174720
test_result: 
    <pre>avocado run --vt-type libvirt virsh.remote_with_ssh.negative_testing.invalid_transport
WARNING:root:No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
WARNING:root:No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
<font color="#2A7BDE">JOB ID     : 0b950558ea2023d7e53a2a6ca0232a62c8ecb718</font>
<font color="#2A7BDE">JOB LOG    : /root/avocado/job-results/job-2021-03-25T06.06-0b95055/job.log</font>
 (1/1) type_specific.io-github-autotest-libvirt.virsh.remote_with_ssh.negative_testing.invalid_transport: <font color="#33DA7A">PASS</font> (37.38 s)
<font color="#2A7BDE">RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0</font>
<font color="#2A7BDE">JOB TIME   : 38.82 s</font>
</pre>

Signed-off-by: Kamil Varga <kvarga@redhat.com>
