### PR TITLE
virsh_detach_serial_device_alias: skip isa-serial for aarch64

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_serial_device_alias.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_serial_device_alias.cfg
@@ -8,6 +8,7 @@
             serial_sources = path:/var/log/libvirt/virt-test
             variants:
                 - isa-serial:
+                    no aarch64
                     target_type = isa-serial
                     hot_plugging_support = "no"
                 - pci-serial:
@@ -16,6 +17,7 @@
             serial_type = pty
             variants:
                 - isa-serial:
+                    no aarch64
                     hot_plugging_support = "no"
                     target_type = isa-serial
                 - pci-serial:


### PR DESCRIPTION
upstream qemu doesn't support isa-serial
```
\# /usr/libexec/qemu-system-aarch64 --version
QEMU emulator version 5.2.90 (v6.0.0-rc0-16-gec2e6e016d)
Copyright (c) 2003-2021 Fabrice Bellard and the QEMU Project developers

\# /usr/libexec/qemu-system-aarch64 --machine virt --device help | grep -serial
name "pci-serial", bus PCI
name "pci-serial-2x", bus PCI
name "pci-serial-4x", bus PCI
name "usb-serial", bus usb-bus
name "virtconsole", bus virtio-serial-bus
name "virtio-serial-device", bus virtio-bus
name "virtio-serial-pci", bus PCI, alias "virtio-serial"
name "virtio-serial-pci-non-transitional", bus PCI
name "virtio-serial-pci-transitional", bus PCI
name "virtserialport", bus virtio-serial-bus
```

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>
