### PR TITLE
Remove python2 from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-    - "2.7"
     - "3.6"
 
 branches:


### PR DESCRIPTION
Since avocado, avocado-vt and aexpect are all not support python2
any more. tp-libvirt should go forward as well. Let's remove python2
from travis.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>