### PR TITLE
Fix blkiotune cgroup2 issues

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blkiotune.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blkiotune.cfg
@@ -1,8 +1,7 @@
 - virsh.blkiotune:
     type = virsh_blkiotune
     libvirtd = "on"
-    qemu_path = "/cgroup/blkio/libvirt/qemu/"
-    schedulerfd = "/sys/block/sda/queue/scheduler"
+    schedulerfd = "/sys/block/%s/queue/scheduler"
     variants:
         - positive:
             status_error = "no"
@@ -55,13 +54,13 @@
                                 - change_device_weights:
                                     variants:
                                         - minimum_boundary:
-                                            blkio_device_weights = "/dev/sda,100"
+                                            blkio_device_weights = "/dev/%s,100"
                                         - inside_boundary:
-                                            blkio_device_weights = "/dev/sda,600"
+                                            blkio_device_weights = "/dev/%s,600"
                                         - maximum_boundary:
-                                            blkio_device_weights = "/dev/sda,1000"
+                                            blkio_device_weights = "/dev/%s,1000"
                                         - remove_device:
-                                            blkio_device_weights = "/dev/sda,0"
+                                            blkio_device_weights = "/dev/%s,0"
                                     variants:
                                         - options:
                                             variants:
@@ -90,11 +89,11 @@
                                 - change_device_weights:
                                     variants:
                                         - minimum_boundary:
-                                            blkio_device_weights = "/dev/sda,100"
+                                            blkio_device_weights = "/dev/%s,100"
                                         - inside_boundary:
-                                            blkio_device_weights = "/dev/sda,800"
+                                            blkio_device_weights = "/dev/%s,800"
                                         - maximum_boundary:
-                                            blkio_device_weights = "/dev/sda,1000"
+                                            blkio_device_weights = "/dev/%s,1000"
                                     variants:
                                         - options:
                                             variants:
@@ -151,11 +150,11 @@
                                 - change_device_weights:
                                     variants:
                                         - lower_boundary:
-                                            blkio_device_weights = /dev/sda,-1
+                                            blkio_device_weights = /dev/%s,-1
                                         - upper_boundary:
-                                            blkio_device_weights = /dev/sda,1001
+                                            blkio_device_weights = /dev/%s,1001
                                         - invalid_device_and_lower_boundary:
-                                            blkio_device_weights = /dev/vda, 99
+                                            blkio_device_weights = /dev/abc, 99
                                         - invalid_value:
                                             blkio_device_weights = "~@#$%^-=_:,.[]{}"
                                     variants:
@@ -196,11 +195,11 @@
                                 - change_device_weights:
                                     variants:
                                         - lower_boundary:
-                                            blkio_device_weights = /dev/sda,-1
+                                            blkio_device_weights = /dev/%s,-1
                                         - upper_boundary:
-                                            blkio_device_weights = /dev/sda,1001
+                                            blkio_device_weights = /dev/%s,1001
                                         - invalid_device_and_lower_boundary:
-                                            blkio_device_weights = /dev/vda, 99
+                                            blkio_device_weights = /dev/abc, 99
                                         - invalid_value:
                                             blkio_device_weights = "~@#$%^-=_:,.[]{}"
                                     variants:


### PR DESCRIPTION
- Existing script does not aplly to cgroup2. So this is to enable
the test script to support both cgroup V1 and V2 and cfq/bfq as well.

- Some hosts are using vda instead sda for the hard disk. So this is
to dynamicly detect the disk and decide which scheduler file to be read.

Before fix:
```
# avocado run --vt-type libvirt --vt-machine-type q35 virsh.blkiotune.positive.set_blkio_parameter.running_guest.change_weight.options.current.maximum_boundary --vt-connect-uri qemu:///system
TestError: Doesn't support controller &lt;blkio&gt;&#10;
```

Signed-off-by: Dan Zheng <dzheng@redhat.com>
