### PR TITLE
serial_pty_log: Extend the timeout for getting login prompt

### DIFF
--- a/libvirt/tests/src/serial/serial_pty_log.py
+++ b/libvirt/tests/src/serial/serial_pty_log.py
@@ -97,7 +97,7 @@ def run(test, params, env):
 
         # Need to wait for a while to get login prompt
         if not utils_misc.wait_for(
-                lambda: check_pty_log_file(log_file, boot_prompt), 3):
+                lambda: check_pty_log_file(log_file, boot_prompt), 6):
             test.fail("Failed to find the vm login prompt from %s" % log_file)
 
     except Exception as e:


### PR DESCRIPTION
Signed-off-by: Hu Shuai <hus.fnst@fujitsu.com>

For some low-performance machines, the running speed is slow, the log has no `login prompt` input within 3s, and the case will fail. This PR extends the timeout to 6s.

Before:
```
# avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio serial.pty.log.file --vt-connect-uri qemu:///system
JOB ID     : da036dd6cdb6b8f36390e27275636279d25699a3                            
JOB LOG    : /var/lib/avocado/job-results/job-2022-05-12T21.50-da036dd/job.log     
 (1/1) type_specific.io-github-autotest-libvirt.serial.pty.log.file: ERROR: Unexpected error: Failed to find the vm login prompt from /var/lib/libvirt/console1.log (52.05 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-05-12T21.50-da036dd/results.html
JOB TIME   : 52.82 s
```

After:
```
# avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio serial.pty.log.file --vt-connect-uri qemu:///system                                                              
JOB ID     : 8e5694194eebc08d6ea53ce5f6870f00ac1a6962
JOB LOG    : /var/lib/avocado/job-results/job-2022-05-12T21.55-8e56941/job.log
 (1/1) type_specific.io-github-autotest-libvirt.serial.pty.log.file: PASS (51.12 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-05-12T21.55-8e56941/results.html
JOB TIME   : 51.89 s
```