### PR TITLE
v2v: update the dependency checking command

### DIFF
--- a/v2v/tests/cfg/v2v_options.cfg
+++ b/v2v/tests/cfg/v2v_options.cfg
@@ -324,7 +324,7 @@
                             win_image = '/DISK_IMAGE_PATH_V2V_EXAMPLE/WINDOWS_IMAGE_V2V_EXAMPLE'
                         - deplist:
                             checkpoint = 'deplist'
-                            check_command = 'yum deplist virt-v2v'
+                            check_command = 'rpm -qR virt-v2v'
                         - no_dcpath:
                             checkpoint = 'no_dcpath'
                             check_command = 'man virt-v2v'


### PR DESCRIPTION
'yum deplist xxx' sometimes cannot query out correct result because
the db is not latest. I'm not sure how it happens. e.g. if you install
the pkg by a url link instead of repos, it always query from the old
package. so I think 'rpm -qR xxx' is better than that in this case.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>
