### PR TITLE
sriov: Fix device detach failure

### DIFF
--- a/libvirt/tests/src/sriov/sriov.py
+++ b/libvirt/tests/src/sriov/sriov.py
@@ -347,7 +347,8 @@ def run(test, params, env):
                     return False
             return True
 
-        result = virsh.detach_device(vm_name, new_iface.xml)
+        result = utils_misc.wait_for(
+            lambda: virsh.detach_device(vm_name, new_iface.xml), 30, first=10)
         utils_test.libvirt.check_exit_status(result, expect_error=False)
         if vf_type == "hostdev":
             check_ret = utils_misc.wait_for(check_addr_attrs, timeout=60)


### PR DESCRIPTION
It takes some time to attach a device, so wait 10s before detaching
it.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
Before the fix:
`
 (1/1) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.nop.hostdev.managed_no: FAIL: The hostdev device detach failed from xml\n (112.10 s)
`


After the fix:
```
 (1/2) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.nop.hostdev.managed_yes: PASS (58.38 s)
 (2/2) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.nop.hostdev.managed_no: PASS (57.30 s)
```