### PR TITLE
sriov: Add a case to test vf detach/reattach

### DIFF
--- a/libvirt/tests/cfg/sriov/sriov_nodedev.cfg
+++ b/libvirt/tests/cfg/sriov/sriov_nodedev.cfg
@@ -3,3 +3,4 @@
     start_vm = "no"
     variants test_case:
         - pf:
+        - vf:

--- a/libvirt/tests/src/sriov/sriov_nodedev.py
+++ b/libvirt/tests/src/sriov/sriov_nodedev.py
@@ -1,22 +1,14 @@
 import logging
-import re
+
+from provider.sriov import sriov_base
 
 from virttest import utils_sriov
 from virttest import virsh
 
 from virttest.libvirt_xml import nodedev_xml
 from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
 from virttest.utils_test import libvirt
-
-
-def get_device_name(pci_id):
-    """
-    Get device name from pci_id
-
-    :param pci_id: PCI ID of a device(eg. 0000:05:10.1)
-    :return: Name of a device(eg. pci_0000_05_00_1)
-    """
-    return '_'.join(['pci']+re.split('[.:]', pci_id))
 
 
 def add_hostdev_device(vm_name, pci):
@@ -30,6 +22,19 @@ def add_hostdev_device(vm_name, pci):
     hostdev_dev = libvirt.create_hostdev_xml(pci)
     vmxml.add_device(hostdev_dev)
     vmxml.sync()
+
+
+def add_hostdev_iface(vm, vf_pci):
+    """
+    Add hostdev device to VM
+
+    :param vm: VM object
+    :param vf_pci: PCI ID of a VF
+    """
+    libvirt_vmxml.remove_vm_devices_by_type(vm, 'interface')
+    iface_dict = {"type": "hostdev", "managed": "yes",
+                  "hostdev_addr": str(utils_sriov.pci_to_addr(vf_pci))}
+    libvirt.modify_vm_iface(vm.name, "update_iface", iface_dict)
 
 
 def run(test, params, env):
@@ -52,15 +57,17 @@ def run(test, params, env):
                       % (dev_xml.driver_name, ' not' if status_error else '',
                          driver_type))
 
-    def nodedev_test(dev_name, status_error=False):
+    def nodedev_test(dev_name, status_error=False, no_reset=False):
         """
         Execute virsh nodedev-* commands
 
         :param dev_name: Name of a device(eg. pci_0000_05_00_1)
         :param status_error: Whether the command should be failed
+        :param no_reset: Whether reset nodedev
         """
-        res = virsh.nodedev_reset(dev_name, debug=True)
-        libvirt.check_exit_status(res, status_error)
+        if not no_reset:
+            res = virsh.nodedev_reset(dev_name, debug=True)
+            libvirt.check_exit_status(res, status_error)
         res = virsh.nodedev_detach(dev_name, debug=True)
         libvirt.check_exit_status(res, status_error)
         res = virsh.nodedev_reattach(dev_name, debug=True)
@@ -80,6 +87,33 @@ def run(test, params, env):
             test.fail("The hostdev device does not exist: %s."
                       % check_hostdev)
 
+    def check_hostdev_iface(vm_name):
+        """
+        Check hostdev interface in VM
+
+        :param vm_name: Name of VM
+        :raise: TestFail if not found
+        """
+        vm_ifaces = [iface.get_type_name() for iface in vm_xml.VMXML.
+                     new_from_dumpxml(vm_name).devices.
+                     by_device_tag("interface")]
+        if 'hostdev' not in vm_ifaces:
+            test.fail("hostdev interface does not exist: %s." % vm_ifaces)
+
+    def compare_vf_mac(pf_name, exp_vf_mac):
+        """
+        Compare the current vf's mac address with exp_vf_mac
+
+        :param pf_name: The PF's
+        :param exp_vf_mac: The expected vf's mac address
+        :raise: TestFail if not match
+        """
+        logging.debug("VF's mac should be %s.", exp_vf_mac)
+        vf_mac_act = utils_sriov.get_vf_mac(pf_name, is_admin=False)
+        if exp_vf_mac != vf_mac_act:
+            test.fail("MAC address changed from '%s' to '%s' after reattaching "
+                      "vf." % (exp_vf_mac, vf_mac_act))
+
     def test_pf():
         """
         Reattach/reset/detach a pci device when it is used in guest
@@ -90,7 +124,7 @@ def run(test, params, env):
         4) Check driver of the device
         5) Detach/Reset/reattach the device again
         """
-        dev_name = get_device_name(pf_pci)
+        dev_name = utils_sriov.get_device_name(pf_pci)
         check_driver_from_xml(dev_name)
         nodedev_test(dev_name)
         add_hostdev_device(vm_name, pf_pci)
@@ -98,6 +132,44 @@ def run(test, params, env):
         check_hostdev_device(vm_name)
         check_driver_from_xml(dev_name, status_error=True)
         nodedev_test(dev_name, True)
+
+    def test_vf():
+        """
+        Detach/Reattach a vf when it is used in guest
+
+        1) Detach/reattach the device
+        2) Add the device to VM
+        3) Start the VM
+        4) Check driver of the device
+        5) Detach/reattach the device again
+        """
+        logging.info("Initialize the vfs.")
+        sriov_base.setup_vf(pf_pci, params)
+        vf_pci = utils_sriov.get_vf_pci_id(pf_pci)
+        pf_name = utils_sriov.get_pf_info_by_pci(pf_pci).get('iface')
+        vf_mac = utils_sriov.get_vf_mac(pf_name, is_admin=False)
+        logging.debug("VF's mac: %s.", vf_mac)
+
+        logging.info("Check the vf's driver, it should not be vfio-pci.")
+        dev_name = utils_sriov.get_device_name(vf_pci)
+        check_driver_from_xml(dev_name)
+
+        logging.info("Detach and reattach the device and check vf's mac.")
+        nodedev_test(dev_name, no_reset=True)
+        compare_vf_mac(pf_name, vf_mac)
+
+        logging.info("Cold-plug the device into the VM.")
+        add_hostdev_iface(vm, vf_pci)
+        vm.start()
+        check_hostdev_iface(vm.name)
+
+        logging.info("Check the device info. It should be vfio-pci.")
+        check_driver_from_xml(dev_name, status_error=True)
+        nodedev_test(dev_name, True)
+
+        logging.info("Destroy the vm, and check the vf's mac is recovered.")
+        vm.destroy(gracefully=False)
+        compare_vf_mac(pf_name, vf_mac)
 
     test_case = params.get("test_case", "")
     run_test = eval("test_%s" % test_case)
@@ -120,3 +192,4 @@ def run(test, params, env):
         if vm.is_alive():
             vm.destroy(gracefully=False)
         orig_config_xml.sync()
+        sriov_base.recover_vf(pf_pci, params)


### PR DESCRIPTION
RHEL-250626 - Reattach/detach a vf when it is used in guest

Signed-off-by: Yingshun Cui <yicui@redhat.com>
depends on: https://github.com/avocado-framework/avocado-vt/pull/3161
**Test results:**
```
JOB ID     : 25f3a8ced7c14674bf880aea0cc048b3131a7e4a
JOB LOG    : /root/avocado/job-results/job-2021-08-02T02.01-25f3a8c/job.log
 (1/2) type_specific.io-github-autotest-libvirt.sriov_nodedev.pf: PASS (8.83 s)
 (2/2) type_specific.io-github-autotest-libvirt.sriov_nodedev.vf: PASS (13.71 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0

```