### PR TITLE
update file after rename utils_secret.py to libvirt_secret.py

### DIFF
--- a/libvirt/tests/src/backingchain/virtual_disks_snapshot_blockpull.py
+++ b/libvirt/tests/src/backingchain/virtual_disks_snapshot_blockpull.py
@@ -10,13 +10,13 @@ from virttest import virt_vm
 from virttest import virsh
 
 from virttest import utils_disk
-from virttest import utils_secret
 
 
 from virttest.utils_test import libvirt
 
 from virttest.utils_libvirt import libvirt_disk
 from virttest.utils_libvirt import libvirt_ceph_utils
+from virttest.utils_libvirt import libvirt_secret
 
 from virttest.utils_nbd import NbdExport
 
@@ -346,7 +346,7 @@ def run(test, params, env):
     # Back up xml file.
     vmxml_backup = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     try:
-        utils_secret.clean_up_secrets()
+        libvirt_secret.clean_up_secrets()
 
         # Setup backend storage
         if backend_storage_type == "iscsi":
@@ -408,7 +408,7 @@ def run(test, params, env):
     finally:
         # Recover VM.
         libvirt.clean_up_snapshots(vm_name, domxml=vmxml_backup)
-        utils_secret.clean_up_secrets()
+        libvirt_secret.clean_up_secrets()
         if vm.is_alive():
             vm.destroy(gracefully=False)
         vmxml_backup.sync()

--- a/libvirt/tests/src/embedded_qemu/embedded_qemu.py
+++ b/libvirt/tests/src/embedded_qemu/embedded_qemu.py
@@ -7,9 +7,9 @@ from avocado.utils import process
 
 from virttest import virsh
 from virttest import utils_misc
-from virttest import utils_secret
-from virttest.utils_test import libvirt
 from virttest.utils_libvirt import libvirt_embedded_qemu
+from virttest.utils_libvirt import libvirt_secret
+from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.disk import Disk
 
@@ -110,7 +110,7 @@ def run(test, params, env):
         if expected_secret:
             libvirt.create_local_disk(disk_type="file", extra=extra_luks_parameter,
                                       path=img_path, size=int(img_cap), disk_format=img_format)
-            utils_secret.clean_up_secrets()
+            libvirt_secret.clean_up_secrets()
             sec_params = {"sec_usage": "volume",
                           "sec_volume": img_path,
                           "sec_desc": "Secret for volume."
@@ -158,7 +158,7 @@ def run(test, params, env):
             test.fail("process did not exit successfully")
         virt_qemu_run.exit()
         process.run('pkill -9 qemu-kvm', ignore_status=True, shell=True)
-        utils_secret.clean_up_secrets()
+        libvirt_secret.clean_up_secrets()
         if os.path.exists(secret_value_file):
             os.remove(secret_value_file)
         if os.path.exists(secret_file):

--- a/libvirt/tests/src/incremental_backup/incremental_backup_event_monitor.py
+++ b/libvirt/tests/src/incremental_backup/incremental_backup_event_monitor.py
@@ -7,11 +7,11 @@ from virttest import virsh
 from virttest import data_dir
 from virttest import utils_disk
 from virttest import utils_backup
-from virttest import utils_secret
 from virttest import utils_misc
 from virttest import xml_utils
 from virttest import libvirt_version
 from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_secret
 from virttest.utils_test import libvirt
 
 
@@ -105,7 +105,7 @@ def run(test, params, env):
 
         # Prepare libvirt secret
         if scratch_luks_encrypted:
-            utils_secret.clean_up_secrets()
+            libvirt_secret.clean_up_secrets()
             luks_secret_uuid = libvirt.create_secret(params)
             virsh.secret_set_value(luks_secret_uuid, luks_passphrase,
                                    encode=True, debug=True)

--- a/libvirt/tests/src/incremental_backup/incremental_backup_pull_mode.py
+++ b/libvirt/tests/src/incremental_backup/incremental_backup_pull_mode.py
@@ -12,12 +12,12 @@ from virttest import utils_backup
 from virttest import utils_disk
 from virttest import utils_libvirtd
 from virttest import utils_misc
-from virttest import utils_secret
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
-from virttest.utils_test import libvirt
 from virttest.utils_config import LibvirtQemuConfig
 from virttest.utils_conn import TLSConnection
+from virttest.utils_libvirt import libvirt_secret
+from virttest.utils_test import libvirt
 
 
 # Using as lower capital is not the best way to do, but this is just a
@@ -136,7 +136,7 @@ def run(test, params, env):
 
         # Prepare libvirt secret
         if scratch_luks_encrypted:
-            utils_secret.clean_up_secrets()
+            libvirt_secret.clean_up_secrets()
             luks_secret_uuid = libvirt.create_secret(params)
             virsh.secret_set_value(luks_secret_uuid, luks_passphrase,
                                    encode=True, debug=True)

--- a/libvirt/tests/src/migration/migrate_options_shared.py
+++ b/libvirt/tests/src/migration/migrate_options_shared.py
@@ -27,12 +27,12 @@ from virttest import libvirt_remote
 from virttest import remote
 from virttest import utils_package
 from virttest import utils_iptables
-from virttest import utils_secret
 from virttest import utils_conn
 from virttest import utils_config
 from virttest import xml_utils
 from virttest import migration
 
+from virttest.utils_libvirt import libvirt_secret
 from virttest.utils_iptables import Iptables
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
@@ -1227,7 +1227,7 @@ def run(test, params, env):
                                  "sec_desc": "sample vTPM secret",
                                  "sec_usage": "vtpm",
                                  "sec_name": "VTPM_example"}
-                utils_secret.clean_up_secrets()
+                libvirt_secret.clean_up_secrets()
                 tpm_sec_uuid = libvirt.create_secret(auth_sec_dict)
                 logging.debug("tpm sec uuid on source: %s", tpm_sec_uuid)
                 tpm_args.update({"encryption_secret": tpm_sec_uuid})
@@ -1237,7 +1237,7 @@ def run(test, params, env):
                                            encode=True, debug=True)
                 if not remote_virsh_session:
                     remote_virsh_session = virsh.VirshPersistent(**remote_virsh_dargs)
-                utils_secret.clean_up_secrets(remote_virsh_session)
+                libvirt_secret.clean_up_secrets(remote_virsh_session)
                 logging.debug("create secret on target")
                 auth_sec_dict.update({"sec_uuid": tpm_sec_uuid})
                 dest_tmp_sec_uuid = libvirt.create_secret(auth_sec_dict,

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
@@ -19,10 +19,10 @@ from virttest import virsh
 from virttest import qemu_storage
 from virttest import data_dir
 from virttest import utils_misc
-from virttest import utils_secret
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import snapshot_xml
 from virttest.utils_test import libvirt as utl
+from virttest.utils_libvirt import libvirt_secret
 
 from virttest.libvirt_xml.devices.disk import Disk
 
@@ -591,7 +591,7 @@ def run(test, params, env):
         tmp_file += dest_extension
         if not dest_path:
             if enable_iscsi_auth:
-                utils_secret.clean_up_secrets()
+                libvirt_secret.clean_up_secrets()
                 setup_auth_enabled_iscsi_disk(vm, params)
                 dest_path = os.path.join(tmp_dir, tmp_file)
             elif with_blockdev:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy_xml.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy_xml.py
@@ -9,8 +9,8 @@ from virttest import virsh
 from virttest import utils_package
 from virttest import ceph
 from virttest import utils_disk
-from virttest import utils_secret
 
+from virttest.utils_libvirt import libvirt_secret
 from virttest.utils_test import libvirt
 from virttest.utils_nbd import NbdExport
 
@@ -99,7 +99,7 @@ def run(test, params, env):
     disks_img = []
     try:
         # Clean up dirty secrets in test environments if there are.
-        utils_secret.clean_up_secrets()
+        libvirt_secret.clean_up_secrets()
         # Setup backend storage
         if backend_storage_type == "file":
             image_filename = params.get("image_filename", "raw.img")

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domblkthreshold.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domblkthreshold.py
@@ -19,13 +19,12 @@ from virttest import libvirt_storage
 
 from virttest.utils_test import libvirt
 from virttest.utils_nbd import NbdExport
+from virttest.utils_libvirt import libvirt_secret
 
 from virttest.libvirt_xml import vm_xml, vol_xml, xcepts
 from virttest.libvirt_xml.devices.disk import Disk
 
 from virttest import libvirt_version
-from virttest import utils_secret
-
 
 # Using as lower capital is not the best way to do, but this is just a
 # workaround to avoid changing the entire file.
@@ -246,7 +245,7 @@ def run(test, params, env):
     libvirt_version.is_libvirt_feature_supported(params)
     try:
         # Clean up dirty secrets in test environments if there are.
-        utils_secret.clean_up_secrets()
+        libvirt_secret.clean_up_secrets()
         # Setup backend storage
         if backend_storage_type == "file":
             image_filename = params.get("image_filename", "raw.img")

--- a/libvirt/tests/src/virt_cmd/virt_xml_validate.py
+++ b/libvirt/tests/src/virt_cmd/virt_xml_validate.py
@@ -8,7 +8,7 @@ from avocado.core import exceptions
 
 from virttest import virsh
 from virttest import data_dir
-from virttest import utils_secret
+from virttest.utils_libvirt import libvirt_secret
 from virttest.utils_test import libvirt
 
 
@@ -149,7 +149,7 @@ def secret_validate(test, secret_volume, file=None, **virsh_dargs):
     Test for schema secret
     """
     # Clean up dirty secrets in test environments if there are.
-    utils_secret.clean_up_secrets()
+    libvirt_secret.clean_up_secrets()
     sec_params = {"sec_usage": "volume",
                   "sec_volume": secret_volume,
                   "sec_desc": "Test for schema secret."
@@ -245,6 +245,6 @@ def run(test, params, env):
             test.fail("xml fails to validate\n"
                       "Detail: %s." % cmd_result)
     finally:
-        utils_secret.clean_up_secrets()
+        libvirt_secret.clean_up_secrets()
         if secret_volume and os.path.isfile(secret_volume):
             os.remove(secret_volume)

--- a/libvirt/tests/src/virtual_disks/virtual_disks_nbd.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_nbd.py
@@ -10,10 +10,10 @@ from virttest import remote
 from virttest import virt_vm
 from virttest import virsh
 from virttest import utils_disk
-from virttest import utils_secret
 from virttest import libvirt_version
 from virttest.utils_test import libvirt
 from virttest.utils_nbd import NbdExport
+from virttest.utils_libvirt import libvirt_secret
 
 from virttest.libvirt_xml import vm_xml, xcepts
 from virttest.libvirt_xml.devices.disk import Disk
@@ -200,7 +200,7 @@ def run(test, params, env):
             # this feature is enabled after libvirt 6.6.0
             if not libvirt_version.version_compare(6, 6, 0):
                 test.cancel("current libvirt version doesn't support client private key encryption")
-            utils_secret.clean_up_secrets()
+            libvirt_secret.clean_up_secrets()
             private_key_sec_uuid = libvirt.create_secret(params)
             logging.debug("A secret created with uuid = '%s'", private_key_sec_uuid)
             private_key_sec_passwd = params.get("private_key_password", "redhat")
@@ -288,7 +288,7 @@ def run(test, params, env):
             libvirt.check_exit_status(result, status_error)
     finally:
         if enable_private_key_encryption:
-            utils_secret.clean_up_secrets()
+            libvirt_secret.clean_up_secrets()
         # Clean up backend storage and TLS
         try:
             if nbd:


### PR DESCRIPTION
  The functions in utils_secret.py are implemented with virsh command. This kind of functions should be put into utils_libvirt/libvirt_secret.py. So we decide to rename utils_secret.py to libvirt_secret.py
 **Depend on** 
https://github.com/avocado-framework/avocado-vt/pull/3368
