### PR TITLE
virsh_blockpull: Update to use data_dir

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockpull.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockpull.py
@@ -255,7 +255,7 @@ def run(test, params, env):
     disk_src_protocol = params.get("disk_source_protocol")
     restart_tgtd = params.get("restart_tgtd", "no")
     vol_name = params.get("vol_name")
-    tmp_dir = data_dir.get_tmp_dir()
+    tmp_dir = data_dir.get_data_dir()
     pool_name = params.get("pool_name", "gluster-pool")
     brick_path = os.path.join(tmp_dir, pool_name)
 


### PR DESCRIPTION
Replace tmp_dir with data_dir to avoid the problem that filesystem
does not support O_DIRECT.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Test result:**
` (1/1) type_specific.io-github-autotest-libvirt.virsh.blockpull.normal_test.block_disk.notimeout.nobase.async: PASS (147.08 s)`
