### PR TITLE
virtio_rng: Cold-plug/unplug a random backend virtio-rng device	

### DIFF
--- a/libvirt/tests/cfg/virtual_device/virtio_rng.cfg
+++ b/libvirt/tests/cfg/virtual_device/virtio_rng.cfg
@@ -1,0 +1,8 @@
+- virtio_rng:
+   type = virtio_rng
+   start_vm = no
+
+   variants test_case:
+       - coldplug_unplug:
+           rng_device_dict = {"rng_model": "virtio", "backend": {"backend_model": "random", "backend_dev": "/dev/urandom"}}
+           backend_dev = "/dev/urandom"

--- a/libvirt/tests/src/virtual_device/virtio_rng.py
+++ b/libvirt/tests/src/virtual_device/virtio_rng.py
@@ -1,0 +1,107 @@
+import logging as log
+
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+
+from provider.virtio_rng import check_points as virtio_provider
+
+logging = log.getLogger('avocado.' + __name__)
+
+
+def check_attached_rng_device(vm_name, rng_device_dict):
+    """
+    Make sure the XML contains all information required by the test after
+    the VM is started.
+
+    :params vm_name: Name of the virtual machine to test
+    :params rng_device_dict: Dictionary containing data that should be
+    in VM rng
+    """
+
+    vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+    virtio_provider.comp_rng_xml(vmxml, rng_device_dict)
+
+
+def check_detached_rng_device(vm_name, test):
+    """
+    Checks if VM XML from dump does not contain a RNG device. Should be used
+    after RNG device was detached.
+
+    params vm_name: Name of the VM to check.
+    params test: Avocado test object
+    """
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    if "<rng model=" in vmxml:
+        logging.debug("Whole VMXML is: %s" % vmxml)
+        test.fail("VM still has RNG device after detachment.")
+
+
+def setup_test(vm):
+    """
+    Function that prepares a test environment and guest.
+
+    :params vm: The virtual machine object
+    """
+    if vm.is_alive():
+        vm.destroy(gracefully=False)
+
+    libvirt_vmxml.remove_vm_devices_by_type(vm, "rng")
+
+
+def execute_test(test, params, vm):
+    """
+    Function that runs the checks that are in the test
+
+    :params test: The avocado test object
+    :params params: Parameters for the test
+    :params vm: The VM object
+    """
+    vm_name = params.get("main_vm")
+    rng_device_dict = eval(params.get("rng_device_dict"))
+    rng_dev = libvirt_vmxml.create_vm_device_by_type(
+        "rng", rng_device_dict)
+    virsh.attach_device(vm_name, rng_dev.xml, flagstr="--config", debug=True)
+    check_attached_rng_device(vm_name, rng_device_dict)
+
+    vm.start()
+    check_attached_rng_device(vm_name, rng_device_dict)
+
+    ssh_session = vm.wait_for_login()
+    virtio_provider.check_host(params.get("backend_dev"))
+    virtio_provider.check_guest_dump(ssh_session)
+    virsh.detach_device(vm_name, rng_dev.xml, flagstr="--config")
+    check_detached_rng_device(vm_name, test)
+    ssh_session.close()
+
+
+def cleanup_test(vmxml_backup, vm):
+    """
+    Remove the changes made by setup_test function
+
+    :params vmxml_backup: Backup XML to restore
+    :params vm: The vm object to remove
+    """
+    if vm.is_alive():
+        vm.destroy(gracefully=False)
+    logging.info("Restoring vm...")
+    vmxml_backup.sync()
+
+
+def run(test, params, env):
+    """
+    Main function of the test to run, executed by avocado
+
+    :params test: The avocado test object
+    :params params: Parameters for the test
+    :params env: The avocado test environment object
+    """
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    vmxml_backup = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+
+    try:
+        setup_test(vm)
+        execute_test(test, params, vm)
+    finally:
+        cleanup_test(vmxml_backup, vm)

--- a/provider/virtio_rng/check_points.py
+++ b/provider/virtio_rng/check_points.py
@@ -1,0 +1,64 @@
+"""Helper functions for virtio device testing"""
+
+import aexpect
+import logging as log
+
+from avocado.utils import process
+
+logging = log.getLogger('avocado.' + __name__)
+
+
+def check_guest_dump(session, exists=True):
+    """
+    Check guest with hexdump
+
+    :param session: ssh session to guest
+    :param exists: check rng device exists/not exists
+    :raises Exception: Exception is raised with information on what went wrong
+    """
+    check_cmd = "hexdump /dev/hwrng -n 100"
+    try:
+        status = session.cmd_status(check_cmd, 60)
+
+        if status != 0 and exists:
+            raise Exception("Fail to check hexdump in guest")
+        if not exists:
+            logging.info("hexdump cmd failed as expected")
+    except aexpect.exceptions.ShellTimeoutError:
+        if not exists:
+            raise Exception("Still can find rng device in guest")
+        logging.info("Hexdump did not fail with error")
+
+
+def check_host(backend_dev):
+    """
+    Check random device on host, by looking if the device is used by qemu
+
+    :params backend_dev: Device file that is expected to be claimed by qemu
+    :raises Exception: Exception is raised with information on what went wrong
+    """
+    cmd = "lsof |grep %s" % backend_dev
+    ret = process.run(cmd, ignore_status=True, shell=True)
+    if ret.exit_status or not ret.stdout_text.count("qemu"):
+        raise Exception("Failed to check random device"
+                        " on host, command output: %s" % ret.stdout_text)
+
+
+def comp_rng_xml(vmxml, rng_dict, status_error=False):
+    """
+    Compare rng xml from VM xml to rng dictionary on all attributes.
+
+    :params vmxml: Vmxml object from where the device should be taken
+    :params rng_dict: Rng device dictionary to compare
+    :params status_error: Set to True if you expect the test to fail
+    :raises Exception: Exception in case the test fails
+    """
+    rng_device = vmxml.get_devices("rng")[0]
+    rng_dev_attributes = rng_device.fetch_attrs()
+    for key, val, in rng_dict.items():
+        if rng_dev_attributes[key] != val and status_error is False:
+            raise Exception("Device XML value: '%s' does not match"
+                            "the entry '%s' in VMXML" % (val, rng_dev_attributes[key]))
+    if status_error is True:
+        raise Exception("Rng device XML matches entry in VMXML, "
+                        "but error was expected")


### PR DESCRIPTION
This test file serves to test RHEL-112408 as well as a basis for
migration of other RNG device tests.

The case simply tests if a rng device can be cold-plugged and unplugged.

```
[root@dell-per740xd-08 tp-libvirt]# avocado run --vt-type libvirt virtio_rng.coldplug_unplug
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : a7ae71091be689c14338ab0b48111ddc1b224c73
JOB LOG    : /var/lib/avocado/job-results/job-2022-06-24T13.52-a7ae710/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtio_rng.coldplug_unplug: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.virtio_rng.coldplug_unplug: PASS (31.30 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-06-24T13.52-a7ae710/results.html
JOB TIME   : 32.59 s
```

RHEL-112408
- [x] Description of the cases
- [x] Links of libvirt features, libvirt bugs or case IDs
- [x] Test results