### PR TITLE
remote_access: Add root password to fix type error

### DIFF
--- a/libvirt/tests/cfg/remote_access/remote_with_unix.cfg
+++ b/libvirt/tests/cfg/remote_access/remote_with_unix.cfg
@@ -60,6 +60,7 @@
                     su_user = "bob"
                     adduser_cmd = "useradd -g ${unix_sock_group} ${su_user}"
                     deluser_cmd = "userdel -r ${su_user}"
+                    auth_pwd = "${local_pwd}"
                 - socket_with_auth_conf:
                     auth_unix_rw = "sasl"
                     sasl_type = "digest-md5"
@@ -125,6 +126,7 @@
                     su_user = "bob"
                     status_error = "no"
                     patterns_virsh_cmd = ".*Permission denied.*"
+                    auth_pwd = "${local_pwd}"
                     variants:
                         - cfg_file:
                             traditional_mode = "yes"


### PR DESCRIPTION
Add root password to pass through the login prompt.

Signed-off-by: lcheng <lcheng@redhat.com>
