### PR TITLE
[nodedev-list] Ignore vlan devices

### DIFF
--- a/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_list.py
+++ b/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_list.py
@@ -86,6 +86,9 @@ def get_net_devices():
                 # Ignore bonding devices
                 if os.path.exists(os.path.join(dev_dir, 'bonding')):
                     continue
+                # Ignore vlan devices
+                if [x for x in os.listdir(dev_dir) if x.startswith('lower')]:
+                    continue
                 address_file = os.path.join(dev_dir, 'address')
                 mac = ''
                 with open(address_file, 'r') as f_addr:


### PR DESCRIPTION
Vlan devices are not expected to be used for passthrough via hostdev.
They are not listed with nodedev-list. Remove them from test
expectation.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>
