### PR TITLE
[virsh_attach_device] fix single_serial on s390x

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_device.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_device.cfg
@@ -184,12 +184,11 @@
                     variants:
                         - single_serial:
                             # SerialFile is name of class in test-module
-                            vadu_dev_objs = "SerialPipe"
-                            # vadu_dev_obj_count_SerialPipe inherited as 1
+                            vadu_dev_objs = "SerialPty"
                             variants:
                                 - without_alias:
                                 - with_alias:
-                                    vadu_dev_obj_alias_SerialPipe = "ua-serial"
+                                    vadu_dev_obj_alias_SerialPty = "ua-serial"
                         - single_serial_lm:
                             # SerialFile is name of class in test-module
                             vadu_dev_objs = "SerialPipe"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
@@ -464,6 +464,27 @@ class SerialPipe(SerialFile):
         return super(SerialPipe, self).init_device(index)  # stub for now
 
 
+class SerialPty(AttachDeviceBase):
+
+    """
+    Simple console pty device
+    """
+
+    type_name = "pty"
+
+    def init_device(self, index):
+        serialclass = self.test_params.vmxml.get_device_class('serial')
+        serial_device = serialclass(type_name=self.type_name,
+                                    virsh_instance=self.test_params.virsh)
+        # Assume default domain serial device on port 0 and index starts at 0
+        if hasattr(self, 'alias') and libvirt_version.version_compare(3, 9, 0):
+            serial_device.alias = {'name': self.alias + str(index)}
+        return serial_device
+
+    def function(self, index):
+        return not self.test_params.status_error
+
+
 class Console(AttachDeviceBase):
 
     """
@@ -505,6 +526,7 @@ class ConsoleFile(Console, SerialFile):
     """
     Simplistic pipe-backed console
     """
+
     def init_device(self, index):
         return _init_device_Serial2Console(self, index)
 
@@ -513,6 +535,7 @@ class ConsolePipe(Console, SerialPipe):
     """
     Simplistic file-backed console
     """
+
     def init_device(self, index):
         return _init_device_Serial2Console(self, index)
 


### PR DESCRIPTION
1. Using `SerialPipe` will set first chardev to a non-pty.
2. Per default 'virsh console' will select the first chardev and
   the system can't be logged into.

Therefore, login will fail if using `SerialPipe`.

Use simple `SerialPty` for `single_serial` to assure test can log in.

`SerialPipe` is still covered in suite `single_serial_lm`.

This change only affects s390x, ie. by configuration only
subcases `serial_s390x.single_serial`. However, the new `SerialPty` can
be used for any platform.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>
