### PR TITLE
sriov: Update string split separator for check_numa function

### DIFF
--- a/libvirt/tests/src/sriov/sriov.py
+++ b/libvirt/tests/src/sriov/sriov.py
@@ -579,7 +579,7 @@ def run(test, params, env):
         vm.create_serial_console()
         session = vm.wait_for_serial_login(timeout=240)
         vf_pci = "/sys/bus/pci/drivers/%s" % vf_driver
-        vf_dir = session.cmd_output("ls -d %s/00*" % vf_pci).strip().split('\n')
+        vf_dir = session.cmd_output("ls -d %s/00*" % vf_pci).strip().split()
         for vf in vf_dir:
             numa_node = session.cmd_output('cat %s/numa_node' % vf).strip().split('\n')[-1]
             logging.debug("The vf is attached to numa node %s\n", numa_node)


### PR DESCRIPTION
The split separator should be any whitespace.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Test result:**
_Before the fix:_
` (1/1) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.nfv.two_nic.vf.managed_yes: FAIL: The vf is not attached to numa node 0\n (357.55 s)`

_After the fix:_
` (1/1) type_specific.io-github-autotest-libvirt.sriov.normal_test.guest_with_vf.cold_plug.nfv.two_nic.vf.managed_yes: PASS (56.96 s)`
