### PR TITLE
blockcommand: Fixup a gluster setup issue

### DIFF
--- a/libvirt/tests/src/backingchain/blockcommand.py
+++ b/libvirt/tests/src/backingchain/blockcommand.py
@@ -168,9 +168,7 @@ def run(test, params, env):
         # Setup gluster
         elif disk_src == 'gluster':
             host_ip = gluster.setup_or_cleanup_gluster(
-                is_setup=True, vol_name=vol_name,
-                brick_path=brick_path, pool_name=pool_name
-            )
+                is_setup=True, brick_path=brick_path, **params)
             logging.debug(host_ip)
             gluster_img = 'test.img'
             img_create_cmd = "qemu-img create -f raw /mnt/%s 10M" % gluster_img
@@ -310,6 +308,7 @@ def run(test, params, env):
                     process.run("pvremove %s" % pv_name, verbose=True, ignore_status=True)
             libvirt.setup_or_cleanup_iscsi(is_setup=False)
         elif disk_src == 'gluster':
-            gluster.setup_or_cleanup_gluster(is_setup=False, vol_name=vol_name, brick_path=brick_path, pool_name=pool_name)
+            gluster.setup_or_cleanup_gluster(
+                is_setup=False, brick_path=brick_path, **params)
         if 'multipathd_status' in locals() and multipathd_status:
             multipathd.start()


### PR DESCRIPTION
The gluster server is deployed in the test environment, so remove
the dependency of "glusterfs-server".

Signed-off-by: Yingshun Cui <yicui@redhat.com>

**Before fix:**
` (1/1) type_specific.io-github-autotest-libvirt.backingchain.blockcommand.blockpull.base_top.positive_test.file_disk.gluster_bk: ERROR: Command 'gluster volume info vol_blockpull' failed.\nstdout: b'Connection failed. Please check if gluster daemon is operational.\n'\nstderr: b''\nadditional_info: None (31.72 s)`
**After fix:**
```
JOB ID     : 14e39073034b29253b568630d76255ff518ace5c
JOB LOG    : /root/avocado/job-results/job-2021-10-27T21.06-14e3907/job.log
 (1/1) type_specific.io-github-autotest-libvirt.backingchain.blockcommand.blockpull.base_top.positive_test.file_disk.gluster_bk: PASS (32.46

```