### PR TITLE
Fix the ping error inside vm

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_stat.py
+++ b/libvirt/tests/src/virtual_network/iface_stat.py
@@ -121,7 +121,7 @@ def run(test, params, env):
             session = vm.wait_for_serial_login(timeout=60)
             iface_in_vm = utils_net.get_linux_ifname(session, iface_mac)
 
-            session.cmd('ping www.redhat.com -c 20')
+            session.cmd('ping www.redhat.com -4 -c 20')
             host_iface_stat = get_host_iface_stat(vm_name, iface_target_dev)
             vm_iface_stat = get_vm_iface_stat(session, iface_in_vm)
             session.close()


### PR DESCRIPTION
Signed-off-by: Kyla Zhang <weizhan@redhat.com>

Before:
```
 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.iface_stat.compare.direct_type: ERROR: Shell command failed: 'ping www.redhat.com -c 20'    (status: 1,    output: 'PING www.redhat.com(g2600-1417-0076-0592-0000-0000-0000-0d44.deploy.static.akamaitechnologies.com (2600:1417:76:592::d44)) 56 data bytes\nFrom 2620:52:0:4972::1fe (2620:52:0:4972... (44.65 s)
```
After:
```
(1/1) type_specific.io-github-autotest-libvirt.virtual_network.iface_stat.compare.direct_type: PASS (45.49 s)
```