### PR TITLE
[minor fix] numa_memory_spread: Fix wrong neighbour node

### DIFF
--- a/libvirt/tests/src/numa/numa_memory_spread.py
+++ b/libvirt/tests/src/numa/numa_memory_spread.py
@@ -62,7 +62,7 @@ def prepare_host_for_test(params, test):
     numa_memory = {
         'mode': params.get('memory_mode', 'strict'),
         # If nodeset is not defined in config, take a first node with memory.
-        'nodeset': params.get('memory_nodeset', online_nodes[0])
+        'nodeset': params.get('memory_nodeset', str(online_nodes[0]))
     }
     # Get the size of a main node
     nodeset_size = int(numa_info.read_from_node_meminfo(
@@ -71,6 +71,7 @@ def prepare_host_for_test(params, test):
     for node in online_nodes:
         if str(node) != numa_memory['nodeset']:
             neighbour = node
+            logging.debug("neighbour node is {}".format(neighbour))
             break
     nodeset_nb_size = int(numa_info.read_from_node_meminfo(
         int(neighbour), 'MemTotal'))


### PR DESCRIPTION
Test compares numa_memory['nodeset'] to online_nodes which have memory
to get neighbour node.

numa_memory['nodeset'] is a str but online_nodes is a int array.
Convert online_nodes element to str to avoid problems caused by
unmatched type.

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Before
```
(1/1) type_specific.io-github-autotest-libvirt.numa_memory_spread.positive_test.default: FAIL: The VM crashed when memhog was executed. (57.61 s)
```

After
```
(1/1) type_specific.io-github-autotest-libvirt.numa_memory_spread.positive_test.default: PASS (63.40 s)
```