### PR TITLE
incremental_backup: Fix backup job not canceled issue

### DIFF
--- a/libvirt/tests/cfg/incremental_backup/incremental_backup_push_mode.cfg
+++ b/libvirt/tests/cfg/incremental_backup/incremental_backup_push_mode.cfg
@@ -33,9 +33,11 @@
                         - destroy_vm:
                             only original_disk_local.coldplug_disk.backup_to_raw.backup_to_block
                             expect_backup_canceled = "yes"
+                            original_disk_size = "1000M"
                         - kill_qemu:
                             only original_disk_local.hotplug_disk.backup_to_qcow2.backup_to_block
                             expect_backup_canceled = "yes"
+                            original_disk_size = "1000M"
                 - positive_test:
     variants:
         - backup_to_qcow2:


### PR DESCRIPTION
The original case is to destroy vm or kill qemu process to make
sure ongoing backup can be canceled normally. But case has random
failures when the backup job is finished too quickly. This fix is
to generate a larger file (1000M) to make sure the backup job
won't finish before destroy_vm/kill_process happens.

Signed-off-by: Yi Sun <yisun@redhat.com>