### PR TITLE
virtual_disks_vhostuser: Set queues of vhost blk to 1

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_vhostuser.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_vhostuser.cfg
@@ -11,6 +11,7 @@
     target_dev = "vdb"
     target_bus = "virtio"
     type_name = "vhostuser"
+    queues = 1
     disk_snapshot_attr = "no"
     variants:
         - start_vhostuser_vm:

--- a/libvirt/tests/src/virtual_disks/virtual_disks_vhostuser.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_vhostuser.py
@@ -58,6 +58,7 @@ def create_vhostuser_disk(params):
     device_target = params.get("target_dev")
     device_bus = params.get("target_bus")
     device_format = params.get("target_format")
+    queues = params.get("queues")
     sock_path = params.get("source_file")
     disk_src_dict = {"attrs": {"type": "unix",
                      "path": sock_path}}
@@ -66,6 +67,7 @@ def create_vhostuser_disk(params):
         device_target, device_bus,
         device_format, disk_src_dict, None)
     vhostuser_disk.snapshot = "no"
+    vhostuser_disk.driver["queues"] = queues
     return vhostuser_disk
 
 


### PR DESCRIPTION
Since QEMU 5.2 (commit a4eef0711b2)[1] the default queues of
vhost-user-blk-pci will be set to the numbers of smp. In case it is over
the default queues value 1 in qemu-storage-daemon, set it to 1.

Fix the 

[1]: https://gitlab.com/qemu/qemu/-/commit/a4eef0711b2cf7a7476c3e2c202a414b68a1baa0

Signed-off-by: Han Han <hhan@redhat.com>