### PR TITLE
migrate_over_unix: stabilize postcopy tests

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_over_unix.cfg
+++ b/libvirt/tests/cfg/migration/migrate_over_unix.cfg
@@ -19,12 +19,16 @@
     virsh_migrate_desturi = "qemu+unix:///system?socket=${desturi_socket_path}"
     virsh_migrate_migrateuri = "unix://${migrateuri_socket_path}"
     virsh_migrate_disks_uri = "unix://${disks_uri_socket_path}"
+    stress_package = "stress"
+    stress_args = "--vm 2 --vm-bytes 512M"
 
     variants:
         - with_postcopy:
             postcopy_options = "--postcopy"
+            stress_guest = yes
         - without_postcopy:
             postcopy_options = ""
+            stress_guest = no
     variants:
         - p2p_live_migration:
             virsh_migrate_options = "--live --p2p --verbose"
@@ -41,7 +45,7 @@
                     variants:
                         - migrate_uri:
                             no live_migration.with_postcopy
-                            virsh_migrate_extra = "--migrateuri ${virsh_migrate_migrateuri} --bandwidth 50"
+                            virsh_migrate_extra = "--migrateuri ${virsh_migrate_migrateuri} --bandwidth 20"
                             action_during_mig = "check_socket"
                             action_during_mig_params_exists = "yes"
                         - multifd:


### PR DESCRIPTION
1. Add stress to in vm for postcopy tests to slow down migration
   further; otherwise, the migration might finish before test
   sockets can be checked. Don't do this when migrating without
   postcopy as it will prevent migration from converging.
2. Retry socket check in case it fails initially.
3. Move part of the socket check comman into python code for
   easier debugging in case the check fails.
4. Reduce bandwidth a bit further to give test more time to
   check sockets.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>
