### PR TITLE
memory_discard: update the regexp of qemu_check cmdline

### DIFF
--- a/libvirt/tests/cfg/memory/memory_discard.cfg
+++ b/libvirt/tests/cfg/memory/memory_discard.cfg
@@ -23,7 +23,7 @@
                     setvm_current_mem_unit = MiB
                     setvm_vcpu = 4
                     setvm_placement = static
-                    qemu_checks = discard-data=yes(,share=\w+)?,size=536870912
+                    qemu_checks = "?discard-data"?(=|:)(yes|true|on)(,"?share"?(=|:)(\w+))?,"?size"?(=|:)536870912
                     discard = 'yes'
                     variants:
                         - discard_yes:
@@ -70,7 +70,7 @@
                     setvm_current_mem_unit = KiB
                     setvm_vcpu = 2
                     setvm_placement = static
-                    qemu_checks = discard-data=yes(,share=\w+)?,size=1073741824,host-nodes=0,policy=bind
+                    qemu_checks = "?discard-data"?(=|:)(yes|true|on)(,"?share"?(=|:)(\w+))?,"?size"?(=|:)1073741824(,"?host-nodes"?(=|:)\[?0\]?)(,"?policy"?(=|:)"?bind"?)
                     discard = 'yes'
                     variants:
                         - discard_yes:


### PR DESCRIPTION
The format of qemu cmdline memory-backend-file has changed since
qemu-kvm 6.0.0

Before qemu-kvm 6.0.0:
-object memory-backend-file,id=ram-node0,\
mem-path=/var/lib/libvirt/qemu/ram/1-avocado-vt-vm1/ram-node0,\
discard-data=yes,share=yes,size=536870912

Since qemu-kvm 6.0.0:
-object {"qom-type":"memory-backend-file","id":"ram-node0",\
"mem-path":"/var/lib/libvirt/qemu/ram/1-avocado-vt-vm1/ram-node0",\
"discard-data":true,"share":true,"size":536870912}

Update the regexp of qemu_checks to fix error that casued by the upgrade
of qemu-kvm.