### PR TITLE
sriov: Checking driver before testing

### DIFF
--- a/libvirt/tests/src/sriov/sriov.py
+++ b/libvirt/tests/src/sriov/sriov.py
@@ -647,6 +647,11 @@ def run(test, params, env):
     vlan_id = eval(params.get("vlan_id", "None"))
     trunk = params.get("trunk", "no") == "yes"
 
+    driver_dir = "/sys/bus/pci/drivers/%s" % driver
+    pci_dirs = glob.glob("%s/000*" % driver_dir)
+    if not pci_dirs:
+        test.cancel("Driver %s is not supported on this host." % driver)
+
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     backup_xml = vmxml.copy()
     vmxml.remove_all_device_by_type('interface')
@@ -678,8 +683,7 @@ def run(test, params, env):
     else:
         if not vm.is_dead():
             vm.destroy()
-    driver_dir = "/sys/bus/pci/drivers/%s" % driver
-    pci_dirs = glob.glob("%s/000*" % driver_dir)
+
     pci_device_dir = "/sys/bus/pci/devices"
     pci_address = ""
     net_name = "test-net"


### PR DESCRIPTION
Cancel the test if the driver does not match.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Test result:**
```
 (1/2) type_specific.io-github-autotest-libvirt.sriov.normal_test.info_check.vf_info.driver.ixgbe: PASS (108.06 s)
 (2/2) type_specific.io-github-autotest-libvirt.sriov.normal_test.info_check.vf_info.driver.i40e: CANCEL: Driver i40e is not supported on this host. (27.27 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 1
JOB TIME   : 137.01 s
```
