### PR TITLE
virttools: add test for long kernel command line

### DIFF
--- a/virttools/tests/cfg/virt_install/kernel_cmdline.cfg
+++ b/virttools/tests/cfg/virt_install/kernel_cmdline.cfg
@@ -1,0 +1,12 @@
+- virt_install.kernel_cmdline:
+    type = kernel_cmdline
+    only s390-virtio
+    variants:
+        - boots_with_long_commandline:
+            # contains a kernel version that supports long commandline
+            location = https://dl.fedoraproject.org/pub/fedora-secondary/development/rawhide/Everything/s390x/os/
+            expected_status = 0
+        - does_not_boot_with_long_commandline:
+            # contains a kernel version that does not support long commandline
+            location = http://mirror.stream.centos.org/9-stream/BaseOS/s390x/os/
+            expected_status = 1

--- a/virttools/tests/src/virt_install/kernel_cmdline.py
+++ b/virttools/tests/src/virt_install/kernel_cmdline.py
@@ -1,0 +1,55 @@
+import logging
+
+from virttest.libvirt_xml.vm_xml import VMXML
+from virttest.utils_misc import cmd_status_output
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+
+def virt_install(vm_name, install_tree, extra_args):
+    """
+    Runs virt-install with specific kernel command line
+    It returns immediately, reporting the status
+
+    :param vm_name: guest name
+    :param install_tree: the installation tree url
+    :param extra_args: extra arguments for kernel command line
+    """
+    cmd = ("virt-install --name %s"
+           " --disk none"
+           " --vcpus 2 --memory 2048"
+           " --nographics --noautoconsole"
+           " --location %s --extra-args '%s'" %
+           (vm_name, install_tree, extra_args))
+    status, out = cmd_status_output(cmd, shell=True, verbose=True)
+    LOG.debug("Command output: %s" % out)
+    return status
+
+
+def run(test, params, env):
+    """
+    Confirm that the 896 byte restriction for kernel
+    command lines has been lifted for newer kernels
+    and older kernels are handled correctly.
+    """
+
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    vmxml = VMXML.new_from_inactive_dumpxml(vm_name)
+
+    location = params.get("location")
+    expected_status = params.get("expected_status")
+    extra_args = "a"*1000
+    LOG.debug("Command line will have at least %s bytes length." % len(bytes(extra_args, 'utf-8')))
+
+    try:
+
+        vm.undefine()
+        status = virt_install(vm_name, location, extra_args)
+
+        if status != expected_status:
+            test.fail("The installation didn't exit as expected."
+                      " Expected: %s, actual: %s" % (expected_status, status))
+
+    finally:
+        vmxml.sync()


### PR DESCRIPTION
Recently, for s390x support has been added for kernel
command lines longer than 896 bytes.

Add a test case for this. As we depend on kernel versions,
use two different `--location` values that are relatively
stable to represent newer and older kernel versions.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>
