### PR TITLE
vcpu_cache: Fix a regex problem

### DIFF
--- a/libvirt/tests/cfg/cpu/vcpu_cache.cfg
+++ b/libvirt/tests/cfg/cpu/vcpu_cache.cfg
@@ -2,7 +2,7 @@
     type = vcpu_cache
     start_vm = "no"
     cmd_in_vm = "lscpu |grep cache"
-    cmd_output_regex = "L3 cache:\s+\d+K"
+    cmd_output_regex = "L3 cache:\s+\d+\s?[KM]"
     status_error = "no"
     no pseries, s390-virtio
     variants:


### PR DESCRIPTION
The output of 'lscpu' has been updated. It contains a space between
size and the unit than before, and the unit may be 'MiB'.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Before fix:**
` (1/1) type_specific.io-github-autotest-libvirt.vcpu_cache.positive_test.L3.host_model: FAIL: The string 'L3 cache:\s+\d+K' is not included in L1d cache:                       64 KiB\nL1i cache:                       64 KiB\nL2 cache:                        8 MiB\nL3 cache:                        32 MiB (26.11 s)`


**After fix:**
`rhel9:` 2 failed cases are caused by BZ 1925384.
 ```
(01/10) type_specific.io-github-autotest-libvirt.vcpu_cache.positive_test.L3.no_cpu_mode: ERROR: No ipv4 DHCP lease for MAC 52:54:00:6a:1f:84 (246.62 s)
 (02/10) type_specific.io-github-autotest-libvirt.vcpu_cache.positive_test.L3.host_model: PASS (22.78 s)
 (03/10) type_specific.io-github-autotest-libvirt.vcpu_cache.positive_test.L3.host_passthrough: PASS (21.99 s)
 (04/10) type_specific.io-github-autotest-libvirt.vcpu_cache.positive_test.passthrough.host_passthrough: PASS (22.85 s)
 (05/10) type_specific.io-github-autotest-libvirt.vcpu_cache.positive_test.disable.no_cpu_mode: ERROR: Could not verify DHCP lease: 52:54:00:6a:1f:84 --> 192.168.122.117 (310.85 s)
 (06/10) type_specific.io-github-autotest-libvirt.vcpu_cache.positive_test.disable.host_model: PASS (22.71 s)
 (07/10) type_specific.io-github-autotest-libvirt.vcpu_cache.positive_test.disable.host_passthrough: PASS (22.10 s)
 (08/10) type_specific.io-github-autotest-libvirt.vcpu_cache.negative_test.L3_with_disable_mode.no_cpu_mode: PASS (4.89 s)
 (09/10) type_specific.io-github-autotest-libvirt.vcpu_cache.negative_test.L2_with_emulate_mode.no_cpu_mode: PASS (4.73 s)
 (10/10) type_specific.io-github-autotest-libvirt.vcpu_cache.negative_test.passthrough_with_host_model.host_model: PASS (4.69 s)
RESULTS    : PASS 8 | ERROR 2 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 685.06 s
```


_rhel8.4 av:_
```
 (01/10) type_specific.io-github-autotest-libvirt.vcpu_cache.positive_test.L3.no_cpu_mode: PASS (33.12 s)
 (02/10) type_specific.io-github-autotest-libvirt.vcpu_cache.positive_test.L3.host_model: PASS (36.59 s)
 (03/10) type_specific.io-github-autotest-libvirt.vcpu_cache.positive_test.L3.host_passthrough: PASS (36.46 s)
 (04/10) type_specific.io-github-autotest-libvirt.vcpu_cache.positive_test.passthrough.host_passthrough: PASS (37.64 s)
 (05/10) type_specific.io-github-autotest-libvirt.vcpu_cache.positive_test.disable.no_cpu_mode: PASS (37.65 s)
 (06/10) type_specific.io-github-autotest-libvirt.vcpu_cache.positive_test.disable.host_model: PASS (37.43 s)
 (07/10) type_specific.io-github-autotest-libvirt.vcpu_cache.positive_test.disable.host_passthrough: PASS (37.67 s)
 (08/10) type_specific.io-github-autotest-libvirt.vcpu_cache.negative_test.L3_with_disable_mode.no_cpu_mode: PASS (7.51 s)
 (09/10) type_specific.io-github-autotest-libvirt.vcpu_cache.negative_test.L2_with_emulate_mode.no_cpu_mode: PASS (8.25 s)
 (10/10) type_specific.io-github-autotest-libvirt.vcpu_cache.negative_test.passthrough_with_host_model.host_model: PASS (9.52 s)
RESULTS    : PASS 10 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 283.33 s

```