### PR TITLE
virsh_net_dhcp_leases: Update expect msg of negative_test blank_leases

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_dhcp_leases.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_dhcp_leases.cfg
@@ -78,6 +78,8 @@
                     range_lease = "{'expiry': '1', 'unit': 'minutes'}"
                     leases_err_msg = "The minimum lease time should be greater than 2 minutes"
                 - blank_lease:
+                    blank_lease = "yes"
                     invalid_lease = "yes"
                     range_lease = "{'expiry': ''}"
                     leases_err_msg = "An error occurred, but the cause is unknown"
+                    new_leases_err_msg = "failed to parse expiry value ''"

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_dhcp_leases.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_dhcp_leases.py
@@ -34,10 +34,13 @@ def run(test, params, env):
     filter_by_mac = "yes" == params.get("filter_by_mac", "no")
     invalid_mac = "yes" == params.get("invalid_mac", "no")
     expect_msg = params.get("leases_err_msg")
+    # upstream expect msg may change on new libvirt
+    new_expect_msg = params.get("new_leases_err_msg")
     range_lease = eval(params.get("range_lease", "None"))
     host_lease = eval(params.get("host_lease", "None"))
     host = eval(params.get("host", "None"))
     invalid_lease = "yes" == params.get("invalid_lease", "no")
+    blank_lease = "yes" == params.get("blank_lease", "no")
     if (host_lease or range_lease) and not libvirt_version.version_compare(6, 2, 0):
         test.cancel("Don't support: libvirt support lease setting since 6.2.0!")
     # Generate a random string as the MAC address
@@ -277,6 +280,8 @@ def run(test, params, env):
                 utlv.check_result(result, expect_msg.split(';'))
     except LibvirtXMLError as e:
         if status_error and invalid_lease:
+            if blank_lease and libvirt_version.version_compare(7, 1, 0):
+                expect_msg = new_expect_msg
             if expect_msg not in e.details:
                 test.fail("Network create fail unexpected: %s", e.details)
             else:


### PR DESCRIPTION
The error msg of <dhcp><lease "expiry" can't be parsed has changed since
libvirt 7.1.0.
https://bugzilla.redhat.com/show_bug.cgi?id=1918674

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Tested on libvirt-7.3.0-1
Before this commit
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virsh.net_dhcp_leases.negative_test.blank_lease
JOB ID     : e2fc39039ba7d1bc8abbdc6f4b4b8581b7fe584d
JOB LOG    : /root/avocado/job-results/job-2021-05-23T23.50-e2fc390/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.net_dhcp_leases.negative_test.blank_lease: ERROR: fail() takes from 1 to 2 positional arguments but 3 were given (10.64 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 11.36 s

# less /root/avocado/job-results/job-2021-05-23T23.50-e2fc390/job.log
[snip]
2021-05-23 23:51:00,651 test             L0917 ERROR| virttest.libvirt_xml.xcepts.LibvirtXMLError: Failed to create transient network virttest_net.
Detail: error: Failed to create network from /tmp/xml_utils_temp_xe7n9eyp.xml
error: XML error: failed to parse expiry value ''
```

After this commit
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virsh.net_dhcp_leases.negative_test.blank_lease
JOB ID     : 1bc02204be94e0f981e02c6bdf30479b56fe795d
JOB LOG    : /root/avocado/job-results/job-2021-05-23T23.37-1bc0220/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.net_dhcp_leases.negative_test.blank_lease: PASS (10.40 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 11.12 s
```