### PR TITLE
virtual_disks_rotation_rate: Add case for disk rotation

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_rotation_rate.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_rotation_rate.cfg
@@ -1,0 +1,39 @@
+- virtual_disks.rotation_rate:
+    type = virtual_disks_rotation_rate
+    start_vm = no
+    cleanup_disks = 'yes'
+    variants:
+        - positive_test:
+            func_supported_since_libvirt_ver = (7, 3, 0)
+            disk_target = 'sda'
+            install_pkgs = "['smartmontools']"
+            variants:
+                - scsi_bus:
+                    disk_target_bus = 'scsi'
+                - sata_bus:
+                    only q35
+                    disk_target_bus = 'sata'
+            variants:
+                - rate_normal:
+                    target_rotation = '5400'
+                    cmds_in_guest = "['smartctl -a /dev/${disk_target} | grep -E \'Rotation Rate:\s.*${target_rotation} rpm\'', ' cat /sys/block/sda/queue/rotational |grep 1']"
+                - rate_small:
+                    only scsi_bus
+                    target_rotation = '1'
+                    cmds_in_guest = "['smartctl -a /dev/${disk_target} | grep -E \'Rotation Rate:\s.*Solid State Device\'', 'cat /sys/block/sda/queue/rotational | grep 0']"
+                - rate_none:
+                    only scsi_bus
+                    target_rotation = ''
+                    cmds_in_guest = "['smartctl -a /dev/${disk_target} | grep -E \'Rotation Rate:\'', 'cat /sys/block/sda/queue/rotational | grep 1']"
+                - at_dt:
+                    only scsi_bus
+                    at_dt = 'yes'
+                    disk_target = 'sdb'
+                    target_rotation = '5400'
+                    cleanup_disks = 'no'
+                    pattern_in_dumpxml = "${disk_target}.*rotation_rate"
+                    source_file = "/var/lib/libvirt/images/disk2.raw"
+                    driver_type = 'raw'
+                    target_bus = ${disk_target_bus}
+                    target_dev = ${disk_target}
+                    cmds_in_guest = "['smartctl -a /dev/%s | grep -E \'Rotation Rate:\s.*${target_rotation} rpm\'', 'lsblk | grep %s']"

--- a/libvirt/tests/src/virtual_disks/virtual_disks_rotation_rate.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_rotation_rate.py
@@ -1,0 +1,111 @@
+import logging
+import time
+
+from virttest import libvirt_version
+from virttest import utils_disk
+from virttest import utils_package
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_test import libvirt
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_misc import cmd_status_output
+
+
+def install_pkg(test, pkg_list, vm_session):
+    """
+    Install required packages in the vm
+
+    :param test: test object
+    :param pkg_list: list, package names
+    :param vm_session: vm session
+    """
+    if not utils_package.package_install(pkg_list, vm_session):
+        test.error("Failed to install package '{}' in the vm".format(pkg_list))
+
+
+def run_cmd_in_guest(test, vm_session, cmd, any_error=False):
+    """
+    Run a command within the guest.
+
+    :param test:  test object
+    :param vm_session: the vm session
+    :param cmd: str, the command to be executed in the vm
+    :param ignore_status: False to test.error when failed, otherwise True
+    :param expect_fail: True if failure is expected, otherwise False
+    """
+    status, output = cmd_status_output(cmd, shell=True, session=vm_session)
+    libvirt.check_status_output(status, output, any_error=any_error)
+
+
+def create_second_disk(disk_dict):
+    """
+    Create another disk using given parameters
+
+    :param disk_dict: dict, parameters to use
+    :return: disk xml
+    """
+    disk_path = disk_dict.get('source_file')
+    disk_format = disk_dict.get('driver_type', 'raw')
+    libvirt.create_local_disk('file', disk_path, '1', disk_format)
+
+    return libvirt.create_disk_xml(disk_dict)
+
+
+def run(test, params, env):
+    """
+    Run tests with disk target configurations
+    """
+
+    libvirt_version.is_libvirt_feature_supported(params)
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    at_dt = params.get('at_dt')
+    cmds_in_guest = eval(params.get('cmds_in_guest'))
+    target_rotation = params.get('target_rotation')
+
+    backup_xml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+
+    try:
+        if not at_dt:
+            libvirt.set_vm_disk(vm, params)
+
+        if not vm.is_alive():
+            vm.start()
+
+        logging.debug(vm_xml.VMXML.new_from_dumpxml(vm_name))
+        vm_session = vm.wait_for_login()
+
+        pkg_list = params.get("install_pkgs")
+        if pkg_list:
+            install_pkg(test, eval(pkg_list), vm_session)
+
+        if at_dt:
+            old_parts = utils_disk.get_parts_list(vm_session)
+            disk_xml = create_second_disk(params)
+            virsh.attach_device(vm_name, disk_xml, debug=True, ignore_status=False)
+            pat_in_dumpxml = params.get('pattern_in_dumpxml')
+            libvirt_vmxml.check_guest_xml(vm_name, pat_in_dumpxml, status_error=False)
+            time.sleep(10)
+            added_parts = utils_disk.get_added_parts(vm_session, old_parts)
+            if not added_parts or len(added_parts) != 1:
+                test.error("Only one new partition is expected in the VM, "
+                           "but found {}".format(added_parts))
+            cmd = cmds_in_guest[0] % added_parts[0]
+            run_cmd_in_guest(test, vm_session, cmd)
+            virsh.detach_device(vm_name, disk_xml, debug=True, ignore_status=False)
+            cmd = cmds_in_guest[1] % added_parts[0]
+            run_cmd_in_guest(test, vm_session, cmd, any_error=True)
+            libvirt_vmxml.check_guest_xml(vm_name, pat_in_dumpxml, status_error=True)
+        else:
+            if cmds_in_guest:
+                for cmd_index in range(0, len(cmds_in_guest)):
+                    any_error = False
+                    if not target_rotation and cmd_index == 0:
+                        any_error = True
+                    run_cmd_in_guest(test, vm_session, cmds_in_guest[cmd_index], any_error=any_error)
+    finally:
+        backup_xml.sync()
+        source_file = params.get('source_file')
+        if source_file:
+            libvirt.delete_local_disk('file', source_file)


### PR DESCRIPTION
Case ID:
RHEL-201842: Start vm with scsi bus and rotation_rate disk
RHEL-201843: Start vm with sata bus and rotation_rate disk
RHEL-201844: Hotplug/unplug rotation_rate disk on scsi bus
RHEL-254338: Set various values for rotation_rate for disk on SCSI bus

Signed-off-by: Dan Zheng <dzheng@redhat.com>
