### PR TITLE
svirt: skip some tests for aarch64

### DIFF
--- a/libvirt/tests/cfg/svirt/dac_nfs_save_restore.cfg
+++ b/libvirt/tests/cfg/svirt/dac_nfs_save_restore.cfg
@@ -32,6 +32,7 @@
             dynamic_ownership = "no"
     variants:
         - qemu_user:
+            no aarch64
         - root_user:
             qemu_user = "root"
             qemu_group = "root"

--- a/libvirt/tests/cfg/svirt/dac_per_disk_hotplug.cfg
+++ b/libvirt/tests/cfg/svirt/dac_per_disk_hotplug.cfg
@@ -40,6 +40,8 @@
     variants:
         - positive_test:
             no relabel_no, img_qemu..root_user, img_root..qemu_user..dynamic_ownership_on, img_root..root_user..dynamic_ownership_off, img_qemu_grp..root_user..dynamic_ownership_off
+            aarch64:
+                no dynamic_ownership_off
             status_error = no
         - negative_test:
             status_error = yes

--- a/libvirt/tests/cfg/svirt/dac_start_destroy.cfg
+++ b/libvirt/tests/cfg/svirt/dac_start_destroy.cfg
@@ -10,9 +10,13 @@
         - with_qemu_conf:
             variants:
                 - qemu_usr:
+                    aarch64:
+                        no positive_test..disable_dynamic_ownership
                     qemu_user = "qemu"
                     qemu_group = "qemu"
                 - qemu_grp_usr:
+                    aarch64:
+                        no positive_test..disable_dynamic_ownership
                     qemu_group_user = "yes"
                     qemu_user = "EXAMPLE"
                     qemu_group = "EXAMPLE"
@@ -20,6 +24,8 @@
                     qemu_user = "root"
                     qemu_group = "root"
                 - qemu_id_mix:
+                    aarch64:
+                        no positive_test..disable_dynamic_ownership
                     qemu_user = "+107"
                     qemu_group = "0"
                 - unconfine:
@@ -27,6 +33,8 @@
                     qemu_group = "qemu"
                     security_default_confined = 0
                 - process_name:
+                    aarch64:
+                        no positive_test..disable_dynamic_ownership
                     qemu_user = "qemu"
                     qemu_group = "qemu"
                     set_process_name = 1

--- a/libvirt/tests/cfg/svirt/svirt_start_destroy.cfg
+++ b/libvirt/tests/cfg/svirt/svirt_start_destroy.cfg
@@ -75,6 +75,8 @@
             status_error = no
             no default_model..st_dynamic..relabel_no, multi_model..st_dynamic..relabel_no, multi_model..st_static..relabel_no, relabel_no..st_dynamic..no_model
             no relabel_no..d_virt_content, security_driver_none..default_model, security_driver_none..multi_model..st_none, unconfined..relabel_yes, st_dynamic..multi_model..unconfined, st_static..multi_model..unconfined, required_confined, mess_t, invalid_str
+            aarch64:
+                no multi_model.with_qemu_conf.unconfined, multi_model.without_qemu_conf
         - negative_test:
             # only when seclabel of VM is not relabeled and
             # img is labeld with "system_u:object_r:virt_content_t:s0",


### PR DESCRIPTION
aarch64 guest use firmware efi which requires nvram file.
E.g
```
<os>
  <type arch='aarch64' machine='virt-rhel8.4.0'>hvm</type>
  <loader readonly='yes' type='pflash'>/usr/share/edk2/aarch64/QEMU_EFI-silent-pflash.raw</loader>
  <nvram>/var/lib/libvirt/qemu/nvram/avocado-vt-vm1_VARS.fd</nvram>
  <boot dev='hd'/>
</os>
```
Some tests set user/group as qemu and disable dynamic_ownership in qemu.conf.

There is a permission conflict when we disable dynamic_ownership and set qemu
user/group as qemu:
Run qemu process as user qemu but nvram belongs to root.

So skip these tests for aarch64

Signed-off-by: Liu <liuyd.fnst@fujitsu.com>
