### PR TITLE
add case for blockcopy with extended_l2 on disk

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockcopy_options.cfg
+++ b/libvirt/tests/cfg/backingchain/blockcopy_options.cfg
@@ -1,0 +1,16 @@
+- backingchain.blockcopy_options:
+    type = blockcopy_options
+    variants:
+        - positive_test:
+            variants:
+                - extended_l2_on:
+                    func_supported_since_libvirt_ver = (8, 0, 0)
+                    extended_l2_value = "on"
+                    new_disk = "vdd"
+                    case_name = "blockcopy_extended_l2"
+                    variants:
+                        - not_encrypt_disk:
+                            enable_encrypt_disk = "no"
+                            extras_options = " -o cluster_size=2M,extended_l2="${extended_l2_value}" "
+                            blockcopy_option = "--wait --verbose --transient-job --pivot "
+                            attach_disk_options = " --subdriver qcow2"

--- a/libvirt/tests/src/backingchain/blockcopy_options.py
+++ b/libvirt/tests/src/backingchain/blockcopy_options.py
@@ -1,0 +1,126 @@
+import logging
+import os
+
+from avocado.utils import process
+
+from virttest import utils_disk
+from virttest import virsh
+from virttest import libvirt_version
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_disk
+from virttest.utils_test import libvirt
+
+
+from provider.backingchain import blockcommand_base
+from provider.backingchain import check_functions
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+
+def run(test, params, env):
+    """
+    Test blockcopy with different options.
+
+    1) Prepare an running guest.
+    2) Create snap.
+    3) Do blockcopy.
+    4) Check status by 'qemu-img info'.
+    """
+
+    def setup_blockcopy_extended_l2():
+        """
+        Prepare running domain with extended_l2=on type image.
+        """
+        # prepare image
+        image_path = test_obj.tmp_dir + '/new_image'
+
+        libvirt.create_local_disk("file", path=image_path, size='500M',
+                                  disk_format="qcow2", extra=disk_extras)
+        check_obj.check_image_info(image_path, check_item='extended l2',
+                                   expected_value='true')
+        test_obj.new_image_path = image_path
+        # start domain and get old parts
+        if not vm.is_alive():
+            vm.start()
+        session = vm.wait_for_login()
+        test_obj.old_parts = utils_disk.get_parts_list(session)
+        session.close()
+        # attach new disk
+        virsh.attach_disk(vm.name, source=image_path, target=device,
+                          extra=attach_disk_extra, debug=True)
+        test_obj.new_dev = device
+
+    def test_blockcopy_extended_l2():
+        """
+        Do blockcopy after creating snapshot with extended_l2 in disk image
+        """
+        # create snap chain and check snap path extended_l2 status
+        test_obj.prepare_snapshot(snap_num=1)
+        check_obj.check_image_info(test_obj.snap_path_list[0],
+                                   check_item='extended l2',
+                                   expected_value='true')
+        # Do blockcopy
+        tmp_copy_path = os.path.join(os.path.dirname(
+            libvirt_disk.get_first_disk_source(vm)), "%s_blockcopy.img" % vm_name)
+        if os.path.exists(tmp_copy_path):
+            process.run('rm -f %s' % tmp_copy_path)
+        virsh.blockcopy(vm_name, device, tmp_copy_path, options=blockcopy_options,
+                        ignore_status=False, debug=True)
+        # Check domain exist blockcopy file and extended_l2 status
+        if len(vmxml.get_disk_source(vm_name)) < 2:
+            test.fail('Domain disk num is less than 2, may attach failed')
+        else:
+            image_file = vmxml.get_disk_source(vm_name)[1].find('source').get('file')
+            if image_file != tmp_copy_path:
+                test.fail('Blockcopy path is not in domain disk ,'
+                          ' blockcopy image path is %s ,actual image path '
+                          'is :%s', tmp_copy_path, image_file)
+            check_obj.check_image_info(tmp_copy_path, check_item='extended l2',
+                                       expected_value='true')
+        # Check domain write file
+        session = vm.wait_for_login()
+        new_parts = utils_disk.get_parts_list(session)
+        added_parts = list(set(new_parts).difference(set(test_obj.old_parts)))
+        utils_disk.linux_disk_check(session, added_parts[0])
+        session.close()
+
+    def teardown_blockcopy_extended_l2():
+        """
+        Clean env.
+        """
+        test_obj.backingchain_common_teardown()
+        # detach disk
+        virsh.detach_disk(vm_name, target=device, wait_for_event=True,
+                          debug=True)
+        process.run('rm -f %s' % test_obj.new_image_path)
+
+    libvirt_version.is_libvirt_feature_supported(params)
+
+    # Process cartesian parameters
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    case_name = params.get('case_name', '')
+    device = params.get('new_disk')
+    disk_extras = params.get('extras_options')
+    blockcopy_options = params.get('blockcopy_option')
+    attach_disk_extra = params.get("attach_disk_options")
+    # Create object
+    test_obj = blockcommand_base.BlockCommand(test, vm, params)
+    check_obj = check_functions.Checkfunction(test, vm, params)
+    # Get vm xml
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+    test_obj.original_disk_source = libvirt_disk.get_first_disk_source(vm)
+    # MAIN TEST CODE ###
+    run_test = eval("test_%s" % case_name)
+    setup_test = eval("setup_%s" % case_name)
+    teardown_test = eval("teardown_%s" % case_name)
+
+    try:
+        # Execute test
+        setup_test()
+        run_test()
+
+    finally:
+        teardown_test()
+        bkxml.sync()


### PR DESCRIPTION
add case for blockcopy with extended_l2 on disk
Signed-off-by: nanli [nanli@redhat.com](mailto:nanli@redhat.com)

**depend on**:  https://github.com/avocado-framework/avocado-vt/pull/3357 

**Test number** :RHEL-288642

**Test result:**
root@dell-per740-33 tp-libvirt]# /usr/local/bin/avocado run --vt-type libvirt --vt-machine-type q35 backingchain.blockcopy_options.positive_test.extended_l2_on.not_encrypt_disk --vt-connect-uri qemu:///system
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : 729b9d3d4c99f7989860e8b2c9b9a87c3c3ebf1c
JOB LOG    : /root/avocado/job-results/job-2022-02-21T05.22-729b9d3/job.log
 (1/1) type_specific.io-github-autotest-libvirt.backingchain.blockcopy_options.positive_test.extended_l2_on.not_encrypt_disk: PASS (36.63 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 37.75 s
