### PR TITLE
remote_access:Fix unix negative test for polkit ro

### DIFF
--- a/libvirt/tests/cfg/remote_access/remote_with_unix.cfg
+++ b/libvirt/tests/cfg/remote_access/remote_with_unix.cfg
@@ -149,5 +149,7 @@
                     main_vm = "avocado-vt-vm1"
                     status_error = "no"
                     patterns_virsh_cmd = ".*authentication unavailable.*"
+                    auth_pwd = "${local_pwd}"
+                    error_pattern = 'System policy prevents management of local virtualized systems'
                     polkit_pkla = "/etc/polkit-1/localauthority/50-local.d/polkit.pkla"
                     polkit_pkla_cxt = "[Allow ${su_user} libvirt monitor permissions]\nIdentity=unix-user:${su_user}\nAction=org.libvirt.unix.monitor\nResultAny=yes\nResultInactive=yes\nResultActive=yes"

--- a/libvirt/tests/src/remote_access/remote_access.py
+++ b/libvirt/tests/src/remote_access/remote_access.py
@@ -60,8 +60,15 @@ def remote_access(params, test):
                 fp.close()
             logging.info("Succeed to connect libvirt daemon.")
         else:
-            test.fail("Failed to connect libvirt daemon!!output: {}"
-                      .format(output))
+            if error_pattern:
+                if error_pattern in output:
+                    logging.info("Expected libvirt output!!")
+                else:
+                    test.fail("Unexpected output: {}, when looking for: {} "
+                              "pattern".format(output, error_pattern))
+            else:
+                test.fail("Failed to connect libvirt daemon!!output: {}"
+                          .format(output))
     else:
         if not ret:
             if error_pattern:


### PR DESCRIPTION
This commit is a fix for remote_with_unix.negative_testing.socket_with_polkit_ro
test case, where response from the libvirt has changed with the recent version
and therefore password prompt is showing up with error message and requiring
root account instead of polkit account which is denied. This fix add root
password to pass through the login prompt and code to check for the new error
message.

Signed-off-by: Kamil Varga <kvarga@redhat.com>

Test results before the fix is applied:
<pre>avocado run --vt-type libvirt --vt-machine-type q35 virsh.remote_with_unix.negative_testing.socket_with_polkit_ro
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
<font color="#2A7BDE">JOB ID     : 8876d5e799d7cecb3039cc3e01990480ea5626ac</font>
<font color="#2A7BDE">JOB LOG    : /root/avocado/job-results/job-2021-11-02T17.01-8876d5e/job.log</font>
 (1/1) type_specific.io-github-autotest-libvirt.virsh.remote_with_unix.negative_testing.socket_with_polkit_ro: <font color="#F66151">ERROR: unsupported operand type(s) for +: &apos;NoneType&apos; and &apos;str&apos;</font> (63.72 s)
<font color="#2A7BDE">RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0</font>
<font color="#2A7BDE">JOB TIME   : 64.93 s</font></pre>

Test results after the fix is applied:
<pre>avocado run --vt-type libvirt --vt-machine-type q35 virsh.remote_with_unix.negative_testing.socket_with_polkit_ro
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
<font color="#2A7BDE">JOB ID     : 44eef5515312129729da4fbd8e509fd3ecb5f2aa</font>
<font color="#2A7BDE">JOB LOG    : /root/avocado/job-results/job-2021-11-03T09.57-44eef55/job.log</font>
 (1/1) type_specific.io-github-autotest-libvirt.virsh.remote_with_unix.negative_testing.socket_with_polkit_ro: <font color="#33DA7A">PASS</font> (65.46 s)
<font color="#2A7BDE">RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0</font>
<font color="#2A7BDE">JOB TIME   : 66.65 s</font></pre>
