### PR TITLE
tpm_device: Enable emulator tpm-tis tests for aarch64

### DIFF
--- a/libvirt/tests/cfg/virtual_device/tpm_device.cfg
+++ b/libvirt/tests/cfg/virtual_device/tpm_device.cfg
@@ -17,7 +17,12 @@
                             only default_model
                 - emulator:
                     backend_type = 'emulator'
-                    only tpm-crb_model,tpm-spapr_model
+                    q35:
+                        only tpm-crb_model
+                    pseries:
+                        only tpm-spapr_model
+                    aarch64:
+                        only tpm-tis_model
                     backend_version = '2.0'
                     variants:
                         - basic:
@@ -60,7 +65,7 @@
                             prepare_secret = 'yes'
             variants:
                 - tpm-tis_model:
-                    only q35
+                    only q35, aarch64
                     tpm_model = 'tpm-tis'
                 - tpm-crb_model:
                     only q35

--- a/libvirt/tests/src/virtual_device/tpm_device.py
+++ b/libvirt/tests/src/virtual_device/tpm_device.py
@@ -70,6 +70,14 @@ def run(test, params, env):
     uefi_disk_url = params.get("uefi_disk_url", "")
     download_file_path = os.path.join(data_dir.get_tmp_dir(), "uefi_disk.qcow2")
 
+    # Tpm emulator tpm-tis_model for aarch64 supported since libvirt 7.1.0
+    if platform.machine() == 'aarch64' and tpm_model == 'tpm-tis' \
+        and backend_type == 'emulator' \
+            and not libvirt_version.version_compare(7, 1, 0):
+
+        test.cancel("Tpm emulator tpm-tis_model for aarch64 "
+                    "is not supported on current libvirt")
+
     # Check tpm chip on host for passthrough testing
     if backend_type == "passthrough":
         dmesg_info = process.getoutput("dmesg|grep tpm -wi", shell=True)


### PR DESCRIPTION
Upstream libvirt support tpm emulator tpm-tis since 7.1.0.
```
commit 7cf60006ce1e9898b960d7810f146ac6c89f6bb0
  Author: Jim Fehlig <jfehlig@suse.com>
  Date:   Tue Feb 9 14:57:22 2021 -0700

    qemu: Fix swtpm device with aarch64

    Starting a VM with swtpm device fails with qemu-system-aarch64.
    E.g. with TPM device config

         <tpm model='tpm-tis'>
           <backend type='emulator' version='2.0'/>
          </tpm>

    QEMU reports the following error

    error: internal error: process exited while connecting to monitor:
    2021-02-07T05:15:35.378927Z qemu-system-aarch64: -device
    tpm-tis,tpmdev=tpm-tpm0,id=tpm0: 'tpm-tis' is not a valid device model name

    Indeed the TPM device name is 'tpm-tis-device' [1][2] for aarch64,
    versus the shorter 'tpm-tis' for x86. The devices are the same from
    a functional POV, i.e. they both emulate a TPM device conforming to
    the TIS specification. Account for the unfortunate name difference
    when building the TPM device option in qemuBuildTPMDevStr(). Also
    include a test case for 'tpm-tis-device'.

    [1] https://qemu.readthedocs.io/en/latest/specs/tpm.html
    [2] https://github.com/qemu/qemu/commit/c294ac327ca99342b90bd3a83d2cef9b447afaa7

    Signed-off-by: Jim Fehlig <jfehlig@suse.com>
    Reviewed-by: Andrea Bolognani <abologna@redhat.com>
```

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>