### PR TITLE
tpm_device: fix unexpected error

### DIFF
--- a/libvirt/tests/src/virtual_device/tpm_device.py
+++ b/libvirt/tests/src/virtual_device/tpm_device.py
@@ -90,14 +90,17 @@ def run(test, params, env):
                     tpm_v = "1.2"
                 # If "1.2 TPM" or no version info in dmesg, try to test a tpm1.2 at first
                 if not utils_package.package_install("tpm-tools"):
-                    test.error("Failed to install tpm-tools on host")
+                    if tpm_v == "1.2":
+                        test.error("Failed to install tpm-tools on host")
+                    else:
+                        logging.debug("Failed to install tpm-tools on host")
     # Check host env for vtpm testing
     elif backend_type == "emulator":
         if not utils_misc.compare_qemu_version(4, 0, 0, is_rhev=False):
             test.cancel("vtpm(emulator backend) is not supported "
                         "on current qemu version.")
         # Install swtpm pkgs on host for vtpm emulation
-        if not utils_package.package_install("swtpm*"):
+        if not utils_package.package_install(["swtpm", "swtpm-tools"]):
             test.error("Failed to install swtpm swtpm-tools on host")
 
     def replace_os_disk(vm_xml, vm_name, nvram):


### PR DESCRIPTION
If no tpm version info in dmesg, should try to test by tpm-tools
then tpm2-tools. So installation failure of tpm-tools should not
report error, but let it continue to try later tpm2-tools.  Also
fix another error that extra dependency fails swtpm* install, 
change to only install swtpm and swtpm-tools, that's enough.

Signed-off-by: Yanqiu Zhang <yanqzhan@redhat.com>

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [ ] Description of the cases
- [ ] Links of libvirt features, libvirt bugs or case IDs
- [ ] Test results

## If the PR is bug cases
- [ ] Bug descriptions or bug links
- [ ] Test results

## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
