### PR TITLE
vcpu_misc: Check cpu xml after managedsave and restore 

### DIFF
--- a/libvirt/tests/cfg/cpu/vcpu_misc.cfg
+++ b/libvirt/tests/cfg/cpu/vcpu_misc.cfg
@@ -25,6 +25,11 @@
                     func_supported_since_libvirt_ver = (7, 3, 0)
                     cpu_mode = 'maximum'
                     cmd_in_guest = "lscpu |grep '^Model name:'|cut -d':' -f2"
+                - managedsave_restore:
+                    cpu_mode = "host-passthrough"
+                    test_operations = "managedsave_restore"
+                    expected_str_after_startup = 'mode="host-passthrough"'
+                    customize_cpu_features = "yes"
         - negative_test:
             status_error = "yes"
             variants:

--- a/spell.ignore
+++ b/spell.ignore
@@ -409,6 +409,7 @@ initscripts
 inodes
 inpect
 installroot
+invtsc
 inx
 io
 ioapci


### PR DESCRIPTION
* Add new case for RHEL7-17959: Check domain cpu xm is not updated after Managedsave and restore

    Signed-off-by: nanli <nanli@redhat.com>


* **Test results** : 
  /usr/local/bin/avocado run --vt-type libvirt --vt-machine-type q35 vcpu_misc.positive_test.managedsave_restore --vt-connect-uri qemu:///system
JOB ID     : 94b232838f0a0d7dd1b54c65c300621f14bbf192
JOB LOG    : /root/avocado/job-results/job-2021-12-15T15.10-94b2328/job.log
 (1/1) type_specific.io-github-autotest-libvirt.vcpu_misc.positive_test.managedsave_restore: PASS (4.64 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 5.07 s


