### PR TITLE
virsh_event: Fix undefine guest issue

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
@@ -679,7 +679,10 @@ def run(test, params, env):
         if dom_newname:
             virsh.domrename(dom_newname, dom.name, **virsh_dargs)
         for xml in vmxml_backup:
-            xml.sync()
+            if "blockcommit" in events_list:
+                xml.sync(options="--snapshots-metadata")
+            else:
+                xml.sync()
         if os.path.exists(dump_path):
             shutil.rmtree(dump_path)
             os.mkdir(dump_path)


### PR DESCRIPTION
If undefine the guest with snapshots, need to add
 --snapshots-metadata option.

Signed-off-by: lcheng <lcheng@redhat.com>
