### PR TITLE
v2v: update expected chipset settings against different rhv server

### DIFF
--- a/provider/v2v_vmcheck_helper.py
+++ b/provider/v2v_vmcheck_helper.py
@@ -85,9 +85,15 @@ class VMChecker(object):
                 self.ovirt_server_version.full_version)
             if self.ovirt_server_version.major >= 4 and self.ovirt_server_version.minor >= 4:
                 self.boottype = int(params.get("boottype", 1))
-            # A temporary workaround to bz1961945, once it's fixed, a
-            # nicer fix will be done.
-            if '4.4.6.8' in self.ovirt_server_version.full_version:
+            rhv_bz_1961945_ver = '[4.4.6.8, 4.4.7.6)'  # bz1961945
+            rhv_bz_1983610_ver = '[4.4.6.8, 4.4.8)'  # bz1983610
+            if utils_v2v.compare_version(
+                rhv_bz_1961945_ver,
+                self.ovirt_server_version.full_version) or self.hypervisor in [
+                'xen',
+                'kvm'] and utils_v2v.compare_version(
+                rhv_bz_1983610_ver,
+                    self.ovirt_server_version.full_version):
                 self.boottype = int(params.get("boottype", 0))
         if compare_version(FEATURE_SUPPORT['q35']):
             self.boottype = int(params.get("boottype", 1))


### PR DESCRIPTION
When converting guest to rhv by v2v + rhv-upload, there are different
result:

1. when rhv < 4.4.6.8, the chipset is set to Q35
2. when 4.4.6.8 < rhv < 4.4.7.6, the chipset is set to BIOS, see bz1961945,
it is fixed in 4.4.7.6.
3. when rhv >= 4.4.7.6, the chipset is set to Q35 when converting from ESX server.
But it is set to BIOS when converting from XEN or Libvirt. see bz1983610. The
issue is target to 4.4.8 right now.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>