### PR TITLE
Add 3 test cases about tap device connection check

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_bridge.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_bridge.cfg
@@ -40,6 +40,18 @@
                     hotplug = "yes"
                     iface_type = "bridge"
                     iface_alias = "ua-cb8914ab-82d9-453e-bf4f-d2e90ca19abd"
+        - reconnect_tap:
+            reconnect_tap = "yes"
+            variants:
+                - bridge_restart_libvirt:
+                - net:
+                    iface_type = "network"
+                    create_network = "yes"
+                    iface_source = "{'network':'host_bridge'}"
+                    variants:
+                        - restart_libvirt:
+                        - restart_net:
+                            restart_net = "yes"
         - test_qos:
             iface_bandwidth_inbound = "{'average':'512','peak':'1024','burst':'32'}"
             iface_bandwidth_outbound = "{'average':'128','peak':'2048','burst':'64'}"


### PR DESCRIPTION
When a tap device is attached to a host shared bridge, and the tap
device is in use, delete and create the bridge will break the connection.
But libvirt can reconnect it to the bridge with a restart.

Signed-off-by: Yalan Zhang <yalzhang@redhat.com>