### PR TITLE
virsh_detach_device_alias.py:fix detach iface alias error

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
@@ -164,13 +164,8 @@ def run(test, params, env):
         attach_device = False
 
     if interface_type:
-        mac = libvirt.get_interface_details(vm_name)[0]['mac']
-        vmxml.remove_all_device_by_type('interface')
-        vmxml.sync()
-
-        interface_dict.update({"alias": {"name": device_alias},
-                               "mac_address": mac})
-        libvirt_vmxml.get_or_create_vm_device_if_absent(
+        interface_dict.update({"alias": {"name": device_alias}})
+        libvirt_vmxml.modify_vm_device(
             vmxml=vmxml, dev_type='interface', dev_dict=interface_dict)
 
         if not vm.is_alive():


### PR DESCRIPTION
   use wrong function , due to merge without depend on pr
Signed-off-by: nanli <nanli@redhat.com>

**Test result**
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 virsh.detach_device_alias.live.network_interface --vt-connect-uri qemu:///system
JOB ID     : d0d1a1bf26fb7ffb663787aab92d91214b1bd115
JOB LOG    : /var/lib/avocado/job-results/job-2022-06-15T02.08-d0d1a1b/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.network_interface: PASS (56.47 s)
