### PR TITLE
v2v: add vsock check for linux VMs

### DIFF
--- a/spell.ignore
+++ b/spell.ignore
@@ -1180,6 +1180,8 @@ xmlfile
 xmls
 xmltreefile
 xorg
+XPath
+xpath
 xxxx
 xxxxx
 xyz


### PR DESCRIPTION
For linux VMs, if kernel supports vsock, v2v will add vsock to the
guest after conversion. This patch adds the check for it.

But some old releases may not support the feature by kernel. We just
simply skip those guests. This is not a good way to do it. But they
could be improved in future.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>