### PR TITLE
Remove event check for detach with --config

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_interface.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_interface.py
@@ -497,11 +497,14 @@ def run(test, params, env):
         options = set_options(iface_type, None, iface_mac,
                               options_suffix, "detach")
 
+        wait_for_event = True
+        if options_suffix == "--config":
+            wait_for_event = False
         # Start detach-interface test
         if save_restore == "yes" and vm_ref == dom_id:
             vm_ref = vm_name
         detach_result = virsh.detach_interface(
-            vm_ref, options, wait_for_event=True, **virsh_dargs)
+            vm_ref, options, wait_for_event=wait_for_event, **virsh_dargs)
         detach_status = detach_result.exit_status
         detach_msg = detach_result.stderr.strip()
 


### PR DESCRIPTION
Signed-off-by: Kyla Zhang <weizhan@redhat.com>
Before:
```
 (1/1) type_specific.io-github-autotest-libvirt.virsh.attach_detach_interface.normal_test.vm_running.default_network.at_option_config.domname: ERROR: Not found event device-removed after 60 seconds (120.67 s)
```
After:
```
 (1/1) type_specific.io-github-autotest-libvirt.virsh.attach_detach_interface.normal_test.vm_running.default_network.at_option_config.domname: PASS (64.15 s)
```