### PR TITLE
Set one memory hotplug case to x86 only

### DIFF
--- a/libvirt/tests/cfg/memory/memory_hotplug.cfg
+++ b/libvirt/tests/cfg/memory/memory_hotplug.cfg
@@ -3,6 +3,7 @@
     start_vm = no
     variants case:
         - report_failure:
+            only x86_64
             setvm_max_mem_rt = 15243264
             setvm_max_mem_rt_unit = 'KiB'
             setvm_max_mem_rt_slots = 16


### PR DESCRIPTION
According to the feature itself

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>
