### PR TITLE
npiv: Fix the scsi hostdev case when sg mod not probed

### DIFF
--- a/libvirt/tests/src/npiv/npiv_hostdev_passthrough.py
+++ b/libvirt/tests/src/npiv/npiv_hostdev_passthrough.py
@@ -93,6 +93,8 @@ def run(test, params, env):
         if scsi_wwnn.count("ENTER.YOUR.WWNN") or \
                 scsi_wwpn.count("ENTER.YOUR.WWPN"):
             test.cancel("You didn't provide proper wwpn/wwnn")
+        # Load sg module if necessary
+        process.run("modprobe sg", shell=True, ignore_status=True, verbose=True)
         if vm.is_dead():
             vm.start()
         session = vm.wait_for_login()


### PR DESCRIPTION
In rhel9, the sg mod is not probed by default, and this will make
scsi hostdev passthrough failed. This fix is to add a 'modprobe sg'
step to make sure sg mod is probed.

Signed-off-by: Yi Sun <yisun@redhat.com>
