### PR TITLE
Enable pcie_expander_bus related cases for aarch64

### DIFF
--- a/libvirt/tests/cfg/controller/controller_functional.cfg
+++ b/libvirt/tests/cfg/controller/controller_functional.cfg
@@ -91,7 +91,10 @@
                     # The controller attached to pcie-expander-bus should be 64:XX.X since busNr is 100(hex 64).
                     guest_patterns = "['64:.* PCI bridge: Red Hat', '64:.* PCI bridge: Intel.*82801']"
                 - pcie_expander_bus_busNr:
-                    only q35
+                    only q35, aarch64
+                    aarch64:
+                        func_supported_since_libvirt_ver = (7, 7, 0)
+                        unspported_err_msg = "pcie-expander-bus is not supported on current build"
                     run_vm = "no"
                     check_contr_addr = "no"
                     check_within_guest = "no"

--- a/libvirt/tests/cfg/controller/controller_functional.cfg
+++ b/libvirt/tests/cfg/controller/controller_functional.cfg
@@ -94,7 +94,7 @@
                     only q35, aarch64
                     aarch64:
                         func_supported_since_libvirt_ver = (7, 7, 0)
-                        unspported_err_msg = "pcie-expander-bus is not supported on current build"
+                        unsupported_err_msg = "pcie-expander-bus is not supported on current build"
                     run_vm = "no"
                     check_contr_addr = "no"
                     check_within_guest = "no"
@@ -137,11 +137,17 @@
                           qemu_monitor_pattern = "macaddr=${nic_mac}"
                           cmd_in_guest = "['ip a |grep ${nic_mac}']"
                 - pcie_expander_bus_numa:
-                    only q35
+                    only q35, aarch64
+                    aarch64:
+                        func_supported_since_libvirt_ver = (7, 7, 0)
+                        unsupported_err_msg = "pcie-expander-bus is not supported on current build"
                     check_contr_addr = "no"
                     check_qemu = "no"
                     vcpu_count = "4"
-                    sound_dict = "{'model': 'ich9', 'bus': '0x04', 'slot': '0x00'}"
+                    q35:
+                        sound_dict = "{'model': 'ich9', 'bus': '0x04', 'slot': '0x00'}"
+                    aarch64:
+                        rng_dict = "{'model': 'virtio', 'bus': '0x04', 'slot': '0x00'}"
                     balloon_dict = "{'model': 'virtio', 'bus': '0x08', 'slot': '0x00'}"
                     add_contrl_list = "[{'model': 'pcie-expander-bus', 'index': '3', 'busNr': '100', 'node': '1'},{'model': 'pcie-root-port', 'index': '4','bus': '0x03', 'slot': '0x01'},{'model': 'pcie-expander-bus', 'index': '7', 'busNr': '200', 'node': '0'},{'model': 'pcie-root-port', 'index': '8','bus': '0x07', 'slot': '0x01'}]"
                     cpu_numa_cells = "[{'id': '0', 'cpus': '0-1', 'memory': '512', 'unit': 'M'}, {'id': '1', 'cpus': '2-3', 'memory': '512', 'unit': 'M'}]"

--- a/libvirt/tests/src/controller/controller_functional.py
+++ b/libvirt/tests/src/controller/controller_functional.py
@@ -8,6 +8,7 @@ from virttest import virsh
 from virttest import remote
 from virttest import data_dir
 from virttest import utils_misc
+from virttest import libvirt_version
 
 from virttest.utils_test import libvirt
 from virttest.utils_libvirt import libvirt_pcicontr
@@ -767,6 +768,8 @@ def run(test, params, env):
     auto_indexes_dict = {}
     auto_index = params.get('auto_index', 'no') == 'yes'
     auto_slot = params.get('auto_slot', 'no') == 'yes'
+
+    libvirt_version.is_libvirt_feature_supported(params)
 
     if index and index_second:
         if int(index) > int(index_second):


### PR DESCRIPTION
libvirt support pcie_expander_bus on aarch64 since 7.7.0.
1. RHEL8 qemu doesn't support ich9 sound device on aarch64, use rng device.
2. RHEL8 qemu doesn't support host-model on aarch64, use host-passthrough.

libvirt7.6.0
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio controller.functional.positive_tests.pcie_expander_bus_numa controller.functional.positive_tests.pcie_expander_bus_busNr
JOB ID     : 4981e78c57a136ca54f37660ccd7e8bbc4f2fa09
JOB LOG    : /root/avocado/job-results/job-2021-10-28T23.30-4981e78/job.log
 (1/3) type_specific.io-github-autotest-libvirt.controller.functional.positive_tests.pcie_expander_bus_numa: CANCEL: transient disk share is not supported on current build (6.81 s)
 (2/3) type_specific.io-github-autotest-libvirt.controller.functional.positive_tests.pcie_expander_bus_busNr.default_busNr: CANCEL: transient disk share is not supported on current build (6.72 s)
 (3/3) type_specific.io-github-autotest-libvirt.controller.functional.positive_tests.pcie_expander_bus_busNr.special_busNr: CANCEL: transient disk share is not supported on current build (6.94 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 3
JOB TIME   : 21.24 s
```

libvirt7.7.0
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio controller.functional.positive_tests.pcie_expander_bus_numa controller.functional.positive_tests.pcie_expander_bus_busNr
JOB ID     : 2b51f8b47224f57808c26a01f23272b27ed4e1b7
JOB LOG    : /root/avocado/job-results/job-2021-10-28T23.30-2b51f8b/job.log
 (1/3) type_specific.io-github-autotest-libvirt.controller.functional.positive_tests.pcie_expander_bus_numa: PASS (43.52 s)
 (2/3) type_specific.io-github-autotest-libvirt.controller.functional.positive_tests.pcie_expander_bus_busNr.default_busNr: PASS (7.52 s)
 (3/3) type_specific.io-github-autotest-libvirt.controller.functional.positive_tests.pcie_expander_bus_busNr.special_busNr: PASS (12.21 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 65.29 s
```