### PR TITLE
Fix driver queues attribute doesn't take effect issue

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_vhostuser.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_vhostuser.py
@@ -58,7 +58,7 @@ def create_vhostuser_disk(params):
     device_target = params.get("target_dev")
     device_bus = params.get("target_bus")
     device_format = params.get("target_format")
-    queues = params.get("queues")
+    queues = params.get("queues", "1")
     sock_path = params.get("source_file")
     disk_src_dict = {"attrs": {"type": "unix",
                      "path": sock_path}}
@@ -67,7 +67,8 @@ def create_vhostuser_disk(params):
         device_target, device_bus,
         device_format, disk_src_dict, None)
     vhostuser_disk.snapshot = "no"
-    vhostuser_disk.driver["queues"] = queues
+    driver_dict = {"name": "qemu", "type": device_format, "queues": int(queues)}
+    vhostuser_disk.driver = driver_dict
     return vhostuser_disk
 
 


### PR DESCRIPTION
Regarding disk object, driver attribute need to be set as whole dict,
rather than single dict key

Signed-off-by: chunfuwen <chwen@redhat.com>

