### PR TITLE
Fix local variable 'virsh_session' referenced before assignment

### DIFF
--- a/provider/migration/migration_base.py
+++ b/provider/migration/migration_base.py
@@ -141,6 +141,9 @@ def monitor_event(params):
     remote_ip = params.get("migrate_dest_host")
     remote_user = params.get("remote_user", "root")
 
+    virsh_session = None
+    remote_virsh_session = None
+
     cmd = "event --loop --all"
     if expected_event_src:
         logging.debug("Running virsh command on source: %s", cmd)


### PR DESCRIPTION
If 'expected_event_src' is empty, it will cause local variable
'virsh_session' referenced before assignment. So update code.

Signed-off-by: lcheng <lcheng@redhat.com>

