### PR TITLE
sriov: Fix 2 issues in unassigned_address cases

### DIFF
--- a/libvirt/tests/cfg/sriov/sriov_attach_hostdev.cfg
+++ b/libvirt/tests/cfg/sriov/sriov_attach_hostdev.cfg
@@ -13,6 +13,8 @@
                     hostdev_dict = {'type': 'pci', 'address': {'attrs':{'type': 'unassigned'}}, 'mode': 'subsystem', 'managed': 'yes', 'source': {'untyped_address': %s}}
                 - hostdev_interface:
                     hostdev_iface_dict = {'managed': 'yes', 'hostdev_address': {'attrs': %s}, 'address': {'attrs':{'type': 'unassigned'}}}
+                    status_error = "yes"
+                    error_msg = "address of type 'unassigned'"
         - duplicated_cust_alias:
             only hot_plug
             hostdev_iface_dict = {'managed': 'yes', 'hostdev_address': {'attrs': %s}, 'alias': {'name': '%s'}}


### PR DESCRIPTION
This pr fixes 2 problems:
    1. The unassigned address changed to only support hostdev device
    2. VM login failure

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Test results:**
```
 (1/5) type_specific.io-github-autotest-libvirt.sriov.attach_hostdev.unassigned_address.hostdev_device.cold_plug: PASS (46.20 s)
 (2/5) type_specific.io-github-autotest-libvirt.sriov.attach_hostdev.unassigned_address.hostdev_device.hot_plug: PASS (47.62 s)
 (3/5) type_specific.io-github-autotest-libvirt.sriov.attach_hostdev.unassigned_address.hostdev_interface.cold_plug: PASS (20.05 s)
 (4/5) type_specific.io-github-autotest-libvirt.sriov.attach_hostdev.unassigned_address.hostdev_interface.hot_plug: PASS (22.76 s)
 (5/5) type_specific.io-github-autotest-libvirt.sriov.attach_hostdev.duplicated_cust_alias.hot_plug: PASS (49.49 s)

```