### PR TITLE
Fix usb disk error_test4 failure by adding define_error = yes

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
@@ -922,6 +922,7 @@
                                         - error_test4:
                                             no pseries
                                             status_error = "yes"
+                                            define_error = "yes"
                                             virt_disk_addr_options = "type=pci,domain=0x0000,bus=0x00,slot=0x09,function=0x0"
                                             usb_error_message = "unexpected address type for usb disk"
                 - disk_duplicate_scsi_controller_index_error_test:


### PR DESCRIPTION
Signed-off-by: chunfuwen <chwen@redhat.com>

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [ ] Description of the cases
- [ ] Links of libvirt features, libvirt bugs or case IDs
- [ ] Test results

## If the PR is bug cases
- [ ] Bug descriptions or bug links
- [ ] Test results

## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
