### PR TITLE
virsh_attach_detach_disk: Fix "No more PCI slots" error on aarch64

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_disk.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_disk.cfg
@@ -113,6 +113,8 @@
                 - twice_diff_target:
                     at_dt_disk_test_twice = 'yes'
                     at_dt_disk_device_target2 = vdx
+                    aarch64:
+                        add_more_pci_controllers = 'yes'
                 - twice_multifunction:
                     only attach_disk
                     qemu_file_lock = '2.9.0'
@@ -129,6 +131,8 @@
                     at_with_shareable = 'yes'
                     at_dt_disk_test_twice = 'yes'
                     at_dt_disk_device_target2 = vdx
+                    aarch64:
+                        add_more_pci_controllers = 'yes'
                 - twice_multifunction_with_shareable:
                     only attach_disk
                     at_with_shareable = 'yes'

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_device.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_device.cfg
@@ -42,6 +42,8 @@
             variants:
                 - hot_attach_hot_vm:
                     start_vm = "yes"
+                    aarch64:
+                        add_more_pci_controllers = "yes"
                     variants:
                         - persistent:
                             vadu_extra = "--persistent"
@@ -54,6 +56,8 @@
                     vadu_extra = "--current"
                     # Functional check should fail after rebooting
                     vadu_pstboot_function_error = "yes"
+                    aarch64:
+                        add_more_pci_controllers = "yes"
                 - cold_attach_cold_vm:
                     start_vm = "no"
                     vadu_config_option = "yes"


### PR DESCRIPTION
Before
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio \
> virsh.attach_detach_disk.attach_disk.normal_test.twice_diff_target \
> virsh.attach_detach_disk.attach_disk.normal_test.twice_diff_target_with_shareable
JOB ID     : 73e1bbe3209cbaaa5529ef6c5ec43d9f8f3a7cd3
JOB LOG    : /root/avocado/job-results/job-2021-03-26T02.52-73e1bbe/job.log
 (1/2) type_specific.io-github-autotest-libvirt.virsh.attach_detach_disk.attach_disk.normal_test.twice_diff_target: FAIL: virsh attach-disk failed. (61.29 s)
 (2/2) type_specific.io-github-autotest-libvirt.virsh.attach_detach_disk.attach_disk.normal_test.twice_diff_target_with_shareable: FAIL: virsh attach-disk failed. (65.05 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 2 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 127.13 s
```
After this commit
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio \
> virsh.attach_detach_disk.attach_disk.normal_test.twice_diff_target \
> virsh.attach_detach_disk.attach_disk.normal_test.twice_diff_target_with_shareable
JOB ID     : 5eff6200614916c91739232aa14dffbd54074da4
JOB LOG    : /root/avocado/job-results/job-2021-03-26T02.42-5eff620/job.log
 (1/2) type_specific.io-github-autotest-libvirt.virsh.attach_detach_disk.attach_disk.normal_test.twice_diff_target: PASS (67.23 s)
 (2/2) type_specific.io-github-autotest-libvirt.virsh.attach_detach_disk.attach_disk.normal_test.twice_diff_target_with_shareable: PASS (67.42 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 135.40 s
```