### PR TITLE
Fix the error for the output format change on ovs list

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_options.py
+++ b/libvirt/tests/src/virtual_network/iface_options.py
@@ -500,7 +500,7 @@ def run(test, params, env):
         # Dict of iface name and statistics
         for iface_name in vhostuser_names.split():
             for ovs_iface in ovs_iface_list:
-                if iface_name == eval(ovs_iface[0]):
+                if iface_name == ovs_iface[0].strip('\"'):
                     format_statis = dict(re.findall(r'(\S*?)=(\d*?),', ovs_iface[1]))
                     ovs_statis_dict[iface_name] = format_statis
                     break


### PR DESCRIPTION
The format changed from '\"name\"' to 'name' so need to change and compatible with the old one

Signed-off-by: Kyla Zhang <weizhan@redhat.com>

Before:
```
(1/1) type_specific.io-github-autotest-libvirt.virtual_network.iface_options.iface_type.type_vhostuser.multi_guests.statistics_check: ERROR: name 'vhost' is not defined (99.08 s)
```
After:
```
(1/1) type_specific.io-github-autotest-libvirt.virtual_network.iface_options.iface_type.type_vhostuser.multi_guests.statistics_check: PASS (130.91 s)
```