### PR TITLE
numa_config_with_auto_placement: fix output parse

### DIFF
--- a/libvirt/tests/src/numa/numa_config_with_auto_placement.py
+++ b/libvirt/tests/src/numa/numa_config_with_auto_placement.py
@@ -190,13 +190,12 @@ def check_cgget_output(test, cgget_message):
     slice_line = None
     cpuset_lines = re.split('\s', cpuset_slices.stdout_text)
     for line in cpuset_lines:
-        if re.search('machine\.slice', line):
-            machine_found = True
-            continue
-        if machine_found and len(line) > 1:
+        if re.search('machine-qemu', line):
             slice_line = line.strip()
             # No more lines need to be checked
             break
+    if not slice_line:
+        test.error("'machine-qemu' is not found in 'systemd-cgls cpuset' output")
     slice_line = slice_line.replace('\\', '\\\\')[2:]
     for item in ['emulator', 'vcpu0']:
         result = process.run('cgget -g cpuset /machine.slice/{}/libvirt/{}'.


### PR DESCRIPTION
'systemd-cgls cpuset' output format is changed in new version of
systemd package systemd-250-4.el9.x86_64. So this is to update
the parsing for the output.

Old format is like:
```
 `-machine.slice
   `-machine-qemu\x2d2\x2davocado\x2dvt\x2dvm1.scope
```

New format is like:
```
`-machine.slice (#5408)
   -> trusted.invocation_id: c4971d14d18345f4b8a0322f2e047b29
   `-machine-qemu\x2d2\x2davocado\x2dvt\x2dvm1.scope ... (#10849)
```

Signed-off-by: Dan Zheng <dzheng@redhat.com>
