### PR TITLE
virsh_domain: Xml to native, quotes in XML output

### DIFF
--- a/libvirt/tests/cfg/bios/virsh_boot_reset_nvram.cfg
+++ b/libvirt/tests/cfg/bios/virsh_boot_reset_nvram.cfg
@@ -1,0 +1,15 @@
+- virsh.boot_reset_nvram:
+    type = virsh_boot_reset_nvram
+    start_vm = "no"
+    only q35
+    option = "--reset-nvram"
+    os_attrs = {'os_firmware': 'efi', 'machine': 'q35', 'type': 'hvm'}
+    func_supported_since_libvirt_ver = (8, 1, 0)
+    err_msg = "system firmware block device\s*has invalid size"
+    variants test_case:
+        - start_destroyed_vm:
+        - start_managedsaved_vm:
+        - restore_saved_vm:
+            output_file = 'save_file'
+        - create_destroyed_vm:
+            output_file = 'dumpxml_file'

--- a/libvirt/tests/cfg/migration/migrate_mem.cfg
+++ b/libvirt/tests/cfg/migration/migrate_mem.cfg
@@ -59,3 +59,7 @@
             qemu_checks = "nvdimm=on.*mem-path=${nvdimm_file_path.*share=yes.*size=536870912.*device.*nvdimm,node=1,label-size=262144}"
             migrate_vm_back = "yes"
             test_file_content = 'migration'
+        - large_mem_vm:
+            memory_unit = 'GiB'
+            memory_value = '4'
+            check_network_accessibility_after_mig = "yes"

--- a/libvirt/tests/cfg/remote_access/remote_with_tls.cfg
+++ b/libvirt/tests/cfg/remote_access/remote_with_tls.cfg
@@ -71,6 +71,7 @@
                 - customized_tls_port:
                     tls_port = "16515"
                 - allowed_dn_list:
+                    change_status_in_new_version = "yes"
                     tls_allowed_dn_list = "CN=${client_cn},O=AUTOTEST.VIRT"
                     tls_port = "16515"
                 - customized_ipv4_listen_address:
@@ -147,6 +148,7 @@
                     # please change your configuration
                     ca_cn_new = "illegal-sign"
                 - allowed_dn_disorder_list:
+                    change_status_in_new_version = "yes"
                     tls_allowed_dn_list = "O=AUTOTEST.VIRT,CN=${client_cn}"
                     tls_port = "16515"
                 - allowed_dn_list_with_invalid_organization:

--- a/libvirt/tests/cfg/remote_access/remote_with_unix.cfg
+++ b/libvirt/tests/cfg/remote_access/remote_with_unix.cfg
@@ -13,7 +13,6 @@
     start_vm = "no"
     port = "22"
     client = "ssh"
-    sasl_allowed_username_list = '["root/admin" ]'
     variants:
         - positive_testing:
             status_error = "no"
@@ -35,21 +34,22 @@
                     auth_unix_rw = "sasl"
                     sasl_type = "plain"
                     sasl_user_pwd = "('sasl_test', 'sasl_pass'),"
-                    sasl_allowed_users = ['sasl_test',]
+                    sasl_allowed_username_list = ['sasl_test',]
                 - allow_sasl_krb_user:
                     auth_unix_rw = "sasl"
                     sasl_type = "gssapi"
                     # need to create SASL user on the local via ssh
                     server_ip = "${client_ip}"
-                    tcp_setup = "yes"
                     kinit_pwd = "redhat"
+                    sasl_allowed_username_list = '["root/admin" ]'
                 - allow_sasl_users:
                     auth_unix_rw = "sasl"
+                    store_vm_info = "no"
                     sasl_type = "digest-md5"
                     # need to create SASL user on the local via ssh
                     server_ip = "${client_ip}"
                     sasl_user_pwd = "('test', '123456'), ('libvirt', '123456')"
-                    sasl_allowed_users = ['test', 'libvirt']
+                    sasl_allowed_username_list = ['test', 'libvirt']
                 - socket_access_controls:
                     traditional_mode = "yes"
                     auth_unix_ro = "none"
@@ -100,17 +100,18 @@
             variants:
                 - no_allowed_sasl_user:
                     auth_unix_rw = "sasl"
+                    auth_unix_ro = "none"
+                    store_vm_info = "no"
                     sasl_type = "digest-md5"
                     server_ip = "${client_ip}"
-                    tcp_setup = "yes"
                     sasl_user_pwd = "('libvirt', '123456'),"
-                    sasl_allowed_users = ['test']
+                    sasl_allowed_username_list = ['test']
                 - allow_sasl_user_with_readonly:
+                    store_vm_info = "no"
                     sasl_type = "digest-md5"
                     server_ip = "${client_ip}"
-                    tcp_setup = "yes"
                     sasl_user_pwd = "('test', '123456'), "
-                    sasl_allowed_users = ['test']
+                    sasl_allowed_username_list = ['test']
                     auth_unix_rw = "sasl"
                     read_only = "-r"
                     virsh_cmd = "start"
@@ -130,6 +131,7 @@
                     variants:
                         - cfg_file:
                             traditional_mode = "yes"
+                            socket_access_controls_cfg_file = "yes"
                             auth_unix_ro = "none"
                             auth_unix_rw = "none"
                             unix_sock_group = "root"
@@ -139,6 +141,7 @@
                             deluser_cmd = "userdel -r ${su_user}"
                         - socket_file:
                             unix_sock_rw_perms = "0660"
+                            auth_unix_rw = "none"
                             adduser_cmd = "useradd ${su_user}"
                             deluser_cmd = "userdel -r ${su_user}"
                 - socket_with_polkit_ro:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blkiotune.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blkiotune.cfg
@@ -202,6 +202,11 @@
                                             blkio_device_weights = /dev/abc, 99
                                         - invalid_value:
                                             blkio_device_weights = "~@#$%^-=_:,.[]{}"
+                                        - vm_fail_start:
+                                            only none
+                                            blkio_device_weights = /dev/%s,200
+                                            validate_vm_not_start = "yes"
+                                            vm_not_start_error_msg = "blkio device weight is valid only for cfq scheduler"
                                     variants:
                                         - options:
                                             variants:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
@@ -25,6 +25,11 @@
                 detach_channel_type = "pty"
                 detach_channel_target = "{'target_type':'virtio', 'target_name':'some.virtio.serial.port.name'}"
                 detach_check_xml = "<channel type='pty'>"
+        - watchdog:
+            only live,config
+            detach_watchdog_type = "watchdog"
+            watchdog_dict = {"model_type":"i6300esb", "action":"poweroff"}
+            detach_check_xml = "<watchdog"
     variants:
         - live:
             detach_alias_options = "--live"

--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_ceph.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_ceph.cfg
@@ -81,7 +81,13 @@
             convert_image = "no"
             variants:
                 - attach_device:
-                    attach_device = "yes"
+                    variants:
+                        - @default:
+                        - virtio-scsi:
+                            disk_target = "sdb"
+                            only hot_plug.with_auth
+                            disk_target_bus = "scsi"
+                            test_qemu_cmd = "no"
                 - attach_disk:
                     attach_disk = "yes"
                 - disk_shareable:

--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_slice_operation.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_slice_operation.cfg
@@ -1,0 +1,39 @@
+- virtual_disks.slice_operation:
+    type = virtual_disks_slice_operation
+    take_regular_screendumps = "no"
+    start_vm = "no"
+    target_bus = "virtio"
+    type_name = "file"
+    target_dev = "vdb"
+    device_type = "disk"
+    status_error = "no"
+    define_error = "no"
+    variants scenario_execution:
+        - slice_blkdeviotune:
+            virt_disk_device_source = "/var/lib/libvirt/images/slice_blkdeviotune.img"
+            additional_driver_attrs = "{'copy_on_read':'off','cache':'none','discard':'ignore','detect_zeroes':'on','io':'native'}"
+            total_bytes_sec = '20000'
+        - slice_disk_blockcopy:
+            virt_disk_device_source = "/var/lib/libvirt/images/slice_disk_blockcopy.img"
+            virt_disk_blockcopy = "/var/lib/libvirt/images/slice_disk_copyfile.img"
+            additional_driver_attrs = "{'copy_on_read':'on','cache':'none','discard':'ignore','detect_zeroes':'on','io':'native'}"
+        - slice_disk_blockcommit:
+            virt_disk_device_source = "/var/lib/libvirt/images/slice_disk_blockcommit.img"
+            disk_slice__override_attrs = "{'slice_type': 'storage', 'slice_offset': '0', 'slice_size': '105185280'}"
+            snapshot_counts = 4
+        - slice_cdrom_update:
+            device_type = "cdrom"
+            target_dev = "sdb"
+            target_bus = "scsi"
+            virt_disk_device_source = "/var/lib/libvirt/images/slice_cdrom.img"
+            additional_driver_attrs = "{'cache':'writeback','discard':'unmap','detect_zeroes':'on','io':'threads'}"
+        - slice_hot_operate:
+            virt_disk_device_source = "/var/lib/libvirt/images/slice_operate.img"
+            additional_driver_attrs = "{'copy_on_read':'on','cache':'none','discard':'ignore','detect_zeroes':'on','io':'native'}"
+    variants:
+        - disk_qcow2:
+            target_format = "qcow2"
+            disk_slice_attrs = "{'slice_type': 'storage', 'slice_offset': '0', 'slice_size': '105185280'}"
+        - disk_raw:
+            target_format = "raw"
+            disk_slice_attrs = "{'slice_type': 'storage', 'slice_offset': '0', 'slice_size': '104857600'}"

--- a/libvirt/tests/cfg/virtual_network/virtual_network_multivms.cfg
+++ b/libvirt/tests/cfg/virtual_network/virtual_network_multivms.cfg
@@ -60,3 +60,21 @@
                         - set_no:
                             net_isolated = 'no'
                             expect_ping_vm = 'yes'
+        - macTableManager:
+            feature = 'macTableManager'
+            variants:
+                - nat:
+                    case = 'nat'
+                    net_ip_address = '192.100.100.1'
+                    net_ip_netmask = '255.255.255.0'
+                    dhcp_start_ipv4 = '192.100.100.2'
+                    dhcp_end_ipv4 = '192.100.100.254'
+                    variants:
+                        - set_libvirt:
+                        - resume_vm:
+                            resume_vm = 'yes'
+                - linux_br:
+                    case = 'linux_br'
+                    variants:
+                        - set_libvirt:
+                            create_linux_bridge = "yes"

--- a/libvirt/tests/src/bios/virsh_boot_reset_nvram.py
+++ b/libvirt/tests/src/bios/virsh_boot_reset_nvram.py
@@ -1,0 +1,190 @@
+import os
+import re
+
+from avocado.utils import process
+
+from virttest import data_dir
+from virttest import libvirt_version
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_test import libvirt
+
+
+def get_size_birth_from_nvram(vm_name, test):
+    """
+    Get the size and birth values from nvram file
+
+    :param vm_name: vm name
+    :return: (size, birth)
+    """
+    cmd = 'stat /var/lib/libvirt/qemu/nvram/%s_VARS.fd' % vm_name
+    ret = process.run(cmd, ignore_status=False, shell=True)
+    size = re.search(r"Size:\s*(\d*)", ret.stdout_text).group(1)
+    birth = re.search(r"Birth:\s*(.*)", ret.stdout_text).group(1)
+    test.log.debug("Return current nvram file with "
+                   "size({}) and birth({})".format(size, birth))
+    return size, birth
+
+
+def setup_reset_nvram(guest_xml, params, virsh_func, test, *args):
+    """
+    Setup for the tests, including
+    1. Configure os firmware attribute
+    2. Create nvram file and make its size invalid
+
+    :param guest_xml: the guest xml
+    :param params: dict for parameters of the tests
+    :param virsh_func: virsh function will be invoked
+    :param args:  tuple, virsh function uses
+    """
+    test.log.info("Config guest xml with firmware efi")
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    os_attrs = eval(params.get('os_attrs'))
+    if os_attrs:
+        osxml = vm_xml.VMOSXML()
+        osxml.setup_attrs(**os_attrs)
+        guest_xml.os = osxml
+        guest_xml.sync()
+    test.log.debug("After configuration, vm xml:\n%s", vm_xml.VMXML.new_from_inactive_dumpxml(vm_name))
+    test.log.info("Start vm to create %s_VARS.fd file" % vm_name)
+    virsh.start(vm_name)
+    test.log.info("Modify the nvram file to make it invalid")
+    cmd = 'echo > /var/lib/libvirt/qemu/nvram/%s_VARS.fd' % vm_name
+    process.run(cmd, ignore_status=False, shell=True)
+    test.log.debug("Prepare the required vm state")
+    if len(args) > 1:
+        virsh_func(args[0], args[1], ignore_status=False)
+    else:
+        virsh_func(args[0], ignore_status=False)
+
+
+def common_test_steps(virsh_func, func_args, params, test):
+    """
+    The common test steps shared by test cases
+
+    :param virsh_func: virsh function to be invoked
+    :param func_args: str, parameter value for virsh function
+    :param params: dict, test parameters
+    :param test:  test object
+    :raises: test.fail if size or birth was not changed
+    """
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    test.log.debug("Step 1: Get the invalid nvram file size and birth ")
+    old_size, old_birth = get_size_birth_from_nvram(vm_name, test)
+    test.log.debug("Step 2: Operate on the vm and check expected result")
+    ret = virsh_func(func_args)
+    err_msg = params.get('err_msg')
+    libvirt.check_result(ret, expected_fails=err_msg)
+    test.log.debug("Step 3: Operate on the vm again but with --reset-nvram option")
+    ret = virsh_func(func_args, options=params.get('option'))
+    libvirt.check_exit_status(ret)
+    test.log.debug("Step 4: Verify the valid nvram file was recreated")
+    new_size, new_birth = get_size_birth_from_nvram(vm_name, test)
+    if (new_size == old_size or new_birth == old_birth):
+        test.fail("New nvram file with size '{}' birth '{}' "
+                  "should not be equal to old ones".format(new_size,
+                                                           new_birth))
+
+
+def test_start_destroyed_vm(guest_xml, params, test):
+    """
+    Test scenario:
+     - Destroyed the vm
+     - Start the vm and failure is expected with invalid nvram file size
+     - Start the vm successfully with --reset-nvram
+     - Check the nvram file is recreated as expected
+
+    :param guest_xml: guest xml
+    :param params: dict, test parameters
+    :param test: test object
+    """
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    setup_reset_nvram(guest_xml, params, virsh.destroy, test, vm_name)
+    common_test_steps(virsh.start, vm_name, params, test)
+
+
+def test_start_managedsaved_vm(guest_xml, params, test):
+    """
+    Test scenario:
+     - Managedsave the vm
+     - Start the vm and failure is expected with invalid nvram file size
+     - Start the vm successfully with --reset-nvram
+     - Check the nvram file is recreated as expected
+
+    :param guest_xml: guest xml
+    :param params: dict, test parameters
+    :param test: test object
+    """
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    setup_reset_nvram(guest_xml, params, virsh.managedsave, test, vm_name)
+    common_test_steps(virsh.start, vm_name, params, test)
+
+
+def test_restore_saved_vm(guest_xml, params, test):
+    """
+    Test scenario:
+     - Save the vm
+     - Restore the vm and failure is expected with invalid nvram file size
+     - Restore the vm successfully with --reset-nvram
+     - Check the nvram file is recreated as expected
+
+    :param guest_xml: guest xml
+    :param params: dict, test parameters
+    :param test: test object
+    """
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    save_file = os.path.join(data_dir.get_data_dir(), params.get('output_file'))
+    setup_reset_nvram(guest_xml, params, virsh.save, test, vm_name, save_file)
+    common_test_steps(virsh.restore, save_file, params, test)
+
+
+def test_create_destroyed_vm(guest_xml, params, test):
+    """
+    Test scenario:
+     - Destroyed the vm
+     - Create the vm and failure is expected with invalid nvram file size
+     - Create the vm successfully with --reset-nvram
+     - Check the nvram file is recreated as expected
+
+    :param guest_xml: guest xml
+    :param params: dict, test parameters
+    :param test: test object
+    """
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    setup_reset_nvram(guest_xml, params, virsh.destroy, test, vm_name)
+    vm_file = os.path.join(data_dir.get_data_dir(), params.get('output_file'))
+    virsh.dumpxml(vm_name, to_file=vm_file)
+    common_test_steps(virsh.create, vm_file, params, test)
+
+
+def teardown_reset_nvram(params):
+    """
+    Clean up test environment
+
+    :param params: dict, test parameters
+    """
+    output_file = params.get('output_file')
+    if output_file:
+        output_file = os.path.join(data_dir.get_data_dir(), output_file)
+        if os.path.exists(output_file):
+            os.remove(output_file)
+
+
+def run(test, params, env):
+    """
+    Test cases for --reset-nvram option
+    """
+
+    libvirt_version.is_libvirt_feature_supported(params)
+    case = params.get('test_case', '')
+    vm_name = params.get('main_vm', '')
+    guest_xml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bk_guest_xml = guest_xml.copy()
+    run_test = eval('test_%s' % case)
+
+    try:
+        run_test(guest_xml, params, test)
+    finally:
+        bk_guest_xml.sync(options='--nvram')
+        teardown_reset_nvram(params)

--- a/libvirt/tests/src/cpu/vcpu_hotpluggable.py
+++ b/libvirt/tests/src/cpu/vcpu_hotpluggable.py
@@ -5,8 +5,6 @@ import ast
 import logging as log
 
 from avocado.utils import process
-from avocado.utils import distro
-from avocado.utils.software_manager import SoftwareManager
 
 from virttest import libvirt_cgroup
 from virttest import virsh
@@ -90,13 +88,6 @@ def run(test, params, env):
     disable_vcpu = params.get("set_disable_vcpu", "")
     start_vm_after_config = params.get('start_vm_after_config', 'yes') == 'yes'
 
-    # Install cgroup utils
-    cgutils = "libcgroup-tools"
-    if distro.detect().name == 'Ubuntu':
-        cgutils = "cgroup-tools"
-    sm = SoftwareManager()
-    if not sm.check_installed(cgutils) and not sm.install(cgutils):
-        test.cancel("cgroup utils package install failed")
     # Backup domain XML
     vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
     vmxml_backup = vmxml.copy()

--- a/libvirt/tests/src/migration/live_migration.py
+++ b/libvirt/tests/src/migration/live_migration.py
@@ -257,6 +257,7 @@ def run(test, params, env):
                                                                   remote_params=server_params)
             # backup /etc/hosts
             backup_hosts = "cp -f /etc/hosts /etc/hosts.bak"
+            process.run(backup_hosts, shell=True)
             remote_old.run_remote_cmd(backup_hosts, params, ignore_status=False)
             if not utils_net.map_hostname_ipaddress(src_hosts_dict):
                 test.error("Failed to set /etc/hosts on source host.")
@@ -398,6 +399,7 @@ def run(test, params, env):
         # Restore /etc/hosts
         if set_migration_host:
             restore_hosts = "mv -f /etc/hosts.bak /etc/hosts"
+            process.run(restore_hosts, shell=True)
             remote_old.run_remote_cmd(restore_hosts, params, ignore_status=False)
         # Restore local or both sides conf and restart libvirtd
         recover_config_file(local_both_conf_obj, params)

--- a/libvirt/tests/src/passthrough/pci/libvirt_pci_passthrough.py
+++ b/libvirt/tests/src/passthrough/pci/libvirt_pci_passthrough.py
@@ -1,5 +1,5 @@
 import logging as log
-import netaddr
+import ipaddress
 import time
 
 from virttest import virsh, virt_vm
@@ -186,7 +186,7 @@ def run(test, params, env):
                     logging.debug("Adapter passthroughed to guest successfully")
                 else:
                     test.fail("Passthrough adapter not found in guest.")
-                net_ip = netaddr.IPAddress(net_ip)
+                net_ip = ipaddress.ip_address(net_ip)
                 nic_list_after = vm.get_pci_devices()
                 nic_list = list(set(nic_list_after).difference(set(nic_list_before)))
                 for val in range(len(nic_list)):

--- a/libvirt/tests/src/remote_access/remote_access.py
+++ b/libvirt/tests/src/remote_access/remote_access.py
@@ -181,6 +181,10 @@ def run(test, params, env):
     """
 
     test_dict = dict(params)
+    socket_access_controls_cfg_file = test_dict.get("socket_access_controls_cfg_file", "no")
+    if socket_access_controls_cfg_file == "yes":
+        if libvirt_version.version_compare(6, 0, 0):
+            test.cancel("This libvirt version doesn't support socket access controls by cfg file.")
     pattern = test_dict.get("filter_pattern", "")
     if ('@LIBVIRT' in pattern and
             distro.detect().name == 'rhel' and
@@ -193,6 +197,16 @@ def run(test, params, env):
     status_error = test_dict.get("status_error", "no")
     allowed_dn_str = params.get("tls_allowed_dn_list")
     if allowed_dn_str:
+        # According to bug 2018488, some cases status changed
+        change_status = test_dict.get("change_status_in_new_version", "no")
+        if (change_status == "yes" and
+                distro.detect().name == "rhel" and
+                int(distro.detect().version) > 8):
+            if status_error == "yes":
+                status_error = "no"
+            else:
+                status_error = "yes"
+            test_dict['status_error'] = status_error
         allowed_dn_list = []
         if not libvirt_version.version_compare(1, 0, 0):
             # Reverse the order in the dn list to workaround the

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blkiotune.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blkiotune.py
@@ -207,6 +207,14 @@ def set_blkio_parameter(test, params, cgstop):
                           " blkio.weight and blkio.weight_device"
                           " value from cgroup blkio controller")
 
+    # Start Vm if needed
+    validate_vm_not_start = "yes" == params.get("validate_vm_not_start", "no")
+    if validate_vm_not_start:
+        result = virsh.start(vm_name, debug=True)
+        vm_not_start_error_msg = params.get("vm_not_start_error_msg")
+        if vm_not_start_error_msg not in result.stderr_text:
+            test.fail("can not find error message: %s" % vm_not_start_error_msg)
+
 
 def prepare_scheduler(params, test, vm):
     """

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_stats.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_stats.py
@@ -29,13 +29,18 @@ def run(test, params, env):
         :param suffix: str, suffix of the CPU accounting.(stat/usage/usage_percpu)
         :return: list, the list of CPU accounting info
         """
-        vm = env.get_vm(vm_ref)
-        cg_obj = libvirt_cgroup.CgroupTest(vm.get_pid())
-        cg_path = cg_obj.get_cgroup_path("cpuacct")
+        if 'cg_obj' not in locals():
+            return
+        # On cgroup v2 use cpu.stat as a substitute
+        if cg_obj.is_cgroup_v2_enabled():
+            cg_path = cg_obj.get_cgroup_path("cpu")
+            para = ('cpu.%s' % suffix)
+        else:
+            cg_path = cg_obj.get_cgroup_path("cpuacct")
+            para = ('cpuacct.%s' % suffix)
         # We only need the info in file which "emulator" is not in path
         if os.path.basename(cg_path) == "emulator":
             cg_path = os.path.dirname(cg_path)
-        para = ('cpuacct.%s' % suffix)
         usage_file = os.path.join(cg_path, para)
         with open(usage_file, 'r') as f:
             cpuacct_info = f.read().strip().split()
@@ -46,12 +51,19 @@ def run(test, params, env):
         user_time = float(total_list[4])
         system_time = float(total_list[7])
 
-        # check libvirt user and system time between pre and next cgroup time
-        # unit conversion (Unit: second)
-        pre_user_time = int(cpuacct_res_pre[1])/100
-        pre_sys_time = int(cpuacct_res_pre[3])/100
-        next_user_time = int(cpuacct_res_next[1])/100
-        next_sys_time = int(cpuacct_res_next[3])/100
+        # Check libvirt user and system time between pre and next cgroup time
+        # Unit conversion (Unit: second)
+        # Default time unit is microseconds on cgroup v2 while 1/100 second on v1
+        if cg_obj.is_cgroup_v2_enabled():
+            pre_user_time = float(cpuacct_res_pre[3])/1000000
+            pre_sys_time = float(cpuacct_res_pre[5])/1000000
+            next_user_time = float(cpuacct_res_next[3])/1000000
+            next_sys_time = float(cpuacct_res_next[5])/1000000
+        else:
+            pre_user_time = float(cpuacct_res_pre[1])/100
+            pre_sys_time = float(cpuacct_res_pre[3])/100
+            next_user_time = float(cpuacct_res_next[1])/100
+            next_sys_time = float(cpuacct_res_next[3])/100
 
         # check user_time
         if next_user_time >= user_time >= pre_user_time:
@@ -85,6 +97,9 @@ def run(test, params, env):
     if vm_ref == "name":
         vm_ref = vm_name
 
+    vm = env.get_vm(vm_ref)
+    if vm and vm.get_pid():
+        cg_obj = libvirt_cgroup.CgroupTest(vm.get_pid())
     # get host cpus num
     cpus = cpu.online_cpus_count()
     logging.debug("host online cpu num is %s", cpus)

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_to_native.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_to_native.py
@@ -69,7 +69,8 @@ def run(test, params, env):
                 # turned into
                 # -blockdev {"driver":"file",...,"discard":"unmap"} in order to
                 # match the qemu command line format
-                if e in ['-blockdev', '-object', '-compat', '-audiodev']:
+                if e in ['-blockdev', '-object', '-compat', '-audiodev',
+                         '-device']:
                     enext = enext.strip("'")
                 # Append this and the next and set our skip flag
                 retlist.append(e + " " + enext)

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool.py
@@ -338,9 +338,12 @@ def run(test, params, env):
             # pool as active. This is independent of autostart.
             # So a directory based storage pool is thus pretty much always active,
             # and so as the SCSI pool.
-            if pool_type not in ["dir", 'scsi']:
-                result = virsh.pool_start(pool_name, ignore_status=True)
-                utlv.check_exit_status(result)
+            if pool_type not in ['dir', 'scsi']:
+                if pool_type == 'disk' and libvirt_version.version_compare(8, 1, 0):
+                    utlv.check_exit_status(result)
+                else:
+                    result = virsh.pool_start(pool_name, ignore_status=True)
+                    utlv.check_exit_status(result)
 
             # Step (16)
             # Pool info

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool_autostart.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool_autostart.py
@@ -90,8 +90,8 @@ def run(test, params, env):
             actual_value = libvirt_pool.pool_autostart(pool_name)
         if actual_value != expect_value:
             if not expect_error:
-                if checkpoint == 'State' and pool_type in ("dir", "scsi"):
-                    debug_msg = "Dir pool should be always active when libvirtd restart. "
+                if checkpoint == 'State' and pool_type in ("dir", "scsi", "disk"):
+                    debug_msg = "Dir/scsi/disk pool should be active when libvirtd restart. "
                     debug_msg += "See https://bugzilla.redhat.com/show_bug.cgi?id=1238610"
                     logging.debug(debug_msg)
                 else:

--- a/libvirt/tests/src/virtual_disks/virtual_disks_slice_operation.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_slice_operation.py
@@ -1,0 +1,361 @@
+import logging
+import os
+
+from avocado.utils import process
+
+from virttest import libvirt_xml
+from virttest import virt_vm
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml, xcepts
+from virttest.utils_libvirt import libvirt_disk
+
+LOG = logging.getLogger('avocado.' + __name__)
+cleanup_files = []
+
+
+def create_customized_disk(params):
+    """
+    Create one customized disk with related attributes
+
+    :param params: dict wrapped with params
+    """
+    type_name = params.get("type_name")
+    disk_device = params.get("device_type")
+    device_target = params.get("target_dev")
+    device_bus = params.get("target_bus")
+    device_format = params.get("target_format")
+    source_file_path = params.get("virt_disk_device_source")
+    source_dict = {}
+
+    if source_file_path:
+        cmd = "qemu-img create -f %s %s %s %s" % (device_format,
+                                                  "-o preallocation=full", source_file_path, "100M")
+        process.run(cmd, shell=True, ignore_status=True)
+        cleanup_files.append(source_file_path)
+        if 'block' in type_name:
+            source_dict.update({"dev": source_file_path})
+        else:
+            source_dict.update({"file": source_file_path})
+
+    disk_src_dict = {"attrs": source_dict}
+
+    customized_disk = libvirt_disk.create_primitive_disk_xml(
+        type_name, disk_device,
+        device_target, device_bus,
+        device_format, disk_src_dict, None)
+
+    # Sometimes, slice size can be gotten by command (du -b source_file_path), but here not necessary
+    disk_slice_attrs = params.get('disk_slice_attrs')
+    if disk_slice_attrs:
+        disk_source = customized_disk.source
+        disk_source.slices = customized_disk.new_slices(**eval(disk_slice_attrs))
+        customized_disk.source = disk_source
+
+    additional_driver_attrs = params.get("additional_driver_attrs")
+    if additional_driver_attrs:
+        customized_disk.driver = dict(customized_disk.driver, **eval(additional_driver_attrs))
+
+    if disk_device == "cdrom":
+        customized_disk.readonly = True
+    LOG.debug("create customized xml: %s", customized_disk)
+    return customized_disk
+
+
+def create_snapshot_xml(params, vm_name, index):
+    """
+    Create one snapshot disk with related attributes
+
+    :param params: dict wrapped with params
+    :param vm_name: VM instance name
+    :param index: snapshot file index
+    :return return one tuple with snap_xml and snap files as elements
+    """
+    snap_xml = libvirt_xml.SnapshotXML()
+    snap_xml.snap_name = "snapshot_create_%s" % index
+    snap_xml.description = "Snapshot Test"
+    # Add all disks into xml file.
+    vmxml = libvirt_xml.VMXML.new_from_dumpxml(vm_name)
+    disks = vmxml.devices.by_device_tag('disk')
+    # Remove non-storage disk such as 'cdrom'
+    for disk in disks:
+        if disk.device != 'disk':
+            disks.remove(disk)
+    new_disks = []
+    for src_disk_xml in disks:
+        disk_xml = snap_xml.SnapDiskXML()
+        disk_target = src_disk_xml.target['dev']
+        disk_xml.disk_name = disk_target
+        if 'vda' in disk_xml.disk_name:
+            disk_xml.snapshot = "no"
+        elif 'vdb' in disk_xml.disk_name:
+            disk_xml.snapshot = "external"
+            driver_type = "qcow2"
+            snapshot_file = "%s_snapshot_%s_%s" % (
+                src_disk_xml.xmltreefile.find('source').get('file'), disk_target, index)
+            disk_slice_attrs = params.get('disk_slice__override_attrs')
+            update_snapshot_disk(disk_xml, snapshot_file, eval(disk_slice_attrs), driver_type)
+        new_disks.append(disk_xml)
+    snap_xml.set_disks(new_disks)
+    LOG.debug("create_snapshot xml: %s", snap_xml)
+    return snap_xml, snapshot_file
+
+
+def update_snapshot_disk(disk_xml, snapshot_file=None, disk_slice_attrs=None, driver_type="qcow2"):
+    """
+    Update snapshot disk xml with related attributes
+
+    :param disk_xml: disk xml will be updated
+    :param snapshot_file: snapshot file attribute in the disk
+    :param disk_slice_attrs: slice attribute in the disk
+    :param driver_type: driver type
+    :return: updated snapshot disk
+    """
+    source_dict = {}
+    driver_dict = {'type': driver_type}
+    if snapshot_file:
+        cmd = "qemu-img create -f %s %s %s %s" % (driver_type,
+                                                  "-o preallocation=full", snapshot_file, "100M")
+        process.run(cmd, shell=True, ignore_status=True)
+        source_dict.update({"file": snapshot_file})
+        cleanup_files.append(snapshot_file)
+
+    disk_xml.source = disk_xml.new_disk_source(**{"attrs": source_dict})
+    disk_xml.driver = driver_dict
+    if disk_slice_attrs:
+        disk_source = disk_xml.source
+        disk_source.slices = disk_xml.new_slices(**disk_slice_attrs)
+        disk_xml.source = disk_source
+
+    LOG.debug("update customized xml: %s", disk_xml)
+    return disk_xml
+
+
+def create_empty_cdrom_xml(params):
+    """
+    Create one empty cdrom xml
+
+    :param params: wrapped parameters in dictionary format
+    :return: empty cdrom xml
+    """
+    if 'virt_disk_device_source' in params:
+        params.pop('virt_disk_device_source')
+    return create_customized_disk(params)
+
+
+def translate_raw_output_into_dict(output, default_delimiter="="):
+    """
+    A utility to translate raw output with key=value attribute into one dictionary
+
+    :param output: raw output
+    :param default_delimiter: delimiter to separate line
+    :return one dictionary
+    """
+    data_dict = {}
+    for line in output.split('\n'):
+        if default_delimiter in line:
+            data_dict.update({"%s" % line.split(default_delimiter)[0].strip():
+                             "%s" % line.split(default_delimiter)[1].strip()})
+    return data_dict
+
+
+def check_slice_hot_operate(vm, params, test):
+    """
+    Check hot operation on disk with slice attribute
+
+    :param vm: one object representing VM
+    :param params: wrapped parameters in dictionary format
+    :param test: test assert object
+    """
+    device_target = params.get("target_dev")
+    try:
+        session = vm.wait_for_login()
+        _, output = session.cmd_status_output(
+            "dd if=/dev/zero of=/dev/%s bs=10M count=1" % device_target)
+        LOG.info("Fill contents in VM:\n%s", output)
+        session.close()
+    except Exception as e:
+        LOG.error(str(e))
+        session.close()
+
+    domstats_raw_output = virsh.domstats(vm.name, "--block",
+                                         ignore_status=False, debug=True).stdout_text.strip()
+    domstats_dict = translate_raw_output_into_dict(domstats_raw_output)
+    domblkinfo_raw_output = virsh.domblkinfo(vm.name, device_target,
+                                             ignore_status=False, debug=True).stdout_text.strip()
+    domblkinfo_dict = translate_raw_output_into_dict(domblkinfo_raw_output, default_delimiter=":")
+
+    # Verify allocation, capacity, and physical are the same from domstats and domblkinfo
+    for key in ['Allocation', 'Capacity', 'Physical']:
+        if domstats_dict["block.1.%s" % key.lower()] != domblkinfo_dict[key]:
+            test.fail("The domstats value: %s is not equal to domblkinfo: %s"
+                      % (domstats_dict["block.1.%s" % key.lower()], domblkinfo_dict[key]))
+
+
+def check_slice_cdrom_update(vm, test):
+    """
+    Check cdrom with slice attribute
+
+    :param vm: one object representing VM
+    :param test: test assert object
+    """
+    try:
+        session = vm.wait_for_login()
+        mnt_cmd = "mount /dev/sr0 /mnt && ls /mnt"
+        status = session.cmd_status(mnt_cmd)
+        if status:
+            test.fail("Failed to mount cdrom device in VM")
+    except Exception as e:
+        LOG.error(str(e))
+    finally:
+        session.close()
+
+
+def check_slice_disk_blockcommit(vm, params):
+    """
+    Check blockcommit on disk with slice attribute
+
+    :param vm: one object representing VM
+    :param params: wrapped parameters in dictionary format
+    """
+    snapshot_counts = int(params.get("snapshot_counts"))
+    snapshot_files = []
+    for index in range(snapshot_counts):
+        snapshot_xml, snapshot_file = create_snapshot_xml(params, vm.name, index)
+        snapshot_option = " %s --no-metadata --disk-only --reuse-external" % snapshot_xml.xml
+        virsh.snapshot_create(vm.name, snapshot_option, debug=True, ignore_status=False)
+        snapshot_files.append(snapshot_file)
+    device_target = params.get("target_dev")
+
+    debug_vm = vm_xml.VMXML.new_from_dumpxml(vm.name)
+    phase_one_blockcommit_options = " --top %s --shallow --wait --verbose" % snapshot_files[0]
+    libvirt_disk.do_blockcommit_repeatedly(vm, device_target, phase_one_blockcommit_options, 1)
+
+    vm.wait_for_login().close()
+    phase_two_blockcommit_options = " --active --wait --verbose --pivot"
+    libvirt_disk.do_blockcommit_repeatedly(vm, device_target, phase_two_blockcommit_options, 1)
+
+
+def check_slice_disk_blockcopy(vm, params):
+    """
+    Check blockcopy on disk with slice attribute
+
+    :param vm: one object representing VM
+    :param params: wrapped parameters in dictionary format
+    """
+
+    device_target = params.get("target_dev")
+    params.update({"virt_disk_device_source": params.get("virt_disk_blockcopy")})
+    blockcopy_disk = create_customized_disk(params)
+
+    debug_vm = vm_xml.VMXML.new_from_dumpxml(vm.name)
+    blockcopy_options = " --wait --verbose --pivot --reuse-external --transient-job"
+    virsh.blockcopy(vm.name, device_target, " --xml %s" % blockcopy_disk.xml,
+                    options=blockcopy_options, ignore_status=False,
+                    debug=True)
+
+
+def check_slice_blkdeviotune(vm, params, test):
+    """
+    Check block blkdeviotune on disk with slice attribute
+
+    :param vm: one object representing VM
+    :param params: wrapped parameters in dictionary format
+    :param test: test assert object
+    """
+    device_target = params.get("target_dev")
+    total_bytes_sec = params.get("total_bytes_sec")
+
+    virsh.blkdeviotune(vm.name, device_target, " --total-bytes-sec %s" % total_bytes_sec,
+                       ignore_status=False, debug=True)
+    blkdeviotune_raw_output = virsh.blkdeviotune(vm.name, device_target,
+                                                 ignore_status=False, debug=True).stdout_text.strip()
+    blkdeviotune_dict = translate_raw_output_into_dict(blkdeviotune_raw_output, default_delimiter=":")
+
+    LOG.debug(blkdeviotune_dict)
+    # Verify total_bytes_sec is the same with preset one
+    if blkdeviotune_dict["total_bytes_sec"] != total_bytes_sec:
+        test.fail("The gotten value: %s is not equal from preset one" % blkdeviotune_dict["total_bytes_sec"])
+
+
+def run(test, params, env):
+    """
+    Test attach cdrom device with option.
+
+    1.Prepare test environment,destroy or suspend a VM.
+    2.Prepare test xml for cdrom devices.
+    3.Perform test operation.
+    4.Recover test environment.
+    5.Confirm the test result.
+    """
+
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    virsh_dargs = {'debug': True, 'ignore_status': True}
+
+    # Disk specific attributes.
+    image_path = params.get("virt_disk_device_source", "/var/lib/libvirt/images/test.img")
+
+    scenario_execution = params.get("scenario_execution")
+
+    status_error = "yes" == params.get("status_error")
+    define_error = "yes" == params.get("define_error", "no")
+
+    device_obj = None
+    # Back up xml file.
+    if vm.is_alive():
+        vm.destroy(gracefully=False)
+    vmxml_backup = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    try:
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        # Create disk xml with slice attribute
+        device_obj = create_customized_disk(params)
+        vmxml.add_device(device_obj)
+        vmxml.sync()
+        vm.start()
+        vm.wait_for_login().close()
+    except virt_vm.VMStartError as e:
+        if status_error:
+            LOG.debug("VM failed to start as expected."
+                      "Error: %s", str(e))
+        else:
+            test.fail("VM failed to start."
+                      "Error: %s" % str(e))
+    except xcepts.LibvirtXMLError as xml_error:
+        if not define_error:
+            test.fail("Failed to define VM:\n%s" % xml_error)
+        else:
+            LOG.info("As expected, failed to define VM")
+    except Exception as ex:
+        test.fail("unexpected exception happen: %s" % str(ex))
+    else:
+        if scenario_execution == "slice_hot_operate":
+            # Need detach slice disk, then attach it again
+            virsh.detach_device(vm_name, device_obj.xml, flagstr="--live", ignore_status=False, debug=True)
+            vm.wait_for_login().close()
+            virsh.attach_device(vm_name, device_obj.xml, flagstr="--live", ignore_status=False, debug=True)
+            check_slice_hot_operate(vm, params, test)
+        elif scenario_execution == "slice_cdrom_update":
+            # Empty cdrom device
+            empty_cdrom = create_empty_cdrom_xml(params)
+            virsh.update_device(vm_name, empty_cdrom.xml, flagstr="--live", ignore_status=False, debug=True)
+            vm.wait_for_login().close()
+            virsh.update_device(vm_name, device_obj.xml, flagstr="--live", ignore_status=False, debug=True)
+            check_slice_cdrom_update(vm, test)
+        elif scenario_execution == "slice_disk_blockcommit":
+            check_slice_disk_blockcommit(vm, params)
+        elif scenario_execution == "slice_disk_blockcopy":
+            check_slice_disk_blockcopy(vm, params)
+        elif scenario_execution == "slice_blkdeviotune":
+            check_slice_blkdeviotune(vm, params, test)
+    finally:
+        libvirt_disk.cleanup_snapshots(vm)
+        # Recover VM.
+        if vm.is_alive():
+            vm.destroy(gracefully=False)
+        LOG.info("Restoring vm...")
+        vmxml_backup.sync()
+        # Clean up images
+        for file_path in cleanup_files:
+            if os.path.exists(file_path):
+                os.remove(file_path)

--- a/libvirt/tests/src/virtual_network/virtual_network_multivms.py
+++ b/libvirt/tests/src/virtual_network/virtual_network_multivms.py
@@ -1,7 +1,10 @@
 import logging as log
 import time
+import re
+import sys
 
 from avocado.utils import process
+from avocado.utils import stacktrace
 
 from virttest import libvirt_version
 from virttest import virsh
@@ -83,6 +86,74 @@ def prepare_network(net_name, **kwargs):
     logging.debug(virsh.net_dumpxml(net_name).stdout_text)
 
 
+def check_br_tap_params(br_name, tap_name, libvirt_manage=True):
+    """
+    When macTableManager is set to libvirt, libvirt disables kernel management
+    of the MAC table (in the case of the Linux host bridge, this means enabling
+    vlan_filtering on the bridge, and disabling learning and unicast_filter for
+    all bridge ports), and explicitly adds/removes entries to the table
+    according to the MAC addresses in the domain interface configurations.
+    The bridge's vlan_filtering should be 1, and the tap device connected to
+    this bridge has unicast_flood and learning set to '0'.
+
+    :param br_name: string, name of the bridge
+    :param tap_name: string, name of the tap device
+    :param libvirt_manage: bool, whether MAC table is managed by libvirt
+    :return: True or False
+    """
+    cmd1 = 'cat /sys/class/net/%s/bridge/vlan_filtering' % br_name
+    cmd2 = 'cat /sys/class/net/%s/brif/%s/learning' % (br_name, tap_name)
+    cmd3 = 'cat /sys/class/net/%s/brif/%s/unicast_flood' % (br_name, tap_name)
+    try:
+        vlan_filtering = process.run(cmd1, ignore_status=True,
+                                     shell=True).stdout_text.strip()
+        learning = process.run(cmd2, ignore_status=True,
+                               shell=True).stdout_text.strip()
+        unicast_flood = process.run(cmd3, ignore_status=True,
+                                    shell=True).stdout_text.strip()
+        logging.debug("bridge's vlan_filtering is {1}, {0} learning is {2}, "
+                      "unicast_flood is {3}".format(tap_name, vlan_filtering,
+                                                    learning, unicast_flood))
+        if libvirt_manage:
+            assert vlan_filtering == '1'
+            assert learning == '0'
+            assert unicast_flood == '0'
+        else:
+            assert vlan_filtering == '0'
+            assert learning == '1'
+            assert unicast_flood == '1'
+    except AssertionError:
+        stacktrace.log_exc_info(sys.exc_info())
+        return False
+    return True
+
+
+def check_fdb(mac, libvirt_manage=True):
+    """
+    Check the bridge's forwarding database table for specific mac. If it's
+    managed by libvirt, the record should be static.
+
+    :params mac: string, mac address to be checked in the forward database table
+    :params libvirt_manage: bool, if forward database table managed by libvirt
+    :params return: True or False. True if get expected result
+    """
+    cmd = 'bridge fdb show | grep %s' % mac
+    out = process.run(cmd, ignore_status=True, shell=True).stdout_text.strip()
+    logging.debug("The related record in fdb table is:\n%s", out)
+    res = re.search(r'%s.*vlan.*?static\n%s.*static' %
+                    (mac, mac), out)
+    if libvirt_manage:
+        if not res:
+            logging.debug("Can't find correct fdb record!")
+            return False
+    else:
+        if res:
+            logging.debug("libvirt do not manage the mactable, "
+                          "but there is static fdb record!")
+            return False
+    return True
+
+
 def run(test, params, env):
     """
     Test network/interface function on 2 vms:
@@ -99,6 +170,7 @@ def run(test, params, env):
 
     feature = params.get('feature', '')
     case = params.get('case', '')
+    create_linux_bridge = 'yes' == params.get('create_linux_bridge', 'no')
     check_ping = 'yes' == params.get('check_ping')
     expect_ping_host = 'yes' == params.get('expect_ping_host', 'no')
     expect_ping_out = 'yes' == params.get('expect_ping_out', 'no')
@@ -108,10 +180,26 @@ def run(test, params, env):
     set_all = 'yes' == params.get('set_all', 'no')
 
     rand_id = '_' + utils_misc.generate_random_string(3)
+    resume_vm = 'yes' == params.get('resume_vm', 'no')
     bridge_name = params.get('bridge_name', 'test_br0') + rand_id
     iface_name = utils_net.get_net_if(state="UP")[0]
-    test_net = 'net_isolated' + rand_id
+    test_net = feature + rand_id
     bridge_created = False
+
+    def pause_resume_vm(vm_name):
+        """
+        Use negative cmd to trigger guest io error to paused, then resume it
+        :params vm_name: string, name of the vm
+        :params return: None
+        """
+        cmd_ = '''virsh qemu-monitor-command %s '{"execute":"stop"}' ''' % vm_name
+        out = process.run(cmd_, shell=True).stdout_text.strip()
+        logging.debug("The out of the qemu-monitor-command is %s", out)
+        vm = env.get_vm(vm_name)
+        if not vm.is_paused():
+            test.error("VM %s is not paused by qemu-monitor-command!" % vm_name)
+        res = virsh.resume(vm_name, debug=True)
+        libvirt.check_exit_status(res)
 
     vmxml_backup_list = []
     for vm_i in vm_list:
@@ -125,7 +213,7 @@ def run(test, params, env):
                             ' > 6.2.0 to support port isolated')
 
             if case.startswith('set_iface'):
-                create_bridge(bridge_name, iface_name)
+                utils_net.create_linux_bridge_tmux(bridge_name, iface_name)
                 bridge_created = True
                 iface_type = case.split('_')[-1]
                 if iface_type == 'network':
@@ -208,7 +296,7 @@ def run(test, params, env):
                     session.close()
 
             if case == 'set_network':
-                create_bridge(bridge_name, iface_name)
+                utils_net.create_linux_bridge_tmux(bridge_name, iface_name)
                 bridge_created = True
                 net_dict = {
                     'net_forward': "{'mode': 'bridge'}",
@@ -225,6 +313,32 @@ def run(test, params, env):
                                             updated_iface_dict)
                     logging.debug(virsh.domiflist(vm_i.name).stdout_text)
 
+        if feature == 'macTableManager':
+            # create network with macTableManager='libvirt'
+            if create_linux_bridge:
+                utils_net.create_linux_bridge_tmux(bridge_name, iface_name)
+                bridge_created = True
+                net_dict = {
+                    'net_forward': "{'mode': 'bridge'}",
+                    'net_bridge': "{'name': '%s', 'macTableManager': 'libvirt'}" % bridge_name,
+                    }
+            else:
+                net_dict = {
+                    'net_forward': "{'mode': 'nat'}",
+                    'net_bridge': "{'name': '%s', 'macTableManager': 'libvirt'}" % bridge_name,
+                    'net_ip_address': params.get('net_ip_address'),
+                    'net_ip_netmask': params.get('net_ip_netmask'),
+                    'dhcp_start_ipv4': params.get('dhcp_start_ipv4'),
+                    'dhcp_end_ipv4': params.get('dhcp_end_ipv4')
+                }
+            iface_dict = {'type': 'network', 'del_mac': True,
+                          'source': "{'network': '%s'}" % test_net}
+            prepare_network(test_net, **net_dict)
+            for i in (0, 1):
+                vm_i = vm_list[i]
+                libvirt.modify_vm_iface(vm_i.name, 'update_iface', iface_dict)
+                logging.debug("After modify vm interface, check vm xml:\n%s",
+                              virsh.dumpxml(vm_i.name).stdout_text)
         # Check ping result from vm session to host, outside, the other vm
         if check_ping:
             for vm_i in vm_list:
@@ -235,15 +349,20 @@ def run(test, params, env):
                 host_ip: expect_ping_host,
                 out_ip: expect_ping_out,
             }
-
+            if resume_vm:
+                for vm_i in vm_list:
+                    vm_i.wait_for_serial_login().close()
+                    pause_resume_vm(str(vm_i.name))
             # A map of vm session and vm's ip addr
             session_n_ip = {}
             for vm_i in vm_list:
-                mac = vm_i.get_mac_address()
+                mac = vm_xml.VMXML.get_first_mac_by_name(vm_i.name)
                 sess = vm_i.wait_for_serial_login()
                 vm_ip = utils_net.get_guest_ip_addr(sess, mac)
                 session_n_ip[sess] = vm_ip
                 logging.debug('Vm %s ip: %s', vm_i.name, vm_ip)
+                if not vm_ip:
+                    test.error("Got vm %s ip as None!" % vm_i.name)
 
             # Check ping result from each vm's session
             for i in (0, 1):
@@ -276,11 +395,20 @@ def run(test, params, env):
                     if len(ip_l_before.splitlines()) == len(ip_l_after.splitlines()):
                         test.fail('Output of "ip l" is not changed afte detach, '
                                   'interface not successfully detached')
-
+        if feature == 'macTableManager':
+            for vm_i in vm_list:
+                iface_mac = vm_xml.VMXML.get_first_mac_by_name(vm_i.name)
+                tap_name = libvirt.get_ifname_host(vm_i.name, iface_mac)
+                logging.debug("Check %s's params for vm %s", tap_name, vm_i.name)
+                res1 = check_br_tap_params(bridge_name, tap_name)
+                res2 = check_fdb(iface_mac)
+                if not res1 or (not res2):
+                    test.fail("macTableManager function check failed!")
     finally:
         for vmxml_i in vmxml_backup_list:
             vmxml_i.sync()
         virsh.net_undefine(test_net, debug=True)
+        virsh.net_destroy(test_net, debug=True)
 
         # Remove test bridge
         if bridge_created:

--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -676,13 +676,18 @@
         - gt_16_disks:
             only esx_70
             main_vm = 'VM_NAME_ESX_GT_16_DISKS_V2V_EXAMPLE'
-        - sata:
-            only esx_65
-            version_required = "[libvirt-7.8.0-1,)"
-            main_vm = VM_NAME_ESX_SATA_DISK_V2V_EXAMPLE
+        - must_ip:
+            only esx_67
+            only it_default
+            only negative_test
+            version_required = "[virt-v2v-1.45.98-1,)"
+            main_vm = VM_NAME_ESX_UEFI_WINDOWS_V2V_EXAMPLE
+            msg_content = 'virt-v2v: error: -i libvirt: expecting -ip passwordfile parameter'
+            expect_msg = yes
+            cmd_has_ip = 'no'
     variants:
         - positive_test:
             status_error = 'no'
         - negative_test:
             status_error = 'yes'
-            only option_root.single,invalid_rhv_pem,no-copy-illegal,system_rhv_pem.unset,logs.open_source,keys.invalid,invalid_mac_ip,block_dev.small,no_space,inodes.less_inodes,windows.external_poweroff
+            only option_root.single,invalid_rhv_pem,no-copy-illegal,system_rhv_pem.unset,logs.open_source,keys.invalid,invalid_mac_ip,block_dev.small,no_space,inodes.less_inodes,windows.external_poweroff,must_ip

--- a/v2v/tests/src/specific_kvm.py
+++ b/v2v/tests/src/specific_kvm.py
@@ -460,12 +460,12 @@ def run(test, params, env):
         Corrupt rpm db
         """
         session = kwargs['session']
-        # If __db.* exist, remove them, then touch _db.001 to corrupt db.
-        if not session.cmd_status('ls /var/lib/rpm/__db.001'):
-            session.cmd('rm -f /var/lib/rpm/__db.*')
+        session.cmd('rm -f /var/lib/rpm/__db.*')
         session.cmd('touch /var/lib/rpm/__db.001')
-        if not session.cmd_status('yum update'):
-            test.error('Corrupt rpmdb failed')
+        output = session.cmd_output('yum update --assumeno')
+        LOG.debug(output)
+        if 'rpmdb open failed' not in output:
+            test.error('Prepare corrupt rpmdb failed')
 
     @vm_shell
     def grub_serial_terminal(**kwargs):


### PR DESCRIPTION
The output, when printing VM configuration from XML contains quotes when describing character device. The same output when printing VM config from native doesn't contain the quotes, so the device argument needs to be added to a list of arguments that should have the quotes removed.