### PR TITLE
virsh_pool_autostart: Restart virtstoraged in modular deamons mode

### DIFF
--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool_autostart.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool_autostart.py
@@ -192,7 +192,7 @@ def run(test, params, env):
             logging.info("Try to restart libvirtd")
             # Remove the autostart management file
             utils_libvirtd.unmark_storage_autostarted()
-            libvirtd = utils_libvirtd.Libvirtd()
+            libvirtd = utils_libvirtd.Libvirtd("virtstoraged")
             libvirtd.restart()
             check_pool(pool_name, pool_type, checkpoint="State",
                        expect_value="active", expect_error=status_error)
@@ -216,7 +216,7 @@ def run(test, params, env):
 
                 # Repeat step (3)
                 logging.debug("Try to restart libvirtd")
-                libvirtd = utils_libvirtd.Libvirtd()
+                libvirtd = utils_libvirtd.Libvirtd('virtstoraged')
                 libvirtd.restart()
                 check_pool(pool_name, pool_type, checkpoint='State',
                            expect_value="inactive", expect_error=status_error)
@@ -236,6 +236,6 @@ def run(test, params, env):
             if os.path.exists(p_xml):
                 os.remove(p_xml)
         except exceptions.TestFail as details:
-            libvirtd = utils_libvirtd.Libvirtd()
+            libvirtd = utils_libvirtd.Libvirtd('virtstoraged')
             libvirtd.restart()
             logging.error(str(details))


### PR DESCRIPTION
Some cases need to restart virtstoraged instead of virtqemud when
modular daemons are enabled.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Test results:**
_Before fix:_
 _(1/1) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.uuid_option.pool_type_iscsi.ipv6_target: FAIL: Pool State isn't active as expected (53.13 s)_


_After fix:_
```
JOB LOG    : /root/avocado/job-results/job-2021-12-07T02.00-c0fa3ab/job.log
 (01/34) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_disk.source_format_dos: PASS (52.33 s)
 (02/34) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_disk.source_format_dvh: PASS (52.67 s)
 (03/34) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_disk.source_format_gpt: PASS (59.43 s)
 (04/34) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_disk.source_format_bsd: PASS (57.36 s)
 (05/34) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_disk.source_format_pc98: PASS (58.16 s)
 (06/34) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_disk.source_format_sun: PASS (59.37 s)
 (07/34) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_fs.source_format_ext2: PASS (59.13 s)
 (08/34) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_fs.source_format_ext3: PASS (60.01 s)
 (09/34) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_fs.source_format_ext4: PASS (58.71 s)
 (10/34) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_fs.source_format_vfat: PASS (63.58 s)
 (11/34) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_fs.source_format_xfs: PASS (48.01 s)
 (12/34) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_logical.source_format_lvm2: PASS (50.93 s)
 (13/34) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_logical.source_format_auto: PASS (48.32 s)
 (14/34) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_netfs.source_format_nfs: PASS (16.23 s)
 (15/34) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_netfs.source_format_glusterfs: PASS (29.30 s)
 (16/34) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_iscsi.ipv4_target: PASS (62.25 s)
 (17/34) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_iscsi.ipv6_target: PASS (57.70 s)
 (18/34) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.uuid_option.pool_type_disk.source_format_dos: PASS (58.75 s)
 (19/34) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.uuid_option.pool_type_disk.source_format_dvh: PASS (61.60 s)
 (20/34) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.uuid_option.pool_type_disk.source_format_gpt: PASS (63.25 s)
 (21/34) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.uuid_option.pool_type_disk.source_format_bsd: PASS (62.48 s)
 (22/34) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.uuid_option.pool_type_disk.source_format_pc98: PASS (58.28 s)
 (23/34) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.uuid_option.pool_type_disk.source_format_sun: PASS (59.74 s)
 (24/34) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.uuid_option.pool_type_fs.source_format_ext2: PASS (59.64 s)
 (25/34) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.uuid_option.pool_type_fs.source_format_ext3: PASS (59.34 s)
 (26/34) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.uuid_option.pool_type_fs.source_format_ext4: PASS (60.19 s)
 (27/34) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.uuid_option.pool_type_fs.source_format_vfat: PASS (62.17 s)
 (28/34) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.uuid_option.pool_type_fs.source_format_xfs: PASS (61.00 s)
 (29/34) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.uuid_option.pool_type_logical.source_format_lvm2: PASS (49.15 s)
 (30/34) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.uuid_option.pool_type_logical.source_format_auto: PASS (48.83 s)
 (31/34) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.uuid_option.pool_type_netfs.source_format_nfs: PASS (15.99 s)
 (32/34) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.uuid_option.pool_type_netfs.source_format_glusterfs: PASS (29.99 s)
 (33/34) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.uuid_option.pool_type_iscsi.ipv4_target: PASS (62.00 s)
 (34/34) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.uuid_option.pool_type_iscsi.ipv6_target: PASS (63.22 s)
RESULTS    : PASS 34 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```

