### PR TITLE
add case for blockjob with async option

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockjob_options.cfg
+++ b/libvirt/tests/cfg/backingchain/blockjob_options.cfg
@@ -7,3 +7,6 @@
         - option_raw:
             option_value = ' --raw'
             case_name = 'blockjob_raw'
+        - option_async:
+            option_value = ' --async'
+            case_name = 'blockjob_async'


### PR DESCRIPTION
add case for blockjob with async option  
   Signed-off-by: nanli <nanli@redhat.com>

**ID**: RHEL-114624 
**Test result :**
(p3-ve) [root@nanli tp-libvirt]# /usr/local/bin/avocado run --vt-type libvirt --vt-machine-type q35 backingchain.blockjob.options.option_async --vt-connect-uri qemu:///system
JOB ID     : 2188799d8a4dc4e7a948d96721451db4d8867bfb
JOB LOG    : /root/avocado/job-results/job-2022-03-28T11.31-2188799/job.log
 (1/1) type_specific.io-github-autotest-libvirt.backingchain.blockjob.options.option_async: PASS (4.49 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 7.92 s