### PR TITLE
fix to use --nvram in virsh undefine

### DIFF
--- a/libvirt/tests/src/backingchain/virtual_disks_blockcopy_options.py
+++ b/libvirt/tests/src/backingchain/virtual_disks_blockcopy_options.py
@@ -235,7 +235,7 @@ def run(test, params, env):
         try:
             # Create a transient VM
             transient_vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
-            virsh.undefine(vm_name, debug=True, ignore_status=False)
+            virsh.undefine(vm_name, options='--nvram', debug=True, ignore_status=False)
             virsh.create(transient_vmxml.xml, ignore_status=False, debug=True)
             vm.wait_for_login().close()
             debug_xml = vm_xml.VMXML.new_from_dumpxml(vm_name)

--- a/libvirt/tests/src/lxc/lxc_life_cycle.py
+++ b/libvirt/tests/src/lxc/lxc_life_cycle.py
@@ -204,7 +204,7 @@ def run(test, params, env):
         check_state('shut off')
 
         # Undefine
-        result = virsh.undefine(vm_name, **virsh_args)
+        result = virsh.undefine(vm_name, options='--nvram', **virsh_args)
         utlv.check_exit_status(result)
         if not virsh.domain_exists(vm_name, **virsh_args):
             logging.info("Undefine LXC domain successfully")

--- a/libvirt/tests/src/multifunction.py
+++ b/libvirt/tests/src/multifunction.py
@@ -38,7 +38,7 @@ def cleanup_vm(vm_name=None, disk_removed=None):
     """
     try:
         if vm_name is not None:
-            virsh.undefine(vm_name)
+            virsh.undefine(vm_name, options='--nvram')
     except process.CmdError:
         pass
     try:

--- a/libvirt/tests/src/numa/numa_preferred_undefine.py
+++ b/libvirt/tests/src/numa/numa_preferred_undefine.py
@@ -34,7 +34,7 @@ def run(test, params, env):
         vmxml.numa_memory = numa_memory
         logging.debug("vm xml is %s", vmxml)
         vmxml.sync()
-        result = virsh.undefine(vm_name, debug=True, ignore_status=True)
+        result = virsh.undefine(vm_name, options='--nvram', debug=True, ignore_status=True)
         if result.exit_status:
             test.fail("Undefine vm failed, check %s" % bug_url)
     finally:

--- a/libvirt/tests/src/passthrough/pci/vfio.py
+++ b/libvirt/tests/src/passthrough/pci/vfio.py
@@ -251,7 +251,7 @@ def cleanup_vm(vm_name=None):
     """
     try:
         if vm_name is not None:
-            virsh.undefine(vm_name)
+            virsh.undefine(vm_name, options='--nvram')
     except process.CmdError:
         pass
 

--- a/libvirt/tests/src/svirt/svirt_start_destroy.py
+++ b/libvirt/tests/src/svirt/svirt_start_destroy.py
@@ -271,7 +271,7 @@ def run(test, params, env):
             os.chown(path, int(label_list[0]), int(label_list[1]))
         backup_xml.sync()
         if xattr_check:
-            virsh.undefine(guest_name, ignore_status=True)
+            virsh.undefine(guest_name, options='--nvram', ignore_status=True)
         utils_selinux.set_status(backup_sestatus)
         if (security_driver or security_default_confined or
                 security_require_confined):

--- a/libvirt/tests/src/svirt/svirt_undefine_define.py
+++ b/libvirt/tests/src/svirt/svirt_undefine_define.py
@@ -58,7 +58,7 @@ def run(test, params, env):
         if vm.is_alive():
             vm.destroy()
         virsh.dumpxml(vm.name, to_file=xml_file)
-        cmd_result = virsh.undefine(vm.name)
+        cmd_result = virsh.undefine(vm.name, options='--nvram')
         if cmd_result.exit_status:
             test.fail("Failed to undefine vm."
                       "Detail: %s" % cmd_result)

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_define.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_define.py
@@ -67,7 +67,7 @@ def run(test, params, env):
         xml_file = new_xml.xmltreefile.name
 
         # undefine the original vm
-        virsh.undefine(vm_name)
+        virsh.undefine(vm_name, options='--nvram')
         return xml_file
 
     # Run test
@@ -101,7 +101,7 @@ def run(test, params, env):
         finally:
             # for positive test, undefine the defined vm firstly
             if not ret.exit_status:
-                virsh.undefine(vm_name)
+                virsh.undefine(vm_name, options='--nvram')
             # restore the original vm
             ret = virsh.define(xml_backup_file)
             if ret.duration > 3:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domif_setlink_getlink.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domif_setlink_getlink.py
@@ -300,7 +300,7 @@ def run(test, params, env):
         # Recover VM.
         if vm.is_alive():
             vm.destroy(gracefully=False)
-        virsh.undefine(vm_name[0])
+        virsh.undefine(vm_name[0], options='--nvram')
         virsh.define(vm_xml_file)
         os.remove(vm_xml_file)
         if os.path.exists(save_file):

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
@@ -217,7 +217,7 @@ def run(test, params, env):
                             dom.pause()
 
                 if event == "undefine":
-                    virsh.undefine(dom.name, **virsh_dargs)
+                    virsh.undefine(dom.name, options='--nvram', **virsh_dargs)
                     expected_events_list.append("'lifecycle' for %s:"
                                                 " Undefined Removed")
                 elif event == "create":

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_managedsave.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_managedsave.py
@@ -110,12 +110,12 @@ def run(test, params, env):
         if not os.path.exists(managed_save_file):
             test.fail("Can't find managed save image")
         #undefine domain with no options.
-        if not virsh.undefine(vm_name, options=None,
+        if not virsh.undefine(vm_name, options='--nvram',
                               ignore_status=True).exit_status:
             test.fail("Guest shouldn't be undefined"
                       "while domain managed save image exists")
         #undefine domain with managed-save option.
-        if virsh.undefine(vm_name, options="--managed-save",
+        if virsh.undefine(vm_name, options="--managed-save --nvram",
                           ignore_status=True).exit_status:
             test.fail("Guest can't be undefine with "
                       "managed-save option")

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_virtio_scsi.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_virtio_scsi.py
@@ -303,7 +303,7 @@ def run(test, params, env):
         # Cleanup created vm anyway
         if vm.is_alive():
             vm.destroy(gracefully=False)
-        virsh.undefine(new_vm_name)
+        virsh.undefine(new_vm_name, options='--nvram')
 
         # Cleanup iscsi device for block if it is necessary
         if source_type == "block":

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_agent_command.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_qemu_agent_command.py
@@ -77,7 +77,7 @@ def reset_env(vm_name, xml_file):
     :xml_file: domain xml file
     """
     virsh.destroy(vm_name)
-    virsh.undefine(vm_name)
+    virsh.undefine(vm_name, options='--nvram')
     virsh.define(xml_file)
     if os.path.exists(xml_file):
         os.remove(xml_file)

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_undefine.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_undefine.py
@@ -63,7 +63,7 @@ def run(test, params, env):
     if wipe_data:
         option += " --wipe-storage"
     nvram_o = None
-    if platform.machine() == 'aarch64':
+    if platform.machine() in ['aarch64', 'x86_64']:
         nvram_o = " --nvram"
         option += nvram_o
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_vcpucount.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_vcpucount.py
@@ -145,7 +145,7 @@ def chk_output_shutoff(output, expect_out, options, test):
 
 def reset_env(vm_name, xml_file):
     virsh.destroy(vm_name)
-    virsh.undefine(vm_name)
+    virsh.undefine(vm_name, options='--nvram')
     virsh.define(xml_file)
     if os.path.exists(xml_file):
         os.remove(xml_file)

--- a/libvirt/tests/src/virsh_cmd/network/virsh_net_destroy.py
+++ b/libvirt/tests/src/virsh_cmd/network/virsh_net_destroy.py
@@ -117,7 +117,7 @@ def run(test, params, env):
             else:
                 logging.debug("undefine the vm, then create the vm...")
                 vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
-                virsh.undefine(vm_name)
+                virsh.undefine(vm_name, options='--nvram')
                 ret = virsh.create(vmxml.xml)
                 logging.debug(ret.stdout)
             # check the create or start cmd status

--- a/libvirt/tests/src/virtual_disks/virtual_disks_luks.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_luks.py
@@ -513,7 +513,7 @@ def run(test, params, env):
             transient_vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
             if vm.is_alive():
                 vm.destroy(gracefully=False)
-            virsh.undefine(vm_name, debug=True, ignore_status=False)
+            virsh.undefine(vm_name, options='--nvram', debug=True, ignore_status=False)
             virsh.create(transient_vmxml.xml, ignore_status=False, debug=True)
             expected_top_image = vm.get_blk_devices()[device_target].get('source')
             options = params.get("blockcopy_options")

--- a/libvirt/tests/src/virtual_network/iface_unprivileged.py
+++ b/libvirt/tests/src/virtual_network/iface_unprivileged.py
@@ -220,7 +220,7 @@ def run(test, params, env):
     finally:
         if 'upu_virsh' in locals():
             virsh.destroy(upu_vm_name, unprivileged_user=up_user)
-            virsh.undefine(upu_vm_name, unprivileged_user=up_user)
+            virsh.undefine(upu_vm_name, options='--nvram', unprivileged_user=up_user)
         if case == 'precreated':
             try:
                 if device_type == 'tap':


### PR DESCRIPTION
--nvram is needed for ovmf guest from RHEL 9.x. And it also does not have side effect
on seabios guest. This option was supported since RHEL7.x which is enough old. The
assumption is that it is no value to test RHEL6 host with libvirt.


Depend on https://github.com/avocado-framework/avocado-vt/pull/3423

Signed-off-by: Dan Zheng <dzheng@redhat.com>
