### PR TITLE
virsh_migrate: Fix 'scsi_disk' UnboundLocalError

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
@@ -822,6 +822,7 @@ def run(test, params, env):
     remove_dict = {}
     remote_libvirt_file = None
     src_libvirt_file = None
+    scsi_disk = None
 
     try:
         # Change the disk of the vm to shared disk


### PR DESCRIPTION
It reports UnboundLocalError: local variable 'scsi_disk'
referenced before assignment, so update script.

Signed-off-by: lcheng <lcheng@redhat.com>
