### PR TITLE
tpm_device: add test for persistent_state

### DIFF
--- a/libvirt/tests/cfg/virtual_device/tpm_device.cfg
+++ b/libvirt/tests/cfg/virtual_device/tpm_device.cfg
@@ -29,6 +29,9 @@
                         - version_default:
                             only plain
                             backend_version = 'none'
+                        - persistent_state:
+                            persistent_state = 'yes'
+                            func_supported_since_libvirt_ver = (7, 0, 0)
                         - multi_vms:
                             multi_vms = 'yes'
                         - test_suite:


### PR DESCRIPTION
The persistent_state attribute indicates whether 'swtpm' TPM state
is kept or not when a transient domain is powered off. Supported
from libvirt 7.0.0. Work with pr: avocado-vt/pull/3091. RHEL-197332

Signed-off-by: Yanqiu Zhang <yanqzhan@redhat.com>
