### PR TITLE
virsh_event: relax regex

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
@@ -572,7 +572,7 @@ def run(test, params, env):
             if re.search("block-threshold", event):
                 event_str = "block-threshold"
             else:
-                event_str = "event " + event % ("domain '%s'" % dom_name)
+                event_str = "event " + event % ("domain.*%s" % dom_name)
             logging.info("Expected event: %s", event_str)
             match = re.search(event_str, output[event_idx:])
             if match:


### PR DESCRIPTION
7494d48d91b9e7d75a8b76b3ef9a79b05f4c796e changed the regex
to match error messages against to reflect newer versions
that use "'". However, older versions now have a test failure.
Instead of introducing a switch over the actual libvirt
version have a less strict regex to confirm that the domain
name is part of the error message independently from the usage
of "'".

Test cases failed with message "FAIL: Not find expected event:event 'lifecycle' for domain 'avocado-vt-vm1'[...]"

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>
