### PR TITLE
virsh_blockcopy.py: remove libvirtd status check

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
@@ -443,7 +443,7 @@ def run(test, params, env):
     extra_dict = {'uri': uri, 'unprivileged_user': unprivileged_user,
                   'debug': True, 'ignore_status': True, 'timeout': timeout}
 
-    libvirtd_utl = utils_libvirtd.Libvirtd()
+    libvirtd_utl = utils_libvirtd.Libvirtd('virtqemud')
     libvirtd_log_path = os.path.join(data_dir.get_tmp_dir(), "libvirt_daemons.log")
     libvirtd_conf_dict = {"log_filter": '"3:json 1:libvirt 1:qemu"',
                           "log_outputs": '"1:file:%s"' % libvirtd_log_path}


### PR DESCRIPTION
virsh_blockcopy.py: remove libvirtd status check to adapt to the split daemon mode

Fix error: Libvirtd service is dead
The libvirtd status check is standing alone and not dependent on other codes. It's only a check of libvirtd service. So remove it to adapt to the split daemon mode.

Signed-off-by: Meina Li <meili@redhat.com>
