### PR TITLE
memory_misc:Remove unsupported tests from other archs

### DIFF
--- a/libvirt/tests/cfg/memory/memory_misc.cfg
+++ b/libvirt/tests/cfg/memory/memory_misc.cfg
@@ -50,6 +50,7 @@
         - xml_check:
             variants case:
                 - smbios:
+                    only x86_64
                     vmxml_max_mem_rt_slots = 16
                     vmxml_max_mem_rt_unit = 'KiB'
                     vmxml_max_mem_rt = 2560000


### PR DESCRIPTION
BIOS serial console only supported on x86 architectures

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>
