### PR TITLE
migration: Update the error message for negative multifd cases

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -505,7 +505,7 @@
                             err_msg = "error: invalid argument: Turn parallel migration on to tune it"
                         - inavalid_connect_num:
                             virsh_migrate_extra = "--parallel --parallel-connections"
-                            err_msg = "error: internal error: unable to execute QEMU command 'migrate-set-parameters': Parameter 'multifd_channels' expects is invalid, it should be in the range of 1 to 255"
+                            err_msg = "error: internal error: unable to execute QEMU command 'migrate-set-parameters': Parameter 'multifd(_|-)channels' expects"
                             variants:
                                 - set_zero:
                                     parallel_cn_nums = 0


### PR DESCRIPTION
The error message was updated, so update it.

Signed-off-by: Yingshun Cui <yicui@redhat.com>

Before fix:
` (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_options_shared.negative_test.multifd.inavalid_connect_num.set_cross_border.without_postcopy: FAIL: Can not find the expected patterns 'error: internal error: unable to execute QEMU command 'migrate-set-parameters': Parameter 'multifd_channels' expects is invalid, it should be in the range of 1 to 255' in output 'error: internal error: unable to execute... (138.35 s)`

After fix:
```
 (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_options_shared.negative_test.multifd.inavalid_connect_num.set_cross_border.without_postcopy: PASS (130.57 s)
 (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_options_shared.negative_test.multifd.inavalid_connect_num.set_zero.without_postcopy: PASS (134.29 s)
```
