### PR TITLE
NUMA:Add test for numad reasonable error

### DIFF
--- a/libvirt/tests/cfg/numa/numa_numad.cfg
+++ b/libvirt/tests/cfg/numa/numa_numad.cfg
@@ -1,0 +1,9 @@
+- numa_numad:
+    type = numa_numad
+    start_vm = "no"
+    kill_vm = "yes"
+    variants:
+        - update_numad:
+            err_msg = 'Failed to query numad for the advisory nodeset'
+            memory_placement = 'auto'
+            memory_mode = 'strict'

--- a/libvirt/tests/src/numa/numa_numad.py
+++ b/libvirt/tests/src/numa/numa_numad.py
@@ -1,0 +1,88 @@
+import logging
+import os.path
+import shutil
+
+from avocado.core import exceptions
+from avocado.utils import process
+
+from virttest import data_dir
+from virttest import libvirt_xml
+from virttest import virt_vm
+
+
+def action_for_numad_file(numad_path='/usr/bin/numad', action='recover'):
+    """
+    Backup and update or recover numad binary
+
+    :param numad_path: system path to numad binary
+    :param action: action to perform with numad file. It can be either "recover"
+    for recovering the binary to default on or "update" to backup the binary and
+    change it's content.
+    """
+    tmp_dir = data_dir.get_data_dir()
+    src = os.path.join(tmp_dir, 'numad') if action == 'recover' else numad_path
+    dst = numad_path if action == 'recover' else os.path.join(tmp_dir, 'numad')
+    if not os.path.exists(src):
+        exceptions.TestError('The numad file does not exists on the provided '
+                             'path: {}'.format(src))
+    try:
+        # Copy numad so it can be overwritten/recovered during/after the test:
+        shutil.copy(src, dst)
+    except Exception as e:
+        exceptions.TestError('Copy numad file from: {} to: {} failed due to:{}'.
+                             format(src, dst, e))
+    else:
+        logging.info('File numad on path:{} successfully overwritten by:{}.'.
+                     format(dst, src))
+    if action == 'update':
+        # Overwrite content of numad binary:
+        ret = process.run("echo -e '#!/bin/sh \n exit 1' > {}".
+                          format(numad_path), shell=True)
+        if ret.exit_status:
+            exceptions.TestError('Cannot edit numad file due to: {}'.
+                                 format(ret.stderr_text))
+        # For info purposes:
+        process.run("cat {}".format(numad_path))
+        # Run restorecon:
+        ret = process.run("restorecon {}".format(numad_path), shell=True)
+        if ret.exit_status:
+            exceptions.TestError('Cannot restorecon numad file due to: {}'.
+                                 format(ret.stderr_text))
+
+
+def run(test, params, env):
+    """
+    Test Live update the numatune nodeset and memory can spread to other node
+    automatically.
+    """
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    backup_xml = libvirt_xml.VMXML.new_from_dumpxml(vm_name)
+    err_msg = params.get("err_msg", '')
+    try:
+        if vm.is_alive():
+            vm.destroy()
+        action_for_numad_file(numad_path='/usr/bin/numad', action='update')
+        memory_mode = params.get('memory_mode', 'strict')
+        memory_placement = params.get('memory_placement', 'auto')
+        numa_memory = {'mode': memory_mode,
+                       'placement': memory_placement}
+        vmxml = libvirt_xml.VMXML.new_from_dumpxml(vm_name)
+        vmxml.numa_memory = numa_memory
+        logging.debug("vm xml is %s", vmxml)
+        vmxml.sync()
+        vm.start()
+    except virt_vm.VMStartError as detail:
+        if err_msg in str(detail):
+            logging.info('Expected VM start failure.')
+        else:
+            test.fail('The VM cannot be started, but from different reason than'
+                      ' expected:{}. The expected error is: {}.'.
+                      format(detail, err_msg))
+    except (exceptions.TestFail, exceptions.TestCancel):
+        raise
+    except Exception as e:
+        test.error("Unexpected failure: {}.".format(e))
+    finally:
+        backup_xml.sync()
+        action_for_numad_file(numad_path='/usr/bin/numad', action='recover')


### PR DESCRIPTION
New test added check reasonable error info when starting VM with
numad failures.- Bug 1716387; Bug 1716907

Signed-off-by: Kamil Varga <kvarga@redhat.com>

- Description of the cases
  There should reasonable error info when starting VM with numad failures.- Bug 1716387; Bug 1716907
- Case ID:
  RHEL-171541
- Test results:
  <pre>avocado run --vt-type libvirt --vt-machine-type q35 numa_numad
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
<font color="#2A7BDE">JOB ID     : 90442a308adbee2b3e531a46df5a5d45989d5f06</font>
<font color="#2A7BDE">JOB LOG    : /root/avocado/job-results/job-2021-10-08T06.00-90442a3/job.log</font>
 (1/1) type_specific.io-github-autotest-libvirt.numa_numad.update_numad: <font color="#33DA7A">PASS</font> (4.53 s)
<font color="#2A7BDE">RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0</font>
<font color="#2A7BDE">JOB TIME   : 5.11 s</font>
</pre>