### PR TITLE
[minor fix] memory_misc: Fix 'member_descriptor' object has no attribute 'getroot'

### DIFF
--- a/libvirt/tests/src/memory/memory_misc.py
+++ b/libvirt/tests/src/memory/memory_misc.py
@@ -123,7 +123,7 @@ def run(test, params, env):
                 if vmxml.xmltreefile.find('cpu'):
                     cpuxml = vmxml.cpu
                 else:
-                    cpuxml = vm_xml.VMCPUXML
+                    cpuxml = vm_xml.VMCPUXML()
                 cpuxml.numa_cell = cpuxml.dicts_to_cells(numa_cells)
                 vmxml.cpu = cpuxml
                 vmxml.vcpu = 4


### PR DESCRIPTION
Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Before
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio  memory_misc.edit_mem.forbid_0.set_with_numa
JOB ID     : 37d5b707b55605e751da1db52717c61b7f38dffc
JOB LOG    : /root/avocado/job-results/job-2021-09-22T22.31-37d5b70/job.log
 (1/1) type_specific.io-github-autotest-libvirt.memory_misc.edit_mem.forbid_0.set_with_numa: ERROR: 'member_descriptor' object has no attribute 'getroot' (8.92 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 9.72 s
```
After
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio  memory_misc.edit_mem.forbid_0.set_with_numa
JOB ID     : 3773e73a670438fa7e1417c64c5ea95c90506849
JOB LOG    : /root/avocado/job-results/job-2021-09-22T22.33-3773e73/job.log
 (1/1) type_specific.io-github-autotest-libvirt.memory_misc.edit_mem.forbid_0.set_with_numa: PASS (9.39 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 10.22 s
```
