### PR TITLE
controller_functional: fix json format

### DIFF
--- a/libvirt/tests/cfg/controller/controller_functional.cfg
+++ b/libvirt/tests/cfg/controller/controller_functional.cfg
@@ -52,7 +52,7 @@
                 - controller_alias:
                     only i440fx
                     add_contrl_list = "[{'model': 'pci-root', 'index': '0', 'alias': 'ua-PCI_ROOT'},{'model': 'pci-bridge', 'alias': 'ua-PCI_BRIDGE'}, {'model': 'pci-expander-bus', 'alias': 'ua-PCI_EXPANDER_BUS'}]"
-                    qemu_patterns = "[('-device', 'pci-bridge,.*,id=ua-PCI_BRIDGE'), ('-device', 'pxb,.*,id=ua-PCI_EXPANDER_BUS')]"
+                    qemu_patterns = "[('-device', 'pci-bridge.*,.*,.*id.*ua-PCI_BRIDGE'), ('-device', 'pxb.*,.*,.*id.*ua-PCI_EXPANDER_BUS')]"
                     check_contr_addr = "no"
                     check_within_guest = "no"
                 - pcie_root_port_model:
@@ -64,7 +64,7 @@
                     old_model = ioh3420
                     auto_index = "yes"
                     attach_option = "--address pci:0000.%s.00.0"
-                    qemu_patterns = "[('-device', 'pcie-root-port,.*,id=pci.%s,bus=pcie.0,.*addr=0x2.*')]"
+                    qemu_patterns = "[('-device', 'pcie-root-port.*,.*id.*pci.%s.*,.*bus.*pcie.0.*,.*addr.*0x2')]"
                     guest_patterns = "['00:.* PCI bridge: Red Hat']"
                     add_contrl_list = "[{'type': 'pci', 'model': 'pcie-root-port', 'bus': '0x00', 'slot': '0x02'}]"
                 - pcie_pci_bridge_autoadd:
@@ -82,7 +82,7 @@
                     run_vm = "yes"
                     check_within_guest = "no"
                     add_contrl_list = "[{'model': 'dmi-to-pci-bridge', 'index': '1', 'bus': '0x00', 'slot': '0x1e'},{'model': 'pcie-root-port', 'index': '3', 'bus': '0x00', 'slot': '0x02'},{'model': 'pcie-expander-bus', 'index': '7', 'bus': '0x00', 'slot': '0x03'}]"
-                    qemu_patterns = "[('-device', 'i82801b11-bridge,id=pci.1,bus=pcie.0,addr=0x1e'), ('-device', 'pcie-root-port,.*,id=pci.3,bus=pcie.0,.*,addr=0x2'), ('-device', 'pxb-pcie,.*,id=pci.7,bus=pcie.0,addr=0x3')]"
+                    qemu_patterns = "[('-device', 'i82801b11-bridge.*,.*id.*pci.1.*,.*bus.*pcie.0.*,.*addr.*0x1e'), ('-device', 'pcie-root-port.*,.*id.*pci.3.*,.*bus.*pcie.0.*,.*addr.*0x2'), ('-device', 'pxb-pcie.*,.*id.*pci.7.*,.*bus.*pcie.0.*,.*addr.*0x3')]"
                 - pcie_expander_bus_child:
                     only q35
                     run_vm = "yes"
@@ -162,7 +162,7 @@
                     auto_bus = 'yes'
                     check_within_guest = "no"
                     add_contrl_list = "[{'type': 'scsi', 'model': 'virtio-scsi', 'bus': '%s', 'slot': '0x00', 'func': '0x0'},{'type': 'scsi', 'model': 'virtio-scsi', 'bus': '%s', 'slot': '0x00', 'func': '0x2'}]"
-                    qemu_patterns = "[('-device', 'virtio-scsi-pci,.*multifunction=on,addr=0x0.*')]"
+                    qemu_patterns = "[('-device', 'virtio-scsi-pci.*,.*multifunction.*[on|true].*,.*addr.*0x0')]"
                 - virtio_serial:
                     no q35
                     controller_type = virtio-serial

--- a/libvirt/tests/cfg/controller/pcibridge.cfg
+++ b/libvirt/tests/cfg/controller/pcibridge.cfg
@@ -96,7 +96,7 @@
                             err_msg = "XML error: Invalid PCI address slot='.*?', must be <= 0x1F"
                         - s_str:
                             slot = 'haha'
-                            err_msg = "internal error: Cannot parse <address> 'slot' attribute|Invalid value for attribute 'slot'.*: '${slot}'. Expected integer value"
+                            err_msg = "internal error: Cannot parse <address> 'slot' attribute|Invalid value for attribute 'slot'.*: '${slot}'"
                     pci_br_kwargs = "{'index': '9'}"
                     iface_kwargs = {'address': "{'type': 'pci', 'domain': '0x0000', 'bus': '0x09', 'slot': '${slot}', 'function': '0x0'}"}
                 - index_v_bus:

--- a/libvirt/tests/src/controller/controller_functional.py
+++ b/libvirt/tests/src/controller/controller_functional.py
@@ -392,11 +392,11 @@ def run(test, params, env):
             if cmpnn_cntlr_num is not None:
                 for num in range(int(cmpnn_cntlr_num)):
                     name = (cmpnn_cntlr_model+str(num+1)).split('-')
-                    pattern = pattern + r"-device.%s-usb-%s.*" % (name[0], name[1])
+                    pattern = pattern + r"-device.*%s-usb-%s.*" % (name[0], name[1])
             elif model == "ehci":
-                pattern = r"-device.usb-ehci"
+                pattern = r"-device.*usb-ehci"
             elif model == "qemu-xhci":
-                pattern = r"-device.qemu-xhci"
+                pattern = r"-device.*qemu-xhci"
 
             logging.debug("pattern is %s", pattern)
 


### PR DESCRIPTION
libvirt uses json format for qemu command line by default from libvirt 8.1.0.
This is to fix the checking compatible to both format.

Signed-off-by: Dan Zheng <dzheng@redhat.com>
