### PR TITLE
filesystem_device: clean up virtiofsd

### DIFF
--- a/libvirt/tests/src/virtual_device/filesystem_device.py
+++ b/libvirt/tests/src/virtual_device/filesystem_device.py
@@ -93,9 +93,14 @@ def run(test, params, env):
         """
         process.run('chcon -t virtd_exec_t %s' % path, ignore_status=False, shell=True)
         cmd = "systemd-run %s --socket-path=%s -o source=%s" % (path, source_socket, source_dir)
-        process.run(cmd, ignore_status=False, shell=True)
-        process.run("chown qemu:qemu %s" % source_socket, ignore_status=False)
-        process.run('chcon -t svirt_image_t %s' % source_socket, ignore_status=False, shell=True)
+        try:
+            process.run(cmd, ignore_status=False, shell=True)
+            process.run("chown qemu:qemu %s" % source_socket, ignore_status=False)
+            process.run('chcon -t svirt_image_t %s' % source_socket, ignore_status=False, shell=True)
+        except Exception as err:
+            cmd = "pkill virtiofsd"
+            process.run(cmd, shell=True)
+            test.fail("{}".format(err))
 
     def prepare_stress_script(script_path, script_content):
         """


### PR DESCRIPTION
Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

The test uses systemd-run to start a virtiofsd process, then change
permession and selinux security context.

But if above operations failed, there is no codes to clean up the remaing
virtiofsd process.

The other tests which need to check the virtiofsd process may fail.
E.g.
```
TestFail: Expected 'cache=none,xattr,flock,no_posix_lock' was not found
in output of 'ps aux | grep virtiofsd | head -n 1'
```

Before
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio \                                                                                 
> virtual_devices.filesystem_device.positive_test.hugepages_backed.nop.externally_launched_fs_test.launched_mode \                                                                           
> virtual_devices.filesystem_device.positive_test.hugepages_backed.nop.fs_test.xattr_on.flock_on.lock_posix_off.cache_mode_none.one_fs.one_guest                                                                    
JOB ID     : 385aa226ac12ba6116ee77ecf1dadaebbe2d4f9e
JOB LOG    : /root/avocado/job-results/job-2021-12-08T01.47-385aa22/job.log
 (1/2) type_specific.io-github-autotest-libvirt.virtual_devices.filesystem_device.positive_test.hugepages_backed.nop.externally_launched_fs_test.launched_mode: ERROR: Command 'chown qemu:qemu /var/tmp/vm001.socket' failed.\nstdout: b''\nstderr: b"chown: cannot access '/var/tmp/vm001.socket': No such file or directory\n"\nadditional_info: None (44.65 s)                         
 (2/2) type_specific.io-github-autotest-libvirt.virtual_devices.filesystem_device.positive_test.hugepages_backed.nop.fs_test.xattr_on.flock_on.lock_posix_off.cache_mode_none.one_fs.one_guest: FAIL: Expected 'cache=none,xattr,flock,no_posix_lock' was not found in output of 'ps aux | grep virtiofsd | head -n 1' (91.97 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 138.21 s

```

After
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio \                                                                                 
> virtual_devices.filesystem_device.positive_test.hugepages_backed.nop.externally_launched_fs_test.launched_mode \                                                                           
> virtual_devices.filesystem_device.positive_test.hugepages_backed.nop.fs_test.xattr_on.flock_on.lock_posix_off.cache_mode_none.one_fs.one_guest                                                                     
JOB ID     : 74e065ce0f7f6ee4f6507e8c871824b21296d557
JOB LOG    : /root/avocado/job-results/job-2021-12-08T01.39-74e065c/job.log
 (1/2) type_specific.io-github-autotest-libvirt.virtual_devices.filesystem_device.positive_test.hugepages_backed.nop.externally_launched_fs_test.launched_mode: FAIL: Command 'chown qemu:qemu /var/tmp/vm001.socket' failed.\nstdout: b''\nstderr: b"chown: cannot access '/var/tmp/vm001.socket': No such file or directory\n"\nadditional_info: None (47.47 s)                          
 (2/2) type_specific.io-github-autotest-libvirt.virtual_devices.filesystem_device.positive_test.hugepages_backed.nop.fs_test.xattr_on.flock_on.lock_posix_off.cache_mode_none.one_fs.one_guest: PASS (104.59 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 153.63 s

```
