### PR TITLE
tpm_device: relax qemu cmdline check

### DIFF
--- a/libvirt/tests/src/virtual_device/tpm_device.py
+++ b/libvirt/tests/src/virtual_device/tpm_device.py
@@ -252,7 +252,7 @@ def run(test, params, env):
             cmdline = cmdline_file.read()
             logging.debug("Qemu cmd line info:\n %s", cmdline)
         # Check tpm model
-        pattern_list = ["-device.%s" % tpm_model]
+        pattern_list = ["-device.*%s" % tpm_model]
         # Check backend type
         if backend_type == "passthrough":
             dev_num = re.search(r"\d+", device_path).group()
@@ -260,10 +260,10 @@ def run(test, params, env):
         else:
             # emulator backend
             backend_segment = "id=tpm-tpm0,chardev=chrtpm"
-        pattern_list.append("-tpmdev.%s,%s" % (backend_type, backend_segment))
+        pattern_list.append("-tpmdev.*%s,%s" % (backend_type, backend_segment))
         # Check chardev socket for vtpm
         if backend_type == "emulator":
-            pattern_list.append("-chardev.socket,id=chrtpm,"
+            pattern_list.append("-chardev.*socket,id=chrtpm,"
                                 "path=.*/run/libvirt/qemu/swtpm/%s-%s-swtpm.sock" % (domid, vm_name))
         for pattern in pattern_list:
             if not re.search(pattern, cmdline):


### PR DESCRIPTION
The used qemu interface for devices has changed from version 6.1 to 6.2.
Update the test code to allow for both 6.1 and 6.2 API.

Signed-off-by: Yanqiu Zhang <yanqzhan@redhat.com>

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [ ] Description of the cases
- [ ] Links of libvirt features, libvirt bugs or case IDs
- [ ] Test results

## If the PR is bug cases
- [ ] Bug descriptions or bug links
- [ ] Test results

## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
