### PR TITLE
sriov: refactor the code for check_vm_network_accessed change

### DIFF
--- a/libvirt/tests/src/sriov/sriov_vf_pool.py
+++ b/libvirt/tests/src/sriov/sriov_vf_pool.py
@@ -1,5 +1,6 @@
 import logging as log
 
+from provider.sriov import check_points
 from provider.sriov import sriov_base
 
 from virttest import utils_libvirtd
@@ -83,7 +84,7 @@ def run(test, params, env):
             virsh.attach_device(vm_name, iface.xml, debug=True,
                                 ignore_status=False)
         libvirt_vmxml.check_guest_xml(vm.name, params["net_name"])
-        sriov_base.check_vm_network_accessed(vm_session)
+        check_points.check_vm_network_accessed(vm_session)
 
     def test_connection():
         """

--- a/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_start_destroy.py
+++ b/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_start_destroy.py
@@ -42,7 +42,7 @@ def run(test, params, env):
         if 'vlan' in iface_dict:
             check_points.check_vlan(sriov_test_obj.pf_name, iface_dict)
         else:
-            sriov_base.check_vm_network_accessed(vm_session)
+            check_points.check_vm_network_accessed(vm_session)
 
         if network_dict:
             libvirt_network.check_network_connection(
@@ -92,9 +92,12 @@ def run(test, params, env):
     orig_config_xml = vmxml.copy()
 
     try:
-        sriov_test_obj.setup_default(dev_name, managed_disabled, network_dict)
+        sriov_test_obj.setup_default(dev_name=dev_name,
+                                     managed_disabled=managed_disabled,
+                                     network_dict=network_dict)
         run_test()
 
     finally:
         sriov_test_obj.teardown_default(
-            orig_config_xml, managed_disabled, dev_name, network_dict)
+            orig_config_xml, managed_disabled=managed_disabled,
+            dev_name=dev_name, network_dict=network_dict)


### PR DESCRIPTION
The function check_vm_network_accessed was moved to check_points
because it's a checkpoint.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
depends on: https://github.com/autotest/tp-libvirt/pull/4253
**Test result:**
 ```
(1/4) type_specific.io-github-autotest-libvirt.sriov.vf_pool.active.at_dt.macvtap_passthrough: PASS (46.35 s)
 (2/4) type_specific.io-github-autotest-libvirt.sriov.vf_pool.active.connection.macvtap_passthrough: PASS (45.55 s)
 (3/4) type_specific.io-github-autotest-libvirt.sriov.vf_pool.active.connection.hostdev: PASS (49.28 s)
 (4/4) type_specific.io-github-autotest-libvirt.sriov.vf_pool.inactive.at_dt.macvtap_passthrough: PASS (47.02 s)
(01/13) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start_destroy.hostdev_interface.vf_address.managed_yes: PASS (51.89 s)
 (02/13) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start_destroy.hostdev_interface.vf_address.managed_no: PASS (50.30 s)
 (03/13) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start_destroy.hostdev_interface.vf_address.without_managed: PASS (50.79 s)
...
(13/13) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start_destroy.network_interface.network.vf_address.without_managed: PASS (51.47 s)
RESULTS    : PASS 13 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0

```