### PR TITLE
nodedev: Fix nodedev driver issue

### DIFF
--- a/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_create_destroy.py
+++ b/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_create_destroy.py
@@ -174,6 +174,8 @@ def destroy_nodedev(test, params):
 
     # libvirt acl polkit related params
     uri = params.get("virsh_uri")
+    if uri and not utils_split_daemons.is_modular_daemon():
+        uri = "qemu:///system"
     unprivileged_user = params.get('unprivileged_user')
     if unprivileged_user:
         if unprivileged_user.count('EXAMPLE'):


### PR DESCRIPTION
Original code will always use nodedev:///system driver to destroy
the node device, even if split daemon not enabled. The fix makes
sure to use qemu:///system driver if split daemon not enabled.

Signed-off-by: Yi Sun <yisun@redhat.com>