### PR TITLE
Fix virtual network err msg failure

### DIFF
--- a/libvirt/tests/cfg/virtual_network/network_misc.cfg
+++ b/libvirt/tests/cfg/virtual_network/network_misc.cfg
@@ -26,9 +26,9 @@
                                 - 65536:
                                     expect_str = 'acpi-index should be less or equal to 16383'
                                 - -2:
-                                    expect_str = 'Expected integer value'
+                                    expect_str = 'Expected integer value|Expected non-negative integer value'
                                 - empty:
                                     acpi_index = ''
-                                    expect_str = 'Expected integer value'
+                                    expect_str = 'Expected integer value|Expected non-negative integer value'
             iface_in_vm = eno${acpi_index}
             iface_attrs = {'acpi': {'index': '${acpi_index}'}, 'type_name': 'network', 'source': {'network': 'default'}, 'model': 'virtio', 'mac_address': '00:11:22:33:44:55'}


### PR DESCRIPTION
Before failure with
```
TestFail: Expect should fail with one of ['Expected integer value'], but failed with:error: Failed to attach device from /tmp/xml_utils_temp_fvs6yf5p.xmlerror: XML error: Invalid value for attribute 'index' in element 'acpi': '-2'. Expected non-negative integer value
```
After pass
```
 (1/2) type_specific.io-github-autotest-libvirt.virtual_network.network_misc.iface_acpi.value_test.negative_test.-2: PASS (24.34 s)
 (2/2) type_specific.io-github-autotest-libvirt.virtual_network.network_misc.iface_acpi.value_test.negative_test.empty: PASS (24.33 s)
```