### PR TITLE
add case for blockjob with raw options

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockjob_options.cfg
+++ b/libvirt/tests/cfg/backingchain/blockjob_options.cfg
@@ -1,0 +1,9 @@
+- backingchain.blockjob.options:
+    type = blockjob_options
+    start_vm = 'yes'
+    status_error = 'no'
+    disk = 'vda'
+    variants:
+        - option_raw:
+            option_value = ' --raw'
+            case_name = 'blockjob_raw'

--- a/libvirt/tests/src/backingchain/blockjob_options.py
+++ b/libvirt/tests/src/backingchain/blockjob_options.py
@@ -1,0 +1,124 @@
+import logging
+import os
+import time
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+from avocado.utils import process
+
+from virttest import virsh
+from virttest import utils_misc
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_disk
+from virttest.utils_libvirt import libvirt_misc
+from virttest.utils_test import libvirt
+
+from provider.backingchain import blockcommand_base
+from provider.backingchain import check_functions
+
+
+def run(test, params, env):
+    """
+    Test blockjob operation
+
+    """
+    def setup_blockjob_raw():
+        """
+        Prepare running domain and do blockcopy
+        """
+        if not vm.is_alive():
+            vm.start()
+
+        if os.path.exists(tmp_copy_path):
+            process.run('rm -rf %s' % tmp_copy_path)
+
+        cmd = "blockcopy %s %s %s --wait --verbose --transient-job " \
+              "--bandwidth 1000 " % (vm_name, dev, tmp_copy_path)
+        virsh_session = virsh.VirshSession(virsh_exec=virsh.VIRSH_EXEC,
+                                           auto_close=True)
+        virsh_session.sendline(cmd)
+
+    def test_blockjob_raw():
+        """
+        Do blockjob with raw option.
+
+        1) Prepare a running guest.
+        2) Do blockcopy.
+        3) Do blockjob with raw option twice and check cur value is changing
+        4) Execute with --pivot and check raw option return empty
+        """
+        options = params.get('option_value', '')
+        # Confirm blockcopy not finished.
+        if not libvirt.check_blockjob(vm_name, dev, "progress", "100"):
+            res_1 = virsh.blockjob(vm_name, dev, options=options, debug=True,
+                                   ignore_status=False)
+            cur1 = libvirt_misc.convert_to_dict(res_1.stdout_text.strip(),
+                                                pattern=r'(\S+)=(\S+)')['cur']
+            time.sleep(1)
+            res_2 = virsh.blockjob(vm_name, dev, options=options, debug=True,
+                                   ignore_status=False)
+            cur2 = libvirt_misc.convert_to_dict(res_2.stdout_text.strip(),
+                                                pattern=r'(\S+)=(\S+)')['cur']
+            LOG.debug('cur1 is %s , cur2 is %s', cur1, cur2)
+
+            if int(cur1) >= int(cur2):
+                test.fail('Two times cur value is not changed according'
+                          ' to the progress of blockcopy.')
+
+            # Abort job and check abort success.
+            if utils_misc.wait_for(
+                    lambda: libvirt.check_blockjob(vm_name,
+                                                   dev, "progress", "100"), 100):
+                virsh.blockjob(vm_name, dev, options=' --pivot',
+                               debug=True,
+                               ignore_status=False)
+            else:
+                test.fail("Blockjob timeout in 100 sec.")
+            # Check no output after abort.
+            result = virsh.blockjob(vm_name, dev, options=options,
+                                    debug=True,
+                                    ignore_status=False)
+            if result.stdout_text.strip():
+                test.fail("Not return empty after pivot, but get:%s",
+                          result.stdout_text.strip())
+        else:
+            test.error('Blockcopy finished too fast, unable to check raw result,\
+             Please consider to reduce bandwith value to retest this case.')
+
+    def teardown_blockjob_raw():
+        """
+        After blockcopy, clean file
+        """
+        # If some steps are broken by accident, execute --abort to
+        # stop blockcopy job
+        virsh.blockjob(vm_name, dev, options=' --abort', debug=True,
+                       ignore_status=True)
+        # Clean copy file
+        process.run('rm -rf %s' % tmp_copy_path)
+
+    # Process cartesian parameters
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    case_name = params.get('case_name', 'blockjob')
+    dev = params.get('disk')
+    # Create object
+    test_obj = blockcommand_base.BlockCommand(test, vm, params)
+    check_obj = check_functions.Checkfunction(test, vm, params)
+
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+    tmp_copy_path = os.path.join(os.path.dirname(
+        libvirt_disk.get_first_disk_source(vm)), "%s_blockcopy.img" % vm_name)
+    # MAIN TEST CODE ###
+    run_test = eval("test_%s" % case_name)
+    setup_test = eval("setup_%s" % case_name)
+    teardown_test = eval("teardown_%s" % case_name)
+
+    try:
+        # Execute test
+        setup_test()
+        run_test()
+
+    finally:
+        teardown_test()
+        bkxml.sync()

--- a/provider/backingchain/blockcommand_base.py
+++ b/provider/backingchain/blockcommand_base.py
@@ -4,7 +4,7 @@ from virttest import virsh
 from virttest import data_dir
 from virttest.utils_test import libvirt
 
-LOG = logging.getLogger('avocado.backingchain.blockcommand_base.')
+LOG = logging.getLogger('avocado.' + __name__)
 
 
 class BlockCommand(object):

--- a/provider/backingchain/check_functions.py
+++ b/provider/backingchain/check_functions.py
@@ -2,6 +2,7 @@ import logging
 import re
 
 from avocado.utils import process
+
 from virttest import libvirt_storage
 
 LOG = logging.getLogger('avocado.backingchain.checkfunction')


### PR DESCRIPTION
**add** case for blockjob with raw option
**Test** number RHEL-114623
    Signed-off-by: nanli <nanli@redhat.com>
**Test result**
root@nanli tp-libvirt]# avocado list --vt-type libvirt backingchain.blockjob.options
VT type_specific.io-github-autotest-libvirt.backingchain.blockjob.options.option_raw
[root@nanli tp-libvirt]# /usr/local/bin/avocado run --vt-type libvirt --vt-machine-type q35 backingchain.blockjob.options.option_raw --vt-connect-uri qemu:///system
JOB ID     : 1b5928dfe6b1fb9a9286439c952edd9438fbb825
JOB LOG    : /root/avocado/job-results/job-2022-02-12T19.34-1b5928d/job.log
 (1/1) type_specific.io-github-autotest-libvirt.backingchain.blockjob.options.option_raw: PASS (109.62 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 116.24 s
