### PR TITLE
migration: Add bandwidth opt to cancel_migration case

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_storage.cfg
+++ b/libvirt/tests/cfg/migration/migrate_storage.cfg
@@ -26,6 +26,7 @@
             variants:
                 - normal_test:
                 - cancel_migration:
+                    virsh_migrate_extra = "--tls --bandwidth 10"
                     cancel_migration = "yes"
                     status_error = "yes"
                     migrate_again = "yes"


### PR DESCRIPTION
Slow down the migration process to do 'cancel' operation during
the migration.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Test result:**
_Before fix:_
```

    rhel.virsh.migrate_storage.with_tls.cancel_migration.copy_storage_inc
        TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'
```

_After fix:_ failed caused by BZ 1978526.
` (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_storage.with_tls.cancel_migration.copy_storage_inc: FAIL: The string '"execute":"blockdev-add","arguments":{"driver":"nbd","server":{"type":"inet","host":".*","port":"49153"},"export":"drive-virtio-disk0","tls-creds":"objlibvirt_migrate_tls0"' is not included in /var/log/libvirt/libvirt_daemons.log (297.83 s)`
