### PR TITLE
virsh_migrate: Update to catch a CmdError

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
@@ -1112,7 +1112,7 @@ def run(test, params, env):
                 obj_migration.do_migration(vms, src_uri, dest_uri, "orderly",
                                            options=migrate_options,
                                            thread_timeout=postcopy_timeout,
-                                           ignore_status=False,
+                                           ignore_status=True,
                                            func=run_migration_cmd,
                                            func_params=cmd,
                                            shell=True)


### PR DESCRIPTION
The error message was unclear if migration failed, so update to
provide a proper error message.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
Before fix:
` (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate.migrate_postcopy.without_cpu_hotplug.compat_migration.non_compat_migration.default: FAIL (160.50 s)`


After fix:
` (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate.migrate_postcopy.without_cpu_hotplug.compat_migration.non_compat_migration.default: FAIL: error: internal error: unable to execute QEMU command 'migrate-set-capabilities': Postcopy is not supported (160.67 s)
`