### PR TITLE
virsh_guestvcpus: fix vcpu0 on AMD

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_guestvcpus.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_guestvcpus.cfg
@@ -46,4 +46,4 @@
                             error_msg = ["error: invalid argument: guest is missing vCPUs"]
                         - disable:
                             option = "--disable"
-                            error_msg = ["error: internal error: unable to execute QEMU agent command 'guest-set-vcpus'"]
+                            error_msg = ["error: internal error: unable to execute QEMU agent command 'guest-set-vcpus'", "vCPU '0' is not offlinable"]


### PR DESCRIPTION
On AMD machine, vcpu0 is not offlinable as designed. So the error message
should be enhanced.

Signed-off-by: Dan Zheng <dzheng@redhat.com>
