### PR TITLE
[minor fix] virsh_undefine: skip no_option test for aarch64

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_undefine.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_undefine.cfg
@@ -12,6 +12,7 @@
             status_error = 'no'
             variants:
                 - no_option:
+                    no aarch64
                 - managedsave:
                     only vm_running
                     undefine_option = "--managed-save"


### PR DESCRIPTION
aarch64 requires '--nvram' option to undefine guest and that conflicts with
no_option. So skip this test for aarch64

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

