### PR TITLE
virsh_event: fix test cases for s390x

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_event.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_event.cfg
@@ -87,9 +87,12 @@
                         device_target_bus = "scsi"
                     pseries:
                         device_target_bus = "scsi"
+                    s390-virtio:
+                        device_target_bus = "scsi"
                     aarch64:
                         device_target_bus = "scsi"
                 - rtc-change_event:
+                    no s390-virtio
                     event_name = "rtc-change"
                     events_list = "hwclock"
                 - metadata-change_event:
@@ -100,6 +103,7 @@
                     metadata_value = "<app xmlns:foobar='http://foo.bar/'></app>"
                 - device-removal-failed_event:
                     no pseries
+                    no s390-virtio
                     event_name = "device-removal-failed"
                     events_list = "detach-dimm"
                     max_mem = 25600000
@@ -113,6 +117,8 @@
                 - watchdog_event:
                     event_all_option = "yes"
                     watchdog_model = 'i6300esb'
+                    s390-virtio:
+                        watchdog_model = 'diag288'
                     events_list = "watchdog"
                     variants:
                         - action_pause:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
@@ -507,6 +507,7 @@ def run(test, params, env):
                     logging.debug("Current vmxml with watchdog dev is %s\n" % vmxml)
                     virsh.start(dom.name, **virsh_dargs)
                     session = dom.wait_for_login()
+                    watchdog_dev.try_modprobe(session)
                     try:
                         session.cmd("echo 0 > /dev/watchdog")
                     except (ShellTimeoutError, ShellProcessTerminatedError) as details:


### PR DESCRIPTION
Depends on https://github.com/avocado-framework/avocado-vt/pull/3309

1. Make sure watchdog is available
   Move logic for module load to avocado-vt
2. Memory hot-(un)-plug not available, don't run
3. Use SCSI controller for cdrom

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>