### PR TITLE
Start guest after reset guest PCI

### DIFF
--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_disk.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_disk.py
@@ -192,6 +192,7 @@ def run(test, params, env):
         if not multi_gluster_disks:
             # Fix No more available PCI slots
             libvirt_pcicontr.reset_pci_num(vm_name, 15)
+            vm.start()
             # Do the attach action.
             out = process.run("qemu-img info %s" % img_path, shell=True)
             logging.debug("The img info is:\n%s" % out.stdout.strip())


### PR DESCRIPTION
Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Before
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virsh.snapshot_disk.no_delete.positive_test.no_pool.attach_img_raw.snapshot_from_xm
l.disk_external.sys_checkpoint.default.memory_external                                                                                     
JOB ID     : c1e8b0a668ba64476707d5fde48ad6e8aa9f3e62                                                                                                                                         
JOB LOG    : /root/avocado/job-results/job-2021-11-30T04.14-c1e8b0a/job.log                                                                          
 (1/1) type_specific.io-github-autotest-libvirt.virsh.snapshot_disk.no_delete.positive_test.no_pool.attach_img_raw.snapshot_from_xml.disk_external.sys_checkpoint.default.memory_external: FAI
L: Failed to create snapshot. Error:error: XML error: memory state cannot be saved with offline or disk-only snapshot. (53.62 s)                          
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0                                                                                                             
JOB TIME   : 54.31 s              
```
After
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virsh.snapshot_disk.no_delete.positive_test.no_pool.attach_img_raw.snapshot_from_xml.disk_external.sys_checkpoint.default.memory_external
JOB ID     : 8ff7afa6f66f0d28a488eed00bab50ce6e218384
JOB LOG    : /root/avocado/job-results/job-2021-11-30T05.16-8ff7afa/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.snapshot_disk.no_delete.positive_test.no_pool.attach_img_raw.snapshot_from_xml.disk_external.sys_checkpoint.default.memory_external: PASS (82.77 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 83.49 s

```
