### PR TITLE
v2v: fix 'Red Hat VirtIO Ethernet Adapte' driver checking failure

### DIFF
--- a/provider/v2v_vmcheck_helper.py
+++ b/provider/v2v_vmcheck_helper.py
@@ -739,7 +739,7 @@ class VMChecker(object):
         expect_video = self.get_expect_video_model()
         has_virtio_win, has_qxldod = self.get_virtio_win_config()
         expect_drivers = ["Red Hat VirtIO SCSI",
-                          "Red Hat VirtIO Ethernet Adapter"]
+                          "Red Hat VirtIO Ethernet Adapte"]
         expect_adapter = 'Microsoft Basic Display Driver'
         virtio_win_qxl_os = ['win2008r2', 'win7']
         virtio_win_qxldod_os = ['win10', 'win2016', 'win2019']

--- a/spell.ignore
+++ b/spell.ignore
@@ -1,10 +1,10 @@
-
 aa
 ABI
 accel
 acl
 acpi
 acpiphp
+Adapte
 addr
 addrss
 AES


### PR DESCRIPTION
The name of 'Red Hat VirtIO Ethernet Adapte' was changed in
db35d6b5aa60c5f9862c54d0d98be4b56f479836. This is a typo issue in
driver. We should keep it when checking the name.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>