### PR TITLE
sriov: Update to check vf's setting

### DIFF
--- a/provider/sriov/sriov_base.py
+++ b/provider/sriov/sriov_base.py
@@ -22,6 +22,10 @@ def setup_vf(pf_pci, params):
     default_vf = process.run(cmd, shell=True, verbose=True).stdout_text
     if not utils_sriov.set_vf(pf_pci_path, vf_no):
         raise exceptions.TestError("Failed to set vf.")
+    if not utils_misc.wait_for(lambda: process.run(
+       cmd, shell=True, verbose=True).stdout_text.strip() == str(vf_no),
+       30, 5):
+        raise exceptions.TestError("VF's number should set to %d." % vf_no)
     return default_vf
 
 


### PR DESCRIPTION
It failed to get the vf without waiting for a period of time after
setting it.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
Before fix:
` (1/1) type_specific.io-github-autotest-libvirt.sriov.attach_from_network.active.networks.macvtap_passthrough: ERROR: Unable to get VF. status: 2, stdout: . (13.17 s)`

After fix:
` (1/1) type_specific.io-github-autotest-libvirt.sriov.attach_from_network.active.networks.macvtap_passthrough: PASS (42.13 s)`
