### PR TITLE
migration: Add a disks_port related case

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_storage.cfg
+++ b/libvirt/tests/cfg/migration/migrate_storage.cfg
@@ -76,3 +76,10 @@
                             variants:
                                 - ipv4_addr:
                                     virsh_migrate_extra = "--disks-uri  tcp://${migrate_dest_host} --listen-address [${ipv6_addr_des}] --migrateuri tcp://[${ipv6_addr_des}] ${bandwidth_opt}"
+        - disks_port:
+            only copy_storage_all
+            check_disks_port = "yes"
+            action_during_mig_params_exists = "yes"
+            port_to_check = 49158
+            virsh_migrate_extra = "--disks-port ${port_to_check}"
+            virsh_migrate_options = "--p2p --persistent --live --verbose --bandwidth 200"


### PR DESCRIPTION
RHEL-201639 - [Migration] [--disks-ports] Do storage migration with
    specified port - p2p

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Test result:**
```
# avocado run --vt-type libvirt virsh.migrate_storage.disks_port
WARNING:root:No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
WARNING:root:No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : 6fdd801213a88f1d978d56adc96a5895897ae5e1
JOB LOG    : /root/avocado/job-results/job-2021-04-25T03.46-6fdd801/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_storage.disks_port.copy_storage_all: PASS (142.28 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0

```