### PR TITLE
add case for encrypted disk wth extended l2 on status

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockcopy_options.cfg
+++ b/libvirt/tests/cfg/backingchain/blockcopy_options.cfg
@@ -8,12 +8,21 @@
                     extended_l2_value = "on"
                     target_disk = "vdd"
                     case_name = "blockcopy_extended_l2"
+                    blockcopy_option = "--wait --verbose --transient-job --pivot "
                     variants:
                         - not_encrypt_disk:
                             enable_encrypt_disk = "no"
                             extras_options = " -o cluster_size=2M,extended_l2="${extended_l2_value}" "
-                            blockcopy_option = "--wait --verbose --transient-job --pivot "
                             attach_disk_options = " --subdriver qcow2"
+                        - encrypt_disk:
+                            enable_encrypt_disk = "yes"
+                            sec_private = "yes"
+                            private_key_password = "EXAMPLE_PWD"
+                            disk_format = "luks"
+                            target_format = "qcow2"
+                            extras_options = " --object secret,id=sec0,data=${private_key_password} -f  ${target_format}  -o encrypt.format=luks,encrypt.key-secret=sec0,extended_l2=${extended_l2_value},cluster_size=2M "
+                            sec_dict = {"secret_ephemeral": "no", "secret_private": "yes", "description": "secret_desc_for_extended_l2_case", "usage": "volume", "volume": "/path/to/volume"}
+                            secret_disk_dict = {'type_name': "file",'target': {"dev": "${target_disk}", "bus": "virtio"},'driver': {"name": "qemu", "type": "${target_format}"},'source':{'encryption':{"encryption": 'luks',"secret": {"type": "passphrase"}}}}
                 - synchronous_writes:
                     func_supported_since_libvirt_ver = (8, 0, 0)
                     case_name = "blockcopy_synchronous_writes"


### PR DESCRIPTION
   add case for encrypted disk wth extended l2 on status
**case id** : RHEL-288643
**Depend on** :  https://github.com/avocado-framework/avocado-vt/pull/3368/
 avocado-framework/avocado-vt#3370 
**Test result**
/usr/local/bin/avocado run --vt-type libvirt --vt-machine-type q35 backingchain.blockcopy_options.positive_test.extended_l2_on.encrypt_disk --vt-connect-uri qemu:///system
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : 7d62c328bb9cf8e141aa663750b802a04a947442
JOB LOG    : /root/avocado/job-results/job-2022-03-07T06.48-7d62c32/job.log
 (1/1) type_specific.io-github-autotest-libvirt.backingchain.blockcopy_options.positive_test.extended_l2_on.encrypt_disk: PASS (61.91 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 63.05 s
