### PR TITLE
libvirt: Update to use avocado namespace for logging

### DIFF
--- a/libvirt/tests/src/backingchain/blockcommand.py
+++ b/libvirt/tests/src/backingchain/blockcommand.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import re
 
 from avocado.utils import process
@@ -15,6 +15,11 @@ from virttest.staging import service
 from virttest.libvirt_xml.devices.disk import Disk
 
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def check_backingchain(img_list, img_info):

--- a/libvirt/tests/src/backingchain/blockcopy.py
+++ b/libvirt/tests/src/backingchain/blockcopy.py
@@ -1,5 +1,5 @@
 import json
-import logging
+import logging as log
 import os
 
 from avocado.utils import process
@@ -11,6 +11,11 @@ from virttest import virsh
 from virttest import libvirt_version
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/bios/boot_integration.py
+++ b/libvirt/tests/src/bios/boot_integration.py
@@ -1,5 +1,5 @@
 import time
-import logging
+import logging as log
 import os
 import re
 
@@ -13,6 +13,11 @@ from virttest.utils_misc import wait_for
 from virttest import data_dir
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def prepare_boot_xml(vmxml, params):

--- a/libvirt/tests/src/bios/virsh_boot.py
+++ b/libvirt/tests/src/bios/virsh_boot.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 import re
 from aexpect.utils import astring
@@ -27,6 +27,11 @@ cleanup_gluster = False
 cleanup_iso_file = False
 cleanup_image_file = False
 cleanup_released_image_file = False
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def get_stripped_output(cont, custom_codes=None):

--- a/libvirt/tests/src/bios/virsh_boot_sysinfo.py
+++ b/libvirt/tests/src/bios/virsh_boot_sysinfo.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 
 from virttest import virsh
@@ -7,6 +7,11 @@ from virttest import libvirt_version
 from virttest import data_dir
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def check_in_vm(test, vm, **kwargs):

--- a/libvirt/tests/src/bios/virsh_boot_tseg.py
+++ b/libvirt/tests/src/bios/virsh_boot_tseg.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from virttest import virsh
 from virttest import utils_package
@@ -7,6 +7,11 @@ from virttest.utils_test import libvirt as utlv
 from virttest.libvirt_xml import xcepts
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def unify_to_MiB(unit, size):

--- a/libvirt/tests/src/channel/channel_functional.py
+++ b/libvirt/tests/src/channel/channel_functional.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import aexpect
 import shutil
 import stat
@@ -11,6 +11,11 @@ from virttest.libvirt_xml.vm_xml import VMXML
 from virttest.libvirt_xml.devices.channel import Channel
 from virttest.utils_test import libvirt as utlv
 from virttest import data_dir
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/conf_file/libvirtd_conf/host_uuid.py
+++ b/libvirt/tests/src/conf_file/libvirtd_conf/host_uuid.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import uuid
 import os
 
@@ -6,6 +6,11 @@ from virttest import utils_config
 from virttest import utils_libvirtd
 from virttest import utils_split_daemons
 from virttest.libvirt_xml import capability_xml
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/conf_file/libvirtd_conf/prefix_num.py
+++ b/libvirt/tests/src/conf_file/libvirtd_conf/prefix_num.py
@@ -1,6 +1,11 @@
-import logging
+import logging as log
 import ast
 import os
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def get_prefix(check_list):

--- a/libvirt/tests/src/conf_file/libvirtd_conf/unix_sock.py
+++ b/libvirt/tests/src/conf_file/libvirtd_conf/unix_sock.py
@@ -1,6 +1,6 @@
 import grp
 import stat
-import logging
+import logging as log
 import os
 from avocado.utils import distro
 from avocado.utils import process
@@ -12,6 +12,11 @@ from virttest import utils_config
 from virttest import utils_libvirtd
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/conf_file/qemu_conf/auto_dump.py
+++ b/libvirt/tests/src/conf_file/qemu_conf/auto_dump.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import shutil
 import platform
 import multiprocessing
@@ -16,6 +16,11 @@ from virttest.libvirt_xml.devices.panic import Panic
 from virttest import data_dir
 from virttest import utils_package
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/conf_file/qemu_conf/clear_emulator_capabilities.py
+++ b/libvirt/tests/src/conf_file/qemu_conf/clear_emulator_capabilities.py
@@ -1,7 +1,12 @@
-import logging
+import logging as log
 
 from virttest import utils_config
 from virttest import utils_libvirtd
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/conf_file/qemu_conf/seccomp_sandbox.py
+++ b/libvirt/tests/src/conf_file/qemu_conf/seccomp_sandbox.py
@@ -1,5 +1,5 @@
 import re
-import logging
+import logging as log
 
 from avocado.utils import process
 
@@ -7,6 +7,11 @@ from virttest import utils_config
 from virttest import utils_libvirtd
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/conf_file/qemu_conf/set_process_name.py
+++ b/libvirt/tests/src/conf_file/qemu_conf/set_process_name.py
@@ -1,10 +1,15 @@
 import re
-import logging
+import logging as log
 
 from avocado.utils import process
 
 from virttest import utils_config
 from virttest import utils_libvirtd
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/conf_file/qemu_conf/set_virtlogd.py
+++ b/libvirt/tests/src/conf_file/qemu_conf/set_virtlogd.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 import stat
 import time
@@ -23,6 +23,11 @@ from virttest import libvirt_version
 
 # Define qemu log path.
 QEMU_LOG_PATH = "/var/log/libvirt/qemu"
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/conf_file/sysconfig_libvirt_guests/libvirt_guests.py
+++ b/libvirt/tests/src/conf_file/sysconfig_libvirt_guests/libvirt_guests.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import re
 import aexpect
 import time
@@ -16,6 +16,11 @@ from virttest import utils_config
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 from virttest.staging import service
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/conf_file/sysconfig_libvirtd/libvirtd_config.py
+++ b/libvirt/tests/src/conf_file/sysconfig_libvirtd/libvirtd_config.py
@@ -1,10 +1,15 @@
 import os
-import logging
+import logging as log
 
 from virttest import utils_config
 from virttest import utils_libvirtd
 from virttest import data_dir
 from virttest.libvirt_xml import capability_xml
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/controller/controller_functional.py
+++ b/libvirt/tests/src/controller/controller_functional.py
@@ -1,5 +1,5 @@
 import re
-import logging
+import logging as log
 import tempfile
 import platform
 
@@ -15,6 +15,11 @@ from virttest.utils_libvirt import libvirt_pcicontr
 from virttest.libvirt_xml.vm_xml import VMXML
 from virttest.libvirt_xml.vm_xml import VMCPUXML
 from virttest.libvirt_xml.devices.controller import Controller
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def remove_devices(vm_xml, type):

--- a/libvirt/tests/src/controller/multiple_controller_ppc.py
+++ b/libvirt/tests/src/controller/multiple_controller_ppc.py
@@ -1,6 +1,6 @@
 import re
 import os
-import logging
+import logging as log
 import platform
 import random
 import string
@@ -15,6 +15,11 @@ from virttest.libvirt_xml.vm_xml import VMCPUXML
 from virttest.libvirt_xml.devices.controller import Controller
 from virttest.libvirt_xml.devices.disk import Disk
 from virttest.libvirt_xml.devices.interface import Interface
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/controller/pcibridge.py
+++ b/libvirt/tests/src/controller/pcibridge.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from virttest import virsh
 from virttest import utils_misc
@@ -8,6 +8,11 @@ from virttest.libvirt_xml.vm_xml import VMXML
 from virttest.libvirt_xml.devices.controller import Controller
 from virttest.libvirt_xml.devices.sound import Sound
 from virttest.libvirt_xml.devices.interface import Interface
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/controller/pcie_controllers.py
+++ b/libvirt/tests/src/controller/pcie_controllers.py
@@ -1,7 +1,7 @@
 import os
 import re
 import time
-import logging
+import logging as log
 
 from virttest import virsh
 from virttest import data_dir
@@ -10,6 +10,11 @@ from virttest.utils_libvirtd import Libvirtd
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml.vm_xml import VMXML
 from virttest.utils_libvirt import libvirt_pcicontr
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/cpu/aarch64_cpu_sve.py
+++ b/libvirt/tests/src/cpu/aarch64_cpu_sve.py
@@ -1,5 +1,5 @@
 import re
-import logging
+import logging as log
 
 from avocado.utils import process
 from avocado.core import exceptions
@@ -9,6 +9,11 @@ from virttest import utils_package
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import LibvirtXMLError
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/cpu/diagnose_data.py
+++ b/libvirt/tests/src/cpu/diagnose_data.py
@@ -1,8 +1,13 @@
-import logging
+import logging as log
 import re
 
 from virttest.libvirt_xml.vm_xml import VMXML, VMFeaturesXML
 from virttest import virsh
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/cpu/diagnose_spinlock_yield_forward.py
+++ b/libvirt/tests/src/cpu/diagnose_spinlock_yield_forward.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import time
 
 
@@ -12,6 +12,11 @@ DEACTIVATE_FORWARDING = 0
 FORWARD_COUNTER_TIMEOUT = 360
 CHECK_INTERVAL = 60
 FORWARD_VALUE_PATH = None
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def update_kvm_parameter(hz):

--- a/libvirt/tests/src/cpu/guestpin.py
+++ b/libvirt/tests/src/cpu/guestpin.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 import random
 import time
@@ -15,6 +15,11 @@ from virttest import libvirt_xml
 from virttest import utils_package
 from virttest.utils_test import libvirt
 from virttest.staging import utils_cgroup
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/cpu/iothread.py
+++ b/libvirt/tests/src/cpu/iothread.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import re
 import os
 
@@ -16,6 +16,11 @@ from virttest.libvirt_xml.xcepts import LibvirtXMLNotFoundError
 
 ORG_IOTHREAD_POOL = {}
 UPDATE_IOTHREAD_POOL = {}
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/cpu/max_vcpus.py
+++ b/libvirt/tests/src/cpu/max_vcpus.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from virttest import virsh
 from virttest import libvirt_xml
@@ -9,6 +9,11 @@ from virttest.libvirt_xml import capability_xml
 from virttest.libvirt_xml.devices.iommu import Iommu
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/cpu/powerpc_hmi.py
+++ b/libvirt/tests/src/cpu/powerpc_hmi.py
@@ -1,6 +1,6 @@
 import os
 import time
-import logging
+import logging as log
 
 from avocado.utils import cpu
 from avocado.utils.software_manager import SoftwareManager
@@ -10,6 +10,11 @@ from virttest import data_dir
 from virttest import virsh
 from virttest import libvirt_xml
 from virttest import utils_test
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/cpu/ppc_cpu_mode.py
+++ b/libvirt/tests/src/cpu/ppc_cpu_mode.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import platform
 
 from avocado.utils import process
@@ -6,6 +6,11 @@ from avocado.utils import process
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/cpu/ppccpucompat.py
+++ b/libvirt/tests/src/cpu/ppccpucompat.py
@@ -1,6 +1,6 @@
 import os
 import time
-import logging
+import logging as log
 
 from avocado.utils import cpu as cpu_util
 
@@ -11,6 +11,11 @@ from virttest import libvirt_xml
 from virttest import cpu
 from virttest import utils_package
 from virttest import utils_test
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/cpu/setvcpu.py
+++ b/libvirt/tests/src/cpu/setvcpu.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import collections
 
 from virttest import virsh
@@ -6,6 +6,11 @@ from virttest import cpu
 from virttest import libvirt_version
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/cpu/vcpu_affinity.py
+++ b/libvirt/tests/src/cpu/vcpu_affinity.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from avocado.utils import cpu as cpuutil
 
@@ -8,6 +8,11 @@ from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import xcepts
 from virttest.utils_test import libvirt
 from virttest import utils_libvirtd
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def check_vcpu_placement(test, params):

--- a/libvirt/tests/src/cpu/vcpu_cache.py
+++ b/libvirt/tests/src/cpu/vcpu_cache.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import re
 
 from avocado.utils import process
@@ -7,6 +7,11 @@ from virttest import virsh
 from virttest import virt_vm
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/cpu/vcpu_feature.py
+++ b/libvirt/tests/src/cpu/vcpu_feature.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from avocado.utils import process
 
@@ -6,6 +6,11 @@ from virttest import virsh
 from virttest import libvirt_version
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/cpu/vcpu_hotpluggable.py
+++ b/libvirt/tests/src/cpu/vcpu_hotpluggable.py
@@ -2,7 +2,7 @@ import os
 import re
 import copy
 import ast
-import logging
+import logging as log
 
 from avocado.utils import process
 from avocado.utils import distro
@@ -15,6 +15,11 @@ from virttest import cpu
 from virttest import data_dir
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def check_vcpu_after_plug_unplug(test, vm_name, config_vcpus, option='--inactive'):

--- a/libvirt/tests/src/cpu/vcpu_misc.py
+++ b/libvirt/tests/src/cpu/vcpu_misc.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 import re
 
@@ -9,6 +9,11 @@ from virttest import virsh
 from virttest.libvirt_xml import domcapability_xml
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def check_vm_cpu_model(vm_cpu_model, cmd_on_host, test):

--- a/libvirt/tests/src/cpu/vcpu_nested.py
+++ b/libvirt/tests/src/cpu/vcpu_nested.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 
 from virttest import virsh
@@ -6,6 +6,11 @@ from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_libvirt import libvirt_nested
 from virttest.utils_misc import cmd_status_output
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run_cmd_in_guest(vm_session, cmd, test):

--- a/libvirt/tests/src/cpu/vcpupin.py
+++ b/libvirt/tests/src/cpu/vcpupin.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 import re
 
@@ -10,6 +10,11 @@ from virttest import virsh
 
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_libvirt import libvirt_misc
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def update_vm_xml(vmxml, params):

--- a/libvirt/tests/src/cpu/vm_features.py
+++ b/libvirt/tests/src/cpu/vm_features.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import re
 
 from avocado.core import exceptions
@@ -10,6 +10,11 @@ from virttest import utils_misc
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def install_pkgs(session, pkgs, test):

--- a/libvirt/tests/src/daemon/crash_regression.py
+++ b/libvirt/tests/src/daemon/crash_regression.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 
 from six.moves import xrange
 
@@ -14,6 +14,11 @@ from virttest.libvirt_xml.xcepts import LibvirtXMLError
 from virttest.libvirt_xml.vm_xml import VMXML, VMCPUXML, VMPMXML
 from virttest.libvirt_xml.network_xml import NetworkXML, IPXML
 from virttest.libvirt_xml.devices import interface
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run_destroy_console(params, libvirtd, vm):

--- a/libvirt/tests/src/daemon/daemon_functional.py
+++ b/libvirt/tests/src/daemon/daemon_functional.py
@@ -1,6 +1,6 @@
 import os
 import time
-import logging
+import logging as log
 
 from avocado.utils import process
 
@@ -12,6 +12,11 @@ from virttest.utils_libvirtd import LibvirtdSession
 from virttest.utils_libvirtd import Libvirtd
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/daemon/init_scripts.py
+++ b/libvirt/tests/src/daemon/init_scripts.py
@@ -1,12 +1,17 @@
 import os
 import glob
 import shutil
-import logging
+import logging as log
 
 from avocado.utils import path
 from avocado.utils import process
 
 from virttest import utils_libvirtd
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/daemon/kill_started.py
+++ b/libvirt/tests/src/daemon/kill_started.py
@@ -1,13 +1,18 @@
 import os
 import time
 import signal
-import logging
+import logging as log
 
 from avocado.utils import process
 
 from virttest import utils_config
 from virttest import utils_split_daemons
 from virttest.utils_libvirtd import Libvirtd
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/daemon/kill_starting.py
+++ b/libvirt/tests/src/daemon/kill_starting.py
@@ -1,8 +1,13 @@
-import logging
+import logging as log
 
 from virttest import utils_misc
 from virttest.utils_libvirtd import LibvirtdSession
 from virttest.utils_libvirtd import Libvirtd
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/daemon/libvirt_guests_service.py
+++ b/libvirt/tests/src/daemon/libvirt_guests_service.py
@@ -1,9 +1,14 @@
-import logging
+import logging as log
 import re
 
 from virttest import utils_libvirtd
 from virttest import utils_misc
 from virttest.staging.service import Factory
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/daemon/restart_consist.py
+++ b/libvirt/tests/src/daemon/restart_consist.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import difflib
 
 from aexpect import ExpectTimeoutError
@@ -9,6 +9,11 @@ from virttest import utils_misc
 from virttest import remote
 from virttest.libvirt_xml import VMXML
 from virttest.libvirt_xml.xcepts import LibvirtXMLNotFoundError
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/embedded_qemu/embedded_qemu.py
+++ b/libvirt/tests/src/embedded_qemu/embedded_qemu.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import re
 import shutil
 
@@ -12,6 +12,11 @@ from virttest.utils_test import libvirt
 from virttest.utils_libvirt import libvirt_embedded_qemu
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.disk import Disk
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/graphics/graphics_functional.py
+++ b/libvirt/tests/src/graphics/graphics_functional.py
@@ -6,7 +6,7 @@ import os
 import random
 import socket
 import shutil
-import logging
+import logging as log
 import threading
 import time
 import datetime
@@ -38,6 +38,11 @@ from virttest.libvirt_xml import vm_xml
 from virttest import libvirt_version
 
 q = Queue.Queue()
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 class PortAllocator(object):

--- a/libvirt/tests/src/guest_agent.py
+++ b/libvirt/tests/src/guest_agent.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 import shutil
 
@@ -7,6 +7,11 @@ from virttest import utils_libvirtd
 from virttest import utils_selinux
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def check_ga_state(vm, vm_name):

--- a/libvirt/tests/src/guest_kernel_debugging/nmi_test.py
+++ b/libvirt/tests/src/guest_kernel_debugging/nmi_test.py
@@ -1,8 +1,13 @@
-import logging
+import logging as log
 
 from virttest import virsh
 from virttest import utils_package
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run_cmd_in_guest(vm, cmd, test, timeout=60):

--- a/libvirt/tests/src/guest_resource_control/control_cgroup.py
+++ b/libvirt/tests/src/guest_resource_control/control_cgroup.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import math
 import os
 import re
@@ -13,6 +13,11 @@ from virttest import virsh
 from virttest.libvirt_cgroup import CgroupTest
 
 from avocado.utils import process
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/hotplug_serial.py
+++ b/libvirt/tests/src/hotplug_serial.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 import stat
 import subprocess
@@ -12,6 +12,11 @@ from virttest.libvirt_xml.vm_xml import VMXML
 from virttest.utils_test import libvirt as utlv
 from virttest.libvirt_xml.devices.controller import Controller
 from virttest import data_dir
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/incremental_backup/incremental_backup_backing_chain.py
+++ b/libvirt/tests/src/incremental_backup/incremental_backup_backing_chain.py
@@ -1,7 +1,7 @@
 import os
 import re
 import json
-import logging
+import logging as log
 import shutil
 
 from avocado.utils import process
@@ -13,6 +13,11 @@ from virttest import utils_backup
 from virttest import libvirt_version
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/incremental_backup/incremental_backup_checkpoint_cmd.py
+++ b/libvirt/tests/src/incremental_backup/incremental_backup_checkpoint_cmd.py
@@ -1,6 +1,6 @@
 import os
 import re
-import logging
+import logging as log
 import operator
 
 from virttest import virsh
@@ -12,6 +12,11 @@ from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import checkpoint_xml
 from virttest.libvirt_xml.devices import graphics
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/incremental_backup/incremental_backup_event_monitor.py
+++ b/libvirt/tests/src/incremental_backup/incremental_backup_event_monitor.py
@@ -1,6 +1,6 @@
 import os
 import re
-import logging
+import logging as log
 import aexpect
 
 from virttest import virsh
@@ -13,6 +13,11 @@ from virttest import xml_utils
 from virttest import libvirt_version
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/incremental_backup/incremental_backup_migration.py
+++ b/libvirt/tests/src/incremental_backup/incremental_backup_migration.py
@@ -1,5 +1,5 @@
 import json
-import logging
+import logging as log
 import os
 
 from virttest import data_dir
@@ -9,6 +9,11 @@ from virttest import utils_disk
 from virttest import virsh
 
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 class MigrationWithCheckpoint(mt.MigrationTemplate):

--- a/libvirt/tests/src/incremental_backup/incremental_backup_multidisk.py
+++ b/libvirt/tests/src/incremental_backup/incremental_backup_multidisk.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 
 from virttest import virsh
 from virttest import data_dir
@@ -7,6 +7,11 @@ from virttest import utils_backup
 from virttest import libvirt_version
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/incremental_backup/incremental_backup_pull_mode.py
+++ b/libvirt/tests/src/incremental_backup/incremental_backup_pull_mode.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 import re
 import signal
@@ -18,6 +18,11 @@ from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 from virttest.utils_config import LibvirtQemuConfig
 from virttest.utils_conn import TLSConnection
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/incremental_backup/incremental_backup_push_mode.py
+++ b/libvirt/tests/src/incremental_backup/incremental_backup_push_mode.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 import signal
 
@@ -14,6 +14,11 @@ from virttest import utils_package
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/kernel_panic.py
+++ b/libvirt/tests/src/kernel_panic.py
@@ -1,9 +1,14 @@
-import logging
+import logging as log
 
 import aexpect
 
 from virttest import virt_vm
 from virttest import virsh
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/lease_device.py
+++ b/libvirt/tests/src/lease_device.py
@@ -1,8 +1,13 @@
-import logging
+import logging as log
 
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices import lease
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def create_lease(**attrs):

--- a/libvirt/tests/src/libvirt_bench/libvirt_bench_domstate_switch_in_loop.py
+++ b/libvirt/tests/src/libvirt_bench/libvirt_bench_domstate_switch_in_loop.py
@@ -1,9 +1,14 @@
 import time
-import logging
+import logging as log
 
 from avocado.core import exceptions
 
 from virttest import virsh
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/libvirt_bench/libvirt_bench_domstate_switch_with_iozone.py
+++ b/libvirt/tests/src/libvirt_bench/libvirt_bench_domstate_switch_with_iozone.py
@@ -1,10 +1,15 @@
 import os
 import time
-import logging
+import logging as log
 
 from virttest import virsh
 from virttest import utils_test
 from virttest import utils_misc
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def func_in_thread(vm, timeout, test):

--- a/libvirt/tests/src/libvirt_bench/libvirt_bench_domstate_switch_with_unixbench.py
+++ b/libvirt/tests/src/libvirt_bench/libvirt_bench_domstate_switch_with_unixbench.py
@@ -1,6 +1,6 @@
 import os
 import time
-import logging
+import logging as log
 import shutil
 import subprocess
 
@@ -8,6 +8,11 @@ from virttest import virsh
 from virttest import utils_test
 from virttest import utils_misc
 from virttest import data_dir
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def func_in_thread(vm, timeout, test):

--- a/libvirt/tests/src/libvirt_bench/libvirt_bench_dump_with_netperf.py
+++ b/libvirt/tests/src/libvirt_bench/libvirt_bench_dump_with_netperf.py
@@ -1,9 +1,14 @@
 import os
-import logging
+import logging as log
 
 from virttest import utils_test
 from virttest import utils_misc
 from virttest import data_dir
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/libvirt_bench/libvirt_bench_dump_with_unixbench.py
+++ b/libvirt/tests/src/libvirt_bench/libvirt_bench_dump_with_unixbench.py
@@ -1,9 +1,14 @@
 import os
-import logging
+import logging as log
 
 from virttest import utils_test
 from virttest import utils_misc
 from virttest import data_dir
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/libvirt_bench/libvirt_bench_ttcp_from_guest_to_host.py
+++ b/libvirt/tests/src/libvirt_bench/libvirt_bench_ttcp_from_guest_to_host.py
@@ -1,5 +1,5 @@
 import time
-import logging
+import logging as log
 
 import aexpect
 
@@ -8,6 +8,11 @@ from avocado.utils import path
 from virttest import utils_net
 from virttest import remote
 from virttest import utils_misc
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/libvirt_bench/libvirt_bench_usb_hotplug.py
+++ b/libvirt/tests/src/libvirt_bench/libvirt_bench_usb_hotplug.py
@@ -1,6 +1,6 @@
 import os
 import shutil
-import logging
+import logging as log
 
 from avocado.utils import process
 
@@ -11,6 +11,11 @@ from virttest import utils_misc
 from virttest.libvirt_xml.vm_xml import VMXML
 from virttest.libvirt_xml.devices.disk import Disk
 from virttest.libvirt_xml.devices.input import Input
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/libvirt_bench/libvirt_bench_vcpu_hotplug.py
+++ b/libvirt/tests/src/libvirt_bench/libvirt_bench_vcpu_hotplug.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import re
 import platform
 
@@ -9,6 +9,11 @@ from virttest import libvirt_vm
 from virttest import utils_test
 from virttest import utils_misc
 from virttest import cpu
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/libvirt_cputune.py
+++ b/libvirt/tests/src/libvirt_cputune.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import ast
 import os
 import re
@@ -10,6 +10,11 @@ from virttest import utils_misc
 from virttest import libvirt_version
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def verify_membind_value(schemata_file, mb_value):

--- a/libvirt/tests/src/libvirt_hooks.py
+++ b/libvirt/tests/src/libvirt_hooks.py
@@ -1,6 +1,6 @@
 import os
 import shutil
-import logging
+import logging as log
 import platform
 import time
 
@@ -16,6 +16,11 @@ from virttest import libvirt_version
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.controller import Controller
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/libvirt_hugepage.py
+++ b/libvirt/tests/src/libvirt_hugepage.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 import time
 
@@ -16,6 +16,11 @@ from virttest.remote import LoginError
 from virttest.virt_vm import VMError
 from virttest.libvirt_xml import vm_xml
 from virttest.staging import utils_memory
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def prepare_c_file():

--- a/libvirt/tests/src/libvirt_mem.py
+++ b/libvirt/tests/src/libvirt_mem.py
@@ -2,7 +2,7 @@ import os
 import re
 import ast
 import uuid
-import logging
+import logging as log
 import platform
 import tempfile
 import time
@@ -30,6 +30,11 @@ from virttest.staging.utils_memory import drop_caches
 from virttest.staging.utils_memory import read_from_numastat
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/libvirt_package.py
+++ b/libvirt/tests/src/libvirt_package.py
@@ -1,10 +1,15 @@
-import logging
+import logging as log
 
 from avocado.utils import process
 from avocado.utils import software_manager
 
 from virttest import utils_libvirtd
 from virttest.libvirt_xml import vm_xml
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/libvirt_qemu_cmdline.py
+++ b/libvirt/tests/src/libvirt_qemu_cmdline.py
@@ -3,7 +3,7 @@ Test libvirt support features in qemu cmdline.
 BTW it not limited to hypervisors CPU/machine features.
 """
 import re
-import logging
+import logging as log
 import platform
 
 from virttest import virsh
@@ -13,6 +13,11 @@ from virttest.utils_test import libvirt
 from virttest import libvirt_version
 
 from avocado.utils import process, astring
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def config_feature_pv_eoi(test, vmxml, **kwargs):

--- a/libvirt/tests/src/libvirt_rng.py
+++ b/libvirt/tests/src/libvirt_rng.py
@@ -2,7 +2,7 @@ import re
 import os
 import ast
 import shutil
-import logging
+import logging as log
 import uuid
 import aexpect
 import socket
@@ -20,6 +20,11 @@ from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import xcepts
 from virttest.libvirt_xml.devices import rng
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/libvirt_scsi_hostdev.py
+++ b/libvirt/tests/src/libvirt_scsi_hostdev.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import re
 import aexpect
 import platform
@@ -18,6 +18,11 @@ from virttest import libvirt_version
 
 from virttest.libvirt_xml.devices import hostdev
 from virttest.libvirt_xml.devices.controller import Controller
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/libvirt_vcpu_plug_unplug.py
+++ b/libvirt/tests/src/libvirt_vcpu_plug_unplug.py
@@ -1,6 +1,6 @@
 import os
 import re
-import logging
+import logging as log
 import platform
 import time
 
@@ -16,6 +16,11 @@ from virttest.utils_test import libvirt
 from virttest.libvirt_xml.vm_xml import VMXML
 
 vm_uptime_init = 0
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/libvirtd/libvirtd.py
+++ b/libvirt/tests/src/libvirtd/libvirtd.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import threading
 import re
 try:
@@ -12,6 +12,11 @@ from virttest import utils_misc
 from virttest import utils_libvirtd
 
 msg_queue = Queue.Queue()
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def start_journal():

--- a/libvirt/tests/src/libvirtd/libvirtd_multi_conn.py
+++ b/libvirt/tests/src/libvirtd/libvirtd_multi_conn.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import time
 
 from avocado.utils import process
@@ -6,6 +6,11 @@ from avocado.utils import process
 from virttest import utils_libvirtd
 from virttest import utils_package
 from virttest import virsh
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/libvirtd_start.py
+++ b/libvirt/tests/src/libvirtd_start.py
@@ -1,6 +1,6 @@
 import os
 import re
-import logging
+import logging as log
 import time
 
 from avocado.core import exceptions
@@ -10,6 +10,11 @@ from avocado.utils import service
 
 from virttest import utils_libvirtd
 from virttest import utils_selinux
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/limit.py
+++ b/libvirt/tests/src/limit.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 from string import ascii_letters as letters
 import os
 
@@ -13,6 +13,11 @@ from virttest import libvirt_xml
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml.devices.interface import Interface
 from virttest.libvirt_xml.devices.disk import Disk
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/lxc/lxc_life_cycle.py
+++ b/libvirt/tests/src/lxc/lxc_life_cycle.py
@@ -1,7 +1,7 @@
 import os
 import re
 import shutil
-import logging
+import logging as log
 
 import aexpect
 
@@ -16,6 +16,11 @@ from virttest.libvirt_xml.devices.emulator import Emulator
 from virttest.libvirt_xml.devices.console import Console
 from virttest.libvirt_xml.devices.filesystem import Filesystem
 from virttest.utils_test import libvirt as utlv
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/memory/allocpages.py
+++ b/libvirt/tests/src/memory/allocpages.py
@@ -1,9 +1,14 @@
-import logging
+import logging as log
 
 from virttest import virsh
 from virttest.staging.utils_memory import get_huge_page_size
 from virttest.staging.utils_memory import get_num_huge_pages
 from virttest.staging.utils_memory import set_num_huge_pages
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/memory/hmat.py
+++ b/libvirt/tests/src/memory/hmat.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from virttest import virsh
 from virttest import libvirt_version
@@ -7,6 +7,11 @@ from virttest.libvirt_xml import vm_xml
 from virttest.utils_libvirt import libvirt_cpu
 from virttest.utils_libvirt import libvirt_numa
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/memory/memballoon.py
+++ b/libvirt/tests/src/memory/memballoon.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
@@ -6,6 +6,11 @@ from virttest.utils_test import libvirt
 
 
 VIRSH_ARGS = {'debug': True, 'ignore_status': False}
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/memory/memory_discard.py
+++ b/libvirt/tests/src/memory/memory_discard.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import ast
 import time
 
@@ -12,6 +12,11 @@ from virttest import utils_libvirtd
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 from virttest.staging import utils_memory
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/memory/memory_hotplug.py
+++ b/libvirt/tests/src/memory/memory_hotplug.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 import re
 
@@ -8,6 +8,11 @@ from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_libvirt import libvirt_cpu
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def pretest_vm_setup(params, case):

--- a/libvirt/tests/src/memory/memory_misc.py
+++ b/libvirt/tests/src/memory/memory_misc.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import re
 
 from avocado.utils import process
@@ -11,6 +11,11 @@ from virttest.libvirt_xml.devices.memory import Memory
 from virttest.utils_test import libvirt
 
 VIRSH_ARGS = {'debug': True, 'ignore_status': False}
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/memory/nvdimm.py
+++ b/libvirt/tests/src/memory/nvdimm.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import time
 import platform
 
@@ -12,6 +12,11 @@ from virttest import utils_package
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices import memory
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/migration/live_migration.py
+++ b/libvirt/tests/src/migration/live_migration.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from virttest import libvirt_vm
 from virttest import migration
@@ -13,6 +13,11 @@ from virttest.utils_libvirt import libvirt_config
 from virttest.utils_libvirt import libvirt_disk
 
 from provider.migration import migration_base
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def get_used_port(func_returns):

--- a/libvirt/tests/src/migration/migrate_bandwidth.py
+++ b/libvirt/tests/src/migration/migrate_bandwidth.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import time
 
 from virttest import libvirt_vm
@@ -14,6 +14,11 @@ from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 from virttest.utils_test import libvirt_domjobinfo
 from virttest.utils_libvirt import libvirt_config
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/migration/migrate_ceph.py
+++ b/libvirt/tests/src/migration/migrate_ceph.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 import re
 
@@ -26,6 +26,11 @@ from virttest.utils_test import libvirt
 from virttest import libvirt_version
 
 MIGRATE_RET = False
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def check_output(test, output_msg, params):

--- a/libvirt/tests/src/migration/migrate_event.py
+++ b/libvirt/tests/src/migration/migrate_event.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from virttest import libvirt_vm
 from virttest import migration
@@ -7,6 +7,11 @@ from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 
 from provider.migration import migration_base
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/migration/migrate_gluster.py
+++ b/libvirt/tests/src/migration/migrate_gluster.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 
 from avocado.utils import process
@@ -15,6 +15,11 @@ from virttest import migration
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_libvirt import libvirt_config
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/migration/migrate_mem.py
+++ b/libvirt/tests/src/migration/migrate_mem.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 
 from virttest import libvirt_vm
 from virttest import defaults
@@ -16,6 +16,11 @@ from virttest.libvirt_xml import vm_xml
 from virttest.utils_libvirt import libvirt_cpu
 from virttest.utils_test import libvirt
 from virttest.utils_libvirt import libvirt_config
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/migration/migrate_network.py
+++ b/libvirt/tests/src/migration/migrate_network.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from virttest import libvirt_version
 from virttest import libvirt_vm
@@ -14,6 +14,11 @@ from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 from virttest.utils_libvirt import libvirt_network
 from virttest.libvirt_xml.devices import interface
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/migration/migrate_options_shared.py
+++ b/libvirt/tests/src/migration/migrate_options_shared.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import time
 import math
 import re
@@ -39,6 +39,11 @@ from virttest.utils_test import libvirt
 from virttest.utils_conn import TLSConnection
 from virttest.utils_libvirt import libvirt_config
 from virttest.libvirt_xml.devices.controller import Controller
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/migration/migrate_over_unix.py
+++ b/libvirt/tests/src/migration/migrate_over_unix.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import time
 
 from avocado.utils import process
@@ -18,6 +18,11 @@ from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 from virttest.utils_libvirt import libvirt_disk
 from virttest.utils_libvirt import libvirt_pcicontr
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/migration/migrate_service_control.py
+++ b/libvirt/tests/src/migration/migrate_service_control.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 
 from pwd import getpwuid
@@ -15,6 +15,11 @@ from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 
 from provider.migration import migration_base
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def check_image_ownership(vm_name, exp_ownership, test):

--- a/libvirt/tests/src/migration/migrate_storage.py
+++ b/libvirt/tests/src/migration/migrate_storage.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import time
 
 from avocado.utils import process
@@ -15,6 +15,11 @@ from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 from virttest.utils_libvirt import libvirt_config
 from virttest.utils_libvirt import libvirt_network
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 import re
 import signal
@@ -49,6 +49,11 @@ from virttest.utils_libvirt import libvirt_config
 from virttest import libvirt_version
 
 MIGRATE_RET = False
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def destroy_active_pool_on_remote(params):

--- a/libvirt/tests/src/migration/migrate_with_legacy_guest.py
+++ b/libvirt/tests/src/migration/migrate_with_legacy_guest.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import re
 
 from avocado.utils import download
@@ -15,6 +15,11 @@ from virttest import libvirt_version
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 from virttest.utils_libvirt import libvirt_config
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/migration/migrate_with_various_hostname.py
+++ b/libvirt/tests/src/migration/migrate_with_various_hostname.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from avocado.utils import process
 
@@ -12,6 +12,11 @@ from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 
 from provider.migration import migration_base
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def get_hostname(test, remote_params=None):

--- a/libvirt/tests/src/migration/migrate_with_virtual_devices.py
+++ b/libvirt/tests/src/migration/migrate_with_virtual_devices.py
@@ -1,6 +1,6 @@
 import ast
 import aexpect
-import logging
+import logging as log
 
 from avocado.utils import process
 
@@ -10,6 +10,11 @@ from virttest.utils_test import libvirt
 from virttest import utils_misc
 from virttest import virsh, libvirt_version
 from virttest import migration_template as mt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 class DeviceNotFoundError(mt.Error):

--- a/libvirt/tests/src/migration/sriov_migrate.py
+++ b/libvirt/tests/src/migration/sriov_migrate.py
@@ -1,6 +1,6 @@
 import os
 import copy
-import logging
+import logging as log
 import re
 
 from avocado.utils import process
@@ -21,6 +21,11 @@ from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices import interface
 from virttest.utils_libvirt import libvirt_config
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/multifunction.py
+++ b/libvirt/tests/src/multifunction.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 
 from avocado.utils import process
@@ -11,6 +11,11 @@ from virttest import data_dir
 from virttest.libvirt_xml import xcepts
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices import disk
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 class MFError(Exception):

--- a/libvirt/tests/src/multiqueue.py
+++ b/libvirt/tests/src/multiqueue.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import time
 import threading
 import re
@@ -11,6 +11,11 @@ from virttest import remote
 from virttest import libvirt_vm
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt as utlv
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def config_xml_multiqueue(vm_name, vcpu=1, multiqueue=4):

--- a/libvirt/tests/src/multivm_loadstress.py
+++ b/libvirt/tests/src/multivm_loadstress.py
@@ -1,8 +1,13 @@
-import logging
+import logging as log
 import time
 
 from avocado.core import exceptions
 from virttest import utils_test
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/multivm_stress/multivm_stress.py
+++ b/libvirt/tests/src/multivm_stress/multivm_stress.py
@@ -1,8 +1,13 @@
-import logging
+import logging as log
 
 from virttest import utils_stress
 from virttest import error_context
 from virttest import utils_test
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 @error_context.context_aware

--- a/libvirt/tests/src/npiv/npiv_concurrent.py
+++ b/libvirt/tests/src/npiv/npiv_concurrent.py
@@ -1,6 +1,6 @@
 import os
 import re
-import logging
+import logging as log
 import threading
 import time
 
@@ -19,6 +19,11 @@ _MPATH_DIR = "/dev/mapper/"
 _BYPATH_DIR = "/dev/disk/by-path/"
 _VM_FILE_PATH = "/tmp/test.txt"
 _REPEAT = 10
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def convert_img_to_dev(test, src_fmt, dest_fmt, img_src, blk_dev):

--- a/libvirt/tests/src/npiv/npiv_hostdev_passthrough.py
+++ b/libvirt/tests/src/npiv/npiv_hostdev_passthrough.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import aexpect
 
 from avocado.utils import process
@@ -14,6 +14,11 @@ from virttest import utils_misc
 
 
 _TIMEOUT = 5
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/npiv/npiv_image_from_pool.py
+++ b/libvirt/tests/src/npiv/npiv_image_from_pool.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 from avocado.core import exceptions
 from avocado.utils import process
@@ -9,6 +9,11 @@ from virttest import utils_misc
 from virttest import libvirt_vm as lib_vm
 from virttest.utils_test import libvirt as utlv
 from virttest import utils_npiv as nodedev
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def mount_and_dd(session, mount_disk):

--- a/libvirt/tests/src/npiv/npiv_nodedev_create_destroy.py
+++ b/libvirt/tests/src/npiv/npiv_nodedev_create_destroy.py
@@ -1,6 +1,6 @@
 import os
 import re
-import logging
+import logging as log
 from tempfile import mktemp
 from avocado.core import exceptions
 from virttest import virsh
@@ -9,6 +9,11 @@ from virttest import utils_misc
 
 _FC_HOST_PATH = "/sys/class/fc_host"
 _DELAY_TIME = 5
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def check_nodedev(dev_name, dev_parent=None):

--- a/libvirt/tests/src/npiv/npiv_pool_regression.py
+++ b/libvirt/tests/src/npiv/npiv_pool_regression.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 from shutil import copyfile
 from avocado.core import exceptions
 from virttest import virsh
@@ -13,6 +13,11 @@ from virttest.utils_test import libvirt as utlv
 from virttest import utils_npiv as nodedev
 
 _DELAY_TIME = 5
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def mount_and_dd(session, mount_disk):

--- a/libvirt/tests/src/npiv/npiv_pool_vol.py
+++ b/libvirt/tests/src/npiv/npiv_pool_vol.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 from shutil import copyfile
 from avocado.core import exceptions
 from avocado.utils import process
@@ -16,6 +16,11 @@ from virttest.libvirt_xml.devices import disk
 from virttest.utils_test import libvirt as utlv
 
 _DELAY_TIME = 5
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def mount_and_dd(session, mount_disk):

--- a/libvirt/tests/src/npiv/npiv_restart_libvirtd.py
+++ b/libvirt/tests/src/npiv/npiv_restart_libvirtd.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import time
 
 from avocado.utils import process
@@ -10,6 +10,11 @@ from virttest import utils_npiv as npiv
 
 
 _TIMEOUT = 5
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def restart_libvirtd_and_check_vhbaxml(scsi_host, test):

--- a/libvirt/tests/src/npiv/npiv_snapshot.py
+++ b/libvirt/tests/src/npiv/npiv_snapshot.py
@@ -1,6 +1,6 @@
 import os
 import re
-import logging
+import logging as log
 
 from avocado.core import exceptions
 from avocado.utils import process
@@ -17,6 +17,11 @@ from virttest.utils_test import libvirt as utlv
 
 _TIMEOUT = 5
 _BY_PATH_DIR = "/dev/disk/by-path"
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def get_symbols_by_blk(blkdev, method="by-path"):

--- a/libvirt/tests/src/npiv/npiv_virtual_disk.py
+++ b/libvirt/tests/src/npiv/npiv_virtual_disk.py
@@ -1,6 +1,6 @@
 import os
 import re
-import logging
+import logging as log
 from shutil import copyfile
 
 from avocado.core import exceptions
@@ -16,6 +16,11 @@ from virttest.utils_test import libvirt as utlv
 
 
 _TIMEOUT = 5
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def get_symbols_by_blk(blkdev, method="by-path"):

--- a/libvirt/tests/src/numa/guest_numa.py
+++ b/libvirt/tests/src/numa/guest_numa.py
@@ -1,5 +1,5 @@
 import re
-import logging
+import logging as log
 import platform
 
 from avocado.utils import process
@@ -12,6 +12,11 @@ from virttest import utils_libvirtd
 from virttest import test_setup
 from virttest import utils_params
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def handle_param(param_tuple, params):

--- a/libvirt/tests/src/numa/numa_capabilities.py
+++ b/libvirt/tests/src/numa/numa_capabilities.py
@@ -1,8 +1,13 @@
-import logging
+import logging as log
 
 from virttest import libvirt_xml
 from virttest import utils_libvirtd
 from virttest import utils_misc
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/numa/numa_config_with_auto_placement.py
+++ b/libvirt/tests/src/numa/numa_config_with_auto_placement.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import re
 
 from avocado.core.exceptions import TestFail, TestError
@@ -9,6 +9,11 @@ from virttest import libvirt_xml
 from virttest import utils_libvirtd
 from virttest import utils_misc
 from virttest import virsh
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run_all_commands(vm_name, config_type, cpu_range):

--- a/libvirt/tests/src/numa/numa_memAccess.py
+++ b/libvirt/tests/src/numa/numa_memAccess.py
@@ -1,9 +1,14 @@
-import logging
+import logging as log
 
 from virttest.utils_test import libvirt
 from virttest import libvirt_xml
 from virttest import utils_test
 from virttest import virsh
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def define_and_check_xml(vmxml, params):

--- a/libvirt/tests/src/numa/numa_memory.py
+++ b/libvirt/tests/src/numa/numa_memory.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import platform
 import random
 
@@ -15,6 +15,11 @@ from virttest import utils_test
 from virttest import utils_config
 from virttest import utils_libvirtd
 from virttest import data_dir
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/numa/numa_memory_migrate.py
+++ b/libvirt/tests/src/numa/numa_memory_migrate.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 
 from avocado.utils import process
 from avocado.core import exceptions
@@ -14,6 +14,11 @@ from virttest import utils_test
 from virttest import utils_config
 from virttest import utils_libvirtd
 from virttest import data_dir
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/numa/numa_memory_spread.py
+++ b/libvirt/tests/src/numa/numa_memory_spread.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import re
 import threading
 
@@ -11,6 +11,11 @@ from virttest import utils_package
 from virttest import virsh
 
 from virttest.staging.utils_memory import read_from_numastat
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def get_qemu_total_for_nodes():

--- a/libvirt/tests/src/numa/numa_node_memory_bind.py
+++ b/libvirt/tests/src/numa/numa_node_memory_bind.py
@@ -1,9 +1,14 @@
-import logging
+import logging as log
 
 from virttest import libvirt_xml
 from virttest import utils_misc
 
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def prepare_vm(vm_name, test):

--- a/libvirt/tests/src/numa/numa_nodeset.py
+++ b/libvirt/tests/src/numa/numa_nodeset.py
@@ -1,9 +1,14 @@
-import logging
+import logging as log
 
 from virttest import libvirt_xml
 from virttest import utils_misc
 from virttest import utils_test
 from virttest import virsh
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def update_xml(vm_name, params):

--- a/libvirt/tests/src/numa/numa_numad.py
+++ b/libvirt/tests/src/numa/numa_numad.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os.path
 import shutil
 
@@ -8,6 +8,11 @@ from avocado.utils import process
 from virttest import data_dir
 from virttest import libvirt_xml
 from virttest import virt_vm
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def action_for_numad_file(numad_path='/usr/bin/numad', action='recover'):

--- a/libvirt/tests/src/numa/numa_numanode_cpu_info.py
+++ b/libvirt/tests/src/numa/numa_numanode_cpu_info.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from avocado.core.exceptions import TestError, TestCancel
 from avocado.utils import process
@@ -7,6 +7,11 @@ from virttest import libvirt_xml
 from virttest import utils_misc
 from virttest import utils_test
 from virttest import virsh
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def update_xml(vm_name, online_nodes, params):

--- a/libvirt/tests/src/numa/numa_numatune_cpu.py
+++ b/libvirt/tests/src/numa/numa_numatune_cpu.py
@@ -1,10 +1,15 @@
-import logging
+import logging as log
 
 from avocado.core import exceptions
 from avocado.utils import process
 
 from virttest import libvirt_xml
 from virttest import utils_misc
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def change_cpu_state_and_check(cpu, state):

--- a/libvirt/tests/src/numa/numa_preferred_undefine.py
+++ b/libvirt/tests/src/numa/numa_preferred_undefine.py
@@ -1,8 +1,13 @@
-import logging
+import logging as log
 
 from virttest import libvirt_xml
 from virttest import virsh
 from virttest import utils_libvirtd
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/numa/numad_vcpupin.py
+++ b/libvirt/tests/src/numa/numad_vcpupin.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from avocado.utils import process
 from avocado.utils import cpu as cpuutils
@@ -7,6 +7,11 @@ from virttest import libvirt_xml
 from virttest import virsh
 from virttest import utils_misc
 from virttest import utils_libvirtd
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/nwfilter/filter_aready_present_binding.py
+++ b/libvirt/tests/src/nwfilter/filter_aready_present_binding.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 import re
 
@@ -10,6 +10,11 @@ from virttest import utils_libvirtd
 from virttest import data_dir
 from virttest.libvirt_xml import nwfilter_binding
 from virttest import utils_package
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/nwfilter/nwfilter_binding_create.py
+++ b/libvirt/tests/src/nwfilter/nwfilter_binding_create.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import time
 
 
@@ -8,6 +8,11 @@ from virttest.utils_test import libvirt as utlv
 from virttest import libvirt_xml
 from virttest.libvirt_xml import nwfilter_binding
 from virttest import utils_libvirtd
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/nwfilter/nwfilter_binding_delete.py
+++ b/libvirt/tests/src/nwfilter/nwfilter_binding_delete.py
@@ -1,10 +1,15 @@
-import logging
+import logging as log
 
 from virttest.libvirt_xml.devices import interface
 from virttest import virsh
 from virttest.utils_test import libvirt as utlv
 from virttest import libvirt_xml
 from virttest import utils_libvirtd
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/nwfilter/nwfilter_binding_dumpxml.py
+++ b/libvirt/tests/src/nwfilter/nwfilter_binding_dumpxml.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 
 from virttest import virsh
@@ -9,6 +9,11 @@ from virttest.libvirt_xml.devices import interface
 from virttest.utils_libvirt import libvirt_pcicontr
 
 from avocado.utils import process
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/nwfilter/nwfilter_binding_list.py
+++ b/libvirt/tests/src/nwfilter/nwfilter_binding_list.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import time
 import re
 
@@ -7,6 +7,11 @@ from virttest.libvirt_xml.devices import interface
 from virttest import virsh
 from virttest import libvirt_xml
 from virttest import utils_package
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/nwfilter/nwfilter_edit_uuid.py
+++ b/libvirt/tests/src/nwfilter/nwfilter_edit_uuid.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 import aexpect
 
@@ -7,6 +7,11 @@ from virttest import libvirt_xml
 from virttest import remote
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/nwfilter/nwfilter_update_lock.py
+++ b/libvirt/tests/src/nwfilter/nwfilter_update_lock.py
@@ -1,6 +1,6 @@
 import time
 import threading
-import logging
+import logging as log
 
 from virttest import virsh
 from virttest import libvirt_xml
@@ -8,6 +8,11 @@ from virttest import utils_misc
 from virttest.libvirt_xml.devices import interface
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/nwfilter/nwfilter_update_vm_running.py
+++ b/libvirt/tests/src/nwfilter/nwfilter_update_vm_running.py
@@ -1,5 +1,5 @@
 import re
-import logging
+import logging as log
 
 from avocado.utils import process
 from avocado.utils import astring
@@ -9,6 +9,11 @@ from virttest import libvirt_xml
 from virttest import utils_misc
 from virttest.utils_test import libvirt as utlv
 from virttest.libvirt_xml.devices import interface
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/nwfilter/nwfilter_vm_attach.py
+++ b/libvirt/tests/src/nwfilter/nwfilter_vm_attach.py
@@ -1,5 +1,5 @@
 import re
-import logging
+import logging as log
 
 from avocado.utils import process
 from avocado.utils import astring
@@ -10,6 +10,11 @@ from virttest import utils_libvirtd
 from virttest import utils_misc
 from virttest.utils_test import libvirt as utlv
 from virttest.libvirt_xml.devices import interface
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/nwfilter/nwfilter_vm_start.py
+++ b/libvirt/tests/src/nwfilter/nwfilter_vm_start.py
@@ -1,5 +1,5 @@
 import re
-import logging
+import logging as log
 import socket
 
 from avocado.utils import process
@@ -17,6 +17,11 @@ from virttest.libvirt_xml.devices import interface
 from virttest import utils_libguestfs
 from virttest import utils_net
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/nwfilter/vm_destroy_with_nwfilter.py
+++ b/libvirt/tests/src/nwfilter/vm_destroy_with_nwfilter.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from avocado.utils import process
 from avocado.utils import astring
@@ -7,6 +7,11 @@ from virttest import libvirt_xml
 from virttest import virsh
 from virttest.libvirt_xml.devices import interface
 from virttest.utils_test import libvirt as utlv
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/papr_hpt.py
+++ b/libvirt/tests/src/papr_hpt.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import platform
 import re
 import os
@@ -13,6 +13,11 @@ from virttest import utils_misc
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 from virttest.staging import utils_memory
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/passthrough/ap/libvirt_ap_passthrough.py
+++ b/libvirt/tests/src/passthrough/ap/libvirt_ap_passthrough.py
@@ -12,7 +12,7 @@
 # Copyright: Red Hat Inc. 2020
 # Author: Sebastian Mitterle <smitterl@redhat.com>
 
-import logging
+import logging as log
 
 from virttest import virsh
 from virttest.utils_zcrypt import CryptoDeviceInfoBuilder, \
@@ -23,6 +23,11 @@ from virttest.utils_misc import wait_for
 
 # minimal supported hwtype
 MIN_HWTYPE = 10
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/passthrough/pci/libvirt_pci_passthrough.py
+++ b/libvirt/tests/src/passthrough/pci/libvirt_pci_passthrough.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import netaddr
 import time
 
@@ -8,6 +8,11 @@ from virttest.libvirt_xml.vm_xml import VMXML
 from virttest.libvirt_xml.nodedev_xml import NodedevXML
 from virttest.test_setup import PciAssignable
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/passthrough/pci/libvirt_pci_passthrough_hotplug.py
+++ b/libvirt/tests/src/passthrough/pci/libvirt_pci_passthrough_hotplug.py
@@ -14,7 +14,7 @@
 
 
 import os
-import logging
+import logging as log
 import aexpect
 import time
 
@@ -31,6 +31,11 @@ from virttest import utils_package
 from virttest import utils_net
 from virttest import libvirt_version
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/passthrough/pci/vfio.py
+++ b/libvirt/tests/src/passthrough/pci/vfio.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import tempfile
 import re
 
@@ -12,6 +12,11 @@ from virttest import utils_misc
 from virttest import virt_vm
 from virttest.utils_test import libvirt as utlv
 from virttest.libvirt_xml import vm_xml
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def add_devices_to_iommu_group(vfio_controller, pci_id_list):

--- a/libvirt/tests/src/passthrough/usb/usb_passthrough.py
+++ b/libvirt/tests/src/passthrough/usb/usb_passthrough.py
@@ -1,9 +1,14 @@
-import logging
+import logging as log
 import re
 
 from avocado.utils import process
 
 from virttest.libvirt_xml.vm_xml import VMXML
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/ppc_device.py
+++ b/libvirt/tests/src/ppc_device.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import platform
 
 from avocado.utils import process
@@ -8,6 +8,11 @@ from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.panic import Panic
 from virttest.utils_test import libvirt
 from virttest.libvirt_version import version_compare
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/remote_access/remote_access.py
+++ b/libvirt/tests/src/remote_access/remote_access.py
@@ -1,6 +1,6 @@
 import re
 import os
-import logging
+import logging as log
 import json
 
 from avocado.utils import distro
@@ -23,6 +23,11 @@ from virttest.utils_test.libvirt import connect_libvirtd
 from virttest.utils_test.libvirt import customize_libvirt_config
 from virttest.utils_test.libvirt import remotely_control_libvirtd
 from virttest.utils_net import check_listening_port_remote_by_service
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def remote_access(params, test):

--- a/libvirt/tests/src/remote_access/remote_tls_multiple_certs.py
+++ b/libvirt/tests/src/remote_access/remote_tls_multiple_certs.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 
 import aexpect
@@ -15,6 +15,11 @@ from virttest import utils_misc
 from virttest import utils_split_daemons
 from virttest import remote as remote_old
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def get_server_details(params):

--- a/libvirt/tests/src/remote_access/remote_tls_priority.py
+++ b/libvirt/tests/src/remote_access/remote_tls_priority.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from virttest import virsh
 from virttest import remote
@@ -10,6 +10,11 @@ from virttest import remote as remote_old
 from virttest.utils_conn import TLSConnection
 from virttest.utils_test.libvirt import remotely_control_libvirtd
 from virttest.utils_test.libvirt import customize_libvirt_config
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def change_parameter_on_remote(connect_params, replacement_dict):

--- a/libvirt/tests/src/remote_access/virsh_non_root_polkit.py
+++ b/libvirt/tests/src/remote_access/virsh_non_root_polkit.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from avocado.core import exceptions
 from avocado.utils import process
@@ -6,6 +6,11 @@ from avocado.utils import process
 from virttest import remote
 from virttest import utils_misc
 from virttest.utils_test.libvirt import connect_libvirtd
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def local_access(params, test):

--- a/libvirt/tests/src/resource_abnormal.py
+++ b/libvirt/tests/src/resource_abnormal.py
@@ -2,7 +2,7 @@ import os
 import time
 import stat
 import signal
-import logging
+import logging as log
 import threading
 
 from avocado.utils import process
@@ -32,12 +32,16 @@ from virttest.utils_iptables import Iptables
 from virttest.utils_misc import SELinuxBoolean
 
 
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
+
+
 class Vol_clone(object):
 
     """
     Test volume clone with abnormal resource
     """
-
     def __init__(self, test, params):
         self.pvtest = None
         self.pool = None

--- a/libvirt/tests/src/serial/serial_functional.py
+++ b/libvirt/tests/src/serial/serial_functional.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import time
 import errno
 import socket
@@ -22,6 +22,11 @@ from virttest.libvirt_xml.devices.graphics import Graphics
 from virttest import libvirt_version
 
 from avocado.utils import astring
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 class Console(aexpect.ShellSession):

--- a/libvirt/tests/src/serial/serial_pty_log.py
+++ b/libvirt/tests/src/serial/serial_pty_log.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from virttest import libvirt_xml
 from virttest import utils_config
@@ -8,6 +8,11 @@ from virttest import virsh
 
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml.devices import librarian
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def check_pty_log_file(file_path, boot_prompt):

--- a/libvirt/tests/src/smt.py
+++ b/libvirt/tests/src/smt.py
@@ -1,5 +1,5 @@
 import time
-import logging
+import logging as log
 import re
 
 from avocado.utils import process
@@ -8,6 +8,11 @@ from avocado.utils import astring
 from virttest.libvirt_xml import vm_xml
 from virttest import utils_package
 from virttest import virt_vm
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/sriov/sriov.py
+++ b/libvirt/tests/src/sriov/sriov.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 import re
 import string
@@ -18,6 +18,11 @@ from virttest.libvirt_xml import network_xml
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.interface import Interface
 from virttest.libvirt_xml.devices.controller import Controller
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/sriov/sriov_managed.py
+++ b/libvirt/tests/src/sriov/sriov_managed.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from provider.sriov import sriov_base
 
@@ -12,6 +12,11 @@ from virttest.utils_libvirt import libvirt_network
 from virttest.utils_libvirt import libvirt_vfio
 from virttest.utils_libvirt import libvirt_vmxml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/sriov/sriov_net_failover.py
+++ b/libvirt/tests/src/sriov/sriov_net_failover.py
@@ -1,5 +1,5 @@
 import aexpect
-import logging
+import logging as log
 import os
 import re
 import time
@@ -23,6 +23,11 @@ from virttest.utils_libvirt import libvirt_network
 from virttest.utils_libvirt import libvirt_vfio
 from virttest.utils_libvirt import libvirt_vmxml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def exec_function(test_func):

--- a/libvirt/tests/src/sriov/sriov_nodedev.py
+++ b/libvirt/tests/src/sriov/sriov_nodedev.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from provider.sriov import sriov_base
 
@@ -9,6 +9,11 @@ from virttest.libvirt_xml import nodedev_xml
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_libvirt import libvirt_vmxml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def add_hostdev_device(vm_name, pci):

--- a/libvirt/tests/src/sriov/sriov_ro_sysfs.py
+++ b/libvirt/tests/src/sriov/sriov_ro_sysfs.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from provider.sriov import sriov_base
 
@@ -13,6 +13,11 @@ from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices import interface
 from virttest.utils_libvirt import libvirt_vmxml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/sriov/sriov_scalability.py
+++ b/libvirt/tests/src/sriov/sriov_scalability.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from provider.sriov import sriov_base
 
@@ -10,6 +10,11 @@ from virttest.libvirt_xml import vm_xml
 from virttest.utils_libvirt import libvirt_network
 from virttest.utils_libvirt import libvirt_vmxml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def get_vm_iface_num(vm_name):

--- a/libvirt/tests/src/sriov/sriov_vf_pool.py
+++ b/libvirt/tests/src/sriov/sriov_vf_pool.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from provider.sriov import sriov_base
 
@@ -13,6 +13,11 @@ from virttest.utils_libvirt import libvirt_network
 from virttest.utils_libvirt import libvirt_pcicontr
 from virttest.utils_libvirt import libvirt_vmxml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def create_network(params):

--- a/libvirt/tests/src/storage_discard.py
+++ b/libvirt/tests/src/storage_discard.py
@@ -3,7 +3,7 @@ Test module for Storage Discard.
 """
 
 import re
-import logging
+import logging as log
 import time
 
 from avocado.utils import lv_utils
@@ -17,6 +17,11 @@ from virttest import qemu_storage
 from virttest import libvirt_vm
 from virttest import utils_misc
 from virttest.utils_test import libvirt as utlv
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def volumes_capacity(lv_name):

--- a/libvirt/tests/src/svirt/dac_nfs_disk.py
+++ b/libvirt/tests/src/svirt/dac_nfs_disk.py
@@ -1,6 +1,6 @@
 import os
 import re
-import logging
+import logging as log
 
 from avocado.utils import process
 from avocado.core import exceptions
@@ -15,6 +15,11 @@ from virttest.utils_test import libvirt as utlv
 from virttest.libvirt_xml import xcepts
 from virttest.libvirt_xml.vm_xml import VMXML
 from virttest import data_dir
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def check_ownership(file_path):

--- a/libvirt/tests/src/svirt/dac_nfs_save_restore.py
+++ b/libvirt/tests/src/svirt/dac_nfs_save_restore.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 
 from avocado.core import exceptions
 from avocado.utils import process
@@ -12,6 +12,11 @@ from virttest import utils_config
 from virttest import utils_libvirtd
 from virttest.utils_test import libvirt as utlv
 from virttest.libvirt_xml.vm_xml import VMXML
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def check_ownership(file_path):

--- a/libvirt/tests/src/svirt/dac_per_disk_hotplug.py
+++ b/libvirt/tests/src/svirt/dac_per_disk_hotplug.py
@@ -1,7 +1,7 @@
 import os
 import pwd
 import grp
-import logging
+import logging as log
 
 from virttest import qemu_storage
 from virttest import data_dir
@@ -12,6 +12,11 @@ from virttest.utils_test import libvirt as utlv
 from virttest.libvirt_xml.vm_xml import VMXML
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def check_ownership(file_path):

--- a/libvirt/tests/src/svirt/dac_start_destroy.py
+++ b/libvirt/tests/src/svirt/dac_start_destroy.py
@@ -2,7 +2,7 @@ import os
 import stat
 import pwd
 import grp
-import logging
+import logging as log
 
 from avocado.utils import process
 
@@ -12,6 +12,11 @@ from virttest import utils_config
 from virttest import utils_libvirtd
 from virttest import libvirt_version
 from virttest.libvirt_xml.vm_xml import VMXML
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def check_qemu_grp_user(user, test):

--- a/libvirt/tests/src/svirt/dac_vm_per_image_start.py
+++ b/libvirt/tests/src/svirt/dac_vm_per_image_start.py
@@ -2,7 +2,7 @@ import os
 import stat
 import pwd
 import grp
-import logging
+import logging as log
 
 from avocado.utils import process
 from avocado.utils import astring
@@ -16,6 +16,11 @@ from virttest import data_dir
 from virttest import libvirt_version
 from virttest.utils_test import libvirt as utlv
 from virttest.libvirt_xml.vm_xml import VMXML
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def format_user_group_str(user, group):

--- a/libvirt/tests/src/svirt/default_dac_check.py
+++ b/libvirt/tests/src/svirt/default_dac_check.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 
 from avocado.utils import process
 
@@ -9,6 +9,11 @@ from virttest import libvirt_version
 from virttest.libvirt_xml import vm_xml
 from virttest.staging import utils_memory
 from virttest.staging.utils_memory import drop_caches
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/svirt/svirt_attach_disk.py
+++ b/libvirt/tests/src/svirt/svirt_attach_disk.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from avocado.utils import process
 from avocado.utils import astring
@@ -20,6 +20,11 @@ from virttest.libvirt_xml.vm_xml import VMXML
 from virttest.libvirt_xml.devices.disk import Disk
 from virttest.libvirt_xml.devices import seclabel
 from virttest.libvirt_xml.devices.controller import Controller
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/svirt/svirt_start_destroy.py
+++ b/libvirt/tests/src/svirt/svirt_start_destroy.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import re
 
 from virttest import utils_selinux
@@ -12,6 +12,11 @@ from virttest import libvirt_version
 from virttest.libvirt_xml.vm_xml import VMXML
 
 from avocado.utils import process
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/timer_management.py
+++ b/libvirt/tests/src/timer_management.py
@@ -3,7 +3,7 @@ Test module for timer management.
 """
 
 import os
-import logging
+import logging as log
 import time
 
 from avocado.core import exceptions
@@ -19,6 +19,11 @@ from virttest.libvirt_xml import xcepts
 from virttest import libvirt_version
 
 CLOCK_SOURCE_PATH = '/sys/devices/system/clocksource/clocksource0/'
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def set_clock_xml(test, vm, params):

--- a/libvirt/tests/src/usb_device.py
+++ b/libvirt/tests/src/usb_device.py
@@ -1,5 +1,5 @@
 import re
-import logging
+import logging as log
 
 from avocado.utils import process
 
@@ -9,6 +9,11 @@ from virttest import utils_package
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.controller import Controller
 from virttest.libvirt_xml.devices.hub import Hub
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk.py
@@ -1,6 +1,6 @@
 import os
 import time
-import logging
+import logging as log
 
 import aexpect
 
@@ -19,6 +19,11 @@ from virttest import utils_disk
 from virttest import utils_misc
 from virttest import data_dir
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk_lxc.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk_lxc.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from avocado.utils import process
 
@@ -7,6 +7,11 @@ from virttest import utils_test
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml, xcepts
 from virttest.staging.service import Factory
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk_matrix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk_matrix.py
@@ -1,12 +1,17 @@
 import os
 import time
-import logging
+import logging as log
 from avocado.core import exceptions
 from virttest import virsh
 from virttest import data_dir
 from virttest import utils_misc
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_interface.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_interface.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import re
 import os
 import time
@@ -13,6 +13,11 @@ from virttest import data_dir
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.interface import Interface
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def set_options(iface_type=None, iface_source=None, iface_mac=None,

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_interface_matrix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_interface_matrix.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import time
 from avocado.core import exceptions
 from avocado.utils import process
@@ -9,6 +9,11 @@ from virttest import utils_misc
 from virttest import libvirt_version
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def set_options(iface_type=None, iface_source=None,

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
@@ -4,7 +4,7 @@ Module to exercise virsh attach-device command with various devices/options
 
 import os
 import os.path
-import logging
+import logging as log
 import aexpect
 import itertools
 import platform
@@ -22,6 +22,11 @@ from virttest.utils_libvirt import libvirt_pcicontr
 
 
 # TODO: Move all these helper classes someplace else
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 class TestParams(object):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device_matrix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device_matrix.py
@@ -1,12 +1,17 @@
 import os
 import time
-import logging
+import logging as log
 from avocado.core import exceptions
 from virttest import virsh
 from virttest import data_dir
 from virttest import utils_misc
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_passthrough_no_bus.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_passthrough_no_bus.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from avocado.utils import process
 
@@ -6,6 +6,11 @@ from virttest.libvirt_xml.devices.input import Input
 from virttest.libvirt_xml.vm_xml import VMXML
 from virttest import virsh
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_autostart.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_autostart.py
@@ -1,8 +1,13 @@
-import logging
+import logging as log
 import os
 
 from virttest import virsh, utils_libvirtd
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blkdeviotune.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blkdeviotune.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import tempfile
 
 
@@ -10,6 +10,11 @@ from virttest import remote
 from virttest import data_dir
 
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def check_blkdeviotune(params):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blkiotune.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blkiotune.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import re
 
 from avocado.utils import process
@@ -11,6 +11,11 @@ from virttest import virsh
 
 from virttest.staging import utils_cgroup
 from virttest.utils_misc import get_dev_major_minor
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def check_blkiotune(test, params):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockcommit.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockcommit.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import tempfile
 import collections
 
@@ -21,6 +21,11 @@ from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def get_images_with_xattr(vm):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 import time
 import re
@@ -27,6 +27,11 @@ from virttest.utils_test import libvirt as utl
 from virttest.libvirt_xml.devices.disk import Disk
 
 from provider import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 class JobTimeout(Exception):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy_xml.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy_xml.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import socket
 from avocado.utils import process
 
@@ -16,6 +16,11 @@ from virttest.utils_nbd import NbdExport
 
 from virttest.libvirt_xml import vm_xml, xcepts
 from virttest.libvirt_xml.devices.disk import Disk
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockjob.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockjob.py
@@ -1,12 +1,17 @@
 import os
 import time
-import logging
+import logging as log
 
 from virttest import data_dir
 from virttest import utils_libvirtd
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt as utl
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def finish_job(vm_name, target, timeout, test):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockpull.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockpull.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import tempfile
 import collections
 
@@ -19,6 +19,11 @@ from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import snapshot_xml
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def check_chain_xml(disk_xml, chain_lst):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockresize.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockresize.py
@@ -1,6 +1,6 @@
 import os
 import re
-import logging
+import logging as log
 
 from avocado.utils import process
 
@@ -12,6 +12,11 @@ from virttest import libvirt_version
 
 
 OVER_SIZE = (1 << 64)
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_change_media.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_change_media.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 
 from avocado.utils import process
 from avocado.utils import path as utils_path
@@ -11,6 +11,11 @@ from virttest import utils_misc
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 from virttest import error_context
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_change_media_matrix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_change_media_matrix.py
@@ -1,10 +1,15 @@
 import os
 import time
-import logging
+import logging as log
 from virttest import virsh
 from virttest import data_dir
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_console.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_console.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import platform
 
 import aexpect
@@ -11,6 +11,11 @@ from virttest.libvirt_xml import vm_xml
 
 
 CMD_TIMEOUT = 30
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def xml_console_config(vm_name, serial_type='pty',

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_baseline.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_baseline.py
@@ -1,12 +1,17 @@
 import re
 import os
-import logging
+import logging as log
 from xml.dom.minidom import parseString
 
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 from virttest import data_dir
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_compare.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_compare.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import platform
 
 from virttest import data_dir
@@ -9,6 +9,11 @@ from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import capability_xml
 from virttest.libvirt_xml.xcepts import LibvirtXMLNotFoundError
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_compare_xml.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_compare_xml.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 
 from virttest import virsh
 from virttest import libvirt_version
@@ -7,6 +7,11 @@ from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import capability_xml
 from virttest.libvirt_xml import domcapability_xml
 from virttest.libvirt_xml.xcepts import LibvirtXMLNotFoundError
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def get_domxml(cpu_mode, vm_name, extract=False):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_stats.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_stats.py
@@ -1,11 +1,16 @@
 import re
 import os.path
-import logging
+import logging as log
 
 from avocado.utils import cpu
 
 from virttest import virsh
 from virttest.staging import utils_cgroup
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_xml.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_xml.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 import tempfile
 
@@ -6,6 +6,11 @@ from virttest import data_dir
 from virttest import virsh               # pylint: disable=W0611
 
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_create.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_create.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import aexpect
 
 from avocado.utils import process
@@ -6,6 +6,11 @@ from virttest import utils_test
 from virttest import virsh
 from virttest import utils_misc
 from virttest.libvirt_xml import vm_xml
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_create_lxc.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_create_lxc.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import time
 import aexpect
 
@@ -9,6 +9,11 @@ from virttest.libvirt_xml import vm_xml
 from virttest import virsh
 from virttest.libvirt_xml.devices.emulator import Emulator
 from virttest.libvirt_xml.devices.console import Console
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_define.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_define.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from virttest import virt_vm
 from virttest import virsh
@@ -6,6 +6,11 @@ from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import LibvirtXMLError
 from virttest.libvirt_xml.devices.video import Video
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_desc.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_desc.py
@@ -1,10 +1,15 @@
-import logging
+import logging as log
 import os
 import uuid
 
 import aexpect
 
 from virttest import virsh
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import shutil
 import uuid
 import threading
@@ -13,6 +13,11 @@ from virttest import data_dir
 from virttest import utils_misc
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
@@ -1,5 +1,5 @@
 import uuid
-import logging
+import logging as log
 
 from virttest import virsh
 from virttest import utils_misc
@@ -8,6 +8,11 @@ from virttest.utils_test import libvirt
 from virttest.utils_disk import get_scsi_info
 
 from avocado.utils import process
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_detach_serial_device_alias.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_detach_serial_device_alias.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import random
 import string
 import platform
@@ -9,6 +9,11 @@ from virttest import libvirt_version
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml.vm_xml import VMXML
 from virttest.libvirt_xml.devices import librarian
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domblkerror.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domblkerror.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import time
 import shutil
 import os
@@ -14,6 +14,11 @@ from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.disk import Disk
 from virttest.staging.service import Factory
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domblklist.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domblklist.py
@@ -1,6 +1,6 @@
 import os
 import re
-import logging
+import logging as log
 from six import iteritems
 
 from avocado.utils import process
@@ -10,6 +10,11 @@ from virttest.libvirt_xml.devices import disk
 from virttest import element_tree as ElementTree
 
 SOURCE_LIST = ['file', 'dev', 'dir', 'name']
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def get_disk_info(vm_name, options):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domblkthreshold.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domblkthreshold.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import aexpect
 import re
 import threading
@@ -25,6 +25,11 @@ from virttest.libvirt_xml.devices.disk import Disk
 
 from virttest import libvirt_version
 from virttest import utils_secret
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domdisplay.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domdisplay.py
@@ -1,7 +1,7 @@
 import re
 import os
 import shutil
-import logging
+import logging as log
 
 from virttest import utils_misc
 from virttest import data_dir
@@ -10,6 +10,11 @@ from virttest import libvirt_version
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.graphics import Graphics
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domfsinfo.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domfsinfo.py
@@ -1,5 +1,5 @@
 import re
-import logging
+import logging as log
 import os
 import time
 import locale
@@ -12,6 +12,11 @@ from virttest import utils_disk
 from virttest.libvirt_xml import vm_xml
 from virttest.staging import lv_utils
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def reset_domain(vm, **kwargs):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domfstrim.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domfstrim.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import time
 
 from avocado.utils import path as utils_path
@@ -13,6 +13,11 @@ from virttest.libvirt_xml.devices.disk import Disk
 from virttest.libvirt_xml.devices.controller import Controller
 
 from provider import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domid.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domid.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from avocado.utils import process
 
@@ -8,6 +8,11 @@ from virttest import virsh
 from virttest import utils_libvirtd
 from virttest import ssh_key
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domif_setlink_getlink.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domif_setlink_getlink.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 import re
 import uuid
@@ -11,6 +11,11 @@ from virttest import utils_misc
 from virttest import utils_libvirtd
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domiflist.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domiflist.py
@@ -1,5 +1,5 @@
 import re
-import logging
+import logging as log
 
 from virttest import virsh
 from virttest import utils_net
@@ -13,6 +13,11 @@ driver_dict = {'virtio': 'virtio_net', '-': '8139cp', 'e1000': 'e1000',
 # Regular expression for the below output
 #      vnet0      bridge     virbr0     virtio      52:54:00:b2:b3:b4
 rg = re.compile(r"^(\w+)\s+(\w+)\s+(\w+)\s+(\S+)\s+(([a-fA-F0-9]{2}:?){6})")
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domiftune.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domiftune.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import re
 
 from virttest import virsh
@@ -6,6 +6,11 @@ from virttest import utils_libvirtd
 from virttest import libvirt_version
 from virttest.libvirt_xml import vm_xml, network_xml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def check_domiftune(params, test_clear):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domjobabort.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domjobabort.py
@@ -1,6 +1,6 @@
 import os
 import subprocess
-import logging
+import logging as log
 import time
 import locale
 
@@ -8,6 +8,11 @@ from virttest import virsh
 from virttest import data_dir
 from virttest import migration
 from virttest import ssh_key
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domjobinfo.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domjobinfo.py
@@ -1,6 +1,6 @@
 import os
 import subprocess
-import logging
+import logging as log
 import time
 import locale
 
@@ -8,6 +8,11 @@ from virttest import virsh
 from virttest import data_dir
 from virttest import utils_libvirtd
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domname.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domname.py
@@ -1,7 +1,12 @@
-import logging
+import logging as log
 
 from virttest import virsh
 from virttest import utils_libvirtd
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_dompmsuspend.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_dompmsuspend.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 import platform
 
@@ -12,6 +12,11 @@ from virttest.libvirt_xml import xcepts
 from virttest.utils_test import libvirt
 
 from provider import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domrename.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domrename.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 
 from avocado.utils import path as utils_path
@@ -12,6 +12,11 @@ from virttest import utils_libguestfs
 from virttest import utils_package
 from virttest import utils_libvirtd
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domtime.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domtime.py
@@ -1,5 +1,5 @@
 import datetime
-import logging
+import logging as log
 import re
 import time
 
@@ -10,6 +10,11 @@ from virttest import error_context
 from virttest import utils_time
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 @error_context.context_aware

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domuuid.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domuuid.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from virttest import virsh
 from virttest import libvirt_xml
@@ -6,6 +6,11 @@ from virttest import utils_libvirtd
 from virttest import libvirt_version
 
 from virttest.utils_test.libvirt import check_domuuid_compliant_with_rfc4122
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_to_native.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_to_native.py
@@ -1,6 +1,6 @@
 import re
 import os
-import logging
+import logging as log
 
 from avocado.utils import process
 
@@ -8,6 +8,11 @@ from virttest import virsh
 from virttest import libvirt_version
 from virttest import utils_libvirtd
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_dump.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_dump.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import multiprocessing
 import time
 import platform
@@ -16,6 +16,11 @@ from virttest.libvirt_xml import vm_xml
 
 
 from provider import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_dumpxml.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_dumpxml.py
@@ -1,5 +1,5 @@
 import re
-import logging
+import logging as log
 import platform
 
 from virttest import virsh
@@ -8,6 +8,11 @@ from virttest import libvirt_version
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import domcapability_xml
 from virttest.utils_test import libvirt as utlv
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_edit.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_edit.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 
 from avocado.utils import path
@@ -9,6 +9,11 @@ from virttest import utils_misc
 from virttest import utils_package
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_emulatorpin.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_emulatorpin.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import random
 
 from avocado.utils import cpu
@@ -11,6 +11,11 @@ from virttest.cpu import cpus_parser
 from virttest.staging import utils_cgroup
 from virttest.virt_vm import VMStartError
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def get_emulatorpin_from_cgroup(params, test):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_emulatorpin_mix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_emulatorpin_mix.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from avocado.utils import cpu
 
@@ -6,6 +6,11 @@ from virttest import virsh
 from virttest import utils_misc
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_libvirt import libvirt_misc
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def prepare_vm(guest_xml, params):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
@@ -1,7 +1,7 @@
 import os
 import time
 import re
-import logging
+import logging as log
 import signal
 import aexpect
 import shutil
@@ -23,6 +23,11 @@ from virttest.libvirt_xml.devices.panic import Panic
 from virttest.libvirt_xml.devices.watchdog import Watchdog
 
 from xml.dom.minidom import parseString
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_guestinfo.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_guestinfo.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import re
 import os
 import json
@@ -9,6 +9,11 @@ from virttest import data_dir
 from virttest import libvirt_version
 from virttest import utils_misc
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_guestvcpus.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_guestvcpus.py
@@ -1,10 +1,15 @@
-import logging
+import logging as log
 
 
 from virttest import virsh
 from virttest import cpu as cpuutil
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_hypervisor_cpu_compare.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_hypervisor_cpu_compare.py
@@ -1,6 +1,6 @@
 import os
 import re
-import logging
+import logging as log
 
 from virttest import virsh
 from virttest import data_dir
@@ -9,6 +9,11 @@ from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import capability_xml
 from virttest.libvirt_xml import domcapability_xml
 from virttest.libvirt_xml.xcepts import LibvirtXMLNotFoundError
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def get_domcapa_output(test):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_iothreadadd.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_iothreadadd.py
@@ -1,10 +1,15 @@
-import logging
+import logging as log
 
 from avocado.core import exceptions
 
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def get_xmlinfo(vm_name, options):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_iothreaddel.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_iothreaddel.py
@@ -1,10 +1,15 @@
-import logging
+import logging as log
 
 from avocado.core import exceptions
 
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def get_xmlinfo(vm_name, options):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_iothreadinfo.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_iothreadinfo.py
@@ -1,10 +1,15 @@
-import logging
+import logging as log
 
 from avocado.core import exceptions
 
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_iothreadpin.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_iothreadpin.py
@@ -1,10 +1,15 @@
-import logging
+import logging as log
 
 from avocado.core import exceptions
 
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def get_xmlinfo(vm_name, options):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_managedsave.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_managedsave.py
@@ -1,7 +1,7 @@
 import os
 import re
 import time
-import logging
+import logging as log
 
 from avocado.utils import process
 from avocado.utils import software_manager
@@ -16,6 +16,11 @@ from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 from virttest.staging.service import Factory
 from virttest.staging.utils_memory import drop_caches
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_managedsave_extra.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_managedsave_extra.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 import shutil
 
@@ -12,6 +12,11 @@ from virttest.libvirt_xml.devices import graphics
 from virttest.utils_test import libvirt
 
 MANAGEDSAVE_FILE = '/var/lib/libvirt/qemu/save/%s.save'
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_memtune.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_memtune.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import re
 import time
 
@@ -11,6 +11,11 @@ from virttest.utils_test import libvirt
 
 
 memtune_types = ['hard_limit', 'soft_limit', 'swap_hard_limit']
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def check_limit(path, expected_value, limit_name, cgname, vm, test, acceptable_minus=8):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_metadata.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_metadata.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import xml.dom.minidom
 
 import aexpect
@@ -10,6 +10,11 @@ from virttest.utils_libvirtd import Libvirtd
 from virttest.libvirt_xml import vm_xml
 
 CMD_TIMEOUT = 60
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 import re
 import time
@@ -27,6 +27,11 @@ from virttest.utils_libvirt import libvirt_config
 from virttest import test_setup
 from virttest.staging import utils_memory
 from virttest.libvirt_xml.xcepts import LibvirtXMLNotFoundError
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_compcache.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_compcache.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import subprocess
 import time
 
@@ -8,6 +8,11 @@ from avocado.utils import path as utils_path
 from virttest import virsh
 from virttest import ssh_key
 from virttest import migration
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def get_page_size():

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_copy_storage.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_copy_storage.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 
 from avocado.core import exceptions
 
@@ -15,6 +15,11 @@ from virttest import remote
 
 from virttest.utils_misc import is_qemu_capability_supported as qemu_test
 from virttest.utils_libvirt import libvirt_config
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def create_destroy_pool_on_remote(test, action, params):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_multi_vms.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_multi_vms.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import threading
 import time
 
@@ -26,6 +26,11 @@ ret_migration = True
 ret_jobabort = True
 ret_downtime_tolerable = True
 flag_migration = True
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def make_migration_options(method, optionstr="", timeout=60):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_option_mix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_option_mix.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import time
 import re
 
@@ -14,6 +14,11 @@ from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices import graphics
 from virttest.libvirt_xml.xcepts import LibvirtXMLNotFoundError
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_set_get_speed.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_set_get_speed.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from virttest import ssh_key
 from virttest import virsh
@@ -23,6 +23,11 @@ UINT32_MiB = UINT32_MAX // (1024 * 1024)
 INT64_MiB = INT64_MAX // (1024 * 1024)
 UINT64_MiB = UINT64_MAX // (1024 * 1024)
 DEFAULT = INT64_MiB
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_setmaxdowntime.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_setmaxdowntime.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import threading
 import time
 import os
@@ -21,6 +21,11 @@ global ret_setmmdt
 global ret_migration
 ret_setmmdt = False
 ret_migration = False
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def thread_func_setmmdt(domain, downtime, extra, dargs):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_stress.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_stress.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from virttest import libvirt_vm
 from virttest import utils_test
@@ -8,6 +8,11 @@ from virttest import migration
 from virttest import remote
 from virttest.libvirt_xml import vm_xml
 from virttest.staging import utils_memory
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def set_cpu_memory(vm_name, cpu, memory):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_virtio_scsi.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_virtio_scsi.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import threading
 import time
 
@@ -15,6 +15,11 @@ from virttest import remote
 from virttest import ssh_key
 from virttest import migration
 from virttest.utils_test import libvirt as utlv
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migration.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migration.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import platform
 
 from virttest import libvirt_vm
@@ -6,6 +6,11 @@ from virttest import virsh
 from virttest import migration
 from virttest.utils_test import libvirt
 from virttest import libvirt_xml
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def update_machinetype(test, vmxml, machine):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_numatune.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_numatune.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from avocado.utils import path as utils_path
 from avocado.utils import process
@@ -10,6 +10,11 @@ from virttest import utils_misc
 from virttest.cpu import cpus_parser
 from virttest.libvirt_xml.xcepts import LibvirtXMLAccessorError
 from virttest.staging import utils_cgroup
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def check_numatune_xml(params):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_agent_command.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_agent_command.py
@@ -1,6 +1,6 @@
 import os
 import time
-import logging
+import logging as log
 
 import aexpect
 
@@ -11,6 +11,11 @@ from virttest import data_dir
 from virttest import remote
 from virttest import utils_libvirtd
 from virttest import utils_misc
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def reset_domain(test, vm, vm_state, needs_agent=False, guest_cpu_busy=False,

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_agent_command_fs.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_agent_command_fs.py
@@ -1,6 +1,6 @@
 import os
 import time
-import logging
+import logging as log
 
 from virttest import virsh
 from virttest import data_dir
@@ -8,6 +8,11 @@ from virttest import utils_disk
 from virttest import utils_misc
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_attach.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_attach.py
@@ -1,9 +1,14 @@
 import re
-import logging
+import logging as log
 
 from virttest import virsh
 from virttest import utils_libvirtd
 from virttest import qemu_vm
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_monitor_blockjob.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_monitor_blockjob.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import time
 import threading
 
@@ -14,6 +14,11 @@ from virttest import libvirt_version
 
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt as utlv
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def set_cpu_memory(vm_name, cpu, memory):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_monitor_command.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_monitor_command.py
@@ -1,7 +1,12 @@
-import logging
+import logging as log
 
 from virttest import virsh
 from virttest import utils_libvirtd
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_reboot.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_reboot.py
@@ -1,5 +1,5 @@
 import re
-import logging
+import logging as log
 import aexpect
 
 from avocado.utils import process
@@ -14,6 +14,11 @@ from virttest import utils_libvirtd
 from virttest import utils_misc
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_reset.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_reset.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import time
 
 from avocado.utils import process
@@ -8,6 +8,11 @@ from virttest import virsh
 from virttest import libvirt_version
 
 from virttest.libvirt_xml import vm_xml
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_restore.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_restore.py
@@ -1,7 +1,7 @@
 import re
 import os
 import stat
-import logging
+import logging as log
 import time
 import pwd
 import grp
@@ -15,6 +15,11 @@ from virttest import libvirt_version
 
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_resume.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_resume.py
@@ -1,8 +1,13 @@
-import logging
+import logging as log
 
 from avocado.core import exceptions
 
 from virttest import virsh
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_save.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_save.py
@@ -1,11 +1,16 @@
 import os
 import re
-import logging
+import logging as log
 
 from virttest import virsh
 from virttest import data_dir
 from virttest import utils_libvirtd
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_save_image_define.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_save_image_define.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import tempfile
 import re
 
@@ -8,6 +8,11 @@ from avocado.core import exceptions
 from virttest import data_dir
 from virttest import virsh
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_save_image_edit.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_save_image_edit.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 import re
 import aexpect
@@ -6,6 +6,11 @@ import aexpect
 from virttest import data_dir
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_schedinfo_qemu_posix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_schedinfo_qemu_posix.py
@@ -1,11 +1,16 @@
 import re
-import logging
+import logging as log
 
 from virttest import virsh
 from virttest import libvirt_cgroup
 from virttest import libvirt_version
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import xcepts
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_schedinfo_xen_credit.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_schedinfo_xen_credit.py
@@ -1,7 +1,12 @@
 import re
-import logging
+import logging as log
 
 from virttest import virsh
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_screenshot.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_screenshot.py
@@ -1,10 +1,15 @@
 import os
-import logging
+import logging as log
 
 from virttest import virsh
 from virttest import libvirt_version
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.video import Video
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def video_device_setup(vm_name, video_type):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_sendkey.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_sendkey.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import time
 
 from virttest import virsh
@@ -10,6 +10,11 @@ from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.input import Input
 
 from avocado.utils import wait
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_set_user_password.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_set_user_password.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from avocado.utils import process
 
@@ -7,6 +7,11 @@ from virttest import remote
 from virttest import virsh
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_setmaxmem.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_setmaxmem.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from avocado.utils import process
 
@@ -6,6 +6,11 @@ from virttest import virsh
 from virttest import virt_vm
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_setmem.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_setmem.py
@@ -1,6 +1,6 @@
 import re
 import os
-import logging
+import logging as log
 import time
 
 from virttest import virsh
@@ -10,6 +10,11 @@ from virttest import utils_misc
 from virttest import libvirt_version
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def manipulate_domain(test, vm_name, action, recover=False):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_setvcpu.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_setvcpu.py
@@ -1,9 +1,14 @@
-import logging
+import logging as log
 
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 from virttest import cpu
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_setvcpus.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_setvcpus.py
@@ -1,6 +1,6 @@
 import re
 import os
-import logging
+import logging as log
 
 from virttest import ssh_key
 from virttest import data_dir
@@ -8,6 +8,11 @@ from virttest import virsh
 from virttest.libvirt_xml import vm_xml, xcepts
 from virttest.libvirt_xml.vm_xml import VMCPUXML
 from virttest import cpu
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_shutdown.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_shutdown.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from avocado.utils import process
 
@@ -11,6 +11,11 @@ from virttest import utils_misc
 from virttest import libvirt_version
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_start.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_start.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from virttest import remote
 from virttest import virsh
@@ -6,6 +6,11 @@ from virttest import libvirt_xml
 from virttest import utils_libvirtd
 from virttest import ssh_key
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_ttyconsole.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_ttyconsole.py
@@ -1,8 +1,13 @@
-import logging
+import logging as log
 
 from virttest import libvirt_vm
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def xml_console_config(vm_name, serial_type='pty',

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_undefine.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_undefine.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import shutil
 import time
 import platform
@@ -19,6 +19,11 @@ from virttest import libvirt_version
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.xcepts import LibvirtXMLError
 from virttest.utils_test import libvirt as utlv
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_update_device.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_update_device.py
@@ -1,7 +1,7 @@
 import os
 import shutil
 import re
-import logging
+import logging as log
 
 from avocado.utils import process
 from virttest import virsh
@@ -10,6 +10,11 @@ from virttest import utils_misc
 from virttest import libvirt_version
 from virttest.libvirt_xml import VMXML
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def create_disk(params, test, vm_name, orig_iso, disk_type, target_dev, disk_format="", mode=""):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_update_device_matrix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_update_device_matrix.py
@@ -1,7 +1,7 @@
 import os
 import time
 import shutil
-import logging
+import logging as log
 
 from avocado.core import exceptions
 from avocado.utils import process
@@ -12,6 +12,11 @@ from virttest import libvirt_version
 
 from virttest.libvirt_xml import VMXML
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def create_disk(vm_name, disk_iso, disk_type, target_dev, mode=""):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_vcpucount.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_vcpucount.py
@@ -1,9 +1,14 @@
 import os
-import logging
+import logging as log
 
 from virttest import virsh
 from virttest import libvirt_xml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def reset_domain(vm, vm_state, maxvcpu, curvcpu, sockets,

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_vcpuinfo.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_vcpuinfo.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from avocado.utils import process
 
@@ -6,6 +6,11 @@ from virttest import virsh
 from virttest import utils_libvirtd
 from virttest import ssh_key
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_vcpupin.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_vcpupin.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import re
 import random
 
@@ -10,6 +10,11 @@ from virttest import cpu
 from virttest import utils_misc
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/filter/virsh_nwfilter_define.py
+++ b/libvirt/tests/src/virsh_cmd/filter/virsh_nwfilter_define.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 
 from virttest import virsh
 from virttest import xml_utils
@@ -10,6 +10,11 @@ from virttest.utils_test import libvirt as utlv
 from virttest import libvirt_version
 
 NWFILTER_ETC_DIR = "/etc/libvirt/nwfilter"
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def check_list(uuid, name):

--- a/libvirt/tests/src/virsh_cmd/filter/virsh_nwfilter_dumpxml.py
+++ b/libvirt/tests/src/virsh_cmd/filter/virsh_nwfilter_dumpxml.py
@@ -1,9 +1,14 @@
-import logging
+import logging as log
 
 from virttest import virsh
 from virttest import libvirt_xml
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def check_list(uuid, name):

--- a/libvirt/tests/src/virsh_cmd/filter/virsh_nwfilter_edit.py
+++ b/libvirt/tests/src/virsh_cmd/filter/virsh_nwfilter_edit.py
@@ -1,9 +1,14 @@
-import logging
+import logging as log
 import aexpect
 
 from virttest import virsh
 from virttest import libvirt_xml
 from virttest import remote
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def edit_filter_xml(test, filter_name, edit_cmd):

--- a/libvirt/tests/src/virsh_cmd/filter/virsh_nwfilter_list.py
+++ b/libvirt/tests/src/virsh_cmd/filter/virsh_nwfilter_list.py
@@ -1,11 +1,16 @@
 import os
-import logging
+import logging as log
 
 from virttest import virsh
 
 from virttest import libvirt_version
 
 NWFILTER_ETC_DIR = "/etc/libvirt/nwfilter"
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/filter/virsh_nwfilter_undefine.py
+++ b/libvirt/tests/src/virsh_cmd/filter/virsh_nwfilter_undefine.py
@@ -1,10 +1,15 @@
-import logging
+import logging as log
 
 from virttest import virsh
 from virttest import libvirt_xml
 from virttest import utils_split_daemons
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def check_list(filter_ref):

--- a/libvirt/tests/src/virsh_cmd/host/virsh_capabilities.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_capabilities.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import platform
 from six import itervalues, iteritems
 
@@ -8,6 +8,11 @@ from avocado.utils import process
 from virttest import libvirt_vm
 from virttest import virsh
 from virttest.libvirt_xml import capability_xml
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/host/virsh_cpu_models.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_cpu_models.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 from six import itervalues
 
 from virttest import ssh_key
@@ -6,6 +6,11 @@ from virttest import virsh
 from virttest import libvirt_vm
 from virttest.libvirt_xml import capability_xml
 from virttest.utils_test import libvirt as utlv
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/host/virsh_deprecate_api.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_deprecate_api.py
@@ -1,5 +1,5 @@
 import json
-import logging
+import logging as log
 import re
 
 from avocado.core import exceptions
@@ -10,6 +10,11 @@ from virttest import utils_misc
 from virttest import virsh
 
 import xml.etree.ElementTree as ET
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def get_deprecated_name_list_qmp(vm_name, cmd):

--- a/libvirt/tests/src/virsh_cmd/host/virsh_freepages.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_freepages.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import time
 
 from virttest import virsh
@@ -6,6 +6,11 @@ from virttest import test_setup
 from virttest import utils_misc
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt as utlv
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def check_freepages(output, expect_result_list):

--- a/libvirt/tests/src/virsh_cmd/host/virsh_hostname.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_hostname.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from avocado.utils import process
 
@@ -9,6 +9,11 @@ from virttest import utils_libvirtd
 from virttest import remote
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/host/virsh_maxvcpus.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_maxvcpus.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from avocado.core import exceptions
 
@@ -9,6 +9,11 @@ from virttest.libvirt_xml import domcapability_xml as domcap
 from virttest.libvirt_xml import capability_xml
 from virttest import libvirt_version
 import platform
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/host/virsh_node_memtune.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_node_memtune.py
@@ -1,11 +1,16 @@
 import os
-import logging
+import logging as log
 
 from avocado.core import exceptions
 from avocado.utils import process
 from virttest import virsh
 
 _SYSFS_MEMORY_KSM_PATH = "/sys/kernel/mm/ksm"
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def recovery_ksm_files_contents(ksm_params, change_list):

--- a/libvirt/tests/src/virsh_cmd/host/virsh_nodecpumap.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_nodecpumap.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import random
 
 from avocado.utils import process
@@ -7,6 +7,11 @@ from avocado.utils import cpu
 from virttest import virsh
 
 SYSFS_SYSTEM_PATH = "/sys/devices/system/cpu"
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def get_present_cpu():

--- a/libvirt/tests/src/virsh_cmd/host/virsh_nodecpustats.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_nodecpustats.py
@@ -1,5 +1,5 @@
 import re
-import logging
+import logging as log
 
 from avocado.utils import cpu as cpuutil
 
@@ -7,6 +7,11 @@ from virttest import virsh
 from virttest import utils_libvirtd
 from virttest import libvirt_version
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/host/virsh_nodeinfo.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_nodeinfo.py
@@ -1,6 +1,6 @@
 import os
 import re
-import logging
+import logging as log
 import platform
 
 from avocado.utils import process
@@ -13,6 +13,11 @@ from virttest.libvirt_xml import capability_xml
 from virttest.staging import utils_memory
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/host/virsh_nodememstats.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_nodememstats.py
@@ -1,10 +1,15 @@
-import logging
+import logging as log
 import re
 
 from virttest import virsh
 from virttest import utils_libvirtd
 from virttest import utils_test
 from virttest.staging import utils_memory
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/host/virsh_nodesuspend.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_nodesuspend.py
@@ -1,5 +1,5 @@
 import time
-import logging
+import logging as log
 
 from avocado.utils import process
 
@@ -7,6 +7,11 @@ from virttest import virsh
 from virttest import libvirt_vm
 from virttest.remote import LoginTimeoutError
 from virttest.remote import LoginProcessTerminatedError
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 class TimeoutError(Exception):

--- a/libvirt/tests/src/virsh_cmd/host/virsh_sysinfo.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_sysinfo.py
@@ -1,9 +1,14 @@
-import logging
+import logging as log
 
 from avocado.utils import process
 
 from virttest import libvirt_xml
 from virttest import virsh
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def get_processor_version():

--- a/libvirt/tests/src/virsh_cmd/host/virsh_uri.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_uri.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from avocado.utils import process
 
@@ -8,6 +8,11 @@ from virttest import utils_libvirtd
 from virttest import ssh_key
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/host/virsh_version.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_version.py
@@ -1,10 +1,15 @@
-import logging
+import logging as log
 
 from virttest import libvirt_vm
 from virttest import virsh
 from virttest import utils_libvirtd
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/interface/virsh_iface.py
+++ b/libvirt/tests/src/virsh_cmd/interface/virsh_iface.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 
 from avocado.utils import process
 from avocado.utils import path as utils_path
@@ -15,6 +15,11 @@ from virttest import data_dir
 from virttest import libvirt_version
 
 NETWORK_SCRIPT = "/etc/sysconfig/network-scripts/ifcfg-"
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def create_xml_file(xml_file, params):

--- a/libvirt/tests/src/virsh_cmd/interface/virsh_iface_bridge.py
+++ b/libvirt/tests/src/virsh_cmd/interface/virsh_iface_bridge.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 
 from avocado.utils import process
 
@@ -13,6 +13,11 @@ from virttest.staging import service
 from virttest import utils_package
 
 NETWORK_SCRIPT = "/etc/sysconfig/network-scripts/ifcfg-"
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/interface/virsh_iface_edit.py
+++ b/libvirt/tests/src/virsh_cmd/interface/virsh_iface_edit.py
@@ -1,6 +1,6 @@
 import os
 import re
-import logging
+import logging as log
 
 import aexpect
 
@@ -11,6 +11,11 @@ from virttest import data_dir
 from virttest import utils_net
 from virttest import virsh
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def get_ifstart_mode(iface_name):

--- a/libvirt/tests/src/virsh_cmd/interface/virsh_iface_list.py
+++ b/libvirt/tests/src/virsh_cmd/interface/virsh_iface_list.py
@@ -4,11 +4,16 @@ Module to test virsh iface-xx commands including: iface-list, iface-dumpxml, ifa
 :copyright: 2021 Red Hat Inc.
 """
 
-import logging
+import logging as log
 import re
 
 from avocado.utils import process, astring
 from virttest import virsh
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/interface/virsh_iface_trans.py
+++ b/libvirt/tests/src/virsh_cmd/interface/virsh_iface_trans.py
@@ -1,6 +1,6 @@
 import os
 import re
-import logging
+import logging as log
 
 from avocado.utils import process
 from avocado.utils import path as utils_path
@@ -9,6 +9,11 @@ from avocado.core import exceptions
 from virttest import virsh
 from virttest import utils_libvirtd
 from virttest import utils_package
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def netcf_trans_control(test, command="status"):

--- a/libvirt/tests/src/virsh_cmd/monitor/virsh_domstate.py
+++ b/libvirt/tests/src/virsh_cmd/monitor/virsh_domstate.py
@@ -1,7 +1,7 @@
 import re
 import os
 import shutil
-import logging
+import logging as log
 import platform
 import signal
 
@@ -23,6 +23,11 @@ from virttest.libvirt_xml.devices.panic import Panic
 from virttest import libvirt_version
 
 find_dump_file = False
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def check_crash_state(cmd_output, crash_action, vm_name, dump_file=""):

--- a/libvirt/tests/src/virsh_cmd/monitor/virsh_domstats.py
+++ b/libvirt/tests/src/virsh_cmd/monitor/virsh_domstats.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from aexpect import ShellTimeoutError
 from aexpect import ShellProcessTerminatedError
@@ -11,6 +11,11 @@ from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.panic import Panic
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def create_snap(vm_name, snap_option):

--- a/libvirt/tests/src/virsh_cmd/monitor/virsh_list.py
+++ b/libvirt/tests/src/virsh_cmd/monitor/virsh_list.py
@@ -1,5 +1,5 @@
 import re
-import logging
+import logging as log
 import time
 
 from avocado.core import exceptions
@@ -10,6 +10,11 @@ from virttest import remote
 from virttest import utils_libvirtd
 from virttest.libvirt_xml import vm_xml
 from virttest import ssh_key
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/monitor/virsh_perf.py
+++ b/libvirt/tests/src/virsh_cmd/monitor/virsh_perf.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import ast
 
 from virttest import virsh
@@ -6,6 +6,11 @@ from virttest import virt_vm
 
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def check_event_value(vm_name, perf_option, event):

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_autostart.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_autostart.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 
 from virttest import virsh
 from virttest import utils_libvirtd
@@ -7,6 +7,11 @@ from virttest import libvirt_version
 from virttest.libvirt_xml import network_xml
 from virttest.libvirt_xml import xcepts
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_create.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_create.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from avocado.utils import process
 
@@ -7,6 +7,11 @@ from virttest.libvirt_xml import NetworkXML
 from virttest.libvirt_xml import LibvirtXMLError
 from virttest import virsh
 from virttest import xml_utils
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def do_low_level_test(virsh_dargs, test_xml, options_ref, extra):

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_define_undefine.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_define_undefine.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from avocado.utils import process
 
@@ -12,6 +12,11 @@ from virttest.libvirt_xml import network_xml
 from virttest.utils_test import libvirt
 from virttest import libvirt_version
 from virttest.utils_libvirt import libvirt_network
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def get_network_xml_instance(virsh_dargs, test_xml, net_name,

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_destroy.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_destroy.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 import re
 
@@ -13,6 +13,11 @@ from virttest import utils_test
 from virttest import virsh
 
 from virttest.libvirt_xml import vm_xml
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_dhcp_leases.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_dhcp_leases.py
@@ -1,5 +1,5 @@
 import re
-import logging
+import logging as log
 import signal
 
 from virttest import utils_net
@@ -13,6 +13,11 @@ from datetime import datetime, timedelta
 from virttest.libvirt_xml import LibvirtXMLError
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_edit.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_edit.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import re
 import aexpect
 
@@ -8,6 +8,11 @@ from virttest import utils_libvirtd
 from virttest.libvirt_xml import network_xml
 from virttest.libvirt_xml import xcepts
 from avocado.utils import process
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_event.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_event.py
@@ -1,10 +1,15 @@
 import re
 import time
-import logging
+import logging as log
 import aexpect
 
 from virttest import virsh
 from virttest.utils_test import libvirt as utlv
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_list.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_list.py
@@ -1,5 +1,5 @@
 import re
-import logging
+import logging as log
 
 from avocado.core import exceptions
 from virttest import virsh
@@ -7,6 +7,11 @@ from virttest.utils_test import libvirt
 from virttest.libvirt_xml import network_xml
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_start.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_start.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import time
 
 from virttest import virsh
@@ -9,6 +9,11 @@ from virttest import utils_split_daemons
 from virttest.libvirt_xml import network_xml, IPXML
 from virttest.staging import service
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_update.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_update.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import re
 import tempfile
 import time
@@ -13,6 +13,11 @@ from virttest.libvirt_xml import network_xml
 from virttest.libvirt_xml import xcepts
 from virttest.libvirt_xml import vm_xml
 from avocado.utils import process
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_uuid.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_uuid.py
@@ -1,8 +1,13 @@
 import re
-import logging
+import logging as log
 
 from virttest import virsh
 from virttest.libvirt_xml import network_xml
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/nodedev/crypto_nodedev_create_destroy.py
+++ b/libvirt/tests/src/virsh_cmd/nodedev/crypto_nodedev_create_destroy.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 
 from uuid import uuid1
@@ -12,6 +12,11 @@ from tempfile import mktemp
 
 # minimal supported hwtype
 HWTYPE = 11
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def find_devices_by_cap(test, cap_type):

--- a/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_create_destroy.py
+++ b/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_create_destroy.py
@@ -1,6 +1,6 @@
 import os
 import re
-import logging
+import logging as log
 from tempfile import mktemp
 
 from avocado.core import exceptions
@@ -12,6 +12,11 @@ from virttest import libvirt_version
 from virttest import utils_split_daemons
 
 _FC_HOST_PATH = "/sys/class/fc_host"
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def check_nodedev(dev_name, dev_parent=None):

--- a/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_detach_reattach.py
+++ b/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_detach_reattach.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 from virttest import virsh
 from virttest.libvirt_xml import nodedev_xml
 from virttest import libvirt_version
@@ -7,6 +7,11 @@ from virttest import utils_split_daemons
 from virttest.utils_test import libvirt
 from avocado.utils import process
 from avocado.core import exceptions
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_dumpxml.py
+++ b/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_dumpxml.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import time
 import os
 
@@ -8,6 +8,11 @@ from virttest.libvirt_xml import nodedev_xml
 from virttest import libvirt_version
 from virttest import utils_split_daemons
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_dumpxml_chain.py
+++ b/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_dumpxml_chain.py
@@ -1,8 +1,13 @@
-import logging
+import logging as log
 import re
 
 from virttest import virsh
 from virttest.libvirt_xml.base import LibvirtXMLBase
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_event.py
+++ b/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_event.py
@@ -1,11 +1,16 @@
 import time
-import logging
+import logging as log
 import aexpect
 from avocado.utils import process
 
 from virttest import virsh
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import nodedev_xml
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_list.py
+++ b/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_list.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 import re
 
@@ -8,6 +8,11 @@ from virttest import virsh
 
 from virttest import libvirt_version
 from virttest import utils_split_daemons
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def get_avail_caps(all_caps):

--- a/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_reset.py
+++ b/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_reset.py
@@ -1,9 +1,14 @@
 import os
 import re
-import logging
+import logging as log
 from virttest import virsh
 from virttest import utils_libvirtd
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_find_storage_pool_sources.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_find_storage_pool_sources.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from avocado.utils import process
 from avocado.core import exceptions
@@ -10,6 +10,11 @@ from virttest import virsh
 from virttest.staging import lv_utils
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_find_storage_pool_sources_as.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_find_storage_pool_sources_as.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from avocado.utils import process
 from avocado.core import exceptions
@@ -8,6 +8,11 @@ from virttest import utils_test
 from virttest.staging import lv_utils
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool.py
@@ -1,6 +1,6 @@
 import re
 import os
-import logging
+import logging as log
 
 from avocado.core import exceptions
 
@@ -14,6 +14,11 @@ from virttest.libvirt_xml import pool_xml
 from virttest import libvirt_version
 from virttest import element_tree as ET
 from virttest import data_dir
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool_acl.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool_acl.py
@@ -1,6 +1,6 @@
 import re
 import os
-import logging
+import logging as log
 
 from avocado.utils import process
 
@@ -12,6 +12,11 @@ from virttest.staging import lv_utils
 from virttest.utils_test import libvirt as utlv
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool_auth.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool_auth.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 
 from avocado.utils import process
 
@@ -13,6 +13,11 @@ from virttest.libvirt_xml import pool_xml
 from virttest.libvirt_xml import xcepts
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool_autostart.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool_autostart.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 
 from avocado.utils import process
 from avocado.core import exceptions
@@ -12,6 +12,11 @@ from virttest.libvirt_xml import pool_xml
 from virttest.staging import lv_utils
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool_capabilities.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool_capabilities.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from avocado.utils import process
 
@@ -7,6 +7,11 @@ from virttest import virsh
 from virttest.libvirt_xml import pool_capability_xml
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool_create.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool_create.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 
 from avocado.utils import process
 from virttest import virsh
@@ -10,6 +10,11 @@ from virttest.utils_test import libvirt as utlv
 from virttest.libvirt_xml import pool_xml
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool_create_as.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool_create_as.py
@@ -1,8 +1,13 @@
 import os
-import logging
+import logging as log
 
 from virttest import libvirt_storage
 from virttest import virsh
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool_edit.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool_edit.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import aexpect
 
 from virttest import virsh
@@ -8,6 +8,11 @@ from virttest import data_dir
 from virttest import remote
 from virttest.libvirt_xml import pool_xml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def edit_pool(test, pool, edit_cmd):

--- a/libvirt/tests/src/virsh_cmd/secret/virsh_secret_define_undefine.py
+++ b/libvirt/tests/src/virsh_cmd/secret/virsh_secret_define_undefine.py
@@ -1,6 +1,6 @@
 import os
 import re
-import logging
+import logging as log
 
 from avocado.utils import process
 
@@ -14,6 +14,11 @@ from virttest import libvirt_version
 
 SECRET_DIR = "/etc/libvirt/secrets/"
 SECRET_BASE64 = "c2VjcmV0X3Rlc3QK"
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/secret/virsh_secret_set_get.py
+++ b/libvirt/tests/src/virsh_cmd/secret/virsh_secret_set_get.py
@@ -1,7 +1,7 @@
 import os
 import re
 import base64
-import logging
+import logging as log
 import locale
 import time
 from tempfile import mktemp
@@ -18,6 +18,11 @@ from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.secret_xml import SecretXML
 
 _VIRT_SECRETS_PATH = "/etc/libvirt/secrets"
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def check_secret(params):

--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import re
 
 from avocado.utils import process
@@ -6,6 +6,11 @@ from avocado.core import exceptions
 from virttest import virt_vm
 
 from virttest import virsh
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_create_as.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_create_as.py
@@ -2,7 +2,7 @@ import re
 import os
 import time
 import string
-import logging
+import logging as log
 
 from avocado.utils import process
 
@@ -21,6 +21,11 @@ from virttest.libvirt_xml.devices import disk
 from virttest import libvirt_storage
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def xml_recover(vmxml):

--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_disk.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_disk.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import re
 import tempfile
 
@@ -17,6 +17,11 @@ from virttest.utils_test import libvirt as utlv
 from virttest.utils_libvirt import libvirt_pcicontr
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_dumpxml.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_dumpxml.py
@@ -1,10 +1,15 @@
 import re
 import time
-import logging
+import logging as log
 
 from virttest import virsh
 from virttest import utils_test
 from virttest.libvirt_xml import vm_xml
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def get_snap_createtime(vm_name, snap_name):

--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_edit.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_edit.py
@@ -1,6 +1,6 @@
 import re
 import time
-import logging
+import logging as log
 
 import aexpect
 
@@ -8,6 +8,11 @@ from virttest import virsh
 from virttest import utils_test
 from virttest import remote
 from virttest.libvirt_xml import vm_xml
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_par_cur.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_par_cur.py
@@ -1,12 +1,17 @@
 import os
 import re
 import time
-import logging
+import logging as log
 
 from virttest import virsh
 from virttest import data_dir
 from virttest import utils_test
 from virttest.libvirt_xml import vm_xml
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/virsh_connect.py
+++ b/libvirt/tests/src/virsh_cmd/virsh_connect.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 import re
 import shutil
@@ -12,6 +12,11 @@ from virttest import virsh
 from virttest import utils_conn
 
 from virttest.utils_test import libvirt as utlv
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def check_virsh_connect_alive(test, params):

--- a/libvirt/tests/src/virsh_cmd/virsh_itself.py
+++ b/libvirt/tests/src/virsh_cmd/virsh_itself.py
@@ -1,10 +1,15 @@
-import logging
+import logging as log
 import aexpect
 
 from avocado.utils import process
 
 from virttest import virsh
 from virttest import element_tree
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def sh_escape(sh_str):

--- a/libvirt/tests/src/virsh_cmd/volume/virsh_vol_clone_wipe.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_vol_clone_wipe.py
@@ -1,6 +1,6 @@
 import os
 import random
-import logging
+import logging as log
 import base64
 import locale
 import re
@@ -19,6 +19,11 @@ from virttest import libvirt_xml
 from virttest import utils_split_daemons
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def create_luks_secret(vol_path, password, test):

--- a/libvirt/tests/src/virsh_cmd/volume/virsh_vol_create.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_vol_create.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import re
 import base64
 import locale
@@ -20,6 +20,11 @@ from virttest.libvirt_xml import secret_xml
 from virttest.libvirt_xml import vm_xml
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/volume/virsh_vol_create_from.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_vol_create_from.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 
 from avocado.core import exceptions
@@ -10,6 +10,11 @@ from virttest.utils_test import libvirt as utlv
 from virttest import utils_misc
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/volume/virsh_vol_download_upload.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_vol_download_upload.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import string
 import hashlib
 import locale
@@ -22,6 +22,11 @@ from virttest.utils_test import libvirt
 from virttest.utils_test import libvirt as utlv
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def digest(path, offset, length):

--- a/libvirt/tests/src/virsh_cmd/volume/virsh_vol_resize.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_vol_resize.py
@@ -1,5 +1,5 @@
 import re
-import logging
+import logging as log
 import os
 import base64
 import locale
@@ -16,6 +16,11 @@ from virttest.utils_test import libvirt
 from virttest.libvirt_xml import secret_xml
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def get_expect_info(new_capacity, vol_path, test, resize_option=None):

--- a/libvirt/tests/src/virsh_cmd/volume/virsh_volume.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_volume.py
@@ -1,6 +1,6 @@
 import os
 import re
-import logging
+import logging as log
 
 from avocado.utils import process
 from avocado.core import exceptions
@@ -16,6 +16,11 @@ from virttest.utils_test import libvirt as utlv
 from virttest.staging import service
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virsh_cmd/volume/virsh_volume_application.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_volume_application.py
@@ -1,6 +1,6 @@
 import os
 import time
-import logging
+import logging as log
 
 from avocado.utils import process
 
@@ -11,6 +11,11 @@ from virttest import utils_selinux
 from virttest import utils_misc
 from virttest.utils_test import libvirt as utlv
 from virttest.tests import unattended_install
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def create_volumes(test, new_pool, volume_count, volume_size):

--- a/libvirt/tests/src/virsh_cmd/volume/vol_concurrent.py
+++ b/libvirt/tests/src/virsh_cmd/volume/vol_concurrent.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 import threading
 import re
@@ -16,6 +16,11 @@ from virttest.utils_test import libvirt as utlv
 
 
 q = Queue.Queue()
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def prepare_vol_xml(vol_name, vol_size, vol_format):

--- a/libvirt/tests/src/virt_admin/management/virt_admin_server_clients_set.py
+++ b/libvirt/tests/src/virt_admin/management/virt_admin_server_clients_set.py
@@ -1,9 +1,14 @@
-import logging
+import logging as log
 from virttest import virt_admin
 from virttest import virsh
 from virttest import utils_libvirtd
 from virttest import utils_iptables
 from virttest.utils_conn import TLSConnection
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virt_admin/management/virt_admin_server_threadpool_set.py
+++ b/libvirt/tests/src/virt_admin/management/virt_admin_server_threadpool_set.py
@@ -1,6 +1,11 @@
-import logging
+import logging as log
 from virttest import virt_admin
 from virttest import utils_libvirtd
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virt_admin/management/virt_admin_server_update_tls.py
+++ b/libvirt/tests/src/virt_admin/management/virt_admin_server_update_tls.py
@@ -1,6 +1,6 @@
 import os
 import re
-import logging
+import logging as log
 
 from avocado.utils import process
 
@@ -10,6 +10,11 @@ from virttest import virt_admin
 from virttest import remote
 from virttest.utils_conn import TLSConnection
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virt_admin/virt_admin_itself.py
+++ b/libvirt/tests/src/virt_admin/virt_admin_itself.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import aexpect
 
 from avocado.utils import process
@@ -6,6 +6,11 @@ from avocado.core import exceptions
 
 from virttest import virt_admin
 from virttest import element_tree
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def sh_escape(sh_str):

--- a/libvirt/tests/src/virt_cmd/virt_top.py
+++ b/libvirt/tests/src/virt_cmd/virt_top.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 
 from avocado.utils import path
 from avocado.utils import process
@@ -8,6 +8,11 @@ from avocado.utils import software_manager
 
 from virttest import virsh
 from virttest import data_dir
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtio_transitional/virtio_transitional_blk.py
+++ b/libvirt/tests/src/virtio_transitional/virtio_transitional_blk.py
@@ -1,6 +1,6 @@
 import os
 import re
-import logging
+import logging as log
 
 from avocado.utils import download
 
@@ -13,6 +13,11 @@ from virttest import utils_libvirtd
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import devices
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def find_device(vm, params):

--- a/libvirt/tests/src/virtio_transitional/virtio_transitional_mem_balloon.py
+++ b/libvirt/tests/src/virtio_transitional/virtio_transitional_mem_balloon.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 
 from avocado.utils import download
 
@@ -10,6 +10,11 @@ from virttest import libvirt_version
 
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtio_transitional/virtio_transitional_nic.py
+++ b/libvirt/tests/src/virtio_transitional/virtio_transitional_nic.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 
 from avocado.utils import process
 from avocado.utils import download
@@ -16,6 +16,11 @@ from virttest import libvirt_version
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.interface import Interface
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtio_transitional/virtio_transitional_rng.py
+++ b/libvirt/tests/src/virtio_transitional/virtio_transitional_rng.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 
 from avocado.utils import download
 from avocado.utils import process
@@ -11,6 +11,11 @@ from virttest import libvirt_version
 
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtio_transitional/virtio_transitional_vsock.py
+++ b/libvirt/tests/src/virtio_transitional/virtio_transitional_vsock.py
@@ -1,6 +1,6 @@
 import os
 import re
-import logging
+import logging as log
 
 from avocado.utils import download
 
@@ -13,6 +13,11 @@ from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 
 from src.virtio_transitional import virtio_transitional_base
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtual_device/filesystem_device.py
+++ b/libvirt/tests/src/virtual_device/filesystem_device.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import time
 import threading
 
@@ -14,6 +14,11 @@ from virttest.staging import utils_memory
 from virttest.utils_test import libvirt_device_utils
 from virttest.utils_test import libvirt
 from virttest.utils_libvirt import libvirt_pcicontr
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtual_device/input_devices.py
+++ b/libvirt/tests/src/virtual_device/input_devices.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import re
 import glob
 import platform
@@ -8,6 +8,11 @@ from virttest.libvirt_xml.vm_xml import VMXML
 from virttest import virsh
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtual_device/sound_device.py
+++ b/libvirt/tests/src/virtual_device/sound_device.py
@@ -1,11 +1,16 @@
 import re
-import logging
+import logging as log
 
 from virttest.libvirt_xml.devices.sound import Sound
 from virttest.libvirt_xml.vm_xml import VMXML
 from virttest import virsh
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtual_device/tpm_device.py
+++ b/libvirt/tests/src/virtual_device/tpm_device.py
@@ -1,6 +1,6 @@
 import os
 import re
-import logging
+import logging as log
 import time
 import platform
 import shutil
@@ -24,6 +24,11 @@ from avocado.utils import service
 from avocado.utils import process
 from avocado.utils import astring
 from avocado.utils import path as utils_path
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtual_device/video_devices.py
+++ b/libvirt/tests/src/virtual_device/video_devices.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import re
 
 from virttest.libvirt_xml.vm_xml import VMXML
@@ -12,6 +12,11 @@ from six import iteritems
 
 from math import ceil
 from math import log
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtual_device/vsock.py
+++ b/libvirt/tests/src/virtual_device/vsock.py
@@ -2,7 +2,7 @@ import os
 import re
 import random
 import uuid
-import logging
+import logging as log
 import time
 
 from threading import Thread
@@ -25,6 +25,11 @@ NC_VSOCK_CMD = os.path.join(NC_VSOCK_DIR, 'nc-vsock')
 NC_VSOCK_SRV_OUT = os.path.join(NC_VSOCK_DIR, "server_out.txt")
 NC_VSOCK_CLI_TXT = os.path.join(NC_VSOCK_DIR, "client_in.txt")
 VSOCK_PORT = 1234
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtual_device/watchdog.py
+++ b/libvirt/tests/src/virtual_device/watchdog.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 import random
 import string
@@ -11,6 +11,11 @@ from virttest import utils_misc
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.watchdog import Watchdog
 from virttest.libvirt_xml.devices.controller import Controller
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtual_disks/at_dt_iscsi_disk.py
+++ b/libvirt/tests/src/virtual_disks/at_dt_iscsi_disk.py
@@ -2,7 +2,7 @@ import os
 import re
 import time
 import base64
-import logging
+import logging as log
 import platform
 import locale
 
@@ -23,6 +23,11 @@ from virttest.libvirt_xml.devices.controller import Controller
 from virttest.staging import lv_utils
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def clean_up_lvm(device_source, vg_name, lv_name):

--- a/libvirt/tests/src/virtual_disks/startup_policy.py
+++ b/libvirt/tests/src/virtual_disks/startup_policy.py
@@ -1,6 +1,6 @@
 import os
 import re
-import logging
+import logging as log
 import shutil
 
 import aexpect
@@ -18,6 +18,11 @@ from virttest.libvirt_xml import pool_xml
 from virttest.xml_utils import XMLTreeFile
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtual_disks/virtual_disks_blockcopy_options.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_blockcopy_options.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 
 from avocado.utils import process
 
@@ -15,6 +15,11 @@ from virttest.utils_test import libvirt
 from virttest.utils_libvirt import libvirt_disk
 
 from virttest.libvirt_xml import vm_xml, xcepts
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtual_disks/virtual_disks_ccw_addr.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_ccw_addr.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 import re
 
@@ -13,6 +13,11 @@ from virttest.libvirt_xml import vm_xml, xcepts
 
 from virttest.utils_test import libvirt
 from virttest.utils_libvirt import libvirt_disk
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def create_ccw_addr_controller(params):

--- a/libvirt/tests/src/virtual_disks/virtual_disks_ceph.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_ceph.py
@@ -1,7 +1,7 @@
 import os
 import re
 import time
-import logging
+import logging as log
 import shutil
 import aexpect
 
@@ -33,6 +33,11 @@ from virttest import data_dir
 from virttest import libvirt_version
 
 TMP_DATA_DIR = data_dir.get_data_dir()
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtual_disks/virtual_disks_dasd.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_dasd.py
@@ -1,6 +1,6 @@
 # pylint: disable=spelling
 # disable pylint spell checker to allow for dasda, fdasda, vdb, vda, virtio, blk
-import logging
+import logging as log
 import re
 
 from avocado.core.exceptions import TestError
@@ -14,6 +14,11 @@ from provider.vfio import ccw
 
 TEST_DASD_ID = None
 TARGET = "vdb"  # suppose guest has only one disk 'vda'
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def get_partitioned_dasd_path():

--- a/libvirt/tests/src/virtual_disks/virtual_disks_encryption.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_encryption.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 import os.path
 import re
@@ -19,6 +19,11 @@ from virttest.libvirt_xml import secret_xml
 from virttest.libvirt_xml.devices.disk import Disk
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtual_disks/virtual_disks_gluster.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_gluster.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 
 from avocado.utils import process
 
@@ -13,6 +13,11 @@ from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.disk import Disk
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtual_disks/virtual_disks_iscsi.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_iscsi.py
@@ -1,7 +1,7 @@
 import os
 import re
 import locale
-import logging
+import logging as log
 import base64
 
 import aexpect
@@ -20,6 +20,11 @@ from virttest.libvirt_xml.devices.disk import Disk
 from virttest.libvirt_xml.devices.controller import Controller
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtual_disks/virtual_disks_luks.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_luks.py
@@ -1,6 +1,6 @@
 import os
 import re
-import logging
+import logging as log
 import aexpect
 import platform
 import time
@@ -24,6 +24,11 @@ from virttest.libvirt_xml.devices.disk import Disk
 from virttest import libvirt_version
 
 TMP_DATA_DIR = data_dir.get_data_dir()
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtual_disks/virtual_disks_metadatacache.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_metadatacache.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 import re
 
@@ -11,6 +11,11 @@ from virttest.libvirt_xml import vm_xml
 
 from virttest.utils_test import libvirt
 from virttest.utils_libvirt import libvirt_disk
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def test_blockcopy_operation(vm_name, disk_path, disk_format,

--- a/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
@@ -3,7 +3,7 @@ import re
 import time
 import base64
 import json
-import logging
+import logging as log
 import platform
 import aexpect
 import locale
@@ -37,6 +37,11 @@ from virttest.staging import lv_utils
 from virttest.utils_libvirt import libvirt_pcicontr
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtual_disks/virtual_disks_multipath.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multipath.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import aexpect
 import platform
 import time
@@ -17,6 +17,11 @@ from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
 
 WAIT_FOR_MPATH_DEVS_TIMEOUT = 60
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtual_disks/virtual_disks_multivms.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multivms.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import aexpect
 
 from avocado.utils import process
@@ -16,6 +16,11 @@ from virttest.libvirt_xml.devices.disk import Disk
 from virttest.libvirt_xml.devices.controller import Controller
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtual_disks/virtual_disks_nbd.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_nbd.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import aexpect
 import platform
 import time
@@ -17,6 +17,11 @@ from virttest.utils_nbd import NbdExport
 
 from virttest.libvirt_xml import vm_xml, xcepts
 from virttest.libvirt_xml.devices.disk import Disk
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtual_disks/virtual_disks_relative_blockcommit.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_relative_blockcommit.py
@@ -6,7 +6,7 @@ This module is meant to wrap test cases to validate virsh blockcommit with relat
 :copyright: 2021 Red Hat Inc.
 """
 
-import logging
+import logging as log
 import os
 import time
 import threading
@@ -24,6 +24,11 @@ from virttest.utils_test import libvirt
 
 from virttest.utils_libvirt import libvirt_ceph_utils
 from virttest.utils_libvirt import libvirt_disk
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtual_disks/virtual_disks_rotation_rate.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_rotation_rate.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import time
 
 from virttest import libvirt_version
@@ -10,6 +10,11 @@ from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 from virttest.utils_libvirt import libvirt_vmxml
 from virttest.utils_misc import cmd_status_output
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def install_pkg(test, pkg_list, vm_session):

--- a/libvirt/tests/src/virtual_disks/virtual_disks_scsi3_persistent_reservation.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_scsi3_persistent_reservation.py
@@ -1,6 +1,6 @@
 import re
 import locale
-import logging
+import logging as log
 import base64
 import time
 import shutil
@@ -20,6 +20,11 @@ from virttest.libvirt_xml.devices.controller import Controller
 from virttest.libvirt_xml.devices.disk import Disk
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtual_disks/virtual_disks_snapshot_blockpull.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_snapshot_blockpull.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import locale
 import base64
 
@@ -21,6 +21,11 @@ from virttest.utils_libvirt import libvirt_ceph_utils
 from virttest.utils_nbd import NbdExport
 
 from virttest.libvirt_xml import vm_xml
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtual_disks/virtual_disks_transient_disk.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_transient_disk.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import aexpect
 
 from avocado.utils import process
@@ -14,6 +14,11 @@ from virttest.utils_libvirt import libvirt_disk
 from virttest.libvirt_xml import vm_xml
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtual_disks/virtual_disks_usb.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_usb.py
@@ -1,6 +1,6 @@
 import os
 import time
-import logging
+import logging as log
 import platform
 import aexpect
 
@@ -14,6 +14,11 @@ from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.disk import Disk
 from virttest.libvirt_xml.devices.controller import Controller
 from virttest import data_dir
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtual_disks/virtual_disks_vhostuser.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_vhostuser.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 
 from avocado.utils import process
@@ -12,6 +12,11 @@ from virttest.utils_libvirt import libvirt_disk
 from virttest.libvirt_xml import vm_xml
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def create_backend_image_file(image_path):

--- a/libvirt/tests/src/virtual_interface/connectivity_check.py
+++ b/libvirt/tests/src/virtual_interface/connectivity_check.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from virttest import libvirt_version
 from virttest import virsh
@@ -13,6 +13,11 @@ from provider.interface import interface_base
 from provider.interface import check_points
 
 VIRSH_ARGS = {'debug': True, 'ignore_status': False}
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtual_interface/domain_lifecycle.py
+++ b/libvirt/tests/src/virtual_interface/domain_lifecycle.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 
 from virttest import data_dir
@@ -15,6 +15,11 @@ from provider.interface import interface_base
 from provider.interface import check_points
 
 VIRSH_ARGS = {'debug': True, 'ignore_status': False}
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtual_interface/hotplug_mem.py
+++ b/libvirt/tests/src/virtual_interface/hotplug_mem.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from avocado.core import exceptions
 from avocado.utils import process
@@ -15,6 +15,11 @@ from virttest.utils_test import libvirt
 from provider.interface import interface_base
 
 VIRSH_ARGS = {'debug': True, 'ignore_status': False}
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def check_soft_memlock(exp_memlock):

--- a/libvirt/tests/src/virtual_interface/interface_hotplug.py
+++ b/libvirt/tests/src/virtual_interface/interface_hotplug.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from virttest import libvirt_version
 from virttest import utils_misc
@@ -9,6 +9,11 @@ from virttest.utils_libvirt import libvirt_vmxml
 
 from provider.interface import interface_base
 from provider.interface import vdpa_base
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtual_network/iface_bridge.py
+++ b/libvirt/tests/src/virtual_network/iface_bridge.py
@@ -1,5 +1,5 @@
 import os
-import logging
+import logging as log
 import re
 import ast
 
@@ -18,6 +18,11 @@ from virttest.libvirt_xml.devices import interface
 from virttest.libvirt_xml import network_xml
 
 NETWORK_SCRIPT = "/etc/sysconfig/network-scripts/ifcfg-"
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtual_network/iface_coalesce.py
+++ b/libvirt/tests/src/virtual_network/iface_coalesce.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import time
 import re
 
@@ -13,6 +13,11 @@ from virttest.libvirt_xml.devices.interface import Interface
 from avocado.utils import process
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtual_network/iface_hotplug.py
+++ b/libvirt/tests/src/virtual_network/iface_hotplug.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import time
 import ast
 
@@ -12,6 +12,11 @@ from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.interface import Interface
 from virttest.utils_test import libvirt
 from avocado.utils import process
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtual_network/iface_network.py
+++ b/libvirt/tests/src/virtual_network/iface_network.py
@@ -2,7 +2,7 @@ import re
 import os
 import sys
 import ast
-import logging
+import logging as log
 import platform
 import shutil
 
@@ -25,6 +25,11 @@ from virttest.libvirt_xml import vm_xml, xcepts
 from virttest.libvirt_xml.network_xml import NetworkXML
 from virttest.libvirt_xml.devices.interface import Interface
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtual_network/iface_nss.py
+++ b/libvirt/tests/src/virtual_network/iface_nss.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 from virttest import utils_package
 from avocado.utils import process
@@ -6,6 +6,11 @@ from virttest.utils_test.__init__ import ping
 from virttest import virsh
 from virttest import libvirt_xml
 from virttest.libvirt_xml.devices import interface
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def check_nss(name):

--- a/libvirt/tests/src/virtual_network/iface_options.py
+++ b/libvirt/tests/src/virtual_network/iface_options.py
@@ -2,7 +2,7 @@ import os
 import re
 import ast
 import time
-import logging
+import logging as log
 import platform
 import shutil
 
@@ -29,6 +29,11 @@ from virttest.libvirt_xml import xcepts
 from virttest.staging import utils_memory
 
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtual_network/iface_ovs.py
+++ b/libvirt/tests/src/virtual_network/iface_ovs.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import shutil
 
 from avocado.utils import distro
@@ -12,6 +12,11 @@ from virttest.staging import service
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.network_xml import NetworkXML
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtual_network/iface_rename.py
+++ b/libvirt/tests/src/virtual_network/iface_rename.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 import time
 
@@ -8,6 +8,11 @@ from virttest import utils_config
 from virttest import utils_net
 from virttest import data_dir
 from virttest import libvirt_version
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtual_network/iface_stat.py
+++ b/libvirt/tests/src/virtual_network/iface_stat.py
@@ -1,5 +1,5 @@
 import datetime
-import logging
+import logging as log
 import re
 
 from virttest import utils_net
@@ -7,6 +7,11 @@ from virttest import virsh
 
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def get_host_iface_stat(vm_name, iface):

--- a/libvirt/tests/src/virtual_network/iface_target.py
+++ b/libvirt/tests/src/virtual_network/iface_target.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import time
 
 from avocado.utils import process
@@ -11,6 +11,11 @@ from virttest.libvirt_xml import vm_xml
 from virttest.utils_libvirt import libvirt_vmxml
 from virttest.utils_libvirt import libvirt_network
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtual_network/iface_unprivileged.py
+++ b/libvirt/tests/src/virtual_network/iface_unprivileged.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import shutil
 import aexpect
 
@@ -12,6 +12,11 @@ from virttest import utils_package
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtual_network/iface_update.py
+++ b/libvirt/tests/src/virtual_network/iface_update.py
@@ -1,6 +1,6 @@
 import os
 import re
-import logging
+import logging as log
 import time
 
 from avocado.utils import process
@@ -12,6 +12,11 @@ from virttest import utils_libvirtd
 from virttest.libvirt_xml import network_xml
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def check_iface_link(session, mac, stat):

--- a/libvirt/tests/src/virtual_network/mtu.py
+++ b/libvirt/tests/src/virtual_network/mtu.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import os
 import time
 import shutil
@@ -19,6 +19,11 @@ from virttest.libvirt_xml.network_xml import NetworkXML
 from virttest.utils_test import libvirt
 
 DEFAULT_NET = 'default'
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):

--- a/libvirt/tests/src/virtual_network/network_misc.py
+++ b/libvirt/tests/src/virtual_network/network_misc.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import re
 
 from avocado.utils.software_manager.backends import rpm
@@ -17,6 +17,11 @@ from virttest.utils_test import libvirt
 
 DEFAULT_NET = 'default'
 VIRSH_ARGS = {'debug': True, 'ignore_status': False}
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def setup_firewalld():

--- a/libvirt/tests/src/virtual_network/virtual_network_multivms.py
+++ b/libvirt/tests/src/virtual_network/virtual_network_multivms.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import time
 
 from avocado.utils import process
@@ -11,6 +11,11 @@ from virttest import utils_package
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices import interface
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def create_bridge(br_name, iface_name):

--- a/libvirt/tests/src/vm_boot_with_kernel_param.py
+++ b/libvirt/tests/src/vm_boot_with_kernel_param.py
@@ -1,9 +1,14 @@
-import logging
+import logging as log
 
 from virttest.libvirt_xml import vm_xml
 from virttest import utils_test
 from virttest import cpu
 from virttest.utils_test.libvirt import check_status_output
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def check_cmdline(session, expected):


### PR DESCRIPTION
Because of logging changes in Avocado, update to use avocado
namespace for logging. For details, please see avocado commit
b2459dd55.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
