### PR TITLE
BIOS: add case for creating snapshot with boot dev/order

### DIFF
--- a/libvirt/tests/cfg/bios/boot_integration.cfg
+++ b/libvirt/tests/cfg/bios/boot_integration.cfg
@@ -9,6 +9,11 @@
     variants:
         - define_start_destroy_save_restore_undefine:
             no s390-virtio
+        - create_snapshot:
+            only by_seabios,by_ovmf
+            with_snapshot = "yes"
+            snapshot_take = "1"
+            postfix = "snap"
         - check_menu:
             only by_qemu_on_s390
             expected_text = "s390-ccw Enumerated Boot Menu.*\[2\].*Please choose.*default will boot in 3 seconds.*"
@@ -34,13 +39,13 @@
             disk_target_dev = 'sda'
             disk_target_bus = 'sata'
         - by_seabios:
-            no s390-virtio
+            only q35
             boot_type = "seabios"
             loader = "/usr/share/seabios/bios.bin"
             loader_type = "rom"
             bios_useserial = "yes"
             bios_reboot_timeout = "1000"
-            disk_target_dev = 'hda'
+            disk_target_dev = 'sda'
             disk_target_bus = 'scsi'
         - by_qemu_on_s390:
             only s390-virtio

--- a/libvirt/tests/src/bios/boot_integration.py
+++ b/libvirt/tests/src/bios/boot_integration.py
@@ -6,6 +6,8 @@ import re
 from virttest import virsh
 from virttest import utils_package
 from virttest.libvirt_xml import vm_xml
+from virttest.libvirt_xml import xcepts
+from virttest.utils_libvirt import libvirt_disk
 from virttest.utils_test import libvirt as utlv
 from virttest.utils_misc import wait_for
 from virttest import data_dir
@@ -82,27 +84,123 @@ def console_check(vm, pattern, debug_log=False):
     return _matches
 
 
+def vmxml_recover_from_snap(vm_name, boot_type, vmxml, test):
+    """
+    Recover old xml config with backup xml.
+
+    :params: vm_name: the vm name
+    :params: boot_type: the type of booting guest
+    :params: vmxml:VMXML object
+    :params: test: system parameter
+    """
+    try:
+        if boot_type == "seabios":
+            options = "--snapshots-metadata"
+        else:
+            options = "--snapshots-metadata --nvram"
+        vmxml.sync(options)
+        logging.debug("Check snapshot config file")
+        path = "/var/lib/libvirt/qemu/snapshot/" + vm_name
+        if os.path.isfile(path):
+            test.fail("Still can find snapshot metadata")
+
+    except xcepts.LibvirtXMLError as detail:
+        logging.error("Recover older xml failed: %s.", detail)
+
+
+def snapshot_list_check(vm_name, snapshot_take, postfix, test):
+    """"
+    Create snapshot for guest with boot dev or boot order
+
+    :params: vm_name: the name of the vm
+    :params: snap_take: the number of snapshots
+    :params: postfix: the postfix of snapshot name
+    :params: test: system parameter
+    """
+
+    # Check the snapshot list
+    get_sname = []
+    for count in range(1, snapshot_take + 1):
+        get_sname.append(("%s_%s") % (postfix, count))
+    snaps_list = virsh.snapshot_list(vm_name, debug=True)
+    find = 0
+    for snap in snaps_list:
+        if snap in get_sname:
+            find += 1
+    if find != snapshot_take:
+        test.fail("Can not find all snapshots %s!" % get_sname)
+
+
+def domain_lifecycle(vmxml, vm, test, virsh_dargs, **kwargs):
+    """
+    Test the lifrcycle of the domain
+
+    :params: vmxml: the xml of the vm
+    :params: vm: vm to wait for login the vm
+    :params: test: system parameter
+    :params: virsh_dargs: the debugging status of virsh command
+    """
+    vm_name = kwargs.get("vm_name")
+    save_file = kwargs.get("save_file")
+    boot_type = kwargs.get("boot_type")
+    nvram_file = kwargs.get("nvram_file")
+
+    ret = virsh.define(vmxml.xml, **virsh_dargs)
+    stdout_patt = "Domain .*%s.* defined from %s" % (vm_name, vmxml.xml)
+    utlv.check_result(ret, expected_match=[stdout_patt])
+
+    ret = virsh.start(vm_name, **virsh_dargs)
+    stdout_patt = "Domain .*%s.* started" % vm_name
+    utlv.check_result(ret, expected_match=[stdout_patt])
+    vm.wait_for_login()
+
+    ret = virsh.destroy(vm_name, **virsh_dargs)
+    stdout_patt = "Domain .*%s.* destroyed" % vm_name
+    utlv.check_result(ret, expected_match=[stdout_patt])
+
+    vm.start()
+    ret = virsh.save(vm_name, save_file, **virsh_dargs)
+    stdout_patt = "Domain .*%s.* saved to %s" % (vm_name, save_file)
+    utlv.check_result(ret, expected_match=[stdout_patt])
+
+    ret = virsh.restore(save_file, **virsh_dargs)
+    stdout_patt = "Domain restored from %s" % save_file
+    utlv.check_result(ret, expected_match=[stdout_patt])
+
+    ret = virsh.undefine(vm_name, options="--nvram", **virsh_dargs)
+    stdout_patt = "Domain .*%s.* has been undefined" % vm_name
+    utlv.check_result(ret, expected_match=[stdout_patt])
+    if boot_type == "ovmf":
+        if os.path.exists(nvram_file):
+            test.fail("nvram file still exists after vm undefine")
+
+
 def run(test, params, env):
     """
-    Test Define/undefine/start/destroy/save/restore a OVMF/Seabios domain
+    1) Test Define/undefine/start/destroy/save/restore a OVMF/Seabios domain
     with 'boot dev' element or 'boot order' element
+    2) Test Create snapshot with 'boot dev' or 'boot order'
 
     Steps:
     1) Prepare a typical VM XML, e.g. for OVMF or Seabios Guest boot
     2) Setup boot sequence by element 'boot dev' or 'boot order'
-    2) Define/undefine/start/destroy/save/restore VM and check result
+    3) Define/undefine/start/destroy/save/restore VM and check result
+    4) Create snapshot with 'boot dev' or 'boot order'
     """
     vm_name = params.get("main_vm", "")
     vm = env.get_vm(vm_name)
-    status_error = "yes" == params.get("status_error", "no")
     boot_type = params.get("boot_type", "seabios")
     boot_ref = params.get("boot_ref", "dev")
     disk_target_dev = params.get("disk_target_dev", "")
     disk_target_bus = params.get("disk_target_bus", "")
-    save_file = os.path.join(data_dir.get_tmp_dir(), vm_name + ".save")
+    tmp_file = data_dir.get_data_dir()
+    save_file = os.path.join(tmp_file, vm_name + ".save")
     nvram_file = params.get("nvram", "")
     expected_text = params.get("expected_text", None)
     boot_entry = params.get("boot_entry", None)
+    with_snapshot = "yes" == params.get("with_snapshot", "no")
+    snapshot_take = int(params.get("snapshot_take", "1"))
+    postfix = params.get("postfix", "")
 
     # Back VM XML
     vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
@@ -164,38 +262,32 @@ def run(test, params, env):
                     test.fail("Boot entry not selected. Please check log.")
                 vm.wait_for_login()
         else:
-            # Start test and check result
-            ret = virsh.define(vmxml.xml, **virsh_dargs)
-            stdout_patt = "Domain .*%s.* defined from %s" % (vm_name, vmxml.xml)
-            utlv.check_result(ret, expected_match=[stdout_patt])
-
-            ret = virsh.start(vm_name, **virsh_dargs)
-            stdout_patt = "Domain .*%s.* started" % vm_name
-            utlv.check_result(ret, expected_match=[stdout_patt])
-            vm.wait_for_login()
-
-            ret = virsh.destroy(vm_name, **virsh_dargs)
-            stdout_patt = "Domain .*%s.* destroyed" % vm_name
-            utlv.check_result(ret, expected_match=[stdout_patt])
-
-            vm.start()
-            ret = virsh.save(vm_name, save_file, **virsh_dargs)
-            stdout_patt = "Domain .*%s.* saved to %s" % (vm_name, save_file)
-            utlv.check_result(ret, expected_match=[stdout_patt])
-
-            ret = virsh.restore(save_file, **virsh_dargs)
-            stdout_patt = "Domain restored from %s" % save_file
-            utlv.check_result(ret, expected_match=[stdout_patt])
-
-            ret = virsh.undefine(vm_name, options="--nvram", **virsh_dargs)
-            stdout_patt = "Domain .*%s.* has been undefined" % vm_name
-            utlv.check_result(ret, expected_match=[stdout_patt])
-            if boot_type == "ovmf":
-                if os.path.exists(nvram_file):
-                    test.fail("nvram file still exists after vm undefine")
+            if with_snapshot:
+                # Create snapshot for guest with boot dev or boot order
+                virsh.define(vmxml.xml, **virsh_dargs)
+                virsh.start(vm_name, **virsh_dargs)
+                vm.wait_for_login()
+                external_snapshot = libvirt_disk.make_external_disk_snapshots(vm, disk_target_dev, postfix, snapshot_take)
+                snapshot_list_check(vm_name, snapshot_take, postfix, test)
+            else:
+                # Test the lifecycle for the guest
+                kwargs = {"vm_name": vm_name,
+                          "save_file": save_file,
+                          "boot_type": boot_type,
+                          "nvram_file": nvram_file}
+                domain_lifecycle(vmxml, vm, test, virsh_dargs, **kwargs)
     finally:
         logging.debug("Start to cleanup")
         if vm.is_alive:
             vm.destroy()
         logging.debug("Restore the VM XML")
-        vmxml_backup.sync()
+        if os.path.exists(save_file):
+            os.remove(save_file)
+        if with_snapshot:
+            vmxml_recover_from_snap(vm_name, boot_type, vmxml_backup, test)
+            # Remove the generated snapshot file
+            for snap_file in external_snapshot:
+                if os.path.exists(snap_file):
+                    os.remove(snap_file)
+        else:
+            vmxml_backup.sync()


### PR DESCRIPTION
Description of the cases: 
Create snapshot for a OVMF/seabios domain with 'boot order' or 'boot dev' element

Links of case IDs:
https://polarion.engineering.redhat.com//polarion/#/project/RedHatEnterpriseLinux7/workitem?id=RHEL7-45939
https://polarion.engineering.redhat.com//polarion/#/project/RedHatEnterpriseLinux7/workitem?id=RHEL7-45937
https://polarion.engineering.redhat.com//polarion/#/project/RedHatEnterpriseLinux7/workitem?id=RHEL7-45938
https://polarion.engineering.redhat.com//polarion/#/project/RedHatEnterpriseLinux7/workitem?id=RHEL7-45940

Signed-off-by: Meina Li <meili@redhat.com>