### PR TITLE
Fix the polkit rule set under split daemon mode

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_detach_reattach.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_detach_reattach.cfg
@@ -17,7 +17,7 @@
                     action_id = "org.libvirt.api.node-device.read org.libvirt.api.node-device.detach"
                     action_lookup = "connect_driver:QEMU|nodedev"
                     unprivileged_user = "EXAMPLE"
-                    virsh_uri = "nodedev:///system"
+                    virsh_uri = "qemu:///system"
                 - non_driver_test:
                     with_driver = 'no'
         - negative:


### PR DESCRIPTION
Update 2 items: 1) update the polkit rule with QEMU and nodedev both;
2) update the logic of pci_device_address() to find a interface without
any connection. It is more safe to detach an interface which is not in use.

Signed-off-by: ‘Yalan <yalzhang@redhat.com>