### PR TITLE
libvirt_rng: relax qemu cmdline check

### DIFF
--- a/libvirt/tests/src/libvirt_rng.py
+++ b/libvirt/tests/src/libvirt_rng.py
@@ -206,6 +206,8 @@ def run(test, params, env):
         backend_source_list = dparams.get("backend_source",
                                           "").split()
         cmd = ("ps -ef | grep %s | grep -v grep" % vm_name)
+        logging.debug("Qemu cmd line info:\n")
+        process.run(cmd, ignore_status=True, shell=True)
         chardev = src_host = src_port = None
         if backend_type == "tcp":
             chardev = "socket"
@@ -223,10 +225,10 @@ def run(test, params, env):
             cmd += (" | grep 'chardev %s,.*host=%s,port=%s'"
                     % (chardev, src_host, src_port))
         if rng_model == "virtio":
-            cmd += (" | grep 'device %s'" % dparams.get("rng_device"))
+            cmd += (" | grep 'device.*%s'" % dparams.get("rng_device"))
         if rng_rate:
             rate = ast.literal_eval(rng_rate)
-            cmd += (" | grep 'max-bytes=%s,period=%s'"
+            cmd += (" | grep 'max-bytes.*%s.*period.*%s'"
                     % (rate['bytes'], rate['period']))
         if with_packed:
             cmd += (" | grep 'packed=%s'" % driver_packed)


### PR DESCRIPTION
The used qemu interface for devices has changed from version 6.1 to 6.2.
Update the test code to allow for both 6.1 and 6.2 API.

Signed-off-by: Yanqiu Zhang <yanqzhan@redhat.com>

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [ ] Description of the cases
- [ ] Links of libvirt features, libvirt bugs or case IDs
- [ ] Test results

## If the PR is bug cases
- [ ] Bug descriptions or bug links
- [ ] Test results

## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
