### PR TITLE
Guest_Agent:Fix for the OpenSSL version as there is no -crypt parameter

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_set_user_password.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_set_user_password.py
@@ -69,7 +69,12 @@ def run(test, params, env):
 
             # Set the user password in vm
             if encrypted:
-                cmd = "openssl passwd -crypt %s" % new_passwd
+                openssl_version = process.run("openssl version",
+                                              ignore_status=False)
+                if "OpenSSL 3.0." in openssl_version.stdout_text:
+                    cmd = "openssl passwd %s" % new_passwd
+                else:
+                    cmd = "openssl passwd -crypt %s" % new_passwd
                 ret = process.run(cmd, shell=True)
                 libvirt.check_exit_status(ret)
                 en_passwd = str(ret.stdout_text.strip())


### PR DESCRIPTION
Since the version OpenSSL 3.0 there is no -crypt parameter available and
therefore this fix adds check for the OpenSSL version and update command
accordingly.

Signed-off-by: Kamil Varga <kvarga@redhat.com>

Test results prior fix:
L0930 ERROR| ERROR 1-type_specific.io-github-autotest-libvirt.virsh.set_user_password.normal_test.normal_user.encrypted -> CmdError: Command 'openssl passwd -crypt aredhat' failed.stdout: b''stderr: b'passwd: Unknown option: -crypt\npasswd: Use -help for summary.\n'additional_info: None

Test result after the fix:
<pre>avocado run --vt-type libvirt --vt-machine-type q35 virsh.set_user_password.normal_test.root.encrypted
WARNING:root:No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
WARNING:root:No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
<font color="#2A7BDE">JOB ID     : d98eba23595ae07113ca614150bdc7c409df5d30</font>
<font color="#2A7BDE">JOB LOG    : /root/avocado/job-results/job-2021-07-23T09.18-d98eba2/job.log</font>
 (1/1) type_specific.io-github-autotest-libvirt.virsh.set_user_password.normal_test.root.encrypted: <font color="#33DA7A">PASS</font> (155.20 s)
<font color="#2A7BDE">RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0</font>
<font color="#2A7BDE">JOB TIME   : 156.35 s</font>
(.libvirt-ci-venv-ci-runtest-rE1PE4) [root@dell-t320-01 ~]# avocado run --vt-type libvirt --vt-machine-type q35 virsh.set_user_password.normal_test.normal_user.encrypted
WARNING:root:No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
WARNING:root:No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
<font color="#2A7BDE">JOB ID     : 2784e4b9dd5433a2edc0dfe265636c31028b83fe</font>
<font color="#2A7BDE">JOB LOG    : /root/avocado/job-results/job-2021-07-23T09.29-2784e4b/job.log</font>
 (1/1) type_specific.io-github-autotest-libvirt.virsh.set_user_password.normal_test.normal_user.encrypted: <font color="#33DA7A">PASS</font> (162.48 s)
<font color="#2A7BDE">RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0</font>
<font color="#2A7BDE">JOB TIME   : 163.60 s</font>
</pre>