### PR TITLE
blockcopy.py: fix libvirt version issue for custom cluster size

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockcopy.cfg
+++ b/libvirt/tests/cfg/backingchain/blockcopy.cfg
@@ -6,6 +6,8 @@
                 - reuse_external:
                     start_vm = 'yes'
                 - custom_cluster_size:
+                    func_supported_since_libvirt_ver = (6, 10, 1)
+                    unsupported_err_msg = "This libvirt version doesn't support feature of custom cluster size"
                     start_vm = 'yes'
                     image_format = 'qcow2'
                     image_size = '100M'

--- a/libvirt/tests/src/backingchain/blockcopy.py
+++ b/libvirt/tests/src/backingchain/blockcopy.py
@@ -8,6 +8,7 @@ from virttest import data_dir
 from virttest import qemu_storage
 from virttest import utils_misc
 from virttest import virsh
+from virttest import libvirt_version
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 
@@ -22,6 +23,7 @@ def run(test, params, env):
 
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     bkxml = vmxml.copy()
+    libvirt_version.is_libvirt_feature_supported(params)
 
     file_to_del = []
     tmp_dir = data_dir.get_data_dir()


### PR DESCRIPTION
blockcopy.py: fix libvirt version issue for custom cluster size
Based on RHEL-196451 - [blockcopy] Blockcopy a vm disk which has cluster_size set (bz1873441)

Signed-off-by: Meina Li <meili@redhat.com>
