### PR TITLE
Add some negative test cases about network define

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_define_undefine.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_define_undefine.cfg
@@ -70,51 +70,108 @@
                     net_define_undefine_trans_ref = "define"
                     # For net-define test only
                     variants:
-                        - invalid_uuid:
-                            net_define_undefine_net_uuid = "1-2-3-4-5-6"
-                        - invalid_netname:
-                            net_define_undefine_net_name = "!@#$%^&*()[]{}:;'',.?/\\|`~-=_+"
-                        - invalid_name_with_slash:
-                            net_define_undefine_net_name = "b/r2"
-                            net_define_undefine_err_msg = "invalid char in name: /"
-                        - invalid_setting:
-                            edit_xml = "yes"
-                            address_v4 = "192.168.100.1"
-                            netmask = "255.255.255.0"
-                            dhcp_ranges_start = "192.168.100.30"
-                            dhcp_ranges_end = "192.168.100.100"
+                        - default:
                             variants:
-                                - reverse_range:
-                                    dhcp_ranges_start = "192.168.100.100"
-                                    dhcp_ranges_end = "192.168.100.30"
-                                    net_define_undefine_err_msg = "is reversed"
-                                - reverse_port:
-                                    test_port = "yes"
-                                    nat_port_start = "65535"
-                                    nat_port_end = "1024"
-                                    net_define_undefine_err_msg = "Missing or invalid 'end' attribute"
-                                - not_within_range:
-                                    dhcp_ranges_start = "192.168.110.2"
-                                    dhcp_ranges_end = "192.168.110.100"
-                                    net_define_undefine_err_msg = "not entirely within"
-                        - multi_dhcp:
-                            multi_ip = "yes"
-                            address_v4 = "192.168.100.1"
-                            netmask = "255.255.255.0"
-                            address_v6_1 = "2001:db8:ca2:7::1"
-                            address_v6_2 = "2001:db8:ca3:7::1"
-                            prefix_v6 = "64"
+                                - invalid_uuid:
+                                    net_define_undefine_net_uuid = "1-2-3-4-5-6"
+                                - invalid_netname:
+                                    net_define_undefine_net_name = "!@#$%^&*()[]{}:;'',.?/\\|`~-=_+"
+                                - invalid_name_with_slash:
+                                    net_define_undefine_net_name = "b/r2"
+                                    net_define_undefine_err_msg = "invalid char in name: /"
+                                - invalid_setting:
+                                    edit_xml = "yes"
+                                    address_v4 = "192.168.100.1"
+                                    netmask = "255.255.255.0"
+                                    dhcp_ranges_start = "192.168.100.30"
+                                    dhcp_ranges_end = "192.168.100.100"
+                                    variants:
+                                        - reverse_range:
+                                            dhcp_ranges_start = "192.168.100.100"
+                                            dhcp_ranges_end = "192.168.100.30"
+                                            net_define_undefine_err_msg = "is reversed"
+                                        - reverse_port:
+                                            test_port = "yes"
+                                            nat_port_start = "65535"
+                                            nat_port_end = "1024"
+                                            net_define_undefine_err_msg = "Missing or invalid 'end' attribute"
+                                        - not_within_range:
+                                            dhcp_ranges_start = "192.168.110.2"
+                                            dhcp_ranges_end = "192.168.110.100"
+                                            net_define_undefine_err_msg = "not entirely within"
+                                - multi_dhcp:
+                                    multi_ip = "yes"
+                                    address_v4 = "192.168.100.1"
+                                    netmask = "255.255.255.0"
+                                    address_v6_1 = "2001:db8:ca2:7::1"
+                                    address_v6_2 = "2001:db8:ca3:7::1"
+                                    prefix_v6 = "64"
+                                    variants:
+                                        - v4:
+                                            dhcp_ranges_start = "192.168.100.5"
+                                            dhcp_ranges_end = "192.168.100.80"
+                                            net_define_undefine_err_msg = "Multiple IPv4 dhcp sections found"
+                                        - v6:
+                                            dhcp_ranges_v6_start_1 = "2001:db8:ca2:7::100"
+                                            dhcp_ranges_v6_end_1 = "2001:db8:ca2:7::1ff"
+                                            dhcp_ranges_v6_start_2 = "2001:db8:ca3:7::100"
+                                            dhcp_ranges_v6_end_2 =   "2001:db8:ca3:7::1ff"
+                                            net_define_undefine_err_msg = "Multiple IPv6 dhcp sections found"
+                        - others:
+                            net_define_undefine_net_name = "test_net"
+                            create_netxml = "yes"
+                            forward = {'mode': 'bridge'}
                             variants:
-                                - v4:
-                                    dhcp_ranges_start = "192.168.100.5"
-                                    dhcp_ranges_end = "192.168.100.80"
-                                    net_define_undefine_err_msg = "Multiple IPv4 dhcp sections found"
-                                - v6:
-                                    dhcp_ranges_v6_start_1 = "2001:db8:ca2:7::100"
-                                    dhcp_ranges_v6_end_1 = "2001:db8:ca2:7::1ff"
-                                    dhcp_ranges_v6_start_2 = "2001:db8:ca3:7::100"
-                                    dhcp_ranges_v6_end_2 =   "2001:db8:ca3:7::1ff"
-                                    net_define_undefine_err_msg = "Multiple IPv6 dhcp sections found"
+                                - direct:
+                                    add_dev = "yes"
+                                - ovs_bridge:
+                                    bridge = ovsbr0
+                                    create_bridge = "yes"
+                                    ovs_bridge = "yes"
+                                    virtualport = "yes"
+                                    virtualport_type = 'openvswitch'
+                                - host_bridge:
+                                    bridge = 'br0'
+                                    create_bridge = "yes"
+                            variants:
+                                - unsupport_dns:
+                                    del_mac = "yes"
+                                    del_ip = "yes"
+                                    net_dns_txt = "{'name':'example','value':'example value'}"
+                                    net_define_undefine_err_msg = "Unsupported <dns> element"
+                                - unsupport_mac:
+                                    del_ip = "yes"
+                                    net_define_undefine_err_msg = "Unsupported <mac> element"
+                                    mac = "52:54:55:66:66:55"
+                                - unsupport_domain:
+                                    domain = "example.com"
+                                    del_mac = "yes"
+                                    del_ip = "yes"
+                                    net_define_undefine_err_msg = "Unsupported <domain> element"
+                                - unsupport_Qos:
+                                    only direct
+                                - unsupport_ip:
+                                    del_mac = "yes"
+                                    net_define_undefine_err_msg = "Unsupported <ip> element"
+                                - invaid_forward:
+                                    only host_bridge, ovs_bridge
+                                    add_dev = "yes"
+                                    del_mac = "yes"
+                                    del_ip = "yes"
+                                    net_define_undefine_err_msg = "a bridge name or a forward dev, but not both"
+                                - invalid_bridge:
+                                    only direct
+                                    bridge = 'br0'
+                                    del_mac = "yes"
+                                    del_ip = "yes"
+                                    net_define_undefine_err_msg = "a bridge name or a forward dev, but not both"
+                                - invalid_qos:
+                                    only direct
+                                    del_mac = "yes"
+                                    del_ip = "yes"
+                                    net_bandwidth_inbound = "{'average':'512','peak':'5000','burst':'1024'}"
+                                    net_bandwidth_outbound = "{'average':'128','peak':'256','burst':'256'}"
+                                    net_define_undefine_err_msg = "Unsupported network-wide <bandwidth> element"
                 - acl_test:
                     variants:
                         - define_acl:


### PR DESCRIPTION
Add some negative test cases about create bridge or direct type network. Some elements
are only available for libvirt managed network such as nat, route, isolated, open, they
can not be used in bridge or direct type network.

Signed-off-by: Yalan Zhang <yalzhang@redhat.com>