### PR TITLE
v2v: filter the rhel9,win11,win2022 guests from xen and esx6.0 in matrix

### DIFF
--- a/v2v/tests/cfg/convert_vm_to_libvirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_libvirt.cfg
@@ -126,6 +126,7 @@
     variants:
         - xen:
             only source_xen
+            no latest9
             hostname = ${xen_hostname}
             xen_pwd = "XEN_PASSWORD"
             variants:
@@ -157,6 +158,7 @@
                 - 6_0:
                     only source_esx.esx_60
                     esx_version = "esx6.0"
+                    no win11,win2022,latest9
             hostname = ${esx_hostname}
             variants:
                 - vm:

--- a/v2v/tests/cfg/convert_vm_to_ovirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_ovirt.cfg
@@ -157,6 +157,7 @@
     variants:
         - xen:
             only source_xen
+            no latest9
             hostname = ${xen_hostname}
             xen_pwd = "XEN_PASSWORD"
             variants:
@@ -187,6 +188,7 @@
                     esx_version = "esx6.5"
                 - 6_0:
                     only source_esx.esx_60
+                    no win11,win2022,latest9
                     esx_version = "esx6.0"
             hostname = ${vpx_hostname}
             variants:


### PR DESCRIPTION
Those guests were not setup in those very old hypervisors. And they will
not be tested, either.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>