### PR TITLE
controller_functional: fix err messages

### DIFF
--- a/libvirt/tests/cfg/controller/controller_functional.cfg
+++ b/libvirt/tests/cfg/controller/controller_functional.cfg
@@ -283,7 +283,7 @@
                     variants:
                         - other_model:
                             model_name = 'pci-root'
-                            err_msg = ".*Unknown PCI controller model name '${model_name}'"
+                            err_msg = ".*Unknown PCI controller model name '${model_name}'|Invalid value for attribute 'name' in element 'model': '${model_name}'"
                 - invalid_root_model:
                     controller_index = 0
                     variants:
@@ -312,5 +312,5 @@
                             err_msg = "PCI controller chassisNr '${chassisNr}' out of range - must be 1-255"
                         - string:
                             chassisNr = 'abc'
-                            err_msg = "Invalid chassisNr '${chassisNr}' in PCI controller"
+                            err_msg = "Invalid chassisNr '${chassisNr}' in PCI controller|Invalid value for attribute 'chassisNr'.*: '${chassisNr}'. Expected integer value"
                     add_contrl_list = "[{'type': 'pci', 'model': 'pci-bridge', 'index': '%s', 'bus': '0x00', 'slot': '%s','chassisNr': '${chassisNr}'}]"

--- a/libvirt/tests/cfg/controller/pcibridge.cfg
+++ b/libvirt/tests/cfg/controller/pcibridge.cfg
@@ -36,7 +36,7 @@
                     pci_model_name = 'pcie-pci-bridge'
                     max_slots = 31
                     need_pci_br = 'yes'
-                    err_msg = "internal error: No more available PCI slots;XML error: Invalid PCI address slot='0x20', must be <= 0x1F"
+                    err_msg = "internal error: No more available PCI slots|XML error: Invalid PCI address slot='0x20', must be <= 0x1F"
                     iface_kwargs = {'address': "{'type': 'pci', 'domain': '0x0000', 'bus': '%s', 'slot': '%s', 'function': '0x0'}"}
                 - vm_with_pcie_br:
                     only q35
@@ -96,7 +96,7 @@
                             err_msg = "XML error: Invalid PCI address slot='.*?', must be <= 0x1F"
                         - s_str:
                             slot = 'haha'
-                            err_msg = "internal error: Cannot parse <address> 'slot' attribute"
+                            err_msg = "internal error: Cannot parse <address> 'slot' attribute|Invalid value for attribute 'slot'.*: '${slot}'. Expected integer value"
                     pci_br_kwargs = "{'index': '9'}"
                     iface_kwargs = {'address': "{'type': 'pci', 'domain': '0x0000', 'bus': '0x09', 'slot': '${slot}', 'function': '0x0'}"}
                 - index_v_bus:
@@ -106,7 +106,7 @@
                     variants:
                         - less_than:
                             case += 'less_than'
-                            err_msg = "internal error: Cannot automatically add a new PCI bus for a device .*?;XML error: The device at PCI address .*? cannot be plugged into the PCI controller with index='.*?'. It requires a controller that accepts a pcie-to-pci-bridge;qemu-kvm: -device pcie-pci-bridge,id=pci.*?,bus=pci.*?,addr=.*?: Bus 'pci.*?' not found"
+                            err_msg = "internal error: Cannot automatically add a new PCI bus for a device .*?|XML error: The device at PCI address .*? cannot be plugged into the PCI controller with index='.*?'. It requires a controller that accepts a pcie-to-pci-bridge|qemu-kvm: -device pcie-pci-bridge,id=pci.*?,bus=pci.*?,addr=.*?: Bus 'pci.*?' not found"
                         - equal_to:
                             case += 'equal_to'
                             err_msg = "XML error: The device at PCI address .*? cannot be plugged into the PCI controller with index='.*?'. It requires a controller that accepts a pcie-to-pci-bridge"

--- a/libvirt/tests/src/controller/pcibridge.py
+++ b/libvirt/tests/src/controller/pcibridge.py
@@ -68,7 +68,7 @@ def run(test, params, env):
 
     vm_name = params.get('main_vm')
     status_error = 'yes' == params.get('status_error', 'no')
-    err_msg = params.get('err_msg', '').split(';')
+    err_msg = params.get('err_msg', '')
     case = params.get('case', '')
     hotplug = 'yes' == params.get('hotplug', 'no')
 

--- a/libvirt/tests/src/serial/serial_functional.py
+++ b/libvirt/tests/src/serial/serial_functional.py
@@ -821,7 +821,7 @@ def run(test, params, env):
         if res.exit_status:
             logging.debug("Can't start the VM, exiting.")
             return
-        check_qemu_cmdline()
+
         # Prepare console after start when console is client
         if console_type == 'client':
             console = prepare_serial_console()


### PR DESCRIPTION
Due to libvirt-7.4.0 new changes, some incorrect configrations are detected
earlier when defining the vm with different error messages. So this is to
update the error messages. In addition, checking qemu command line is
unneccessary, so I remove it to avoid of future errors.

Signed-off-by: Dan Zheng <dzheng@redhat.com>