### PR TITLE
virsh_blockcommit: Update to use data_dir

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockcommit.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockcommit.py
@@ -372,7 +372,7 @@ def run(test, params, env):
     disk_src_protocol = params.get("disk_source_protocol")
     restart_tgtd = params.get("restart_tgtd", 'no')
     vol_name = params.get("vol_name")
-    tmp_dir = data_dir.get_tmp_dir()
+    tmp_dir = data_dir.get_data_dir()
     pool_name = params.get("pool_name", "gluster-pool")
     brick_path = os.path.join(tmp_dir, pool_name)
 


### PR DESCRIPTION
Replace tmp_dir with data_dir to avoid the problem that filesystem
does not support O_DIRECT.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Test result:**
_Before fix:_
 (1/1) type_specific.io-github-autotest-`libvirt.virsh.blockcommit.normal_test.single_chain.file_disk.local.no_ga.notimeout.nobase.top_active.with_pivot: FAIL: Failed to make snapshots for disks! (23.69 s)`

_After fix:_
` (1/1) type_specific.io-github-autotest-libvirt.virsh.blockcommit.normal_test.single_chain.file_disk.local.no_ga.notimeout.nobase.top_active.with_pivot: PASS (25.70 s)`
