### PR TITLE
Fix variable referenced before assignment error

### DIFF
--- a/libvirt/tests/src/migration/migrate_with_various_hostname.py
+++ b/libvirt/tests/src/migration/migrate_with_various_hostname.py
@@ -132,6 +132,8 @@ def run(test, params, env):
     src_libvirtd = None
     src_NM_service = None
     dest_NM_service = None
+    old_dst_hostname = None
+    old_source_hostname = None
 
     # For safety reasons, we'd better back up  xmlfile.
     new_xml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)


### PR DESCRIPTION
Fix error:
  UnboundLocalError: local variable 'old_dst_hostname' referenced
  before assignment

Signed-off-by: lcheng <lcheng@redhat.com>
