### PR TITLE
Fix virt-admin connect uri for libvirtd daemon

### DIFF
--- a/libvirt/tests/src/daemon/daemon_functional.py
+++ b/libvirt/tests/src/daemon/daemon_functional.py
@@ -89,10 +89,7 @@ def run(test, params, env):
         """
         Check whether the config file take effects by checking max_clients.
         """
-        if daemon_name == "libvirtd":
-            connect_uri = "qemu:///system"
-        else:
-            connect_uri = daemon_name + ":///system"
+        connect_uri = daemon_name + ":///system"
         vp = virt_admin.VirtadminPersistent(uri=connect_uri)
         result = vp.srv_clients_info(daemon_name, uri=connect_uri, ignore_status=True, debug=True)
         output = result.stdout.strip().splitlines()


### PR DESCRIPTION
Signed-off-by: Yan Fu <yafu@redhat.com>

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [ ] Description of the cases
- [ ] Links of libvirt features, libvirt bugs or case IDs
- [ ] Test results

## If the PR is bug cases
- [ ] Bug descriptions or bug links
- [ ] Test results

## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
