### PR TITLE
Fix test.fail()format issue in vhost-user case

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_vhostuser.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_vhostuser.py
@@ -162,7 +162,7 @@ def run(test, params, env):
             test.fail("VM failed to start."
                       "Error: %s" % str(e))
     except Exception as ex:
-        test.fail("unexpected exception happen: %s", str(ex))
+        test.fail("unexpected exception happen: %s" % str(ex))
     finally:
         # Recover VM.
         if vm.is_alive():


### PR DESCRIPTION
Wrongly use test.fail() format

Signed-off-by: chunfuwen <chwen@redhat.com>

