### PR TITLE
virsh_qemu_monitor_command: Update error message

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_monitor_command.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_monitor_command.py
@@ -58,7 +58,8 @@ def run(test, params, env):
         if status_error:
             if not status:
                 # Return status is 0 with unknown command
-                if "unknown command:" in output:
+                # From libvirt-7.9.0, return status is 0 with CommandNotFound
+                if "unknown command:" in output or "CommandNotFound" in output:
                     logging.debug("Command failed: %s" % output)
                 else:
                     test.fail("Expect fail, but run successfully.")


### PR DESCRIPTION
From libvirt-7.9.0, run invalid qemu_monitor_command will return 0.
For libvirt-7.9.0:
    # virsh qemu-monitor-command vm1  --cmd '{system_reset}'
    {"id":"libvirt-390","error":{"class":"CommandNotFound","desc":"The command {system_reset} has not been found"}}
    # echo $?
    0

For libvirt-7.8.0:
    # virsh qemu-monitor-command vm1  --cmd '{system_reset}'
    error: internal error: cannot parse json {system_reset}: lexical error: invalid char in json text.
                                          {system_reset}
                         (right here) ------^
    # echo $?
    1

Signed-off-by: lcheng <lcheng@redhat.com>
