### PR TITLE
sriov_migration: Add 3 cases

### DIFF
--- a/libvirt/tests/cfg/migration/sriov_migrate.cfg
+++ b/libvirt/tests/cfg/migration/sriov_migrate.cfg
@@ -16,7 +16,7 @@
     setup_local_nfs = 'yes'
     virsh_migrate_dest_state = running
     virsh_migrate_src_state = running
-    virsh_migrate_options = "--live --verbose --bandwidth 10"
+    virsh_migrate_options = "--p2p --live --verbose --bandwidth 10"
     # Local URI
     virsh_migrate_connect_uri = "qemu:///system"
     only x86_64
@@ -41,3 +41,14 @@
                     only without_postcopy
                     status_error = 'yes'
                     cancel_migration = 'yes'
+            variants:
+                - hostdev_iface:
+                    enable_hostdev_iface = "yes"
+                    func_supported_since_libvirt_ver = (6, 0, 0)
+                    unspported_err_msg = "This libvirt version doesn't support migration with net failover devices."
+                - hostdev_device_with_teaming:
+                    cmd_during_mig = ""
+                    enable_hostdev_device = "yes"
+                    func_supported_since_libvirt_ver = (7, 0, 0)
+                    unspported_err_msg = "This libvirt version doesn't support teaming element in plain hostdev elment."
+                    hostdev_device_teaming_dict = {'type': 'transient', 'persistent': 'ua-backup0'}


### PR DESCRIPTION
This PR adds 3 cases as below:
RHEL-198861 - migrate vm with hostdev device - VF
RHEL-205050 - postcopy migrate vm with hostdev device(VF) and
    teaming setting
RHEL-205051 - Cancel migration for vm with hostdev device(VF)
    and teaming setting

And update to access the migrated VM via the virsh session, because
the ssh connection from the target host to the migrated VM
is not stable sometimes.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**depends on:**
avocado-framework/avocado-vt#3055
avocado-framework/avocado-vt#3054
avocado-framework/avocado-vt#3061
**Test results:** 4 cases are failed because of the known bugs
```
# avocado run --vt-type libvirt sriov_migrate.
WARNING:root:No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
WARNING:root:No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : a37f25ef8bee10b808988a0f6706e6588a2468ea
JOB LOG    : /root/avocado/job-results/job-2021-05-19T02.57-a37f25e/job.log
 (1/6) type_specific.io-github-autotest-libvirt.virsh.sriov_migrate.net_failover.hostdev_iface.normal_test.with_postcopy: FAIL: 3 interfaces should be found on the vm, but find ['enp1s0', 'enp1s0nsby']. (192.65 s)
 (2/6) type_specific.io-github-autotest-libvirt.virsh.sriov_migrate.net_failover.hostdev_iface.normal_test.without_postcopy: FAIL: The network does not work well during the migration peirod. ping output: PING www.wshifen.com (45.113.192.102) 56(84) bytes of data.\n64 bytes from 45.113.192.102 (45.113.192.102): icmp_seq=1 ttl=43 time=97.6 ms\n64 bytes from 45.113.192.102 (45.113.192.102... (250.44 s)
 (3/6) type_specific.io-github-autotest-libvirt.virsh.sriov_migrate.net_failover.hostdev_iface.cancel_migration.without_postcopy: PASS (188.29 s)
 (4/6) type_specific.io-github-autotest-libvirt.virsh.sriov_migrate.net_failover.hostdev_device_with_teaming.normal_test.with_postcopy: FAIL: 3 interfaces should be found on the vm, but find ['enp1s0', 'enp1s0nsby']. (190.69 s)
 (5/6) type_specific.io-github-autotest-libvirt.virsh.sriov_migrate.net_failover.hostdev_device_with_teaming.normal_test.without_postcopy: FAIL: The network does not work well during the migration peirod. ping output: PING www.wshifen.com (104.193.88.123) 56(84) bytes of data.\n64 bytes from 104.193.88.123 (104.193.88.123): icmp_seq=1 ttl=47 time=166 ms\n64 bytes from 104.193.88.123 (104.193.88.123)... (260.16 s)
 (6/6) type_specific.io-github-autotest-libvirt.virsh.sriov_migrate.net_failover.hostdev_device_with_teaming.cancel_migration.without_postcopy: PASS (181.47 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 4 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 1265.31 s

```