### PR TITLE
Fix cmd line mapping error for qemu-kvm change again

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_setmem.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_setmem.cfg
@@ -114,7 +114,7 @@
                     with_packed = "yes"
                     driver_packed = "on"
                     expect_xml_line = "<driver packed="%s""
-                    expect_qemu_line = "-device.*virtio-balloon-pci.*packed\W{1,2}%s"
+                    expect_qemu_line = "-device.*virtio-balloon-pci.*packed\W{1,2}(true|on)"
         - invalid_options:
             # These should fail on all versions
             status_error = "yes"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_setmem.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_setmem.py
@@ -284,10 +284,6 @@ def run(test, params, env):
     # Check guest dumpxml and qemu command in with_packed attribute
     if with_packed:
         expect_xml_line = expect_xml_line % driver_packed
-        if utils_misc.compare_qemu_version(6, 2, 0, is_rhev=False):
-            expect_qemu_line = expect_qemu_line % "true"
-        else:
-            expect_qemu_line = expect_qemu_line % driver_packed
         libvirt.check_dumpxml(vm, expect_xml_line)
         libvirt.check_qemu_cmd_line(expect_qemu_line)
 

--- a/libvirt/tests/src/virtual_device/video_devices.py
+++ b/libvirt/tests/src/virtual_device/video_devices.py
@@ -6,7 +6,6 @@ from virttest.libvirt_xml.devices.video import Video
 from virttest.utils_test import libvirt
 from virttest import virsh
 from virttest import libvirt_version
-from virttest import utils_misc
 
 from six import iteritems
 
@@ -123,10 +122,7 @@ def run(test, params, env):
             elif model_type == "virtio":
                 pattern = r"-device.*virtio-gpu-pci"
                 if with_packed:
-                    if utils_misc.compare_qemu_version(6, 2, 0, is_rhev=False):
-                        pattern = r"-device.*virtio-gpu-pci.*packed\W{1,2}%s" % "true"
-                    else:
-                        pattern = r"-device.*virtio-gpu-pci.*packed\W{1,2}%s" % driver_packed
+                    pattern = r"-device.*virtio-gpu-pci.*packed\W{1,2}(true|on)"
             if guest_arch == 's390x':
                 pattern = s390x_pattern
             if not re.search(pattern, cmdline):


### PR DESCRIPTION
Signed-off-by: Kyla Zhang <weizhan@redhat.com>

pass on new and old qemu-kvm version
```
 (1/1) type_specific.io-github-autotest-libvirt.virsh.setmem.memballoon_option.with_packed_on: PASS (62.01 s)

 (1/1) type_specific.io-github-autotest-libvirt.virsh.setmem.memballoon_option.with_packed_on: PASS (62.02 s)

 (2/4) type_specific.io-github-autotest-libvirt.virtual_devices.video_devices.positive_test.primary_video.vga.secondary_video.virtio.model_test.with_packed_on: PASS (28.45 s)
 (3/4) type_specific.io-github-autotest-libvirt.virtual_devices.video_devices.positive_test.primary_video.cirrus.secondary_video.virtio.model_test.with_packed_on: PASS (29.67 s)
 (4/4) type_specific.io-github-autotest-libvirt.virtual_devices.video_devices.positive_test.primary_video.virtio.secondary_video.virtio.model_test.with_packed_on: PASS (29.72 s)

 (2/4) type_specific.io-github-autotest-libvirt.virtual_devices.video_devices.positive_test.primary_video.vga.secondary_video.virtio.model_test.with_packed_on: PASS (30.26 s)
 (3/4) type_specific.io-github-autotest-libvirt.virtual_devices.video_devices.positive_test.primary_video.cirrus.secondary_video.virtio.model_test.with_packed_on: PASS (28.20 s)
 (4/4) type_specific.io-github-autotest-libvirt.virtual_devices.video_devices.positive_test.primary_video.virtio.secondary_video.virtio.model_test.with_packed_on: PASS (29.36 s)
```