### PR TITLE
add case for Hotunplug vsock device by device alias

### DIFF
--- a/libvirt/tests/cfg/virtual_device/vsock.cfg
+++ b/libvirt/tests/cfg/virtual_device/vsock.cfg
@@ -23,6 +23,9 @@
                             no_vsock = "yes"
                         - communication:
                             communication = "yes"
+                        - detach_device_alias:
+                            only static_cid
+                            detach_device_alias = "yes"
                 - coldplug:
                     attach_option = "--config"
                 - edit_start:


### PR DESCRIPTION
Hotunplug vsock device with virsh detach-device-alias
Signed-off-by: nanli <nanli@redhat.com>

**case id** :  RHEL-145277
**Test result:**
[root@hpe-xl220agen8v2-02 tp-libvirt]# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 vsock.normal_test.hotplug.detach_device_alias.static_cid --vt-connect-uri qemu:///system
JOB ID     : a4cc1a6ad8a2044ddf5c22fd1c2766095576bad5
JOB LOG    : /var/lib/avocado/job-results/job-2022-05-11T09.58-a4cc1a6/job.log
 (1/1) type_specific.io-github-autotest-libvirt.vsock.normal_test.hotplug.detach_device_alias.static_cid: PASS (69.92 s)
RESULTS    : **PASS** 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-05-11T09.58-a4cc1a6/results.html
JOB TIME   : 71.02 s

**Other related case:** 
[root@hpe-xl220agen8v2-02 tp-libvirt]# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 vsock --vt-connect-uri qemu:///system
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : e6ca82d99d973e3dc9a8cd7352203f3ef0547b8d
JOB LOG    : /var/lib/avocado/job-results/job-2022-05-11T10.16-e6ca82d/job.log
 (01/15) type_specific.io-github-autotest-libvirt.vsock.normal_test.hotplug.nop.auto_cid: PASS (71.33 s)
 (02/15) type_specific.io-github-autotest-libvirt.vsock.normal_test.hotplug.nop.static_cid: PASS (76.25 s)
 (03/15) type_specific.io-github-autotest-libvirt.vsock.normal_test.hotplug.managedsave_with_vsock.auto_cid: PASS (85.91 s)
 (04/15) type_specific.io-github-autotest-libvirt.vsock.normal_test.hotplug.managedsave_with_vsock.static_cid: PASS (84.96 s)
 (05/15) type_specific.io-github-autotest-libvirt.vsock.normal_test.hotplug.managedsave_after_vsock.auto_cid: PASS (94.94 s)
 (06/15) type_specific.io-github-autotest-libvirt.vsock.normal_test.hotplug.managedsave_after_vsock.static_cid: PASS (89.24 s)
 (07/15) type_specific.io-github-autotest-libvirt.vsock.normal_test.hotplug.communication.auto_cid: PASS (153.77 s)
 (08/15) type_specific.io-github-autotest-libvirt.vsock.normal_test.hotplug.communication.static_cid: PASS (143.82 s)
 (09/15) type_specific.io-github-autotest-libvirt.vsock.normal_test.hotplug.detach_device_alias.static_cid: PASS (57.78 s)
 (10/15) type_specific.io-github-autotest-libvirt.vsock.normal_test.coldplug.auto_cid: PASS (55.69 s)
 (11/15) type_specific.io-github-autotest-libvirt.vsock.normal_test.coldplug.static_cid: PASS (58.53 s)
 (12/15) type_specific.io-github-autotest-libvirt.vsock.normal_test.edit_start.auto_cid: PASS (29.91 s)
 (13/15) type_specific.io-github-autotest-libvirt.vsock.normal_test.edit_start.static_cid: PASS (28.99 s)
 (14/15) type_specific.io-github-autotest-libvirt.vsock.negative_test.invalid_cid.static_cid: PASS (54.88 s)
 (15/15) type_specific.io-github-autotest-libvirt.vsock.negative_test.two_vsocks.static_cid: PASS (57.32 s)
RESULTS    : PASS 15 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-05-11T10.16-e6ca82d/results.html
JOB TIME   : 1145.36 s

