### PR TITLE
sriov: Add 2 'managed' related cases

### DIFF
--- a/libvirt/tests/cfg/sriov/sriov_managed.cfg
+++ b/libvirt/tests/cfg/sriov/sriov_managed.cfg
@@ -1,0 +1,15 @@
+- sriov.managed:
+    type = sriov_managed
+    start_vm = "no"
+    variants test_case:
+        - networks:
+            net_name = "vfio-passthrough"
+            variants:
+                - managed_no:
+                    net_forward = {"mode": "hostdev", "managed": "no"}
+                - @default:
+                    net_forward = {"mode": "hostdev"}
+        - device_hotplug:
+            variants:
+                - managed_no:
+                    iface_dict = {"type": "hostdev", "managed": "no", "mac": mac_addr,"hostdev_addr": "%s"}

--- a/libvirt/tests/src/sriov/sriov_managed.py
+++ b/libvirt/tests/src/sriov/sriov_managed.py
@@ -1,0 +1,152 @@
+import logging
+
+from provider.sriov import sriov_base
+
+from virttest import utils_net
+from virttest import utils_sriov
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.libvirt_xml.devices import interface
+from virttest.utils_libvirt import libvirt_network
+from virttest.utils_libvirt import libvirt_vfio
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+
+def run(test, params, env):
+    """
+    SR-IOV: managed related test.
+    """
+    def start_vm(vm, test_login=False, destroy_vm=False):
+        """
+        Start up VM
+
+        :param vm: The vm object
+        :param test_login: Whether to login VM
+        :param destroy_vm: Whether to destroy VM
+        """
+        if vm.is_alive():
+            vm.destroy()
+        vm.start()
+        if test_login:
+            vm.wait_for_serial_login(timeout=180).close()
+        if destroy_vm:
+            vm.destroy()
+
+    def create_vf_pool():
+        """
+        Create VF pool
+        """
+        net_hostdev_dict = {"net_name": params.get("net_name"),
+                            "net_forward": params.get("net_forward"),
+                            "vf_list_attrs": "[%s]" % utils_sriov.pci_to_addr(vf_pci)}
+        libvirt_network.create_or_del_network(net_hostdev_dict)
+
+    def check_vm_iface_managed(vm_name, iface_dict):
+        """
+        Check 'managed' in VM's iface
+
+        :param vm_name: Name of VM
+        :param iface_dict: The parameters dict
+        :raise: TestFail if not match
+        """
+        vm_iface_managed = [iface.get("managed") for iface in vm_xml.VMXML.
+                            new_from_dumpxml(vm_name).
+                            devices.by_device_tag("interface")][0]
+        expr_managed = "yes" if iface_dict.get("managed", "") == "yes" else None
+        if vm_iface_managed != expr_managed:
+            test.fail("Unable to get the expected managed! Actual: %s, "
+                      "Expected: %s." % (vm_iface_managed, expr_managed))
+
+    def test_networks():
+        """
+        Start vm with VF from VF Pool with "managed=no" or default setting
+
+        1) Create VF pool
+        2) Prepare device xml and hot-plug to the guest
+        3) Detach the device from host
+        4) Check the driver of device
+        5) Start VM
+        6) Destroy vm then check the driver
+        7) Reattach the device to the host and check the driver
+        """
+        create_vf_pool()
+        libvirt_vfio.check_vfio_pci(vf_pci, status_error=True)
+        iface_dict = {"type": "network",
+                      "source": "{'network': '%s'}" % params.get("net_name")}
+        libvirt.modify_vm_iface(vm.name, "update_iface", iface_dict)
+        res = virsh.start(vm.name, debug=True)
+        libvirt.check_exit_status(res, True)
+
+        virsh.nodedev_detach(dev_name, debug=True, ignore_status=False)
+        libvirt_vfio.check_vfio_pci(vf_pci)
+        start_vm(vm, True, True)
+        libvirt_vfio.check_vfio_pci(vf_pci)
+        virsh.nodedev_reattach(dev_name, debug=True, ignore_status=False)
+        libvirt_vfio.check_vfio_pci(vf_pci, status_error=True)
+
+    def test_device_hotplug():
+        """
+        Hotplug/unplug VF with managed='no'
+
+        1) Prepare a running guest
+        2) Check the driver of vf on host
+        3) Prepare a xml with "managed=no"and attach to guest
+        4) Detach the device from host
+        5) Check the driver of vf on host
+        6) Attach the device to guest
+        7) Check the interface of the guest
+        8) Detach the device from guest and check the driver
+        9) Reattach the device to the host and check the driver
+        """
+        libvirt_vmxml.remove_vm_devices_by_type(vm, 'interface')
+        start_vm(vm)
+        libvirt_vfio.check_vfio_pci(vf_pci, status_error=True)
+        mac_addr = utils_net.generate_mac_address_simple()
+        iface_dict = eval(params.get('iface_dict', '{"hostdev_addr": "%s"}')
+                          % utils_sriov.pci_to_addr(vf_pci))
+        iface = interface.Interface("hostdev")
+        iface.xml = libvirt.modify_vm_iface(vm.name, "get_xml", iface_dict)
+        res = virsh.attach_device(vm_name, iface.xml, debug=True)
+        libvirt.check_exit_status(res, True)
+        virsh.nodedev_detach(dev_name, debug=True, ignore_status=False)
+        libvirt_vfio.check_vfio_pci(vf_pci)
+        virsh.attach_device(vm_name, iface.xml, debug=True,
+                            ignore_status=False)
+
+        check_vm_iface_managed(vm_name, iface_dict)
+        vm.wait_for_serial_login().close()
+        virsh.detach_device(vm_name, iface.xml, wait_remove_event=True,
+                            debug=True, ignore_status=False)
+        libvirt_vfio.check_vfio_pci(vf_pci)
+        virsh.nodedev_reattach(dev_name, debug=True, ignore_status=False)
+        libvirt_vfio.check_vfio_pci(vf_pci, status_error=True)
+
+    test_case = params.get("test_case", "")
+    run_test = eval("test_%s" % test_case)
+
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    vm = env.get_vm(vm_name)
+    pf_pci = utils_sriov.get_pf_pci()
+    if not pf_pci:
+        test.cancel("NO available pf found.")
+    default_vf = sriov_base.setup_vf(pf_pci, params)
+
+    vf_pci = utils_sriov.get_vf_pci_id(pf_pci)
+    dev_name = utils_sriov.get_device_name(vf_pci)
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    orig_config_xml = vmxml.copy()
+
+    try:
+        run_test()
+
+    finally:
+        logging.info("Recover test enviroment.")
+        sriov_base.recover_vf(pf_pci, params, default_vf)
+        if vm.is_alive():
+            vm.destroy(gracefully=False)
+        orig_config_xml.sync()
+        libvirt_network.create_or_del_network(
+            {"net_name": params.get("net_name")}, True)
+        virsh.nodedev_reattach(dev_name, debug=True)

--- a/provider/sriov/sriov_base.py
+++ b/provider/sriov/sriov_base.py
@@ -1,0 +1,39 @@
+from avocado.core import exceptions
+from avocado.utils import process
+
+from virttest import utils_misc
+from virttest import utils_sriov
+
+
+def setup_vf(pf_pci, params):
+    """
+    Enable vf setting
+
+    :param pf_pci: The pci of PF
+    :return: The original vf value
+    """
+    default_vf = 0
+    try:
+        vf_no = int(params.get("vf_no", "4"))
+    except ValueError as e:
+        raise exceptions.TestError(e)
+    pf_pci_path = utils_misc.get_pci_path(pf_pci)
+    cmd = "cat %s/sriov_numvfs" % (pf_pci_path)
+    default_vf = process.run(cmd, shell=True, verbose=True).stdout_text
+    if not utils_sriov.set_vf(pf_pci_path, vf_no):
+        raise exceptions.TestError("Failed to set vf.")
+    return default_vf
+
+
+def recover_vf(pf_pci, params, default_vf=0):
+    """
+    Recover vf setting
+
+    :param pf_pci: The pci of PF
+    :param params: the parameters dict
+    :param default_vf: The value to be set
+    """
+    pf_pci_path = utils_misc.get_pci_path(pf_pci)
+    vf_no = int(params.get("vf_no", "4"))
+    if default_vf != vf_no:
+        utils_sriov.set_vf(pf_pci_path, default_vf)


### PR DESCRIPTION
RHEL7-18519 - [network] Start vm with VF from VF Pool
    with "managed=no" or default setting
RHEL7-43422 - [attach-device] Hotplug/unplug VF with managed='no'

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**depends on:**
https://github.com/avocado-framework/avocado-vt/pull/3133
https://github.com/avocado-framework/avocado-vt/pull/3136
https://github.com/avocado-framework/avocado-vt/pull/3137
https://github.com/avocado-framework/avocado-vt/pull/3138
**Test results:**
 ```
(1/3) type_specific.io-github-autotest-libvirt.sriov.managed.networks.managed_no: PASS (109.36 s)
 (2/3) type_specific.io-github-autotest-libvirt.sriov.managed.networks.default: PASS (170.95 s)
 (3/3) type_specific.io-github-autotest-libvirt.sriov.managed.device_hotplug.managed_no: PASS (40.63 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 322.76 s

```