### PR TITLE
[virsh.guestinfo]Add the scenario for testing serial name of virsh gu…

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_guestinfo.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_guestinfo.cfg
@@ -22,6 +22,7 @@
                     option = "--disk"
                     disk_target_name = "vdb"
                     disk_name = "vdb.img"
+                    serial_num = "12345678"
         - negative:
             status_error = "yes"
             variants:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_guestinfo.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_guestinfo.py
@@ -23,9 +23,10 @@ def run(test, params, env):
         """
         device_source = os.path.join(data_dir.get_tmp_dir(), disk_name)
         libvirt.create_local_disk("file", device_source, size='1')
+        extra_option = "--serial %s" % serial_num
         try:
-            res = virsh.attach_disk(vm_name, device_source,
-                                    disk_target_name, debug=True)
+            res = virsh.attach_disk(vm_name, device_source, disk_target_name,
+                                    extra=extra_option, debug=True)
             utils_misc.wait_for(lambda: (res.stdout ==
                                 "Disk attached successfully"), 10)
         except Exception:
@@ -46,7 +47,8 @@ def run(test, params, env):
             try:
                 if disk_info[prefix + 'alias'] == target_name:
                     if (disk_info[prefix + 'name'] == disk_logical_name and
-                            disk_info[prefix + 'partition'] == 'no'):
+                            disk_info[prefix + 'partition'] == 'no' and
+                            disk_info[prefix + 'serial'] == serial_num):
                         attached_disk_info_reported = True
                         break
             except KeyError:
@@ -254,6 +256,7 @@ def run(test, params, env):
     prepare_channel = ("yes" == params.get("prepare_channel", "yes"))
     disk_target_name = params.get("disk_target_name")
     disk_name = params.get("disk_name")
+    serial_num = params.get("serial_num")
     readonly_mode = ("yes" == params.get("readonly_mode"))
 
     if not libvirt_version.version_compare(6, 0, 0):


### PR DESCRIPTION
…estinfo

Expose disk serial number in virDomainGetGuestInfo(), complete the
case for flag --disk of virsh guestinfo.

Signed-off-by: Lili Zhu <lizhu@redhat.com>

Case ID: RHEL-201783

Testing result:
JOB ID     : a6e0380cd09bad2b796b76b121ac94e301111022
JOB LOG    : /root/avocado/job-results/job-2021-10-28T06.41-a6e0380/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.guestinfo.positive.disk_info: PASS (84.03 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 86.39 s


