### PR TITLE
virsh_setmem: fix cmdline for s390x

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_setmem.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_setmem.cfg
@@ -115,6 +115,8 @@
                     driver_packed = "on"
                     expect_xml_line = "<driver packed="%s""
                     expect_qemu_line = "-device.*virtio-balloon-pci.*packed\W{1,2}(true|on)"
+                    s390-virtio:
+                        expect_qemu_line = "-device.*virtio-balloon-ccw.*packed\W{1,2}(true|on)"
         - invalid_options:
             # These should fail on all versions
             status_error = "yes"


### PR DESCRIPTION
s390x uses bus ccw; fix cmdline check accordingly.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>
