### PR TITLE
libvirt_guests: Fix the issue for hanging of libvirt-guests

### DIFF
--- a/libvirt/tests/src/conf_file/sysconfig_libvirt_guests/libvirt_guests.py
+++ b/libvirt/tests/src/conf_file/sysconfig_libvirt_guests/libvirt_guests.py
@@ -327,8 +327,8 @@ def run(test, params, env):
                 dom.destroy(gracefully=False)
             virsh.remove_domain(dom.name, "--remove-all-storage")
 
-        if not libvirt_guests_service.status():
-            libvirt_guests_service.start()
+        if libvirt_guests_service.status():
+            libvirt_guests_service.stop()
 
         if nfs_vol:
             cleanup_nfs_backend_guest(vmxml_backup)


### PR DESCRIPTION
Stopping libvirt-guests service will hang when libvirtd is off now.
Refer to bug 1964855. This fix is to Make sure libvirt-guests
service is off after testing.

Signed-off-by: Lily Zhu <lizhu@redhat.com>