### PR TITLE
Fix the detach interface fail issue

### DIFF
--- a/libvirt/tests/src/nwfilter/nwfilter_binding_list.py
+++ b/libvirt/tests/src/nwfilter/nwfilter_binding_list.py
@@ -114,7 +114,10 @@ def run(test, params, env):
         ret = virsh.nwfilter_binding_list(debug=True)
         utlv.check_result(ret, expected_match=[r"vnet\d+\s+clean-traffic"])
         utlv.check_result(ret, expected_match=[r"vnet\d+\s+allow-dhcp-server"])
-        # detach a interface
+        # detach a interface, before detach, make sure guest boot up
+        vm.cleanup_serial_console()
+        vm.create_serial_console()
+        vm.wait_for_serial_login().close
         option = "--type network" + " --mac " + new_iface_1.mac_address
         ret = virsh.detach_interface(vm_name, option, debug=True)
         time.sleep(time_wait)


### PR DESCRIPTION
Unplugging a PCI device properly requires cooperation from the guest OS.
If the guest OS isn't running yet, the unplug won't complete, so qemu
(and libvirt) still show the device as plugged into the guest. Add
serail_login() to make sure guest is running when detach interface.

Signed-off-by: Yalan Zhang <yalzhang@redhat.com>