### PR TITLE
v2v: new case for converting ova file by non-root user

### DIFF
--- a/v2v/tests/cfg/convert_from_file.cfg
+++ b/v2v/tests/cfg/convert_from_file.cfg
@@ -98,6 +98,10 @@
                                 - user_has_space:
                                     ova_dir = OVA_DIR_BUG_2069768_V2V_EXAMPLE
                                     input_file = '${ova_copy_dir}/OVA_FILE_BUG_2069768_V2V_EXAMPLE'
+                                - normal_user:
+                                    unprivileged_user = 'USER_UNPRIVILEGED_V2V_EXAMPLE'
+                                    ova_dir = OVA_DIR_BUG_2069768_V2V_EXAMPLE
+                                    input_file = '${ova_copy_dir}/OVA_FILE_BUG_2069768_V2V_EXAMPLE'
                         - special:
                             ova_dir = 'OVA_DIR_SPECIAL_V2V_EXAMPLE'
                             variants:


### PR DESCRIPTION
See#bz1984938.
The 'qemu-nbd' will be used in v2v when converting a qcow2 disk by
'-i disk' or ova file by '-i ova'. Both ways can verify the bug.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>