### PR TITLE
virsh_detach_device_alias.py: fix detach device alias get params error

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
@@ -44,7 +44,7 @@ def run(test, params, env):
     channel_target = eval(params.get("detach_channel_target", "{}"))
     # watchdog params
     watchdog_type = params.get("detach_watchdog_type")
-    watchdog_dict = eval(params.get('watchdog_dict', {}))
+    watchdog_dict = eval(params.get('watchdog_dict', '{}'))
 
     device_alias = "ua-" + str(uuid.uuid4())
 


### PR DESCRIPTION
 fix detach device alias get params error 
 convert dict to str
Signed-off-by: nanli <nanli@redhat.com>

**Test result** 
 [root@dell-per740xd-11 ~]#  avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 virsh.detach_device_alias --vt-connect-uri qemu:///system
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : 4b95d6b4cdc86f795970a005e11f362b09d4239a
JOB LOG    : /var/lib/avocado/job-results/job-2022-05-06T00.31-4b95d6b/job.log
 (01/14) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.hostdev: PASS (28.09 s)
 (02/14) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.controller: PASS (27.94 s)
 (03/14) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.redirdev: PASS (27.63 s)
 (04/14) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.channel: PASS (27.54 s)
 (05/14) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.watchdog: PASS (46.59 s)
 (06/14) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.config.hostdev: PASS (27.45 s)
 (07/14) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.config.controller: PASS (25.70 s)
 (08/14) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.config.redirdev: PASS (25.44 s)
 (09/14) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.config.channel: PASS (25.74 s)
 (10/14) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.config.watchdog: PASS (44.47 s)
 (11/14) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.current.hostdev: PASS (29.55 s)
 (12/14) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.current.controller: PASS (27.65 s)
 (13/14) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.current.redirdev: PASS (27.84 s)
 (14/14) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.current.channel: PASS (27.72 s)
