### PR TITLE
virsh_sendkey: Fix sysrq doesn't work

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_sendkey.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_sendkey.cfg
@@ -85,10 +85,13 @@
             sendkey_sysrq = "yes"
             variants:
                 - help:
+                    need_keyboard_device = "yes"
                     sendkey = "KEY_LEFTALT KEY_SYSRQ KEY_H"
                 - show_memory_usage:
+                    need_keyboard_device = "yes"
                     sendkey = "KEY_LEFTALT KEY_SYSRQ KEY_M"
                 - show_task_status:
+                    need_keyboard_device = "yes"
                     sendkey = "KEY_LEFTALT KEY_SYSRQ KEY_T"
                 - reboot_guest:
                     sendkey = "KEY_LEFTALT KEY_SYSRQ KEY_B"


### PR DESCRIPTION
Part of sysrq tests failed since sysrq doesn't work. The root cause is
the lack of keyboard device.
Refer to BZ#1526862.

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>