### PR TITLE
Fixup: update regex for managedsave case

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_managedsave.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_managedsave.py
@@ -159,7 +159,7 @@ def run(test, params, env):
         is_systemd = process.run("cat /proc/1/comm", shell=True).stdout_text.count("systemd")
         if is_systemd:
             libvirt_guests.restart()
-            pattern = r'(.+ \d\d:\d\d:\d\d).+: Resuming guest.+done'
+            pattern = r'(.+ \d\d:\d\d:\d\d).+: Resuming guest .*?[\n]*.*done'
         else:
             ret = process.run("service libvirt-guests restart | \
                               awk '{ print strftime(\"%b %y %H:%M:%S\"), \


### PR DESCRIPTION
The output of libvirt-guests differs between products, therefore
the regex of pattern needs update.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>
