### PR TITLE
Update the error msg for better check

### DIFF
--- a/libvirt/tests/cfg/virtual_network/network_misc.cfg
+++ b/libvirt/tests/cfg/virtual_network/network_misc.cfg
@@ -26,9 +26,9 @@
                                 - 65536:
                                     expect_str = 'acpi-index should be less or equal to 16383'
                                 - -2:
-                                    expect_str = 'Expected integer value'
+                                    expect_str = ['Expected', 'integer value']
                                 - empty:
                                     acpi_index = ''
-                                    expect_str = 'Expected integer value'
+                                    expect_str = ['Expected', 'integer value']
             iface_in_vm = eno${acpi_index}
             iface_attrs = {'acpi': {'index': '${acpi_index}'}, 'type_name': 'network', 'source': {'network': 'default'}, 'model': 'virtio', 'mac_address': '00:11:22:33:44:55'}


### PR DESCRIPTION
New version updated the error msg from "Expected integer value" to
"Expected non-negative integer value". To match both the old and new
version, update the msg for better check.

Signed-off-by: Yalan Zhang <yalzhang@redhat.com>