### PR TITLE
misc_virtual_devices: Extend event_timeout for detach_device_alias

### DIFF
--- a/libvirt/tests/src/virtual_device/filesystem_device.py
+++ b/libvirt/tests/src/virtual_device/filesystem_device.py
@@ -402,7 +402,8 @@ def run(test, params, env):
                                         test.fail("When setting stdio_handler as logd, the command"
                                                   "to write log should be virtlogd!")
                             ret = virsh.detach_device_alias(vm.name, alias, ignore_status=True,
-                                                            debug=True, wait_for_event=True)
+                                                            debug=True, wait_for_event=True,
+                                                            event_timeout=10)
                         else:
                             ret = virsh.detach_device(vm.name, fs_dev.xml, ignore_status=True,
                                                       debug=True, wait_for_event=True)


### PR DESCRIPTION
Signed-off-by: Hu Shuai <hus.fnst@fujitsu.com>

The default `event_timeout` for `detach_device_alias` is 7s, but on ARM, it spends about 7.01s. So the test cases always fails.
This PR extends the `event_timeout` to 8s.

Befor:
```
# avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio virtual_devices.filesystem_device.positive_test.hugepages_backed.hotplug_unplug.detach_device_alias.stdio_handler.file.fs_test.xattr_on.flock_on.lock_posix_on.cache_mode_none.one_fs.one_guest --vt-connect-uri qemu:///system                                                                                                                                                                             
JOB ID     : 344d9c91b181df747a6d036670d7fe82c8b29a09
JOB LOG    : /root/avocado/job-results/job-2022-05-13T02.42-344d9c9/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_devices.filesystem_device.positive_test.hugepages_backed.hotplug_unplug.detach_device_alias.stdio_handler.file.fs_test.xattr_on.flock_on.lock_posix_on.cache_mode_none.one_fs.one_gues
t: ERROR: Not found event device-removed after 7 seconds (64.67 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/avocado/job-results/job-2022-05-13T02.42-344d9c9/results.html
JOB TIME   : 65.42 s
```

After:
```
# avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio virtual_devices.filesystem_device.positive_test.hugepages_backed.hotplug_unplug.detach_device_alias.stdio_handler.file.fs_test.xattr_on.flock_on.lock_posix_on.cache_mode_none.one_fs.one_guest --vt-connect-uri qemu:///system                                                                        
JOB ID     : 08b64955600c654cb625368482fa6a193a4c8bd4
JOB LOG    : /root/avocado/job-results/job-2022-05-13T04.07-08b6495/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_devices.filesystem_device.positive_test.hugepages_backed.hotplug_unplug.detach_device_alias.stdio_handler.file.fs_test.xattr_on.flock_on.lock_posix_on.cache_mode_none.one_fs.one_guest: PASS (69.38 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/avocado/job-results/job-2022-05-13T04.07-08b6495/results.html
JOB TIME   : 70.14 s
```