### PR TITLE
crypto_nodedev_create_destroy: restore matrix device

### DIFF
--- a/libvirt/tests/src/passthrough/ap/libvirt_ap_passthrough.py
+++ b/libvirt/tests/src/passthrough/ap/libvirt_ap_passthrough.py
@@ -51,6 +51,7 @@ def run(test, params, env):
         load_vfio_ap()
 
         info = CryptoDeviceInfoBuilder.get()
+        logging.debug("Host lszcrypt got %s", info)
 
         if not info.entries or int(info.domains[0].hwtype) < MIN_HWTYPE:
             test.error("vfio-ap requires at least HWTYPE %s." % MIN_HWTYPE)

--- a/libvirt/tests/src/virsh_cmd/nodedev/crypto_nodedev_create_destroy.py
+++ b/libvirt/tests/src/virsh_cmd/nodedev/crypto_nodedev_create_destroy.py
@@ -120,6 +120,7 @@ def run(test, params, env):
     libvirt_version.is_libvirt_feature_supported(params)
     matrix_cap = 'ap_matrix'
     device_file = None
+    mask_helper = None
 
     info = CryptoDeviceInfoBuilder.get()
     if int(info.entries[0].hwtype) < HWTYPE:
@@ -132,7 +133,7 @@ def run(test, params, env):
             load_vfio_ap()
         if find_devices_by_cap(test, matrix_cap):
             devices = [info.domains[0]]
-            APMaskHelper.from_infos(devices)
+            mask_helper = APMaskHelper.from_infos(devices)
             device_file = create_nodedev_from_xml(uuid, adapter, domain)
         else:
             raise test.fail("Could not get %s correctly through nodedev-API" %
@@ -143,6 +144,8 @@ def run(test, params, env):
         destroy_nodedev(dev_name)
         check_device_was_destroyed(test)
     finally:
+        if mask_helper:
+            mask_helper.return_to_host_all()
         unload_vfio_ap()
         if device_file:
             os.remove(device_file)


### PR DESCRIPTION
The test didn't assign the devices back to host correctly
which caused test failure in libvirt_ap_passthrough if run
afterwards.

Restore the matrix device at tear down and add an additional
log message to help determine host state for passthrough test
if it fails again.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>