### PR TITLE
serial_pty_log: Adjust test for aarch64

### DIFF
--- a/libvirt/tests/cfg/serial/serial_pty_log.cfg
+++ b/libvirt/tests/cfg/serial/serial_pty_log.cfg
@@ -8,10 +8,18 @@
             log_file = /var/lib/libvirt/console1.log
             target_type = isa-serial
             target_model = isa-serial
+            aarch64:
+                target_type = system-serial
+                target_model = pl011
+                boot_prompt = 'localhost login'
             stdio_handler = 'file'
         - logd:
             serial_dev_type = pty
             log_file = /var/lib/libvirt/console1.log
             target_type = isa-serial
             target_model = isa-serial
+            aarch64:
+                target_type = system-serial
+                target_model = pl011
+                boot_prompt = 'localhost login'
             stdio_handler = 'logd'


### PR DESCRIPTION
Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Before
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio serial.pty.log.file serial.pty.log.logd                                                                  
JOB ID     : b8840ab359bab88704856ba104411807a835822a
JOB LOG    : /root/avocado/job-results/job-2021-12-15T01.50-b8840ab/job.log
 (1/2) type_specific.io-github-autotest-libvirt.serial.pty.log.file: ERROR: Unexpected error: Failed to find the vm login prompt from /var/lib/libvirt/console1.log (86.22 s)                
 (2/2) type_specific.io-github-autotest-libvirt.serial.pty.log.logd: ERROR: Unexpected error: Failed to find the vm login prompt from /var/lib/libvirt/console1.log (86.05 s)                
RESULTS    : PASS 0 | ERROR 2 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 173.87 s

```

After
aarch64:
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio serial.pty.log.file serial.pty.log.logd                                                           
JOB ID     : 9df4b9c30fcd96a1d67fe7355cba79c5b40114b7
JOB LOG    : /root/avocado/job-results/job-2021-12-15T01.55-9df4b9c/job.log
 (1/2) type_specific.io-github-autotest-libvirt.serial.pty.log.file: PASS (85.34 s)
 (2/2) type_specific.io-github-autotest-libvirt.serial.pty.log.logd: PASS (86.42 s)
```

x86_64
```
# avocado run --vt-type libvirt --vt-machine-type q35 serial.pty.log.file serial.pty.log.logd
JOB ID     : bfea24689b56bceb47d2df80695f0ae012646c0a
JOB LOG    : /root/avocado/job-results/job-2021-12-15T21.02-bfea246/job.log
 (1/2) type_specific.io-github-autotest-libvirt.serial.pty.log.file: PASS (30.62 s)
 (2/2) type_specific.io-github-autotest-libvirt.serial.pty.log.logd: PASS (31.00 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 62.02 s
```