### PR TITLE
Remove hypervisor_cpu_baseline cases from pseries tests

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_cpu_xml.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_cpu_xml.cfg
@@ -19,7 +19,7 @@
                     file_path = '../../../deps/capability_cpu.xml'
             variants:
                 - hypervisor_cpu_baseline:
-                    no aarch64
+                    no aarch64, pseries
                     virsh_function = 'virsh.hypervisor_cpu_baseline'
                 - cpu_baseline:
                     virsh_function = 'virsh.cpu_baseline'


### PR DESCRIPTION
computing baseline hypervisor CPU is not supported for arch ppc64le

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>
