### PR TITLE
incremental_backup: fix 'NoneType is not iterable' error

### DIFF
--- a/libvirt/tests/src/incremental_backup/incremental_backup_pull_mode.py
+++ b/libvirt/tests/src/incremental_backup/incremental_backup_pull_mode.py
@@ -418,8 +418,9 @@ def run(test, params, env):
     finally:
         # Remove checkpoints
         clean_checkpoint_metadata = not vm.is_alive()
-        if "error_operation" in locals() and "kill_qemu" in error_operation:
-            clean_checkpoint_metadata = True
+        if "error_operation" in locals() and error_operation is not None:
+            if "kill_qemu" in error_operation:
+                clean_checkpoint_metadata = True
         utils_backup.clean_checkpoints(vm_name,
                                        clean_metadata=clean_checkpoint_metadata)
 


### PR DESCRIPTION
The 'error_operation' could be existing but None, so the
'"kill_qemu" in error_operation' could lead to a 'NoneType is not
iterable' error. This patch is to fix this.

Signed-off-by: Yi Sun <yisun@redhat.com>