### PR TITLE
Fix no space error

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blkdeviotune.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blkdeviotune.cfg
@@ -384,7 +384,6 @@
                     variants:
                         - slice_test:
                             disk_slice_enabled = yes
-                            test_size = "10"
                             type_name = "file"
                             target_dev = "vdb"
                             target_bus = "scsi"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blkdeviotune.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blkdeviotune.py
@@ -249,3 +249,4 @@ def run(test, params, env):
     finally:
         # Restore guest
         original_vm_xml.sync()
+        libvirt.delete_local_disk('file', path=disk_source)


### PR DESCRIPTION
'qemu-img create' fails due to no enough space in certain environment.
In these cases, we do not need to create big image, 1G is enough. And
we should delete it after the case execution is done.

Signed-off-by: Dan Zheng <dzheng@redhat.com>
