### PR TITLE
v2v: fix qemu-ga service not found issue

### DIFF
--- a/v2v/tests/src/function_test_esx.py
+++ b/v2v/tests/src/function_test_esx.py
@@ -17,7 +17,7 @@ from virttest.utils_test import libvirt
 from virttest.utils_v2v import params_get
 from avocado.utils import process
 from avocado.utils import download
-from aexpect.exceptions import ShellProcessTerminatedError, ShellTimeoutError
+from aexpect.exceptions import ShellProcessTerminatedError, ShellTimeoutError, ShellStatusError
 
 from provider.v2v_vmcheck_helper import VMChecker
 from provider.v2v_vmcheck_helper import check_json_output
@@ -296,7 +296,7 @@ def run(test, params, env):
                     re.I),
                 600,
                 step=30)
-        except ShellProcessTerminatedError:
+        except (ShellProcessTerminatedError, ShellStatusError):
             # Windows guest may reboot after installing qemu-ga service
             logging.debug('Windows guest is rebooting')
             if vmcheck.session:


### PR DESCRIPTION
From the backtrace, aexpect.exceptions.ShellStatusError is returned
instead of ShellProcessTerminatedError, so the guest reboot process
was not captured.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>