### PR TITLE
Fix Unknown protocol iscsi issue when using qemu-img

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_luks.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_luks.py
@@ -291,8 +291,8 @@ def run(test, params, env):
                     iscsi_target, lun_num = libvirt.setup_or_cleanup_iscsi(
                         is_setup=True, is_login=False, image_size=storage_size,
                         portal_ip=iscsi_host)
-                device_source = "iscsi://%s:%s/%s/%s" % (iscsi_host, iscsi_port,
-                                                         iscsi_target, lun_num)
+                # hardcode
+                device_source = '/var/lib/avocado/data/avocado-vt/emulated-iscsi'
                 disk_src_dict = {"attrs": {"protocol": "iscsi",
                                            "name": "%s/%s" % (iscsi_target, lun_num)},
                                  "hosts": [{"name": iscsi_host, "port": iscsi_port}]}


### PR DESCRIPTION
qemu-img create -f luks xx iscsi://127.0.0.1:3260/iqn.2021-06.com.virttest:emulated-iscsi.target/0 500M
is not supported in latest version due to feature depreciation
and need use direct file path instead

Signed-off-by: chunfuwen <chwen@redhat.com>

