### PR TITLE
remote_with_unix: Fix UNIX connection issues

### DIFF
--- a/libvirt/tests/cfg/remote_access/remote_with_unix.cfg
+++ b/libvirt/tests/cfg/remote_access/remote_with_unix.cfg
@@ -13,7 +13,6 @@
     start_vm = "no"
     port = "22"
     client = "ssh"
-    sasl_allowed_username_list = '["root/admin" ]'
     variants:
         - positive_testing:
             status_error = "no"
@@ -35,21 +34,22 @@
                     auth_unix_rw = "sasl"
                     sasl_type = "plain"
                     sasl_user_pwd = "('sasl_test', 'sasl_pass'),"
-                    sasl_allowed_users = ['sasl_test',]
+                    sasl_allowed_username_list = ['sasl_test',]
                 - allow_sasl_krb_user:
                     auth_unix_rw = "sasl"
                     sasl_type = "gssapi"
                     # need to create SASL user on the local via ssh
                     server_ip = "${client_ip}"
-                    tcp_setup = "yes"
                     kinit_pwd = "redhat"
+                    sasl_allowed_username_list = '["root/admin" ]'
                 - allow_sasl_users:
                     auth_unix_rw = "sasl"
+                    store_vm_info = "no"
                     sasl_type = "digest-md5"
                     # need to create SASL user on the local via ssh
                     server_ip = "${client_ip}"
                     sasl_user_pwd = "('test', '123456'), ('libvirt', '123456')"
-                    sasl_allowed_users = ['test', 'libvirt']
+                    sasl_allowed_username_list = ['test', 'libvirt']
                 - socket_access_controls:
                     traditional_mode = "yes"
                     auth_unix_ro = "none"
@@ -100,17 +100,18 @@
             variants:
                 - no_allowed_sasl_user:
                     auth_unix_rw = "sasl"
+                    auth_unix_ro = "none"
+                    store_vm_info = "no"
                     sasl_type = "digest-md5"
                     server_ip = "${client_ip}"
-                    tcp_setup = "yes"
                     sasl_user_pwd = "('libvirt', '123456'),"
-                    sasl_allowed_users = ['test']
+                    sasl_allowed_username_list = ['test']
                 - allow_sasl_user_with_readonly:
+                    store_vm_info = "no"
                     sasl_type = "digest-md5"
                     server_ip = "${client_ip}"
-                    tcp_setup = "yes"
                     sasl_user_pwd = "('test', '123456'), "
-                    sasl_allowed_users = ['test']
+                    sasl_allowed_username_list = ['test']
                     auth_unix_rw = "sasl"
                     read_only = "-r"
                     virsh_cmd = "start"
@@ -130,6 +131,7 @@
                     variants:
                         - cfg_file:
                             traditional_mode = "yes"
+                            socket_access_controls_cfg_file = "yes"
                             auth_unix_ro = "none"
                             auth_unix_rw = "none"
                             unix_sock_group = "root"
@@ -139,6 +141,7 @@
                             deluser_cmd = "userdel -r ${su_user}"
                         - socket_file:
                             unix_sock_rw_perms = "0660"
+                            auth_unix_rw = "none"
                             adduser_cmd = "useradd ${su_user}"
                             deluser_cmd = "userdel -r ${su_user}"
                 - socket_with_polkit_ro:

--- a/libvirt/tests/src/remote_access/remote_access.py
+++ b/libvirt/tests/src/remote_access/remote_access.py
@@ -181,6 +181,10 @@ def run(test, params, env):
     """
 
     test_dict = dict(params)
+    socket_access_controls_cfg_file = test_dict.get("socket_access_controls_cfg_file", "no")
+    if socket_access_controls_cfg_file == "yes":
+        if libvirt_version.version_compare(6, 0, 0):
+            test.cancel("This libvirt version doesn't support socket access controls by cfg file.")
     pattern = test_dict.get("filter_pattern", "")
     if ('@LIBVIRT' in pattern and
             distro.detect().name == 'rhel' and


### PR DESCRIPTION
In modular daemon environment, 'virsh -c qemu+unix:///system' will
connect to virtqemud directly. So need config virtqemud.conf.

Signed-off-by: lcheng <lcheng@redhat.com>
