### PR TITLE
sriov: Fix event catcher failure

### DIFF
--- a/libvirt/tests/src/sriov/sriov_managed.py
+++ b/libvirt/tests/src/sriov/sriov_managed.py
@@ -117,7 +117,7 @@ def run(test, params, env):
 
         check_vm_iface_managed(vm_name, iface_dict)
         vm.wait_for_serial_login().close()
-        virsh.detach_device(vm_name, iface.xml, wait_remove_event=True,
+        virsh.detach_device(vm_name, iface.xml, wait_for_event=True,
                             debug=True, ignore_status=False)
         libvirt_vfio.check_vfio_pci(vf_pci)
         virsh.nodedev_reattach(dev_name, debug=True, ignore_status=False)

--- a/libvirt/tests/src/sriov/sriov_net_failover.py
+++ b/libvirt/tests/src/sriov/sriov_net_failover.py
@@ -84,7 +84,7 @@ def run(test, params, env):
             if ifc.type_name == "hostdev":
                 ifc.del_address()
                 hostdev_iface = ifc
-        virsh.detach_device(vm_name, hostdev_iface.xml, wait_remove_event=True,
+        virsh.detach_device(vm_name, hostdev_iface.xml, wait_for_event=True,
                             debug=True, ignore_status=False)
         check_ifaces(vm_name, expected_ifaces={"hostdev"}, status_error=True)
 
@@ -125,7 +125,7 @@ def run(test, params, env):
                                   tcpdump_iface=bridge_name,
                                   tcpdump_status_error=True)
         logging.info("Detach the hostdev device.")
-        virsh.detach_device(vm_name, hostdev_dev.xml, wait_remove_event=True,
+        virsh.detach_device(vm_name, hostdev_dev.xml, wait_for_event=True,
                             debug=True, ignore_status=False)
         logging.debug("Recover vf's mac to %s.", default_vf_mac)
         utils_sriov.set_vf_mac(pf_name, default_vf_mac)
@@ -175,7 +175,7 @@ def run(test, params, env):
         logging.info("Detach the hostdev device.")
         hostdev_dev = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name).devices.\
             by_device_tag("hostdev")
-        virsh.detach_device(vm_name, hostdev_dev.xml, wait_remove_event=True,
+        virsh.detach_device(vm_name, hostdev_dev.xml, wait_for_event=True,
                             debug=True, ignore_status=False)
         check_hostdev = vm_xml.VMXML.new_from_dumpxml(vm_name)\
             .devices.by_device_tag('hostdev')


### PR DESCRIPTION
Event checking should be controlled by wait_for_event=True.

Signed-off-by: Yingshun Cui <yicui@redhat.com>

depends on: https://github.com/avocado-framework/avocado-vt/pull/3225
test results:
```
 (1/1) type_specific.io-github-autotest-libvirt.sriov.managed.device_hotplug.managed_no: PASS (34.43 s)

 (1/1) type_specific.io-github-autotest-libvirt.sriov_net_failover.hotplug_hostdev_iface_with_teaming: PASS (97.54 s)

```
