### PR TITLE
[virt_admin]Fix some issues about split daemon changes

### DIFF
--- a/libvirt/tests/cfg/virt_admin/management/virt_admin_client_disconnect.cfg
+++ b/libvirt/tests/cfg/virt_admin/management/virt_admin_client_disconnect.cfg
@@ -2,3 +2,5 @@
     type = virt_admin_client_disconnect
     start_vm = no
     num_clients = 2
+    server_cn = "ENTER.YOUR.SERVER_CN"
+    client_cn = "ENTER.YOUR.CLIENT_CN"

--- a/libvirt/tests/cfg/virt_admin/management/virt_admin_server_clients_set.cfg
+++ b/libvirt/tests/cfg/virt_admin/management/virt_admin_server_clients_set.cfg
@@ -1,6 +1,8 @@
 - virt_admin.server_clients_set:
     type = virt_admin_server_clients_set
     start_vm = no
+    server_cn = "ENTER.YOUR.SERVER_CN"
+    client_cn = "ENTER.YOUR.CLIENT_CN"
     variants:
         - normal_test:
             is_positive = yes

--- a/libvirt/tests/cfg/virt_admin/monitor/virt_admin_srv_clients_info.cfg
+++ b/libvirt/tests/cfg/virt_admin/monitor/virt_admin_srv_clients_info.cfg
@@ -4,3 +4,5 @@
     max_clients = 6000
     max_anonymous_clients = 30
     num_clients = 3
+    server_cn = "ENTER.YOUR.SERVER_CN"
+    client_cn = "ENTER.YOUR.CLIENT_CN"

--- a/libvirt/tests/src/virt_admin/management/virt_admin_client_disconnect.py
+++ b/libvirt/tests/src/virt_admin/management/virt_admin_client_disconnect.py
@@ -1,7 +1,8 @@
 from virttest import virt_admin
 from virttest import virsh
 from virttest import utils_libvirtd
-from virttest import ssh_key
+from virttest import utils_iptables
+from virttest.utils_conn import TLSConnection
 
 
 def run(test, params, env):
@@ -15,33 +16,52 @@ def run(test, params, env):
     4) check whether srv_clients_info gives out the
        correct info about the virsh clients.
     """
+
     num_clients = params.get("num_clients")
     server_name = params.get("server_name")
-    vp = virt_admin.VirtadminPersistent()
-    daemon = utils_libvirtd.Libvirtd()
-    local_pwd = params.get("local_pwd")
+    server_ip = params["server_ip"] = params.get("local_ip")
+    server_user = params["server_user"] = params.get("local_user", "root")
+    server_pwd = params["server_pwd"] = params.get("local_pwd")
+    client_ip = params["client_ip"] = params.get("remote_ip")
+    client_pwd = params["client_pwd"] = params.get("remote_pwd")
+    client_user = params["server_user"] = params.get("remote_user", "root")
+    tls_port = params.get("tls_port", "16514")
+    tls_uri = "qemu+tls://%s:%s/system" % (server_ip, tls_port)
+    tls_obj = None
+    remote_virsh_dargs = {'remote_ip': client_ip, 'remote_user': client_user,
+                          'remote_pwd': client_pwd, 'uri': tls_uri,
+                          'ssh_remote_auth': True}
 
     if not server_name:
         server_name = virt_admin.check_server_name()
-    ssh_key.setup_remote_ssh_key("localhost", "root", local_pwd)
+
+    daemon = utils_libvirtd.Libvirtd("virtproxyd")
 
     try:
-        virsh_instant = []
-        for _ in range(int(num_clients)):
-            virsh_instant.append(virsh.VirshPersistent(
-                uri="qemu+ssh://localhost/system"))
+        tls_obj = TLSConnection(params)
+        tls_obj.conn_setup()
+        tls_obj.auto_recover = True
+        utils_iptables.Firewall_cmd().add_port(tls_port, 'tcp', permanent=True)
 
-        out = vp.srv_clients_list(server_name,
-                                  ignore_status=True, debug=True)
-        client_id = out.stdout.strip().splitlines()[-1].split()[0]
-        result = vp.client_disconnect(server_name, client_id,
-                                      ignore_status=True, debug=True)
+        clients_instant = []
+        for _ in range(int(num_clients)):
+            # Under split daemon mode, we can connect to virtproxyd via
+            # remote tcp/tls connections,can not connect to virtproxyd direct
+            # on local host
+            clients_instant.append(virsh.VirshPersistent(**remote_virsh_dargs))
+
+        out = virt_admin.srv_clients_list(server_name, ignore_status=True,
+                                          debug=True)
+        client_id = out.stdout_text.strip().splitlines()[-1].split()[0]
+        result = virt_admin.client_disconnect(server_name, client_id,
+                                              ignore_status=True, debug=True)
 
         if result.exit_status:
             test.fail("This operation should "
                       "success but failed. output: \n %s" % result)
-        elif result.stdout.strip().split()[1][1:-1] != client_id:
+        elif result.stdout.decode().strip().split()[1][1:-1] != client_id:
             test.fail("virt-admin did not "
                       "disconnect the correct client.")
     finally:
         daemon.restart()
+        utils_iptables.Firewall_cmd().remove_port(tls_port, 'tcp', permanent=True)

--- a/libvirt/tests/src/virt_admin/management/virt_admin_server_clients_set.py
+++ b/libvirt/tests/src/virt_admin/management/virt_admin_server_clients_set.py
@@ -2,7 +2,8 @@ import logging
 from virttest import virt_admin
 from virttest import virsh
 from virttest import utils_libvirtd
-from virttest import ssh_key
+from virttest import utils_iptables
+from virttest.utils_conn import TLSConnection
 
 
 def run(test, params, env):
@@ -15,25 +16,6 @@ def run(test, params, env):
     6) check whether the above connection status is correct.
     """
 
-    server_name = params.get("server_name")
-    is_positive = params.get("is_positive") == "yes"
-    options_ref = params.get("options_ref")
-    nclients_max = params.get("nclients_maxi")
-    nclients = params.get("nclients")
-    nclients_unauth_max = params.get("nclients_unauth_maxi")
-    connect_able = params.get("connect_able")
-    options_test_together = params.get("options_test_together")
-    local_pwd = params.get("local_pwd")
-
-    if not server_name:
-        server_name = virt_admin.check_server_name()
-
-    config = virt_admin.managed_daemon_config()
-    daemon = utils_libvirtd.Libvirtd()
-    ssh_key.setup_remote_ssh_key("localhost", "root", local_pwd)
-    vp = virt_admin.VirtadminPersistent()
-    virsh_instance = []
-
     def clients_info(server):
         """
         check the attributes by server-clients-set.
@@ -42,16 +24,16 @@ def run(test, params, env):
         :params server: print the info of the clients connecting to this server
         :return: a dict obtained by transforming the result_info
         """
-        result_info = vp.srv_clients_info(server, ignore_status=True,
-                                          debug=True)
-        out = result_info.stdout.strip().splitlines()
+        result_info = virt_admin.srv_clients_info(server, ignore_status=True,
+                                                  debug=True)
+        out = result_info.stdout_text.strip().splitlines()
         out_split = [item.split(':') for item in out]
         out_dict = dict([[item[0].strip(), item[1].strip()] for item in out_split])
         return out_dict
 
     def chk_connect_to_daemon(connect_able):
         try:
-            virsh_instance.append(virsh.VirshPersistent(uri='qemu+ssh://localhost/system'))
+            virsh_instance.append(virsh.VirshPersistent(**remote_virsh_dargs))
         except Exception as info:
             if connect_able == "yes":
                 test.fail("Connection to daemon is not success, error:\n %s" % info)
@@ -66,7 +48,41 @@ def run(test, params, env):
                 test.fail("error: Connection to daemon should not success! "
                           "Check the attributes.")
 
+    server_name = params.get("server_name")
+    is_positive = params.get("is_positive") == "yes"
+    options_ref = params.get("options_ref")
+    nclients_max = params.get("nclients_maxi")
+    nclients = params.get("nclients")
+    nclients_unauth_max = params.get("nclients_unauth_maxi")
+    connect_able = params.get("connect_able")
+    options_test_together = params.get("options_test_together")
+    server_ip = params["server_ip"] = params.get("local_ip")
+    server_user = params["server_user"] = params.get("local_user", "root")
+    server_pwd = params["server_pwd"] = params.get("local_pwd")
+    client_ip = params["client_ip"] = params.get("remote_ip")
+    client_pwd = params["client_pwd"] = params.get("remote_pwd")
+    client_user = params["server_user"] = params.get("remote_user", "root")
+    tls_port = params.get("tls_port", "16514")
+    tls_uri = "qemu+tls://%s:%s/system" % (server_ip, tls_port)
+    tls_obj = None
+    remote_virsh_dargs = {'remote_ip': client_ip, 'remote_user': client_user,
+                          'remote_pwd': client_pwd, 'uri': tls_uri,
+                          'ssh_remote_auth': True}
+
+    if not server_name:
+        server_name = virt_admin.check_server_name()
+
+    config = virt_admin.managed_daemon_config()
+    daemon = utils_libvirtd.Libvirtd("virtproxyd")
+    virsh_instance = []
+
     try:
+        if nclients:
+            tls_obj = TLSConnection(params)
+            tls_obj.conn_setup()
+            tls_obj.auto_recover = True
+            utils_iptables.Firewall_cmd().add_port(tls_port, 'tcp', permanent=True)
+
         if options_ref:
             if "max-clients" in options_ref:
                 if nclients:
@@ -75,28 +91,26 @@ def run(test, params, env):
                         config.max_anonymous_clients = nclients_unauth_max
                         daemon.restart()
                         for _ in range(int(nclients)):
-                            virsh_instance.append(virsh.VirshPersistent(
-                                uri='qemu+ssh://localhost/system'))
-                        result = vp.srv_clients_set(server_name, max_clients=nclients_max,
-                                                    ignore_status=True, debug=True)
+                            virsh_instance.append(virsh.VirshPersistent(**remote_virsh_dargs))
+                        result = virt_admin.srv_clients_set(server_name, max_clients=nclients_max,
+                                                            ignore_status=True, debug=True)
                     elif int(nclients_max) <= int(nclients):
                         for _ in range(int(nclients)):
-                            virsh_instance.append(virsh.VirshPersistent(
-                                uri='qemu+ssh://localhost/system'))
-                        result = vp.srv_clients_set(server_name, max_clients=nclients_max,
-                                                    max_unauth_clients=nclients_unauth_max,
-                                                    ignore_status=True, debug=True)
+                            virsh_instance.append(virsh.VirshPersistent(**remote_virsh_dargs))
+                        result = virt_admin.srv_clients_set(server_name, max_clients=nclients_max,
+                                                            max_unauth_clients=nclients_unauth_max,
+                                                            ignore_status=True, debug=True)
 
                 else:
-                    result = vp.srv_clients_set(server_name, max_clients=nclients_max,
-                                                ignore_status=True, debug=True)
+                    result = virt_admin.srv_clients_set(server_name, max_clients=nclients_max,
+                                                        ignore_status=True, debug=True)
             elif "max-unauth-clients" in options_ref:
-                result = vp.srv_clients_set(server_name, max_unauth_clients=nclients_unauth_max,
-                                            ignore_status=True, debug=True)
+                result = virt_admin.srv_clients_set(server_name, max_unauth_clients=nclients_unauth_max,
+                                                    ignore_status=True, debug=True)
         elif options_test_together:
-            result = vp.srv_clients_set(server_name, max_clients=nclients_max,
-                                        max_unauth_clients=nclients_unauth_max,
-                                        ignore_status=True, debug=True)
+            result = virt_admin.srv_clients_set(server_name, max_clients=nclients_max,
+                                                max_unauth_clients=nclients_unauth_max,
+                                                ignore_status=True, debug=True)
 
         outdict = clients_info(server_name)
 
@@ -131,3 +145,4 @@ def run(test, params, env):
             session.close_session()
         config.restore()
         daemon.restart()
+        utils_iptables.Firewall_cmd().remove_port(tls_port, 'tcp', permanent=True)

--- a/libvirt/tests/src/virt_admin/monitor/virt_admin_srv_clients_info.py
+++ b/libvirt/tests/src/virt_admin/monitor/virt_admin_srv_clients_info.py
@@ -1,7 +1,8 @@
 from virttest import virt_admin
 from virttest import utils_libvirtd
+from virttest import utils_iptables
 from virttest import virsh
-from virttest import ssh_key
+from virttest.utils_conn import TLSConnection
 
 
 def run(test, params, env):
@@ -14,35 +15,48 @@ def run(test, params, env):
     4) Check whether the parameters value listed by srv-clients-info
        are the same with the above settings.
     """
+
     max_clients = params.get("max_clients")
     max_anonymous_clients = params.get("max_anonymous_clients")
     server_name = params.get("server_name")
     num_clients = params.get("num_clients")
-    local_pwd = params.get("local_pwd")
-
+    server_ip = params["server_ip"] = params.get("local_ip")
+    server_user = params["server_user"] = params.get("local_user", "root")
+    server_pwd = params["server_pwd"] = params.get("local_pwd")
+    client_ip = params["client_ip"] = params.get("remote_ip")
+    client_pwd = params["client_pwd"] = params.get("remote_pwd")
+    client_user = params["server_user"] = params.get("remote_user", "root")
+    tls_port = params.get("tls_port", "16514")
+    tls_uri = "qemu+tls://%s:%s/system" % (server_ip, tls_port)
+    tls_obj = None
+    remote_virsh_dargs = {'remote_ip': client_ip, 'remote_user': client_user,
+                          'remote_pwd': client_pwd, 'uri': tls_uri,
+                          'ssh_remote_auth': True}
     if not server_name:
         server_name = virt_admin.check_server_name()
 
     config = virt_admin.managed_daemon_config()
-    daemon = utils_libvirtd.Libvirtd()
-    ssh_key.setup_remote_ssh_key("localhost", "root", local_pwd)
+    daemon = utils_libvirtd.Libvirtd("virtproxyd")
 
     try:
         config.max_clients = max_clients
         config.max_anonymous_clients = max_anonymous_clients
         daemon.restart()
-        vp = virt_admin.VirtadminPersistent()
 
-        virsh_instant = []
+        tls_obj = TLSConnection(params)
+        tls_obj.conn_setup()
+        tls_obj.auto_recover = True
+        utils_iptables.Firewall_cmd().add_port(tls_port, 'tcp', permanent=True)
+
+        clients_instant = []
         for _ in range(int(num_clients)):
             # Under split daemon mode, we can connect to virtproxyd via
-            # remote connections,can not connect to virtproxyd direct
+            # remote tls/tcp connections,can not connect to virtproxyd direct
             # on local host
-            virsh_instant.append(virsh.VirshPersistent(
-                uri="qemu+ssh://localhost/system"))
+            clients_instant.append(virsh.VirshPersistent(**remote_virsh_dargs))
 
-        result = vp.srv_clients_info(server_name, ignore_status=True, debug=True)
-        output = result.stdout.strip().splitlines()
+        result = virt_admin.srv_clients_info(server_name, ignore_status=True, debug=True)
+        output = result.stdout_text.strip().splitlines()
         out_split = [item.split(':') for item in output]
         out_dict = dict([[item[0].strip(), item[1].strip()] for item in out_split])
 
@@ -60,3 +74,4 @@ def run(test, params, env):
     finally:
         config.restore()
         daemon.restart()
+        utils_iptables.Firewall_cmd().remove_port(tls_port, 'tcp', permanent=True)


### PR DESCRIPTION
1)Now, we can not connect to virtproxyd by ssh connection,
the original ssh connection is acctually connected to virtqemud.
Hence, now we can only connect to virtproxyd by tls/tcp.

2)Now, we need to specify server_name, otherwise utils_libvirtd.Libvirtd()
will connect to virtqemud by default

3)Remove VirtadminPersistent, as under split daemon, connection
will be disconnected when stop/restart daemon

Signed-off-by: Lili Zhu <lizhu@redhat.com>

