### PR TITLE
v2v: enable crypto policy to LEGACY for old guests

### DIFF
--- a/v2v/tests/cfg/convert_from_file.cfg
+++ b/v2v/tests/cfg/convert_from_file.cfg
@@ -76,6 +76,7 @@
                                     input_file = '${ova_copy_dir}/OVA_TAR_FILE_V2V_EXAMPLE'
                                     checkpoint = permission
                                 - rhel6_5:
+                                    enable_legacy_policy = yes
                                     ova_dir = OVA_DIR_RHEL65_V2V_EXAMPLE
                                     input_file = ${ova_copy_dir}/OVA_FILE_RHEL65_V2V_EXAMPLE
                                 - linux:
@@ -98,6 +99,7 @@
                             ova_dir = 'OVA_DIR_SPECIAL_V2V_EXAMPLE'
                             variants:
                                 - parent_ctrl:
+                                    enable_legacy_policy = yes
                                     checkpoint = "parent_ctrl"
                                     input_file = "${ova_copy_dir}/OVA_FILE_BUG_1167302_V2V_EXAMPLE"
                                 - win2008r2_ostk:
@@ -141,6 +143,7 @@
                                     ova_file = OVA_FILE_WIN2019_AWS_V2V_EXAMPLE
                                     os_version = OS_VERSION_WIN2019_AWS_V2V_EXAMPLE
                                 - ec2:
+                                    enable_legacy_policy = yes
                                     ova_file = OVA_FILE_EC2_V2V_EXAMPLE
                                 - Eaton:
                                     ova_file = OVA_FILE_EATON_V2V_EXAMPLE
@@ -167,6 +170,7 @@
                                     only esx_67
                                     main_vm = 'VM_NAME_RHEL7_V2V_EXAMPLE'
                                 - latest6:
+                                    enable_legacy_policy = yes
                                     only esx_67
                                     main_vm = 'VM_NAME_RHEL6_V2V_EXAMPLE'
                                 - regular_user_sudo:
@@ -224,6 +228,7 @@
                                     only esx_67
                                     main_vm = 'VM_NAME_RHEL7_V2V_EXAMPLE'
                                 - latest6:
+                                    enable_legacy_policy = yes
                                     only esx_67
                                     main_vm = 'VM_NAME_RHEL6_V2V_EXAMPLE'
 

--- a/v2v/tests/cfg/convert_vm_to_libvirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_libvirt.cfg
@@ -48,8 +48,10 @@
                     os_version = "LATEST7"
                 - latest6:
                     os_version = "LATEST6"
+                    enable_legacy_policy = yes
                 - 5_11:
                     os_version = "rhel5.11"
+                    enable_legacy_policy = yes
                 - debian:
                     only source_esx.esx_67, source_esx.esx_70
                     #os_short_id = "DEBIAN_SHORT_ID"
@@ -129,6 +131,7 @@
             no latest9
             hostname = ${xen_hostname}
             xen_pwd = "XEN_PASSWORD"
+            enable_legacy_policy = yes
             variants:
                 - pv:
                     no latest8

--- a/v2v/tests/cfg/convert_vm_to_ovirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_ovirt.cfg
@@ -82,8 +82,10 @@
                     os_version = "LATEST7"
                 - latest6:
                     os_version = "LATEST6"
+                    enable_legacy_policy = yes
                 - 5_11:
                     os_version = "rhel5.11"
+                    enable_legacy_policy = yes
                 - debian:
                     only source_esx.esx_67, source_esx.esx_70
                     os_version = "DEBIAN_VERSION"
@@ -158,6 +160,7 @@
             no latest9
             hostname = ${xen_hostname}
             xen_pwd = "XEN_PASSWORD"
+            enable_legacy_policy = yes
             variants:
                 - pv:
                     no latest8

--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -273,7 +273,7 @@
         - modprobe:
             only esx_60
             main_vm = VM_NAME_RHEL5_V2V_EXAMPLE
-            enable_legacy_crypto_policies = yes
+            enable_legacy_policy = yes
             checkpoint = modprobe
             cfg_content = 'alias eth0 virtio_net'
         - passthru:
@@ -341,6 +341,7 @@
             main_vm = VM_NAME_RESUME_RHEL7_V2V_EXAMPLE
         - resume_rhel6:
             only esx_67
+            enable_legacy_policy = yes
             os_version = OS_VERSION_RESUME_RHEL6_V2V_EXAMPLE
             checkpoint = resume_swap
             main_vm = VM_NAME_RESUME_RHEL6_V2V_EXAMPLE
@@ -353,7 +354,7 @@
             only esx_67
             main_vm = 'VM_NAME_ESX_EPOCH_V2V_EXAMPLE'
             version_required = "[libguestfs-1.40.2-1,)"
-            enable_legacy_crypto_policies = yes
+            enable_legacy_policy = yes
         - without_file_architecture:
             only esx_67
             main_vm = 'VM_NAME_NO_FILE_ARCHITECTURE_V2V_EXAMPLE'
@@ -423,6 +424,7 @@
             variants:
                 - rhel6:
                   only esx_67
+                  enable_legacy_policy = yes
                   qa_path = 'linux/el6'
                   qa_url = QEMU_GUEST_AGENT_EL6_DOWNLOAD_URL_V2V_EXAMPLE
                   main_vm = VM_NAME_RHEL6_V2V_EXAMPLE
@@ -585,6 +587,7 @@
             main_vm = VM_NAME_ESX70_RHEL8_V2V_EXAMPLE
         - buggy_selinux_context:
             only esx_67
+            enable_legacy_policy = yes
             main_vm = VM_NAME_ESX_BUGGY_SELINUX_CONTEXT_V2V_EXAMPLE
         - admin_account:
             only esx_70

--- a/v2v/tests/cfg/specific_kvm.cfg
+++ b/v2v/tests/cfg/specific_kvm.cfg
@@ -62,6 +62,7 @@
         - xen:
             vms = ""
             only source_xen
+            enable_legacy_policy = yes
             xen_host_user = 'root'
             xen_host_passwd = 'XEN_PASSWORD'
             remote_host = ${xen_hostname}
@@ -148,6 +149,7 @@
             main_vm = 'VM_BOGUS_KERNEL_V2V_EXAMPLE'
             msg_content = 'kernel [\s\S]* in bootloader, as it does not exist'
             expect_msg = 'yes'
+            enable_legacy_policy = yes
         - unclean_fs:
             only source_kvm
             checkpoint = 'unclean_fs'

--- a/v2v/tests/src/convert_from_file.py
+++ b/v2v/tests/src/convert_from_file.py
@@ -13,7 +13,10 @@ from virttest import utils_sasl
 from virttest import data_dir
 from virttest import ppm_utils
 from virttest import remote
+
+from virttest.utils_conn import update_crypto_policy
 from virttest.utils_test import libvirt
+from virttest.utils_v2v import params_get
 
 from provider.v2v_vmcheck_helper import VMChecker
 from provider.v2v_vmcheck_helper import check_json_output
@@ -35,6 +38,7 @@ def run(test, params, env):
     # name
     vm_name = params['original_vm_name'] = params.get('main_vm', 'EXAMPLE')
     unprivileged_user = params.get('unprivileged_user')
+    enable_legacy_policy = params_get(params, "enable_legacy_policy") == 'yes'
     target = params.get('target')
     input_mode = params.get('input_mode')
     input_file = params.get('input_file')
@@ -179,6 +183,8 @@ def run(test, params, env):
                 (len(error_list), error_list))
 
     try:
+        if enable_legacy_policy:
+            update_crypto_policy("LEGACY")
         if checkpoint == 'regular_user_sudo':
             regular_sudo_config = '/etc/sudoers.d/v2v_test'
             with open(regular_sudo_config, 'w') as fd:
@@ -295,3 +301,5 @@ def run(test, params, env):
             process.system("userdel -fr %s" % unprivileged_user)
         if input_mode == 'vmx' and input_transport == 'ssh':
             process.run("killall ssh-agent")
+        if enable_legacy_policy:
+            update_crypto_policy()

--- a/v2v/tests/src/v2v_options.py
+++ b/v2v/tests/src/v2v_options.py
@@ -845,6 +845,9 @@ def run(test, params, env):
             cmd = 'echo "%s" >> ~/.ssh/authorized_keys' % public_key
             process.run(cmd, shell=True)
 
+        if checkpoint == 'length_of_error' and utils_v2v.v2v_supported_option('--wrap'):
+            v2v_options += ' --wrap'
+
         # Running virt-v2v command
         cmd = "%s %s %s %s" % (utils_v2v.V2V_EXEC, input_option,
                                output_option, v2v_options)
@@ -870,9 +873,6 @@ def run(test, params, env):
                 output_func=utils_misc.log_line,
                 output_params=(params['tail_log'],)
             )
-        if checkpoint == 'length_of_error':
-            if utils_v2v.v2v_supported_option('--wrap'):
-                v2v_options += ' --wrap'
 
         cmd_result = process.run(cmd, timeout=v2v_timeout, verbose=True,
                                  ignore_status=True)


### PR DESCRIPTION
There are some changes about SHA1 in recent openssh package, it
blocks the connection to old guest, such as rhel6. A workaround
is enable LEGACY policy in order to connect to those guests.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>