### PR TITLE
iothread: Update the value of iothread_quota

### DIFF
--- a/libvirt/tests/src/cpu/iothread.py
+++ b/libvirt/tests/src/cpu/iothread.py
@@ -371,7 +371,10 @@ def run(test, params, env):
             libvirt.check_exit_status(result)
             if update_error:
                 items.update({"iothread_period": 100000})
-                items.update({"iothread_quota": -1})
+                if libvirt_version.version_compare(7, 4, 0):
+                    items.update({"iothread_quota": 17592186044415})
+                else:
+                    items.update({"iothread_quota": -1})
             for key, val in items.items():
                 if not re.findall(key+'\s*:\s+'+str(val), result.stdout):
                     test.fail("Unable to find expected value {}:{} from {}"


### PR DESCRIPTION
The value of iothread_quota was changed, so update the code
accordingly.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
Before fix:
```
JOB LOG    : /root/avocado/job-results/job-2021-06-17T02.15-a149309/job.log
 (1/1) type_specific.io-github-autotest-libvirt.cpu.iothread.negative_test.iothread_quota_period_without_iothreads: FAIL: Unable to find expected value iothread_quota:-1 from command: '/bin/virsh schedinfo avocado-vt-vm1 '\nexit_status: 0\nduration: 0.016992568969726562\ninterrupted: False\npid: 265584\nencoding: 'UTF-8'\nstdout: 'Scheduler      : posix\ncpu_shares     : 100\nvcpu... (23.72 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```

After fix:
```
JOB LOG    : /root/avocado/job-results/job-2021-06-17T02.26-9a57335/job.log
 (1/1) type_specific.io-github-autotest-libvirt.cpu.iothread.negative_test.iothread_quota_period_without_iothreads: PASS (23.77 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```
