### PR TITLE
provider: Update to use avocado namespace for logging

### DIFF
--- a/provider/interface/check_points.py
+++ b/provider/interface/check_points.py
@@ -1,7 +1,12 @@
-import logging
+import logging as log
 from avocado.core import exceptions
 
 from provider.interface import vdpa_base
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def check_network_accessibility(vm, **kwargs):

--- a/provider/interface/interface_base.py
+++ b/provider/interface/interface_base.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import time
 
 from avocado.core import exceptions
@@ -10,6 +10,11 @@ from virttest.libvirt_xml.devices import interface
 from virttest.utils_libvirt import libvirt_misc
 from virttest.utils_libvirt import libvirt_vmxml
 from virttest.utils_test import libvirt
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def create_iface(iface_type, iface_dict):

--- a/provider/interface/vdpa_base.py
+++ b/provider/interface/vdpa_base.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import re
 
 from avocado.core import exceptions
@@ -9,6 +9,11 @@ from provider.interface import interface_base
 from virttest import utils_test
 from virttest import utils_misc
 from virttest.staging import service
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def config_vdpa_conn(vm_session, vm_iface, br_name,

--- a/provider/migration/migration_base.py
+++ b/provider/migration/migration_base.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 import types
 import re
 import signal                                        # pylint: disable=W0611
@@ -9,6 +9,11 @@ from virttest import utils_misc                      # pylint: disable=W0611
 from virttest.utils_conn import TLSConnection
 from virttest.utils_libvirt import libvirt_network   # pylint: disable=W0611
 from virttest.migration import MigrationTest
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def parse_funcs(action_during_mig, test, params):

--- a/provider/vfio/ccw.py
+++ b/provider/vfio/ccw.py
@@ -1,4 +1,4 @@
-import logging
+import logging as log
 
 from avocado.core.exceptions import TestError
 
@@ -14,6 +14,11 @@ DASD_DISK = "/dev/dasda"
 DASD_PART = "/dev/dasda1"
 # default mount path inside guest
 MOUNT = "/mnt"
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
 
 
 def read_write_operations_work(session, chpids, makefs=True):


### PR DESCRIPTION
Because of logging changes in Avocado, update to use avocado
namespace for logging. For details, please see avocado commit
b2459dd55.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
