### PR TITLE
iface_target: Fix no device-removed event error

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_target.py
+++ b/libvirt/tests/src/virtual_network/iface_target.py
@@ -154,7 +154,7 @@ def run(test, params, env):
         # one interface with same iface type attached, counter increase by 1
         counter = counter + 1
         # detach the new attached interface
-        time.sleep(10)
+        time.sleep(15)
         virsh.detach_device(vm_name, iface_add_xml, wait_remove_event=True,
                             debug=True, ignore_status=False)
         if flush_after_detach:


### PR DESCRIPTION
Sometimes test failed since it can't get device-removed event. Increase
the time of waiting detach cmd to fix this error.

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Before
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio  virtual_network..flush_with_occupation                                                 
JOB ID     : b14c6e93d009d1379064c4b9e7de91099e01119a
JOB LOG    : /root/avocado/job-results/job-2021-09-27T01.56-b14c6e9/job.log
 (1/4) type_specific.io-github-autotest-libvirt.virtual_network.iface_target.flush_after_detach.flush_with_occupation.default: ERROR: Command '/usr/bin/virsh event  --domain avocado-vt-vm1 --event device-removed --timeout 7' failed.\nstdout: b'event loop timed out\nevents received: 0\n\n'\nstderr: b''\nadditional_info: None (66.27 s)                                            
 (2/4) type_specific.io-github-autotest-libvirt.virtual_network.iface_target.flush_after_detach.flush_with_occupation.macvtap: ERROR: Command '/usr/bin/virsh event  --domain avocado-vt-vm1 --event device-removed --timeout 7' failed.\nstdout: b'event loop timed out\nevents received: 0\n\n'\nstderr: b''\nadditional_info: None (70.01 s)                                            
 (3/4) type_specific.io-github-autotest-libvirt.virtual_network.iface_target.no_flush_after_detach.flush_with_occupation.default: ERROR: Command '/usr/bin/virsh event  --domain avocado-vt-vm1 --event device-removed --timeout 7' failed.\nstdout: b'event loop timed out\nevents received: 0\n\n'\nstderr: b''\nadditional_info: None (66.42 s)
 (4/4) type_specific.io-github-autotest-libvirt.virtual_network.iface_target.no_flush_after_detach.flush_with_occupation.macvtap: ERROR: Command '/usr/bin/virsh event  --domain avocado-vt-vm1 --event device-removed --timeout 7' failed.\nstdout: b'event loop timed out\nevents received: 0\n\n'\nstderr: b''\nadditional_info: None (69.55 s)
RESULTS    : PASS 0 | ERROR 4 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 273.11 s
```
After
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio  virtual_network..flush_with_occupation
JOB ID     : c5770ced10f7c54f7cb0cc0ba4dcfb7469fda8ed
JOB LOG    : /root/avocado/job-results/job-2021-09-27T02.02-c5770ce/job.log
 (1/4) type_specific.io-github-autotest-libvirt.virtual_network.iface_target.flush_after_detach.flush_with_occupation.default: PASS (66.98 s)
 (2/4) type_specific.io-github-autotest-libvirt.virtual_network.iface_target.flush_after_detach.flush_with_occupation.macvtap: PASS (70.82 s)
 (3/4) type_specific.io-github-autotest-libvirt.virtual_network.iface_target.no_flush_after_detach.flush_with_occupation.default: PASS (66.29 s)
 (4/4) type_specific.io-github-autotest-libvirt.virtual_network.iface_target.no_flush_after_detach.flush_with_occupation.macvtap: PASS (69.50 s)
RESULTS    : PASS 4 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 274.45 s
```
