### PR TITLE
[migrate_vm] fix iscsi image path

### DIFF
--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -1133,7 +1133,7 @@ def create_image_on_iscsi(test, vm, disk_source, disk_format, emulated_image):
     :param disk_format: image target format
     :param emulated_image: fileio backstore file target
     """
-    tmpdir = data_dir.get_tmp_dir()
+    tmpdir = data_dir.get_data_dir()
     emulated_path = os.path.join(tmpdir, emulated_image)
     if vm.is_alive():
         vm.destroy()


### PR DESCRIPTION
Avocado-vt commit f5b2953ca adjusted the folder path for temporary
image files to use `data_dir.get_data_dir()`.

Therefore, the test failed as it copied the machine image for iscsi
to a different location and the vm couldn't start from that empty image.

Update the path correspondingly.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>
