### PR TITLE
add case for blockcopy with sync writes option

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockcopy_options.cfg
+++ b/libvirt/tests/cfg/backingchain/blockcopy_options.cfg
@@ -6,7 +6,7 @@
                 - extended_l2_on:
                     func_supported_since_libvirt_ver = (8, 0, 0)
                     extended_l2_value = "on"
-                    new_disk = "vdd"
+                    target_disk = "vdd"
                     case_name = "blockcopy_extended_l2"
                     variants:
                         - not_encrypt_disk:
@@ -14,3 +14,8 @@
                             extras_options = " -o cluster_size=2M,extended_l2="${extended_l2_value}" "
                             blockcopy_option = "--wait --verbose --transient-job --pivot "
                             attach_disk_options = " --subdriver qcow2"
+                - synchronous_writes:
+                    func_supported_since_libvirt_ver = (8, 0, 0)
+                    case_name = "blockcopy_synchronous_writes"
+                    blockcopy_option = " --synchronous-writes --wait --verbose --transient-job"
+                    target_disk = "vda"

--- a/libvirt/tests/src/backingchain/blockcopy_options.py
+++ b/libvirt/tests/src/backingchain/blockcopy_options.py
@@ -3,9 +3,9 @@ import os
 
 from avocado.utils import process
 
+from virttest import libvirt_version
 from virttest import utils_disk
 from virttest import virsh
-from virttest import libvirt_version
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_libvirt import libvirt_disk
 from virttest.utils_test import libvirt
@@ -49,6 +49,9 @@ def run(test, params, env):
         virsh.attach_disk(vm.name, source=image_path, target=device,
                           extra=attach_disk_extra, debug=True)
         test_obj.new_dev = device
+        # clean copy file
+        if os.path.exists(tmp_copy_path):
+            process.run('rm -f %s' % tmp_copy_path)
 
     def test_blockcopy_extended_l2():
         """
@@ -60,10 +63,6 @@ def run(test, params, env):
                                    check_item='extended l2',
                                    expected_value='true')
         # Do blockcopy
-        tmp_copy_path = os.path.join(os.path.dirname(
-            libvirt_disk.get_first_disk_source(vm)), "%s_blockcopy.img" % vm_name)
-        if os.path.exists(tmp_copy_path):
-            process.run('rm -f %s' % tmp_copy_path)
         virsh.blockcopy(vm_name, device, tmp_copy_path, options=blockcopy_options,
                         ignore_status=False, debug=True)
         # Check domain exist blockcopy file and extended_l2 status
@@ -94,13 +93,73 @@ def run(test, params, env):
                           debug=True)
         process.run('rm -f %s' % test_obj.new_image_path)
 
+    def setup_blockcopy_synchronous_writes():
+        """
+        Start domain and clean exist copy file
+        """
+        if not vm.is_alive():
+            vm.start()
+        if os.path.exists(tmp_copy_path):
+            process.run('rm -f %s' % tmp_copy_path)
+
+    def test_blockcopy_synchronous_writes():
+        """
+        Test blockcopy with --synchronous-writes option.
+        """
+        ret = virsh.blockcopy(vm_name, device, tmp_copy_path,
+                              options=blockcopy_options,
+                              ignore_status=False, debug=True)
+        if not ret.stdout_text.count("Now in mirroring phase"):
+            test.fail("Not in mirroring phase")
+        test_obj.new_image_path = tmp_copy_path
+        # Check exist mirror tag after blockcopy.
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm.name)
+        disk_list = vmxml.get_disk_all()[device]
+        if not disk_list.find('mirror'):
+            test.fail('No mirror tag in current domain xml :%s' % vmxml)
+        else:
+            # Check file in mirror should be new copy file
+            mirror_file = disk_list.find('mirror').get('file')
+            if mirror_file != tmp_copy_path:
+                test.fail('Current mirror tag file:%s is not same as:%s' %
+                          (mirror_file, tmp_copy_path))
+            # Check file in mirror >source > file should be new copy file
+            mirror_source_file = disk_list.find('mirror').\
+                find('source').get('file')
+            if mirror_source_file != tmp_copy_path:
+                test.fail('Current source tag file:%s is not same as:%s' %
+                          (mirror_source_file, tmp_copy_path))
+
+        # Check domain write file
+        session = vm.wait_for_login()
+        utils_disk.dd_data_to_vm_disk(session, device)
+        session.close()
+        # Abort job and check disk source changed.
+        virsh.blockjob(vm_name, device, options=' --pivot',
+                       debug=True, ignore_status=False)
+        current_source = libvirt_disk.get_first_disk_source(vm)
+        if current_source != tmp_copy_path:
+            test.fail("Current source: %s is not same as original blockcopy"
+                      " path:%s" % (current_source, tmp_copy_path))
+        # Check domain write file after
+        session = vm.wait_for_login()
+        utils_disk.dd_data_to_vm_disk(session, device)
+        session.close()
+
+    def teardown_blockcopy_synchronous_writes():
+        """
+        Clean env
+        """
+        if os.path.exists(test_obj.new_image_path):
+            process.run('rm -f %s' % test_obj.new_image_path)
+
     libvirt_version.is_libvirt_feature_supported(params)
 
     # Process cartesian parameters
     vm_name = params.get("main_vm")
     vm = env.get_vm(vm_name)
     case_name = params.get('case_name', '')
-    device = params.get('new_disk')
+    device = params.get('target_disk')
     disk_extras = params.get('extras_options')
     blockcopy_options = params.get('blockcopy_option')
     attach_disk_extra = params.get("attach_disk_options")
@@ -111,6 +170,8 @@ def run(test, params, env):
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     bkxml = vmxml.copy()
     test_obj.original_disk_source = libvirt_disk.get_first_disk_source(vm)
+    tmp_copy_path = os.path.join(os.path.dirname(
+        libvirt_disk.get_first_disk_source(vm)), "%s_blockcopy.img" % vm_name)
     # MAIN TEST CODE ###
     run_test = eval("test_%s" % case_name)
     setup_test = eval("setup_%s" % case_name)


### PR DESCRIPTION
add case for blockcopy with --synchronous-writes option

Signed-off-by: nanli <nanli@redhat.com>

**id** : RHEL-289790: 
**Test result:**
 /usr/local/bin/avocado run --vt-type libvirt --vt-machine-type q35 backingchain.blockcopy_options.positive_test.synchronous_writes --vt-connect-uri qemu:///system
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : 4fcd77a14ebd7378a63907b957812c35e3f7d8a6
JOB LOG    : /root/avocado/job-results/job-2022-03-07T08.06-4fcd77a/job.log
 (1/1) type_specific.io-github-autotest-libvirt.backingchain.blockcopy_options.positive_test.synchronous_writes: PASS (38.57 s)
RESULTS    : **PASS 1** | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 39.74 s


