### PR TITLE
Fix no more available PCI slots for interface device

### DIFF
--- a/libvirt/tests/src/libvirt_hooks.py
+++ b/libvirt/tests/src/libvirt_hooks.py
@@ -379,7 +379,7 @@ def run(test, params, env):
                 return len(vm_xml.VMXML.new_from_dumpxml(vm_name).get_devices("interface")) == interface_num + 1
 
             ret = virsh.attach_interface(vm_name,
-                                         ("network %s --mac %s" % (net_name, mac_addr)))
+                                         ("network %s --mac %s --model virtio" % (net_name, mac_addr)))
             libvirt.check_exit_status(ret)
             if utils_misc.wait_for(is_attached_interface, timeout=20) is not True:
                 test.fail("Attaching interface failed.")


### PR DESCRIPTION
When hotplug interface, it will use rtl8139 as the default model.
Add this interface device will be plugged into 'pcie-to-pci-bridge'.
If no such controller on guest, the hotplug interface will fail.

For example:
#virsh attach-interface vm1 --type network --source default
error: Failed to attach interface
error: internal error: No more available PCI slots

If set model to 'virtio', it will succeed. Because it will be
plugged into pcie slot(pcie-root-port).

Signed-off-by: lcheng <lcheng@redhat.com>
