### PR TITLE
virsh_domiftune: Fix outbound value

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domiftune.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domiftune.cfg
@@ -143,6 +143,7 @@
                                             outbound = "~@#$%^-=_:,.[]{}"
                                         - outside_boundary:
                                             outbound = '4294968'
+                                            outbound_new = '4294967296'
                                     variants:
                                         - options:
                                             variants:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domiftune.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domiftune.py
@@ -236,6 +236,7 @@ def set_domiftune_parameter(params, test, libvirtd):
     vm_name = params.get("main_vm")
     inbound = params.get("inbound", "")
     outbound = params.get("outbound", "")
+    outbound_new = params.get("outbound_new")
     options = params.get("options", None)
     interface = params.get("iface_dev")
     check_clear = params.get("check_clear", "no")
@@ -270,7 +271,8 @@ def set_domiftune_parameter(params, test, libvirtd):
             # error on the following set, but a pass for
             # the test since the error is expected.
             status_error = "yes"
-
+    if libvirt_version.version_compare(7, 3, 0) and outbound_new:
+        outbound = outbound_new
     result = virsh.domiftune(vm_name, interface, options, inbound, outbound, debug=True)
     status = result.exit_status
 


### PR DESCRIPTION
Since libvirt-7.3.0, the outbound average value was changed.
So this is to update with new outbound value.

Signed-off-by: Dan Zheng <dzheng@redhat.com>
