### PR TITLE
sriov: Add 2 cases about network connections

### DIFF
--- a/libvirt/tests/cfg/sriov/sriov_vf_pool.cfg
+++ b/libvirt/tests/cfg/sriov/sriov_vf_pool.cfg
@@ -7,6 +7,20 @@
                 - macvtap_passthrough:
                     net_name = "macvtap-passthrough"
                     net_forward = {"mode": "passthrough"}
+        - connection:
+            only active
+            net_forward_pf = "yes"
+            vf_no = 4
+            attach_extra_opts = "--model virtio"
+            variants:
+                - macvtap_passthrough:
+                    net_name = "macvtap-passthrough"
+                    net_forward = {"mode": "passthrough"}
+                    iface_type = "direct"
+                - hostdev:
+                    net_name = "hostdev-net"
+                    net_forward = {"mode": "hostdev", "managed": "yes"}
+                    iface_type = "hostdev"
     variants pf_status:
         - active:
         - inactive:

--- a/libvirt/tests/src/sriov/sriov_vf_pool.py
+++ b/libvirt/tests/src/sriov/sriov_vf_pool.py
@@ -2,6 +2,7 @@ import logging
 
 from provider.sriov import sriov_base
 
+from virttest import utils_libvirtd
 from virttest import utils_net
 from virttest import utils_sriov
 from virttest import virsh
@@ -9,6 +10,7 @@ from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices import interface
 from virttest.utils_libvirt import libvirt_network
+from virttest.utils_libvirt import libvirt_pcicontr
 from virttest.utils_libvirt import libvirt_vmxml
 from virttest.utils_test import libvirt
 
@@ -18,8 +20,13 @@ def create_network(params):
     Create VF pool
     """
     net_dict = {"net_name": params.get("net_name"),
-                "net_forward": params.get("net_forward"),
-                "forward_iface": params.get("vf_iface")}
+                "net_forward": params.get("net_forward")}
+    net_forward_pf = "yes" == params.get("net_forward_pf")
+    if net_forward_pf:
+        net_dict.update(
+            {"net_forward_pf": '{"dev": "%s"}' % params.get("pf_name")})
+    else:
+        net_dict.update({"forward_iface": params.get("vf_iface")})
     libvirt_network.create_or_del_network(net_dict)
 
 
@@ -73,6 +80,54 @@ def run(test, params, env):
         libvirt_vmxml.check_guest_xml(vm.name, params["net_name"])
         sriov_base.check_vm_network_accessed(vm_session)
 
+    def test_connection():
+        """
+        Test network connections
+
+        1. Create a network
+        2. Attach the interfaces and check network connections
+        3. Check the network connections after detaching ifaces, restarting
+            libvirtd and destroying the VM
+        """
+        vf_no = int(params.get("vf_no", "4"))
+        net_name = params.get("net_name")
+        iface_type = params.get("iface_type")
+
+        logging.info("Define network - %s.", net_name)
+        create_network(params)
+        libvirt_vmxml.remove_vm_devices_by_type(vm, 'interface')
+        libvirt_pcicontr.reset_pci_num(vm_name)
+        vm.start()
+        vm.wait_for_serial_login(timeout=240)
+
+        logging.info("Attach 4 interfaces to the guest.")
+        opts = ' '.join(["network", net_name, params.get(
+            'attach_extra_opts', "")])
+        for i in range(vf_no):
+            virsh.attach_interface(vm_name, option=opts, debug=True,
+                                   ignore_status=False)
+            libvirt_network.check_network_connection(net_name, i+1)
+
+        logging.info("Try to attach one more interface.")
+        res = virsh.attach_interface(vm_name, option=opts, debug=True)
+        libvirt.check_exit_status(res, True)
+
+        logging.info("Detach an interface.")
+        vm_ifaces = [iface for iface in vm_xml.VMXML.new_from_dumpxml(vm_name).
+                     devices.by_device_tag("interface")]
+        mac_addr = vm_ifaces[0].get_mac_address()
+        opts = ' '.join([iface_type, "--mac %s" % mac_addr])
+        virsh.detach_interface(vm_name, option=opts, debug=True,
+                               ignore_status=False)
+        libvirt_network.check_network_connection(net_name, vf_no-1)
+
+        logging.info("Restart libvirtd service and check the network connection.")
+        utils_libvirtd.Libvirtd().restart()
+        libvirt_network.check_network_connection(net_name, vf_no-1)
+        logging.info("Destroy the VM and check the network connection.")
+        vm.destroy(gracefully=False)
+        libvirt_network.check_network_connection(net_name, 0)
+
     test_case = params.get("test_case", "")
     run_test = eval("test_%s" % test_case)
     status_error = "yes" == params.get("status_error", "no")
@@ -88,6 +143,7 @@ def run(test, params, env):
     params['vf_iface'] = utils_sriov.get_iface_name(vf_pci)
     pf_status = "active" == params.get("pf_status", "active")
     pf_name = utils_sriov.get_pf_info_by_pci(pf_pci).get('iface')
+    params['pf_name'] = pf_name
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     orig_config_xml = vmxml.copy()
 


### PR DESCRIPTION
1. RHEL7-18531 - Check the number of connections on hostdev
    network during hotplug / unplug
2. RHEL7-98468 - Check the the connections of macvtap network
    with VF

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**depends on** https://github.com/avocado-framework/avocado-vt/pull/3207
**Test results:**
```
 (1/4) type_specific.io-github-autotest-libvirt.sriov.vf_pool.active.at_dt.macvtap_passthrough: PASS (38.85 s)
 (2/4) type_specific.io-github-autotest-libvirt.sriov.vf_pool.active.connection.macvtap_passthrough: PASS (38.20 s)
 (3/4) type_specific.io-github-autotest-libvirt.sriov.vf_pool.active.connection.hostdev: PASS (40.73 s)
 (4/4) type_specific.io-github-autotest-libvirt.sriov.vf_pool.inactive.at_dt.macvtap_passthrough: PASS (46.89 s)
```