### PR TITLE
v2v: allow v2v execution by non-root user

### DIFF
--- a/v2v/tests/cfg/convert_vm_to_ovirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_ovirt.cfg
@@ -19,6 +19,13 @@
     skip_vm_check = no
 
     variants:
+        - non_root:
+            only rhv_upload
+            only esx
+            unprivileged_user = 'USER_UNPRIVILEGED_V2V_EXAMPLE'
+        - root:
+
+    variants:
         - it_vddk:
             only source_esx
             input_transport = 'vddk'


### PR DESCRIPTION
This only works when converting guest from esx to ovirt by rhv-upload.
Other scenarios are not supported in automation.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>