### PR TITLE
Delete starting libvirtd in foreground

### DIFF
--- a/libvirt/tests/src/nwfilter/nwfilter_update_lock.py
+++ b/libvirt/tests/src/nwfilter/nwfilter_update_lock.py
@@ -4,7 +4,6 @@ import logging
 
 from virttest import virsh
 from virttest import libvirt_xml
-from virttest import utils_libvirtd
 from virttest import utils_misc
 from virttest.libvirt_xml.devices import interface
 
@@ -37,7 +36,6 @@ def run(test, params, env):
     vmxml_backup = libvirt_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     backup_filter = libvirt_xml.NwfilterXML()
     filterxml = backup_filter.new_from_filter_dumpxml(filter_name)
-    libvirtd = utils_libvirtd.LibvirtdSession()
 
     def nwfilter_sync_loop(filter_name, filerxml):
         """
@@ -58,7 +56,6 @@ def run(test, params, env):
             vm.destroy(gracefully=False)
 
     try:
-        libvirtd.start()
         # Update first vm interface with filter
         vmxml = libvirt_xml.VMXML.new_from_inactive_dumpxml(vm_name)
         iface_xml = vmxml.get_devices('interface')[0]
@@ -79,17 +76,16 @@ def run(test, params, env):
         time.sleep(0.3)
         vm_thread.start()
 
-        ret = utils_misc.wait_for(lambda: not libvirtd.is_working(),
+        ret = utils_misc.wait_for(lambda: virsh.dom_list(debug=True),
                                   timeout=240,
                                   step=1)
 
         filter_thread.join()
         vm_thread.join()
-        if ret:
+        if not ret:
             test.fail("Libvirtd hang, %s" % bug_url)
 
     finally:
-        libvirtd.exit()
         # Clean env
         if vm.is_alive():
             vm.destroy(gracefully=False)


### PR DESCRIPTION
1.No need to start libvirtd in foreground using libvirtd started by systemctl instead;
2.Libvirtd and virtlogd need to start in the same method;

Signed-off-by: Yan Fu <yafu@redhat.com>

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [ ] Description of the cases
- [ ] Links of libvirt features, libvirt bugs or case IDs
- [ ] Test results

## If the PR is bug cases
- [ ] Bug descriptions or bug links
- [ ] Test results

## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
