### PR TITLE
Update reference for mem utils

### DIFF
--- a/libvirt/tests/src/libvirt_mem.py
+++ b/libvirt/tests/src/libvirt_mem.py
@@ -18,18 +18,17 @@ from virttest import utils_libvirtd
 from virttest import utils_misc
 from virttest import utils_config
 from virttest import utils_numeric
-from virttest import utils_hotplug
 from virttest import libvirt_version
 from virttest import virt_vm
 from virttest import data_dir
-from virttest.utils_test import libvirt
+
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import xcepts
+from virttest.utils_libvirt import libvirt_memory
+from virttest.utils_test import libvirt
 from virttest.staging import utils_memory
 from virttest.staging.utils_memory import drop_caches
 from virttest.staging.utils_memory import read_from_numastat
-
-from virttest import libvirt_version
 
 
 # Using as lower capital is not the best way to do, but this is just a
@@ -520,12 +519,12 @@ def run(test, params, env):
                 # If any error excepted, command error status should be
                 # checked in the last time
                 device_alias = "ua-" + str(uuid.uuid4())
-                dev_xml = utils_hotplug.create_mem_xml(tg_size, pg_size,
-                                                       mem_addr, tg_sizeunit,
-                                                       pg_unit, tg_node,
-                                                       node_mask, mem_model,
-                                                       mem_discard,
-                                                       device_alias)
+                dev_xml = libvirt_memory.create_mem_xml(tg_size, pg_size,
+                                                        mem_addr, tg_sizeunit,
+                                                        pg_unit, tg_node,
+                                                        node_mask, mem_model,
+                                                        mem_discard,
+                                                        device_alias)
                 randvar = randvar + 1
                 logging.debug("attaching device count = %s", x)
                 if x == at_times - 1:
@@ -582,10 +581,10 @@ def run(test, params, env):
             process.run('ps -ef|grep qemu', shell=True, verbose=True)
             session = vm.wait_for_login()
             original_mem = vm.get_totalmem_sys()
-            dev_xml = utils_hotplug.create_mem_xml(tg_size, pg_size,
-                                                   mem_addr, tg_sizeunit,
-                                                   pg_unit, tg_node,
-                                                   node_mask, mem_model)
+            dev_xml = libvirt_memory.create_mem_xml(tg_size, pg_size,
+                                                    mem_addr, tg_sizeunit,
+                                                    pg_unit, tg_node,
+                                                    node_mask, mem_model)
             add_device(dev_xml, True)
             mem_after = vm.get_totalmem_sys()
             params['delta'] = mem_after - original_mem
@@ -659,11 +658,11 @@ def run(test, params, env):
         # Detach the memory device
         unplug_failed_with_known_error = False
         if detach_device:
-            dev_xml = utils_hotplug.create_mem_xml(tg_size, pg_size,
-                                                   mem_addr, tg_sizeunit,
-                                                   pg_unit, tg_node,
-                                                   node_mask, mem_model,
-                                                   mem_discard)
+            dev_xml = libvirt_memory.create_mem_xml(tg_size, pg_size,
+                                                    mem_addr, tg_sizeunit,
+                                                    pg_unit, tg_node,
+                                                    node_mask, mem_model,
+                                                    mem_discard)
             for x in xrange(at_times):
                 if not detach_alias:
                     ret = virsh.detach_device(vm_name, dev_xml.xml,

--- a/libvirt/tests/src/memory/memory_discard.py
+++ b/libvirt/tests/src/memory/memory_discard.py
@@ -4,12 +4,12 @@ import time
 
 from virttest import virsh
 from virttest import virt_vm
-from virttest import utils_hotplug
 from virttest import utils_config
 from virttest import utils_misc
 from virttest import utils_libvirtd
 
 from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_memory
 from virttest.utils_test import libvirt
 from virttest.staging import utils_memory
 
@@ -105,7 +105,7 @@ def run(test, params, env):
         """
         Create xml of dimm memory device
         """
-        mem_xml = utils_hotplug.create_mem_xml(
+        mem_xml = libvirt_memory.create_mem_xml(
             pg_size=int(mem_param['source_pagesize']),
             tg_size=mem_param['target_size'],
             tg_sizeunit=mem_param['target_size_unit'],

--- a/libvirt/tests/src/memory/memory_hotplug.py
+++ b/libvirt/tests/src/memory/memory_hotplug.py
@@ -2,13 +2,12 @@ import logging as log
 import os
 import re
 
-from virttest import utils_hotplug
 from virttest import utils_sys
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_libvirt import libvirt_cpu
 from virttest.utils_test import libvirt
-
+from virttest.utils_libvirt import libvirt_memory
 
 # Using as lower capital is not the best way to do, but this is just a
 # workaround to avoid changing the entire file.
@@ -73,7 +72,7 @@ def create_mem_device(params):
         k.replace('mem_device_', ''): v
         for k, v in params.items() if k.startswith('mem_device_')
     }
-    return utils_hotplug.create_mem_xml(**mem_device_params)
+    return libvirt_memory.create_mem_xml(**mem_device_params)
 
 
 def check_event(target_event, event_output):

--- a/libvirt/tests/src/memory/nvdimm.py
+++ b/libvirt/tests/src/memory/nvdimm.py
@@ -7,10 +7,10 @@ from avocado.utils import process
 
 from virttest import libvirt_version
 from virttest import virsh
-from virttest import utils_hotplug
 from virttest import utils_package
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices import memory
+from virttest.utils_libvirt import libvirt_memory
 from virttest.utils_test import libvirt
 
 
@@ -91,7 +91,7 @@ def run(test, params, env):
         """
         Create xml of nvdimm memory device
         """
-        mem_xml = utils_hotplug.create_mem_xml(
+        mem_xml = libvirt_memory.create_mem_xml(
             tg_size=mem_param['target_size'],
             mem_addr={'slot': mem_param['address_slot']},
             tg_sizeunit=mem_param['target_size_unit'],

--- a/libvirt/tests/src/migration/migrate_mem.py
+++ b/libvirt/tests/src/migration/migrate_mem.py
@@ -10,13 +10,12 @@ from virttest import utils_split_daemons
 from virttest import utils_misc
 from virttest import remote
 from virttest import virt_vm
-from virttest import utils_hotplug
 
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_libvirt import libvirt_cpu
 from virttest.utils_test import libvirt
 from virttest.utils_libvirt import libvirt_config
-
+from virttest.utils_libvirt import libvirt_memory
 
 # Using as lower capital is not the best way to do, but this is just a
 # workaround to avoid changing the entire file.
@@ -108,7 +107,7 @@ def run(test, params, env):
 
             dimm_params = {k.replace('memdev_', ''): v
                            for k, v in params.items() if k.startswith('memdev_')}
-            dimm_xml = utils_hotplug.create_mem_xml(**dimm_params)
+            dimm_xml = libvirt_memory.create_mem_xml(**dimm_params)
 
             libvirt.add_vm_device(new_xml, dimm_xml)
             logging.debug(virsh.dumpxml(vm_name))

--- a/libvirt/tests/src/papr_hpt.py
+++ b/libvirt/tests/src/papr_hpt.py
@@ -7,10 +7,10 @@ from avocado.utils import cpu
 from avocado.utils import process
 
 from virttest import virsh
-from virttest import utils_hotplug
 from virttest import utils_libvirtd
 from virttest import utils_misc
 from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_memory
 from virttest.utils_test import libvirt
 from virttest.staging import utils_memory
 
@@ -208,7 +208,7 @@ def run(test, params, env):
                 check_hp_in_vm(session, maxpagesize * 1024)
 
             if resizing == 'enabled':
-                mem_xml = utils_hotplug.create_mem_xml(
+                mem_xml = libvirt_memory.create_mem_xml(
                     tg_size=int(params.get('mem_size', 2048000)),
                     tg_sizeunit=params.get('size_unit', 'KiB'),
                     tg_node=int(params.get('mem_node', 0)),

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
@@ -15,12 +15,12 @@ from virttest import virsh
 from virttest import data_dir
 from virttest import remote
 from virttest import utils_misc
-from virttest import utils_hotplug
 from virttest.libvirt_xml import vm_xml
-from virttest.utils_test import libvirt as utlv
 from virttest.libvirt_xml.devices.interface import Interface
 from virttest.libvirt_xml.devices.panic import Panic
 from virttest.libvirt_xml.devices.watchdog import Watchdog
+from virttest.utils_libvirt import libvirt_memory
+from virttest.utils_test import libvirt as utlv
 
 from xml.dom.minidom import parseString
 
@@ -493,7 +493,7 @@ def run(test, params, env):
                     prepare_vmxml_mem(vmxml)
                     tg_size = params.get("dimm_size")
                     tg_sizeunit = params.get("dimm_unit")
-                    dimm_xml = utils_hotplug.create_mem_xml(tg_size, None, None, tg_sizeunit)
+                    dimm_xml = libvirt_memory.create_mem_xml(tg_size, None, None, tg_sizeunit)
                     virsh.attach_device(dom.name, dimm_xml.xml,
                                         flagstr="--config", **virsh_dargs)
                     vmxml_dimm = vm_xml.VMXML.new_from_dumpxml(dom.name)


### PR DESCRIPTION
Update the reference for memory utils function's new location
Depend on https://github.com/avocado-framework/avocado-vt/pull/3374

Signed-off-by: Dan Zheng <dzheng@redhat.com>
