### PR TITLE
numa_memory_spread: Fix session exception handling

### DIFF
--- a/libvirt/tests/src/numa/numa_memory_spread.py
+++ b/libvirt/tests/src/numa/numa_memory_spread.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import threading
 
 from avocado.utils import distro
 from avocado.utils import process
@@ -172,6 +173,21 @@ def check_cgget_output(test, cgget_message):
         test.fail('{} not found in cgget output'.format(cgget_message))
 
 
+def run_memhog(test, session, test_memory, memhog_rt):
+    """
+    Run memhog in guest to consume memory
+
+    :param test: test object
+    :param session: guest session
+    :param test_memory: the memory that guest needs to consume
+    :param memhog_rt: save error message
+    """
+    try:
+        session.cmd('memhog -r1 {}k'.format(test_memory), timeout=120)
+    except Exception as err:
+        memhog_rt["err"] = str(err)
+
+
 def run(test, params, env):
     """
     Test Live update the numatune nodeset and memory can spread to other node
@@ -181,6 +197,7 @@ def run(test, params, env):
     vm_name = params.get("main_vm")
     vm = env.get_vm(vm_name)
     backup_xml = libvirt_xml.VMXML.new_from_dumpxml(vm_name)
+    memhog_rt = {}
 
     try:
         # Prepare host
@@ -204,11 +221,20 @@ def run(test, params, env):
         # And get the numastat prior the test
         total_prior = get_qemu_total_for_nodes()
         # Start test
-        result = session.cmd('memhog -r1 {}k'.format(memory_to_eat),
-                             timeout=120)
-        logging.debug(result)
-        if vm.is_dead():
-            test.fail('The VM crashed when memhog was executed.')
+        memhog_thread = threading.Thread(target=run_memhog,
+                                         args=(test, session,
+                                               memory_to_eat, memhog_rt))
+        memhog_thread.setDaemon(True)
+        memhog_thread.start()
+        while True:
+            if memhog_thread.is_alive():
+                if vm.is_dead():
+                    test.fail("The VM crashed when memhog was executed.")
+            else:
+                if memhog_rt:
+                    test.fail("Failed to run memhog:{}".
+                              format(memhog_rt["err"]))
+                break
         # Get the numastat after the test
         total_after = get_qemu_total_for_nodes()
         limit = int(params.get("limit_mb"))


### PR DESCRIPTION
This test uses memhog to cost memory. The guest may be killed by host
OS due to OOM. So we need to check whether the guest is alive during
memhog running. Otherwise the cmd doesn't return when OOM and test will be
aborted by TIMEOUT exception.

Run a thread to run guest mmehog and keep checking whether guest is alive.
If guest died, that means memory doesn't spread across multiple nodes, test fail.
If cmd timeout, just raise an error. Increase guest memory or timeout
may fix this error.

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Before: When guest crashed due to OOM, the session.cmd keep waiting memhog cmd return until timeout.
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio numa_memory_spread.default                                                                         
JOB ID     : 63217680ce14bb36d882fb693d6c7dce9329a30d
JOB LOG    : /root/avocado/job-results/job-2021-11-25T05.21-6321768/job.log
 (1/1) type_specific.io-github-autotest-libvirt.numa_memory_spread.default: ERROR: Timeout expired while waiting for shell command to complete: 'memhog -r1 8644947k'    (output: '.................................................................................................................................................................. (174.57 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 175.35 s
```

After:
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio numa_memory_spread.default

JOB ID     : 411e733c033f6c4305b3e64c0f8309ee7ec33cd4
JOB LOG    : /root/avocado/job-results/job-2021-11-25T05.17-411e733/job.log
 (1/1) type_specific.io-github-autotest-libvirt.numa_memory_spread.default: FAIL: The VM crashed when memhog was executed. (62.42 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 63.20 s

```
