### PR TITLE
v2v: change the target of the lvm_multiple_disks

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -46,7 +46,7 @@
                     json_disk_pattern = '%%{GuestName}-%{GuestName}-%{DiskDeviceName}-%{DiskNo}'
         - libvirt:
             only dest_libvirt
-            only uefi, GPO_AV, special_name, suse, local_storage, unset
+            only uefi,GPO_AV,special_name,suse,local_storage,unset,lvm_multiple_disks
         - rhev:
             only dest_rhev.NFS
             variants:
@@ -337,6 +337,7 @@
             v2v_debug = force_on
         - lvm_multiple_disks:
             only esx_65
+            only libvirt
             main_vm = VM_NAME_LVM_MULTIPLE_DISKS_V2V_EXAMPLE
         - resume_rhel7:
             only esx_65


### PR DESCRIPTION
Because rhv is not new enough for including the fix of bz1924972,
the '-o rhv/rhv_upload' will not work at the moment.
So change the target to 'libvirt' to cover this case.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>
