### PR TITLE
v2v: update corrupt rpmdb guest source and fix import timeout issue

### DIFF
--- a/v2v/tests/cfg/specific_kvm.cfg
+++ b/v2v/tests/cfg/specific_kvm.cfg
@@ -51,6 +51,8 @@
             vpx_passwd_file = "/tmp/v2v_vpx_passwd"
             v2v_opts = " -ip ${vpx_passwd_file}"
             variants:
+                - esx_70:
+                    only source_esx.esx_70
                 - esx_67:
                     only source_esx.esx_67
                 - esx_65:
@@ -142,8 +144,9 @@
                     expect_msg = 'yes'
                     main_vm = 'VM_INVALID_FSTAB_V2V_EXAMPLE'
         - corrupt_rpmdb:
-            only source_kvm
+            only source_esx.esx_70
             checkpoint = 'corrupt_rpmdb'
+            main_vm = 'VM_CORRUPT_RPMDB_V2V_EXAMPLE'
             expect_msg = 'no'
             msg_content = 'error: rpmdb'
         - bogus_kernel:

--- a/v2v/tests/src/v2v_options.py
+++ b/v2v/tests/src/v2v_options.py
@@ -468,7 +468,7 @@ def run(test, params, env):
                 expected_uri = re.findall(r"-oc\s(\S+)", cmd)[0]
                 check_connection(output, expected_uri)
             if output_mode == "rhev":
-                if not utils_v2v.import_vm_to_ovirt(params, address_cache):
+                if not utils_v2v.import_vm_to_ovirt(params, address_cache, 1800):
                     test.fail("Import VM failed")
                 else:
                     vmchecker = VMChecker(test, params, env)


### PR DESCRIPTION
1. The way of creating corrupt rpmdb in avocado-vt-vm1 doesn't work
since RHEL9.1(maybe?). See developer's comment:
   https://bugzilla.redhat.com/show_bug.cgi?id=2089623#c12
   So we use a rhel8 guest in esx server to test this case.
2. Extend the timeout of waiting for import images.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>