### PR TITLE
Add case about restart SRC libvirtd during migration

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_service_control.cfg
+++ b/libvirt/tests/cfg/migration/migrate_service_control.cfg
@@ -44,3 +44,11 @@
                 - kill_libvirtd_on_src:
                     service_name = "libvirtd"
                     err_msg = 'End of file while reading data: Input/output error'
+        - restart_service_on_src:
+            migrate_speed = 1
+            status_error = 'yes'
+            action_during_mig = '[{"func": "utils_libvirtd.libvirtd_restart", "after_event": "migration-iteration", "before_event": "Suspended Migrated"}]'
+            vm_state_after_abort = "{'source': 'running', 'target': 'nonexist'}"
+            err_msg = 'Disconnected .*'
+            migrate_again = 'yes'
+            migrate_again_status_error = 'no'


### PR DESCRIPTION
Restart SRC libvirtd during Perform Phase of live migration.

Signed-off-by: cliping <lcheng@redhat.com>

