### PR TITLE
npiv: Fix device type problem

### DIFF
--- a/libvirt/tests/cfg/npiv/npiv_virtual_disk.cfg
+++ b/libvirt/tests/cfg/npiv/npiv_virtual_disk.cfg
@@ -25,7 +25,7 @@
                     variants:
                         - readonly:
                             lun_dir_method = "by-path"
-                            device_type = "file"
+                            device_type = "block"
                             disk_device = "disk"
                             driver_type = "raw"
                             device_target = "vdb"

--- a/libvirt/tests/src/npiv/npiv_virtual_disk.py
+++ b/libvirt/tests/src/npiv/npiv_virtual_disk.py
@@ -118,7 +118,7 @@ def run(test, params, env):
     wwpn = params.get("wwpn", "WWPN_EXAMPLE")
     wwnn = params.get("wwnn", "WWNN_EXAMPLE")
     disk_device = params.get("disk_device", "disk")
-    device_type = params.get("device_type", "file")
+    device_type = params.get("device_type", "block")
     device_target = params.get("device_target", "vdb")
     lun_dir_method = params.get("lun_dir_method", "by-path")
     driver_name = params.get("driver_name", "qemu")


### PR DESCRIPTION
The npiv storage is actually a block device. Previously libvirt
allows to use a block device with "device_type='file'". But it's
forbidden in rhel9. So change the device_type='file' to
device_type='block' to avoid this issue.

Signed-off-by: Yi Sun <yisun@redhat.com>
