### PR TITLE
virsh_numatune: Remove meaningless negative test

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_numatune.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_numatune.cfg
@@ -131,9 +131,6 @@
                                             numa_mode = 'preferred'
                                         - interleave:
                                             numa_mode = 'interleave'
-                                        - restrictive:
-                                            numa_nodeset = 0
-                                            numa_mode = 'restrictive'
                                     variants:
                                         - options:
                                             variants:


### PR DESCRIPTION
The default numa_mode of this test is restrictive and libvirt has
forbidden migrating memory for <numatune/> mode='strict' since libvirt
8.0.
So remove restrictive mode negative test from change_mode series.

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Remove case so there is no rt.