### PR TITLE
Add cases to cover hotplug rbd disk with enabled authentication as vi…

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_ceph.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_ceph.cfg
@@ -81,7 +81,13 @@
             convert_image = "no"
             variants:
                 - attach_device:
-                    attach_device = "yes"
+                    variants:
+                        - @default:
+                        - virtio-scsi:
+                            disk_target = "sdb"
+                            only hot_plug.with_auth
+                            disk_target_bus = "scsi"
+                            test_qemu_cmd = "no"
                 - attach_disk:
                     attach_disk = "yes"
                 - disk_shareable:


### PR DESCRIPTION
…rtio-scsi device

Those cases are related to bug1411398 1406442

Signed-off-by: chunfuwen <chwen@redhat.com>

