### PR TITLE
vDPA: Add a case to check nodedev-info

### DIFF
--- a/libvirt/tests/cfg/virtual_interface/iface_nodedev_info.cfg
+++ b/libvirt/tests/cfg/virtual_interface/iface_nodedev_info.cfg
@@ -1,0 +1,13 @@
+- iface.nodedev_info:
+    type = iface_nodedev_info
+    start_vm = no
+
+    variants dev_type:
+        - vdpa:
+            only x86_64
+            func_supported_since_libvirt_ver = (7, 3, 0)
+            func_supported_since_qemu_kvm_ver = (6, 0, 0)
+            dev_dict = {'path': 'vdpa0', 'name': 'vdpa_vdpa0', 'driver_name': 'vhost_vdpa', 'cap_type': 'vdpa'}
+            variants test_target:
+                - simulator:
+                - mellanox:

--- a/libvirt/tests/src/virtual_interface/iface_nodedev_info.py
+++ b/libvirt/tests/src/virtual_interface/iface_nodedev_info.py
@@ -1,0 +1,111 @@
+from virttest import libvirt_version
+from virttest import utils_misc
+from virttest import utils_vdpa
+from virttest import virsh
+
+from virttest.libvirt_xml import nodedev_xml
+
+
+VIRSH_ARGS = {'debug': True, 'ignore_status': False}
+
+
+def run(test, params, env):
+    """
+    Check the nodedev info for the device
+    """
+
+    def check_environment(params):
+        """
+        Check the test environment
+
+        :param params: Dictionary with the test parameters
+        """
+        libvirt_version.is_libvirt_feature_supported(params)
+        utils_misc.is_qemu_function_supported(params)
+
+    def setup_test(dev_type):
+        """
+        Setup test environment for a specific interface if needed
+
+        :param dev_type: interface type
+        :return: An object of special test environment
+        """
+        test_env_obj = None
+        if dev_type == 'vdpa':
+            test_env_obj = setup_vdpa()
+
+        return test_env_obj
+
+    def teardown_test(dev_type):
+        """
+        Default cleanup
+
+        :param dev_type: interface type
+        """
+        if dev_type == 'vdpa':
+            teardown_vdpa()
+
+    def setup_vdpa():
+        """
+        Setup vDPA environment
+        """
+        test_env_obj = None
+        test_target = params.get('test_target', '')
+        test.log.info("TEST_SETUP: Setup vDPA environment.")
+        if test_target == "simulator":
+            test_env_obj = utils_vdpa.VDPASimulatorTest()
+        else:
+            pf_pci = utils_vdpa.get_vdpa_pci()
+            test_env_obj = utils_vdpa.VDPAOvsTest(pf_pci)
+        test_env_obj.setup()
+        return test_env_obj
+
+    def teardown_vdpa():
+        """
+        Cleanup vDPA environment
+        """
+        test.log.info("TEST_TEARDOWN: Clean up vDPA environment.")
+        if test_obj:
+            test_obj.cleanup()
+
+    def check_nodedev_info(dev_dict):
+        """Check nodedev info for the node device
+
+        1) virsh nodedev-list and check the device
+        2) virsh nodedev-dumpxml and check the device info
+        3) Validate using virt-xml-validate
+
+        :param dev_dict: device params
+        """
+        dev_name = dev_dict.get('name')
+        test.log.info("TEST_STEP1: List %s device using virsh nodedev-list.",
+                      dev_name)
+        result = virsh.nodedev_list(**VIRSH_ARGS)
+        if dev_name not in result.stdout_text:
+            test.fail("Failed to list %s device!" % dev_name)
+
+        test.log.info("TEST_STEP2: Check device info using virsh nodedev-dumpxml.")
+        dev_xml = nodedev_xml.NodedevXML.new_from_dumpxml(dev_name)
+        test.log.debug("Nodedev xml: {}".format(dev_xml))
+        if not all([getattr(dev_xml, attr).endswith(value) for attr, value in
+                   dev_dict.items()]):
+            test.fail('nodedev xml comparison failed.')
+
+        test.log.info("TEST_STEP3: Validate xml using virt-xml-validate.")
+        if not dev_xml.get_validates():
+            test.fail("Failed to validate node device xml!")
+
+    check_environment(params)
+    # Variable assignment
+    dev_type = params.get('dev_type', '')
+    dev_dict = eval(params.get('dev_dict', '{}'))
+
+    test_obj = None
+    try:
+        # Execute test
+        test.log.info("TEST_CASE: %s", check_nodedev_info.__doc__.split('\n')[0])
+        test_obj = setup_test(dev_type)
+        check_nodedev_info(dev_dict)
+
+    finally:
+        teardown_test(dev_type)


### PR DESCRIPTION
This PR adds:
    RHEL-196262: nodedev-list/nodedev-dumpxml for vdpa devices

Signed-off-by: Yingshun Cui <yicui@redhat.com>

**Test results:**
```
JOB LOG    : /root/avocado/job-results/job-2022-01-26T03.35-e1d4743/job.log
 (1/2) type_specific.io-github-autotest-libvirt.iface.nodedev_info.vdpa.simulator: PASS (7.44 s)
 (2/2) type_specific.io-github-autotest-libvirt.iface.nodedev_info.vdpa.mellanox: PASS (31.93 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 40.95 s
```
