### PR TITLE
v2v: add checkpoint for glance deprecate on RHEL9

### DIFF
--- a/v2v/tests/src/v2v_options.py
+++ b/v2v/tests/src/v2v_options.py
@@ -31,6 +31,8 @@ def run(test, params, env):
     """
     Test various options of virt-v2v.
     """
+    V2V_UNSUPPORT_GLANCE_VER = "[virt-v2v-1.45.2-1.el9,)"
+
     if utils_v2v.V2V_EXEC is None:
         raise ValueError('Missing command: virt-v2v')
     for v in list(params.values()):
@@ -560,9 +562,8 @@ def run(test, params, env):
                     with open(params['example_file']) as f:
                         for line in f:
                             if line.strip() not in output_stdout.strip():
-                                test.fail(
-                                    '%s not in --machine-readable output' %
-                                    line.strip())
+                                if utils_v2v.multiple_versions_compare(V2V_UNSUPPORT_GLANCE_VER) and 'glance' in line:
+                                    continue
                 else:
                     test.error('No content to compare with')
             if checkpoint == 'compress':


### PR DESCRIPTION
Check bz #1977539.

Signed-off-by: vwu-vera <vwu@redhat.com>
