### PR TITLE
add case for cancel migration

### DIFF
--- a/libvirt/tests/cfg/migration/live_migration.cfg
+++ b/libvirt/tests/cfg/migration/live_migration.cfg
@@ -17,7 +17,7 @@
     virsh_migrate_src_state = running
     # Local URI
     virsh_migrate_connect_uri = "qemu:///system"
-    
+    image_convert = 'no'
     variants:
         - with_postcopy:
             postcopy_options = "--postcopy --timeout 10 --timeout-postcopy"
@@ -30,8 +30,12 @@
             virsh_migrate_options = "--live --p2p --persistent --verbose"
         - non_p2p_live:
             virsh_migrate_options = "--live --verbose"
+        - p2p_live_undefinesource:
+            only domjobabort
+            virsh_migrate_options = "--live --p2p --persistent --undefinesource --verbose"
     variants:
         - migrateuri:
+            migrate_speed = 15
             stress_package = "stress"
             stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20s"
             action_during_mig = "libvirt_network.check_established"
@@ -54,7 +58,7 @@
             stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20s"
             action_during_mig = "libvirt_network.check_established"
             action_during_mig_params_exists = "yes"
-            bandwidth_opt = "--bandwidth 200"
+            bandwidth_opt = "--bandwidth 15"
             ipv6_addr_des = "ENTER.YOUR.IPv6.DESTINATION"
             ipv6_addr_src = "ENTER.YOUR.IPv6.SOURCE"
             variants:
@@ -82,3 +86,15 @@
                                 action_during_mig = ''
                         - ipv6:
                             virsh_migrate_extra = "${virsh_migrate_migrateuri} --listen-address :: ${bandwidth_opt}"
+        - domjobabort:
+            migrate_again = 'yes'
+            wait_for_event = False
+            status_error = 'yes'
+            err_msg = 'operation aborted: migration out job: canceled by client'
+            migrate_again_status_error = 'no'
+            vm_state_after_abort = "{'source': 'running', 'target': 'nonexist'}"
+            migrate_speed = 10
+            check_local_port = 'yes'
+            return_port = 'yes'
+            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "virsh.domjobabort", "after_event": "iteration: '1'", "func_param": "'%s' % params.get('migrate_main_vm')"}]'
+            action_during_mig_again = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}]'

--- a/libvirt/tests/src/migration/live_migration.py
+++ b/libvirt/tests/src/migration/live_migration.py
@@ -2,14 +2,59 @@ import logging
 
 from virttest import libvirt_vm
 from virttest import migration
+from virttest import virsh
 
 from virttest.libvirt_xml import vm_xml
-from virttest.utils_libvirt import libvirt_network  # pylint: disable=W0611
 from virttest.utils_test import libvirt
+
+from provider.migration import migration_base
+
+
+def get_used_port(func_returns):
+    """
+    Get the port used in migration
+
+    :param func_returns: dict, the function return results
+                               from MigrationTest
+    :return: str or None
+    """
+    for func_ref, func_return in func_returns.items():
+        if func_ref.__name__ == 'libvirt_network.check_established':
+            return func_return
+
+    return None
+
+
+def check_vm_state_after_abort(vm_name, vm_state_after_abort, src_uri, dest_uri, test):
+    """
+    Check the VM state after domjobabort the migration
+
+    :param vm_name: str, vm name
+    :param vm_state_after_abort: str, like "{'source': 'running', 'target': 'nonexist'}"
+                                 source: local host, target: remote host
+    :param src_uri: uri for source host
+    :param dest_uri: uri for target host
+    :param test: test object
+    """
+    state_dict = eval(vm_state_after_abort)
+    logging.debug("Check guest state should be {} on source host".format(state_dict['source']))
+    libvirt.check_vm_state(vm_name, state=state_dict['source'], uri=src_uri)
+    logging.debug("Check guest persistent on source host")
+    cmd_res = virsh.domstats(vm_name, '--list-persistent', debug=True, ignore_status=False)
+    if not cmd_res.stdout_text.count(vm_name):
+        test.fail("The guest is expected to be persistent on source host, but it isn't")
+    logging.debug("Check guest state should be {} on target host".format(state_dict['target']))
+    if state_dict['target'] == 'nonexist':
+        if virsh.domain_exists(vm_name, uri=dest_uri):
+            test.fail("The domain on target host is found, but expected not")
+    else:
+        libvirt.check_vm_state(vm_name, state=state_dict['target'], uri=dest_uri)
 
 
 def run(test, params, env):
     """
+    Run the test
+
     :param test: test object
     :param params: Dictionary with the test parameters
     :param env: Dictionary with test environment.
@@ -35,9 +80,15 @@ def run(test, params, env):
     virsh_options = params.get("virsh_options", "")
     stress_package = params.get("stress_package")
     action_during_mig = params.get("action_during_mig")
-    if action_during_mig:
-        action_during_mig = eval(action_during_mig)
+    #action_params_map = params.get('action_params_map')
+    migrate_speed = params.get("migrate_speed")
+    migrate_again = "yes" == params.get("migrate_again", "no")
+    vm_state_after_abort = params.get("vm_state_after_abort")
+    return_port = params.get("return_port")
 
+    if action_during_mig:
+        action_during_mig = migration_base.parse_funcs(action_during_mig,
+                                                       test, params)
     # For safety reasons, we'd better back up  xmlfile.
     new_xml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     orig_config_xml = new_xml.copy()
@@ -54,17 +105,43 @@ def run(test, params, env):
 
         if stress_package:
             migration_test.run_stress_in_vm(vm, params)
-
+        if migrate_speed:
+            mode = 'both' if '--postcopy' in postcopy_options else 'precopy'
+            migration_test.control_migrate_speed(vm_name,
+                                                 int(migrate_speed),
+                                                 mode)
         # Execute migration process
-        logging.info("Starting migration...")
-        vms = [vm]
-        migration_test.do_migration(vms, None, dest_uri, 'orderly',
-                                    options, thread_timeout=900,
-                                    ignore_status=True,
-                                    virsh_opt=virsh_options,
-                                    extra_opts=extra,
-                                    func=action_during_mig,
-                                    **extra_args)
+        migration_base.do_migration(vm, migration_test, None, dest_uri,
+                                    options, virsh_options, extra,
+                                    action_during_mig,
+                                    extra_args)
+
+        func_returns = dict(migration_test.func_ret)
+        migration_test.func_ret.clear()
+        if return_port:
+            port_used = get_used_port(func_returns)
+
+        if vm_state_after_abort:
+            check_vm_state_after_abort(vm_name, vm_state_after_abort,
+                                       bk_uri, dest_uri, test)
+
+        if migrate_again:
+            action_during_mig = migration_base.parse_funcs(params.get('action_during_mig_again'),
+                                                           test,
+                                                           params)
+            extra_args['status_error'] = params.get("migrate_again_status_error", "no")
+            migration_base.do_migration(vm, migration_test, None, dest_uri,
+                                        options, virsh_options,
+                                        extra, action_during_mig,
+                                        extra_args)
+            if return_port:
+                func_returns = dict(migration_test.func_ret)
+                port_second = get_used_port(func_returns)
+                if port_used != port_second:
+                    test.fail("Expect same port '{}' is used as previous one, "
+                              "but found new one '{}'".format(port_used,
+                                                              port_second))
+        migration_test.post_migration_check([vm], params, uri=dest_uri)
     finally:
         logging.info("Recover test environment")
         vm.connect_uri = bk_uri

--- a/provider/migration/migration_base.py
+++ b/provider/migration/migration_base.py
@@ -1,0 +1,90 @@
+import logging
+import types
+
+from virttest import virsh                           # pylint: disable=W0611
+from virttest.utils_libvirt import libvirt_network   # pylint: disable=W0611
+
+
+def parse_funcs(action_during_mig, test, params):
+    """
+    Parse action_during_mig parameter
+
+    :param action_during_mig: function or list of function
+            For example,
+            action_during_mig = '[{"func_name": "check_established",
+                                   "after_event": "iteration: '1'",
+                                   "before_pause": "yes",
+                                   "func_param": params},
+                                  {"func_name": "virsh.domjobabort",
+                                   "before_pause": "yes"}]'
+            Or
+            action_during_mig = "libvirt_network.check_established"
+    :param test:  test object
+    :param params: dict, this is implicitly used in this function,
+                         by providing required dependent parameters
+    :return: list or None, the function list
+    """
+    if not action_during_mig:
+        return None
+    tmp_action = eval(action_during_mig)
+    action_during_mig = []
+    if isinstance(tmp_action, types.FunctionType):
+        return tmp_action
+    elif isinstance(tmp_action, list):
+        for one_action in tmp_action:
+            if 'func' not in one_action:
+                test.error("Key 'func' for dict 'action_during_mig or "
+                           "action_during_mig_again' is required")
+            act_dict = {}
+            func_param = one_action.get('func_param')
+            if func_param:
+                func_param = eval(func_param)
+
+            act_dict.update({'func': eval(one_action.get('func')),
+                             'after_event': one_action.get('after_event'),
+                             'before_event': one_action.get('before_event'),
+                             'before_pause': one_action.get('before_pause'),
+                             'func_param': func_param})
+            action_during_mig.append(act_dict)
+        return action_during_mig
+    else:
+        test.error("'action_during_mig' value format is invalid, only "
+                   "function name and list are supported")
+
+
+def do_migration(vm, mig_test, src_uri, dest_uri, options, virsh_options,
+                 extra, action_during_mig, extra_args):
+    """
+    The wrapper function to call migration
+
+    :param vm: vm object
+    :param mig_test: MigrationTest object
+    :param src_uri: source uri
+    :param dest_uri: target uri
+    :param options: migration options
+    :param virsh_options: virsh options
+    :param extra: extra options for migration
+    :param action_during_mig: list or single function to run during migration
+    :param extra_args: arguments for test
+    """
+    logging.info("Starting migration...")
+    vms = [vm]
+    if not action_during_mig or isinstance(action_during_mig,
+                                           types.FunctionType):
+        mig_test.do_migration(vms, src_uri, dest_uri, 'orderly',
+                              options, thread_timeout=900,
+                              ignore_status=True,
+                              virsh_opt=virsh_options,
+                              extra_opts=extra,
+                              func=action_during_mig,
+                              multi_funcs=None,
+                              **extra_args)
+    elif isinstance(action_during_mig, list):
+        mig_test.do_migration(vms, src_uri, dest_uri, 'orderly',
+                              options, thread_timeout=900,
+                              ignore_status=True,
+                              virsh_opt=virsh_options,
+                              extra_opts=extra,
+                              func=None,
+                              multi_funcs=action_during_mig,
+                              **extra_args)


### PR DESCRIPTION
1. Add test scenario below - RHEL-201595
- Check port and cancel migration job, then migrate again and check
the port can be reused.

2. Some minor adjustments for migration speed in order to adapt to
different test environments.

3. Enable not to convert image for migration in order to save
execution time.

4. Create a new common package for migration cases shared usage

Signed-off-by: Dan Zheng <dzheng@redhat.com>