### PR TITLE
migrate_storage.py: update qemu-img create info with -F option

### DIFF
--- a/libvirt/tests/src/migration/migrate_storage.py
+++ b/libvirt/tests/src/migration/migrate_storage.py
@@ -71,8 +71,8 @@ def run(test, params, env):
         process.run(disk_cmd, ignore_status=False, verbose=True)
         local_image_list.append("%s/%s" % (mnt_path, backingfile_img))
         logging.debug("Create a local image backing on NFS.")
-        disk_cmd = ("qemu-img create -f %s -b %s/%s %s" %
-                    (disk_format, mnt_path, backingfile_img, disk_img))
+        disk_cmd = ("qemu-img create -f %s -F %s -b %s/%s %s" %
+                    (disk_format, disk_format, mnt_path, backingfile_img, disk_img))
         process.run(disk_cmd, ignore_status=False, verbose=True)
         local_image_list.append(disk_img)
         if precreation:


### PR DESCRIPTION
In RHEL 8.6, qemu-img should specify the backing format when creating a new file based on backing file. So add -F option in this command, which don't affect the previous test result.

Signed-off-by: Meina Li <meili@redhat.com>
