### PR TITLE
blockcopy: replace virsh.undefine with vm.undefine

### DIFF
--- a/libvirt/tests/src/backingchain/blockcopy.py
+++ b/libvirt/tests/src/backingchain/blockcopy.py
@@ -13,6 +13,7 @@ def run(test, params, env):
     Test vm backingchain, blockcopy
     """
     vm_name = params.get('main_vm')
+    vm = env.get_vm(vm_name)
     case = params.get('case', '')
 
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
@@ -24,7 +25,7 @@ def run(test, params, env):
         if case:
             if case == 'reuse_external':
                 # Create a transient vm for test
-                virsh.undefine(vm_name, debug=True, ignore_status=False)
+                vm.undefine()
                 virsh.create(vmxml.xml)
 
                 all_disks = vmxml.get_disk_source(vm_name)


### PR DESCRIPTION
Fix undefine error, vm.undefine will  add undefine "--nvram" option
automatically for aarch64 machine.

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Before
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio backingchain.blockcopy.positive_test.reuse_external
JOB ID     : 7f02aa89fb492ebafc1f18c9988148d26a643c7b
JOB LOG    : /root/avocado/job-results/job-2021-04-01T22.46-7f02aa8/job.log
 (1/1) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.positive_test.reuse_external: ERROR: Command '/usr/bin/virsh undefine avocado-vt-vm1' failed.\nstdout: b'\n'\nstderr: b"error: Failed to undefine domain 'avocado-vt-vm1'\nerror: Requested operation is not valid: cannot undefine domain with nvram\n"\nadditional_info: None (9.47 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 10.19 s
```

After
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio backingchain.blockcopy.positive_test.reuse_external
JOB ID     : 3537857228b384068661d469a592bbcc780f65e7
JOB LOG    : /root/avocado/job-results/job-2021-04-01T22.44-3537857/job.log
 (1/1) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.positive_test.reuse_external: PASS (12.96 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 13.68 s
```
