### PR TITLE
migrate_mem: add case maxmemory

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_mem.cfg
+++ b/libvirt/tests/cfg/migration/migrate_mem.cfg
@@ -49,6 +49,8 @@
             memdev_tg_node = "0"
             # migrate from 8.2 to 8.3.1, the qemu cmdline is "-numa node,nodeid=1,cpus=2-3,mem=1024 -object memory-backend-ram,id=memdimm0,size=536870912"
             qemu_checks = "?memory-backend-ram"?,"?id"?(=|:)"?memdimm0"?,"?size"?(=|:)"?536870912"?
+            check_str_local_log = 'Unsupported migration cookie feature memory-hotplug'
+            str_in_log = False
         - mem_balloon:
             ballooned_mem = "716800"
         - mem_nvdimm:

--- a/libvirt/tests/src/migration/migrate_mem.py
+++ b/libvirt/tests/src/migration/migrate_mem.py
@@ -160,7 +160,9 @@ def verify_test_default(vm, params, test):
     """
     check_str_local_log = params.get("check_str_local_log")
     if check_str_local_log:
-        libvirt.check_logfile(check_str_local_log, params.get("libvirtd_debug_file"))
+        libvirt.check_logfile(check_str_local_log,
+                              params.get("libvirtd_debug_file"),
+                              eval(params.get('str_in_log', 'True')))
 
 
 def verify_test_mem_balloon(vm, params, test):
@@ -213,6 +215,7 @@ def verify_test_mem_device(vm, params, test):
     :param params: dict, test parameters
     :param test: test object
     """
+    verify_test_default(vm, params, test)
     remote_ip = params.get("remote_ip")
     remote_user = params.get("remote_user")
     remote_pwd = params.get("remote_pwd")


### PR DESCRIPTION
Test scenario: migration with maxmemory and check no specified error in libvirt daemon log
VIRT-38151

Signed-off-by: Dan Zheng <dzheng@redhat.com>
