### PR TITLE
virsh_cpu_baseline: new case --migratable

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_cpu_baseline.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_cpu_baseline.cfg
@@ -24,6 +24,11 @@
                     vms = "avocado-vt-vm1"
                     main_vm = "avocado-vt-vm1"
                     config_guest = "yes"
+                - migratable:
+                    only q35
+                    cpu_baseline_extra = '--migratable'
+                    cpu_baseline_test_feature = "invtsc"
+                    feature_exist = "no"
         - negative_test:
             status_error = "yes"
             variants:


### PR DESCRIPTION
Case ID: RHEL7-20178
Case Title: [cmd/cpu-baseline] Obtain cpu baseline with "--migratable"
            through XML contains invtsc from "virsh capabilities"
This case requires the host has 'invtsc' feature.
This case is to test no 'invtsc' feature outputed in virsh.cpu_baseline

Signed-off-by: Dan Zheng <dzheng@redhat.com>
