### PR TITLE
numa_memory_migrate: remove foreground daemon

### DIFF
--- a/libvirt/tests/cfg/numa/numa_memory_migrate.cfg
+++ b/libvirt/tests/cfg/numa/numa_memory_migrate.cfg
@@ -4,6 +4,8 @@
     kill_vm = "yes"
     memory_mode = "restrictive"
     take_regular_screendumps = "no"
+    libvirtd_debug_file = "/var/log/libvirt/daemon.log"
+    libvirtd_debug_level = "1"
     variants:
         - mem_auto:
             memory_placement = "auto"


### PR DESCRIPTION
Orignal codes use LibvirtdSession to start daemon in foreground which
does have problem on modular daemon mode. This is to change to use
backgroupd daemon start as well as changing the log message verifying.

Signed-off-by: Dan Zheng <dzheng@redhat.com>
