### PR TITLE
fix blockcopy job undefine with --nvram option

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
@@ -630,7 +630,7 @@ def run(test, params, env):
 
         # Prepare transient/persistent vm
         if persistent_vm == "no" and vm.is_persistent():
-            vm.undefine()
+            virsh.undefine(vm_name, '--nvram', ignore_status=False)
         elif persistent_vm == "yes" and not vm.is_persistent():
             new_xml.define()
 


### PR DESCRIPTION
   need nvram option while undefine
Signed-off-by: nanli <nanli@redhat.com>

```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 virsh.blockcopy.positive_test.non_acl.block_disk.disk_t.default.block_type.no_blockdev.no_shallow.mirror_state_lock --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.virsh.blockcopy.positive_test.non_acl.block_disk.disk_t.default.block_type.no_blockdev.no_shallow.mirror_state_lock: PASS (60.12 s)
 (1/1) type_specific.io-github-autotest-libvirt.virsh.blockcopy.positive_test.non_acl.block_disk.disk_t.default.volume_type.no_blockdev.shallow.no_option: PASS (142.91 s)
(1/1) type_specific.io-github-autotest-libvirt.virsh.blockcopy.positive_test.non_acl.block_disk.disk_t.default.volume_type.no_blockdev.no_shallow.mirror_state_lock: PASS (127.45 s)
 (1/1) type_specific.io-github-autotest-libvirt.virsh.blockcopy.positive_test.non_acl.block_disk.disk_t.default.volume_type.no_blockdev.no_shallow.raw_format: PASS (125.25 s)
```

