### PR TITLE
Fix No more available PCI slots for virtual devices

### DIFF
--- a/libvirt/tests/src/virtual_device/filesystem_device.py
+++ b/libvirt/tests/src/virtual_device/filesystem_device.py
@@ -13,6 +13,7 @@ from virttest.libvirt_xml import vm_xml
 from virttest.staging import utils_memory
 from virttest.utils_test import libvirt_device_utils
 from virttest.utils_test import libvirt
+from virttest.utils_libvirt import libvirt_pcicontr
 
 
 def run(test, params, env):
@@ -259,6 +260,7 @@ def run(test, params, env):
                         vmxml.add_device(fs)
                         vmxml.sync()
             logging.debug(vmxml)
+            libvirt_pcicontr.reset_pci_num(vm_names[index])
             result = virsh.start(vm_names[index], debug=True)
             if hotplug_unplug:
                 for fs_dev in fs_devs:


### PR DESCRIPTION
Signed-off-by: Kyla Zhang <weizhan@redhat.com>

```
 (1/6) type_specific.io-github-autotest-libvirt.virtual_devices.filesystem_device.positive_test.hugepages_backed.hotplug_unplug.detach_device_alias.fs_test.xattr_on.flock_on.lock_posix_on.cache_mode_none.multiple_fs.one_guest: PASS (74.51 s)
 (2/6) type_specific.io-github-autotest-libvirt.virtual_devices.filesystem_device.positive_test.hugepages_backed.hotplug_unplug.detach_device.fs_test.xattr_on.flock_on.lock_posix_on.cache_mode_none.multiple_fs.one_guest: PASS (82.01 s)
 (3/6) type_specific.io-github-autotest-libvirt.virtual_devices.filesystem_device.positive_test.file_backed.hotplug_unplug.detach_device_alias.fs_test.xattr_on.flock_on.lock_posix_on.cache_mode_none.multiple_fs.one_guest: PASS (72.22 s)
 (4/6) type_specific.io-github-autotest-libvirt.virtual_devices.filesystem_device.positive_test.file_backed.hotplug_unplug.detach_device.fs_test.xattr_on.flock_on.lock_posix_on.cache_mode_none.multiple_fs.one_guest: PASS (77.41 s)
 (5/6) type_specific.io-github-autotest-libvirt.virtual_devices.filesystem_device.positive_test.memfd_backed.hotplug_unplug.detach_device_alias.fs_test.xattr_on.flock_on.lock_posix_on.cache_mode_none.multiple_fs.one_guest: PASS (78.77 s)
 (6/6) type_specific.io-github-autotest-libvirt.virtual_devices.filesystem_device.positive_test.memfd_backed.hotplug_unplug.detach_device.fs_test.xattr_on.flock_on.lock_posix_on.cache_mode_none.multiple_fs.one_guest: PASS (132.79 s)
RESULTS    : PASS 6 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 518.72 s
```