### PR TITLE
filesystem_device: Add case for BZ#1940276

### DIFF
--- a/libvirt/tests/cfg/virtual_device/filesystem_device.cfg
+++ b/libvirt/tests/cfg/virtual_device/filesystem_device.cfg
@@ -76,6 +76,11 @@
                 - edit_start:
                     edit_start = "yes"
                     error_msg_start = "qemu-kvm: -foo: invalid option"
+                - destroy_start:
+                    only file_backed
+                    bug_url = "https://bugzilla.redhat.com/show_bug.cgi?id=1940276"
+                    destroy_start = "yes"
+                    stress_script = "#!/usr/bin/python3;import os;while True:;    os.open("%s/moo", os.O_CREAT | os.O_RDWR);    os.unlink("%s/moo");"
         - coldplug_coldunplug:
             only xattr_on.flock_on.lock_posix_on.cache_mode_none.one_fs
             coldplug = "yes"


### PR DESCRIPTION
Bug link: https://bugzilla.redhat.com/show_bug.cgi?id=1940276

 - RHEL-281745
Check virtiofsd process exit before 'virsh destroy' cmd return.

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>