### PR TITLE
v2v: conversion succeeds with --no-copy after virt-v2v-1.45.3-1.el9

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -372,6 +372,8 @@
             has_rhv_disk_uuid = 'yes'
             variants:
                 - no_rhv-disk-uuid:
+                    # Means version between virt-v2v-1.45.1-1 and  virt-v2v-1.45.3-1.el9
+                    version_requried = "[virt-v2v-1.45.1-1,virt-v2v-1.45.3-1.el9)"
                     msg_content = "virt-v2v: error: there must be .-oo rhv-disk-uuid. parameters passed on"
                     checkpoint = "no_uuid"
                 - mismatched_rhv-disk-uuid:
@@ -402,6 +404,12 @@
             v2v_opts = "--no-copy"
             skip_vm_check = yes
             skip_reason = '--no-copy is specified, no images will be copied'
+            variants:
+                - normal:
+                - without_rhv-disk-uuid:
+                  # Means version >= virt-v2v-1.45.3-1.el9
+                  version_requried = "[virt-v2v-1.45.3-1.el9,)"
+                  checkpoint = "no_uuid"
         # ovirt-guest-agent-common
         - OGAC:
             checkpoint = "ogac"


### PR DESCRIPTION
Conversion succeeds with --no-copy after virt-v2v-1.45.3-1.el9

Signed-off-by: vwu-vera <vwu@redhat.com>

