### PR TITLE
virtio_transitional_blk_negative：Correct the exception

### DIFF
--- a/libvirt/tests/src/virtio_transitional/virtio_transitional_blk_negative.py
+++ b/libvirt/tests/src/virtio_transitional/virtio_transitional_blk_negative.py
@@ -6,6 +6,7 @@ from avocado.utils import download
 from virttest import data_dir
 from virttest import utils_misc
 from virttest import libvirt_version
+from virttest import remote
 
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import xcepts
@@ -53,7 +54,7 @@ def run(test, params, env):
             if not vm.is_alive():
                 vm.start()
             vm.wait_for_serial_login()
-        except aexpect.ExpectError:
+        except (remote.LoginTimeoutError, aexpect.ExpectError):
             pass
         else:
             test.fail("Vm is expected to fail on booting from disk"


### PR DESCRIPTION
The expected exception should be updated to cover
remote.LoginTimeoutError.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
_Before fix:_
```
 (1/1) type_specific.io-github-autotest-libvirt.virtio_transitional_blk_negative.with_virtio_blk.virtio: ERROR: Login timeout expired    (output: 'exceeded 240 s timeout') (259.15 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```


_After fix:_
```
JOB LOG    : /root/avocado/job-results/job-2021-06-15T03.04-f86a1de/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtio_transitional_blk_negative.with_virtio_blk.virtio: PASS (259.17 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 259.65 s
```
