### PR TITLE
virtual_disks_vhostuser: skip cases on ppc

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_rotation_rate.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_rotation_rate.cfg
@@ -27,6 +27,7 @@
                     cmds_in_guest = "['smartctl -a /dev/${disk_target} | grep -E \'Rotation Rate:\'', 'cat /sys/block/sda/queue/rotational | grep 1']"
                 - at_dt:
                     only scsi_bus
+                    no ppc64le
                     at_dt = 'yes'
                     disk_target = 'sdb'
                     target_rotation = '5400'

--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_vhostuser.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_vhostuser.cfg
@@ -13,6 +13,7 @@
     type_name = "vhostuser"
     queues = 1
     disk_snapshot_attr = "no"
+    no ppc64le
     variants:
         - start_vhostuser_vm:
     variants:


### PR DESCRIPTION
- scsi bus does not support hotplug on ppc
- vhostuser does not support on ppc

Signed-off-by: Dan Zheng <dzheng@redhat.com>
