### PR TITLE
NUMA:Add case for NUMA numatune with invalid nodeset.

### DIFF
--- a/libvirt/tests/cfg/numa/numa_nodeset.cfg
+++ b/libvirt/tests/cfg/numa/numa_nodeset.cfg
@@ -1,0 +1,7 @@
+- numa_nodeset:
+    type = numa_nodeset
+    memory_mode = "strict"
+    cellid = "0"
+    variants:
+        - invalid:
+            error_msg = 'unsupported configuration: NUMA node \d+ is unavailable'

--- a/libvirt/tests/src/numa/numa_nodeset.py
+++ b/libvirt/tests/src/numa/numa_nodeset.py
@@ -1,0 +1,56 @@
+import logging
+
+from virttest import libvirt_xml
+from virttest import utils_misc
+from virttest import utils_test
+from virttest import virsh
+
+
+def update_xml(vm_name, params):
+    numa_info = utils_misc.NumaInfo()
+    online_nodes = numa_info.get_all_nodes()
+    # Prepare a memnode list
+    numa_memnode = [{
+        'mode': params.get('memory_mode', 'strict'),
+        'cellid': params.get('cellid', '0'),
+        # Take a first node above available nodes.
+        'nodeset': params.get('memory_nodeset', str(int(online_nodes[-1]) + 1))
+    }]
+    # Prepare a numa cells list
+    numa_cells = [{
+        'id': '0',
+        # cpus attribute is optional and if omitted a CPU-less NUMA node is
+        # created as per libvirt.org documentation.
+        'memory': '512000',
+        'unit': 'KiB'}
+    ]
+    vmxml = libvirt_xml.VMXML.new_from_dumpxml(vm_name)
+    del vmxml.numa_memory
+
+    vmxml.setup_attrs(**{
+        'numa_memnode': numa_memnode,
+        'cpu': {'reset_all': True, 'mode': 'host-model', 'numa_cell': numa_cells}
+    })
+
+    logging.debug("vm xml is %s", vmxml)
+    vmxml.sync()
+
+
+def run(test, params, env):
+    """
+    Test the numatune nodeset for invalid value.
+    """
+    vm_name = params.get("main_vm")
+    error_message = params.get("error_msg")
+    backup_xml = libvirt_xml.VMXML.new_from_dumpxml(vm_name)
+    try:
+        update_xml(vm_name, params)
+        # Try to start the VM with invalid node, fail is expected
+        ret = virsh.start(vm_name, ignore_status=True)
+        utils_test.libvirt.check_status_output(ret.exit_status,
+                                               ret.stderr_text,
+                                               expected_fails=[error_message])
+    except Exception as e:
+        test.error("Unexpected error: {}".format(e))
+    finally:
+        backup_xml.sync()


### PR DESCRIPTION
Test case comes from: report invalid Host nodeset for memnode -
bug 1186175. The test verifies the error message, when invalid
nodeset is used.

Signed-off-by: Kamil Varga <kvarga@redhat.com>

- Description of the case:
  report invalid Host nodeset for memnode - bug 1186175
- case IDs:
  RHEL7-16419
- Test results:
  <pre>avocado run --vt-type libvirt --vt-machine-type q35 numa_invalid_nodeset
WARNING:root:No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
WARNING:root:No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
<font color="#2A7BDE">JOB ID     : 28a69ed2d2b8772004f6446f2e73ca423784c950</font>
<font color="#2A7BDE">JOB LOG    : /root/avocado/job-results/job-2021-08-27T12.38-28a69ed/job.log</font>
 (1/1) type_specific.io-github-autotest-libvirt.numa_invalid_nodeset.default: <font color="#33DA7A">PASS</font> (6.91 s)
<font color="#2A7BDE">RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0</font>
<font color="#2A7BDE">JOB TIME   : 7.60 s</font></pre>