### PR TITLE
increm_mig: Disable nfs setup

### DIFF
--- a/libvirt/tests/cfg/incremental_backup/incremental_backup_migration.cfg
+++ b/libvirt/tests/cfg/incremental_backup/incremental_backup_migration.cfg
@@ -7,4 +7,7 @@
             test_disk_target = "vdb"
             checkpoint_rounds = 3
             copy_storage_all = "yes"
+            storage_type = ""
+            setup_local_nfs = "no"
+            setup_remote_nfs = "no"
             migrate_vm_back = "no"


### PR DESCRIPTION
Nfs setup is enabled in base.cfg as glocal setting, but this case
uses local storage, so need to disable nfs setup in this case.

Signed-off-by: Fangge Jin <fjin@redhat.com>

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [ ] Description of the cases
- [ ] Links of libvirt features, libvirt bugs or case IDs
- [ ] Test results

## If the PR is bug cases
- [ ] Bug descriptions or bug links
- [ ] Test results

## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
