### PR TITLE
virsh_event: modify metadata-change event output

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
@@ -402,8 +402,12 @@ def run(test, params, env):
                                    key=metadata_key,
                                    new_metadata=metadata_value,
                                    **virsh_dargs)
-                    expected_events_list.append("'metadata-change' for %s: "
-                                                "element http://app.org/")
+                    if not libvirt_version.version_compare(7, 10, 0):
+                        expected_events_list.append("'metadata-change' for %s: "
+                                                    "element http://app.org/")
+                    else:
+                        expected_events_list.append("'metadata-change' for %s: "
+                                                    "type element, uri http://app.org/")
                 elif event == "metadata_edit":
                     metadata_uri = "http://herp.derp/"
                     metadata_key = "herp"


### PR DESCRIPTION
Modify metadata-change event output per libvirt-7.10.

Signed-off-by: Yanqiu Zhang <yanqzhan@redhat.com>

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [ ] Description of the cases
- [ ] Links of libvirt features, libvirt bugs or case IDs
- [ ] Test results

## If the PR is bug cases
- [ ] Bug descriptions or bug links
- [ ] Test results

## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
