### PR TITLE
Fix nodedev split daemon polkit setting

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_create_destroy.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_create_destroy.cfg
@@ -15,9 +15,9 @@
                 - acl_test:
                     setup_libvirt_polkit = "yes"
                     action_id = "org.libvirt.api.node-device.write org.libvirt.api.node-device.start org.libvirt.api.node-device.stop"
-                    action_lookup = "connect_driver:QEMU"
+                    action_lookup = "connect_driver:QEMU|nodedev"
                     unprivileged_user = "EXAMPLE"
-                    virsh_uri = "qemu:///system"
+                    virsh_uri = "nodedev:///system"
         - negative_testing:
             status_error = "yes"
             variants:

--- a/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_detach_reattach.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_detach_reattach.cfg
@@ -15,9 +15,9 @@
                 - acl_test:
                     setup_libvirt_polkit = "yes"
                     action_id = "org.libvirt.api.node-device.read org.libvirt.api.node-device.detach"
-                    action_lookup = "connect_driver:QEMU"
+                    action_lookup = "connect_driver:QEMU|nodedev"
                     unprivileged_user = "EXAMPLE"
-                    virsh_uri = "qemu:///system"
+                    virsh_uri = "nodedev:///system"
                 - non_driver_test:
                     with_driver = 'no'
         - negative:

--- a/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_dumpxml.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_dumpxml.cfg
@@ -21,9 +21,9 @@
                 - acl_test:
                     setup_libvirt_polkit = "yes"
                     unprivileged_user = "EXAMPLE"
-                    virsh_uri = "qemu:///system"
+                    virsh_uri = "nodedev:///system"
                     action_id = "org.libvirt.api.node-device.read"
-                    action_lookup = "connect_driver:QEMU node_device_name:${nodedev_device_name}"
+                    action_lookup = "connect_driver:QEMU|nodedev node_device_name:${nodedev_device_name}"
         - negative_test:
             status_error = "yes"
             variants:

--- a/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_list.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_list.cfg
@@ -26,7 +26,7 @@
                 - acl_test:
                     setup_libvirt_polkit = "yes"
                     unprivileged_user = "EXAMPLE"
-                    virsh_uri = "qemu:///system"
+                    virsh_uri = "nodedev:///system"
         - invalid_option:
             expect_succeed = no
             variants:

--- a/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_create_destroy.py
+++ b/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_create_destroy.py
@@ -9,6 +9,7 @@ from virttest import virsh
 from virttest.libvirt_xml.nodedev_xml import NodedevXML
 
 from virttest import libvirt_version
+from virttest import utils_split_daemons
 
 _FC_HOST_PATH = "/sys/class/fc_host"
 
@@ -109,6 +110,8 @@ def create_nodedev_from_xml(test, params):
 
     # libvirt acl polkit related params
     uri = params.get("virsh_uri")
+    if uri and not utils_split_daemons.is_modular_daemon():
+        uri = "qemu:///system"
     unprivileged_user = params.get('unprivileged_user')
     if unprivileged_user:
         if unprivileged_user.count('EXAMPLE'):

--- a/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_detach_reattach.py
+++ b/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_detach_reattach.py
@@ -3,6 +3,7 @@ import logging
 from virttest import virsh
 from virttest.libvirt_xml import nodedev_xml
 from virttest import libvirt_version
+from virttest import utils_split_daemons
 from virttest.utils_test import libvirt
 from avocado.utils import process
 from avocado.core import exceptions
@@ -49,6 +50,8 @@ def run(test, params, env):
         """
         # Libvirt acl polkit related params
         uri = params.get("virsh_uri")
+        if uri and not utils_split_daemons.is_modular_daemon():
+            uri = "qemu:///system"
         unprivileged_user = params.get('unprivileged_user')
         readonly = (params.get('nodedev_detach_readonly', 'no') == 'yes')
         if unprivileged_user:

--- a/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_dumpxml.py
+++ b/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_dumpxml.py
@@ -6,6 +6,7 @@ from avocado.utils import process
 from virttest import virsh
 from virttest.libvirt_xml import nodedev_xml
 from virttest import libvirt_version
+from virttest import utils_split_daemons
 from virttest.utils_test import libvirt
 
 
@@ -93,6 +94,8 @@ def run(test, params, env):
 
     # acl polkit params
     uri = params.get("virsh_uri")
+    if uri and not utils_split_daemons.is_modular_daemon():
+        uri = "qemu:///system"
     unprivileged_user = params.get('unprivileged_user')
     if unprivileged_user:
         if unprivileged_user.count('EXAMPLE'):

--- a/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_list.py
+++ b/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_list.py
@@ -7,6 +7,7 @@ from avocado.utils import path as utils_path
 from virttest import virsh
 
 from virttest import libvirt_version
+from virttest import utils_split_daemons
 
 
 def get_avail_caps(all_caps):
@@ -253,6 +254,8 @@ def run(test, params, env):
 
     # acl polkit params
     uri = params.get("virsh_uri")
+    if uri and not utils_split_daemons.is_modular_daemon():
+        uri = "qemu:///system"
     unprivileged_user = params.get('unprivileged_user')
     if unprivileged_user:
         if unprivileged_user.count('EXAMPLE'):


### PR DESCRIPTION
As acl setting in split daemon is different, update the cfg file and py file.
