### PR TITLE
Fix qemu command line output change issue due to json format as default

### DIFF
--- a/libvirt/tests/src/virtual_disks/at_dt_iscsi_disk.py
+++ b/libvirt/tests/src/virtual_disks/at_dt_iscsi_disk.py
@@ -363,8 +363,6 @@ def run(test, params, env):
         elif domain_operation == "start_with_packed":
             expect_xml_line = "packed=\"%s\"" % driver_packed
             libvirt.check_dumpxml(vm, expect_xml_line)
-            expect_qemu_line = "packed=%s" % driver_packed
-            libvirt.check_qemu_cmd_line(expect_qemu_line)
         elif domain_operation == "":
             logging.debug("No domain operation provided, so skip it")
         else:


### PR DESCRIPTION
    Fix qemu command line output change issue due to json format as default
    
    driver_packed value change from on|off to true|false, and key=value equation become key: value format
    
    those checking operation is already covered in libvirt upstream CI test[1] ,so remove qemu command line checking here
    
    [1]https://gitlab.com/libvirt/libvirt/-/blob/master/tests/qemuxml2argvdata/virtio-options-disk-packed.x86_64-latest.args
    
    Signed-off-by: chunfuwen <chwen@redhat.com>



