### PR TITLE
libvirt_guests:Check the lenth of list before getting its item

### DIFF
--- a/libvirt/tests/src/conf_file/sysconfig_libvirt_guests/libvirt_guests.py
+++ b/libvirt/tests/src/conf_file/sysconfig_libvirt_guests/libvirt_guests.py
@@ -132,6 +132,10 @@ def run(test, params, env):
                       shut_complete_first_line)
 
         para_shut = int(parallel_shutdown)
+        logging.debug('shut_start_line_nums: %s', shut_start_line_nums)
+        if len(shut_start_line_nums) <= para_shut:
+            test.error('Did not get expected output. What we have is: %s' %
+                       shut_start_line_nums)
         if shut_start_line_nums[para_shut-1] > shut_complete_first_line:
             test.fail("Since parallel_shutdown is setting to non_zero, "
                       "%s guests should be shutdown concurrently."


### PR DESCRIPTION
To avoid list out of range error if the output is not expected.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>
