### PR TITLE
sriov_net_failover: Correct the err messge

### DIFF
--- a/libvirt/tests/src/sriov/sriov_net_failover.py
+++ b/libvirt/tests/src/sriov/sriov_net_failover.py
@@ -256,10 +256,10 @@ def run(test, params, env):
                      devices.by_device_tag("interface")]
         ifaces_net = {iface.get_type_name() for iface in vm_ifaces}
         if expected_ifaces.issubset(ifaces_net) == status_error:
-            test.fail("Unable to get the expected interfaces %s, "
-                      "it should%s be %s."
-                      % (expected_ifaces,  ' not' if status_error else '',
-                         ifaces_net))
+            test.fail("Unable to get expected interface. The interface %s "
+                      "should%s be %s."
+                      % (ifaces_net,  ' not' if status_error else '',
+                         expected_ifaces))
         else:
             logging.debug("{}Found iface(s) as expected: {}."
                           .format('Not ' if status_error else '',


### PR DESCRIPTION
The message was incorrect, so fix it.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
```
 (1/1) type_specific.io-github-autotest-libvirt.sriov_net_failover.hotplug_hostdev_iface_with_teaming: FAIL: Unable to get expected interface. The interface {'bridge'} should be {'bridge', 'hostdev'}. (44.58 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```
