### PR TITLE
remote_access:Added a new case for the @KEYWORD specifier support in the libvirt.

### DIFF
--- a/libvirt/tests/cfg/remote_access/remote_with_tls.cfg
+++ b/libvirt/tests/cfg/remote_access/remote_with_tls.cfg
@@ -54,6 +54,9 @@
                             client_cn = "${ipv6_addr_src}"
                             server_ip = "${ipv6_addr_des}"
                 - default_tls_port_and_auth_tls:
+                - default_tls_priority_specifier:
+                    filter_pattern = "Setting priority string \'@LIBVIRT\,SYSTEM\'"
+                    log_level= "LIBVIRT_DEBUG=1"
                 - no_verify_certificate:
                     tls_verify_cert = "no"
                     # please change your configuration

--- a/libvirt/tests/src/remote_access/remote_access.py
+++ b/libvirt/tests/src/remote_access/remote_access.py
@@ -3,6 +3,7 @@ import os
 import logging
 import json
 
+from avocado.utils import distro
 from avocado.utils import process
 
 from virttest import remote
@@ -142,6 +143,14 @@ def run(test, params, env):
     """
 
     test_dict = dict(params)
+    pattern = test_dict.get("filter_pattern", "")
+    if ('@LIBVIRT' in pattern and
+            distro.detect().name == 'rhel' and
+            int(distro.detect().version) < 8):
+        test.cancel("The test {} is not supported on current OS({}{}<8.0) as "
+                    "the keyword @LIBVIRT is not supported by gnutls on this "
+                    "OS.".format(test.name, distro.detect().name,
+                                 distro.detect().version))
     vm_name = test_dict.get("main_vm")
     status_error = test_dict.get("status_error", "no")
     allowed_dn_str = params.get("tls_allowed_dn_list")


### PR DESCRIPTION
Signed-off-by: Kamil Varga <kvarga@redhat.com>

- Description of the case:
    RHEL-7 is the only system where gnutls is too old to support @LIBVIRT specifier
- Introduced in:
    https://libvirt.org/remote.html
Case_ID:
    RHEL-152181
- Test results:
    <pre>avocado run --vt-type libvirt virsh.remote_with_tls.positive_testing.default_tls_priority_specifier
WARNING:root:No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
WARNING:root:No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
<font color="#2A7BDE">JOB ID     : 8b5478e00978660aefd81005520ec92a65c4de52</font>
<font color="#2A7BDE">JOB LOG    : /root/avocado/job-results/job-2021-03-26T06.09-8b5478e/job.log</font>
 (1/1) type_specific.io-github-autotest-libvirt.virsh.remote_with_tls.positive_testing.default_tls_priority_specifier: <font color="#33DA7A">PASS</font> (128.44 s)
<font color="#2A7BDE">RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0</font>
<font color="#2A7BDE">JOB TIME   : 129.86 s</font></pre>