### PR TITLE
Fix virsh.change_media_matrix..default.eject_update case failure

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_change_media_matrix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_change_media_matrix.py
@@ -300,6 +300,7 @@ def run(test, params, env):
                 wait_for_event = True
             ret = virsh.change_media(vm_ref, target_device, all_options,
                                      wait_for_event=wait_for_event,
+                                     event_timeout=14,
                                      ignore_status=True, debug=True)
             status_error = False
             if pre_vm_state == "shutoff":


### PR DESCRIPTION

By extending timeout for this event, this will give more confidence to wait for expected event

Signed-off-by: chunfuwen <chwen@redhat.com>

