### PR TITLE
memory_discard: disable tests on s390x

### DIFF
--- a/libvirt/tests/cfg/memory/memory_discard.cfg
+++ b/libvirt/tests/cfg/memory/memory_discard.cfg
@@ -3,6 +3,7 @@
     start_vm = no
     page_size = 2048
     page_unit = KiB
+    no s390-virtio
     variants:
         - common:
             variants:


### PR DESCRIPTION
Test cases require memory hotplug which is not
supported on s390x at this point.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>
