### PR TITLE
v2v: remove rhev_apt service check on rhel9

### DIFF
--- a/v2v/tests/src/function_test_esx.py
+++ b/v2v/tests/src/function_test_esx.py
@@ -539,7 +539,10 @@ def run(test, params, env):
                 # check_windows_ogac, it waits until rebooting completes.
                 vmchecker.checker.create_session()
                 if os_type == 'windows':
-                    services = ['qemu-ga', 'rhev-apt']
+                    services = ['qemu-ga']
+                    V2V_UNSUPPORT_RHEV_APT_VER = "[virt-v2v-1.43.3-4.el9,)"
+                    if not utils_v2v.multiple_versions_compare(V2V_UNSUPPORT_RHEV_APT_VER):
+                        services.append('rhev-apt')
                     if 'rhv-guest-tools' in os.getenv('VIRTIO_WIN'):
                         services.append('spice-ga')
                     for ser in services:


### PR DESCRIPTION
rhev_apt.exe is removed from v2v on rhel9, so the service don't need
to be checked any more.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>