### PR TITLE
virsh_managedsave_extra: Fix IndexError: list index out of range

### DIFF
--- a/libvirt/tests/src/incremental_backup/incremental_backup_checkpoint_cmd.py
+++ b/libvirt/tests/src/incremental_backup/incremental_backup_checkpoint_cmd.py
@@ -10,6 +10,7 @@ from virttest import utils_disk
 from virttest import utils_backup
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import checkpoint_xml
+from virttest.libvirt_xml.devices import graphics
 from virttest.utils_test import libvirt
 
 
@@ -267,6 +268,10 @@ def run(test, params, env):
                 if vm.is_alive():
                     vm.destroy(gracefully=False)
                 password = "xyzxyzabcabc"
+                # Add graphics vnc if guest doesn't have
+                if not vmxml.get_devices(device_type="graphics"):
+                    logging.debug("Guest doesn't have graphic, add one")
+                    graphics.Graphics.add_graphic(vm_name, graphic="vnc")
                 vm_xml.VMXML.set_graphics_attr(vm_name, {'passwd': password})
                 vm.start()
                 vm.wait_for_login().close()

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_managedsave_extra.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_managedsave_extra.py
@@ -8,6 +8,7 @@ from virttest import data_dir
 from virttest import virsh
 from virttest import utils_libvirtd
 from virttest.libvirt_xml import vm_xml
+from virttest.libvirt_xml.devices import graphics
 from virttest.utils_test import libvirt
 
 MANAGEDSAVE_FILE = '/var/lib/libvirt/qemu/save/%s.save'
@@ -59,6 +60,10 @@ def run(test, params, env):
         if checkpoint == 'secure_info':
             # Check managedsave-dumpxml with option --security-info
             vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+            # Add graphics vnc if guest doesn't have
+            if not vmxml.get_devices(device_type="graphics"):
+                logging.debug("Guest doesn't have graphic, add one")
+                graphics.Graphics.add_graphic(vm_name, graphic="vnc")
             vm_xml.VMXML.set_graphics_attr(vm_name, {'passwd': '123456'})
             start_and_login_vm()
             virsh.managedsave(vm_name, **virsh_dargs)


### PR DESCRIPTION
Add graphics if guest doesn't have to fix IndexError

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Before
```
[root@hpe-apollo80-01-n00 ~]# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio \
> virsh.managedsave_extra.positive_test.dumpxml.secure_info \
> incremental_backup.checkpoint_cmd.checkpoint-dumpxml.security-info
JOB ID     : 9c3bc33694952c44f4f9017ac2b4c09f3f258723
JOB LOG    : /root/avocado/job-results/job-2021-08-23T02.34-9c3bc33/job.log
 (1/2) type_specific.io-github-autotest-libvirt.virsh.managedsave_extra.positive_test.dumpxml.secure_info: ERROR: list index out of range (8.87 s)
 (2/2) type_specific.io-github-autotest-libvirt.incremental_backup.checkpoint_cmd.checkpoint-dumpxml.security-info: ERROR: list index out of range (42.06 s)
```
After
```
[root@hpe-apollo80-01-n00 ~]# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virsh.managedsave_extra.positive_test.dumpxml.secure_info incremental_backup.checkpoint_cmd.checkpoint-dumpxml.security-info
JOB ID     : 5ac8698f002614c8b4a16e6d51e545cd8a3b6ed0
JOB LOG    : /root/avocado/job-results/job-2021-08-23T02.45-5ac8698/job.log
 (1/2) type_specific.io-github-autotest-libvirt.virsh.managedsave_extra.positive_test.dumpxml.secure_info: PASS (61.89 s)
 (2/2) type_specific.io-github-autotest-libvirt.incremental_backup.checkpoint_cmd.checkpoint-dumpxml.security-info: PASS (77.06 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 139.73 s
```
