### PR TITLE
virsh_vol_create.py: fix secret issue in storage volume with acl test

### DIFF
--- a/libvirt/tests/src/virsh_cmd/volume/virsh_vol_create.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_vol_create.py
@@ -369,7 +369,7 @@ def run(test, params, env):
                                 for index, v in enumerate(rule):
                                     if v.find("secret") >= 0:
                                         nextline = rule[index + 1]
-                                        s = nextline.replace("QEMU", "secret").replace(
+                                        s = re.sub("QEMU|storage", "secret", nextline).replace(
                                                 "pool_name", "secret_uuid").replace(
                                                         "virt-dir-pool", "%s" % luks_secret_uuid)
                                         rule[index + 1] = s


### PR DESCRIPTION
Add secret setting in poklit rule when action_lookup="connect_driver: storage" in split daemon mode

Signed-off-by: Meina Li <meili@redhat.com>
