### PR TITLE
libvirt_vcpu_plug_unplug: disable test on s390x

### DIFF
--- a/libvirt/tests/cfg/libvirt_vcpu_plug_unplug.cfg
+++ b/libvirt/tests/cfg/libvirt_vcpu_plug_unplug.cfg
@@ -60,6 +60,7 @@
                                     pin_vcpu = "0"
                                     pin_cpu_list = "x,y"
                                 - pin_unplug:
+                                    no s390-virtio
                                     vcpu_plug = "no"
                                     pin_before_unplug = "yes"
                                     pin_vcpu = "2"


### PR DESCRIPTION
The test case requires a vcpu hot-unplug which is
not supported on s390x.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>
