### PR TITLE
libvirt_rng: add config to force virtio device usage

### DIFF
--- a/libvirt/tests/cfg/libvirt_rng.cfg
+++ b/libvirt/tests/cfg/libvirt_rng.cfg
@@ -3,6 +3,8 @@
     start_vm = no
     # Enter a partition name for partition case in scsi test.
     status_error = no
+    s390-virtio:
+        set_virtio_current = yes
     variants:
         - hotplug_unplug:
             only backend_rdm.default, backend_tcp, backend_udp, backend_builtin

--- a/libvirt/tests/src/libvirt_rng.py
+++ b/libvirt/tests/src/libvirt_rng.py
@@ -329,7 +329,8 @@ def run(test, params, env):
             else:
                 logging.info("Hexdump do not fail with error")
 
-    def check_guest(session, expect_fail=False):
+    def check_guest(session, expect_fail=False,
+                    set_virtio_current=False):
         """
         Check random device on guest
 
@@ -344,8 +345,18 @@ def run(test, params, env):
         rng_currt = session.cmd_output("cat %s" % rng_files[1],
                                        timeout=timeout).strip()
         logging.debug("rng avail:%s, current:%s", rng_avail, rng_currt)
+        if not rng_avail.count("virtio"):
+            test.fail("Failed to check rng file on guest."
+                      " The virtio device is not available.")
+        if set_virtio_current:
+            virtio_dev = [x for x in rng_avail.split('\n') if 'virtio' in x][0]
+            _ = session.cmd_output(("echo -n %s > %s" %
+                                    (virtio_dev, rng_files[1])),
+                                   timeout=timeout)
+            rng_currt = virtio_dev
         if not rng_currt.count("virtio") or rng_currt not in rng_avail:
-            test.fail("Failed to check rng file on guest")
+            test.fail("Failed to check rng file on guest."
+                      " The virtio device is not the current rng device.")
 
         # Read the random device
         rng_rate = params.get("rng_rate")
@@ -450,6 +461,7 @@ def run(test, params, env):
 
     test_host = "yes" == params.get("test_host", "no")
     test_guest = "yes" == params.get("test_guest", "no")
+    set_virtio_current = "yes" == params.get("set_virtio_current", "no")
     test_guest_dump = "yes" == params.get("test_guest_dump", "no")
     test_qemu_cmd = "yes" == params.get("test_qemu_cmd", "no")
     test_snapshot = "yes" == params.get("test_snapshot", "no")
@@ -605,7 +617,7 @@ def run(test, params, env):
                 check_host()
             session = vm.wait_for_login()
             if test_guest:
-                check_guest(session)
+                check_guest(session, set_virtio_current=set_virtio_current)
             if test_guest_dump:
                 check_guest_dump(session, True)
             if test_snapshot:


### PR DESCRIPTION
The guest kernel selects per default an rng device based
on the available devices' priorities.

On s390x, guest kernels will choose the s390-trng device
available through the CPU feature msa 7 and selected, ref.
https://github.com/torvalds/linux/commit/d041315ef75cf52df19613f56a2da2c5911c163c

This will make tests fail with message

"Failed to check rng file on guest"

Add a config switch to force usage of the virtio rng device.
The default is not to force, ie. the current behavior isn't changed
for other architectures.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>