### PR TITLE
virsh_vol_create_from.py: update the image size to fix scsi/iscsi issue

### DIFF
--- a/libvirt/tests/src/virsh_cmd/volume/virsh_vol_create_from.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_vol_create_from.py
@@ -54,7 +54,7 @@ def run(test, params, env):
 
         pvt = utlv.PoolVolumeTest(test, params)
         pvt.pre_pool(src_pool_name, src_pool_type, src_pool_target,
-                     src_emulated_image, image_size="100M",
+                     src_emulated_image, image_size="60M",
                      pre_disk_vol=["1M"])
 
         if src_pool_type != dest_pool_type:


### PR DESCRIPTION
Fix no large enough free extent in scsi/iscsi pool which caused by https://github.com/autotest/tp-libvirt/pull/4079.

Signed-off-by: Meina Li <meili@redhat.com>
