### PR TITLE
ovmf: update the guest xml to keep consistent with the previous script

### DIFF
--- a/libvirt/tests/src/bios/virsh_boot.py
+++ b/libvirt/tests/src/bios/virsh_boot.py
@@ -674,6 +674,11 @@ def run(test, params, env):
     # Back VM XML
     vmxml_backup = vm_xml.VMXML.new_from_dumpxml(vm_name)
     vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+    # Remove loader/nvram element if exist which may affect newly added same elements
+    for item in ["loader", "nvram"]:
+        if item in str(vmxml):
+            vmxml.xmltreefile.remove_by_xpath("/os/%s" % item, remove_all=True)
+            vmxml.sync()
 
     # Prepare a blank params to confirm if delete the configure at the end of the test
     ceph_cfg = ''

--- a/libvirt/tests/src/bios/virsh_boot_tseg.py
+++ b/libvirt/tests/src/bios/virsh_boot_tseg.py
@@ -70,6 +70,11 @@ def run(test, params, env):
     # Back VM XML
     v_xml_backup = vm_xml.VMXML.new_from_dumpxml(vm_name)
     v_xml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+    # Remove loader/nvram element if exist which may affect newly added same elements
+    for item in ["loader", "nvram"]:
+        if item in str(v_xml):
+            v_xml.xmltreefile.remove_by_xpath("/os/%s" % item, remove_all=True)
+            v_xml.sync()
 
     try:
         # Specify boot loader for OVMF


### PR DESCRIPTION
For ovmf job, the previous script mainly depends on seabios os xml, which is different with ovmf os xml. So after we changing it to ovmf guest, the loader and nvram parts of os element wil affect some test cases, especially some negative cases. So here update the guest xml.

Signed-off-by: Meina Li <meili@redhat.com>
