### PR TITLE
tpm_device: remove spaces in pcrread output

### DIFF
--- a/libvirt/tests/src/virtual_device/tpm_device.py
+++ b/libvirt/tests/src/virtual_device/tpm_device.py
@@ -470,7 +470,7 @@ def run(test, params, env):
                 elif expect_fail:
                     test.fail("Expect fail but guest tpm still works")
                 if active_pcr_banks or check_pcrbanks:
-                    output3 = session.cmd_output("tpm2_pcrread")
+                    output3 = session.cmd_output("tpm2_pcrread").replace(' ', '')
                     logging.debug("Command output:\n %s", output3)
                     actual_pcrbanks = []
                     if output3.find('sha256') != 6:


### PR DESCRIPTION
Remove spaces in pcrread output to better judge active pcr banks.

Signed-off-by: Yanqiu Zhang <yanqzhan@redhat.com>

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [ ] Description of the cases
- [ ] Links of libvirt features, libvirt bugs or case IDs
- [ ] Test results

## If the PR is bug cases
- [ ] Bug descriptions or bug links
- [ ] Test results

## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
