### PR TITLE
v2v: fix chipset type checkpoint in rhv4.4.6.8

### DIFF
--- a/provider/v2v_vmcheck_helper.py
+++ b/provider/v2v_vmcheck_helper.py
@@ -85,6 +85,10 @@ class VMChecker(object):
                 self.ovirt_server_version.full_version)
             if self.ovirt_server_version.major >= 4 and self.ovirt_server_version.minor >= 4:
                 self.boottype = int(params.get("boottype", 1))
+            # A temporary workaround to bz1961945, once it's fixed, a
+            # nicer fix will be done.
+            if '4.4.6.8' in self.ovirt_server_version.full_version:
+                self.boottype = int(params.get("boottype", 0))
         if compare_version(FEATURE_SUPPORT['q35']):
             self.boottype = int(params.get("boottype", 1))
 


### PR DESCRIPTION
See bz1961945.
Because of above bug, the chipset setting was broken in rhv4.4.6.8.
And it blocks all our testing. A temporary workaround is done to
avoid all scripts failure. Once it's fixed, a better solution will
replace this one.