### PR TITLE
[filesystem_device]Add the cases to test the stdio_handler

### DIFF
--- a/libvirt/tests/cfg/virtual_device/filesystem_device.cfg
+++ b/libvirt/tests/cfg/virtual_device/filesystem_device.cfg
@@ -88,10 +88,18 @@
             hotplug_unplug = "yes"
             variants:
                 - detach_device_alias:
-                  detach_device_alias = "yes"
-                  only xattr_on.flock_on.lock_posix_on.cache_mode_none
+                    detach_device_alias = "yes"
+                    only xattr_on.flock_on.lock_posix_on.cache_mode_none
+                    variants:
+                        - stdio_handler:
+                            variants:
+                                - file:
+                                    stdio_handler = "file"
+                                    only one_fs.one_guest
+                                - logd:
+                                    stdio_handler = "logd"
                 - detach_device:
-                  detach_device_alias = "no"
+                    detach_device_alias = "no"
     variants:
         - positive_test:
             status_error = "no"


### PR DESCRIPTION
When setting stdio_handler as default, the process to write log is virtlogd;
while setting stdio_handler as file, the process should be virtiofsd.

Signed-off-by: Lili Zhu <lizhu@redhat.com>

Case ID: RHEL-288048

# avocado run --vt-type libvirt filesystem_device                                                                                                         
JOB ID     : e60419e14dfec643527a1e38f8f70b4e8345a0f2                                                                                                                             
JOB LOG    : /root/avocado/job-results/job-2022-03-05T05.03-e60419e/job.log                                                                                                       
 (001/272) type_specific.io-github-autotest-libvirt.virtual_devices.filesystem_device.positive_test.hugepages_backed.nop.externally_launched_fs_test.launched_mode: PASS (36.12 s)
......
 (271/272) type_specific.io-github-autotest-libvirt.virtual_devices.filesystem_device.negative_test.invalid_queue_size.larger_than_1024.hotplug_unplug.detach_device.fs_test.xattr
_on.flock_on.lock_posix_on.cache_mode_none.one_fs.one_guest: PASS (24.38 s)                                                                                                       
 (272/272) type_specific.io-github-autotest-libvirt.virtual_devices.filesystem_device.negative_test.managedsave.nop.fs_test.xattr_on.flock_on.lock_posix_on.cache_mode_none.one_fs
.one_guest: PASS (25.54 s)                                                                                                                                                        
RESULTS    : PASS 272 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0                                                                                               
JOB TIME   : 9862.56 s  

