### PR TITLE
nvdimm: add case for pmem and alignsize and readonnly

### DIFF
--- a/libvirt/tests/cfg/memory/nvdimm.cfg
+++ b/libvirt/tests/cfg/memory/nvdimm.cfg
@@ -1,6 +1,7 @@
 - nvdimm:
     type = nvdimm
     start_vm = no
+    nvdimm_file_size = '512M'
     variants:
         - back_file:
             nvdimm_file = /tmp/nvdimm
@@ -13,6 +14,8 @@
             variants:
                 - label:
                     check = label_back_file
+                    test_str = 'This is a test with label'
+                    test_file = 'foo-label'
                     cpuxml_numa_cell = [{'id': '0', 'cpus': '0-1', 'memory': '512', 'unit': 'M'}, {'id': '1', 'cpus': '2-3', 'memory': '512', 'unit': 'M'}]
                     nvdimmxml_target_size = 512
                     nvdimmxml_target_size_unit = M
@@ -39,6 +42,14 @@
                             nvdimmxml_discard = yes
                             status_error = yes
                             error_msg = 'discard is not supported for nvdimms'
+                        - pmem_alignsize:
+                            check = pmem_alignsize
+                            nvdimm_file_path = '/tmp/nvdimm'
+                            alignsize = 2048
+                            vm_attrs = {'max_mem_rt': 8192, 'max_mem_rt_slots': 8, 'max_mem_rt_unit': 'M', 'vcpu': 4, 'cpu': {'mode': 'host-model', 'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '2097152', 'unit': 'K'}, {'id': '1', 'cpus': '2-3', 'memory': '2097152', 'unit': 'K'}]}}
+                            mem_device_attrs = {'mem_model': 'nvdimm', 'source': {'path': '${nvdimm_file_path}', 'alignsize': ${alignsize}, 'alignsize_unit': 'K', 'pmem': True}, 'target': {'size': 512, 'size_unit': 'M', 'node': 1, 'readonly': True, 'label': {'size': 128, 'size_unit': 'KiB'}}}
+                            qemu_checks = "align.*pmem"
+                            error_msg = "['pwrite.* failed: Operation not permitted', 'wrong fs type, bad option, bad superblock on /dev/pmem0']"
                         - with_uuid:
                             only pseries
                             nvdimmxml_uuid = '8ec948ec-8898-46af-889c-470b50297999'
@@ -57,6 +68,7 @@
                                     error_msg = 'minimum target size for the NVDIMM must be 256MB plus the label size'
                 - no_label:
                     check = back_file
+                    test_str = 'test no label'
                     cpuxml_topology = {'sockets': '2', 'cores': '1', 'threads': '1'}
                     cpuxml_numa_cell = [{'id': '0', 'cpus': '0-1', 'memory': '1048576', 'unit': 'KiB'}]
                     nvdimmxml_target_size = 524288

--- a/libvirt/tests/src/memory/nvdimm.py
+++ b/libvirt/tests/src/memory/nvdimm.py
@@ -1,4 +1,5 @@
 import os
+import re
 import logging as log
 import time
 import platform
@@ -19,107 +20,440 @@ from virttest.utils_test import libvirt
 logging = log.getLogger('avocado.' + __name__)
 
 
+def check_boot_config(session, test):
+    """
+    Check /boot/config-$KVER file
+
+    :param session: vm session
+    :param test: test object
+    :raises: test.fail if checking fails
+    """
+    check_list = [
+        'CONFIG_LIBNVDIMM=m',
+        'CONFIG_BLK_DEV_PMEM=m',
+        'CONFIG_ACPI_NFIT=m'
+    ]
+    current_boot = session.cmd('uname -r').strip()
+    content = session.cmd('cat /boot/config-%s' % current_boot).strip()
+    for item in check_list:
+        if item in content:
+            logging.info(item)
+        else:
+            logging.error(item)
+            test.fail('/boot/config content not correct')
+
+
+def check_file_in_vm(session, path, test, expect=True):
+    """
+    Check whether the existence of file meets expectation
+
+    :param session:  vm session
+    :param path: str, file path to be checked
+    :param test: test object
+    :param expect: boolean, True to expect existence. False to not
+    :raises: test.fail if checking fails
+    """
+    exist = session.cmd_status('ls %s' % path)
+    logging.debug(exist)
+    exist = True if exist == 0 else False
+    status = '' if exist else 'NOT'
+    logging.info('File %s does %s exist', path, status)
+    if exist != expect:
+        err_msg = 'Existance doesn\'t meet expectation: %s ' % path
+        if expect:
+            err_msg += 'should exist.'
+        else:
+            err_msg += 'should not exist'
+        test.fail(err_msg)
+
+
+def create_cpuxml(params):
+    """
+    Create cpu xml for test
+
+    :param params: dict, test parameters
+    :return: VMCPUXML object
+    """
+    cpu_params = {k: v for k, v in params.items() if k.startswith('cpuxml_')}
+    logging.debug(cpu_params)
+    cpu_xml = vm_xml.VMCPUXML()
+    cpu_xml.xml = "<cpu><numa/></cpu>"
+    if 'cpuxml_numa_cell' in cpu_params:
+        cpu_params['cpuxml_numa_cell'] = cpu_xml.dicts_to_cells(
+            eval(cpu_params['cpuxml_numa_cell']))
+    for attr_key in cpu_params:
+        val = cpu_params[attr_key]
+        logging.debug('Set cpu params')
+        setattr(cpu_xml, attr_key.replace('cpuxml_', ''),
+                eval(val) if ':' in val else val)
+    logging.debug(cpu_xml)
+    return cpu_xml.copy()
+
+
+def create_nvdimm_xml(**mem_param):
+    """
+    Create xml of nvdimm memory device
+
+    :param mem_param: dict, test parameters
+    :return: Memory object
+    """
+    mem_xml = utils_hotplug.create_mem_xml(
+        tg_size=mem_param['target_size'],
+        mem_addr={'slot': mem_param['address_slot']},
+        tg_sizeunit=mem_param['target_size_unit'],
+        tg_node=mem_param['target_node'],
+        mem_discard=mem_param.get('discard'),
+        mem_model="nvdimm",
+        lb_size=mem_param.get('label_size'),
+        lb_sizeunit=mem_param.get('label_size_unit'),
+        mem_access=mem_param['mem_access'],
+        uuid=mem_param.get('uuid')
+    )
+
+    source_xml = memory.Memory.Source()
+    source_xml.path = mem_param['source_path']
+    mem_xml.source = source_xml
+    logging.debug(mem_xml)
+
+    return mem_xml.copy()
+
+
+def check_nvdimm_file(test_str, file_name, vm_session, test):
+    """
+    check if expected content exists in nvdimm memory file
+
+    :param test_str: str, to be checked in nvdimm file
+    :param file_name: str, the file name in nvdimm file
+    :param vm_session: session to the vm
+    :param test: test object
+    :raises test.fail, if test_str is not in the file
+    """
+    if test_str not in vm_session.cmd('cat /mnt/%s ' % file_name):
+        test.fail('"%s" should be in output' % test_str)
+
+
+def setup_test_pmem_alignsize(guest_xml, params):
+    """
+    Setup steps for pmem and alignsize test
+
+    :param guest_xml: guest xml
+    :param params: dict, test parameters
+    :return: the updated guest xml
+    """
+    vm_attrs = eval(params.get('vm_attrs', '{}'))
+    mem_device_attrs = eval(params.get('mem_device_attrs', '{}'))
+    if vm_attrs:
+        guest_xml.setup_attrs(**vm_attrs)
+    if mem_device_attrs:
+        mem_device = memory.Memory()
+        mem_device.setup_attrs(**mem_device_attrs)
+        guest_xml.add_device(mem_device)
+    guest_xml.sync()
+    return guest_xml
+
+
+def setup_test_default(guest_xml, params):
+    """
+    Setup steps by default
+
+    :param guest_xml: guest xml
+    :param params: dict, test parameters
+    :return: the updated guest xml
+    """
+    # Create nvdimm file on the host
+    nvdimm_file_size = params.get('nvdimm_file_size')
+    nvdimm_file = params.get('nvdimm_file')
+    process.run('truncate -s %s %s' % (nvdimm_file_size, nvdimm_file), verbose=True)
+
+    if params.get('vm_attrs'):
+        guest_xml = setup_test_pmem_alignsize(guest_xml, params)
+        return guest_xml
+    # Set cpu according to params
+    cpu_xml = create_cpuxml(params)
+    guest_xml.cpu = cpu_xml
+
+    # Update other vcpu, memory info according to params
+    update_vm_args = {k: params[k] for k in params
+                      if k.startswith('setvm_')}
+    logging.debug(update_vm_args)
+    for key, value in list(update_vm_args.items()):
+        attr = key.replace('setvm_', '')
+        logging.debug('Set %s = %s', attr, value)
+        setattr(guest_xml, attr, int(value) if value.isdigit() else value)
+
+    # Add an nvdimm mem device to vm xml
+    nvdimm_params = {k.replace('nvdimmxml_', ''): v
+                     for k, v in params.items() if k.startswith('nvdimmxml_')}
+    nvdimm_xml = create_nvdimm_xml(**nvdimm_params)
+    guest_xml.add_device(nvdimm_xml)
+    error_msg = params.get('error_msg')
+    check = params.get('check')
+    check_define_list = ['ppc_no_label', 'discard']
+    if libvirt_version.version_compare(7, 0, 0):
+        check_define_list.append('less_than_256')
+
+    if check in check_define_list:
+        result = virsh.define(guest_xml.xml, debug=True)
+        libvirt.check_result(result, expected_fails=[error_msg])
+        return None
+
+    guest_xml.sync()
+    logging.debug(virsh.dumpxml(params.get('main_vm')).stdout_text)
+    return guest_xml
+
+
+def create_file_within_nvdimm_disk(vm_session, test_file, test_str, test, block_size=0):
+    """
+    Create a test file in the nvdimm file disk
+
+    :param vm_session: VM session
+    :param test_file: str, file name to be used
+    :param test_str: str to be written into the nvdimm file disk
+    :param test: test object
+    :param block_size: int, block size for mkfs.xfs -b
+    """
+    # Create a file system on /dev/pmem0
+    bsize_str = '-b size={}'.format(block_size) if block_size != 0 else ''
+    if any(platform.platform().find(ver) for ver in ('el8', 'el9')):
+        cmd = 'mkfs.xfs -f {} /dev/pmem0 -m reflink=0'.format(bsize_str)
+    else:
+        cmd = 'mkfs.xfs -f {} /dev/pmem0'.format(bsize_str)
+    output = vm_session.cmd_output(cmd)
+    test.log.debug("Command '%s' output:%s", cmd, output)
+    # Mount the file system with DAX enabled for page cache bypass
+    cmd = 'mount -o dax /dev/pmem0 /mnt'
+    output = vm_session.cmd_output(cmd)
+    test.log.debug("Mount output:%s", output)
+
+    cmd = 'echo \"%s\" >/mnt/%s' % (test_str, test_file)
+    vm_session.cmd(cmd)
+
+    check_nvdimm_file(test_str, test_file, vm_session, test)
+
+    vm_session.cmd('umount /mnt')
+
+
+def test_no_label(vm, params, test):
+    """
+    Test nvdimm without label setting
+
+    :param vm: vm object
+    :param params: dict, test parameters
+    :param test: test object
+    :raises: test.fail if checkpoints fail
+    """
+    test_str = params.get('test_str')
+    vm_session = vm.wait_for_login()
+    # Create a file system on /dev/pmem0
+    create_file_within_nvdimm_disk(vm_session, 'foo', test_str, test)
+    vm_session.close()
+
+    # Shutdown the guest, then start it, remount /dev/pmem0,
+    # check if the test file is still on the file system
+    vm.destroy()
+    vm.start()
+    vm_session = vm.wait_for_login()
+
+    vm_session.cmd('mount -o dax /dev/pmem0 /mnt')
+    check_nvdimm_file(test_str, 'foo', vm_session, test)
+    # From the host, check the file has changed:
+    host_output = process.run('hexdump -C /tmp/nvdimm',
+                              shell=True, verbose=True).stdout_text
+    if test_str not in host_output:
+        test.fail('\"%s\" should be in output' % test_str)
+
+    # Shutdown the guest, and edit the xml,
+    # include: access='private'
+    vm_session.close()
+    vm.destroy()
+    guest_xml = vm_xml.VMXML.new_from_dumpxml(params.get('main_vm'))
+    vm_devices = guest_xml.devices
+    nvdimm_device = vm_devices.by_device_tag('memory')[0]
+    nvdimm_index = vm_devices.index(nvdimm_device)
+    vm_devices[nvdimm_index].mem_access = 'private'
+    guest_xml.devices = vm_devices
+    guest_xml.sync()
+
+    # Login to the guest, mount the /dev/pmem0 and .
+    # create a file: foo-private
+    vm.start()
+    vm_session = vm.wait_for_login()
+    IS_PPC_TEST = 'ppc64le' in platform.machine().lower()
+    if IS_PPC_TEST:
+        libvirt.check_qemu_cmd_line('mem-path=/tmp/nvdimm,share=no')
+
+    private_str = 'This is a test for foo-private'
+    vm_session.cmd('mount -o dax /dev/pmem0 /mnt/')
+
+    file_private = 'foo-private'
+    vm_session.cmd("echo '%s' >/mnt/%s" % (private_str, file_private))
+    check_nvdimm_file(private_str, file_private, vm_session, test)
+    # Shutdown the guest, then start it,
+    # check the file: foo-private is no longer existed
+    vm_session.close()
+    vm.destroy()
+
+    vm.start()
+    vm_session = vm.wait_for_login()
+    vm_session.cmd('mount -o dax /dev/pmem0 /mnt/')
+    if file_private in vm_session.cmd('ls /mnt/'):
+        test.fail('%s should not exist, for it was '
+                  'created when access=private' % file_private)
+
+
+def test_with_label(vm, params, test):
+    """
+    Test nvdimm with label setting
+
+    :param vm: vm object
+    :param params: dict, test parameters
+    :param test: test object
+    :raises: test.fail if checkpoints fail
+    """
+    test_str = params.get('test_str')
+    test_file = params.get('test_file')
+    vm_name = params.get('main_vm')
+    vm_session = vm.wait_for_login()
+    # Create a file on the nvdimm device.
+    create_file_within_nvdimm_disk(vm_session, test_file, test_str, test, block_size=4096)
+
+    # Reboot the guest, and remount the nvdimm device in the guest.
+    # Check the file foo-label is exited
+    vm_session.close()
+    virsh.reboot(vm_name, debug=True)
+    vm_session = vm.wait_for_login()
+
+    vm_session.cmd('mount -o dax /dev/pmem0  /mnt')
+    if test_str not in vm_session.cmd('cat /mnt/foo-label '):
+        test.fail('"%s" should be in output' % test_str)
+    vm_session.close()
+    if params.get('check_life_cycle', 'no') == 'yes':
+        virsh.managedsave(vm_name, ignore_status=False, debug=True)
+        vm.start()
+        vm_session = vm.wait_for_login()
+        check_nvdimm_file(test_str, test_file, vm_session, test)
+        vm_session.close()
+        vm_s1 = vm_name + ".s1"
+        virsh.save(vm_name, vm_s1, ignore_status=False, debug=True)
+        virsh.restore(vm_s1, ignore_status=False, debug=True)
+        vm_session = vm.wait_for_login()
+        check_nvdimm_file(test_str, test_file, vm_session, test)
+        vm_session.close()
+        virsh.snapshot_create_as(vm_name, vm_s1, ignore_status=False, debug=True)
+        virsh.snapshot_revert(vm_name, vm_s1, ignore_status=False, debug=True)
+        virsh.snapshot_delete(vm_name, vm_s1, ignore_status=False, debug=True)
+
+
+def test_hotplug(vm, params, test):
+    """
+    Test nvdimm device hotplug
+
+    :param vm: vm object
+    :param params: dict, test parameters
+    :param test: test object
+    :raises: test.fail if checkpoints fail
+    """
+    vm_name = params.get('main_vm')
+    nvdimm_file_2 = params.get('nvdimm_file_2')
+    process.run('truncate -s 512M %s' % nvdimm_file_2)
+    vm_session = vm.wait_for_login()
+    # Add 2nd nvdimm device to vm xml
+    nvdimm2_params = {k.replace('nvdimmxml2_', ''): v
+                      for k, v in params.items() if k.startswith('nvdimmxml2_')}
+    nvdimm2_xml = create_nvdimm_xml(**nvdimm2_params)
+
+    ori_devices = vm_xml.VMXML.new_from_dumpxml(vm_name).get_devices('memory')
+    logging.debug('Starts with %d memory devices', len(ori_devices))
+
+    result = virsh.attach_device(vm_name, nvdimm2_xml.xml, debug=True)
+    libvirt.check_exit_status(result)
+
+    # After attach, there should be an extra memory device
+    devices_after_attach = vm_xml.VMXML.new_from_dumpxml(vm_name).get_devices('memory')
+    logging.debug('After detach, vm has %d memory devices',
+                  len(devices_after_attach))
+    if len(ori_devices) != len(devices_after_attach) - 1:
+        test.fail('Number of memory devices after attach is %d, should be %d'
+                  % (len(devices_after_attach), len(ori_devices) + 1))
+
+    # Create namespace for ppc tests
+    IS_PPC_TEST = 'ppc64le' in platform.machine().lower()
+    if IS_PPC_TEST:
+        logging.debug(vm_session.cmd_output(
+            'ndctl create-namespace --mode=fsdax --region=region1'))
+
+    time.sleep(int(params.get('wait_sec', 5)))
+    check_file_in_vm(vm_session, '/dev/pmem1', test)
+    alive_vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+    nvdimm_detach = alive_vmxml.get_devices('memory')[-1]
+    logging.debug(nvdimm_detach)
+
+    # Hot-unplug nvdimm device
+    result = virsh.detach_device(vm_name, nvdimm_detach.xml, debug=True)
+    libvirt.check_exit_status(result)
+
+    vm_session.close()
+    vm_session = vm.wait_for_login()
+
+    logging.debug(virsh.dumpxml(vm_name).stdout_text)
+
+    left_devices = vm_xml.VMXML.new_from_dumpxml(vm_name).get_devices('memory')
+    logging.debug(left_devices)
+
+    if len(left_devices) != len(ori_devices):
+        test.fail('Number of memory devices after detach is %d, should be %d'
+                  % (len(left_devices), len(ori_devices)))
+
+    time.sleep(int(params.get('wait_sec', 5)))
+    check_file_in_vm(vm_session, '/dev/pmem1', test, expect=False)
+
+
+def test_pmem_alignsize(vm, params, test):
+    """
+    Test nvdimm with pmem and alignsize setting
+
+    :param vm: vm object
+    :param params: dict, test parameters
+    :param test: test object
+    :raises: test.fail if checkpoints fail
+    """
+    error_msg = eval(params.get('error_msg'))
+    libvirt.check_qemu_cmd_line(params.get('qemu_checks'))
+
+    vm_session = vm.wait_for_login()
+    # Create a file on the nvdimm device.
+    output = vm_session.cmd_output('mkfs.xfs -f /dev/pmem0'.format())
+
+    if not re.search(error_msg[0], output):
+        test.fail("The error '{}' should be in the output \n'{}'".format(error_msg[0], output))
+    output = vm_session.cmd_output('mount /dev/pmem0 /mnt')
+    if not re.search(error_msg[1], output):
+        test.fail("The error '{}' should be in the output \n'{}'".format(error_msg[1], output))
+
+    vm_session.close()
+
+
+def cleanup_test_default(params):
+    """
+    Cleanup steps for the test by default
+
+    :param params: dict, test parameters
+    :return:
+    """
+    for one_file in [params.get('nvdimm_file_2'), params.get('nvdimm_file')]:
+        if one_file:
+            os.remove(one_file)
+
+
 def run(test, params, env):
     """
     Test memory management of nvdimm
     """
     vm_name = params.get('main_vm')
-
-    nvdimm_file = params.get('nvdimm_file')
     check = params.get('check', '')
     status_error = "yes" == params.get('status_error', 'no')
     error_msg = params.get('error_msg', '')
     qemu_checks = params.get('qemu_checks', '').split('`')
-    wait_sec = int(params.get('wait_sec', 5))
-    test_str = 'This is a test'
-
-    def check_boot_config(session):
-        """
-        Check /boot/config-$KVER file
-        """
-        check_list = [
-            'CONFIG_LIBNVDIMM=m',
-            'CONFIG_BLK_DEV_PMEM=m',
-            'CONFIG_ACPI_NFIT=m'
-        ]
-        current_boot = session.cmd('uname -r').strip()
-        content = session.cmd('cat /boot/config-%s' % current_boot).strip()
-        for item in check_list:
-            if item in content:
-                logging.info(item)
-            else:
-                logging.error(item)
-                test.fail('/boot/config content not correct')
-
-    def check_file_in_vm(session, path, expect=True):
-        """
-        Check whether the existence of file meets expectation
-        """
-        exist = session.cmd_status('ls %s' % path)
-        logging.debug(exist)
-        exist = True if exist == 0 else False
-        status = '' if exist else 'NOT'
-        logging.info('File %s does %s exist', path, status)
-        if exist != expect:
-            err_msg = 'Existance doesn\'t meet expectation: %s ' % path
-            if expect:
-                err_msg += 'should exist.'
-            else:
-                err_msg += 'should not exist'
-            test.fail(err_msg)
-
-    def create_cpuxml():
-        """
-        Create cpu xml for test
-        """
-        cpu_params = {k: v for k, v in params.items() if k.startswith('cpuxml_')}
-        logging.debug(cpu_params)
-        cpu_xml = vm_xml.VMCPUXML()
-        cpu_xml.xml = "<cpu><numa/></cpu>"
-        if 'cpuxml_numa_cell' in cpu_params:
-            cpu_params['cpuxml_numa_cell'] = cpu_xml.dicts_to_cells(
-                eval(cpu_params['cpuxml_numa_cell']))
-        for attr_key in cpu_params:
-            val = cpu_params[attr_key]
-            logging.debug('Set cpu params')
-            setattr(cpu_xml, attr_key.replace('cpuxml_', ''),
-                    eval(val) if ':' in val else val)
-        logging.debug(cpu_xml)
-        return cpu_xml.copy()
-
-    def create_nvdimm_xml(**mem_param):
-        """
-        Create xml of nvdimm memory device
-        """
-        mem_xml = utils_hotplug.create_mem_xml(
-            tg_size=mem_param['target_size'],
-            mem_addr={'slot': mem_param['address_slot']},
-            tg_sizeunit=mem_param['target_size_unit'],
-            tg_node=mem_param['target_node'],
-            mem_discard=mem_param.get('discard'),
-            mem_model="nvdimm",
-            lb_size=mem_param.get('label_size'),
-            lb_sizeunit=mem_param.get('label_size_unit'),
-            mem_access=mem_param['mem_access'],
-            uuid=mem_param.get('uuid')
-        )
-
-        source_xml = memory.Memory.Source()
-        source_xml.path = mem_param['source_path']
-        mem_xml.source = source_xml
-        logging.debug(mem_xml)
-
-        return mem_xml.copy()
-
-    def check_nvdimm_file(file_name):
-        """
-        check if the file exists in nvdimm memory device
-
-        :param file_name: the file name in nvdimm device
-        """
-        vm_session = vm.wait_for_login()
-        if test_str not in vm_session.cmd('cat /mnt/%s ' % file_name):
-            test.fail('"%s" should be in output' % test_str)
 
     bkxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
 
@@ -129,40 +463,13 @@ def run(test, params, env):
             test.cancel('Libvirt version should be > 6.2.0'
                         ' to support nvdimm on pseries')
 
+    vm = env.get_vm(vm_name)
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+
     try:
-        vm = env.get_vm(vm_name)
-        # Create nvdimm file on the host
-        process.run('truncate -s 512M %s' % nvdimm_file, verbose=True)
-        vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
-
-        # Set cpu according to params
-        cpu_xml = create_cpuxml()
-        vmxml.cpu = cpu_xml
-
-        # Update other vcpu, memory info according to params
-        update_vm_args = {k: params[k] for k in params
-                          if k.startswith('setvm_')}
-        logging.debug(update_vm_args)
-        for key, value in list(update_vm_args.items()):
-            attr = key.replace('setvm_', '')
-            logging.debug('Set %s = %s', attr, value)
-            setattr(vmxml, attr, int(value) if value.isdigit() else value)
-        logging.debug(virsh.dumpxml(vm_name).stdout_text)
-
-        # Add an nvdimm mem device to vm xml
-        nvdimm_params = {k.replace('nvdimmxml_', ''): v
-                         for k, v in params.items() if k.startswith('nvdimmxml_')}
-        nvdimm_xml = create_nvdimm_xml(**nvdimm_params)
-        vmxml.add_device(nvdimm_xml)
-        check_define_list = ['ppc_no_label', 'discard']
-        if libvirt_version.version_compare(7, 0, 0):
-            check_define_list.append('less_than_256')
-        if check in check_define_list:
-            result = virsh.define(vmxml.xml, debug=True)
-            libvirt.check_result(result, expected_fails=[error_msg])
+        vmxml = setup_test_default(vmxml, params)
+        if not vmxml:
             return
-        vmxml.sync()
-        logging.debug(virsh.dumpxml(vm_name).stdout_text)
 
         if IS_PPC_TEST:
             # Check whether uuid is automatically created
@@ -189,13 +496,11 @@ def run(test, params, env):
         if IS_PPC_TEST:
             list(map(libvirt.check_qemu_cmd_line, qemu_checks))
 
-        alive_vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
-
         # Check if the guest support NVDIMM:
         # check /boot/config-$KVER file
         vm_session = vm.wait_for_login()
         if not IS_PPC_TEST:
-            check_boot_config(vm_session)
+            check_boot_config(vm_session, test)
 
         # ppc test requires ndctl
         if IS_PPC_TEST:
@@ -205,174 +510,18 @@ def run(test, params, env):
                 'ndctl create-namespace --mode=fsdax --region=region0'))
 
         # check /dev/pmem0 existed inside guest
-        check_file_in_vm(vm_session, '/dev/pmem0')
+        check_file_in_vm(vm_session, '/dev/pmem0', test)
 
         if check == 'back_file':
-            # Create a file system on /dev/pmem0
-            if any(platform.platform().find(ver) for ver in ('el8', 'el9')):
-                vm_session.cmd('mkfs.xfs -f /dev/pmem0 -m reflink=0')
-            else:
-                vm_session.cmd('mkfs.xfs -f /dev/pmem0')
-
-            vm_session.cmd('mount -o dax /dev/pmem0 /mnt')
-            vm_session.cmd('echo \"%s\" >/mnt/foo' % test_str)
-            vm_session.cmd('umount /mnt')
-            vm_session.close()
-
-            # Shutdown the guest, then start it, remount /dev/pmem0,
-            # check if the test file is still on the file system
-            vm.destroy()
-            vm.start()
-            vm_session = vm.wait_for_login()
-
-            vm_session.cmd('mount -o dax /dev/pmem0 /mnt')
-            if test_str not in vm_session.cmd('cat /mnt/foo'):
-                test.fail('\"%s\" should be in /mnt/foo' % test_str)
-
-            # From the host, check the file has changed:
-            host_output = process.run('hexdump -C /tmp/nvdimm',
-                                      shell=True, verbose=True).stdout_text
-            if test_str not in host_output:
-                test.fail('\"%s\" should be in output' % test_str)
-
-            # Shutdown the guest, and edit the xml,
-            # include: access='private'
-            vm_session.close()
-            vm.destroy()
-            vm_devices = vmxml.devices
-            nvdimm_device = vm_devices.by_device_tag('memory')[0]
-            nvdimm_index = vm_devices.index(nvdimm_device)
-            vm_devices[nvdimm_index].mem_access = 'private'
-            vmxml.devices = vm_devices
-            vmxml.sync()
-
-            # Login to the guest, mount the /dev/pmem0 and .
-            # create a file: foo-private
-            vm.start()
-            vm_session = vm.wait_for_login()
-
-            if IS_PPC_TEST:
-                libvirt.check_qemu_cmd_line('mem-path=/tmp/nvdimm,share=no')
-
-            private_str = 'This is a test for foo-private'
-            vm_session.cmd('mount -o dax /dev/pmem0 /mnt/')
-
-            file_private = 'foo-private'
-            vm_session.cmd("echo '%s' >/mnt/%s" % (private_str, file_private))
-            if private_str not in vm_session.cmd('cat /mnt/%s' % file_private):
-                test.fail('"%s" should be in output' % private_str)
-
-            # Shutdown the guest, then start it,
-            # check the file: foo-private is no longer existed
-            vm_session.close()
-            vm.destroy()
-
-            vm.start()
-            vm_session = vm.wait_for_login()
-            vm_session.cmd('mount -o dax /dev/pmem0 /mnt/')
-            if file_private in vm_session.cmd('ls /mnt/'):
-                test.fail('%s should not exist, for it was '
-                          'created when access=private' % file_private)
-
+            test_no_label(vm, params, test)
+        if check == 'pmem_alignsize':
+            test_pmem_alignsize(vm, params, test)
         if check == 'label_back_file':
-            # Create an xfs file system on /dev/pmem0
-            if any(platform.platform().find(ver) for ver in ('el8', 'el9')):
-                vm_session.cmd('mkfs.xfs -f -b size=4096 /dev/pmem0 -m reflink=0')
-            else:
-                vm_session.cmd('mkfs.xfs -f -b size=4096 /dev/pmem0')
-
-            # Mount the file system with DAX enabled for page cache bypass
-            output = vm_session.cmd_output('mount -o dax /dev/pmem0 /mnt/')
-            logging.info(output)
-
-            # Create a file on the nvdimm device.
-            test_str = 'This is a test with label'
-            vm_session.cmd('echo "%s" >/mnt/foo-label' % test_str)
-            if test_str not in vm_session.cmd('cat /mnt/foo-label '):
-                test.fail('"%s" should be in the output of cat cmd' % test_str)
-
-            vm_session.cmd('umount /mnt')
-            # Reboot the guest, and remount the nvdimm device in the guest.
-            # Check the file foo-label is exited
-            vm_session.close()
-            virsh.reboot(vm_name, debug=True)
-            vm_session = vm.wait_for_login()
-
-            vm_session.cmd('mount -o dax /dev/pmem0  /mnt')
-            if test_str not in vm_session.cmd('cat /mnt/foo-label '):
-                test.fail('"%s" should be in output' % test_str)
-
-            if params.get('check_life_cycle', 'no') == 'yes':
-                virsh.managedsave(vm_name, ignore_status=False, debug=True)
-                vm.start()
-                check_nvdimm_file('foo-label')
-
-                vm_s1 = vm_name + ".s1"
-                virsh.save(vm_name, vm_s1, ignore_status=False, debug=True)
-                virsh.restore(vm_s1, ignore_status=False, debug=True)
-                check_nvdimm_file('foo-label')
-
-                virsh.snapshot_create_as(vm_name, vm_s1, ignore_status=False, debug=True)
-                virsh.snapshot_revert(vm_name, vm_s1, ignore_status=False, debug=True)
-                virsh.snapshot_delete(vm_name, vm_s1, ignore_status=False, debug=True)
-
+            test_with_label(vm, params, test)
         if check == 'hot_plug':
-            # Create file for 2nd nvdimm device
-            nvdimm_file_2 = params.get('nvdimm_file_2')
-            process.run('truncate -s 512M %s' % nvdimm_file_2)
-
-            # Add 2nd nvdimm device to vm xml
-            nvdimm2_params = {k.replace('nvdimmxml2_', ''): v
-                              for k, v in params.items() if k.startswith('nvdimmxml2_')}
-            nvdimm2_xml = create_nvdimm_xml(**nvdimm2_params)
-
-            ori_devices = vm_xml.VMXML.new_from_dumpxml(vm_name).get_devices('memory')
-            logging.debug('Starts with %d memory devices', len(ori_devices))
-
-            result = virsh.attach_device(vm_name, nvdimm2_xml.xml, debug=True)
-            libvirt.check_exit_status(result)
-
-            # After attach, there should be an extra memory device
-            devices_after_attach = vm_xml.VMXML.new_from_dumpxml(vm_name).get_devices('memory')
-            logging.debug('After detach, vm has %d memory devices',
-                          len(devices_after_attach))
-            if len(ori_devices) != len(devices_after_attach) - 1:
-                test.fail('Number of memory devices after attach is %d, should be %d'
-                          % (len(devices_after_attach), len(ori_devices) + 1))
-
-            # Create namespace for ppc tests
-            if IS_PPC_TEST:
-                logging.debug(vm_session.cmd_output(
-                    'ndctl create-namespace --mode=fsdax --region=region1'))
-
-            time.sleep(wait_sec)
-            check_file_in_vm(vm_session, '/dev/pmem1')
-
-            nvdimm_detach = alive_vmxml.get_devices('memory')[-1]
-            logging.debug(nvdimm_detach)
-
-            # Hot-unplug nvdimm device
-            result = virsh.detach_device(vm_name, nvdimm_detach.xml, debug=True)
-            libvirt.check_exit_status(result)
-
-            vm_session.close()
-            vm_session = vm.wait_for_login()
-
-            logging.debug(virsh.dumpxml(vm_name).stdout_text)
-
-            left_devices = vm_xml.VMXML.new_from_dumpxml(vm_name).get_devices('memory')
-            logging.debug(left_devices)
-
-            if len(left_devices) != len(ori_devices):
-                test.fail('Number of memory devices after detach is %d, should be %d'
-                          % (len(left_devices), len(ori_devices)))
-
-            time.sleep(5)
-            check_file_in_vm(vm_session, '/dev/pmem1', expect=False)
+            test_hotplug(vm, params, test)
     finally:
         if vm.is_alive():
             vm.destroy(gracefully=False)
         bkxml.sync()
-        os.remove(nvdimm_file)
-        if 'nvdimm_file_2' in locals():
-            os.remove(nvdimm_file_2)
+        cleanup_test_default(params)

--- a/spell.ignore
+++ b/spell.ignore
@@ -12,6 +12,7 @@ aexpect
 afeter
 aggregater
 agregators
+alignsize
 amd
 analyse
 Analyse
@@ -730,6 +731,7 @@ pkgs
 pki
 pkipath
 plaintext
+pmem
 pmsuspend
 pmsuspended
 polkit


### PR DESCRIPTION
Test scenario: support pmem, alignsize and readonly in nvdimm memory device
RHEL-160330

Depend on https://github.com/avocado-framework/avocado-vt/pull/3401

Signed-off-by: Dan Zheng <dzheng@redhat.com>