### PR TITLE
v2v: adapt vga device in v2v helper

### DIFF
--- a/provider/v2v_vmcheck_helper.py
+++ b/provider/v2v_vmcheck_helper.py
@@ -523,6 +523,8 @@ class VMChecker(object):
             'Virtio GPU': ['1050'],
             'Virtio input': ['1052'],
             'Inter-VM shared memory': ['1110'],
+            # https://pci-ids.ucw.cz/read/PC/1234/1111
+            'vga': ['1111'],
             # QXL paravirtual graphic card
             'qxl': ['0100'],
             # Cirrus Logic

--- a/v2v/tests/cfg/function_test_xen.cfg
+++ b/v2v/tests/cfg/function_test_xen.cfg
@@ -81,7 +81,6 @@
                 - sdl:
                     os_version = 'rhel6'
                     main_vm = 'SDL_VM_NAME_V2V_EXAMPLE'
-                    checkpoint = 'sdl'
         - scsi_disk:
             main_vm = 'SCSI_VM_NAME_V2V_EXAMPLE'
         - ide_disk:

--- a/v2v/tests/src/function_test_xen.py
+++ b/v2v/tests/src/function_test_xen.py
@@ -166,11 +166,6 @@ def run(test, params, env):
                 check_grub_file(vmchecker.checker, 'console_xvc0')
             if checkpoint in ('vnc_autoport', 'vnc_encrypt'):
                 vmchecker.check_graphics(params[checkpoint])
-            if checkpoint == 'sdl':
-                if output_mode == 'libvirt':
-                    vmchecker.check_graphics({'type': 'vnc'})
-                elif output_mode == 'rhev':
-                    vmchecker.check_graphics({'type': 'spice'})
             if checkpoint == 'pv_with_regular_kernel':
                 check_kernel(vmchecker.checker)
             if checkpoint in ['sound', 'pcspk']:


### PR DESCRIPTION
Add vga device into v2v helper. And remove the graphics checks in
sdl case. This is duplicate with the public checkpoint.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>