### PR TITLE
iface_unprivileged:Remove nvram tag to avoid permission issue

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_options.py
+++ b/libvirt/tests/src/virtual_network/iface_options.py
@@ -158,6 +158,11 @@ def run(test, params, env):
                          " removing from domain xml if present...")
             vmxml.del_seclabel([('model', 'dac')])
 
+            # Remove nvram to avoid permission issue
+            os_xml = vmxml.os
+            os_xml.del_nvram()
+            vmxml.os = os_xml
+
             # Set vm memory to 2G if it's larger than 2G
             if vmxml.memory > 2097152:
                 vmxml.memory = vmxml.current_mem = 2097152
@@ -609,7 +614,8 @@ def run(test, params, env):
     status_error = "yes" == params.get("status_error", "no")
     start_error = "yes" == params.get("start_error", "no")
     define_error = "yes" == params.get("define_error", "no")
-    unprivileged_user = params.get("unprivileged_user")
+    unprivileged_user = params.get("unprivileged_user", "autotest"
+                                   ) + utils_misc.generate_random_string(3)
 
     # Interface specific attributes.
     iface_type = params.get("iface_type", "network")

--- a/libvirt/tests/src/virtual_network/iface_unprivileged.py
+++ b/libvirt/tests/src/virtual_network/iface_unprivileged.py
@@ -124,6 +124,11 @@ def run(test, params, env):
         upu_vmxml = vm_xml.VMXML()
         upu_vmxml.xml = virsh.dumpxml(upu_vm_name, **upu_args).stdout_text
 
+        # Remove nvram tag of os to avoid permission issue
+        os_xml = upu_vmxml.os
+        os_xml.del_nvram()
+        upu_vmxml.os = os_xml
+
         if case == 'precreated':
             if device_type == 'tap':
                 # Create bridge
@@ -196,6 +201,7 @@ def run(test, params, env):
             shutil.copyfile(upu_vmxml.xml, new_xml_path)
             upu_vmxml.xml = new_xml_path
             virsh.define(new_xml_path, **upu_args)
+            logging.debug(virsh.dumpxml(upu_vm_name, **upu_args).stdout_text)
 
             # Switch to unprivileged user and modify vm's interface
             # Start vm as unprivileged user and test network


### PR DESCRIPTION
The vmxml of vm created by unprivileged user was copied from vm created
by root user. The nvram tag might contain path that unprivileged users
are not allowed to access. Therefore remove the tag and let libvirt to
create it automatically after define.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>
