### PR TITLE
Cgroup V2: Update virsh_emulatorpin cases

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_emulatorpin.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_emulatorpin.py
@@ -4,6 +4,7 @@ import random
 
 from avocado.utils import cpu
 
+from virttest import libvirt_cgroup
 from virttest import utils_libvirtd, virsh
 from virttest.libvirt_xml import vm_xml, xcepts
 from virttest.cpu import cpus_parser
@@ -22,10 +23,13 @@ def get_emulatorpin_from_cgroup(params, test):
     """
     vm = params.get("vm")
 
-    cpuset_path = \
-        utils_cgroup.resolve_task_cgroup_path(vm.get_pid(), "cpuset")
-
-    cpuset_file = os.path.join(cpuset_path, "cpuset.cpus")
+    cg_obj = libvirt_cgroup.CgroupTest(vm.get_pid())
+    cpuset_path = cg_obj.get_cgroup_path("cpuset")
+    if cg_obj.is_cgroup_v2_enabled():
+        cpuset_file = os.path.join(cpuset_path,
+                                   "emulator/cpuset.cpus.effective")
+    else:
+        cpuset_file = os.path.join(cpuset_path, "cpuset.cpus")
 
     try:
         with open(cpuset_file, "rU") as f_emulatorpin_params:


### PR DESCRIPTION
Cgroup v2 is enabled by default on rhel9, so update cases to
support cgroup v1 and v2.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Test result:**
_cgroup v1:_
` (1/1) type_specific.io-github-autotest-libvirt.virsh.emulatorpin.positive_testing.set_emulatorpin_parameter.running_guest.cpulist.emulatorpin_options.live.comma_list: PASS (9.79 s)`

_cgroup v2:_
```
JOB LOG    : /root/avocado/job-results/job-2021-04-24T23.23-16a2c7e/job.log
 (1/7) type_specific.io-github-autotest-libvirt.virsh.emulatorpin.positive_testing.get_emulatorpin_parameter.running_guest.emulatorpin_options.none: PASS (7.40 s)
 (2/7) type_specific.io-github-autotest-libvirt.virsh.emulatorpin.positive_testing.get_emulatorpin_parameter.running_guest.emulatorpin_options.live: PASS (7.48 s)
 (3/7) type_specific.io-github-autotest-libvirt.virsh.emulatorpin.positive_testing.get_emulatorpin_parameter.running_guest.emulatorpin_options.current: PASS (7.62 s)
 (4/7) type_specific.io-github-autotest-libvirt.virsh.emulatorpin.positive_testing.get_emulatorpin_parameter.shutoff_guest.emulatorpin_options.none: PASS (6.05 s)
 (5/7) type_specific.io-github-autotest-libvirt.virsh.emulatorpin.positive_testing.get_emulatorpin_parameter.shutoff_guest.emulatorpin_options.config: PASS (6.00 s)
 (6/7) type_specific.io-github-autotest-libvirt.virsh.emulatorpin.positive_testing.get_emulatorpin_parameter.shutoff_guest.emulatorpin_options.current: PASS (5.98 s)
 (7/7) type_specific.io-github-autotest-libvirt.virsh.emulatorpin.positive_testing.set_emulatorpin_parameter.running_guest.cpulist.emulatorpin_options.live.comma_list: PASS (7.79 s)
RESULTS    : PASS 7 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0

```