### PR TITLE
sriov: Extend sleep time before checking initialization of VFs

### DIFF
--- a/libvirt/tests/src/sriov/sriov.py
+++ b/libvirt/tests/src/sriov/sriov.py
@@ -118,7 +118,7 @@ def run(test, params, env):
             except process.CmdError:
                 raise test.fail("Get net list with 'virsh nodedev-list' failed\n")
 
-        net_diff = utils_misc.wait_for(_vf_init_completed, timeout=300)
+        net_diff = utils_misc.wait_for(_vf_init_completed, 300, 10)
         pci_list_sriov = virsh.nodedev_list(cap='pci').stdout.strip().splitlines()
         pci_list_sriov = set(pci_list_sriov)
         pci_diff = list(pci_list_sriov.difference(pci_list_before))


### PR DESCRIPTION
Some drivers need more time to make vfs work.

Signed-off-by: Yingshun Cui <yicui@redhat.com>

**Test result:**
_Before the fix:_
` (1/1) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.restart_libvirtd.vf_pool.vf_list: FAIL: Get net list with 'virsh nodedev-list' failed\n (338.48 s)`

_After the fix:_
```
 (1/1) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.restart_libvirtd.vf_pool.vf_list: PASS (80.43 s)
 (1/1) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.hotplug.default.nop.vf_vlan.managed_yes: PASS (141.80 s)
```
