### PR TITLE
Extend the wait time when bring up the interface

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domif_setlink_getlink.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domif_setlink_getlink.py
@@ -273,7 +273,7 @@ def run(test, params, env):
             session.cmd_status_output(cmd, timeout=10)
             pattern = "%s:.*state UP.*" % guest_if_name
             if not utils_misc.wait_for(lambda: guest_cmd_check(
-                    pattern_cmd, session, pattern), timeout=5):
+                    pattern_cmd, session, pattern), timeout=20):
                 test.fail("Could not bring up interface %s inside guest"
                           % guest_if_name)
         else:  # negative test


### PR DESCRIPTION
Bring up the interface need more time than expected sometimes.
Extend the wait time to 20s.

Signed-off-by: Yalan Zhang <yalzhang@redhat.com>