### PR TITLE
Add cases to cover start a guest with luks encrypted image that has 2…

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_luks.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_luks.cfg
@@ -85,7 +85,6 @@
             backend_storage_type = "nfs"
             nfs_image_name = "nfs.img"
         - dir_pool_test:
-            only coldplug
             backend_storage_type = "dir"
             pool_name = "dir_pool"
             pool_target = "/var/lib/libvirt/images/luks"
@@ -139,6 +138,7 @@
             variants:
                 - wrong_password:
                     luks_secret_passwd = "stopword"
+                    no hotplug.device_disk.dir_pool_test
                 - duplicated_encryption:
                     only dir_pool_test..encryption_in_source
                     define_error = "yes"


### PR DESCRIPTION
… encryption elements

start a guest with a volume type luks encrypted image

XX-115486,XX-115485

Signed-off-by: chunfuwen <chwen@redhat.com>

