### PR TITLE
v2v: always install virt-v2v package when recovering envrionment

### DIFF
--- a/v2v/tests/src/v2v_options.py
+++ b/v2v/tests/src/v2v_options.py
@@ -888,7 +888,7 @@ def run(test, params, env):
         if hypervisor == "esx":
             process.run("rm -rf %s" % vpx_passwd_file)
         if checkpoint == "weak_dendency":
-            utils_package.package_install('libguestfs-xfs')
+            utils_package.package_install(['libguestfs-xfs', 'virt-v2v'])
         for vdsm_dir in [vdsm_domain_dir, vdsm_image_dir, vdsm_vm_dir]:
             if os.path.exists(vdsm_dir):
                 shutil.rmtree(vdsm_dir)


### PR DESCRIPTION
If some error happens, virt-v2v may be uninstalled unexpectedly.
In order to aovid failure of subsequent scripts, virt-v2v should
be installed no matter it was uninstalled or not.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>