### PR TITLE
Make the cfg file more robust

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_network.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_network.cfg
@@ -241,7 +241,7 @@
                             net_bridge = "{'name':'virbr3'}"
                             define_error = "yes"
                         - duplicate_dev:
-                            forward_iface = "eno1 eno2 eno1"
+                            forward_iface = "eno1 eno2 eno2"
                             net_forward = "{'mode':'bridge'}"
                             define_error = "yes"
                 - net_bridge:
@@ -275,7 +275,7 @@
                     serial_login = "yes"
                     test_dhcp_range = "yes"
                 - net_private:
-                    forward_iface = "eno1 eno2"
+                    forward_iface = "eno1"
                     net_forward = "{'mode':'private'}"
                     change_iface_option = "yes"
                     iface_source = "{'network':'nettest'}"


### PR DESCRIPTION
As we will update the first interface to be the one exists on the host,
and do not care the others(the others will not be used by the guest, so
it is acceptable), if we test duplicate dev, we should ensure the others
are duplicate. For net_private test, no need 2 deivces as it may cause
error on certain systems.

Signed-off-by: Yalan <yalzhang@redhat.com>