### PR TITLE
crypto_nodedev_create_destroy: add version switch

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/nodedev/crypto_nodedev_create_destroy.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/nodedev/crypto_nodedev_create_destroy.cfg
@@ -3,5 +3,6 @@
     start_vm = "no"
     take_regular_screendumps = "no"
     only s390-virtio
+    func_supported_since_libvirt_ver = (7, 0, 0)
     variants:
         - positive:

--- a/libvirt/tests/src/virsh_cmd/nodedev/crypto_nodedev_create_destroy.py
+++ b/libvirt/tests/src/virsh_cmd/nodedev/crypto_nodedev_create_destroy.py
@@ -3,6 +3,7 @@ import os
 
 from uuid import uuid1
 
+from virttest import libvirt_version
 from virttest import virsh
 from virttest import utils_misc
 from virttest.utils_zcrypt import CryptoDeviceInfoBuilder, \
@@ -109,6 +110,7 @@ def run(test, params, env):
     :return:
     '''
 
+    libvirt_version.is_libvirt_feature_supported(params)
     matrix_cap = 'ap_matrix'
     device_file = None
 


### PR DESCRIPTION
'ap_matrix' device support has been added in libvirt 7.0.0
(s. libvirt commit 53cc4951792f809ace308187c327758ffc64c831).

Cancel test run if earlier version.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>