### PR TITLE
aarch64_cpu_sve: Add sve cases

### DIFF
--- a/libvirt/tests/cfg/cpu/aarch64_cpu_sve.cfg
+++ b/libvirt/tests/cfg/cpu/aarch64_cpu_sve.cfg
@@ -29,14 +29,21 @@
                                     vector_length = "sve256"
                                 - sve512:
                                     vector_length = "sve512"
+                        - mutiple_vector:
+                            vector_lenth_list = '[{"sve128":"require"}, {"sve256":"require"}, {"sve384":"disable"}, {"sve512":"require"}]'
                 - invalid_length:
                     only negative_test
                     expect_sve = "no"
                     vector_length = "sve1234"
                     expect_msg = "unsupported configuration: unknown CPU feature: sve1234"
+                - conflict_length:
+                    only negative_test
+                    vector_lenth_list = '[{"sve":"disable"}, {"sve128":"require"}]'
+                    define_error = "yes"
+                    expect_msg = "SVE disabled, but SVE vector lengths provided"
     variants:
         - positive_test:
             status_error = "no"
         - negative_test:
-            only invalid_length
+            only invalid_length, conflict_length
             status_error = "yes"


### PR DESCRIPTION
1. Add positive case of setting multiple vector length.
2. Add negative case of setting conflict sve policy.
3. Fix the wrong logic that caused the test to be cancelled.

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio \
> aarch64_cpu_sve.positive_test.vector_length_test.valid_length.mutiple_vector \
> aarch64_cpu_sve.negative_test.vector_length_test.conflict_length
JOB ID     : 807025b478216feca36e553ff316ae9eca656a65
JOB LOG    : /root/avocado/job-results/job-2021-09-09T22.52-807025b/job.log
 (1/2) type_specific.io-github-autotest-libvirt.aarch64_cpu_sve.positive_test.vector_length_test.valid_length.mutiple_vector: PASS (79.12 s)
 (2/2) type_specific.io-github-autotest-libvirt.aarch64_cpu_sve.negative_test.vector_length_test.conflict_length: PASS (44.59 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 124.53 s
```
