### PR TITLE
cpu: Update iothread_quota's value

### DIFF
--- a/libvirt/tests/src/cpu/iothread.py
+++ b/libvirt/tests/src/cpu/iothread.py
@@ -370,11 +370,8 @@ def run(test, params, env):
             result = virsh.schedinfo(vm_name, debug=True)
             libvirt.check_exit_status(result)
             if update_error:
-                items.update({"iothread_period": 100000})
-                if libvirt_version.version_compare(7, 4, 0):
-                    items.update({"iothread_quota": 17592186044415})
-                else:
-                    items.update({"iothread_quota": -1})
+                items.update({"iothread_period": 100000,
+                              "iothread_quota": '(17592186044415|-1)'})
             for key, val in items.items():
                 if not re.findall(key+'\s*:\s+'+str(val), result.stdout):
                     test.fail("Unable to find expected value {}:{} from {}"


### PR DESCRIPTION
The value of iothread_quota is different in rhel9 and rhel8.5, so
it shouldn't check libvirt version.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Test result:**
_rhel8.5, libvirt 7.5.0-1:_
```
 (01/21) type_specific.io-github-autotest-libvirt.cpu.iothread.positive_test.iothread_config.only_iothread_id: PASS (51.11 s)
 (02/21) type_specific.io-github-autotest-libvirt.cpu.iothread.positive_test.iothread_config.only_iothread_num: PASS (47.13 s)
 (03/21) type_specific.io-github-autotest-libvirt.cpu.iothread.positive_test.iothread_config.both_iothread_id_num: PASS (48.00 s)
 (04/21) type_specific.io-github-autotest-libvirt.cpu.iothread.positive_test.iothreadpin: PASS (51.86 s)
 (05/21) type_specific.io-github-autotest-libvirt.cpu.iothread.positive_test.iothread_poll: PASS (52.87 s)
 (06/21) type_specific.io-github-autotest-libvirt.cpu.iothread.positive_test.disk_attach: PASS (60.50 s)
 (07/21) type_specific.io-github-autotest-libvirt.cpu.iothread.negative_test.iothreadpin.out_of_range: PASS (31.55 s)
 (08/21) type_specific.io-github-autotest-libvirt.cpu.iothread.negative_test.iothreadpin.no_matchs_iothread: PASS (5.63 s)
 (09/21) type_specific.io-github-autotest-libvirt.cpu.iothread.negative_test.iothread_poll.invalid_value.poll_max_ns: PASS (30.66 s)
 (10/21) type_specific.io-github-autotest-libvirt.cpu.iothread.negative_test.iothread_poll.invalid_value.poll_grow: PASS (30.21 s)
 (11/21) type_specific.io-github-autotest-libvirt.cpu.iothread.negative_test.iothread_poll.invalid_value.poll_shrink: PASS (30.25 s)
 (12/21) type_specific.io-github-autotest-libvirt.cpu.iothread.negative_test.iothread_poll.invalid_string.poll_max_ns: PASS (31.25 s)
 (13/21) type_specific.io-github-autotest-libvirt.cpu.iothread.negative_test.iothread_poll.invalid_string.poll_grow: PASS (31.19 s)
 (14/21) type_specific.io-github-autotest-libvirt.cpu.iothread.negative_test.iothread_poll.invalid_string.poll_shrink: PASS (30.16 s)
 (15/21) type_specific.io-github-autotest-libvirt.cpu.iothread.negative_test.iothread_poll.no_matching_id: PASS (31.31 s)
 (16/21) type_specific.io-github-autotest-libvirt.cpu.iothread.negative_test.iothreadsched.no_iothread.no_iothreads_xml: PASS (5.58 s)
 (17/21) type_specific.io-github-autotest-libvirt.cpu.iothread.negative_test.iothreadsched.no_iothread.no_matching_id: PASS (5.59 s)
 (18/21) type_specific.io-github-autotest-libvirt.cpu.iothread.negative_test.iothreadsched.invalid: PASS (5.56 s)
 (19/21) type_specific.io-github-autotest-libvirt.cpu.iothread.negative_test.iothread_quota_period_without_iothreads: PASS (30.26 s)
 (20/21) type_specific.io-github-autotest-libvirt.cpu.iothread.negative_test.disk_attach.no_iothread: PASS (49.87 s)
 (21/21) type_specific.io-github-autotest-libvirt.cpu.iothread.negative_test.disk_attach.delete_without_detach: PASS (49.08 s)
RESULTS    : PASS 21 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 711.93 s
```
_rhel9, libvirt 7.4.0-1:_
` (1/1) type_specific.io-github-autotest-libvirt.cpu.iothread.negative_test.iothread_quota_period_without_iothreads: PASS (28.97 s)`
