### PR TITLE
detach_interface: Replace wait_remove_event to wait_for_event

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_interface.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_interface.py
@@ -496,7 +496,7 @@ def run(test, params, env):
         if save_restore == "yes" and vm_ref == dom_id:
             vm_ref = vm_name
         detach_result = virsh.detach_interface(
-            vm_ref, options, wait_remove_event=True, **virsh_dargs)
+            vm_ref, options, wait_for_event=True, **virsh_dargs)
         detach_status = detach_result.exit_status
         detach_msg = detach_result.stderr.strip()
 


### PR DESCRIPTION
The function detach_interface has been updated to use wait_for_event
to check the event, so update the code accordingly.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
depends on https://github.com/avocado-framework/avocado-vt/pull/3326