### PR TITLE
virsh_nodecpustats: add case disable cpu

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_nodecpustats.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_nodecpustats.cfg
@@ -5,23 +5,16 @@
     # this is number of iterations the command will be executed and
     # the actual delta values will be listed at the end of testcase for
     # all iterations
-    inner_test_iterations = 5
-    variants:
-        - no_option:
-            virsh_cpunodestats_options = ""
-            status_error = "no"
-            libvirtd = "on"
-        - unexpect_option:
-            status_error = "yes"
-            libvirtd = "on"
-            invalid_cpunum = "no"
-            variants:
-                - invalid_option:
-                    virsh_cpunodestats_options = "--xyz"
-                - invalid_cpuNum:
-                    invalid_cpunum = "yes"
-                    virsh_cpunodestats_options = ""
+    inner_test_iterations = 1
+    libvirtd = "on"
+    variants test_case:
+        - all_options_all_cpus:
+        - disable_enable_cpu:
+            err_msg = 'Invalid cpuNum in virHostCPUGetStatsLinux'
         - with_libvirtd_stop:
-            virsh_cpunodestats_options = ""
-            status_error = "yes"
             libvirtd = "off"
+        - invalid_option:
+            virsh_cpunodestats_options = "--xyz"
+        - invalid_cpuNum:
+            invalid_cpunum = "yes"
+            err_msg = 'Invalid cpuNum in virHostCPUGetStatsLinux|malformed or out of range'

--- a/libvirt/tests/src/virsh_cmd/host/virsh_nodecpustats.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_nodecpustats.py
@@ -1,4 +1,3 @@
-import re
 import logging as log
 
 from avocado.utils import cpu as cpuutil
@@ -6,6 +5,8 @@ from avocado.utils import cpu as cpuutil
 from virttest import virsh
 from virttest import utils_libvirtd
 from virttest import libvirt_version
+
+from virttest.utils_libvirt import libvirt_misc
 from virttest.utils_test import libvirt
 
 
@@ -14,253 +15,316 @@ from virttest.utils_test import libvirt
 logging = log.getLogger('avocado.' + __name__)
 
 
+def get_expected_stat(cpu=None):
+    """
+    Parse cpu stats from /proc/stat
+
+    :param cpu: cpu index, None for total cpu stat
+    :return: dict of cpu stats
+    """
+    stats = {}
+    cpu_stat = []
+    with open("/proc/stat", "r") as fl:
+        for line in fl.readlines():
+            if line.startswith("cpu"):
+                cpu_stat.append(line.strip().split(" ")[1:])
+    # Delete additional space in the total cpu stats line
+    del cpu_stat[0][0]
+    if cpu is None:
+        idx = 0
+    else:
+        idx = int(cpu) + 1
+    stats['user'] = int(cpu_stat[idx][0]) + int(cpu_stat[idx][1])
+    stats['system'] = int(cpu_stat[idx][2]) + int(cpu_stat[idx][5]) + int(cpu_stat[idx][6])
+    stats['idle'] = int(cpu_stat[idx][3])
+    stats['iowait'] = int(cpu_stat[idx][4])
+    stats['total'] = stats['user'] + stats['system'] + stats['idle'] + stats['iowait']
+    return stats
+
+
+def virsh_check_nodecpustats_percpu(test, actual_stats, cpu):
+    """
+    Check the actual nodecpustats output value
+    total time <= total stat from proc
+
+    :param test: test object
+    :param actual_stats: Actual cpu stats
+    :param cpu: cpu index
+
+    :return: True if matches, else failout
+    """
+
+    # Normalise to seconds from nano seconds
+    total = float((int(actual_stats['system']) + int(actual_stats['user']) +
+                   int(actual_stats['idle']) + int(actual_stats['iowait'])) / (10 ** 9))
+
+    expected = get_expected_stat(cpu)
+    if not total <= expected['total']:
+        test.fail("Commands 'virsh nodecpustats' not succeeded"
+                  " as total time: %f is more"
+                  " than proc/stat: %f" % (total, expected['total']))
+    return True
+
+
+def virsh_check_nodecpustats(test, actual_stats):
+    """
+    Check the actual nodecpustats output value
+    total time <= total stat from proc
+
+    :param test: test object
+    :param actual_stats: Actual cpu stats
+    :return: True if matches, else failout
+    """
+
+    # Normalise to seconds from nano seconds and get for one cpu
+    total = float(((int(actual_stats['system']) + int(actual_stats['user']) +
+                    int(actual_stats['idle']) + int(actual_stats['iowait'])) / (10 ** 9)))
+    expected = get_expected_stat()
+    if not total <= expected['total']:
+        test.fail("Commands 'virsh nodecpustats' not succeeded"
+                  " as total time: %f is more"
+                  " than proc/stat: %f" % (total, expected['total']))
+    return True
+
+
+def virsh_check_nodecpustats_percentage(test, actual_per):
+    """
+    Check the actual nodecpustats percentage adds up to 100%
+
+    :param test: test object
+    :param actual_per: Actual cpu stats percentage
+    :raises: test.fail if not match
+    """
+    total = int(round(float(actual_per['user']) + float(actual_per['system']) +
+                      float(actual_per['idle']) + float(actual_per['iowait'])))
+
+    if not total == 100:
+        test.fail("Commands 'virsh nodecpustats' not succeeded"
+                  " as the total percentage value: %d"
+                  " is not equal 100" % total)
+
+
+def run_nodecpustats(option=""):
+    """
+    Common utility function to run virsh nodecpustats
+
+    :param option: virsh command option
+    :return: a tuple (status, result)
+    """
+    output = virsh.nodecpustats(ignore_status=True, option=option, debug=True)
+    status = output.exit_status
+    return (status, output)
+
+
+def subtest_no_any_option(test):
+    """
+    Run virsh nodecpustats and check result
+
+    :param test: test object
+    :raises: test.fail if command checking fails
+    """
+    option = ''
+    status, output = run_nodecpustats(option)
+    if not status:
+        actual_value = libvirt_misc.convert_to_dict(output.stdout, r"^(\w+)\s*:\s+(\d+)")
+        virsh_check_nodecpustats(test, actual_value)
+    else:
+        test.fail("Command 'virsh nodecpustats %s'"
+                  " not succeeded" % option)
+
+
+def subtest_cpu_option(test, cpu, index, with_cpu_option=True):
+    """
+    Run virsh nodecpustats --cpu xx and check result
+
+    :param test: test object
+    :param cpu: a specified host cpu
+    :param index: cpu index in online host cpu list
+    :param with_cpu_option: True, use '--cpu', otherwise, doesn't
+    :raises: test.fail if command checking fails
+    """
+    option = "--cpu %s" % cpu if with_cpu_option else " %s" % cpu
+    status, output = run_nodecpustats(option)
+    if not status:
+        actual_value = libvirt_misc.convert_to_dict(output.stdout, r"^(\w+)\s*:\s+(\d+)")
+        virsh_check_nodecpustats_percpu(test, actual_value, index)
+    else:
+        test.fail("Command 'virsh nodecpustats %s'"
+                  "not succeeded" % option)
+
+
+def subtest_cpu_percentage_option(test, cpu, with_cpu_option=True):
+    """
+    Run virsh nodecpustats --cpu xxx --percent and check result
+
+    :param test: test object
+    :param cpu: a specified host cpu
+    :param with_cpu_option: True, use '--cpu', otherwise, does not
+    :raises: test.fail if command checking fails
+    """
+    option = "--cpu %s --percent" % cpu if with_cpu_option else " %s --percent" % cpu
+    status, output = run_nodecpustats(option)
+    if not status:
+        actual_value = libvirt_misc.convert_to_dict(output.stdout, r"^(\w+)\s*:\s+(\d+.\d+)")
+        virsh_check_nodecpustats_percentage(test, actual_value)
+    else:
+        test.fail("Command 'virsh nodecpustats %s'"
+                  " not succeeded" % option)
+
+
+def subtest_percentage_option(test):
+    """
+    Run virsh nodecpustats --percent and check result
+
+    :param test: test object
+    :raises: test.fail if command checking fails
+    """
+    # Test the total cpus to get the stats in percentage
+    option = "--percent"
+    status, output = run_nodecpustats(option)
+    if not status:
+        actual_value = libvirt_misc.convert_to_dict(output.stdout, r"^(\w+)\s*:\s+(\d+.\d+)")
+        virsh_check_nodecpustats_percentage(test, actual_value)
+    else:
+        test.fail("Command 'virsh nodecpustats %s'"
+                  " not succeeded" % option)
+
+
+def test_all_options_all_cpus(test, host_cpus_list, params):
+    """
+    Test nodecpustats command with following setting:
+
+    1. virsh nodecpustats
+    2. virsh nodecpustats --percent
+    3. virsh nodecpustats --cpu xx
+    4. virsh nodecpustats xx
+    5. virsh nodecpustats --cpu xx --percent
+    6. virsh nodecpustats xx --percent
+
+    :param test: test object
+    :param host_cpus_list: list, host cpu list
+    :param params: dict, test parameters
+    """
+    # Run test case for 1 iteration as default and can be changed
+    # in subtests.cfg file
+    itr = int(params.get("inner_test_iterations"))
+    for i in range(itr):
+        # Test with no any option
+        subtest_no_any_option(test)
+        # Test the total cpus to get the stats in percentage
+        subtest_percentage_option(test)
+        for idx, cpu in enumerate(host_cpus_list):
+            # Test each cpu to get the cpu stats with --cpu
+            subtest_cpu_option(test, cpu, idx)
+            # Test each cpu to get the cpu stats without --cpu
+            subtest_cpu_option(test, cpu, idx, with_cpu_option=False)
+            # Test each cpu to get the cpu stats in percentage with --cpu
+            subtest_cpu_percentage_option(test, cpu)
+            # Test each cpu to get the cpu stats in percentage without --cpu
+            subtest_cpu_percentage_option(test, cpu, with_cpu_option=False)
+
+
+def test_disable_enable_cpu(test, host_cpus_list, params):
+    """
+    Test nodecpustats command when disable one cpu and then enable it respectively
+
+    :param test: test object
+    :param host_cpus_list: list, host cpu list
+    :param params: dict, test parameters
+    :raises: test.error if cpu offline or online fails
+    """
+    logging.debug("Offline host cpu %s" % host_cpus_list[-1])
+    if cpuutil.offline(host_cpus_list[-1]):
+        test.error("Failed to offline host cpu %s" % host_cpus_list[-1])
+    option = "--cpu %s" % host_cpus_list[-1]
+    status, output = run_nodecpustats(option)
+    err_msg = params.get("err_msg", '')
+    libvirt.check_result(output, expected_fails=[err_msg])
+
+    logging.debug("Online host cpu %s" % host_cpus_list[-1])
+    if cpuutil.online(host_cpus_list[-1]):
+        test.error("Failed to online host cpu %s" % host_cpus_list[-1])
+    subtest_cpu_percentage_option(test, host_cpus_list[-1], with_cpu_option=False)
+
+
+def test_invalid_option(test, host_cpus_list, params):
+    """
+    Test nodecpustats command with invalid command option
+
+    :param test:  test object
+    :param host_cpus_list: list, host cpu list
+    :param params: dict, test parameters
+    :raises: test.fail if command checking fails
+    """
+    option = params.get("virsh_cpunodestats_options", '')
+    status, _ = run_nodecpustats(option)
+    if not status:
+        test.fail("Command 'virsh nodecpustats %s' "
+                  "succeeded with invalid option" % option)
+
+
+def test_invalid_cpuNum(test, host_cpus_list, params):
+    """
+    Test nodecpustats command with different invalid cpu
+
+    :param test: test object
+    :param host_cpus_list: list, host cpu list
+    :param params: dict, test parameters
+    :return: None
+    """
+
+    for offset_value in [0, 5, 3200000000000000000000]:
+        option = "--cpu %s" % (len(host_cpus_list) + offset_value)
+        status, output = run_nodecpustats(option)
+        err_msg = ''
+        if (libvirt_version.version_compare(6, 2, 0)):
+            err_msg = params.get('err_msg')
+        libvirt.check_result(output, expected_fails=[err_msg])
+
+
+def test_with_libvirtd_stop(test, host_cpus_list, params):
+    """
+    Test nodecpustats command when libvirt daemon is stopped
+
+    :param test: test object
+    :param host_cpus_list: list, host online cpu list
+    :param params: dict, test parameters
+    :raises: test.fail if command checking fails
+    """
+    utils_libvirtd.libvirtd_stop()
+    status, _ = run_nodecpustats()
+    if not status:
+        if libvirt_version.version_compare(5, 6, 0):
+            logging.debug("From libvirt version 5.6.0 libvirtd is restarted"
+                          " and command should succeed")
+        else:
+            test.fail("Command 'virsh nodecpustats' "
+                      "succeeded with libvirtd service "
+                      "stopped, incorrect")
+
+
 def run(test, params, env):
     """
     Test the command virsh nodecpustats
 
-    (1) Call the virsh nodecpustats command for all cpu host cpus
-        separately
-    (2) Get the output
-    (3) Check the against /proc/stat output(o) for respective cpu
-        user: o[0] + o[1]
-        system: o[2] + o[5] + o[6]
-        idle: o[3]
-        iowait: o[4]
-    (4) Call the virsh nodecpustats command with an unexpected option
-    (5) Call the virsh nodecpustats command with libvirtd service stop
+    Scenario 1: Test for all host cpus separately with all options,
+                like --cpu, --percent
+    Scenario 2: Disable one cpu, test nodecpustats command, then
+                enable this cpu and test nodecpustats again
+    Scenario 3: Test with invalid command option, like '--xyz'
+    Scenario 4: Test with invalid cpu
+    Scenario 5: Test with stopped libvirt daemons
     """
-
-    def get_expected_stat(cpu=None):
-        """
-        Parse cpu stats from /proc/stat
-
-        :param cpu: cpu index, None for total cpu stat
-        :return: dict of cpu stats
-        """
-        stats = {}
-        cpu_stat = []
-        with open("/proc/stat", "r") as fl:
-            for line in fl.readlines():
-                if line.startswith("cpu"):
-                    cpu_stat.append(line.strip().split(" ")[1:])
-        # Delete additional space in the total cpu stats line
-        del cpu_stat[0][0]
-        if cpu is None:
-            idx = 0
-        else:
-            idx = int(cpu) + 1
-        stats['user'] = int(cpu_stat[idx][0]) + int(cpu_stat[idx][1])
-        stats['system'] = int(cpu_stat[idx][2]) + int(cpu_stat[idx][5]) + int(cpu_stat[idx][6])
-        stats['idle'] = int(cpu_stat[idx][3])
-        stats['iowait'] = int(cpu_stat[idx][4])
-        stats['total'] = stats['user'] + stats['system'] + stats['idle'] + stats['iowait']
-        return stats
-
-    def virsh_check_nodecpustats_percpu(actual_stats, cpu):
-        """
-        Check the actual nodecpustats output value
-        total time <= total stat from proc
-
-        :param actual_stats: Actual cpu stats
-        :param cpu: cpu index
-
-        :return: True if matches, else failout
-        """
-
-        # Normalise to seconds from nano seconds
-        total = float((actual_stats['system'] + actual_stats['user'] +
-                       actual_stats['idle'] + actual_stats['iowait']) / (10 ** 9))
-
-        expected = get_expected_stat(cpu)
-        if not total <= expected['total']:
-            test.fail("Commands 'virsh nodecpustats' not succeeded"
-                      " as total time: %f is more"
-                      " than proc/stat: %f" % (total, expected['total']))
-        return True
-
-    def virsh_check_nodecpustats(actual_stats):
-        """
-        Check the actual nodecpustats output value
-        total time <= total stat from proc
-
-        :param actual_stats: Actual cpu stats
-        :return: True if matches, else failout
-        """
-
-        # Normalise to seconds from nano seconds and get for one cpu
-        total = float(((actual_stats['system'] + actual_stats['user'] +
-                        actual_stats['idle'] + actual_stats['iowait']) / (10 ** 9)))
-        expected = get_expected_stat()
-        if not total <= expected['total']:
-            test.fail("Commands 'virsh nodecpustats' not succeeded"
-                      " as total time: %f is more"
-                      " than proc/stat: %f" % (total, expected['total']))
-        return True
-
-    def virsh_check_nodecpustats_percentage(actual_per):
-        """
-        Check the actual nodecpustats percentage adds up to 100%
-
-        :param actual_per: Actual cpu stats percentage
-        :return: True if matches, else failout
-        """
-
-        total = int(round(actual_per['user'] + actual_per['system'] +
-                          actual_per['idle'] + actual_per['iowait']))
-
-        if not total == 100:
-            test.fail("Commands 'virsh nodecpustats' not succeeded"
-                      " as the total percentage value: %d"
-                      " is not equal 100" % total)
-
-    def parse_output(output):
-        """
-        To get the output parsed into a dictionary
-
-        :param output: virsh command output
-        :return: dict of user,system,idle,iowait times
-        """
-
-        # From the beginning of a line, group 1 is one or more word-characters,
-        # followed by zero or more whitespace characters and a ':',
-        # then one or more whitespace characters,
-        # followed by group 2, which is one or more digit characters,
-        # e.g as below
-        # user:                  6163690000000
-        #
-        regex_obj = re.compile(r"^(\w+)\s*:\s+(\d+)")
-        actual = {}
-
-        for line in output.stdout.split('\n'):
-            match_obj = regex_obj.search(line)
-            # Due to the extra space in the list
-            if match_obj is not None:
-                name = match_obj.group(1)
-                value = match_obj.group(2)
-                actual[name] = int(value)
-        return actual
-
-    def parse_percentage_output(output):
-        """
-        To get the output parsed into a dictionary
-
-        :param output: virsh command output
-        :return: dict of user,system,idle,iowait times
-        """
-
-        # From the beginning of a line, group 1 is one or more word-characters,
-        # followed by zero or more whitespace characters and a ':',
-        # then one or more whitespace characters,
-        # followed by group 2, which is one or more digit characters,
-        # e.g as below
-        # user:             1.5%
-        #
-        regex_obj = re.compile(r"^(\w+)\s*:\s+(\d+.\d+)")
-        actual_percentage = {}
-
-        for line in output.stdout.split('\n'):
-            match_obj = regex_obj.search(line)
-            # Due to the extra space in the list
-            if match_obj is not None:
-                name = match_obj.group(1)
-                value = match_obj.group(2)
-                actual_percentage[name] = float(value)
-        return actual_percentage
-
+    test_case = params.get("test_case", "")
+    run_test = eval("test_%s" % test_case)
     # Initialize the variables
-    itr = int(params.get("inner_test_iterations"))
-    option = params.get("virsh_cpunodestats_options")
-    invalid_cpunum = params.get("invalid_cpunum")
-    status_error = params.get("status_error")
     libvirtd = params.get("libvirtd", "on")
 
-    # Prepare libvirtd service
-    if libvirtd == "off":
-        utils_libvirtd.libvirtd_stop()
-
-    # Get the host cpu list
-    host_cpus_list = cpuutil.cpu_online_list()
-
-    # Run test case for 5 iterations default can be changed in subtests.cfg
-    # file
-    for i in range(itr):
-
-        if status_error == "yes":
-            if invalid_cpunum == "yes":
-                option = "--cpu %s" % (len(host_cpus_list) + 1)
-            output = virsh.nodecpustats(ignore_status=True, option=option)
-            status = output.exit_status
-
-            if status == 0:
-                if libvirtd == "off":
-                    if libvirt_version.version_compare(5, 6, 0):
-                        logging.debug("From libvirt version 5.6.0 libvirtd is restarted"
-                                      " and command should succeed")
-                    else:
-                        utils_libvirtd.libvirtd_start()
-                        test.fail("Command 'virsh nodecpustats' "
-                                  "succeeded with libvirtd service "
-                                  "stopped, incorrect")
-                else:
-                    test.fail("Command 'virsh nodecpustats %s' "
-                              "succeeded (incorrect command)" % option)
-            if (invalid_cpunum == "yes" and
-               libvirt_version.version_compare(6, 2, 0)):
-                err_msg = "Invalid cpuNum in virHostCPUGetStatsLinux"
-                libvirt.check_result(output, expected_fails=[err_msg])
-
-        elif status_error == "no":
-            # Run the testcase for each cpu to get the cpu stats
-            for idx, cpu in enumerate(host_cpus_list):
-                option = "--cpu %s" % cpu
-                output = virsh.nodecpustats(ignore_status=True, option=option)
-                status = output.exit_status
-
-                if status == 0:
-                    actual_value = parse_output(output)
-                    virsh_check_nodecpustats_percpu(actual_value, idx)
-                else:
-                    test.fail("Command 'virsh nodecpustats %s'"
-                              "not succeeded" % option)
-
-            # Run the test case for each cpu to get the cpu stats in percentage
-            for cpu in host_cpus_list:
-                option = "--cpu %s --percent" % cpu
-                output = virsh.nodecpustats(ignore_status=True, option=option)
-                status = output.exit_status
-
-                if status == 0:
-                    actual_value = parse_percentage_output(output)
-                    virsh_check_nodecpustats_percentage(actual_value)
-                else:
-                    test.fail("Command 'virsh nodecpustats %s'"
-                              " not succeeded" % option)
-
-            option = ''
-            # Run the test case for total cpus to get the cpus stats
-            output = virsh.nodecpustats(ignore_status=True, option=option)
-            status = output.exit_status
-
-            if status == 0:
-                actual_value = parse_output(output)
-                virsh_check_nodecpustats(actual_value)
-            else:
-                test.fail("Command 'virsh nodecpustats %s'"
-                          " not succeeded" % option)
-
-            # Run the test case for the total cpus to get the stats in
-            # percentage
-            option = "--percent"
-            output = virsh.nodecpustats(ignore_status=True, option=option)
-            status = output.exit_status
-
-            if status == 0:
-                actual_value = parse_percentage_output(output)
-                virsh_check_nodecpustats_percentage(actual_value)
-            else:
-                test.fail("Command 'virsh nodecpustats %s'"
-                          " not succeeded" % option)
-
-    # Recover libvirtd service start
-    if libvirtd == "off":
-        utils_libvirtd.libvirtd_start()
+    try:
+        # Get the host cpu list
+        host_cpus_list = cpuutil.cpu_online_list()
+        run_test(test, host_cpus_list, params)
+    finally:
+        # Recover libvirtd service state
+        if libvirtd == "off":
+            utils_libvirtd.libvirtd_start()


### PR DESCRIPTION
Reorg the original cases because of not pretty good readability
virsh_xxx functions logics are not changed, just moved outside of run()

Add new case: RHEL7-17029

    Scenario 1: Test for all host cpus separately with all options,
                like --cpu, --percent
    Scenario 2: Disable one cpu, test nodecpustats command, then
                enable this cpu and test nodecpustats again
    Scenario 3: Test with invalid command option, like '--xyz'
    Scenario 4: Test with invalid cpu
    Scenario 5: Test with stopped libvirt daemons

Signed-off-by: Dan Zheng <dzheng@redhat.com>
