### PR TITLE
Update the error message for invalid lease

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_dhcp_leases.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_dhcp_leases.cfg
@@ -80,4 +80,4 @@
                 - blank_lease:
                     invalid_lease = "yes"
                     range_lease = "{'expiry': ''}"
-                    leases_err_msg = "An error occurred, but the cause is unknown"
+                    leases_err_msg = "failed to parse expiry value ''"

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_dhcp_leases.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_dhcp_leases.py
@@ -75,6 +75,7 @@ def run(test, params, env):
             new_host.lease_attrs = host_lease
             ipxml.hosts = [new_host]
         netxml.set_ip(ipxml)
+        logging.debug("The network xml is %s", netxml)
         netxml.create()
 
     def get_net_dhcp_leases(output):
@@ -120,7 +121,7 @@ def run(test, params, env):
 
             delta = get_ex_time - now_time
             logging.debug("The get_ex_time is %s, the now_time is %s, "
-                          "duration is %s" % (get_ex_time, now_time, duration))
+                          "duration is %s", get_ex_time, now_time, duration)
             if delta > timedelta(seconds=dur_sec):
                 test.fail("Get expiry time %s longer than the setting %s!!"
                           % (delta, timedelta(seconds=dur_sec)))
@@ -278,7 +279,7 @@ def run(test, params, env):
     except LibvirtXMLError as e:
         if status_error and invalid_lease:
             if expect_msg not in e.details:
-                test.fail("Network create fail unexpected: %s", e.details)
+                test.fail("Network create fail with unexpected error message %s" % e.details)
             else:
                 logging.debug("Network create fail expected: %s", e.details)
     finally:


### PR DESCRIPTION
As the bug about the 'cause unknown' error message fixed, update the error_msg
in the *.cfg file and update the error message to the more explicit.

Signed-off-by: Yalan Zhang <yalzhang@redhat.com>