### PR TITLE
 Add a migration case to check the VM with direct type interface 

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_network.cfg
+++ b/libvirt/tests/cfg/migration/migrate_network.cfg
@@ -41,3 +41,11 @@
                 - macvtap_exists_dest:
                     modify_target_vm = "yes"
                     check_macvtap_exists = "yes"
+                - fake_macvtap_exists_dest:
+                    status_error = 'yes'
+                    err_msg = "cannot get interface flags on macvtap tap"
+                    func_supported_since_libvirt_ver = (6, 6, 0)
+                    modify_target_vm = "yes"
+                    check_macvtap_exists = "yes"
+                    create_fake_tap_dest = "yes"
+                    migrate_vm_back = "no"


### PR DESCRIPTION
RHEL-189837 - Migrate vm with direct type interface assigned from
virtual network (auto-generated macvtap device name + fake tap
device exists on dst host).

Signed-off-by: Yingshun Cui <yicui@redhat.com>
```
JOB ID     : 362814ebb6c5c766f605d052d640b34d61784405
JOB LOG    : /root/avocado/job-results/job-2021-06-07T21.30-362814e/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_network.direct.fake_macvtap_exists_dest.without_postcopy: PASS (175.11 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 176.59 s
```
