### PR TITLE
Add case to check nested feature at run-time

### DIFF
--- a/libvirt/tests/cfg/cpu/vcpu_nested.cfg
+++ b/libvirt/tests/cfg/cpu/vcpu_nested.cfg
@@ -10,3 +10,6 @@
                     cpu_old_mode = 'host-model'
                     cpu_new_mode = 'host-passthrough'
                     cmd_in_guest = "stat %s|grep '^Modify: '|cut -d' ' -f2-3"
+                - check_nested_capability:
+                    case = 'check_nested_capability'
+                    cpu_old_mode = 'host-model'


### PR DESCRIPTION
1.Add new case to check whether feature nested virt is enabled at run-time.
2.Add return value of function run_domcap_in_guest as needed.
3.Create separate functions for cases, add descriptions.

Polarion ID:RHEL-150289

Signed-off-by: haonanpan <hpan@redhat.com>
