### PR TITLE
v2v:add the latest RHEL9 to matrix of auto testing

### DIFF
--- a/v2v/tests/cfg/convert_vm_to_libvirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_libvirt.cfg
@@ -37,6 +37,9 @@
             vm_user = ${username}
             vm_pwd = ${password}
             variants:
+                - latest9:
+                    os_short_id = "RHEL9_SHORT_ID"
+                    os_version = "LATEST9"
                 - latest8:
                     os_short_id = "RHEL8_SHORT_ID"
                     os_version = "LATEST8"

--- a/v2v/tests/cfg/convert_vm_to_ovirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_ovirt.cfg
@@ -76,6 +76,8 @@
             vm_user = ${username}
             vm_pwd = GENERAL_GUEST_PASSWORD
             variants:
+                - latest9:
+                    os_version = "LATEST9"
                 - latest8:
                     os_version = "LATEST8"
                 - latest7:


### PR DESCRIPTION
Add the new guest RHEL9.0 to the matrix of auto testing