### PR TITLE
virsh_boot.cfg: fix boot error in BIOS negative test

### DIFF
--- a/libvirt/tests/cfg/bios/virsh_boot.cfg
+++ b/libvirt/tests/cfg/bios/virsh_boot.cfg
@@ -279,7 +279,7 @@
                         - not_existing_boot_dev:
                             boot_dev = "noexist"
                             define_error = "yes"
-                            checkpoint = "error: unsupported configuration: unknown boot device"
+                            checkpoint = "error: unsupported configuration: unknown boot device|XML error: Invalid value for attribute 'dev'"
                         - special_boot_order:
                             boot_ref = "order"
                             define_error = "yes"


### PR DESCRIPTION
virsh_boot.cfg: fix boot error in BIOS negative test

Signed-off-by: Meina Li <meili@redhat.com>
