### PR TITLE
guest_agent: Fix the guest_agent guestinfo case for hostname

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_guestinfo.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_guestinfo.py
@@ -116,9 +116,11 @@ def run(test, params, env):
         hostname_info = {}
         session = vm.wait_for_login()
         try:
-            output = session.cmd_output('hostnamectl --static').strip()
+            output = session.cmd_output('hostname').strip()
             if not output:
-                output = session.cmd_output('hostnamectl --transient').strip()
+                output = session.cmd_output('hostnamectl --static').strip()
+                if not output:
+                    output = session.cmd_output('hostnamectl --transient').strip()
         finally:
             session.close()
         hostname_info['hostname'] = output


### PR DESCRIPTION
In the past, there were no _hostname_ command available in some images
and therefore the _hostnamectl_ was used instead. The _hostname_ is available
again and the _hostnamectl_ causing issues right now and therefore the
_hostname_ command was added back, but the _hostnamectl_ is there as a backup
for images, where the _hostname_ might not be available.

Signed-off-by: Kamil Varga <kvarga@redhat.com>

- Test results before the fix:
<pre>avocado run --vt-type libvirt --vt-machine-type q35 virsh.guestinfo.positive.hostname_info
WARNING:root:No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
WARNING:root:No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
<font color="#2A7BDE">JOB ID     : 6498781559957ef4f0972e2db2aadc84661d8196</font>
<font color="#2A7BDE">JOB LOG    : /root/avocado/job-results/job-2021-08-19T03.30-6498781/job.log</font>
 (1/1) type_specific.io-github-autotest-libvirt.virsh.guestinfo.positive.hostname_info: <font color="#F66151">FAIL: The hostname info get from guestinfo cmd is not correct.</font> (73.99 s)
<font color="#2A7BDE">RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0</font>
<font color="#2A7BDE">JOB TIME   : 74.54 s</font></pre>

- Test results after the fix is applied:
<pre>avocado run --vt-type libvirt --vt-machine-type q35 virsh.guestinfo.positive.hostname_info
WARNING:root:No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
WARNING:root:No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
<font color="#2A7BDE">JOB ID     : 0d0601e89098db1810287c303e3a43fa6e9048f7</font>
<font color="#2A7BDE">JOB LOG    : /root/avocado/job-results/job-2021-08-19T04.26-0d0601e/job.log</font>
 (1/1) type_specific.io-github-autotest-libvirt.virsh.guestinfo.positive.hostname_info: <font color="#33DA7A">PASS</font> (69.17 s)
<font color="#2A7BDE">RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0</font>
<font color="#2A7BDE">JOB TIME   : 69.73 s</font>
</pre>

