### PR TITLE
virsh_pool_autostart.py: update disk pool status from inactive to active

### DIFF
--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool.py
@@ -338,9 +338,12 @@ def run(test, params, env):
             # pool as active. This is independent of autostart.
             # So a directory based storage pool is thus pretty much always active,
             # and so as the SCSI pool.
-            if pool_type not in ["dir", 'scsi']:
-                result = virsh.pool_start(pool_name, ignore_status=True)
-                utlv.check_exit_status(result)
+            if pool_type not in ['dir', 'scsi']:
+                if pool_type == 'disk' and libvirt_version.version_compare(8, 1, 0):
+                    utlv.check_exit_status(result)
+                else:
+                    result = virsh.pool_start(pool_name, ignore_status=True)
+                    utlv.check_exit_status(result)
 
             # Step (16)
             # Pool info

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool_autostart.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool_autostart.py
@@ -90,8 +90,8 @@ def run(test, params, env):
             actual_value = libvirt_pool.pool_autostart(pool_name)
         if actual_value != expect_value:
             if not expect_error:
-                if checkpoint == 'State' and pool_type in ("dir", "scsi"):
-                    debug_msg = "Dir pool should be always active when libvirtd restart. "
+                if checkpoint == 'State' and pool_type in ("dir", "scsi", "disk"):
+                    debug_msg = "Dir/scsi/disk pool should be active when libvirtd restart. "
                     debug_msg += "See https://bugzilla.redhat.com/show_bug.cgi?id=1238610"
                     logging.debug(debug_msg)
                 else:


### PR DESCRIPTION
The disk pool will be active after restart libvirtd/virtstoraged even though we set no autostart to it. It's an intended behavior now as the dir pool. So update the disk pool status from inactive to active.

Signed-off-by: Meina Li <meili@redhat.com>
