### PR TITLE
Add version check the the vhost_dpdk case

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_options.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_options.cfg
@@ -244,6 +244,7 @@
                             attach_iface_device = "config"
                             expect_target_devs = "['vhost-user1', 'vhost-user2', 'vhost-client-1']"
                         - vhost_dpdk:
+                            func_supported_since_libvirt_ver = (7, 0, 0)
                             need_vhostuser_env = "no"
                             change_iface_options = "no"
                             test_iface_option_cmd = "no"

--- a/libvirt/tests/src/virtual_network/iface_options.py
+++ b/libvirt/tests/src/virtual_network/iface_options.py
@@ -667,6 +667,7 @@ def run(test, params, env):
     check_statistics = "yes" == params.get("check_statistics", "no")
     enable_multiqueue = "yes" == params.get("enable_multiqueue", "no")
 
+    libvirt_version.is_libvirt_feature_supported(params)
     queue_size = None
     if iface_driver:
         driver_dict = ast.literal_eval(iface_driver)


### PR DESCRIPTION
The vhost_dpdk case is to cover the bug 1767013 which was fixed on
libvirt-7.0.0-1. So add the version check in the case.

Signed-off-by: Yalan Zhang <yalzhang@redhat.com>