### PR TITLE
tpm_device: add active_pcr_banks test

### DIFF
--- a/libvirt/tests/cfg/virtual_device/tpm_device.cfg
+++ b/libvirt/tests/cfg/virtual_device/tpm_device.cfg
@@ -63,6 +63,31 @@
                         - restart_libvirtd:
                             restart_libvirtd = 'yes'
                     variants:
+                        - pcrbank_default:
+                            basic:
+                                check_pcrbanks = 'yes'
+                        - pcrbank_single:
+                            only basic
+                            only encrypted
+                            variants:
+                                - sha1:
+                                    active_pcr_banks = 'sha1'
+                                - sha256:
+                                    active_pcr_banks = 'sha256'
+                                - sha384:
+                                    active_pcr_banks = 'sha384'
+                                - sha512:
+                                    active_pcr_banks = 'sha512'
+                        - pcrbank_multi:
+                            only basic
+                            only encrypted
+                            active_pcr_banks = 'sha256,sha384'
+                        - pcrbank_all:
+                            no version_default multi_vms test_suite restart_vm
+                            plain:
+                                only basic
+                            active_pcr_banks = 'sha1,sha256,sha384,sha512'
+                    variants:
                         - plain:
                         - encrypted:
                             prepare_secret = 'yes'


### PR DESCRIPTION
Add active_pcr_banks normal tests for emualtor backend tpm device.

Signed-off-by: Yanqiu Zhang <yanqzhan@redhat.com>

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [x] Description of the cases
- [x] Links of libvirt features, libvirt bugs or case IDs
- [x] Test results

## If the PR is bug cases
- [ ] Bug descriptions or bug links
- [ ] Test results

## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
