### PR TITLE
graphics_functional: Remove extra steps for vnc

### DIFF
--- a/libvirt/tests/cfg/graphics/graphics_functional.cfg
+++ b/libvirt/tests/cfg/graphics/graphics_functional.cfg
@@ -6,10 +6,12 @@
     macvtap_device = 'EXAMPLE.MACVTAP.DEVICE'
     bridge_device = 'EXAMPLE.BRIDGE.DEVICE'
     remote_viewer_check = 'no'
+    spice_prepare_cert = 'no'
     variants:
         - positive_tests:
             variants:
                 - spice_only:
+                    spice_prepare_cert = 'yes'
                     spice_xml = yes
                     variants:
                         - default:
@@ -295,6 +297,7 @@
                 - spice_vnc:
                     spice_xml = yes
                     vnc_xml = yes
+                    spice_prepare_cert = 'yes'
                     variants:
                         - default:
                         - listen_all_ipv4:
@@ -322,6 +325,7 @@
             variants:
                 - spice_only:
                     spice_xml = yes
+                    spice_prepare_cert = 'yes'
                     variants:
                         - spice_tls_disabled_with_secure_channel:
                             spice_tls = 0
@@ -394,6 +398,7 @@
                 - spice_vnc:
                     spice_xml = yes
                     vnc_xml = yes
+                    spice_prepare_cert = 'yes'
                     variants:
                         - no_port_avail:
                             remote_display_port_min = 5910


### PR DESCRIPTION
Prepare spice cert is unneccessary for vnc. So update cfg file.

Signed-off-by: lcheng <lcheng@redhat.com>
