### PR TITLE
migration: Add some live migration cases

### DIFF
--- a/libvirt/tests/cfg/migration/live_migration.cfg
+++ b/libvirt/tests/cfg/migration/live_migration.cfg
@@ -1,0 +1,84 @@
+- virsh.live_migration:
+    type = live_migration
+    migration_setup = "yes"
+    storage_type = 'nfs'
+    setup_local_nfs = 'yes'
+    disk_type = "file"
+    disk_source_protocol = "netfs"
+    mnt_path_name = ${nfs_mount_dir}
+    # Console output can only be monitored via virsh console output
+    only_pty = True
+    take_regular_screendumps = no
+    # Extra options to pass after <domain> <desturi>
+    virsh_migrate_extra = ""
+    # SSH connection time out
+    ssh_timeout = 60
+    virsh_migrate_dest_state = running
+    virsh_migrate_src_state = running
+    # Local URI
+    virsh_migrate_connect_uri = "qemu:///system"
+    
+    variants:
+        - with_postcopy:
+            postcopy_options = "--postcopy --timeout 10 --timeout-postcopy"
+            wait_for_event = True
+            event_type = "Post-copy"
+        - without_postcopy:
+            postcopy_options = ""
+    variants:
+        - p2p_live:
+            virsh_migrate_options = "--live --p2p --persistent --verbose"
+        - non_p2p_live:
+            virsh_migrate_options = "--live --verbose"
+    variants:
+        - migrateuri:
+            stress_package = "stress"
+            stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20s"
+            action_during_mig = "libvirt_network.check_established"
+            action_during_mig_params_exists = "yes"
+            variants:
+                - with_port:
+                    port_to_check = 49157
+                    virsh_migrate_extra = "--migrateuri tcp://${migrate_dest_host}:${port_to_check}"
+                - default:
+                    variants:
+                        - ipv4:
+                            virsh_migrate_extra = "--migrateuri tcp://${migrate_dest_host}"
+                        - ipv6:
+                            ipv6_config = "yes"
+                            ipv6_addr_src = "ENTER.YOUR.IPv6.SOURCE"
+                            ipv6_addr_des = "ENTER.YOUR.IPv6.DESTINATION"
+                            virsh_migrate_extra = "--migrateuri tcp://[${ipv6_addr_des}]"
+        - listen_address:
+            stress_package = "stress"
+            stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20s"
+            action_during_mig = "libvirt_network.check_established"
+            action_during_mig_params_exists = "yes"
+            bandwidth_opt = "--bandwidth 200"
+            ipv6_addr_des = "ENTER.YOUR.IPv6.DESTINATION"
+            ipv6_addr_src = "ENTER.YOUR.IPv6.SOURCE"
+            variants:
+                - migrateuri_ipv4_addr:
+                    virsh_migrate_migrateuri = "--migrateuri tcp://${migrate_dest_host}"
+                - migrateuri_ipv6_addr:
+                    ipv6_config = "yes"
+                    virsh_migrate_migrateuri = "--migrateuri tcp://[${ipv6_addr_des}]"
+            variants:
+                - specific_ipv6_addr:
+                    virsh_migrate_extra = "${virsh_migrate_migrateuri} --listen-address [${ipv6_addr_des}] ${bandwidth_opt}"
+                    migrateuri_ipv4_addr:
+                        stress_package = ''
+                        status_error = 'yes'
+                        err_msg = "unable to connect to server.*Connection refused"
+                        action_during_mig = ''
+                - all_ipaddrs:
+                    variants:
+                        - ipv4:
+                            virsh_migrate_extra = "${virsh_migrate_migrateuri} --listen-address 0.0.0.0 ${bandwidth_opt}"
+                            migrateuri_ipv6_addr:
+                                stress_package = ''
+                                status_error = 'yes'
+                                err_msg = "unable to connect to server.*Connection refused"
+                                action_during_mig = ''
+                        - ipv6:
+                            virsh_migrate_extra = "${virsh_migrate_migrateuri} --listen-address :: ${bandwidth_opt}"

--- a/libvirt/tests/src/migration/live_migration.py
+++ b/libvirt/tests/src/migration/live_migration.py
@@ -1,0 +1,74 @@
+import logging
+
+from virttest import libvirt_vm
+from virttest import migration
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_network  # pylint: disable=W0611
+from virttest.utils_test import libvirt
+
+
+def run(test, params, env):
+    """
+    :param test: test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    vm_name = params.get("migrate_main_vm")
+    vm = env.get_vm(vm_name)
+    vm.verify_alive()
+    bk_uri = vm.connect_uri
+
+    migration_test = migration.MigrationTest()
+    migration_test.check_parameters(params)
+    extra_args = migration_test.update_virsh_migrate_extra_args(params)
+
+    extra = params.get("virsh_migrate_extra")
+    postcopy_options = params.get("postcopy_options")
+    if postcopy_options:
+        extra = "%s %s" % (extra, postcopy_options)
+    params["virsh_migrate_desturi"] = libvirt_vm.complete_uri(
+        params.get("migrate_dest_host"))
+    dest_uri = params.get("virsh_migrate_desturi")
+    options = params.get("virsh_migrate_options",
+                         "--live --p2p --persistent --verbose")
+    virsh_options = params.get("virsh_options", "")
+    stress_package = params.get("stress_package")
+    action_during_mig = params.get("action_during_mig")
+    if action_during_mig:
+        action_during_mig = eval(action_during_mig)
+
+    # For safety reasons, we'd better back up  xmlfile.
+    new_xml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    orig_config_xml = new_xml.copy()
+
+    try:
+        libvirt.set_vm_disk(vm, params)
+        if not vm.is_alive():
+            vm.start()
+
+        logging.debug("Guest xml after starting:\n%s",
+                      vm_xml.VMXML.new_from_dumpxml(vm_name))
+
+        vm.wait_for_login().close()
+
+        if stress_package:
+            migration_test.run_stress_in_vm(vm, params)
+
+        # Execute migration process
+        logging.info("Starting migration...")
+        vms = [vm]
+        migration_test.do_migration(vms, None, dest_uri, 'orderly',
+                                    options, thread_timeout=900,
+                                    ignore_status=True,
+                                    virsh_opt=virsh_options,
+                                    extra_opts=extra,
+                                    func=action_during_mig,
+                                    **extra_args)
+    finally:
+        logging.info("Recover test environment")
+        vm.connect_uri = bk_uri
+        # Clean VM on destination and source
+        migration_test.cleanup_vm(vm, dest_uri)
+
+        orig_config_xml.sync()


### PR DESCRIPTION
This PR adds below cases:
1. RHEL-196112 - [Migration][--migrateuri] Specify migrate URI for
    live migration - TCP - IP address + port
2. RHEL-199037 - [Migration][--listen-address] Specify a listen
    address for incoming migration connections - 1 - p2p migration
3. RHEL-201638 - [Migration][--migrateuri] Specify migrate URI for
    live migration - TCP - IP address - p2p migration **(critical case)**
4. RHEL-201653: [Migration][--listen-address] Specify a listen
    address for incoming migration connections - 1 - non-p2p

Signed-off-by: Yingshun Cui <yicui@redhat.com>


depends on: https://github.com/avocado-framework/avocado-vt/pull/2979
https://github.com/avocado-framework/avocado-vt/pull/3018

**Test results:**
```
# avocado run --vt-type libvirt virsh.live_migration
WARNING:root:No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
WARNING:root:No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : fe1cf2d7b1ae7da5200f78ec7fd97872c0e5c91a
JOB LOG    : /root/avocado/job-results/job-2021-04-13T02.08-fe1cf2d/job.log
 (01/15) type_specific.io-github-autotest-libvirt.virsh.live_migration.migrateuri.with_port.p2p_live.without_postcopy: PASS (97.41 s)
 (02/15) type_specific.io-github-autotest-libvirt.virsh.live_migration.migrateuri.default.ipv4.p2p_live.without_postcopy: PASS (94.96 s)
 (03/15) type_specific.io-github-autotest-libvirt.virsh.live_migration.migrateuri.default.ipv6.p2p_live.without_postcopy: PASS (94.97 s)
 (04/15) type_specific.io-github-autotest-libvirt.virsh.live_migration.listen_address.specific_ipv6_addr.migrateuri_ipv4_addr.p2p_live.without_postcopy: PASS (62.18 s)
 (05/15) type_specific.io-github-autotest-libvirt.virsh.live_migration.listen_address.specific_ipv6_addr.migrateuri_ipv4_addr.non_p2p_live.without_postcopy: PASS (67.76 s)
 (06/15) type_specific.io-github-autotest-libvirt.virsh.live_migration.listen_address.specific_ipv6_addr.migrateuri_ipv6_addr.p2p_live.without_postcopy: PASS (95.69 s)
 (07/15) type_specific.io-github-autotest-libvirt.virsh.live_migration.listen_address.specific_ipv6_addr.migrateuri_ipv6_addr.non_p2p_live.without_postcopy: PASS (95.99 s)
 (08/15) type_specific.io-github-autotest-libvirt.virsh.live_migration.listen_address.all_ipaddrs.ipv4.migrateuri_ipv4_addr.p2p_live.without_postcopy: PASS (97.24 s)
 (09/15) type_specific.io-github-autotest-libvirt.virsh.live_migration.listen_address.all_ipaddrs.ipv4.migrateuri_ipv4_addr.non_p2p_live.without_postcopy: PASS (98.87 s)
 (10/15) type_specific.io-github-autotest-libvirt.virsh.live_migration.listen_address.all_ipaddrs.ipv4.migrateuri_ipv6_addr.p2p_live.without_postcopy: PASS (64.46 s)
 (11/15) type_specific.io-github-autotest-libvirt.virsh.live_migration.listen_address.all_ipaddrs.ipv4.migrateuri_ipv6_addr.non_p2p_live.without_postcopy: PASS (69.62 s)
 (12/15) type_specific.io-github-autotest-libvirt.virsh.live_migration.listen_address.all_ipaddrs.ipv6.migrateuri_ipv4_addr.p2p_live.without_postcopy: PASS (101.22 s)
 (13/15) type_specific.io-github-autotest-libvirt.virsh.live_migration.listen_address.all_ipaddrs.ipv6.migrateuri_ipv4_addr.non_p2p_live.without_postcopy: PASS (99.32 s)
 (14/15) type_specific.io-github-autotest-libvirt.virsh.live_migration.listen_address.all_ipaddrs.ipv6.migrateuri_ipv6_addr.p2p_live.without_postcopy: PASS (97.82 s)
 (15/15) type_specific.io-github-autotest-libvirt.virsh.live_migration.listen_address.all_ipaddrs.ipv6.migrateuri_ipv6_addr.non_p2p_live.without_postcopy: PASS (103.85 s)
RESULTS    : PASS 15 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 1342.30 s

```

```
JOB LOG    : /root/avocado/job-results/job-2021-04-24T22.15-c592311/job.log
 (1/2) type_specific.io-github-autotest-libvirt.virsh.live_migration.migrateuri.with_port.p2p_live.with_postcopy: PASS (196.19 s)
 (2/2) type_specific.io-github-autotest-libvirt.virsh.live_migration.migrateuri.with_port.p2p_live.without_postcopy: PASS (203.39 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 400.82 s
```
