### PR TITLE
nmi_test: skip nmi test on aarch64

### DIFF
--- a/libvirt/tests/cfg/guest_kernel_debugging/nmi_test.cfg
+++ b/libvirt/tests/cfg/guest_kernel_debugging/nmi_test.cfg
@@ -1,4 +1,5 @@
 - guest_kernel_debugging.nmi_test:
+    no aarch64
     type = nmi_test
     take_regular_screendumps = "no"
     login_timeout = 240


### PR DESCRIPTION
AArch64 (aka arm64 in the Linux tree) does not provide architected NMIs
```
\# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio guest_kernel_debugging.nmi_test.positive_testing.send_nmi
JOB ID     : 0169905ac3599e0f59a031730f04075c4c47475f
JOB LOG    : /root/avocado/job-results/job-2021-04-13T22.12-0169905/job.log
 (1/1) type_specific.io-github-autotest-libvirt.guest_kernel_debugging.nmi_test.positive_testing.send_nmi: ERROR: Can not run 'grep NMI /proc/interrupts' in guest:  (133.79 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 134.53 s
```

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>
