### PR TITLE
hmat: disable tests on s390x

### DIFF
--- a/libvirt/tests/cfg/memory/hmat.cfg
+++ b/libvirt/tests/cfg/memory/hmat.cfg
@@ -11,6 +11,7 @@
     setvm_current_mem_unit = "M"
     setvm_vcpu = 6
     setvm_placement = static
+    no s390-virtio
     variants:
         - hmat:
             chk = "hmat"


### PR DESCRIPTION
The test suite requires NUMA which is not available
on s390x. Disable test cases.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>
