### PR TITLE
migrate_vm: Fix variable 'uri' reference issue

### DIFF
--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -1189,6 +1189,7 @@ def run(test, params, env):
     test_dict = dict(params)
     vm_name = test_dict.get("main_vm")
     vm = env.get_vm(vm_name)
+    uri = params.get("desuri")
     start_vm = test_dict.get("start_vm", "no")
     transport = test_dict.get("transport")
     plus = test_dict.get("conn_plus", "+")


### PR DESCRIPTION
Fix error:
UnboundLocalError: local variable 'uri' referenced before assignment

Signed-off-by: lcheng <lcheng@redhat.com>
