### PR TITLE
incremental_backup: Check backup canceled when vm killed or destroyed

### DIFF
--- a/libvirt/tests/cfg/incremental_backup/incremental_backup_pull_mode.cfg
+++ b/libvirt/tests/cfg/incremental_backup/incremental_backup_pull_mode.cfg
@@ -46,7 +46,7 @@
             variants:
                 - negative_test:
                     backup_rounds = 1
-                    variants:
+                    variants error_operation:
                         # We need to add case after bz1816692 fixed, otherwise
                         # we don't know if the virsh cmd expecting a failure.
                         #- blk_scratch_no_space:
@@ -57,6 +57,12 @@
                             backup_error = "yes"
                             prepare_scratch_blkdev = "no"
                             scratch_blkdev_path = "/non/exist"
+                        - destroy_vm:
+                            expect_backup_canceled = "yes"
+                            only tls_disabled.original_disk_local.hotplug_disk.nbd_tcp.scratch_to_block.negative_test..default_exportbitmap.default_exportname.scratch_not_encrypted
+                        - kill_qemu:
+                            only tls_disabled.original_disk_local.coldplug_disk.nbd_unix.scratch_to_block.negative_test..default_exportbitmap.default_exportname.scratch_not_encrypted
+                            expect_backup_canceled = "yes"
                 - positive_test:
     variants:
         - nbd_unix:


### PR DESCRIPTION
Description:
When vm is destroyed or killed, its backup job should be canceled,
otherwise a deadlock will happen when vm started again.
Polarion Case: RHEL-199902 (pull mode part)
Test result: PASS

Signed-off-by: Yi Sun <yisun@redhat.com>