### PR TITLE
Delete one invalid case for update device

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_update.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_update.cfg
@@ -119,9 +119,6 @@
                 - update_target:
                     new_iface_target = "{'dev':'test'}"
                     expect_err_msg = "Operation not supported: cannot modify network device tap name"
-                - update_address:
-                    new_iface_addr = "{'type':'pci','domain':'0x0000','bus':'0x00','slot':'0x03','function':'0x1'}"
-                    expect_err_msg = "no device matching MAC address.* found on 0000:00:03.1"
                 - update_mtu:
                     iface_mtu = "{'size':'9000'}"
                     variants:


### PR DESCRIPTION
As libvirt use PCI address as one of the items to match the interface
device, update it makes no sense. Delete this kind of scenario.

Signed-off-by: Yalan <yalzhang@redhat.com>