### PR TITLE
Update mtu 4096

### DIFF
--- a/libvirt/tests/cfg/virtual_network/mtu.cfg
+++ b/libvirt/tests/cfg/virtual_network/mtu.cfg
@@ -1,7 +1,7 @@
 - virtual_network.mtu:
     type = mtu
     start_vm = no
-    mtu_size = 6000
+    mtu_size = 4096
     model = virtio
     timeout = 240
     pseries:


### PR DESCRIPTION
The mtu '6000' or '4096' both can set successfully on x86 systems.
But on big endian systems, '4096' is judged as invalid as one kernel
bug 2026234. Update this test parameter to '4096' to cover this bug.

Signed-off-by: Yalan Zhang <yalzhang@redhat.com>