### PR TITLE
Add test for checking daemons are removed after removing libvirtd pkgs

### DIFF
--- a/libvirt/tests/cfg/daemon/check_daemon_after_remove_pkgs.cfg
+++ b/libvirt/tests/cfg/daemon/check_daemon_after_remove_pkgs.cfg
@@ -1,0 +1,13 @@
+- daemon.check_daemon_after_remove_pkgs:
+    type = check_daemon_after_remove_pkgs
+    start_vm = yes
+    check_image = no
+    take_regular_screendumps = no
+    exit_time_tolerance = 1
+    variants:
+        - legacy_daemon:
+            require_modular_daemon = "no"
+            daemons = "virtlogd libvirtd virtlockd"
+        - modular_daemon:
+            require_modular_daemon = "yes"
+            daemons = "virtlogd virtlockd virtqemud virtnetworkd virtnodedevd virtsecretd virtstoraged virtinterfaced virtnwfilterd virtproxyd"

--- a/libvirt/tests/src/daemon/check_daemon_after_remove_pkgs.py
+++ b/libvirt/tests/src/daemon/check_daemon_after_remove_pkgs.py
@@ -1,0 +1,57 @@
+import logging
+
+from virttest import virsh
+from virttest import remote
+from virttest import utils_package
+from virttest import utils_split_daemons
+from virttest.staging import service
+
+LOGGER = logging.getLogger('avocado.' + __name__)
+
+
+def run(test, params, env):
+    """
+    Check libvirt daemons are removed after removing libvirt pkgs.
+    """
+    daemons = params.get('daemons', "").split()
+    require_modular_daemon = params.get('require_modular_daemon', "no") == "yes"
+
+    utils_split_daemons.daemon_mode_check(require_modular_daemon)
+
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+
+    try:
+        vm_name = params.get("main_vm")
+        vm = env.get_vm(vm_name)
+        if not vm.is_alive():
+            vm.start()
+
+        session = vm.wait_for_login()
+        if not utils_package.package_install("libvirt*", session):
+            test.error("Failed to install libvirt package on guest")
+
+        virsh.reboot(vm)
+        if session is None:
+            session = vm.wait_for_login()
+
+        #Destroy default network, otherwise network daemon will not be removed after removed libvirt pkgs
+        cmd = "virsh net-destroy default"
+        session.cmd(cmd, ignore_all_errors=True)
+
+        runner = remote.RemoteRunner(session=session).run
+        service.Factory.create_service('virtlogd', run=runner).start()
+
+        if not utils_package.package_remove("libvirt*", session):
+            test.error("Failed to remove libvirt packages on guest")
+
+        for daemon in daemons:
+            cmd = "systemctl -a | grep %s" % daemon
+            if not session.cmd_status(cmd):
+                test.fail("%s still exists after removing libvirt pkgs" % daemon)
+
+    finally:
+        if session is not None:
+            session.close()
+        if vm.is_alive():
+            vm.destroy()


### PR DESCRIPTION
Signed-off-by: Yan Fu <yafu@redhat.com>

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [ ] Description of the cases
- [ ] Links of libvirt features, libvirt bugs or case IDs
- [ ] Test results

## If the PR is bug cases
- [ ] Bug descriptions or bug links
- [ ] Test results

## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
