### PR TITLE
[virt_admin]Fix some issues according to current change

### DIFF
--- a/libvirt/tests/src/virt_admin/monitor/virt_admin_srv_threadpool_info.py
+++ b/libvirt/tests/src/virt_admin/monitor/virt_admin_srv_threadpool_info.py
@@ -20,8 +20,9 @@ def run(test, params, env):
 
     if not server_name:
         server_name = virt_admin.check_server_name()
+
     config = virt_admin.managed_daemon_config()
-    daemon = utils_libvirtd.Libvirtd()
+    daemon = utils_libvirtd.Libvirtd("virtproxyd")
 
     try:
         if server_name == "admin":
@@ -33,10 +34,10 @@ def run(test, params, env):
             config.prio_workers = prio_workers
 
         daemon.restart()
-        vp = virt_admin.VirtadminPersistent()
-        result = vp.srv_threadpool_info(server_name, ignore_status=True, debug=True)
+        result = virt_admin.srv_threadpool_info(server_name, ignore_status=True,
+                                                debug=True)
 
-        output = result.stdout.strip().splitlines()
+        output = result.stdout_text.strip().splitlines()
         out_split = [item.split(':') for item in output]
         out_dict = dict([[item[0].strip(), item[1].strip()] for item in out_split])
 


### PR DESCRIPTION
1)Now, we need to specify daemon name, otherwise utils_libvirtd.Libvirtd()
will connect to virtqemud by default. In this script, there is
other server called 'admin'. It is not suitable to use the server_name
as daemon_name. Hence, we need to specify the daemon name

2)Remove VirtadminPersistent, as under split daemon, connection
will be disconnected when stop/restart daemon

Signed-off-by: Lili Zhu <lizhu@redhat.com>