### PR TITLE
virtual_disks_relative_blockcommit: Fix snapshot-create-as hang

### DIFF
--- a/libvirt/tests/src/backingchain/virtual_disks_relative_blockcommit.py
+++ b/libvirt/tests/src/backingchain/virtual_disks_relative_blockcommit.py
@@ -302,6 +302,7 @@ def run(test, params, env):
             # Reset VM to initial state
             vmxml_backup.sync("--snapshots-metadata")
             vm.start()
+            vm.wait_for_login()
             snap_del_disks = libvirt_disk.make_external_disk_snapshots(vm, disk_target, snapshot_prefix, snapshot_take)
             tmp_option = opt.get('blkcomopt')
             top_file = opt.get('top')
@@ -439,6 +440,7 @@ def run(test, params, env):
                 # Reset VM to initial state
                 vmxml_backup.sync("--snapshots-metadata")
                 vm.start()
+                vm.wait_for_login()
             snap_del_disks = libvirt_disk.make_external_disk_snapshots(vm, disk_target, snapshot_prefix, snapshot_take)
             scenarios = prepare_case_scenarios(snap_del_disks, base_file)
             libvirt_disk.cleanup_snapshots(vm, snap_del_disks)


### PR DESCRIPTION
Make sure the guest boot successfully before snapshot-create-as.
Otherwise the test will get stuck.

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Before
Test got stuck.
```
 (1/1) type_specific.io-github-autotest-libvirt.virtual_disks.relativepath.blockcommit.normal_test.network_disk.iscsi.relative_path.validate_delete_option.shallow.top_active: ERROR: Command '/bin/virsh snapshot-create-as avocado-vt-vm1 relativesnap_4 relativesnap4-desc --diskspec  vda,snapshot=external,file=/var/lib/avocado/data/avocado-vt/images/jeos-27-aarch64.relativesnap4  --disk-only --atomic' failed.\nstdout: b'\n'\nstderr: b'err... (539.96 s)

```
After
```
(1/1) type_specific.io-github-autotest-libvirt.virtual_disks.relativepath.blockcommit.normal_test.network_disk.iscsi.relative_path.validate_delete_option.shallow.top_active: PASS (312.93 s)
```
