### PR TITLE
virsh_event: relax regex

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
@@ -572,7 +572,7 @@ def run(test, params, env):
             if re.search("block-threshold", event):
                 event_str = "block-threshold"
             else:
-                event_str = "event " + event % ("domain.*%s" % dom_name)
+                event_str = "event " + event % ("domain.*%s.*" % dom_name)
             logging.info("Expected event: %s", event_str)
             match = re.search(event_str, output[event_idx:])
             if match:


### PR DESCRIPTION
e12b8991613f2247fe12344a9fbdb047646d7c7f made the regex less
prone to errors. However, some tests would fail if additional
"'" was after domain name.
Fix now to allow for both "'domain_name'" and "domain_name".

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>