### PR TITLE
virsh_cpu_xml: add case comparing skylake cascadelake

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_cpu_xml.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_cpu_xml.cfg
@@ -17,6 +17,23 @@
                 - cap_cpu_xml:
                     only cpu_baseline
                     file_path = '../../../deps/capability_cpu.xml'
+                - cap_skylake_server_cascadelake:
+                    only x86_64
+                    func_supported_since_libvirt_ver = (8, 0, 0)
+                    file_path = '../../../deps/caps_skylake_server_cascadelake_server.xml'
+                    out_msg = 'model.*Skylake'
+                - domcap_skylake_serv_cascadelake:
+                    only x86_64
+                    only hypervisor_cpu_baseline
+                    func_supported_since_libvirt_ver = (8, 0, 0)
+                    file_path = '../../../deps/domcaps_skylake_server_cascadelake_server.xml'
+                    out_msg = 'model.*Skylake'
+                - domcap_skylake_clie_cascadelake:
+                    only x86_64
+                    only hypervisor_cpu_baseline
+                    func_supported_since_libvirt_ver = (8, 0, 0)
+                    file_path = '../../../deps/domcaps_skylake_server_cascadelake_server.xml'
+                    out_msg = 'model.*Skylake'
             variants:
                 - hypervisor_cpu_baseline:
                     no aarch64, pseries

--- a/libvirt/tests/deps/caps_skylake_server_cascadelake_server.xml
+++ b/libvirt/tests/deps/caps_skylake_server_cascadelake_server.xml
@@ -1,0 +1,86 @@
+<cpu>
+  <arch>x86_64</arch>
+  <model>Skylake-Server-IBRS</model>
+  <vendor>Intel</vendor>
+  <microcode version='33554537'/>
+  <counter name='tsc' frequency='2600005000' scaling='yes'/>
+  <topology sockets='1' dies='1' cores='12' threads='2'/>
+  <feature name='ds'/>
+  <feature name='acpi'/>
+  <feature name='ss'/>
+  <feature name='ht'/>
+  <feature name='tm'/>
+  <feature name='pbe'/>
+  <feature name='dtes64'/>
+  <feature name='monitor'/>
+  <feature name='ds_cpl'/>
+  <feature name='vmx'/>
+  <feature name='smx'/>
+  <feature name='est'/>
+  <feature name='tm2'/>
+  <feature name='xtpr'/>
+  <feature name='pdcm'/>
+  <feature name='dca'/>
+  <feature name='osxsave'/>
+  <feature name='tsc_adjust'/>
+  <feature name='cmt'/>
+  <feature name='clflushopt'/>
+  <feature name='intel-pt'/>
+  <feature name='pku'/>
+  <feature name='ospke'/>
+  <feature name='md-clear'/>
+  <feature name='stibp'/>
+  <feature name='ssbd'/>
+  <feature name='xsaves'/>
+  <feature name='mbm_total'/>
+  <feature name='mbm_local'/>
+  <feature name='invtsc'/>
+  <pages unit='KiB' size='4'/>
+  <pages unit='KiB' size='2048'/>
+  <pages unit='KiB' size='1048576'/>
+</cpu>
+<cpu>
+  <arch>x86_64</arch>
+  <model>Cascadelake-Server</model>
+  <vendor>Intel</vendor>
+  <microcode version='83886124'/>
+  <counter name='tsc' frequency='2099999000' scaling='yes'/>
+  <topology sockets='1' dies='1' cores='20' threads='2'/>
+  <feature name='ds'/>
+  <feature name='acpi'/>
+  <feature name='ss'/>
+  <feature name='ht'/>
+  <feature name='tm'/>
+  <feature name='pbe'/>
+  <feature name='dtes64'/>
+  <feature name='monitor'/>
+  <feature name='ds_cpl'/>
+  <feature name='vmx'/>
+  <feature name='smx'/>
+  <feature name='est'/>
+  <feature name='tm2'/>
+  <feature name='xtpr'/>
+  <feature name='pdcm'/>
+  <feature name='dca'/>
+  <feature name='osxsave'/>
+  <feature name='tsc_adjust'/>
+  <feature name='cmt'/>
+  <feature name='intel-pt'/>
+  <feature name='pku'/>
+  <feature name='ospke'/>
+  <feature name='md-clear'/>
+  <feature name='stibp'/>
+  <feature name='arch-capabilities'/>
+  <feature name='xsaves'/>
+  <feature name='mbm_total'/>
+  <feature name='mbm_local'/>
+  <feature name='invtsc'/>
+  <feature name='rdctl-no'/>
+  <feature name='ibrs-all'/>
+  <feature name='skip-l1dfl-vmentry'/>
+  <feature name='mds-no'/>
+  <feature name='tsx-ctrl'/>
+  <pages unit='KiB' size='4'/>
+  <pages unit='KiB' size='2048'/>
+  <pages unit='KiB' size='1048576'/>
+</cpu>

--- a/libvirt/tests/deps/domcaps_skylake_client_cascadelake_server.xml
+++ b/libvirt/tests/deps/domcaps_skylake_client_cascadelake_server.xml
@@ -1,0 +1,450 @@
+<domainCapabilities>
+  <path>/usr/libexec/qemu-kvm</path>
+  <domain>kvm</domain>
+  <machine>pc-i440fx-rhel7.6.0</machine>
+  <arch>x86_64</arch>
+  <vcpu max='240'/>
+  <iothreads supported='yes'/>
+  <os supported='yes'>
+    <enum name='firmware'/>
+    <loader supported='yes'>
+      <value>/usr/share/OVMF/OVMF_CODE.secboot.fd</value>
+      <enum name='type'>
+        <value>rom</value>
+        <value>pflash</value>
+      </enum>
+      <enum name='readonly'>
+        <value>yes</value>
+        <value>no</value>
+      </enum>
+      <enum name='secure'>
+        <value>no</value>
+      </enum>
+    </loader>
+  </os>
+  <cpu>
+    <mode name='host-passthrough' supported='yes'>
+      <enum name='hostPassthroughMigratable'>
+        <value>on</value>
+        <value>off</value>
+      </enum>
+    </mode>
+    <mode name='maximum' supported='yes'>
+      <enum name='maximumMigratable'>
+        <value>on</value>
+        <value>off</value>
+      </enum>
+    </mode>
+    <mode name='host-model' supported='yes'>
+      <model fallback='forbid'>Skylake-Client-IBRS</model>
+      <vendor>Intel</vendor>
+      <feature policy='require' name='ss'/>
+      <feature policy='require' name='vmx'/>
+      <feature policy='require' name='pdcm'/>
+      <feature policy='require' name='hypervisor'/>
+      <feature policy='require' name='tsc_adjust'/>
+      <feature policy='require' name='clflushopt'/>
+      <feature policy='require' name='umip'/>
+      <feature policy='require' name='md-clear'/>
+      <feature policy='require' name='stibp'/>
+      <feature policy='require' name='arch-capabilities'/>
+      <feature policy='require' name='ssbd'/>
+      <feature policy='require' name='xsaves'/>
+      <feature policy='require' name='pdpe1gb'/>
+      <feature policy='require' name='invtsc'/>
+      <feature policy='require' name='ibpb'/>
+      <feature policy='require' name='ibrs'/>
+      <feature policy='require' name='amd-stibp'/>
+      <feature policy='require' name='amd-ssbd'/>
+      <feature policy='require' name='rsba'/>
+      <feature policy='require' name='skip-l1dfl-vmentry'/>
+      <feature policy='require' name='pschange-mc-no'/>
+      <feature policy='disable' name='hle'/>
+      <feature policy='disable' name='rtm'/>
+    </mode>
+    <mode name='custom' supported='yes'>
+      <model usable='yes'>qemu64</model>
+      <model usable='yes'>qemu32</model>
+      <model usable='no'>phenom</model>
+      <model usable='yes'>pentium3</model>
+      <model usable='yes'>pentium2</model>
+      <model usable='yes'>pentium</model>
+      <model usable='yes'>n270</model>
+      <model usable='yes'>kvm64</model>
+      <model usable='yes'>kvm32</model>
+      <model usable='yes'>coreduo</model>
+      <model usable='yes'>core2duo</model>
+      <model usable='no'>athlon</model>
+      <model usable='yes'>Westmere-IBRS</model>
+      <model usable='yes'>Westmere</model>
+      <model usable='no'>Snowridge</model>
+      <model usable='no'>Skylake-Server-noTSX-IBRS</model>
+      <model usable='no'>Skylake-Server-IBRS</model>
+      <model usable='no'>Skylake-Server</model>
+      <model usable='yes'>Skylake-Client-noTSX-IBRS</model>
+      <model usable='no'>Skylake-Client-IBRS</model>
+      <model usable='no'>Skylake-Client</model>
+      <model usable='yes'>SandyBridge-IBRS</model>
+      <model usable='yes'>SandyBridge</model>
+      <model usable='yes'>Penryn</model>
+      <model usable='no'>Opteron_G5</model>
+      <model usable='no'>Opteron_G4</model>
+      <model usable='no'>Opteron_G3</model>
+      <model usable='yes'>Opteron_G2</model>
+      <model usable='yes'>Opteron_G1</model>
+      <model usable='yes'>Nehalem-IBRS</model>
+      <model usable='yes'>Nehalem</model>
+      <model usable='yes'>IvyBridge-IBRS</model>
+      <model usable='yes'>IvyBridge</model>
+      <model usable='no'>Icelake-Server-noTSX</model>
+      <model usable='no'>Icelake-Server</model>
+      <model usable='no' deprecated='yes'>Icelake-Client-noTSX</model>
+      <model usable='no' deprecated='yes'>Icelake-Client</model>
+      <model usable='yes'>Haswell-noTSX-IBRS</model>
+      <model usable='yes'>Haswell-noTSX</model>
+      <model usable='no'>Haswell-IBRS</model>
+      <model usable='no'>Haswell</model>
+      <model usable='no'>EPYC-Rome</model>
+      <model usable='no'>EPYC-Milan</model>
+      <model usable='no'>EPYC-IBPB</model>
+      <model usable='no'>EPYC</model>
+      <model usable='no'>Dhyana</model>
+      <model usable='no'>Cooperlake</model>
+      <model usable='yes'>Conroe</model>
+      <model usable='no'>Cascadelake-Server-noTSX</model>
+      <model usable='no'>Cascadelake-Server</model>
+      <model usable='yes'>Broadwell-noTSX-IBRS</model>
+      <model usable='yes'>Broadwell-noTSX</model>
+      <model usable='no'>Broadwell-IBRS</model>
+      <model usable='no'>Broadwell</model>
+      <model usable='yes'>486</model>
+    </mode>
+  </cpu>
+  <memoryBacking supported='yes'>
+    <enum name='sourceType'>
+      <value>file</value>
+      <value>anonymous</value>
+      <value>memfd</value>
+    </enum>
+  </memoryBacking>
+  <devices>
+    <disk supported='yes'>
+      <enum name='diskDevice'>
+        <value>disk</value>
+        <value>cdrom</value>
+        <value>floppy</value>
+        <value>lun</value>
+      </enum>
+      <enum name='bus'>
+        <value>ide</value>
+        <value>fdc</value>
+        <value>scsi</value>
+        <value>virtio</value>
+        <value>usb</value>
+        <value>sata</value>
+      </enum>
+      <enum name='model'>
+        <value>virtio</value>
+        <value>virtio-transitional</value>
+        <value>virtio-non-transitional</value>
+      </enum>
+    </disk>
+    <graphics supported='yes'>
+      <enum name='type'>
+        <value>vnc</value>
+        <value>egl-headless</value>
+      </enum>
+    </graphics>
+    <video supported='yes'>
+      <enum name='modelType'>
+        <value>vga</value>
+        <value>cirrus</value>
+        <value>virtio</value>
+        <value>none</value>
+        <value>bochs</value>
+        <value>ramfb</value>
+      </enum>
+    </video>
+    <hostdev supported='yes'>
+      <enum name='mode'>
+        <value>subsystem</value>
+      </enum>
+      <enum name='startupPolicy'>
+        <value>default</value>
+        <value>mandatory</value>
+        <value>requisite</value>
+        <value>optional</value>
+      </enum>
+      <enum name='subsysType'>
+        <value>usb</value>
+        <value>pci</value>
+        <value>scsi</value>
+      </enum>
+      <enum name='capsType'/>
+      <enum name='pciBackend'/>
+    </hostdev>
+    <rng supported='yes'>
+      <enum name='model'>
+        <value>virtio</value>
+        <value>virtio-transitional</value>
+        <value>virtio-non-transitional</value>
+      </enum>
+      <enum name='backendModel'>
+        <value>random</value>
+        <value>egd</value>
+        <value>builtin</value>
+      </enum>
+    </rng>
+    <filesystem supported='yes'>
+      <enum name='driverType'>
+        <value>path</value>
+        <value>handle</value>
+        <value>virtiofs</value>
+      </enum>
+    </filesystem>
+    <tpm supported='yes'>
+      <enum name='model'>
+        <value>tpm-tis</value>
+        <value>tpm-crb</value>
+      </enum>
+      <enum name='backendModel'>
+        <value>emulator</value>
+      </enum>
+    </tpm>
+  </devices>
+  <features>
+    <gic supported='no'/>
+    <vmcoreinfo supported='yes'/>
+    <genid supported='yes'/>
+    <backingStoreInput supported='yes'/>
+    <backup supported='yes'/>
+    <sev supported='no'/>
+  </features>
+</domainCapabilities>
+<domainCapabilities>
+  <path>/usr/libexec/qemu-kvm</path>
+  <domain>kvm</domain>
+  <machine>pc-i440fx-rhel7.6.0</machine>
+  <arch>x86_64</arch>
+  <vcpu max='240'/>
+  <iothreads supported='yes'/>
+  <os supported='yes'>
+    <enum name='firmware'/>
+    <loader supported='yes'>
+      <value>/usr/share/OVMF/OVMF_CODE.secboot.fd</value>
+      <enum name='type'>
+        <value>rom</value>
+        <value>pflash</value>
+      </enum>
+      <enum name='readonly'>
+        <value>yes</value>
+        <value>no</value>
+      </enum>
+      <enum name='secure'>
+        <value>no</value>
+      </enum>
+    </loader>
+  </os>
+  <cpu>
+    <mode name='host-passthrough' supported='yes'>
+      <enum name='hostPassthroughMigratable'>
+        <value>on</value>
+        <value>off</value>
+      </enum>
+    </mode>
+    <mode name='maximum' supported='yes'>
+      <enum name='maximumMigratable'>
+        <value>on</value>
+        <value>off</value>
+      </enum>
+    </mode>
+    <mode name='host-model' supported='yes'>
+      <model fallback='forbid'>Cascadelake-Server</model>
+      <vendor>Intel</vendor>
+      <feature policy='require' name='ss'/>
+      <feature policy='require' name='vmx'/>
+      <feature policy='require' name='pdcm'/>
+      <feature policy='require' name='hypervisor'/>
+      <feature policy='require' name='tsc_adjust'/>
+      <feature policy='require' name='umip'/>
+      <feature policy='require' name='pku'/>
+      <feature policy='require' name='md-clear'/>
+      <feature policy='require' name='stibp'/>
+      <feature policy='require' name='arch-capabilities'/>
+      <feature policy='require' name='xsaves'/>
+      <feature policy='require' name='invtsc'/>
+      <feature policy='require' name='ibpb'/>
+      <feature policy='require' name='ibrs'/>
+      <feature policy='require' name='amd-stibp'/>
+      <feature policy='require' name='amd-ssbd'/>
+      <feature policy='require' name='rdctl-no'/>
+      <feature policy='require' name='ibrs-all'/>
+      <feature policy='require' name='skip-l1dfl-vmentry'/>
+      <feature policy='require' name='mds-no'/>
+      <feature policy='require' name='pschange-mc-no'/>
+      <feature policy='require' name='tsx-ctrl'/>
+      <feature policy='disable' name='hle'/>
+      <feature policy='disable' name='rtm'/>
+    </mode>
+    <mode name='custom' supported='yes'>
+      <model usable='yes'>qemu64</model>
+      <model usable='yes'>qemu32</model>
+      <model usable='no'>phenom</model>
+      <model usable='yes'>pentium3</model>
+      <model usable='yes'>pentium2</model>
+      <model usable='yes'>pentium</model>
+      <model usable='yes'>n270</model>
+      <model usable='yes'>kvm64</model>
+      <model usable='yes'>kvm32</model>
+      <model usable='yes'>coreduo</model>
+      <model usable='yes'>core2duo</model>
+      <model usable='no'>athlon</model>
+      <model usable='yes'>Westmere-IBRS</model>
+      <model usable='yes'>Westmere</model>
+      <model usable='no'>Snowridge</model>
+      <model usable='yes'>Skylake-Server-noTSX-IBRS</model>
+      <model usable='no'>Skylake-Server-IBRS</model>
+      <model usable='no'>Skylake-Server</model>
+      <model usable='yes'>Skylake-Client-noTSX-IBRS</model>
+      <model usable='no'>Skylake-Client-IBRS</model>
+      <model usable='no'>Skylake-Client</model>
+      <model usable='yes'>SandyBridge-IBRS</model>
+      <model usable='yes'>SandyBridge</model>
+      <model usable='yes'>Penryn</model>
+      <model usable='no'>Opteron_G5</model>
+      <model usable='no'>Opteron_G4</model>
+      <model usable='no'>Opteron_G3</model>
+      <model usable='yes'>Opteron_G2</model>
+      <model usable='yes'>Opteron_G1</model>
+      <model usable='yes'>Nehalem-IBRS</model>
+      <model usable='yes'>Nehalem</model>
+      <model usable='yes'>IvyBridge-IBRS</model>
+      <model usable='yes'>IvyBridge</model>
+      <model usable='no'>Icelake-Server-noTSX</model>
+      <model usable='no'>Icelake-Server</model>
+      <model usable='no' deprecated='yes'>Icelake-Client-noTSX</model>
+      <model usable='no' deprecated='yes'>Icelake-Client</model>
+      <model usable='yes'>Haswell-noTSX-IBRS</model>
+      <model usable='yes'>Haswell-noTSX</model>
+      <model usable='no'>Haswell-IBRS</model>
+      <model usable='no'>Haswell</model>
+      <model usable='no'>EPYC-Rome</model>
+      <model usable='no'>EPYC-Milan</model>
+      <model usable='no'>EPYC-IBPB</model>
+      <model usable='no'>EPYC</model>
+      <model usable='no'>Dhyana</model>
+      <model usable='no'>Cooperlake</model>
+      <model usable='yes'>Conroe</model>
+      <model usable='yes'>Cascadelake-Server-noTSX</model>
+      <model usable='no'>Cascadelake-Server</model>
+      <model usable='yes'>Broadwell-noTSX-IBRS</model>
+      <model usable='yes'>Broadwell-noTSX</model>
+      <model usable='no'>Broadwell-IBRS</model>
+      <model usable='no'>Broadwell</model>
+      <model usable='yes'>486</model>
+    </mode>
+  </cpu>
+  <memoryBacking supported='yes'>
+    <enum name='sourceType'>
+      <value>file</value>
+      <value>anonymous</value>
+      <value>memfd</value>
+    </enum>
+  </memoryBacking>
+  <devices>
+    <disk supported='yes'>
+      <enum name='diskDevice'>
+        <value>disk</value>
+        <value>cdrom</value>
+        <value>floppy</value>
+        <value>lun</value>
+      </enum>
+      <enum name='bus'>
+        <value>ide</value>
+        <value>fdc</value>
+        <value>scsi</value>
+        <value>virtio</value>
+        <value>usb</value>
+        <value>sata</value>
+      </enum>
+      <enum name='model'>
+        <value>virtio</value>
+        <value>virtio-transitional</value>
+        <value>virtio-non-transitional</value>
+      </enum>
+    </disk>
+    <graphics supported='yes'>
+      <enum name='type'>
+        <value>vnc</value>
+        <value>spice</value>
+        <value>egl-headless</value>
+      </enum>
+    </graphics>
+    <video supported='yes'>
+      <enum name='modelType'>
+        <value>vga</value>
+        <value>cirrus</value>
+        <value>qxl</value>
+        <value>virtio</value>
+        <value>none</value>
+        <value>bochs</value>
+        <value>ramfb</value>
+      </enum>
+    </video>
+    <hostdev supported='yes'>
+      <enum name='mode'>
+        <value>subsystem</value>
+      </enum>
+      <enum name='startupPolicy'>
+        <value>default</value>
+        <value>mandatory</value>
+        <value>requisite</value>
+        <value>optional</value>
+      </enum>
+      <enum name='subsysType'>
+        <value>usb</value>
+        <value>pci</value>
+        <value>scsi</value>
+      </enum>
+      <enum name='capsType'/>
+      <enum name='pciBackend'/>
+    </hostdev>
+    <rng supported='yes'>
+      <enum name='model'>
+        <value>virtio</value>
+        <value>virtio-transitional</value>
+        <value>virtio-non-transitional</value>
+      </enum>
+      <enum name='backendModel'>
+        <value>random</value>
+        <value>egd</value>
+        <value>builtin</value>
+      </enum>
+    </rng>
+    <filesystem supported='yes'>
+      <enum name='driverType'>
+        <value>path</value>
+        <value>handle</value>
+        <value>virtiofs</value>
+      </enum>
+    </filesystem>
+    <tpm supported='yes'>
+      <enum name='model'>
+        <value>tpm-tis</value>
+        <value>tpm-crb</value>
+      </enum>
+      <enum name='backendModel'>
+        <value>passthrough</value>
+        <value>emulator</value>
+      </enum>
+    </tpm>
+  </devices>
+  <features>
+    <gic supported='no'/>
+    <vmcoreinfo supported='yes'/>
+    <genid supported='yes'/>
+    <backingStoreInput supported='yes'/>
+    <backup supported='yes'/>
+    <sev supported='no'/>
+  </features>
+</domainCapabilities>

--- a/libvirt/tests/deps/domcaps_skylake_server_cascadelake_server.xml
+++ b/libvirt/tests/deps/domcaps_skylake_server_cascadelake_server.xml
@@ -1,0 +1,451 @@
+<domainCapabilities>
+  <path>/usr/libexec/qemu-kvm</path>
+  <domain>kvm</domain>
+  <machine>pc-i440fx-rhel7.6.0</machine>
+  <arch>x86_64</arch>
+  <vcpu max='240'/>
+  <iothreads supported='yes'/>
+  <os supported='yes'>
+    <enum name='firmware'/>
+    <loader supported='yes'>
+      <value>/usr/share/OVMF/OVMF_CODE.secboot.fd</value>
+      <enum name='type'>
+        <value>rom</value>
+        <value>pflash</value>
+      </enum>
+      <enum name='readonly'>
+        <value>yes</value>
+        <value>no</value>
+      </enum>
+      <enum name='secure'>
+        <value>no</value>
+      </enum>
+    </loader>
+  </os>
+  <cpu>
+    <mode name='host-passthrough' supported='yes'>
+      <enum name='hostPassthroughMigratable'>
+        <value>on</value>
+        <value>off</value>
+      </enum>
+    </mode>
+    <mode name='maximum' supported='yes'>
+      <enum name='maximumMigratable'>
+        <value>on</value>
+        <value>off</value>
+      </enum>
+    </mode>
+    <mode name='host-model' supported='yes'>
+      <model fallback='forbid'>Skylake-Server-IBRS</model>
+      <vendor>Intel</vendor>
+      <feature policy='require' name='ss'/>
+      <feature policy='require' name='vmx'/>
+      <feature policy='require' name='pdcm'/>
+      <feature policy='require' name='hypervisor'/>
+      <feature policy='require' name='tsc_adjust'/>
+      <feature policy='require' name='clflushopt'/>
+      <feature policy='require' name='umip'/>
+      <feature policy='require' name='pku'/>
+      <feature policy='require' name='md-clear'/>
+      <feature policy='require' name='stibp'/>
+      <feature policy='require' name='arch-capabilities'/>
+      <feature policy='require' name='ssbd'/>
+      <feature policy='require' name='xsaves'/>
+      <feature policy='require' name='invtsc'/>
+      <feature policy='require' name='ibpb'/>
+      <feature policy='require' name='ibrs'/>
+      <feature policy='require' name='amd-stibp'/>
+      <feature policy='require' name='amd-ssbd'/>
+      <feature policy='require' name='rsba'/>
+      <feature policy='require' name='skip-l1dfl-vmentry'/>
+      <feature policy='require' name='pschange-mc-no'/>
+    </mode>
+    <mode name='custom' supported='yes'>
+      <model usable='yes'>qemu64</model>
+      <model usable='yes'>qemu32</model>
+      <model usable='no'>phenom</model>
+      <model usable='yes'>pentium3</model>
+      <model usable='yes'>pentium2</model>
+      <model usable='yes'>pentium</model>
+      <model usable='yes'>n270</model>
+      <model usable='yes'>kvm64</model>
+      <model usable='yes'>kvm32</model>
+      <model usable='yes'>coreduo</model>
+      <model usable='yes'>core2duo</model>
+      <model usable='no'>athlon</model>
+      <model usable='yes'>Westmere-IBRS</model>
+      <model usable='yes'>Westmere</model>
+      <model usable='no'>Snowridge</model>
+      <model usable='yes'>Skylake-Server-noTSX-IBRS</model>
+      <model usable='yes'>Skylake-Server-IBRS</model>
+      <model usable='yes'>Skylake-Server</model>
+      <model usable='yes'>Skylake-Client-noTSX-IBRS</model>
+      <model usable='yes'>Skylake-Client-IBRS</model>
+      <model usable='yes'>Skylake-Client</model>
+      <model usable='yes'>SandyBridge-IBRS</model>
+      <model usable='yes'>SandyBridge</model>
+      <model usable='yes'>Penryn</model>
+      <model usable='no'>Opteron_G5</model>
+      <model usable='no'>Opteron_G4</model>
+      <model usable='no'>Opteron_G3</model>
+      <model usable='yes'>Opteron_G2</model>
+      <model usable='yes'>Opteron_G1</model>
+      <model usable='yes'>Nehalem-IBRS</model>
+      <model usable='yes'>Nehalem</model>
+      <model usable='yes'>IvyBridge-IBRS</model>
+      <model usable='yes'>IvyBridge</model>
+      <model usable='no'>Icelake-Server-noTSX</model>
+      <model usable='no'>Icelake-Server</model>
+      <model usable='no' deprecated='yes'>Icelake-Client-noTSX</model>
+      <model usable='no' deprecated='yes'>Icelake-Client</model>
+      <model usable='yes'>Haswell-noTSX-IBRS</model>
+      <model usable='yes'>Haswell-noTSX</model>
+      <model usable='yes'>Haswell-IBRS</model>
+      <model usable='yes'>Haswell</model>
+      <model usable='no'>EPYC-Rome</model>
+      <model usable='no'>EPYC-Milan</model>
+      <model usable='no'>EPYC-IBPB</model>
+      <model usable='no'>EPYC</model>
+      <model usable='no'>Dhyana</model>
+      <model usable='no'>Cooperlake</model>
+      <model usable='yes'>Conroe</model>
+      <model usable='no'>Cascadelake-Server-noTSX</model>
+      <model usable='no'>Cascadelake-Server</model>
+      <model usable='yes'>Broadwell-noTSX-IBRS</model>
+      <model usable='yes'>Broadwell-noTSX</model>
+      <model usable='yes'>Broadwell-IBRS</model>
+      <model usable='yes'>Broadwell</model>
+      <model usable='yes'>486</model>
+    </mode>
+  </cpu>
+  <memoryBacking supported='yes'>
+    <enum name='sourceType'>
+      <value>file</value>
+      <value>anonymous</value>
+      <value>memfd</value>
+    </enum>
+  </memoryBacking>
+  <devices>
+    <disk supported='yes'>
+      <enum name='diskDevice'>
+        <value>disk</value>
+        <value>cdrom</value>
+        <value>floppy</value>
+        <value>lun</value>
+      </enum>
+      <enum name='bus'>
+        <value>ide</value>
+        <value>fdc</value>
+        <value>scsi</value>
+        <value>virtio</value>
+        <value>usb</value>
+        <value>sata</value>
+      </enum>
+      <enum name='model'>
+        <value>virtio</value>
+        <value>virtio-transitional</value>
+        <value>virtio-non-transitional</value>
+      </enum>
+    </disk>
+    <graphics supported='yes'>
+      <enum name='type'>
+        <value>vnc</value>
+        <value>spice</value>
+        <value>egl-headless</value>
+      </enum>
+    </graphics>
+    <video supported='yes'>
+      <enum name='modelType'>
+        <value>vga</value>
+        <value>cirrus</value>
+        <value>qxl</value>
+        <value>virtio</value>
+        <value>none</value>
+        <value>bochs</value>
+        <value>ramfb</value>
+      </enum>
+    </video>
+    <hostdev supported='yes'>
+      <enum name='mode'>
+        <value>subsystem</value>
+      </enum>
+      <enum name='startupPolicy'>
+        <value>default</value>
+        <value>mandatory</value>
+        <value>requisite</value>
+        <value>optional</value>
+      </enum>
+      <enum name='subsysType'>
+        <value>usb</value>
+        <value>pci</value>
+        <value>scsi</value>
+      </enum>
+      <enum name='capsType'/>
+      <enum name='pciBackend'/>
+    </hostdev>
+    <rng supported='yes'>
+      <enum name='model'>
+        <value>virtio</value>
+        <value>virtio-transitional</value>
+        <value>virtio-non-transitional</value>
+      </enum>
+      <enum name='backendModel'>
+        <value>random</value>
+        <value>egd</value>
+        <value>builtin</value>
+      </enum>
+    </rng>
+    <filesystem supported='yes'>
+      <enum name='driverType'>
+        <value>path</value>
+        <value>handle</value>
+        <value>virtiofs</value>
+      </enum>
+    </filesystem>
+    <tpm supported='yes'>
+      <enum name='model'>
+        <value>tpm-tis</value>
+        <value>tpm-crb</value>
+      </enum>
+      <enum name='backendModel'>
+        <value>passthrough</value>
+        <value>emulator</value>
+      </enum>
+    </tpm>
+  </devices>
+  <features>
+    <gic supported='no'/>
+    <vmcoreinfo supported='yes'/>
+    <genid supported='yes'/>
+    <backingStoreInput supported='yes'/>
+    <backup supported='yes'/>
+    <sev supported='no'/>
+  </features>
+</domainCapabilities>
+<domainCapabilities>
+  <path>/usr/libexec/qemu-kvm</path>
+  <domain>kvm</domain>
+  <machine>pc-i440fx-rhel7.6.0</machine>
+  <arch>x86_64</arch>
+  <vcpu max='240'/>
+  <iothreads supported='yes'/>
+  <os supported='yes'>
+    <enum name='firmware'/>
+    <loader supported='yes'>
+      <value>/usr/share/OVMF/OVMF_CODE.secboot.fd</value>
+      <enum name='type'>
+        <value>rom</value>
+        <value>pflash</value>
+      </enum>
+      <enum name='readonly'>
+        <value>yes</value>
+        <value>no</value>
+      </enum>
+      <enum name='secure'>
+        <value>no</value>
+      </enum>
+    </loader>
+  </os>
+  <cpu>
+    <mode name='host-passthrough' supported='yes'>
+      <enum name='hostPassthroughMigratable'>
+        <value>on</value>
+        <value>off</value>
+      </enum>
+    </mode>
+    <mode name='maximum' supported='yes'>
+      <enum name='maximumMigratable'>
+        <value>on</value>
+        <value>off</value>
+      </enum>
+    </mode>
+    <mode name='host-model' supported='yes'>
+      <model fallback='forbid'>Cascadelake-Server</model>
+      <vendor>Intel</vendor>
+      <feature policy='require' name='ss'/>
+      <feature policy='require' name='vmx'/>
+      <feature policy='require' name='pdcm'/>
+      <feature policy='require' name='hypervisor'/>
+      <feature policy='require' name='tsc_adjust'/>
+      <feature policy='require' name='umip'/>
+      <feature policy='require' name='pku'/>
+      <feature policy='require' name='md-clear'/>
+      <feature policy='require' name='stibp'/>
+      <feature policy='require' name='arch-capabilities'/>
+      <feature policy='require' name='xsaves'/>
+      <feature policy='require' name='invtsc'/>
+      <feature policy='require' name='ibpb'/>
+      <feature policy='require' name='ibrs'/>
+      <feature policy='require' name='amd-stibp'/>
+      <feature policy='require' name='amd-ssbd'/>
+      <feature policy='require' name='rdctl-no'/>
+      <feature policy='require' name='ibrs-all'/>
+      <feature policy='require' name='skip-l1dfl-vmentry'/>
+      <feature policy='require' name='mds-no'/>
+      <feature policy='require' name='pschange-mc-no'/>
+      <feature policy='require' name='tsx-ctrl'/>
+      <feature policy='disable' name='hle'/>
+      <feature policy='disable' name='rtm'/>
+    </mode>
+    <mode name='custom' supported='yes'>
+      <model usable='yes'>qemu64</model>
+      <model usable='yes'>qemu32</model>
+      <model usable='no'>phenom</model>
+      <model usable='yes'>pentium3</model>
+      <model usable='yes'>pentium2</model>
+      <model usable='yes'>pentium</model>
+      <model usable='yes'>n270</model>
+      <model usable='yes'>kvm64</model>
+      <model usable='yes'>kvm32</model>
+      <model usable='yes'>coreduo</model>
+      <model usable='yes'>core2duo</model>
+      <model usable='no'>athlon</model>
+      <model usable='yes'>Westmere-IBRS</model>
+      <model usable='yes'>Westmere</model>
+      <model usable='no'>Snowridge</model>
+      <model usable='yes'>Skylake-Server-noTSX-IBRS</model>
+      <model usable='no'>Skylake-Server-IBRS</model>
+      <model usable='no'>Skylake-Server</model>
+      <model usable='yes'>Skylake-Client-noTSX-IBRS</model>
+      <model usable='no'>Skylake-Client-IBRS</model>
+      <model usable='no'>Skylake-Client</model>
+      <model usable='yes'>SandyBridge-IBRS</model>
+      <model usable='yes'>SandyBridge</model>
+      <model usable='yes'>Penryn</model>
+      <model usable='no'>Opteron_G5</model>
+      <model usable='no'>Opteron_G4</model>
+      <model usable='no'>Opteron_G3</model>
+      <model usable='yes'>Opteron_G2</model>
+      <model usable='yes'>Opteron_G1</model>
+      <model usable='yes'>Nehalem-IBRS</model>
+      <model usable='yes'>Nehalem</model>
+      <model usable='yes'>IvyBridge-IBRS</model>
+      <model usable='yes'>IvyBridge</model>
+      <model usable='no'>Icelake-Server-noTSX</model>
+      <model usable='no'>Icelake-Server</model>
+      <model usable='no' deprecated='yes'>Icelake-Client-noTSX</model>
+      <model usable='no' deprecated='yes'>Icelake-Client</model>
+      <model usable='yes'>Haswell-noTSX-IBRS</model>
+      <model usable='yes'>Haswell-noTSX</model>
+      <model usable='no'>Haswell-IBRS</model>
+      <model usable='no'>Haswell</model>
+      <model usable='no'>EPYC-Rome</model>
+      <model usable='no'>EPYC-Milan</model>
+      <model usable='no'>EPYC-IBPB</model>
+      <model usable='no'>EPYC</model>
+      <model usable='no'>Dhyana</model>
+      <model usable='no'>Cooperlake</model>
+      <model usable='yes'>Conroe</model>
+      <model usable='yes'>Cascadelake-Server-noTSX</model>
+      <model usable='no'>Cascadelake-Server</model>
+      <model usable='yes'>Broadwell-noTSX-IBRS</model>
+      <model usable='yes'>Broadwell-noTSX</model>
+      <model usable='no'>Broadwell-IBRS</model>
+      <model usable='no'>Broadwell</model>
+      <model usable='yes'>486</model>
+    </mode>
+  </cpu>
+  <memoryBacking supported='yes'>
+    <enum name='sourceType'>
+      <value>file</value>
+      <value>anonymous</value>
+      <value>memfd</value>
+    </enum>
+  </memoryBacking>
+  <devices>
+    <disk supported='yes'>
+      <enum name='diskDevice'>
+        <value>disk</value>
+        <value>cdrom</value>
+        <value>floppy</value>
+        <value>lun</value>
+      </enum>
+      <enum name='bus'>
+        <value>ide</value>
+        <value>fdc</value>
+        <value>scsi</value>
+        <value>virtio</value>
+        <value>usb</value>
+        <value>sata</value>
+      </enum>
+      <enum name='model'>
+        <value>virtio</value>
+        <value>virtio-transitional</value>
+        <value>virtio-non-transitional</value>
+      </enum>
+    </disk>
+    <graphics supported='yes'>
+      <enum name='type'>
+        <value>vnc</value>
+        <value>spice</value>
+        <value>egl-headless</value>
+      </enum>
+    </graphics>
+    <video supported='yes'>
+      <enum name='modelType'>
+        <value>vga</value>
+        <value>cirrus</value>
+        <value>qxl</value>
+        <value>virtio</value>
+        <value>none</value>
+        <value>bochs</value>
+        <value>ramfb</value>
+      </enum>
+    </video>
+    <hostdev supported='yes'>
+      <enum name='mode'>
+        <value>subsystem</value>
+      </enum>
+      <enum name='startupPolicy'>
+        <value>default</value>
+        <value>mandatory</value>
+        <value>requisite</value>
+        <value>optional</value>
+      </enum>
+      <enum name='subsysType'>
+        <value>usb</value>
+        <value>pci</value>
+        <value>scsi</value>
+      </enum>
+      <enum name='capsType'/>
+      <enum name='pciBackend'/>
+    </hostdev>
+    <rng supported='yes'>
+      <enum name='model'>
+        <value>virtio</value>
+        <value>virtio-transitional</value>
+        <value>virtio-non-transitional</value>
+      </enum>
+      <enum name='backendModel'>
+        <value>random</value>
+        <value>egd</value>
+        <value>builtin</value>
+      </enum>
+    </rng>
+    <filesystem supported='yes'>
+      <enum name='driverType'>
+        <value>path</value>
+        <value>handle</value>
+        <value>virtiofs</value>
+      </enum>
+    </filesystem>
+    <tpm supported='yes'>
+      <enum name='model'>
+        <value>tpm-tis</value>
+        <value>tpm-crb</value>
+      </enum>
+      <enum name='backendModel'>
+        <value>passthrough</value>
+        <value>emulator</value>
+      </enum>
+    </tpm>
+  </devices>
+  <features>
+    <gic supported='no'/>
+    <vmcoreinfo supported='yes'/>
+    <genid supported='yes'/>
+    <backingStoreInput supported='yes'/>
+    <backup supported='yes'/>
+    <sev supported='no'/>
+  </features>
+</domainCapabilities>

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_xml.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_xml.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 
 from virttest import data_dir
+from virttest import libvirt_version
 from virttest import virsh               # pylint: disable=W0611
 
 from virttest.utils_test import libvirt
@@ -22,7 +23,7 @@ def run(test, params, env):
         cpu xml within capabilities xml from two different hosts
         cpu xml within domain dumpxml from two different hosts
     """
-
+    libvirt_version.is_libvirt_feature_supported(params)
     file_path = params.get('file_path')
     file_xml_declaration = params.get('file_xml_declaration')
     virsh_function = eval(params.get('virsh_function'))


### PR DESCRIPTION
The test scenarios:

Between domcapabilities and capbilities xml for hosts with skylake and cascadelake cpu
, cpu_baseline and hypervisor_cpu_basline commands should return skylake cpu info(old cpu)
instead of cascadelake cpu info (new cpu).

Signed-off-by: Dan Zheng <dzheng@redhat.com>
