### PR TITLE
sriov_vf_pool: Wait device_removed event for detach-interface

### DIFF
--- a/libvirt/tests/src/sriov/sriov_vf_pool.py
+++ b/libvirt/tests/src/sriov/sriov_vf_pool.py
@@ -118,6 +118,7 @@ def run(test, params, env):
         mac_addr = vm_ifaces[0].get_mac_address()
         opts = ' '.join([iface_type, "--mac %s" % mac_addr])
         virsh.detach_interface(vm_name, option=opts, debug=True,
+                               wait_for_event=True,
                                ignore_status=False)
         libvirt_network.check_network_connection(net_name, vf_no-1)
 


### PR DESCRIPTION
Update to check the connections after the interface is removed
properly.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
depends on: https://github.com/avocado-framework/avocado-vt/pull/3326

**Test results:**
_before the fix:_
` (1/1) type_specific.io-github-autotest-libvirt.sriov.vf_pool.active.connection.hostdev: FAIL: Unable to get the expected connection number. Expected: 3, Actual: 4. (67.17 s)`

_after the fix:_
```
 (1/1) type_specific.io-github-autotest-libvirt.sriov.vf_pool.active.connection.hostdev: PASS (51.36 s)
 (1/1) type_specific.io-github-autotest-libvirt.sriov.vf_pool.active.connection.macvtap_passthrough: PASS (47.75 s)
```
