### PR TITLE
v2v: set an initial setting for luks password

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -477,7 +477,7 @@
                     main_vm = VM_NAME_SWAP_3LUKS_V2V_EXAMPLE
                     luks_password = LUKS_PASSWORD1
                     v2v_opts = ' --keys-from-stdin'
-                    env_settings = "LUKS_PASSWORD_INPUT_FROM_STDIN"
+                    env_settings = "echo -e '${luks_password}\n${luks_password}\n${luks_password}\n${luks_password}\n' |"
                     expect_msg = 'no'
                     msg_content = 'Enter key or passphrase'
         - logs:


### PR DESCRIPTION
A better solution is replacing the marco with real value in libvirt-ci,
but '\n' in the string will cause a malform testcase cfg file in
tp-libvirt.

e.g.
variant:
  - case1:
    env_settings = "echo -e '${{{{luks_password}}}}
${{{{luks_password}}}}
${{{{luks_password}}}}
${{{{luks_password}}}}
' |"
  - case2:
    env_settings = "wrold"

There is not a good solution for keeping the '\n', meanwhile, don't
append the '\n' at the end of the string.

And this is not a typical senario, let's just set the real value to
avoid the risk of breaking libvit-ci.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>