### PR TITLE
Fix inspekt checkall issue

### DIFF
--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -4,4 +4,8 @@ nosexcover==1.0.8
 tox==1.5.0
 virtualenv==1.9.1
 simplejson==3.8.1
+# inspektor (static and style checks)
+pylint==1.9.3; python_version <= '2.7'
+pylint==2.7.2; python_version >= '3.6'
 inspektor==0.5.2
+


### PR DESCRIPTION
This is caused by mismatch inspekt and pylint version

Signed-off-by: chunfuwen <chwen@redhat.com>

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [ ] Description of the cases
- [ ] Links of libvirt features, libvirt bugs or case IDs
- [ ] Test results

## If the PR is bug cases
- [ ] Bug descriptions or bug links
- [ ] Test results

## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
