### PR TITLE
v2v: fix wrong expected video type in case function_test_esx..uefi.wi…

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -108,6 +108,7 @@
                         - win2019:
                             only esx_67
                             main_vm = VM_NAME_ESX_UEFI_WINDOWS_V2V_EXAMPLE
+                            os_version = "win2019"
                             checkpoint = 'fstrim_warning'
                             msg_content = 'virt-v2v: warning: fstrim on guest filesystem /dev/.*? failed.  Usually'
                             expect_msg = yes


### PR DESCRIPTION
…n2019

Windows guest should add os_version variant, so the script can set
correct expected video type in checkpoint.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>
