### PR TITLE
sriov: Add 2 cases about vm lifecycle

### DIFF
--- a/libvirt/tests/cfg/sriov/vm_lifecycle/direct_passthrough_vm_lifecycle_start_destroy.cfg
+++ b/libvirt/tests/cfg/sriov/vm_lifecycle/direct_passthrough_vm_lifecycle_start_destroy.cfg
@@ -1,0 +1,23 @@
+- direct_passthrough.vm_lifecycle.start_destroy:
+    type = direct_passthrough_vm_lifecycle_start_destroy
+    start_vm = "no"
+    device_type = "interface"
+    only x86_64
+    variants dev_type:
+        - direct_interface:
+            variants dev_source:
+                - vf_name:
+                    variants:
+                        - @default:
+                            iface_dict = {'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}, 'type_name': 'direct', 'source': {'dev': vf_name, 'mode': 'passthrough'}}
+                        - vlan:
+                            iface_dict = {'mac_address': mac_addr, 'vlan': {'tags': [{'id': '50'}]}, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}, 'type_name': 'direct', 'source': {'dev': vf_name, 'mode': 'passthrough'}}
+        - network_interface:
+            variants dev_source:
+                - network:
+                    variants net_source:
+                        - vf_name:
+                            variants:
+                                - @default:
+                                    iface_dict = {'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}, 'type_name': 'network', 'source': {'network': 'macvtap-passthrough'}}
+                                    network_dict = {"net_name":'macvtap-passthrough',"net_forward": '{"mode": "passthrough", "dev": "%s"}' % vf_name, "forward_iface": vf_name}

--- a/libvirt/tests/cfg/sriov/vm_lifecycle/sriov_vm_lifecycle_iommu_at_dt_hostdev.cfg
+++ b/libvirt/tests/cfg/sriov/vm_lifecycle/sriov_vm_lifecycle_iommu_at_dt_hostdev.cfg
@@ -1,0 +1,21 @@
+- sriov.vm_lifecycle.iommu.at_dt_hostdev:
+    type = sriov_vm_lifecycle_iommu_at_dt_hostdev
+    start_vm = "yes"
+    enable_guest_iommu = "yes"
+    iommu_dict = {'driver': {'intremap': 'on', 'caching_mode': 'on'}, 'model': 'intel'}
+    expr_iface_no = 1
+
+    only x86_64
+    variants dev_type:
+        - hostdev_interface:
+            variants test_scenario:
+                - managed_yes:
+                    iface_dict = {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}}                    
+                - failover:
+                    expr_iface_no = 3 
+                    br_dict = {'source': {'bridge': 'br0'}, 'teaming': {'type': 'persistent'}, 'alias': {'name': 'ua-3f13c36e-186b-4c6b-ba54-0ec483613931'}, 'mac_address': mac_addr, 'model': 'virtio', 'type_name': 'bridge'}
+                    iface_dict = {'teaming': {'type': 'transient', 'persistent': 'ua-3f13c36e-186b-4c6b-ba54-0ec483613931'}, 'mac_address': mac_addr, 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}}
+        - hostdev_device:
+            variants test_scenario:
+                - managed_yes:
+                    hostdev_dict = {'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': pf_pci_addr}, 'managed': 'yes'}

--- a/libvirt/tests/src/sriov/sriov_vf_pool.py
+++ b/libvirt/tests/src/sriov/sriov_vf_pool.py
@@ -1,5 +1,6 @@
 import logging as log
 
+from provider.sriov import check_points
 from provider.sriov import sriov_base
 
 from virttest import utils_libvirtd
@@ -83,7 +84,7 @@ def run(test, params, env):
             virsh.attach_device(vm_name, iface.xml, debug=True,
                                 ignore_status=False)
         libvirt_vmxml.check_guest_xml(vm.name, params["net_name"])
-        sriov_base.check_vm_network_accessed(vm_session)
+        check_points.check_vm_network_accessed(vm_session)
 
     def test_connection():
         """

--- a/libvirt/tests/src/sriov/vm_lifecycle/direct_passthrough_vm_lifecycle_start_destroy.py
+++ b/libvirt/tests/src/sriov/vm_lifecycle/direct_passthrough_vm_lifecycle_start_destroy.py
@@ -1,26 +1,21 @@
-from virttest import utils_misc
-from virttest import virsh
+from provider.sriov import sriov_base
+from provider.sriov import check_points
 
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_libvirt import libvirt_network
-from virttest.utils_libvirt import libvirt_vfio
 from virttest.utils_test import libvirt
-
-from provider.sriov import sriov_base
-from provider.sriov import check_points
 
 
 def run(test, params, env):
     """
-    Start vm with a hostdev device or hostdev interface
+    start vm with direct type + passthrough mode interface
     """
     def run_test():
         """
-        Start vm with an interface/device of hostdev type, and test the network
-        function.
+        start vm with direct type + passthrough mode interface with vf
         """
 
-        test.log.info("TEST_STEP1: Attach a hostdev interface/device to VM")
+        test.log.info("TEST_STEP1: Attach a direct interface to VM")
         iface_dev = sriov_test_obj.create_iface_dev(dev_type, iface_dict)
         vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
         libvirt.add_vm_device(vmxml, iface_dev)
@@ -29,12 +24,12 @@ def run(test, params, env):
         vm.start()
         vm_session = vm.wait_for_serial_login(timeout=240)
 
-        test.log.info("TEST_STEP3: Check hostdev xml after VM startup")
+        test.log.info("TEST_STEP3: Check interface xml after VM startup")
         if dev_type == "network_interface":
-            iface_dict.update({'type_name': 'hostdev'})
+            iface_dict.update({'type_name': 'direct'})
         check_points.comp_hostdev_xml(vm, device_type, iface_dict)
 
-        test.log.info("TEST_STEP4: Check hostdev information - mac, "
+        test.log.info("TEST_STEP4: Check interface information - mac, "
                       "vlan, network accessibility and so on")
         check_points.check_mac_addr(
             vm_session, vm.name, device_type, iface_dict)
@@ -51,53 +46,32 @@ def run(test, params, env):
         test.log.info("TEST_STEP5: Destroy VM")
         vm.destroy(gracefully=False)
 
-        test.log.info("TEST_STEP6: Check environment recovery - mac, driver, "
-                      "vlan")
+        test.log.info("TEST_STEP6: Check environment recovery - mac, vlan ")
         if network_dict:
             libvirt_network.check_network_connection(
                 network_dict.get("net_name"), 0)
 
         check_points.check_vlan(sriov_test_obj.pf_name, iface_dict, True)
 
-        if not utils_misc.wait_for(
-            lambda: libvirt_vfio.check_vfio_pci(
-                dev_pci, not managed_disabled, True), 10, 5):
-            test.fail("Got incorrect driver!")
-        if managed_disabled:
-            virsh.nodedev_reattach(dev_name, debug=True, ignore_errors=False)
-            libvirt_vfio.check_vfio_pci(dev_pci, True)
         check_points.check_mac_addr_recovery(
             sriov_test_obj.pf_name, device_type, iface_dict)
 
     dev_type = params.get("dev_type", "")
-    dev_source = params.get("dev_source", "")
 
     vm_name = params.get("main_vm", "avocado-vt-vm1")
     vm = env.get_vm(vm_name)
     sriov_test_obj = sriov_base.SRIOVTest(vm, test, params)
-    if dev_type == "hostdev_device" and dev_source.startswith("pf"):
-        dev_name = sriov_test_obj.pf_dev_name
-        dev_pci = sriov_test_obj.pf_pci
-    else:
-        dev_name = sriov_test_obj.vf_dev_name
-        dev_pci = sriov_test_obj.vf_pci
 
     iface_dict = sriov_test_obj.parse_iface_dict()
     network_dict = sriov_test_obj.parse_network_dict()
-    managed_disabled = iface_dict.get('managed') != "yes" or \
-        (network_dict and network_dict.get('managed') != "yes")
-    device_type = "hostdev" if dev_type == "hostdev_device" else "interface"
+    device_type = params.get("device_type", "interface")
 
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     orig_config_xml = vmxml.copy()
 
     try:
-        sriov_test_obj.setup_default(dev_name=dev_name,
-                                     managed_disabled=managed_disabled,
-                                     network_dict=network_dict)
+        sriov_test_obj.setup_default(network_dict=network_dict)
         run_test()
 
     finally:
-        sriov_test_obj.teardown_default(
-            orig_config_xml, managed_disabled=managed_disabled,
-            dev_name=dev_name, network_dict=network_dict)
+        sriov_test_obj.teardown_default(orig_config_xml, network_dict=network_dict)

--- a/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_iommu_at_dt_hostdev.py
+++ b/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_iommu_at_dt_hostdev.py
@@ -1,0 +1,96 @@
+from provider.sriov import sriov_base
+from provider.sriov import check_points
+
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_test import libvirt
+
+
+def run(test, params, env):
+    """
+    Test the hostdev interface works well with the vIOMMU enabled.
+    """
+    def run_test():
+        """
+        Start vm with IOMMU device and hostdev interface/device, hotunplug and
+        hotplug
+
+        1. Start vm with iommu enabled, and guest kernel cmd line with iommu
+        enabled
+        2. Test network connectivity. for failover, also check the interface
+        quantity on the vm.
+        3. Hotunplug the hostdev interface/device, check the device is
+        removed from the live xml, and the interface on the vm
+        4. Hotplug back the hostdev interface/device, check the network
+        connectivity again
+        """
+        test.log.info("TEST_STEP1: Attach a hostdev interface/device to VM")
+        iface_dev = sriov_test_obj.create_iface_dev(dev_type, iface_dict)
+        libvirt.add_vm_device(vm_xml.VMXML.new_from_dumpxml(vm_name), iface_dev)
+
+        test.log.info("TEST_STEP2: Start the VM with iommu enabled")
+        vm.start()
+        vm.cleanup_serial_console()
+        vm.create_serial_console()
+        vm_session = vm.wait_for_serial_login(timeout=240)
+
+        test.log.info("TEST_STEP3: Check network accessibility")
+        br_name = None
+        if test_scenario == 'failover':
+            br_name = br_dict['source'].get('bridge')
+        check_points.check_vm_network_accessed(vm_session,
+                                               tcpdump_iface=br_name,
+                                               tcpdump_status_error=True)
+        check_points.check_vm_iface_num(vm_session, expr_iface_no)
+
+        test.log.info("TEST_STEP4: Hotunplug a hostdev interface/device")
+        iface_cur = libvirt.get_vm_device(
+            vm_xml.VMXML.new_from_dumpxml(vm_name), device_type, index=-1)[0]
+        virsh.detach_device(vm_name, iface_cur.xml, wait_for_event=True,
+                            debug=True, ignore_status=False)
+        check_points.check_vm_iface_num(vm_session, expr_iface_no-1)
+
+        test.log.info("TEST_STEP5: Hotplug back the hostdev interface/device, "
+                      "check the network connectivity.")
+        virsh.attach_device(vm_name, iface_cur.xml, debug=True,
+                            ignore_status=False)
+
+        check_points.check_vm_iface_num(vm_session, expr_iface_no,
+                                        timeout=40, first=15)
+        check_points.check_vm_network_accessed(vm_session,
+                                               tcpdump_iface=br_name,
+                                               tcpdump_status_error=True)
+
+    dev_type = params.get("dev_type", "")
+    test_scenario = params.get("test_scenario", "")
+
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    vm = env.get_vm(vm_name)
+    sriov_test_obj = sriov_base.SRIOVTest(vm, test, params)
+    if dev_type == "hostdev_device":
+        dev_name = sriov_test_obj.pf_dev_name
+    else:
+        dev_name = sriov_test_obj.vf_dev_name
+    iface_dict = sriov_test_obj.parse_iface_dict()
+    network_dict = sriov_test_obj.parse_network_dict()
+
+    device_type = "hostdev" if dev_type == "hostdev_device" else "interface"
+    managed_disabled = iface_dict.get('managed') != "yes" or \
+        (network_dict and network_dict.get('managed') != "yes")
+    test_dict = sriov_test_obj.parse_iommu_test_params()
+    test_dict.update({"network_dict": network_dict,
+                      "managed_disabled": managed_disabled,
+                      "dev_name": dev_name})
+    br_dict = test_dict.get('br_dict', {'source': {'bridge': 'br0'}})
+    expr_iface_no = int(params.get("expr_iface_no", '1'))
+
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    orig_config_xml = vmxml.copy()
+
+    try:
+        sriov_test_obj.setup_iommu_test(**test_dict)
+        run_test()
+
+    finally:
+        sriov_test_obj.teardown_iommu_test(orig_config_xml, **test_dict)


### PR DESCRIPTION
This PR adds:
    1. VIRT-293144 - Start vm with direct type + passthrough mode
        interface with vf
    2. VIRT-293920 - Start vm with IOMMU device and hostdev
        interface/device, hotunplug and hotplug
BTW, refactor the code for check_vm_network_accessed and default
setup/teardown changes.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Depends on**: https://github.com/avocado-framework/avocado-vt/pull/3421
**Test results:**  The failed case is caused by a known issue.
 ```
(1/3) type_specific.io-github-autotest-libvirt.direct_passthrough.vm_lifecycle.start_destroy.direct_interface.vf_name.default: PASS (49.72 s)
 (2/3) type_specific.io-github-autotest-libvirt.direct_passthrough.vm_lifecycle.start_destroy.direct_interface.vf_name.vlan: FAIL: Unable to get vlan value from 'ip l show enp59s0f0 '! (43.82 s)
 (3/3) type_specific.io-github-autotest-libvirt.direct_passthrough.vm_lifecycle.start_destroy.network_interface.network.vf_name.default: PASS (50.67 s)

 (1/3) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.iommu.at_dt_hostdev.hostdev_interface.managed_yes: PASS (200.52 s)
 (2/3) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.iommu.at_dt_hostdev.hostdev_interface.failover: PASS (220.96 s)
 (3/3) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.iommu.at_dt_hostdev.hostdev_device.managed_yes: PASS (199.20 s)

(1/4) type_specific.io-github-autotest-libvirt.sriov.vf_pool.active.at_dt.macvtap_passthrough: PASS (46.35 s)
(2/4) type_specific.io-github-autotest-libvirt.sriov.vf_pool.active.connection.macvtap_passthrough: PASS (45.55 s)
(3/4) type_specific.io-github-autotest-libvirt.sriov.vf_pool.active.connection.hostdev: PASS (49.28 s)
(4/4) type_specific.io-github-autotest-libvirt.sriov.vf_pool.inactive.at_dt.macvtap_passthrough: PASS (47.02 s)
(01/13) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start_destroy.hostdev_interface.vf_address.managed_yes: PASS (51.89 s)
(02/13) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start_destroy.hostdev_interface.vf_address.managed_no: PASS (50.30 s)
(03/13) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start_destroy.hostdev_interface.vf_address.without_managed: PASS (50.79 s)
...
(13/13) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start_destroy.network_interface.network.vf_address.without_managed: PASS (51.47 s)
RESULTS    : PASS 13 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0


```