### PR TITLE
iface_network: direct br iface with vlan

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_network.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_network.cfg
@@ -267,6 +267,13 @@
                             forward_iface = "eno1 eno2 eno2"
                             net_forward = "{'mode':'bridge'}"
                             define_error = "yes"
+                        - direct_br_vlan:
+                            create_network = "no"
+                            change_iface_option = "yes"
+                            iface_type = "direct"
+                            iface_source = "{'dev':'eno1','mode':'bridge'}"
+                            iface_vlan = "{'trunk': 'no', 'tags': [{'id': '47'}]}"
+                            start_error = "yes"
                 - net_bridge:
                     change_iface_option = "yes"
                     iface_source = "{'network':'nettest'}"

--- a/libvirt/tests/src/virtual_network/iface_network.py
+++ b/libvirt/tests/src/virtual_network/iface_network.py
@@ -129,6 +129,8 @@ TIMEOUT 3"""
             source['dev'] = net_ifs[0]
         del iface.source
         iface.source = source
+        if iface_vlan:
+            iface.vlan = iface.new_vlan(**iface_vlan)
         if iface_model:
             iface.model = get_iface_model(iface_model, host_arch)
         if iface_rom:
@@ -617,6 +619,7 @@ TIMEOUT 3"""
     iface_boot = params.get("iface_boot")
     iface_model = params.get("iface_model")
     iface_driver = params.get("iface_driver")
+    iface_vlan = eval(params.get("iface_vlan", "None"))
     multiple_guests = params.get("multiple_guests")
     create_network = "yes" == params.get("create_network", "no")
     attach_iface = "yes" == params.get("attach_iface", "no")


### PR DESCRIPTION
Vm with direct type bridge mode interface with vlan tag will start
fail.

Signed-off-by: Yanqiu Zhang <yanqzhan@redhat.com>

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [x] Description of the cases
- [x] Links of libvirt features, libvirt bugs or case IDs
- [x] Test results

## If the PR is bug cases
- [ ] Bug descriptions or bug links
- [ ] Test results

## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
