### PR TITLE
net_update: add ip-dhcp-range on nonexist index

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/network/virsh_net_update.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/network/virsh_net_update.cfg
@@ -369,6 +369,11 @@
                                         - add:
                                             only ip_dhcp_range
                                             update_command = "add"
+                                - index_nonexist:
+                                      error_type = "index-nonexist"
+                                      parent_index = 1
+                                      only ip_dhcp_range
+                                      update_command = "add"
                                 - delete_host_mismatch:
                                     only ip_dhcp_host
                                     error_type = "host-mismatch"

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_update.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_update.py
@@ -447,6 +447,11 @@ def run(test, params, env):
                     without_ip_dhcp == "no"):
                 test_xml.del_element(element="/ip/dhcp", index=section_index)
 
+            if error_type == "index-nonexist":
+                for idx in [3, 2, 1]:
+                    test_xml.del_element(element="/ip", index=idx)
+                test_xml.del_element(element="/route")
+
             if loop == 0:
                 try:
                     # Define and start network
@@ -563,6 +568,10 @@ def run(test, params, env):
                     # range-mismatch error info
                     err_dic["range-mismatch"] = "couldn't locate a matching dhcp " + \
                                                 "range entry in network "
+                    # index-nonexist error info
+                    err_dic["index-nonexist"] = "couldn't update dhcp host entry " + \
+                                                "- no <ip.* element found at index 1 in network"
+
                     # host-mismatch error info
                     err_dic["host-mismatch"] = "couldn't locate a matching dhcp " + \
                                                "host entry in network "


### PR DESCRIPTION
Expecting fail when add ip-dhcp-range on nonexist index.

Signed-off-by: Yanqiu Zhang <yanqzhan@redhat.com>

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [x] Description of the cases
- [x] Links of libvirt features, libvirt bugs or case IDs
- [x] Test results

## If the PR is bug cases
- [ ] Bug descriptions or bug links
- [ ] Test results

## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
