### PR TITLE
Fix No more available PCI slot

### DIFF
--- a/libvirt/tests/src/nwfilter/nwfilter_binding_dumpxml.py
+++ b/libvirt/tests/src/nwfilter/nwfilter_binding_dumpxml.py
@@ -6,6 +6,7 @@ from virttest import libvirt_xml
 from virttest import data_dir
 from virttest.utils_test import libvirt as utlv
 from virttest.libvirt_xml.devices import interface
+from virttest.utils_libvirt import libvirt_pcicontr
 
 from avocado.utils import process
 
@@ -67,8 +68,11 @@ def run(test, params, env):
         set two interface with different network filter
         and change interface type
         """
-        virsh.attach_interface(vm_name, option)
+        # Add enough PCI to attach interface
+        libvirt_pcicontr.reset_pci_num(vm_name)
+        virsh.attach_interface(vm_name, option, debug=True)
         vmxml = libvirt_xml.VMXML.new_from_dumpxml(vm_name)
+        logging.debug("Guest xml is {}".format(vmxml))
         devices = vmxml.get_devices('interface')
         iface_xml = devices[0]
         iface_xml_2 = devices[1]

--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_disk.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_disk.py
@@ -14,6 +14,7 @@ from virttest import libvirt_storage
 from virttest import utils_libvirtd
 from virttest import gluster
 from virttest.utils_test import libvirt as utlv
+from virttest.utils_libvirt import libvirt_pcicontr
 
 from virttest import libvirt_version
 
@@ -189,6 +190,8 @@ def run(test, params, env):
             extra = "--persistent --subdriver %s" % image_format
 
         if not multi_gluster_disks:
+            # Fix No more available PCI slots
+            libvirt_pcicontr.reset_pci_num(vm_name, 15)
             # Do the attach action.
             out = process.run("qemu-img info %s" % img_path, shell=True)
             logging.debug("The img info is:\n%s" % out.stdout.strip())


### PR DESCRIPTION
Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Before
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio \                                                     
> virsh.snapshot_disk.no_delete.negative_test.pool_vol.fs_pool.attach_img_raw.snapshot_from_xml.disk_internal.memory_none \                                                                  
> virsh.snapshot_disk.no_delete.negative_test.pool_vol.iscsi_pool.attach_img_raw.snapshot_default.no_current                                                                                                   
JOB ID     : 78a8f43ea2e7d1b7538030f7613c3775d45d699c
JOB LOG    : /root/avocado/job-results/job-2021-11-22T03.26-78a8f43/job.log
 (1/2) type_specific.io-github-autotest-libvirt.virsh.snapshot_disk.no_delete.negative_test.pool_vol.fs_pool.attach_img_raw.snapshot_from_xml.disk_internal.memory_none: ERROR: Failed to attach disk /var/lib/avocado/data/avocado-vt/fs/snap_pool_vol to VM.Detail: error: Failed to attach disk\nerror: internal error: No more available PCI slots\n. (66.38 s)                        
 (2/2) type_specific.io-github-autotest-libvirt.virsh.snapshot_disk.no_delete.negative_test.pool_vol.iscsi_pool.attach_img_raw.snapshot_default.no_current: ERROR: Failed to attach disk /dev/disk/by-path/ip-127.0.0.1:3260-iscsi-iqn.2021-11.com.virttest:iscsi-pool.target-lun-0 to VM.Detail: error: Failed to attach disk\nerror: internal error: No more available PCI slots\n. (66.89 s)
RESULTS    : PASS 0 | ERROR 2 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 134.01 s
```
After
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virsh.snapshot_disk.no_delete.negative_test.pool_vol.fs_pool.attach_img_raw.snapsho
t_from_xml.disk_internal.memory_none virsh.snapshot_disk.no_delete.negative_test.pool_vol.iscsi_pool.attach_img_raw.snapshot_default.no_current                                                                     
JOB ID     : ce6d06999c4fac9a4bb4c2bdc043faba5961e5eb
JOB LOG    : /root/avocado/job-results/job-2021-11-22T03.33-ce6d069/job.log
 (1/2) type_specific.io-github-autotest-libvirt.virsh.snapshot_disk.no_delete.negative_test.pool_vol.fs_pool.attach_img_raw.snapshot_from_xml.disk_internal.memory_none: PASS (70.37 s)      
 (2/2) type_specific.io-github-autotest-libvirt.virsh.snapshot_disk.no_delete.negative_test.pool_vol.iscsi_pool.attach_img_raw.snapshot_default.no_current: PASS (73.46 s)                   
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 144.57 s
```


