### PR TITLE
v2v: fix nonetype iteration issue

### DIFF
--- a/provider/v2v_vmcheck_helper.py
+++ b/provider/v2v_vmcheck_helper.py
@@ -105,7 +105,7 @@ class VMChecker(object):
             self.boottype = int(params.get("boottype", 1))
 
         self.os_type = params.get('os_type')
-        self.os_version = params.get('os_version')
+        self.os_version = params.get('os_version', '')
         self.original_vmxml = params.get('original_vmxml')
         self.vmx_nfs_src = params.get('vmx_nfs_src')
         self.virsh_session = params.get('virsh_session')


### PR DESCRIPTION
When os_version is not set, the default value is None. This causes
the exception 'TypeError: argument of type 'NoneType' is not iterable'.

Let's set it to '' instead of None.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>