### PR TITLE
[filesystem_device]Add the cases of hotplug_unplug filesystem device

### DIFF
--- a/libvirt/tests/cfg/virtual_device/filesystem_device.cfg
+++ b/libvirt/tests/cfg/virtual_device/filesystem_device.cfg
@@ -28,11 +28,11 @@
         - fs_test:
             variants:
                 - one_guest:
-                    guest_num = 1  
+                    guest_num = 1
                 - two_guests:
                     vms = "avocado-vt-vm1 avocado-vt-vm2"
                     guest_num = 2
-                    only nop.fs_test.xattr_on.flock_on.lock_posix_on.cache_mode_none.one_fs
+                    only nop.fs_test.xattr_on.flock_on.lock_posix_on.cache_mode_none.one_fs, hotplug_unplug..fs_test.xattr_on.flock_on.lock_posix_on.cache_mode_none.one_fs
             variants:
                 - one_fs:
                     fs_num = 1
@@ -84,6 +84,14 @@
         - coldplug_coldunplug:
             only xattr_on.flock_on.lock_posix_on.cache_mode_none.one_fs
             coldplug = "yes"
+        - hotplug_unplug:
+            hotplug_unplug = "yes"
+            variants:
+                - detach_device_alias:
+                  detach_device_alias = "yes"
+                  only xattr_on.flock_on.lock_posix_on.cache_mode_none
+                - detach_device:
+                  detach_device_alias = "no"
     variants:
         - positive_test:
             status_error = "no"
@@ -96,10 +104,11 @@
                       with_hugepages = no
                       with_memfd = yes
         - negative_test:
-            only nop.fs_test.xattr_on.flock_on.lock_posix_on.cache_mode_none.one_fs.one_guest
+            only fs_test.xattr_on.flock_on.lock_posix_on.cache_mode_none.one_fs.one_guest
             status_error = "yes"
             variants:
                 - invalid_queue_size:
+                    only nop, hotplug_unplug.detach_device
                     variants:
                         - larger_than_uint16:
                             queue_size = 1048576
@@ -111,5 +120,6 @@
                             queue_size = 2048
                             error_msg_start = "queue-size property must be 1024 or smaller"
                 - managedsave:
+                    only nop
                     managedsave = "yes"
                     error_msg_save = "migration with virtiofs device is not supported"


### PR DESCRIPTION
Signed-off-by: Lili Zhu <lizhu@redhat.com>


Test cases: RHEL-285215 RHEL-285255 RHEL-286256 RHEL-286733
Bug: 1897708

Test result:
# avocado run --vt-type libvirt filesystem_device     
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your dis
tro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : 5a856d58ed721159f6fe0b18768cff7191c080b1
JOB LOG    : /root/avocado/job-results/job-2021-11-28T21.39-5a856d5/job.log
 (001/260) type_specific.io-github-autotest-libvirt.virtual_devices.filesystem_device.positive_test.hugepages_backed.nop.externally_launched_fs_test.launched_mode: PASS (28.02 s)
 (002/260) type_specific.io-github-autotest-libvirt.virtual_devices.filesystem_device.positive_test.hugepages_backed.nop.fs_test.xattr_on.flock_on.lock_posix_off.cache_mode_none.
one_fs.one_guest: PASS (28.81 s)
...
(259/260) type_specific.io-github-autotest-libvirt.virtual_devices.filesystem_device.negative_test.invalid_queue_size.larger_than_1024.hotplug_unplug.fs_test.xattr_on.flock_on.l
ock_posix_on.cache_mode_none.one_fs.one_guest: PASS (20.12 s)
 (260/260) type_specific.io-github-autotest-libvirt.virtual_devices.filesystem_device.negative_test.managedsave.nop.fs_test.xattr_on.flock_on.lock_posix_on.cache_mode_none.one_fs
.one_guest: PASS (21.01 s)
RESULTS    : PASS 260 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 8357.35 s