### PR TITLE
Resolve the mem case have coredump issue

### DIFF
--- a/libvirt/tests/cfg/memory/memory_misc.cfg
+++ b/libvirt/tests/cfg/memory/memory_misc.cfg
@@ -13,9 +13,9 @@
                         - no_limit:
                             expect_msg = 'MEMLOCK\s+max\s+locked-in-memory\s+address\s+space\s+unlimited\s+unlimited\s+bytes'
                         - hard_limit:
-                            hard_limit = 3024000
+                            hard_limit = 10485760
                             hard_limit_unit = 'KiB'
-                            expect_msg = 'MEMLOCK\s+max\s+locked-in-memory\s+address\s+space\s+3096576000\s+3096576000\s+bytes'
+                            expect_msg = 'MEMLOCK\s+max\s+locked-in-memory\s+address\s+space\s+10737418240\s+10737418240\s+bytes'
         - edit_mem:
             variants case:
                 - forbid_0:


### PR DESCRIPTION
Signed-off-by: Kyla Zhang <weizhan@redhat.com>
```
 (1/1) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.mem_lock.hard_limit: PASS (8.69 s)
```