### PR TITLE
Draft: Fix nwfilter failure under split daemon mode

### DIFF
--- a/libvirt/tests/src/virsh_cmd/filter/virsh_nwfilter_define.py
+++ b/libvirt/tests/src/virsh_cmd/filter/virsh_nwfilter_define.py
@@ -4,6 +4,8 @@ import logging
 from virttest import virsh
 from virttest import xml_utils
 from virttest import libvirt_xml
+from virttest import utils_split_daemons
+
 from virttest.utils_test import libvirt as utlv
 
 from virttest import libvirt_version
@@ -52,6 +54,10 @@ def run(test, params, env):
 
     # libvirt acl polkit related params
     uri = params.get("virsh_uri")
+    # Under split daemon mode, uri need change to nwfilter:///system
+    if utils_split_daemons.is_modular_daemon():
+        uri = uri.replace('qemu', 'nwfilter')
+
     unprivileged_user = params.get('unprivileged_user')
     if unprivileged_user:
         if unprivileged_user.count('EXAMPLE'):


### PR DESCRIPTION
Under split daemon mode, uri need change from "qemu:///system"
to "nwfilter:///system"

Signed-off-by: chunfuwen <chwen@redhat.com>

