### PR TITLE
migrate_storage: improve test when migrate again

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_storage.cfg
+++ b/libvirt/tests/cfg/migration/migrate_storage.cfg
@@ -27,6 +27,7 @@
                 - normal_test:
                 - cancel_migration:
                     virsh_migrate_extra = "--tls --bandwidth 10"
+                    virsh_migrate_extra_again = "--tls --unsafe"
                     cancel_migration = "yes"
                     status_error = "yes"
                     migrate_again = "yes"

--- a/libvirt/tests/src/migration/migrate_storage.py
+++ b/libvirt/tests/src/migration/migrate_storage.py
@@ -105,6 +105,7 @@ def run(test, params, env):
     virsh_options = params.get("virsh_options", "")
     copy_storage_option = params.get("copy_storage_option")
     extra = params.get("virsh_migrate_extra", "")
+    extra_again = params.get("virsh_migrate_extra_again", extra)
     options = params.get("virsh_migrate_options", "--live --verbose")
     backingfile_type = params.get("backingfile_type")
     check_str_local_log = params.get("check_str_local_log", "")
@@ -217,7 +218,7 @@ def run(test, params, env):
                                         options, thread_timeout=900,
                                         ignore_status=True,
                                         virsh_opt=virsh_options,
-                                        extra_opts=extra,
+                                        extra_opts=extra_again,
                                         func=action_during_mig,
                                         **extra_args)
 


### PR DESCRIPTION
8fd5e336fc03936594927fe89ab0d8deaac5cd2e introduced
`--bandwidth 10` to make sure migration can be cancelled
in the cancel-retry test cases. However, this slows the
actual test run down and can lead to timeouts resulting
in a failed test case.

Introduce an additional parameter for all those test cases
that run migration again. If not given, it will default to the
given extra parameters in order to maintain default behavior.
However, the parameter is set in the cancel test case in
order to avoid timeouts by using default bandwidth (not passing
the `--bandwith 10` flag again).

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>
