### PR TITLE
tpm_device: modify swtpm pid grep

### DIFF
--- a/libvirt/tests/src/virtual_device/tpm_device.py
+++ b/libvirt/tests/src/virtual_device/tpm_device.py
@@ -293,18 +293,18 @@ def run(test, params, env):
         """
         logging.info("------Checking swtpm cmdline and files------")
         # Check swtpm cmdline
-        swtpm_pid = utils_misc.get_pid("%s-swtpm.pid" % vm_name)
+        swtpm_pid = utils_misc.get_pid("swtpm socket.*%s" % vm_name)
         if not swtpm_pid:
             if not remove_dev:
-                test.fail('swtpm pid file missing.')
+                test.fail('swtpm socket process missing.')
             else:
                 return
         elif remove_dev:
-            test.fail('swtpm pid file still exists after remove vtpm and restart')
+            test.fail('swtpm socket process still exists after remove vtpm and restart')
         with open('/proc/%s/cmdline' % swtpm_pid) as cmdline_file:
             cmdline = cmdline_file.read()
             logging.debug("Swtpm cmd line info:\n %s", cmdline)
-        pattern_list = ["--daemon", "--ctrl", "--tpmstate", "--log", "--tpm2", "--pid"]
+        pattern_list = ["--ctrl", "--tpmstate", "--log", "--tpm2"]
         if prepare_secret:
             pattern_list.extend(["--key", "--migration-key"])
         for pattern in pattern_list:


### PR DESCRIPTION
'--pid' and '--daemon' is not used by libvirt anymore from libvirt
v8.1.0. So skip these two params checkng in pattern_list, and get
swtpm process id by grep 'swtpm socket' words instead of pid file
name. Since these checking do not affect function, no need to judge
libvirt_version.

Signed-off-by: Yanqiu Zhang <yanqzhan@redhat.com>

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [ ] Description of the cases
- [ ] Links of libvirt features, libvirt bugs or case IDs
- [ ] Test results

## If the PR is bug cases
- [ ] Bug descriptions or bug links
- [ ] Test results

## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
