### PR TITLE
virsh_change_media_matrix: Fix pre_vm_state_paused TIMEOUT issue

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_change_media_matrix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_change_media_matrix.py
@@ -298,7 +298,7 @@ def run(test, params, env):
                 wait_for_event = False
             else:
                 wait_for_event = True
-            if vm.is_alive():
+            if vm.is_alive() and not pre_vm_state == "paused":
                 vm.wait_for_login().close()
             ret = virsh.change_media(vm_ref, target_device, all_options,
                                      wait_for_event=wait_for_event,


### PR DESCRIPTION
pre_vm_state_paused make the guest paused. But vm.is_alive() judge paused guest
as alive. So pre_vm_state_paused cased failed due to TIMEOUT when we try to
login it.

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Before
```
# avocado run  --vt-type libvirt --vt-machine-type arm64-mmio virsh.change_media_matrix.pre_vm_state_paused.cdrom_test.config.action_twice.force.insert_update                          
JOB ID     : 04a32029b857be947788560252fb647d93263021                                                                                                                                        
JOB LOG    : /root/avocado/job-results/job-2021-12-09T02.48-04a3202/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.change_media_matrix.pre_vm_state_paused.cdrom_test.config.action_twice.force.insert_update: ERROR: Login timeout expired    (output: 'ex
ceeded 240 s timeout, last failure: Could not verify DHCP lease: 52:54:00:43:50:16 --> 192.168.122.87') (449.08 s)                                                                           
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 450.63 s              
```
After
```

# avocado run  --vt-type libvirt --vt-machine-type arm64-mmio virsh.change_media_matrix.pre_vm_state_paused.cdrom_test.config.action_twice.force.insert_update
JOB ID     : 25dc848f94cd4d0da2703a8f0c73c1af5064b78f
JOB LOG    : /root/avocado/job-results/job-2021-12-09T03.48-25dc848/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.change_media_matrix.pre_vm_state_paused.cdrom_test.config.action_twice.force.insert_update: PASS (79.36 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 80.88 s
```
