### PR TITLE
Add p2p migration case for with_migrate_disks

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_vm.cfg
+++ b/libvirt/tests/cfg/migration/migrate_vm.cfg
@@ -546,6 +546,19 @@
                                 - part_non_shared_disks:
                                     status_error = "yes"
                                     virsh_options = "--live --verbose --copy-storage-all --migrate-disks vda"
+                        - with_migrate_disks_p2p:
+                            setup_nfs = "yes"
+                            enable_virt_use_nfs = "yes"
+                            migrate_disks = "yes"
+                            attach_A_disk_source = "${nfs_mount_src}/test1.qcow2"
+                            attach_B_disk_source = "${nfs_mount_dir}/test2.qcow2"
+                            config_libvirtd = "yes"
+                            variants:
+                                - all_non_shared_disks:
+                                    virsh_options = "--live --p2p --verbose --copy-storage-all --migrate-disks vda,vdb"
+                                - part_non_shared_disks:
+                                    status_error = "yes"
+                                    virsh_options = "--live --p2p --verbose --copy-storage-all --migrate-disks vda"
                         - disk_ports:
                             nfs_mount_dir =
                             set_migration_speed = 100


### PR DESCRIPTION
RHEL-201640: [Migration][--migrate-disks] Specify the disks to be
    migrated for storage migration - p2p

Signed-off-by: Yingshun Cui <yicui@redhat.com>
