### PR TITLE
numa_numanode_cpu_info: Run bash cmd in subshell

### DIFF
--- a/libvirt/tests/src/numa/numa_numanode_cpu_info.py
+++ b/libvirt/tests/src/numa/numa_numanode_cpu_info.py
@@ -40,13 +40,13 @@ def setup_host(online_nodes, pages_list):
         for pages in pages_list:
             ret = process.run(
                 'echo {} > /sys/devices/system/node/node{}/hugepages/hugepages-2048kB/nr_hugepages'.
-                format(pages, online_nodes[index]))
+                format(pages, online_nodes[index]), shell=True)
             if ret.exit_status:
                 raise TestError('Cannot set {} hugepages on node {}'.
                                 format(pages, online_nodes[index]))
             ret = process.run(
                 'cat /sys/devices/system/node/node{}/hugepages/hugepages-2048kB/nr_hugepages'.
-                format(online_nodes[index]))
+                format(online_nodes[index]), shell=True)
             if pages not in ret.stdout_text:
                 raise TestError('Setting {} hugepages on node {} was unsuccessful'.
                                 format(pages, online_nodes[index]))


### PR DESCRIPTION
'>' is a shell construct meaning that the command needs to be run as input to
a shell.
```
echo {} >
/sys/devices/system/node/node{}/hugepages/hugepages-2048kB/nr_hugepages
```
If we don't set shell=True, process just echo this cmd instead of
writing the nr_hugepages.

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Before
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio numa_numanode_cpu_info.default                                                                        
JOB ID     : 8f1e1130ecd01b148207f3495fa50ae075ae4f4f
JOB LOG    : /root/avocado/job-results/job-2021-11-22T05.09-8f1e113/job.log
 (1/1) type_specific.io-github-autotest-libvirt.numa_numanode_cpu_info.default: ERROR: Setting 900 hugepages on node 0 was unsuccessful (9.08 s)                                             
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 9.78 s
```
After
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio numa_numanode_cpu_info.default                                                                       
JOB ID     : 8dfa3b875b13b69eb187bbe029ca86745a9ca8c9
JOB LOG    : /root/avocado/job-results/job-2021-11-22T05.11-8dfa3b8/job.log
 (1/1) type_specific.io-github-autotest-libvirt.numa_numanode_cpu_info.default: PASS (10.30 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 11.01 s
```
