### PR TITLE
Add timeout related p2p migration case

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_vm.cfg
+++ b/libvirt/tests/cfg/migration/migrate_vm.cfg
@@ -258,6 +258,14 @@
                             virsh_options = "--live --p2p --verbose --compressed"
                             default_cache = "64.000 MiB"
                             grep_str_from_local_libvirt_log = '"capability":"xbzrle","state":true'
+                        - timeout:
+                            set_migration_speed = 1
+                            migration_cmd_timeout = 30
+                            run_migrate_cmd_in_front = "no"
+                            run_migrate_cmd_in_back = "yes"
+                            check_job_info = "yes"
+                            check_complete_job = "no"
+                            virsh_options = "--live --p2p --persistent --verbose --timeout ${migration_cmd_timeout}"
                 - tunnelled_migration:
                     variants:
                         - basic:


### PR DESCRIPTION
RHEL-202913 - [Migration][--timeout]Set timeout for live
migration - default action(suspend guest after timeout)
- p2p migration - precopy

Signed-off-by: Yingshun Cui <yicui@redhat.com>

```
 (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_vm.positive_testing.p2p_migration.timeout.without_postcopy: PASS (167.21 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 168.20 s

```
