### PR TITLE
vdpa: Add a case to check network connectivity

### DIFF
--- a/libvirt/tests/cfg/virtual_interface/connectivity_check.cfg
+++ b/libvirt/tests/cfg/virtual_interface/connectivity_check.cfg
@@ -1,0 +1,15 @@
+- iface.connectivity_check:
+    type = connectivity_check
+    start_vm = no
+
+    variants dev_type:
+        - vdpa:
+            only x86_64
+            func_supported_since_libvirt_ver = (7, 3, 0)
+            func_supported_since_qemu_kvm_ver = (6, 0, 0)
+            iface_dict = {"source": {'dev':'/dev/vhost-vdpa-0'}}
+            save_error = "yes"
+            vm_iface_driver = "virtio_net"
+            variants test_target:
+                - simulator:
+                - mellanox:

--- a/libvirt/tests/src/virtual_interface/connectivity_check.py
+++ b/libvirt/tests/src/virtual_interface/connectivity_check.py
@@ -1,0 +1,115 @@
+import logging
+
+from virttest import libvirt_version
+from virttest import virsh
+from virttest import utils_misc
+from virttest import utils_vdpa
+from virttest.libvirt_xml import vm_xml
+from virttest.staging import service
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+from provider.interface import interface_base
+from provider.interface import check_points
+
+VIRSH_ARGS = {'debug': True, 'ignore_status': False}
+
+
+def run(test, params, env):
+    """
+    Test network connectivity
+    """
+
+    def setup_default():
+        """
+        Default setup
+        """
+        logging.debug("Remove VM's interface devices.")
+        libvirt_vmxml.remove_vm_devices_by_type(vm, 'interface')
+
+    def teardown_default():
+        """
+        Default cleanup
+        """
+        pass
+
+    def setup_vdpa():
+        """
+        Setup vDPA environment
+        """
+        setup_default()
+        test_env_obj = None
+        if test_target == "simulator":
+            test_env_obj = utils_vdpa.VDPASimulatorTest()
+        else:
+            pf_pci = utils_vdpa.get_vdpa_pci()
+            test_env_obj = utils_vdpa.VDPAOvsTest(pf_pci)
+        test_env_obj.setup()
+        return test_env_obj
+
+    def teardown_vdpa():
+        """
+        Cleanup vDPA environment
+        """
+        if test_target != "simulator":
+            service.Factory.create_service("NetworkManager").restart()
+        if test_obj:
+            test_obj.cleanup()
+
+    def run_test(dev_type, params, test_obj=None):
+        """
+        Test the connectivity of vm's interface
+
+        1) Start the vm with a interface
+        2) Check the network driver of VM's interface
+        3) Check the network connectivity
+        4) Destroy the VM
+        """
+        # Setup Iface device
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        iface_dict = eval(params.get('iface_dict', '{}'))
+        iface_dev = interface_base.create_iface(dev_type, iface_dict)
+        libvirt.add_vm_device(vmxml, iface_dev)
+
+        logging.info("Start a VM with a '%s' type interface.", dev_type)
+        vm.start()
+        vm_session = vm.wait_for_serial_login(timeout=240)
+        vm_iface_info = interface_base.get_vm_iface_info(vm_session)
+        if params.get('vm_iface_driver'):
+            if vm_iface_info.get('driver') != params.get('vm_iface_driver'):
+                test.fail("VM iface should be {}, but got {}."
+                          .format(params.get('vm_iface_driver'),
+                                  vm_iface_info.get('driver')))
+
+        logging.info("Check the network connectivity")
+        check_points.check_network_accessibility(
+            vm, test_obj=test_obj, **params)
+        virsh.destroy(vm.name, **VIRSH_ARGS)
+
+    libvirt_version.is_libvirt_feature_supported(params)
+    utils_misc.is_qemu_function_supported(params)
+
+    # Variable assignment
+    test_target = params.get('test_target', '')
+    dev_type = params.get('dev_type', '')
+
+    vm_name = params.get('main_vm')
+    vm = env.get_vm(vm_name)
+
+    vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+    backup_vmxml = vmxml.copy()
+
+    setup_test = eval("setup_%s" % dev_type) if "setup_%s" % dev_type in \
+        locals() else setup_default
+    teardown_test = eval("teardown_%s" % dev_type) if "teardown_%s" % \
+        dev_type in locals() else teardown_default
+
+    test_obj = None
+    try:
+        # Execute test
+        test_obj = setup_test()
+        run_test(dev_type, params, test_obj=test_obj)
+
+    finally:
+        backup_vmxml.sync()
+        teardown_test()

--- a/provider/interface/interface_base.py
+++ b/provider/interface/interface_base.py
@@ -7,6 +7,7 @@ from virttest import utils_net
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices import interface
+from virttest.utils_libvirt import libvirt_misc
 from virttest.utils_libvirt import libvirt_vmxml
 from virttest.utils_test import libvirt
 
@@ -38,6 +39,22 @@ def get_vm_iface(vm_session):
     if not vm_iface:
         raise exceptions.TestFail("Failed to get vm's iface!")
     return vm_iface[0]
+
+
+def get_vm_iface_info(vm_session):
+    """
+    Get VM's interface info using 'ethtool' command
+
+    :param vm_session: VM's session
+    :return: Dict, vm's interface infomation
+    """
+    vm_iface = get_vm_iface(vm_session)
+    cmd = 'ethtool -i %s' % vm_iface
+    output_str = vm_session.cmd_output(cmd).strip()
+    if_info = libvirt_misc.convert_to_dict(
+        output_str, pattern=r'(\S+): +(\S+)')
+    logging.debug("VM interface info: %s.", if_info)
+    return if_info
 
 
 def attach_iface_device(vm_name, dev_type, params):


### PR DESCRIPTION
This PR adds:
RHEL-284762 - network connectivity check for vdpa type interface

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Test results:**
```
JOB ID     : 5f7d364cab86ad72b8e4f052b80a5e6ac9947b50
JOB LOG    : /root/avocado/job-results/job-2021-11-29T01.12-5f7d364/job.log
 (1/2) type_specific.io-github-autotest-libvirt.iface.connectivity_check.vdpa.simulator: PASS (30.19 s)
 (2/2) type_specific.io-github-autotest-libvirt.iface.connectivity_check.vdpa.mellanox: PASS (71.37 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 103.03 s
```
