### PR TITLE
provider/vfio/ccw: improve logging

### DIFF
--- a/provider/vfio/ccw.py
+++ b/provider/vfio/ccw.py
@@ -83,7 +83,8 @@ def make_dasd_part(path, session):
     cmd = "fdasd -a %s" % path
     err, out = cmd_status_output(cmd, shell=True, session=session)
     if err:
-        raise TestError("Couldn't create partition. %s" % out)
+        raise TestError("Couldn't create partition. Status code '%s'. %s."
+                        % (err, out))
     return True
 
 


### PR DESCRIPTION
I suspect fdasd might succeed sometimes despite a non-zero
status code though I couldn't reproduce it. This made the test
case fail. (I think this could happen because of a warning
when the disk is detected as used by several hosts.)

Add the status report to the log in case this reproduces.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>