### PR TITLE
Fix nvdimm on qemu command line change on new version

### DIFF
--- a/libvirt/tests/cfg/memory/nvdimm.cfg
+++ b/libvirt/tests/cfg/memory/nvdimm.cfg
@@ -29,9 +29,7 @@
                     setvm_current_mem_unit = M
                     setvm_vcpu = 4
                     setvm_placement = static
-                    qemu_checks = -numa node,nodeid=1,cpus=2-3`mem-path=${nvdimm_file},share=yes,.*size=536870912`label-size=262144
                     pseries:
-                        qemu_checks = nvdimm=on`mem-path=${nvdimm_file},share=yes`-device nvdimm,node=1,label-size=262144
                     variants:
                         - default:
                         - check_life_cycle:
@@ -74,7 +72,6 @@
                     setvm_current_mem_unit = KiB
                     setvm_vcpu = 2
                     setvm_placement = static
-                    qemu_checks = nvdimm=on`-smp 2,sockets=2,dies=1,cores=1,threads=1`-numa node,nodeid=0,cpus=0-1,mem=512|-object memory-backend-ram,id=ram-node0,size=536870912 -numa node,nodeid=0,cpus=0-1,memdev=ram-node0`mem-path=${nvdimm_file},share=yes`node=0
                     pseries:
                         check = ppc_no_label
                         status_error = yes


### PR DESCRIPTION
Signed-off-by: qijing <jinqi@redhat.com>

Fix nvdimm mount command on rhel9, add umount before reboot vm and fix the qemu
 command line check for the changes in new version

