### PR TITLE
migrate_vm: Add '-F' option to qemu-img create command

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_vm.cfg
+++ b/libvirt/tests/cfg/migration/migrate_vm.cfg
@@ -758,7 +758,7 @@
                             target_image_name = "foo_bar_test.${target_image_format}"
                             new_disk_source = "${target_image_path}/${target_image_name}"
                             # create disk image based on ${nfs_mount_dir}/${image_name} both local and remote host
-                            create_local_disk_backfile_cmd = "qemu-img create ${new_disk_source} -f qcow2 -b ${nfs_mount_dir}/"
+                            create_local_disk_backfile_cmd = "qemu-img create ${new_disk_source} -f qcow2 -F ${target_image_format} -b ${nfs_mount_dir}/"
                             create_remote_disk_backfile_cmd = "${create_local_disk_backfile_cmd}"
                             # create disk image in the VM
                             dd_image_count = 100000


### PR DESCRIPTION
To create a backing file, the option '-F' is required, so update
accordingly.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
Test result:

 (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_vm.negative_testing.live_storage_migration.backing_file_with_copy_storage_inc.without_postcopy: PASS (98.56 s)
