### PR TITLE
Add cmd status check for blockcopy

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
@@ -172,6 +172,9 @@ def finish_job(vm_name, target, timeout):
     """
     job_time = 0
     while job_time < timeout:
+        # Check cmd execute status and report error directly if have
+        virsh.blockjob(vm_name, target, "--info", debug=True, ignore_status=False)
+
         # As BZ#1359679, blockjob may disappear during the process,
         # so we need check it all the time
         if utl.check_blockjob(vm_name, target, 'none', '0'):


### PR DESCRIPTION
 As the old method will ignore the cmd err check so when it happened it will timeout

Signed-off-by: Kyla Zhang <weizhan@redhat.com>

```
 (1/1) type_specific.io-github-autotest-libvirt.virsh.blockcopy.positive_test.non_acl.block_disk.disk_t.default.block_type.blockdev.no_shallow.no_option: PASS (200.64 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 201.52 s

```