### PR TITLE
Update the interface device with different iface type

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_update.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_update.cfg
@@ -19,6 +19,15 @@
                     iface_rom = "{'enabled':'yes','bar':'on','file':'/usr/share/qemu-kvm/%s-virtio.rom'}"
                     new_iface_link = "up"
                     del_address = "yes"
+                - update_link_diff_type:
+                    direct_net = "yes"
+                    net_name = "direct_net"
+                    direct_mode = "bridge"
+                    new_iface_link = "down"
+                    create_new_net = "yes"
+                    iface_source = "{'network': 'direct_net'}"
+                    new_iface_source = "{'network': 'direct_net'}"
+                    new_iface_type = "network"
                 - update_source:
                     create_new_net = "yes"
                     new_iface_type = "network"


### PR DESCRIPTION
If interface type='network' connected to a direct type network,
the live xml will changed to interface type='direct', then do
interface update, it should not reject the update. It is to automate
RHEL-190487. related bug: 1887775.

Signed-off-by: Yalan <yalzhang@redhat.com>