### PR TITLE
Ignore case distinctions in 'grep' for expected pattern

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_sendkey.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_sendkey.py
@@ -191,13 +191,13 @@ def run(test, params, env):
             timeout = 60
             while timeout >= 0:
                 if "KEY_H" in keystrokes:
-                    cmd = "cat %s | grep 'SysRq.*HELP'" % LOG_FILE
+                    cmd = "cat %s | grep -i 'SysRq.*HELP'" % LOG_FILE
                     get_status = session.cmd_status(cmd)
                 elif "KEY_M" in keystrokes:
-                    cmd = "cat %s | grep 'SysRq.*Show Memory'" % LOG_FILE
+                    cmd = "cat %s | grep -i 'SysRq.*Show Memory'" % LOG_FILE
                     get_status = session.cmd_status(cmd)
                 elif "KEY_T" in keystrokes:
-                    cmd = "cat %s | grep 'SysRq.*Show State'" % LOG_FILE
+                    cmd = "cat %s | grep -i 'SysRq.*Show State'" % LOG_FILE
                     get_status = session.cmd_status(cmd)
                     # Sometimes SysRq.*Show State string missed in LOG_FILE
                     # as a fall back check for runnable tasks logged


### PR DESCRIPTION
Signed-off-by: Yan Fu <yafu@redhat.com>

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [ ] Description of the cases
- [ ] Links of libvirt features, libvirt bugs or case IDs
- [ ] Test results

## If the PR is bug cases
- [ ] Bug descriptions or bug links
- [ ] Test results

## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
