### PR TITLE
numa_memory: fix foreground libvirtd start

### DIFF
--- a/libvirt/tests/cfg/numa/numa_memory.cfg
+++ b/libvirt/tests/cfg/numa/numa_memory.cfg
@@ -3,6 +3,8 @@
     start_vm = "no"
     kill_vm = "yes"
     status_error = "no"
+    libvirtd_debug_file = "/var/log/libvirt/daemon.log"
+    libvirtd_debug_level = "1"
     variants:
         - possitive_test:
              variants:

--- a/libvirt/tests/src/numa/numa_memory.py
+++ b/libvirt/tests/src/numa/numa_memory.py
@@ -1,10 +1,9 @@
-import os
 import logging as log
 import platform
 import random
+import re
 
 from avocado.utils import process
-from avocado.utils import path
 
 from virttest import virt_vm
 from virttest import libvirt_xml
@@ -12,9 +11,6 @@ from virttest import virsh
 from virttest import utils_misc
 from virttest import cpu
 from virttest import utils_test
-from virttest import utils_config
-from virttest import utils_libvirtd
-from virttest import data_dir
 
 
 # Using as lower capital is not the best way to do, but this is just a
@@ -22,92 +18,145 @@ from virttest import data_dir
 logging = log.getLogger('avocado.' + __name__)
 
 
+def cpu_affinity_check(test, vm_name, cpuset=None, node=None):
+    """
+    Check vcpuinfo cpu affinity
+
+    :param test: test object
+    :param vm_name: the vm name
+    :param cpuset: cpuset list
+    :param node: node number list
+    :raises: test.fail if cpu affinity is not expected
+    """
+
+    result = virsh.vcpuinfo(vm_name, debug=True)
+    output = result.stdout.strip().splitlines()[-1]
+    cpu_affinity = output.split(":")[-1].strip()
+    if node:
+        tmp_list = []
+        for node_num in node:
+            host_node = utils_misc.NumaNode(i=node_num + 1)
+            logging.debug("node %s cpu list is %s" %
+                          (node_num, host_node.cpus))
+            tmp_list += host_node.cpus
+        cpu_list = [int(i) for i in tmp_list]
+    if cpuset:
+        cpu_list = cpuset
+    ret = format_affinity_str(cpu_list)
+    logging.debug("expect cpu affinity is %s", ret)
+    if cpu_affinity != ret:
+        test.fail("vcpuinfo cpu affinity not expected")
+
+
+def format_affinity_str(cpu_list):
+    """
+    Format affinity str
+
+    :param cpu_list: list of cpu number
+    :return: cpu affinity string
+    """
+    cmd = "lscpu | grep '^CPU(s):'"
+    ret = process.run(cmd, shell=True)
+    cpu_num = int(ret.stdout_text.split(':')[1].strip())
+    cpu_affinity_str = ""
+    for i in range(cpu_num):
+        if i in cpu_list:
+            cpu_affinity_str += "y"
+        else:
+            cpu_affinity_str += "-"
+    return cpu_affinity_str
+
+
+def numa_mode_check(test, vm, mode_nodeset):
+    """
+    when the mode = 'preferred' or 'interleave', it is better to check
+    numa_maps.
+
+    :param test: test object
+    :param vm: the vm object
+    :param mode_nodeset: the nodeset mode in the vm
+    :raises: test.fail if numa node and nodeset are not expected
+    """
+    vm_pid = vm.get_pid()
+    numa_map = '/proc/%s/numa_maps' % vm_pid
+    # Open a file
+    with open(numa_map) as file:
+        for line in file.readlines():
+            if line.split()[1] != mode_nodeset:
+                test.fail("numa node and nodeset %s is "
+                          "not expected" % mode_nodeset)
+
+
+def mem_compare(test, used_node, left_node, memory_status):
+    """
+    Memory in used nodes should greater than left nodes
+
+    :param test: test object
+    :param used_node: used node list
+    :param left_node: left node list
+    :param memory_status: the memory status of the vm process
+    :raises: test.fail if nodes memory usage is not expected
+    """
+    used_mem_total = 0
+    left_node_mem_total = 0
+    for i in used_node:
+        used_mem_total += int(memory_status[i])
+    for i in left_node:
+        left_node_mem_total += int(memory_status[i])
+    if left_node_mem_total > used_mem_total:
+        test.fail("nodes memory usage not expected.")
+
+
+def verify_numa_for_auto_replacement(test, params, vmxml, node_list, qemu_cpu, vm, memory_status):
+    """
+    Verify the checkpoints when placement = auto
+
+    :param test: test object
+    :param params: dict for the test
+    :param vmxml: VMXML object
+    :param node_list: list of the host numa nodes
+    :param qemu_cpu: cpu list in each node
+    :param vm: vm object
+    :param memory_status: memory info in each node
+    :raises: test.fail if cpu usage in node is not expected
+    :return:
+    """
+    log_file = params.get("libvirtd_debug_file")
+    vcpu_placement = params.get("vcpu_placement")
+    numa_memory = vmxml.numa_memory
+    numad_cmd_opt = "-w %s:%s" % (vmxml.vcpu, vmxml.max_mem // 1024)
+    utils_test.libvirt.check_logfile('.*numad\s*%s' % numad_cmd_opt, log_file)
+    check_res = utils_test.libvirt.check_logfile('Nodeset returned from numad:', log_file)
+    # Sample: Nodeset returned from numad: 0-1
+    match_obj = re.search(r'Nodeset returned from numad:\s(.*)', check_res.stdout_text)
+    numad_ret = match_obj.group(1)
+    logging.debug("Nodeset returned from numad: %s", numad_ret)
+
+    numad_node = cpu.cpus_parser(numad_ret)
+    left_node = [node_list.index(i) for i in node_list if i not in numad_node]
+    numad_node_seq = [node_list.index(i) for i in numad_node]
+    logging.debug("numad nodes are %s", numad_node)
+    if numa_memory.get('placement') == 'auto':
+        if numa_memory.get('mode') == 'strict':
+            mem_compare(test, numad_node_seq, left_node, memory_status=memory_status)
+        elif numa_memory.get('mode') == 'preferred':
+            mode_nodeset = 'prefer:' + numad_ret
+            numa_mode_check(test, vm, mode_nodeset)
+        else:
+            mode_nodeset = numa_memory.get('mode') + ':' + numad_ret
+            numa_mode_check(test, vm, mode_nodeset)
+    if vcpu_placement == 'auto':
+        for i in left_node:
+            if qemu_cpu[i]:
+                test.fail("cpu usage in node %s is not expected" % i)
+        cpu_affinity_check(test, params.get("main_vm"), node=numad_node)
+
+
 def run(test, params, env):
     """
     Test numa tuning with memory
     """
-    numad_log = []
     memory_status = []
-
-    def _logger(line):
-        """
-        Callback function to log libvirtd output.
-        """
-        numad_log.append(line)
-
-    def mem_compare(used_node, left_node):
-        """
-        Memory in used nodes should greater than left nodes
-
-        :param used_node: used node list
-        :param left_node: left node list
-        """
-        used_mem_total = 0
-        left_node_mem_total = 0
-        for i in used_node:
-            used_mem_total += int(memory_status[i])
-        for i in left_node:
-            left_node_mem_total += int(memory_status[i])
-        if left_node_mem_total > used_mem_total:
-            test.fail("nodes memory usage not expected.")
-
-    def format_affinity_str(cpu_list):
-        """
-        Format affinity str
-
-        :param cpu_list: list of cpu number
-        :return: cpu affinity string
-        """
-        cmd = "lscpu | grep '^CPU(s):'"
-        ret = process.run(cmd, shell=True)
-        cpu_num = int(ret.stdout_text.split(':')[1].strip())
-        cpu_affinity_str = ""
-        for i in range(cpu_num):
-            if i in cpu_list:
-                cpu_affinity_str += "y"
-            else:
-                cpu_affinity_str += "-"
-        return cpu_affinity_str
-
-    def cpu_affinity_check(cpuset=None, node=None):
-        """
-        Check vcpuinfo cpu affinity
-
-        :param cpuset: cpuset list
-        :param node: node number list
-        """
-        result = virsh.vcpuinfo(vm_name, debug=True)
-        output = result.stdout.strip().splitlines()[-1]
-        cpu_affinity = output.split(":")[-1].strip()
-        if node:
-            tmp_list = []
-            for node_num in node:
-                host_node = utils_misc.NumaNode(i=node_num + 1)
-                logging.debug("node %s cpu list is %s" %
-                              (node_num, host_node.cpus))
-                tmp_list += host_node.cpus
-            cpu_list = [int(i) for i in tmp_list]
-        if cpuset:
-            cpu_list = cpuset
-        ret = format_affinity_str(cpu_list)
-        logging.debug("expect cpu affinity is %s", ret)
-        if cpu_affinity != ret:
-            test.fail("vcpuinfo cpu affinity not expected")
-
-    def numa_mode_check(mode_nodeset):
-        """
-        when the mode = 'preferred' or 'interleave', it is better to check
-        numa_maps.
-        """
-        vm_pid = vm.get_pid()
-        numa_map = '/proc/%s/numa_maps' % vm_pid
-        # Open a file
-        with open(numa_map) as file:
-            for line in file.readlines():
-                if line.split()[1] != mode_nodeset:
-                    test.fail("numa node and nodeset %s is "
-                              "not expected" % mode_nodeset)
-
     vcpu_placement = params.get("vcpu_placement")
     vcpu_cpuset = params.get("vcpu_cpuset")
     bug_url = params.get("bug_url", "")
@@ -119,6 +168,7 @@ def run(test, params, env):
     # Get host numa node list
     host_numa_node = utils_misc.NumaInfo()
     node_list = host_numa_node.online_nodes_withmem
+
     logging.debug("host node list is %s", " ".join(map(str, node_list)))
 
     # Prepare numatune memory parameter dict
@@ -144,34 +194,7 @@ def run(test, params, env):
         except (KeyError, IndexError):
             pass
 
-    # Prepare libvirtd session with log level as 1
-    config_path = os.path.join(data_dir.get_tmp_dir(), "virt-test.conf")
-    open(config_path, 'a').close()
-    config = utils_config.LibvirtdConfig(config_path)
-    config.log_level = 1
-    arg_str = "--config %s" % config_path
-    numad_reg = ".*numad"
-    libvirtd = utils_libvirtd.LibvirtdSession(logging_handler=_logger,
-                                              logging_pattern=numad_reg)
-
     try:
-        libvirtd.start(arg_str=arg_str)
-        # As libvirtd start as session use root, need stop virtlogd service
-        # and start it as daemon to fix selinux denial
-        try:
-            path.find_command('virtlogd')
-            process.run("service virtlogd stop", ignore_status=True)
-            process.run("virtlogd -d")
-        except path.CmdNotFoundError:
-            pass
-
-        # Allow for more times to libvirtd restarted successfully.
-        ret = utils_misc.wait_for(lambda: libvirtd.is_working(),
-                                  timeout=240,
-                                  step=1)
-        if not ret:
-            test.fail("Libvirtd hang after restarted")
-
         # Get host cpu list
         tmp_list = []
         for node_num in node_list:
@@ -199,6 +222,7 @@ def run(test, params, env):
                             test.cancel("nodeset %s out of range" % numa_memory['nodeset'])
                         else:
                             numa_memory['nodeset'] = node_list[:nodes_size]
+                            logging.debug("Update the numa memory nodeset to '%s'", node_list[:nodes_size])
 
         if vcpu_cpuset:
             pre_cpuset = cpu.cpus_parser(vcpu_cpuset)
@@ -221,8 +245,6 @@ def run(test, params, env):
 
         vmxml = libvirt_xml.VMXML.new_from_dumpxml(vm_name)
         vmxml.numa_memory = numa_memory
-        vcpu_num = vmxml.vcpu
-        max_mem = vmxml.max_mem
         if vmxml.xmltreefile.find('cputune'):
             vmxml.xmltreefile.remove_by_xpath('/cputune')
         else:
@@ -233,11 +255,10 @@ def run(test, params, env):
             vmxml.cpuset = vcpu_cpuset
         logging.debug("vm xml is %s", vmxml)
         vmxml.sync()
-        numad_cmd_opt = "-w %s:%s" % (vcpu_num, max_mem // 1024)
 
         try:
             vm.start()
-            vm.wait_for_login()
+            vm.wait_for_login().close()
             vmxml_new = libvirt_xml.VMXML.new_from_dumpxml(vm_name)
             numa_memory_new = vmxml_new.numa_memory
             logging.debug("Current memory config dict is %s" % numa_memory_new)
@@ -286,7 +307,7 @@ def run(test, params, env):
             for i in total_cpu:
                 if int(i) not in pre_cpuset:
                     test.fail("cpu %s is not expected" % i)
-            cpu_affinity_check(cpuset=pre_cpuset)
+            cpu_affinity_check(test, vm_name, cpuset=pre_cpuset)
         if numa_memory.get('nodeset'):
             # If there are inconsistent node numbers on host,
             # convert it into sequence number so that it can be used
@@ -294,53 +315,20 @@ def run(test, params, env):
             if numa_memory.get('mode') == 'strict':
                 left_node = [node_list.index(i) for i in node_list if i not in used_node]
                 used_node = [node_list.index(i) for i in used_node]
-                mem_compare(used_node, left_node)
+                mem_compare(test, used_node, left_node, memory_status=memory_status)
             elif numa_memory.get('mode') == 'preferred':
                 mode_nodeset = 'prefer:' + numa_memory.get('nodeset')
-                numa_mode_check(mode_nodeset)
+                numa_mode_check(test, vm, mode_nodeset)
             else:
                 mode_nodeset = numa_memory.get('mode') + ':' + numa_memory.get('nodeset')
-                numa_mode_check(mode_nodeset)
-        logging.debug("numad log list is %s", numad_log)
+                numa_mode_check(test, vm, mode_nodeset)
+
         if vcpu_placement == 'auto' or numa_memory.get('placement') == 'auto':
-            if not numad_log:
-                test.fail("numad usage not found in libvirtd log")
-            if numad_log[0].split("numad ")[-1] != numad_cmd_opt:
-                logging.warning('numa log:\n%s\n' % numad_log[0].split("numad ")[-1])
-                logging.warning('numa cmd opt:\n%s\n' % numad_cmd_opt)
-                test.fail("numad command not expected in log")
-            numad_ret = numad_log[1].split("numad: ")[-1]
-            numad_node = cpu.cpus_parser(numad_ret)
-            left_node = [node_list.index(i) for i in node_list if i not in numad_node]
-            numad_node_seq = [node_list.index(i) for i in numad_node]
-            logging.debug("numad nodes are %s", numad_node)
-            if numa_memory.get('placement') == 'auto':
-                if numa_memory.get('mode') == 'strict':
-                    mem_compare(numad_node_seq, left_node)
-                elif numa_memory.get('mode') == 'preferred':
-                    mode_nodeset = 'prefer:' + numad_ret
-                    numa_mode_check(mode_nodeset)
-                else:
-                    mode_nodeset = numa_memory.get('mode') + ':' + numad_ret
-                    numa_mode_check(mode_nodeset)
-            if vcpu_placement == 'auto':
-                for i in left_node:
-                    if qemu_cpu[i]:
-                        test.fail("cpu usage in node %s is not expected" % i)
-                cpu_affinity_check(node=numad_node)
+            verify_numa_for_auto_replacement(test, params, vmxml,
+                                             node_list, qemu_cpu, vm,
+                                             memory_status=memory_status)
 
     finally:
-        try:
-            path.find_command('virtlogd')
-            process.run('pkill virtlogd', ignore_status=True)
-            process.run('systemctl restart virtlogd.socket', ignore_status=True)
-        except path.CmdNotFoundError:
-            pass
-        libvirtd.exit()
-        if config_path:
-            config.restore()
-            if os.path.exists(config_path):
-                os.remove(config_path)
         if vm.is_alive():
             vm.destroy(gracefully=False)
         backup_xml.sync()


### PR DESCRIPTION
Orignal codes use LibvirtdSession to start daemon in foreground which
does have problem on modular daemon mode. This is to change to use
backgroupd daemon start as well as changing the log message verifying.

depend on https://github.com/avocado-framework/avocado-vt/pull/3386
Signed-off-by: Dan Zheng <dzheng@redhat.com>
