### PR TITLE
graphics_functional: Fix vnc expect option check

### DIFF
--- a/libvirt/tests/src/graphics/graphics_functional.py
+++ b/libvirt/tests/src/graphics/graphics_functional.py
@@ -826,6 +826,12 @@ def get_expected_vnc_options(params, networks, expected_result):
         'port': port,
     }
 
+    if libvirt_version.version_compare(7, 2, 0):
+        # libvirt auto-populate <audio> elements for vnc since 7.2.0
+        vmxml = VMXML.new_from_dumpxml(vm_name)
+        audio_id = vmxml.get_devices(device_type="audio")[0].id
+        expected_opts['audiodev'] = "audio" + audio_id
+
     if vnc_tls == '1':
         expected_opts['tls'] = 'yes'
         if tls_x509_verify == '1':


### PR DESCRIPTION
libvirt auto-populate <audio> elements for vnc since 7.2.0
```
commit e88367095f3cad2cf80a687fd599dfaeb3073841
Author: Daniel P. Berrangé <berrange@redhat.com>
Date:   Wed Feb 24 14:24:10 2021 +0000

    qemu: populate <audio> element with default config

    Currently the QEMU driver secretly sets the QEMU_AUDIO_DRV env variable

     - VNC - set to "none", unless passthrough of host env variable is set
     - SPICE - always set to "spice"
     - SDL - always passthrough host env
     - No graphics - set to "none", unless passthrough of host env variable is set

    The setting of the QEMU_AUDIO_DRV env variable is done in the code which
    configures graphics.

    If no <audio> element is present, we now auto-populate <audio> elements
    to reflect this historical default config. This avoids need to set audio
    env when processing graphics.

    Reviewed-by: Michal Privoznik <mprivozn@redhat.com>
    Signed-off-by: Daniel P. Berrangé <berrange@redhat.com>
```

That caused qemu cmdline to change
Before
```
-vnc 127.0.0.1:0
```
Now
```
-vnc 127.0.0.1:0,audiodev=audio1
```