### PR TITLE
Fix virsh_attach_detach_interface aarch64

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_interface.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_interface.cfg
@@ -17,12 +17,12 @@
                 - domid:
                     at_detach_iface_vm_ref = "domid"
                     at_detach_iface_model = "rtl8139"
-                    pseries, s390-virtio:
+                    pseries, s390-virtio, aarch64:
                         at_detach_iface_model = "virtio"
                 - domuuid:
                     at_detach_iface_vm_ref = "domuuid"
                     at_detach_iface_model = "e1000e"
-                    pseries, s390-virtio:
+                    pseries, s390-virtio, aarch64:
                         at_detach_iface_model = "virtio"
             variants:
                 - default_network:


### PR DESCRIPTION
virsh_attach_detach_interface: Use virtio as only supported option in this case for aarch64.

Signed-off-by: Ma Xinjian <maxj.fnst@cn.fujitsu.com>

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [ ] Description of the cases
- [ ] Links of libvirt features, libvirt bugs or case IDs
- [ ] Test results

## If the PR is bug cases
- [x] Bug descriptions or bug links
test on rhel, qemu-kvm doesn't support e1000e or rtl8139
`
$ /usr/libexec/qemu-kvm -M virt -device help | grep e1000
`
`
$ /usr/libexec/qemu-kvm -M virt -device help | grep rtl8139
`

- [x] Test results
before: 
`
$ avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio   virsh.attach_detach_interface.normal_test.vm_running.default_network.default.domid
JOB ID     : ee459cb451c65ddefead9d4063daaff43c66a8ea
JOB LOG    : /root/avocado/job-results/job-2021-05-27T03.10-ee459cb/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.attach_detach_interface.normal_test.vm_running.default_network.default.domid: FAIL: ['Attach Failed: error: Failed to attach interface\nerror: internal error: No more available PCI slots\n'] (69.35 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 70.02 s
`
after:
`
$ avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio unattended_install.import.import.default_install.aio_native  virsh.attach_detach_interface.normal_test.vm_running.default_network.default.domid
JOB ID     : 1b5519afcf54386c24b558399f0eddb2d15e9c00
JOB LOG    : /root/avocado/job-results/job-2021-05-27T03.41-1b5519a/job.log
 (1/2) io-github-autotest-qemu.unattended_install.import.import.default_install.aio_native: PASS (48.34 s)
 (2/2) type_specific.io-github-autotest-libvirt.virsh.attach_detach_interface.normal_test.vm_running.default_network.default.domid: PASS (58.81 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 107.85 s
`
## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
