### PR TITLE
Remote Access:New case for a virsh connect polkit with a non-root user

### DIFF
--- a/libvirt/tests/cfg/remote_access/virsh_non_root_polkit.cfg
+++ b/libvirt/tests/cfg/remote_access/virsh_non_root_polkit.cfg
@@ -1,0 +1,30 @@
+- virsh.non_root_polkit:
+    type = virsh_non_root_polkit
+    auth_user = root
+    auth_pwd = "${local_pwd}"
+    transport = "ssh"
+    start_vm = "no"
+    main_vm = ""
+    su_user = "non-root"
+    su_user_pass = "toor"
+    variants:
+        - positive_testing:
+            variants:
+                - virsh_connect_non_root:
+                    uri = "qemu:///system"
+                    message = "System policy prevents management of local virtualized systems"
+                - virsh_connect_non_root_over_ssh:
+                    uri = "qemu:///system"
+                    ssh_connection = "yes"
+                    message = "System policy prevents management of local virtualized systems"
+                - virsh_connect_non_root_over_ssh_with_x:
+                    uri = "qemu:///system"
+                    ssh_connection = "yes"
+                    ssh_params = "-X"
+                    message = "System policy prevents management of local virtualized systems"
+        - negative_testing:
+            variants:
+                - virsh_ssh_non_root:
+                    auth_pwd = "${su_user_pass}"
+                    uri = "qemu+ssh://localhost/system"
+                    message = "authentication unavailable: no polkit agent available to authenticate action"

--- a/libvirt/tests/src/remote_access/virsh_non_root_polkit.py
+++ b/libvirt/tests/src/remote_access/virsh_non_root_polkit.py
@@ -1,0 +1,140 @@
+import logging
+
+from avocado.core import exceptions
+from avocado.utils import process
+
+from virttest import remote
+from virttest import utils_misc
+from virttest.utils_test.libvirt import connect_libvirtd
+
+
+def local_access(params, test):
+    """
+    Connect local libvirt daemon as a non-root user.
+
+    :param params: dict of test parameters
+    :param test: Avocado-VT test instance
+    """
+    uri = params.get("uri")
+    auth_user = params.get("auth_user", "root")
+    auth_pwd = params.get("auth_pwd")
+    virsh_cmd = params.get("virsh_cmd", "list")
+    read_only = params.get("read_only", "")
+    vm_name = params.get("main_vm", "")
+    extra_env = params.get("extra_env", "")
+    su_user = params.get("su_user", "")
+    message = params.get("message", "")
+    virsh_patterns = params.get("patterns_virsh_cmd", r".*Id\s*Name\s*State\s*.*")
+    patterns_extra_dict = params.get("patterns_extra_dict", None)
+    log_level = params.get("log_level", "LIBVIRT_DEBUG=3")
+    status_error = params.get("status_error", "yes")
+    ret, output = connect_libvirtd(uri, read_only, virsh_cmd, auth_user,
+                                   auth_pwd, vm_name, status_error, extra_env,
+                                   log_level, su_user, virsh_patterns,
+                                   patterns_extra_dict)
+    if message not in output:
+        test.fail("Expected message: {} not found in the output".format(message))
+    else:
+        logging.info("The test has passed.")
+
+
+def ssh_access(params, test):
+    """
+    Connect local libvirt daemon over SSH as a non-root user
+
+    :param params: dict of test parameters
+    :param test: Avocado-VT test instance
+    """
+    non_root_name = params.get("su_user")
+    non_root_pass = params.get("su_user_pass", "toor")
+    auth_pwd = params.get("auth_pwd")
+    uri = params.get("uri")
+    ssh_params = params.get("ssh_params", "")
+    message = params.get("message", "")
+    session = remote.remote_login("ssh", "localhost", "22", non_root_name,
+                                  non_root_pass, r"[\#\$]\s*$",
+                                  extra_cmdline=ssh_params)
+    try:
+        command = ("virsh -c {}".format(uri))
+        session.sendline(command)
+        match, output = session.read_until_output_matches([r".*[Pp]assword.*", ],
+                                                          timeout=10.0,
+                                                          print_func=logging.debug)
+        logging.debug(output)
+        if message not in output:
+            test.fail("Expected message: {} not found in the output".
+                      format(message))
+        else:
+            logging.info("The test has passed.")
+        session.sendline(auth_pwd)
+        session.read_until_output_matches(["#", ],
+                                          timeout=10.0,
+                                          print_func=logging.debug)
+        session.sendline("quit")
+    except Exception as e:
+        test.error("The virsh connection over SSH was unsuccessful with "
+                   "non-root user due to:{}".format(e))
+    finally:
+        session.close()
+        logging.debug("The SSH session has been closed.")
+
+
+def create_non_root_user(params, test):
+    """
+    Create a non-root user with a valid password on the local machine
+
+    :param params: dict of test parameters
+    :param test: Avocado-VT test instance
+    """
+    non_root_name = params.get("su_user")
+    non_root_pass = params.get("su_user_pass", "toor")
+    try:
+        # Check if user exists
+        ret = process.run("id -u {}".format(non_root_name), ignore_status=True)
+        # User does not exists on system, we can add him
+        if ret.exit_status:
+            # Add a non-root user
+            ret = process.run("useradd {}".format(non_root_name))
+            if ret.exit_status:
+                test.error("Creation of a non-root: {} user has failed.".
+                           format(non_root_name))
+            else:
+                # Create a password for a new non-root user
+                ret = process.run('echo {}:{} | chpasswd'.
+                                  format(non_root_name, non_root_pass),
+                                  shell=True)
+                if ret.exit_status:
+                    test.error("Cannot create a password:{} for non-root "
+                               "user:{}.".format(non_root_pass, non_root_name))
+        else:
+            test.error("The user {} already exists on the system and therefore "
+                       "it is not safe to continue.".format(non_root_name))
+    except (exceptions.TestFail, exceptions.TestCancel):
+        raise
+    except Exception as e:
+        test.error("Unexpected error: {}".format(e))
+
+
+def run(test, params, env):
+    """
+    Test virsh polkit for non-root user
+    """
+    ssh_connection = params.get("ssh_connection", "no") == "yes"
+    non_root_name = params.get("su_user")
+
+    create_non_root_user(params, test)
+    try:
+        if ssh_connection:
+            ssh_access(params, test)
+        else:
+            local_access(params, test)
+    except (exceptions.TestFail, exceptions.TestCancel):
+        raise
+    except Exception as e:
+        test.error("Unexpected error: {}".format(e))
+    finally:
+        res = utils_misc.wait_for(lambda: not process.run("userdel {}".
+                                                          format(non_root_name),
+                                                          ignore_status=True).exit_status, 50)
+        if not res:
+            test.error("Cannot delete non-root user: {}.".format(non_root_name))


### PR DESCRIPTION
New cases added to verify the polkit with virsh for non-root access via ssh or
local connection.

Signed-off-by: kvarga <kvarga@redhat.com>

-  Description of the cases:
  using polkit with virsh for non-root access should work via ssh or locally
-  Case ID:
  RHEL7-18311
- Test results:
  <pre>avocado run --vt-type libvirt --vt-machine-type q35 virsh.non_root_polkit
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
<font color="#2A7BDE">JOB ID     : 16eb075cf24472903b06eef8034c1a1a9382fbb1</font>
<font color="#2A7BDE">JOB LOG    : /root/avocado/job-results/job-2021-09-22T16.10-16eb075/job.log</font>
 (1/4) type_specific.io-github-autotest-libvirt.virsh.non_root_polkit.positive_testing.virsh_connect_non_root: <font color="#33DA7A">PASS</font> (5.75 s)
 (2/4) type_specific.io-github-autotest-libvirt.virsh.non_root_polkit.positive_testing.virsh_connect_non_root_over_ssh: <font color="#33DA7A">PASS</font> (17.54 s)
 (3/4) type_specific.io-github-autotest-libvirt.virsh.non_root_polkit.positive_testing.virsh_connect_non_root_over_ssh_with_x: <font color="#33DA7A">PASS</font> (17.94 s)
 (4/4) type_specific.io-github-autotest-libvirt.virsh.non_root_polkit.negative_testing.virsh_ssh_non_root: <font color="#33DA7A">PASS</font> (17.75 s)
<font color="#2A7BDE">RESULTS    : PASS 4 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0</font>
<font color="#2A7BDE">JOB TIME   : 59.53 s</font></pre>