### PR TITLE
SR-IOV: Add 2 macvtap passthrough related cases

### DIFF
--- a/libvirt/tests/cfg/sriov/sriov_vf_pool.cfg
+++ b/libvirt/tests/cfg/sriov/sriov_vf_pool.cfg
@@ -1,0 +1,14 @@
+- sriov.vf_pool:
+    type = sriov_vf_pool
+    start_vm = "no"
+    variants test_case:
+        - at_dt:
+            variants:
+                - macvtap_passthrough:
+                    net_name = "macvtap-passthrough"
+                    net_forward = {"mode": "passthrough"}
+    variants pf_status:
+        - active:
+        - inactive:
+            status_error = "yes"
+                        

--- a/libvirt/tests/src/sriov/sriov_vf_pool.py
+++ b/libvirt/tests/src/sriov/sriov_vf_pool.py
@@ -1,0 +1,107 @@
+import logging
+
+from provider.sriov import sriov_base
+
+from virttest import utils_net
+from virttest import utils_sriov
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.libvirt_xml.devices import interface
+from virttest.utils_libvirt import libvirt_network
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+
+def create_network(params):
+    """
+    Create VF pool
+    """
+    net_dict = {"net_name": params.get("net_name"),
+                "net_forward": params.get("net_forward"),
+                "forward_iface": params.get("vf_iface")}
+    libvirt_network.create_or_del_network(net_dict)
+
+
+def create_iface(iface_dict):
+    """
+    Create Interface device
+
+    :param iface_dict: Dict, attrs of Interface
+    :return: xml object of interface
+    """
+    iface = interface.Interface("network")
+    iface.setup_attrs(**iface_dict)
+
+    logging.debug("Interface XML: %s", iface)
+    return iface
+
+
+def run(test, params, env):
+    """
+    Test interfaces attached from network
+    """
+
+    def test_at_dt():
+        """
+        Test attach-detach interfaces
+        """
+        if not pf_status:
+            logging.info("Set pf state to down.")
+            pf_iface_obj = utils_net.Interface(pf_name)
+            pf_iface_obj.down()
+
+        logging.info("Define network - %s.", params.get("net_name"))
+        create_network(params)
+
+        logging.debug("Remove VM's interface devices.")
+        libvirt_vmxml.remove_vm_devices_by_type(vm, 'interface')
+        vm.start()
+        vm_session = vm.wait_for_serial_login(timeout=240)
+
+        logging.info("Hotplug an interface to VM.")
+        iface_dict = {"model": "virtio",
+                      "source": {'network': params.get("net_name")}}
+        iface = create_iface(iface_dict)
+        res = virsh.attach_device(vm_name, iface.xml, debug=True)
+        libvirt.check_exit_status(res, status_error)
+        if not pf_status:
+            logging.info("Set pf state to up then check again.")
+            pf_iface_obj.up()
+            virsh.attach_device(vm_name, iface.xml, debug=True,
+                                ignore_status=False)
+        libvirt_vmxml.check_guest_xml(vm.name, params["net_name"])
+        sriov_base.check_vm_network_accessed(vm_session)
+
+    test_case = params.get("test_case", "")
+    run_test = eval("test_%s" % test_case)
+    status_error = "yes" == params.get("status_error", "no")
+
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    vm = env.get_vm(vm_name)
+    pf_pci = utils_sriov.get_pf_pci()
+    if not pf_pci:
+        test.cancel("NO available pf found.")
+    sriov_base.setup_vf(pf_pci, params)
+
+    vf_pci = utils_sriov.get_vf_pci_id(pf_pci)
+    params['vf_iface'] = utils_sriov.get_iface_name(vf_pci)
+    pf_status = "active" == params.get("pf_status", "active")
+    pf_name = utils_sriov.get_pf_info_by_pci(pf_pci).get('iface')
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    orig_config_xml = vmxml.copy()
+
+    try:
+        run_test()
+
+    finally:
+        logging.info("Recover test enviroment.")
+        if not pf_status:
+            pf_iface_obj = utils_net.Interface(pf_name)
+            pf_iface_obj.up()
+        sriov_base.recover_vf(pf_pci, params)
+        if vm.is_alive():
+            vm.destroy(gracefully=False)
+        orig_config_xml.sync()
+        libvirt_network.create_or_del_network(
+            {"net_name": params.get("net_name")}, True)

--- a/provider/sriov/sriov_base.py
+++ b/provider/sriov/sriov_base.py
@@ -7,6 +7,7 @@ from virttest import utils_misc
 from virttest import utils_net
 from virttest import utils_package
 from virttest import utils_sriov
+from virttest import utils_test
 
 
 def setup_vf(pf_pci, params):
@@ -76,3 +77,20 @@ def get_ping_dest(vm_session, mac_addr="", restart_network=False):
         raise exceptions.TestError("Failed to run cmd - {}, status - {}, "
                                    "output - {}.".format(cmd, status, output))
     return re.sub('\d+$', '1', output.strip())
+
+
+def check_vm_network_accessed(vm_session, ping_count=3, ping_timeout=5):
+    """
+    Test VM's network accessibility
+
+    :param vm_session: The session object to the guest
+    :param ping_count: The count value of ping command
+    :param ping_timeout: The timeout of ping command
+    :raise: test.fail when ping fails.
+    """
+    ping_dest = get_ping_dest(vm_session)
+    s, o = utils_test.ping(
+        ping_dest, count=ping_count, timeout=ping_timeout, session=vm_session)
+    if s:
+        raise exceptions.TestFail("Failed to ping %s! status: %s, "
+                                  "output: %s." % (ping_dest, s, o))


### PR DESCRIPTION
This PR adds:
1. RHEL7-18529: Attach/detach interfaces from macvtap network
    with passthrough mode
2. RHEL7-103842: Attach VF in direct passthrough mode with PF is down

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Test result:**
```
 (1/2) type_specific.io-github-autotest-libvirt.sriov.vf_pool.active.at_dt.macvtap_passthrough: PASS (36.60 s)
 (2/2) type_specific.io-github-autotest-libvirt.sriov.vf_pool.inactive.at_dt.macvtap_passthrough: PASS (46.42 s)

```