### PR TITLE
Add more error message for mapping new result

### DIFF
--- a/libvirt/tests/cfg/bios/virsh_boot.cfg
+++ b/libvirt/tests/cfg/bios/virsh_boot.cfg
@@ -157,7 +157,7 @@
                         - invalid_boot_dev:
                             define_error = "yes"
                             boot_dev = "noexist"
-                            checkpoint = "error: unsupported configuration: unknown boot device"
+                            checkpoint = "error: unsupported configuration: unknown boot device|XML error: Invalid value for attribute 'dev' in element 'boot': 'noexist'"
                         - special_boot_order:
                             boot_ref = "order"
                             define_error = "yes"


### PR DESCRIPTION
Before failure is 
```
TestFail: Expect should fail with one of ['error: unsupported configuration: unknown boot device'], but failed with:error: Failed to define domain from /tmp/xml_utils_temp_k6o4pe3h.xmlerror: XML error: Invalid value for attribute 'dev' in element 'boot': 'noexist'
```
After
``` 
(1/1) type_specific.io-github-autotest-libvirt.virsh.boot.by_ovmf.negative_test.invalid_boot_dev: PASS (12.00 s)
```