### PR TITLE
sriov: limit net fail over cases to q35 only

### DIFF
--- a/libvirt/tests/cfg/sriov/sriov_net_failover.cfg
+++ b/libvirt/tests/cfg/sriov/sriov_net_failover.cfg
@@ -6,6 +6,7 @@
     net_bridge_fwd = '{"mode": "bridge"}'
     bridge_name = "br0"
 
+    only q35
     variants test_case:
         - hotplug_hostdev_device_with_teaming:
             func_supported_since_libvirt_ver = (7, 0, 0)


### PR DESCRIPTION
Net fail over feature is supported for q35 only.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
