### PR TITLE
change_media_matrix: fix bus for s390x

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_change_media_matrix.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_change_media_matrix.cfg
@@ -17,6 +17,9 @@
     aarch64:
         change_media_target_bus = "scsi"
         change_media_target_device = "sdc"
+    s390-virtio:
+        change_media_target_bus = "scsi"
+        change_media_target_device = "sdc"
     kill_vm = yes
     variants:
         - action_twice:


### PR DESCRIPTION
For s390x, cdrom are attached as scsi.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>
