### PR TITLE
migrate_options_shared: Increase slow_speed for aarch64

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -280,6 +280,8 @@
                     asynch_migrate = "yes"
                     virsh_opt = ' -k0'
                     low_speed = "10"
+                    aarch64:
+                        low_speed = "50"
                     stress_in_vm = "yes"
                     stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M --timeout 70"
                     migrate_maxdowntime = '0.100000'
@@ -396,6 +398,8 @@
                             asynch_migrate = "yes"
                             virsh_opt = ' -k0'
                             low_speed = "10"
+                            aarch64:
+                                low_speed = "50"
                             stress_in_vm = "yes"
                             stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M --timeout 70"
                             migrate_maxdowntime = '0.100000'


### PR DESCRIPTION
Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Before
```
virsh.migrate_options_shared.positive_test.p2p_migration.check_domstats.without_postcopy
Error Details
TestError: No migration result is returned.&#10;

virsh.migrate_options_shared.positive_test.check_domjobinfo.without_postcopy
Error Details
Result message not found. Please check log instead.
```
After
```
virsh.migrate_options_shared.positive_test.p2p_migration.check_domstats.without_postcopy: PASS
virsh.migrate_options_shared.positive_test.check_domjobinfo.without_postcopy: PASS
```
