### PR TITLE
virsh_blockcommit:fix create snap failed issue

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockcommit.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockcommit.py
@@ -289,7 +289,7 @@ def run(test, params, env):
             backing_file_path = os.path.join(root_dir, key)
             external_snap_shot = "%s/%s" % (backing_file_path, value)
             snapshot_external_disks.append(external_snap_shot)
-            options = "%s --diskspec %s,file=%s" % (meta_options, disk_target, external_snap_shot)
+            options = "%s %s --diskspec %s,file=%s" % ('snap-%s' % key, meta_options, disk_target, external_snap_shot)
             cmd_result = virsh.snapshot_create_as(vm_name, options,
                                                   ignore_status=False,
                                                   debug=True)


### PR DESCRIPTION
    * Add snap name for create_reuse_external_snapshots function. If use timezone as
     snap name, it will fail when running too fast.

      Signed-off-by: nanli <nanli@redhat.com>
* **Test result**:
[root@dell-per740-41 domain]# /usr/local/bin/avocado run --vt-type libvirt --vt-machine-type q35 virsh.blockcommit.normal_test.single_chain.block_disk.reuse-external.timeout.shallow.top_active.without_pivot --vt-connect-uri qemu:///system
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : b5574cf952e2c65dc01fdcdbd3003734a0163e16
JOB LOG    : /root/avocado/job-results/job-2022-01-12T02.55-b5574cf/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.blockcommit.normal_test.single_chain.block_disk.reuse-external.timeout.shallow.top_active.without_pivot: **PASS** (56.44 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 57.23 s
