### PR TITLE
Increase memory size to fix vm crash some time

### DIFF
--- a/libvirt/tests/cfg/memory/memory_discard.cfg
+++ b/libvirt/tests/cfg/memory/memory_discard.cfg
@@ -52,7 +52,7 @@
                     cpuxml_check = partial
                     cpuxml_fallback = allow
                     cpuxml_topology = {'sockets': '2', 'cores': '1', 'threads': '1'}
-                    cpuxml_numa_cell = [{'id': '0', 'cpus': '0-1', 'memory': '512', 'unit': 'MiB', 'discard': 'yes'}]
+                    cpuxml_numa_cell = [{'id': '0', 'cpus': '0-1', 'memory': '1024', 'unit': 'MiB', 'discard': 'yes'}]
                     dimmxml_mem_model = dimm
                     dimmxml_source_pagesize = 4
                     dimmxml_source_pagesize_unit = KiB
@@ -88,7 +88,7 @@
                              discard = 'no'
                         - discard_no:
                              mbxml_discard = 'yes'
-                             cpuxml_numa_cell = [{'id': '0', 'cpus': '0-1', 'memory': '512', 'unit': 'MiB', 'discard': 'no'}]
+                             cpuxml_numa_cell = [{'id': '0', 'cpus': '0-1', 'memory': '1024', 'unit': 'MiB', 'discard': 'no'}]
                              discard = 'no'
                              mbxml_access_mode = 'shared'
                              mbxml_source_type = 'file'


### PR DESCRIPTION
Signed-off-by: qijing <jinqi@redhat.com>

Increase memory size for the vm in case vm crash some time

