### PR TITLE
Add Qos test for bridge type interface

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_bridge.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_bridge.cfg
@@ -40,7 +40,26 @@
                     hotplug = "yes"
                     iface_type = "bridge"
                     iface_alias = "ua-cb8914ab-82d9-453e-bf4f-d2e90ca19abd"
-
+        - test_qos:
+            iface_bandwidth_inbound = "{'average':'512','peak':'1024','burst':'32'}"
+            iface_bandwidth_outbound = "{'average':'128','peak':'2048','burst':'64'}"
+            test_qos = "yes"
+            variants:
+                - start:
+                - hotplug_iface:
+                    attach_interface = "yes"
+                    hotplug = "yes"
+                    iface_type = "bridge"
+                    iface_source = "{'bridge':'test_br0'}"
+                - network:
+                    iface_type = "network"
+                    create_network = "yes"
+                    iface_source = "{'network':'host_bridge'}"
+                    net_bandwidth_inbound = "{'average':'512','peak':'1024','burst':'32'}"
+                    net_bandwidth_outbound = "{'average':'128','peak':'2048','burst':'64'}"
+                    test_net_qos = "yes"
+                    iface_bandwidth_inbound = "{'average':'0'}"
+                    iface_bandwidth_outbound = "{'average':'0'}"
 
 
 


### PR DESCRIPTION
Test Qos for bridge type interface and networks. Move the tc rule
check function from the iface_network.py into avocado-vt for sharing.
Depends on https://github.com/avocado-framework/avocado-vt/pull/3124

Signed-off-by: Yalan <yalzhang@redhat.com>