### PR TITLE
Update to check the result of virsh vol-download command

### DIFF
--- a/libvirt/tests/src/virsh_cmd/volume/virsh_vol_download_upload.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_vol_download_upload.py
@@ -384,6 +384,7 @@ def run(test, params, env):
             result = virsh.vol_download(file_name, download_file_path, options,
                                         unprivileged_user=unpri_user,
                                         uri=uri, debug=True)
+            libvirt.check_exit_status(result)
 
             #Check download image size.
             one_g_in_bytes = 1073741824


### PR DESCRIPTION
The virsh vol-download command was failed due to a known issue
but the error message of this case was incorrect. So update to
check virsh command to report a proper error message.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
Before fix:
` (1/1) type_specific.io-github-autotest-libvirt.virsh.vol_download_upload.mix_download_upload.dir_pool.sparse: ERROR: Fail to get information of /tmp/avocado_i66gkatt/download-sparse.raw:\nCommand 'qemu-img info /tmp/avocado_i66gkatt/download-sparse.raw -U' failed.\nstdout: b''\nstderr: b"qemu-img: Could not open '/tmp/avocado_i66gkatt/download-sparse.raw': Could not open '... (52.39 s)`


After fix:
` (1/1) type_specific.io-github-autotest-libvirt.virsh.vol_download_upload.mix_download_upload.dir_pool.sparse: FAIL: error: cannot receive data from volume test-img\nerror: this function is not supported by the connection driver: virStreamInData\n (49.71 s)`


NOTE: This case will be skipped in CI with the updated error message fail-regex.