### PR TITLE
vsock: Extend event_timeout for detach_device_alias

### DIFF
--- a/libvirt/tests/src/virtual_device/vsock.py
+++ b/libvirt/tests/src/virtual_device/vsock.py
@@ -269,7 +269,7 @@ def run(test, params, env):
             if detach_device_alias:
                 result = virsh.detach_device_alias(
                     vm.name, vsock_dev.alias['name'], ignore_status=False,
-                    debug=True, wait_for_event=True)
+                    debug=True, wait_for_event=True, event_timeout=20)
             else:
                 result = virsh.detach_device(vm_name, vsock_dev.xml, debug=True)
             utils_test.libvirt.check_exit_status(result, expect_error=False)


### PR DESCRIPTION
Signed-off-by: Hu Shuai <hus.fnst@fujitsu.com>

Similar to #4212 

The [default 7s](https://github.com/avocado-framework/avocado-vt/blob/master/virttest/virsh.py#L1880-L1881) is not enough for `detach_device_alias` in case `rhel.vsock.normal_test.hotplug.detach_device_alias.static_cid` on ARM. I tested several times and it spent about 8.64s every time. This PR extends the `event_timeout` to 20s.