### PR TITLE
virsh_non_root_polkit: Change 'uri' to 'virsh_uri'

### DIFF
--- a/libvirt/tests/cfg/remote_access/virsh_non_root_polkit.cfg
+++ b/libvirt/tests/cfg/remote_access/virsh_non_root_polkit.cfg
@@ -11,14 +11,14 @@
         - positive_testing:
             variants:
                 - virsh_connect_non_root:
-                    uri = "qemu:///system"
+                    virsh_uri = "qemu:///system"
                     message = "System policy prevents management of local virtualized systems"
                 - virsh_connect_non_root_over_ssh:
-                    uri = "qemu:///system"
+                    virsh_uri = "qemu:///system"
                     ssh_connection = "yes"
                     message = "System policy prevents management of local virtualized systems"
                 - virsh_connect_non_root_over_ssh_with_x:
-                    uri = "qemu:///system"
+                    virsh_uri = "qemu:///system"
                     ssh_connection = "yes"
                     ssh_params = "-X"
                     message = "System policy prevents management of local virtualized systems"
@@ -26,5 +26,5 @@
             variants:
                 - virsh_ssh_non_root:
                     auth_pwd = "${su_user_pass}"
-                    uri = "qemu+ssh://localhost/system"
+                    virsh_uri = "qemu+ssh://localhost/system"
                     message = "authentication unavailable: no polkit agent available to authenticate action"

--- a/libvirt/tests/src/remote_access/virsh_non_root_polkit.py
+++ b/libvirt/tests/src/remote_access/virsh_non_root_polkit.py
@@ -20,7 +20,7 @@ def local_access(params, test):
     :param params: dict of test parameters
     :param test: Avocado-VT test instance
     """
-    uri = params.get("uri")
+    virsh_uri = params.get("virsh_uri")
     auth_user = params.get("auth_user", "root")
     auth_pwd = params.get("auth_pwd")
     virsh_cmd = params.get("virsh_cmd", "list")
@@ -33,7 +33,7 @@ def local_access(params, test):
     patterns_extra_dict = params.get("patterns_extra_dict", None)
     log_level = params.get("log_level", "LIBVIRT_DEBUG=3")
     status_error = params.get("status_error", "yes")
-    ret, output = connect_libvirtd(uri, read_only, virsh_cmd, auth_user,
+    ret, output = connect_libvirtd(virsh_uri, read_only, virsh_cmd, auth_user,
                                    auth_pwd, vm_name, status_error, extra_env,
                                    log_level, su_user, virsh_patterns,
                                    patterns_extra_dict)
@@ -53,14 +53,14 @@ def ssh_access(params, test):
     non_root_name = params.get("su_user")
     non_root_pass = params.get("su_user_pass", "toor")
     auth_pwd = params.get("auth_pwd")
-    uri = params.get("uri")
+    virsh_uri = params.get("virsh_uri")
     ssh_params = params.get("ssh_params", "")
     message = params.get("message", "")
     session = remote.remote_login("ssh", "localhost", "22", non_root_name,
                                   non_root_pass, r"[\#\$]\s*$",
                                   extra_cmdline=ssh_params)
     try:
-        command = ("virsh -c {}".format(uri))
+        command = ("virsh -c {}".format(virsh_uri))
         session.sendline(command)
         match, output = session.read_until_output_matches([r".*[Pp]assword.*", ],
                                                           timeout=10.0,


### PR DESCRIPTION
Unable to list cases of virsh_non_root_polkit.
It reports "__init__() got multiple values for argument 'uri'".

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Test results:**
 ```
(1/4) type_specific.io-github-autotest-libvirt.virsh.non_root_polkit.positive_testing.virsh_connect_non_root: STARTED
 (1/4) type_specific.io-github-autotest-libvirt.virsh.non_root_polkit.positive_testing.virsh_connect_non_root: PASS (9.50 s)
 (2/4) type_specific.io-github-autotest-libvirt.virsh.non_root_polkit.positive_testing.virsh_connect_non_root_over_ssh: STARTED
 (2/4) type_specific.io-github-autotest-libvirt.virsh.non_root_polkit.positive_testing.virsh_connect_non_root_over_ssh: PASS (20.47 s)
 (3/4) type_specific.io-github-autotest-libvirt.virsh.non_root_polkit.positive_testing.virsh_connect_non_root_over_ssh_with_x: STARTED
 (3/4) type_specific.io-github-autotest-libvirt.virsh.non_root_polkit.positive_testing.virsh_connect_non_root_over_ssh_with_x: PASS (20.40 s)
 (4/4) type_specific.io-github-autotest-libvirt.virsh.non_root_polkit.negative_testing.virsh_ssh_non_root: STARTED
 (4/4) type_specific.io-github-autotest-libvirt.virsh.non_root_polkit.negative_testing.virsh_ssh_non_root: PASS (18.74 s)

```