### PR TITLE
virsh_attach_detach_disk: Fix "No more PCI slots" error

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_disk.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_disk.cfg
@@ -113,6 +113,8 @@
                 - twice_diff_target:
                     at_dt_disk_test_twice = 'yes'
                     at_dt_disk_device_target2 = vdx
+                    aarch64:
+                        reset_pci_controllers_nums = 'yes'
                 - twice_multifunction:
                     only attach_disk
                     qemu_file_lock = '2.9.0'
@@ -129,6 +131,8 @@
                     at_with_shareable = 'yes'
                     at_dt_disk_test_twice = 'yes'
                     at_dt_disk_device_target2 = vdx
+                    aarch64:
+                        reset_pci_controllers_nums = 'yes'
                 - twice_multifunction_with_shareable:
                     only attach_disk
                     at_with_shareable = 'yes'

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk.py
@@ -14,6 +14,7 @@ from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 from virttest.staging.service import Factory
 from virttest.staging import lv_utils
+from virttest.utils_libvirt import libvirt_pcicontr
 from virttest import utils_disk
 from virttest import utils_misc
 from virttest import data_dir
@@ -255,6 +256,10 @@ def run(test, params, env):
                 q35_pcie_dict1.update({'controller_index': "%d" % i})
                 vm_dump_xml.add_device(libvirt.create_controller_xml(q35_pcie_dict1))
             vm_dump_xml.sync()
+
+    if params.get("reset_pci_controllers_nums", "no") == "yes" \
+            and 'attach-disk' in test_cmd:
+        libvirt_pcicontr.reset_pci_num(vm_name, 15)
 
     # if we are testing audit, we need to start audit servcie first.
     if test_audit:


### PR DESCRIPTION
Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Before
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio \
> virsh.attach_detach_disk.attach_disk.normal_test.twice_diff_target \
> virsh.attach_detach_disk.attach_disk.normal_test.twice_diff_target_with_shareable
JOB ID     : bb3e8143c3ccb32d139bc383fb9b6ff3e73525f4
JOB LOG    : /root/avocado/job-results/job-2021-03-29T04.54-bb3e814/job.log
 (1/2) type_specific.io-github-autotest-libvirt.virsh.attach_detach_disk.attach_disk.normal_test.twice_diff_target: FAIL: virsh attach-disk failed. (65.58 s)
 (2/2) type_specific.io-github-autotest-libvirt.virsh.attach_detach_disk.attach_disk.normal_test.twice_diff_target_with_shareable: FAIL: virsh attach-disk failed. (64.74 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 2 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 131.08 s
```
After this fix
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio \
> virsh.attach_detach_disk.attach_disk.normal_test.twice_diff_target \
> virsh.attach_detach_disk.attach_disk.normal_test.twice_diff_target_with_shareable
JOB ID     : 89075c2d100826ba595b556c51f7879b6b2ccc5f
JOB LOG    : /root/avocado/job-results/job-2021-03-29T04.46-89075c2/job.log
 (1/2) type_specific.io-github-autotest-libvirt.virsh.attach_detach_disk.attach_disk.normal_test.twice_diff_target: PASS (74.98 s)
 (2/2) type_specific.io-github-autotest-libvirt.virsh.attach_detach_disk.attach_disk.normal_test.twice_diff_target_with_shareable: PASS (75.13 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 150.83 s
```