### PR TITLE
Modify the expect ownership of '/var/cache/libvirt/qemu' after libvir…

### DIFF
--- a/libvirt/tests/src/svirt/default_dac_check.py
+++ b/libvirt/tests/src/svirt/default_dac_check.py
@@ -5,6 +5,7 @@ from avocado.utils import process
 
 from virttest import utils_libvirtd
 from virttest import utils_misc
+from virttest import libvirt_version
 from virttest.libvirt_xml import vm_xml
 from virttest.staging import utils_memory
 from virttest.staging.utils_memory import drop_caches
@@ -86,7 +87,10 @@ def run(test, params, env):
         result = process.run("ls -ld %s" % filename, shell=True).stdout_text.strip().split(' ')
         ownership = "%s:%s" % (result[2], result[3])
         logging.debug(ownership)
-        expect_result = "qemu:qemu"
+        if libvirt_version.version_compare(7, 8, 0) and filename == "/var/cache/libvirt/qemu":
+            expect_result = "root:root"
+        else:
+            expect_result = "qemu:qemu"
         if ownership != expect_result:
             test.fail("The ownership of %s is %s" % (filename, ownership))
 


### PR DESCRIPTION
…t-7.8.0

1.This change is introduced by commit 4c0cf7c4dc5260ffd541f33458b842b1f6cb3865

Signed-off-by: Yan Fu <yafu@redhat.com>

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [ ] Description of the cases
- [ ] Links of libvirt features, libvirt bugs or case IDs
- [ ] Test results

## If the PR is bug cases
- [ ] Bug descriptions or bug links
- [ ] Test results

## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
