### PR TITLE
virsh_numatune: fix_numa_nodeset

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_numatune.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_numatune.cfg
@@ -5,6 +5,7 @@
     variants:
         - positive_testing:
             status_error = "no"
+            dynamic_nodeset = "yes"
             variants:
                 - set_numa_parameter:
                     change_parameters = "yes"
@@ -14,7 +15,7 @@
                             kill_vm = "yes"
                             variants:
                                 - change_mode:
-                                    numa_nodeset = 0
+                                    numa_nodeset = x
                                     variants:
                                         - preferred:
                                             numa_mode = 'preferred'
@@ -32,13 +33,13 @@
                                 - change_nodeset:
                                     variants:
                                         - comma_list:
-                                            numa_nodeset = 0,1,2
+                                            numa_nodeset = x,y
                                         - ranges:
-                                            numa_nodeset = 0-2
+                                            numa_nodeset = x-y
                                         - excluding:
-                                            numa_nodeset = 0-2,^1
+                                            numa_nodeset = x-y,^y
                                         - single:
-                                            numa_nodeset = 0
+                                            numa_nodeset = x
                                     variants:
                                         - options:
                                             variants:
@@ -53,15 +54,13 @@
                                 - change_nodeset:
                                     variants:
                                         - comma_list:
-                                            numa_nodeset = 0,1
-                                            dynamic_nodeset = "yes"
+                                            numa_nodeset = x,y
                                         - ranges:
-                                            numa_nodeset = 0-1
-                                            dynamic_nodeset = "yes"
+                                            numa_nodeset = x-y
                                         - excluding:
-                                            numa_nodeset = 0-1,^1
+                                            numa_nodeset = x-y,^y
                                         - single:
-                                            numa_nodeset = 0
+                                            numa_nodeset = x
                                     variants:
                                         - options:
                                             variants:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_numatune.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_numatune.py
@@ -7,10 +7,11 @@ from virttest import libvirt_xml
 from virttest import virsh
 from virttest import utils_libvirtd
 from virttest import utils_misc
+
 from virttest.cpu import cpus_parser
 from virttest.libvirt_xml.xcepts import LibvirtXMLAccessorError
 from virttest.staging import utils_cgroup
-
+from virttest.utils_libvirt import libvirt_numa
 
 # Using as lower capital is not the best way to do, but this is just a
 # workaround to avoid changing the entire file.
@@ -193,9 +194,12 @@ def dynamic_node_replacement(params, numa_info, test_obj):
     :param test_obj: test object - for cancel case
     """
     node_list = numa_info.get_online_nodes_withmem()
+    numa_nodeset_format = params.get('numa_nodeset')
     dynamic_nodeset = params.get('dynamic_nodeset', 'no') == 'yes'
     if dynamic_nodeset and 'numa_nodeset' in params:
-        params['numa_nodeset'] = ','.join([str(elem) for elem in node_list])
+        params['numa_nodeset'] = libvirt_numa.parse_numa_nodeset_to_str(numa_nodeset_format,
+                                                                        node_list)
+
         logging.debug('The parameter "numa_nodeset" from config file is going to be replaced by: {} '
                       'available on this system'.format(params['numa_nodeset']))
 


### PR DESCRIPTION
This is to enable all positive cases supporting dynamic numanode selection.
This enhancement will improve the cases to run with more numa hosts which
have different numa node configurations.

depends on https://github.com/avocado-framework/avocado-vt/pull/3378
Signed-off-by: Dan Zheng <dzheng@redhat.com>
