### PR TITLE
sriov: Remove maxCount checking in pf_info test

### DIFF
--- a/libvirt/tests/src/sriov/sriov.py
+++ b/libvirt/tests/src/sriov/sriov.py
@@ -267,11 +267,8 @@ def run(test, params, env):
             xml = NodedevXML.new_from_dumpxml(nodedev_pci)
             if info_type == "pf_info":
                 product_info = xml.cap.product_info
-                max_count = xml.max_count
                 if pci_info.find(product_info) == -1:
                     test.fail("The product_info show in nodedev-dumpxml is wrong\n")
-                if int(max_count) != max_vfs:
-                    test.fail("The maxCount show in nodedev-dumpxml is wrong\n")
             if info_type == "vf_order":
                 vf_addr_list = xml.cap.virt_functions
                 if len(vf_addr_list) != max_vfs:


### PR DESCRIPTION
The maxCount settings are different in different drivers.
Confirmed with dev that this is not a bug. And it's not related
to pf infomation checking test, so delete it.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Test result:**
` (1/1) type_specific.io-github-autotest-libvirt.sriov.normal_test.info_check.pf_info: PASS (53.70 s)`
