### PR TITLE
Add one case about test multiqueue on direct type interface

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_options.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_options.cfg
@@ -293,6 +293,11 @@
                 - driver_vhost:
                 - driver_qemu:
                     iface_driver = "{'name':'qemu'}"
+            variants:
+                - default:
+                - multiqueue:
+                    only driver_vhost
+                    iface_driver =  "{'name':'vhost','queues':'4'}"
         - iface_backend:
             change_iface_options = "yes"
             test_iface_option_cmd = "yes"

--- a/libvirt/tests/src/virtual_network/iface_options.py
+++ b/libvirt/tests/src/virtual_network/iface_options.py
@@ -21,6 +21,7 @@ from virttest import utils_libvirtd
 from virttest import utils_config
 from virttest import data_dir
 from virttest import utils_selinux
+from virttest import network
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import capability_xml
@@ -237,6 +238,10 @@ def run(test, params, env):
             if iface_target == "macvtap" and "mode" in iface.source:
                 cmd = "ip -d link show %s" % iface.target["dev"]
                 output = process.run(cmd, shell=True).stdout_text
+                if not re.findall("noqueue", output):
+                    test.fail("The default qdisc type should be noqueue, but it's not, check output '%s'" % output)
+                else:
+                    logging.info("Check the qisc type is expected noqueue")
                 logging.debug("ip link output: %s", output)
                 mode = iface.source["mode"]
                 if mode == "passthrough":
@@ -867,6 +872,15 @@ def run(test, params, env):
                             logging.info("Find TX settint TX:%s by ethtool", driver_dict['tx_queue_size'])
                         else:
                             test.fail("Cannot find matching tx setting")
+            if queue_size and not status_error:
+                logging.debug("The queue size set in the xml is %s" % queue_size)
+                ifname_guest = utils_net.get_linux_ifname(session, iface_mac)
+                max, cur = network.get_channel_info(session, ifname_guest)
+                logging.debug("Get the channel info as: max %s  current %s" % (max, cur))
+                if int(max.get("Combined")) != queue_size:
+                    test.fail("The multiqueue did not set correctly on the vm, refer to %s!" % max)
+                if not network.set_channel(session, ifname_guest, "combined", queue_size):
+                    test.fail("Setting Combined to %s on vm failed!" % queue_size)
             if test_target:
                 logging.debug("Check if the target dev is set")
                 run_xml_test(iface_mac)


### PR DESCRIPTION
Multiqueue is supported on direct type interface, add 1 test case
about it. And add the checkpoint for interface with multiqueue to
check the channel info in vm, and set the channel info. Also add 1
check point about qdisc check.