### PR TITLE
Detach interface match by alias

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_hotplug.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_hotplug.cfg
@@ -109,12 +109,15 @@
                         - by_pci:
                             del_mac = "yes"
                             del_pci = "no"
+                            del_alias = "yes"
                         - by_mac_pci:
                             del_mac = "no"
                             del_pci = "no"
+                            del_alias = "yes"
                         - by_mac:
                             del_mac = "no"
                             del_pci = "yes"
+                            del_alias = "yes"
                         - by_wrong_mac:
                             set_mac = "yes"
                             status_error = "yes"
@@ -122,10 +125,40 @@
                             set_pci = "yes"
                             pci = {'slot': '0x0b', 'bus': '0x00', 'domain': '0x0000', 'type': 'pci', 'function': '0x6'}
                             status_error = "yes"
+                        - by_alias_dup_mac:
+                            del_pci = "yes"
+                            del_mac = "no"
+                            del_alias = "no"
+                            start_vm = "no"
+                            iface_num = '2'
+                            customer_alias = "yes"
+                            attach_option = "--persistent"
+                            iface_mac = "9a:9b:b9:f5:51:b0"
+                        - by_dup_mac:
+                            del_pci = "yes"
+                            del_mac = "no"
+                            del_alias = "yes"
+                            start_vm = "no"
+                            attach_option = "--persistent"
+                            iface_num = '2'
+                            iface_mac = "9a:9b:b9:f5:51:b0"
+                            detach_error = "multiple devices matching MAC"
+                            status_error = "yes"
+                        - by_mac_wrong_alias:
+                            del_pci = "yes"
+                            del_mac = "no"
+                            del_alias = "yes"
+                            set_alias = "yes"
+                            status_error = "yes"
+                            detach_error = "device not found"
+                        - by_alias_wrong_mac:
+                            del_pci = "yes"
+                            del_mac = "yes"
+                            del_alias = "no"
+                            set_mac = "yes"
+                            status_error = "yes"
+                            detach_error = "device not found"
             variants:
-                - model_e1000:
-                    no s390-virtio
-                    iface_model = "e1000"
                 - model_rtl8139:
                     no s390-virtio
                     iface_model = "rtl8139"


### PR DESCRIPTION
When there are 2 interfaces with duplicate mac address, detach by
mac address will fail. So libvirt add one more match method to match
interface by alias. Add 2 test cases both positive and negative to
test the match method.

Signed-off-by: Yalan <yalzhang@redhat.com>
