### PR TITLE
virsh_domstate: Extend the wait time for kill action

### DIFF
--- a/libvirt/tests/src/virsh_cmd/monitor/virsh_domstate.py
+++ b/libvirt/tests/src/virsh_cmd/monitor/virsh_domstate.py
@@ -4,7 +4,6 @@ import shutil
 import logging
 import platform
 import signal
-import time
 
 from aexpect import ShellTimeoutError
 from aexpect import ShellProcessTerminatedError
@@ -238,7 +237,7 @@ def run(test, params, env):
         # Timing issue cause test to check domstate before prior action
         # kill gets completed
         if vm_action == "kill":
-            time.sleep(2)
+            utils_misc.wait_for(vm.is_dead, timeout=20)
 
         if remote_uri:
             remote_ip = params.get("remote_ip", "REMOTE.EXAMPLE.COM")


### PR DESCRIPTION
Extend the wait time for test as it need more time to complete
 the kill action.

Signed-off-by: lcheng <lcheng@redhat.com>
