### PR TITLE
libvirt_rng: Add case for virtio-rng device /dev/urandom backend

### DIFF
--- a/libvirt/tests/cfg/libvirt_rng.cfg
+++ b/libvirt/tests/cfg/libvirt_rng.cfg
@@ -36,6 +36,10 @@
             backend_dev = "/dev/random"
             variants:
                 - default:
+                - urandom:
+                    backend_dev = "/dev/urandom"
+                    urandom = "yes"
+                    test_guest_dump = "yes"
                 - detach_device_alias:
                     rng_detach_alias = "yes"
                     variants:


### PR DESCRIPTION
… /dev/urandom

A new automation scirpt is added one that adds automation for checking
RNG device.

We need to improve our test coverage when attaching random number generation devices. Previously we did not check with enough detail.

The polarion case that is being automated is [VIRT-98310](https://polarion.engineering.redhat.com/polarion/#/project/RHELVIRT/workitem?id=VIRT-98310).
Jira Case: https://issues.redhat.com/browse/LIBVIRTAT-12924
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1347642

Test results:
```
# avocado run --vt-type libvirt libvirt_rng.test_device.device_assign
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : 5c8f5e493fe3fcd8b4e0a1dff8480a78955701ae
JOB LOG    : /var/lib/avocado/job-results/job-2022-05-18T10.38-5c8f5e4/job.log
 (1/1) type_specific.io-github-autotest-libvirt.libvirt_rng.test_device.device_assign: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.libvirt_rng.test_device.device_assign: PASS (51.05 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-05-18T10.38-5c8f5e4/results.html
JOB TIME   : 52.61 s
```

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [x] Description of the cases
- [x] Links of libvirt features, libvirt bugs or case IDs
- [x] Test results
