### PR TITLE
v2v: add a switch for legacy crypto policies

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -237,6 +237,7 @@
         - modprobe:
             only esx_60
             main_vm = VM_NAME_RHEL5_V2V_EXAMPLE
+            enable_legacy_crypto_policies = yes
             checkpoint = modprobe
             cfg_content = 'alias eth0 virtio_net'
         - passthru:
@@ -316,6 +317,7 @@
             only esx_67
             main_vm = 'VM_NAME_ESX_EPOCH_V2V_EXAMPLE'
             version_requried = "[libguestfs-1.40.2-1,)"
+            enable_legacy_crypto_policies = yes
         - without_file_architecture:
             only esx_67
             main_vm = 'VM_NAME_NO_FILE_ARCHITECTURE_V2V_EXAMPLE'


### PR DESCRIPTION
Some guests like rhel5 cannot be logged in on rhel9 by default
because of crypto policies problem.
In order to fix the problem, a switch variant should be added
to indicate if legacy crypto policies should be enabled.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>