### PR TITLE
Fix virtual_disks gluster default_pool cases failures

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_gluster.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_gluster.py
@@ -202,11 +202,6 @@ def run(test, params, env):
                 # 'iothreads' may not invalid number in negative tests
                 logging.debug("Can't convert '%s' to integer type",
                               dom_iothreads)
-        if default_pool:
-            disks_dev = vmxml.get_devices(device_type="disk")
-            for disk in disks_dev:
-                vmxml.del_device(disk)
-            vmxml.sync()
 
         # If hot plug, start VM first, otherwise stop VM if running.
         if start_vm:


### PR DESCRIPTION
Previous logic will remove VM system disk, which leads to login timeout in VM itself
So remove these logic

Signed-off-by: chunfuwen <chwen@redhat.com>

