### PR TITLE
virsh_domblkerror: fix mkfs.ext3 timeout

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domblkerror.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domblkerror.py
@@ -166,10 +166,10 @@ def run(test, params, env):
 
             # create partition and file system
             session.cmd("parted -s %s mklabel msdos" % new_disk)
-            session.cmd("parted -s %s mkpart primary ext3 '0%%' '100%%'" %
+            session.cmd("parted -s %s mkpart primary ext4 '0%%' '100%%'" %
                         new_disk)
             # mount disk and write file in it
-            session.cmd("mkfs.ext3 %s1" % new_disk)
+            session.cmd("mkfs.ext4 %s1" % new_disk)
             session.cmd("mkdir -p %s && mount %s1 %s" %
                         (mnt_dir, new_disk, mnt_dir))
 


### PR DESCRIPTION
There is a conflict mkfs command for iscsi disk which causes the cases unstable.
For example, the newly created iscsi disk is executed with 'mkfs.ext4 -F /dev/sdb ',
then this disk passed to vm and is executed with 'mkfs.ext3 /dev/vdb1' which makes
conflict. So sometimes the case will fail with
'Timeout expired while waiting for shell command to complete: 'mkfs.ext3 /dev/vdb1''
