### PR TITLE
migrate_vm: Fix variable 'remote_session' reference issue

### DIFF
--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -59,6 +59,7 @@ def destroy_active_pool_on_remote(params):
     :return True if successful, otherwise False
     """
     ret = True
+    remote_session = None
 
     remote_ip = params.get("migrate_dest_host")
     remote_user = params.get("migrate_dest_user", "root")


### PR DESCRIPTION
Fix error:
  UnboundLocalError: local variable 'remote_session' referenced
  before assignment

Signed-off-by: lcheng <lcheng@redhat.com>
