### PR TITLE
Cgroup V2: Update vcpu_affinity cases

### DIFF
--- a/libvirt/tests/cfg/cpu/vcpu_affinity.cfg
+++ b/libvirt/tests/cfg/cpu/vcpu_affinity.cfg
@@ -6,7 +6,6 @@
     current_vcpu = "3"
     vcpu = "0"
     start_timeout = "180"
-    machine_cpuset_path = "/sys/fs/cgroup/cpuset/machine.slice/cpuset.cpus"
     variants:
         - positive_test:
             status_error = "no"

--- a/libvirt/tests/src/cpu/vcpu_affinity.py
+++ b/libvirt/tests/src/cpu/vcpu_affinity.py
@@ -1,7 +1,6 @@
 import logging
 
 from avocado.utils import cpu as cpuutil
-from avocado.utils import process
 
 from virttest import virsh
 from virttest import cpu
@@ -80,7 +79,6 @@ def run(test, params, env):
     err_msg = params.get("err_msg", "")
     start_timeout = int(params.get("start_timeout", "180"))
     offline_hostcpus = params.get("offline_hostcpus", "")
-    machine_cpuset_path = params.get("machine_cpuset_path", "")
 
     vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
     vmxml_backup = vmxml.copy()
@@ -224,5 +222,3 @@ def run(test, params, env):
         # recovery the host cpu env
         for x in range(1, hostcpu_num):
             cpuutil.online(x)
-        cmd = "echo '0-{}' > {}".format(hostcpu_num-1, machine_cpuset_path)
-        process.run(cmd, shell=True)


### PR DESCRIPTION
After discussion with function owner, there is no need to write
the machine_cpuset_path in the "finally" block.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Test result:**
_Before fix:_
```
 (1/1) type_specific.io-github-autotest-libvirt.vcpu_affinity.positive_test.vcpu: ERROR: Command 'echo '0-31' > /sys/fs/cgroup/cpuset/machine.slice/cpuset.cpus' failed.\nstdout: b''\nstderr: b'/bin/sh: line 1: /sys/fs/cgroup/cpuset/machine.slice/cpuset.cpus: No such file or directory\n'\nadditional_info: None (31.57 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```

_After fix:_
```
# avocado run --vt-type libvirt vcpu_affinity.positive_test.vcpu
WARNING:root:No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
WARNING:root:No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : c9f1b7778eda9189731f257cbcb354389de4cf83
JOB LOG    : /root/avocado/job-results/job-2021-04-22T00.29-c9f1b77/job.log
 (1/1) type_specific.io-github-autotest-libvirt.vcpu_affinity.positive_test.vcpu: PASS (51.00 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 51.62 s
```