### PR TITLE
fix qemu cmd line check failure for memory_misc

### DIFF
--- a/libvirt/tests/cfg/memory/memory_misc.cfg
+++ b/libvirt/tests/cfg/memory/memory_misc.cfg
@@ -58,7 +58,7 @@
                     dimm_device_1 = {'mem_model': 'dimm', 'target': {'size': 524288, 'size_unit': 'KiB', 'node': 0}, 'alias': {'name': 'dimm2'}, 'address': {'attrs': {'type': 'dimm', 'slot': '2', 'base': '0x120000000'}}}
                     dimm_device_2 = {'mem_model': 'dimm', 'target': {'size': 524288, 'size_unit': 'KiB', 'node': 0}, 'alias': {'name': 'dimm4'}, 'address': {'attrs': {'type': 'dimm', 'slot': '4', 'base': '0x140000000'}}}
                     at_dimm_device = {'mem_model': 'dimm', 'target': {'size': 524288, 'size_unit': 'KiB', 'node': 0}, 'address': {'attrs': {'type': 'dimm', 'slot': '12'}}}
-                    qemu_check = 'id=dimm12,slot=12'
+                    qemu_check = 'id\W{1,3}dimm12.*slot\W{1,2}12'
         - audit_size:
             variants case:
                 - at_dt_mem:

--- a/libvirt/tests/src/memory/memory_misc.py
+++ b/libvirt/tests/src/memory/memory_misc.py
@@ -260,9 +260,11 @@ def run(test, params, env):
         dimm_device_num = len(dimm_devices_attrs)
         qemu_cmd = 'pgrep -a qemu'
         qemu_cmd_output = process.run(qemu_cmd, verbose=True).stdout_text
-        if qemu_cmd_output.count('-device pc-dimm') != dimm_device_num:
+        qemu_cmd_num = len(re.findall("-device.*?pc-dimm", qemu_cmd_output))
+        if qemu_cmd_num != dimm_device_num:
             test.fail('The amount of dimm device in qemu command line does not'
-                      ' match vmxml, should be %d' % dimm_device_num)
+                      ' match vmxml, expect %d, but get %d' % (dimm_device_num,
+                                                               qemu_cmd_num))
 
         # Attach a mem device
         at_dimm_device_attrs = eval(params.get('at_dimm_device'))
@@ -276,9 +278,11 @@ def run(test, params, env):
 
         # Check qemu cmd line for attached dimm device
         new_qemu_cmd_output = process.run(qemu_cmd, verbose=True).stdout_text
-        if new_qemu_cmd_output.count('-device pc-dimm') != dimm_device_num + 1:
+        new_qemu_cmd_num = len(re.findall("-device.*?pc-dimm", new_qemu_cmd_output))
+        if new_qemu_cmd_num != dimm_device_num + 1:
             test.fail('The amount of dimm device in qemu command line does not'
-                      ' match vmxml, should be %d' % (dimm_device_num + 1))
+                      ' match vmxml, expect %d, but get %d' % (dimm_device_num + 1,
+                                                               new_qemu_cmd_num))
         libvirt.check_qemu_cmd_line(qemu_check)
 
     def setup_test_audit_size(case):


### PR DESCRIPTION
Signed-off-by: Kyla Zhang <weizhan@redhat.com>
2 qemu-kvm version results all pass
```
 (1/1) type_specific.io-github-autotest-libvirt.memory_misc.dimm.multiop: PASS (11.28 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 12.01 s

 (1/1) type_specific.io-github-autotest-libvirt.memory_misc.dimm.multiop: PASS (11.02 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 11.71 s
```