### PR TITLE
virtual_disks_multidisks: Fix disk_scsi_block_size No more PCI error

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
@@ -294,6 +294,8 @@
                                 virtio_scsi_controller_type = "pci"
                                 virtio_scsi_controller_model = "pcie-root-port"
                                 virtio_scsi_controller_addr = "type=pci,bus=0x00,domain=0x0000,function=0x0,slot=0x0,multifunction=on"
+                            aarch64:
+                                reset_pci_controllers_nums = 'yes'
                         - virt_xml_validate_on_file_lun:
                             only coldplug
                             test_file_image_on_disk = "yes"


### PR DESCRIPTION
Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Before this commit
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virtual_disks.multidisks.hotplug.single_disk_test.disk_scsi_block_size.file_image_on_disk
JOB ID     : a61304ff83b20020b8b7f6aa0e7640b38698d680
JOB LOG    : /root/avocado/job-results/job-2021-05-10T21.11-a61304f/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_disks.multidisks.hotplug.single_disk_test.disk_scsi_block_size.file_image_on_disk: FAIL: error: Failed to attach device from /tmp/xml_utils_temp_rxechjg1.xml\nerror: internal error: No more available PCI slots\n (71.33 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 72.08 s
```

After this commit
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virtual_disks.multidisks.hotplug.single_disk_test.disk_scsi_block_size.file_image_on_disk
JOB ID     : 47e679381b97db67cb4f524f39589609ea1ced52
JOB LOG    : /root/avocado/job-results/job-2021-05-10T21.14-47e6793/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_disks.multidisks.hotplug.single_disk_test.disk_scsi_block_size.file_image_on_disk: PASS (91.07 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 91.78 s
```