### PR TITLE
virsh_detach_device_alias: check pci_id/device before create_hostdev_xml

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_serial_device_alias.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_serial_device_alias.cfg
@@ -8,6 +8,7 @@
             serial_sources = path:/var/log/libvirt/virt-test
             variants:
                 - isa-serial:
+                  no aarch64
                     target_type = isa-serial
                     hot_plugging_support = "no"
                 - pci-serial:
@@ -16,6 +17,7 @@
             serial_type = pty
             variants:
                 - isa-serial:
+                  no aarch64
                     hot_plugging_support = "no"
                     target_type = isa-serial
                 - pci-serial:


### PR DESCRIPTION
Sometimes pci_id may be empty then create_hostdev_xml failed on below
issue.
```
IndexError: list index out of range
```

Add a check for pci_id/device to avoid this issue.
Since create_hostdev_xml depends on pci_id/device, cancel test if pci_id/device
is empty.

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Before
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virsh.detach_device_alias.live.hostdev
JOB ID     : 78f7d82c475cc25507886c83ea2a9a7f9e4adf07
JOB LOG    : /root/avocado/job-results/job-2021-03-31T00.08-78f7d82/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.hostdev: ERROR: list index out of range (44.28 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 44.98 s
```
After
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virsh.detach_device_alias.config.hostdev
JOB ID     : a29bb0f0df3534a388187e5bc8945d756d9dacf4
JOB LOG    : /root/avocado/job-results/job-2021-03-31T02.18-a29bb0f/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.config.hostdev: CANCEL: pci_id/device id is empty (44.50 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 1
JOB TIME   : 45.21 s
```
