### PR TITLE
Sleep 3s before hot-unplug an interface

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_hotplug.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_hotplug.cfg
@@ -99,7 +99,7 @@
                             check_mac = "yes"
                             only at_device..active
                 - stress_test:
-                    iface_num = '500'
+                    iface_num = '20'
                     stress_test = "yes" 
                 - detach_match_test:
                     only at_device

--- a/libvirt/tests/src/virtual_network/iface_hotplug.py
+++ b/libvirt/tests/src/virtual_network/iface_hotplug.py
@@ -192,16 +192,16 @@ def run(test, params, env):
                         test.fail("Failed to attach-interface: %s" % ret.stderr.strip())
                 elif stress_test:
                     if attach_device:
-                        # Detach the device immediately for stress test
-                        ret = virsh.detach_device(vm_name, iface_xml_obj.xml,
-                                                  flagstr=detach_option,
-                                                  ignore_status=True)
+                        # Detach the device for stress test
+                        ret = utils_misc.wait_for(lambda: virsh.detach_device(vm_name, iface_xml_obj.xml,
+                                                                              flagstr=detach_option, debug=True),
+                                                  timeout=9, first=3, step=1)
                     elif attach_iface:
                         # Detach the device immediately for stress test
                         options = ("--type %s --mac %s %s" %
                                    (iface_type, mac, detach_option))
-                        ret = virsh.detach_interface(vm_name, options,
-                                                     ignore_status=True)
+                        ret = utils_misc.wait_for(lambda: virsh.detach_interface(vm_name, options, debug=True),
+                                                  timeout=9, first=3, step=1)
                     libvirt.check_exit_status(ret)
                 else:
                     if attach_device:


### PR DESCRIPTION
Qemu has add power indicator blink check since v6.2.0(commit 81124b3c7a).
It will cause the hot-unplug interface immediately after hotplug fail.
Add sleep 3s before the hot-unplug operation in our test script.

Signed-off-by: Yalan Zhang <yalzhang@redhat.com>