### PR TITLE
Fix the setmem case qemu-cmd-line match error

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_setmem.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_setmem.cfg
@@ -114,7 +114,7 @@
                     with_packed = "yes"
                     driver_packed = "on"
                     expect_xml_line = "<driver packed="%s""
-                    expect_qemu_line = "-device virtio-balloon-pci.*packed=%s"
+                    expect_qemu_line = "-device.*virtio-balloon-pci.*packed\W{1,2}%s"
         - invalid_options:
             # These should fail on all versions
             status_error = "yes"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_setmem.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_setmem.py
@@ -284,7 +284,10 @@ def run(test, params, env):
     # Check guest dumpxml and qemu command in with_packed attribute
     if with_packed:
         expect_xml_line = expect_xml_line % driver_packed
-        expect_qemu_line = expect_qemu_line % driver_packed
+        if utils_misc.compare_qemu_version(6, 2, 0, is_rhev=False):
+            expect_qemu_line = expect_qemu_line % "true"
+        else:
+            expect_qemu_line = expect_qemu_line % driver_packed
         libvirt.check_dumpxml(vm, expect_xml_line)
         libvirt.check_qemu_cmd_line(expect_qemu_line)
 


### PR DESCRIPTION
Signed-off-by: Kyla Zhang <weizhan@redhat.com>

Pass on both old and new qemu-kvm package
```
 (1/1) type_specific.io-github-autotest-libvirt.virsh.setmem.memballoon_option.with_packed_on: PASS (60.79 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 61.48 s

 (1/1) type_specific.io-github-autotest-libvirt.virsh.setmem.memballoon_option.with_packed_on: PASS (60.74 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 61.46 s
```