### PR TITLE
Fix Failed to start domain 'avocado-vt-vm1' error due to the fact tha…

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_managedsave.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_managedsave.py
@@ -404,6 +404,7 @@ def run(test, params, env):
 
         # Wait for vm in stable state
         if params.get("start_vm") == "yes":
+            utils_misc.wait_for(lambda: vm.state() == "shut off", 10)
             if vm.state() == "shut off":
                 vm.start()
                 vm.wait_for_login()


### PR DESCRIPTION
…t VM destroy may not be completed

Confirmed with feature owner, it is actually not related to selinux
Some eror message can be seen with Requested operation is not valid: Setting different SELinux label
on /var/lib/libvirt/qemu/domain-1-avocado-vt-vm1/master-key.aes which is already in use

Signed-off-by: chunfuwen <chwen@redhat.com>

