### PR TITLE
v2v: modify dir location for -o json and add cleanup

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -39,6 +39,7 @@
         - json:
             only dest_json
             only uefi.win2019,device_map,without_ip_option,env_leak,block_dev
+            base_os_directory="/var/lib/libvirt/images"
             variants:
                 - default:
                   no block_dev

--- a/v2v/tests/src/function_test_esx.py
+++ b/v2v/tests/src/function_test_esx.py
@@ -781,6 +781,14 @@ def run(test, params, env):
         if output_mode == 'libvirt':
             pvt.pre_pool(pool_name, pool_type, pool_target, '')
 
+        # Create json output dir
+        if output_mode == 'json':
+            base_os_directory = params_get(params, 'base_os_directory')
+            os_directory = None
+            os_directory = tempfile.TemporaryDirectory(prefix='v2v_test_', dir=base_os_directory)
+            logging.info("-os dir is %s", os_directory)
+            params['os_directory'] = os_directory.name
+
         if 'root' in checkpoint and 'ask' in checkpoint:
             v2v_params['v2v_opts'] += ' --root ask'
             v2v_params['custom_inputs'] = params.get('choice', '2')
@@ -1018,6 +1026,8 @@ def run(test, params, env):
             v2v_sasl.close_session()
         if output_mode == 'libvirt':
             pvt.cleanup_pool(pool_name, pool_type, pool_target, '')
+        if output_mode == 'json' and os_directory:
+            os_directory.cleanup()
         if 'with_proxy' in checkpoint:
             logging.info('Unset http_proxy&https_proxy')
             os.environ.pop('http_proxy')


### PR DESCRIPTION
-os dir in original script is /tmp and TC failed due to insufficient space in /tmp folder.

Modify the folder to /var/lib/libvirt/images and add the cleanup dir.

Signed-off-by: vwu-vera <vwu@redhat.com>

