### PR TITLE
watchdog: relax qemu cmdline check

### DIFF
--- a/libvirt/tests/src/virtual_device/watchdog.py
+++ b/libvirt/tests/src/virtual_device/watchdog.py
@@ -29,7 +29,7 @@ def run(test, params, env):
 
         :param model: action when watchdog triggered
         """
-        watchdog_device = "device %s" % model
+        watchdog_device = model
         if action == "dump":
             watchdog_action = "watchdog-action pause"
         else:
@@ -238,6 +238,7 @@ def run(test, params, env):
             if not utils_misc.wait_for(lambda: watchdog_attached(vm.name), 60):
                 test.fail("Failed to hotplug watchdog device.")
         session = vm.wait_for_login()
+        logging.debug("Current XML: %s" % vm_xml.VMXML.new_from_dumpxml(vm_name))
 
         # No need to trigger watchdog after hotunplug
         if hotunplug_test:


### PR DESCRIPTION
The used qemu interface for watchdog devices has changed from
version 6.1 to 6.2.

Compare

6.1: -device diag288,id=watchdog0 -watchdog-action inject-nmi
6.2: -device {"driver":"diag288","id":"watchdog0"} -watchdog-action
  inject-nmi

Therefore, tests failed with qemu 6.2 because they checked the qemu
cmdline according to 6.1 interface.

Update the test code to only check if the name is listed. This should
sufficient, esp. considering that the actual actions are tested later
on. The variable 'watchdog_device' is only used for the cmdline check.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>
