### PR TITLE
virsh_blockcopy:fix blockcopy domxml not expected

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
@@ -667,7 +667,7 @@ def run(test, params, env):
         if not status_error:
             if status == 0:
                 ret = utils_misc.wait_for(
-                    lambda: check_xml(vm_name, target, dest_path, options), 5)
+                    lambda: check_xml(vm_name, target, dest_path, options), 20)
                 if not ret:
                     raise exceptions.TestFail("Domain xml not expected after"
                                               " blockcopy")


### PR DESCRIPTION
   Need more time to check domain xml
Signed-off-by: nanli <nanli@redhat.com>

[root@dell-per740-43 tp-libvirt]# **/usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 virsh.blockcopy.positive_test.non_acl.block_disk.disk_t.default.volume_type.no_blockdev.no_shallow.finish_async_option --vt-connect-uri qemu:///system**
JOB ID     : c72dbcb2a83e66e3011815eaf01df21e09b93657
JOB LOG    : /var/lib/avocado/job-results/job-2022-05-19T03.23-c72dbcb/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.blockcopy.positive_test.non_acl.block_disk.disk_t.default.volume_type.no_blockdev.no_shallow.finish_async_option: PASS (121.69 s)
RESULTS    : **PASS** 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 122.33 s
[root@dell-per740-43 tp-libvirt]# **/usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 virsh.blockcopy.positive_test.non_acl.block_disk.disk_t.default.volume_type.no_blockdev.no_shallow.pivot_async_option --vt-connect-uri qemu:///system**
JOB ID     : 6e0cccf0246c0f873496199d7f6a0e1900541822
JOB LOG    : /var/lib/avocado/job-results/job-2022-05-19T03.25-6e0cccf/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.blockcopy.positive_test.non_acl.block_disk.disk_t.default.volume_type.no_blockdev.no_shallow.pivot_async_option: **PASS** (135.26 s)
