### PR TITLE
virsh_domstats: add case for iothread

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/monitor/virsh_domstats.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/monitor/virsh_domstats.cfg
@@ -68,6 +68,12 @@
                             domstats_option = "--state --block"
                         - cpu_total_vcpu:
                             domstats_option = "--cpu-total --vcpu"
+                        - iothread:
+                            only specific_domain
+                            only running
+                            domstats_option = "--iothread"
+                            iothread_add_ids = "[1, 2, 3]"
+                            iothread_del_ids = "[1, 2]"
                         - nowait:
                             domstats_option = "--nowait"
                             only normal_test.domain_state.active.option..default_print.not_enforce.specific_domain


### PR DESCRIPTION
Case ID: RHEL-180191
Case title: [iothread-domstats] Check iothread id info through "virsh domstats"
Scenario:
- Start vm
- Add some iothreads
- Check domstats output for the iothread info
- Delete some iothreads
- Check domstats output for updated iothread info

Signed-off-by: Dan Zheng <dzheng@redhat.com>
