### PR TITLE
fix path exception error

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_edit.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_edit.py
@@ -44,7 +44,7 @@ def run(test, params, env):
     # check whether vim editor is set as $EDITOR in environment
     try:
         vim = path.find_command("vim")
-    except path.path.CmdNotFoundError:
+    except path.CmdNotFoundError:
         if not utils_package.package_install("vim"):
             test.cancel("virsh edit need vim editor for using regex to edit "
                         "vmxml")


### PR DESCRIPTION
When the "vim" is not installed in the machine, the path exception
should be used correctly

Signed-off-by: Jin Li <jil@redhat.com>

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [ ] Description of the cases
- [ ] Links of libvirt features, libvirt bugs or case IDs
- [ ] Test results

## If the PR is bug cases
- [ ] Bug descriptions or bug links
- [ ] Test results

## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
