### PR TITLE
sriov: Update to get pf from pf info dict

### DIFF
--- a/libvirt/tests/cfg/sriov/sriov.cfg
+++ b/libvirt/tests/cfg/sriov/sriov.cfg
@@ -3,21 +3,6 @@
     take_regular_screendumps = "no"
     start_vm = "yes"
     variants:
-        - driver:
-            variants:
-                - ixgbe:
-                    driver = ixgbe
-                - igb:
-                    driver = igb
-                - be2net:
-                    driver = be2net
-                - mlx:
-                    driver = mlx4_core
-                - enic:
-                    driver = enic
-                - i40e:
-                    driver = i40e
-    variants:
         - guest_with_vf:
             variants:
                 - vf:

--- a/libvirt/tests/src/sriov/sriov_net_failover.py
+++ b/libvirt/tests/src/sriov/sriov_net_failover.py
@@ -389,7 +389,10 @@ def run(test, params, env):
     libvirt_version.is_libvirt_feature_supported(params)
 
     mac_addr = utils_net.generate_mac_address_simple()
-    pf_name, pf_pci = utils_sriov.find_pf(driver)
+    pf_pci = utils_sriov.get_pf_pci()
+    if not pf_pci:
+        test.cancel("NO available pf found.")
+    pf_name = utils_sriov.get_pf_info_by_pci(pf_pci).get('iface')
     brg_dict = {'pf_name': pf_name, 'bridge_name': bridge_name}
     bridge_dict = {"net_name": net_bridge_name,
                    "net_forward": net_bridge_fwd,

--- a/libvirt/tests/src/sriov/sriov_nodedev.py
+++ b/libvirt/tests/src/sriov/sriov_nodedev.py
@@ -105,8 +105,9 @@ def run(test, params, env):
     vm_name = params.get("main_vm", "avocado-vt-vm1")
     vm = env.get_vm(vm_name)
 
-    driver = params.get("driver", "ixgbe")
-    pf_name, pf_pci = utils_sriov.find_pf(driver)
+    pf_pci = utils_sriov.get_pf_pci()
+    if not pf_pci:
+        test.cancel("NO available pf found.")
 
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     orig_config_xml = vmxml.copy()


### PR DESCRIPTION
PF is got from the given driver in the previous code. If the driver
does not exist, it will not work, so update to get it directly
from the system.

Signed-off-by: Yingshun Cui <yicui@redhat.com>

depends on https://github.com/avocado-framework/avocado-vt/pull/3146

Test results:
```
 (1/2) type_specific.io-github-autotest-libvirt.sriov_nodedev.pf: PASS (11.15 s)
 (2/2) type_specific.io-github-autotest-libvirt.sriov_net_failover.hotplug_hostdev_device_with_teaming: PASS (136.45 s)
 (001/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.resume_suspend.vf.managed_no: PASS (98.91 s)
 (002/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.resume_suspend.vf.managed_yes: PASS (97.19 s)
 (003/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.resume_suspend.vf_vlan.managed_no: PASS (256.58 s)
 (004/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.resume_suspend.vf_vlan.managed_yes: PASS (253.52 s)
 (005/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.resume_suspend.vf_pool_vlan.vf_list: PASS (257.29 s)
 (006/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.resume_suspend.vf_pool_vlan.pf.managed_yes: PASS (254.53 s)
 (007/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.resume_suspend.macvtap_network: PASS (96.14 s)
 (008/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.resume_suspend.macvtap_network_vlan: PASS (252.67 s)
 (009/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.resume_suspend.macvtap_interface: PASS (251.48 s)
 (010/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.resume_suspend.macvtap_interface_vlan: PASS (253.16 s)
 (011/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.reboot.vf.managed_no: PASS (278.93 s)
 (012/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.reboot.vf.managed_yes: PASS (269.62 s)
 (013/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.reboot.vf_vlan.managed_no: PASS (277.01 s)
 (014/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.reboot.vf_vlan.managed_yes: PASS (277.34 s)
 (015/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.reboot.vf_pool_vlan.vf_list: PASS (276.75 s)
 (016/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.reboot.vf_pool_vlan.pf.managed_yes: PASS (279.30 s)
 (017/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.reboot.macvtap_network: PASS (114.55 s)
 (018/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.reboot.macvtap_network_vlan: PASS (275.60 s)
 (019/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.reboot.macvtap_interface: PASS (276.61 s)
 (020/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.reboot.macvtap_interface_vlan: PASS (273.73 s)
 (021/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.mac_check.vf.managed_no: PASS (92.91 s)
 (022/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.mac_check.vf.managed_yes: PASS (152.53 s)
 (023/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.mac_check.vf_vlan.managed_no: PASS (173.62 s)
 (024/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.mac_check.vf_vlan.managed_yes: PASS (170.80 s)
 (025/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.mac_check.vf_pool_vlan.vf_list: PASS (171.90 s)
 (026/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.mac_check.vf_pool_vlan.pf.managed_yes: PASS (173.50 s)
 (027/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.mac_check.macvtap_network: PASS (167.47 s)
 (028/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.mac_check.macvtap_network_vlan: PASS (169.78 s)
 (029/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.mac_check.macvtap_interface: PASS (169.35 s)
 (030/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.mac_check.macvtap_interface_vlan: PASS (169.02 s)
 (031/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.nop.vf.managed_no: PASS (171.33 s)
 (032/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.nop.vf.managed_yes: PASS (92.75 s)
 (033/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.nop.hostdev.managed_no: PASS (77.27 s)
 (034/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.nop.hostdev.managed_yes: PASS (79.49 s)
 (035/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.nop.vf_vlan.managed_no: PASS (171.89 s)
 (036/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.nop.vf_vlan.managed_yes: PASS (170.30 s)
 (037/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.nop.vf_pool.vf_list: PASS (138.22 s)
 (038/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.nop.vf_pool.pf.managed_yes: PASS (110.85 s)
 (039/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.nop.vf_pool.pf.managed_no: PASS (141.42 s)
 (040/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.nop.vf_pool_vlan.vf_list: PASS (172.87 s)
 (041/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.nop.vf_pool_vlan.pf.managed_yes: PASS (172.80 s)
 (042/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.nop.vf_pool_vlan.pf.managed_no: PASS (172.67 s)
 (043/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.nop.macvtap_network: PASS (169.47 s)
 (044/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.nop.macvtap_network_vlan: PASS (170.72 s)
 (045/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.nop.macvtap_interface: PASS (91.21 s)
 (046/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.nop.macvtap_interface_vlan: PASS (168.82 s)
 (047/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.restart_libvirtd.vf.managed_no: PASS (258.04 s)
 (048/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.restart_libvirtd.vf.managed_yes: PASS (261.13 s)
 (049/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.restart_libvirtd.hostdev.managed_no: PASS (87.50 s)
 (050/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.restart_libvirtd.hostdev.managed_yes: PASS (88.09 s)
 (051/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.restart_libvirtd.vf_pool.vf_list: PASS (264.01 s)
 (052/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.restart_libvirtd.vf_pool.pf.managed_yes: PASS (263.42 s)
 (053/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.resume_suspend.vf.managed_no: PASS (246.73 s)
 (054/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.resume_suspend.vf.managed_yes: PASS (133.38 s)
 (055/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.resume_suspend.vf_vlan.managed_no: PASS (246.62 s)
 (056/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.resume_suspend.vf_vlan.managed_yes: PASS (247.93 s)
 (057/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.resume_suspend.vf_pool_vlan.vf_list: PASS (248.61 s)
 (058/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.resume_suspend.vf_pool_vlan.pf.managed_yes: PASS (246.16 s)
 (059/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.resume_suspend.macvtap_network: PASS (84.26 s)
 (060/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.resume_suspend.macvtap_network_vlan: PASS (243.20 s)
 (061/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.resume_suspend.macvtap_interface: PASS (84.26 s)
 (062/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.resume_suspend.macvtap_interface_vlan: PASS (240.49 s)
 (063/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.reboot.vf.managed_no: PASS (117.40 s)
 (064/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.reboot.vf.managed_yes: PASS (116.88 s)
 (065/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.reboot.vf_vlan.managed_no: PASS (269.43 s)
 (066/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.reboot.vf_vlan.managed_yes: PASS (267.57 s)
 (067/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.reboot.vf_pool_vlan.vf_list: PASS (268.34 s)
 (068/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.reboot.vf_pool_vlan.pf.managed_yes: PASS (269.07 s)
 (069/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.reboot.macvtap_network: PASS (109.11 s)
 (070/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.reboot.macvtap_network_vlan: PASS (262.64 s)
 (071/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.reboot.macvtap_interface: PASS (103.36 s)
 (072/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.reboot.macvtap_interface_vlan: PASS (261.43 s)
 (073/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.mac_check.vf.managed_no: PASS (87.63 s)
 (074/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.mac_check.vf.managed_yes: PASS (85.52 s)
 (075/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.mac_check.vf_vlan.managed_no: PASS (162.43 s)
 (076/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.mac_check.vf_vlan.managed_yes: PASS (165.51 s)
 (077/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.mac_check.vf_pool_vlan.vf_list: PASS (164.16 s)
 (078/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.mac_check.vf_pool_vlan.pf.managed_yes: PASS (166.02 s)
 (079/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.mac_check.macvtap_network: PASS (79.32 s)
 (080/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.mac_check.macvtap_network_vlan: PASS (156.16 s)
 (081/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.mac_check.macvtap_interface: PASS (79.61 s)
 (082/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.mac_check.macvtap_interface_vlan: PASS (156.73 s)
 (083/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.nop.vf.managed_no: PASS (87.64 s)
 (084/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.nop.vf.managed_yes: PASS (85.78 s)
 (085/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.nop.hostdev.managed_no: PASS (63.84 s)
 (086/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.nop.hostdev.managed_yes: PASS (65.93 s)
 (087/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.nop.vf_vlan.managed_no: PASS (163.39 s)
 (088/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.nop.vf_vlan.managed_yes: PASS (164.21 s)
 (089/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.nop.vf_pool.vf_list: PASS (86.84 s)
 (090/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.nop.vf_pool.pf.managed_yes: PASS (86.70 s)
 (091/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.nop.vf_pool_vlan.vf_list: PASS (164.02 s)
 (092/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.nop.vf_pool_vlan.pf.managed_yes: PASS (162.52 s)
 (093/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.nop.macvtap_network: PASS (79.06 s)
 (094/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.nop.macvtap_network_vlan: PASS (156.71 s)
 (095/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.nop.macvtap_interface: PASS (79.95 s)
 (096/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.nop.macvtap_interface_vlan: PASS (158.14 s)
 (097/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.nfv.one_nic.vf.managed_yes: PASS (83.00 s)
 (098/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.nfv.two_nic.vf.managed_yes: PASS (87.34 s)
 (099/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.scalability_test.multiple_times.nop.vf.managed_yes: PASS (1065.55 s)
 (100/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.scalability_test.max_vfs.nop.vf.managed_yes: ERROR: Failed to define avocado-vt-vm1 for reason:\nerror: Failed to define domain from /tmp/xml_utils_temp_ksovq9ds.xml\nerror: XML error: Multiple 'pci' controllers with index '1'\n (7.51 s)
 (101/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.info_check.vf_info: PASS (106.46 s)
 (102/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.info_check.pf_info: PASS (105.64 s)
 (103/110) type_specific.io-github-autotest-libvirt.sriov.normal_test.info_check.vf_order: PASS (106.30 s)
 (104/110) type_specific.io-github-autotest-libvirt.sriov.error_test.invalid_vf_pf.duplicate_vf.guest_with_vf.hotplug.default.nop.vf_pool.vf_list: PASS (71.38 s)
 (105/110) type_specific.io-github-autotest-libvirt.sriov.error_test.invalid_vf_pf.including_pf.guest_with_vf.hotplug.default.nop.vf_pool.vf_list: PASS (70.26 s)
 (106/110) type_specific.io-github-autotest-libvirt.sriov.error_test.invalid_vf_pf.non_existing_pf.guest_with_vf.hotplug.default.nop.vf_pool.pf.managed_yes: PASS (69.73 s)
 (107/110) type_specific.io-github-autotest-libvirt.sriov.error_test.inactive_pool.guest_with_vf.hotplug.default.nop.vf_pool.pf.managed_yes: PASS (69.80 s)
 (108/110) type_specific.io-github-autotest-libvirt.sriov.error_test.domain_save.guest_with_vf.hotplug.default.nop.vf_pool.pf.managed_yes: PASS (94.07 s)
 (109/110) type_specific.io-github-autotest-libvirt.sriov.error_test.vlan_trunk.guest_with_vf.hotplug.default.nop.vf_pool.vf_list: PASS (69.83 s)
 (110/110) type_specific.io-github-autotest-libvirt.sriov.error_test.vlan_trunk.guest_with_vf.hotplug.default.nop.macvtap_network: PASS (69.99 s)
RESULTS    : PASS 109 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 18833.65 s

```
The failed case passed after rerun.
` (1/1) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.scalability_test.max_vfs.nop.vf.managed_yes: PASS (2952.53 s)`

