### PR TITLE
sriov: Add 1 net failover case

### DIFF
--- a/libvirt/tests/cfg/sriov/sriov_net_failover.cfg
+++ b/libvirt/tests/cfg/sriov/sriov_net_failover.cfg
@@ -20,3 +20,8 @@
             func_supported_since_libvirt_ver = (7, 0, 0)
             unspported_err_msg = "This libvirt version doesn't support to set teaming element in plain hostdev elment."
             hostdev_device_teaming_dict = {'type': 'transient', 'persistent': 'ua-backup0'}
+        - save_restore_hostdev_iface_with_teaming:
+            func_supported_since_libvirt_ver = (6, 0, 0)
+            unspported_err_msg = "This libvirt version doesn't support to set teaming element in hostdev interface."
+            net_hostdev_name = "hostdev-net"
+            net_hostdev_fwd = '{"mode": "hostdev", "managed": "yes"}'


### PR DESCRIPTION
RHEL-187001 - [save/restore][net failover] Save & restore for vm
with hostdev type interface and teaming setting

Signed-off-by: Yingshun Cui <yicui@redhat.com>
Test result: Failed because of BZ1815426.
` (1/1) type_specific.io-github-autotest-libvirt.sriov_net_failover.save_restore_hostdev_iface_with_teaming: ERROR: Command '/usr/bin/virsh save avocado-vt-vm1 /tmp/avocado_t4n0wh7t/save_file ' failed.\nstdout: b''\nstderr: b''\nadditional_info: None (188.27 s)`
