### PR TITLE
remote_access:Fix remote unix readonly sasl

### DIFF
--- a/libvirt/tests/cfg/remote_access/remote_with_unix.cfg
+++ b/libvirt/tests/cfg/remote_access/remote_with_unix.cfg
@@ -107,7 +107,7 @@
                     read_only = "-r"
                     virsh_cmd = "start"
                     main_vm = "avocado-vt-vm1"
-                    patterns_virsh_cmd = ".*Domain\s\'?*${main_vm}\'?\s*started\s*.*"
+                    patterns_virsh_cmd = ".*Domain\s*\'?${main_vm}\'?\s*started\s*.*"
                 - readonly_without_auth:
                     read_only = "-r"
                     virsh_cmd = "start"


### PR DESCRIPTION
Regular expression in config file was wrong for
virsh.remote_with_unix.negative_testing.allow_sasl_user_with_readonly
test and caused an error: multiple repeat at position 13. This commit fixes 
the regular expression, so the test can pass.