### PR TITLE
virsh_migrate_option_mix: Update vnc pwd

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_option_mix.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_migrate_option_mix.cfg
@@ -66,7 +66,7 @@
         - graphic_passwd:
             # Uni-direction migration with spice passwd
             with_graphic_passwd = "yes"
-            graphic_passwd = "abc123!@#"
+            graphic_passwd = "abc12!@#"
         - no_graphic_passwd:
             # Uni-direction migratin without spice passwd
             with_graphic_passwd = "no"


### PR DESCRIPTION
Update the vnc password 8 characters because of BZ 1506689.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
_Before the fix:_
 `(1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_option_mix.persistent.no_persistent_xml.xml.no_dname.undefinesource.src_vm_running.src_vm_persistent.graphic_passwd.p2p.precopy.live: ERROR: Failed to define avocado-vt-vm1 for reason:\nerror: Failed to define domain from /tmp/xml_utils_temp_nag1lth8.xml\nerror: unsupported configuration: VNC password is 9 characters long, only 8 permitted\n (395.28 s)
`

_After the fix:_
` (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_option_mix.persistent.no_persistent_xml.xml.no_dname.undefinesource.src_vm_running.src_vm_persistent.graphic_passwd.p2p.precopy.live: PASS (340.35 s)
`