### PR TITLE
NUMA: Add test to cover bug 1186199

### DIFF
--- a/libvirt/tests/cfg/numa/numa_node_memory_bind.cfg
+++ b/libvirt/tests/cfg/numa/numa_node_memory_bind.cfg
@@ -1,0 +1,7 @@
+- numa_node_memory_bind:
+    type = numa_node_memory_bind
+    variants:
+        - vcpu_bind:
+            replace_string =  :%s:<vcpu placement='static'>:<vcpu placement='auto'>:
+        - placement_bind:
+            replace_string =  :%s:<numatune>:<numatune>\r<memory mode='strict' placement='auto'/>:

--- a/libvirt/tests/src/numa/numa_node_memory_bind.py
+++ b/libvirt/tests/src/numa/numa_node_memory_bind.py
@@ -1,0 +1,55 @@
+import logging
+
+from virttest import libvirt_xml
+from virttest import utils_misc
+
+from virttest.utils_test import libvirt
+
+
+def prepare_vm(vm_name, test):
+    host_numa_node = utils_misc.NumaInfo()
+    node_list = host_numa_node.online_nodes_withmem
+    if len(node_list) < 2:
+        test.cancel("Not enough numa nodes available")
+    vmxml = libvirt_xml.VMXML.new_from_dumpxml(vm_name)
+    numa_memnode = [
+        {'cellid': '0', 'mode': 'strict', 'nodeset': str(node_list[0])},
+        {'cellid': '1', 'mode': 'preferred', 'nodeset': str(node_list[1])}
+    ]
+    numa_cells = [
+        {'id': '0', 'memory': '512000', 'unit': 'KiB'},
+        {'id': '1', 'memory': '512000', 'unit': 'KiB'}
+    ]
+    vmxml.setup_attrs(**{
+        'numa_memnode': numa_memnode,
+        'cpu': {'reset_all': True, 'mode': 'host-model',
+                'numa_cell': numa_cells}
+    })
+    logging.debug('VM XML prior test: {}'.format(vmxml))
+    vmxml.sync()
+
+
+def run(test, params, env):
+    """
+    Test numa node memory binding with automatic numa placement
+    """
+
+    logging.debug("The test has been started.")
+    vm_name = params.get("main_vm")
+    backup_xml = libvirt_xml.VMXML.new_from_dumpxml(vm_name)
+    replace_string = params.get("replace_string", '')
+    try:
+        prepare_vm(vm_name, test)
+        status = libvirt.exec_virsh_edit(vm_name, [replace_string])
+        if status:
+            test.fail(
+                'Failure expected during virsh edit, but no failure occurs.')
+        else:
+            logging.info(
+                'Virsh edit has failed, but that is intentional in '
+                'negative cases.')
+    except Exception as e:
+        test.error("Unexpected error happened during the test execution: {}"
+                   .format(e))
+    finally:
+        backup_xml.sync()


### PR DESCRIPTION
This test is to cover the per-node memory binding is not compatible
with automatic NUMA placement.

Signed-off-by: Kamil Varga <kvarga@redhat.com>

-  Description of the cases:
  Per-node memory binding is not compatible with automatic NUMA placement - bug 1186199
- Case ID:
  RHEL7-16422
- Test results:
<pre>avocado run --vt-type libvirt --vt-machine-type q35 numa_node_memory_bind
WARNING:root:No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
WARNING:root:No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
<font color="#2A7BDE">JOB ID     : 03a4e7903154e3ade82a0238a4fe23f05d6a0104</font>
<font color="#2A7BDE">JOB LOG    : /root/avocado/job-results/job-2021-09-13T03.24-03a4e79/job.log</font>
 (1/2) type_specific.io-github-autotest-libvirt.numa_node_memory_bind.vcpu_bind: <font color="#33DA7A">PASS</font> (26.44 s)
 (2/2) type_specific.io-github-autotest-libvirt.numa_node_memory_bind.placement_bind: <font color="#33DA7A">PASS</font> (29.18 s)
<font color="#2A7BDE">RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0</font>
<font color="#2A7BDE">JOB TIME   : 57.58 s</font>
</pre>