### PR TITLE
input_devices: relax qemu cmdline check

### DIFF
--- a/libvirt/tests/src/virtual_device/input_devices.py
+++ b/libvirt/tests/src/virtual_device/input_devices.py
@@ -43,16 +43,16 @@ def run(test, params, env):
         with open('/proc/%s/cmdline' % vm.get_pid(), 'r') as cmdline_file:
             cmdline = cmdline_file.read()
         if bus_type == "usb" and input_type == "keyboard":
-            pattern = r"-device.%s-kbd" % bus_type
+            pattern = r"-device.*%s-kbd" % bus_type
         elif input_type == "passthrough":
-            pattern = r"-device.%s-input-host-pci" % bus_type
+            pattern = r"-device.*%s-input-host-pci" % bus_type
         else:
-            pattern = r"-device.%s-%s" % (bus_type, input_type)
+            pattern = r"-device.*%s-%s" % (bus_type, input_type)
         if not re.search(pattern, cmdline):
             test.fail("Can not find the %s input device "
                       "in qemu cmd line." % input_type)
         if with_packed:
-            pattern = r"packed=%s" % driver_packed
+            pattern = r"packed.*%s" % driver_packed
             if not re.search(pattern, cmdline):
                 test.fail("Can not find the packed driver "
                           "in qemu cmd line")


### PR DESCRIPTION
The used qemu interface for devices has changed from version 6.1 to 6.2.
Tests will failed with qemu 6.2 during qemu commandline check.

Update the test code to allow for both 6.1 and 6.2 API.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>