### PR TITLE
memory: Add cases about virtio-mem device

### DIFF
--- a/libvirt/tests/cfg/memory/memory_attach_device.cfg
+++ b/libvirt/tests/cfg/memory/memory_attach_device.cfg
@@ -1,0 +1,18 @@
+- memory_attach_device:
+    type = memory_attach_device
+
+    variants:
+        - cold_plug:
+            start_vm = 'no'
+        - hot_plug:
+            start_vm = 'yes'
+    variants test_case:
+        - virtio_mem:
+            no pseries
+            set_num_huge_pages = 1000
+            required_kernel = [5.14.0,)
+            guest_required_kernel = [5.8.0,)
+            func_supported_since_libvirt_ver = (8, 0, 0)
+            func_supported_since_qemu_kvm_ver = (6, 2, 0)
+            vm_attrs = {'max_mem_rt': 10485760, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB', 'vcpu': 4, 'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '524288', 'unit': 'KiB'}]}}
+            mem_device_attrs = {'mem_model': 'virtio-mem', 'target': {'requested_unit': 'KiB', 'size': 262144, 'node': 0, 'size_unit': 'KiB', 'requested_size': 131072, 'block_unit': 'KiB', 'block_size': 2048}, 'source': {'pagesize_unit': 'KiB', 'pagesize': 2048, 'nodemask': '0'}}

--- a/libvirt/tests/cfg/memory/memory_update_device.cfg
+++ b/libvirt/tests/cfg/memory/memory_update_device.cfg
@@ -1,0 +1,17 @@
+- memory_update_device:
+    type = memory_update_device
+    start_vm = no
+
+    variants test_case:
+        - virtio_mem:
+            no pseries
+            set_num_huge_pages = 1000
+            required_kernel = [5.14.0,)
+            guest_required_kernel = [5.8.0,)
+            func_supported_since_libvirt_ver = (8, 0, 0)
+            func_supported_since_qemu_kvm_ver = (6, 2, 0)
+            vm_attrs = {'max_mem_rt': 10485760, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB', 'vcpu': 4, 'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '524288', 'unit': 'KiB'}]}}
+            mem_device_attrs = {'mem_model': 'virtio-mem', 'target': {'requested_unit': 'KiB', 'size': 262144, 'node': 0, 'size_unit': 'KiB', 'requested_size': 131072, 'block_unit': 'KiB', 'block_size': 2048}, 'source': {'pagesize_unit': 'KiB', 'pagesize': 2048, 'nodemask': '0'}}
+            requested_size = 80MiB
+            check_log_str = "MEMORY_DEVICE_SIZE_CHANGE.*virtiomem"
+            virsh_opts = "--alias %s --requested-size ${requested_size}"

--- a/libvirt/tests/src/memory/memory_attach_device.py
+++ b/libvirt/tests/src/memory/memory_attach_device.py
@@ -1,0 +1,142 @@
+from virttest import libvirt_version
+from virttest import utils_misc
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.libvirt_xml.devices.memory import Memory
+from virttest.staging import utils_memory
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_version import VersionInterval
+
+VIRSH_ARGS = {'debug': True, 'ignore_status': False}
+ORG_HP = utils_memory.get_num_huge_pages()
+
+
+def run(test, params, env):
+    """
+    Test memory function
+    """
+    def check_environment(vm, params):
+        """
+        Check the test environment
+
+        :param vm: VM object
+        :param params: Dictionary with the test parameters
+        """
+        libvirt_version.is_libvirt_feature_supported(params)
+        utils_misc.is_qemu_function_supported(params)
+
+        guest_required_kernel = params.get('guest_required_kernel')
+        if guest_required_kernel:
+            if not vm.is_alive():
+                vm.start()
+            vm_session = vm.wait_for_login()
+            vm_kerv = vm_session.cmd_output('uname -r').strip().split('-')[0]
+            vm_session.close()
+            if vm_kerv not in VersionInterval(guest_required_kernel):
+                test.cancel("Got guest kernel version:%s, which is not in %s" %
+                            (vm_kerv, guest_required_kernel))
+
+        if params.get("start_vm", "no") == "no":
+            vm.destroy()
+
+    def setup_test_default():
+        """
+        Default setup for test cases
+        """
+        pass
+
+    def cleanup_test_default():
+        """
+        Default cleanup for test cases
+        """
+        pass
+
+    def setup_test_virtio_mem():
+        """
+        Setup vmxml for test
+        """
+        set_num_huge_pages = params.get("set_num_huge_pages")
+        if set_num_huge_pages:
+            utils_memory.set_num_huge_pages(int(set_num_huge_pages))
+
+        libvirt_vmxml.remove_vm_devices_by_type(vm, 'memory')
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        vm_attrs = eval(params.get('vm_attrs', '{}'))
+        vmxml.setup_attrs(**vm_attrs)
+        vmxml.sync()
+
+        if params.get("start_vm") == "yes":
+            vm.start()
+            vm.wait_for_login().close()
+
+    def run_test_virtio_mem():
+        """
+        Attach a virtio-mem device
+        """
+        mem_device_attrs = eval(params.get('mem_device_attrs', '{}'))
+        mem_device = Memory()
+        mem_device.setup_attrs(**mem_device_attrs)
+
+        test.log.info("TEST_STEP1: Attach a virtio-mem device.")
+        options = '' if vm.is_alive() else '--config'
+        virsh.attach_device(vm_name, mem_device.xml, flagstr=options,
+                            debug=True, ignore_status=False)
+
+        if not vm.is_alive():
+            vm.start()
+            vm.wait_for_login().close()
+
+        test.log.info("TEST_STEP2: Check requested and current size.")
+        vmxml_cur = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        test.log.debug("Current VM XML: %s.", vmxml_cur)
+        mem_dev = vmxml_cur.devices.by_device_tag("memory")[0]
+        expr_requested_size = mem_device_attrs['target']['requested_size']
+        for check_item in ['requested_size', 'current_size']:
+            if getattr(mem_dev.target, check_item) != expr_requested_size:
+                test.fail("Incorrect %s! It should be %s, but got %s."
+                          % (check_item, expr_requested_size,
+                             getattr(mem_dev.target, check_item)))
+
+        test.log.info("TEST_STEP3: Check VM memory.")
+        memory_gap = vmxml_cur.get_memory() - vmxml_cur.get_current_mem()
+        virtio_mem_gap = mem_dev.target.get_size() - \
+            mem_dev.target.get_current_size()
+        if memory_gap != virtio_mem_gap:
+            test.fail("Size of memory - currentMemory(%s) should be equal to "
+                      "virtio-mem size - current(%s)."
+                      % (memory_gap, virtio_mem_gap))
+
+    def cleanup_test_virtio_mem():
+        """
+        Clean up environment
+        """
+        if utils_memory.get_num_huge_pages() != ORG_HP:
+            utils_memory.set_num_huge_pages(ORG_HP)
+
+    # Variable assignment
+    test_case = params.get('test_case', '')
+
+    vm_name = params.get('main_vm')
+    vm = env.get_vm(vm_name)
+
+    check_environment(vm, params)
+    bkxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+
+    # Get setup function
+    setup_test = eval('setup_test_%s' % test_case) \
+        if 'setup_test_%s' % test_case in locals() else setup_test_default
+    # Get runtest function
+    run_test = eval('run_test_%s' % test_case)
+    # Get cleanup function
+    cleanup_test = eval('cleanup_test_%s' % test_case) \
+        if 'cleanup_test_%s' % test_case in locals() else cleanup_test_default
+
+    try:
+        # Execute test
+        setup_test()
+        run_test()
+
+    finally:
+        bkxml.sync()
+        cleanup_test()

--- a/libvirt/tests/src/memory/memory_update_device.py
+++ b/libvirt/tests/src/memory/memory_update_device.py
@@ -1,0 +1,157 @@
+import re
+
+from virttest import libvirt_version
+from virttest import utils_misc
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.libvirt_xml.devices.memory import Memory
+from virttest.staging import utils_memory
+from virttest.utils_test import libvirt
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_version import VersionInterval
+
+VIRSH_ARGS = {'debug': True, 'ignore_status': False}
+ORG_HP = utils_memory.get_num_huge_pages()
+
+
+def run(test, params, env):
+    """
+    Update memory device
+    """
+    def check_environment(vm, params):
+        """
+        Check the test environment
+
+        :param vm: VM object
+        :param params: Dictionary with the test parameters
+        """
+        libvirt_version.is_libvirt_feature_supported(params)
+        utils_misc.is_qemu_function_supported(params)
+
+        guest_required_kernel = params.get('guest_required_kernel')
+        if guest_required_kernel:
+            if not vm.is_alive():
+                vm.start()
+            vm_session = vm.wait_for_login()
+            vm_kerv = vm_session.cmd_output('uname -r').strip().split('-')[0]
+            vm_session.close()
+            if vm_kerv not in VersionInterval(guest_required_kernel):
+                test.cancel("Got guest kernel version:%s, which is not in %s" %
+                            (vm_kerv, guest_required_kernel))
+
+        if params.get("start_vm", "no") == "no":
+            vm.destroy()
+
+    def setup_test_default():
+        """
+        Default setup for test cases
+        """
+        pass
+
+    def cleanup_test_default():
+        """
+        Default cleanup for test cases
+        """
+        pass
+
+    def setup_test_virtio_mem():
+        """
+        Setup vmxml for test
+        """
+        set_num_huge_pages = params.get("set_num_huge_pages")
+        if set_num_huge_pages:
+            utils_memory.set_num_huge_pages(int(set_num_huge_pages))
+
+        libvirt_vmxml.remove_vm_devices_by_type(vm, 'memory')
+        vm_attrs = eval(params.get('vm_attrs', '{}'))
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        vmxml.setup_attrs(**vm_attrs)
+        vmxml.sync()
+        mem_device_attrs = eval(params.get('mem_device_attrs', '{}'))
+        mem_device = Memory()
+        mem_device.setup_attrs(**mem_device_attrs)
+
+        virsh.attach_device(vm_name, mem_device.xml, flagstr='--config',
+                            debug=True, ignore_status=False)
+
+    def run_test_virtio_mem():
+        """
+        Update memory device for virtio-mem device
+        """
+        mem_device_attrs = eval(params.get('mem_device_attrs', '{}'))
+        vm.start()
+        vm_session = vm.wait_for_login()
+        cmdRes = vm_session.cmd_output('free -m')
+        vm_mem_before = int(re.findall(r'Mem:\s+(\d+)\s+\d+\s+', cmdRes)[-1])
+        test.log.debug("VM's memory before updating requested size: %s",
+                       vm_mem_before)
+
+        test.log.info("TEST_STEP1: Update requested size for virtio-mem device.")
+        vmxml_cur = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        mem_dev = vmxml_cur.devices.by_device_tag("memory")[0]
+        mem_dev_alias = mem_dev.fetch_attrs()['alias']['name']
+        virsh_opts = params.get('virsh_opts') % mem_dev_alias
+        virsh.update_memory_device(vm.name, options=virsh_opts,
+                                   wait_for_event=True, **VIRSH_ARGS)
+
+        test.log.info("TEST_STEP2: Check requested and current size changes.")
+        mem_dev = vm_xml.VMXML.new_from_dumpxml(vm_name).devices.\
+            by_device_tag("memory")[0]
+        expr_requested_size = int(float(utils_misc.normalize_data_size(
+            params.get("requested_size", '80Mib'), order_magnitude='K')))
+        for check_item in ['requested_size', 'current_size']:
+            if getattr(mem_dev.target, check_item) != expr_requested_size:
+                test.fail("Incorrect %s! It should be %s, but got %s."
+                          % (check_item, expr_requested_size,
+                             getattr(mem_dev.target, check_item)))
+
+        test.log.info("TEST_STEP3: Check 'MEMORY_DEVICE_SIZE_CHANGE' in "
+                      "libvirtd/virtqemud log")
+        log_file = utils_misc.get_path(test.debugdir, "libvirtd.log")
+        check_log_str = params.get("check_log_str", "MEMORY_DEVICE_SIZE_CHANGE")
+        libvirt.check_logfile(check_log_str, log_file)
+
+        test.log.info("TEST STEP4: Check memory in the VM.")
+        cmdRes = vm_session.cmd_output('free -m')
+        vm_mem_after = int(re.findall(r'Mem:\s+(\d+)\s+\d+\s+', cmdRes)[-1])
+        mem_request_decrease = (mem_device_attrs['target']['requested_size'] -
+                                expr_requested_size)/1024
+        vm_mem_decrease = vm_mem_before - vm_mem_after
+        if mem_request_decrease != vm_mem_decrease:
+            test.fail("VM mem change comparison failed! Expect %d, but got %d."
+                      % (mem_request_decrease, vm_mem_decrease))
+
+    def cleanup_test_virtio_mem():
+        """
+        Clean up environment
+        """
+        if utils_memory.get_num_huge_pages() != ORG_HP:
+            utils_memory.set_num_huge_pages(ORG_HP)
+
+    # Variable assignment
+    test_case = params.get('test_case', '')
+
+    vm_name = params.get('main_vm')
+    vm = env.get_vm(vm_name)
+
+    check_environment(vm, params)
+    bkxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+
+    # Get setup function
+    setup_test = eval('setup_test_%s' % test_case) \
+        if 'setup_test_%s' % test_case in locals() else setup_test_default
+    # Get runtest function
+    run_test = eval('run_test_%s' % test_case)
+    # Get cleanup function
+    cleanup_test = eval('cleanup_test_%s' % test_case) \
+        if 'cleanup_test_%s' % test_case in locals() else cleanup_test_default
+
+    try:
+        # Execute test
+        setup_test()
+        run_test()
+
+    finally:
+        bkxml.sync()
+        cleanup_test()


### PR DESCRIPTION
This PR adds:
    RHEL-288949: Start VM with virtio-mem device
    RHEL-288950: Hotplug a virtio-mem device
    RHEL-288951: update memory device for virtio-mem device

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Depends on:**
https://github.com/avocado-framework/avocado-vt/pull/3377
https://github.com/avocado-framework/avocado-vt/pull/3376

**Test results:**
```
 (1/3) type_specific.io-github-autotest-libvirt.memory_update_device.virtio_mem: PASS (42.25 s)
 (2/3) type_specific.io-github-autotest-libvirt.memory_attach_device.virtio_mem.cold_plug: PASS (39.91 s)
 (3/3) type_specific.io-github-autotest-libvirt.memory_attach_device.virtio_mem.hot_plug: PASS (37.06 s)
```
