### PR TITLE
migrate_event: Fix OSError

### DIFF
--- a/libvirt/tests/src/migration/migrate_event.py
+++ b/libvirt/tests/src/migration/migrate_event.py
@@ -1,3 +1,5 @@
+import aexpect
+
 import logging as log
 
 from virttest import libvirt_vm
@@ -84,6 +86,7 @@ def run(test, params, env):
         func_returns = dict(migration_test.func_ret)
         migration_test.func_ret.clear()
         logging.debug("Migration returns function results:%s", func_returns)
+        aexpect.kill_tail_threads()
 
         # Check event output
         migration_base.check_event_output(params, test, virsh_session, remote_virsh_session)


### PR DESCRIPTION
Fix a OSError as follows:
  [stderr] Exception in thread tail_thread_I1QJja8d_virsh -c q:
  [stderr] Traceback (most recent call last):
  [stderr]   File "/usr/lib64/python3.6/threading.py", line 937, in _bootstrap_inner
  [stderr]     self.run()
  [stderr]   File "/usr/lib64/python3.6/threading.py", line 885, in run
  [stderr]     self._target(*self._args, **self._kwargs)
  [stderr]   File "/usr/local/lib/python3.6/site-packages/aexpect/client.py", line 650, in _tail
  [stderr]     _print_line(line)
  [stderr]   File "/usr/local/lib/python3.6/site-packages/aexpect/client.py", line 615, in _print_line
  [stderr]     self.output_func(*out_params)
  [stderr]   File "/var/tmp/libvirt-ci/runtest/avocado-vt/avocado-vt/virttest/utils_misc.py", line 448, in log_line
  [stderr]     _open_log_files[base_file].flush()
  [stderr] OSError: [Errno 9] Bad file descriptor

Signed-off-by: cliping <lcheng@redhat.com>
