### PR TITLE
Add 2 new cases for "get vhost-user VNIC stats by domstats" and "vhostuser with dpdk"

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_options.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_options.cfg
@@ -232,6 +232,25 @@
                                     restart_libvirtd = "yes"
                                     test_iface_option_cmd = "no"
                                 - passthrough:
+                        - get_domstats:
+                            change_iface_options = "no"
+                            test_iface_option_cmd = "no"
+                            vhostuser_names = "vhost-user1 vhost-user2"
+                            iface_source = "[{'type':'unix','path':'/var/run/openvswitch/vhost-user1','mode':'client'}, {'type':'unix','path':'/var/run/openvswitch/vhost-user2','mode':'client'}, {'type':'unix','path':'/var/lib/libvirt/qemu/vhost-client-1','mode':'server'}]"
+                            vhost_client_name = "vhost-client-1"
+                            vhost_client_type = "dpdkvhostuserclient"
+                            vhost_client_options = "vhost-server-path=/var/lib/libvirt/qemu/vhost-client-1"
+                            vhost_client_path = "/var/lib/libvirt/qemu/"
+                            attach_iface_device = "config"
+                            expect_target_devs = "['vhost-user1', 'vhost-user2', 'vhost-client-1']"
+                        - vhost_dpdk:
+                            need_vhostuser_env = "no"
+                            change_iface_options = "no"
+                            test_iface_option_cmd = "no"
+                            vhostuser_names = "vhost-user1 vhost-user2"
+                            iface_source = "[{'type':'unix','path':'/tmp/vhost-user1','mode':'server'}, {'type':'unix','path':'/tmp/vhost-user2','mode':'server'}]"
+                            attach_iface_device = "config"
+                            testpmd_cmd = "dpdk-testpmd -l 1-3 --socket-mem 1024 -n 4 --vdev 'net_vhost0,iface=/tmp/vhost-user1,queues=2,client=1,iommu-support=1' --vdev 'net_vhost1,iface=/tmp/vhost-user2,queues=2,client=1,iommu-support=1' -d /usr/lib64/librte_net_vhost.so.21 -- --portmask=f -i --rxd=512 --txd=512 --rxq=2 --txq=2 --nb-cores=2 --forward-mode=io"
                         - multi_guests:
                             additional_guest = "yes"
                             vhostuser_names = "vhost-user1 vhost-user2"


### PR DESCRIPTION
Signed-off-by: Kyla Zhang <weizhan@redhat.com>

depends on https://github.com/avocado-framework/avocado-vt/pull/3006 

case ID: RHEL-197483 RHEL-197487
```
# avocado run --vt-type libvirt virtual_network.iface_options.iface_type.type_vhostuser.vhost_client
JOB ID     : 7b0f45e843af1fc738341ee2b250ed4399b8724f
JOB LOG    : /root/avocado/job-results/job-2021-04-14T08.08-7b0f45e/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.iface_options.iface_type.type_vhostuser.vhost_client: PASS (46.71 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 48.35 s
```	
And also test 2 other cases to make sure no effect to others
```
# avocado run --vt-type libvirt virtual_network.iface_options.iface_type.type_vhostuser.queue_size_check
JOB ID     : b099acb801d42e87303c0338ef464e906606f027
JOB LOG    : /root/avocado/job-results/job-2021-04-15T07.14-b099acb/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.iface_options.iface_type.type_vhostuser.queue_size_check: PASS (49.40 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 50.99 s
# avocado run --vt-type libvirt virtual_network.iface_options.iface_type.type_vhostuser.multi_queue.hotplug

JOB ID     : 5b6dd998e5cb5a8fe1d876d3f2e5e857ed98752d
JOB LOG    : /root/avocado/job-results/job-2021-04-15T07.27-5b6dd99/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.iface_options.iface_type.type_vhostuser.multi_queue.hotplug: PASS (52.36 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 53.98 s

```