### PR TITLE
virsh_blockcommit/blockpull/snapshot: remove transport protocol 'rdma' in gluster disk test

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcommit.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcommit.cfg
@@ -103,8 +103,6 @@
                             pool_name = "gluster-pool"
                             variants:
                                 - transport_default:
-                                - transport_rdma:
-                                    transport = "rdma"
                                 - transport_tcp:
                                     transport = "tcp"
                             variants:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockpull.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockpull.cfg
@@ -65,8 +65,6 @@
                             pool_name = "gluster-pool"
                             variants:
                                 - transport_default:
-                                - transport_rdma:
-                                    transport = "rdma"
                                 - transport_tcp:
                                     transport = "tcp"
                             variants:

--- a/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_create_as.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_create_as.cfg
@@ -185,8 +185,6 @@
                             pool_name = "gluster-pool"
                             variants:
                                 - transport_default:
-                                - transport_rdma:
-                                    transport = "rdma"
                                 - transport_tcp:
                                     transport = "tcp"
                             variants:

--- a/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_disk.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_disk.cfg
@@ -74,8 +74,6 @@
                                 - multi_disks:
                                     multi_gluster_disks = 'yes'
                                 - transport_default:
-                                - transport_rdma:
-                                    transport = "rdma"
                                 - transport_tcp:
                                     transport = "tcp"
                         - inactive:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockcommit.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockcommit.py
@@ -381,12 +381,6 @@ def run(test, params, env):
             test.cancel("live active block commit is not supported"
                         " in current libvirt version.")
 
-    # This is brought by new feature:block-dev
-    if (libvirt_version.version_compare(6, 0, 0) and
-       params.get("transport", "") == "rdma"):
-        test.cancel("If blockdev is enabled, the transport protocol 'rdma' is "
-                    "not yet supported.")
-
     # A backup of original vm
     vmxml_backup = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockpull.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockpull.py
@@ -259,12 +259,6 @@ def run(test, params, env):
     pool_name = params.get("pool_name", "gluster-pool")
     brick_path = os.path.join(tmp_dir, pool_name)
 
-    # This is brought by new feature:block-dev
-    if (libvirt_version.version_compare(6, 0, 0) and
-       params.get("transport", "") == "rdma"):
-        test.cancel("If blockdev is enabled, the transport protocol 'rdma' is "
-                    "not yet supported.")
-
     # A backup of original vm
     vmxml_backup = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     logging.debug("original xml is %s", vmxml_backup)

--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_create_as.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_create_as.py
@@ -393,10 +393,6 @@ def run(test, params, env):
                          "in this libvirt version. Not expecting a failure.")
             status_error = "no"
 
-    # This is brought by new feature:block-dev
-    if libvirt_version.version_compare(6, 0, 0) and transport == "rdma":
-        test.cancel("transport protocol 'rdma' is not yet supported")
-
     opt_names = locals()
     if memspec_opts is not None:
         mem_options = compose_disk_options(test, params, memspec_opts)

--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_disk.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_disk.py
@@ -102,10 +102,6 @@ def run(test, params, env):
                         "https://bugzilla.redhat.com/buglist.cgi?"
                         "bug_id=1017289,1032370")
 
-    # This is brought by new feature:block-dev
-    if libvirt_version.version_compare(6, 0, 0) and transport == "rdma":
-        test.cancel("transport protocol 'rdma' is not yet supported")
-
     if disk_cluster_size_set and not libvirt_version.version_compare(6, 10, 0):
         test.cancel("current libvirt version doesn't support the feature that "
                     "snapshot and backing file share the cluster size ")


### PR DESCRIPTION
The reasons for remove 'rdma' protocol:
1. From libvirt 6.0.0, the transport protocol 'rdma' is  not yet supported
2. Before libvirt 6.0.0, actually it's also not supported because it just transfer into tcp protocol.
3. No need to update polarion test cases

Signed-off-by: Meina Li <meili@redhat.com>
