### PR TITLE
backingchain: add case for blockcommit with block disk

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockcommit_basic_function.cfg
+++ b/libvirt/tests/cfg/backingchain/blockcommit_basic_function.cfg
@@ -1,0 +1,12 @@
+- backingchain.blockcommit.basic_function:
+    type = blockcommit_basic_function
+    start_vm = 'no'
+    status_error = 'no'
+    variants:
+        - block_disk:
+            disk_type = 'block'
+            driver_type = 'raw'
+    variants:
+        - commit_tb:
+            case_name = 'commit_top_to_base'
+            check_func = 'base_top'

--- a/libvirt/tests/src/backingchain/blockcommit_basic_function.py
+++ b/libvirt/tests/src/backingchain/blockcommit_basic_function.py
@@ -1,0 +1,81 @@
+import logging
+
+from avocado.utils import process
+
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_test import libvirt
+
+from provider.backingchain import blockcommand_base
+from provider.backingchain import check_functions
+
+LOG = logging.getLogger('avocado.backingchain.checkfunction')
+
+
+def run(test, params, env):
+    """
+    Case for RHEL-288322
+    Test blockcommit operation after creating disk-only snapshot.
+
+    1) Prepare block type disk and snap chain
+    2) Test blockcommit operation from top to base.
+    3) Check result.
+    """
+
+    def setup_commit_top_to_base():
+        """
+        Prepare specific type disk and create snapshots.
+        """
+        libvirt.setup_or_cleanup_iscsi(is_setup=False)
+        test_obj.update_disk()
+        test_obj.prepare_snapshot()
+        check_obj.check_backingchain(test_obj.snap_path_list[::-1])
+
+    def test_commit_top_to_base():
+        """
+        Do blockcommit from top to base after creating external
+        disk-only snapshot with specific disk type
+        """
+        commit_options = " --top %s --pivot " % (test_obj.snap_path_list[-1])
+        virsh.blockcommit(vm.name, test_obj.new_dev, commit_options,
+                          ignore_status=False, debug=True)
+        # Check result after block commit
+        vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm.name)
+        check_obj.check_block_operation_result(vmxml, 'blockcommit',
+                                               test_obj.new_dev,
+                                               test_obj.snap_path_list[::-1] +
+                                               [test_obj.src_path])
+
+    def teardown_commit_top_to_base():
+        """
+        Clean data.
+        """
+        LOG.info('Start cleaning up.')
+        for ss in test_obj.snap_name_list:
+            virsh.snapshot_delete(vm_name, '%s --metadata' % ss, debug=True)
+        for sp in test_obj.snap_path_list:
+            process.run('rm -rf %s' % sp)
+        bkxml.sync()
+        libvirt.setup_or_cleanup_iscsi(is_setup=False)
+
+    # Process cartesian parameters
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    case_name = params.get('case_name', '')
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+    # Create object
+    test_obj = blockcommand_base.BlockCommand(test, vm, params)
+    check_obj = check_functions.Checkfunction(test, vm, params)
+    # MAIN TEST CODE ###
+    run_test = eval("test_%s" % case_name)
+    setup_test = eval("setup_%s" % case_name)
+    teardown_test = eval("teardown_%s" % case_name)
+
+    try:
+        # Execute test
+        setup_test()
+        run_test()
+
+    finally:
+        teardown_test()

--- a/provider/backingchain/blockcommand_base.py
+++ b/provider/backingchain/blockcommand_base.py
@@ -1,0 +1,84 @@
+import logging
+
+from virttest import virsh
+from virttest import data_dir
+from virttest.utils_test import libvirt
+
+LOG = logging.getLogger('avocado.backingchain.blockcommand_base.')
+
+
+class BlockCommand(object):
+    """
+        Prepare data for blockcommand test
+
+        :param test: Test object
+        :param vm:  A libvirt_vm.VM class instance.
+        :param params: Dict with the test parameters.
+    """
+    def __init__(self, test, vm, params):
+        self.test = test
+        self.vm = vm
+        self.params = params
+        self.new_dev = ''
+        self.src_path = ''
+        self.snap_path_list = []
+        self.snap_name_list = []
+        self.tmp_dir = data_dir.get_data_dir()
+        self.new_image_path = ''
+
+    def prepare_iscsi(self):
+        """
+        Prepare iscsi target and set specific params for disk.
+        """
+        driver_type = self.params.get('driver_type', 'raw')
+        disk_type = self.params.get('disk_type', 'block')
+
+        first_disk = self.vm.get_first_disk_devices()
+        new_dev = first_disk['target']
+
+        # Setup iscsi target
+        device_name = libvirt.setup_or_cleanup_iscsi(is_setup=True)
+        # Prepare block type disk params
+        self.params['cleanup_disks'] = 'yes'
+        self.params.update({'disk_format': driver_type,
+                            'disk_type': disk_type,
+                            'disk_target': new_dev,
+                            'disk_source_name': device_name})
+        self.new_dev = new_dev
+        self.src_path = device_name
+
+    def update_disk(self):
+        """
+        Update vm disk with specific params
+
+        """
+        # Get disk type
+        disk_type = self.params.get('disk_type')
+
+        # Check disk type
+        if disk_type == 'block':
+            if not self.vm.is_alive():
+                self.vm.start()
+            self.prepare_iscsi()
+
+        # Update vm disk
+        libvirt.set_vm_disk(self.vm, self.params)
+
+    def prepare_snapshot(self, snap_num=3, option='--disk-only'):
+        """
+        Prepare domain snapshot
+
+        :params snap_num: snapshot number, default value is 3
+        :params option: option to create snapshot, default value is '--disk-only'
+        """
+        # Create backing chain
+        for i in range(snap_num):
+            snap_option = "%s %s --diskspec %s,file=%s" % \
+                          ('snap%d' % i, option, self.new_dev,
+                           self.tmp_dir + 'snap%d' % i)
+
+            virsh.snapshot_create_as(self.vm.name, snap_option,
+                                     ignore_status=False,
+                                     debug=True)
+            self.snap_path_list.append(self.tmp_dir + 'snap%d' % i)
+            self.snap_name_list.append('snap%d' % i)

--- a/provider/backingchain/check_functions.py
+++ b/provider/backingchain/check_functions.py
@@ -1,0 +1,115 @@
+import logging
+import re
+
+from avocado.utils import process
+from virttest import libvirt_storage
+
+LOG = logging.getLogger('avocado.backingchain.checkfunction')
+
+
+class Checkfunction(object):
+    """
+        Prepare data for blockcommand test
+
+        :param test: Test object
+        :param vm:  A libvirt_vm.VM class instance.
+        :param params: Dict with the test parameters.
+    """
+
+    def __init__(self, test, vm, params):
+        self.test = test
+        self.vm = vm
+        self.params = params
+
+    def check_block_operation_result(self, vmxml, blockcommand,
+                                     target_dev, bc_chain):
+        """
+        Run specific check backing chain function.
+
+        :param vmxml: vmxml obj of vm
+        :param blockcommand: blockpull, blockcommit..
+        :param target_dev: dev of target disk, different disks could have
+        different chain
+        :param bc_chain: original backing chain info as a list of source files
+        """
+        check_func = self.params.get('check_func', '')
+        check_bc_func_name = 'self.check_bc_%s' % check_func
+        check_bc = eval(check_bc_func_name)
+        # Run specific check backing chain function
+        if not check_bc(blockcommand, vmxml, target_dev, bc_chain):
+            self.test.fail('Backing chain check after %s failed' % blockcommand)
+
+    def check_bc_base_top(self, command, vmxml, dev, bc_chain):
+        """
+        Check backing chain info after blockpull/commit
+        from base to top(or top to base)
+
+        :param command: blockpull, blockcommit..
+        :param vmxml: vmxml obj of vm
+        :param dev: dev of target disk
+        :param bc_chain: original backing chain info as a list of source files
+        :return: True if check passed, False if failed
+        """
+        LOG.info('Check backing chain after %s', command)
+        disk = vmxml.get_disk_all()[dev]
+        disk_type = disk.get('type')
+        disk_source = disk.find('source')
+        if disk_type == 'file':
+            src_path = disk_source.get('file')
+        elif disk_type == 'block':
+            src_path = disk_source.get('dev')
+        elif disk_type == 'network':
+            src_path = '{}://{}/{}'.format(disk_source.get('protocol'),
+                                           disk_source.find('host').get('name'),
+                                           disk_source.get('name'))
+        else:
+            LOG.error('Unknown disk type: %s', disk_type)
+            return False
+        LOG.debug('Current source file: %s', src_path)
+        if command == 'blockpull':
+            index = 0
+        elif command == 'blockcommit':
+            index = -1
+        else:
+            LOG.error('Unsupported command: %s', command)
+            return False
+        if src_path != bc_chain[index]:
+            LOG.error('Expect source file to be %s, but got %s', bc_chain[index], src_path)
+            return False
+        bs = disk.find('backingStore')
+        LOG.debug('Current backing store: %s', bs)
+        if bs and bs.find('source') is not None:
+            LOG.error('Backing store of disk %s, should be empty', dev)
+            return False
+
+        LOG.info('Backing chain check PASS.')
+        return True
+
+    def check_backingchain(self, img_list):
+        """
+        Check backing chain info through qemu-img info
+
+        :param img_list: expected backingchain list
+        :return: bool, meets expectation or not
+        """
+        # Get actual backingchain list
+        qemu_img_cmd = 'qemu-img info --backing-chain %s' % img_list[0]
+        if libvirt_storage.check_qemu_image_lock_support():
+            qemu_img_cmd += " -U"
+        img_info = process.run(qemu_img_cmd, verbose=True, shell=True).stdout_text
+        # Set check pattern
+        pattern = ''
+        chain_length = len(img_list)
+        for i in range(chain_length):
+            pattern += 'image: ' + img_list[i]
+            if i + 1 < chain_length:
+                pattern += '.*backing file: ' + img_list[i + 1]
+            pattern += '.*'
+        LOG.debug('The pattern to match the current backing chain is:%s'
+                  % pattern)
+        # compare list
+        exist = re.search(pattern, img_info, re.DOTALL)
+        if not exist:
+            self.test.fail('qemu-img info output of backing chain '
+                           'is not correct: %s' % img_info)
+        return exist


### PR DESCRIPTION
**Add** new case for RHEL7-16568:test blockcommit from top
 to base after creating external disk-only snapshot with "block" disk type

Signed-off-by: nanli <nanli@redhat.com>
**Test result**:
 /usr/local/bin/avocado run --vt-type libvirt --vt-machine-type q35 backingchain.blockcommit.basic_function.commit_tb.block_disk --vt-connect-uri qemu:///system
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : 761cabd3101b66ec788cf28344f7cd73b535de34
JOB LOG    : /root/avocado/job-results/job-2022-01-26T02.45-761cabd/job.log
 (1/1) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.basic_function.commit_tb.block_disk: PASS (21.57 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 21.98 s
