### PR TITLE
v2v: delete all windows configuration from xen

### DIFF
--- a/v2v/tests/cfg/function_test_xen.cfg
+++ b/v2v/tests/cfg/function_test_xen.cfg
@@ -119,25 +119,6 @@
             checkpoint = multidisk
         - rhel6_2:
             main_vm = VM_NAME_XEN_RHEL62_V2V_EXAMPLE
-        - windows:
-            os_type = 'windows'
-            shutdown_command = 'shutdown /s /f /t 0'
-            reboot_command = 'shutdown /r /f /t 0'
-            status_test_command = 'echo %errorlevel%'
-            shell_prompt = '^\w:\\.*>\s*$'
-            shell_linesep = '\r\n'
-            shell_client = 'nc'
-            shell_port = 10022
-            file_transfer_client = 'rss'
-            file_transfer_port = 10023
-            redirs += ' file_transfer'
-            guest_port_remote_shell = 10022
-            guest_port_file_transfer = 10023
-            rtc_base = 'localtime'
-            network_query = 'ipconfig /all'
-            restart_network = 'ipconfig /renew'
-            vm_user = 'Administrator'
-            vm_pwd = DEFAULT_WIN_VM_PASSWORD
     variants:
         - positive_test:
             status_error = 'no'


### PR DESCRIPTION
Because the windows guests is too old on xen server, they were
removed in 9a600c4df4b194d34ec8d800f12dacc9f50c3f21, but the
windows pre-configuration were left by mistake, this patch fixes
the problem.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>