### PR TITLE
v2v: don't test to rhv when VIRITO_WIN or virtio-win is not set

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -151,6 +151,7 @@
                         - unset:
                             checkpoint += 'unset'
                             missing = 'Red Hat VirtIO SCSI,Red Hat VirtIO Ethernet Adapte'
+                            only dest_libvirt
                         - custom:
                             checkpoint += 'custom'
                         - iso_mount:


### PR DESCRIPTION
see bz#1913577

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>