### PR TITLE
migrate_vm: Update netperf version

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_vm.cfg
+++ b/libvirt/tests/cfg/migration/migrate_vm.cfg
@@ -174,7 +174,7 @@
                                             migration_timeout = 600
                                             virsh_options = "--live --verbose"
                                         - netperf_network:
-                                            netperf_version = "netperf-2.6.0"
+                                            netperf_version = "netperf-2.6.0-1"
                                             netperf_source = "shared/deps/netperf/${netperf_version}.tar.bz2"
                                             client_path = "/var/tmp/"
                                             server_path = "/var/tmp/"


### PR DESCRIPTION
Compile netperf meet following error:
  gcc -o netperf netperf.o netlib.o netsh.o nettest_bsd.o nettest_dlpi.o nettest_unix.o nettest_xti.o nettest_sctp.o nettest_sdp.o nettest_omni.o net_uuid.o dscp.o netcpu_none.o netrt_none.o netdrv_none.o netslot_none.o netsys_none.o netsec_none.o -lm
  /usr/bin/ld: nettest_omni.o:(.bss+0x398): multiple definition of loc_nodelay'; nettest_bsd.o:(.bss+0x20): first defined here /usr/bin/ld: nettest_omni.o:(.bss+0x39c): multiple definition of rem_nodelay'; nettest_bsd.o:(.bss+0x24): first defined here
  /usr/bin/ld: nettest_omni.o:(.bss+0x3a0): multiple definition of loc_sndavoid'; nettest_bsd.o:(.bss+0x30): first defined here /usr/bin/ld: nettest_omni.o:(.bss+0x3a4): multiple definition of loc_rcvavoid'; nettest_bsd.o:(.bss+0x34): first defined here
  /usr/bin/ld: nettest_omni.o:(.bss+0x3a8): multiple definition of rem_sndavoid'; nettest_bsd.o:(.bss+0x38): first defined here /usr/bin/ld: nettest_omni.o:(.bss+0x3ac): multiple definition of rem_rcvavoid'; nettest_bsd.o:(.bss+0x3c): first defined here
  collect2: error: ld returned 1 exit status
  make[3]: *** [Makefile:443: netperf] Error 1

So update netperf package version.

Signed-off-by: lcheng <lcheng@redhat.com>
