### PR TITLE
[virsh_blockjob] Introduce configuration to slow down blockjob

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockjob.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockjob.cfg
@@ -3,6 +3,7 @@
     blockjob_options = ""
     blockjob_bandwidth = ""
     no_blockjob = "no"
+    blockjob_under_test_options = "--bandwidth 300"
     variants:
         - positive_test:
             status_error = "no"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockjob.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockjob.py
@@ -83,6 +83,7 @@ def run(test, params, env):
     invalid_disk = params.get("invalid_disk")
     persistent_vm = "yes" == params.get("persistent_vm", "no")
     status_error = "yes" == params.get("status_error", "no")
+    blockcopy_options = params.get("blockjob_under_test_options", "")
 
     target = get_disk(vm_name, test)
     if not target:
@@ -99,7 +100,7 @@ def run(test, params, env):
     tmp_file = time.strftime("%Y-%m-%d-%H.%M.%S.img")
     dest_path = os.path.join(data_dir.get_tmp_dir(), tmp_file)
     if not no_blockjob:
-        cmd_result = virsh.blockcopy(vm_name, target, dest_path, "",
+        cmd_result = virsh.blockcopy(vm_name, target, dest_path, blockcopy_options,
                                      ignore_status=True, debug=True)
         status = cmd_result.exit_status
         if status != 0:


### PR DESCRIPTION
1. The tests start a blockjob (blockcopy) and then execute
several blockjob commands often expecting the blockjob to be
running.

2. The test waits 3 seconds after starting the blockjob.

As a result, if the blockjob ends before 3 seconds have passed
there will be no blockjob and the domain will have been stopped.
Therefore, the test will fail.

Introduce the bandwidth parameter value. It will cause the blockjob
to take more time. Value 300 was chosen to not slow down the .with_pivot
subcase too much as it waits for the job to finish.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>

Test results:
```bash
# avocado run --vt-type libvirt --vt-machine-type s390-virtio virsh.blockjob --vt-connect-uri qemu:///system                                                                                                                         
JOB ID     : 86c1c6cb8a041e87e33ead58f6be461c3694b9f4
JOB LOG    : /root/avocado/job-results/job-2021-04-14T12.36-86c1c6c/job.log
 (01/14) type_specific.io-github-autotest-libvirt.virsh.blockjob.positive_test.no_option: PASS (16.64 s)
 (02/14) type_specific.io-github-autotest-libvirt.virsh.blockjob.positive_test.min_bandwidth: PASS (13.53 s)
 (03/14) type_specific.io-github-autotest-libvirt.virsh.blockjob.positive_test.max_bandwidth: PASS (14.96 s)
 (04/14) type_specific.io-github-autotest-libvirt.virsh.blockjob.positive_test.abort_option: PASS (13.59 s)
 (05/14) type_specific.io-github-autotest-libvirt.virsh.blockjob.positive_test.async_option: PASS (13.59 s)
 (06/14) type_specific.io-github-autotest-libvirt.virsh.blockjob.positive_test.pivot_option: PASS (48.95 s)
 (07/14) type_specific.io-github-autotest-libvirt.virsh.blockjob.positive_test.info_option: PASS (13.54 s)
 (08/14) type_specific.io-github-autotest-libvirt.virsh.blockjob.positive_test.info_bytes_option: PASS (13.57 s)
 (09/14) type_specific.io-github-autotest-libvirt.virsh.blockjob.positive_test.bandwidth_bytes_option: PASS (13.52 s)
 (10/14) type_specific.io-github-autotest-libvirt.virsh.blockjob.negative_test.invalid_disk: PASS (13.67 s)
 (11/14) type_specific.io-github-autotest-libvirt.virsh.blockjob.negative_test.invalid_bandwidth: PASS (14.02 s)
 (12/14) type_specific.io-github-autotest-libvirt.virsh.blockjob.negative_test.no_blockjob_pivot: PASS (13.89 s)
 (13/14) type_specific.io-github-autotest-libvirt.virsh.blockjob.negative_test.no_blockjob_abort: PASS (13.88 s)
 (14/14) type_specific.io-github-autotest-libvirt.virsh.blockjob.negative_test.no_blockjob_info: PASS (12.04 s)
RESULTS    : PASS 14 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 229.83 s
```