### PR TITLE
BIOS: add feature related cases of firmware to os

### DIFF
--- a/libvirt/tests/cfg/bios/virsh_boot.cfg
+++ b/libvirt/tests/cfg/bios/virsh_boot.cfg
@@ -44,14 +44,28 @@
                     variants:
                         - options:
                             variants:
-                                - secure_boot:
+                                - os_firmware:
                                     with_loader = "no"
                                     with_nvram = "no"
                                     test_cmd = "dmesg|grep -i secure"
-                                    release_os_url = "EXAMPLE_RELEASED_OS_URL"
                                     variants:
-                                        - without_secure_option:
+                                        - firmware_feature:
+                                            only boot.hd.file_disk.boot_dev
+                                            with_feature = "yes"
+                                            func_supported_since_libvirt_ver = (7, 2, 0)
+                                            unspported_err_msg = "This libvirt version doesn't support feature of firmware"
+                                            variants:
+                                                - signed_image:
+                                                    release_os_url = "EXAMPLE_RELEASED_OS_URL"
+                                                    variants:
+                                                        - enabled_enrolled:
+                                                            vm_os_attrs = {'firmware':{'feature':[{'enabled':'yes','name':'enrolled-keys'},{'enabled':'yes','name':'secure-boot'}]}}
+                                                        - disable_enrolled:
+                                                            vm_os_attrs = {'firmware':{'feature':[{'enabled':'no','name':'enrolled-keys'},{'enabled':'yes','name':'secure-boot'}]}}
+                                                - unsigned_image:
+                                                    vm_os_attrs = {'firmware':{'feature':[{'enabled':'no','name':'enrolled-keys'},{'enabled':'yes','name':'secure-boot'}]}}
                                         - with_secure_option:
+                                            release_os_url = "EXAMPLE_RELEASED_OS_URL"
                                             with_secure = "yes"
                                 - os_loader:
                                     variants:

--- a/libvirt/tests/src/bios/virsh_boot.py
+++ b/libvirt/tests/src/bios/virsh_boot.py
@@ -311,6 +311,7 @@ def apply_boot_options(vmxml, params, test):
     with_loader_type = (params.get("with_loader_type", "yes") == "yes")
     with_nvram_template = (params.get("with_nvram_template", "yes") == "yes")
     vm_name = params.get("main_vm", "")
+    with_feature = params.get("with_feature", "no") == "yes"
 
     dict_os_attrs = {}
     # Set attributes of loader of VMOSXML
@@ -331,6 +332,10 @@ def apply_boot_options(vmxml, params, test):
             # Include secure='yes' in loader and support no smm element in guest xml
             if with_secure:
                 dict_os_attrs.update({"secure": "yes"})
+            # Set attributes of feature of VMOSFWXML
+            if with_feature:
+                vm_os_attrs = eval(params.get('vm_os_attrs', '{}'))
+                vmxml.setup_attrs(**{'os': vm_os_attrs})
 
     # To use BIOS Serial Console, need set userserial=yes in VMOSXML
     if boot_type == "seabios" and boot_dev == "cdrom":
@@ -653,6 +658,7 @@ def run(test, params, env):
     brick_path = os.path.join(test.virtdir, "gluster-pool")
     boot_type = params.get("boot_type", "seabios")
     boot_loadparm = params.get("boot_loadparm", None)
+    libvirt_version.is_libvirt_feature_supported(params)
 
     # Prepare result checkpoint list
     check_points = []


### PR DESCRIPTION
Polarion cases:
RHEL-203277 - Boot OVMF guest with signed image - secure-boot/enrolled-key enabled/disabled
RHEL-203278 - Boot OVMF guest with non-signed image - secure-boot/enrolled-key enabled/disabled

Signed-off-by: Meina Li <meili@redhat.com>