### PR TITLE
Remote Access: Fix for Xen cases

### DIFF
--- a/libvirt/tests/src/remote_access/remote_access.py
+++ b/libvirt/tests/src/remote_access/remote_access.py
@@ -269,6 +269,12 @@ def run(test, params, env):
                        "[output]: %s." % (status, output))
     server_session.close()
 
+    if distro.detect().name == 'rhel' and int(distro.detect().version) >= 9:
+        # Update crypto policies to legacy for RHEL>=9 per Bug 1931723 or
+        # https://libguestfs.org/virt-v2v-input-xen.1.html#ssh-authentication
+        crypto_policies = process.run("update-crypto-policies --set LEGACY",
+                                      ignore_status=False)
+
     # only simply connect libvirt daemon then return
     if no_any_config == "yes":
         test_dict["uri"] = "%s%s%s://%s" % (driver, plus, transport, uri_path)


### PR DESCRIPTION
As mentioned in the Bug 1931723, the legacy support must be enabled
in RHEL >= 9 as follows: update-crypto-policies --set LEGACY.
This is also documented in the man page:
https://libguestfs.org/virt-v2v-input-xen.1.html#ssh-authentication

Signed-off-by: Kamil Varga <kvarga@redhat.com>

-  Test results:
<pre>avocado run --vt-type libvirt --vt-machine-type q35 virsh.remote_with_ssh.positive_testing.xen_uri_with_root_user
WARNING:root:No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
WARNING:root:No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
<font color="#2A7BDE">JOB ID     : c47800062d027b4494077277f7cc253002774f36</font>
<font color="#2A7BDE">JOB LOG    : /root/avocado/job-results/job-2021-08-09T02.54-c478000/job.log</font>
 (1/1) type_specific.io-github-autotest-libvirt.virsh.remote_with_ssh.positive_testing.xen_uri_with_root_user: <font color="#33DA7A">PASS</font> (29.26 s)
<font color="#2A7BDE">RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0</font>
<font color="#2A7BDE">JOB TIME   : 30.24 s</font>
(.libvirt-ci-venv-ci-runtest-PkjrxE) [root@ibm-x3250m4-13 ~]# avocado run --vt-type libvirt --vt-machine-type q35 virsh.remote_with_ssh.positive_testing.xen_uri_with_default_user
WARNING:root:No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
WARNING:root:No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
<font color="#2A7BDE">JOB ID     : 1926c9a143e413bf8046282ccce7d1b27dc98109</font>
<font color="#2A7BDE">JOB LOG    : /root/avocado/job-results/job-2021-08-09T02.55-1926c9a/job.log</font>
 (1/1) type_specific.io-github-autotest-libvirt.virsh.remote_with_ssh.positive_testing.xen_uri_with_default_user: <font color="#33DA7A">PASS</font> (30.39 s)
<font color="#2A7BDE">RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0</font>
<font color="#2A7BDE">JOB TIME   : 31.75 s</font>
</pre>