### PR TITLE
virsh_snapshot_create_as: replace /tmp with new dir

### DIFF
--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_disk.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_disk.py
@@ -44,7 +44,7 @@ def run(test, params, env):
     replace_vm_disk = "yes" == params.get("replace_vm_disk", "no")
     disk_source_protocol = params.get("disk_source_protocol")
     vol_name = params.get("vol_name")
-    tmp_dir = data_dir.get_tmp_dir()
+    tmp_dir = data_dir.get_data_dir()
     pool_name = params.get("pool_name", "gluster-pool")
     brick_path = os.path.join(tmp_dir, pool_name)
     multi_gluster_disks = "yes" == params.get("multi_gluster_disks", "no")


### PR DESCRIPTION
This is to use alternative directory instead of /tmp to avoid some failures due to
tmpfs issues.

Signed-off-by: Dan Zheng <dzheng@redhat.com>
