### PR TITLE
numa_memory_spread: Fix timeout error

### DIFF
--- a/libvirt/tests/src/numa/numa_memory_spread.py
+++ b/libvirt/tests/src/numa/numa_memory_spread.py
@@ -189,9 +189,8 @@ def run(test, params, env):
         # And get the numastat prior the test
         total_prior = get_qemu_total_for_nodes()
         # Start test
-        result = session.cmd_status_output('memhog -r1 {}k'.
-                                           format(memory_to_eat),
-                                           timeout=60)
+        result = session.cmd('memhog -r1 {}k'.format(memory_to_eat),
+                             timeout=120)
         logging.debug(result)
         if vm.is_dead():
             test.fail('The VM crashed when memhog was executed.')
@@ -210,3 +209,4 @@ def run(test, params, env):
 
     finally:
         backup_xml.sync()
+        process.run("swapon -a", shell=True)


### PR DESCRIPTION
1. Replace session.cmd_status_output with session.cmd
I noticed that sometimes memhog return successfully but session is still
waiting for expected msg.
```
Timeout expired while looking for pattern '[\\#\\$]\\s*$'
```
Use session.cmd as a workaround
2. Increase timeout for memhog. Sometimes memhog cost more than 60s
3. Recover mem swap

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Before
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio numa_memory_spread.default
JOB ID     : 18991d2ce2a0a02d6b8104b8a255ed1dc47cafff
JOB LOG    : /root/avocado/job-results/job-2021-09-24T05.12-18991d2/job.log
 (1/1) type_specific.io-github-autotest-libvirt.numa_memory_spread.default: ERROR: Timeout expired while waiting for shell command to complete: 'memhog -r1 8554020k'    (output: '.................................................................................................................................................................. (137.09 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 138.85 s
```
After
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio numa_memory_spread.default
JOB ID     : 0ff986cebb29a9b5f3e045facdc911a8be8c1c83
JOB LOG    : /root/avocado/job-results/job-2021-09-24T04.54-0ff986c/job.log
 (1/1) type_specific.io-github-autotest-libvirt.numa_memory_spread.default: PASS (185.03 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 186.75 s
```