### PR TITLE
Add case to check commands work well when disable cpuset 

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_emulatorpin_mix.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_emulatorpin_mix.cfg
@@ -13,3 +13,11 @@
                 - start_with_emulatorpin:
                     vcpu_attrs = {'placement': 'static', 'current_vcpu': 3, 'vcpu': 4}
                     cputune_attrs = {'emulatorpin': '%s'}
+                - change_with_disabled_cpuset:
+                    iothreadids = {'iothread': ['2', '1']}
+                    changed_id = '2'
+                    use_taskset = "yes"
+                    cputune_attrs = {'emulatorpin': '1', "iothreadpins": [{'iothread': '2', 'cpuset': '1'}, {'iothread': '1', 'cpuset': '0'}]}
+                    qemu_conf_dict = {'cgroup_controllers': '["devices", "memory", "blkio", "cpu", "cpuacct"]'}
+                    vcpu_attrs = {'placement': 'static', 'current_vcpu': 3, 'vcpu': 4}
+                    cmd_option = '{"execute": "query-iothreads"}'


### PR DESCRIPTION
Add new case to check whether the commands which not require
cgroup will work well when disable them in configure file.

Polarion ID:RHEL7-19570

Signed-off-by: haonanpan <hpan@redhat.com>