### PR TITLE
Correct compare_qemu_version

### DIFF
--- a/libvirt/tests/src/migration/migrate_with_virtual_devices.py
+++ b/libvirt/tests/src/migration/migrate_with_virtual_devices.py
@@ -180,7 +180,7 @@ class MigrationWithRng(MigrationVirtualDevicesBase):
         # and qemu-kvm>=4.2.0
         if (self.backend_model == "builtin" and
                 (not libvirt_version.version_compare(6, 2, 0)
-                    or not utils_misc.compare_qemu_version(4, 2, 0))):
+                    or not utils_misc.compare_qemu_version(4, 2, 0, False))):
             self.test.cancel("backend model builtin is not supported"
                              "by this hypervisor version")
 


### PR DESCRIPTION
There is no "module" or "scrmod" in qemu version's output since
rhel9, so update is_rhev to False to return the correct value.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Test results:**
rhel9: QEMU emulator version 6.0.0 (qemu-kvm-6.0.0-5.el9)
Before fix:
```
>>> utils_misc.compare_qemu_version(4, 2, 0)
False

```
After fix:
```
>>> utils_misc.compare_qemu_version(4, 2, 0, False)
True
```
rhel8.4: QEMU emulator version 5.2.0 (qemu-kvm-5.2.0-16.module+el8.4.0+10806+b7d97207)
```
>>> utils_misc.compare_qemu_version(4, 2, 0)
True
>>> utils_misc.compare_qemu_version(4, 2, 0, False)
True
>>> 
```
