### PR TITLE
virsh_detach_device_alias: Fix hostdev detach device by alias on aarch64

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
@@ -5,7 +5,7 @@
             detach_hostdev_type = "usb"
             detach_hostdev_managed = "no"
             detach_check_xml = "<hostdev"
-            s390-virtio:
+            s390-virtio, aarch64:
                 detach_hostdev_type = "scsi"
         - controller:
             detach_controller_type = "scsi"


### PR DESCRIPTION
Sometimes pci_id may be empty then create_hostdev_xml failed on below
issue.
```
IndexError: list index out of range
```

Add a check for pci_id/device to avoid this issue.
Since create_hostdev_xml depends on pci_id/device, cancel test if pci_id/device
is empty.

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Before
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virsh.detach_device_alias.live.hostdev
JOB ID     : 7fe65df58bc794ff98c846141e2f0dfa1f7a570f
JOB LOG    : /root/avocado/job-results/job-2021-03-31T03.44-7fe65df/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.hostdev: ERROR: list index out of range (44.11 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 44.81 s
```
After
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virsh.detach_device_alias.live.hostdev
JOB ID     : d61e0a15185ebbcc1ff0189392b4f961b4062891
JOB LOG    : /root/avocado/job-results/job-2021-03-31T03.39-d61e0a1/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.hostdev: CANCEL: pci_id/device id is empty (48.00 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 1
JOB TIME   : 48.69 s
```
