### PR TITLE
virsh_cpu_xml: disable test cases for s390x

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_cpu_xml.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_cpu_xml.cfg
@@ -39,6 +39,7 @@
                     no aarch64, pseries
                     virsh_function = 'virsh.hypervisor_cpu_baseline'
                 - cpu_baseline:
+                    no s390-virtio
                     virsh_function = 'virsh.cpu_baseline'
         - negative:
             variants:
@@ -51,6 +52,7 @@
                     file_path = '../../../deps/capabilities.xml'
             variants:
                 - cpu_baseline:
+                    no s390-virtio
                     virsh_function = 'virsh.cpu_baseline'
                     err_msg = 'CPU vendors do not match'
                 - hypervisor_cpu_compare:
@@ -59,6 +61,7 @@
                     virsh_function = 'virsh.hypervisor_cpu_compare'
                     err_msg = 'CPU described.*is incompatible with the CPU provided by hypervisor on the host'
                 - cpu_compare:
+                    no s390-virtio
                     only xml_declaration
                     virsh_function = 'virsh.cpu_compare'
                     err_msg = 'CPU described in.*is identical to host CPU|CPU described in.*is incompatible with host CPU'


### PR DESCRIPTION
On s390x, the virsh commands 'cpu-baseline' and 'cpu-compare'
are not valid. Instead, use 'hypervisor-cpu-baseline' and
'hypervisor-cpu-compare'. Correspondingly, filter test cases.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>
