### PR TITLE
iface_network: add version switch

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_network.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_network.cfg
@@ -167,7 +167,9 @@
                             test_ipv4_address = "no"
                             variants:
                                 - default:
+                                    func_supported_since_libvirt_ver = (6, 6, 0)
                                 - bridge_type:
+                                    func_supported_since_libvirt_ver = (7, 0, 0)
                                     iface_model = "virtio"
                                     iface_type = "bridge"
                                     change_iface_option = "yes"

--- a/libvirt/tests/src/virtual_network/iface_network.py
+++ b/libvirt/tests/src/virtual_network/iface_network.py
@@ -653,16 +653,7 @@ TIMEOUT 3"""
     define_macvtap = "yes" == params.get("define_macvtap", "no")
     net_dns_forwarders = params.get("net_dns_forwarders", "").split()
 
-    # Destroy VM first
-    if vm.is_alive() and not update_device:
-        vm.destroy(gracefully=False)
-
-    # Back up xml file.
-    netxml_backup = NetworkXML.new_from_net_dumpxml("default")
-    iface_mac = vm_xml.VMXML.get_first_mac_by_name(vm_name)
-    params["guest_mac"] = iface_mac
-    vmxml_backup = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
-    vms_list = []
+    # Cancel if not yet supported in libvirt version under test
     if "floor" in ast.literal_eval(iface_bandwidth_inbound):
         if not libvirt_version.version_compare(1, 0, 1):
             test.cancel("Not supported Qos options 'floor'")
@@ -674,6 +665,19 @@ TIMEOUT 3"""
             test.cancel('Test case might fail before 6.5.0 where it was'
                         ' fixed with libvirt commit'
                         ' 876211ef4a192df1603b45715044ec14567d7e9f')
+
+    libvirt_version.is_libvirt_feature_supported(params)
+
+    # Destroy VM first
+    if vm.is_alive() and not update_device:
+        vm.destroy(gracefully=False)
+
+    # Back up xml file.
+    netxml_backup = NetworkXML.new_from_net_dumpxml("default")
+    iface_mac = vm_xml.VMXML.get_first_mac_by_name(vm_name)
+    params["guest_mac"] = iface_mac
+    vmxml_backup = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    vms_list = []
 
     # Enabling IPv6 forwarding with RA routes without accept_ra set to 2
     # is likely to cause routes loss


### PR DESCRIPTION
This was fixed only with 7.0.0 and confirmed with devs
there are no plans to backport at this point because there's
a workaround.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>
