### PR TITLE
numa_memory: fix bitmap error

### DIFF
--- a/libvirt/tests/src/numa/numa_memory.py
+++ b/libvirt/tests/src/numa/numa_memory.py
@@ -221,8 +221,9 @@ def run(test, params, env):
                         if nodes_size > len(node_list):
                             test.cancel("nodeset %s out of range" % numa_memory['nodeset'])
                         else:
-                            numa_memory['nodeset'] = node_list[:nodes_size]
-                            logging.debug("Update the numa memory nodeset to '%s'", node_list[:nodes_size])
+
+                            numa_memory['nodeset'] = ','.join(map(str,
+                                                                  node_list[:nodes_size]))
 
         if vcpu_cpuset:
             pre_cpuset = cpu.cpus_parser(vcpu_cpuset)


### PR DESCRIPTION
This is to fix the wrong value assignment. A string value is expected,
but not a list value.

Signed-off-by: Dan Zheng <dzheng@redhat.com>
