### PR TITLE
virtual_interface: Add 2 cases to check update-device

### DIFF
--- a/libvirt/tests/cfg/virtual_interface/interface_update_device_offline_domain.cfg
+++ b/libvirt/tests/cfg/virtual_interface/interface_update_device_offline_domain.cfg
@@ -1,0 +1,22 @@
+- iface.update_device.offline_domain:
+    type = interface_update_device_offline_domain
+    start_vm = no
+    iface_dict = {'link_state':'down'}
+
+    variants test_scenario:
+        - opts_affect_running_vm:
+            status_error = "yes"
+            error_msg = "domain is not running"
+            variants virsh_opt:
+                - live:
+                - live_config:
+        - opts_affect_offline_vm:
+            variants virsh_opt:
+                - config:
+                - current:
+                - persistent:
+        - current_exclusive:
+            status_error = "yes"
+            error_msg = "exclusive"
+            variants virsh_opt:
+                - persistent_current:

--- a/libvirt/tests/cfg/virtual_interface/interface_update_device_running_domain.cfg
+++ b/libvirt/tests/cfg/virtual_interface/interface_update_device_running_domain.cfg
@@ -1,0 +1,38 @@
+- iface.update_device.running_domain:
+    type = interface_update_device_running_domain
+    start_vm = "yes"
+
+    variants test_group:
+        - device_exists:
+            iface_dict = {'link_state':'down'}
+            variants:
+                - opts_affect_running_vm:
+                    expr_active_xml_changes = "yes"
+                    variants virsh_opt:
+                        - live:
+                        - current:
+                - opts_affect_offline_vm:
+                    expr_inactive_xml_changes = "yes"
+                    variants virsh_opt:
+                        - config:
+                - opts_affect_both_running_offline_vm:
+                    expr_active_xml_changes = "yes"
+                    expr_inactive_xml_changes = "yes"
+                    variants virsh_opt:
+                        - live_config:
+                        - persistent:
+                - current_exclusive:
+                    status_error = "yes"
+                    error_msg = "exclusive"
+                    variants virsh_opt:
+                        - current_live:
+        - no_matching_device:
+            status_error = "yes"
+            iface_dict = {'link_state':'down', 'alias': {'name': 'net3'}}
+            variants virsh_opt:
+                - no_option:
+                - live:
+                - persistent:
+                - config:
+                    status_error = "no"
+                    expr_inactive_xml_changes = "yes"

--- a/libvirt/tests/src/virtual_interface/interface_update_device_offline_domain.py
+++ b/libvirt/tests/src/virtual_interface/interface_update_device_offline_domain.py
@@ -1,0 +1,29 @@
+from virttest.libvirt_xml import vm_xml
+
+from provider.interface import interface_base
+from provider.interface import check_points
+
+
+def run(test, params, env):
+    """
+    Update an interface by update-device with different options on an offline
+    domain.
+    """
+    # Variable assignment
+    iface_dict = eval(params.get('iface_dict', '{}'))
+    status_error = "yes" == params.get("status_error", "no")
+
+    vm_name = params.get('main_vm')
+    vm = env.get_vm(vm_name)
+
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    backup_vmxml = vmxml.copy()
+
+    try:
+        # Execute test
+        interface_base.update_iface_device(vm, params)
+        vmxml_inactive = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+        check_points.comp_interface_xml(
+            vmxml_inactive, iface_dict, status_error)
+    finally:
+        backup_vmxml.sync()

--- a/libvirt/tests/src/virtual_interface/interface_update_device_running_domain.py
+++ b/libvirt/tests/src/virtual_interface/interface_update_device_running_domain.py
@@ -1,0 +1,30 @@
+from virttest.libvirt_xml import vm_xml
+
+from provider.interface import interface_base
+from provider.interface import check_points
+
+
+def run(test, params, env):
+    """
+    Update an interface by update-device with different options on a running
+    domain.
+    """
+    # Variable assignment
+    iface_dict = eval(params.get('iface_dict', '{}'))
+    vm_name = params.get('main_vm')
+    vm = env.get_vm(vm_name)
+
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    backup_vmxml = vmxml.copy()
+
+    try:
+        # Execute test
+        interface_base.update_iface_device(vm, params)
+        if params.get('expr_active_xml_changes', 'no') == "yes":
+            vmxml_active = vm_xml.VMXML.new_from_dumpxml(vm_name)
+            check_points.comp_interface_xml(vmxml_active, iface_dict)
+        if params.get('expr_inactive_xml_changes', 'no') == "yes":
+            vmxml_active = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+            check_points.comp_interface_xml(vmxml_active, iface_dict)
+    finally:
+        backup_vmxml.sync()

--- a/provider/interface/check_points.py
+++ b/provider/interface/check_points.py
@@ -74,3 +74,21 @@ def check_vm_iface_queues(vm_session, params):
         raise exceptions.TestFail("Incorrect combined number in current status!"
                                   "It should be %d but got %s."
                                   % (current_exp, current_combined))
+
+
+def comp_interface_xml(vmxml, iface_dict, status_error=False):
+    """
+    Compare interface xml
+
+    :param vmxml: VM xml
+    :param iface_dict: Interface parameters dict
+    :param status_error: True if expects mismatch, otherwise False
+    :raise: TestFail if comparison fails
+    """
+    iface = vmxml.get_devices('interface')[0]
+    cur_iface = iface.fetch_attrs()
+    for key, val in iface_dict.items():
+        if key != 'alias' and (cur_iface.get(key) == val) == status_error:
+            raise exceptions.TestFail('Interface xml compare fails! The value '
+                                      'of %s should be %s, but got %s.'
+                                      % (key, cur_iface.get(key), val))


### PR DESCRIPTION
This PR adds:
1. RHEL-286748 - Update an interface by update-device with different options on
    inactive domain
2. RHEL-286741 - Update an interface by update-device with different options on
    running domain

Signed-off-by: Yingshun Cui <yicui@redhat.com>

**Test results:**
```
 (01/16) type_specific.io-github-autotest-libvirt.iface.update_device.running_domain.device_exists.opts_affect_running_vm.live: PASS (7.99 s)
 (02/16) type_specific.io-github-autotest-libvirt.iface.update_device.running_domain.device_exists.opts_affect_running_vm.current: PASS (8.08 s)
 (03/16) type_specific.io-github-autotest-libvirt.iface.update_device.running_domain.device_exists.opts_affect_offline_vm.config: PASS (12.69 s)
 (04/16) type_specific.io-github-autotest-libvirt.iface.update_device.running_domain.device_exists.opts_affect_both_running_offline_vm.live_config: PASS (8.23 s)
 (05/16) type_specific.io-github-autotest-libvirt.iface.update_device.running_domain.device_exists.opts_affect_both_running_offline_vm.persistent: PASS (8.27 s)
 (06/16) type_specific.io-github-autotest-libvirt.iface.update_device.running_domain.device_exists.current_exclusive.current_live: PASS (8.01 s)
 (07/16) type_specific.io-github-autotest-libvirt.iface.update_device.running_domain.no_matching_device.no_option: PASS (8.31 s)
 (08/16) type_specific.io-github-autotest-libvirt.iface.update_device.running_domain.no_matching_device.live: PASS (8.20 s)
 (09/16) type_specific.io-github-autotest-libvirt.iface.update_device.running_domain.no_matching_device.persistent: PASS (8.17 s)
 (10/16) type_specific.io-github-autotest-libvirt.iface.update_device.running_domain.no_matching_device.config: PASS (8.06 s)
 (11/16) type_specific.io-github-autotest-libvirt.iface.update_device.offline_domain.opts_affect_running_vm.live: PASS (6.84 s)
 (12/16) type_specific.io-github-autotest-libvirt.iface.update_device.offline_domain.opts_affect_running_vm.live_config: PASS (7.12 s)
 (13/16) type_specific.io-github-autotest-libvirt.iface.update_device.offline_domain.opts_affect_offline_vm.config: PASS (7.10 s)
 (14/16) type_specific.io-github-autotest-libvirt.iface.update_device.offline_domain.opts_affect_offline_vm.current: PASS (7.11 s)
 (15/16) type_specific.io-github-autotest-libvirt.iface.update_device.offline_domain.opts_affect_offline_vm.persistent: PASS (7.01 s)
 (16/16) type_specific.io-github-autotest-libvirt.iface.update_device.offline_domain.current_exclusive.persistent_current: PASS (7.06 s)

```