### PR TITLE
Fix the attach xml can not find error for virtual network

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_ovs.py
+++ b/libvirt/tests/src/virtual_network/iface_ovs.py
@@ -1,11 +1,13 @@
 import logging as log
 import ast
+import os
 import re
 import shutil
 
 from avocado.utils import distro
 from avocado.utils import process
 
+from virttest import data_dir
 from virttest import virt_vm
 from virttest import virsh
 from virttest import utils_net
@@ -142,7 +144,8 @@ def run(test, params, env):
             if not hotplug:
                 libvirt.modify_vm_iface(vm_name, 'update_iface', iface_dict)
             else:
-                iface_attach_xml = libvirt.modify_vm_iface(vm_name, 'get_xml', iface_dict)
+                iface_attach_xml = os.path.join(data_dir.get_data_dir(), "iface_attach.xml")
+                shutil.copyfile(libvirt.modify_vm_iface(vm_name, 'get_xml', iface_dict), iface_attach_xml)
                 libvirt_vmxml.remove_vm_devices_by_type(vm, 'interface')
 
         try:
@@ -191,4 +194,6 @@ def run(test, params, env):
         # Try to recovery ovs bridge
         if utils_net.ovs_br_exists(bridge_name):
             utils_net.del_ovs_bridge(bridge_name)
+        if "iface_attach_xml" in locals():
+            os.remove(iface_attach_xml)
         vmxml_backup.sync()

--- a/libvirt/tests/src/virtual_network/iface_target.py
+++ b/libvirt/tests/src/virtual_network/iface_target.py
@@ -1,8 +1,11 @@
 import logging as log
+import os
+import shutil
 import time
 
 from avocado.utils import process
 
+from virttest import data_dir
 from virttest import libvirt_version
 from virttest import utils_libvirtd
 from virttest import utils_net
@@ -150,7 +153,8 @@ def run(test, params, env):
         if_dict = prepare_iface_dict(test_macvtap)
         mac_addr = utils_net.generate_mac_address_simple()
         if_dict['mac'] = mac_addr
-        iface_add_xml = libvirt.modify_vm_iface(vm_name, 'get_xml', if_dict)
+        iface_add_xml = os.path.join(data_dir.get_data_dir(), "iface_add.xml")
+        shutil.copyfile(libvirt.modify_vm_iface(vm_name, 'get_xml', if_dict), iface_add_xml)
         virsh.attach_device(vm_name, iface_add_xml, debug=True, ignore_status=False)
         time.sleep(2)
         logging.debug("3. Check tap name after hotplug an interface:")
@@ -175,4 +179,6 @@ def run(test, params, env):
     finally:
         if vm.is_alive():
             vm.destroy(gracefully=False)
+        if "iface_add_xml" in locals():
+            os.remove(iface_add_xml)
         vmxml_backup.sync()


### PR DESCRIPTION
Signed-off-by: Kyla Zhang <weizhan@redhat.com>

```
 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.iface_target.flush_after_detach.flush_with_occupation.default: PASS (57.17 s)
 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.iface_ovs.net_ovs.ovs_qos.hotplug_iface: PASS (8.14 s)
```