### PR TITLE
hostdev: Add memory hot plugging cases

### DIFF
--- a/libvirt/tests/cfg/virtual_interface/hotplug_mem.cfg
+++ b/libvirt/tests/cfg/virtual_interface/hotplug_mem.cfg
@@ -8,10 +8,15 @@
             func_supported_since_libvirt_ver = (7, 3, 0)
             func_supported_since_qemu_kvm_ver = (6, 0, 0)
             iface_dict = {"source": {'dev':'/dev/vhost-vdpa-0'}}
-            save_error = "yes"
             variants test_target:
                 - simulator:
                 - mellanox:
+        - hostdev:
+            only x86_64
+            iface_dict = {'managed': 'yes', 'hostdev_address': {'attrs': %s}}
+        - hostdev_device:
+            only x86_64
+            hostdev_dict = {'type': 'pci', 'mode': 'subsystem', 'managed': 'yes', 'source': {'untyped_address': %s}}
     variants test_scenario:
         - at_memory_to_vm_with_iface:
             vm_attrs = {'max_mem_rt': 6291456, 'max_mem_rt_slots': 32, 'max_mem_rt_unit': 'K', 'current_mem':1048576, 'current_mem_unit': 'KiB','vcpu': 8, 'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-3', 'memory': '524288', 'unit': 'KiB'}, {'id': '1', 'cpus': '4-7', 'memory': '524288', 'unit': 'KiB'}]}}


### PR DESCRIPTION
This PR adds 'hostdev interface' and 'hostdev device' types test in
RHEL-283024: hotplug memory to vm with vdpa/hostdev type interface.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Test results:**
```
# avocado run --vt-type libvirt iface.hotplug_mem..hostdev_device iface.hotplug_mem..hostdev
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : b57739faae31a46edff35a76a7c65769b7559333
JOB LOG    : /root/avocado/job-results/job-2022-03-22T00.36-b57739f/job.log
 (1/6) type_specific.io-github-autotest-libvirt.iface.hotplug_mem.at_memory_to_vm_with_iface.hostdev_device: PASS (40.39 s)
 (2/6) type_specific.io-github-autotest-libvirt.iface.hotplug_mem.at_memory_to_vm_with_iface_and_locked_mem.hostdev_device: PASS (40.80 s)
 (3/6) type_specific.io-github-autotest-libvirt.iface.hotplug_mem.at_iface_and_memory.hostdev_device: PASS (56.63 s)
 (4/6) type_specific.io-github-autotest-libvirt.iface.hotplug_mem.at_memory_to_vm_with_iface.hostdev: PASS (40.75 s)
 (5/6) type_specific.io-github-autotest-libvirt.iface.hotplug_mem.at_memory_to_vm_with_iface_and_locked_mem.hostdev:PASS (41.11 s)
 (6/6) type_specific.io-github-autotest-libvirt.iface.hotplug_mem.at_iface_and_memory.hostdev: PASS (57.45 s)
RESULTS    : PASS 6 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 278.87 s

```