### PR TITLE
Fix one failure in snapshot blockcopy

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_snapshot_blockpull.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_snapshot_blockpull.py
@@ -363,7 +363,7 @@ def run(test, params, env):
                 test.fail("VM should start but failed: %s" % str(details))
 
         if fill_in_vm:
-            libvirt_disk.fill_sth_in_vm(vm, device_target)
+            libvirt_disk.fill_null_in_vm(vm, device_target)
 
         if backend_path in ['native_path']:
             external_snapshot_disks = libvirt_disk.make_external_disk_snapshots(vm, device_target, "blockpull_snapshot", snapshot_take)


### PR DESCRIPTION
The called method in libvirt_disk.py change from fill_sth_in_vm to fill_null_in_vm

Signed-off-by: chunfuwen <chwen@redhat.com>

