### PR TITLE
v2v: fix qxl check for win11 and win2022 guests

### DIFF
--- a/provider/v2v_vmcheck_helper.py
+++ b/provider/v2v_vmcheck_helper.py
@@ -292,6 +292,9 @@ class VMChecker(object):
                 video_model = 'qxl'
             elif self.os_version in ['win7', 'win2008r2']:
                 video_model = 'qxl'
+            # win11 and win2022 don't have qxldod driver in virtio-win, but they are unexpectedly
+            # inspected to win10 and win2016 by v2v, so the qxl driver is installed by mistake.
+            # this only affects RHEL8.
             elif self.os_version in ['win10', 'win2016', 'win2019', 'win11', 'win2022'] and has_qxldod:
                 video_model = 'qxl'
             else:
@@ -751,8 +754,14 @@ class VMChecker(object):
         expect_adapter = 'Microsoft Basic Display Driver'
         virtio_win_qxl_os = ['win2008r2', 'win7']
         virtio_win_qxldod_os = ['win10', 'win2016', 'win2019']
+        # bz1997446, bz2012658
+        # Those guests are incorrectly inspected to other versions, so
+        # the QXL drivers are installed unexpectedly. This only happens
+        # in RHEL8 and the issue is not going to be fixed. so add a
+        # workaround to pass the checking.
+        unexpected_qxldod_os = ['win11', 'win2022']
         if has_virtio_win and expect_video == 'qxl':
-            if has_qxldod and self.os_version in virtio_win_qxldod_os:
+            if has_qxldod and self.os_version in virtio_win_qxldod_os + unexpected_qxldod_os:
                 expect_adapter = 'Red Hat QXL controller'
             elif self.os_version in virtio_win_qxl_os:
                 expect_adapter = 'Red Hat QXL GPU'

--- a/v2v/tests/src/convert_vm_to_ovirt.py
+++ b/v2v/tests/src/convert_vm_to_ovirt.py
@@ -15,6 +15,47 @@ from provider.v2v_vmcheck_helper import VMChecker
 LOG = logging.getLogger('avocado.v2v.' + __name__)
 
 
+def check_qxl_warning(buf, os_type, os_version):
+    """
+    Check the qxl warning message
+    :param buf: the v2v debug log
+    :param os_type: the guest's os_type(linux, windows)
+    :param os_version: the guest's os version
+    """
+    err_list = []
+    virtio_win_ver = "[virtio-win-1.9.16-1,)"
+    virtio_win_qxl_os = ['win2008r2', 'win7']
+    virtio_win_qxldod_os = ['win10', 'win2016', 'win2019']
+    unexpected_qxldod_os = ['win11', 'win2022']
+    v2v_unsupport_qxl_ver = "[virt-v2v-1.45.96,)"
+
+    # RHEL9 doesn't support qxl.
+    if utils_v2v.multiple_versions_compare(v2v_unsupport_qxl_ver):
+        return err_list
+
+    # Skip qxl check for win11 and win2022. The virtio-win doesn't include
+    # qxl driver for them. But because of bugs in libguestfs, they are inspected
+    # to win10 and win2016 unexpectedly. so the qxl driver is installed by
+    # mistake. I think the warning check can be skipped here. And the warning
+    # is not that important, either.
+    if os_type == 'windows' and os_version not in unexpected_qxldod_os:
+        virtio_win_support_qxldod = utils_v2v.multiple_versions_compare(
+            virtio_win_ver)
+        qxl_warning = "there is no QXL driver for this version of Windows"
+        if virtio_win_support_qxldod and os_version in virtio_win_qxldod_os:
+            has_qxl_warning = False
+        elif os_version in virtio_win_qxl_os:
+            has_qxl_warning = False
+        else:
+            has_qxl_warning = True
+
+        if has_qxl_warning and not re.search(qxl_warning, buf):
+            err_list.append('Not find QXL warning')
+        if not has_qxl_warning and re.search(qxl_warning, buf):
+            err_list.append('Unexpected QXL warning')
+
+    return err_list
+
 def run(test, params, env):
     """
     Convert a remote vm to remote ovirt node.
@@ -199,29 +240,7 @@ def run(test, params, env):
             return
 
         ret = vmchecker.run()
-
-        err_list = []
-        virtio_win_ver = "[virtio-win-1.9.16-1,)"
-        virtio_win_qxl_os = ['win2008r2', 'win7']
-        virtio_win_qxldod_os = ['win10', 'win2016', 'win2019']
-
-        if os_type == 'windows':
-            virtio_win_support_qxldod = utils_v2v.multiple_versions_compare(
-                virtio_win_ver)
-            qxl_warning = "there is no QXL driver for this version of Windows"
-            if virtio_win_support_qxldod and os_version in virtio_win_qxldod_os:
-                has_qxl_warning = False
-            elif os_version in virtio_win_qxl_os:
-                has_qxl_warning = False
-            else:
-                has_qxl_warning = True
-
-            if has_qxl_warning and not re.search(qxl_warning, v2v_ret.stdout_text):
-                err_list.append('Not find QXL warning')
-            if not has_qxl_warning and re.search(qxl_warning, v2v_ret.stdout_text):
-                err_list.append('Unexpected QXL warning')
-
-        ret.extend(err_list)
+        ret.extend(check_qxl_warning(v2v_ret.stdout_text, os_type, os_version))
 
         if len(ret) == 0:
             LOG.info("All checkpoints passed")

--- a/v2v/tests/src/convert_vm_to_ovirt.py
+++ b/v2v/tests/src/convert_vm_to_ovirt.py
@@ -56,6 +56,7 @@ def check_qxl_warning(buf, os_type, os_version):
 
     return err_list
 
+
 def run(test, params, env):
     """
     Convert a remote vm to remote ovirt node.


### PR DESCRIPTION
For rhel9, we don't need to do any qxl check because it's not supported.

For rhel8, because 1997446 and 2012658, the win11 and win2022 are
inspected to win10 and win2016 unexpectedly by libguestfs, and this is
not going to be fixed in rhel8. so the qxl driver is installed for win11
and win2022 by mistake. BTW, virtio-win has already removed qxldod
driver for win11 and win2022. Because this problem, in order to make
out test run successfully, we'll continue checking the qxl for win11 and
win2022, but for the qxl warning message in v2v debug log, the scrip
will skip checking it. This warning is not that important and will make
the logic more complicate to understand.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>