### PR TITLE
fix device_removed event not found in blockresize

### DIFF
--- a/libvirt/tests/src/backingchain/blockresize.py
+++ b/libvirt/tests/src/backingchain/blockresize.py
@@ -23,6 +23,9 @@ def run(test, params, env):
         """
         Prepare raw disk and create snapshots.
         """
+        if not vm.is_alive():
+            vm.start()
+        vm.wait_for_login().close()
         # Create raw type image
         image_path = test_obj.tmp_dir + '/blockresize_test'
         libvirt.create_local_disk("file", path=image_path, size='500K',


### PR DESCRIPTION
  not found event after disk detached due to disk attached before vm finished start
Signed-off-by: nanli <nanli@redhat.com>

**test result** 

(.libvirt-ci-venv-ci-runtest-OYdoZi) [root@dell-per730-62 tp-libvirt]# 
(.libvirt-ci-venv-ci-runtest-OYdoZi) [root@dell-per730-62 tp-libvirt]# **/usr/local/bin/avocado run --vt-type libvirt --vt-machine-type q35 backingchain.blockresize.positive_test.raw_image.size_mb --vt-connect-uri qemu:///system**
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : c43c12b5ae3c7578d8c4e7a7f6cedd3e57569910
JOB LOG    : /root/avocado/job-results/job-2022-04-06T04.41-c43c12b/job.log
 (1/1) type_specific.io-github-autotest-libvirt.backingchain.blockresize.positive_test.raw_image.size_mb: PASS (29.78 s)
RESULTS    : **PASS** 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 30.60 s
(.libvirt-ci-venv-ci-runtest-OYdoZi) [root@dell-per730-62 tp-libvirt]# **/usr/local/bin/avocado run --vt-type libvirt --vt-machine-type q35 backingchain.blockresize.positive_test.raw_image.size_g --vt-connect-uri qemu:///system**
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : d90d77cc26e2b0c4d4878ffaffa575d9369f3f2a
JOB LOG    : /root/avocado/job-results/job-2022-04-06T04.42-d90d77c/job.log
 (1/1) type_specific.io-github-autotest-libvirt.backingchain.blockresize.positive_test.raw_image.size_g: PASS (26.75 s)
RESULTS    : **PASS** 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 27.52 s
(.libvirt-ci-venv-ci-runtest-OYdoZi) [root@dell-per730-62 tp-libvirt]# 
(.libvirt-ci-venv-ci-runtest-OYdoZi) [root@dell-per730-62 tp-libvirt]# 
(.libvirt-ci-venv-ci-runtest-OYdoZi) [root@dell-per730-62 tp-libvirt]# **/usr/local/bin/avocado run --vt-type libvirt --vt-machine-type q35 backingchain.blockresize.positive_test.raw_image.size_b --vt-connect-uri qemu:///system**
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : 694db7edb81dbb47768aa16fdd0559da30154dfc
JOB LOG    : /root/avocado/job-results/job-2022-04-06T04.42-694db7e/job.log
 (1/1) type_specific.io-github-autotest-libvirt.backingchain.blockresize.positive_test.raw_image.size_b: PASS (33.18 s)
RESULTS    : **PASS** 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 33.98 s
(.libvirt-ci-venv-ci-runtest-OYdoZi) [root@dell-per730-62 tp-libvirt]# cat /proc/version
Linux version 5.14.0-70.6.1.el9_0.x86_64 (mockbuild@x86-vm-08.build.eng.bos.redhat.com) (gcc (GCC) 11.2.1 20220127 (Red Hat 11.2.1-9), GNU ld version 2.35.2-17.el9) #1 SMP PREEMPT Mon Mar 28 17:49:35 EDT 2022
