### PR TITLE
blockcopy, virsh_blockjob :fix undefine domain with nvram

### DIFF
--- a/libvirt/tests/src/backingchain/blockcopy.py
+++ b/libvirt/tests/src/backingchain/blockcopy.py
@@ -37,7 +37,7 @@ def run(test, params, env):
         if case:
             if case == 'reuse_external':
                 # Create a transient vm for test
-                vm.undefine()
+                virsh.undefine(vm_name, '--nvram', ignore_status=False)
                 virsh.create(vmxml.xml)
 
                 all_disks = vmxml.get_disk_source(vm_name)

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockjob.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockjob.py
@@ -97,7 +97,7 @@ def run(test, params, env):
     # Prepare transient/persistent vm
     original_xml = vm.backup_xml()
     if not persistent_vm and vm.is_persistent():
-        vm.undefine()
+        virsh.undefine(vm_name, '--nvram', ignore_status=False)
     elif persistent_vm and not vm.is_persistent():
         vm.define(original_xml)
 


### PR DESCRIPTION
  need  nvram option
Signed-off-by: nanli <nanli@redhat.com>

```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockcopy.positive_test.reuse_external --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.positive_test.reuse_external: PASS (10.59 s)

```