### PR TITLE
Fix the unprivileged user misuse issue

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_options.py
+++ b/libvirt/tests/src/virtual_network/iface_options.py
@@ -614,8 +614,7 @@ def run(test, params, env):
     status_error = "yes" == params.get("status_error", "no")
     start_error = "yes" == params.get("start_error", "no")
     define_error = "yes" == params.get("define_error", "no")
-    unprivileged_user = params.get("unprivileged_user", "autotest"
-                                   ) + utils_misc.generate_random_string(3)
+    unprivileged_user = params.get("unprivileged_user")
 
     # Interface specific attributes.
     iface_type = params.get("iface_type", "network")


### PR DESCRIPTION
Commit cd56a075cc12 tried to clean up the unprivileged user name,
but it brought the side effect that some case without the unprivileged
user parameter will be assigned with a unprivileged user name. Rework
it to fix the issue.

Signed-off-by: Yalan Zhang <yalzhang@redhat.com>