### PR TITLE
virtual_disks_multidisks: fix virtio bus check on s390x

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
@@ -1854,15 +1854,10 @@ def run(test, params, env):
                 dev_devno = vm_xml.VMXML.get_disk_attr(vm_name, device_targets[0],
                                                        "address", "devno").replace("0x", "")
                 dev_id_prefix = "fe.0."
-                device_option = "scsi=off"
 
-                cmd += (" | grep virtio-blk-ccw,%s,devno=%s%s"
-                        % (device_option, dev_id_prefix, dev_devno))
+                cmd += (" | grep virtio-blk-ccw,devno=%s%s"
+                        % (dev_id_prefix, dev_devno))
 
-                if device_bus[0] == 'scsi':
-                    dev_id = vm_xml.VMXML.get_disk_attr(vm_name, device_targets[0],
-                                                        "alias", "name")
-                    cmd += " | grep -E 'drive\W+id\W+%s'" % dev_id
             else:
                 dev_bus = int(vm_xml.VMXML.get_disk_attr(vm_name, device_targets[0],
                                                          "address", "bus"), 16)


### PR DESCRIPTION
1. Remove 'scsi=off' from check: It's the default value and
   recent libvirt versions don't set it explicitly anymore,
   s. also 435fc297e505412dd25e6b7acfa33486b8c97bcd
   In the team we agreed that the qemu commandline does not
   need to be checked in general. So, relax the expression
   searched for to reduce brittleness and avoid libvirt
   version specific code.

2. Remove dead code: There was code below the first condition
   where it checks for arch == s390x. That code could never
   have been executed because the block requires device bus
   to be 'virtio'.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>
