### PR TITLE
migration: Fix VM login failure

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_with_legacy_guest.cfg
+++ b/libvirt/tests/cfg/migration/migrate_with_legacy_guest.cfg
@@ -49,6 +49,7 @@
                 - rhel6_guest:
                     only virtio_transitional
                     guest_src_url = ${rhel6_url}
+                    set_crypto_policy = "LEGACY"
         - test_disk:
             only q35
             no virtio
@@ -60,6 +61,7 @@
                     only unspecified_model,virtio_transitional
                     guest_src_url = ${rhel6_url}
                     iface_model = "virtio-transitional"
+                    set_crypto_policy = "LEGACY"
             variants:
                 - disk_qcow2:
                     disk_format = "qcow2"
@@ -92,6 +94,7 @@
                     only virtio_transitional
                     guest_src_url = ${rhel6_url}
                     iface_model = "virtio-transitional"
+                    set_crypto_policy = "LEGACY"
                 - @default:
                     no virtio_transitional
         - test_rng:
@@ -105,6 +108,7 @@
                     only virtio_transitional
                     guest_src_url = ${rhel6_url}
                     iface_model = "virtio-transitional"
+                    set_crypto_policy = "LEGACY"
                 - @default:
                     no virtio_transitional
 

--- a/libvirt/tests/src/migration/migrate_with_legacy_guest.py
+++ b/libvirt/tests/src/migration/migrate_with_legacy_guest.py
@@ -70,6 +70,7 @@ def run(test, params, env):
                     'model': iface_model,
                     'del_addr': True,
                     'source': '{"network": "default"}'}
+    set_crypto_policy = params.get("set_crypto_policy")
 
     check_memballoon = "yes" == params.get("check_memballoon")
     membal_model = params.get("membal_model")
@@ -135,6 +136,8 @@ def run(test, params, env):
                 libvirt.modify_vm_iface(vm_name, "update_iface", iface_dict)
             if not check_disk:
                 params["disk_model"] = "virtio-transitional"
+        if set_crypto_policy:
+            utils_conn.update_crypto_policy(set_crypto_policy)
 
         if check_interface:
             libvirt.modify_vm_iface(vm_name, "update_iface", iface_params)
@@ -255,3 +258,5 @@ def run(test, params, env):
         libvirt.delete_local_disk("file", path=source_file)
         if guest_src_url and blk_source:
             libvirt.delete_local_disk("file", path=blk_source)
+        if set_crypto_policy:
+            utils_conn.update_crypto_policy()


### PR DESCRIPTION
Need 'LEGACY' crypto-policy to access rhel6 guests because SHA1
is disabled in openssl by default for now.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
Test results:
```

 (1/5) type_specific.io-github-autotest-libvirt.virsh.migrate_with_legacy_guest.test_interface.rhel6_guest.virtio_transitional: PASS (182.51 s)
 (2/5) type_specific.io-github-autotest-libvirt.virsh.migrate_with_legacy_guest.test_disk.with_virtio_scsi.disk_raw.rhel6_guest.unspecified_model: PASS (251.40 s)
 (3/5) type_specific.io-github-autotest-libvirt.virsh.migrate_with_legacy_guest.test_disk.with_virtio_blk.disk_qcow2.rhel6_guest.virtio_transitional: PASS (244.48 s)
 (4/5) type_specific.io-github-autotest-libvirt.virsh.migrate_with_legacy_guest.test_memballoon.rhel6_guest.virtio_transitional: PASS (184.06 s)
 (5/5) type_specific.io-github-autotest-libvirt.virsh.migrate_with_legacy_guest.test_rng.rhel6_guest.virtio_transitional: PASS (183.52 s)
RESULTS    : PASS 5 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 1047.72 s

```