### PR TITLE
net_start: Fix polkit setting

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_start.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_start.cfg
@@ -22,9 +22,9 @@
                 - acl_test:
                     setup_libvirt_polkit = "yes"
                     action_id = "org.libvirt.api.network.start"
-                    action_lookup = "connect_driver:QEMU network_name:default"
+                    action_lookup = "connect_driver:QEMU|network network_name:default"
                     unprivileged_user = "EXAMPLE"
-                    virsh_uri = "qemu:///system"
+                    virsh_uri = "network:///system"
                 - restart_firewalld:
                     only valid_netname
                     firewalld_operate = "restart"
@@ -52,7 +52,7 @@
                     net_start_net_ref = netname
                     setup_libvirt_polkit = "yes"
                     unprivileged_user = "EXAMPLE"
-                    virsh_uri = "qemu:///system"
+                    virsh_uri = "network:///system"
                 - net_start_readonly_test:
                     net_start_readonly = "yes"
                     net_start_net_ref = netname

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_start.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_start.py
@@ -5,6 +5,7 @@ from virttest import virsh
 from virttest import libvirt_vm
 from virttest import libvirt_version
 from virttest import utils_libvirtd
+from virttest import utils_split_daemons
 from virttest.libvirt_xml import network_xml, IPXML
 from virttest.staging import service
 from virttest.utils_test import libvirt
@@ -35,6 +36,8 @@ def run(test, params, env):
                         " libvirt version.")
 
     virsh_uri = params.get("virsh_uri")
+    if virsh_uri and not utils_split_daemons.is_modular_daemon():
+        virsh_uri = "qemu:///system"
     unprivileged_user = params.get('unprivileged_user')
     if unprivileged_user:
         if unprivileged_user.count('EXAMPLE'):


### PR DESCRIPTION
It needs 'network' driver instead of 'QEMU' when modular daemons
are enabled.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**depends on:**
https://github.com/avocado-framework/avocado-vt/pull/3266

**Test results:**
_modular daemons:_
```
JOB ID     : 95e46068065edf8b35abf1a0f2754a3cc251fcc9
JOB LOG    : /root/avocado/job-results/job-2021-11-03T21.01-95e4606/job.log
 (01/14) type_specific.io-github-autotest-libvirt.virsh.net_start.normal_test.non_acl.valid_netname: PASS (6.85 s)
 (02/14) type_specific.io-github-autotest-libvirt.virsh.net_start.normal_test.non_acl.valid_netuuid: PASS (6.84 s)
 (03/14) type_specific.io-github-autotest-libvirt.virsh.net_start.normal_test.acl_test.valid_netname: PASS (8.90 s)
 (04/14) type_specific.io-github-autotest-libvirt.virsh.net_start.normal_test.acl_test.valid_netuuid: PASS (8.83 s)
 (05/14) type_specific.io-github-autotest-libvirt.virsh.net_start.normal_test.restart_firewalld.valid_netname: PASS (17.52 s)
 (06/14) type_specific.io-github-autotest-libvirt.virsh.net_start.normal_test.stop_start_firewalld.valid_netname: PASS (12.56 s)
 (07/14) type_specific.io-github-autotest-libvirt.virsh.net_start.route_test: PASS (7.55 s)
 (08/14) type_specific.io-github-autotest-libvirt.virsh.net_start.error_test.none: PASS (6.65 s)
 (09/14) type_specific.io-github-autotest-libvirt.virsh.net_start.error_test.start_twice: PASS (5.69 s)
 (10/14) type_specific.io-github-autotest-libvirt.virsh.net_start.error_test.invalid_netname: PASS (6.68 s)
 (11/14) type_specific.io-github-autotest-libvirt.virsh.net_start.error_test.additional_args: PASS (6.64 s)
 (12/14) type_specific.io-github-autotest-libvirt.virsh.net_start.error_test.additional_option: PASS (6.65 s)
 (13/14) type_specific.io-github-autotest-libvirt.virsh.net_start.error_test.acl_test: PASS (9.36 s)
 (14/14) type_specific.io-github-autotest-libvirt.virsh.net_start.error_test.net_start_readonly_test: PASS (6.64 s)
RESULTS    : PASS 14 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 118.02 s

```
_monolithic libvirtd:_
```

 
JOB ID     : 916a1d9e5a1852a13b82d62f2514a0bfaac5db08
JOB LOG    : /root/avocado/job-results/job-2021-11-03T21.06-916a1d9/job.log
 (01/14) type_specific.io-github-autotest-libvirt.virsh.net_start.normal_test.non_acl.valid_netname: PASS (6.33 s)
 (02/14) type_specific.io-github-autotest-libvirt.virsh.net_start.normal_test.non_acl.valid_netuuid: PASS (6.25 s)
 (03/14) type_specific.io-github-autotest-libvirt.virsh.net_start.normal_test.acl_test.valid_netname: PASS (7.49 s)
 (04/14) type_specific.io-github-autotest-libvirt.virsh.net_start.normal_test.acl_test.valid_netuuid: PASS (7.60 s)
 (05/14) type_specific.io-github-autotest-libvirt.virsh.net_start.normal_test.restart_firewalld.valid_netname: PASS (17.61 s)
 (06/14) type_specific.io-github-autotest-libvirt.virsh.net_start.normal_test.stop_start_firewalld.valid_netname: PASS (12.68 s)
 (07/14) type_specific.io-github-autotest-libvirt.virsh.net_start.route_test: PASS (6.90 s)
 (08/14) type_specific.io-github-autotest-libvirt.virsh.net_start.error_test.none: PASS (6.18 s)
 (09/14) type_specific.io-github-autotest-libvirt.virsh.net_start.error_test.start_twice: PASS (5.06 s)
 (10/14) type_specific.io-github-autotest-libvirt.virsh.net_start.error_test.invalid_netname: PASS (6.04 s)
 (11/14) type_specific.io-github-autotest-libvirt.virsh.net_start.error_test.additional_args: PASS (6.01 s)
 (12/14) type_specific.io-github-autotest-libvirt.virsh.net_start.error_test.additional_option: PASS (6.13 s)
 (13/14) type_specific.io-github-autotest-libvirt.virsh.net_start.error_test.acl_test: PASS (7.79 s)
 (14/14) type_specific.io-github-autotest-libvirt.virsh.net_start.error_test.net_start_readonly_test: PASS (6.02 s)
RESULTS    : PASS 14 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 108.92 s

```

