### PR TITLE
virttools/virt_install.kernel_cmdline: fix test condition

### DIFF
--- a/virttools/tests/src/virt_install/kernel_cmdline.py
+++ b/virttools/tests/src/virt_install/kernel_cmdline.py
@@ -47,7 +47,7 @@ def run(test, params, env):
         vm.undefine()
         status = virt_install(vm_name, location, extra_args)
 
-        if status != expected_status:
+        if str(status) != str(expected_status):
             test.fail("The installation didn't exit as expected."
                       " Expected: %s, actual: %s" % (expected_status, status))
 


### PR DESCRIPTION
The last test runs failed although the failure message confirmed
the status was correct. It seemed this was a type issue.

Cast all values in test condition to string to make sure type
issue cannot occur.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>
