### PR TITLE
vcpu_hotpluggable: Remove cgroup utils installation

### DIFF
--- a/libvirt/tests/src/cpu/vcpu_hotpluggable.py
+++ b/libvirt/tests/src/cpu/vcpu_hotpluggable.py
@@ -5,8 +5,6 @@ import ast
 import logging as log
 
 from avocado.utils import process
-from avocado.utils import distro
-from avocado.utils.software_manager import SoftwareManager
 
 from virttest import libvirt_cgroup
 from virttest import virsh
@@ -90,13 +88,6 @@ def run(test, params, env):
     disable_vcpu = params.get("set_disable_vcpu", "")
     start_vm_after_config = params.get('start_vm_after_config', 'yes') == 'yes'
 
-    # Install cgroup utils
-    cgutils = "libcgroup-tools"
-    if distro.detect().name == 'Ubuntu':
-        cgutils = "cgroup-tools"
-    sm = SoftwareManager()
-    if not sm.check_installed(cgutils) and not sm.install(cgutils):
-        test.cancel("cgroup utils package install failed")
     # Backup domain XML
     vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
     vmxml_backup = vmxml.copy()


### PR DESCRIPTION
Cgroup utils package is no longer needed.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Test results:**
 ```
(01/11) type_specific.io-github-autotest-libvirt.vcpu_hotpluggable.positive_test.vcpus_with_order: PASS (38.69 s)
 (02/11) type_specific.io-github-autotest-libvirt.vcpu_hotpluggable.positive_test.enable: PASS (31.87 s)
 (03/11) type_specific.io-github-autotest-libvirt.vcpu_hotpluggable.positive_test.disable: PASS (31.27 s)
 (04/11) type_specific.io-github-autotest-libvirt.vcpu_hotpluggable.positive_test.unplug.live: PASS (32.39 s)
 (05/11) type_specific.io-github-autotest-libvirt.vcpu_hotpluggable.positive_test.unplug.config.running_vm: PASS (31.45 s)
 (06/11) type_specific.io-github-autotest-libvirt.vcpu_hotpluggable.positive_test.unplug.config.shutoff_vm: PASS (11.05 s)
 (07/11) type_specific.io-github-autotest-libvirt.vcpu_hotpluggable.positive_test.plug.live: PASS (32.76 s)
 (08/11) type_specific.io-github-autotest-libvirt.vcpu_hotpluggable.positive_test.plug.config.running_vm: PASS (31.41 s)
 (09/11) type_specific.io-github-autotest-libvirt.vcpu_hotpluggable.positive_test.plug.config.shutoff_vm: PASS (11.11 s)
 (10/11) type_specific.io-github-autotest-libvirt.vcpu_hotpluggable.negative_test.dup_order1: PASS (10.26 s)
 (11/11) type_specific.io-github-autotest-libvirt.vcpu_hotpluggable.negative_test.dup_order2: PASS (10.32 s)
RESULTS    : PASS 11 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 274.66 s
```
