### PR TITLE
domif_setlink: add restart_libvirtd, save_restore

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domif_setlink_getlink.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domif_setlink_getlink.cfg
@@ -12,6 +12,22 @@
                             if_operation = "up"
                         - setlink_down:
                             if_operation = "down"
+                        - stable_test:
+                            only running_guest
+                            only domain_name
+                            only no_config
+                            variants:
+                                - restart_libvirtd:
+                                    only interface_net
+                                    post_action = "restart_libvirtd"
+                                - save_restore:
+                                    only interface_mac
+                                    post_action = "save_restore"
+                            variants:
+                                - setlink_up:
+                                    if_operation = "up"
+                                - setlink_down:
+                                    if_operation = "down"
             variants:
                 - running_guest:
                     start_vm = "yes"


### PR DESCRIPTION
Add restart_libvirtd, save_restore post actions test after set iface
link. Auto RHEL7-97270.

Signed-off-by: Yanqiu Zhang <yanqzhan@redhat.com>

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [ ] Description of the cases
- [ ] Links of libvirt features, libvirt bugs or case IDs
- [ ] Test results

## If the PR is bug cases
- [ ] Bug descriptions or bug links
- [ ] Test results

## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
