### PR TITLE
controller_functional: skip pci_root for aarch64

### DIFF
--- a/libvirt/tests/cfg/controller/controller_functional.cfg
+++ b/libvirt/tests/cfg/controller/controller_functional.cfg
@@ -117,7 +117,7 @@
                     remove_nic = "yes"
                     attach_option = "network default --model e1000e --config"
                 - pci_root_plug_child:
-                    no q35
+                    no q35, aarch64
                     check_contr_addr = "no"
                     setup_controller = "no"
                     check_qemu = "no"


### PR DESCRIPTION
aarch64 use pcie_root by default. Skip this test for aarch64

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>
