### PR TITLE
Add case to cover validating libvirtd/virtqemud crash scenarios

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_cdrom_device.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_cdrom_device.cfg
@@ -86,6 +86,22 @@
             backend_device = "copy_on_read_not_compatible_with_readonly"
             virt_disk_device_source = "/var/lib/libvirt/images/copy_on_read.iso"
             virt_disk_device_source_second = "/var/lib/libvirt/images/copy_on_read_second.iso"
+        - libvirtd_not_crash_on_domstats:
+            type_name = "file"
+            target_format = "raw"
+            virt_disk_device_source = "/var/lib/libvirt/images/test_crash.iso"
+            target_dev = "sdb"
+            backend_device = "libvirtd_not_crash_on_domstats"
+            only hotplug..positive_test
+        - attach_block_lun_source_disk:
+            only hotplug..positive_test
+            status_error = "no"
+            target_format = "qcow2"
+            type_name = "block"
+            target_dev = "sdb"
+            device_type = "lun"
+            backend_device = "block_lun_source"
+            virt_disk_device_source = "/var/lib/libvirt/images/test_block.img"
     variants:
         - hotplug:
             virt_device_hotplug = "yes"


### PR DESCRIPTION
When domain with cdrom attach and then eject, then virsh domstats,
Libvirtd/Virtqemud should not crash[1]
start a guest with lun device + scsi bus + qcow2 format [2]

[1]https://bugzilla.redhat.com/show_bug.cgi?id=1420718
[2]https://bugzilla.redhat.com/show_bug.cgi?id=1379196

Signed-off-by: chunfuwen <chwen@redhat.com>

