### PR TITLE
numa_nodeset: Fix unsupported cpu model for aarch64

### DIFF
--- a/libvirt/tests/cfg/numa/numa_nodeset.cfg
+++ b/libvirt/tests/cfg/numa/numa_nodeset.cfg
@@ -2,6 +2,8 @@
     type = numa_nodeset
     memory_mode = "strict"
     cellid = "0"
+    aarch64:
+        cpu_mode = "host-passthrough"
     variants:
         - invalid:
             error_msg = 'unsupported configuration: NUMA node \d+ is unavailable'

--- a/libvirt/tests/src/numa/numa_nodeset.py
+++ b/libvirt/tests/src/numa/numa_nodeset.py
@@ -9,6 +9,7 @@ from virttest import virsh
 def update_xml(vm_name, params):
     numa_info = utils_misc.NumaInfo()
     online_nodes = numa_info.get_all_nodes()
+    cpu_mode = params.get('cpu_mode', 'host-model')
     # Prepare a memnode list
     numa_memnode = [{
         'mode': params.get('memory_mode', 'strict'),
@@ -29,7 +30,7 @@ def update_xml(vm_name, params):
 
     vmxml.setup_attrs(**{
         'numa_memnode': numa_memnode,
-        'cpu': {'reset_all': True, 'mode': 'host-model', 'numa_cell': numa_cells}
+        'cpu': {'reset_all': True, 'mode': cpu_mode, 'numa_cell': numa_cells}
     })
 
     logging.debug("vm xml is %s", vmxml)


### PR DESCRIPTION
host-model is not supported by the underlying hypervisor on aarch64.
Set host-passthrough as the default aarch64 cpu model.

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Before
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio numa_nodeset.invalid
JOB ID     : 92fe61e1c15742d3dc36533d231f369742dda30e                                                                                                                                        
JOB LOG    : /root/avocado/job-results/job-2021-10-12T22.42-92fe61e/job.log                               
 (1/1) type_specific.io-github-autotest-libvirt.numa_nodeset.invalid: ERROR: Unexpected error: Expect should fail with one of ['unsupported configuration: NUMA node \\d+ is unavailable'], bu
t failed with:\nerror: Failed to start domain 'avocado-vt-vm1'\nerror: unsupported configuration: CPU mode 'host-model' for aarch64 kvm domain o... (12.50 s)                                
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0                                                                                                            
JOB TIME   : 13.23 s             
```
After
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio numa_nodeset.invalid                                                                                    
JOB ID     : 31e39947477fa0cbf1b694633aff3f41d560d2c1
JOB LOG    : /root/avocado/job-results/job-2021-10-12T22.47-31e3994/job.log
 (1/1) type_specific.io-github-autotest-libvirt.numa_nodeset.invalid: PASS (11.99 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 12.71 s
```