### PR TITLE
Fix qemu cmd change for new version

### DIFF
--- a/libvirt/tests/cfg/libvirt_mem.cfg
+++ b/libvirt/tests/cfg/libvirt_mem.cfg
@@ -34,12 +34,11 @@
                     max_mem = 1536000
                     current_mem = 1536000
                     numa_cells = "{'id':'0','cpus':'0-1','memory':'1024000','unit':'KiB'} {'id':'1','cpus':'2-3','memory':'512000','unit':'KiB'}"
+                    test_qemu_cmd = "no"
                     variants:
                         - default:
-                            test_qemu_cmd = "no"
                         - cold_plug_discard:
                             cold_plug_discard = "yes"
-                            test_qemu_cmd = "yes"
                         - discard:
                             numa_cells = "{'id':'0','cpus':'0-1','memory':'1024000','unit':'KiB','discard':'yes'} {'id':'1','cpus':'2-3','memory':'512000','unit':'KiB','discard':'no'}"
                             discard = "yes"
@@ -76,6 +75,7 @@
                         - cold:
                             attach_option = "--config"
                 - no_attach:
+                    test_qemu_cmd = "no"
                 - with_source:
                     test_qemu_cmd = "no"
                     tg_size = 524288
@@ -115,10 +115,8 @@
                             attach_device = "yes"
                             detach_device = "yes"
                         - cold_plug:
-                            test_qemu_cmd = "yes"
                         - cold_plug_discard:
                             cold_plug_discard = "yes"
-                            test_qemu_cmd = "yes"
                         - discard:
                             numa_cells = "{'id':'0','cpus':'0-1','memory':'1048576','unit':'KiB','discard':'yes'} {'id':'1','cpus':'2-3','memory':'1048576','unit':'KiB','discard':'no'}"
                             discard = "yes"

--- a/libvirt/tests/src/libvirt_mem.py
+++ b/libvirt/tests/src/libvirt_mem.py
@@ -19,6 +19,7 @@ from virttest import utils_misc
 from virttest import utils_config
 from virttest import utils_numeric
 from virttest import utils_hotplug
+from virttest import libvirt_version
 from virttest import virt_vm
 from virttest import data_dir
 from virttest.utils_test import libvirt
@@ -109,7 +110,10 @@ def run(test, params, env):
         """
         cmd = ("ps -ef | grep %s | grep -v grep " % vm_name)
         if discard:
-            cmd += " | grep 'discard-data=yes'"
+            if libvirt_version.version_compare(7, 3, 0):
+                cmd = cmd + " | grep " + '\\"discard-data\\":true'
+            else:
+                cmd += " | grep 'discard-data=yes'"
         elif max_mem_rt:
             cmd += (" | grep 'slots=%s,maxmem=%sk'"
                     % (max_mem_slots, max_mem_rt))


### PR DESCRIPTION
Signed-off-by: qijing <jinqi@redhat.com>

Fix qemu cmd change, it affects below test cases

# avocado run --vt-type libvirt libvirt_mem.positive_test.mem_basic.discard
It it is the fix of typos, comments or documents, the description of PR could be skipped.
JOB ID     : 412834442e235178a310625caf8ef3fa1cb513c3
JOB LOG    : /root/avocado/job-results/job-2021-05-24T01.52-4128344/job.log
 (1/1) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.mem_basic.discard: PASS (104.64 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0

avocado run --vt-type libvirt libvirt_mem.positive_test..with_source 
JOB ID     : 412834442e235178a310625caf8ef3fa1cb513c3
JOB LOG    : /root/avocado/job-results/job-2021-05-24T01.52-4128344/job.log
 (1/1) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.mem_basic.discard: PASS (104.64 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0

# avocado run --vt-type libvirt libvirt_mem.positive_test..hugepages
WARNING:root:No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
WARNING:root:No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : 2419c22e3c7ca1f861054835596ec156362f150f
JOB LOG    : /root/avocado/job-results/job-2021-05-24T02.44-2419c22/job.log
 (01/10) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.hugepages.no_numatune.hot_plug: PASS (144.94 s)
 (02/10) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.hugepages.no_numatune.hot_unplug: PASS (151.46 s)
 (03/10) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.hugepages.no_numatune.cold_plug: PASS (116.55 s)
 (04/10) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.hugepages.no_numatune.cold_plug_discard: PASS (117.10 s)
 (05/10) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.hugepages.no_numatune.discard: PASS (148.57 s)
 (06/10) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.hugepages.with_numatune.hot_plug: PASS (145.70 s)
 (07/10) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.hugepages.with_numatune.hot_unplug: PASS (149.32 s)
 (08/10) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.hugepages.with_numatune.cold_plug: PASS (114.89 s)
 (09/10) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.hugepages.with_numatune.cold_plug_discard: PASS (116.13 s)
 (10/10) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.hugepages.with_numatune.discard: PASS (149.41 s)
RESULTS    : PASS 10 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0


