### PR TITLE
blockresize: add blockresize case

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockresize.cfg
+++ b/libvirt/tests/cfg/backingchain/blockresize.cfg
@@ -1,0 +1,20 @@
+- backingchain.blockresize:
+    type = blockresize
+    start_vm = 'yes'
+    status_error = 'no'
+    variants:
+        - positive_test:
+            status_error = "no"
+            variants:
+                - raw_image:
+                    driver_type = 'raw'
+                    case_name = 'raw_disk_blockresize'
+                    attach_disk_extra_options = ' --subdriver raw'
+                    new_disk = 'vdd'
+                    variants:
+                        - size_g:
+                            expected_block_size = '15g'
+                        - size_b:
+                            expected_block_size = '1024b'
+                        - size_mb:
+                            expected_block_size = '1024m'

--- a/libvirt/tests/src/backingchain/blockresize.py
+++ b/libvirt/tests/src/backingchain/blockresize.py
@@ -1,0 +1,86 @@
+import logging
+
+from avocado.utils import process
+
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_disk
+from virttest.utils_test import libvirt
+
+from provider.backingchain import blockcommand_base
+from provider.backingchain import check_functions
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+
+def run(test, params, env):
+    """
+    Test blockresize for domain which has backing chain element.
+
+    """
+
+    def setup_raw_disk_blockresize():
+        """
+        Prepare raw disk and create snapshots.
+        """
+        # Create raw type image
+        image_path = test_obj.tmp_dir + '/blockresize_test'
+        libvirt.create_local_disk("file", path=image_path, size='500K',
+                                  disk_format="raw")
+        test_obj.new_image_path = image_path
+        # attach new disk
+        virsh.attach_disk(vm.name, source=image_path, target=device,
+                          extra=extra, debug=True)
+        test_obj.new_dev = device
+        # create snap chain
+        test_obj.prepare_snapshot()
+
+    def test_raw_disk_blockresize():
+        """
+        Test blockresize for raw type device which has backing chain element.
+        """
+        new_size = params.get('expected_block_size')
+        result = virsh.blockresize(vm_name, test_obj.snap_path_list[-1],
+                                   new_size, debug=True)
+        libvirt.check_exit_status(result)
+        check_obj.check_image_info(test_obj.snap_path_list[-1], 'vsize', new_size)
+
+    def teardown_raw_disk_blockresize():
+        """
+        Clean env and resize with origin size.
+        """
+        # clean new disk file
+        test_obj.backingchain_common_teardown()
+        # detach disk
+        virsh.detach_disk(vm_name, target=test_obj.new_dev,
+                          wait_for_event=True, debug=True)
+        # clean image file
+        process.run('rm -f %s' % test_obj.new_image_path)
+
+    # Process cartesian parameters
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    case_name = params.get('case_name', '')
+    device = params.get('new_disk')
+    extra = params.get('attach_disk_extra_options')
+    # Create object
+    test_obj = blockcommand_base.BlockCommand(test, vm, params)
+    check_obj = check_functions.Checkfunction(test, vm, params)
+    # Get vm xml
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+    test_obj.original_disk_source = libvirt_disk.get_first_disk_source(vm)
+
+    # MAIN TEST CODE ###
+    run_test = eval("test_%s" % case_name)
+    setup_test = eval("setup_%s" % case_name)
+    teardown_test = eval("teardown_%s" % case_name)
+
+    try:
+        # Execute test
+        setup_test()
+        run_test()
+
+    finally:
+        teardown_test()
+        bkxml.sync()

--- a/provider/backingchain/check_functions.py
+++ b/provider/backingchain/check_functions.py
@@ -4,7 +4,7 @@ import re
 from avocado.utils import process
 from virttest import libvirt_storage
 
-LOG = logging.getLogger('avocado.backingchain.checkfunction')
+LOG = logging.getLogger('avocado.' + __name__)
 
 
 class Checkfunction(object):
@@ -74,7 +74,8 @@ class Checkfunction(object):
             LOG.error('Unsupported command: %s', command)
             return False
         if src_path != bc_chain[index]:
-            LOG.error('Expect source file to be %s, but got %s', bc_chain[index], src_path)
+            LOG.error('Expect source file to be %s, '
+                      'but got %s' % (bc_chain[index], src_path))
             return False
         bs = disk.find('backingStore')
         LOG.debug('Current backing store: %s', bs)


### PR DESCRIPTION
**add** blockresize case: add blockresize case with b,mb,gb unit disk
Signed-off-by: nanli <nanli@redhat.com>

**Test number** : RHEL-133310

**Depend on ** :
 https://github.com/avocado-framework/avocado-vt/pull/3357 
 https://github.com/autotest/tp-libvirt/pull/4062 
**Influence other case file** : `libvirt/tests/src/virtual_disks/ at_dt_iscsi_disk.py virtual_disks_ceph.py, virtual_disks_multidisks.py`  RUN PASSED https://github.com/autotest/tp-libvirt/pull/4059 

**Test result :**
**[root@nanli tp-libvirt]**# /usr/local/bin/avocado run --vt-type libvirt --vt-machine-type q35 backingchain.blockresize.positive_test.raw_image.size_mb --vt-connect-uri qemu:///system
RESULTS : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME : 13.26 s
**[root@nanli tp-libvirt]**# /usr/local/bin/avocado run --vt-type libvirt --vt-machine-type q35 backingchain.blockresize.normal_test.raw_image.size_g --vt-connect-uri qemu:///system
RESULTS : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME : 13.30 s
**[root@nanli tp-libvirt]**# /usr/local/bin/avocado run --vt-type libvirt --vt-machine-type q35 backingchain.blockresize.normal_test.raw_image.size_b --vt-connect-uri qemu:///system
RESULTS : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME : 13.45 s
[root@nanli tp-libvirt]#
