### PR TITLE
virsh_attach_device: Attach character devices on sequential ports

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
@@ -985,7 +985,7 @@ def run(test, params, env):
                 test_params.main_vm.destroy(gracefully=True)
             libvirt_pcicontr.reset_pci_num(vm_name, 24)
             logging.debug(
-                    "Guest XMl with adding many controllers: %s",
+                    "Guest XML with many controllers added: %s",
                     test_params.main_vm.get_xml())
             if previous_state_running:
                 test_params.main_vm.start()

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
@@ -5,10 +5,10 @@ Module to exercise virsh attach-device command with various devices/options
 import os
 import os.path
 import logging as log
-import aexpect
+from string import ascii_lowercase
 import itertools
 import platform
-from string import ascii_lowercase
+import aexpect
 
 from six import iteritems
 
@@ -27,6 +27,9 @@ from virttest.utils_libvirt import libvirt_pcicontr
 # Using as lower capital is not the best way to do, but this is just a
 # workaround to avoid changing the entire file.
 logging = log.getLogger('avocado.' + __name__)
+# Prepare a generator for assigning ports
+global port_number_sequence
+port_number_sequence = itertools.count(1)
 
 
 class TestParams(object):
@@ -422,11 +425,14 @@ class SerialFile(AttachDeviceBase):
                                     virsh_instance=self.test_params.virsh)
         serial_device.add_source(path=filepath)
         # Assume default domain serial device on port 0 and index starts at 0
-        serial_device.add_target(port=str(index + 1))
+        serial_device.add_target(port=str(next(port_number_sequence)))
         if hasattr(self, 'models'):
             this_model = self.models.split(" ")[index]
             if 'sclp' in this_model:
-                serial_device.update_target(index=0, port=str(index+1), type='sclp-serial')
+                serial_device.update_target(
+                        index=0,
+                        port=str(next(port_number_sequence)),
+                        type='sclp-serial')
             serial_device.target_model = this_model
         if hasattr(self, 'alias') and libvirt_version.version_compare(3, 9, 0):
             serial_device.alias = {'name': self.alias + str(index)}
@@ -501,7 +507,7 @@ class Console(AttachDeviceBase):
         console_device = consoleclass(type_name=self.type,
                                       virsh_instance=self.test_params.virsh)
         # Assume default domain console device on port 0 and index starts at 0
-        console_device.add_target(type=self.targettype, port=str(index + 1))
+        console_device.add_target(type=self.targettype, port=str(next(port_number_sequence)))
         if hasattr(self, 'alias') and libvirt_version.version_compare(3, 9, 0):
             console_device.alias = {'name': self.alias + str(index)}
         return console_device
@@ -978,7 +984,9 @@ def run(test, params, env):
             if previous_state_running:
                 test_params.main_vm.destroy(gracefully=True)
             libvirt_pcicontr.reset_pci_num(vm_name, 24)
-            logging.debug("Guest XMl with adding many controllers: %s", test_params.main_vm.get_xml())
+            logging.debug(
+                    "Guest XMl with adding many controllers: %s",
+                    test_params.main_vm.get_xml())
             if previous_state_running:
                 test_params.main_vm.start()
 


### PR DESCRIPTION
In previous versions of libvirt duplicate devices could be mounted on
single port. This is no longer possible on the newest versions of
libvirt. This commit changes the port numbering so that devices are
always attached on sequentially ordered ports regardless of type.

## If the PR is bug cases
- [x] Bug descriptions or bug links
In previous versions of libvirt duplicate devices could be mounted on
single port. This is no longer possible on the newest versions of
libvirt. This commit changes the port numbering so that devices are
always attached on sequentially ordered ports regardless of type.
- [x] Test results

```
avocado run --vt-type libvirt virsh.attach_device.character.serial.multi_type.normal_test.cold_attach_cold_vm.persistent.name_ref.file_argument.domain_argument
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : 5b74a3cbe756f4c575a00861bf66434c0684fce8
JOB LOG    : /root/avocado/job-results/job-2022-04-25T05.34-5b74a3c/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.attach_device.character.serial.multi_type.normal_test.cold_attach_cold_vm.persistent.name_ref.file_argument.domain_argument: PASS (51.61 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 52.29 s
```
```
avocado run --vt-type libvirt virsh.attach_device.character.serial.multi_type.normal_test.cold_attach_cold_vm.config.name_ref.file_argument.domain_argument
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : 1ca74e28f3c09588079fe798d75f7f611d3393f3
JOB LOG    : /root/avocado/job-results/job-2022-04-25T05.36-1ca74e2/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.attach_device.character.serial.multi_type.normal_test.cold_attach_cold_vm.config.name_ref.file_argument.domain_argument: PASS (52.08 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 52.72 s
```
```
avocado run --vt-type libvirt virsh.attach_device.character.serial.multi_type.normal_test.cold_attach_hot_vm.name_ref.file_argument.domain_argument
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : 6d1dfd585b29d1b10ad98b18583a612d550da123
JOB LOG    : /root/avocado/job-results/job-2022-04-25T05.38-6d1dfd5/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.attach_device.character.serial.multi_type.normal_test.cold_attach_hot_vm.name_ref.file_argument.domain_argument: PASS (61.78 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 62.46 s
```

