### PR TITLE
live_migration: Fix wrong disk type

### DIFF
--- a/libvirt/tests/cfg/migration/live_migration.cfg
+++ b/libvirt/tests/cfg/migration/live_migration.cfg
@@ -256,7 +256,7 @@
         - execute_statistics_cmd:
             block_device_name = 'migration_test_disk.img'
             target_dev = 'vdb'
-            disk_type = 'block'
+            loop_disk_type = 'block'
             exec_statistics_cmd = 'yes'
             migrate_speed = 10
             action_during_mig = '[{"func": "execute_statistics_command", "after_event": "iteration: '1'", "func_param": "params"}]'

--- a/provider/migration/migration_base.py
+++ b/provider/migration/migration_base.py
@@ -237,7 +237,7 @@ def execute_statistics_command(params):
     :param params: dict, used to setup the connection
     """
     vm_name = params.get("migrate_main_vm")
-    disk_type = params.get("disk_type")
+    disk_type = params.get("loop_disk_type")
 
     vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
     disks = vmxml.get_disk_all_by_expr('type==%s' % disk_type, 'device==disk')


### PR DESCRIPTION
To fix following error:
  'host_device' driver requires
  '/var/lib/libvirt/migrate/jeos-27-x86_64.qcow2' to be either
  a character or block device

Signed-off-by: cliping <lcheng@redhat.com>
