### PR TITLE
Add case to start vm with cpuset config and live update emulatorpin

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_emulatorpin.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_emulatorpin.cfg
@@ -48,7 +48,7 @@
                                         - single:
                                             emulatorpin_cpulist = "x"
                                         - auto_placement:
-                                            emulatorpin_placement = "auto"
+                                            vcpu_attrs = {'placement': 'auto'}
                                             emulatorpin_cpulist = "x"
                                     variants:
                                         - emulatorpin_options:
@@ -77,6 +77,11 @@
                                             emulatorpin_cpulist = "x-y,^z"
                                         - single:
                                             emulatorpin_cpulist = "x"
+                                            variants:
+                                                - @default:
+                                                - start_with_cpuset_config:
+                                                    vcpu_attrs = {'placement': 'static', 'cpuset': 'x,y', 'current_vcpu': 1, 'vcpu': 7}
+                                                    check_cpus_allowed_list = 'yes'
                                     variants:
                                         - emulatorpin_options:
                                             variants:
@@ -84,7 +89,6 @@
                                                     emulatorpin_options = "live"
                                                 - current:
                                                     emulatorpin_options = "current"
-
         - negative_testing:
             status_error = "yes"
             variants:


### PR DESCRIPTION
Add case to start vm with cpuset config and live update emulatorpin

This case start guest with overall cpuset setting
but without emulatorpin setting, and check whether allowed list
is expected before and after live update emulatorpin.

Polarion ID:RHEL-114491

Signed-off-by: haonanpan <hpan@redhat.com>