### PR TITLE
virsh_cpu_xml: fix superset host cpu

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_cpu_xml.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_cpu_xml.cfg
@@ -45,3 +45,4 @@
                     only xml_declaration
                     virsh_function = 'virsh.cpu_compare'
                     err_msg = 'CPU described in.*is identical to host CPU|CPU described in.*is incompatible with host CPU'
+                    out_msg = 'Host CPU is a superset of CPU described in.*'

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_xml.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_xml.py
@@ -27,6 +27,7 @@ def run(test, params, env):
     file_xml_declaration = params.get('file_xml_declaration')
     virsh_function = eval(params.get('virsh_function'))
     err_msg = params.get('err_msg')
+    out_msg = params.get('out_msg')
     data_file = tempfile.mktemp(dir=data_dir.get_tmp_dir())
     file_content = None
     file_path = os.path.join(os.path.dirname(__file__), file_path)
@@ -45,6 +46,9 @@ def run(test, params, env):
 
     if virsh_function:
         ret = virsh_function(data_file, ignore_status=True, debug=True)
-        libvirt.check_result(ret,
-                             expected_fails=err_msg,
-                             check_both_on_error=True)
+        if not ret.exit_status and out_msg:
+            libvirt.check_result(ret, expected_match=out_msg)
+        else:
+            libvirt.check_result(ret,
+                                 expected_fails=err_msg,
+                                 check_both_on_error=True)


### PR DESCRIPTION
When comparing cpu, the result depends on the real Host cpu. So sometimes
the virsh command result is zero and return output message is superset.

Signed-off-by: Dan Zheng <dzheng@redhat.com>
