### PR TITLE
Fix the vm can not login issue

### DIFF
--- a/libvirt/tests/src/sriov/sriov.py
+++ b/libvirt/tests/src/sriov/sriov.py
@@ -542,7 +542,7 @@ def run(test, params, env):
                 numa_dict = {}
         # Add cpu device with numa node setting in domain xml
         vmxml_cpu = vm_xml.VMCPUXML()
-        vmxml_cpu.xml = "<cpu><numa/></cpu>"
+        vmxml_cpu.xml = "<cpu mode='host-model'><numa/></cpu>"
         vmxml_cpu.numa_cell = vmxml_cpu.dicts_to_cells(numa_dict_list)
         vmxml.cpu = vmxml_cpu
 


### PR DESCRIPTION
In cases 'cold_plug.nfv..', we need to set the numa node for the vm.
So there is a function add_numa(), which will delete the original cpu
setting and initiate the cpu part to '<cpu><numa/></cpu>' which ignored
the cpu mode setting, it will default to 'qemu64', which has bug
on some releases. Workaround it to be 'host-model' which is the original
vm setting.

Signed-off-by: Yalan Zhang <yalzhang@redhat.com>