### PR TITLE
fix virsh_domerename failed cases by add '--nvram' in virsh undefine

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domrename.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domrename.py
@@ -152,7 +152,7 @@ def run(test, params, env):
                 new_vm.destroy(gracefully=False)
             if pre_vm_state == "with_snapshot":
                 libvirt.clean_up_snapshots(new_name)
-            new_vm.undefine()
+            new_vm.undefine(options='--nvram')
 
         # Recover domain state
         if pre_vm_state != "shutoff":


### PR DESCRIPTION
the new created ovmf guest undefine would be failed without “--nvarm” and affect other cases. 

Signed-off-by: zhentang <zhetang@redhat.com>

