### PR TITLE
migrate_gluster: Update disk type

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_gluster.cfg
+++ b/libvirt/tests/cfg/migration/migrate_gluster.cfg
@@ -4,11 +4,10 @@
     ssh_timeout = 60
     migration_setup = "yes"
     replace_vm_disk = "yes"
-    disk_type = "network"
+    disk_type = "file"
     disk_target = "vda"
     disk_target_bus = "virtio"
     disk_format = "qcow2"
-    disk_source_protocol = "gluster"
     image_size = "10G"
     vol_name = "vol_migrate_vm"
     pool_name = "glusterfs"


### PR DESCRIPTION
Don't support driver gluster in new version of libvirt, so update
 disk type from 'network' to 'file'.

Signed-off-by: lcheng <lcheng@redhat.com>
