### PR TITLE
Fix Not found event tray-change issue

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_change_media_matrix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_change_media_matrix.py
@@ -300,7 +300,7 @@ def run(test, params, env):
                 wait_for_event = True
             ret = virsh.change_media(vm_ref, target_device, all_options,
                                      wait_for_event=wait_for_event,
-                                     event_timeout=14,
+                                     event_timeout=40,
                                      ignore_status=True, debug=True)
             status_error = False
             if pre_vm_state == "shutoff":


### PR DESCRIPTION
In extreme case, current 14 seconds may not be enough to receive event

Signed-off-by: chunfuwen <chwen@redhat.com>


