### PR TITLE
virsh_console: Don't update console for aarch64

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_console.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_console.cfg
@@ -12,6 +12,8 @@
     update_console = "yes"
     console_device = "ttyS0"
     console_speed = "115200"
+    aarch64:
+        update_console = "no"
     variants:
         - normal_test:
             status_error = "no"


### PR DESCRIPTION
guest kernel console options are set by default in image file.
No need to update_console again.

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>
