### PR TITLE
migrate_storage: Fix IPv4 address error

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_storage.cfg
+++ b/libvirt/tests/cfg/migration/migrate_storage.cfg
@@ -39,7 +39,7 @@
                 - inconsistent_cn_server:
                     only copy_storage_all
                     status_error = "yes"
-                    server_info_ip = ""
+                    server_info_ip = "192.168.10.123"
                     virsh_migrate_extra = "--tls --migrateuri tcp://${migrate_dest_host}"
                     err_msg = "Certificate does not match the hostname"
         - migrateuri:


### PR DESCRIPTION
If ip_address in server.info is empty, we will meet following error:
  #certtool --generate-certificate --load-privkey server-key.pem
  --load-ca-certificate ca-cert.pem --load-ca-privkey ca-key.pem
   --template server.info --outfile server-cert.pem
  Generating a signed certificate...
  Error in IPv4 address

Signed-off-by: lcheng <lcheng@redhat.com>
