### PR TITLE
Storage: add vol-resize/clone/download/upload cases with clusterSize

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_clone_wipe.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_clone_wipe.cfg
@@ -21,6 +21,15 @@
                     variants:
                         - dir:
                             pool_type = "dir"
+                            variants:
+                                - default:
+                                - with_clusterSize:
+                                    only luks_encrypt.non_acl.vol_format.qcow2_f.no_prealloc
+                                    with_clusterSize = "yes"
+                                    vol_clusterSize = "128"
+                                    vol_clusterSize_unit = "KiB"
+                                    func_supported_since_libvirt_ver = (7, 4, 0)
+                                    unspported_err_msg = "This libvirt version doesn't support clusterSize"
                         - fs:
                             pool_type = "fs"
                         - logical:

--- a/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_download_upload.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_download_upload.cfg
@@ -60,6 +60,16 @@
                     vol_download_upload_pool_target = "dir-pool"
                     vol_download_upload_vol_name = "dir-vol"
                     vol_download_upload_format = "qcow2"
+                    variants:
+                        - default:
+                        - with_clusterSize:
+                            only luks_encrypt..non_acl.0-end
+                            with_clusterSize = "yes"
+                            vol_clusterSize = "128"
+                            vol_clusterSize_unit = "KiB"
+                            vol_format = "qcow2"
+                            func_supported_since_libvirt_ver = (7, 4, 0)
+                            unspported_err_msg = "This libvirt version doesn't support clusterSize"
                 - fs_pool:
                     vol_download_upload_pool_type = "fs"
                     vol_download_upload_pool_name = "fs-pool"

--- a/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_resize.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_resize.cfg
@@ -19,6 +19,15 @@
             variants:
                 - dir_pool:
                     pool_type = "dir"
+                    variants:
+                        - default:
+                        - with_clusterSize:
+                            only luks_encrypt.qcow2_format..delta_capacity
+                            with_clusterSize = "yes"
+                            vol_clusterSize = "128"
+                            vol_clusterSize_unit = "KiB"
+                            func_supported_since_libvirt_ver = (7, 4, 0)
+                            unspported_err_msg = "This libvirt version doesn't support clusterSize"
                 - fs_pool:
                     pool_type = "fs"
                 - netfs:

--- a/libvirt/tests/src/virsh_cmd/volume/virsh_vol_clone_wipe.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_vol_clone_wipe.py
@@ -99,6 +99,10 @@ def run(test, params, env):
     encryption_password = params.get("encryption_password", "redhat")
     secret_uuids = []
     wipe_old_vol = False
+    with_clusterSize = "yes" == params.get("with_clusterSize")
+    vol_clusterSize = params.get("vol_clusterSize", "64")
+    vol_clusterSize_unit = params.get("vol_clusterSize_unit")
+    libvirt_version.is_libvirt_feature_supported(params)
 
     if virsh.has_command_help_match("vol-clone", "--prealloc-metadata") is None:
         if "prealloc-metadata" in clone_option:
@@ -173,6 +177,9 @@ def run(test, params, env):
                 vol_arg['capacity'] = int(vol_capability)
                 vol_arg['allocation'] = int(vol_allocation)
                 vol_arg['format'] = vol_format
+                if with_clusterSize:
+                    vol_arg['clusterSize'] = int(vol_clusterSize)
+                    vol_arg['clusterSize_unit'] = vol_clusterSize_unit
                 create_luks_vol(pool_name, vol_name, luks_sec_uuid, vol_arg)
             else:
                 libvirt_pvt.pre_vol(vol_name=vol_name,

--- a/libvirt/tests/src/virsh_cmd/volume/virsh_vol_download_upload.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_vol_download_upload.py
@@ -171,6 +171,11 @@ def run(test, params, env):
     vm = env.get_vm(vm_name)
     virsh_dargs = {'debug': True, 'ignore_status': True}
     sparse_option_support = "yes" == params.get("sparse_option_support", "yes")
+    with_clusterSize = "yes" == params.get("with_clusterSize")
+    vol_clusterSize = params.get("vol_clusterSize", "64")
+    vol_clusterSize_unit = params.get("vol_clusterSize_unit")
+    vol_format = params.get("vol_format", "qcow2")
+    libvirt_version.is_libvirt_feature_supported(params)
 
     # libvirt acl polkit related params
     uri = params.get("virsh_uri")
@@ -219,6 +224,10 @@ def run(test, params, env):
                 vol_arg['name'] = vol_name
                 vol_arg['capacity'] = int(capacity)
                 vol_arg['allocation'] = int(allocation)
+                if with_clusterSize:
+                    vol_arg['format'] = vol_format
+                    vol_arg['clusterSize'] = int(vol_clusterSize)
+                    vol_arg['clusterSize_unit'] = vol_clusterSize_unit
                 create_luks_vol(pool_name, vol_name, luks_sec_uuid, vol_arg)
             else:
                 pvt.pre_vol(vol_name, frmt, capacity, allocation, pool_name)

--- a/libvirt/tests/src/virsh_cmd/volume/virsh_vol_resize.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_vol_resize.py
@@ -154,7 +154,7 @@ def create_luks_vol(vol_name, sec_uuid, params, test):
     vol_arg = {}
     for key in list(params.keys()):
         if (key.startswith('vol_') and not key.startswith('vol_new')):
-            if key[4:] in ['capacity', 'allocation']:
+            if key[4:] in ['capacity', 'allocation', 'clusterSize']:
                 vol_arg[key[4:]] = int(float(utils_misc.normalize_data_size(params[key],
                                                                             "B", 1024)))
             elif key[4:] in ['owner', 'group']:
@@ -249,6 +249,8 @@ def run(test, params, env):
     b_luks_encrypt = "luks" == params.get("encryption_method")
     encryption_password = params.get("encryption_password", "redhat")
     secret_uuids = []
+    with_clusterSize = "yes" == params.get("with_clusterSize")
+    libvirt_version.is_libvirt_feature_supported(params)
 
     if not libvirt_version.version_compare(1, 0, 0):
         if "--allocate" in resize_option:


### PR DESCRIPTION
Polarion case:
RHEL-249798 - Volume lifecycle test with cluster size in dir pool

Signed-off-by: Meina Li <meili@redhat.com>
