### PR TITLE
Fix the failures when running negative tests

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_stats.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_stats.py
@@ -29,6 +29,8 @@ def run(test, params, env):
         :param suffix: str, suffix of the CPU accounting.(stat/usage/usage_percpu)
         :return: list, the list of CPU accounting info
         """
+        if 'cg_obj' not in locals():
+            return
         # On cgroup v2 use cpu.stat as a substitute
         if cg_obj.is_cgroup_v2_enabled():
             cg_path = cg_obj.get_cgroup_path("cpu")
@@ -96,7 +98,8 @@ def run(test, params, env):
         vm_ref = vm_name
 
     vm = env.get_vm(vm_ref)
-    cg_obj = libvirt_cgroup.CgroupTest(vm.get_pid())
+    if vm and vm.get_pid():
+        cg_obj = libvirt_cgroup.CgroupTest(vm.get_pid())
     # get host cpus num
     cpus = cpu.online_cpus_count()
     logging.debug("host online cpu num is %s", cpus)


### PR DESCRIPTION
This PR fix the "No such file" error which caused by
reading the domain file when the domain is not start.

Signed-off-by: haonanpan <hpan@redhat.com>

