### PR TITLE
Fix wwn cases failure due to qemu output format change for json

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
@@ -1755,10 +1755,18 @@ def run(test, params, env):
             if len(serial) != 0 and serial[0] != "":
                 cmd += " | grep serial=%s" % serial[0]
             if len(wwn) != 0 and wwn[0] != "":
+                wwn0_value = wwn[0]
+                # After libvirt 7.9.0, qemu output becomes json format,
+                # therefore wwn in hex is changed to decimal
+                if libvirt_version.version_compare(7, 9, 0):
+                    wwn0_value = str(int(wwn[0], 16))
                 if len(wwn) > 1:
-                    cmd += " | grep -E \"wwn=(0x)?%s.*wwn=(0x)?%s\"" % (wwn[0], wwn[1])
+                    wwn1_value = wwn[1]
+                    if libvirt_version.version_compare(7, 9, 0):
+                        wwn1_value = str(int(wwn[1], 16))
+                    cmd += " | grep -E \"wwn=(0x)?%s.*wwn=(0x)?%s\"" % (wwn0_value, wwn1_value)
                 else:
-                    cmd += " | grep -E \"wwn=(0x)?%s\"" % wwn[0]
+                    cmd += " | grep -E \"wwn=(0x)?%s\"" % wwn0_value
             if vendor != "":
                 cmd += " | grep vendor=%s" % vendor
             if product != "":


### PR DESCRIPTION
After libvirt 7.9.0 version and afterwards, qemu wwn output is changed to decimal
instead of hex

Signed-off-by: chunfuwen <chwen@redhat.com>

