### PR TITLE
blockcommit_blockpull: Rename rbd image name

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockcommit.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockcommit.py
@@ -5,6 +5,7 @@ import collections
 
 import aexpect
 
+from avocado.utils import distro
 from avocado.utils import process
 
 from multiprocessing.pool import ThreadPool
@@ -440,10 +441,14 @@ def run(test, params, env):
                 ceph_cfg = ceph.create_config_file(mon_host)
                 if src_host.count("EXAMPLE") or mon_host.count("EXAMPLE"):
                     test.cancel("Please provide rbd host first.")
-
+                detected_distro = distro.detect()
+                rbd_img_prefix = '_'.join(['rbd', detected_distro.name,
+                                           detected_distro.version,
+                                           detected_distro.release,
+                                           detected_distro.arch])
                 params.update(
                    {"disk_source_name": os.path.join(
-                      pool_name, 'rbd_'+utils_misc.generate_random_string(4)+'.img')})
+                      pool_name, rbd_img_prefix + '.img')})
                 if utils_package.package_install(["ceph-common"]):
                     ceph.rbd_image_rm(mon_host, *params.get("disk_source_name").split('/'))
                 else:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockpull.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockpull.py
@@ -3,12 +3,12 @@ import logging
 import tempfile
 import collections
 
+from avocado.utils import distro
 from avocado.utils import process
 
 from virttest import virsh
 from virttest import data_dir
 from virttest import utils_libvirtd
-from virttest import utils_misc
 from virttest import utils_package
 from virttest import libvirt_storage
 from virttest import ceph
@@ -294,12 +294,15 @@ def run(test, params, env):
                 ceph_cfg = ceph.create_config_file(mon_host)
                 if src_host.count("EXAMPLE") or mon_host.count("EXAMPLE"):
                     test.cancel("Please provide ceph host first.")
-
+                detected_distro = distro.detect()
+                rbd_img_prefix = '_'.join(['rbd', detected_distro.name,
+                                           detected_distro.version,
+                                           detected_distro.release,
+                                           detected_distro.arch])
                 params.update(
                    {"disk_source_name": os.path.join(
                       pool_name,
-                      'rbd_blockpull_' + utils_misc.generate_random_string(4) +
-                      '.img')})
+                      rbd_img_prefix + '.img')})
                 if utils_package.package_install(["ceph-common"]):
                     ceph.rbd_image_rm(
                         mon_host, *params.get("disk_source_name").split('/'))


### PR DESCRIPTION
If the case does not finish normally for some reasons(bug or
cancelled by user), the rbd image might unexpectedly remain in
the ceph server. To avoid using too many quotas, update to name
the image with distribution details.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
Case failed due to a known issue, but the image name is updated as expected.
```
[root@libvirtceph ~]# rbd ls blockcommit-pool    
rbd_rhel_8_<release>_x86_64.img                   <-----the img exists before a case is executed, <release> is release version.

[root@libvirtceph ~]# rbd ls blockcommit-pool      <---- the image is deleted and recreated during the case execution
[root@libvirtceph ~]# rbd ls blockcommit-pool
rbd_rhel_8_<release>_x86_64.img
```

