### PR TITLE
svirt:Destroy vm after test to avoid permission issue

### DIFF
--- a/libvirt/tests/src/svirt/dac_nfs_save_restore.py
+++ b/libvirt/tests/src/svirt/dac_nfs_save_restore.py
@@ -205,6 +205,7 @@ def run(test, params, env):
 
     finally:
         # clean up
+        virsh.destroy(vm_name, debug=True)
         for path, label in list(backup_labels_of_disks.items()):
             label_list = label.split(":")
             os.chown(path, int(label_list[0]), int(label_list[1]))

--- a/libvirt/tests/src/svirt/dac_start_destroy.py
+++ b/libvirt/tests/src/svirt/dac_start_destroy.py
@@ -359,6 +359,7 @@ def run(test, params, env):
                               "error: %s" % e)
     finally:
         # clean up
+        vm.destroy(gracefully=False)
         for path, label in list(backup_labels_of_disks.items()):
             label_list = label.split(":")
             os.chown(path, int(label_list[0]), int(label_list[1]))


### PR DESCRIPTION
Destroy vm before other cleanup steps to avoid leaving VARS.fd
file which will cause permission issue in future tests.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>
