### PR TITLE
Fix virsh change_media_matrix cases failure due to vm.undefine

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_change_media_matrix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_change_media_matrix.py
@@ -243,7 +243,7 @@ def run(test, params, env):
             time.sleep(5)
         elif pre_vm_state == "transient":
             logging.info("Creating %s..." % vm_name)
-            vm.undefine()
+            virsh.undefine(vm_name, '--nvram', ignore_status=False)
             if virsh.create(vmxml_for_test.xml, **virsh_dargs).exit_status:
                 vmxml_backup.define()
                 test.cancel("Can't create the domain")


### PR DESCRIPTION
After OVMF as default bios setting, VM undefine need use --nvram option

Signed-off-by: chunfuwen <chwen@redhat.com>


