### PR TITLE
filesystem_devices/virtiofs: add memfd memory backing

### DIFF
--- a/libvirt/tests/cfg/virtual_device/filesystem_device.cfg
+++ b/libvirt/tests/cfg/virtual_device/filesystem_device.cfg
@@ -82,6 +82,9 @@
                       with_hugepages = yes
                 - file_backed:
                       with_hugepages = no
+                - memfd_backed:
+                      with_hugepages = no
+                      with_memfd = yes
         - negative_test:
             only nop.fs_test.xattr_on.flock_on.lock_posix_on.cache_mode_none.one_fs.one_guest
             status_error = "yes"

--- a/libvirt/tests/src/virtual_device/filesystem_device.py
+++ b/libvirt/tests/src/virtual_device/filesystem_device.py
@@ -107,6 +107,7 @@ def run(test, params, env):
     edit_start = params.get("edit_start", "no") == "yes"
     with_hugepages = params.get("with_hugepages", "yes") == "yes"
     with_numa = params.get("with_numa", "yes") == "yes"
+    with_memfd = params.get("with_memfd", "no") == "yes"
 
     fs_devs = []
     vms = []
@@ -166,7 +167,7 @@ def run(test, params, env):
                 numa_no = vmxml.vcpu // vcpus_per_cell if vmxml.vcpu != 1 else 1
             vm_xml.VMXML.set_vm_vcpus(vmxml.vm_name, vmxml.vcpu, numa_number=numa_no)
             vm_xml.VMXML.set_memoryBacking_tag(vmxml.vm_name, access_mode="shared",
-                                               hpgs=with_hugepages)
+                                               hpgs=with_hugepages, memfd=with_memfd)
             vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_names[index])
             logging.debug(vmxml)
             if coldplug:


### PR DESCRIPTION
Memory backing with 'memfd' is available as by [1].
Add this option, sample xml:

  <memoryBacking>
    <source type="memfd" />
    <access mode="shared" />
  </memoryBacking>

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [ ] Description of the cases
- [ ] Links of libvirt features, libvirt bugs or case IDs
- [ ] Test results

## If the PR is bug cases
- [ ] Bug descriptions or bug links
- [ ] Test results

## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
