### PR TITLE
nodedev-create-destroy: add comment about precondition

### DIFF
--- a/libvirt/tests/src/virsh_cmd/nodedev/crypto_nodedev_create_destroy.py
+++ b/libvirt/tests/src/virsh_cmd/nodedev/crypto_nodedev_create_destroy.py
@@ -104,6 +104,13 @@ def run(test, params, env):
     5. Destroy the mdev
     6. Confirm the mdev was destroyed successfully
 
+    NOTE: It can take a while after loading vfio_ap for the
+          matrix device to become available due to current
+          performance issues with the API if there are several
+          mdev definitions already available. The test supposes
+          no other mdev devices have been defined yet in order
+          to avoid complexity in the test code.
+
     :param test: test object
     :param params: Dict with test parameters
     :param env: Dict with the test environment


### PR DESCRIPTION
We found that due to performance issues with older mdevctl versions
the test might fail because it takes libvirt longer to identify the
ap_matrix device.

In order to avoid code to become more complex add a note about
pre-conditions for anybody who might run into this.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>
