### PR TITLE
sriov: Add a case to check iommu

### DIFF
--- a/libvirt/tests/cfg/sriov/sriov_capabilities.cfg
+++ b/libvirt/tests/cfg/sriov/sriov_capabilities.cfg
@@ -1,0 +1,6 @@
+- sriov.capabilities:
+    type = sriov_capabilities
+    start_vm = "no"
+    only x86_64
+    variants test_case:
+        - intel_iommu:

--- a/libvirt/tests/src/sriov/sriov_capabilities.py
+++ b/libvirt/tests/src/sriov/sriov_capabilities.py
@@ -1,0 +1,26 @@
+import re
+
+from virttest import utils_misc
+from virttest.libvirt_xml import capability_xml
+
+
+def run(test, params, env):
+    """
+    Sriov: Virsh capabilities related test.
+    """
+
+    def test_intel_iommu():
+        kernel_cmd = utils_misc.get_ker_cmd()
+        res = re.search("iommu=on", kernel_cmd)
+        if not res:
+            test.error("iommu should be enabled in kernel cmd line - "
+                       "'%s'." % res)
+        cap_xml = capability_xml.CapabilityXML()
+        if cap_xml.get_iommu().get('support') != 'yes':
+            test.fail("IOMMU is disabled in capabilities: %s. "
+                      % cap_xml.get_iommu())
+
+    test_case = params.get("test_case", "")
+    run_test = eval("test_%s" % test_case)
+
+    run_test()


### PR DESCRIPTION
This PR adds a case:
RHEL-144331 - [Capabilities] check virsh capabilites output
    includes iommu support element

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Depends on:** 
https://github.com/avocado-framework/avocado-vt/pull/3115
**Test result:**
` (1/1) type_specific.io-github-autotest-libvirt.sriov.capabilities.intel_iommu: PASS (3.50 s)`
