### PR TITLE
Add testcase for all the sub-daemons starting in foreground

### DIFF
--- a/libvirt/tests/cfg/daemon/daemon_functional.cfg
+++ b/libvirt/tests/cfg/daemon/daemon_functional.cfg
@@ -7,6 +7,29 @@
     pseries:
         exit_time_tolerance = 2
     variants:
+        - legacy_daemon:
+            require_modular_daemon = "no"
+            variants:
+                - libvirtd:
+                    daemon_name = "libvirtd"
+        - modular_daemon:
+            require_modular_daemon = "yes"
+            variants:
+                - virtnetworkd:
+                    daemon_name = "virtnetworkd"
+                - virtnodedevd:
+                    daemon_name = "virtnodedevd"
+                - virtsecretd:
+                    daemon_name = "virtsecretd"
+                - virtstoraged:
+                    daemon_name = "virtstoraged"
+                - virtinterfaced:
+                    daemon_name = "virtinterfaced"
+                - virtnwfilterd:
+                    daemon_name = "virtnwfilterd"
+                - virtqemud:
+                    daemon_name = "virtqemud"
+    variants:
         - no_opt:
         - opt_help:
             libvirtd_arg = '--help'
@@ -20,11 +43,12 @@
             libvirtd_arg = '--timeout 3'
             expected_exit_time = 3
         - opt_timeout_3_live_vm:
+            only virtqemud, libvirtd
             libvirtd_arg = '--timeout 3'
             start_vm = yes
         - opt_config:
-            libvirtd_arg = '--config /tmp/virt-test.conf'
-            expected_config_path = '/tmp/virt-test.conf'
+            test_config = 'yes'
+            libvirtd_arg = '--config '
         - opt_pid:
             libvirtd_arg = '--pid-file /tmp/virt-test.pid'
             expected_pid_path = '/tmp/virt-test.pid'


### PR DESCRIPTION
1.Will run all the testcases for sub-daemons in modular daemon mode
  and cancel testcases for legacy libvirtd;
2.Will run testcases for libvirtd in legacy libvirtd mode and cancel
  testcases for modular daemon;

Signed-off-by: Yan Fu <yafu@redhat.com>

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [ ] Description of the cases
- [ ] Links of libvirt features, libvirt bugs or case IDs
- [ ] Test results

## If the PR is bug cases
- [ ] Bug descriptions or bug links
- [ ] Test results

## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
