### PR TITLE
blockjob_options:Set timeout to wait for blockjob to be aborted

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockjob_options.cfg
+++ b/libvirt/tests/cfg/backingchain/blockjob_options.cfg
@@ -10,3 +10,4 @@
         - option_async:
             option_value = ' --async'
             case_name = 'blockjob_async'
+            bandwidth = 1


### PR DESCRIPTION
Test sometimes fails on pseries because of a short delay. Set a
timeout for the case and allow the short delay and the problem
is gone.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>
