### PR TITLE
migrate_mem: Fix command error in check_logfile

### DIFF
--- a/libvirt/tests/src/migration/migrate_mem.py
+++ b/libvirt/tests/src/migration/migrate_mem.py
@@ -160,9 +160,11 @@ def verify_test_default(vm, params, test):
     """
     check_str_local_log = params.get("check_str_local_log")
     if check_str_local_log:
-        libvirt.check_logfile(check_str_local_log,
-                              params.get("libvirtd_debug_file"),
-                              eval(params.get('str_in_log', 'True')))
+        if not libvirt.check_logfile(check_str_local_log,
+                                     params.get("libvirtd_debug_file"),
+                                     eval(params.get('str_in_log', 'True')),
+                                     ignore_status=True):
+            test.fail("Found message in local log: %s", check_str_local_log)
 
 
 def verify_test_mem_balloon(vm, params, test):


### PR DESCRIPTION
To fix error as follows:
CmdError: Command 'grep -E 'Unsupported migration cookie feature
 memory-hotplug' /var/log/libvirt/libvirt_daemons.log'
failed.stdout: b''stderr: b''additional_info: None

Because of commit b6a011b7b98e26dbff87cb97a3b7680639241a69, we need
set ignore_status to True in this case.

Signed-off-by: cliping <lcheng@redhat.com>
