### PR TITLE
[virsh_net_define_undefine] fix inspektor violation

### DIFF
--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_define_undefine.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_define_undefine.py
@@ -234,7 +234,7 @@ def run(test, params, env):
                         'dns_txt': net_dns_txt, 'domain': domain, 'bridge': bridge,
                         'forward': forward, 'interface_dev': iface_name,
                         'virtualport': virtualport, 'virtualport_type': virtualport_type,
-                        'mac': mac,'net_bandwidth_inbound': net_bandwidth_inbound,
+                        'mac': mac, 'net_bandwidth_inbound': net_bandwidth_inbound,
                         'net_bandwidth_outbound': net_bandwidth_outbound}
             logging.debug("net_dict is %s" % net_dict)
             testnet_xml = libvirt_network.modify_network_xml(net_dict, testnet_xml)


### PR DESCRIPTION
Fix inspektor violation " E231 missing whitespace after ','"

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>
