### PR TITLE
virsh_destroy: Add testcase for BZ#2045879

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_destroy.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_destroy.cfg
@@ -7,6 +7,12 @@
         - normal_test:
             status_error = "no"
             variants:
+                - no_option:
+                    only non_acl
+                    variants:
+                        - clean_domain_socket:
+                            start_destroy_times = "100"
+                            limit_nofile = "LimitNOFILE=100"
                 - id_option:
                     destroy_vm_ref = "id"
                 - name_option:

--- a/spell.ignore
+++ b/spell.ignore
@@ -1116,6 +1116,7 @@ virtiofsd
 virtlogd
 virtnet
 virtproxyd
+virtqemud
 virttype
 virtualizati
 virtualization


### PR DESCRIPTION
Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>


libvirt-8.0.0-2
```
(1/1) type_specific.io-github-autotest-libvirt.virsh.destroy.normal_test.non_acl.no_option.clean_domain_socket: FAIL: Failed to start guest: error: Failed to start domain 'avocado-vt-vm1'\nerror: cannot open /dev/null: Too many open files\n (72.72 s)
```

libvirt-8.0.0-5
```
 (1/1) type_specific.io-github-autotest-libvirt.virsh.destroy.normal_test.non_acl.no_option.clean_domain_socket: PASS (122.57 s)
```