### PR TITLE
numa:The cpu mode updated to host-model to prevent issues

### DIFF
--- a/libvirt/tests/src/numa/guest_numa.py
+++ b/libvirt/tests/src/numa/guest_numa.py
@@ -344,7 +344,7 @@ def run(test, params, env):
 
         # guest numa cpu setting
         vmcpuxml = libvirt_xml.vm_xml.VMCPUXML()
-        vmcpuxml.xml = "<cpu><numa/></cpu>"
+        vmcpuxml.xml = "<cpu mode='host-model'><numa/></cpu>"
         if topology:
             vmcpuxml.topology = topology
         logging.debug(vmcpuxml.numa_cell)


### PR DESCRIPTION
Since the default cpu mode may cause issues, the cpu mode-'host-model'
is used instead.

Signed-off-by: Kamil Varga <kvarga@redhat.com>

- Depends on https://github.com/avocado-framework/avocado-vt/pull/2995.
- Test results: 
<pre>avocado run --vt-type libvirt --vt-machine-type q35 guest_numa.possitive_test.no_hugepage.no_mem_backend.topology.no_numatune_memnode.numatune_mem
WARNING:root:No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
WARNING:root:No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
<font color="#2A7BDE">JOB ID     : 76d55a9b24dd3f6afde1b228c99f3bf564400aab</font>
<font color="#2A7BDE">JOB LOG    : /root/avocado/job-results/job-2021-04-11T17.27-76d55a9/job.log</font>
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.no_hugepage.no_mem_backend.topology.no_numatune_memnode.numatune_mem: <font color="#33DA7A">PASS</font> (21.33 s)
<font color="#2A7BDE">RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0</font>
<font color="#2A7BDE">JOB TIME   : 22.14 s</font></pre>
