### PR TITLE
Fix bz 2014369

### DIFF
--- a/libvirt/tests/cfg/numa/numa_memory_migrate.cfg
+++ b/libvirt/tests/cfg/numa/numa_memory_migrate.cfg
@@ -2,7 +2,7 @@
     type = numa_memory_migrate
     start_vm = "no"
     kill_vm = "yes"
-    memory_mode = "strict"
+    memory_mode = "restrictive"
     take_regular_screendumps = "no"
     variants:
         - mem_auto:

--- a/libvirt/tests/cfg/numa/numa_memory_spread.cfg
+++ b/libvirt/tests/cfg/numa/numa_memory_spread.cfg
@@ -1,6 +1,6 @@
 - numa_memory_spread:
     type = numa_memory_spread
-    memory_mode = "strict"
+    memory_mode = "restrictive"
     memory_nodeset = '0'
     variants:
         - default:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_numatune.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_numatune.cfg
@@ -20,8 +20,8 @@
                                             numa_mode = 'preferred'
                                         - interleave:
                                             numa_mode = 'interleave'
-                                        - strict:
-                                            numa_mode = 'strict'
+                                        - restrictive:
+                                            numa_mode = 'restrictive'
                                     variants:
                                         - options:
                                             variants:
@@ -48,7 +48,7 @@
                                                     options = "current"
                         - running_guest:
                             start_vm = "yes"
-                            numa_mode = 'strict'
+                            numa_mode = 'restrictive'
                             variants:
                                 - change_nodeset:
                                     variants:
@@ -131,9 +131,9 @@
                                             numa_mode = 'preferred'
                                         - interleave:
                                             numa_mode = 'interleave'
-                                        - strict:
+                                        - restrictive:
                                             numa_nodeset = 0
-                                            numa_mode = 'strict'
+                                            numa_mode = 'restrictive'
                                     variants:
                                         - options:
                                             variants:

--- a/libvirt/tests/src/numa/numa_memory_migrate.py
+++ b/libvirt/tests/src/numa/numa_memory_migrate.py
@@ -129,8 +129,8 @@ def run(test, params, env):
 
         # run numatune live change numa memory config
         for node in left_node:
-            virsh.numatune(vm_name, 'strict', str(node), options,
-                           debug=True, ignore_status=False)
+            virsh.numatune(vm_name, numa_memory.get('memory_mode'), str(node),
+                           options, debug=True, ignore_status=False)
 
             vmxml_new = libvirt_xml.VMXML.new_from_dumpxml(vm_name)
             numa_memory_new = vmxml_new.numa_memory

--- a/libvirt/tests/src/numa/numa_memory_spread.py
+++ b/libvirt/tests/src/numa/numa_memory_spread.py
@@ -102,9 +102,9 @@ def prepare_guest_for_test(
     result = virsh.numatune(vm_name, debug=True)
     if result.exit_status:
         test.fail("Something went wrong during the virsh numatune command.")
-    result = virsh.numatune(vm_name, mode='0', nodeset=nodeset_string, debug=True)
+    result = virsh.numatune(vm_name, mode='restrictive', nodeset=nodeset_string, debug=True)
     if result.exit_status:
-        test.fail("Something went wrong during the 'virsh numatune 0 {}' "
+        test.fail("Something went wrong during the 'virsh numatune restrictive {}' "
                   "command.".format(nodeset_string))
     result = virsh.setmem(vm_name, oversize, debug=True)
     if result.exit_status:


### PR DESCRIPTION
libvirt has forbidden migrating memory for <numatune/> mode='strict' since
libvirt 8.0. Use restrictive mode to test memory migration.

Fix https://bugzilla.redhat.com/show_bug.cgi?id=2014369

Reference: libvirt 06f405c627 qemu: Explicitly forbid live changing
nodeset for strict numatune

Before
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio \
> virsh.numatune.positive_testing.set_numa_parameter.running_guest.change_nodeset.options \
> numa_memory_spread.default \
> numa_memory_migrate.mem_auto
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : eeb9631261a3ea2b56c9e7e9d9e11a79ca05acff
JOB LOG    : /root/avocado/job-results/job-2022-01-16T22.32-eeb9631/job.log
 (01/10) type_specific.io-github-autotest-libvirt.virsh.numatune.positive_testing.set_numa_parameter.running_guest.change_nodeset.options.live.comma_list: FAIL: error: Unable to change numa parameters\nerror: Requested operation is not valid: can't change nodeset for strict mode for running domain\n (18.85 s)
 (02/10) type_specific.io-github-autotest-libvirt.virsh.numatune.positive_testing.set_numa_parameter.running_guest.change_nodeset.options.live.ranges: FAIL: error: Unable to change numa parameters\nerror: Requested operation is not valid: can't change nodeset for strict mode for running domain\n (18.88 s)
 (03/10) type_specific.io-github-autotest-libvirt.virsh.numatune.positive_testing.set_numa_parameter.running_guest.change_nodeset.options.live.excluding: FAIL: error: Unable to change numa parameters\nerror: Requested operation is not valid: can't change nodeset for strict mode for running domain\n (18.97 s)
 (04/10) type_specific.io-github-autotest-libvirt.virsh.numatune.positive_testing.set_numa_parameter.running_guest.change_nodeset.options.live.single: FAIL: error: Unable to change numa parameters\nerror: Requested operation is not valid: can't change nodeset for strict mode for running domain\n (18.93 s)
 (05/10) type_specific.io-github-autotest-libvirt.virsh.numatune.positive_testing.set_numa_parameter.running_guest.change_nodeset.options.current.comma_list: FAIL: error: Unable to change numa parameters\nerror: Requested operation is not valid: can't change nodeset for strict mode for running domain\n (18.69 s)
 (06/10) type_specific.io-github-autotest-libvirt.virsh.numatune.positive_testing.set_numa_parameter.running_guest.change_nodeset.options.current.ranges: FAIL: error: Unable to change numa parameters\nerror: Requested operation is not valid: can't change nodeset for strict mode for running domain\n (19.25 s)
 (07/10) type_specific.io-github-autotest-libvirt.virsh.numatune.positive_testing.set_numa_parameter.running_guest.change_nodeset.options.current.excluding: FAIL: error: Unable to change numa parameters\nerror: Requested operation is not valid: can't change nodeset for strict mode for running domain\n (18.86 s)
 (08/10) type_specific.io-github-autotest-libvirt.virsh.numatune.positive_testing.set_numa_parameter.running_guest.change_nodeset.options.current.single: FAIL: error: Unable to change numa parameters\nerror: Requested operation is not valid: can't change nodeset for strict mode for running domain\n (18.83 s)
 (09/10) type_specific.io-github-autotest-libvirt.numa_memory_spread.default: FAIL: Something went wrong during the 'virsh numatune 0 0,1' command. (49.62 s)
 (10/10) type_specific.io-github-autotest-libvirt.numa_memory_migrate.mem_auto: ERROR: Command '/bin/virsh numatune avocado-vt-vm1 --live --mode strict --nodeset 0' failed.\nstdout: b'\n'\nstderr: b"error: Unable to change numa parameters\nerror: Requested operation is not valid: can't change nodeset for strict mode for running domain\n"\naddi... (51.50 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 9 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 253.46 s
```
After
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio \                                                                   
> virsh.numatune.positive_testing.set_numa_parameter.running_guest.change_nodeset.options \
> numa_memory_spread.default \
> numa_memory_migrate.mem_auto
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.       
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.                          
JOB ID     : 1905804d92cde677a0850fea66d8948f4014f495
JOB LOG    : /root/avocado/job-results/job-2022-01-16T22.25-1905804/job.log
 (01/10) type_specific.io-github-autotest-libvirt.virsh.numatune.positive_testing.set_numa_parameter.running_guest.change_nodeset.options.live.comma_list: PASS (18.08 s)                    
 (02/10) type_specific.io-github-autotest-libvirt.virsh.numatune.positive_testing.set_numa_parameter.running_guest.change_nodeset.options.live.ranges: PASS (18.09 s)                        
 (03/10) type_specific.io-github-autotest-libvirt.virsh.numatune.positive_testing.set_numa_parameter.running_guest.change_nodeset.options.live.excluding: PASS (20.01 s)                     
 (04/10) type_specific.io-github-autotest-libvirt.virsh.numatune.positive_testing.set_numa_parameter.running_guest.change_nodeset.options.live.single: PASS (18.01 s)                        
 (05/10) type_specific.io-github-autotest-libvirt.virsh.numatune.positive_testing.set_numa_parameter.running_guest.change_nodeset.options.current.comma_list: PASS (20.35 s)                 
 (06/10) type_specific.io-github-autotest-libvirt.virsh.numatune.positive_testing.set_numa_parameter.running_guest.change_nodeset.options.current.ranges: PASS (20.09 s)
 (07/10) type_specific.io-github-autotest-libvirt.virsh.numatune.positive_testing.set_numa_parameter.running_guest.change_nodeset.options.current.excluding: PASS (17.85 s)
 (08/10) type_specific.io-github-autotest-libvirt.virsh.numatune.positive_testing.set_numa_parameter.running_guest.change_nodeset.options.current.single: PASS (19.89 s)
 (09/10) type_specific.io-github-autotest-libvirt.numa_memory_spread.default: PASS (80.51 s)
 (10/10) type_specific.io-github-autotest-libvirt.numa_memory_migrate.mem_auto: PASS (56.11 s)
RESULTS    : PASS 10 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 290.16 s

```
