### PR TITLE
virsh_save: change to paused_state pattern name

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_save.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_save.cfg
@@ -26,7 +26,7 @@
                 - id_option:
                     save_vm_ref = "id"
                 - normal_option:
-                - paused_option:
+                - paused_state:
                     paused_after_start_vm = "yes"
                 - uuid_option:
                     save_vm_ref = "uuid"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_save.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_save.py
@@ -71,6 +71,7 @@ def run(test, params, env):
 
     if progress:
         options += " --verbose"
+    virsh.domstate(vm_name, ignore_status=True, debug=True)
     result = virsh.save(vm_ref, savefile, options, ignore_status=True,
                         unprivileged_user=unprivileged_user,
                         uri=uri, debug=True, readonly=readonly)
@@ -83,6 +84,7 @@ def run(test, params, env):
 
     if savefile:
         virsh.restore(savefile, debug=True)
+    virsh.domstate(vm_name, ignore_status=True, debug=True)
 
     # check status_error
     try:


### PR DESCRIPTION
'paused_state' is better than 'paused_option' which is duplicated
with later options. And add domstate to display vm status better
for readers in log.

Signed-off-by: Yanqiu Zhang <yanqzhan@redhat.com>

