### PR TITLE
migration: Fix a TypeError

### DIFF
--- a/libvirt/tests/src/migration/network_data_transports/migration_network_data_transports_tcp.py
+++ b/libvirt/tests/src/migration/network_data_transports/migration_network_data_transports_tcp.py
@@ -29,7 +29,7 @@ def run(test, params, env):
         if uri_port:
             migration_test.migrate_pre_setup(dest_uri, params, cleanup=False, ports=uri_port)
 
-        migration_base.setup_conn_obj('tcp', conn_obj_list, params, test)
+        conn_obj_list.append(migration_base.setup_conn_obj('tcp', params, test))
         base_steps.setup_default(vm, params, test)
 
     def cleanup_tcp(migration_test, vm, dest_uri, src_uri, orig_config_xml, test):

--- a/provider/migration/migration_base.py
+++ b/provider/migration/migration_base.py
@@ -103,14 +103,14 @@ def do_migration(vm, mig_test, src_uri, dest_uri, options, virsh_options,
                               **extra_args)
 
 
-def setup_conn_obj(conn_type, conn_obj_list, params, test):
+def setup_conn_obj(conn_type, params, test):
     """
     Setup connection object, like TLS
 
     :param conn_type: str, connection type
-    :param conn_obj_list, connection object list
     :param params: dict, used to setup the connection
     :param test: test object
+    :return: the connection object
     """
     test.log.debug("Begin to create new {} connection".format(conn_type.upper()))
     conn_obj = None
@@ -124,9 +124,9 @@ def setup_conn_obj(conn_type, conn_obj_list, params, test):
         test.cancel("TODO: rdma")
     else:
         test.error("Invalid parameter, only support tls/tcp/unix_socket/rdma")
-    conn_obj_list.append(conn_obj)
     conn_obj.auto_recover = True
     conn_obj.conn_setup()
+    return conn_obj
 
 
 def cleanup_conn_obj(conn_obj_list, test):


### PR DESCRIPTION
Fix following issue:
  TypeError: setup_conn_obj() missing 1 required positional
  argument: 'test'

Signed-off-by: cliping <lcheng@redhat.com>
