### PR TITLE
add case for detach virtual disk by alias

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
@@ -25,6 +25,11 @@
                 detach_channel_type = "pty"
                 detach_channel_target = "{'target_type':'virtio', 'target_name':'some.virtio.serial.port.name'}"
                 detach_check_xml = "<channel type='pty'>"
+        - virtual_disk:
+            only live,config
+            detach_virtual_disk_type = "virtual_disk"
+            virtual_disk_dict = {"type_name": "file","target": {"dev": "vdd", "bus": "virtio"},"driver": {"name": "qemu", "type": "qcow2"}}
+            detach_check_xml = "<target dev='vdd' bus='virtio'/>"
         - watchdog:
             only live,config
             detach_watchdog_type = "watchdog"


### PR DESCRIPTION
    RHEL-148231: Detach virtual disk by alias with --live and --config
Signed-off-by: nanli <nanli@redhat.com>

**Test result:**
/usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 virsh.detach_device_alias..virtual_disk  --vt-connect-uri qemu:///system
 (1/2) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.virtual_disk: PASS (53.09 s)
 (2/2) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.config.virtual_disk: PASS (53.12 s)
