### PR TITLE
Fix gluster disk device detach event issue

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_gluster.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_gluster.py
@@ -207,6 +207,7 @@ def run(test, params, env):
         if start_vm:
             if vm.is_dead():
                 vm.start()
+                vm.wait_for_login().close()
         else:
             if not vm.is_dead():
                 vm.destroy()


### PR DESCRIPTION
When detach gluster disk device, device-removed may not be sent out

Signed-off-by: chunfuwen <chwen@redhat.com>


