### PR TITLE
memory_misc:update comparing method of 2 xmls

### DIFF
--- a/libvirt/tests/cfg/memory/memory_misc.cfg
+++ b/libvirt/tests/cfg/memory/memory_misc.cfg
@@ -46,7 +46,7 @@
                     vmxml_current_mem = 1024000
                     vmxml_vcpu = 4
                     sysinfo_attrs = {'type': 'smbios', 'bios': {'entry': 'LENOVO', 'entry_name': 'vendor'}}
-                    os_attrs = {'boots': ['hd', 'cdrom'], 'bootmenu_enable': 'yes', 'bootmenu_timeout': 3000, 'bios_useserial': 'yes', 'bios_reboot_timeout': 0, 'smbios_mode': 'sysinfo'}
+                    os_attrs = {'boots': ['hd', 'cdrom'], 'bootmenu_enable': 'yes', 'bootmenu_timeout': '3000', 'bios_useserial': 'yes', 'bios_reboot_timeout': '0', 'smbios_mode': 'sysinfo'}
                     idmap_attrs = {'uid': {'start': '0', 'target': '1000', 'count': '10'}, 'gid': {'start': '0', 'target': '1000', 'count': '10'}}
                     cpu_attrs = {'numa_cell': [{'id': '0', 'cpus': '0,2', 'memory': '513024', 'unit': 'KiB'}, {'id': '1', 'cpus': '1,3', 'memory': '513024', 'unit': 'KiB'}]}
                     memxml_attrs = {'mem_model': 'dimm', 'target': {'size': 512000, 'node': 1}}

--- a/libvirt/tests/src/memory/memory_misc.py
+++ b/libvirt/tests/src/memory/memory_misc.py
@@ -231,14 +231,18 @@ def run(test, params, env):
             logging.debug(virsh.dumpxml(vm_name).stdout_text)
             newxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
 
-            for attr in cmp_list:
-                logging.debug('Comparing %s of 2 xmls: \n%s\n%s',
-                              attr, getattr(vmxml, attr),
-                              getattr(newxml, attr))
-                if getattr(vmxml, attr) == getattr(newxml, attr):
-                    logging.debug('Result: Equal.')
+            for tag in cmp_list:
+                old_xml = getattr(vmxml, tag)
+                new_xml = getattr(newxml, tag)
+                new_xml_attrs = new_xml.fetch_attrs()
+                old_attrs = eval(params.get('%s_attrs' % tag))
+
+                logging.debug('Comparing attributes of %s of 2 xmls: \n%s\n%s\n%s\n%s',
+                              tag, old_xml, old_attrs, new_xml, new_xml_attrs)
+                if all([new_xml_attrs.get(k) == old_attrs[k] for k in old_attrs]):
+                    logging.debug('Result: Target xml settings are equal.')
                 else:
-                    test.fail('Xml comparison of %s failed.', attr)
+                    test.fail('Xml comparison of %s failed.' % tag)
 
     def run_test_dimm(case):
         """


### PR DESCRIPTION
The old way of comparing 2 xmls could get incorrect result of test.
We'll only compare the setup values instead of the whole xml object.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>
