### PR TITLE
[minor fix] virsh_deprecate_api: Raise cancel and fail exceptions

### DIFF
--- a/libvirt/tests/src/virsh_cmd/host/virsh_deprecate_api.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_deprecate_api.py
@@ -2,6 +2,7 @@ import json
 import logging
 import re
 
+from avocado.core import exceptions
 from virttest import libvirt_version
 from virttest import libvirt_xml
 from virttest import utils_libvirtd
@@ -215,6 +216,8 @@ def run(test, params, env):
             utils_misc.wait_for(lambda: vm.state() == 'shut off', 60)
             check_dominfo(test, vm_name, deprecated_list, empty=True)
 
+    except (exceptions.TestFail, exceptions.TestCancel):
+        raise
     except Exception as e:
         test.error('Unexpected error: {}'.format(e))
     finally:


### PR DESCRIPTION
Raise cancel and fail exceptions otherwise all exceptions will be
treated as test.error.

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Before
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virsh.deprecate_api.domain_deprecated_info.positive_test.cpu_machine_type
JOB ID     : e659776f2580a48bcfcb3401c120fd4e9107141b
JOB LOG    : /root/avocado/job-results/job-2021-09-15T23.26-e659776/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.deprecate_api.domain_deprecated_info.positive_test.cpu_machine_type: ERROR: Unexpected error: There is no deprecated cpu or machine type in current qemu version, skipping the test. (48.09 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 48.85 s
```
After
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virsh.deprecate_api.domain_deprecated_info.positive_test.cpu_machine_type
JOB ID     : 16266ed1981263e3992dbddbf5304e45c6f77859
JOB LOG    : /root/avocado/job-results/job-2021-09-15T23.35-16266ed/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.deprecate_api.domain_deprecated_info.positive_test.cpu_machine_type: CANCEL: There is no deprecated cpu or machine type in current qemu version, skipping the test. (47.04 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 1
JOB TIME   : 47.81 s
```
