### PR TITLE
virsh_domstats: Undefine guest with --snapshots-metadata option

### DIFF
--- a/libvirt/tests/src/virsh_cmd/monitor/virsh_domstats.py
+++ b/libvirt/tests/src/virsh_cmd/monitor/virsh_domstats.py
@@ -279,4 +279,7 @@ def run(test, params, env):
         except AttributeError:
             pass
         for backup_xml in backup_xml_list:
-            backup_xml.sync()
+            if "--nowait" in domstats_option:
+                backup_xml.sync(options="--snapshots-metadata")
+            else:
+                backup_xml.sync()


### PR DESCRIPTION
If undefine the guest with snapshots, need to add
 --snapshots-metadata option.

Signed-off-by: lcheng <lcheng@redhat.com>
