### PR TITLE
libvirt: Add '--nvram' option to vm.undefine

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_update_device_matrix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_update_device_matrix.py
@@ -351,7 +351,7 @@ def run(test, params, env):
                 raise exceptions.TestSkipError("Can't pause the domain")
         elif pre_vm_state == "transient":
             logging.info("Creating %s..." % vm_name)
-            vm.undefine()
+            vm.undefine(options='--nvram')
             if virsh.create(vmxml_for_test.xml, **virsh_dargs).exit_status:
                 vmxml_backup.define()
                 raise exceptions.TestSkipError("Can't create the domain")

--- a/libvirt/tests/src/virtual_disks/virtual_disks_ceph.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_ceph.py
@@ -903,7 +903,7 @@ def run(test, params, env):
             vmxml_for_test = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
             if vm.is_alive():
                 vm.destroy(gracefully=False)
-            vm.undefine()
+            vm.undefine(options='--nvram')
             if virsh.create(vmxml_for_test.xml, **virsh_dargs).exit_status:
                 vmxml_backup.define()
                 test.fail("Can't create the domain")


### PR DESCRIPTION
Add '--nvram' option in case of the following undefine failure
for VM with UEFI:

error: Failed to undefine domain 'avocado-vt-vm1'
error: Requested operation is not valid: cannot undefine domain with nvram

Signed-off-by: Han Han <hhan@redhat.com>