### PR TITLE
v2v: replace output '-o json' with '-o local'

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -44,6 +44,9 @@
                   no block_dev
                 - pattern:
                     json_disk_pattern = '%%{GuestName}-%{GuestName}-%{DiskDeviceName}-%{DiskNo}'
+        - local:
+            only dest_local
+            only uefi.win2019,device_map,without_ip_option,env_leak,block_dev
         - libvirt:
             only dest_libvirt
             only uefi, GPO_AV, special_name, suse, local_storage, unset
@@ -509,7 +512,7 @@
             main_vm = VM_NAME_ESX70_RHEL7_V2V_EXAMPLE
         - env_leak:
             only esx_67
-            only dest_json
+            only dest_json,local
             main_vm = VM_NAME_WIN2019_V2V_EXAMPLE
             env_settings = 'HOME=/root LIBGUESTFS_BACKEND=direct'
             unprivileged_user = 'USER_UNPRIVILEGED_V2V_EXAMPLE'
@@ -518,7 +521,7 @@
             msg_content = 'Can\'t read path'
         - block_dev:
             only esx_70
-            only dest_json
+            only dest_json,local
             main_vm = VM_NAME_ESX70_RHEL8_V2V_EXAMPLE
             checkpoint = "block_dev"
             os_directory = '/var/lib/libvirt/images/'


### PR DESCRIPTION
Because '-o json' is removed in upstream of v2v, and nobody will
use them in rhel9, so add a new '-o local' target to replace the
'-o json' target. The '-o json' will be kept but skipped during
running.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>