### PR TITLE
memory/allocpages: test huge pages can be allocated on s390x

### DIFF
--- a/libvirt/tests/cfg/memory/allocpages.cfg
+++ b/libvirt/tests/cfg/memory/allocpages.cfg
@@ -1,0 +1,8 @@
+- virsh.allocpages:
+    type = allocpages
+    start_vm = no
+    variants:
+        - s390x_1M:
+            only s390-virtio
+            expected_size = "1M"
+            number_of_hugepages = 1024

--- a/libvirt/tests/src/memory/allocpages.py
+++ b/libvirt/tests/src/memory/allocpages.py
@@ -1,0 +1,35 @@
+import logging
+
+from virttest import virsh
+from virttest.staging.utils_memory import get_huge_page_size
+from virttest.staging.utils_memory import get_num_huge_pages
+from virttest.staging.utils_memory import set_num_huge_pages
+
+
+def run(test, params, env):
+    """
+    Test huge page allocation
+    Available huge page size is arch dependent
+    """
+    try:
+        expected_size = params.get("expected_size", "")
+        number_of_huge_pages = params.get("number_of_hugepages", "")
+        previous_allocation = ""
+        previous_allocation = get_num_huge_pages()
+
+        logging.debug("Try to set '%s' huge pages."
+                      " Expected size: '%s'. Actual size: '%s'." %
+                      (number_of_huge_pages, expected_size,
+                       get_huge_page_size()))
+        virsh.allocpages(expected_size, number_of_huge_pages,
+                         ignore_status=False)
+
+        actual_allocation = get_num_huge_pages()
+        if str(actual_allocation) != str(number_of_huge_pages):
+            test.fail("Huge page allocation failed."
+                      " Expected '%s', got '%s'." %
+                      (number_of_huge_pages, actual_allocation))
+    finally:
+        if previous_allocation:
+            logging.debug("Restore huge page allocation")
+            set_num_huge_pages(previous_allocation)


### PR DESCRIPTION
Depends on: https://github.com/avocado-framework/avocado-vt/pull/3289

Add test caste to set huge pages via 'virsh' command.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>