### PR TITLE
virsh_define: update test case for BZ#2030119

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_define.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_define.py
@@ -103,7 +103,9 @@ def run(test, params, env):
             if not ret.exit_status:
                 virsh.undefine(vm_name)
             # restore the original vm
-            virsh.define(xml_backup_file)
+            ret = virsh.define(xml_backup_file)
+            if ret.duration > 3:
+                test.fail("Define timeout: expected no more than 3s; actually spent %.2fs" % ret.duration)
         return
 
     assert uuid is not None


### PR DESCRIPTION
virsh xml operation slow down on libvirt-7.10.0-1

This bug was fixed in libvirt-8.0.0

Signed-off-by: Hu Shuai <hus.fnst@fujitsu.com>

Test on libvirt 8.0.0-2
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio type_specific.io-github-autotest-libvirt.virsh.define.positive_test.timeout
JOB ID     : 20b0dfb6099bc8fc9566a3b3a40c68ba94e2ed52
JOB LOG    : /root/avocado/job-results/job-2022-02-11T03.15-20b0dfb/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.define.positive_test.timeout: PASS (5.70 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 6.22 s

```

Test on libvirt 7.10.0-1
```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio type_specific.io-github-autotest-libvirt.virsh.define.positive_test.timeout
JOB ID     : 2f600f472dc59c3b14a0cd1a7920637a64fc1f37
JOB LOG    : /root/avocado/job-results/job-2022-02-11T02.43-2f600f4/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.define.positive_test.timeout: FAIL: Define timeout: expected no more than 3s; actually spends 4.74s (12.37 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 13.27 s
```