### PR TITLE
inc_backcup: Fix vnc password issue

### DIFF
--- a/libvirt/tests/cfg/incremental_backup/incremental_backup_checkpoint_cmd.cfg
+++ b/libvirt/tests/cfg/incremental_backup/incremental_backup_checkpoint_cmd.cfg
@@ -56,6 +56,7 @@
                 - security-info:
                     required_checkpoints = 0
                     flag = "--security-info"
+                    vnc_password = "aabbccdd"
                 - size:
                     flag = "--size"
         - checkpoint-parent:

--- a/libvirt/tests/src/incremental_backup/incremental_backup_checkpoint_cmd.py
+++ b/libvirt/tests/src/incremental_backup/incremental_backup_checkpoint_cmd.py
@@ -272,7 +272,7 @@ def run(test, params, env):
             elif "--security-info" in cmd_flag:
                 if vm.is_alive():
                     vm.destroy(gracefully=False)
-                password = "xyzxyzabcabc"
+                password = params.get("vnc_password", "aabbccdd")
                 # Add graphics vnc if guest doesn't have
                 if not vmxml.get_devices(device_type="graphics"):
                     logging.debug("Guest doesn't have graphic, add one")


### PR DESCRIPTION
Since libvirt commit 27c1d06b, at most 8 chars can be used for
vnc password. So the original test script will be failed due to
password is too long. Now change it to a valid value.

Signed-off-by: Yi Sun <yisun@redhat.com>
