### PR TITLE
Increase the init memory size and numa config to avoid vm crash

### DIFF
--- a/libvirt/tests/cfg/libvirt_mem.cfg
+++ b/libvirt/tests/cfg/libvirt_mem.cfg
@@ -48,9 +48,12 @@
                     variants:
                         - default:
                         - max_slots:
+                            max_mem = 4194304
+                            current_mem = 4194304
                             max_mem_rt = 138412032
                             max_mem_slots = 256
                             attach_times = 255
+                            numa_cells = "{'id':'0','cpus':'0-1','memory':'4194304','unit':'KiB','discard':'yes'}"
                             variants:
                                 - without_reboot:
                                 # Do not enable hot_reboot until unless it has to be tested.

--- a/libvirt/tests/src/libvirt_mem.py
+++ b/libvirt/tests/src/libvirt_mem.py
@@ -323,6 +323,10 @@ def run(test, params, env):
             vmxml.max_mem_rt = int(max_mem_rt)
             vmxml.max_mem_rt_slots = max_mem_slots
             vmxml.max_mem_rt_unit = mem_unit
+        if max_mem:
+            vmxml.max_mem = int(max_mem)
+        if cur_mem:
+            vmxml.current_mem = int(cur_mem)
         if memory_val:
             vmxml.memory = int(memory_val)
         if vcpu:


### PR DESCRIPTION
Signed-off-by: qijing <jinqi@redhat.com>

Increase the inital memory size and numa config to avoid crashing