### PR TITLE
nodedev_persistence: add test case for nodedev persistent setup API

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_persistence_mdev.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_persistence_mdev.cfg
@@ -1,0 +1,7 @@
+- virsh.nodedev_persistence.mdev:
+    type = virsh_nodedev_persistence_mdev
+    start_vm = "no"
+    func_supported_since_libvirt_ver = (7, 6, 0)
+    variants:
+        - ccw:
+            only s390-virtio

--- a/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_persistence_mdev.py
+++ b/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_persistence_mdev.py
@@ -1,0 +1,88 @@
+import logging
+import re
+
+from avocado.core.exceptions import TestFail
+from virttest import virsh
+from virttest.libvirt_xml.nodedev_xml import NodedevXML, MdevXML
+from provider.vfio import ccw
+
+
+LOG = logging.getLogger("avocado." + __name__)
+
+
+def get_device_xml(schid):
+    """
+    Returns the nodedev device xml path.
+
+    :param schid: the subchannel id for the ccw device, e.g. 0.0.0062
+    """
+
+    parent_name = "css_" + schid.replace(".", "_")
+    device_xml = NodedevXML()
+    device_xml['parent'] = parent_name
+    mdev_xml = MdevXML()
+    mdev_xml['type_id'] = 'vfio_ccw-io'
+    mdev_xml['uuid'] = '8d312cf6-f92a-485c-8db8-ba9299848f46'
+    device_xml.set_cap(mdev_xml)
+    return device_xml.xml
+
+
+def get_device_name():
+    """
+    Returns first defined but not started
+    mdev device name.
+    """
+
+    try:
+        result = virsh.nodedev_list(cap="mdev", options="--all", ignore_status=False, debug=True)
+        return result.stdout.strip().splitlines()[0]
+    except:
+        raise TestFail("Mdev device not found.")
+
+
+def check_autostart(device_name):
+    """
+    Check if device is configured to autostart
+
+    :param device_name: nodedev device name
+    :raises: TestFail if autostart is not configured
+    """
+    result = virsh.nodedev_info(device_name, ignore_status=False, debug=True)
+    if not re.findall("Autostart.*yes", result.stdout_text):
+        raise TestFail("Device %s not configured to autostart." % device_name)
+
+
+def run(test, params, env):
+    """
+    Round trip for persistent setup via nodedev API:
+    define, set autostart, start, destroy, undefine
+
+    The test assumes no other mediated device is available
+    in the test environment.
+
+    A typical node device xml would look like:
+    <device>
+        <parent>css_0_0_0062</parent>
+            <capability type="mdev">
+                <type id="vfio_ccw-io"/>
+                <uuid>8d312cf6-f92a-485c-8db8-ba9299848f46</uuid>
+            </capability>
+    </device>
+    """
+
+    schid = None
+
+    try:
+        schid, _ = ccw.get_device_info()
+        ccw.set_override(schid)
+        nodedev_file_path = get_device_xml(schid)
+        virsh.nodedev_define(nodedev_file_path, ignore_status=False, debug=True)
+        device_name = get_device_name()
+        virsh.nodedev_autostart(device_name, ignore_status=False, debug=True)
+        check_autostart(device_name)
+        virsh.nodedev_start(device_name, ignore_status=False, debug=True)
+        virsh.nodedev_destroy(device_name, ignore_status=False, debug=True)
+        virsh.nodedev_undefine(device_name, ignore_status=False, debug=True)
+    finally:
+        if schid:
+            ccw.unset_override(schid)

--- a/spell.ignore
+++ b/spell.ignore
@@ -176,6 +176,7 @@ de
 deduplicate
 del
 deplist
+deps
 desc
 dest
 desturi
@@ -844,6 +845,7 @@ schedinfo
 schid
 scp
 scsi
+schid
 sd
 sda
 sdb


### PR DESCRIPTION
Depends on https://github.com/avocado-framework/avocado-vt/pull/3333
Depends on https://github.com/avocado-framework/avocado-vt/pull/3384

Add a roundtrip test case to cover the lifecycle of a ccw mdev device
that's set up persistently via libvirt's nodedev API.

As avocado can't restart the host and continue the test run,
the autostart configuration is only covered to be correctly set.

All other commands are expected to fail if there was any issue.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>