### PR TITLE
Cgroup V2: Update virsh_schedinfo cases

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_schedinfo_qemu_posix.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_schedinfo_qemu_posix.cfg
@@ -36,10 +36,11 @@
                     variants:
                         - value_negative:
                             schedinfo_set_value = -1
-                            schedinfo_set_value_expected = -1
+                            schedinfo_set_value_expected = max
+                            cgroup_v2_unsupported_reason = 'negative cpu quota not supported by cgroupV2'
                         - value_zero:
                             schedinfo_set_value = 0
-                            schedinfo_set_value_expected = -1
+                            schedinfo_set_value_expected = max
                         - value_min:
                             schedinfo_set_value = 1000
                             schedinfo_set_value_expected = 1000
@@ -48,10 +49,10 @@
                             schedinfo_set_value_expected = 80000
                         - value_max:
                             schedinfo_set_value = 17592186044415
-                            schedinfo_set_value_expected = 17592186044415
+                            schedinfo_set_value_expected = max
                             libvirt_ver_function_changed = [6, 0, 0]
                             schedinfo_set_value_bk = 18446744073709551
-                            schedinfo_set_value_expected_bk = 18446744073709551
+                            schedinfo_set_value_expected_bk = max
                 - for_period:
                     variants:
                         - value_zero:
@@ -77,6 +78,8 @@
                         - value_maximum:
                             schedinfo_set_value = 262144
                             schedinfo_set_value_expected = 262144
+                            schedinfo_set_value_cgroupv2 = 10000
+                            schedinfo_set_value_expected_cgroupv2 = 10000
             variants:
                 # Do not set, just show the parameters
                 - show_schedinfo:
@@ -87,7 +90,8 @@
                     schedinfo_set_ref = "vcpu_quota,vcpu_period,emulator_period,emulator_quota"
                     schedinfo_set_method = 'cmd'
                     schedinfo_set_value = "-1,100001,900002,-1"
-                    schedinfo_set_value_expected = "-1,100001,900002,-1"
+                    schedinfo_set_value_cgroupv2 = "17592186044415,100001,900002,17592186044415"
+                    schedinfo_set_value_expected = "max,100001,900002,max"
                 - set_cpu_param:
                     no set_by_self
                     schedinfo_param = "vcpu"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_schedinfo_qemu_posix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_schedinfo_qemu_posix.py
@@ -1,13 +1,11 @@
 import re
 import logging
-import os
 
 from virttest import virsh
+from virttest import libvirt_cgroup
 from virttest import libvirt_version
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import xcepts
-
-from virttest.staging import utils_cgroup
 
 
 def run(test, params, env):
@@ -32,66 +30,43 @@ def run(test, params, env):
         :Param vm: the vm object
         :Param cgroup_type: type of cgroup we want, vcpu or emulator.
         :Param parameter: the cgroup parameter of vm which we need to get.
-        :return: False if expected controller is not mounted.
-                 else return value's result object.
+        :return: the value of parameter in cgroup.
         """
-        cgroup_path = \
-            utils_cgroup.resolve_task_cgroup_path(vm.get_pid(), "cpu")
-        logging.debug("cgroup_path=%s", cgroup_path)
-        if not cgroup_type == "emulator":
-            # When a VM has an 'emulator' child cgroup present, we must
-            # strip off that suffix when detecting the cgroup for a machine
-            if os.path.basename(cgroup_path) == "emulator":
-                cgroup_path = os.path.dirname(cgroup_path)
-            if cgroup_type == 'iothread':
-                parameter = 'iothread1/%s' % parameter
-            if cgroup_type == 'vcpu' and parameter != 'cpu.shares':
-                parameter = 'vcpu0/%s' % parameter
-            if parameter == 'cpu.shares' and libvirt_version.version_compare(7, 0, 0):
-                cgroup_path = os.path.dirname(cgroup_path)
-            logging.debug("cgroup_path is updated to '%s'", cgroup_path)
-        cgroup_file = os.path.join(cgroup_path, parameter)
-        logging.debug("cgroup_file=%s", cgroup_file)
+        vm_pid = vm.get_pid()
+        cgtest = libvirt_cgroup.CgroupTest(vm_pid)
+        cgroup_info = cgtest.get_standardized_cgroup_info("schedinfo")
 
-        cg_file = None
-        try:
-            try:
-                cg_file = open(cgroup_file)
-                result = cg_file.read()
-            except IOError:
-                test.error("Failed to open cgroup file %s"
-                           % cgroup_file)
-        finally:
-            if cg_file is not None:
-                cg_file.close()
-        return result.strip()
+        logging.debug("cgroup_info is %s" % cgroup_info)
+        if parameter in ["cpu.cfs_period_us", "cpu.cfs_quota_us"]:
+            if cgroup_type == "emulator":
+                parameter = "%s/%s" % (cgroup_type, parameter)
+            elif cgroup_type in ["vcpu", "iothread"]:
+                parameter = "<%sX>/%s" % (cgroup_type, parameter)
+        for key, value in libvirt_cgroup.CGROUP_V1_SCHEDINFO_FILE_MAPPING.items():
+            if value == parameter:
+                cgroup_ref_key = key
+                break
+        if 'cgroup_ref_key' not in locals():
+            test.error("{} is not found in CGROUP_V1_SCHEDINFO_FILE_MAPPING."
+                       .format(parameter))
+        return cgroup_info[cgroup_ref_key]
 
-    def schedinfo_output_analyse(result, set_ref, scheduler="posix"):
+    def analyse_schedinfo_output(result, set_ref):
         """
         Get the value of set_ref.
 
         :param result: CmdResult struct
         :param set_ref: the parameter has been set
-        :param scheduler: the scheduler of qemu(default is posix)
+        :return: the value of the parameter.
         """
-        output = result.stdout.strip()
-        if not re.search("Scheduler", output):
-            test.fail("Output is not standard:\n%s" % output)
-
-        result_lines = output.splitlines()
+        cg_obj = libvirt_cgroup.CgroupTest(None)
+        output_dict = cg_obj.convert_virsh_output_to_dict(result)
+        result_info = cg_obj.get_standardized_virsh_info("schedinfo", output_dict)
         set_value_list = []
         for set_ref_node in set_ref.split(","):
-            for line in result_lines:
-                key_value = line.split(":")
-                key = key_value[0].strip()
-                value = key_value[1].strip()
-                if key == "Scheduler":
-                    if value != scheduler:
-                        test.cancel("This test do not support"
-                                    " %s scheduler." % scheduler)
-                elif key == set_ref_node:
-                    set_value_list.append(value)
-                    break
+            if result_info.get(set_ref_node):
+                set_value_list.append(result_info.get(set_ref_node))
+
         return set_value_list
 
     def get_current_value():
@@ -100,8 +75,7 @@ def run(test, params, env):
         """
         current_result = virsh.schedinfo(vm_ref, " --current",
                                          ignore_status=True, debug=True)
-        current_value = schedinfo_output_analyse(current_result, set_ref,
-                                                 scheduler_value)
+        current_value = analyse_schedinfo_output(current_result, set_ref)
         return current_value
 
     # Prepare test options
@@ -123,6 +97,15 @@ def run(test, params, env):
     start_vm = ("yes" == params.get("start_vm"))
     readonly = ("yes" == params.get("schedinfo_readonly", "no"))
     expect_msg = params.get("schedinfo_err_msg", "")
+
+    if libvirt_cgroup.CgroupTest(None).is_cgroup_v2_enabled():
+        if params.get("schedinfo_set_value_cgroupv2"):
+            set_value = params.get("schedinfo_set_value_cgroupv2")
+        if params.get("schedinfo_set_value_expected_cgroupv2"):
+            set_value_expected = params.get(
+                "schedinfo_set_value_expected_cgroupv2")
+        if params.get("cgroup_v2_unsupported_reason"):
+            test.cancel(params.get('cgroup_v2_unsupported_reason'))
 
     if libvirt_ver_function_changed:
         if not libvirt_version.version_compare(*libvirt_ver_function_changed):
@@ -175,11 +158,17 @@ def run(test, params, env):
             cputune[name_map[set_ref]] = int(set_value)
             xml.cputune = cputune
             xml.sync()
-            logging.debug("After setting xml, VM XML:\n%s", vm_xml.VMXML.new_from_dumpxml(vm_name))
+            logging.debug("After setting xml, VM XML:\n%s",
+                          vm_xml.VMXML.new_from_dumpxml(vm_name))
 
     vm = env.get_vm(vm_name)
     if vm.is_dead() and start_vm:
-        vm.start()
+        try:
+            vm.start()
+        except Exception as detail:
+            orig_config_xml.sync()
+            test.error(detail)
+
     domid = vm.get_id()
     domuuid = vm.get_uuid()
 
@@ -229,8 +218,7 @@ def run(test, params, env):
         vm.destroy(gracefully=False)
 
         if set_ref:
-            set_value_of_output = schedinfo_output_analyse(result, set_ref,
-                                                           scheduler_value)
+            set_value_of_output = analyse_schedinfo_output(result, set_ref)
 
         # Check result
         if status_error == "no":


### PR DESCRIPTION
Cgroup v2 is enabled by default on rhel9, so update cases to
support cgroup v1 and v2.

Signed-off-by: Yingshun Cui <yicui@redhat.com>

**depends on:**
https://github.com/avocado-framework/avocado-vt/pull/3004
https://github.com/avocado-framework/avocado-vt/pull/2924

**test results:**
_rhel 9:_
```
# avocado run --vt-type libvirt  virsh.schedinfo_qemu_posix
(001/110) type_specific.io-github-autotest-libvirt.virsh.schedinfo_qemu_posix.normal_test.show_schedinfo.for_show.set_by_self.valid_domname.running_guest: PASS (5.48 s)
 (002/110) type_specific.io-github-autotest-libvirt.virsh.schedinfo_qemu_posix.normal_test.show_schedinfo.for_show.set_by_self.valid_domuuid.running_guest: PASS (5.41 s)
 (003/110) type_specific.io-github-autotest-libvirt.virsh.schedinfo_qemu_posix.normal_test.set_multi_params.for_multi.set_by_self.valid_domname.running_guest: PASS (5.75 s)
... ...
 (110/110) type_specific.io-github-autotest-libvirt.virsh.schedinfo_qemu_posix.error_test.set_none: PASS (5.47 s)
RESULTS    : PASS 102 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 8
JOB TIME   : 1097.15 s
```


