### PR TITLE
sriov: Add reboot/suspend_resume cases

### DIFF
--- a/libvirt/tests/cfg/sriov/vm_lifecycle/sriov_vm_lifecycle_reboot.cfg
+++ b/libvirt/tests/cfg/sriov/vm_lifecycle/sriov_vm_lifecycle_reboot.cfg
@@ -1,0 +1,71 @@
+- sriov.vm_lifecycle.reboot:
+    type = sriov_vm_lifecycle_reboot
+    start_vm = "no"
+
+    only x86_64
+    variants:
+        - with_iommu:
+            only vf_address..managed_yes, failover
+            no network_interface
+            start_vm = "yes"
+            enable_guest_iommu = "yes"
+            iommu_dict = {'driver': {'intremap': 'on', 'caching_mode': 'on'}, 'model': 'intel'}
+        - without_iommu:
+            no failover
+    variants dev_type:
+        - hostdev_interface:
+            variants dev_source:
+                - vf_address:
+                    variants test_scenario:
+                        - managed_yes:
+                            iface_dict = {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}, 'driver': {'driver_attr': {'name': 'vfio'}}, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}, 'mac_address': mac_addr}
+                        - managed_no:
+                            iface_dict = {'managed': 'no', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
+                        - without_managed:
+                            iface_dict = {'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
+                        - vlan:
+                            iface_dict = {'type_name': 'hostdev', 'vlan': {'tags': [{'id': '42'}]}, 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}, 'managed': 'yes', 'driver': {'driver_attr': {'name': 'vfio'}}, 'mac_address': mac_addr}
+                        - failover:
+                            br_dict = {'source': {'bridge': 'br0'}, 'teaming': {'type': 'persistent'}, 'alias': {'name': 'ua-3f13c36e-186b-4c6b-ba54-0ec483613931'}, 'mac_address': mac_addr, 'model': 'virtio', 'type_name': 'bridge'}
+                            iface_dict = {'teaming': {'type': 'transient', 'persistent': 'ua-3f13c36e-186b-4c6b-ba54-0ec483613931'}, 'mac_address': mac_addr, 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}}
+        - hostdev_device:
+            variants dev_source:
+                - vf_address:
+                    variants test_scenario:
+                        - managed_yes:
+                            hostdev_dict = {'alias': {'name': 'ua-1bcbabff-f022-4d4f-ae8c-13f2d3a07906'}, 'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': vf_pci_addr}, 'managed': 'yes'}
+                        - managed_no:
+                            hostdev_dict = {'alias': {'name': 'ua-1bcbabff-f022-4d4f-ae8c-13f2d3a07906'}, 'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': vf_pci_addr}, 'managed': 'no'}
+                - pf_address:
+                    variants test_scenario:
+                        - managed_yes:
+                            hostdev_dict = {'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': pf_pci_addr}, 'managed': 'yes'}
+                        - managed_no:
+                            hostdev_dict = {'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': pf_pci_addr}, 'managed': 'no'}
+        - network_interface:
+            variants dev_source:
+                - network:
+                    variants net_source:
+                        - pf_name:
+                            variants network_mode:
+                                - hostdev:
+                                    variants test_scenario:
+                                        - managed_no:
+                                            iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
+                                            network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev", "managed": "no"}', 'net_forward_pf': net_forward_pf}
+                                        - managed_yes:
+                                            iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
+                                            network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev", "managed": "yes"}', 'net_forward_pf': net_forward_pf}
+                                        - without_managed:
+                                            iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
+                                            network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev"}', 'net_forward_pf': net_forward_pf}
+                        - vf_address:
+                            variants network_mode:
+                                - hostdev:
+                                    variants test_scenario:
+                                        - managed_yes:
+                                            iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
+                                            network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev", "managed": "yes"}', 'vf_list_attrs': vf_list_attrs}
+                                        - without_managed:
+                                            iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
+                                            network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev"}', 'vf_list_attrs': vf_list_attrs}

--- a/libvirt/tests/cfg/sriov/vm_lifecycle/sriov_vm_lifecycle_suspend_resume.cfg
+++ b/libvirt/tests/cfg/sriov/vm_lifecycle/sriov_vm_lifecycle_suspend_resume.cfg
@@ -1,0 +1,71 @@
+- sriov.vm_lifecycle.suspend_resume:
+    type = sriov_vm_lifecycle_suspend_resume
+    start_vm = "no"
+
+    only x86_64
+    variants:
+        - with_iommu:
+            only vf_address..managed_yes, failover
+            no network_interface
+            start_vm = "yes"
+            enable_guest_iommu = "yes"
+            iommu_dict = {'driver': {'intremap': 'on', 'caching_mode': 'on'}, 'model': 'intel'}
+        - without_iommu:
+            no failover
+    variants dev_type:
+        - hostdev_interface:
+            variants dev_source:
+                - vf_address:
+                    variants test_scenario:
+                        - managed_yes:
+                            iface_dict = {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}, 'driver': {'driver_attr': {'name': 'vfio'}}, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}, 'mac_address': mac_addr}
+                        - managed_no:
+                            iface_dict = {'managed': 'no', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
+                        - without_managed:
+                            iface_dict = {'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
+                        - vlan:
+                            iface_dict = {'type_name': 'hostdev', 'vlan': {'tags': [{'id': '42'}]}, 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}, 'managed': 'yes', 'driver': {'driver_attr': {'name': 'vfio'}}, 'mac_address': mac_addr}
+                        - failover:
+                            br_dict = {'source': {'bridge': 'br0'}, 'teaming': {'type': 'persistent'}, 'alias': {'name': 'ua-3f13c36e-186b-4c6b-ba54-0ec483613931'}, 'mac_address': mac_addr, 'model': 'virtio', 'type_name': 'bridge'}
+                            iface_dict = {'teaming': {'type': 'transient', 'persistent': 'ua-3f13c36e-186b-4c6b-ba54-0ec483613931'}, 'mac_address': mac_addr, 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}}
+        - hostdev_device:
+            variants dev_source:
+                - vf_address:
+                    variants test_scenario:
+                        - managed_yes:
+                            hostdev_dict = {'alias': {'name': 'ua-1bcbabff-f022-4d4f-ae8c-13f2d3a07906'}, 'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': vf_pci_addr}, 'managed': 'yes'}
+                        - managed_no:
+                            hostdev_dict = {'alias': {'name': 'ua-1bcbabff-f022-4d4f-ae8c-13f2d3a07906'}, 'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': vf_pci_addr}, 'managed': 'no'}
+                - pf_address:
+                    variants test_scenario:
+                        - managed_yes:
+                            hostdev_dict = {'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': pf_pci_addr}, 'managed': 'yes'}
+                        - managed_no:
+                            hostdev_dict = {'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': pf_pci_addr}, 'managed': 'no'}
+        - network_interface:
+            variants dev_source:
+                - network:
+                    variants net_source:
+                        - pf_name:
+                            variants network_mode:
+                                - hostdev:
+                                    variants test_scenario:
+                                        - managed_no:
+                                            iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
+                                            network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev", "managed": "no"}', 'net_forward_pf': net_forward_pf}
+                                        - managed_yes:
+                                            iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
+                                            network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev", "managed": "yes"}', 'net_forward_pf': net_forward_pf}
+                                        - without_managed:
+                                            iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
+                                            network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev"}', 'net_forward_pf': net_forward_pf}
+                        - vf_address:
+                            variants network_mode:
+                                - hostdev:
+                                    variants test_scenario:
+                                        - managed_yes:
+                                            iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
+                                            network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev", "managed": "yes"}', 'vf_list_attrs': vf_list_attrs}
+                                        - without_managed:
+                                            iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
+                                            network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev"}', 'vf_list_attrs': vf_list_attrs}

--- a/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_reboot.py
+++ b/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_reboot.py
@@ -1,0 +1,86 @@
+from provider.sriov import check_points
+from provider.sriov import sriov_base
+
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_test import libvirt
+
+
+def run(test, params, env):
+    """
+    Reboot vm with a hostdev interface/device
+    """
+    def run_test():
+        """
+        Reboot vm with a hostdev interface/device, make sure guest network
+        connectivity still works well.
+
+        1) Start the VM
+        2) Suspend the VM and check the state
+        3) Resume and check the state
+        4) Check network connectivity
+        """
+
+        test.log.info("TEST_STEP1: Attach a hostdev interface/device to VM")
+        iface_dev = sriov_test_obj.create_iface_dev(dev_type, iface_dict)
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        libvirt.add_vm_device(vmxml, iface_dev)
+
+        test.log.info("TEST_STEP2: Start the VM")
+        vm.start()
+        vm.cleanup_serial_console()
+        vm.create_serial_console()
+        vm.wait_for_serial_login(timeout=240).close()
+
+        test.log.info("TEST_STEP3: Reboot the vm")
+        virsh.reboot(vm.name, debug=True, ignore_status=False)
+        vm_session = vm.wait_for_serial_login(timeout=240)
+
+        test.log.info("TEST_STEP4: Check network accessibility")
+        if 'vlan' in iface_dict:
+            check_points.check_vlan(sriov_test_obj.pf_name, iface_dict)
+        else:
+            br_name = None
+            if test_scenario == 'failover':
+                br_name = br_dict['source'].get('bridge')
+            check_points.check_vm_network_accessed(vm_session,
+                                                   tcpdump_iface=br_name,
+                                                   tcpdump_status_error=True)
+
+    dev_type = params.get("dev_type", "")
+    dev_source = params.get("dev_source", "")
+    test_scenario = params.get("test_scenario", "")
+
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    vm = env.get_vm(vm_name)
+    sriov_test_obj = sriov_base.SRIOVTest(vm, test, params)
+    if dev_type == "hostdev_device" and dev_source.startswith("pf"):
+        dev_name = sriov_test_obj.pf_dev_name
+    else:
+        dev_name = sriov_test_obj.vf_dev_name
+
+    iface_dict = sriov_test_obj.parse_iface_dict()
+    network_dict = sriov_test_obj.parse_network_dict()
+
+    managed_disabled = iface_dict.get('managed') != "yes" or \
+        (network_dict and network_dict.get('managed') != "yes")
+    test_dict = sriov_test_obj.parse_iommu_test_params()
+    test_dict.update({"network_dict": network_dict,
+                      "managed_disabled": managed_disabled,
+                      "dev_name": dev_name})
+    br_dict = test_dict.get('br_dict', {'source': {'bridge': 'br0'}})
+
+    test_setup = sriov_test_obj.setup_iommu_test if test_dict.get('iommu_dict') \
+        else sriov_test_obj.setup_default
+    test_teardown = sriov_test_obj.teardown_iommu_test if test_dict.get('iommu_dict')\
+        else sriov_test_obj.teardown_default
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    orig_config_xml = vmxml.copy()
+
+    try:
+        test_setup(**test_dict)
+        run_test()
+
+    finally:
+        test_teardown(orig_config_xml, **test_dict)

--- a/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_suspend_resume.py
+++ b/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_suspend_resume.py
@@ -1,0 +1,91 @@
+from provider.sriov import check_points
+from provider.sriov import sriov_base
+
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_test import libvirt
+
+
+def run(test, params, env):
+    """
+    Suspend and resume vm with an interface/device of hostdev type
+    """
+    def run_test():
+        """
+        Suspend and resume vm with an interface/device of hostdev type,
+        and check if the network connectivity still works well.
+
+        1) Start the VM
+        2) Suspend the VM and check the state
+        3) Resume and check the state
+        4) Check network connectivity
+        """
+
+        test.log.info("TEST_STEP1: Attach a hostdev interface/device to VM")
+        iface_dev = sriov_test_obj.create_iface_dev(dev_type, iface_dict)
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        libvirt.add_vm_device(vmxml, iface_dev)
+
+        test.log.info("TEST_STEP2: Start the VM")
+        vm.start()
+        vm.cleanup_serial_console()
+        vm.create_serial_console()
+        vm_session = vm.wait_for_serial_login(timeout=240)
+
+        test.log.info("TEST_STEP3: Suspend VM and check vm's state.")
+        virsh.suspend(vm.name, debug=True, ignore_status=False)
+        if not libvirt.check_vm_state(vm_name, "paused"):
+            test.fail("The guest should be down after executing 'virsh suspend'.")
+
+        test.log.info("TEST_STEP4: Resume the VM and check vm's state.")
+        virsh.resume(vm.name, debug=True, ignore_status=False)
+        if not libvirt.check_vm_state(vm_name, "running"):
+            test.fail("The guest should be down after executing 'virsh resume'.")
+
+        test.log.info("TEST_STEP5: Check network accessibility")
+        if 'vlan' in iface_dict:
+            check_points.check_vlan(sriov_test_obj.pf_name, iface_dict)
+        else:
+            br_name = None
+            if test_scenario == 'failover':
+                br_name = br_dict['source'].get('bridge')
+            check_points.check_vm_network_accessed(vm_session,
+                                                   tcpdump_iface=br_name,
+                                                   tcpdump_status_error=True)
+
+    dev_type = params.get("dev_type", "")
+    dev_source = params.get("dev_source", "")
+    test_scenario = params.get("test_scenario", "")
+
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    vm = env.get_vm(vm_name)
+    sriov_test_obj = sriov_base.SRIOVTest(vm, test, params)
+    if dev_type == "hostdev_device" and dev_source.startswith("pf"):
+        dev_name = sriov_test_obj.pf_dev_name
+    else:
+        dev_name = sriov_test_obj.vf_dev_name
+
+    iface_dict = sriov_test_obj.parse_iface_dict()
+    network_dict = sriov_test_obj.parse_network_dict()
+
+    managed_disabled = iface_dict.get('managed') != "yes" or \
+        (network_dict and network_dict.get('managed') != "yes")
+    test_dict = sriov_test_obj.parse_iommu_test_params()
+    test_dict.update({"network_dict": network_dict,
+                      "managed_disabled": managed_disabled,
+                      "dev_name": dev_name})
+    br_dict = test_dict.get('br_dict', {'source': {'bridge': 'br0'}})
+    test_setup = sriov_test_obj.setup_iommu_test if test_dict.get('iommu_dict') \
+        else sriov_test_obj.setup_default
+    test_teardown = sriov_test_obj.teardown_iommu_test if test_dict.get('iommu_dict')\
+        else sriov_test_obj.teardown_default
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    orig_config_xml = vmxml.copy()
+
+    try:
+        test_setup(**test_dict)
+        run_test()
+
+    finally:
+        test_teardown(orig_config_xml, **test_dict)


### PR DESCRIPTION
This PR adds:
    VIRT-293134 - Reboot vm with a hostdev interface/device
    VIRT-292863 - Suspend and resume vm with an interface/device
        of hostdev type

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**depends on:** https://github.com/autotest/tp-libvirt/pull/4253
**test results:**
```

 (01/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.suspend_resume.hostdev_interface.vf_address.managed_yes.with_iommu: PASS (167.29 s)
 (02/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.suspend_resume.hostdev_interface.vf_address.managed_yes.without_iommu: PASS (45.65 s)
 (03/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.suspend_resume.hostdev_interface.vf_address.managed_no.without_iommu: PASS (45.50 s)
 (04/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.suspend_resume.hostdev_interface.vf_address.without_managed.without_iommu: PASS (48.30 s)
 (05/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.suspend_resume.hostdev_interface.vf_address.vlan.without_iommu: PASS (44.29 s)
 (06/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.suspend_resume.hostdev_interface.vf_address.failover.with_iommu: PASS (193.29 s)
 (07/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.suspend_resume.hostdev_device.vf_address.managed_yes.with_iommu: PASS (164.68 s)
 (08/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.suspend_resume.hostdev_device.vf_address.managed_yes.without_iommu: PASS (45.59 s)
 (09/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.suspend_resume.hostdev_device.vf_address.managed_no.without_iommu: PASS (45.71 s)
 (10/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.suspend_resume.hostdev_device.pf_address.managed_yes.without_iommu: PASS (48.64 s)
 (11/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.suspend_resume.hostdev_device.pf_address.managed_no.without_iommu: PASS (47.59 s)
 (12/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.suspend_resume.network_interface.network.pf_name.hostdev.managed_no.without_iommu: PASS (46.37 s)
 (13/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.suspend_resume.network_interface.network.pf_name.hostdev.managed_yes.without_iommu: PASS (46.28 s)
 (14/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.suspend_resume.network_interface.network.pf_name.hostdev.without_managed.without_iommu: PASS (46.27 s)
 (15/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.suspend_resume.network_interface.network.vf_address.hostdev.managed_yes.without_iommu: PASS (49.09 s)
 (16/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.suspend_resume.network_interface.network.vf_address.hostdev.without_managed.without_iommu: PASS (49.00 s)
(01/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.hostdev_interface.vf_address.managed_yes.with_iommu: PASS (188.44 s)
 (02/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.hostdev_interface.vf_address.managed_yes.without_iommu: PASS (68.77 s)
 (03/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.hostdev_interface.vf_address.managed_no.without_iommu: PASS (69.03 s)
 (04/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.hostdev_interface.vf_address.without_managed.without_iommu: PASS (68.86 s)
 (05/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.hostdev_interface.vf_address.vlan.without_iommu: PASS (66.10 s)
 (06/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.hostdev_interface.vf_address.failover.with_iommu: PASS (216.71 s)
 (07/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.hostdev_device.vf_address.managed_yes.with_iommu: PASS (187.86 s)
 (08/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.hostdev_device.vf_address.managed_yes.without_iommu: PASS (68.28 s)
 (09/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.hostdev_device.vf_address.managed_no.without_iommu: PASS (68.94 s)
 (10/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.hostdev_device.pf_address.managed_yes.without_iommu: PASS (70.35 s)
 (11/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.hostdev_device.pf_address.managed_no.without_iommu: PASS (70.64 s)
 (12/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.network_interface.network.pf_name.hostdev.managed_no.without_iommu: PASS (69.43 s)
 (13/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.network_interface.network.pf_name.hostdev.managed_yes.without_iommu: PASS (70.00 s)
 (14/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.network_interface.network.pf_name.hostdev.without_managed.without_iommu: PASS (69.76 s)
 (15/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.network_interface.network.vf_address.hostdev.managed_yes.without_iommu: PASS (69.48 s)
 (16/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.network_interface.network.vf_address.hostdev.without_managed.without_iommu: PASS (70.01 s)

```