### PR TITLE
v2v: seperate the dir permission from usr_partition case

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -330,8 +330,11 @@
             esx_https_proxy = HTTPS_PROXY_V2V_EXAMPLE
         - usr_partition:
             only esx_70
-            no libvirt
             main_vm = VM_NAME_USR_PARTITION_V2V_EXAMPLE
+        - dir_permission:
+            only esx_70
+            main_vm = VM_NAME_ESX70_RHEL9_V2V_EXAMPLE
+            version_required = "[virt-v2v-1.45.99-2,)"
             msg_content = 'setting owner of .*? to 107:root'
             expect_msg = yes
             v2v_debug = force_on


### PR DESCRIPTION
Because the dir_permission case only works in rhel9. We should make
sure it won't fail in rhel8.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>