### PR TITLE
controller_functional: Fix model for ppc

### DIFF
--- a/libvirt/tests/src/controller/controller_functional.py
+++ b/libvirt/tests/src/controller/controller_functional.py
@@ -799,8 +799,9 @@ def run(test, params, env):
         if remove_nic:
             remove_devices(vm_xml, 'interface')
         # Get the max controller index in current vm xml
+        the_model = 'pci-root' if 'ppc' in platform.machine() else 'pcie-root-port'
         if add_contrl_list:
-            ret_indexes = libvirt_pcicontr.get_max_contr_indexes(vm_xml, 'pci', 'pcie-root-port')
+            ret_indexes = libvirt_pcicontr.get_max_contr_indexes(vm_xml, 'pci', the_model)
             if ret_indexes and len(ret_indexes) > 0:
                 if auto_bus:
                     new_index = "0x%02x" % (int(ret_indexes[0]) + 1)


### PR DESCRIPTION
On ppc, there is only pci-root model, not pcie-root-port model.

Signed-off-by: Dan Zheng <dzheng@redhat.com>
