### PR TITLE
Update the rom file path if needed

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_update.py
+++ b/libvirt/tests/src/virtual_network/iface_update.py
@@ -4,6 +4,7 @@ import logging
 import time
 
 from avocado.utils import process
+from avocado.utils.software_manager.backends import rpm
 
 from virttest import virsh
 from virttest import utils_net
@@ -102,6 +103,11 @@ def run(test, params, env):
         # According to the different os find different file for rom
         if (iface_rom and "file" in eval(iface_rom)
                 and "%s" in eval(iface_rom)['file']):
+            if rpm.RpmBackend().check_installed('ipxe-roms-qemu', '20200823'):
+                logging.debug("Update the file path since "
+                              "ipxe-20200823-5:")
+                iface_rom_new = iface_rom.replace('qemu-kvm', 'ipxe/qemu')
+                iface_rom = iface_rom_new
             if os.path.exists(eval(iface_rom)['file'] % "pxe"):
                 iface_rom = iface_rom % "pxe"
             elif os.path.exists(eval(iface_rom)['file'] % "efi"):


### PR DESCRIPTION
Update the rom file path as the qemu changes in bug 1980139. qemu has drop all /usr/share/qemu-kvm rom symlinking in the spec file since qemu-kvm-6.0.0-11.el9. So the original file path  "/usr/share/qemu-kvm" will no longer used. To support it, ipxe also change a bit since ipxe-20200823-5.git4bd064de.el9. As it will be easier to check the ipxe version than qemu(qemu version differs in different releases), add the version check based on the package ipxe-roms-qemu.

Signed-off-by: Yalan Zhang <yalzhang@redhat.com>