### PR TITLE
Fix Virtualdiskbasic serialFile serialpipe failure

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
@@ -37,7 +37,7 @@ class TestParams(object):
         self.virsh = None  # Can't be known yet
         self._e = env
         self._p = params
-        self.serial_dir = params.get("serial_dir", "/var/log/libvirt")
+        self.serial_dir = params.get("serial_dir", "/var/lib/libvirt")
 
     @property
     def start_vm(self):


### PR DESCRIPTION
On lastest RHEL, /var/log/libvirt has write permisison issue
so change  to /var/lib/libvirt instead

Signed-off-by: chunfuwen <chwen@redhat.com>

