### PR TITLE
guest_resource_control: Do extra operations when set cgroup values

### DIFF
--- a/libvirt/tests/cfg/guest_resource_control/control_cgroup.cfg
+++ b/libvirt/tests/cfg/guest_resource_control/control_cgroup.cfg
@@ -80,6 +80,7 @@
                     variants:
                         - positive:
                             virsh_cmd_param_value = "123;/dev/sda,1234000000;/dev/sda,2345000000;/dev/sda,3456000000;/dev/sda,5678000000"
+                            extra_operations = "daemon-relaod"
                         - negative:
                             status_error = "yes"
                             virsh_cmd_param_value = "123;/dev/sda,1fda00000;/dev/sda,2345000000;/dev/sda,-3456000000;/dev/sda,a678000000"
@@ -91,6 +92,7 @@
                     variants:
                         - positive:
                             virsh_cmd_param_value = "10000000"
+                            extra_operations = "restart-libvirtd"
                         - negative:
                             status_error = "yes"
                             variants:
@@ -124,6 +126,7 @@
                     variants:
                         - positive:
                             virsh_cmd_param_value = "1000"
+                            extra_operations = "daemon-reload"
                         - negative:
                             status_error = "yes"
                             variants:


### PR DESCRIPTION
- Description:
We need to recheck cgroup values When reload daemons after setting
vm's cgroup values, issues happened before.
- Case ID:
RHEL-202437
- Test result (rhel9):
PASSED with memtune&blkiotune cases
FAILED with schedinfo cases, expected due to bz1798463 not fixed
on rhel9

Signed-off-by: Yi Sun <yisun@redhat.com>