### PR TITLE
diagnose_data: improve failure message

### DIFF
--- a/libvirt/tests/src/cpu/diagnose_data.py
+++ b/libvirt/tests/src/cpu/diagnose_data.py
@@ -69,9 +69,13 @@ def raise_if_only_zero_entries(session):
     :param session: guest session
     :raises AssertionError: if check fails
     """
-    out = session.cmd_output('cat /sys/kernel/debug/diag_stat|grep "diag 318"')
+    out = session.cmd_output('cat /sys/kernel/debug/diag_stat')
     logging.debug("diag_stat contains: %s", out)
-    no_zeros = out.replace("0", "").replace("diag 318", "")
+    diag_318_line = [x for x in out.split('\n') if 'diag 318' in x]
+    if not diag_318_line:
+        raise AssertionError("No diag 318 entry."
+                             " Please, check log.")
+    no_zeros = diag_318_line[0].replace("0", "").replace("diag 318", "")
     if not re.search(r"\d", no_zeros):
-        raise AssertionError("Expected counters to be none zero, got: %s"
-                             % out)
+        raise AssertionError("Expected counters to be none zero."
+                             " Please, check log.")


### PR DESCRIPTION
The diag 318 might not be available in some older kernels.
Handle that situation and improve the log.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>