### PR TITLE
Storage: add clusterSize element cases to volume

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_create.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_create.cfg
@@ -18,6 +18,16 @@
                     encryption_secret_type = "passphrase"
                     action_lookup = "connect_driver:QEMU"
                 - non_encryption:
+                - with_clusterSize:
+                    only fs_like_pool.vol_format.v_qcow2.src_pool_type
+                    with_clusterSize = "yes"
+                    vol_clusterSize = "2048"
+                    vol_clusterSize_unit = "KiB"
+                    disk_target = 'vdb'
+                    disk_target_bus = 'virtio'
+                    attach_options = '--config'
+                    func_supported_since_libvirt_ver = (7, 4, 0)
+                    unspported_err_msg = "clusterSize not supported in current libvirt version"
             variants:
                 - logical_pool:
                     src_pool_type = "logical"


### PR DESCRIPTION
Description of the cases:
RHEL-249800 - Create volume with cluster size in netfs pool
RHEL-249799 - Start the guest with volume disk created with cluster size

Related RFE Bug:
Bug 1945401 - RFE: Add support for specifying cluster_size/subcluster allocation for qcow2 volumes via virStorageVolCreateXML

Signed-off-by: Meina Li <meili@redhat.com>