### PR TITLE
incremental_backup_push_mode: Replace vm.destroy with virsh.destroy

### DIFF
--- a/libvirt/tests/src/incremental_backup/incremental_backup_push_mode.py
+++ b/libvirt/tests/src/incremental_backup/incremental_backup_push_mode.py
@@ -269,7 +269,7 @@ def run(test, params, env):
             error_operation = params.get("error_operation")
             if error_operation:
                 if "destroy_vm" in error_operation:
-                    vm.destroy(gracefully=False)
+                    virsh.destroy(vm_name, debug=True)
                 if "kill_qemu" in error_operation:
                     utils_misc.safe_kill(vm.get_pid(), signal.SIGKILL)
                 if utils_misc.wait_for(lambda: utils_backup.is_backup_canceled(vm_name),


### PR DESCRIPTION
vm.destroy costs a lot of time to destroy guest on aarch64.
It caused backup-begin operation finished before destroying the guest.

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Before
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio incremental_backup.push_mode.original_disk_local.coldplug_disk.backup_to_raw.backu
p_to_block.negative_test.destroy_vm                     
JOB ID     : e28c9040485b2739a69e7dd9aa46a6845f934541
JOB LOG    : /root/avocado/job-results/job-2021-10-19T03.25-e28c904/job.log
 (1/1) type_specific.io-github-autotest-libvirt.incremental_backup.push_mode.original_disk_local.coldplug_disk.backup_to_raw.backup_to_block.negative_test.destroy_vm: FAIL: Backup job should be canceled but not. (73.22 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 74.20 s
```
After
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio incremental_backup.push_mode.original_disk_local.coldplug_disk.backup_to_raw.backup_to_block.negative_test.destroy_vm
JOB ID     : 7c6ad288db8c549cd95eb3a51ec47f012828ffaa
JOB LOG    : /root/avocado/job-results/job-2021-10-19T03.34-7c6ad28/job.log
 (1/1) type_specific.io-github-autotest-libvirt.incremental_backup.push_mode.original_disk_local.coldplug_disk.backup_to_raw.backup_to_block.negative_test.destroy_vm: PASS (95.73 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 96.70 s
```
