### PR TITLE
virsh_detach_device_alias: fix timeout

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
@@ -122,7 +122,8 @@ def run(test, params, env):
 
         # Detach xml with alias
         result = virsh.detach_device_alias(vm_name, device_alias, detach_options,
-                                           wait_for_event=True, debug=True)
+                                           wait_for_event=True, event_timeout=60,
+                                           debug=True)
         libvirt.check_exit_status(result)
         if not utils_misc.wait_for(check_detached_xml_noexist,
                                    60,


### PR DESCRIPTION
In tp-libvirt 3278, the wait_for_event is enabled, but the event_timeout value
is too small (7 seconds by default) which causes a event timeout error. So the
fix is to increase this value.

Signed-off-by: Dan Zheng <dzheng@redhat.com>
