### PR TITLE
virsh_detach_serial_device_alias: fix serial type ppc

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_serial_device_alias.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_serial_device_alias.cfg
@@ -4,7 +4,7 @@
     hot_plugging_support = "yes"
     variants:
         - serial_type_file:
-            serial_type = file
+            serial_dev_type = file
             serial_sources = path:/var/lib/libvirt/virt-test
             variants:
                 - isa-serial:
@@ -14,7 +14,7 @@
                 - pci-serial:
                     target_type = pci-serial
         - serial_type_pty:
-            serial_type = pty
+            serial_dev_type = pty
             variants:
                 - isa-serial:
                     no aarch64

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_detach_serial_device_alias.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_detach_serial_device_alias.py
@@ -90,7 +90,7 @@ def run(test, params, env):
             if os.path.exists('/var/log/libvirt/virt-test'):
                 os.remove('/var/log/libvirt/virt-test')
 
-    serial_type = params.get('serial_type', 'pty')
+    serial_type = params.get('serial_dev_type', 'pty')
     target_type = params.get('target_type', 'isa-serial')
     sources_str = params.get('serial_sources', '')
     hot_plug_support = "yes" == params.get('hot_plugging_support')


### PR DESCRIPTION
In avocado-vt machine.cfg, there is another serial_type definition for pseries which is used
by tp-qemu and not suitable for libvirt test. So this is to rename the variable to avoid
naming overlap.

Signed-off-by: Dan Zheng <dzheng@redhat.com>
