### PR TITLE
video_devices: Fix qemu cmdline regex

### DIFF
--- a/libvirt/tests/src/virtual_device/video_devices.py
+++ b/libvirt/tests/src/virtual_device/video_devices.py
@@ -129,7 +129,7 @@ def run(test, params, env):
                 pattern = r"-device.*virtio-gpu-pci"
                 if with_packed:
                     if utils_misc.compare_qemu_version(6, 2, 0, is_rhev=False):
-                        pattern = r"-device.*virtio-gpu-pci.*packed\W{1,2}%s" % "true"
+                        pattern = r"-device.*virtio-gpu-pci.*packed\W{1,2}(on|true)"
                     else:
                         pattern = r"-device.*virtio-gpu-pci.*packed\W{1,2}%s" % driver_packed
             if guest_arch == 's390x':


### PR DESCRIPTION
Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Before
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virtual_devices.video_devices.positive_test.primary_video.virtio.secondary_video.virtio.model_test.with_packed_on
JOB ID     : 615d352af6875efa6d1a4f0e8a4e0f0d410f183d
JOB LOG    : /root/avocado/job-results/job-2022-01-26T03.12-615d352/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_devices.video_devices.positive_test.primary_video.virtio.secondary_video.virtio.model_test.with_packed_on: FAIL: Can not find the secondary virtio video device in qemu cmd line. (17.57 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 18.36 s
```
After
```
 avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio virtual_devices.video_devices.positive_test.primary_video.virtio.secondary_video.virtio.model_test.with_packed_on                     
JOB ID     : ae5193195e71b32a841fa31a107e03659c154edb
JOB LOG    : /root/avocado/job-results/job-2022-01-26T02.07-ae51931/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_devices.video_devices.positive_test.primary_video.virtio.secondary_video.virtio.model_test.with_packed_on: PASS (16.51 s)            
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 17.33 s
   
```

