### PR TITLE
virtio_transitional: Fix rhel6 guest login failure

### DIFF
--- a/libvirt/tests/cfg/virtio_transitional/virtio_transitional_blk.cfg
+++ b/libvirt/tests/cfg/virtio_transitional/virtio_transitional_blk.cfg
@@ -53,6 +53,7 @@
             no Windows
             image_path = images/rhel6-x86_64-latest.qcow2
             guest_src_url = "http://download.libvirt.redhat.com/libvirt-CI-resources/RHEL-6.10-x86_64-latest.qcow2"
+            set_crypto_policy = "LEGACY"
             variants:
                 - @default:
                     q35:

--- a/libvirt/tests/cfg/virtio_transitional/virtio_transitional_mem_balloon.cfg
+++ b/libvirt/tests/cfg/virtio_transitional/virtio_transitional_mem_balloon.cfg
@@ -17,4 +17,5 @@
             os_variant = rhel6
             image_path = images/rhel6-x86_64-latest.qcow2
             guest_src_url = "http://download.libvirt.redhat.com/libvirt-CI-resources/RHEL-6.10-x86_64-latest.qcow2"
+            set_crypto_policy = "LEGACY"
             only virtio_transitional

--- a/libvirt/tests/cfg/virtio_transitional/virtio_transitional_nic.cfg
+++ b/libvirt/tests/cfg/virtio_transitional/virtio_transitional_nic.cfg
@@ -35,3 +35,4 @@
             no Windows
             image_path = images/rhel6-x86_64-latest.qcow2
             guest_src_url = "http://download.libvirt.redhat.com/libvirt-CI-resources/RHEL-6.10-x86_64-latest.qcow2"
+            set_crypto_policy = "LEGACY"

--- a/libvirt/tests/cfg/virtio_transitional/virtio_transitional_rng.cfg
+++ b/libvirt/tests/cfg/virtio_transitional/virtio_transitional_rng.cfg
@@ -29,6 +29,7 @@
             disk_model = 'virtio-transitional'
             image_path = images/rhel6-x86_64-latest.qcow2
             guest_src_url = "http://download.libvirt.redhat.com/libvirt-CI-resources/RHEL-6.10-x86_64-latest.qcow2"
+            set_crypto_policy = "LEGACY"
             variants:
                 - @default:
                     only virtio_transitional

--- a/libvirt/tests/cfg/virtio_transitional/virtio_transitional_serial.cfg
+++ b/libvirt/tests/cfg/virtio_transitional/virtio_transitional_serial.cfg
@@ -6,6 +6,7 @@
     disk_model = "virtio-transitional"
     image_path = images/rhel6-x86_64-latest.qcow2
     guest_src_url = "http://download.libvirt.redhat.com/libvirt-CI-resources/RHEL-6.10-x86_64-latest.qcow2"
+    set_crypto_policy = "LEGACY"
     variants:
         - @default:
             only virtio_transitional

--- a/libvirt/tests/src/virtio_transitional/virtio_transitional_blk.py
+++ b/libvirt/tests/src/virtio_transitional/virtio_transitional_blk.py
@@ -6,6 +6,7 @@ from avocado.utils import download
 
 from virttest import virsh
 from virttest import data_dir
+from virttest import utils_conn
 from virttest import utils_misc
 from virttest import libvirt_version
 from virttest import utils_libvirtd
@@ -220,6 +221,7 @@ def run(test, params, env):
     pci_bridge_index = None
     tmp_dir = data_dir.get_tmp_dir()
     guest_src_url = params.get("guest_src_url")
+    set_crypto_policy = params.get("set_crypto_policy")
 
     if not libvirt_version.version_compare(5, 0, 0):
         test.cancel("This libvirt version doesn't support "
@@ -231,7 +233,8 @@ def run(test, params, env):
         if not os.path.exists(target_path):
             download.get_file(guest_src_url, target_path)
         params["blk_source_name"] = target_path
-
+    if set_crypto_policy:
+        utils_conn.update_crypto_policy(set_crypto_policy)
     try:
         if add_pcie_to_pci_bridge:
             pci_controllers = vmxml.get_controllers('pci')
@@ -282,3 +285,5 @@ def run(test, params, env):
         backup_xml.sync()
         if guest_src_url and target_path:
             libvirt.delete_local_disk("file", path=target_path)
+        if set_crypto_policy:
+            utils_conn.update_crypto_policy()

--- a/libvirt/tests/src/virtio_transitional/virtio_transitional_mem_balloon.py
+++ b/libvirt/tests/src/virtio_transitional/virtio_transitional_mem_balloon.py
@@ -5,6 +5,7 @@ from avocado.utils import download
 
 from virttest import virsh
 from virttest import data_dir
+from virttest import utils_conn
 from virttest import utils_misc
 from virttest import libvirt_version
 
@@ -42,6 +43,7 @@ def run(test, params, env):
     virtio_model = params['virtio_model']
     os_variant = params.get("os_variant", "")
     params["disk_model"] = virtio_model
+    set_crypto_policy = params.get("set_crypto_policy")
 
     if not libvirt_version.version_compare(5, 0, 0):
         test.cancel("This libvirt version doesn't support "
@@ -54,6 +56,8 @@ def run(test, params, env):
         if not os.path.exists(target_path):
             download.get_file(guest_src_url, target_path)
         params["blk_source_name"] = target_path
+    if set_crypto_policy:
+        utils_conn.update_crypto_policy(set_crypto_policy)
 
     try:
         # Update disk and interface to correct model
@@ -114,3 +118,5 @@ def run(test, params, env):
     finally:
         vm.destroy()
         backup_xml.sync()
+        if set_crypto_policy:
+            utils_conn.update_crypto_policy()

--- a/libvirt/tests/src/virtio_transitional/virtio_transitional_nic.py
+++ b/libvirt/tests/src/virtio_transitional/virtio_transitional_nic.py
@@ -8,6 +8,7 @@ from avocado.core import exceptions
 from virttest import virsh
 from virttest import virt_vm
 from virttest import data_dir
+from virttest import utils_conn
 from virttest import utils_net
 from virttest import utils_test
 from virttest import utils_misc
@@ -274,6 +275,7 @@ def run(test, params, env):
     guest_src_url = params.get("guest_src_url")
     params['disk_model'] = params['virtio_model']
     guest_os_type = params['os_type']
+    set_crypto_policy = params.get("set_crypto_policy")
 
     target_path = None
 
@@ -288,6 +290,9 @@ def run(test, params, env):
         if not os.path.exists(target_path):
             download.get_file(guest_src_url, target_path)
         params["blk_source_name"] = target_path
+    if set_crypto_policy:
+        utils_conn.update_crypto_policy(set_crypto_policy)
+
     libvirt.set_vm_disk(vm, params)
 
     # Add pcie-to-pci-bridge when there is no one
@@ -318,3 +323,5 @@ def run(test, params, env):
 
         if guest_src_url and target_path:
             libvirt.delete_local_disk("file", path=target_path)
+        if set_crypto_policy:
+            utils_conn.update_crypto_policy()

--- a/libvirt/tests/src/virtio_transitional/virtio_transitional_rng.py
+++ b/libvirt/tests/src/virtio_transitional/virtio_transitional_rng.py
@@ -6,6 +6,7 @@ from avocado.utils import process
 
 from virttest import data_dir
 from virttest import virsh
+from virttest import utils_conn
 from virttest import utils_misc
 from virttest import libvirt_version
 
@@ -120,6 +121,7 @@ def run(test, params, env):
     hotplug = (params.get('hotplug', 'no') == 'yes')
     device_exists = (params.get('device_exists', 'yes') == 'yes')
     plug_to = params.get('plug_to', '')
+    set_crypto_policy = params.get("set_crypto_policy")
 
     if not libvirt_version.version_compare(5, 0, 0):
         test.cancel("This libvirt version doesn't support "
@@ -132,6 +134,8 @@ def run(test, params, env):
         if not os.path.exists(target_path):
             download.get_file(guest_src_url, target_path)
         params["blk_source_name"] = target_path
+    if set_crypto_policy:
+        utils_conn.update_crypto_policy(set_crypto_policy)
 
     try:
         # Add 'pcie-to-pci-bridge' if there is no one
@@ -216,3 +220,5 @@ def run(test, params, env):
 
         if guest_src_url and target_path:
             libvirt.delete_local_disk("file", path=target_path)
+        if set_crypto_policy:
+            utils_conn.update_crypto_policy()

--- a/libvirt/tests/src/virtio_transitional/virtio_transitional_serial.py
+++ b/libvirt/tests/src/virtio_transitional/virtio_transitional_serial.py
@@ -4,6 +4,7 @@ import aexpect
 from avocado.utils import download
 
 from virttest import data_dir
+from virttest import utils_conn
 from virttest import utils_misc
 from virttest import libvirt_version
 
@@ -74,6 +75,7 @@ def run(test, params, env):
     add_pcie_to_pci_bridge = params.get("add_pcie_to_pci_bridge")
     guest_src_url = params.get("guest_src_url")
     virtio_model = params['virtio_model']
+    set_crypto_policy = params.get("set_crypto_policy")
 
     if not libvirt_version.version_compare(5, 0, 0):
         test.cancel("This libvirt version doesn't support "
@@ -86,6 +88,8 @@ def run(test, params, env):
         if not os.path.exists(target_path):
             download.get_file(guest_src_url, target_path)
         params["blk_source_name"] = target_path
+    if set_crypto_policy:
+        utils_conn.update_crypto_policy(set_crypto_policy)
 
     try:
         # Add pcie-to-pci-bridge when it is required
@@ -162,3 +166,5 @@ def run(test, params, env):
 
         if guest_src_url and target_path:
             libvirt.delete_local_disk("file", path=target_path)
+        if set_crypto_policy:
+            utils_conn.update_crypto_policy()


### PR DESCRIPTION
Need 'LEGACY' crypto-policy to access rhel6 guests because SHA1
is disabled in openssl by default for now.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Test results:**
```
avocado run --vt-type libvirt --vt-machine-type q35 virtio_transitional_blk virtio_transitional_serial virtio_transitional_mem_balloon virtio_transitional_nic virtio_transitional_rng virtio_transitional_blk_negative
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : 108955e5643f949525c07ba5877af48bc74b82b8
JOB LOG    : /root/avocado/job-results/job-2022-03-18T04.33-108955e/job.log
 (01/49) type_specific.io-github-autotest-libvirt.virtio_transitional_blk.default.with_virtio_blk.boot_test.virtio: PASS (47.29 s)
 (02/49) type_specific.io-github-autotest-libvirt.virtio_transitional_blk.default.with_virtio_blk.boot_test.virtio_non_transitional: PASS (50.91 s)
 (03/49) type_specific.io-github-autotest-libvirt.virtio_transitional_blk.default.with_virtio_scsi.boot_test.virtio: PASS (53.75 s)
 (04/49) type_specific.io-github-autotest-libvirt.virtio_transitional_blk.rhel6_guest.default.with_virtio_blk.boot_test.virtio_transitional: PASS (60.17 s)
 (05/49) type_specific.io-github-autotest-libvirt.virtio_transitional_blk.rhel6_guest.default.with_virtio_blk.hotplug_test.virtio_transitional: PASS (165.73 s)
 (06/49) type_specific.io-github-autotest-libvirt.virtio_transitional_blk.rhel6_guest.default.with_virtio_blk.coldplug_test.virtio_transitional: PASS (233.30 s)
...
(49/49) type_specific.io-github-autotest-libvirt.virtio_transitional_blk_negative.with_virtio_scsi.invalid_model.disk_virtio_transitional: PASS (14.85 s)
RESULTS    : PASS 49 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 7752.14 s

```