### PR TITLE
live_migration: Add case about migration_port_min

### DIFF
--- a/libvirt/tests/cfg/migration/live_migration.cfg
+++ b/libvirt/tests/cfg/migration/live_migration.cfg
@@ -208,3 +208,10 @@
             migrate_again = 'yes'
             migrate_again_status_error = 'no'
             action_during_mig = '[{"func": "virsh.destroy", "after_event": "iteration: '1'", "func_param": "'%s' % params.get('migrate_main_vm')"}]'
+        - migration_minport_occupied:
+            check_port = 'yes'
+            min_port = 49152
+            qemu_conf_list = '["migration_port_min", "migration_port_max"]'
+            qemu_conf_path = '/etc/libvirt/qemu.conf'
+            migrate_speed = 10
+            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}]'


### PR DESCRIPTION
RHEL7-17384 - [Migration] Do live VM migration with the minimum
available migration port occupied by other app

Signed-off-by: lcheng <lcheng@redhat.com>
