### PR TITLE
remote_access: New case for SSH with SASL plain

### DIFF
--- a/libvirt/tests/cfg/remote_access/remote_with_unix.cfg
+++ b/libvirt/tests/cfg/remote_access/remote_with_unix.cfg
@@ -29,6 +29,13 @@
                     virsh_cmd = "start"
                     main_vm = "avocado-vt-vm1"
                     patterns_virsh_cmd = ".*Domain\s*\'?${main_vm}\'?\s*started\s*.*"
+                - allow_sasl_plain:
+                    transport = 'ssh'
+                    run_on_remote = 'yes'
+                    auth_unix_rw = "sasl"
+                    sasl_type = "plain"
+                    sasl_user_pwd = "('sasl_test', 'sasl_pass'),"
+                    sasl_allowed_users = ['sasl_test',]
                 - allow_sasl_krb_user:
                     auth_unix_rw = "sasl"
                     sasl_type = "gssapi"


### PR DESCRIPTION
The new case for SSH connection to the hypervisor has been added per
RHEL7-18313. Deprecated function for remote libvirt control replaced
by the supported one.

 - Description of the case:
Connect to the hypervisor running on host over an SSH connection with sasl plain authentication 
 - Introduced in:
https://libvirt.org/remote.html
 - Case_ID:
RHEL7-18313
- Test results:
<pre>avocado run --vt-type libvirt virsh.remote_with_ssh.positive_testing.sasl_plain_auth
WARNING:root:No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
WARNING:root:No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
<font color="#2A7BDE">JOB ID     : e6818a76f95967144a8de3795a8962fdae8dd240</font>
<font color="#2A7BDE">JOB LOG    : /root/avocado/job-results/job-2021-04-08T03.41-e6818a7/job.log</font>
 (1/1) type_specific.io-github-autotest-libvirt.virsh.remote_with_ssh.positive_testing.sasl_plain_auth: <font color="#33DA7A">PASS</font> (58.34 s)
<font color="#2A7BDE">RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0</font>
<font color="#2A7BDE">JOB TIME   : 59.51 s</font>
</pre>

Signed-off-by: Kamil Varga <kvarga@redhat.com>