### PR TITLE
virsh_detach_device_alias: Fix tmp file removed

### DIFF
--- a/libvirt/tests/src/ppc_device.py
+++ b/libvirt/tests/src/ppc_device.py
@@ -65,7 +65,7 @@ def run(test, params, env):
                 if max_id > 7:
                     break
                 new_pci_id = '.'.join([prefix, str(max_id)])
-                new_pci_xml = libvirt.create_hostdev_xml(new_pci_id, xmlfile=False)
+                new_pci_xml = libvirt.create_hostdev_xml(new_pci_id)
                 vmxml.add_device(new_pci_xml)
             vmxml.sync()
             logging.debug('Vm xml after adding unavailable pci devices: \n%s', vmxml)

--- a/libvirt/tests/src/sriov/sriov.py
+++ b/libvirt/tests/src/sriov/sriov.py
@@ -725,8 +725,7 @@ def run(test, params, env):
             if dev_type:
                 mac_addr = vf_mac_list[0]
                 new_iface = utils_test.libvirt.create_hostdev_xml(vf_addr,
-                                                                  managed=managed,
-                                                                  xmlfile=False)
+                                                                  managed=managed)
             else:
                 new_iface = create_interface()
                 mac_addr = new_iface.mac_address

--- a/libvirt/tests/src/vfio.py
+++ b/libvirt/tests/src/vfio.py
@@ -295,7 +295,7 @@ def test_nic_group(test, vm, params):
                                    debug=True, ignore_status=False)
         else:
             xmlfile = utlv.create_hostdev_xml(pci_id)
-            virsh.attach_device(vm.name, xmlfile,
+            virsh.attach_device(vm.name, xmlfile.xml,
                                 flagstr="--config", debug=True,
                                 ignore_status=False)
         vmxml = vm_xml.VMXML.new_from_dumpxml(vm.name)
@@ -380,7 +380,7 @@ def test_fibre_group(test, vm, params):
             utlv.alter_boot_order(vm.name, pci_id, boot_order)
         else:
             xmlfile = utlv.create_hostdev_xml(pci_id)
-            virsh.attach_device(vm.name, xmlfile,
+            virsh.attach_device(vm.name, xmlfile.xml,
                                 flagstr="--config", debug=True,
                                 ignore_status=False)
         logging.debug("VMXML with disk boot:\n%s", virsh.dumpxml(vm.name))
@@ -450,7 +450,7 @@ def test_win_fibre_group(test, vm, params):
     xmlfile = utlv.create_hostdev_xml(pci_id)
     prepare_devices(test, pci_id, device_type)
     try:
-        virsh.attach_device(vm.name, xmlfile,
+        virsh.attach_device(vm.name, xmlfile.xml,
                             flagstr="--config", debug=True,
                             ignore_status=False)
         vm.start()
@@ -515,11 +515,11 @@ def test_nic_fibre_group(test, vm, params):
     prepare_devices(test, fibre_pci_id, "Fibre")
     try:
         nicxmlfile = utlv.create_hostdev_xml(nic_pci_id)
-        virsh.attach_device(vm.name, nicxmlfile,
+        virsh.attach_device(vm.name, nicxmlfile.xml,
                             flagstr="--config", debug=True,
                             ignore_status=False)
         fibrexmlfile = utlv.create_hostdev_xml(fibre_pci_id)
-        virsh.attach_device(vm.name, fibrexmlfile,
+        virsh.attach_device(vm.name, fibrexmlfile.xml,
                             flagstr="--config", debug=True,
                             ignore_status=False)
         vm.start()
@@ -604,7 +604,7 @@ def test_nic_single(test, vm, params):
     prepare_devices(test, pci_id, device_type, only=True)
     try:
         xmlfile = utlv.create_hostdev_xml(pci_id)
-        virsh.attach_device(vm.name, xmlfile,
+        virsh.attach_device(vm.name, xmlfile.xml,
                             flagstr="--config", debug=True,
                             ignore_status=False)
         vm.start()

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
@@ -55,6 +55,7 @@ def run(test, params, env):
     # backup xml
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     backup_xml = vmxml.copy()
+    device_xml = None
 
     if not vm.is_alive():
         vm.start()
@@ -83,7 +84,7 @@ def run(test, params, env):
                       "controller_model": contr_model,
                       "controller_index": contr_index,
                       "contr_alias": device_alias}
-        device_xml = libvirt.create_controller_xml(contr_dict).xml
+        device_xml = libvirt.create_controller_xml(contr_dict)
         detach_check_xml = detach_check_xml % contr_index
 
     if redir_type:
@@ -92,7 +93,7 @@ def run(test, params, env):
     if channel_type:
         channel_params = {'channel_type_name': channel_type}
         channel_params.update(channel_target)
-        device_xml = libvirt.create_channel_xml(channel_params, device_alias).xml
+        device_xml = libvirt.create_channel_xml(channel_params, device_alias)
 
     try:
         dump_option = ""
@@ -100,8 +101,8 @@ def run(test, params, env):
             dump_option = "--inactive"
 
         # Attach xml to domain
-        logging.info("Attach xml is %s" % process.run("cat %s" % device_xml).stdout_text)
-        virsh.attach_device(vm_name, device_xml, flagstr=detach_options,
+        logging.info("Attach xml is %s" % process.run("cat %s" % device_xml.xml).stdout_text)
+        virsh.attach_device(vm_name, device_xml.xml, flagstr=detach_options,
                             debug=True, ignore_status=False)
         domxml_at = virsh.dumpxml(vm_name, dump_option, debug=True).stdout.strip()
         if detach_check_xml not in domxml_at:


### PR DESCRIPTION
Adjust the invoke method for the utility function in avocado-vt 2988.

Signed-off-by: Dan Zheng <dzheng@redhat.com>
