### PR TITLE
remote_access: Check the connection to virsh after wrong attempt

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/virsh_connect.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/virsh_connect.cfg
@@ -31,6 +31,9 @@
                             connect_arg = "lxc:///"
                         - readonly:
                             connect_opt = "--readonly"
+                        - connection_alive:
+                            alive = "yes"
+                            expected_result_patt = "error: failed to connect to the hypervisor\nerror: no connection driver available"
                 - error_test:
                     status_error = "yes"
                     variants:


### PR DESCRIPTION
New case added for checking if the connection to virsh is still
alive, after the wrong attempt.

Signed-off-by: Kamil Varga <kvarga@redhat.com>

- Description of the cases: libvirt connection shouldn't be broken after connect a bad hypervisor
- Case IDs: RHEL7-18310
- Test results:
<pre>avocado run --vt-type libvirt --vt-machine-type q35 virsh.connect.local_connect.normal_test.connection_alive
WARNING:root:No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
WARNING:root:No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
<font color="#2A7BDE">JOB ID     : 2ca804fd25ad6d99b8408282fa741fd1745a6960</font>
<font color="#2A7BDE">JOB LOG    : /root/avocado/job-results/job-2021-06-11T12.15-2ca804f/job.log</font>
 (1/1) type_specific.io-github-autotest-libvirt.virsh.connect.local_connect.normal_test.connection_alive: <font color="#33DA7A">PASS</font> (4.89 s)
<font color="#2A7BDE">RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0</font>
<font color="#2A7BDE">JOB TIME   : 5.70 s</font></pre>