### PR TITLE
filesystem_device: enable kvm hugepage support

### DIFF
--- a/libvirt/tests/cfg/virtual_device/filesystem_device.cfg
+++ b/libvirt/tests/cfg/virtual_device/filesystem_device.cfg
@@ -123,5 +123,7 @@
                             error_msg_start = "queue-size property must be 1024 or smaller"
                 - managedsave:
                     only nop
+                    s390-virtio:
+                        kvm_module_parameters = "hpage=1"
                     managedsave = "yes"
                     error_msg_save = "migration with virtiofs device is not supported"


### PR DESCRIPTION
Enable kvm hugepage support to make test pass.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>