### PR TITLE
Fix managesave multi_guests case failure

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_managedsave.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_managedsave.py
@@ -172,7 +172,7 @@ def run(test, params, env):
         def wait_func():
             return libvirt_guests.raw_status().stdout.count("Resuming guest")
 
-        utils_misc.wait_for(wait_func, 5)
+        utils_misc.wait_for(wait_func, 15)
         if is_systemd:
             ret = libvirt_guests.raw_status()
         logging.info("status output: %s", ret.stdout_text)


### PR DESCRIPTION
Previous timeout 5 seconds may not be enough in extreme case

Signed-off-by: chunfuwen <chwen@redhat.com>


