### PR TITLE
cpu_stats: Correct the cpu time checking

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_stats.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_stats.py
@@ -123,7 +123,7 @@ def run(test, params, env):
                 system_time = int(total_list[7])
 
                 # check Total cpu_time >= User + System cpu_time
-                if user_time + system_time >= total_time:
+                if user_time + system_time > total_time:
                     test.fail("total cpu_time < user_time + "
                               "system_time")
                 logging.debug("Check total cpu_time %d >= user + system "


### PR DESCRIPTION
The value of the total time and the sum of user and system time
are allowed to be the same.

Signed-off-by: Yingshun Cui <yicui@redhat.com>

Test result:
` (1/1) type_specific.io-github-autotest-libvirt.virsh.cpu_stats.positive_test.option2: PASS (259.89 s)`
