### PR TITLE
Add cases for tls verify client migration

### DIFF
--- a/libvirt/tests/cfg/migration/live_migration.cfg
+++ b/libvirt/tests/cfg/migration/live_migration.cfg
@@ -18,9 +18,6 @@
     # Local URI
     virsh_migrate_connect_uri = "qemu:///system"
     image_convert = 'no'
-    server_ip = "${migrate_dest_host}"
-    server_user = "${remote_user}"
-    server_pwd = "${migrate_dest_pwd}"
     variants:
         - with_postcopy:
             postcopy_options = "--postcopy --timeout 10 --timeout-postcopy"
@@ -105,8 +102,9 @@
             setup_tls = "yes"
             custom_pki_path = "/etc/pki/qemu"
             qemu_tls = "yes"
-            server_cn = "ENTER.YOUR.SERVER_CN.EXAMPLE"
-            client_cn = "ENTER.YOUR.CLIENT_CN.EXAMPLE"
+            server_cn = "ENTER.YOUR.EXAMPLE.SERVER_CN"
+            client_cn = "ENTER.YOUR.EXAMPLE.CLIENT_CN"
+            func_supported_since_libvirt_ver = (6, 9, 0)
             variants:
                 - default_src_and_dest:
                     # Use default migrate_tls_force on source and dest
@@ -138,3 +136,43 @@
                 - disable_src_and_dest:
                     qemu_conf_src = '{"migrate_tls_force": "0"}'
                     qemu_conf_dest = '{r".*migrate_tls_force\s*=.*": "migrate_tls_force=0"}'
+        - native_tls:
+            custom_pki_path = "/etc/pki/qemu"
+            setup_tls = "yes"
+            qemu_tls = "yes"
+            server_cn = "ENTER.YOUR.EXAMPLE.SERVER_CN"
+            client_cn = "ENTER.YOUR.EXAMPLE.CLIENT_CN"
+            scp_list_server = 'cacert,servercert,serverkey'
+            scp_list_client = 'cacert'
+            variants:
+                - by_storage:
+                    virsh_migrate_extra = "--tls --copy-storage-all"
+                - by_shared:
+                    virsh_migrate_extra = "--tls"
+            variants:
+                - default_x509_no:
+                    no migrate_x509_one
+                - default_x509_one:
+                    no migrate_x509_one
+                    default_tls_x509_verify = 1
+                - default_x509_zero:
+                    no migrate_x509_zero
+                    default_tls_x509_verify = 0
+            variants:
+                - migrate_x509_no:
+                    default_x509_no, default_x509_one:
+                        err_msg = "Cannot write to TLS channel | Cannot read from TLS channel"
+                        migrate_again = 'yes'
+                        status_error = 'yes'
+                        migrate_again_status_error = 'no'
+                        scp_list_client_again = 'cacert,clientcert,clientkey'
+                - migrate_x509_one:
+                    migrate_tls_x509_verify = 1
+                    default_x509_zero:
+                        err_msg = "Cannot write to TLS channel | Cannot read from TLS channel"
+                        migrate_again = 'yes'
+                        status_error = 'yes'
+                        migrate_again_status_error = 'no'
+                        scp_list_client_again = 'cacert,clientcert,clientkey'
+                - migrate_x509_zero:
+                    migrate_tls_x509_verify = 0

--- a/libvirt/tests/src/migration/live_migration.py
+++ b/libvirt/tests/src/migration/live_migration.py
@@ -2,14 +2,15 @@ import logging
 
 from virttest import libvirt_vm
 from virttest import migration
+from virttest import remote as remote_old
 from virttest import virsh
 from virttest import libvirt_remote
 from virttest import libvirt_version
 
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
-from virttest.utils_conn import TLSConnection
 from virttest.utils_libvirt import libvirt_config
+from virttest.utils_libvirt import libvirt_disk
 
 from provider.migration import migration_base
 
@@ -57,6 +58,59 @@ def check_vm_state_after_abort(vm_name, vm_state_after_abort, src_uri, dest_uri,
         libvirt.check_vm_state(vm_name, state=state_dict['target'], uri=dest_uri)
 
 
+def update_local_or_both_conf_file(params, conf_type='qemu'):
+    """
+    Read and update used parameter for the configuration file
+
+    :param params: dict, parameters used
+    :param conf_type: str, the configuration type
+    :return: utils_config.LibvirtConfigCommon object
+    """
+    logging.debug("Update configuration file")
+    migrate_tls_x509_verify = params.get('migrate_tls_x509_verify')
+    default_tls_x509_verify = params.get('default_tls_x509_verify')
+    qemu_conf_src = eval(params.get("qemu_conf_src", "{}"))
+    mode = 'both'
+    conf_dict = {}
+
+    if migrate_tls_x509_verify:
+        conf_dict.update({'migrate_tls_x509_verify': migrate_tls_x509_verify})
+    if default_tls_x509_verify:
+        conf_dict.update({'default_tls_x509_verify': default_tls_x509_verify})
+    # If qemu_conf_src is defined, we only support local update
+    if qemu_conf_src:
+        mode = 'local'
+        conf_dict.update(qemu_conf_src)
+    if len(conf_dict) > 0:
+        return libvirt.customize_libvirt_config(conf_dict,
+                                                config_type=conf_type,
+                                                remote_host=True if mode == 'both' else False,
+                                                extra_params=params)
+    else:
+        logging.debug("No key/value configuration is given.")
+        return None
+
+
+def recover_config_file(conf_obj, params):
+    """
+    Recover the configuration files
+
+    :param conf_obj: utils_config.LibvirtConfigCommon object to be restored
+    :param params: dict, parameters used
+    """
+    if not conf_obj:
+        logging.debug("No configuration object to recover")
+        return
+    logging.debug("Recover the configuration file")
+    qemu_conf_src = eval(params.get("qemu_conf_src", "{}"))
+    is_remote = False if qemu_conf_src else True
+    libvirt.customize_libvirt_config(None,
+                                     remote_host=is_remote,
+                                     is_recover=True,
+                                     extra_params=params,
+                                     config_object=conf_obj)
+
+
 def run(test, params, env):
     """
     Run the test
@@ -65,6 +119,8 @@ def run(test, params, env):
     :param params: Dictionary with the test parameters
     :param env: Dictionary with test environment.
     """
+    libvirt_version.is_libvirt_feature_supported(params)
+
     vm_name = params.get("migrate_main_vm")
     vm = env.get_vm(vm_name)
     vm.verify_alive()
@@ -86,63 +142,64 @@ def run(test, params, env):
     virsh_options = params.get("virsh_options", "")
     stress_package = params.get("stress_package")
     action_during_mig = params.get("action_during_mig")
-    #action_params_map = params.get('action_params_map')
     migrate_speed = params.get("migrate_speed")
     migrate_again = "yes" == params.get("migrate_again", "no")
     vm_state_after_abort = params.get("vm_state_after_abort")
-    return_port = params.get("return_port")
+    return_port = "yes" == params.get("return_port", "no")
+    params['server_pwd'] = params.get("migrate_dest_pwd")
+    params['server_ip'] = params.get("migrate_dest_host")
+    params['server_user'] = params.get("remote_user", "root")
+    is_storage_migration = True if extra.count('--copy-storage-all') else False
+    setup_tls = "yes" == params.get("setup_tls", "no")
+    qemu_conf_dest = params.get("qemu_conf_dest", "{}")
+    migrate_tls_force_default = "yes" == params.get("migrate_tls_force_default", "no")
+    server_params = {'server_ip': params.get("migrate_dest_host"),
+                     'server_user': params.get("remote_user", "root"),
+                     'server_pwd': params.get("migrate_dest_pwd")}
 
     if action_during_mig:
         action_during_mig = migration_base.parse_funcs(action_during_mig,
                                                        test, params)
-    setup_tls = params.get("setup_tls", "no")
-    if setup_tls == "yes":
-        if not libvirt_version.version_compare(6, 9, 0):
-            test.cancel("Cannot support migrate_tls_force in this libvirt version.")
 
-    qemu_conf_src = eval(params.get("qemu_conf_src", "{}"))
-    qemu_conf_dest = params.get("qemu_conf_dest", "{}")
-    status_error = "yes" == params.get("status_error", "no")
-    migrate_tls_force_default = "yes" == params.get("migrate_tls_force_default", "no")
-    server_ip = params.get("server_ip")
-    server_user = params.get("server_user")
-    server_pwd = params.get("server_pwd")
-    server_params = {'server_ip': server_ip,
-                     'server_user': server_user,
-                     'server_pwd': server_pwd}
-    tls_obj = None
-    qemu_conf_local = None
     qemu_conf_remote = None
+    (remove_key_local, remove_key_remote) = (None, None)
 
     # For safety reasons, we'd better back up  xmlfile.
     new_xml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     orig_config_xml = new_xml.copy()
+    local_both_conf_obj = None
+    remote_file_list = []
+    conn_obj_list = []
 
     try:
-        libvirt.set_vm_disk(vm, params)
-
-        # Setup libvirtd remote connection TLS connection env
-        if setup_tls == "yes":
-            tls_obj = TLSConnection(params)
-            tls_obj.auto_recover = True
-            tls_obj.conn_setup()
-
         # Setup default value for migrate_tls_force
         if migrate_tls_force_default:
             value_list = ["migrate_tls_force"]
             # Setup migrate_tls_force default value on remote
             server_params['file_path'] = "/etc/libvirt/qemu.conf"
-            libvirt_config.remove_key_in_conf(value_list, "qemu", remote_params=server_params)
+            remove_key_remote = libvirt_config.remove_key_in_conf(value_list,
+                                                                  "qemu",
+                                                                  remote_params=server_params)
             # Setup migrate_tls_force default value on local
-            libvirt_config.remove_key_in_conf(value_list, "qemu")
-
-        # Update remote qemu conf
+            remove_key_local = libvirt_config.remove_key_in_conf(value_list,
+                                                                 "qemu")
+        # Update only remote qemu conf
         if qemu_conf_dest:
             qemu_conf_remote = libvirt_remote.update_remote_file(
                 server_params, qemu_conf_dest, "/etc/libvirt/qemu.conf")
-        # Update local qemu conf
-        if qemu_conf_src:
-            qemu_conf_local = libvirt.customize_libvirt_config(qemu_conf_src, "qemu")
+        # Update local or both sides configuration files
+        local_both_conf_obj = update_local_or_both_conf_file(params)
+        # Setup TLS
+        if setup_tls:
+            conn_obj_list.append(migration_base.setup_conn_obj('tls',
+                                                               params,
+                                                               test))
+        # Update guest disk xml
+        if not is_storage_migration:
+            libvirt.set_vm_disk(vm, params)
+        else:
+            remote_file_list.append(libvirt_disk.create_remote_disk_by_same_metadata(vm,
+                                                                                     params))
 
         if not vm.is_alive():
             vm.start()
@@ -177,11 +234,19 @@ def run(test, params, env):
 
         if migrate_again:
             action_during_mig = migration_base.parse_funcs(params.get('action_during_mig_again'),
-                                                           test,
-                                                           params)
+                                                           test, params)
             extra_args['status_error'] = params.get("migrate_again_status_error", "no")
+
             if params.get("virsh_migrate_extra_mig_again"):
                 extra = params.get("virsh_migrate_extra_mig_again")
+
+            if params.get('scp_list_client_again'):
+                params['scp_list_client'] = params.get('scp_list_client_again')
+                # Recreate tlsconnection object using new parameter values
+                conn_obj_list.append(migration_base.setup_conn_obj('tls',
+                                                                   params,
+                                                                   test))
+
             migration_base.do_migration(vm, migration_test, None, dest_uri,
                                         options, virsh_options,
                                         extra, action_during_mig,
@@ -205,19 +270,24 @@ def run(test, params, env):
         vm.connect_uri = bk_uri
         # Clean VM on destination and source
         migration_test.cleanup_vm(vm, dest_uri)
-
-        # Restore local qemu conf and restart libvirtd
-        if qemu_conf_local:
-            logging.debug("Recover local qemu configurations")
-            libvirt.customize_libvirt_config(None, config_type="qemu", is_recover=True,
-                                             config_object=qemu_conf_local)
         # Restore remote qemu conf and restart libvirtd
         if qemu_conf_remote:
             logging.debug("Recover remote qemu configurations")
             del qemu_conf_remote
+        # Restore local or both sides conf and restart libvirtd
 
-        # Clean up TLS test env:
-        if setup_tls and tls_obj:
-            logging.debug("Clean up TLS object")
-            del tls_obj
+        recover_config_file(local_both_conf_obj, params)
+        if remove_key_remote:
+            del remove_key_remote
+        if remove_key_local:
+            libvirt.customize_libvirt_config(None,
+                                             config_object=remove_key_local,
+                                             config_type='qemu')
+        # Clean up connection object, like TLS
+        migration_base.cleanup_conn_obj(conn_obj_list, test)
+
+        for one_file in remote_file_list:
+            if one_file:
+                remote_old.run_remote_cmd("rm -rf %s" % one_file, params)
+
         orig_config_xml.sync()

--- a/provider/migration/migration_base.py
+++ b/provider/migration/migration_base.py
@@ -2,6 +2,8 @@ import logging
 import types
 
 from virttest import virsh                           # pylint: disable=W0611
+
+from virttest.utils_conn import TLSConnection
 from virttest.utils_libvirt import libvirt_network   # pylint: disable=W0611
 
 
@@ -88,3 +90,38 @@ def do_migration(vm, mig_test, src_uri, dest_uri, options, virsh_options,
                               func=None,
                               multi_funcs=action_during_mig,
                               **extra_args)
+
+
+def setup_conn_obj(conn_type, params, test):
+    """
+    Setup connection object, like TLS
+
+    :param conn_type: str, 'tls' for now
+    :param params: dict, used to setup the connection
+    :param test: test object
+    :return: TLSConnection, the connection object
+    """
+    logging.debug("Begin to create new {} connection".format(conn_type.upper()))
+    conn_obj = None
+    if conn_type.upper() == 'TLS':
+        conn_obj = TLSConnection(params)
+        conn_obj.auto_recover = True
+        conn_obj.conn_setup()
+    else:
+        test.error("Invalid parameter, only support 'tls'")
+    return conn_obj
+
+
+def cleanup_conn_obj(obj_list, test):
+    """
+    Clean up TLS/SSH/TCP/UNIX connection objects
+
+    :param obj_list: list, object list
+    :param test: test object
+    """
+    if not obj_list:
+        test.error("No connection object needs to be cleaned up")
+    for one_conn in obj_list:
+        if one_conn:
+            logging.debug("Clean up one connection object")
+            del one_conn


### PR DESCRIPTION
Case ID :RHEL-196368
Test scenarios:
Test matrix for default/migrate_tls_x509_verify with qemu native
TLS encryption migration. Different combinations are to test if
the verifying client x509 cert is required and migration can be
succeeded.

Signed-off-by: Dan Zheng <dzheng@redhat.com>