### PR TITLE
Update one parameter name of func detach_device()

### DIFF
--- a/libvirt/tests/src/sriov/sriov_managed.py
+++ b/libvirt/tests/src/sriov/sriov_managed.py
@@ -117,7 +117,7 @@ def run(test, params, env):
 
         check_vm_iface_managed(vm_name, iface_dict)
         vm.wait_for_serial_login().close()
-        virsh.detach_device(vm_name, iface.xml, wait_remove_event=True,
+        virsh.detach_device(vm_name, iface.xml, wait_for_event=True,
                             debug=True, ignore_status=False)
         libvirt_vfio.check_vfio_pci(vf_pci)
         virsh.nodedev_reattach(dev_name, debug=True, ignore_status=False)

--- a/libvirt/tests/src/sriov/sriov_net_failover.py
+++ b/libvirt/tests/src/sriov/sriov_net_failover.py
@@ -84,7 +84,7 @@ def run(test, params, env):
             if ifc.type_name == "hostdev":
                 ifc.del_address()
                 hostdev_iface = ifc
-        virsh.detach_device(vm_name, hostdev_iface.xml, wait_remove_event=True,
+        virsh.detach_device(vm_name, hostdev_iface.xml, wait_for_event=True,
                             debug=True, ignore_status=False)
         check_ifaces(vm_name, expected_ifaces={"hostdev"}, status_error=True)
 
@@ -125,7 +125,7 @@ def run(test, params, env):
                                   tcpdump_iface=bridge_name,
                                   tcpdump_status_error=True)
         logging.info("Detach the hostdev device.")
-        virsh.detach_device(vm_name, hostdev_dev.xml, wait_remove_event=True,
+        virsh.detach_device(vm_name, hostdev_dev.xml, wait_for_event=True,
                             debug=True, ignore_status=False)
         logging.debug("Recover vf's mac to %s.", default_vf_mac)
         utils_sriov.set_vf_mac(pf_name, default_vf_mac)
@@ -175,7 +175,7 @@ def run(test, params, env):
         logging.info("Detach the hostdev device.")
         hostdev_dev = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name).devices.\
             by_device_tag("hostdev")
-        virsh.detach_device(vm_name, hostdev_dev.xml, wait_remove_event=True,
+        virsh.detach_device(vm_name, hostdev_dev.xml, wait_for_event=True,
                             debug=True, ignore_status=False)
         check_hostdev = vm_xml.VMXML.new_from_dumpxml(vm_name)\
             .devices.by_device_tag('hostdev')

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device.py
@@ -158,7 +158,7 @@ def run(test, params, env):
             func_name = virsh.detach_device_alias if by_alias else virsh.detach_device
             func_name(vm_ref, detach_target,
                       extra=dt_options,
-                      wait_remove_event=True,
+                      wait_for_event=True,
                       event_timeout=7,
                       debug=True)
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
@@ -122,7 +122,7 @@ def run(test, params, env):
 
         # Detach xml with alias
         result = virsh.detach_device_alias(vm_name, device_alias, detach_options,
-                                           wait_remove_event=True, debug=True)
+                                           wait_for_event=True, debug=True)
         libvirt.check_exit_status(result)
         if not utils_misc.wait_for(check_detached_xml_noexist,
                                    60,

--- a/libvirt/tests/src/virtual_disks/virtual_disks_ceph.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_ceph.py
@@ -971,10 +971,10 @@ def run(test, params, env):
         # Detach the device.
         if attach_device:
             xml_file = libvirt.create_disk_xml(params)
-            ret = virsh.detach_device(vm_name, xml_file, wait_remove_event=True)
+            ret = virsh.detach_device(vm_name, xml_file, wait_for_event=True)
             libvirt.check_exit_status(ret)
             if additional_guest:
-                ret = virsh.detach_device(guest_name, xml_file, wait_remove_event=True)
+                ret = virsh.detach_device(guest_name, xml_file, wait_for_event=True)
                 libvirt.check_exit_status(ret)
         elif attach_disk:
             ret = virsh.detach_disk(vm_name, targetdev, wait_remove_event=True)

--- a/libvirt/tests/src/virtual_disks/virtual_disks_encryption.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_encryption.py
@@ -275,7 +275,7 @@ def run(test, params, env):
                     if not check_in_vm(vm, device_target, old_parts):
                         test.fail("Check encryption disk in VM failed")
                     result = virsh.detach_device(vm_name, disk_xml.xml,
-                                                 debug=True, wait_remove_event=True)
+                                                 debug=True, wait_for_event=True)
                     libvirt.check_exit_status(result)
                 else:
                     if not check_in_vm(vm, device_target, old_parts):

--- a/libvirt/tests/src/virtual_disks/virtual_disks_gluster.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_gluster.py
@@ -262,7 +262,7 @@ def run(test, params, env):
         if start_vm and not default_pool:
             if gluster_disk:
                 ret = virsh.detach_device(vm_name, custom_disk.xml,
-                                          flagstr=attach_option, dargs=virsh_dargs, wait_remove_event=True)
+                                          flagstr=attach_option, dargs=virsh_dargs, wait_for_event=True)
                 libvirt.check_exit_status(ret)
 
     finally:

--- a/libvirt/tests/src/virtual_disks/virtual_disks_metadatacache.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_metadatacache.py
@@ -225,7 +225,7 @@ def run(test, params, env):
         # Detach hot plugged device.
         if hot_plug:
             virsh.detach_device(vm_name, custom_disk.xml,
-                                flagstr=attach_option, dargs=virsh_dargs, ignore_status=False, wait_remove_event=True)
+                                flagstr=attach_option, dargs=virsh_dargs, ignore_status=False, wait_for_event=True)
     finally:
         # Recover VM.
         if vm.is_alive():

--- a/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
@@ -2011,7 +2011,7 @@ def run(test, params, env):
                 for counter in range(0, iteration_times):
                     logging.info("Begin to execute attach or detach %d operations", counter)
                     ret = virsh.detach_device(vm_name, disks_xml[0].xml,
-                                              flagstr=attach_option, debug=True, wait_remove_event=True)
+                                              flagstr=attach_option, debug=True, wait_for_event=True)
                     libvirt.check_exit_status(ret)
                     # Sleep 10 seconds to let VM really cleanup devices.
                     time.sleep(10)
@@ -2030,7 +2030,7 @@ def run(test, params, env):
                     if device_attach_error[i] == "yes":
                         continue
                 ret = virsh.detach_device(vm_name, disks_xml[i].xml,
-                                          flagstr=attach_option, wait_remove_event=True, **virsh_dargs)
+                                          flagstr=attach_option, wait_for_event=True, **virsh_dargs)
                 os.remove(disks_xml[i].xml)
                 libvirt.check_exit_status(ret)
 

--- a/libvirt/tests/src/virtual_disks/virtual_disks_nbd.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_nbd.py
@@ -279,7 +279,7 @@ def run(test, params, env):
         # Unplug disk.
         if hotplug_disk:
             result = virsh.detach_device(vm_name, disk_xml.xml,
-                                         ignore_status=True, debug=True, wait_remove_event=True)
+                                         ignore_status=True, debug=True, wait_for_event=True)
             libvirt.check_exit_status(result, status_error)
     finally:
         if enable_private_key_encryption:

--- a/libvirt/tests/src/virtual_disks/virtual_disks_scsi3_persistent_reservation.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_scsi3_persistent_reservation.py
@@ -245,7 +245,7 @@ def run(test, params, env):
             new_part = new_parts[0]
             check_pr_cmds(vm, new_part)
             result = virsh.detach_device(vm_name, disk_xml.xml,
-                                         ignore_status=True, debug=True, wait_remove_event=True)
+                                         ignore_status=True, debug=True, wait_for_event=True)
             libvirt.check_exit_status(result)
         except virt_vm.VMStartError as e:
             test.fail("VM failed to start."

--- a/libvirt/tests/src/virtual_disks/virtual_disks_usb.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_usb.py
@@ -234,7 +234,7 @@ def run(test, params, env):
         # Detach the disk from vm
         result = virsh.detach_device(vm_name, disk_xml.xml,
                                      flagstr=attach_options,
-                                     ignore_status=True, debug=True, wait_remove_event=True)
+                                     ignore_status=True, debug=True, wait_for_event=True)
         libvirt.check_exit_status(result, status_error)
 
         # Check the detached disk in vm

--- a/libvirt/tests/src/virtual_disks/virtual_disks_vhostuser.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_vhostuser.py
@@ -146,7 +146,7 @@ def run(test, params, env):
                 if not libvirt_disk.check_in_vm(vm, device_target, old_parts):
                     test.fail("Check encryption disk in VM failed")
                 virsh.detach_device(vm_name, disk_xml.xml, ignore_status=True,
-                                    debug=True, wait_remove_event=True)
+                                    debug=True, wait_for_event=True)
                 if not libvirt_disk.check_in_vm(vm, device_target, old_parts, is_equal=True):
                     test.fail("can not detach device successfully")
             else:

--- a/libvirt/tests/src/virtual_network/iface_target.py
+++ b/libvirt/tests/src/virtual_network/iface_target.py
@@ -155,7 +155,7 @@ def run(test, params, env):
         counter = counter + 1
         # detach the new attached interface
         time.sleep(10)
-        virsh.detach_device(vm_name, iface_add_xml, wait_remove_event=True,
+        virsh.detach_device(vm_name, iface_add_xml, wait_for_event=True,
                             debug=True, ignore_status=False)
         if flush_after_detach:
             libvirtd.restart()

--- a/libvirt/tests/src/virtual_network/virtual_network_multivms.py
+++ b/libvirt/tests/src/virtual_network/virtual_network_multivms.py
@@ -259,7 +259,7 @@ def run(test, params, env):
                     virsh.detach_device(
                         vm_name_i,
                         new_ifaces[vm_name_i].xml,
-                        wait_remove_event=True,
+                        wait_for_event=True,
                         debug=True, ignore_status=False
                     )
 


### PR DESCRIPTION
Update the parameter name from "wait_remove_event" to "wait for event".
Depends on https://github.com/avocado-framework/avocado-vt/pull/3225.

Signed-off-by: Yalan Zhang <yalzhang@redhat.com>