### PR TITLE
NUMA: Add new test for numanode not defined in cpu info

### DIFF
--- a/libvirt/tests/cfg/numa/numa_numanode_cpu_info.cfg
+++ b/libvirt/tests/cfg/numa/numa_numanode_cpu_info.cfg
@@ -1,0 +1,10 @@
+- numa_numanode_cpu_info:
+    type = numa_numanode_cpu_info
+    start_vm = "no"
+    kill_vm = "yes"
+    numa_cells_with_memory_required = 2
+    variants:
+        - default:
+            err_msg = 'unable to map backing store for guest RAM: Cannot allocate memory'
+            nodes_pages = ['900', '300']
+            memory_mode = "strict"

--- a/libvirt/tests/src/numa/numa_numanode_cpu_info.py
+++ b/libvirt/tests/src/numa/numa_numanode_cpu_info.py
@@ -1,0 +1,83 @@
+import logging
+
+from avocado.core.exceptions import TestError, TestCancel
+from avocado.utils import process
+
+from virttest import libvirt_xml
+from virttest import utils_misc
+from virttest import utils_test
+from virttest import virsh
+
+
+def update_xml(vm_name, online_nodes, params):
+    """
+    Update XML with numatune and memoryBacking
+
+    :param vm_name: Name of VM
+    :param online_nodes: List of all online nodes with memory available
+    """
+    vmxml = libvirt_xml.VMXML.new_from_dumpxml(vm_name)
+    memory_mode = params.get("memory_mode")
+    numa_memory = {'mode': memory_mode,
+                   'nodeset': online_nodes[1]}
+    vmxml.numa_memory = numa_memory
+    mb_xml = libvirt_xml.vm_xml.VMMemBackingXML()
+    mb_xml.hugepages = libvirt_xml.vm_xml.VMHugepagesXML()
+    vmxml.mb = mb_xml
+    logging.debug("vm xml is %s", vmxml)
+    vmxml.sync()
+
+
+def setup_host(online_nodes, pages_list):
+    """
+    Setup host for test - update number of hugepages and check
+
+    :param online_nodes: List of all online nodes with memory available
+    :param pages_list: List of required number of pages for particular nodes
+    """
+    index = 0
+    if len(online_nodes) > 2:
+        for pages in pages_list:
+            ret = process.run(
+                'echo {} > /sys/devices/system/node/node{}/hugepages/hugepages-2048kB/nr_hugepages'.
+                format(pages, online_nodes[index]))
+            if ret.exit_status:
+                raise TestError('Cannot set {} hugepages on node {}'.
+                                format(pages, online_nodes[index]))
+            ret = process.run(
+                'cat /sys/devices/system/node/node{}/hugepages/hugepages-2048kB/nr_hugepages'.
+                format(online_nodes[index]))
+            if pages not in ret.stdout_text:
+                raise TestError('Setting {} hugepages on node {} was unsuccessful'.
+                                format(pages, online_nodes[index]))
+            index += 1
+    else:
+        raise TestCancel("The test cannot continue since there is no enough "
+                         "available NUMA nodes with memory.")
+
+
+def run(test, params, env):
+    """
+    Test the numanode info in cpu section.
+    """
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    error_message = params.get("err_msg")
+    pages_list = eval(params.get('nodes_pages'))
+    backup_xml = libvirt_xml.VMXML.new_from_dumpxml(vm_name)
+    numa_info = utils_misc.NumaInfo()
+    online_nodes = numa_info.get_online_nodes_withmem()
+    setup_host(online_nodes, pages_list)
+    try:
+        if vm.is_alive():
+            vm.destroy()
+        update_xml(vm_name, online_nodes, params)
+        # Try to start the VM with invalid node, fail is expected
+        ret = virsh.start(vm_name, ignore_status=True)
+        utils_test.libvirt.check_status_output(ret.exit_status,
+                                               ret.stderr_text,
+                                               expected_fails=[error_message])
+    except Exception as e:
+        test.error("Unexpected error: {}".format(e))
+    finally:
+        backup_xml.sync()


### PR DESCRIPTION
Start VM with 1 numa node defined in numatune and without numanode
info in cpu when vm have hugepage settings, when the memory in
this node is not enough, VM should start failed.

- Description of the cases:
  Start VM with 1 numa node defined in numatune and without numanode info in cpu when vm have hugepage settings, when the memory in this node is not enough, VM should start failed.
- Case IDs:
  RHEL-171445
- Test results:
  <pre>avocado run --vt-type libvirt --vt-machine-type q35 numa_numanode_cpu_info
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
<font color="#2A7BDE">JOB ID     : 6f5c59e0e06bcf540fca85baea3e133364e83e48</font>
<font color="#2A7BDE">JOB LOG    : /root/avocado/job-results/job-2021-10-14T08.27-6f5c59e/job.log</font>
 (1/1) type_specific.io-github-autotest-libvirt.numa_numanode_cpu_info.default: <font color="#33DA7A">PASS</font> (3.98 s)
<font color="#2A7BDE">RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0</font>
<font color="#2A7BDE">JOB TIME   : 4.40 s</font></pre>