### PR TITLE
v2v: cleanup the os_directory content at the end

### DIFF
--- a/v2v/tests/src/function_test_esx.py
+++ b/v2v/tests/src/function_test_esx.py
@@ -1034,5 +1034,7 @@ def run(test, params, env):
             os.environ.pop('https_proxy')
         if unprivileged_user:
             process.system("userdel -fr %s" % unprivileged_user)
+        if params.get('os_directory') and os.path.isdir(params['os_directory']):
+            shutil.rmtree(params['os_directory'], ignore_errors=True)
         # Cleanup constant files
         utils_v2v.cleanup_constant_files(params)


### PR DESCRIPTION
If os_directory was set in cfg file, the directory would not be
cleaned up correctly. This patch fixes the issue.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>