### PR TITLE
Fix qemu-cmd-line issue for sound device

### DIFF
--- a/libvirt/tests/src/virtual_device/sound_device.py
+++ b/libvirt/tests/src/virtual_device/sound_device.py
@@ -52,23 +52,23 @@ def run(test, params, env):
             cmdline = cmdline_file.read()
         # Check sound model
         if sound_model == "ac97":
-            pattern = r"-device.AC97"
+            pattern = r"-device.*AC97"
         elif sound_model == "ich6":
-            pattern = r"-device.intel-hda"
+            pattern = r"-device.*intel-hda"
         else:
-            pattern = r"-device.ich9-intel-hda"
+            pattern = r"-device.*ich9-intel-hda"
         if not re.search(pattern, cmdline):
             test.fail("Can not find the %s sound device "
                       "in qemu cmd line." % sound_model)
         # Check codec type
         if sound_model in ["ich6", "ich9"]:
             if codec_type == "micro":
-                pattern = r"-device.hda-micro"
+                pattern = r"-device.*hda-micro"
             else:
                 # Duplex is default in qemu cli even codec not set
                 # But before 0.9.13, no codec_type so no default
                 if libvirt_version.version_compare(0, 9, 13):
-                    pattern = r"-device.hda-duplex"
+                    pattern = r"-device.*hda-duplex"
             if not re.search(pattern, cmdline):
                 test.fail("Can not find the %s codec for sound dev "
                           "in qemu cmd line." % codec_type)


### PR DESCRIPTION
Signed-off-by: Kyla Zhang <weizhan@redhat.com>

Test all pass on old and new qemu-kvm version. Remove AC97 test as not supported
```
 (2/7) type_specific.io-github-autotest-libvirt.virtual_devices.sound_device.positive_test.sound_model_ich6.no_codec_type: PASS (8.72 s)
 (3/7) type_specific.io-github-autotest-libvirt.virtual_devices.sound_device.positive_test.sound_model_ich6.codec_type_duplex: PASS (15.12 s)
 (4/7) type_specific.io-github-autotest-libvirt.virtual_devices.sound_device.positive_test.sound_model_ich6.codec_type_micro: PASS (13.95 s)
 (5/7) type_specific.io-github-autotest-libvirt.virtual_devices.sound_device.positive_test.sound_model_ich9.no_codec_type: PASS (14.55 s)
 (6/7) type_specific.io-github-autotest-libvirt.virtual_devices.sound_device.positive_test.sound_model_ich9.codec_type_duplex: PASS (14.91 s)
 (7/7) type_specific.io-github-autotest-libvirt.virtual_devices.sound_device.positive_test.sound_model_ich9.codec_type_micro: PASS (14.55 s)

 (2/7) type_specific.io-github-autotest-libvirt.virtual_devices.sound_device.positive_test.sound_model_ich6.no_codec_type: PASS (14.79 s)
 (3/7) type_specific.io-github-autotest-libvirt.virtual_devices.sound_device.positive_test.sound_model_ich6.codec_type_duplex: PASS (14.86 s)
 (4/7) type_specific.io-github-autotest-libvirt.virtual_devices.sound_device.positive_test.sound_model_ich6.codec_type_micro: PASS (15.04 s)
 (5/7) type_specific.io-github-autotest-libvirt.virtual_devices.sound_device.positive_test.sound_model_ich9.no_codec_type: PASS (14.06 s)
 (6/7) type_specific.io-github-autotest-libvirt.virtual_devices.sound_device.positive_test.sound_model_ich9.codec_type_duplex: PASS (14.91 s)
 (7/7) type_specific.io-github-autotest-libvirt.virtual_devices.sound_device.positive_test.sound_model_ich9.codec_type_micro: PASS (14.73 s)
```