### PR TITLE
remote_access: new tests added for uri aliases/default

### DIFF
--- a/libvirt/tests/cfg/remote_access/remote_with_ssh.cfg
+++ b/libvirt/tests/cfg/remote_access/remote_with_ssh.cfg
@@ -41,16 +41,32 @@
                     extra_env = "KRB5CCNAME=libvirt_krb_test"
                     filter_pattern = ".*${extra_env}.*ssh.*${server_ip}.*libvirt-sock.*"
                     log_level= "LIBVIRT_DEBUG=1"
-                - test_uri_with_default_user:
+                - uri_with_default_user:
                     test_driver = "test"
                     uri_path = "/default"
                     auth_pwd = "${client_pwd}"
                     no_any_config = "yes"
-                - test_uri_with_root_user:
+                - uri_with_root_user:
                     test_driver = "test"
                     uri_path = "root@${server_ip}/default"
                     auth_pwd = "${server_pwd}"
                     no_any_config = "yes"
+                - uri_alias_list:
+                    uri_aliases = ["zhpeng=qemu+ssh://root@${remote_ip}/system", "pengzhimoutest\.\$=qemu+ssh://root@${local_ip}/system",]
+                    test_alias = 'zhpeng'
+                - uri_one_alias:
+                    uri_aliases = ["zhpeng=qemu+ssh://root@${remote_ip}/system",]
+                    test_alias = 'zhpeng'
+                - check_uri:
+                     uri_aliases = ["hail=qemu+ssh://root@${remote_ip}/system", "sleet=qemu+ssh://root@${local_ip}/system",]
+                     virsh_cmd = 'uri'
+                     test_alias = 'hail'
+                     error_pattern = "qemu+ssh://root@${remote_ip}/system"
+                     status_error = "yes"
+                - uri_default_local:
+                    uri_default = '"qemu:///session"'
+                - uri_default_remote:
+                    uri_default = '"qemu+ssh://${remote_ip}/system"'
                 - xen_uri_with_default_user:
                     test_driver = "xen"
                     uri_path = "ENTER.YOUR.REMOTE.XEN.EXAMPLE.COM"
@@ -84,6 +100,14 @@
                     transport = "libssh2"
                 - ssh_no_uri_path:
                     uri_path = ""
+                - uri_invalid_alias:
+                    uri_aliases = ["zhpeng=qemu+ssh://root@${remote_ip}/system", "pengzhimoutest\.\$=qemu+ssh://root@${local_ip}/system"]
+                    test_alias = 'pengzhimoutest\.\$'
+                    error_pattern = "Malformed 'uri_aliases' config entry"
+                - uri_invalid_alias_string:
+                    uri_aliases = '"zhpeng=qemu+ssh://root@${remote_ip}/system"'
+                    test_alias = 'zhpeng'
+                    error_pattern = "expected a string list for 'uri_aliases' parameter"
                 - invalid_transport:
                     inv_transport = "abc"
                     error_pattern = "transport in URL not recognised"


### PR DESCRIPTION
The new test cases added to test uri default and uri aliases.

Signed-off-by: Kamil Varga <kvarga@redhat.com>

- Description of the cases: custom uri aliases and uri default
- case ID: RHEL7-18304
- Test results:
<pre>WARNING:root:No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
WARNING:root:No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
<font color="#2A7BDE">JOB ID     : 095e334a76344f8b7d924ab0d8242c27ca83beba</font>
<font color="#2A7BDE">JOB LOG    : /root/avocado/job-results/job-2021-05-31T03.22-095e334/job.log</font>
 (1/1) type_specific.io-github-autotest-libvirt.virsh.remote_with_ssh.positive_testing.test_uri_alias_list: <font color="#33DA7A">PASS</font> (35.45 s)
<font color="#2A7BDE">RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0</font>
<font color="#2A7BDE">JOB TIME   : 37.08 s</font>
WARNING:root:No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
WARNING:root:No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
<font color="#2A7BDE">JOB ID     : 87dfb16735153cf83e3f20df723bab6becab4a35</font>
<font color="#2A7BDE">JOB LOG    : /root/avocado/job-results/job-2021-05-31T03.23-87dfb16/job.log</font>
 (1/1) type_specific.io-github-autotest-libvirt.virsh.remote_with_ssh.positive_testing.test_uri_one_alias: <font color="#33DA7A">PASS</font> (35.52 s)
<font color="#2A7BDE">RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0</font>
<font color="#2A7BDE">JOB TIME   : 36.31 s</font>
WARNING:root:No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
WARNING:root:No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
<font color="#2A7BDE">JOB ID     : 5fadcd6d41b38417bef5212112be91425c71eac7</font>
<font color="#2A7BDE">JOB LOG    : /root/avocado/job-results/job-2021-05-31T03.24-5fadcd6/job.log</font>
 (1/1) type_specific.io-github-autotest-libvirt.virsh.remote_with_ssh.positive_testing.check_uri: <font color="#33DA7A">PASS</font> (35.43 s)
<font color="#2A7BDE">RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0</font>
<font color="#2A7BDE">JOB TIME   : 36.22 s</font>
WARNING:root:No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
WARNING:root:No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
<font color="#2A7BDE">JOB ID     : 627207f318dcfa51acd75b87b400bab7708c99ae</font>
<font color="#2A7BDE">JOB LOG    : /root/avocado/job-results/job-2021-05-31T03.24-627207f/job.log</font>
 (1/1) type_specific.io-github-autotest-libvirt.virsh.remote_with_ssh.positive_testing.test_uri_default_local: <font color="#33DA7A">PASS</font> (34.77 s)
<font color="#2A7BDE">RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0</font>
<font color="#2A7BDE">JOB TIME   : 35.68 s</font>
WARNING:root:No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
WARNING:root:No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
<font color="#2A7BDE">JOB ID     : 5a6b0444c4973f1404eccbc5fe7f557f1a89d762</font>
<font color="#2A7BDE">JOB LOG    : /root/avocado/job-results/job-2021-05-31T03.25-5a6b044/job.log</font>
 (1/1) type_specific.io-github-autotest-libvirt.virsh.remote_with_ssh.positive_testing.test_uri_default_remote: <font color="#33DA7A">PASS</font> (35.87 s)
<font color="#2A7BDE">RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0</font>
<font color="#2A7BDE">JOB TIME   : 36.67 s</font>
WARNING:root:No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
WARNING:root:No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
<font color="#2A7BDE">JOB ID     : 95f761ae95910ec718d1baee3e7305611878d122</font>
<font color="#2A7BDE">JOB LOG    : /root/avocado/job-results/job-2021-05-31T03.26-95f761a/job.log</font>
 (1/1) type_specific.io-github-autotest-libvirt.virsh.remote_with_ssh.negative_testing.test_uri_invalid_alias: <font color="#33DA7A">PASS</font> (34.86 s)
<font color="#2A7BDE">RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0</font>
<font color="#2A7BDE">JOB TIME   : 35.58 s</font>
WARNING:root:No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
WARNING:root:No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
<font color="#2A7BDE">JOB ID     : a03ef0763697de41b32dfe6abea1c1ae5efe3aab</font>
<font color="#2A7BDE">JOB LOG    : /root/avocado/job-results/job-2021-05-31T03.26-a03ef07/job.log</font>
 (1/1) type_specific.io-github-autotest-libvirt.virsh.remote_with_ssh.negative_testing.test_uri_invalid_alias_string: <font color="#33DA7A">PASS</font> (34.87 s)
<font color="#2A7BDE">RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0</font>
<font color="#2A7BDE">JOB TIME   : 35.76 s</font>
</pre>