### PR TITLE
update cpu xml with host-model

### DIFF
--- a/libvirt/tests/src/libvirt_mem.py
+++ b/libvirt/tests/src/libvirt_mem.py
@@ -346,7 +346,7 @@ def run(test, params, env):
                         align_to_value))
                     cells[cell]["memory"] = memory_value
             cpu_xml = vm_xml.VMCPUXML()
-            cpu_xml.xml = "<cpu><numa/></cpu>"
+            cpu_xml.xml = "<cpu mode='host-model'><numa/></cpu>"
             cpu_mode = params.get("cpu_mode")
             model_fallback = params.get("model_fallback")
             if cpu_mode:

--- a/libvirt/tests/src/numa/guest_numa.py
+++ b/libvirt/tests/src/numa/guest_numa.py
@@ -344,7 +344,7 @@ def run(test, params, env):
 
         # guest numa cpu setting
         vmcpuxml = libvirt_xml.vm_xml.VMCPUXML()
-        vmcpuxml.xml = "<cpu><numa/></cpu>"
+        vmcpuxml.xml = "<cpu mode='host-model'><numa/></cpu>"
         if topology:
             vmcpuxml.topology = topology
         logging.debug(vmcpuxml.numa_cell)


### PR DESCRIPTION
without it on new version test will cause kernel panic

Signed-off-by: Kyla Zhang <weizhan@redhat.com>
```
# avocado run --vt-type libvirt guest_numa.possitive_test.hugepage.per_node.2M.topology.numatune_memnode.m_strict.numatune_mem
JOB ID     : f4b88785fb26f951aa18d764d3838bf51a5b94e9
JOB LOG    : /root/avocado/job-results/job-2021-04-01T08.37-f4b8878/job.log
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.2M.topology.numatune_memnode.m_strict.numatune_mem: PASS (52.13 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 52.87 s
# avocado run --vt-type libvirt libvirt_mem.positive_test.with_source
JOB ID     : 24339f1437c9cd6ee1887387210f8cf14c5aa4d6
JOB LOG    : /root/avocado/job-results/job-2021-04-01T08.38-24339f1/job.log
 (1/1) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.with_source: PASS (66.77 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 67.47 s
```

