### PR TITLE
blockcopy: add case to check image cluster size after blockcopy

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockcopy.cfg
+++ b/libvirt/tests/cfg/backingchain/blockcopy.cfg
@@ -2,7 +2,13 @@
     type = blockcopy
     variants:
         - positive_test:
-            variants:
+            variants case:
                 - reuse_external:
-                    case = 'reuse_external'
                     start_vm = 'yes'
+                - custom_cluster_size:
+                    start_vm = 'yes'
+                    image_format = 'qcow2'
+                    image_size = '100M'
+                    image_cluster_size = '1024'
+                    source_image_name = 'source_image'
+                    target_image_name = 'target_image'


### PR DESCRIPTION
Case description: Use a qcow2 image with customized cluster size
in vm, and blockcopy it to a target path. Check the target image
has same cluster size as source image.
Case ID: RHEL-196451
Test result: PASSED with libvirt-7.0.0-4.el9.x86_64

Signed-off-by: Yi Sun <yisun@redhat.com>

