### PR TITLE
Update the test.fail() to test.cancel()

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_rename.py
+++ b/libvirt/tests/src/virtual_network/iface_rename.py
@@ -45,7 +45,7 @@ def run(test, params, env):
             if libvirt_version.version_compare(6, 3, 0):
                 test.fail("libvirtd.log get error: %s" % out)
             else:
-                test.fail("The bug 1557902 is fixed since libvirt-6.3.0")
+                test.cancel("The bug 1557902 is fixed since libvirt-6.3.0")
 
     finally:
         process.run("ip l delete %s; ip l delete %s" % (name_2, name_1), ignore_status=True, shell=True)


### PR DESCRIPTION
It is better to use test.cancel() than test.fail() when the libvirt
version without the fix.

Signed-off-by: Yalan Zhang <yalzhang@redhat.com>