### PR TITLE
Add case for modular redesign backingchain

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockcommit/blockcommit_conventional_chain.cfg
+++ b/libvirt/tests/cfg/backingchain/blockcommit/blockcommit_conventional_chain.cfg
@@ -1,0 +1,41 @@
+- backingchain.blockcommit.conventional_chain:
+    type = blockcommit_conventional_chain
+    start_vm = "yes"
+    commit_options = " --wait --verbose"
+    target_disk = "vdb"
+    variants:
+        - mid_to_mid:
+            top_image_suffix = 3
+            base_image_suffix = 1
+            expected_chain = "4>1>base"
+        - top_to_base:
+            top_image_suffix = 4
+            expected_chain = "base"
+        - top_to_mid:
+            base_image_suffix = 1
+            expected_chain = "1>base"
+        - mid_to_base:
+            top_image_suffix = 3
+            expected_chain = "4>base"
+    variants:
+        - file_disk:
+            disk_type = "file"
+            disk_dict = {"type_name":"${disk_type}", "target":{"dev": "${target_disk}", "bus": "virtio"}, "driver": {"name": "qemu", "type":"qcow2"}}
+        - block_disk:
+            disk_type = "block"
+            disk_dict = {"type_name":"${disk_type}", "target":{"dev": "${target_disk}", "bus": "virtio"}, "driver": {"name": "qemu", "type":"raw"}}
+        - volume_disk:
+            disk_type = "volume"
+            disk_dict = {"type_name":"${disk_type}", "target":{"dev": "${target_disk}", "bus": "virtio"}, "driver": {"name": "qemu", "type":"raw"}}
+        - nfs_disk:
+            disk_type = "nfs"
+            disk_dict = {"type_name":"file", "target":{"dev": "${target_disk}", "bus": "virtio"}, "driver": {"name": "qemu", "type":"qcow2"}}
+        - rbd_with_auth_disk:
+            disk_type = "rbd_with_auth"
+            disk_source_protocol = "rbd"
+            mon_host = "EXAMPLE_MON_HOST"
+            auth_key = "EXAMPLE_AUTH_KEY"
+            auth_user = "EXAMPLE_AUTH_USER"
+            image_path = "EXAMPLE_IMAGE_PATH"
+            sec_dict = {"secret_ephemeral": "no", "secret_private": "yes", "description": "secret_desc_for_backingchain", "usage": "ceph", "usage_name": "cephlibvirt"}
+            disk_dict = {"type_name":"network", "target":{"dev": "${target_disk}", "bus": "virtio"}, "driver": {"name": "qemu", "type":"raw"}}

--- a/libvirt/tests/src/backingchain/blockcommit/blockcommit_conventional_chain.py
+++ b/libvirt/tests/src/backingchain/blockcommit/blockcommit_conventional_chain.py
@@ -1,0 +1,114 @@
+import logging
+
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_disk
+
+from provider.backingchain import blockcommand_base
+from provider.backingchain import check_functions
+from provider.virtual_disk import disk_base
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+
+def run(test, params, env):
+    """
+    Do blockcommit for conventional chain.
+
+    1) Prepare different type disk and snap chain
+        disk types: file, block, volume, file(nfs), network(rbd with auth)
+    2) Do blockcommit:
+        from middle to middle
+        from top to base
+        from top to middle
+        from middle to base
+    3) Check result:
+        hash value of file in vm are correct
+        vm is alive
+    """
+
+    def setup_test():
+        """
+        Prepare specific type disk and create snapshots.
+       """
+        test_obj.new_image_path = disk_obj.add_vm_disk(disk_type, disk_dict)
+
+        if not vm.is_alive():
+            vm.start()
+        vm.wait_for_login().close()
+        test_obj.prepare_snapshot(snap_num=4)
+        check_obj.check_backingchain(test_obj.snap_path_list[::-1])
+
+    def run_test():
+        """
+        Do blockcommit and check backingchain result , file hash value
+        """
+        top_option = " --top %s" % test_obj.snap_path_list[int(top_index)-1]\
+            if top_index else " --pivot"
+        if base_index:
+            # this scenario is from middle to middle and from top to middle
+            base_option = " --base %s" % test_obj.snap_path_list[int(base_index) - 1]
+        elif top_option.split()[-1] == test_obj.snap_path_list[-1]:
+            # this scenario is from top to base
+            base_option = " --pivot"
+        else:
+            # this scenario is from middle to base
+            base_option = " "
+
+        session = vm.wait_for_login()
+
+        status, _ = session.cmd_status_output("which sha256sum")
+        if status:
+            test.error("Not find sha256sum command on guest.")
+        ret, expected_hash = session.cmd_status_output("sha256sum %s" %
+                                                       test_obj.new_dev)
+
+        virsh.blockcommit(vm.name, target_disk,
+                          commit_options+top_option+base_option,
+                          ignore_status=False, debug=True)
+
+        expected_chain = test_obj.convert_expected_chain(expected_chain_index)
+        check_obj.check_backingchain_from_vmxml(disk_type, test_obj.new_dev,
+                                                expected_chain)
+        check_obj.check_hash_list([test_obj.new_dev], [expected_hash], session)
+        session.close()
+
+        if not vm.is_alive():
+            test.fail("The vm should be alive after blockcommit, "
+                      "but it's in %s state.", vm.state)
+
+    def teardown_test():
+        """
+        Clean data.
+        """
+        test_obj.backingchain_common_teardown()
+
+        bkxml.sync()
+        disk_obj.cleanup_disk_preparation(disk_type)
+
+    # Process cartesian parameters
+    vm_name = params.get("main_vm")
+    target_disk = params.get('target_disk')
+    disk_type = params.get('disk_type')
+    disk_dict = eval(params.get('disk_dict', '{}'))
+    commit_options = params.get('commit_options')
+    expected_chain_index = params.get('expected_chain')
+    top_index = params.get('top_image_suffix')
+    base_index = params.get('base_image_suffix')
+
+    vm = env.get_vm(vm_name)
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+
+    # Create object
+    test_obj = blockcommand_base.BlockCommand(test, vm, params)
+    check_obj = check_functions.Checkfunction(test, vm, params)
+    disk_obj = disk_base.DiskBase(test, vm, params)
+    test_obj.original_disk_source = libvirt_disk.get_first_disk_source(vm)
+
+    try:
+        setup_test()
+        run_test()
+
+    finally:
+        teardown_test()

--- a/provider/virtual_disk/disk_base.py
+++ b/provider/virtual_disk/disk_base.py
@@ -1,0 +1,212 @@
+import logging
+
+from avocado.utils import lv_utils, process
+
+from virttest import ceph
+from virttest import data_dir
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.libvirt_xml.devices.disk import Disk
+from virttest.utils_test import libvirt
+from virttest.utils_libvirt import libvirt_secret
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+
+class DiskBase(object):
+    """
+    Prepare disk related function
+    """
+
+    def __init__(self, test, vm, params):
+        """
+        Init the default value for disk object.
+
+        :param test: Test object
+        :param vm: A libvirt_vm.VM class instance.
+        :param params: Dict with the test parameters.
+        """
+        self.test = test
+        self.vm = vm
+        self.params = params
+        self.vg_name = 'vg0'
+        self.lv_name = 'lv0'
+        self.pool_name = 'pool_name'
+        self.pool_type = 'dir'
+        self.pool_target = 'dir_pool'
+        self.emulated_image = 'dir_pool_img'
+        self.new_image_path = ''
+
+    def add_vm_disk(self, disk_type, disk_dict, new_image_path='', **kwargs):
+        """
+        Add vm a disk.
+
+        :param disk_type: disk type
+        :param disk_dict: dict to update disk
+        :param new_image_path: new disk image if needed
+        :return new_image_path: return the updated new image path of new disk
+        """
+
+        vmxml = vm_xml.VMXML.new_from_dumpxml(self.vm.name)
+
+        if disk_type == 'file':
+            if not new_image_path:
+                new_image_path = data_dir.get_data_dir() + '/test.img'
+                libvirt.create_local_disk("file", path=new_image_path,
+                                          size='50M', disk_format="qcow2", **kwargs)
+            disk_dict.update({'source': {'attrs': {'file': new_image_path}}})
+
+        elif disk_type == 'block':
+            if not new_image_path:
+                new_image_path = self.create_lvm_disk_path(
+                    vg_name=self.vg_name, lv_name=self.lv_name, **kwargs)
+            disk_dict.update({'source': {'attrs': {'dev': new_image_path}}})
+
+        elif disk_type == 'volume':
+            if not new_image_path:
+                pool_name, new_image_path = self.create_volume_for_disk_path(
+                    self.test, self.params, self.pool_name,
+                    self.pool_type, self.pool_target, self.emulated_image, **kwargs)
+            disk_dict.update({'source': {'attrs': {'pool': self.pool_name,
+                                                   'volume': new_image_path}}})
+        elif disk_type == 'nfs':
+            if not new_image_path:
+                nfs_res = libvirt.setup_or_cleanup_nfs(is_setup=True, is_mount=True)
+                new_image_path = nfs_res['mount_dir'] + '/test.img'
+
+                libvirt.create_local_disk("file", path=new_image_path, size='50M',
+                                          disk_format="qcow2", **kwargs)
+            disk_dict.update({'source': {'attrs': {'file': new_image_path}}})
+
+        elif disk_type == 'rbd_with_auth':
+            mon_host, auth_username, new_image_path = \
+                self.create_rbd_disk_path(self.params)
+            disk_dict.update({'source': {
+                    'attrs': {'protocol': "rbd", "name": new_image_path},
+                    "hosts": [{"name": mon_host}],
+                    "auth": {"auth_user": auth_username,
+                             "secret_usage": "cephlibvirt",
+                             "secret_type": "ceph"}}})
+
+        disk_xml = self.set_disk_xml(disk_dict)
+        libvirt.add_vm_device(vmxml, disk_xml)
+
+        vmxml = vm_xml.VMXML.new_from_dumpxml(self.vm.name)
+        LOG.debug('vmxml after update disk is:%s', vmxml)
+
+        return new_image_path
+
+    def cleanup_disk_preparation(self, disk_type):
+        """
+        Clean up the preparation of different type disk
+
+        :param disk_type: disk type
+        """
+        if disk_type == 'block':
+            self.cleanup_block_disk_preparation(self.vg_name, self.lv_name)
+
+        elif disk_type == 'file':
+            process.run('rm -f %s' % self.new_image_path)
+
+        elif disk_type == 'volume':
+            pvt = libvirt.PoolVolumeTest(self.test, self.params)
+            pvt.cleanup_pool(self.pool_name, self.pool_type, self.pool_target,
+                             self.emulated_image)
+
+        elif disk_type == 'nfs':
+            libvirt.setup_or_cleanup_nfs(is_setup=False)
+
+        elif disk_type == "rbd_with_auth":
+            libvirt_secret.clean_up_secrets()
+
+    @staticmethod
+    def cleanup_block_disk_preparation(vg_name, lv_name):
+        """
+        Clean up volume group, logical volume, iscsi target.
+
+        :params vg_name: volume group name
+        :params lv_name: volume name
+        """
+        lv_utils.lv_remove(vg_name, lv_name)
+        lv_utils.vg_remove(vg_name)
+        libvirt.setup_or_cleanup_iscsi(is_setup=False)
+
+    @staticmethod
+    def create_volume_for_disk_path(test, params, pool_name='pool_name',
+                                    pool_type='dir', pool_target='dir_pool',
+                                    emulated_image='dir_pool_img',
+                                    vol_name='vol_name', capacity='2G',
+                                    allocation='2G', volume_type='qcow2', **kwargs):
+        """
+        Prepare volume type disk image path
+
+        :param test: test object
+        :param params: Dict with the test parameters.
+        :param pool_name: pool name
+        :param vol_name: volume name
+        :param capacity: volume capacity size
+        :param allocation: volume allocation size
+        :param pool_target: target of storage pool
+        :param pool_type: dir, disk, logical, fs, netfs or else
+        :param emulated_image: use an image file to simulate a scsi disk, it could
+        be used for disk, logical pool, etc
+        :param volume_type: volume type
+        :return pool_name, vol_name: For disk source path
+        """
+        pvt = libvirt.PoolVolumeTest(test, params)
+        pvt.pre_pool(pool_name, pool_type, pool_target, emulated_image)
+
+        virsh.vol_create_as(vol_name, pool_name, capacity, allocation,
+                            volume_type, debug=True, **kwargs)
+
+        return pool_name, vol_name
+
+    @staticmethod
+    def create_lvm_disk_path(vg_name='vg0', lv_name='lv0', **kwargs):
+        """
+        Prepare lvm type disk image path
+
+        :params vg_name: volume group name
+        :params lv_name: volume name
+        :return path: path for disk image
+        """
+        device_name = libvirt.setup_or_cleanup_iscsi(is_setup=True)
+        lv_utils.vg_create(vg_name, device_name)
+        path = libvirt.create_local_disk("lvm", size="10M", vgname=vg_name,
+                                         lvname=lv_name, **kwargs)
+
+        return path
+
+    @staticmethod
+    def create_rbd_disk_path(params):
+        """
+        Prepare rbd type disk image path
+
+        :params params: Dict with the test parameters.
+        :return new_image_path: path for disk image
+        """
+        sec_dict = eval(params.get("sec_dict", '{}'))
+        auth_key = params.get("auth_key")
+        mon_host = params.get("mon_host")
+        new_image_path = params.get("image_path")
+        auth_username = params.get("auth_user")
+
+        ceph.create_config_file(mon_host)
+        libvirt_secret.clean_up_secrets()
+        sec_uuid = libvirt_secret.create_secret(sec_dict=sec_dict)
+        virsh.secret_set_value(sec_uuid, auth_key, debug=True)
+
+        return mon_host, auth_username, new_image_path
+
+    @staticmethod
+    def set_disk_xml(disk_dict):
+        """
+        Set vm disk xml by disk dict.
+
+        :params disk_dict: dict to get disk xml
+        :return: disk xml
+        """
+        new_disk = Disk()
+        new_disk.setup_attrs(**disk_dict)
+
+        return new_disk


### PR DESCRIPTION
Add case for modular redesign backingchain 
Signed-off-by: nanli <nanli@redhat.com>

Case id: VIRT-292832

 [root@dell-per730-62 tp-libvirt]# /**usr/local/bin/avocado run --vt-type libvirt --vt-machine-type q35 backingchain.blockcommit.conventional_chain --vt-connect-uri qemu:///system**
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : 291a6f75d12ea9734925f93c6eb0e4a2286e8e97
JOB LOG    : /root/avocado/job-results/job-2022-04-25T07.23-291a6f7/job.log
 (01/20) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.file_disk.mid_to_mid: PASS (45.95 s)
 (02/20) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.file_disk.top_to_base: PASS (48.95 s)
 (03/20) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.file_disk.top_to_mid: PASS (49.50 s)
 (04/20) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.file_disk.mid_to_base: PASS (48.14 s)
 (05/20) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.block_disk.mid_to_mid: PASS (69.15 s)
 (06/20) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.block_disk.top_to_base: PASS (74.34 s)
 (07/20) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.block_disk.top_to_mid: PASS (69.89 s)
 (08/20) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.block_disk.mid_to_base: PASS (70.27 s)
 (09/20) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.volume_disk.mid_to_mid: PASS (49.09 s)
 (10/20) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.volume_disk.top_to_base: PASS (50.63 s)
 (11/20) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.volume_disk.top_to_mid: PASS (47.39 s)
 (12/20) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.volume_disk.mid_to_base: PASS (49.76 s)
 (13/20) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.nfs_disk.mid_to_mid: PASS (50.08 s)
 (14/20) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.nfs_disk.top_to_base: PASS (50.88 s)
 (15/20) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.nfs_disk.top_to_mid: PASS (50.98 s)
 (16/20) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.nfs_disk.mid_to_base: PASS (51.89 s)
 (17/20) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.rbd_with_auth_disk.mid_to_mid: PASS (61.63 s)
 (18/20) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.rbd_with_auth_disk.top_to_base: PASS (72.47 s)
 (19/20) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.rbd_with_auth_disk.top_to_mid: PASS (119.01 s)
 (20/20) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.rbd_with_auth_disk.mid_to_base: PASS (131.73 s)

