### PR TITLE
Fix the port created is not really exist issue

### DIFF
--- a/libvirt/tests/src/channel/channel_functional.py
+++ b/libvirt/tests/src/channel/channel_functional.py
@@ -249,6 +249,9 @@ def run(test, params, env):
                 port_number = active_xml.xmltreefile.find(
                     '/devices/channel/address').get('port')
                 vport = 'vport1p%s' % port_number
+                # sometimes the vport created above is not correct
+                if vport not in vports:
+                    vport = vports[0]
             guest_path = '/dev/%s' % vport
             return guest_path, host_path
 


### PR DESCRIPTION
Signed-off-by: qijing <jinqi@redhat.com>

The ported created by the rule changed in rhel9 and use the first port found