### PR TITLE
migrate_vm: Check vm's stats before destroying it

### DIFF
--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -2924,8 +2924,9 @@ def run(test, params, env):
                                                 cleanup=True,
                                                 ports=uri_port[1:])
                 remote_virsh_session = virsh.VirshPersistent(**remote_virsh_dargs)
-                logging.debug("Destroy remote guest")
-                remote_virsh_session.destroy(target_vm_name)
+                if remote_virsh_session.is_alive(target_vm_name):
+                    logging.debug("Destroy remote guest")
+                    remote_virsh_session.destroy(target_vm_name)
                 logging.debug("Recover remote guest xml")
                 remote_virsh_session.define(xml_path)
             except (process.CmdError, remote.SCPError) as detail:


### PR DESCRIPTION
The VM on the remote host is not running in some cases. So it can't
be destroyed correctly. Update to check vm's stats before destroying
it to fix this problem.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
Before fix:
` (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_vm.positive_testing.p2p_migration.basic.with_tls_reverse.with_postcopy: ERROR: Timeout expired while waiting for shell command to complete: 'destroy avocado-vt-remote-vm1 '    (output: "\nvirsh # error: Failed to destroy domain 'avocado-vt-remote-vm1'\nerror: Requested operation is not valid: domain is not running\n") (91.44 s)`

After fix:
` (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_vm.positive_testing.p2p_migration.basic.with_tls_reverse.with_postcopy: PASS (185.68 s)`

