### PR TITLE
Add case for hot-plug with different addresses

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_disk.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_disk.cfg
@@ -72,6 +72,19 @@
                             at_dt_disk_bus_type = ide
                         - invalid_cache:
                             at_dt_disk_at_options = "--cache sdkfhskhf"
+                        -  hotplug_ide:
+                            only i440fx
+                            at_dt_disk_device_target = "hda"
+                            at_dt_disk_at_options =  " --address ide:00.01.0"
+                        -  hotplug_ccw:
+                            only s390-virtio
+                            at_dt_disk_at_options =  " --address ccw:0xfe.0.0000"
+                        -  hotplug_sata:
+                            at_dt_disk_device_target = "hda"
+                            at_dt_disk_at_options = " --address sata:00.01.0"
+                        - invalid_scsi_address:
+                            at_dt_disk_device_target = "sdb"
+                            at_dt_disk_at_options =  " --address scsi:00.01.0"
         - normal_test:
             status_error = 'no'
             variants:
@@ -115,6 +128,14 @@
                     at_dt_disk_device_target2 = vdx
                     aarch64:
                         reset_pci_controllers_nums = 'yes'
+                - twice_same_target_diff_scsi_address:
+                    only attach_disk
+                    at_dt_disk_device_target = "sdb"
+                    add_more_pci_controllers = "yes"
+                    twice_same_target_diff_address = "yes"
+                    at_dt_disk_at_options =  " --targetbus scsi"
+                    at_dt_disk_address = " scsi:00.00.0"
+                    at_dt_disk_address2 = " scsi:01.00.0"
                 - twice_multifunction:
                     only attach_disk
                     qemu_file_lock = '2.9.0'


### PR DESCRIPTION
 VIRT-85116 and VIRT-294590 : Add positive and negative addresses cases
Signed-off-by: nanli <nanli@redhat.com>

**Test result:**
(p3-ve) [root@nanli tp-libvirt]# /**usr/local/bin/avocado run --vt-type libvirt --vt-machine-type q35 virsh.attach_detach_disk..twice_same_target_diff_scsi_address  --vt-connect-uri qemu:///system**
JOB ID     : 62f6a91498a59e0d994b9847fbb19148b742a376
JOB LOG    : /root/avocado/job-results/job-2022-05-17T16.47-62f6a91/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.attach_detach_disk.attach_disk.normal_test.twice_same_target_diff_scsi_address: PASS (40.55 s)
RESULTS    : **PASS** 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 46.74 s
(p3-ve) [root@nanli tp-libvirt]# **/usr/local/bin/avocado run --vt-type libvirt --vt-machine-type q35 virsh.attach_detach_disk.attach_disk.error_test.only_attach_disk.invalid_scsi_address** 
JOB ID     : 841bbf4489b4c752e6a26ec4e1d6fa8c60bdf845
JOB LOG    : /root/avocado/job-results/job-2022-05-17T16.48-841bbf4/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.attach_detach_disk.attach_disk.error_test.only_attach_disk.invalid_scsi_address: PASS (32.12 s)
RESULTS    : **PASS** 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 38.39 s
(p3-ve) [root@nanli tp-libvirt]# /**usr/local/bin/avocado run --vt-type libvirt --vt-machine-type q35 virsh.attach_detach_disk.attach_disk.error_test.only_attach_disk.hotplug_ccw**  
JOB ID     : bbad7820e26a30ec43423bd24bb8151ed557e854
JOB LOG    : /root/avocado/job-results/job-2022-05-17T16.49-bbad782/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.attach_detach_disk.attach_disk.error_test.only_attach_disk.hotplug_ccw: PASS (34.17 s)
RESULTS    : **PASS** 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 37.43 s

(p3-ve) [root@nanli tp-libvirt]# **/usr/local/bin/avocado run --vt-type libvirt --vt-machine-type q35 virsh.attach_detach_disk.attach_disk.error_test.only_attach_disk.hotplug_ide**  
JOB ID     : 7caebe990c5beb5a556a1817d728545a1959b3ed
JOB LOG    : /root/avocado/job-results/job-2022-05-17T16.50-7caebe9/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.attach_detach_disk.attach_disk.error_test.only_attach_disk.hotplug_ide: PASS (29.59 s)
RESULTS    : **PASS** 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0

**/usr/local/bin/avocado run --vt-type libvirt --vt-machine-type q35 virsh.attach_detach_disk.attach_disk.error_test.only_attach_disk.hotplug_sata**  
