### PR TITLE
libvirt_cputune: disable tests on s390x

### DIFF
--- a/libvirt/tests/cfg/libvirt_cputune.cfg
+++ b/libvirt/tests/cfg/libvirt_cputune.cfg
@@ -15,7 +15,7 @@
     topology_correction = False
     variants:
         - normal_test:
-            no pseries
+            no pseries, s390-virtio
             status_error = "no"
             variants:
                 - wo_cachetune:


### PR DESCRIPTION
On s390x,
- cpu flag 'mba' is not available
- numad is not supported by libvirt

Disable tests accordingly.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>
