### PR TITLE
live_migration: Add case for an unreachable migrate URI

### DIFF
--- a/libvirt/tests/cfg/migration/live_migration.cfg
+++ b/libvirt/tests/cfg/migration/live_migration.cfg
@@ -219,3 +219,10 @@
             qemu_conf_path = '/etc/libvirt/qemu.conf'
             migrate_speed = 10
             action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}]'
+        - unreachable_migrateuri:
+            virsh_migrate_extra = "tcp://192.168.5.123"
+            status_error = 'yes'
+            err_msg = 'unable to connect to server at'
+            migrate_again = 'yes'
+            migrate_again_status_error = 'no'
+            virsh_migrate_extra_mig_again = "tcp://${migrate_dest_host}"


### PR DESCRIPTION
RHEL7-17296: [Migration][--migrateuri] Specify an unreachable
migrate URI for live migration - bug 720269

Signed-off-by: lcheng <lcheng@redhat.com>
