### PR TITLE
vcpu_nested: adapt for modular daemons

### DIFF
--- a/libvirt/tests/cfg/cpu/vcpu_nested.cfg
+++ b/libvirt/tests/cfg/cpu/vcpu_nested.cfg
@@ -9,8 +9,4 @@
                     case = 'change_vm_cpu'
                     cpu_old_mode = 'host-model'
                     cpu_new_mode = 'host-passthrough'
-                    enable_libvirtd_debug_in_vm = 'yes'
-                    log_file = '/var/log/libvirt/libvirtd.log'
-                    libvirtd_conf_dict = '{r".*log_level\s*=.*": "log_level=1", r".*log_outputs.*=.*": "log_outputs=\"1:file:${log_file}\""}'
-                    search_str_in_vm_libvirtd = 'Outdated capabilities for.*: host CPU changed'
                     cmd_in_guest = "stat %s|grep '^Modify: '|cut -d' ' -f2-3"


### PR DESCRIPTION
1 - Checking log is sometimes not statble. After confirming with feature
owner, this step is not required for this case. So I remove it to
make the script stabler.

2 - After libvirt packages are installed in L1, to make the default
libvirt daemons start automatically, we have 2 ways. One is rebooting
the vm, the other is to explicitly start the service names according
to different libvirt versions to judge monolithic vs. modular daemons
to use. It seems the first way is easier.

Signed-off-by: Dan Zheng <dzheng@redhat.com>
