### PR TITLE
Fix value compare error for rx

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_stat.py
+++ b/libvirt/tests/src/virtual_network/iface_stat.py
@@ -84,6 +84,8 @@ def compare_iface_stat(vm_stat, host_stat, bar=0.2):
 
     for key in vm_stat.keys():
         delta = abs(vm_stat[key] - host_stat[key])
+        if key == 'rx_errs' or key == 'rx_drop':
+            continue
         if delta == 0:
             continue
         elif delta / max(vm_stat[key], host_stat[key]) > bar:


### PR DESCRIPTION
Signed-off-by: Kyla Zhang <weizhan@redhat.com>

For compare_iface_stat when host rx_errs and rx_drop are not 0(as in vm it may always 0), the delta/max_value will larger than expect value. Already checked with feature owner that we do not need to compare these 2 value. So remove the compare for them

before:
```
 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.iface_stat.compare.direct_type: FAIL: Iface stat of host and vm should be close. (64.33 s)
```
after:
```
 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.iface_stat.compare.direct_type: PASS (63.30 s)
```