### PR TITLE
Fixup acl test

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/filter/virsh_nwfilter_define.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/filter/virsh_nwfilter_define.cfg
@@ -24,9 +24,9 @@
                 - acl_test:
                     setup_libvirt_polkit = "yes"
                     action_id = "org.libvirt.api.nwfilter.write org.libvirt.api.nwfilter.save"
-                    action_lookup = "connect_driver:QEMU nwfilter_name:${filter_name}"
+                    action_lookup = "connect_driver:QEMU|nwfilter nwfilter_name:${filter_name}"
                     unprivileged_user = "EXAMPLE"
-                    virsh_uri = "qemu:///system"
+                    virsh_uri = "nwfilter:///system"
         - negative_test:
             status_error = "yes"
             variants:
@@ -91,9 +91,9 @@
                 - acl_test:
                     setup_libvirt_polkit = "yes"
                     action_id = "org.libvirt.api.nwfilter.write org.libvirt.api.nwfilter.save"
-                    action_lookup = "connect_driver:QEMU nwfilter_name:testcase"
+                    action_lookup = "connect_driver:QEMU|nwfilter nwfilter_name:testcase"
                     unprivileged_user = "EXAMPLE"
-                    virsh_uri = "qemu:///system"
+                    virsh_uri = "nwfilter:///system"
             variants:
                 - mac_test:
                     rule = "rule_action=accept rule_direction=out protocol=mac srcmacaddr=1:2:3:4:5:6 srcmacmask=ff:ff:ff:ff:ff:ff protocolid=arp EOL rule_action=accept rule_direction=in protocol=mac srcmacaddr=aa:bb:cc:dd:ee:ff srcmacmask=ff:ff:ff:ff:ff:ff protocolid=ipv4 EOL rule_action=accept rule_direction=out protocol=mac srcmacaddr=aa:bb:cc:dd:ee:ff srcmacmask=ff:ff:ff:ff:ff:ff protocolid=1536 EOL rule_action=accept rule_direction=out protocol=mac srcmacaddr=aa:bb:cc:dd:ee:ff srcmacmask=ff:ff:ff:ff:ff:ff protocolid=65535"

--- a/libvirt/tests/cfg/virsh_cmd/filter/virsh_nwfilter_undefine.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/filter/virsh_nwfilter_undefine.cfg
@@ -13,9 +13,9 @@
                 - acl_test:
                     setup_libvirt_polkit = "yes"
                     action_id = "org.libvirt.api.nwfilter.delete"
-                    action_lookup = "connect_driver:QEMU nwfilter_name:no-mac-spoofing"
+                    action_lookup = "connect_driver:QEMU|nwfilter nwfilter_name:no-mac-spoofing"
                     unprivileged_user = "EXAMPLE"
-                    virsh_uri = "qemu:///system"
+                    virsh_uri = "nwfilter:///system"
         - error_test:
             status_error = "yes"
             variants:
@@ -26,4 +26,4 @@
                 - acl_test:
                     setup_libvirt_polkit = "yes"
                     unprivileged_user = "EXAMPLE"
-                    virsh_uri = "qemu:///system"
+                    virsh_uri = "nwfilter:///system"

--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_define_undefine.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_define_undefine.cfg
@@ -32,9 +32,9 @@
                         - acl_test:
                             setup_libvirt_polkit = "yes"
                             action_id = "org.libvirt.api.network.write org.libvirt.api.network.save org.libvirt.api.network.start org.libvirt.api.network.stop org.libvirt.api.network.delete"
-                            action_lookup = "connect_driver:QEMU network_name:foobar"
+                            action_lookup = "connect_driver:QEMU|network network_name:foobar"
                             unprivileged_user = "EXAMPLE"
-                            virsh_uri = "qemu:///system"
+                            virsh_uri = "network:///system"
                         - state_persistent_active:
                             check_states = "yes"
                             net_persistent = "yes"
@@ -55,9 +55,9 @@
                         - acl_test:
                             setup_libvirt_polkit = "yes"
                             action_id = "org.libvirt.api.network.write org.libvirt.api.network.save org.libvirt.api.network.start org.libvirt.api.network.stop org.libvirt.api.network.delete"
-                            action_lookup = "connect_driver:QEMU network_name:default"
+                            action_lookup = "connect_driver:QEMU|network network_name:default"
                             unprivileged_user = "EXAMPLE"
-                            virsh_uri = "qemu:///system"
+                            virsh_uri = "network:///system"
                 - net_name_with_dot:
                     net_define_undefine_net_name = ".b"
                 - reliability:
@@ -179,15 +179,15 @@
                             net_define_undefine_net_name = "default"
                             setup_libvirt_polkit = "yes"
                             unprivileged_user = "EXAMPLE"
-                            virsh_uri = "qemu:///system"
+                            virsh_uri = "network:///system"
                         - undefine_acl:
                             net_define_undefine_trans_ref = "undefine"
                             net_define_undefine_net_name = "default"
                             setup_libvirt_polkit = "yes"
                             action_id = "org.libvirt.api.network.write org.libvirt.api.network.save org.libvirt.api.network.start org.libvirt.api.network.stop"
-                            action_lookup = "connect_driver:QEMU network_name:default"
+                            action_lookup = "connect_driver:QEMU|network network_name:default"
                             unprivileged_user = "EXAMPLE"
-                            virsh_uri = "qemu:///system"
+                            virsh_uri = "network:///system"
                 - invalid_options:
                     variants:
                         - none_option:

--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_destroy.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_destroy.cfg
@@ -31,9 +31,9 @@
                 - acl_test:
                     setup_libvirt_polkit = "yes"
                     action_id = "org.libvirt.api.network.stop"
-                    action_lookup = "connect_driver:QEMU network_name:default"
+                    action_lookup = "connect_driver:QEMU|network network_name:default"
                     unprivileged_user = "EXAMPLE"
-                    virsh_uri = "qemu:///system"
+                    virsh_uri = "network:///system"
         - check_libvirtd:
             only persistent
             check_libvirtd = "yes"
@@ -73,7 +73,7 @@
                 - acl_test:
                     setup_libvirt_polkit = "yes"
                     unprivileged_user = "EXAMPLE"
-                    virsh_uri = "qemu:///system"
+                    virsh_uri = "network:///system"
                 - net_destroy_name_readonly:
                     net_destroy_readonly = "yes"
                 - net_destroy_uuid_readonly:

--- a/libvirt/tests/cfg/virsh_cmd/pool/virsh_find_storage_pool_sources.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/pool/virsh_find_storage_pool_sources.cfg
@@ -38,9 +38,9 @@
                 - acl_test:
                     setup_libvirt_polkit = "yes"
                     action_id = "org.libvirt.api.connect.detect-storage-pools"
-                    action_lookup = "connect_driver:QEMU"
+                    action_lookup = "connect_driver:QEMU|storage"
                     unprivileged_user = "EXAMPLE"
-                    virsh_uri = "qemu:///system"
+                    virsh_uri = "storage:///system"
         - negative_test:
             status_error = "yes"
             variants:
@@ -56,4 +56,4 @@
                     source_type = "netfs"
                     setup_libvirt_polkit = "yes"
                     unprivileged_user = "EXAMPLE"
-                    virsh_uri = "qemu:///system"
+                    virsh_uri = "storage:///system"

--- a/libvirt/tests/cfg/virsh_cmd/pool/virsh_pool_acl.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/pool/virsh_pool_acl.cfg
@@ -11,9 +11,9 @@
     variants:
         - positive_test:
             setup_libvirt_polkit = "yes"
-            action_lookup = "connect_driver:QEMU pool_name:${pool_name}"
+            action_lookup = "connect_driver:QEMU|storage pool_name:${pool_name}"
             unprivileged_user = "EXAMPLE"
-            virsh_uri = "qemu:///system"
+            virsh_uri = "storage:///system"
             variants:
                 - dir_pool:
                     pool_type = "dir"
@@ -87,7 +87,7 @@
             pool_target = "dir-pool"
             setup_libvirt_polkit = "yes"
             unprivileged_user = "EXAMPLE"
-            virsh_uri = "qemu:///system"
+            virsh_uri = "storage:///system"
             variants:
                 - undefine_acl:
                     undefine_acl = "yes"

--- a/libvirt/tests/cfg/virsh_cmd/secret/virsh_secret_define_undefine.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/secret/virsh_secret_define_undefine.cfg
@@ -26,9 +26,9 @@
                 - non_acl:
                 - acl_test:
                     setup_libvirt_polkit = "yes"
-                    action_lookup = "connect_driver:QEMU"
+                    action_lookup = "connect_driver:QEMU|secret"
                     unprivileged_user = "EXAMPLE"
-                    virsh_uri = "qemu:///system"
+                    virsh_uri = "secret:///system"
                     variants:
                         - define_acl:
                             define_acl = "yes"
@@ -49,7 +49,7 @@
                     secret_ref = "secret_valid_uuid"
                     setup_libvirt_polkit = "yes"
                     unprivileged_user = "EXAMPLE"
-                    virsh_uri = "qemu:///system"
+                    virsh_uri = "secret:///system"
                     variants:
                         - undefine_acl:
                             undefine_acl = "yes"

--- a/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_clone_wipe.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_clone_wipe.cfg
@@ -68,9 +68,9 @@
                 - acl_test:
                     setup_libvirt_polkit = "yes"
                     action_id = "org.libvirt.api.storage-vol.format"
-                    action_lookup = "connect_driver:QEMU vol_name:clone_vol_1"
+                    action_lookup = "connect_driver:QEMU|storage vol_name:clone_vol_1"
                     unprivileged_user = "EXAMPLE"
-                    virsh_uri = "qemu:///system"
+                    virsh_uri = "storage:///system"
             variants:
                 - non_encrypt:
                 - luks_encrypt:
@@ -94,7 +94,7 @@
                     pool_type = "dir"
                     setup_libvirt_polkit = "yes"
                     unprivileged_user = "EXAMPLE"
-                    virsh_uri = "qemu:///system"
+                    virsh_uri = "storage:///system"
                 - bad_cloned_vol_name:
                     clone_status_error = "yes"
                     bad_cloned_vol_name = "test/vol"

--- a/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_create.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_create.cfg
@@ -101,9 +101,9 @@
                                         - acl_test:
                                             setup_libvirt_polkit = "yes"
                                             action_id = "org.libvirt.api.storage-vol.create org.libvirt.api.storage-vol.delete org.libvirt.api.secret.read-secure"
-                                            action_lookup = "connect_driver:QEMU pool_name:virt-dir-pool"
+                                            action_lookup = "connect_driver:QEMU|storage pool_name:virt-dir-pool"
                                             unprivileged_user = "EXAMPLE"
-                                            virsh_uri = "qemu:///system"
+                                            virsh_uri = "storage:///system"
                                 - fs:
                                     src_pool_type = "fs"
                                     src_pool_target = "fs"

--- a/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_download_upload.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_download_upload.cfg
@@ -30,9 +30,9 @@
                         - acl_test:
                             setup_libvirt_polkit = "yes"
                             action_id = "org.libvirt.api.storage-vol.data-read"
-                            action_lookup = "connect_driver:QEMU vol_name:dir-vol"
+                            action_lookup = "connect_driver:QEMU|storage vol_name:dir-vol"
                             unprivileged_user = "EXAMPLE"
-                            virsh_uri = "qemu:///system"
+                            virsh_uri = "storage:///system"
                 - upload:
                     vol_download_upload_operation = "upload"
                     variants:
@@ -49,9 +49,9 @@
                         - acl_test:
                             setup_libvirt_polkit = "yes"
                             action_id = "org.libvirt.api.storage-vol.data-write"
-                            action_lookup = "connect_driver:QEMU vol_name:dir-vol"
+                            action_lookup = "connect_driver:QEMU|storage vol_name:dir-vol"
                             unprivileged_user = "EXAMPLE"
-                            virsh_uri = "qemu:///system"
+                            virsh_uri = "storage:///system"
             variants:
                 # iscsi pool do not support create volume in it so did not test it
                 - dir_pool:
@@ -75,27 +75,27 @@
                     vol_download_upload_pool_name = "fs-pool"
                     vol_download_upload_pool_target = "fs-pool"
                     vol_download_upload_vol_name = "fs-vol"
-                    action_lookup = "connect_driver:QEMU vol_name:fs-vol"
+                    action_lookup = "connect_driver:QEMU|storage vol_name:fs-vol"
                 - disk_pool:
                     vol_download_upload_pool_type = "disk"
                     vol_download_upload_pool_name = "disk-pool"
                     vol_download_upload_pool_target = "/dev"
                     vol_download_upload_vol_name = "disk-vol"
-                    action_lookup = "connect_driver:QEMU vol_name:disk-vol"
+                    action_lookup = "connect_driver:QEMU|storage vol_name:disk-vol"
                 - logical_pool:
                     vol_download_upload_pool_type = "logical"
                     vol_download_upload_pool_name = "logical-pool"
                     vol_download_upload_pool_target = "/dev/vg_logical"
                     vol_download_upload_vol_name = "logical-vol"
                     vol_download_upload_format = "qcow2"
-                    action_lookup = "connect_driver:QEMU vol_name:logical-vol"
+                    action_lookup = "connect_driver:QEMU|storage vol_name:logical-vol"
                 - netfs_pool:
                     vol_download_upload_pool_type = "netfs"
                     vol_download_upload_pool_name = "netfs-pool"
                     vol_download_upload_pool_target = "/nfs-mount"
                     vol_download_upload_vol_name = "netfs-vol"
                     vol_download_upload_format = "qcow2"
-                    action_lookup = "connect_driver:QEMU vol_name:netfs-vol"
+                    action_lookup = "connect_driver:QEMU|storage vol_name:netfs-vol"
             variants:
                 - non_encrypt:
                 - luks_encrypt:

--- a/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_resize.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_resize.cfg
@@ -55,9 +55,9 @@
                 - acl_test:
                     setup_libvirt_polkit = "yes"
                     action_id = "org.libvirt.api.storage-vol.resize"
-                    action_lookup = "connect_driver:QEMU vol_name:${vol_name}"
+                    action_lookup = "connect_driver:QEMU|storage vol_name:${vol_name}"
                     unprivileged_user = "EXAMPLE"
-                    virsh_uri = "qemu:///system"
+                    virsh_uri = "storage:///system"
             variants:
                 - non_encrypt:
                 - luks_encrypt:
@@ -83,4 +83,4 @@
                     pool_type = "dir"
                     setup_libvirt_polkit = "yes"
                     unprivileged_user = "EXAMPLE"
-                    virsh_uri = "qemu:///system"
+                    virsh_uri = "storage:///system"

--- a/libvirt/tests/src/virsh_cmd/filter/virsh_nwfilter_define.py
+++ b/libvirt/tests/src/virsh_cmd/filter/virsh_nwfilter_define.py
@@ -4,6 +4,7 @@ import logging
 from virttest import virsh
 from virttest import xml_utils
 from virttest import libvirt_xml
+from virttest import utils_split_daemons
 from virttest.utils_test import libvirt as utlv
 
 from virttest import libvirt_version
@@ -52,6 +53,8 @@ def run(test, params, env):
 
     # libvirt acl polkit related params
     uri = params.get("virsh_uri")
+    if uri and not utils_split_daemons.is_modular_daemon():
+        uri = "qemu:///system"
     unprivileged_user = params.get('unprivileged_user')
     if unprivileged_user:
         if unprivileged_user.count('EXAMPLE'):

--- a/libvirt/tests/src/virsh_cmd/filter/virsh_nwfilter_undefine.py
+++ b/libvirt/tests/src/virsh_cmd/filter/virsh_nwfilter_undefine.py
@@ -2,6 +2,7 @@ import logging
 
 from virttest import virsh
 from virttest import libvirt_xml
+from virttest import utils_split_daemons
 
 from virttest import libvirt_version
 
@@ -42,6 +43,8 @@ def run(test, params, env):
 
     # libvirt acl polkit related params
     uri = params.get("virsh_uri")
+    if uri and not utils_split_daemons.is_modular_daemon():
+        uri = "qemu:///system"
     unprivileged_user = params.get('unprivileged_user')
     try:
         if unprivileged_user:

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_define_undefine.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_define_undefine.py
@@ -7,6 +7,7 @@ from virttest import libvirt_vm
 from virttest import xml_utils
 from virttest import utils_libvirtd
 from virttest import utils_net
+from virttest import utils_split_daemons
 from virttest.libvirt_xml import network_xml
 from virttest.utils_test import libvirt
 from virttest import libvirt_version
@@ -137,6 +138,8 @@ def run(test, params, env):
                         " libvirt version.")
 
     virsh_uri = params.get("virsh_uri")
+    if virsh_uri and not utils_split_daemons.is_modular_daemon():
+        virsh_uri = "qemu:///system"
     unprivileged_user = params.get('unprivileged_user')
     if unprivileged_user:
         if unprivileged_user.count('EXAMPLE'):

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_destroy.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_destroy.py
@@ -1,14 +1,18 @@
-import re
 import logging
 import os
-from virttest import data_dir
+import re
+
 from avocado.utils import process
-from virttest import virsh
+
+from virttest import data_dir
 from virttest import libvirt_version
-from virttest import utils_test
-from virttest.libvirt_xml import vm_xml
 from virttest import utils_libvirtd
 from virttest import utils_misc
+from virttest import utils_split_daemons
+from virttest import utils_test
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
 
 
 def run(test, params, env):
@@ -42,6 +46,8 @@ def run(test, params, env):
                         " libvirt version.")
 
     uri = params.get("virsh_uri")
+    if uri and not utils_split_daemons.is_modular_daemon():
+        uri = "qemu:///system"
     unprivileged_user = params.get('unprivileged_user')
     if unprivileged_user:
         if unprivileged_user.count('EXAMPLE'):

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_find_storage_pool_sources.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_find_storage_pool_sources.py
@@ -4,6 +4,7 @@ from avocado.utils import process
 from avocado.core import exceptions
 
 from virttest import xml_utils
+from virttest import utils_split_daemons
 from virttest import utils_test
 from virttest import virsh
 from virttest.staging import lv_utils
@@ -31,6 +32,8 @@ def run(test, params, env):
     ro_flag = "yes" == params.get("readonly_mode", "no")
     status_error = "yes" == params.get("status_error", "no")
     uri = params.get("virsh_uri")
+    if uri and not utils_split_daemons.is_modular_daemon():
+        uri = "qemu:///system"
     unprivileged_user = params.get('unprivileged_user')
     if unprivileged_user:
         if unprivileged_user.count('EXAMPLE'):

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool_acl.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool_acl.py
@@ -6,6 +6,7 @@ from avocado.utils import process
 
 from virttest import libvirt_storage
 from virttest import data_dir
+from virttest import utils_split_daemons
 from virttest import virsh
 from virttest.staging import lv_utils
 from virttest.utils_test import libvirt as utlv
@@ -67,6 +68,8 @@ def run(test, params, env):
     cleanup_env = [False, False, False, "", False]
     # libvirt acl related params
     uri = params.get("virsh_uri")
+    if uri and not utils_split_daemons.is_modular_daemon():
+        uri = "qemu:///system"
     unprivileged_user = params.get('unprivileged_user')
     if unprivileged_user:
         if unprivileged_user.count('EXAMPLE'):

--- a/libvirt/tests/src/virsh_cmd/secret/virsh_secret_define_undefine.py
+++ b/libvirt/tests/src/virsh_cmd/secret/virsh_secret_define_undefine.py
@@ -6,6 +6,7 @@ from avocado.utils import process
 
 from virttest import virsh
 from virttest import data_dir
+from virttest import utils_split_daemons
 from virttest.libvirt_xml.secret_xml import SecretXML
 from virttest.utils_test import libvirt
 
@@ -43,6 +44,8 @@ def run(test, params, env):
 
     # libvirt acl related params
     uri = params.get("virsh_uri")
+    if uri and not utils_split_daemons.is_modular_daemon():
+        uri = "qemu:///system"
     unprivileged_user = params.get('unprivileged_user')
     define_acl = "yes" == params.get("define_acl", "no")
     undefine_acl = "yes" == params.get("undefine_acl", "no")

--- a/libvirt/tests/src/virsh_cmd/volume/virsh_vol_clone_wipe.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_vol_clone_wipe.py
@@ -16,6 +16,7 @@ from virttest import data_dir
 from virttest import virsh
 from virttest import utils_misc
 from virttest import libvirt_xml
+from virttest import utils_split_daemons
 
 from virttest import libvirt_version
 
@@ -115,6 +116,8 @@ def run(test, params, env):
 
     # libvirt acl polkit related params
     uri = params.get("virsh_uri")
+    if uri and not utils_split_daemons.is_modular_daemon():
+        uri = "qemu:///system"
     unpri_user = params.get('unprivileged_user')
     if unpri_user:
         if unpri_user.count('EXAMPLE'):

--- a/libvirt/tests/src/virsh_cmd/volume/virsh_vol_create.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_vol_create.py
@@ -12,6 +12,7 @@ from virttest import virsh
 from virttest import libvirt_storage
 from virttest import libvirt_xml
 from virttest import test_setup
+from virttest import utils_split_daemons
 from virttest import virt_vm
 from virttest.utils_test import libvirt as utlv
 from virttest.staging import service
@@ -91,6 +92,8 @@ def run(test, params, env):
             test.cancel("API acl test not supported in current"
                         " libvirt version.")
     uri = params.get("virsh_uri")
+    if uri and not utils_split_daemons.is_modular_daemon():
+        uri = "qemu:///system"
     unprivileged_user = params.get('unprivileged_user')
     if unprivileged_user:
         if unprivileged_user.count('EXAMPLE'):

--- a/libvirt/tests/src/virsh_cmd/volume/virsh_vol_download_upload.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_vol_download_upload.py
@@ -7,11 +7,12 @@ import aexpect
 
 from avocado.utils import process
 
-from virttest import virsh
 from virttest import data_dir
 from virttest import libvirt_xml
-from virttest import utils_misc
 from virttest import remote
+from virttest import utils_misc
+from virttest import utils_split_daemons
+from virttest import virsh
 from virttest import virt_vm
 
 from virttest.libvirt_xml import vm_xml
@@ -179,6 +180,8 @@ def run(test, params, env):
 
     # libvirt acl polkit related params
     uri = params.get("virsh_uri")
+    if uri and not utils_split_daemons.is_modular_daemon():
+        uri = "qemu:///system"
     unpri_user = params.get('unprivileged_user')
     if unpri_user:
         if unpri_user.count('EXAMPLE'):

--- a/libvirt/tests/src/virsh_cmd/volume/virsh_vol_resize.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_vol_resize.py
@@ -9,6 +9,7 @@ from avocado.core import exceptions
 
 from virttest import libvirt_storage
 from virttest import utils_misc
+from virttest import utils_split_daemons
 from virttest import virsh
 from virttest import libvirt_xml
 from virttest.utils_test import libvirt
@@ -259,6 +260,8 @@ def run(test, params, env):
 
     # libvirt acl polkit related params
     uri = params.get("virsh_uri")
+    if uri and not utils_split_daemons.is_modular_daemon():
+        uri = "qemu:///system"
     unpri_user = params.get('unprivileged_user')
     if unpri_user:
         if unpri_user.count('EXAMPLE'):


### PR DESCRIPTION
Some tests need sub-driver instead of 'QEMU' when modular daemons
are enabled.

