### PR TITLE
vm_features: Check the result of the package download

### DIFF
--- a/libvirt/tests/src/cpu/vm_features.py
+++ b/libvirt/tests/src/cpu/vm_features.py
@@ -26,9 +26,12 @@ def install_pkgs(session, cpuid_uri, test):
     if cpuid_uri:
         if not utils_package.package_install('wget', session=session):
             test.error("Fail to install 'wget' tool via repo")
-        utils_misc.cmd_status_output('wget %s' % cpuid_uri, shell=True,
-                                     ignore_status=False, verbose=True,
-                                     session=session)
+        status, _o = utils_misc.cmd_status_output(
+            'wget %s' % cpuid_uri, shell=True, ignore_status=False,
+            verbose=True, session=session)
+        if status:
+            test.error("Fail to download the package %s!"
+                       % os.path.basename(cpuid_uri))
         if not utils_package.package_install('cpuid*.rpm', session=session):
             test.error("Fail to install package "
                        "'%s'" % os.path.basename(cpuid_uri))


### PR DESCRIPTION
The cpuid package was unable to download sometimes.
In that case, wget command did not return immediately and the
session to the vm was unable to use for other checks. So update
to check the result of the package download.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
Before fix:
` (1/1) type_specific.io-github-autotest-libvirt.vm_features.positive_test.kvm_hidden.enable: ERROR: Timeout expired while waiting for shell command to complete: 'which apt-get'    (output: '') (147.73 s)`

After fix:
` (1/1) type_specific.io-github-autotest-libvirt.vm_features.positive_test.kvm_hidden.enable: ERROR: Fail to download the package cpuid-20201006-1.x86_64.rpm! (88.52 s)`
