### PR TITLE
[filesystem_device][virtio-fs] Add version switch

### DIFF
--- a/libvirt/tests/src/virtual_device/filesystem_device.py
+++ b/libvirt/tests/src/virtual_device/filesystem_device.py
@@ -119,6 +119,10 @@ def run(test, params, env):
 
     if len(vm_names) != guest_num:
         test.cancel("This test needs exactly %d vms." % guest_num)
+
+    if not libvirt_version.version_compare(7, 0, 0) and not with_numa:
+        test.cancel("Not supported without NUMA before 7.0.0")
+
     try:
         # Define filesystem device xml
         for index in range(fs_num):


### PR DESCRIPTION
Test cases without NUMA are supported only since 7.0.

Add switch in order to cancel test execution on earlier versions.

libvirt commit:
bff2ad5d6b1f25da02802273934d2a519159fec7

https://gitlab.com/libvirt/libvirt/-/commit/bff2ad5d6b1f25da02802273934d2a519159fec7

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>