### PR TITLE
boot_integration: Update seabios file

### DIFF
--- a/libvirt/tests/cfg/bios/boot_integration.cfg
+++ b/libvirt/tests/cfg/bios/boot_integration.cfg
@@ -41,7 +41,7 @@
         - by_seabios:
             only q35
             boot_type = "seabios"
-            loader = "/usr/share/seabios/bios.bin"
+            loader = "/usr/share/seabios/bios-256k.bin"
             loader_type = "rom"
             bios_useserial = "yes"
             bios_reboot_timeout = "1000"


### PR DESCRIPTION
No bios.bin file in new seabios-bin package. So update to use
bios-256k.bin.

Signed-off-by: lcheng <lcheng@redhat.com>

