### PR TITLE
Add sleep between event track and trigger

### DIFF
--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_event.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_event.py
@@ -131,6 +131,8 @@ def run(test, params, env):
                                      options=net_event_option, **virsh_dargs)
             utlv.check_exit_status(result, status_error)
 
+        time.sleep(1)
+
         if not status_error:
             # Verify 'lifecycle' events
             if not net_event_list and net_event_name == 'lifecycle':


### PR DESCRIPTION
Signed-off-by: Kyla Zhang <weizhan@redhat.com>

```
 (1/1) type_specific.io-github-autotest-libvirt.virsh.net_event.positive_test.no_timeout.loop.lifecycle_event.default: PASS (7.58 s)
```