### PR TITLE
live_migration: Add case about abort migration

### DIFF
--- a/libvirt/tests/cfg/migration/live_migration.cfg
+++ b/libvirt/tests/cfg/migration/live_migration.cfg
@@ -36,6 +36,9 @@
         - p2p_live_undefinesource:
             only domjobabort
             virsh_migrate_options = "--live --p2p --persistent --undefinesource --verbose"
+        - non_p2p_live_undefinesource:
+            only domjobabort
+            virsh_migrate_options = "--live --persistent --undefinesource --verbose"
     variants:
         - migrateuri:
             migrate_speed = 15
@@ -96,7 +99,8 @@
             err_msg = 'operation aborted: migration out job: canceled by client'
             migrate_again_status_error = 'no'
             vm_state_after_abort = "{'source': 'running', 'target': 'nonexist'}"
-            migrate_speed = 10
+            migrate_speed = 1
+            migrate_speed_again = 20
             check_local_port = 'yes'
             return_port = 'yes'
             action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "virsh.domjobabort", "after_event": "iteration: '1'", "func_param": "'%s' % params.get('migrate_main_vm')"}]'

--- a/libvirt/tests/src/migration/live_migration.py
+++ b/libvirt/tests/src/migration/live_migration.py
@@ -143,6 +143,7 @@ def run(test, params, env):
     stress_package = params.get("stress_package")
     action_during_mig = params.get("action_during_mig")
     migrate_speed = params.get("migrate_speed")
+    migrate_speed_again = params.get("migrate_speed_again")
     migrate_again = "yes" == params.get("migrate_again", "no")
     vm_state_after_abort = params.get("vm_state_after_abort")
     return_port = "yes" == params.get("return_port", "no")
@@ -235,8 +236,8 @@ def run(test, params, env):
 
         if stress_package:
             migration_test.run_stress_in_vm(vm, params)
+        mode = 'both' if '--postcopy' in postcopy_options else 'precopy'
         if migrate_speed:
-            mode = 'both' if '--postcopy' in postcopy_options else 'precopy'
             migration_test.control_migrate_speed(vm_name,
                                                  int(migrate_speed),
                                                  mode)
@@ -277,6 +278,11 @@ def run(test, params, env):
                 conn_obj_list.append(migration_base.setup_conn_obj('tls',
                                                                    params,
                                                                    test))
+
+            if migrate_speed_again:
+                migration_test.control_migrate_speed(vm_name,
+                                                     int(migrate_speed_again),
+                                                     mode)
 
             migration_base.do_migration(vm, migration_test, None, dest_uri,
                                         options, virsh_options,


### PR DESCRIPTION
RHEL7-17410 - [Migration][domjobabort] Abort migration in
PerformPhase on source host and migrate again - non-p2p migration

Signed-off-by: lcheng <lcheng@redhat.com>
