### PR TITLE
incremental_backup: Fix checkpoint metadata issue when qemu killed

### DIFF
--- a/libvirt/tests/src/incremental_backup/incremental_backup_pull_mode.py
+++ b/libvirt/tests/src/incremental_backup/incremental_backup_pull_mode.py
@@ -417,8 +417,11 @@ def run(test, params, env):
             test.fail("Backup job canceled: %s" % detail)
     finally:
         # Remove checkpoints
+        clean_checkpoint_metadata = not vm.is_alive()
+        if "error_operation" in locals() and "kill_qemu" in error_operation:
+            clean_checkpoint_metadata = True
         utils_backup.clean_checkpoints(vm_name,
-                                       clean_metadata=not vm.is_alive())
+                                       clean_metadata=clean_checkpoint_metadata)
 
         if vm.is_alive():
             vm.destroy(gracefully=False)


### PR DESCRIPTION
When qemu killed, the checkpoint's metadata will be inconsistent
with the checkpoint data in image files. This cause failures when
undefine vm during cleanup process. This patch is to fix this
problem.

Signed-off-by: Yi Sun <yisun@redhat.com>
