### PR TITLE
virsh_domxml_to_native: Add -device to list of args with redundant quotes

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_to_native.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_to_native.py
@@ -69,7 +69,8 @@ def run(test, params, env):
                 # turned into
                 # -blockdev {"driver":"file",...,"discard":"unmap"} in order to
                 # match the qemu command line format
-                if e in ['-blockdev', '-object', '-compat', '-audiodev']:
+                if e in ['-blockdev', '-object', '-compat', '-audiodev',
+                         '-device']:
                     enext = enext.strip("'")
                 # Append this and the next and set our skip flag
                 retlist.append(e + " " + enext)


### PR DESCRIPTION
In virsh_domxml_to_native.py, when exporting setup from xml,
for some arguments quotes are added. The testing script removes them but
the list of arguments that is supposed to be removed is edited manually.

One of the missing arguments is -device arguments that this commit adds.

Similar commit is bab218c2074e3537db1b18e0d0c8e1c4bbc9cd04
https://github.com/autotest/tp-libvirt/commit/bab218c2074e3537db1b18e0d0c8e1c4bbc9cd04

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [ ] Description of the cases
- [ ] Links of libvirt features, libvirt bugs or case IDs
- [ ] Test results

## If the PR is bug cases
- [ ] Bug descriptions or bug links
- [ ] Test results

## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
