### PR TITLE
v2v: fix expected video erro when qxldod is not in virtio-win

### DIFF
--- a/provider/v2v_vmcheck_helper.py
+++ b/provider/v2v_vmcheck_helper.py
@@ -250,6 +250,8 @@ class VMChecker(object):
 
         if not virtio_win_installed:
             if virtio_win_env:
+                # Users should assure VIRTIO_WIN is valid
+                virtio_win_installed = True
                 if os.path.isdir(virtio_win_env):
                     virtio_win_iso_dir = virtio_win_env
                     qxldods = glob.glob(
@@ -270,7 +272,6 @@ class VMChecker(object):
                 logging.debug('Found qxldods: %s', qxldods)
                 if qxldods:
                     virtio_win_support_qxldod = True
-                    virtio_win_installed = True
         else:
             virtio_win_support_qxldod = utils_v2v.multiple_versions_compare(
                 virtio_win_ver)


### PR DESCRIPTION
When qxldod.inf is not found in virtio-win.iso, virtio_win_installed
will be set to False incorrectly. Acutally, virtio_win_installed
should only related to the rpm virtio-win and VIRIO_WIN env, either
one is true, the virtio_win_installed should be true.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>