### PR TITLE
incremental_backup: Check push backup canceled when vm killed or dest…

### DIFF
--- a/libvirt/tests/cfg/incremental_backup/incremental_backup_push_mode.cfg
+++ b/libvirt/tests/cfg/incremental_backup/incremental_backup_push_mode.cfg
@@ -25,11 +25,17 @@
             prepare_target_blkdev = "yes"
             variants:
                 - negative_test:
-                    backup_error = "yes"
-                    variants:
-                    - target_blkdev_not_exist:
-                        prepare_target_blkdev = "no"
-                        target_blkdev_path = "/dev/not/exist"
+                    variants error_operation:
+                        - target_blkdev_not_exist:
+                            backup_error = "yes"
+                            prepare_target_blkdev = "no"
+                            target_blkdev_path = "/dev/not/exist"
+                        - destroy_vm:
+                            only original_disk_local.coldplug_disk.backup_to_raw.backup_to_block
+                            expect_backup_canceled = "yes"
+                        - kill_qemu:
+                            only original_disk_local.hotplug_disk.backup_to_qcow2.backup_to_block
+                            expect_backup_canceled = "yes"
                 - positive_test:
     variants:
         - backup_to_qcow2:


### PR DESCRIPTION
…royed

Description:
When vm is destroyed or killed, its backup job should be canceled,
otherwise a deadlock will happen when vm started again.
Polarion Case: RHEL-199902 (push mode part)
Test result: PASS

Signed-off-by: Yi Sun yisun@redhat.com