### PR TITLE
numa_memory_migrate: enhance to use available numa node

### DIFF
--- a/libvirt/tests/cfg/numa/numa_memory_migrate.cfg
+++ b/libvirt/tests/cfg/numa/numa_memory_migrate.cfg
@@ -11,4 +11,4 @@
             memory_placement = "auto"
         - mem_nodeset:
             memory_placement = "static"
-            memory_nodeset = "0"
+            memory_nodeset = x

--- a/libvirt/tests/src/numa/numa_memory_migrate.py
+++ b/libvirt/tests/src/numa/numa_memory_migrate.py
@@ -10,6 +10,7 @@ from virttest import utils_misc
 from virttest import cpu
 from virttest import utils_test
 
+from virttest.utils_libvirt import libvirt_numa
 
 # Using as lower capital is not the best way to do, but this is just a
 # workaround to avoid changing the entire file.
@@ -61,12 +62,11 @@ def run(test, params, env):
 
     try:
         if numa_memory.get('nodeset'):
+            numa_nodeset_format = numa_memory.get('nodeset')
+            numa_memory['nodeset'] = libvirt_numa.parse_numa_nodeset_to_str(numa_nodeset_format,
+                                                                            node_list)
             used_node = cpu.cpus_parser(numa_memory['nodeset'])
             logging.debug("set node list is %s", used_node)
-            for i in used_node:
-                if i not in node_list:
-                    raise exceptions.TestSkipError("nodeset %s out of range" %
-                                                   numa_memory['nodeset'])
 
         vmxml = libvirt_xml.VMXML.new_from_dumpxml(vm_name)
         vmxml.numa_memory = numa_memory


### PR DESCRIPTION
Hardcoded numa node limits the case's adaptibility on different
numa hosts. The enhancement will increase the adaptibilty with
dynamically setting the numa node.
Depends on https://github.com/avocado-framework/avocado-vt/pull/3378
Signed-off-by: Dan Zheng <dzheng@redhat.com>
