### PR TITLE
Fix nbd default port pre-occupied issue

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_nbd.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_nbd.cfg
@@ -11,7 +11,7 @@
     virt_disk_device_type = "network"
     backend_storage_type = "nbd"
     emulated_image = "/var/lib/libvirt/images/nbd.qcow2"
-    nbd_server_port = "10001"
+    nbd_server_port = "10002"
     define_error = "no"
     status_error = "no"
     variants:


### PR DESCRIPTION
Default nbd 10001 is pre-occupied,change to another one

Signed-off-by: chunfuwen <chwen@redhat.com>

