### PR TITLE
sriov_nodedev: Ignore mac address change of VF

### DIFF
--- a/libvirt/tests/src/sriov/sriov_nodedev.py
+++ b/libvirt/tests/src/sriov/sriov_nodedev.py
@@ -106,13 +106,13 @@ def run(test, params, env):
 
         :param pf_name: The PF's
         :param exp_vf_mac: The expected vf's mac address
-        :raise: TestFail if not match
         """
-        logging.debug("VF's mac should be %s.", exp_vf_mac)
         vf_mac_act = utils_sriov.get_vf_mac(pf_name, is_admin=False)
         if exp_vf_mac != vf_mac_act:
-            test.fail("MAC address changed from '%s' to '%s' after reattaching "
-                      "vf." % (exp_vf_mac, vf_mac_act))
+            logging.error("MAC address changed from '%s' to '%s' after "
+                          "reattaching vf.", exp_vf_mac, vf_mac_act)
+        else:
+            logging.debug("VF's mac is still %s.", exp_vf_mac)
 
     def test_pf():
         """


### PR DESCRIPTION
The VF's mac address may be changed in some drivers.
Checked with feature owner, it's not a checkpoint of this case,
so update to log a message as error level.

Signed-off-by: Yingshun Cui <yicui@redhat.com>

Before the fix:
` (1/1) type_specific.io-github-autotest-libvirt.sriov_nodedev.vf: FAIL: MAC address changed from '9a:4a:27:b3:ad:b3' to '2a:78:eb:1e:b8:cc' after reattaching vf. (20.85 s)`

After the fix:
` (1/1) type_specific.io-github-autotest-libvirt.sriov_nodedev.vf: PASS (24.18 s)`
