### PR TITLE
Restart libvirtd will re-connect the detached tap device

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_network.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_network.cfg
@@ -151,6 +151,17 @@
                             net2_net_ip_address = '192.168.150.1'
                             net2_dhcp_start_ipv4 = '192.168.150.2'
                             net2_dhcp_end_ipv4 = '192.168.150.254'
+                        - reconnect_tap:
+                            reconnect_tap = "yes"
+                            test_ipv6_address = "no"
+                            test_ipv4_address = "no"
+                            variants:
+                                - default:
+                                - bridge_type:
+                                    iface_model = "virtio"
+                                    iface_type = "bridge"
+                                    change_iface_option = "yes"
+                                    iface_source = "{'bridge':'virbr3'}"
                 - net_route:
                     net_name = "routetest"
                     iface_source = "{'network':'routetest'}"


### PR DESCRIPTION
A network destroy and start will make all the connected tap devices detached.
And libvirtd service restart can recover it.

Signed-off-by: Yalan <yalzhang@redhat.com>