### PR TITLE
migraion: Add a case to check p2p precopy migration of the paused VM

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -460,13 +460,13 @@
                             with_postcopy:
                                 actions_during_migration = "suspendvm,setmigratepostcopy"
                         - pause_vm_before_migration:
-                            only with_postcopy
                             pause_vm_before_migration = "yes"
-                            asynch_migrate = "yes"
-                            stress_in_vm = "yes"
-                            stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M --timeout 70"
-                            actions_during_migration = "setmigratepostcopy"
                             actions_after_migration = "checkdomstate"
+                            with_postcopy:
+                                asynch_migrate = "yes"
+                                stress_in_vm = "yes"
+                                stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M --timeout 70"
+                                actions_during_migration = "setmigratepostcopy"
                         - cancel_concurrent_migration:
                             only without_postcopy
                             concurrent_migration = "yes"


### PR DESCRIPTION
RHEL-201634: Do VM migration for a paused VM - p2p migration

Signed-off-by: Yingshun Cui <yicui@redhat.com>


**Test result:**
```
JOB ID     : fb2a4cd932653d09d1365c81127c2d28409cf177
JOB LOG    : /root/avocado/job-results/job-2021-04-02T02.22-fb2a4cd/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_options_shared.positive_test.p2p_migration.pause_vm_before_migration.without_postcopy: PASS (155.22 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 158.40 s
```
