### PR TITLE
migrate_vm: revert Update hugepage number

### DIFF
--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -1153,19 +1153,18 @@ def run(test, params, env):
     Test remote access with TCP, TLS connection
     """
 
-    def get_target_hugepage_num(params, mem):
+    def get_target_hugepage_num(params):
         """
         Get the number of hugepage on target host
 
         :param params: The parameters used
-        :param mem: Current VM's memory
         :return: the number of hugepage to be allocated on target host
         """
         hugepage_file = params.get("kernel_hp_file", "/proc/sys/vm/nr_hugepages")
         with open(hugepage_file, 'r') as fp:
             hugepage_num = int(fp.readline().strip())
         more_less_hp = int(params.get("remote_target_hugepages", "0"))
-        target_hugepage = min(int(mem/(1024*2)), hugepage_num) + more_less_hp
+        target_hugepage = (hugepage_num + more_less_hp)
         logging.debug("Number of huge pages on target host to be allocated:%d", target_hugepage)
         return target_hugepage
 
@@ -1236,6 +1235,7 @@ def run(test, params, env):
                                                      "no")
     enable_kvm_hugepages = "yes" == test_dict.get("enable_kvm_hugepages", "no")
     enable_remote_kvm_hugepages = "yes" == test_dict.get("enable_remote_kvm_hugepages", "no")
+    remote_tgt_hugepages = get_target_hugepage_num(test_dict)
     remote_hugetlbfs_path = test_dict.get("remote_hugetlbfs_path")
     delay = int(params.get("delay_time", 10))
 
@@ -1396,9 +1396,8 @@ def run(test, params, env):
 
     # Get current VM's memory
     current_mem = vmxml_backup.current_mem
-    logging.debug("Current VM memory: %s", current_mem)
-
-    remote_tgt_hugepages = get_target_hugepage_num(test_dict, current_mem)
+    logging.debug("Current VM memory KiB: %s", current_mem)
+    logging.debug("Configured VM memory MB for setup_hugepages: %s" , mem)
 
     # Disk XML file
     disk_xml = None


### PR DESCRIPTION
This reverts e6ff5b9c6d277696c884a3869ba38b5f22a5123b
That commit introduced logic to calculate the target machines
required number of hugepages differently to make sure the
negative scenario of "not enough hugepages on destination"
test case will pass.
Unfortunately, now the positive test case started failing on
an environment with
Guest VM memory MB: 1024
Hugepagesize: 1024 kB

Notice that the test cases use the `setup_hugepages` variable.
That variable is used during setup (avocado-vt's `env_process.py`)
to set up the hugepages that are read as `hugepage_num` in the
`migrate_vm.py`'s `get_target_hugepage_num`. The `env_process.py`
will use `virttest/test_setup.py/HugePageConfig` to set up the necessary
hugepages on the host using the `mem` parameter of the `virttest/shared/cfg/base.cfg`.

Therefore, if the `mem` value is too big, the negative test case will fail althouth the
positive test case will pass.

Add additional logging to make sure we can compare the `current_mem` as reflected by the
domain xml and the `mem` that's used for the hugepage handling in the test setup.

Finally, note that the `target_remote_hugepages` value might need to be lower depending
on the available hugepage size and vm guest memory size, just as before.

This approach has simpler code and worked before.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [ ] Description of the cases
- [ ] Links of libvirt features, libvirt bugs or case IDs
- [ ] Test results

## If the PR is bug cases
- [ ] Bug descriptions or bug links
- [ ] Test results

## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
