### PR TITLE
Fix data_dir.get_tmp_dir() permission deny issue

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_ceph.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_ceph.py
@@ -32,6 +32,8 @@ from virttest import data_dir
 
 from virttest import libvirt_version
 
+TMP_DATA_DIR = data_dir.get_data_dir()
+
 
 def run(test, params, env):
     """
@@ -46,7 +48,7 @@ def run(test, params, env):
     vm_name = params.get("main_vm")
     vm = env.get_vm(vm_name)
     virsh_dargs = {'debug': True, 'ignore_status': True}
-    additional_xml_file = os.path.join(data_dir.get_tmp_dir(), "additional_disk.xml")
+    additional_xml_file = os.path.join(TMP_DATA_DIR, "additional_disk.xml")
 
     def config_ceph():
         """
@@ -231,7 +233,7 @@ def run(test, params, env):
         """
         Test save and restore operation
         """
-        save_file = os.path.join(data_dir.get_tmp_dir(),
+        save_file = os.path.join(TMP_DATA_DIR,
                                  "%s.save" % vm_name)
         ret = virsh.save(vm_name, save_file, **virsh_dargs)
         libvirt.check_exit_status(ret)
@@ -247,8 +249,8 @@ def run(test, params, env):
         Test snapshot operation.
         """
         snap_name = "s1"
-        snap_mem = os.path.join(data_dir.get_tmp_dir(), "rbd.mem")
-        snap_disk = os.path.join(data_dir.get_tmp_dir(), "rbd.disk")
+        snap_mem = os.path.join(TMP_DATA_DIR, "rbd.mem")
+        snap_disk = os.path.join(TMP_DATA_DIR, "rbd.disk")
         xml_snap_exp = ["disk name='%s' snapshot='external' type='file'" % target_dev]
         xml_dom_exp = ["source file='%s'" % snap_disk,
                        "backingStore type='network' index='1'",
@@ -296,7 +298,7 @@ def run(test, params, env):
         """
         Block copy operation test.
         """
-        blk_file = os.path.join(data_dir.get_tmp_dir(), "blk.rbd")
+        blk_file = os.path.join(TMP_DATA_DIR, "blk.rbd")
         if os.path.exists(blk_file):
             os.remove(blk_file)
         blk_mirror = ("mirror type='file' file='%s' "
@@ -440,12 +442,12 @@ def run(test, params, env):
         logging.info("Making snapshot...")
         first_disk_source = vm.get_first_disk_devices()['source']
         snapshot_path_list = []
-        snapshot2_file = os.path.join(data_dir.get_tmp_dir(), "mem.s2")
-        snapshot3_file = os.path.join(data_dir.get_tmp_dir(), "mem.s3")
-        snapshot4_file = os.path.join(data_dir.get_tmp_dir(), "mem.s4")
-        snapshot4_disk_file = os.path.join(data_dir.get_tmp_dir(), "disk.s4")
-        snapshot5_file = os.path.join(data_dir.get_tmp_dir(), "mem.s5")
-        snapshot5_disk_file = os.path.join(data_dir.get_tmp_dir(), "disk.s5")
+        snapshot2_file = os.path.join(TMP_DATA_DIR, "mem.s2")
+        snapshot3_file = os.path.join(TMP_DATA_DIR, "mem.s3")
+        snapshot4_file = os.path.join(TMP_DATA_DIR, "mem.s4")
+        snapshot4_disk_file = os.path.join(TMP_DATA_DIR, "disk.s4")
+        snapshot5_file = os.path.join(TMP_DATA_DIR, "mem.s5")
+        snapshot5_disk_file = os.path.join(TMP_DATA_DIR, "disk.s5")
 
         # Attempt to take different types of snapshots.
         snapshots_param_dict = {"s1": "s1 --disk-only --no-metadata",
@@ -566,10 +568,10 @@ def run(test, params, env):
     key_opt = ""
     secret_uuid = None
     snapshot_path = None
-    key_file = os.path.join(data_dir.get_tmp_dir(), "ceph.key")
-    img_file = os.path.join(data_dir.get_tmp_dir(),
+    key_file = os.path.join(TMP_DATA_DIR, "ceph.key")
+    img_file = os.path.join(TMP_DATA_DIR,
                             "%s_test.img" % vm_name)
-    front_end_img_file = os.path.join(data_dir.get_tmp_dir(),
+    front_end_img_file = os.path.join(TMP_DATA_DIR,
                                       "%s_frontend_test.img" % vm_name)
     # Construct a unsupported error message list to skip these kind of tests
     unsupported_err = []

--- a/libvirt/tests/src/virtual_disks/virtual_disks_gluster.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_gluster.py
@@ -109,7 +109,7 @@ def run(test, params, env):
             vm.wait_for_login()
         # Create swap partition if nessesary.
         if not vm.has_swap():
-            swap_path = os.path.join(data_dir.get_tmp_dir(), 'swap.img')
+            swap_path = os.path.join(data_dir.get_data_dir(), 'swap.img')
             vm.create_swap_partition(swap_path)
         ret = virsh.dompmsuspend(vm_name, "disk", **virsh_dargs)
         libvirt.check_exit_status(ret)

--- a/libvirt/tests/src/virtual_disks/virtual_disks_iscsi.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_iscsi.py
@@ -340,7 +340,7 @@ def run(test, params, env):
 
             # Test domain save/restore/snapshot.
             if test_save_snapshot:
-                save_file = os.path.join(data_dir.get_tmp_dir(), "%.save" % vm_name)
+                save_file = os.path.join(data_dir.get_data_dir(), "%.save" % vm_name)
                 check_save_restore(save_file)
                 check_snapshot()
                 if os.path.exists(save_file):

--- a/libvirt/tests/src/virtual_disks/virtual_disks_luks.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_luks.py
@@ -23,6 +23,8 @@ from virttest.libvirt_xml.devices.disk import Disk
 
 from virttest import libvirt_version
 
+TMP_DATA_DIR = data_dir.get_data_dir()
+
 
 def run(test, params, env):
     """
@@ -321,7 +323,7 @@ def run(test, params, env):
             ceph_auth_user = params.get("ceph_auth_user")
             ceph_auth_key = params.get("ceph_auth_key")
             enable_auth = "yes" == params.get("enable_auth")
-            key_file = os.path.join(data_dir.get_tmp_dir(), "ceph.key")
+            key_file = os.path.join(TMP_DATA_DIR, "ceph.key")
             key_opt = ""
             # Prepare a blank params to confirm if delete the configure at the end of the test
             ceph_cfg = ""
@@ -366,7 +368,7 @@ def run(test, params, env):
             nfs_server_dir = params.get("nfs_server_dir", "nfs_server")
             emulated_image = params.get("emulated_image")
             image_name = params.get("nfs_image_name", "nfs.img")
-            tmp_dir = data_dir.get_tmp_dir()
+            tmp_dir = TMP_DATA_DIR
             pvt = libvirt.PoolVolumeTest(test, params)
             pvt.pre_pool(pool_name, pool_type, pool_target, emulated_image)
             nfs_mount_dir = os.path.join(tmp_dir, pool_target)
@@ -428,7 +430,7 @@ def run(test, params, env):
             disk_src_dict = {'attrs': {'file': volume_target_path}}
             device_source = volume_target_path
         elif backend_storage_type == "file":
-            tmp_dir = data_dir.get_tmp_dir()
+            tmp_dir = TMP_DATA_DIR
             image_name = params.get("file_image_name", "slice.img")
             device_source = os.path.join(tmp_dir, image_name)
             disk_src_dict = {'attrs': {'file': device_source}}
@@ -510,7 +512,7 @@ def run(test, params, env):
             virsh.create(transient_vmxml.xml, ignore_status=False, debug=True)
             expected_top_image = vm.get_blk_devices()[device_target].get('source')
             options = params.get("blockcopy_options")
-            tmp_dir = data_dir.get_tmp_dir()
+            tmp_dir = TMP_DATA_DIR
             tmp_file = time.strftime("%Y-%m-%d-%H.%M.%S.img")
             dest_path = os.path.join(tmp_dir, tmp_file)
 

--- a/libvirt/tests/src/virtual_disks/virtual_disks_multivms.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multivms.py
@@ -115,7 +115,7 @@ def run(test, params, env):
                                             "no")
     test_shareable = "yes" == params.get("virt_disk_test_shareable", "no")
     test_readonly = "yes" == params.get("virt_disk_test_readonly", "no")
-    disk_source_path = data_dir.get_tmp_dir()
+    disk_source_path = data_dir.get_data_dir()
     disk_path = ""
     tmp_filename = "cdrom_te.tmp"
     tmp_readonly_file = ""

--- a/libvirt/tests/src/virtual_disks/virtual_disks_usb.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_usb.py
@@ -144,7 +144,7 @@ def run(test, params, env):
         image_filename = params.get("image_filename", "raw.img")
         image_format = params.get("image_format", "raw")
         image_size = params.get("image_size", "1G")
-        image_path = os.path.join(data_dir.get_tmp_dir(), image_filename)
+        image_path = os.path.join(data_dir.get_data_dir(), image_filename)
         try:
             if image_format in ["raw", "qcow2"]:
                 image_path = libvirt.create_local_disk("file",


### PR DESCRIPTION
data_dir.get_tmp_dir() need to be replaced by data_dir.get_data_dir()

Signed-off-by: chunfuwen <chwen@redhat.com>

