### PR TITLE
migrate_options_shared: Fix aarch64 unexpected established con num

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -64,6 +64,8 @@
                                     parallel_cn_nums = 255
                         - default_connection:
                             stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M --timeout 70"
+                            aarch64:
+                                stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 512M --timeout 70"
                             stress_in_vm = "yes"
                             asynch_migrate = "yes"
                             actions_during_migration = "checkestablished"


### PR DESCRIPTION
As of now, the load of aarch64 guest that created by stress tool is too
small. Migration finished too fast.
When test check the num of established connection, migration was
finishd so the number always be 0.

Increase the load of guest during migration to fix the issue.

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Before
```
(.libvirt-ci-venv-ci-runtest-TzvLnZ) [root@hpe-moonshot-02-c20 ~]# avocado run --vt-type libvirt --vt-machine-type arm64-pci virsh.migrate_options_shared.positive_test.multifd.default_connection.with_postcopy  --vt-connect-uri qemu:///systm
JOB ID     : 1fe5a7b90e0ce52335136e2c88337191fef17d8a
JOB LOG    : /root/avocado/job-results/job-2021-07-09T04.31-1fe5a7b/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_options_shared.positive_test.multifd.default_connection.with_postcopy: FAIL: The number of established connections is unexpected: 0 (228.73 s)
```

After the fix
```
(.libvirt-ci-venv-ci-runtest-TzvLnZ) [root@hpe-moonshot-02-c20 test-providers.d]# avocado run --vt-type libvirt --vt-machine-type arm64-pci virsh.migrate_options_shared.positive_test.multifd.default_connection.with_postcopy  --vt-connect-uri qemu:///systm
JOB ID     : a0c2baa2258e0a72ef2e2a1a704d1915a0aa9e49
JOB LOG    : /root/avocado/job-results/job-2021-07-09T04.44-a0c2baa/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_options_shared.positive_test.multifd.default_connection.with_postcopy: PASS (231.48 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 232.16 s

```