### PR TITLE
Add testcase for systemd config file

### DIFF
--- a/libvirt/tests/cfg/conf_file/systemd_config/systemd_config.cfg
+++ b/libvirt/tests/cfg/conf_file/systemd_config/systemd_config.cfg
@@ -1,0 +1,31 @@
+- conf_file.systemd_config:
+    type = systemd_config
+    start_vm = yes
+    config_dir = "/usr/lib/systemd/system/"
+    variants:
+        - daemon_mode:
+            variants:
+                - legacy_daemon:
+                    require_modular_daemon = "no"
+                    variants daemon_name:
+                        - libvirtd:
+                - modular_daemon:
+                    require_modular_daemon = "yes"
+                    variants daemon_name:
+                        - virtqemud:
+                        - virtnetworkd:
+                        - virtstoraged:
+                        - virtproxyd:
+                        - virtsecretd:
+                        - virtinterfaced:
+                        - virtnwfilterd:
+    variants test_type:
+        - set_exec_args:
+            only modular_daemon
+            exec_args = "--timeout 100"
+        - set_limitNOFILE:
+            only libvirtd,virtqemud 
+            limitNOFILE = "LimitNOFILE=1048576"
+        - set_limitMEMLOCK:
+            only libvirtd,virtqemud
+            limitMEMLOCK = "LimitMEMLOCK=134217728B"

--- a/libvirt/tests/src/conf_file/systemd_config/systemd_config.py
+++ b/libvirt/tests/src/conf_file/systemd_config/systemd_config.py
@@ -1,0 +1,107 @@
+import logging as log
+import os
+import re
+import shutil
+
+from avocado.utils import process
+
+from virttest import data_dir
+from virttest import utils_split_daemons
+from virttest import utils_libvirtd
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
+
+
+def run(test, params, env):
+    """
+    Test the config in systemd config file of services
+
+    1.Set the exec_args.
+    2.Set LimitNOFILE.
+    3.Set LimitMEMLOCK.
+    """
+
+    def set_config(ori_config_line, new_config_line, config_file):
+        """
+        Set config for the daemon systemd config
+
+        :param ori_config_line: original config
+        :param new_config_line: new config
+        :param config_file: daemon systemd config file
+        """
+        with open(systemd_file, 'r') as fr:
+            alllines = fr.readlines()
+        with open(systemd_file, 'w+') as fw:
+            for line in alllines:
+                newline = re.sub(ori_config_line, new_config_line, line)
+                fw.writelines(newline)
+
+    def test_exec_config(daemon_name, new_config_line):
+        """
+        Set exec_args in the daemon systemd config and restart daemon,
+        then confirm the config works
+
+        :param daemon_name: daemon name
+        :param new_config_line: new config
+        """
+        ori_config_line = process.getoutput("cat %s |grep timeout" % systemd_file, shell=True)
+        ori_config_line = ori_config_line.split('\"')[1]
+        new_config_line = ori_config_line.replace(ori_config_line, exec_args)
+        set_config(ori_config_line, new_config_line, systemd_file)
+        process.run("systemctl daemon-reload")
+        utils_libvirtd.Libvirtd(daemon_name).restart()
+        daemon_process = process.getoutput("ps aux |grep %s |grep -v grep" % daemon_name, shell=True)
+        logging.debug("The process is started by:%s", daemon_process)
+        daemon_exec_args = daemon_process.split(daemon_name)[-1]
+        if not re.search(exec_args, daemon_exec_args):
+            test.fail("The exec_args %s does not take effect" % exec_args)
+
+    def test_limit_config(test_type, limit_config):
+        """
+        Set limitNOFILE and limitMEMLOCK in the daemon systemd config
+        and restart daemon, then confirm the config works
+
+        :param test_type: the type of limit
+        :param limit_config: config of limit
+        """
+        process.run("prlimit -p `pidof %s` | grep %s" % (daemon_name, test_type), shell=True)
+        ori_config_line = process.getoutput("cat %s |grep %s" % (systemd_file, test_type), shell=True)
+        set_config(ori_config_line, limit_config, systemd_file)
+        process.run("systemctl daemon-reload")
+        utils_libvirtd.Libvirtd('virtqemud').restart()
+        limit_info = process.getoutput("prlimit -p `pidof %s` | grep -i %s" % (daemon_name, test_type), shell=True)
+        logging.debug("The limit resource for daemon is %s", limit_info)
+        if not re.search(re.compile(r'[0-9]\d+').findall(limit_info)[0], limit_config):
+            test.fail("The limit set %s does not take effect" % limit_config)
+
+    daemons = params.get('daemons', "").split()
+    require_modular_daemon = params.get('require_modular_daemon', "no") == "yes"
+    config_dir = params.get('config_dir', "")
+    daemon_name = params.get('daemon_name', "")
+    test_type = params.get('test_type', "")
+    exec_args = params.get('exec_args', "")
+    limitNOFILE = params.get('limitNOFILE', "")
+    limitMEMLOCK = params.get('limitMEMLOCK', "")
+
+    utils_split_daemons.daemon_mode_check(require_modular_daemon)
+
+    try:
+        systemd_file = config_dir + daemon_name + ".service"
+        backup_file = os.path.join(data_dir.get_tmp_dir(), systemd_file + "-bak")
+        shutil.copy(systemd_file, backup_file)
+        if test_type == "set_exec_args":
+            test_exec_config(daemon_name, systemd_file)
+        if test_type == "set_limitNOFILE" or test_type == "set_limitMEMLOCK":
+            test_type = test_type.replace('set_limit', '')
+            limit_config = limitNOFILE + limitMEMLOCK
+            test_limit_config(test_type, limit_config)
+
+    finally:
+        if os.path.exists(backup_file):
+            shutil.copy(backup_file, systemd_file)
+            os.remove(backup_file)
+        process.run("systemctl daemon-reload")
+        utils_libvirtd.Libvirtd(daemon_name).restart()


### PR DESCRIPTION
Add testcase for systemd config file:
1.Automation for case VIRT-19536.
2.Test result:
$ avocado run systemd_config --vt-type libvirt
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : 88e39df5cfea6dd1f38ebb44a995e2346bf5e7ff
JOB LOG    : /var/lib/avocado/job-results/job-2022-05-19T22.50-88e39df/job.log
 (01/11) type_specific.io-github-autotest-libvirt.conf_file.systemd_config.set_exec_args.daemon_mode.modular_daemon.virtqemud: STARTED
 (01/11) type_specific.io-github-autotest-libvirt.conf_file.systemd_config.set_exec_args.daemon_mode.modular_daemon.virtqemud: PASS (31.77 s)
 (02/11) type_specific.io-github-autotest-libvirt.conf_file.systemd_config.set_exec_args.daemon_mode.modular_daemon.virtnetworkd: STARTED
 (02/11) type_specific.io-github-autotest-libvirt.conf_file.systemd_config.set_exec_args.daemon_mode.modular_daemon.virtnetworkd: PASS (32.80 s)
 (03/11) type_specific.io-github-autotest-libvirt.conf_file.systemd_config.set_exec_args.daemon_mode.modular_daemon.virtstoraged: STARTED
 (03/11) type_specific.io-github-autotest-libvirt.conf_file.systemd_config.set_exec_args.daemon_mode.modular_daemon.virtstoraged: PASS (32.63 s)
 (04/11) type_specific.io-github-autotest-libvirt.conf_file.systemd_config.set_exec_args.daemon_mode.modular_daemon.virtproxyd: STARTED
 (04/11) type_specific.io-github-autotest-libvirt.conf_file.systemd_config.set_exec_args.daemon_mode.modular_daemon.virtproxyd: PASS (32.68 s)
 (05/11) type_specific.io-github-autotest-libvirt.conf_file.systemd_config.set_exec_args.daemon_mode.modular_daemon.virtsecretd: STARTED
 (05/11) type_specific.io-github-autotest-libvirt.conf_file.systemd_config.set_exec_args.daemon_mode.modular_daemon.virtsecretd: PASS (34.26 s)
 (06/11) type_specific.io-github-autotest-libvirt.conf_file.systemd_config.set_exec_args.daemon_mode.modular_daemon.virtinterfaced: STARTED
 (06/11) type_specific.io-github-autotest-libvirt.conf_file.systemd_config.set_exec_args.daemon_mode.modular_daemon.virtinterfaced: PASS (32.65 s)
 (07/11) type_specific.io-github-autotest-libvirt.conf_file.systemd_config.set_exec_args.daemon_mode.modular_daemon.virtnwfilterd: STARTED
 (07/11) type_specific.io-github-autotest-libvirt.conf_file.systemd_config.set_exec_args.daemon_mode.modular_daemon.virtnwfilterd: PASS (32.66 s)
 (08/11) type_specific.io-github-autotest-libvirt.conf_file.systemd_config.set_limitNOFILE.daemon_mode.legacy_daemon.libvirtd: STARTED
 (08/11) type_specific.io-github-autotest-libvirt.conf_file.systemd_config.set_limitNOFILE.daemon_mode.legacy_daemon.libvirtd: CANCEL: This daemon mode is not the same as the required daemon mode. (33.55 s)
 (09/11) type_specific.io-github-autotest-libvirt.conf_file.systemd_config.set_limitNOFILE.daemon_mode.modular_daemon.virtqemud: STARTED
 (09/11) type_specific.io-github-autotest-libvirt.conf_file.systemd_config.set_limitNOFILE.daemon_mode.modular_daemon.virtqemud: PASS (32.38 s)
 (10/11) type_specific.io-github-autotest-libvirt.conf_file.systemd_config.set_limitMEMLOCK.daemon_mode.legacy_daemon.libvirtd: STARTED
 (10/11) type_specific.io-github-autotest-libvirt.conf_file.systemd_config.set_limitMEMLOCK.daemon_mode.legacy_daemon.libvirtd: CANCEL: This daemon mode is not the same as the required daemon mode. (32.61 s)
 (11/11) type_specific.io-github-autotest-libvirt.conf_file.systemd_config.set_limitMEMLOCK.daemon_mode.modular_daemon.virtqemud: STARTED
 (11/11) type_specific.io-github-autotest-libvirt.conf_file.systemd_config.set_limitMEMLOCK.daemon_mode.modular_daemon.virtqemud: PASS (32.57 s)
RESULTS    : PASS 9 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 2
JOB HTML   : /var/lib/avocado/job-results/job-2022-05-19T22.50-88e39df/results.html
JOB TIME   : 367.72 s

