### PR TITLE
libvirt_ccw_passthrough: Improve test stability

### DIFF
--- a/libvirt/tests/src/passthrough/ccw/libvirt_ccw_passthrough.py
+++ b/libvirt/tests/src/passthrough/ccw/libvirt_ccw_passthrough.py
@@ -62,7 +62,9 @@ def run(test, params, env):
                 test.fail("Device not visible after restoring setup.")
 
     finally:
-        if chpids:
+        if vm.is_alive():
+            vm.destroy()
+        if chpids and device_removal_case:
             ChannelPaths.set_online(chpids)
         if uuid:
             ccw.stop_device(uuid)

--- a/provider/vfio/ccw.py
+++ b/provider/vfio/ccw.py
@@ -103,7 +103,7 @@ def format_dasd(path, session):
     :raises TestError: if disk can't be formatted
     """
 
-    cmd = "dasdfmt -b 4096 -M quick -p -y %s" % path
+    cmd = "dasdfmt -b 4096 -M quick --force -p -y %s" % path
     err, out = cmd_status_output(cmd, shell=True, session=session)
     if err:
         raise TestError("Couldn't format disk. %s" % out)


### PR DESCRIPTION
1. Improve tear down

On older kernel versions[1] the teardown might get stuck.
Improve teardown to pass tests also on older kernel versions.

[1] Kernel (5.11+):
bccce80bbd44 vfio-ccw: Wire in the request callback
a15ac665b9e9 vfio-mdev: Wire in a request handler for mdev parent

2. Improve formatting

Add `--force` flag to avoid interference between tests. Without it
the tool might consider the disk in use due to recent use in other
tests and tests would fail.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>
