### PR TITLE
Close aexpect session to avoid leaving processes

### DIFF
--- a/libvirt/tests/src/conf_file/sysconfig_libvirt_guests/libvirt_guests.py
+++ b/libvirt/tests/src/conf_file/sysconfig_libvirt_guests/libvirt_guests.py
@@ -37,7 +37,8 @@ def run(test, params, env):
         tailed_log_file = os.path.join(data_dir.get_tmp_dir(), 'tail_log')
         tailed_messages = aexpect.Tail(command='tail -f /var/log/messages',
                                        output_func=utils_misc.log_line,
-                                       output_params=(tailed_log_file))
+                                       output_params=(tailed_log_file),
+                                       auto_close=True)
         return tailed_messages
 
     def chk_on_shutdown(status_error, on_shutdown, parallel_shutdown, output):


### PR DESCRIPTION
Not-closed session could leave aexpect-helper processes which
could affect future test process depending on the command that
was running in the session. Close it to fix the problem.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>
