### PR TITLE
migrate_options_shared: Add case for migrateuri parameter

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -269,7 +269,17 @@
                         - nonexistence:
                             remove_cache = "yes"
                 - migrate_uri:
-                    virsh_migrate_extra = "--migrateuri tcp://${migrate_dest_host}"
+                    low_speed = "20"
+                    actions_during_migration = "check_ipaddr"
+                    asynch_migrate = "yes"
+                    variants:
+                        - ipv4:
+                            ipaddress = '${migrate_dest_host}'
+                            virsh_migrate_extra = "--migrateuri tcp://${migrate_dest_host}"
+                        - ipv6:
+                            ipv6_addr_des = 'ENTER.YOUR.IPv6.DESTINATION'
+                            ipaddress = '${ipv6_addr_des}'
+                            virsh_migrate_extra = "--migrateuri tcp://[${ipv6_addr_des}]"
                 - check_domjobinfo:
                     libvirtd_conf_dict = '{"keepalive_interval": "-1"}'
                     # Set conf type to the value in modular daemon mode, it will be converted to the\


### PR DESCRIPTION
RHEL-131931 - [Migration][--migrateuri] Specify migrate URI for
live migration - TCP - IP address - non-p2p

Signed-off-by: lcheng <lcheng@redhat.com>
