### PR TITLE
Fix attach detach_disk matrix cases failure due to undefine VM

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk_matrix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_disk_matrix.py
@@ -193,7 +193,7 @@ def run(test, params, env):
             raise exceptions.TestSkipError("Can't pause the domain")
     elif pre_vm_state == "transient":
         logging.info("Creating %s...", vm_name)
-        vm.undefine()
+        virsh.undefine(vm_name, '--nvram', ignore_status=False)
         if virsh.create(backup_xml.xml, **virsh_dargs).exit_status:
             backup_xml.define()
             raise exceptions.TestSkipError("Can't create the domain")


### PR DESCRIPTION
Need add '--nvram' option when undefine VM

Signed-off-by: chunfuwen <chwen@redhat.com>


