### PR TITLE
Fix 'Not found event device-removed' error

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
@@ -2030,7 +2030,7 @@ def run(test, params, env):
                     if device_attach_error[i] == "yes":
                         continue
                 ret = virsh.detach_device(vm_name, disks_xml[i].xml,
-                                          flagstr=attach_option, wait_for_event=True, **virsh_dargs)
+                                          flagstr=attach_option, wait_for_event=False, **virsh_dargs)
                 os.remove(disks_xml[i].xml)
                 libvirt.check_exit_status(ret)
 

--- a/libvirt/tests/src/virtual_network/iface_target.py
+++ b/libvirt/tests/src/virtual_network/iface_target.py
@@ -152,8 +152,9 @@ def run(test, params, env):
         check_target_name(counter, test_macvtap)
         # one interface with same iface type attached, counter increase by 1
         counter = counter + 1
+        # Make sure the guest boots up. Otherwise detach_device won't complete
+        vm.wait_for_serial_login(timeout=180).close()
         # detach the new attached interface
-        time.sleep(10)
         virsh.detach_device(vm_name, iface_add_xml, wait_for_event=True,
                             debug=True, ignore_status=False)
         if flush_after_detach:


### PR DESCRIPTION
1. Set wait_for_event=False for the cold unplug case
2. Makesure the guest boots up before detach device

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Before
```
 (1/4) type_specific.io-github-autotest-libvirt.virtual_network.iface_target.flush_after_detach.flush_with_occupation.default: ERROR: Not found event device-removed after 7 seconds (67.31 s)
 (2/4) type_specific.io-github-autotest-libvirt.virtual_network.iface_target.flush_after_detach.flush_with_occupation.macvtap: PASS (180.25 s)                                               
 (3/4) type_specific.io-github-autotest-libvirt.virtual_network.iface_target.flush_after_detach.flush_without_occupation.default: ERROR: Not found event device-removed after 7 seconds (181.68 s)
 (4/4) type_specific.io-github-autotest-libvirt.virtual_network.iface_target.flush_after_detach.flush_without_occupation.macvtap: PASS (179.47 s)
 (1/1) type_specific.io-github-autotest-libvirt.virtual_disks.multidisks.hotplug.multi_disks_test.disks_bootorder_error_test: ERROR: Not found event device-removed after 7 seconds
```

After
```
 (1/4) type_specific.io-github-autotest-libvirt.virtual_network.iface_target.flush_after_detach.flush_with_occupation.default: PASS (221.85 s)                                               
 (2/4) type_specific.io-github-autotest-libvirt.virtual_network.iface_target.flush_after_detach.flush_with_occupation.macvtap: PASS (188.52 s)                                               
 (3/4) type_specific.io-github-autotest-libvirt.virtual_network.iface_target.flush_after_detach.flush_without_occupation.default: ERROR: Login timeout expired    (output: 'exceeded 180 s timeout') (355.33 s)
 (4/4) type_specific.io-github-autotest-libvirt.virtual_network.iface_target.flush_after_detach.flush_without_occupation.macvtap: PASS (187.40 s)
(1/1) type_specific.io-github-autotest-libvirt.virtual_disks.multidisks.hotplug.multi_disks_test.disks_bootorder_error_test: PASS (47.06 s)

```