### PR TITLE
virsh_blockcopy: Fix selinux issue

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcopy.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockcopy.cfg
@@ -99,6 +99,9 @@
                             copy_to_nfs = "no"
                         - dest_nfs:
                             bug_url = "https://bugzilla.redhat.com/show_bug.cgi?id=924151"
+                            set_sebool_local = "yes"
+                            local_boolean_varible = "virt_use_nfs"
+                            local_boolean_value = "on"
                             copy_to_nfs = "yes"
                 - block_disk:
                     replace_vm_disk = "yes"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
@@ -361,6 +361,12 @@ def run(test, params, env):
     snapshots_take = int(params.get("snapshots_take", '0'))
     external_disk_only_snapshot = "yes" == params.get("external_disk_only_snapshot", "no")
     enable_iscsi_auth = "yes" == params.get("enable_iscsi_auth", "no")
+    selinux_local = "yes" == params.get("set_sebool_local", "no")
+
+    # Set selinux
+    if selinux_local:
+        selinux_bool = utils_misc.SELinuxBoolean(params)
+        selinux_bool.setup()
 
     # Skip/Fail early
     if with_blockdev and not libvirt_version.version_compare(1, 2, 13):
@@ -784,3 +790,5 @@ def run(test, params, env):
             process.run('systemctl restart virtlogd ')
         except path.CmdNotFoundError:
             pass
+        if selinux_local:
+            selinux_bool.cleanup(keep_authorized_keys=True)


### PR DESCRIPTION
Based on the reproduce steps of
https://bugzilla.redhat.com/show_bug.cgi?id=924151

Set virt_use_nfs on to fix selinux issue
------
stderr: 'error: Failed to start domain \'avocado-vt-vm1\'\nerror: internal error: qemu unexpectedly closed the monitor: 2021-07-27T07:56:48.770625Z qemu-kvm: -blockdev {"driver":"file","filename":"/var/lib/avocado/data/avocado-vt/nfs-mount/nfs-img","node-name":"libvirt-1-storage","cache":{"direct":true,"no-flush":false},"auto-read-only":true,"discard":"unmap"}: Could not open \'/var/lib/avocado/data/avocado-vt/nfs-mount/nfs-img\': Permission denied\n'
------

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Before
```
[root@hpe-moonshot-02-c25 ~]# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virsh.blockcopy.positive_test.non_acl.nfs_disk.dest_nfs.no_blockdev.shallow.pivot_option
JOB ID     : 7fb3714ec49d959973fc5ebd21ef52b0cd7b96f5
JOB LOG    : /root/avocado/job-results/job-2021-07-27T03.55-7fb3714/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.blockcopy.positive_test.non_acl.nfs_disk.dest_nfs.no_blockdev.shallow.pivot_option: ERROR: VM 'avocado-vt-vm1' failed to start: error: Failed to start domain 'avocado-vt-vm1'\nerror: internal error: qemu unexpectedly closed the monitor: 2021-07-27T07:56:48.770625Z qemu-kvm: -blockdev {"driver":"file","filename":"/var/lib/avocado/data/avocado-vt/... (264.44 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 265.11 s
```
After
```
[root@hpe-moonshot-02-c25 ~]# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virsh.blockcopy.positive_test.non_acl.nfs_disk.dest_nfs.no_blockdev.shallow.pivot_option
JOB ID     : b016acfd5ce5ab302685415e64d6baf384ba0adf
JOB LOG    : /root/avocado/job-results/job-2021-07-27T04.01-b016acf/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.blockcopy.positive_test.non_acl.nfs_disk.dest_nfs.no_blockdev.shallow.pivot_option: PASS (87.31 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 87.99 s
```
