### PR TITLE
libvirt_rng: relax test condition inside guest

### DIFF
--- a/libvirt/tests/src/libvirt_rng.py
+++ b/libvirt/tests/src/libvirt_rng.py
@@ -342,7 +342,7 @@ def run(test, params, env):
         rng_currt = session.cmd_output("cat %s" % rng_files[1],
                                        timeout=timeout).strip()
         logging.debug("rng avail:%s, current:%s", rng_avail, rng_currt)
-        if not rng_currt.count("virtio") or rng_currt not in rng_avail:
+        if "virtio" not in rng_avail or not rng_currt.strip():
             test.fail("Failed to check rng file on guest")
 
         # Read the random device


### PR DESCRIPTION
The test case currently expects virtio to be rng hw_device
that's selected by the kernel but this depends on the
kernel code. Let's just check that some hw_device is set
and the virtio device is available. The way the kernel selects
the device is unlikely to change unintentionally and
the current_rng can always be set manually.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>
