### PR TITLE
iface_ovs: Fix 'No interface file' error

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_ovs.py
+++ b/libvirt/tests/src/virtual_network/iface_ovs.py
@@ -16,6 +16,7 @@ from virttest.utils_test import libvirt
 from virttest.utils_libvirt import libvirt_vmxml
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.network_xml import NetworkXML
+from virttest.libvirt_xml.devices import interface
 
 
 # Using as lower capital is not the best way to do, but this is just a
@@ -142,7 +143,8 @@ def run(test, params, env):
             if not hotplug:
                 libvirt.modify_vm_iface(vm_name, 'update_iface', iface_dict)
             else:
-                iface_attach_xml = libvirt.modify_vm_iface(vm_name, 'get_xml', iface_dict)
+                new_iface = interface.Interface('network')
+                new_iface.xml = libvirt.modify_vm_iface(vm_name, 'get_xml', iface_dict)
                 libvirt_vmxml.remove_vm_devices_by_type(vm, 'interface')
 
         try:
@@ -151,7 +153,7 @@ def run(test, params, env):
             if start_error:
                 test.fail("VM started unexpectedly")
             if hotplug:
-                virsh.attach_device(vm_name, iface_attach_xml, debug=True,
+                virsh.attach_device(vm_name, new_iface.xml, debug=True,
                                     ignore_status=False)
             iface_name = libvirt.get_ifname_host(vm_name, iface_mac)
             if test_ovs_port:


### PR DESCRIPTION
libvirt.modify_vm_iface will return vm interface xml attribute. But the
following line remove_vm_devices_by_type removes the vm interface member.

So hotplug test failed due to missing vm interface xml.

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Before
```
(1/1) type_specific.io-github-autotest-libvirt.virtual_network.iface_ovs.net_ovs.ovs_qos.hotplug_iface: ERROR: Command '/usr/bin/virsh attach-device avocado-vt-vm1 /tmp/xml_utils_temp_dm89eoca.xml' failed.\nstdout: b'\n'\nstderr: b"error: Failed to open file '/tmp/xml_utils_temp_dm89eoca.xml': No such file or directory\n"\nadditional_info: None (14.35 s)
```

After
```
(1/1) type_specific.io-github-autotest-libvirt.virtual_network.iface_ovs.net_ovs.ovs_qos.hotplug_iface: PASS (15.58 s)
```