### PR TITLE
Add case for detach virtual network interface by alias

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
@@ -35,6 +35,11 @@
             detach_watchdog_type = "watchdog"
             watchdog_dict = {"model_type":"i6300esb", "action":"poweroff"}
             detach_check_xml = "<watchdog"
+        - network_interface:
+            only live,config
+            detach_interface_type = "network_interface"
+            interface_dict = {"source": {'network':'default','bridge':'virbr0'},"target":{'dev': 'vnet0'}}
+            detach_check_xml = "<interface"
     variants:
         - live:
             detach_alias_options = "--live"


### PR DESCRIPTION
  RHEL-148232:Detach device by 'virsh detach-device-alias' cmd while use network interface
Signed-off-by: nanli <nanli@redhat.com>

Depend on https://github.com/avocado-framework/avocado-vt/pull/3420 

[root@dell-per740-07 tp-libvirt]# **/usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 virsh.detach_device_alias.live.network_interface  --vt-connect-uri qemu:///system**
 (1/1) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.network_interface: PASS (64.74 s)
RESULTS    : **PASS 1** | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-05-20T03.52-72c27c7/results.html
 [root@dell-per740-07 tp-libvirt]# **/usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 virsh.detach_device_alias.config.network_interface  --vt-connect-uri qemu:///system**
 (1/1) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.config.network_interface: PASS (64.02 s)
RESULTS    : **PASS 1** | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-05-20T03.56-10d08a3/results.html
JOB TIME   : 64.85 s

