### PR TITLE
vm_features/vcpu_feature: disable test cases on s390x

### DIFF
--- a/libvirt/tests/cfg/cpu/vcpu_feature.cfg
+++ b/libvirt/tests/cfg/cpu/vcpu_feature.cfg
@@ -22,7 +22,7 @@
             status_error = "yes"
             variants:
                 - host_without_cr8legacy:
-                    no pseries, aarch64
+                    no pseries, aarch64, s390-virtio
                     only policy_require
                     host_supported_feature = "no"
                     feature_name = "cr8legacy"

--- a/libvirt/tests/cfg/cpu/vm_features.cfg
+++ b/libvirt/tests/cfg/cpu/vm_features.cfg
@@ -43,7 +43,7 @@
                         - disable:
                             hidden_attr={'kvm_hidden_state': 'off'}
                 - kvm_poll_control:
-                    no pseries, aarch64
+                    no pseries, aarch64, s390x
                     variants:
                         - enable:
                             kvm_poll_control_attr = {'kvm_poll_control': 'on'}


### PR DESCRIPTION
Test cases are invalid on s390x.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>