### PR TITLE
update detach disk event influnced file

### DIFF
--- a/libvirt/tests/src/virtual_disks/at_dt_iscsi_disk.py
+++ b/libvirt/tests/src/virtual_disks/at_dt_iscsi_disk.py
@@ -402,7 +402,7 @@ def run(test, params, env):
         find_attach_disk(not status_error)
 
         # Detach disk
-        cmd_result = virsh.detach_disk(vm_name, disk_target, wait_remove_event=True)
+        cmd_result = virsh.detach_disk(vm_name, disk_target, wait_for_event=True)
         libvirt.check_exit_status(cmd_result, status_error)
 
         # Check disk inside the VM

--- a/libvirt/tests/src/virtual_disks/virtual_disks_ceph.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_ceph.py
@@ -982,7 +982,7 @@ def run(test, params, env):
                 ret = virsh.detach_device(guest_name, xml_file, wait_for_event=True)
                 libvirt.check_exit_status(ret)
         elif attach_disk:
-            ret = virsh.detach_disk(vm_name, targetdev, wait_remove_event=True)
+            ret = virsh.detach_disk(vm_name, targetdev, wait_for_event=True)
             libvirt.check_exit_status(ret)
 
         # Check disk in vm after detachment.

--- a/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
@@ -1974,7 +1974,7 @@ def run(test, params, env):
                 if devices[i] == "cdrom":
                     dt_options = "--config"
                 ret = virsh.detach_disk(vm_name, device_targets[i],
-                                        dt_options, wait_remove_event=True,
+                                        dt_options, wait_for_event=True,
                                         **virsh_dargs)
                 disk_detach_error = False
                 if len(device_attach_error) > i:


### PR DESCRIPTION
  detach disk event will influence file ,so update it
Signed-off-by: nanli <nanli@redhat.com>

**Depend on avocado-vt pr** : https://github.com/avocado-framework/avocado-vt/pull/3356
Influence other case file : libvirt/tests/src/virtual_disks/ at_dt_iscsi_disk.py virtual_disks_ceph.py, virtual_disks_multidisks.py RUN PASSED

**Test result**
[root@dell-per740-19 ~]# /usr/local/bin/avocado run --vt-type libvirt --vt-machine-type q35 virtual_disks.multidisks.coldplug.multi_disks_test.disk_virtio_iothread.error_test.dom_iothreads.num_minus --vt-connect-uri qemu:///system
JOB ID : 5824c2143886efc57d5b8c60620a79ecd0dd73ed
JOB LOG : /root/avocado/job-results/job-2022-02-18T11.57-5824c21/job.log
(1/1) type_specific.io-github-autotest-libvirt.virtual_disks.multidisks.coldplug.multi_disks_test.disk_virtio_iothread.error_test.dom_iothreads.num_minus: PASS (4.49 s)

[root@dell-per740-19 ~]# /usr/local/bin/avocado run --vt-type libvirt --vt-machine-type q35 virtual_disks.at_dt_iscsi_disk.positive_test.cold_plug.network_disk.readonly_mode --vt-connect-uri qemu:///system
JOB ID : c2338539d968fb914963a599099cd4a79378e71b
JOB LOG : /root/avocado/job-results/job-2022-02-17T23.32-c233853/job.log
(1/1) type_specific.io-github-autotest-libvirt.virtual_disks.at_dt_iscsi_disk.positive_test.cold_plug.network_disk.readonly_mode: PASS (35.43 s)
RESULTS : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME : 36.19 s

[root@dell-per740-19 ~]# /usr/local/bin/avocado run --vt-type libvirt --vt-machine-type q35 virtual_disks.at_dt_iscsi_disk.positive_test.hot_plug.volume_disk.iscsi_direct_pool.auth_in_pool --vt-connect-uri qemu:///system
JOB ID : 4836e17a134aae564fe1fcf9edf05e43ccb74b35
JOB LOG : /root/avocado/job-results/job-2022-02-17T23.36-4836e17/job.log
(1/1) type_specific.io-github-autotest-libvirt.virtual_disks.at_dt_iscsi_disk.positive_test.hot_plug.volume_disk.iscsi_direct_pool.auth_in_pool: PASS (40.40 s)
RESULTS : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME : 41.12 s