### PR TITLE
live_migration: Fixup VM startup failure

### DIFF
--- a/libvirt/tests/cfg/migration/live_migration.cfg
+++ b/libvirt/tests/cfg/migration/live_migration.cfg
@@ -17,7 +17,6 @@
     virsh_migrate_src_state = running
     # Local URI
     virsh_migrate_connect_uri = "qemu:///system"
-    image_convert = 'no'
     qemu_conf_path = '/etc/libvirt/qemu.conf'
     variants:
         - with_postcopy:


### PR DESCRIPTION
Signed-off-by: Yingshun Cui <yicui@redhat.com>

# Format of PR title < sub-system: summary >
**Before the fix:**
` (1/1) type_specific.io-github-autotest-libvirt.virsh.live_migration.migrateuri.default.ipv4.p2p_live.without_postcopy: ERROR: VM 'avocado-vt-vm1' failed to start: error: Failed to start domain 'avocado-vt-vm1'\nerror: Cannot access storage file '/var/lib/libvirt/migrate/jeos-27-x86_64.qcow2' (as uid:107, gid:107): No such file or directory (154.09 s)
`

**After the fix:**
` (1/1) type_specific.io-github-autotest-libvirt.virsh.live_migration.migrateuri.default.ipv4.p2p_live.without_postcopy: PASS (708.43 s)`
