### PR TITLE
blockcopy: Replace tmp_dir with data_dir

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
@@ -385,7 +385,7 @@ def run(test, params, env):
                                                                   vm_name))
 
     original_xml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
-    tmp_dir = data_dir.get_tmp_dir()
+    tmp_dir = data_dir.get_data_dir()
 
     # Prepare dest path params
     dest_path = params.get("dest_path", "")


### PR DESCRIPTION
To avoid failures caused by tmpfs

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>
