### PR TITLE
Disable qemu-cmd-check for libvirt_mem basic test

### DIFF
--- a/libvirt/tests/cfg/libvirt_mem.cfg
+++ b/libvirt/tests/cfg/libvirt_mem.cfg
@@ -77,6 +77,7 @@
                             attach_option = "--config"
                 - no_attach:
                 - with_source:
+                    test_qemu_cmd = "no"
                     tg_size = 524288
                     tg_node = 0
                     page_size = 4


### PR DESCRIPTION
Signed-off-by: Kyla Zhang <weizhan@redhat.com>

```
(1/1) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.with_source: PASS (64.50 s)
```