### PR TITLE
Modify to start 'virtnetworkd' to do the test in the modular daemon mode

### DIFF
--- a/libvirt/tests/src/libvirtd_start.py
+++ b/libvirt/tests/src/libvirtd_start.py
@@ -119,6 +119,7 @@ def run(test, params, env):
         errors = []
         # Run libvirt session and collect errors in log.
         libvirtd_session = utils_libvirtd.LibvirtdSession(
+            service_name="virtnetworkd",
             logging_handler=_error_handler,
             logging_params=(errors,),
             logging_pattern=r'[-\d]+ [.:+\d]+ [:\d]+ error :',
@@ -143,6 +144,8 @@ def run(test, params, env):
         _check_errors()
     finally:
         logging.info('Recovering services status')
+        #Restart socket service after starting process at foreground
+        utils_libvirtd.Libvirtd("virtnetworkd.socket").restart()
         # If service do not exists, then backup status and current status
         # will all be none and nothing will be done
         if service_mgr.status('iptables') != backup_iptables_status:


### PR DESCRIPTION
1.Keep using 'libvirtd' in legacy libvirtd mode;
2.Using 'virtnetworkd' in modular daemon mode;

Signed-off-by: Yan Fu <yafu@redhat.com>

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [ ] Description of the cases
- [ ] Links of libvirt features, libvirt bugs or case IDs
- [ ] Test results

## If the PR is bug cases
- [ ] Bug descriptions or bug links
- [ ] Test results

## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
