### PR TITLE
Add cases about virtio driver option page_per_vq

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_options.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_options.cfg
@@ -22,6 +22,18 @@
                     iface_driver = "{'txmode':'iothread'}"
                 - driver_txmode_timer:
                     iface_driver = "{'txmode':'timer'}"
+                - driver_page_per_vq:
+                    func_supported_since_libvirt_ver = (7, 9, 0)
+                    iface_driver = "{'queues':'5','page_per_vq':'on','tx_queue_size':'1024','rx_queue_size':'1024'}"
+                    variants:
+                        - on:
+                        - off:
+                            iface_driver = "{'queues':'5','page_per_vq':'off','tx_queue_size':'1024','rx_queue_size':'1024'}"
+                        - attach_device:
+                            change_iface_options = "no"
+                            test_iface_option_cmd = "no"
+                            test_iface_option_xml = "yes"
+                            attach_iface_device = "live"
                 - driver_queues_positive:
                     iface_driver =  "{'name':'vhost','txmode':'iothread','ioeventfd':'on','event_idx':'off','queues':'5'}"
                     variants:

--- a/libvirt/tests/src/virtual_network/iface_options.py
+++ b/libvirt/tests/src/virtual_network/iface_options.py
@@ -343,6 +343,11 @@ def run(test, params, env):
                 tmp = opt.rsplit("=")
                 cmd_opt[tmp[0]] = tmp[1]
         logging.debug("Command line options \n%s", cmd_opt)
+        # Because '_' in below attribute name in guest xml will be converted to
+        # '-' in corresponding qemu command line for this page_per_vq option,
+        # we replace it here for the convenience of further comparing.
+        if 'page_per_vq' in driver_dict:
+            driver_dict['page-per-vq'] = driver_dict.pop('page_per_vq')
         logging.debug("setting options \n%s", driver_dict)
 
         for driver_opt in list(driver_dict.keys()):


### PR DESCRIPTION
Start vm with virtio driver option page_per_vq set as on or off.

Signed-off-by: Yalan Zhang <yalzhang@redhat.com>