### PR TITLE
libguestfs: Fix the arguments for the testcases of guestfs_list_operations.py

### DIFF
--- a/libguestfs/tests/guestfs_list_operations.py
+++ b/libguestfs/tests/guestfs_list_operations.py
@@ -244,4 +244,5 @@ def run(test, params, env):
         vm.destroy()
 
     operation = params.get("list_operation")
-    eval("test_%s(vm, params)" % operation)
+    testcase = globals()["test_%s" % operation]
+    testcase(test, vm, params)


### PR DESCRIPTION
libguestfs/tests/guestfs_list_operations.py always fails because of "missing 1 required positional argument: 'params'"

```
  # avocado run --vt-type=libguestfs type_specific.io-github-autotest-libvirt.guestfs_list_operations.list_with_mount
  ...
  JOB ID     : 707f75ecc937e27de3ceb18e1e190bac7f35b911
  JOB LOG    : /root/avocado/job-results/job-2021-12-09T14.58-707f75e/job.log
   (1/1) type_specific.io-github-autotest-libvirt.guestfs_list_operations.list_with_mount: STARTED
   (1/1) type_specific.io-github-autotest-libvirt.guestfs_list_operations.list_with_mount: ERROR: test_list_with_mount() missing 1 required positional argument: 'params' (15.56 s)
  RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
  JOB TIME   : 20.58 s
  #
```

That's because the testcases require three arguments, however they get two arguments actually.

Let's fix it as same way as libguestfs/tests/guestfs_file_operations.py.