### PR TITLE
Fix local variable 'ori_pid_libvirtd' referenced before assignment issue

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_ccw_addr.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_ccw_addr.py
@@ -185,6 +185,7 @@ def run(test, params, env):
     expected_fails_msg.append(error_msg)
 
     device_obj = None
+    ori_pid_libvirtd = None
 
     # Back up xml file.
     if vm.is_alive():


### PR DESCRIPTION
Initialize ori_pid_libvirtd=None at early stage of logic

Signed-off-by: chunfuwen <chwen@redhat.com>

