### PR TITLE
iface_network: add dig test for net_dns_host

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_network.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_network.cfg
@@ -48,8 +48,7 @@
                     test_dns_host = "yes"
                     serial_login = "yes"
                     net_dns_txt = "{'name':'example','value':'example value'}"
-                    net_dns_srv = "{'service':'name','protocol':'tcp','domain':'domain-name','target':'nay.domain-name','port':'1024','priority':'10','weight':'10'}"
-                    net_dns_forwarders = "{'addr':'8.8.8.8'}"
+                    net_dns_srv = "{'service':'name','protocol':'tcp','domain':'redhat.com','target':'nay.redhat.com','port':'1024','priority':'10','weight':'20'}"
                     net_dns_hostip = "2.2.2.2"
                     net_dns_hostnames = "test1.com test2.com"
                 - net_netmask:


### PR DESCRIPTION
8.8.8.8 is useless now. Change it to use one of host dns nameservers.
And add dig test inside guest to verify the configurations really work.
RHEL7-18747.

Signed-off-by: Yanqiu Zhang <yanqzhan@redhat.com>

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [ ] Description of the cases
- [ ] Links of libvirt features, libvirt bugs or case IDs
- [ ] Test results

## If the PR is bug cases
- [ ] Bug descriptions or bug links
- [ ] Test results

## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
