### PR TITLE
virsh_boot.cfg: update error info of negative case

### DIFF
--- a/libvirt/tests/cfg/bios/virsh_boot.cfg
+++ b/libvirt/tests/cfg/bios/virsh_boot.cfg
@@ -183,7 +183,7 @@
                             template = "/usr/share/OVMF/OVMF_VARS.secboot.fd"
                             uefi_device_bus = "sata"
                             uefi_target_dev = "sda"
-                            check_prompt = "error:.*has invalid signature"
+                            check_prompt = ".*has invalid signature" || "'Verification failed: (0x1A) Security Violation'"
         - by_seabios:
             boot_type = "seabios"
             loader = "/usr/share/seabios/bios-256k.bin"


### PR DESCRIPTION
There're some change in error info for virsh.boot.by_ovmf.negative_test.non_released_version. So update it.

Signed-off-by: Meina Li <meili@redhat.com>
