### PR TITLE
tpm_device: add pcrbank modify scenarios

### DIFF
--- a/libvirt/tests/cfg/virtual_device/tpm_device.cfg
+++ b/libvirt/tests/cfg/virtual_device/tpm_device.cfg
@@ -4,6 +4,7 @@
     loader = "/usr/share/edk2/ovmf/OVMF_CODE.secboot.fd"
     nvram = "/var/lib/libvirt/qemu/nvram/<VM_NAME>_VARS.fd"
     uefi_disk_url = "EXAMPLE_UEFI_DISK_URL"
+    no s390-virtio
     variants:
         - normal_test:
             variants:
@@ -54,6 +55,8 @@
                                     only encrypted
                                     secret_value = 'change'
                                     rm_statefile = 'yes'
+                                - remove_pcrbank:
+                                    remove_pcrbank = 'yes'
                         - restore_vm:
                             vm_operate = 'managedsave'
                         - suspend_resume:
@@ -66,6 +69,8 @@
                         - pcrbank_default:
                             basic:
                                 check_pcrbanks = 'yes'
+                            restart_vm:
+                                no remove_pcrbank
                         - pcrbank_single:
                             only basic
                             only encrypted
@@ -83,9 +88,11 @@
                             only encrypted
                             active_pcr_banks = 'sha256,sha384'
                         - pcrbank_all:
-                            no version_default multi_vms test_suite restart_vm
+                            no version_default multi_vms test_suite
                             plain:
                                 only basic
+                            restart_vm:
+                                only remove_pcrbank
                             active_pcr_banks = 'sha1,sha256,sha384,sha512'
                     variants:
                         - plain:
@@ -173,3 +180,11 @@
                                         - newpw_keepstate:
                                         - newpw_rmstate:
                                             rm_statefile = 'yes'
+                        - pcrbank_test:
+                            backend_version = '2.0'
+                            prepare_secret = 'yes'
+                            variants:
+                                - managedsave_modify:
+                                    active_pcr_banks = 'sha384'
+                                    vm_operate = 'managedsave'
+                                    pcrbank_change = 'sha256'


### PR DESCRIPTION
Add two cases: restart vm with pcrbank removed, modify pcrbank for
managedsaved vm.

Signed-off-by: Yanqiu Zhang <yanqzhan@redhat.com>

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [x] Description of the cases
- [x] Links of libvirt features, libvirt bugs or case IDs
- [x] Test results

## If the PR is bug cases
- [ ] Bug descriptions or bug links
- [ ] Test results

## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
