### PR TITLE
virsh_attach_passthrough_no_bus: Check host passthrough device

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_passthrough_no_bus.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_passthrough_no_bus.py
@@ -1,4 +1,7 @@
 import logging
+
+from avocado.utils import process
+
 from virttest.libvirt_xml.devices.input import Input
 from virttest.libvirt_xml.vm_xml import VMXML
 from virttest import virsh
@@ -21,6 +24,11 @@ def run(test, params, env):
     # Create a new passthrough device without bus assigned
     input_dev = Input(type_name="passthrough")
     input_dev.source_evdev = "/dev/input/event1"
+
+    # Check whether host has passthrough device
+    if process.run("ls /dev/input/event1", ignore_status=True).exit_status:
+        test.cancel("Host doesn't have passthrough device")
+
     xml = input_dev.get_xml()
     logging.debug('Attached device xml:\n{}'.format(input_dev.xmltreefile))
     logging.debug('New Passthrough device XML is available at:{}'.format(xml))


### PR DESCRIPTION
This test needs passthrough host device to guest and uses
/dev/input/event1 by default.
Add a check for default passthrough deivce, cancel test if host doesn't
have test device.

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Before
An aarch64 host which doesn't have /dev/input/event1, test fail
```
[root@hpe-apollo80-01-n00 ~]# avocado run  --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virsh.attach_passthrough_no_bus
JOB ID     : e82ef14308b050c102b3de5e25c48198091bfbcf
JOB LOG    : /root/avocado/job-results/job-2021-07-21T04.05-e82ef14/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.attach_passthrough_no_bus: ERROR: error: Failed to attach device from /tmp/xml_utils_temp_wutd2jev.xml\nerror: Path '/dev/input/event1' is not accessible: No such file or directory\n (40.93 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 41.67 s
```
An aarch64 host which has /dev/input/event1, test pass
```
[root@ampere-mtjade-altra-06 run_test_script]# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virsh.attach_passthrough_no_bus
JOB ID     : c548efc825de71619d9bf9d17675f96106820200
JOB LOG    : /root/avocado/job-results/job-2021-07-21T04.04-c548efc/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.attach_passthrough_no_bus: PASS (21.79 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 22.29 s
```

After
```
[root@hpe-apollo80-01-n00 ~]# avocado run  --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virsh.attach_passthrough_no_bus
JOB ID     : 6a2f69b0f617b430085602f367c19bdb4b427710
JOB LOG    : /root/avocado/job-results/job-2021-07-21T03.34-6a2f69b/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.attach_passthrough_no_bus: CANCEL: Host doesn't have passthrough device (7.25 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 1
JOB TIME   : 7.98 s
```