### PR TITLE
Fix virtual_disks usb failures due to detaching events detection

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_usb.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_usb.py
@@ -232,9 +232,11 @@ def run(test, params, env):
             test.fail("Cannot operate the newly added disk in vm.")
 
         # Detach the disk from vm
+        wait_for_event = False if coldplug else True
         result = virsh.detach_device(vm_name, disk_xml.xml,
                                      flagstr=attach_options,
-                                     ignore_status=True, debug=True, wait_for_event=True)
+                                     ignore_status=True, debug=True,
+                                     wait_for_event=wait_for_event)
         libvirt.check_exit_status(result, status_error)
 
         # Check the detached disk in vm


### PR DESCRIPTION
virtual_disks.usb.coldplug related cases fail due to unnessary event checking
Signed-off-by: chunfuwen <chwen@redhat.com>

