### PR TITLE
dac_vm_per_image_start: fix virt_use_nfs missing

### DIFF
--- a/libvirt/tests/cfg/svirt/dac_vm_per_image_start.cfg
+++ b/libvirt/tests/cfg/svirt/dac_vm_per_image_start.cfg
@@ -42,6 +42,7 @@
                 - nfs:
                     no invalid_per_img_label
                     disk_source_protocol = "netfs"
+                    virt_use_nfs = "yes"
                     export_options = "rw,no_root_squash"
                     disk_type = "file"
                     disk_target = "vda"
@@ -51,6 +52,7 @@
                 - nfs_root_squash:
                     only positive_test.model_default.file_disk.nfs_root_squash.vm_t_dynamic.per_img_relabel_no
                     disk_source_protocol = "netfs"
+                    virt_use_nfs = "yes"
                     set_qemu_conf = "no"
                     export_options = "rw,root_squash"
                     image_owner_group = "qemu:qemu"

--- a/libvirt/tests/src/svirt/dac_vm_per_image_start.py
+++ b/libvirt/tests/src/svirt/dac_vm_per_image_start.py
@@ -95,6 +95,8 @@ def run(test, params, env):
     qemu_group = params.get("qemu_group", 'qemu')
     dynamic_ownership = "yes" == params.get("dynamic_ownership", "yes")
 
+    # When using nfs, the virt_use_nfs should be enabled
+    enable_virt_use_nfs = 'yes' == params.get("virt_use_nfs", 'no')
     # Get variables about VM and get a VM object and VMXML instance.
     vm_name = params.get("main_vm")
     vm = env.get_vm(vm_name)
@@ -108,6 +110,8 @@ def run(test, params, env):
                     "mode. it must be in Enforcing "
                     "mode to run this test")
     utils_selinux.set_status(host_sestatus)
+    if enable_virt_use_nfs:
+        process.run("setsebool virt_use_nfs on", shell=True)
 
     qemu_sock_mod = False
     qemu_sock_path = '/var/lib/libvirt/qemu/'


### PR DESCRIPTION
'virt_use_nfs' should be on when libvirt use nfs.

Signed-off-by: Dan Zheng <dzheng@redhat.com>
