### PR TITLE
filesystem_device: reload kvm for hugepages on s390x

### DIFF
--- a/libvirt/tests/cfg/virtual_device/filesystem_device.cfg
+++ b/libvirt/tests/cfg/virtual_device/filesystem_device.cfg
@@ -90,6 +90,8 @@
             variants:
                 - hugepages_backed:
                       with_hugepages = yes
+                      s390-virtio:
+                          kvm_module_parameters = "hpage=1"
                 - file_backed:
                       with_hugepages = no
                 - memfd_backed:


### PR DESCRIPTION
Use avocado-vt's env_process to make sure hugepages are
supported for kvm on s390x.
Details s. avocado-vt/virttest/utils_kernel_module.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>
