### PR TITLE
virsh_detach_device_alias: Fix tmp file removed

### DIFF
--- a/libvirt/tests/src/ppc_device.py
+++ b/libvirt/tests/src/ppc_device.py
@@ -65,7 +65,7 @@ def run(test, params, env):
                 if max_id > 7:
                     break
                 new_pci_id = '.'.join([prefix, str(max_id)])
-                new_pci_xml = libvirt.create_hostdev_xml(new_pci_id, xmlfile=False)
+                new_pci_xml = libvirt.create_hostdev_xml(new_pci_id)
                 vmxml.add_device(new_pci_xml)
             vmxml.sync()
             logging.debug('Vm xml after adding unavailable pci devices: \n%s', vmxml)

--- a/libvirt/tests/src/sriov/sriov.py
+++ b/libvirt/tests/src/sriov/sriov.py
@@ -725,8 +725,7 @@ def run(test, params, env):
             if dev_type:
                 mac_addr = vf_mac_list[0]
                 new_iface = utils_test.libvirt.create_hostdev_xml(vf_addr,
-                                                                  managed=managed,
-                                                                  xmlfile=False)
+                                                                  managed=managed)
             else:
                 new_iface = create_interface()
                 mac_addr = new_iface.mac_address

--- a/libvirt/tests/src/vfio.py
+++ b/libvirt/tests/src/vfio.py
@@ -295,7 +295,7 @@ def test_nic_group(test, vm, params):
                                    debug=True, ignore_status=False)
         else:
             xmlfile = utlv.create_hostdev_xml(pci_id)
-            virsh.attach_device(vm.name, xmlfile,
+            virsh.attach_device(vm.name, xmlfile.xml,
                                 flagstr="--config", debug=True,
                                 ignore_status=False)
         vmxml = vm_xml.VMXML.new_from_dumpxml(vm.name)
@@ -380,7 +380,7 @@ def test_fibre_group(test, vm, params):
             utlv.alter_boot_order(vm.name, pci_id, boot_order)
         else:
             xmlfile = utlv.create_hostdev_xml(pci_id)
-            virsh.attach_device(vm.name, xmlfile,
+            virsh.attach_device(vm.name, xmlfile.xml,
                                 flagstr="--config", debug=True,
                                 ignore_status=False)
         logging.debug("VMXML with disk boot:\n%s", virsh.dumpxml(vm.name))
@@ -450,7 +450,7 @@ def test_win_fibre_group(test, vm, params):
     xmlfile = utlv.create_hostdev_xml(pci_id)
     prepare_devices(test, pci_id, device_type)
     try:
-        virsh.attach_device(vm.name, xmlfile,
+        virsh.attach_device(vm.name, xmlfile.xml,
                             flagstr="--config", debug=True,
                             ignore_status=False)
         vm.start()
@@ -515,11 +515,11 @@ def test_nic_fibre_group(test, vm, params):
     prepare_devices(test, fibre_pci_id, "Fibre")
     try:
         nicxmlfile = utlv.create_hostdev_xml(nic_pci_id)
-        virsh.attach_device(vm.name, nicxmlfile,
+        virsh.attach_device(vm.name, nicxmlfile.xml,
                             flagstr="--config", debug=True,
                             ignore_status=False)
         fibrexmlfile = utlv.create_hostdev_xml(fibre_pci_id)
-        virsh.attach_device(vm.name, fibrexmlfile,
+        virsh.attach_device(vm.name, fibrexmlfile.xml,
                             flagstr="--config", debug=True,
                             ignore_status=False)
         vm.start()
@@ -604,7 +604,7 @@ def test_nic_single(test, vm, params):
     prepare_devices(test, pci_id, device_type, only=True)
     try:
         xmlfile = utlv.create_hostdev_xml(pci_id)
-        virsh.attach_device(vm.name, xmlfile,
+        virsh.attach_device(vm.name, xmlfile.xml,
                             flagstr="--config", debug=True,
                             ignore_status=False)
         vm.start()

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
@@ -51,7 +51,7 @@ def run(test, params, env):
             return result.stdout_text.rstrip(':')
         else:
             test.error("Can not get usb hub info for testing")
-
+q
     # backup xml
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     backup_xml = vmxml.copy()
@@ -72,7 +72,7 @@ def run(test, params, env):
             device_xml = libvirt.create_hostdev_xml(pci_id=pci_id,
                                                     dev_type=hostdev_type,
                                                     managed=hostdev_managed,
-                                                    alias=device_alias)
+                                                    alias=device_alias).xml
         else:
             test.error("Hostdev type %s not handled by test."
                        " Please check code." % hostdev_type)


### PR DESCRIPTION
Adjust the invoke method for the utility function in avocado-vt 2988.

Signed-off-by: Dan Zheng <dzheng@redhat.com>
