### PR TITLE
vcpu_feature: Update error message for host_without_cr8legacy

### DIFF
--- a/libvirt/tests/cfg/cpu/vcpu_feature.cfg
+++ b/libvirt/tests/cfg/cpu/vcpu_feature.cfg
@@ -26,4 +26,4 @@
                     only policy_require
                     host_supported_feature = "no"
                     feature_name = "cr8legacy"
-                    err_msg = "guest CPU doesn't match specification: missing features: ${feature_name}"
+                    err_msg = "guest CPU doesn't match specification: missing features: .*${feature_name}"


### PR DESCRIPTION
Update the error message to only match the name of cr8legacy.

Signed-off-by: Yingshun Cui <yicui@redhat.com>

**Test result:**
_Before the fix:_
` (1/1) type_specific.io-github-autotest-libvirt.vcpu_feature.negative_test.host_without_cr8legacy.host_passthrough.policy_require: FAIL: Expect should fail with one of ["guest CPU doesn't match specification: missing features: cr8legacy"], but failed with:\n\n\nerror: Failed to start domain 'avocado-vt-vm1'\nerror: operation failed: guest CPU doesn't match specification: missing features: hle,... (7.98 s)`

_After fix:_
` (1/1) type_specific.io-github-autotest-libvirt.vcpu_feature.negative_test.host_without_cr8legacy.host_passthrough.policy_require: PASS (8.09 s)`
