### PR TITLE
[minor fix] filesystem_device: fix "chown: cannot access '/var/tmp/vm001.socket

### DIFF
--- a/libvirt/tests/src/virtual_device/filesystem_device.py
+++ b/libvirt/tests/src/virtual_device/filesystem_device.py
@@ -7,6 +7,7 @@ from avocado.utils import process
 
 from virttest import virsh
 from virttest import utils_test
+from virttest import utils_misc
 from virttest import libvirt_version
 from virttest.libvirt_xml import vm_xml
 from virttest.staging import utils_memory
@@ -95,6 +96,8 @@ def run(test, params, env):
         cmd = "systemd-run %s --socket-path=%s -o source=%s" % (path, source_socket, source_dir)
         try:
             process.run(cmd, ignore_status=False, shell=True)
+            # Make sure the socket is created
+            utils_misc.wait_for(lambda: os.path.isdir(source_socket), timeout=3)
             process.run("chown qemu:qemu %s" % source_socket, ignore_status=False)
             process.run('chcon -t svirt_image_t %s' % source_socket, ignore_status=False, shell=True)
         except Exception as err:


### PR DESCRIPTION
Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Before
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virtual_devices.filesystem_device.positive_test.hugepages_backed.nop.externally_launched_fs_test.launched_mode                  
JOB ID     : 0d4c065e312bd03e3561b1b32d813f38111f19d4
JOB LOG    : /root/avocado/job-results/job-2021-12-16T04.19-0d4c065/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_devices.filesystem_device.positive_test.hugepages_backed.nop.externally_launched_fs_test.launched_mode: FAIL: Command 'chown qemu:qemu /var/tmp/vm001.socket' failed.\nstdout: b''\nstderr: b"chown: cannot access '/var/tmp/vm001.socket': No such file or directory\n"\nadditional_info: None (39.83 s)                          
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 41.44 s
```

After
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virtual_devices.filesystem_device.positive_test.hugepages_backed.nop.externally_launched_fs_test.launched_mode                     
JOB ID     : f0cf43d0ede66fc845f364000fa27b4ed28b59b3
JOB LOG    : /root/avocado/job-results/job-2021-12-16T04.20-f0cf43d/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_devices.filesystem_device.positive_test.hugepages_backed.nop.externally_launched_fs_test.launched_mode: PASS (97.90 s)               
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 99.51 s
```

