### PR TITLE
sriov: Add a vm lifecycle case

### DIFF
--- a/libvirt/tests/cfg/sriov/vm_lifecycle/sriov_vm_lifecycle_start_destroy.cfg
+++ b/libvirt/tests/cfg/sriov/vm_lifecycle/sriov_vm_lifecycle_start_destroy.cfg
@@ -1,0 +1,55 @@
+- sriov.vm_lifecycle.start_destroy:
+    type = sriov_vm_lifecycle_start_destroy
+    start_vm = "no"
+
+    only x86_64
+    variants dev_type:
+        - hostdev_interface:
+            variants dev_source:
+                - vf_address:
+                    variants:
+                        - managed_yes:
+                            iface_dict = {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}, 'driver': {'driver_attr': {'name': 'vfio'}}, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}, 'mac_address': mac_addr}
+                        - managed_no:
+                            iface_dict = {'managed': 'no', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
+                        - without_managed:
+                            iface_dict = {'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
+                        - vlan:
+                            iface_dict = {'type_name': 'hostdev', 'vlan': {'tags': [{'id': '42'}]}, 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}, 'managed': 'yes', 'driver': {'driver_attr': {'name': 'vfio'}}, 'mac_address': mac_addr}
+        - hostdev_device:
+            variants dev_source:
+                - vf_address:
+                    variants:
+                        - managed_yes:
+                            hostdev_dict = {'alias': {'name': 'ua-1bcbabff-f022-4d4f-ae8c-13f2d3a07906'}, 'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': vf_pci_addr}, 'managed': 'yes'}
+                        - managed_no:
+                            hostdev_dict = {'alias': {'name': 'ua-1bcbabff-f022-4d4f-ae8c-13f2d3a07906'}, 'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': vf_pci_addr}, 'managed': 'no'}
+                - pf_address:
+                    variants:
+                        - managed_yes:
+                            hostdev_dict = {'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': pf_pci_addr}, 'managed': 'yes'}
+                        - managed_no:
+                            hostdev_dict = {'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': pf_pci_addr}, 'managed': 'no'}
+        - network_interface:
+            variants dev_source:
+                - network:
+                    variants net_source:
+                        - pf_name:
+                            variants:
+                                - managed_no:
+                                    iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
+                                    network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev", "managed": "no"}', 'net_forward_pf': net_forward_pf}
+                                - managed_yes:
+                                    iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
+                                    network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev", "managed": "yes"}', 'net_forward_pf': net_forward_pf}
+                                - without_managed:
+                                    iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
+                                    network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev"}', 'net_forward_pf': net_forward_pf}
+                        - vf_address:
+                            variants:
+                                - managed_yes:
+                                    iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
+                                    network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev", "managed": "yes"}', 'vf_list_attrs': vf_list_attrs}
+                                - without_managed:
+                                    iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
+                                    network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev"}', 'vf_list_attrs': vf_list_attrs}

--- a/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_start_destroy.py
+++ b/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_start_destroy.py
@@ -1,0 +1,100 @@
+from virttest import utils_misc
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_network
+from virttest.utils_libvirt import libvirt_vfio
+from virttest.utils_test import libvirt
+
+from provider.sriov import sriov_base
+from provider.sriov import check_points
+
+
+def run(test, params, env):
+    """
+    Start vm with a hostdev device or hostdev interface
+    """
+    def run_test():
+        """
+        Start vm with an interface/device of hostdev type, and test the network
+        function.
+        """
+
+        test.log.info("TEST_STEP1: Attach a hostdev interface/device to VM")
+        iface_dev = sriov_test_obj.create_iface_dev(dev_type, iface_dict)
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        libvirt.add_vm_device(vmxml, iface_dev)
+
+        test.log.info("TEST_STEP2: Start the VM")
+        vm.start()
+        vm_session = vm.wait_for_serial_login(timeout=240)
+
+        test.log.info("TEST_STEP3: Check hostdev xml after VM startup")
+        if dev_type == "network_interface":
+            iface_dict.update({'type_name': 'hostdev'})
+        check_points.comp_hostdev_xml(vm, device_type, iface_dict)
+
+        test.log.info("TEST_STEP4: Check hostdev information - mac, "
+                      "vlan, network accessibility and so on")
+        check_points.check_mac_addr(
+            vm_session, vm.name, device_type, iface_dict)
+
+        if 'vlan' in iface_dict:
+            check_points.check_vlan(sriov_test_obj.pf_name, iface_dict)
+        else:
+            sriov_base.check_vm_network_accessed(vm_session)
+
+        if network_dict:
+            libvirt_network.check_network_connection(
+                network_dict.get("net_name"), 1)
+
+        test.log.info("TEST_STEP5: Destroy VM")
+        vm.destroy(gracefully=False)
+
+        test.log.info("TEST_STEP6: Check environment recovery - mac, driver, "
+                      "vlan")
+        if network_dict:
+            libvirt_network.check_network_connection(
+                network_dict.get("net_name"), 0)
+
+        check_points.check_vlan(sriov_test_obj.pf_name, iface_dict, True)
+
+        if not utils_misc.wait_for(
+            lambda: libvirt_vfio.check_vfio_pci(
+                dev_pci, not managed_disabled, True), 10, 5):
+            test.fail("Got incorrect driver!")
+        if managed_disabled:
+            virsh.nodedev_reattach(dev_name, debug=True, ignore_errors=False)
+            libvirt_vfio.check_vfio_pci(dev_pci, True)
+        check_points.check_mac_addr_recovery(
+            sriov_test_obj.pf_name, device_type, iface_dict)
+
+    dev_type = params.get("dev_type", "")
+    dev_source = params.get("dev_source", "")
+
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    vm = env.get_vm(vm_name)
+    sriov_test_obj = sriov_base.SRIOVTest(vm, test, params)
+    if dev_type == "hostdev_device" and dev_source.startswith("pf"):
+        dev_name = sriov_test_obj.pf_dev_name
+        dev_pci = sriov_test_obj.pf_pci
+    else:
+        dev_name = sriov_test_obj.vf_dev_name
+        dev_pci = sriov_test_obj.vf_pci
+
+    iface_dict = sriov_test_obj.parse_iface_dict()
+    network_dict = sriov_test_obj.parse_network_dict()
+    managed_disabled = iface_dict.get('managed') != "yes" or \
+        (network_dict and network_dict.get('managed') != "yes")
+    device_type = "hostdev" if dev_type == "hostdev_device" else "interface"
+
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    orig_config_xml = vmxml.copy()
+
+    try:
+        sriov_test_obj.setup_default(dev_name, managed_disabled, network_dict)
+        run_test()
+
+    finally:
+        sriov_test_obj.teardown_default(
+            orig_config_xml, managed_disabled, dev_name, network_dict)

--- a/provider/sriov/check_points.py
+++ b/provider/sriov/check_points.py
@@ -1,5 +1,11 @@
 import logging
+import re
+
 from avocado.core import exceptions
+from avocado.utils import process
+
+from virttest import utils_net
+from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 
 
@@ -22,14 +28,90 @@ def comp_hostdev_xml(vm, device_type, hostdev_dict):
     for attr, value in hostdev_dict.items():
         if attr == 'source':
             vm_hostdev_val = vm_hostdev_dict.get(attr).get('untyped_address')
+            if not vm_hostdev_val:
+                continue
             value = hostdev_dict[attr]['untyped_address']
         elif attr in ['address', 'hostdev_address']:
             vm_hostdev_val = vm_hostdev_dict.get(attr).get('attrs')
             value = hostdev_dict[attr]['attrs']
         else:
+            if attr == "managed" and value == "no" and device_type == "interface":
+                value = None
             vm_hostdev_val = vm_hostdev_dict.get(attr)
 
         if vm_hostdev_val != value:
             raise exceptions.TestFail('hostdev xml(%s) comparison failed.'
                                       'Expected "%s",got "%s".'
                                       % (attr, value, vm_hostdev_val))
+
+
+def check_mac_addr(vm_session, vm_name, device_type, iface_dict):
+    """
+    Check VM interface's mac_address
+
+    :param vm_session: VM session
+    :param vm_name: VM name
+    :param device_type: Device type, eg, interface or hostdev
+    :param iface_dict: Interface dict
+    :raises: TestFail if check fails
+    """
+    mac = iface_dict.get("mac_address")
+    if device_type != 'interface' or not mac:
+        LOG.warning("No need to check mac address.")
+        return
+    iface = utils_net.get_linux_iface_info(mac, vm_session)
+    if not iface:
+        raise exceptions.TestFail("Unable to get VM interface with given mac "
+                                  "address - %s!" % mac)
+    if mac not in virsh.domiflist(vm_name, debug=True).stdout_text:
+        raise exceptions.TestFail("Unable to get mac %s in virsh output!"
+                                  % mac)
+
+
+def check_mac_addr_recovery(dev_name, device_type, iface_dict):
+    """
+    Check if mac address is recovered
+
+    :param dev_name: Device name
+    :param device_type: Device type, eg, interface or hostdev
+    :param iface_dict: Interface dict
+    :raises: TestFail if mac address is not restored
+    """
+    mac = iface_dict.get("mac_address")
+    if device_type != 'interface' or not mac:
+        LOG.warning("No need to check mac address.")
+        return
+    cmd = "ip l show %s " % dev_name
+    res = process.run(cmd, shell=True, verbose=True)
+    if mac in res.stdout_text:
+        raise exceptions.TestFail("Still get mac %s in %s!"
+                                  % (mac, res.stdout_text))
+
+
+def check_vlan(dev_name, iface_dict, status_error=False):
+    """
+    Check vlan setting
+
+    :param dev_name: Device name
+    :param iface_dict: Interface dict
+    :param status_error: Whether the vlan should be cleared, defaults to False
+    :raises: TestFail if check fails
+    """
+    if 'vlan' not in iface_dict:
+        LOG.warning("No need to check vlan.")
+        return
+    cmd = "ip l show %s " % dev_name
+    res = process.run(cmd, shell=True, verbose=True)
+    vlan_check = re.findall("vf 0.*vlan (\d+)", res.stdout_text)
+    if status_error:
+        if vlan_check:
+            raise exceptions.TestFail("Still get vlan value from '%s'!" % cmd)
+    else:
+        if not vlan_check:
+            raise exceptions.TestFail("Unable to get vlan value from '%s'!"
+                                      % cmd)
+        act_value = vlan_check[0]
+        exp_value = iface_dict['vlan']['tags'][0]['id']
+        if act_value != exp_value:
+            raise exceptions.TestFail("Incorrect vlan setting! Expected: %s, "
+                                      "Actual: %s." % (exp_value, act_value))


### PR DESCRIPTION
This PR adds below case:
VIRT-292833 - Start vm with an hostdev device or hostdev interface

Signed-off-by: Yingshun Cui <yicui@redhat.com>
depends on https://github.com/autotest/tp-libvirt/pull/4120

**Test result:**
```

 (01/13) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start_destroy.hostdev_interface.vf_address.managed_yes: PASS (50.04 s)
 (02/13) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start_destroy.hostdev_interface.vf_address.managed_no: PASS (50.23 s)
 (03/13) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start_destroy.hostdev_interface.vf_address.without_managed: PASS (50.03 s)
 (04/13) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start_destroy.hostdev_interface.vf_address.vlan: PASS (47.04 s)
 (05/13) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start_destroy.hostdev_device.vf_address.managed_yes: PASS (49.91 s)
 (06/13) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start_destroy.hostdev_device.vf_address.managed_no: PASS (44.18 s)
 (07/13) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start_destroy.hostdev_device.pf_address.managed_yes: PASS (67.08 s)
 (08/13) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start_destroy.hostdev_device.pf_address.managed_no: PASS (62.43 s)
 (09/13) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start_destroy.network_interface.network.pf_name.managed_no: PASS (51.22 s)
 (10/13) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start_destroy.network_interface.network.pf_name.managed_yes: PASS (51.06 s)
 (11/13) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start_destroy.network_interface.network.pf_name.without_managed: PASS (50.90 s)
 (12/13) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start_destroy.network_interface.network.vf_address.managed_yes: PASS (50.85 s)
 (13/13) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start_destroy.network_interface.network.vf_address.without_managed: PASS (50.89 s)
RESULTS    : PASS 13 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0

```