### PR TITLE
domblkthreshold.py: fix get no event after domblkthreshold

### DIFF
--- a/libvirt/tests/src/backingchain/domblkthreshold.py
+++ b/libvirt/tests/src/backingchain/domblkthreshold.py
@@ -22,6 +22,9 @@ def run(test, params, env):
         """
         Prepare backingchain
         """
+        if not vm.is_alive():
+            vm.start()
+        vm.wait_for_login().close()
         test_obj.prepare_snapshot(snap_num=1)
 
     def test_domblkthreshold_inactivate_layer():
@@ -44,7 +47,7 @@ def run(test, params, env):
         session.close()
 
         # Check blockcommit will trigger threshold event
-        event = r"event \'block-threshold\' for domain %s: dev: %s\[%s\].*%s.*" \
+        event = r"\'block-threshold\' for domain .*%s.*: dev: %s\[%s\].*%s.*" \
                 % (vm_name, primary_target, bs_index, domblk_threshold)
         LOG.debug('Checking event pattern is :%s ', event)
 
@@ -53,7 +56,8 @@ def run(test, params, env):
                           ignore_status=False, debug=True)
         event_output = virsh.EventTracker.finish_get_event(event_session)
         if not re.search(event, event_output):
-            test.fail('Not find: %s from event output:%s' % (event, event_output))
+            test.fail('Not find: %s from event output:%s' % (event,
+                                                             event_output))
 
     def teardown_domblkthreshold_inactivate_layer():
         """


### PR DESCRIPTION
fix get no event after domblkthreshold
Signed-off-by: nanli <nanli@redhat.com>

There are two problems here 
1. Need wait time to get event
2. The patten to match event list needs to update

**Depend on** https://github.com/avocado-framework/avocado-vt/pull/3403 
**Test result** 
 [root@dell-per730-62 ~]# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.domblkthreshold.positive_test.inactivate_layer --vt-connect-uri qemu:///system
JOB ID     : 9fad959c892235f2b77557a43290ef8028843684
JOB LOG    : /root/avocado/job-results/job-2022-05-05T21.31-9fad959/job.log
 (1/1) type_specific.io-github-autotest-libvirt.backingchain.domblkthreshold.positive_test.inactivate_layer: PASS (41.59 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 42.46 s
**PASSED on RHEL 8.6/9.0/9.1**