### PR TITLE
memory_misc: disable test cases on s390x

### DIFF
--- a/libvirt/tests/cfg/memory/memory_misc.cfg
+++ b/libvirt/tests/cfg/memory/memory_misc.cfg
@@ -67,6 +67,7 @@
         - dimm:
             variants case:
                 - multiop:
+                    no s390-virtio
                     vm_attrs = {'max_mem_rt': 4096, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'M', 'vcpu': 4, 'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '512', 'unit': 'M'}, {'id': '1', 'cpus': '2-3', 'memory': '512', 'unit': 'M'}]}}
                     dimm_device_0 = {'mem_model': 'dimm', 'target': {'size': 524288, 'size_unit': 'KiB', 'node': 0}, 'alias': {'name': 'ua-c80aba6e-b6d8-448b-ab6e-8c7b5c29f354'}, 'address': {'attrs': {'type': 'dimm', 'slot': '0', 'base': '0x100000000'}}}
                     dimm_device_1 = {'mem_model': 'dimm', 'target': {'size': 524288, 'size_unit': 'KiB', 'node': 0}, 'alias': {'name': 'dimm2'}, 'address': {'attrs': {'type': 'dimm', 'slot': '2', 'base': '0x120000000'}}}
@@ -76,6 +77,7 @@
         - audit_size:
             variants case:
                 - at_dt_mem:
+                    no s390-virtio
                     numa_node_size = 2048000
                     at_size = 1048576
                     vmxml_max_mem_rt_slots = 16


### PR DESCRIPTION
On s390x, no DIMM or NUMA support. Therefore, disable
test cases.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>
