### PR TITLE
v2v: add windows2022 to matrix of auto testing

### DIFF
--- a/v2v/tests/cfg/convert_vm_to_libvirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_libvirt.cfg
@@ -114,6 +114,9 @@
                 - win2019:
                     only esx
                     os_version = "win2019"
+                - win2022:
+                    only esx
+                    os_version = "win2022"
     variants:
         - xen:
             only source_xen

--- a/v2v/tests/cfg/convert_vm_to_ovirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_ovirt.cfg
@@ -146,6 +146,9 @@
                 - win2019:
                     no xen
                     os_version = "win2019"
+                - win2022:
+                    no xen
+                    os_version = "win2022"
     variants:
         - xen:
             only source_xen


### PR DESCRIPTION
Add the latest windows version: win2022 into auto testing.
