### PR TITLE
virsh_domxml_to_native: Fix env variable

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_to_native.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_to_native.py
@@ -64,7 +64,7 @@ def run(test, params, env):
                 # turned into
                 # -blockdev {"driver":"file",...,"discard":"unmap"} in order to
                 # match the qemu command line format
-                if e == '-blockdev':
+                if e in ['-blockdev', '-object']:
                     enext = enext.strip("'")
                 # Append this and the next and set our skip flag
                 retlist.append(e + " " + enext)
@@ -101,6 +101,9 @@ def run(test, params, env):
                 continue
             elif re.search("-cpu", arg):
                 continue
+            # libvirt commit id 'd96fb5cb'
+            elif re.search("master-key.aes", arg):
+                continue
             retlist.append(arg)
 
         return retlist
@@ -116,9 +119,10 @@ def run(test, params, env):
         """
         expected_env_vars = [
             'LC_ALL',
-            'PATH',
-            'QEMU_AUDIO_DRV',
+            'PATH'
             ]
+        if not libvirt_version.version_compare(7, 3, 0):
+            expected_env_vars += ['QEMU_AUDIO_DRV']
         if libvirt_version.version_compare(5, 2, 0):
             expected_env_vars += [
                 'HOME',


### PR DESCRIPTION
In libvirt commit d96fb5cb31b, QEMU_AUDIO_DRV is replaced by -audiodev argument.
So we need not to check it after libvirt 7.3.0. In addition, some minor changes
are also updated and ignore to check.

Signed-off-by: Dan Zheng <dzheng@redhat.com>
