### PR TITLE
Clean coredump info for cases generating coredump during test

### DIFF
--- a/libvirt/tests/cfg/daemon/kill_qemu.cfg
+++ b/libvirt/tests/cfg/daemon/kill_qemu.cfg
@@ -10,12 +10,14 @@
             signal = SIGTERM
         -sigabrt:
             signal = SIGABRT
+            expect_coredump = yes
         -sighup:
             signal = SIGHUP
         -sigkill:
             signal = SIGKILL
         -sigquit:
             signal = SIGQUIT
+            expect_coredump = yes
     variants:
         -running:
             vm_state = "running"

--- a/libvirt/tests/cfg/daemon/kill_started.cfg
+++ b/libvirt/tests/cfg/daemon/kill_started.cfg
@@ -19,6 +19,7 @@
         - sigabrt:
             signal = 'SIGABRT'
             expect_restart = yes
+            expect_coredump = yes
             restart_timeout = 3
         - sigkill:
             signal = 'SIGKILL'
@@ -27,5 +28,6 @@
             signal = 'SIGSEGV'
             restart_timeout = 3
             expect_restart = yes
+            expect_coredump = yes
             sysconfig = 'DAEMON_COREFILE_LIMIT=unlimited'
             check_dmesg = 'code=dumped, status=11/SEGV'


### PR DESCRIPTION
Signed-off-by: Yan Fu <yafu@redhat.com>

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [ ] Description of the cases
- [ ] Links of libvirt features, libvirt bugs or case IDs
- [ ] Test results

## If the PR is bug cases
- [ ] Bug descriptions or bug links
- [ ] Test results

## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
