### PR TITLE
Fix the serial source path permission issues in rhel9

### DIFF
--- a/libvirt/tests/cfg/serial/serial_functional.cfg
+++ b/libvirt/tests/cfg/serial/serial_functional.cfg
@@ -19,7 +19,7 @@
             target_model = sclplmconsole
         - type_file:
             serial_dev_type = file
-            serial_sources = path:/var/log/libvirt/virt-test
+            serial_sources = path:/var/lib/libvirt/virt-test
         - type_pipe:
             serial_dev_type = pipe
             serial_sources = path:/tmp/virt-test

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_serial_device_alias.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_serial_device_alias.cfg
@@ -5,7 +5,7 @@
     variants:
         - serial_type_file:
             serial_type = file
-            serial_sources = path:/var/log/libvirt/virt-test
+            serial_sources = path:/var/lib/libvirt/virt-test
             variants:
                 - isa-serial:
                     no aarch64

--- a/libvirt/tests/src/serial/serial_functional.py
+++ b/libvirt/tests/src/serial/serial_functional.py
@@ -532,7 +532,7 @@ def run(test, params, env):
             service = 2445
             console = Console('udp', (host, service), is_server)
         elif serial_type == 'file':
-            socket_path = '/var/log/libvirt/virt-test'
+            socket_path = '/var/lib/libvirt/virt-test'
             console = Console('file', socket_path, is_server)
         elif serial_type == 'pipe':
             socket_path = '/tmp/virt-test'
@@ -710,8 +710,8 @@ def run(test, params, env):
         Clean up test environment
         """
         if serial_type == 'file':
-            if os.path.exists('/var/log/libvirt/virt-test'):
-                os.remove('/var/log/libvirt/virt-test')
+            if os.path.exists('/var/lib/libvirt/virt-test'):
+                os.remove('/var/lib/libvirt/virt-test')
 
         # recovery test environment
         for obj in objs_list:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
@@ -37,7 +37,7 @@ class TestParams(object):
         self.virsh = None  # Can't be known yet
         self._e = env
         self._p = params
-        self.serial_dir = params.get("serial_dir", "/var/log/libvirt")
+        self.serial_dir = params.get("serial_dir", "/var/lib/libvirt")
 
     @property
     def start_vm(self):
@@ -394,7 +394,7 @@ class SerialFile(AttachDeviceBase):
         # auto-cleaned at end of test
         if self.type_name == 'file':
             if libvirt_version.version_compare(3, 2, 0):
-                serial_dir = '/var/log/libvirt'
+                serial_dir = '/var/lib/libvirt'
             else:
                 serial_dir = self.test_params.serial_dir
         else:


### PR DESCRIPTION
Signed-off-by: qijing <jinqi@redhat.com>

The serial source path can't use /var/log in rhel9 for having permission issues
