### PR TITLE
Fix blockcopy slice case failure

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_ceph.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_ceph.py
@@ -866,7 +866,8 @@ def run(test, params, env):
                 disk_cmd = ("rbd -m %s %s create %s --size 400M 2> /dev/null"
                             % (mon_host, key_opt, disk_src_name))
                 process.run(disk_cmd, ignore_status=False, shell=True)
-                slice_dict = {"slice_type": "storage", "slice_offset": "12345", "slice_size": "105185280"}
+                slice_dict = {"slice_type": "storage", "slice_offset": "12345",
+                              "slice_size": "52428800"}
                 params.update({"disk_slice": slice_dict})
                 logging.debug('create one volume on ceph backend storage for slice testing')
             # Create one file on VM before doing blockcopy


### PR DESCRIPTION
slice_offset+slice_size need be equal to size of src_img
as per description in [1]

[1]https://github.com/autotest/tp-libvirt/issues/3751

Signed-off-by: chunfuwen <chwen@redhat.com>

