### PR TITLE
cpu: Remove pm setting

### DIFF
--- a/libvirt/tests/src/libvirt_vcpu_plug_unplug.py
+++ b/libvirt/tests/src/libvirt_vcpu_plug_unplug.py
@@ -1,7 +1,6 @@
 import os
 import re
 import logging as log
-import platform
 import time
 
 from avocado.utils import cpu as cpu_util
@@ -299,10 +298,6 @@ def run(test, params, env):
 
         vmxml.set_vm_vcpus(vm_name, vcpu_max_num, vcpu_current_num,
                            topology_correction=topology_correction)
-        # Do not apply S3/S4 on power
-        cpu_arch = platform.machine()
-        if cpu_arch in ('x86_64', 'i386', 'i686'):
-            vmxml.set_pm_suspend(vm_name, "yes", "yes")
         vm.start()
         vm_uptime_init = vm.uptime()
         if with_stress:


### PR DESCRIPTION
The pm setting should be enabled by s3/s4 related cases, hence
removing it from general test steps.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Test results:**
```
(01/39) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.positive_test.vcpu_set.live.vm_operate.no_operation: PASS (66.05 s)
 (02/39) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.positive_test.vcpu_set.live.vm_operate.save: PASS (68.89 s)
 (03/39) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.positive_test.vcpu_set.live.vm_operate.managedsave: PASS (72.69 s)
 (04/39) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.positive_test.vcpu_set.live.vm_operate.suspend: PASS (63.41 s)
 (05/39) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.positive_test.vcpu_set.live.vm_operate.save_with_unplug: PASS (99.99 s)
 (06/39) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.positive_test.vcpu_set.live.vm_operate.managedsave_with_unplug: PASS (100.46 s)
 (07/39) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.positive_test.vcpu_set.live.vm_operate.suspend_with_unplug: PASS (86.38 s)
 (08/39) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.positive_test.vcpu_set.live.vm_operate.reboot: PASS (169.92 s)
 (09/39) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.positive_test.vcpu_set.live.libvirtd_restart: PASS (71.59 s)
 (10/39) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.positive_test.vcpu_set.live.vcpu_pin.pin_plug_unplug: PASS (72.33 s)
 (11/39) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.positive_test.vcpu_set.live.vcpu_pin.pin_unplug: PASS (58.98 s)
 (12/39) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.positive_test.vcpu_set.live.vcpu_pin.plug_pin: PASS (56.60 s)
 (13/39) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.positive_test.vcpu_set.live.vcpu_pin.unplug_pin: PASS (59.29 s)
 (14/39) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.positive_test.vcpu_set.live.with_iteration: PASS (386.27 s)
 (15/39) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.positive_test.vcpu_set.config.vm_operate.no_operation: PASS (54.16 s)
 (16/39) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.positive_test.vcpu_set.config.vm_operate.save: PASS (53.56 s)
 (17/39) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.positive_test.vcpu_set.config.vm_operate.managedsave: PASS (55.57 s)
 (18/39) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.positive_test.vcpu_set.config.vm_operate.suspend: PASS (46.43 s)
 (19/39) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.positive_test.vcpu_set.config.vm_operate.save_with_unplug: PASS (70.09 s)
 (20/39) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.positive_test.vcpu_set.config.vm_operate.managedsave_with_unplug: PASS (70.29 s)
 (21/39) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.positive_test.vcpu_set.config.vm_operate.suspend_with_unplug: PASS (56.70 s)
 (22/39) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.positive_test.vcpu_set.config.vm_operate.reboot: PASS (126.25 s)
 (23/39) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.positive_test.vcpu_set.config.libvirtd_restart: PASS (54.65 s)
 (24/39) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.positive_test.vcpu_set.guest.vm_operate.no_operation: PASS (81.83 s)
 (25/39) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.positive_test.vcpu_set.guest.vm_operate.save: PASS (73.06 s)
 (26/39) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.positive_test.vcpu_set.guest.vm_operate.managedsave: PASS (72.67 s)
 (27/39) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.positive_test.vcpu_set.guest.vm_operate.suspend: PASS (70.75 s)
 (28/39) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.positive_test.vcpu_set.guest.vm_operate.save_with_unplug: PASS (90.52 s)
 (29/39) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.positive_test.vcpu_set.guest.vm_operate.managedsave_with_unplug: PASS (89.99 s)
 (30/39) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.positive_test.vcpu_set.guest.vm_operate.suspend_with_unplug: PASS (82.96 s)
 (31/39) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.positive_test.vcpu_set.guest.vm_operate.reboot: PASS (117.50 s)
 (32/39) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.positive_test.vcpu_set.guest.libvirtd_restart: PASS (80.12 s)
 (33/39) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.negative_test.greater_plug_number: PASS (44.80 s)
 (34/39) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.negative_test.readonly_setvcpu: PASS (50.78 s)
 (35/39) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.negative_test.no_ga_channel: PASS (50.97 s)
 (36/39) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.negative_test.no_install_qemuga: PASS (49.24 s)
 (37/39) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.negative_test.no_start_qemuga: PASS (80.27 s)
 (38/39) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.negative_test.guest_plug.more_than_current: PASS (73.38 s)
 (39/39) type_specific.io-github-autotest-libvirt.libvirt_vcpu_plug_unplug.negative_test.guest_plug.more_than_max: PASS (71.15 s)
RESULTS    : PASS 39 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-05-18T23.45-bc172e2/results.html
JOB TIME   : 3202.02 s

```