### PR TITLE
Remove win7 scenario from v2v job as win7 is not supported anymore

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -117,9 +117,6 @@
                         - win2008r2:
                             os_version = "win2008r2"
                             main_vm = VM_NAME_WIN2008R2_V2V_EXAMPLE
-                        - win7:
-                            os_version = "win7"
-                            main_vm = VM_NAME_WIN7_V2V_EXAMPLE
                         - win8:
                             os_version = "win8"
                             main_vm = VM_NAME_WIN8_V2V_EXAMPLE


### PR DESCRIPTION
Signed-off-by: mxie91 <mxie@redhat.com>

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [ ] Description of the cases
- [ ] Links of libvirt features, libvirt bugs or case IDs
- [ ] Test results

## If the PR is bug cases
- [ ] Bug descriptions or bug links
- [ ] Test results

## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
