### PR TITLE
Fix for slow vm

### DIFF
--- a/libvirt/tests/src/controller/pcibridge.py
+++ b/libvirt/tests/src/controller/pcibridge.py
@@ -1,4 +1,5 @@
 import logging
+import time
 
 from virttest import virsh
 from virttest import utils_misc
@@ -334,12 +335,12 @@ def run(test, params, env):
                 libvirt.check_exit_status(result_define_vm)
                 result_start_vm = virsh.start(vm_name, debug=True)
                 libvirt.check_exit_status(result_start_vm)
-
+                logging.debug(virsh.dumpxml(vm_name))
+                # Workaround for vm starting slower in certain environment
+                time.sleep(30)
                 # Login to make sure vm is actually started
                 vm.create_serial_console()
                 vm.wait_for_serial_login().close()
-
-                logging.debug(virsh.dumpxml(vm_name))
 
                 # Get all pcie-to-pci-bridge after test operations
                 new_vmxml = VMXML.new_from_inactive_dumpxml(vm_name)

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_create.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_create.py
@@ -1,4 +1,7 @@
+
 import logging
+import time
+
 import aexpect
 
 from avocado.utils import process
@@ -97,6 +100,7 @@ def run(test, params, env):
 
             # make sure guest is running
             ret = utils_misc.wait_for(lambda: vm.state() == "running", 30)
+            time.sleep(30)
             if ret:
                 logging.info("Guest is running now.")
             else:


### PR DESCRIPTION
VM starts slower in certain environment, so wait_for_serial_login()
might not able to handle the messed up vm console messages. We need
to wait for a while in order for the VM starting completely and then
aexpect session can match the expected content, otherwise aexpect
session might get ExpectError.

Signed-off-by: Dan Zheng <dzheng@redhat.com>
