### PR TITLE
v2v: move windows cases from xen to esx

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -45,7 +45,7 @@
                     json_disk_pattern = '%%{GuestName}-%{GuestName}-%{DiskDeviceName}-%{DiskNo}'
         - libvirt:
             only dest_libvirt
-            only uefi, GPO_AV, special_name, suse, local_storage
+            only uefi, GPO_AV, special_name, suse, local_storage, unset
         - rhev:
             only dest_rhev.NFS
             variants:
@@ -142,6 +142,23 @@
                         - win2019:
                             main_vm = VM_NAME_WIN2019_V2V_EXAMPLE
                             os_version = "win2019"
+                - virtio_win:
+                    only esx_67
+                    main_vm = 'ESX_VM_NAME_VIRTIO_WIN_V2V_EXAMPLE'
+                    os_version = 'OS_VERSION_VIRTIO_WIN_V2V_EXAMPLE'
+                    virtio_win_dir = '/usr/share/virtio-win/'
+                    virtio_win_env = 'VIRTIO_WIN'
+                    checkpoint = 'virtio_win_'
+                    variants:
+                        - unset:
+                            checkpoint += 'unset'
+                            missing = 'Red Hat VirtIO SCSI,Red Hat VirtIO Ethernet Adapte'
+                        - custom:
+                            checkpoint += 'custom'
+                        - iso_mount:
+                            checkpoint += 'iso_mount'
+                        - iso_file:
+                            checkpoint += 'iso_file'
                 - virtio_iso_blk:
                     only esx_67
                     checkpoint = "virtio_iso_blk"
@@ -157,6 +174,11 @@
                     only esx_70
                     checkpoint = 'vmware_tools'
                     main_vm = VM_NAME_WIN_VMWARE_TOOLS_V2V_EXAMPLE
+                - rhsrvany_md5:
+                    only esx_67
+                    checkpoint = 'rhsrvany_checksum'
+                    main_vm = VM_NAME_WIN2019_V2V_EXAMPLE
+                    os_version = 'win2019'
         - with_cdrom:
             only esx_70
             main_vm = 'VM_NAME_ESX_CDROM_V2V_EXAMPLE'

--- a/v2v/tests/cfg/function_test_xen.cfg
+++ b/v2v/tests/cfg/function_test_xen.cfg
@@ -138,48 +138,17 @@
             restart_network = 'ipconfig /renew'
             vm_user = 'Administrator'
             vm_pwd = DEFAULT_WIN_VM_PASSWORD
-            variants:
-                - default_install:
-                    windows_root = 'WINDOWS_ROOT_V2V_EXAMPLE'
-                    os_version = 'WINDOWS_ROOT_OS_VERSION_V2V_EXAMPLE'
-                    main_vm = 'WINDOWS_ROOT_VM_NAME_V2V_EXAMPLE'
-                    skip_vm_check = yes
-                    skip_reason = 'there is no virtio driver for win2003 guest'
-                - virtio_win:
-                    main_vm = 'XEN_VM_NAME_VIRTIO_WIN_V2V_EXAMPLE'
-                    os_version = 'OS_VERSION_VIRTIO_WIN_V2V_EXAMPLE'
-                    virtio_win_dir = '/usr/share/virtio-win/'
-                    virtio_win_env = 'VIRTIO_WIN'
-                    checkpoint = 'virtio_win_'
-                    variants:
-                        - unset:
-                            checkpoint += 'unset'
-                            missing = 'Red Hat VirtIO SCSI,Red Hat VirtIO Ethernet Adapte,Red Hat QXL GPU'
-                        - custom:
-                            checkpoint += 'custom'
-                        - iso_mount:
-                            checkpoint += 'iso_mount'
-                        - iso_file:
-                            checkpoint += 'iso_file'
-                - rhsrvany_md5:
-                    checkpoint = rhsrvany_md5
-                    val_md5 = 460f8985213cc6ec45e7635aca81cd68
-                    val_sha1 = 2bd96e478fc004cd323b5bd754c856641877dac6
-                    cmd_sha1 = 'certutil -hashfile "C:\Program Files\Guestfs\Firstboot\rhsrvany.exe"'
-                    main_vm = XEN_VM_NAME_RHSRVANYMD5_V2V_EXAMPLE
-                    os_version = OS_VERSION_RHSRVANYMD5_V2V_EXAMPLE
     variants:
         - positive_test:
             status_error = 'no'
             no xen_vm_default
             variants:
                 - libvirt:
-                    only pool_uuid, display, sound, virtio_win, with_vdsm
+                    only pool_uuid, display, sound, with_vdsm
                     only output_mode.libvirt
                     no encrypt_warning
                 - rhev:
-                   # As guest have qxl video mode after converting to rhev, but expected video for windows guest is cirrus in virtio_win.unset, skip the case in rhev
-                    no pool_uuid, display.vnc.encrypt, virtio_win.unset
+                    no pool_uuid, display.vnc.encrypt
                     only output_mode.rhev
         - negative_test:
             status_error = 'yes'

--- a/v2v/tests/cfg/specific_kvm.cfg
+++ b/v2v/tests/cfg/specific_kvm.cfg
@@ -258,6 +258,10 @@
         - file_image:
             only source_kvm
             checkpoint = file_image
+        - win_rootonlinux:
+            only source_xen
+            os_version = 'WINDOWS_ROOT_OS_VERSION_V2V_EXAMPLE'
+            main_vm = 'WINDOWS_ROOT_VM_NAME_V2V_EXAMPLE'
     variants:
         - positive_test:
             status_error = 'no'
@@ -270,6 +274,7 @@
                     no network.e1000
                     no fstab.invalid
                     no display.mix
+                    no win_rootonlinux
                     only output_mode.rhev
                 - windows:
                     os_type = 'windows'
@@ -299,6 +304,9 @@
                 - to_libvirt:
                     only display.mix,display.listen,mem_alloc
                     only output_mode.libvirt
+                - to_local:
+                    only win_rootonlinux
+                    only output_mode.local
         - negative_test:
             status_error = 'yes'
             variants:

--- a/v2v/tests/src/specific_kvm.py
+++ b/v2v/tests/src/specific_kvm.py
@@ -21,6 +21,8 @@ from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt as utlv
 
 from provider.v2v_vmcheck_helper import VMChecker
+from provider.v2v_vmcheck_helper import check_json_output
+from provider.v2v_vmcheck_helper import check_local_output
 
 
 def run(test, params, env):
@@ -578,6 +580,13 @@ def run(test, params, env):
         utlv.check_exit_status(result, status_error)
         output = result.stdout_text + result.stderr_text
         if not status_error:
+            if output_mode == 'json' and not check_json_output(params):
+                test.fail('check json output failed')
+            if output_mode == 'local' and not check_local_output(params):
+                test.fail('check local output failed')
+            if output_mode in ['null', 'json', 'local']:
+                return
+
             vmchecker = VMChecker(test, params, env)
             params['vmchecker'] = vmchecker
             if output_mode == 'rhev':


### PR DESCRIPTION
This patch mainly move the windows cases from xen to esx because
the windows version which are supported on the xen host are not in
testing plan, those test scenaroes must be migrated to newer windows
version and so must be migrated to esx server, too.

The changes in this patch are:
1) Fix the expect_adapter setting when virtio-win is not installed but
   users set in by env VIRTIO_WIN.
2) Migrate virtio_win cases from function_test_xen to function_test_esx
   and adapt the codes.
3) Migrate rhsrvany_md5 from function_test_xen to function_test_esx and
   adapt the codes.
4) Migrate default_install from xen to esx and rename it to win_rootonlinux
   and change the output_mode to local only, because the win2003 guest is too
   old and the spical guest cannot be made in other windows versions. so just
   checking v2v can convert it without reporting errors.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>