### PR TITLE
vDPA: Add a test to check hotplug/unplug vdpa type interface

### DIFF
--- a/libvirt/tests/cfg/virtual_interface/interface_hotplug.cfg
+++ b/libvirt/tests/cfg/virtual_interface/interface_hotplug.cfg
@@ -1,0 +1,14 @@
+- interface_hotplug:
+    type = interface_hotplug
+    start_vm = no
+    repeat_times = 1
+
+    variants dev_type:
+        - vdpa:
+            only x86_64
+            func_supported_since_libvirt_ver = (7, 3, 0)
+            func_supported_since_qemu_kvm_ver = (6, 0, 0)
+            iface_dict = {"source": {'dev':'/dev/vhost-vdpa-0'}}
+            variants test_target:
+                - simulator:
+                - mellanox:

--- a/libvirt/tests/src/virtual_interface/interface_hotplug.py
+++ b/libvirt/tests/src/virtual_interface/interface_hotplug.py
@@ -1,0 +1,104 @@
+import logging
+
+from virttest import libvirt_version
+from virttest import utils_misc
+from virttest import utils_vdpa
+from virttest.libvirt_xml import vm_xml
+from virttest.staging import service
+from virttest.utils_libvirt import libvirt_vmxml
+
+from provider.interface import interface_base
+from provider.interface import vdpa_base
+
+
+def run(test, params, env):
+    """
+    Test Hotplug/unplug interface device(s)
+    """
+
+    def setup_default():
+        """
+        Default setup
+        """
+        logging.debug("Remove VM's interface devices.")
+        libvirt_vmxml.remove_vm_devices_by_type(vm, 'interface')
+
+    def teardown_default():
+        """
+        Default cleanup
+        """
+        pass
+
+    def setup_vdpa():
+        """
+        Setup vDPA environment
+        """
+        setup_default()
+        test_env_obj = None
+        if test_target == "simulator":
+            test_env_obj = utils_vdpa.VDPASimulatorTest()
+        else:
+            pf_pci = utils_vdpa.get_vdpa_pci()
+            test_env_obj = utils_vdpa.VDPAOvsTest(pf_pci)
+        test_env_obj.setup()
+        return test_env_obj
+
+    def teardown_vdpa():
+        """
+        Cleanup vDPA environment
+        """
+        if test_target != "simulator":
+            service.Factory.create_service("NetworkManager").restart()
+        if test_obj:
+            test_obj.cleanup()
+
+    def test_vdpa():
+        """
+        Hotplug/unplug vDPA type interface
+
+        1) Start the vm, hotplug the interface
+        2) Login to the vm and check the network function
+        3) Hot-unplug the interface
+        """
+        vm.start()
+        vm_session = vm.wait_for_serial_login(timeout=240)
+
+        br_name = None
+        if test_target == "mellanox":
+            br_name = test_obj.br_name
+        for _i in range(eval(params.get('repeat_times', '1'))):
+            interface_base.attach_iface_device(vm_name, dev_type, params)
+            vdpa_base.check_vdpa_conn(vm_session, test_target, br_name)
+            interface_base.detach_iface_device(vm_name, dev_type)
+
+    libvirt_version.is_libvirt_feature_supported(params)
+    supported_qemu_ver = eval(params.get('func_supported_since_qemu_kvm_ver', '()'))
+    if supported_qemu_ver:
+        if not utils_misc.compare_qemu_version(*supported_qemu_ver, False):
+            test.cancel("Current qemu version doesn't support this test!")
+
+    # Variable assignment
+    test_target = params.get('test_target', '')
+    dev_type = params.get('dev_type', '')
+
+    vm_name = params.get('main_vm')
+    vm = env.get_vm(vm_name)
+
+    vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+    backup_vmxml = vmxml.copy()
+
+    run_test = eval("test_%s" % dev_type)
+    setup_test = eval("setup_%s" % dev_type) if "setup_%s" % dev_type in \
+        locals() else setup_default
+    teardown_test = eval("teardown_%s" % dev_type) if "teardown_%s" % \
+        dev_type in locals() else teardown_default
+
+    test_obj = None
+    try:
+        # Execute test
+        test_obj = setup_test()
+        run_test()
+
+    finally:
+        backup_vmxml.sync()
+        teardown_test()

--- a/provider/interface/interface_base.py
+++ b/provider/interface/interface_base.py
@@ -1,0 +1,74 @@
+import logging
+import time
+
+from avocado.core import exceptions
+
+from virttest import utils_net
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.libvirt_xml.devices import interface
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+
+def create_iface(iface_type, iface_dict):
+    """
+    Create Interface device
+
+    :param iface_type: String, interface type
+    :param iface_dict: Dict, attrs of Interface
+    :return: xml object of interface
+    """
+    iface = interface.Interface(iface_type)
+    iface.setup_attrs(**iface_dict)
+
+    logging.debug("Interface XML: %s", iface)
+    return iface
+
+
+def get_vm_iface(vm_session):
+    """
+    Get VM's 1st interface
+
+    :param vm_session: An session to VM
+    :return: VM's first interface
+    """
+    p_iface, _v_ifc = utils_net.get_remote_host_net_ifs(vm_session)
+    vm_iface = p_iface[:1:]
+    if not vm_iface:
+        raise exceptions.TestFail("Failed to get vm's iface!")
+    return vm_iface[0]
+
+
+def attach_iface_device(vm_name, dev_type, params):
+    """
+    Attach an interface to VM
+
+    :param vm_name: VM's name
+    :param dev_type: Interface device type
+    :param params: Dictionary with the test parameters
+    """
+    iface_dict = eval(params.get('iface_dict', '{}'))
+    status_error = "yes" == params.get('status_error', 'no')
+
+    iface = create_iface(dev_type, iface_dict)
+    res = virsh.attach_device(vm_name, iface.xml, debug=True)
+    libvirt.check_exit_status(res, status_error)
+    libvirt_vmxml.check_guest_xml(vm_name, dev_type)
+    # FIXME: Sleep for 20 secs to make iface work properly
+    time.sleep(20)
+
+
+def detach_iface_device(vm_name, dev_type):
+    """
+    Detach an interface from VM
+
+    :param vm_name: VM's name
+    :param dev_type: Interface device type
+    """
+    iface = interface.Interface(dev_type)
+    iface = vm_xml.VMXML.new_from_dumpxml(vm_name).devices.by_device_tag(
+        "interface")[0]
+    virsh.detach_device(vm_name, iface.xml, wait_for_event=True,
+                        debug=True, ignore_status=False)
+    libvirt_vmxml.check_guest_xml(vm_name, dev_type, status_error=True)

--- a/provider/interface/vdpa_base.py
+++ b/provider/interface/vdpa_base.py
@@ -1,0 +1,90 @@
+import logging
+import re
+
+from avocado.core import exceptions
+from avocado.utils import process
+
+from provider.interface import interface_base
+
+from virttest import utils_test
+from virttest import utils_misc
+from virttest.staging import service
+
+
+def config_vdpa_conn(vm_session, vm_iface, br_name,
+                     br_ip_addr='100.100.100.100', cidr='24'):
+    """
+    Config vdpa connection
+
+    :param vm_session: An session to VM
+    :param vm_iface: VM's interface
+    :param br_name: Bridge name
+    :param br_ip_addr: IP address of the bridge
+    :param cidr: CIDR
+    """
+    vm_ip = re.sub('\d+$', '60', br_ip_addr)
+    service.Factory.create_service("NetworkManager").stop()
+
+    logging.debug("Config static ip %s for vm.", vm_ip)
+    cmd = ("nmcli con del {0}; nmcli con add type ethernet ifname {0} "
+           "con-name {0} ipv4.method manual ipv4.address {1}/{2}"
+           .format(vm_iface, vm_ip, cidr))
+    vm_session.cmd(cmd)
+    logging.debug("Set ip address of the bridge.")
+    cmd = ("ip addr add {0}/{1} dev {2}; sleep 5;ip link set {2} up"
+           .format(br_ip_addr, cidr, br_name))
+    process.run(cmd, shell=True)
+
+
+def check_vdpa_network(vm_session, vm_iface, br_name,
+                       ping_dest="100.100.100.100"):
+    """
+    Check vdpa network connection
+
+    :param vm_session: An session to VM
+    :param vm_iface: VM's interface
+    :param br_name: Bridge name
+    :param ping_dest: The ip address to ping
+    """
+    config_vdpa_conn(vm_session, vm_iface, br_name)
+
+    if not utils_misc.wait_for(lambda: not utils_test.ping(
+           ping_dest, count=3, timeout=5, output_func=logging.debug,
+           session=vm_session)[0], first=5, timeout=30):
+        raise exceptions.TestFail("Failed to ping %s." % ping_dest)
+
+
+def check_rx_tx_packages(vm_session, vm_iface):
+    """
+    Check rx and tx package
+
+    :param vm_session: An session to VM
+    :param vm_iface: VM's interface
+    """
+    cmd = "ip -s -json link show %s" % vm_iface
+    status, stdout = vm_session.cmd_status_output(cmd)
+    if status or not stdout:
+        raise exceptions.TestFail("Failed to run cmd - {}, status - {}, "
+                                  "output - {}.".format(cmd, status, stdout))
+    ip_info = eval(stdout.strip())
+    logging.debug("VM iface's info: %s.", ip_info)
+
+    tx_info = ip_info[0]['stats64']['tx']['packets']
+    rx_info = ip_info[0]['stats64']['rx']['packets']
+    if rx_info != tx_info:
+        raise exceptions.TestFail("The value of rx and tx should be same.")
+
+
+def check_vdpa_conn(vm_session, test_target, br_name=None):
+    """
+    Check vDPA connection
+
+    :param vm_session: An session to VM
+    :param test_target: Test target env, eg, "mellanox" or "simulator"
+    :param br_name: Bridge name
+    """
+    vm_iface = interface_base.get_vm_iface(vm_session)
+    if test_target == "mellanox":
+        check_vdpa_network(vm_session, vm_iface, br_name)
+    elif test_target == "simulator":
+        check_rx_tx_packages(vm_session, vm_iface)


### PR DESCRIPTION
This PR adds:
RHEL-196261: hotplug/unplug vdpa type interface

Signed-off-by: Yingshun Cui <yicui@redhat.com>

**Depends on**: https://github.com/avocado-framework/avocado-vt/pull/3260
**Test results:**
```
 (1/2) type_specific.io-github-autotest-libvirt.interface_hotplug.vdpa.simulator: PASS (41.79 s)
 (2/2) type_specific.io-github-autotest-libvirt.interface_hotplug.vdpa.mellanox: PASS (91.56 s)
```
