### PR TITLE
virsh_domfsinfo:fix for error message rewording in new version of libvirt.

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domfsinfo.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domfsinfo.cfg
@@ -37,4 +37,4 @@
                     check_point_msg = "error: operation forbidden: read only access prevents virDomainGetFSInfo"
                 - fs_freezed:
                     domfsfreeze = "yes"
-                    check_point_msg = "The command guest-get-fsinfo has been disabled for this instance"
+                    check_point_msg = "The command guest-get-fsinfo has been disabled for this instance;Command guest-get-fsinfo has been disabled: the agent is in frozen state"


### PR DESCRIPTION
Added an error message to the config file as the message was reworded
in a newer versions of the libvirt.

Signed-off-by: Kamil Varga <kvarga@redhat.com>