### PR TITLE
migration: Fix dhclient command not found problem

### DIFF
--- a/libvirt/tests/src/migration/migrate_network.py
+++ b/libvirt/tests/src/migration/migrate_network.py
@@ -8,6 +8,7 @@ from virttest import migration
 from virttest import remote
 from virttest import utils_net
 from virttest import utils_conn
+from virttest import utils_package
 from virttest import virt_vm
 
 from virttest.libvirt_xml import vm_xml
@@ -294,6 +295,8 @@ def run(test, params, env):
             vm.cleanup_serial_console()
         vm.create_serial_console()
         vm_session = vm.wait_for_serial_login(timeout=240)
+        if not utils_package.package_install('dhcp-client', session=vm_session):
+            test.error("Failed to install dhcp-client on guest.")
         utils_net.restart_guest_network(vm_session)
         vm_ip = utils_net.get_guest_ip_addr(vm_session, mac)
         logging.debug("VM IP Addr: %s", vm_ip)


### PR DESCRIPTION
The package 'dhcp-client' is not installed by default on the
guest. This makes dhclient commands fail.

Signed-off-by: Yingshun Cui <yicui@redhat.com>

**Test result:**
_Before fix_:
```
JOB LOG    : /root/avocado/job-results/job-2021-04-06T23.27-0df524a/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_network.direct.macvtap_exists_dest.without_postcopy: ERROR: Shell command failed: 'dhclient -r; dhclient'    (status: 127,    output: '-bash: dhclient: command not found\n-bash: dhclient: command not found\n') (162.03 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 162.64 s

```
_After fix:_
```
JOB ID     : 6bfa1159d19239ca5322df6422b906e502456717
JOB LOG    : /root/avocado/job-results/job-2021-04-06T23.51-6bfa115/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_network.direct.macvtap_exists_dest.without_postcopy: PASS (265.33 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 265.94 s

```