### PR TITLE
Revert "Exclude s390x for vhostuser related test"

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_options.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_options.cfg
@@ -104,7 +104,6 @@
                             change_iface_options = "no"
                             iface_driver = "{'name':'vhost','queues':'5','rx_queue_size':'sdf'}"
                 - driver_vhost_rx_tx:
-                    no s390-virtio
                     ovs_br_name = "ovsbr0"
                     vhostuser_names = "vhost-user1"
                     need_vhostuser_env = "yes"
@@ -203,7 +202,6 @@
                     test_iface_mcast = "yes"
                     serial_login = "yes"
                 - type_vhostuser:
-                    no s390-virtio
                     need_vhostuser_env = "yes"
                     vhostuser_names = "vhost-user1"
                     iface_type = "vhostuser"


### PR DESCRIPTION
Reverts autotest/tp-libvirt#3724
After discussed with others, we prefer to add these cases into skiplist instead, as the openvswitch+s390x can be in upstream.