### PR TITLE
iothread: Fix detach disk error

### DIFF
--- a/libvirt/tests/src/cpu/iothread.py
+++ b/libvirt/tests/src/cpu/iothread.py
@@ -312,10 +312,12 @@ def run(test, params, env):
         :param dargs: standardized virsh function API keywords
         :raise: test.fail if disk is not detached
         """
-        virsh.detach_disk(vm_name, disk_path, debug=True)
 
         def _check_disk(target):
             return target not in vm.get_blk_devices()
+
+        utils_misc.wait_for(lambda: not _check_disk(target), 10, 3)
+        virsh.detach_disk(vm_name, disk_path, debug=True)
 
         if not utils_misc.wait_for(lambda: _check_disk(target), 10):
             test.fail("Disk {} is not detached.".format(target))


### PR DESCRIPTION
It reports an error - "Failed to detach diskerror: internal error:
unable to execute QEMU command 'device_del': Hot-unplug failed:
guest is busy (power indicator blinking)", if a disk is detached
shortly after attaching it. So update to wait for disk to attach
correctly.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Test result:**
` (1/1) type_specific.io-github-autotest-libvirt.cpu.iothread.positive_test.disk_attach: PASS (94.96 s)`

