### PR TITLE
Update the path of the loader

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_network.py
+++ b/libvirt/tests/src/virtual_network/iface_network.py
@@ -88,7 +88,7 @@ TIMEOUT 3"""
             osxml.type = vmxml.os.type
             osxml.arch = vmxml.os.arch
             osxml.machine = vmxml.os.machine
-            osxml.loader = "/usr/share/seabios/bios.bin"
+            osxml.loader = "/usr/share/seabios/bios-256k.bin"
             osxml.bios_useserial = "yes"
             if utils_misc.compare_qemu_version(4, 0, 0, False):
                 osxml.bios_reboot_timeout = "-1"


### PR DESCRIPTION
VM use "/usr/share/seabios/bios-256k.bin" both on rhel 8&9.
Correct the path of the loader.

Signed-off-by: Yalan Zhang <yalzhang@redhat.com>