### PR TITLE
numa_memory_spread: use first numa node with mem

### DIFF
--- a/libvirt/tests/cfg/numa/numa_memory_spread.cfg
+++ b/libvirt/tests/cfg/numa/numa_memory_spread.cfg
@@ -2,7 +2,6 @@
     type = numa_memory_spread
     start_vm = "no"
     memory_mode = "restrictive"
-    memory_nodeset = '0'
     variants:
         - positive_test:
             status_error = "no"


### PR DESCRIPTION
Original codes use numa node 0 to test, but on some numa hosts,
node 0 has no memory, so the vm will fail to start with it.
This is a fix to use the first available numa node with memory for
testing.

Signed-off-by: Dan Zheng <dzheng@redhat.com>
