### PR TITLE
[minor fix] numa_memory_spread: Add numa nodes check

### DIFF
--- a/libvirt/tests/src/numa/numa_memory_spread.py
+++ b/libvirt/tests/src/numa/numa_memory_spread.py
@@ -50,6 +50,8 @@ def prepare_host_for_test(params, test):
     # Create a NumaInfo object to get NUMA related information
     numa_info = utils_misc.NumaInfo()
     online_nodes = numa_info.get_online_nodes_withmem()
+    if len(online_nodes) < 2:
+        test.cancel("This test needs at least 2 available numa nodes")
     numa_memory = {
         'mode': params.get('memory_mode', 'strict'),
         # If nodeset is not defined in config, take a first node with memory.


### PR DESCRIPTION
This test needs at least 2 numa nodes.

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Before
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio numa_memory_spread.default
JOB ID     : a8f28dd3b9994ab764ced92f26a802e477aaa070
JOB LOG    : /root/avocado/job-results/job-2021-09-14T23.40-a8f28dd/job.log
 (1/1) type_specific.io-github-autotest-libvirt.numa_memory_spread.default: ERROR: local variable 'neighbour' referenced before assignment (20.47 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 21.10 s

```
After
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio numa_memory_spread.default
JOB ID     : b83e7da48c05a98e987c758929976bda6bad913e
JOB LOG    : /root/avocado/job-results/job-2021-09-14T23.38-b83e7da/job.log
 (1/1) type_specific.io-github-autotest-libvirt.numa_memory_spread.default: CANCEL: This test needs at least 2 available numa nodes (10.54 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 1
JOB TIME   : 11.18 s
```