### PR TITLE
numa_memory_spread: Add negative test for strict mode

### DIFF
--- a/libvirt/tests/cfg/numa/numa_memory_spread.cfg
+++ b/libvirt/tests/cfg/numa/numa_memory_spread.cfg
@@ -1,8 +1,18 @@
 - numa_memory_spread:
     type = numa_memory_spread
+    start_vm = "no"
     memory_mode = "restrictive"
     memory_nodeset = '0'
     variants:
-        - default:
-            limit_mb = 100
-            cgget_message = 'cpuset.memory_migrate: 1'
+        - positive_test:
+            status_error = "no"
+            variants:
+                - default:
+                    limit_mb = 100
+                    cgget_message = 'cpuset.memory_migrate: 1'
+        - negative_test:
+            status_error = "yes"
+            variants:
+                - strict_memory_mode:
+                    memory_mode = "strict"
+                    error_message = "can't change nodeset for strict mode for running domain"


### PR DESCRIPTION
Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Tested with libvirt-8.0.0-1.el8.aarch64
```
JOB LOG    : /root/avocado/job-results/job-2022-01-21T04.53-c469e66/job.log
 (1/2) type_specific.io-github-autotest-libvirt.numa_memory_spread.positive_test.default: STARTED                                                                                            
 (1/2) type_specific.io-github-autotest-libvirt.numa_memory_spread.positive_test.default: PASS (84.04 s)                                                                                     
 (2/2) type_specific.io-github-autotest-libvirt.numa_memory_spread.negative_test.strict_memory_mode: STARTED                                                                                 
 (2/2) type_specific.io-github-autotest-libvirt.numa_memory_spread.negative_test.strict_memory_mode: PASS (49.70 s)                                                                          
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0

```