### PR TITLE
Fix video devices qemu cmd check failure

### DIFF
--- a/libvirt/tests/src/virtual_device/video_devices.py
+++ b/libvirt/tests/src/virtual_device/video_devices.py
@@ -6,6 +6,7 @@ from virttest.libvirt_xml.devices.video import Video
 from virttest.utils_test import libvirt
 from virttest import virsh
 from virttest import libvirt_version
+from virttest import utils_misc
 
 from six import iteritems
 
@@ -100,15 +101,15 @@ def run(test, params, env):
         cmdline = open('/proc/%s/cmdline' % vm.get_pid()).read().replace("\x00", " ")
         logging.debug("the cmdline is: %s" % cmdline)
         # s390x only supports virtio
-        s390x_pattern = r"-device\svirtio-gpu-ccw"
+        s390x_pattern = r"-device.*virtio-gpu-ccw"
         # aarch64 only supports virtio
-        aarch64_pattern = r"-device\svirtio-gpu-pci"
+        aarch64_pattern = r"-device.*virtio-gpu-pci"
 
         if is_primary or is_primary is None:
             if model_type == "vga":
-                pattern = r"-device\sVGA"
+                pattern = r"-device.*VGA"
             else:
-                pattern = r"-device\s%s-vga" % model_type
+                pattern = r"-device.*%s-vga" % model_type
             if guest_arch == 's390x':
                 pattern = s390x_pattern
             elif guest_arch == 'aarch64':
@@ -118,11 +119,14 @@ def run(test, params, env):
                           "in qemu cmd line." % model_type)
         else:
             if model_type == "qxl":
-                pattern = r"-device\sqxl,"
+                pattern = r"-device.*qxl,"
             elif model_type == "virtio":
-                pattern = r"-device\svirtio-gpu-pci"
+                pattern = r"-device.*virtio-gpu-pci"
                 if with_packed:
-                    pattern = r"-device\svirtio-gpu-pci.*packed=%s" % driver_packed
+                    if utils_misc.compare_qemu_version(6, 2, 0, is_rhev=False):
+                        pattern = r"-device.*virtio-gpu-pci.*packed\W{1,2}%s" % "true"
+                    else:
+                        pattern = r"-device.*virtio-gpu-pci.*packed\W{1,2}%s" % driver_packed
             if guest_arch == 's390x':
                 pattern = s390x_pattern
             if not re.search(pattern, cmdline):
@@ -137,14 +141,14 @@ def run(test, params, env):
         cmdline = open('/proc/%s/cmdline' % vm.get_pid()).read().replace("\x00", " ")
         logging.debug("the cmdline is: %s" % cmdline)
         # s390x only supports virtio
-        s390x_pattern = r"-device\svirtio-gpu-ccw\S+max_outputs=%s"
+        s390x_pattern = r"-device.*virtio-gpu-ccw.*max_outputs\W{1,2}%s"
         # aarch64 only supports virtio
-        aarch64_pattern = r"-device\svirtio-gpu-pci\S+max_outputs=%s"
+        aarch64_pattern = r"-device.*virtio-gpu-pci.*max_outputs\W{1,2}%s"
 
         if is_primary or is_primary is None:
             model_heads = kwargs.get("model_heads", default_primary_heads)
             if model_type == "qxl" or model_type == "virtio":
-                pattern = r"-device\s%s-vga\S+max_outputs=%s" % (model_type, model_heads)
+                pattern = r"-device.*%s-vga.*max_outputs\W{1,2}%s" % (model_type, model_heads)
                 if guest_arch == 's390x':
                     pattern = s390x_pattern % model_heads
                 elif guest_arch == 'aarch64':
@@ -157,7 +161,7 @@ def run(test, params, env):
             if model_type == "qxl":
                 pattern = r"-device\sqxl\S+max_outputs=%s" % model_heads
             elif model_type == "virtio":
-                pattern = r"-device\svirtio-gpu-pci\S+max_outputs=%s" % model_heads
+                pattern = r"-device.*virtio-gpu-pci.*max_outputs\W{1,2}%s" % model_heads
             if guest_arch == 's390x':
                 pattern = s390x_pattern % model_heads
             if not re.search(pattern, cmdline):
@@ -174,16 +178,16 @@ def run(test, params, env):
 
         if mem_type == "ram" or mem_type == "vram":
             cmd_mem_size = str(int(mem_size)*1024)
-            pattern = r"-device\sqxl-vga\S+%s_size=%s" % (mem_type, cmd_mem_size)
+            pattern = r"-device.*qxl-vga.*%s_size\W{1,2}%s" % (mem_type, cmd_mem_size)
         if mem_type == "vram" and model_type == "vga":
             cmd_mem_size = str(int(mem_size)//1024)
-            pattern = r"-device\sVGA\S+vgamem_mb=%s" % cmd_mem_size
+            pattern = r"-device.*VGA.*vgamem_mb\W{1,2}%s" % cmd_mem_size
         if mem_type == "vgamem":
             cmd_mem_size = str(int(mem_size)//1024)
-            pattern = r"-device\sqxl-vga\S+vgamem_mb=%s" % cmd_mem_size
+            pattern = r"-device.*qxl-vga.*vgamem_mb\W{1,2}%s" % cmd_mem_size
         if mem_type == "vram64":
             cmd_mem_size = str(int(mem_size)//1024)
-            pattern = r"-device\sqxl-vga\S+vram64_size_mb=%s" % cmd_mem_size
+            pattern = r"-device.*qxl-vga.*vram64_size_mb\W{1,2}%s" % cmd_mem_size
 
         if not re.search(pattern, cmdline):
             test.fail("The %s memory size of %s video device "


### PR DESCRIPTION
Signed-off-by: Kyla Zhang <weizhan@redhat.com>
Test pass on both qemu-kvm version, remove the qxl test as it is not supported
```
 (01/12) type_specific.io-github-autotest-libvirt.virtual_devices.video_devices.positive_test.primary_video.virtio.no_secondary_video.model_test.with_packed_on: PASS (9.91 s)
 (02/12) type_specific.io-github-autotest-libvirt.virtual_devices.video_devices.positive_test.primary_video.virtio.no_secondary_video.model_test.default: PASS (15.19 s)
 (03/12) type_specific.io-github-autotest-libvirt.virtual_devices.video_devices.positive_test.primary_video.virtio.no_secondary_video.heads_test.default_heads: PASS (15.92 s)
 (04/12) type_specific.io-github-autotest-libvirt.virtual_devices.video_devices.positive_test.primary_video.virtio.no_secondary_video.heads_test.specified_heads: PASS (14.74 s)
 (09/12) type_specific.io-github-autotest-libvirt.virtual_devices.video_devices.positive_test.primary_video.virtio.secondary_video.virtio.model_test.with_packed_on: PASS (12.19 s)
 (10/12) type_specific.io-github-autotest-libvirt.virtual_devices.video_devices.positive_test.primary_video.virtio.secondary_video.virtio.model_test.default: PASS (16.29 s)
 (11/12) type_specific.io-github-autotest-libvirt.virtual_devices.video_devices.positive_test.primary_video.virtio.secondary_video.virtio.heads_test.default_heads: PASS (17.22 s)
 (12/12) type_specific.io-github-autotest-libvirt.virtual_devices.video_devices.positive_test.primary_video.virtio.secondary_video.virtio.heads_test.specified_heads: PASS (18.03 s)

 (01/11) type_specific.io-github-autotest-libvirt.virtual_devices.video_devices.positive_test.primary_video.vga.no_secondary_video.model_test.default: PASS (10.03 s)
 (02/11) type_specific.io-github-autotest-libvirt.virtual_devices.video_devices.positive_test.primary_video.vga.no_secondary_video.heads_test.default_heads: PASS (15.15 s)
 (03/11) type_specific.io-github-autotest-libvirt.virtual_devices.video_devices.positive_test.primary_video.vga.no_secondary_video.mem_test.vram.vga_default_size: PASS (15.59 s)
 (04/11) type_specific.io-github-autotest-libvirt.virtual_devices.video_devices.positive_test.primary_video.vga.no_secondary_video.mem_test.vram.specified_size.power_of_2: PASS (15.34 s)
 (05/11) type_specific.io-github-autotest-libvirt.virtual_devices.video_devices.positive_test.primary_video.vga.no_secondary_video.mem_test.vram.specified_size.vga_zero_size: PASS (15.50 s)
 (06/11) type_specific.io-github-autotest-libvirt.virtual_devices.video_devices.positive_test.primary_video.vga.no_secondary_video.mem_test.vram.specified_size.non_power_of_2: PASS (15.61 s)
 (09/11) type_specific.io-github-autotest-libvirt.virtual_devices.video_devices.positive_test.primary_video.vga.secondary_video.virtio.model_test.with_packed_on: PASS (11.66 s)
 (10/11) type_specific.io-github-autotest-libvirt.virtual_devices.video_devices.positive_test.primary_video.vga.secondary_video.virtio.model_test.default: PASS (16.66 s)
 (11/11) type_specific.io-github-autotest-libvirt.virtual_devices.video_devices.positive_test.primary_video.vga.secondary_video.virtio.heads_test.default_heads: PASS (17.88 s)

 (1/7) type_specific.io-github-autotest-libvirt.virtual_devices.video_devices.positive_test.primary_video.cirrus.no_secondary_video.model_test.default: PASS (10.31 s)
 (2/7) type_specific.io-github-autotest-libvirt.virtual_devices.video_devices.positive_test.primary_video.cirrus.no_secondary_video.heads_test.default_heads: PASS (15.92 s)
 (5/7) type_specific.io-github-autotest-libvirt.virtual_devices.video_devices.positive_test.primary_video.cirrus.secondary_video.virtio.model_test.with_packed_on: PASS (11.81 s)
 (6/7) type_specific.io-github-autotest-libvirt.virtual_devices.video_devices.positive_test.primary_video.cirrus.secondary_video.virtio.model_test.default: PASS (17.34 s)
 (7/7) type_specific.io-github-autotest-libvirt.virtual_devices.video_devices.positive_test.primary_video.cirrus.secondary_video.virtio.heads_test.default_heads: PASS (17.59 s)
```
