### PR TITLE
blockcommand: Add stype=type to virsh snapshot-create-as

### DIFF
--- a/libvirt/tests/src/backingchain/blockcommand.py
+++ b/libvirt/tests/src/backingchain/blockcommand.py
@@ -227,8 +227,9 @@ def run(test, params, env):
         for i in range(len(params['snapshot_list'])):
             virsh.snapshot_create_as(
                 vm_name,
-                '%s --disk-only --diskspec %s,file=%s' %
-                (params['snapshot_list'][i], new_dev, snapshot_image_list[i]),
+                '%s --disk-only --diskspec %s,file=%s,stype=%s' %
+                (params['snapshot_list'][i], new_dev, snapshot_image_list[i],
+                 disk_type),
                 **virsh_dargs
             )
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockcommit.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockcommit.py
@@ -470,7 +470,7 @@ def run(test, params, env):
                                        % ("qcow2", first_src_file, "qcow2", block_type_backstore))
             process.run(backing_file_create_cmd, ignore_status=False, shell=True)
             meta_options = " --reuse-external --disk-only --no-metadata"
-            options = "%s --diskspec %s,file=%s" % (meta_options, 'vda', block_type_backstore)
+            options = "%s --diskspec %s,file=%s,stype=block" % (meta_options, 'vda', block_type_backstore)
             virsh.snapshot_create_as(vm_name, options,
                                      ignore_status=False,
                                      debug=True)


### PR DESCRIPTION
It failed to create a block type snapshot for now, so update the
option of virsh snapshot-create-as command.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
