### PR TITLE
emulatorpin: Update the error message

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_emulatorpin.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_emulatorpin.cfg
@@ -129,7 +129,7 @@
                                                     err_msg = 'CPU.*in cpulist.*exceed the maxcpu'
                                                 - set_by_xml:
                                                     set_emulatorpin_by_xml = "yes"
-                                                    err_msg = 'cannot set CPU affinity on process.*: Invalid argument'
+                                                    err_msg = 'cannot set CPU affinity on process.*: Invalid argument|result out of range'
                                     variants:
                                         - emulatorpin_options:
                                             variants:


### PR DESCRIPTION
The error message has changed, so update it accordingly.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
Before fix:
` (1/1) type_specific.io-github-autotest-libvirt.virsh.emulatorpin.negative_testing.set_emulatorpin_parameter.running_guest.change_emulatorpin.emulatorpin_options.current.noexist.set_by_xml: FAIL: Expect should fail with one of ['cannot set CPU affinity on process.*: Invalid argument'], but failed with:\n\n\nerror: Failed to start domain 'avocado-vt-vm1'\nerror: Unable to write to '/sys/fs/cgroup/machine.slice/machine-qemu\x2d2\x2davocado\x2dvt\x2dvm1.... (31.56 s)`


After the fix:
```
JOB LOG    : /root/avocado/job-results/job-2021-12-08T02.10-a9caa74/job.log
 (1/3) type_specific.io-github-autotest-libvirt.virsh.emulatorpin.negative_testing.set_emulatorpin_parameter.running_guest.change_emulatorpin.emulatorpin_options.live.noexist.set_by_xml: PASS (30.76 s)
 (2/3) type_specific.io-github-autotest-libvirt.virsh.emulatorpin.negative_testing.set_emulatorpin_parameter.running_guest.change_emulatorpin.emulatorpin_options.config.noexist.set_by_xml: PASS (24.28 s)
 (3/3) type_specific.io-github-autotest-libvirt.virsh.emulatorpin.negative_testing.set_emulatorpin_parameter.running_guest.change_emulatorpin.emulatorpin_options.current.noexist.set_by_xml: PASS (24.29 s)

```