### PR TITLE
live_migration: Update to do post checks when migration is successful

### DIFF
--- a/libvirt/tests/src/migration/live_migration.py
+++ b/libvirt/tests/src/migration/live_migration.py
@@ -263,8 +263,8 @@ def run(test, params, env):
                 else:
                     logging.debug("Same port '%s' was used as "
                                   "expected", port_second)
-
-        migration_test.post_migration_check([vm], params, uri=dest_uri)
+        if int(migration_test.ret.exit_status) == 0:
+            migration_test.post_migration_check([vm], params, uri=dest_uri)
     finally:
         logging.info("Recover test environment")
         vm.connect_uri = bk_uri


### PR DESCRIPTION
It was introduced by 104ad96260c.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Test result:**
_Before fix:_
` (1/1) type_specific.io-github-autotest-libvirt.virsh.live_migration.listen_address.specific_ipv6_addr.migrateuri_ipv4_addr.non_p2p_live.without_postcopy: FAIL: Migrated VMs failed to be in running state at destination (176.47 s)`

_After fix:_
` (1/1) type_specific.io-github-autotest-libvirt.virsh.live_migration.listen_address.specific_ipv6_addr.migrateuri_ipv4_addr.non_p2p_live.without_postcopy: PASS (173.64 s)`

