### PR TITLE
virsh_domjobinfo: test --keep-completed option

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domjobinfo.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domjobinfo.cfg
@@ -21,9 +21,14 @@
                     domjobinfo_action = "dump"
                     variants:
                         - live_dump:
-                            dump_opt="--live"
+                            dump_opt = "--live"
                         - crash_dump:
-                            dump_opt="--crash"
+                            dump_opt = "--crash"
+                        - keep_complete_test:
+                          only running_state
+                          only vm_name
+                          dump_opt = "--live"
+                          keep_complete = "yes"
                 - save_action:
                     domjobinfo_action = "save"
                 - managedsave_action:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domjobinfo.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domjobinfo.py
@@ -64,7 +64,7 @@ def run(test, params, env):
             if out_dict["Job type"].strip() != job_type:
                 test.fail("Expect %s Job type but got %s" %
                           (job_type, out_dict["Job type"].strip()))
-            if out_dict["Operation"].strip() != actions.capitalize():
+            if job_type != "None" and out_dict["Operation"].strip() != actions.capitalize():
                 test.fail("Expect %s Operation but got %s" %
                           (actions.capitalize(), out_dict["Operation"].strip()))
 
@@ -89,6 +89,7 @@ def run(test, params, env):
     act_opt = params.get("dump_opt", "")
     vm_ref = params.get("domjobinfo_vm_ref")
     status_error = params.get("status_error", "no")
+    keep_complete = "yes" == params.get("keep_complete", "no")
     libvirtd = params.get("libvirtd", "on")
     # Use tmp_pipe to act as target file for job operation in subprocess,
     # such as vm.dump, vm.save, etc.
@@ -183,7 +184,13 @@ def run(test, params, env):
             except OSError:
                 pass
 
-    # Get completed domjobinfo
+    # Get completed domjobinfo with --keep-completed option, next completed domjobinfo gathering will still get statistics.
+    if keep_complete:
+        time.sleep(5)
+        vm_ref_tmp = "%s --completed --keep-completed" % vm_ref
+        virsh.domjobinfo(vm_ref_tmp, ignore_status=False, debug=True)
+
+    # Get completed domjobinfo.(Without -keep-completed option, later completed domjobinfo gathering will get None.)
     if status_error == "no":
         time.sleep(5)
         if act_opt != "--live" and vm_ref == domid:
@@ -192,6 +199,10 @@ def run(test, params, env):
         vm_ref = "%s --completed" % vm_ref
         ret_cmplt = virsh.domjobinfo(vm_ref, ignore_status=True, debug=True)
         status_cmplt = ret_cmplt.exit_status
+
+    # Get completed domjobinfo again, get None.
+    if keep_complete:
+        ret_cmplt_later = virsh.domjobinfo(vm_ref, ignore_status=True, debug=True)
 
     # Recover the environment.
     if actions == "managedsave":
@@ -225,3 +236,7 @@ def run(test, params, env):
         info_list[info_list.index("Expected downtime")] = "Total downtime"
         logging.debug("The expected info_list for completed job is %s", info_list)
         cmp_jobinfo(ret_cmplt, info_list, "Completed", actions)
+        # Check output of later "virsh domjobinfo --completed"
+        if keep_complete:
+            info_list = ["Job type"]
+            cmp_jobinfo(ret_cmplt_later, info_list, "None", actions)


### PR DESCRIPTION
Test --keep-completed option for completed domjobinfo, take live dump
action as a demo.

Signed-off-by: Yanqiu Zhang <yanqzhan@redhat.com>
