### PR TITLE
sriov: Update to check driver after re-attaching the device

### DIFF
--- a/libvirt/tests/src/sriov/sriov_nodedev.py
+++ b/libvirt/tests/src/sriov/sriov_nodedev.py
@@ -2,11 +2,13 @@ import logging as log
 
 from provider.sriov import sriov_base
 
+from virttest import utils_misc
 from virttest import utils_sriov
 from virttest import virsh
 
 from virttest.libvirt_xml import nodedev_xml
 from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vfio
 from virttest.utils_libvirt import libvirt_vmxml
 from virttest.utils_test import libvirt
 
@@ -161,6 +163,8 @@ def run(test, params, env):
 
         logging.info("Detach and reattach the device and check vf's mac.")
         nodedev_test(dev_name, no_reset=True)
+        utils_misc.wait_for(
+            lambda: libvirt_vfio.check_vfio_pci(vf_pci, True, True), 10, 5)
         compare_vf_mac(pf_name, vf_mac)
 
         logging.info("Cold-plug the device into the VM.")


### PR DESCRIPTION
Ater re-attching the device, i40e driver needs more time to make
it work. So update to check the driver before comparing mac address.

Signed-off-by: Yingshun Cui <yicui@redhat.com>

**Test result:**
_Before the fix:_
` (1/1) type_specific.io-github-autotest-libvirt.sriov_nodedev.vf: ERROR: Unable to get iface name of 0000:3b:02.0. (16.25 s)`


_After the fix:_
` (1/1) type_specific.io-github-autotest-libvirt.sriov_nodedev.vf: PASS (24.68 s)`
