### PR TITLE
tpm_dev: passthrough error msg fix

### DIFF
--- a/libvirt/tests/cfg/virtual_device/tpm_device.cfg
+++ b/libvirt/tests/cfg/virtual_device/tpm_device.cfg
@@ -100,7 +100,7 @@
                             device_path = '/dev/tpm0'
                         - multi_passthrgh_tpm:
                             tpm_num = 2
-                            xml_errmsg = 'only a single TPM non-proxy device is supported'
+                            xml_errmsg = 'only a single TPM .*device is supported'
                 - emulator:
                     backend_type='emulator'
                     tpm_model = 'tpm-crb'


### PR DESCRIPTION
On rhel product, the error msg when passhthrough multiple tpm
devices would be different from rhel-av. Update the error msg to
adapt to more situations.

Signed-off-by: Yanqiu Zhang <yanqzhan@redhat.com>

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [ ] Description of the cases
- [ ] Links of libvirt features, libvirt bugs or case IDs
- [ ] Test results

## If the PR is bug cases
- [ ] Bug descriptions or bug links
- [ ] Test results

## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
