### PR TITLE
virtual_disks_transient_disk: Add case for BZ#1978821

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_transient_disk.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_transient_disk.cfg
@@ -8,6 +8,8 @@
     virt_disk_format = "qcow2"
     virt_target_format = "qcow2"
     vms = avocado-vt-vm1 vm1
+    func_supported_since_libvirt_ver = (7, 4, 0)
+    unspported_err_msg = "transient disk share is not supported on current build"
     variants:
         - positive_tests:
             status_error = "yes yes"
@@ -24,6 +26,12 @@
                 - no_sharebacking:
                     only hotplug
                     share_transient = "no no"
+                - on_reboot_destroy:
+                    only coldplug
+                    func_supported_since_libvirt_ver = (7, 6, 0)
+                    unspported_err_msg = "Bug 1978821 is not fixed on current build"
+                    on_reboot_destroy = "yes"
+                    share_transient = "no yes"
         - negtive_tests:
             only coldplug
             status_error = "yes no"


### PR DESCRIPTION
libvirt transient shareBacking option doesn't work with
<on_reboot>destroy</on_reboot>

This bug was fixed in libvirt-7.6.0

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Test on libvirt 7.6.0
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio   virtual_disks.transient_disk.coldplug.positive_tests.on_reboot_destroy
JOB ID     : 5830e7169569d366290f4ddb67a059e52142126e
JOB LOG    : /root/avocado/job-results/job-2021-10-25T03.49-5830e71/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_disks.transient_disk.coldplug.positive_tests.on_reboot_destroy: PASS (98.96 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 99.86 s
```

Test on libvirt 7.4.0 (Cancel Test)
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio   virtual_disks.transient_disk.coldplug.positive_tests.on_reboot_destroy
JOB ID     : c1e0f8e09037bb3d3ffd1ff4401da21591023b43
JOB LOG    : /root/avocado/job-results/job-2021-10-25T03.44-c1e0f8e/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_disks.transient_disk.coldplug.positive_tests.on_reboot_destroy: CANCEL: Bug https://bugzilla.redhat.com/show_bug.cgi?id=1978821 not fixed on current build (57.84 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 1
JOB TIME   : 58.73 s
```
