### PR TITLE
virsh_cpu_xml: add cases for cpu

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_cpu_xml.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_cpu_xml.cfg
@@ -1,0 +1,45 @@
+- virsh.cpu_xml:
+    type = virsh_cpu_xml
+    variants:
+        - positive:
+            variants:
+                - xml_declaration:
+                    file_xml_declaration = "<?xml version='1.0' encoding='UTF-8'?>"
+                    file_path = 'libvirt/tests/deps/capabilities.xml'
+                - cpu_xml:
+                    no cpu_baseline
+                    file_path = 'libvirt/tests/deps/cpu.xml'
+                - domcap_xml:
+                    no cpu_baseline
+                    file_path = 'libvirt/tests/deps/domcapabilities.xml'
+                - cap_xml:
+                    file_path = 'libvirt/tests/deps/capabilities.xml'
+                - cap_cpu_xml:
+                    only cpu_baseline
+                    file_path = 'libvirt/tests/deps/capability_cpu.xml'
+            variants:
+                - hypervisor_cpu_baseline:
+                    virsh_function = 'virsh.hypervisor_cpu_baseline'
+                - cpu_baseline:
+                    virsh_function = 'virsh.cpu_baseline'
+        - negative:
+            variants:
+                - cap_xml_mix:
+                    only cpu_baseline
+                    file_path = 'libvirt/tests/deps/cap_mix.xml'
+                - xml_declaration:
+                    no cpu_baseline
+                    file_xml_declaration = "<?xml version='1.0' encoding='UTF-8'?>"
+                    file_path = 'libvirt/tests/deps/capabilities.xml'
+            variants:
+                - cpu_baseline:
+                    virsh_function = 'virsh.cpu_baseline'
+                    err_msg = 'CPU vendors do not match'
+                - hypervisor_cpu_compare:
+                    only xml_declaration
+                    virsh_function = 'virsh.hypervisor_cpu_compare'
+                    err_msg = 'CPU described.*is incompatible with the CPU provided by hypervisor on the host'
+                - cpu_compare:
+                    only xml_declaration
+                    virsh_function = 'virsh.cpu_compare'
+                    err_msg = 'CPU described in.*is identical to host CPU|CPU described in.*is incompatible with host CPU'

--- a/libvirt/tests/deps/cap_mix.xml
+++ b/libvirt/tests/deps/cap_mix.xml
@@ -1,0 +1,411 @@
+<capabilities>
+
+  <host>
+    <uuid>087c55cc-2f1c-11b2-a85c-ad091a1958a0</uuid>
+    <cpu>
+      <arch>x86_64</arch>
+      <model>Skylake-Client-noTSX-IBRS</model>
+      <vendor>Intel</vendor>
+      <microcode version='214'/>
+      <counter name='tsc' frequency='2304000000' scaling='no'/>
+      <topology sockets='1' dies='1' cores='4' threads='2'/>
+      <feature name='ds'/>
+      <feature name='acpi'/>
+      <feature name='ss'/>
+      <feature name='ht'/>
+      <feature name='tm'/>
+      <feature name='pbe'/>
+      <feature name='dtes64'/>
+      <feature name='monitor'/>
+      <feature name='ds_cpl'/>
+      <feature name='vmx'/>
+      <feature name='smx'/>
+      <feature name='est'/>
+      <feature name='tm2'/>
+      <feature name='xtpr'/>
+      <feature name='pdcm'/>
+      <feature name='osxsave'/>
+      <feature name='tsc_adjust'/>
+      <feature name='clflushopt'/>
+      <feature name='intel-pt'/>
+      <feature name='md-clear'/>
+      <feature name='stibp'/>
+      <feature name='arch-capabilities'/>
+      <feature name='ssbd'/>
+      <feature name='xsaves'/>
+      <feature name='pdpe1gb'/>
+      <feature name='invtsc'/>
+      <feature name='rdctl-no'/>
+      <feature name='ibrs-all'/>
+      <feature name='skip-l1dfl-vmentry'/>
+      <feature name='mds-no'/>
+      <feature name='tsx-ctrl'/>
+      <pages unit='KiB' size='4'/>
+      <pages unit='KiB' size='2048'/>
+      <pages unit='KiB' size='1048576'/>
+    </cpu>
+    <power_management>
+      <suspend_mem/>
+    </power_management>
+    <iommu support='no'/>
+    <migration_features>
+      <live/>
+      <uri_transports>
+        <uri_transport>tcp</uri_transport>
+        <uri_transport>rdma</uri_transport>
+      </uri_transports>
+    </migration_features>
+    <topology>
+      <cells num='1'>
+        <cell id='0'>
+          <memory unit='KiB'>32305476</memory>
+          <pages unit='KiB' size='4'>8076369</pages>
+          <pages unit='KiB' size='2048'>0</pages>
+          <pages unit='KiB' size='1048576'>0</pages>
+          <distances>
+            <sibling id='0' value='10'/>
+          </distances>
+          <cpus num='8'>
+            <cpu id='0' socket_id='0' die_id='0' core_id='0' siblings='0,4'/>
+            <cpu id='1' socket_id='0' die_id='0' core_id='1' siblings='1,5'/>
+            <cpu id='2' socket_id='0' die_id='0' core_id='2' siblings='2,6'/>
+            <cpu id='3' socket_id='0' die_id='0' core_id='3' siblings='3,7'/>
+            <cpu id='4' socket_id='0' die_id='0' core_id='0' siblings='0,4'/>
+            <cpu id='5' socket_id='0' die_id='0' core_id='1' siblings='1,5'/>
+            <cpu id='6' socket_id='0' die_id='0' core_id='2' siblings='2,6'/>
+            <cpu id='7' socket_id='0' die_id='0' core_id='3' siblings='3,7'/>
+          </cpus>
+        </cell>
+      </cells>
+    </topology>
+    <cache>
+      <bank id='0' level='3' type='both' size='8' unit='MiB' cpus='0-7'/>
+    </cache>
+    <secmodel>
+      <model>selinux</model>
+      <doi>0</doi>
+      <baselabel type='kvm'>system_u:system_r:svirt_t:s0</baselabel>
+      <baselabel type='qemu'>system_u:system_r:svirt_tcg_t:s0</baselabel>
+    </secmodel>
+    <secmodel>
+      <model>dac</model>
+      <doi>0</doi>
+      <baselabel type='kvm'>+107:+107</baselabel>
+      <baselabel type='qemu'>+107:+107</baselabel>
+    </secmodel>
+  </host>
+
+  <guest>
+    <os_type>hvm</os_type>
+    <arch name='i686'>
+      <wordsize>32</wordsize>
+      <emulator>/usr/libexec/qemu-kvm</emulator>
+      <machine maxCpus='240'>pc-i440fx-rhel7.6.0</machine>
+      <machine canonical='pc-i440fx-rhel7.6.0' maxCpus='240'>pc</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.0.0</machine>
+      <machine maxCpus='384'>pc-q35-rhel7.6.0</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.5.0</machine>
+      <machine maxCpus='384'>pc-q35-rhel8.2.0</machine>
+      <machine canonical='pc-q35-rhel8.2.0' maxCpus='384'>q35</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.1.0</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.2.0</machine>
+      <machine maxCpus='255'>pc-q35-rhel7.3.0</machine>
+      <machine maxCpus='384'>pc-q35-rhel7.4.0</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.3.0</machine>
+      <machine maxCpus='384'>pc-q35-rhel8.0.0</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.4.0</machine>
+      <machine maxCpus='384'>pc-q35-rhel8.1.0</machine>
+      <machine maxCpus='384'>pc-q35-rhel7.5.0</machine>
+      <domain type='qemu'/>
+      <domain type='kvm'/>
+    </arch>
+    <features>
+      <pae/>
+      <nonpae/>
+      <acpi default='on' toggle='yes'/>
+      <apic default='on' toggle='no'/>
+      <cpuselection/>
+      <deviceboot/>
+      <disksnapshot default='on' toggle='no'/>
+    </features>
+  </guest>
+
+  <guest>
+    <os_type>hvm</os_type>
+    <arch name='x86_64'>
+      <wordsize>64</wordsize>
+      <emulator>/usr/libexec/qemu-kvm</emulator>
+      <machine maxCpus='240'>pc-i440fx-rhel7.6.0</machine>
+      <machine canonical='pc-i440fx-rhel7.6.0' maxCpus='240'>pc</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.0.0</machine>
+      <machine maxCpus='384'>pc-q35-rhel7.6.0</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.5.0</machine>
+      <machine maxCpus='384'>pc-q35-rhel8.2.0</machine>
+      <machine canonical='pc-q35-rhel8.2.0' maxCpus='384'>q35</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.1.0</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.2.0</machine>
+      <machine maxCpus='255'>pc-q35-rhel7.3.0</machine>
+      <machine maxCpus='384'>pc-q35-rhel7.4.0</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.3.0</machine>
+      <machine maxCpus='384'>pc-q35-rhel8.0.0</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.4.0</machine>
+      <machine maxCpus='384'>pc-q35-rhel8.1.0</machine>
+      <machine maxCpus='384'>pc-q35-rhel7.5.0</machine>
+      <domain type='qemu'/>
+      <domain type='kvm'/>
+    </arch>
+    <features>
+      <acpi default='on' toggle='yes'/>
+      <apic default='on' toggle='no'/>
+      <cpuselection/>
+      <deviceboot/>
+      <disksnapshot default='on' toggle='no'/>
+    </features>
+  </guest>
+
+</capabilities>
+<capabilities>
+
+  <host>
+    <uuid>32333536-3330-4336-5535-333957465448</uuid>
+    <cpu>
+      <arch>x86_64</arch>
+      <model>Opteron_G5</model>
+      <vendor>AMD</vendor>
+      <microcode version='100665426'/>
+      <counter name='tsc' frequency='2593499000'/>
+      <topology sockets='1' dies='1' cores='24' threads='1'/>
+      <feature name='vme'/>
+      <feature name='ht'/>
+      <feature name='monitor'/>
+      <feature name='osxsave'/>
+      <feature name='bmi1'/>
+      <feature name='mmxext'/>
+      <feature name='fxsr_opt'/>
+      <feature name='cmp_legacy'/>
+      <feature name='extapic'/>
+      <feature name='cr8legacy'/>
+      <feature name='osvw'/>
+      <feature name='ibs'/>
+      <feature name='skinit'/>
+      <feature name='wdt'/>
+      <feature name='lwp'/>
+      <feature name='tce'/>
+      <feature name='nodeid_msr'/>
+      <feature name='topoext'/>
+      <feature name='perfctr_core'/>
+      <feature name='perfctr_nb'/>
+      <feature name='invtsc'/>
+      <feature name='ibpb'/>
+      <feature name='npt'/>
+      <feature name='lbrv'/>
+      <feature name='svm-lock'/>
+      <feature name='nrip-save'/>
+      <feature name='tsc-scale'/>
+      <feature name='vmcb-clean'/>
+      <feature name='flushbyasid'/>
+      <feature name='decodeassists'/>
+      <feature name='pause-filter'/>
+      <feature name='pfthreshold'/>
+      <pages unit='KiB' size='4'/>
+      <pages unit='KiB' size='2048'/>
+      <pages unit='KiB' size='1048576'/>
+    </cpu>
+    <power_management>
+      <suspend_mem/>
+      <suspend_disk/>
+      <suspend_hybrid/>
+    </power_management>
+    <iommu support='yes'/>
+    <migration_features>
+      <live/>
+      <uri_transports>
+        <uri_transport>tcp</uri_transport>
+        <uri_transport>rdma</uri_transport>
+      </uri_transports>
+    </migration_features>
+    <topology>
+      <cells num='4'>
+        <cell id='0'>
+          <memory unit='KiB'>7957932</memory>
+          <pages unit='KiB' size='4'>1989483</pages>
+          <pages unit='KiB' size='2048'>0</pages>
+          <pages unit='KiB' size='1048576'>0</pages>
+          <distances>
+            <sibling id='0' value='10'/>
+            <sibling id='1' value='16'/>
+            <sibling id='2' value='16'/>
+            <sibling id='3' value='16'/>
+          </distances>
+          <cpus num='6'>
+            <cpu id='0' socket_id='0' die_id='0' core_id='0' siblings='0,2'/>
+            <cpu id='2' socket_id='0' die_id='0' core_id='1' siblings='0,2'/>
+            <cpu id='4' socket_id='0' die_id='0' core_id='2' siblings='4,6'/>
+            <cpu id='6' socket_id='0' die_id='0' core_id='3' siblings='4,6'/>
+            <cpu id='8' socket_id='0' die_id='0' core_id='4' siblings='8,10'/>
+            <cpu id='10' socket_id='0' die_id='0' core_id='5' siblings='8,10'/>
+          </cpus>
+        </cell>
+        <cell id='1'>
+          <memory unit='KiB'>8217860</memory>
+          <pages unit='KiB' size='4'>2054465</pages>
+          <pages unit='KiB' size='2048'>0</pages>
+          <pages unit='KiB' size='1048576'>0</pages>
+          <distances>
+            <sibling id='0' value='16'/>
+            <sibling id='1' value='10'/>
+            <sibling id='2' value='16'/>
+            <sibling id='3' value='16'/>
+          </distances>
+          <cpus num='6'>
+            <cpu id='12' socket_id='0' die_id='0' core_id='0' siblings='12,14'/>
+            <cpu id='14' socket_id='0' die_id='0' core_id='1' siblings='12,14'/>
+            <cpu id='16' socket_id='0' die_id='0' core_id='2' siblings='16,18'/>
+            <cpu id='18' socket_id='0' die_id='0' core_id='3' siblings='16,18'/>
+            <cpu id='20' socket_id='0' die_id='0' core_id='4' siblings='20,22'/>
+            <cpu id='22' socket_id='0' die_id='0' core_id='5' siblings='20,22'/>
+          </cpus>
+        </cell>
+        <cell id='2'>
+          <memory unit='KiB'>8256064</memory>
+          <pages unit='KiB' size='4'>2064016</pages>
+          <pages unit='KiB' size='2048'>0</pages>
+          <pages unit='KiB' size='1048576'>0</pages>
+          <distances>
+            <sibling id='0' value='16'/>
+            <sibling id='1' value='16'/>
+            <sibling id='2' value='10'/>
+            <sibling id='3' value='16'/>
+          </distances>
+          <cpus num='6'>
+            <cpu id='1' socket_id='1' die_id='0' core_id='0' siblings='1,3'/>
+            <cpu id='3' socket_id='1' die_id='0' core_id='1' siblings='1,3'/>
+            <cpu id='5' socket_id='1' die_id='0' core_id='2' siblings='5,7'/>
+            <cpu id='7' socket_id='1' die_id='0' core_id='3' siblings='5,7'/>
+            <cpu id='9' socket_id='1' die_id='0' core_id='4' siblings='9,11'/>
+            <cpu id='11' socket_id='1' die_id='0' core_id='5' siblings='9,11'/>
+          </cpus>
+        </cell>
+        <cell id='3'>
+          <memory unit='KiB'>8239224</memory>
+          <pages unit='KiB' size='4'>2059806</pages>
+          <pages unit='KiB' size='2048'>0</pages>
+          <pages unit='KiB' size='1048576'>0</pages>
+          <distances>
+            <sibling id='0' value='16'/>
+            <sibling id='1' value='16'/>
+            <sibling id='2' value='16'/>
+            <sibling id='3' value='10'/>
+          </distances>
+          <cpus num='6'>
+            <cpu id='13' socket_id='1' die_id='0' core_id='0' siblings='13,15'/>
+            <cpu id='15' socket_id='1' die_id='0' core_id='1' siblings='13,15'/>
+            <cpu id='17' socket_id='1' die_id='0' core_id='2' siblings='17,19'/>
+            <cpu id='19' socket_id='1' die_id='0' core_id='3' siblings='17,19'/>
+            <cpu id='21' socket_id='1' die_id='0' core_id='4' siblings='21,23'/>
+            <cpu id='23' socket_id='1' die_id='0' core_id='5' siblings='21,23'/>
+          </cpus>
+        </cell>
+      </cells>
+    </topology>
+    <cache>
+      <bank id='4' level='3' type='both' size='6' unit='MiB' cpus='0,2,4,6,8,10'/>
+      <bank id='4' level='3' type='both' size='6' unit='MiB' cpus='12,14,16,18,20,22'/>
+      <bank id='5' level='3' type='both' size='6' unit='MiB' cpus='12,14,16,18,20,22'/>
+      <bank id='8' level='3' type='both' size='6' unit='MiB' cpus='1,3,5,7,9,11'/>
+      <bank id='8' level='3' type='both' size='6' unit='MiB' cpus='13,15,17,19,21,23'/>
+      <bank id='9' level='3' type='both' size='6' unit='MiB' cpus='13,15,17,19,21,23'/>
+    </cache>
+    <secmodel>
+      <model>selinux</model>
+      <doi>0</doi>
+      <baselabel type='kvm'>system_u:system_r:svirt_t:s0</baselabel>
+      <baselabel type='qemu'>system_u:system_r:svirt_tcg_t:s0</baselabel>
+    </secmodel>
+    <secmodel>
+      <model>dac</model>
+      <doi>0</doi>
+      <baselabel type='kvm'>+107:+107</baselabel>
+      <baselabel type='qemu'>+107:+107</baselabel>
+    </secmodel>
+  </host>
+
+  <guest>
+    <os_type>hvm</os_type>
+    <arch name='i686'>
+      <wordsize>32</wordsize>
+      <emulator>/usr/libexec/qemu-kvm</emulator>
+      <machine maxCpus='240'>pc-i440fx-rhel7.6.0</machine>
+      <machine canonical='pc-i440fx-rhel7.6.0' maxCpus='240'>pc</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.0.0</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.5.0</machine>
+      <machine maxCpus='240' deprecated='yes'>pc-i440fx-4.2</machine>
+      <machine maxCpus='710'>pc-q35-rhel8.5.0</machine>
+      <machine canonical='pc-q35-rhel8.5.0' maxCpus='710'>q35</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.3.0</machine>
+      <machine maxCpus='710'>pc-q35-rhel8.3.0</machine>
+      <machine maxCpus='710'>pc-q35-rhel7.6.0</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.1.0</machine>
+      <machine maxCpus='710'>pc-q35-rhel8.1.0</machine>
+      <machine maxCpus='710'>pc-q35-rhel7.4.0</machine>
+      <machine maxCpus='710'>pc-q35-rhel8.4.0</machine>
+      <machine maxCpus='240' deprecated='yes'>pc-i440fx-2.11</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.4.0</machine>
+      <machine maxCpus='710'>pc-q35-rhel8.2.0</machine>
+      <machine maxCpus='710'>pc-q35-rhel7.5.0</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.2.0</machine>
+      <machine maxCpus='710'>pc-q35-rhel8.0.0</machine>
+      <machine maxCpus='255'>pc-q35-rhel7.3.0</machine>
+      <domain type='qemu'/>
+      <domain type='kvm'/>
+    </arch>
+    <features>
+      <pae/>
+      <nonpae/>
+      <acpi default='on' toggle='yes'/>
+      <apic default='on' toggle='no'/>
+      <cpuselection/>
+      <deviceboot/>
+      <disksnapshot default='on' toggle='no'/>
+    </features>
+  </guest>
+
+  <guest>
+    <os_type>hvm</os_type>
+    <arch name='x86_64'>
+      <wordsize>64</wordsize>
+      <emulator>/usr/libexec/qemu-kvm</emulator>
+      <machine maxCpus='240'>pc-i440fx-rhel7.6.0</machine>
+      <machine canonical='pc-i440fx-rhel7.6.0' maxCpus='240'>pc</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.0.0</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.5.0</machine>
+      <machine maxCpus='240' deprecated='yes'>pc-i440fx-4.2</machine>
+      <machine maxCpus='710'>pc-q35-rhel8.5.0</machine>
+      <machine canonical='pc-q35-rhel8.5.0' maxCpus='710'>q35</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.3.0</machine>
+      <machine maxCpus='710'>pc-q35-rhel8.3.0</machine>
+      <machine maxCpus='710'>pc-q35-rhel7.6.0</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.1.0</machine>
+      <machine maxCpus='710'>pc-q35-rhel8.1.0</machine>
+      <machine maxCpus='710'>pc-q35-rhel7.4.0</machine>
+      <machine maxCpus='710'>pc-q35-rhel8.4.0</machine>
+      <machine maxCpus='240' deprecated='yes'>pc-i440fx-2.11</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.4.0</machine>
+      <machine maxCpus='710'>pc-q35-rhel8.2.0</machine>
+      <machine maxCpus='710'>pc-q35-rhel7.5.0</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.2.0</machine>
+      <machine maxCpus='710'>pc-q35-rhel8.0.0</machine>
+      <machine maxCpus='255'>pc-q35-rhel7.3.0</machine>
+      <domain type='qemu'/>
+      <domain type='kvm'/>
+    </arch>
+    <features>
+      <acpi default='on' toggle='yes'/>
+      <apic default='on' toggle='no'/>
+      <cpuselection/>
+      <deviceboot/>
+      <disksnapshot default='on' toggle='no'/>
+    </features>
+  </guest>
+
+</capabilities>

--- a/libvirt/tests/deps/capabilities.xml
+++ b/libvirt/tests/deps/capabilities.xml
@@ -1,0 +1,321 @@
+<capabilities>
+
+  <host>
+    <uuid>087c55cc-2f1c-11b2-a85c-ad091a1958a0</uuid>
+    <cpu>
+      <arch>x86_64</arch>
+      <model>Skylake-Client-noTSX-IBRS</model>
+      <vendor>Intel</vendor>
+      <microcode version='214'/>
+      <counter name='tsc' frequency='2304000000' scaling='no'/>
+      <topology sockets='1' dies='1' cores='4' threads='2'/>
+      <feature name='ds'/>
+      <feature name='acpi'/>
+      <feature name='ss'/>
+      <feature name='ht'/>
+      <feature name='tm'/>
+      <feature name='pbe'/>
+      <feature name='dtes64'/>
+      <feature name='monitor'/>
+      <feature name='ds_cpl'/>
+      <feature name='vmx'/>
+      <feature name='smx'/>
+      <feature name='est'/>
+      <feature name='tm2'/>
+      <feature name='xtpr'/>
+      <feature name='pdcm'/>
+      <feature name='osxsave'/>
+      <feature name='tsc_adjust'/>
+      <feature name='clflushopt'/>
+      <feature name='intel-pt'/>
+      <feature name='md-clear'/>
+      <feature name='stibp'/>
+      <feature name='arch-capabilities'/>
+      <feature name='ssbd'/>
+      <feature name='xsaves'/>
+      <feature name='pdpe1gb'/>
+      <feature name='invtsc'/>
+      <feature name='rdctl-no'/>
+      <feature name='ibrs-all'/>
+      <feature name='skip-l1dfl-vmentry'/>
+      <feature name='mds-no'/>
+      <feature name='tsx-ctrl'/>
+      <pages unit='KiB' size='4'/>
+      <pages unit='KiB' size='2048'/>
+      <pages unit='KiB' size='1048576'/>
+    </cpu>
+    <power_management>
+      <suspend_mem/>
+    </power_management>
+    <iommu support='no'/>
+    <migration_features>
+      <live/>
+      <uri_transports>
+        <uri_transport>tcp</uri_transport>
+        <uri_transport>rdma</uri_transport>
+      </uri_transports>
+    </migration_features>
+    <topology>
+      <cells num='1'>
+        <cell id='0'>
+          <memory unit='KiB'>32305476</memory>
+          <pages unit='KiB' size='4'>8076369</pages>
+          <pages unit='KiB' size='2048'>0</pages>
+          <pages unit='KiB' size='1048576'>0</pages>
+          <distances>
+            <sibling id='0' value='10'/>
+          </distances>
+          <cpus num='8'>
+            <cpu id='0' socket_id='0' die_id='0' core_id='0' siblings='0,4'/>
+            <cpu id='1' socket_id='0' die_id='0' core_id='1' siblings='1,5'/>
+            <cpu id='2' socket_id='0' die_id='0' core_id='2' siblings='2,6'/>
+            <cpu id='3' socket_id='0' die_id='0' core_id='3' siblings='3,7'/>
+            <cpu id='4' socket_id='0' die_id='0' core_id='0' siblings='0,4'/>
+            <cpu id='5' socket_id='0' die_id='0' core_id='1' siblings='1,5'/>
+            <cpu id='6' socket_id='0' die_id='0' core_id='2' siblings='2,6'/>
+            <cpu id='7' socket_id='0' die_id='0' core_id='3' siblings='3,7'/>
+          </cpus>
+        </cell>
+      </cells>
+    </topology>
+    <cache>
+      <bank id='0' level='3' type='both' size='8' unit='MiB' cpus='0-7'/>
+    </cache>
+    <secmodel>
+      <model>selinux</model>
+      <doi>0</doi>
+      <baselabel type='kvm'>system_u:system_r:svirt_t:s0</baselabel>
+      <baselabel type='qemu'>system_u:system_r:svirt_tcg_t:s0</baselabel>
+    </secmodel>
+    <secmodel>
+      <model>dac</model>
+      <doi>0</doi>
+      <baselabel type='kvm'>+107:+107</baselabel>
+      <baselabel type='qemu'>+107:+107</baselabel>
+    </secmodel>
+  </host>
+
+  <guest>
+    <os_type>hvm</os_type>
+    <arch name='i686'>
+      <wordsize>32</wordsize>
+      <emulator>/usr/libexec/qemu-kvm</emulator>
+      <machine maxCpus='240'>pc-i440fx-rhel7.6.0</machine>
+      <machine canonical='pc-i440fx-rhel7.6.0' maxCpus='240'>pc</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.0.0</machine>
+      <machine maxCpus='384'>pc-q35-rhel7.6.0</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.5.0</machine>
+      <machine maxCpus='384'>pc-q35-rhel8.2.0</machine>
+      <machine canonical='pc-q35-rhel8.2.0' maxCpus='384'>q35</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.1.0</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.2.0</machine>
+      <machine maxCpus='255'>pc-q35-rhel7.3.0</machine>
+      <machine maxCpus='384'>pc-q35-rhel7.4.0</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.3.0</machine>
+      <machine maxCpus='384'>pc-q35-rhel8.0.0</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.4.0</machine>
+      <machine maxCpus='384'>pc-q35-rhel8.1.0</machine>
+      <machine maxCpus='384'>pc-q35-rhel7.5.0</machine>
+      <domain type='qemu'/>
+      <domain type='kvm'/>
+    </arch>
+    <features>
+      <pae/>
+      <nonpae/>
+      <acpi default='on' toggle='yes'/>
+      <apic default='on' toggle='no'/>
+      <cpuselection/>
+      <deviceboot/>
+      <disksnapshot default='on' toggle='no'/>
+    </features>
+  </guest>
+
+  <guest>
+    <os_type>hvm</os_type>
+    <arch name='x86_64'>
+      <wordsize>64</wordsize>
+      <emulator>/usr/libexec/qemu-kvm</emulator>
+      <machine maxCpus='240'>pc-i440fx-rhel7.6.0</machine>
+      <machine canonical='pc-i440fx-rhel7.6.0' maxCpus='240'>pc</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.0.0</machine>
+      <machine maxCpus='384'>pc-q35-rhel7.6.0</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.5.0</machine>
+      <machine maxCpus='384'>pc-q35-rhel8.2.0</machine>
+      <machine canonical='pc-q35-rhel8.2.0' maxCpus='384'>q35</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.1.0</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.2.0</machine>
+      <machine maxCpus='255'>pc-q35-rhel7.3.0</machine>
+      <machine maxCpus='384'>pc-q35-rhel7.4.0</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.3.0</machine>
+      <machine maxCpus='384'>pc-q35-rhel8.0.0</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.4.0</machine>
+      <machine maxCpus='384'>pc-q35-rhel8.1.0</machine>
+      <machine maxCpus='384'>pc-q35-rhel7.5.0</machine>
+      <domain type='qemu'/>
+      <domain type='kvm'/>
+    </arch>
+    <features>
+      <acpi default='on' toggle='yes'/>
+      <apic default='on' toggle='no'/>
+      <cpuselection/>
+      <deviceboot/>
+      <disksnapshot default='on' toggle='no'/>
+    </features>
+  </guest>
+
+</capabilities>
+
+<capabilities>
+
+  <host>
+    <uuid>d781f420-0039-11e3-a32a-285e66af1d00</uuid>
+    <cpu>
+      <arch>x86_64</arch>
+      <model>IvyBridge-IBRS</model>
+      <vendor>Intel</vendor>
+      <microcode version='33'/>
+      <counter name='tsc' frequency='3192738000' scaling='no'/>
+      <topology sockets='1' dies='1' cores='4' threads='1'/>
+      <feature name='ds'/>
+      <feature name='acpi'/>
+      <feature name='ss'/>
+      <feature name='ht'/>
+      <feature name='tm'/>
+      <feature name='pbe'/>
+      <feature name='dtes64'/>
+      <feature name='monitor'/>
+      <feature name='ds_cpl'/>
+      <feature name='vmx'/>
+      <feature name='smx'/>
+      <feature name='est'/>
+      <feature name='tm2'/>
+      <feature name='xtpr'/>
+      <feature name='pdcm'/>
+      <feature name='pcid'/>
+      <feature name='osxsave'/>
+      <feature name='arat'/>
+      <feature name='md-clear'/>
+      <feature name='stibp'/>
+      <feature name='ssbd'/>
+      <feature name='xsaveopt'/>
+      <feature name='invtsc'/>
+      <pages unit='KiB' size='4'/>
+      <pages unit='KiB' size='2048'/>
+    </cpu>
+    <power_management>
+      <suspend_mem/>
+      <suspend_disk/>
+      <suspend_hybrid/>
+    </power_management>
+    <iommu support='no'/>
+    <migration_features>
+      <live/>
+      <uri_transports>
+        <uri_transport>tcp</uri_transport>
+        <uri_transport>rdma</uri_transport>
+      </uri_transports>
+    </migration_features>
+    <topology>
+      <cells num='1'>
+        <cell id='0'>
+          <memory unit='KiB'>7794888</memory>
+          <pages unit='KiB' size='4'>1948722</pages>
+          <pages unit='KiB' size='2048'>0</pages>
+          <distances>
+            <sibling id='0' value='10'/>
+          </distances>
+          <cpus num='4'>
+            <cpu id='0' socket_id='0' die_id='0' core_id='0' siblings='0'/>
+            <cpu id='1' socket_id='0' die_id='0' core_id='1' siblings='1'/>
+            <cpu id='2' socket_id='0' die_id='0' core_id='2' siblings='2'/>
+            <cpu id='3' socket_id='0' die_id='0' core_id='3' siblings='3'/>
+          </cpus>
+        </cell>
+      </cells>
+    </topology>
+    <cache>
+      <bank id='0' level='3' type='both' size='6' unit='MiB' cpus='0-3'/>
+    </cache>
+    <secmodel>
+      <model>selinux</model>
+      <doi>0</doi>
+      <baselabel type='kvm'>system_u:system_r:svirt_t:s0</baselabel>
+      <baselabel type='qemu'>system_u:system_r:svirt_tcg_t:s0</baselabel>
+    </secmodel>
+    <secmodel>
+      <model>dac</model>
+      <doi>0</doi>
+      <baselabel type='kvm'>+107:+107</baselabel>
+      <baselabel type='qemu'>+107:+107</baselabel>
+    </secmodel>
+  </host>
+
+  <guest>
+    <os_type>hvm</os_type>
+    <arch name='i686'>
+      <wordsize>32</wordsize>
+      <emulator>/usr/libexec/qemu-kvm</emulator>
+      <machine maxCpus='240'>pc-i440fx-rhel7.6.0</machine>
+      <machine canonical='pc-i440fx-rhel7.6.0' maxCpus='240'>pc</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.0.0</machine>
+      <machine maxCpus='384'>pc-q35-rhel7.6.0</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.5.0</machine>
+      <machine maxCpus='384'>pc-q35-rhel8.2.0</machine>
+      <machine canonical='pc-q35-rhel8.2.0' maxCpus='384'>q35</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.1.0</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.2.0</machine>
+      <machine maxCpus='255'>pc-q35-rhel7.3.0</machine>
+      <machine maxCpus='384'>pc-q35-rhel7.4.0</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.3.0</machine>
+      <machine maxCpus='384'>pc-q35-rhel8.0.0</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.4.0</machine>
+      <machine maxCpus='384'>pc-q35-rhel8.1.0</machine>
+      <machine maxCpus='384'>pc-q35-rhel7.5.0</machine>
+      <domain type='qemu'/>
+      <domain type='kvm'/>
+    </arch>
+    <features>
+      <pae/>
+      <nonpae/>
+      <acpi default='on' toggle='yes'/>
+      <apic default='on' toggle='no'/>
+      <cpuselection/>
+      <deviceboot/>
+      <disksnapshot default='on' toggle='no'/>
+    </features>
+  </guest>
+
+  <guest>
+    <os_type>hvm</os_type>
+    <arch name='x86_64'>
+      <wordsize>64</wordsize>
+      <emulator>/usr/libexec/qemu-kvm</emulator>
+      <machine maxCpus='240'>pc-i440fx-rhel7.6.0</machine>
+      <machine canonical='pc-i440fx-rhel7.6.0' maxCpus='240'>pc</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.0.0</machine>
+      <machine maxCpus='384'>pc-q35-rhel7.6.0</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.5.0</machine>
+      <machine maxCpus='384'>pc-q35-rhel8.2.0</machine>
+      <machine canonical='pc-q35-rhel8.2.0' maxCpus='384'>q35</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.1.0</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.2.0</machine>
+      <machine maxCpus='255'>pc-q35-rhel7.3.0</machine>
+      <machine maxCpus='384'>pc-q35-rhel7.4.0</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.3.0</machine>
+      <machine maxCpus='384'>pc-q35-rhel8.0.0</machine>
+      <machine maxCpus='240'>pc-i440fx-rhel7.4.0</machine>
+      <machine maxCpus='384'>pc-q35-rhel8.1.0</machine>
+      <machine maxCpus='384'>pc-q35-rhel7.5.0</machine>
+      <domain type='qemu'/>
+      <domain type='kvm'/>
+    </arch>
+    <features>
+      <acpi default='on' toggle='yes'/>
+      <apic default='on' toggle='no'/>
+      <cpuselection/>
+      <deviceboot/>
+      <disksnapshot default='on' toggle='no'/>
+    </features>
+  </guest>
+
+</capabilities>

--- a/libvirt/tests/deps/capability_cpu.xml
+++ b/libvirt/tests/deps/capability_cpu.xml
@@ -1,0 +1,75 @@
+    <cpu>
+      <arch>x86_64</arch>
+      <model>Skylake-Client-noTSX-IBRS</model>
+      <vendor>Intel</vendor>
+      <microcode version='214'/>
+      <counter name='tsc' frequency='2304000000' scaling='no'/>
+      <topology sockets='1' dies='1' cores='4' threads='2'/>
+      <feature name='ds'/>
+      <feature name='acpi'/>
+      <feature name='ss'/>
+      <feature name='ht'/>
+      <feature name='tm'/>
+      <feature name='pbe'/>
+      <feature name='dtes64'/>
+      <feature name='monitor'/>
+      <feature name='ds_cpl'/>
+      <feature name='vmx'/>
+      <feature name='smx'/>
+      <feature name='est'/>
+      <feature name='tm2'/>
+      <feature name='xtpr'/>
+      <feature name='pdcm'/>
+      <feature name='osxsave'/>
+      <feature name='tsc_adjust'/>
+      <feature name='clflushopt'/>
+      <feature name='intel-pt'/>
+      <feature name='md-clear'/>
+      <feature name='stibp'/>
+      <feature name='arch-capabilities'/>
+      <feature name='ssbd'/>
+      <feature name='xsaves'/>
+      <feature name='pdpe1gb'/>
+      <feature name='invtsc'/>
+      <feature name='rdctl-no'/>
+      <feature name='ibrs-all'/>
+      <feature name='skip-l1dfl-vmentry'/>
+      <feature name='mds-no'/>
+      <feature name='tsx-ctrl'/>
+      <pages unit='KiB' size='4'/>
+      <pages unit='KiB' size='2048'/>
+      <pages unit='KiB' size='1048576'/>
+    </cpu>
+    <cpu>
+      <arch>x86_64</arch>
+      <model>IvyBridge-IBRS</model>
+      <vendor>Intel</vendor>
+      <microcode version='33'/>
+      <counter name='tsc' frequency='3192738000' scaling='no'/>
+      <topology sockets='1' dies='1' cores='4' threads='1'/>
+      <feature name='ds'/>
+      <feature name='acpi'/>
+      <feature name='ss'/>
+      <feature name='ht'/>
+      <feature name='tm'/>
+      <feature name='pbe'/>
+      <feature name='dtes64'/>
+      <feature name='monitor'/>
+      <feature name='ds_cpl'/>
+      <feature name='vmx'/>
+      <feature name='smx'/>
+      <feature name='est'/>
+      <feature name='tm2'/>
+      <feature name='xtpr'/>
+      <feature name='pdcm'/>
+      <feature name='pcid'/>
+      <feature name='osxsave'/>
+      <feature name='arat'/>
+      <feature name='md-clear'/>
+      <feature name='stibp'/>
+      <feature name='ssbd'/>
+      <feature name='xsaveopt'/>
+      <feature name='invtsc'/>
+      <pages unit='KiB' size='4'/>
+      <pages unit='KiB' size='2048'/>
+    </cpu>

--- a/libvirt/tests/deps/cpu.xml
+++ b/libvirt/tests/deps/cpu.xml
@@ -1,0 +1,21 @@
+<cpu mode='custom' match='exact' check='full'>
+  <model fallback='forbid'>Skylake-Client-IBRS</model>
+  <vendor>Intel</vendor>
+  <feature policy='require' name='ss'/>
+  <feature policy='require' name='tsc_adjust'/>
+  <feature policy='require' name='clflushopt'/>
+  <feature policy='require' name='pdpe1gb'/>
+  <feature policy='require' name='invtsc'/>
+  <feature policy='require' name='hypervisor'/>
+</cpu>
+<cpu mode='custom' match='exact'>
+  <model fallback='forbid'>SandyBridge-IBRS</model>
+  <vendor>Intel</vendor>
+  <feature policy='require' name='vme'/>
+  <feature policy='require' name='ss'/>
+  <feature policy='require' name='pcid'/>
+  <feature policy='require' name='arat'/>
+  <feature policy='require' name='xsaveopt'/>
+  <feature policy='require' name='invtsc'/>
+    <feature policy='require' name='hypervisor'/>
+</cpu>

--- a/libvirt/tests/deps/domcapabilities.xml
+++ b/libvirt/tests/deps/domcapabilities.xml
@@ -1,0 +1,358 @@
+<domainCapabilities>
+  <path>/usr/libexec/qemu-kvm</path>
+  <domain>kvm</domain>
+  <machine>pc-i440fx-rhel7.6.0</machine>
+  <arch>x86_64</arch>
+  <vcpu max='240'/>
+  <iothreads supported='yes'/>
+  <os supported='yes'>
+    <enum name='firmware'/>
+    <loader supported='yes'>
+      <value>/usr/share/OVMF/OVMF_CODE.secboot.fd</value>
+      <enum name='type'>
+        <value>rom</value>
+        <value>pflash</value>
+      </enum>
+      <enum name='readonly'>
+        <value>yes</value>
+        <value>no</value>
+      </enum>
+      <enum name='secure'>
+        <value>no</value>
+      </enum>
+    </loader>
+  </os>
+  <cpu>
+    <mode name='host-passthrough' supported='yes'/>
+    <mode name='host-model' supported='yes'>
+      <model fallback='forbid'>Skylake-Client-IBRS</model>
+      <vendor>Intel</vendor>
+      <feature policy='require' name='ss'/>
+      <feature policy='require' name='vmx'/>
+      <feature policy='require' name='hypervisor'/>
+      <feature policy='require' name='tsc_adjust'/>
+      <feature policy='require' name='clflushopt'/>
+      <feature policy='require' name='umip'/>
+      <feature policy='require' name='md-clear'/>
+      <feature policy='require' name='stibp'/>
+      <feature policy='require' name='arch-capabilities'/>
+      <feature policy='require' name='ssbd'/>
+      <feature policy='require' name='xsaves'/>
+      <feature policy='require' name='pdpe1gb'/>
+      <feature policy='require' name='invtsc'/>
+      <feature policy='require' name='ibpb'/>
+      <feature policy='require' name='amd-ssbd'/>
+      <feature policy='require' name='rdctl-no'/>
+      <feature policy='require' name='ibrs-all'/>
+      <feature policy='require' name='skip-l1dfl-vmentry'/>
+      <feature policy='require' name='mds-no'/>
+      <feature policy='require' name='pschange-mc-no'/>
+      <feature policy='disable' name='hle'/>
+      <feature policy='disable' name='rtm'/>
+    </mode>
+    <mode name='custom' supported='yes'>
+      <model usable='yes'>qemu64</model>
+      <model usable='yes'>qemu32</model>
+      <model usable='no'>phenom</model>
+      <model usable='yes'>pentium3</model>
+      <model usable='yes'>pentium2</model>
+      <model usable='yes'>pentium</model>
+      <model usable='yes'>n270</model>
+      <model usable='yes'>kvm64</model>
+      <model usable='yes'>kvm32</model>
+      <model usable='yes'>coreduo</model>
+      <model usable='yes'>core2duo</model>
+      <model usable='no'>athlon</model>
+      <model usable='yes'>Westmere-IBRS</model>
+      <model usable='yes'>Westmere</model>
+      <model usable='no'>Skylake-Server-noTSX-IBRS</model>
+      <model usable='no'>Skylake-Server-IBRS</model>
+      <model usable='no'>Skylake-Server</model>
+      <model usable='yes'>Skylake-Client-noTSX-IBRS</model>
+      <model usable='no'>Skylake-Client-IBRS</model>
+      <model usable='no'>Skylake-Client</model>
+      <model usable='yes'>SandyBridge-IBRS</model>
+      <model usable='yes'>SandyBridge</model>
+      <model usable='yes'>Penryn</model>
+      <model usable='no'>Opteron_G5</model>
+      <model usable='no'>Opteron_G4</model>
+      <model usable='no'>Opteron_G3</model>
+      <model usable='yes'>Opteron_G2</model>
+      <model usable='yes'>Opteron_G1</model>
+      <model usable='yes'>Nehalem-IBRS</model>
+      <model usable='yes'>Nehalem</model>
+      <model usable='yes'>IvyBridge-IBRS</model>
+      <model usable='yes'>IvyBridge</model>
+      <model usable='no'>Icelake-Server-noTSX</model>
+      <model usable='no'>Icelake-Server</model>
+      <model usable='no'>Icelake-Client-noTSX</model>
+      <model usable='no'>Icelake-Client</model>
+      <model usable='yes'>Haswell-noTSX-IBRS</model>
+      <model usable='yes'>Haswell-noTSX</model>
+      <model usable='no'>Haswell-IBRS</model>
+      <model usable='no'>Haswell</model>
+      <model usable='no'>EPYC-IBPB</model>
+      <model usable='no'>EPYC</model>
+      <model usable='no'>Dhyana</model>
+      <model usable='no'>Cooperlake</model>
+      <model usable='yes'>Conroe</model>
+      <model usable='no'>Cascadelake-Server-noTSX</model>
+      <model usable='no'>Cascadelake-Server</model>
+      <model usable='yes'>Broadwell-noTSX-IBRS</model>
+      <model usable='yes'>Broadwell-noTSX</model>
+      <model usable='no'>Broadwell-IBRS</model>
+      <model usable='no'>Broadwell</model>
+      <model usable='yes'>486</model>
+    </mode>
+  </cpu>
+  <devices>
+    <disk supported='yes'>
+      <enum name='diskDevice'>
+        <value>disk</value>
+        <value>cdrom</value>
+        <value>floppy</value>
+        <value>lun</value>
+      </enum>
+      <enum name='bus'>
+        <value>ide</value>
+        <value>fdc</value>
+        <value>scsi</value>
+        <value>virtio</value>
+        <value>usb</value>
+        <value>sata</value>
+      </enum>
+      <enum name='model'>
+        <value>virtio</value>
+        <value>virtio-transitional</value>
+        <value>virtio-non-transitional</value>
+      </enum>
+    </disk>
+    <graphics supported='yes'>
+      <enum name='type'>
+        <value>sdl</value>
+        <value>vnc</value>
+        <value>spice</value>
+      </enum>
+    </graphics>
+    <video supported='yes'>
+      <enum name='modelType'>
+        <value>vga</value>
+        <value>cirrus</value>
+        <value>qxl</value>
+        <value>virtio</value>
+        <value>none</value>
+        <value>bochs</value>
+        <value>ramfb</value>
+      </enum>
+    </video>
+    <hostdev supported='yes'>
+      <enum name='mode'>
+        <value>subsystem</value>
+      </enum>
+      <enum name='startupPolicy'>
+        <value>default</value>
+        <value>mandatory</value>
+        <value>requisite</value>
+        <value>optional</value>
+      </enum>
+      <enum name='subsysType'>
+        <value>usb</value>
+        <value>pci</value>
+        <value>scsi</value>
+      </enum>
+      <enum name='capsType'/>
+      <enum name='pciBackend'/>
+    </hostdev>
+    <rng supported='yes'>
+      <enum name='model'>
+        <value>virtio</value>
+        <value>virtio-transitional</value>
+        <value>virtio-non-transitional</value>
+      </enum>
+      <enum name='backendModel'>
+        <value>random</value>
+        <value>egd</value>
+      </enum>
+    </rng>
+  </devices>
+  <features>
+    <gic supported='no'/>
+    <vmcoreinfo supported='yes'/>
+    <genid supported='yes'/>
+    <backingStoreInput supported='yes'/>
+    <backup supported='no'/>
+    <sev supported='no'/>
+  </features>
+</domainCapabilities>
+<domainCapabilities>
+  <path>/usr/libexec/qemu-kvm</path>
+  <domain>kvm</domain>
+  <machine>pc-i440fx-rhel7.6.0</machine>
+  <arch>x86_64</arch>
+  <vcpu max='240'/>
+  <iothreads supported='yes'/>
+  <os supported='yes'>
+    <enum name='firmware'/>
+    <loader supported='yes'>
+      <value>/usr/share/OVMF/OVMF_CODE.secboot.fd</value>
+      <enum name='type'>
+        <value>rom</value>
+        <value>pflash</value>
+      </enum>
+      <enum name='readonly'>
+        <value>yes</value>
+        <value>no</value>
+      </enum>
+      <enum name='secure'>
+        <value>no</value>
+      </enum>
+    </loader>
+  </os>
+  <cpu>
+    <mode name='host-passthrough' supported='yes'/>
+    <mode name='host-model' supported='yes'>
+      <model fallback='forbid'>IvyBridge-IBRS</model>
+      <vendor>Intel</vendor>
+      <feature policy='require' name='ss'/>
+      <feature policy='require' name='pcid'/>
+      <feature policy='require' name='hypervisor'/>
+      <feature policy='require' name='arat'/>
+      <feature policy='require' name='tsc_adjust'/>
+      <feature policy='require' name='umip'/>
+      <feature policy='require' name='stibp'/>
+      <feature policy='require' name='ssbd'/>
+      <feature policy='require' name='xsaveopt'/>
+      <feature policy='require' name='invtsc'/>
+    </mode>
+    <mode name='custom' supported='yes'>
+      <model usable='yes'>qemu64</model>
+      <model usable='yes'>qemu32</model>
+      <model usable='no'>phenom</model>
+      <model usable='yes'>pentium3</model>
+      <model usable='yes'>pentium2</model>
+      <model usable='yes'>pentium</model>
+      <model usable='no'>n270</model>
+      <model usable='yes'>kvm64</model>
+      <model usable='yes'>kvm32</model>
+      <model usable='yes'>coreduo</model>
+      <model usable='yes'>core2duo</model>
+      <model usable='no'>athlon</model>
+      <model usable='yes'>Westmere-IBRS</model>
+      <model usable='yes'>Westmere</model>
+      <model usable='no'>Skylake-Server-noTSX-IBRS</model>
+      <model usable='no'>Skylake-Server-IBRS</model>
+      <model usable='no'>Skylake-Server</model>
+      <model usable='no'>Skylake-Client-noTSX-IBRS</model>
+      <model usable='no'>Skylake-Client-IBRS</model>
+      <model usable='no'>Skylake-Client</model>
+      <model usable='yes'>SandyBridge-IBRS</model>
+      <model usable='yes'>SandyBridge</model>
+      <model usable='yes'>Penryn</model>
+      <model usable='no'>Opteron_G5</model>
+      <model usable='no'>Opteron_G4</model>
+      <model usable='no'>Opteron_G3</model>
+      <model usable='yes'>Opteron_G2</model>
+      <model usable='yes'>Opteron_G1</model>
+      <model usable='yes'>Nehalem-IBRS</model>
+      <model usable='yes'>Nehalem</model>
+      <model usable='yes'>IvyBridge-IBRS</model>
+      <model usable='yes'>IvyBridge</model>
+      <model usable='no'>Icelake-Server-noTSX</model>
+      <model usable='no'>Icelake-Server</model>
+      <model usable='no'>Icelake-Client-noTSX</model>
+      <model usable='no'>Icelake-Client</model>
+      <model usable='no'>Haswell-noTSX-IBRS</model>
+      <model usable='no'>Haswell-noTSX</model>
+      <model usable='no'>Haswell-IBRS</model>
+      <model usable='no'>Haswell</model>
+      <model usable='no'>EPYC-IBPB</model>
+      <model usable='no'>EPYC</model>
+      <model usable='no'>Dhyana</model>
+      <model usable='yes'>Conroe</model>
+      <model usable='no'>Cascadelake-Server-noTSX</model>
+      <model usable='no'>Cascadelake-Server</model>
+      <model usable='no'>Broadwell-noTSX-IBRS</model>
+      <model usable='no'>Broadwell-noTSX</model>
+      <model usable='no'>Broadwell-IBRS</model>
+      <model usable='no'>Broadwell</model>
+      <model usable='yes'>486</model>
+    </mode>
+  </cpu>
+  <devices>
+    <disk supported='yes'>
+      <enum name='diskDevice'>
+        <value>disk</value>
+        <value>cdrom</value>
+        <value>floppy</value>
+        <value>lun</value>
+      </enum>
+      <enum name='bus'>
+        <value>ide</value>
+        <value>fdc</value>
+        <value>scsi</value>
+        <value>virtio</value>
+        <value>usb</value>
+        <value>sata</value>
+      </enum>
+      <enum name='model'>
+        <value>virtio</value>
+        <value>virtio-transitional</value>
+        <value>virtio-non-transitional</value>
+      </enum>
+    </disk>
+    <graphics supported='yes'>
+      <enum name='type'>
+        <value>sdl</value>
+        <value>vnc</value>
+        <value>spice</value>
+      </enum>
+    </graphics>
+    <video supported='yes'>
+      <enum name='modelType'>
+        <value>vga</value>
+        <value>cirrus</value>
+        <value>qxl</value>
+        <value>virtio</value>
+        <value>none</value>
+        <value>bochs</value>
+      </enum>
+    </video>
+    <hostdev supported='yes'>
+      <enum name='mode'>
+        <value>subsystem</value>
+      </enum>
+      <enum name='startupPolicy'>
+        <value>default</value>
+        <value>mandatory</value>
+        <value>requisite</value>
+        <value>optional</value>
+      </enum>
+      <enum name='subsysType'>
+        <value>usb</value>
+        <value>pci</value>
+        <value>scsi</value>
+      </enum>
+      <enum name='capsType'/>
+      <enum name='pciBackend'/>
+    </hostdev>
+    <rng supported='yes'>
+      <enum name='model'>
+        <value>virtio</value>
+        <value>virtio-transitional</value>
+        <value>virtio-non-transitional</value>
+      </enum>
+      <enum name='backendModel'>
+        <value>random</value>
+        <value>egd</value>
+      </enum>
+    </rng>
+  </devices>
+  <features>
+    <gic supported='no'/>
+    <vmcoreinfo supported='yes'/>
+    <genid supported='yes'/>
+    <backingStoreInput supported='yes'/>
+    <backup supported='no'/>
+    <sev supported='no'/>
+  </features>
+</domainCapabilities>

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_xml.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_xml.py
@@ -1,0 +1,43 @@
+import logging
+import tempfile
+
+from virttest import data_dir
+from virttest import virsh               # pylint: disable=W0611
+
+from virttest.utils_test import libvirt
+
+
+def run(test, params, env):
+    """
+    Run tests for {hypervisor_}cpu_{baseline,compare} with different xmls
+    Those xmls include:
+        domcapabilities xml from two different hosts
+        capabilities xml from two different hosts
+        cpu xml within capabilities xml from two different hosts
+        cpu xml within domain dumpxml from two different hosts
+    """
+
+    file_path = params.get('file_path')
+    file_xml_declaration = params.get('file_xml_declaration')
+    virsh_function = eval(params.get('virsh_function'))
+    err_msg = params.get('err_msg')
+    data_file = tempfile.mktemp(dir=data_dir.get_tmp_dir())
+    file_content = None
+    if file_xml_declaration:
+        with open(file_path) as path_fd:
+            file_content = path_fd.read()
+        with open(data_file, 'w+') as data_fd:
+            data_fd.write(file_xml_declaration)
+            data_fd.write('\n')
+            data_fd.write(file_content)
+    else:
+        data_file = file_path
+
+    with open(data_file) as fd:
+        logging.debug("The XML file under test:\n%s", fd.read())
+
+    if virsh_function:
+        ret = virsh_function(data_file, ignore_status=True, debug=True)
+        libvirt.check_result(ret,
+                             expected_fails=err_msg,
+                             check_both_on_error=True)


### PR DESCRIPTION
RHEL-150995: Test "virsh {hypervisor-}cpu-{baseline,compare}" cmds with XML file with XML declaration
RHEL-139122: Test 'virsh hypervisor-cpu-baseline' cmd with <cpu>/domcapabilities/capabilities XML
RHEL-139119: Test 'virsh cpu-baseline' cmd with <cpu> definition / capabilities XML

Signed-off-by: Dan Zheng <dzheng@redhat.com>

