### PR TITLE
v2v: clean up the guest when setup_session raise exception

### DIFF
--- a/provider/v2v_vmcheck_helper.py
+++ b/provider/v2v_vmcheck_helper.py
@@ -100,7 +100,12 @@ class VMChecker(object):
         self.virsh_session_id = self.virsh_session.get_id(
             ) if self.virsh_session else params.get('virsh_session_id')
         self.checker = utils_v2v.VMCheck(test, params, env)
-        self.setup_session()
+        # Should delete the guest when setup_session failed
+        try:
+            self.setup_session()
+        except Exception:
+            self.checker.cleanup()
+            raise
         if not self.checker.virsh_session_id:
             self.checker.virsh_session_id = self.virsh_session_id
         self.init_vmxml(raise_exception=False)


### PR DESCRIPTION
If setup_session failed and raised an exception, the vm will not
be cleaned up by normal in finnaly clause. This patch clean it
asap.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>