### PR TITLE
virsh_event: metadata-change event output fix

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
@@ -434,16 +434,24 @@ def run(test, params, env):
                                    options="",
                                    key=metadata_key,
                                    **virsh_dargs)
-                    expected_events_list.append("'metadata-change' for %s: "
-                                                "element http://app.org/")
+                    if not libvirt_version.version_compare(7, 10, 0):
+                        expected_events_list.append("'metadata-change' for %s: "
+                                                    "element http://app.org/")
+                    else:
+                        expected_events_list.append("'metadata-change' for %s: "
+                                                    "type element, uri http://app.org/")
                 elif event == "metadata_remove":
                     virsh.metadata(dom.name,
                                    metadata_uri,
                                    options="--remove",
                                    key=metadata_key,
                                    **virsh_dargs)
-                    expected_events_list.append("'metadata-change' for %s: "
-                                                "element http://app.org/")
+                    if not libvirt_version.version_compare(7, 10, 0):
+                        expected_events_list.append("'metadata-change' for %s: "
+                                                    "element http://app.org/")
+                    else:
+                        expected_events_list.append("'metadata-change' for %s: "
+                                                    "type element, uri http://app.org/")
                 elif event == "blockcommit":
                     disk_path = dom.get_blk_devices()['vda']['source']
                     virsh.snapshot_create_as(dom.name, "s1 --disk-only --no-metadata", **virsh_dargs)


### PR DESCRIPTION
There're still 2 areas of metadata-change event output not updated.
Fix them this time.

Signed-off-by: Yanqiu Zhang <yanqzhan@redhat.com>

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [ ] Description of the cases
- [ ] Links of libvirt features, libvirt bugs or case IDs
- [ ] Test results

## If the PR is bug cases
- [ ] Bug descriptions or bug links
- [ ] Test results

## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
