### PR TITLE
virsh_hypervisor_cpu_baseline: add new cases

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_hypervisor_cpu_baseline.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_hypervisor_cpu_baseline.cfg
@@ -1,0 +1,31 @@
+- virsh.hypervisor_cpu_baseline:
+    type = virsh_hypervisor_cpu_baseline
+    start_vm = "no"
+    domcap_path = 'libvirt/tests/deps/domcapabilities.xml'
+    variants:
+        - positive:
+            variants:
+                - virttype_option:
+                    hypv_cpu_baseline_option = "--virttype kvm"
+                - virttype_emulator:
+                    hypv_cpu_baseline_option = "--virttype kvm --emulator /usr/libexec/qemu-kvm"
+                - virttype_emulator_arch:
+                    hypv_cpu_baseline_option = "--virttype kvm --emulator /usr/libexec/qemu-kvm --arch %s"
+                - virttype_emulator_arch_machine:
+                    hypv_cpu_baseline_option = "--virttype kvm --emulator /usr/libexec/qemu-kvm --arch %s --machine %s"
+                - virttype_emulator_arch_machine_feature_migratable:
+                    hypv_cpu_baseline_option = "--virttype kvm --emulator /usr/libexec/qemu-kvm --arch %s --machine %s --features --migratable"
+        - negative:
+            variants:
+                - virttype_option:
+                    hypv_cpu_baseline_option = "--virttype 123"
+                    err_msg = 'unknown virttype'
+                - virttype_emulator:
+                    hypv_cpu_baseline_option = "--virttype kvm --emulator /usr/libexec/qemu-kvm123"
+                    err_msg = 'No such file or directory'
+                - virttype_emulator_arch:
+                    hypv_cpu_baseline_option = "--virttype kvm --emulator /usr/libexec/qemu-kvm --arch 123#"
+                    err_msg = 'unknown architecture'
+                - virttype_emulator_arch_machine:
+                    hypv_cpu_baseline_option = "--virttype kvm --emulator /usr/libexec/qemu-kvm --arch %s --machine pc-q35-123"
+                    err_msg = "machine 'pc-q35-123' is not supported by emulator '/usr/libexec/qemu-kvm'"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_hypervisor_cpu_baseline.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_hypervisor_cpu_baseline.py
@@ -1,0 +1,36 @@
+import platform
+import re
+
+from virttest import virsh
+
+from virttest.utils_test import libvirt
+
+
+def substitute_param(params):
+    """
+    Substitute specified parameters with necessary information
+
+    :param params: dict, parameters used
+    :return: str, the parameter after substituted
+    """
+
+    baseline_option = params.get('hypv_cpu_baseline_option')
+    machine_type = params.get("machine_type")
+    baseline_option = re.sub(r"--arch %s", "--arch %s" % platform.machine().lower(), baseline_option)
+    baseline_option = re.sub(r"--machine %s", "--machine %s" % machine_type, baseline_option)
+    return baseline_option
+
+
+def run(test, params, env):
+    """
+    Run tests for virsh hypervisor-cpu-baseline with parameters
+    """
+    baseline_option = substitute_param(params)
+    domcap_path = params.get("domcap_path")
+    err_msg = params.get("err_msg")
+
+    ret = virsh.hypervisor_cpu_baseline(domcap_path,
+                                        options=baseline_option,
+                                        ignore_status=True,
+                                        debug=True)
+    libvirt.check_result(ret, expected_fails=err_msg)


### PR DESCRIPTION
RHEL-136603: Test parameters for 'virsh hypervisor-cpu-baseline' cmd

Signed-off-by: Dan Zheng <dzheng@redhat.com>
