### PR TITLE
Fix: add a libvirt version check

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_network.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_network.cfg
@@ -97,6 +97,7 @@
                             iface_bandwidth_inbound = "{'average':'1000','peak':'5000','burst':'1024'}"
                             iface_bandwidth_outbound = "{'average':'128','peak':'256','burst':'256'}"
                             iface_driver =  "{'queues':'5'}"
+                            iface_model = "virtio"
                         - negtive_start_test:
                             start_error = "yes"
                         - negtive_remove_test:

--- a/libvirt/tests/src/virtual_network/iface_network.py
+++ b/libvirt/tests/src/virtual_network/iface_network.py
@@ -571,6 +571,8 @@ TIMEOUT 3"""
         """
         if not vm.is_alive():
             vm.start()
+        if not libvirt_version.version_compare(7, 0, 0):
+            return
         mac = vm_xml.VMXML.get_iface_dev(vm_name)[0]
         iface_features = vm_xml.VMXML.get_iface_by_mac(vm_name, mac)
         target_dev = iface_features.get('target', {}).get('dev')

--- a/libvirt/tests/src/virtual_network/iface_options.py
+++ b/libvirt/tests/src/virtual_network/iface_options.py
@@ -238,10 +238,11 @@ def run(test, params, env):
             if iface_target == "macvtap" and "mode" in iface.source:
                 cmd = "ip -d link show %s" % iface.target["dev"]
                 output = process.run(cmd, shell=True).stdout_text
-                if not re.findall("noqueue", output):
-                    test.fail("The default qdisc type should be noqueue, but it's not, check output '%s'" % output)
-                else:
-                    logging.info("Check the qisc type is expected noqueue")
+                if libvirt_version.version_compare(7, 0, 0):
+                    if not re.findall("noqueue", output):
+                        test.fail("The default qdisc type should be noqueue, but it's not, check output '%s'" % output)
+                    else:
+                        logging.info("Check the qisc type is expected noqueue")
                 logging.debug("ip link output: %s", output)
                 mode = iface.source["mode"]
                 if mode == "passthrough":


### PR DESCRIPTION
Qdisc noqueue is supported since libvirt 7.0.0, add the versoin check before
the noqueue check.

Signed-off-by: Yalan <yalzhang@redhat.com>