### PR TITLE
v2v: don't check fstrim warning on rhel9

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -108,6 +108,7 @@
                         - win2019:
                             only esx_67
                             main_vm = VM_NAME_ESX_UEFI_WINDOWS_V2V_EXAMPLE
+                            checkpoint = 'fstrim_warning'
                             msg_content = 'virt-v2v: warning: fstrim on guest filesystem /dev/.*? failed.  Usually'
                             expect_msg = yes
                 - OGAC:

--- a/v2v/tests/src/function_test_esx.py
+++ b/v2v/tests/src/function_test_esx.py
@@ -684,6 +684,13 @@ def run(test, params, env):
         if 'block_dev' in checkpoint:
             if not os.path.exists(blk_dev_link):
                 test.fail("checkpoint '%s' failed" % checkpoint)
+        if 'fstrim_warning' in checkpoint:
+            # Actually, fstrim has no relationship with v2v, it may be related
+            # to kernel, this warning really doesn't matter and has no harm to
+            # the convertion.
+            V2V_FSTRIM_SUCESS_VER = "[virt-v2v-1.45.1-1.el9,)"
+            if utils_v2v.multiple_versions_compare(V2V_FSTRIM_SUCESS_VER):
+                params.update({'expect_msg': None})
         # Log checking
         log_check = utils_v2v.check_log(params, output)
         if log_check:


### PR DESCRIPTION
The warning displays because of fstrim failure to the partiion of
the guest, it's no harm to the real convertion. And now on rhel9
the fstrim operation can success, it may be related to the kernel
change. Let's just ignore this warning checking.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>