### PR TITLE
migration: No result check for some migration cases

### DIFF
--- a/libvirt/tests/src/migration/migrate_options_shared.py
+++ b/libvirt/tests/src/migration/migrate_options_shared.py
@@ -1389,6 +1389,7 @@ def run(test, params, env):
         # Execute migration process
         if not asynch_migration:
             mig_result = do_migration(vm, dest_uri, options, extra)
+            migration_test.check_result(mig_result, params)
         else:
 
             logging.debug("vm.connect_uri=%s", vm.connect_uri)


### PR DESCRIPTION
Update to check the result of migration process.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
_Before fix:_
` (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_options_shared.positive_test.native_tls.verify_client.no_post_after_precopy.without_postcopy: FAIL: The string '"dir":"/etc/pki/qemu","endpoint":"client","verify-peer":true' is not included in /var/log/libvirt/libvirtd.log (203.20 s)`

_After fix:(It's a known bug.)_
` (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_options_shared.positive_test.native_tls.verify_client.no_post_after_precopy.without_postcopy: FAIL: error: internal error: unable to execute QEMU command 'object-add': Parameter 'props' is unexpected (182.60 s)
`