### PR TITLE
sriov_migration: Cancel p2p migration via virsh.domjobabort

### DIFF
--- a/libvirt/tests/cfg/migration/sriov_migrate.cfg
+++ b/libvirt/tests/cfg/migration/sriov_migrate.cfg
@@ -41,6 +41,8 @@
                     only without_postcopy
                     status_error = 'yes'
                     cancel_migration = 'yes'
+                    action_during_mig_params = "'%s' % params.get('migrate_main_vm')"
+                    action_during_mig_params_exists = "yes"
             variants:
                 - hostdev_iface:
                     enable_hostdev_iface = "yes"

--- a/libvirt/tests/src/migration/sriov_migrate.py
+++ b/libvirt/tests/src/migration/sriov_migrate.py
@@ -436,7 +436,7 @@ def run(test, params, env):
         if extra.count("--postcopy"):
             action_during_mig = virsh.migrate_postcopy
         if cancel_migration:
-            action_during_mig = migration_test.do_cancel
+            action_during_mig = virsh.domjobabort
 
         remove_dict = {"do_search": '{"%s": "ssh:/"}' % dest_uri}
         src_libvirt_file = libvirt_config.remove_key_for_modular_daemon(


### PR DESCRIPTION
The command 'kill -9' can't stop P2P live migration process safely,
so update to use 'virsh domjobabort'.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Test result:**
_Before the fix:_
`(1/1) type_specific.io-github-autotest-libvirt.virsh.sriov_migrate.net_failover.hostdev_iface.cancel_migration.without_postcopy: FAIL: Ping failed, status: 1, output: PING 10.73.33.129 (10.73.33.129) 56(84) bytes of data.\nFrom 10.73.33.226 icmp_seq=1 Destination Host Unreachable\nFrom 10.73.33.226 icmp_seq=2 Destination Host Unreachable\nFrom 10.73.33.226 icmp_seq=3 Destination Host Unreac... (205.34 s)
`
_After fix:_
`(1/1) type_specific.io-github-autotest-libvirt.virsh.sriov_migrate.net_failover.hostdev_iface.cancel_migration.without_postcopy: PASS (213.04 s)`

