### PR TITLE
migraion: refactor code to adopt MigrationTest/libvirt_migraion

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_over_unix.cfg
+++ b/libvirt/tests/cfg/migration/migrate_over_unix.cfg
@@ -43,13 +43,13 @@
                             no live_migration.with_postcopy
                             virsh_migrate_extra = "--migrateuri ${virsh_migrate_migrateuri} --bandwidth 50"
                             action_during_mig = "check_socket"
-                            func_params_exists = "yes"
+                            action_during_mig_params_exists = "yes"
                         - multifd:
                             only without_postcopy
                             only p2p_live_migration                    
                             virsh_migrate_extra = "--migrateuri ${virsh_migrate_migrateuri} --bandwidth 50 --parallel --parallel-connections 4"
                             action_during_mig = "check_socket"
-                            func_params_exists = "yes"
+                            action_during_mig_params_exists = "yes"
                             expected_socket_num = "6"
                         - tunnelled:
                             only without_postcopy
@@ -76,8 +76,8 @@
                     only p2p_live_migration
                     only without_postcopy
                     action_during_mig = "virsh.domjobabort"
-                    func_params_exists = "yes"
-                    func_params = "'%s' % vm_name"
+                    action_during_mig_params_exists = "yes"
+                    action_during_mig_params = "'%s' % params.get('migrate_main_vm')"
                     migrate_again = "yes"
                     migrate_again_status_error = "no"
                     migrate_again_clear_func = "yes"

--- a/libvirt/tests/cfg/migration/migrate_storage.cfg
+++ b/libvirt/tests/cfg/migration/migrate_storage.cfg
@@ -38,7 +38,7 @@
         - migrateuri:
             only copy_storage_all
             check_disks_port = "yes"
-            func_params_exists = "yes"
+            action_during_mig_params_exists = "yes"
             bandwidth_opt = "--bandwidth 200"
             variants:
                 - @default:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_copy_storage.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_copy_storage.cfg
@@ -29,6 +29,7 @@
         - error_test:
             # Migrate vm again after repairing the incorrect operation
             migrate_again = "yes"
+            status_error = "yes"
             variants:
                 - space_occupied:
                     abnormal_type = "occupied_disk"

--- a/libvirt/tests/src/migration/migrate_options_shared.py
+++ b/libvirt/tests/src/migration/migrate_options_shared.py
@@ -1083,7 +1083,9 @@ def run(test, params, env):
     cache = params.get("cache")
     remove_cache = "yes" == params.get("remove_cache", "no")
     err_msg = params.get("err_msg")
-
+    extra_args = {'func_params': params,
+                  'status_error': params.get("status_error", "no"),
+                  'err_msg': err_msg}
     arch = platform.machine()
     if any([hpt_resize, contrl_index, htm_state]) and 'ppc64' not in arch:
         test.cancel("The case is PPC only.")
@@ -1338,9 +1340,9 @@ def run(test, params, env):
             source_vm_host_time_diff = time_diff_between_vm_host(localvm=True)
 
         if extra.count("timeout-postcopy"):
-            func_name = check_timeout_postcopy
+            action_during_mig = check_timeout_postcopy
         if params.get("actions_during_migration"):
-            func_name = do_actions_during_migrate
+            action_during_mig = do_actions_during_migrate
         if extra.count("comp-xbzrle-cache"):
             cache = get_usable_compress_cache(memory.get_page_size())
             extra = "%s %s" % (extra, cache)
@@ -1394,8 +1396,8 @@ def run(test, params, env):
                 migration_test.do_migration(vms, None, dest_uri, 'orderly',
                                             options, thread_timeout=900,
                                             ignore_status=True, virsh_opt=virsh_opt,
-                                            func=func_name, extra_opts=extra,
-                                            func_params=params)
+                                            func=action_during_mig, extra_opts=extra,
+                                            **extra_args)
                 mig_result = migration_test.ret
             except exceptions.TestFail as fail_detail:
                 test.fail(fail_detail)
@@ -1406,8 +1408,6 @@ def run(test, params, env):
             except Exception as details:
                 mig_result = migration_test.ret
                 logging.error(details)
-
-        migration_test.check_result(mig_result, params)
 
         if add_channel:
             # Get the channel device source path of remote guest
@@ -1630,12 +1630,9 @@ def run(test, params, env):
                                                              cleanup=True)
 
             # Clean VM on destination
-            migration_test.cleanup_dest_vm(vm, vm.connect_uri, dest_uri)
+            migration_test.cleanup_vm(vm, dest_uri)
 
-            if vm.is_alive():
-                vm.destroy(gracefully=False)
-
-            logging.info("Recovery VM XML configration")
+            logging.info("Recover VM XML configration")
             orig_config_xml.sync()
             logging.debug("The current VM XML:\n%s", orig_config_xml.xmltreefile)
 

--- a/libvirt/tests/src/migration/migrate_with_legacy_guest.py
+++ b/libvirt/tests/src/migration/migrate_with_legacy_guest.py
@@ -104,6 +104,8 @@ def run(test, params, env):
     src_uri = params.get("virsh_migrate_connect_uri")
     dest_uri = params.get("virsh_migrate_desturi")
 
+    extra_args = migration_test.update_virsh_migrate_extra_args(params)
+
     vm_name = params.get("migrate_main_vm")
     vm = env.get_vm(vm_name)
     vm.verify_alive()
@@ -165,10 +167,8 @@ def run(test, params, env):
         migration_test.do_migration(vms, None, dest_uri, 'orderly',
                                     options, thread_timeout=900,
                                     ignore_status=True, virsh_opt=virsh_options,
-                                    extra_opts=extra)
+                                    extra_opts=extra, **extra_args)
         mig_result = migration_test.ret
-
-        migration_test.check_result(mig_result, params)
 
         if int(mig_result.exit_status) == 0:
             migration_test.ping_vm(vm, params, dest_uri)
@@ -225,11 +225,9 @@ def run(test, params, env):
     finally:
         logging.debug("Recover test environment")
         # Clean VM on destination
-        migration_test.cleanup_dest_vm(vm, vm.connect_uri, dest_uri)
-        if vm.is_alive():
-            vm.destroy(gracefully=False)
+        migration_test.cleanup_vm(vm, dest_uri)
 
-        logging.info("Recovery VM XML configration")
+        logging.info("Recover VM XML configration")
         orig_config_xml.sync()
         logging.debug("The current VM XML:\n%s", orig_config_xml.xmltreefile)
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_copy_storage.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_copy_storage.py
@@ -117,11 +117,12 @@ def copied_migration(test, vms, vms_ip, params):
     username = params.get("migrate_dest_user", "root")
     password = params.get("migrate_dest_pwd")
     timeout = int(params.get("thread_timeout", 1200))
+    status_error = params.get("status_error", "no")
     options = "--live %s" % copy_option
 
     cp_mig = migration.MigrationTest()
     cp_mig.do_migration(vms, None, dest_uri, "orderly", options, timeout,
-                        ignore_status=True)
+                        ignore_status=True, status_error=status_error)
     check_ip_failures = []
 
     if cp_mig.RET_MIGRATION:
@@ -293,6 +294,7 @@ def run(test, params, env):
                 raise
 
             # Migrate it again to confirm failed reason
+            params["status_error"] = "no"
             cp_mig = copied_migration(test, vms, vms_ip, params)
     finally:
         # Recover created vm

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_multi_vms.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_multi_vms.py
@@ -106,21 +106,22 @@ def thread_func_jobabort(vm):
 
 def multi_migration(vm, src_uri, dest_uri, options, migrate_type,
                     migrate_thread_timeout, jobabort=False,
-                    lrunner=None, rrunner=None):
+                    lrunner=None, rrunner=None, status_error=None):
     """
     Migrate multiple vms simultaneously or not.
 
     :param vm: list of all vm instances
     :param src_uri: source ip address for migration
     :param dest_uri: destination ipaddress for migration
-    :options: options to be passed in migration command
-    :migrate_type: orderly or simultaneous migration type
-    :migrate_thread_timeout: thread timeout for migrating vms
-    :jobabort: If jobabort is True, run "virsh domjobabort vm_name"
+    :param options: options to be passed in migration command
+    :param migrate_type: orderly or simultaneous migration type
+    :param migrate_thread_timeout: thread timeout for migrating vms
+    :param jobabort: If jobabort is True, run "virsh domjobabort vm_name"
                during migration.
-    :param timeout: thread's timeout
-    :lrunner: local session instance
-    :rrunner: remote session instance
+    :param param timeout: thread's timeout
+    :param lrunner: local session instance
+    :param rrunner: remote session instance
+    :param status_error: Whether expect error status
     """
 
     obj_migration = migration.MigrationTest()
@@ -132,7 +133,8 @@ def multi_migration(vm, src_uri, dest_uri, options, migrate_type,
                                        migration_type="simultaneous",
                                        options=options,
                                        thread_timeout=migrate_thread_timeout,
-                                       ignore_status=False)
+                                       ignore_status=False,
+                                       status_error=status_error)
             if jobabort:
                 # To ensure Migration has been started.
                 time.sleep(5)
@@ -159,7 +161,8 @@ def multi_migration(vm, src_uri, dest_uri, options, migrate_type,
                                        migration_type="orderly",
                                        options=options,
                                        thread_timeout=migrate_thread_timeout,
-                                       ignore_status=False)
+                                       ignore_status=False,
+                                       status_error=status_error)
             for each_vm in vm:
                 ping_thread = threading.Thread(target=thread_func_ping,
                                                args=(lrunner, rrunner,
@@ -278,7 +281,7 @@ def run(test, params, env):
                 vm.wait_for_login()
         multi_migration(vms, srcuri, desturi, option, migration_type,
                         migrate_timeout, jobabort, lrunner=localrunner,
-                        rrunner=remoterunner)
+                        rrunner=remoterunner, status_error=status_error)
     except Exception as info:
         logging.error("Test failed: %s" % info)
         flag_migration = False

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_option_mix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_option_mix.py
@@ -344,8 +344,6 @@ def run(test, params, env):
                                        options="",
                                        ignore_status=True,
                                        extra_opts=extra_options)
-            # Check migration result
-            obj_migration.check_result(obj_migration.ret, params)
 
         """
         # Check src vm after migration


### PR DESCRIPTION
1. MigrationTest.do_migration changes to check result
2. Update vm cleaning part
3. Fix typo

Signed-off-by: Yingshun Cui <yicui@redhat.com>


**depends on:**
https://github.com/avocado-framework/avocado-vt/pull/2979

**Test results:**
one case failed due to BZ 1806856, and one case was cancelled because it's unsupported.
```
 (01/13) type_specific.io-github-autotest-libvirt.virsh.migrate_option_mix.persistent.no_persistent_xml.no_xml.no_dname.undefinesource.src_vm_running.src_vm_persistent.graphic_passwd.tunnelled.precopy.live: PASS (375.92 s)
 (02/13) type_specific.io-github-autotest-libvirt.virsh.migrate_set_get_speed.normal_test.zero: PASS (47.37 s)
 (03/13) type_specific.io-github-autotest-libvirt.virsh.migrate_set_get_speed.error_test.uint64_max: PASS (43.80 s)
 (04/13) type_specific.io-github-autotest-libvirt.virsh.migrate_copy_storage.normal_test.single_disk.copy_storage_all.file_image: PASS (162.76 s)
 (05/13) type_specific.io-github-autotest-libvirt.virsh.migrate_copy_storage.error_test.nonexist_image.copy_storage_inc.file_image: CANCEL: Known error: Bug 1249587 --- error: Operation not supported: pre-creation of storage targets for incremental storage migration is not supported in command: "/usr/bin/virsh -c 'qemu:///system' migrate --live --copy-storage-inc --domain avocado-vt-vm1 --des... (64.52 s)
 (06/13) type_specific.io-github-autotest-libvirt.virsh.migrate_gluster.backend_disk.mount_dir.without_postcopy: PASS (520.32 s)
 (07/13) type_specific.io-github-autotest-libvirt.virsh.migrate_network.direct.macvtap_exists_dest.with_postcopy: PASS (302.59 s)
 (08/13) type_specific.io-github-autotest-libvirt.virsh.migrate_options_shared.positive_test.p2p_migration.cancel_concurrent_migration.without_postcopy: PASS (273.58 s)
 (09/13) type_specific.io-github-autotest-libvirt.virsh.migrate_over_unix.negative_test.domjobabort.storage_migration.p2p_live_migration.without_postcopy: PASS (235.62 s)
 (10/13) type_specific.io-github-autotest-libvirt.virsh.migrate_bandwidth.postcopy.precopy_bandwidth_opt: FAIL: Migration speed is expected to be '5 MiB/s', but '8796093022207 MiB/s' found! (163.68 s)
 (11/13) type_specific.io-github-autotest-libvirt.virsh.migrate.there_timeout_suspend.without_cpu_hotplug.compat_migration.non_compat_migration.default: PASS (258.83 s)
 (12/13) type_specific.io-github-autotest-libvirt.virsh.migrate_options_shared.positive_test.p2p_migration.check_domstats.without_postcopy: PASS (305.62 s)
 (13/13) type_specific.io-github-autotest-libvirt.virsh.migrate_options_shared.negative_test.multifd.inavalid_connect_num.set_zero.without_postcopy: PASS (133.47 s)
RESULTS    : PASS 11 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 1
JOB TIME   : 2889.90 s
...
 (01/10) type_specific.io-github-autotest-libvirt.virsh.migrate_bandwidth.postcopy.postcopy_bandwidth_opt.p2p_migration: PASS (322.76 s)
 (02/10) type_specific.io-github-autotest-libvirt.virsh.migrate_bandwidth.postcopy.postcopy_bandwidth_opt.live_migration: PASS (320.36 s)

```