### PR TITLE
set_virtlogd: Set matched_msg for aarch64

### DIFF
--- a/libvirt/tests/cfg/conf_file/qemu_conf/set_virtlogd.cfg
+++ b/libvirt/tests/cfg/conf_file/qemu_conf/set_virtlogd.cfg
@@ -1,6 +1,9 @@
 - conf_file.qemu_conf.set_virtlogd:
     type = set_virtlogd
     start_vm = yes
+    matched_msg = "Powering off"
+    aarch64:
+        matched_msg = "Power down"
     variants:
         - positive_test:
             expected_result = virtlogd_enabled

--- a/libvirt/tests/src/conf_file/qemu_conf/set_virtlogd.py
+++ b/libvirt/tests/src/conf_file/qemu_conf/set_virtlogd.py
@@ -219,6 +219,7 @@ def run(test, params, env):
     vm_name = params.get("main_vm", "avocado-vt-vm1")
     expected_result = params.get("expected_result", "virtlogd_disabled")
     stdio_handler = params.get("stdio_handler", "not_set")
+    matched_msg = params.get("matched_msg", "Powering off")
     start_vm = "yes" == params.get("start_vm", "yes")
     reload_virtlogd = "yes" == params.get("reload_virtlogd", "no")
     restart_libvirtd = "yes" == params.get("restart_libvirtd", "no")
@@ -391,7 +392,7 @@ def run(test, params, env):
             # Check VM shutdown log is written into log file correctly.
             if with_console_log:
                 check_info_in_vm_log_file(vm_name, guest_log_file,
-                                          matchedMsg="Powering off")
+                                          matchedMsg=matched_msg)
             else:
                 check_info_in_vm_log_file(vm_name, guest_log_file, matchedMsg="shutting down")
 


### PR DESCRIPTION
Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

aarch64 console log is different with x86, set matched_msg for aarch64. 
Before
```
[root@hpe-apollo80-01-n00 ~]# avocado run --vt-type libvirt --vt-machine-type arm64-mmio conf_file.qemu_conf.set_virtlogd.positive_test.reload.vm_with_console_log
JOB ID     : 7fece0a29d7e10831b661d12f49336cd16319e2d
JOB LOG    : /root/avocado/job-results/job-2021-07-15T04.03-7fece0a/job.log
 (1/1) type_specific.io-github-autotest-libvirt.conf_file.qemu_conf.set_virtlogd.positive_test.reload.vm_with_console_log: FAIL: Failed to get VM started log from VM log file: /var/log/libvirt/qemu/avocado-vt-vm1-console.log. (57.06 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 57.81 s
```
After
```
[root@hpe-apollo80-01-n00 ~]# avocado run --vt-type libvirt --vt-machine-type arm64-mmio conf_file.qemu_conf.set_virtlogd.positive_test.reload.vm_with_console_log
JOB ID     : 66c4fe6e25cd693e58d10449976587cf2eb84465
JOB LOG    : /root/avocado/job-results/job-2021-07-15T03.52-66c4fe6/job.log
 (1/1) type_specific.io-github-autotest-libvirt.conf_file.qemu_conf.set_virtlogd.positive_test.reload.vm_with_console_log: PASS (60.28 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 61.03 s
```
