### PR TITLE
sriov: Fix a command failure

### DIFF
--- a/provider/sriov/sriov_base.py
+++ b/provider/sriov/sriov_base.py
@@ -70,14 +70,13 @@ def get_ping_dest(vm_session, mac_addr="", restart_network=False):
     utils_misc.wait_for(
          lambda: utils_net.get_net_if_addrs(
             iface_name, vm_session.cmd_output).get('ipv4'), 20)
-    cmd = ("ip route |awk -F '/' '/^[0-9]/, /dev %s/ {print $1}' |tail -1"
-           % iface_name)
+    cmd = ("ip route |awk -F '/' '/^[0-9]/, /dev %s/ {print $1}'" % iface_name)
     status, output = utils_misc.cmd_status_output(cmd, shell=True,
                                                   session=vm_session)
     if status or not output:
         raise exceptions.TestError("Failed to run cmd - {}, status - {}, "
                                    "output - {}.".format(cmd, status, output))
-    return re.sub('\d+$', '1', output.strip())
+    return re.sub('\d+$', '1', output.strip().splitlines()[-1])
 
 
 def check_vm_network_accessed(vm_session, ping_count=3, ping_timeout=5):


### PR DESCRIPTION
The 'tail' command in the VM was changed to 'taiil' unexpectedly.
It's not 100% repeatable, but occurs in some environments. So, as
a workaround, shorten the command.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Test result:**
Before the fix:
` (1/1) type_specific.io-github-autotest-libvirt.sriov.vf_pool.active.at_dt.macvtap_passthrough: FAIL: Failed to ping ip route |awk -F '/' '/^[0-9]/, /dev enp1s0/ {print $1}' |taiil -1\n10.73.32.1! status: 127, output: ping ip route |awk -F '/' '/^[0-9]/, /dev enp1s0/ {print $1}'' |taiil -1\n-bash: taiil: command not found\nping: route: Name or service not kn... (39.05 s)`

After:
```
 (1/1) type_specific.io-github-autotest-libvirt.sriov.vf_pool.active.at_dt.macvtap_passthrough: PASS (39.02 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 40.57 s
(.libvirt-ci-venv-ci-runtest-F2ugsU) [root@dell-per730-59 sriov]#
 (1/1) type_specific.io-github-autotest-libvirt.sriov.vf_pool.active.at_dt.macvtap_passthrough: PASS (38.67 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 40.19 s
(.libvirt-ci-venv-ci-runtest-VFj4wQ) [root@dell-per740-18 sriov]# 
```
