### PR TITLE
vcpu_cache: Update the error message

### DIFF
--- a/libvirt/tests/cfg/cpu/vcpu_cache.cfg
+++ b/libvirt/tests/cfg/cpu/vcpu_cache.cfg
@@ -44,4 +44,4 @@
                 - passthrough_with_host_model:
                     only host_model
                     cache_mode = "passthrough"
-                    err_msg = "error: unsupported configuration: CPU cache mode 'passthrough' can only be used with 'host-passthrough' CPUs"               
+                    err_msg = "error: unsupported configuration: CPU cache mode 'passthrough' can only be used with 'host-passthrough'.* CPUs"


### PR DESCRIPTION
The error message was updated, so update it accordingly.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
Test result:
Before fix:
` (1/1) type_specific.io-github-autotest-libvirt.vcpu_cache.negative_test.passthrough_with_host_model.host_model: FAIL: Expect should fail with one of ["error: unsupported configuration: CPU cache mode 'passthrough' can only be used with 'host-passthrough' CPUs"], but failed with:\n\n\nerror: Failed to define domain from /tmp/xml_utils_temp_ybv8evo0.xml\nerror: unsupported con... (4.38 s)`

After fix: libvirt 7.4:
` (1/1) type_specific.io-github-autotest-libvirt.vcpu_cache.negative_test.passthrough_with_host_model.host_model: PASS (4.87 s)`
libvirt 7.0:
```

 (1/1) type_specific.io-github-autotest-libvirt.vcpu_cache.negative_test.passthrough_with_host_model.host_model:PASS (6.19 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 8.04 s
```

