### PR TITLE
virtual_disks.ccw_addr: disable tests on s390x

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_ccw_addr.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_ccw_addr.cfg
@@ -3,6 +3,7 @@
     take_regular_screendumps = "no"
     start_vm = "no"
     target_bus = "virtio"
+    no s390-virtio
     variants:
         - start_vm:
     variants:


### PR DESCRIPTION
Despite their name, these tests are meant to be run
on a system that uses PCI per default and check their behaviour.
Almost all of these tests are negative. They do not apply
to s390x where CCW is the default. Therefore, disable them.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>
