### PR TITLE
migration: Fix "No more available PCI slots" problem

### DIFF
--- a/libvirt/tests/src/migration/migrate_over_unix.py
+++ b/libvirt/tests/src/migration/migrate_over_unix.py
@@ -17,6 +17,7 @@ from virttest import libvirt_version
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 from virttest.utils_libvirt import libvirt_disk
+from virttest.utils_libvirt import libvirt_pcicontr
 
 
 def run(test, params, env):
@@ -75,6 +76,11 @@ def run(test, params, env):
 
                 target_dev = 'vd' + chr(idx + ord('a') - 1)
                 new_disk_dict = {"driver_type": disk_format}
+                vm_was_running = vm.is_alive()
+                libvirt_pcicontr.reset_pci_num(vm_name)
+                if vm_was_running and not vm.is_alive():
+                    vm.start()
+                    vm.wait_for_login().close()
                 result = libvirt.attach_additional_device(vm_name, target_dev,
                                                           disk_path,
                                                           new_disk_dict, False)


### PR DESCRIPTION
Update the number of VM's pci if needed.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**depends on**: https://github.com/avocado-framework/avocado-vt/pull/3068
**Test results:**
_Before fix:_
` (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_over_unix.positive_testing.with_copy_storage.default.multi_disks.p2p_live_migration.without_postcopy: FAIL: error: Failed to attach device from /tmp/avocado_neocfhcb/xml_file\nerror: internal error: No more available PCI slots\n (18.65 s)
`
_After fix:_
` (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_over_unix.positive_testing.with_copy_storage.default.multi_disks.p2p_live_migration.without_postcopy: PASS (92.29 s)`
