### PR TITLE
add case for backingchain modular redesign: blockcommit with all block chain

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockcommit/blockcommit_all_block_chain.cfg
+++ b/libvirt/tests/cfg/backingchain/blockcommit/blockcommit_all_block_chain.cfg
@@ -1,0 +1,25 @@
+- backingchain.blockcommit.all_block_chain:
+    type = blockcommit_all_block_chain
+    start_vm = "yes"
+    disk_type = "block"
+    target_disk = "vdb"
+    disk_dict = {"type_name":"${disk_type}", "target":{"dev": "${target_disk}", "bus": "virtio"}, "driver": {"name": "qemu", "type":"raw"}}
+    snap_option = " --no-metadata --reuse-external --disk-only"
+    extra_option = ",stype=block --diskspec vda,snapshot=no"
+    lvm_num = 4
+    commit_times = 3
+    snap_nums = 4
+    variants:
+        - shallow_inactive:
+            test_scenario = "shallow_inactive"
+            commit_options = "--top %s --shallow --wait --verbose"
+            expected_chain_1 = "4>3>2>base"
+            expected_chain_2 = "4>3>base"
+            expected_chain_3 = "4>base"
+        - shallow_active:
+            test_scenario = "shallow_active"
+            commit_options = "--active --shallow --wait --verbose --pivot"
+            expected_chain_1 = "3>2>1>base"
+            expected_chain_2 = "2>1>base"
+            expected_chain_3 = "1>base"
+

--- a/libvirt/tests/src/backingchain/blockcommit/blockcommit_all_block_chain.py
+++ b/libvirt/tests/src/backingchain/blockcommit/blockcommit_all_block_chain.py
@@ -1,0 +1,121 @@
+import logging
+
+from avocado.utils import lv_utils
+
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_test import libvirt
+
+from provider.backingchain import blockcommand_base
+from provider.backingchain import check_functions
+from provider.virtual_disk import disk_base
+
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+
+def run(test, params, env):
+    """
+    Do blockcommit with all block disks in chain
+
+    Scenarios:
+    1) Do shallow inactive blockcommit .
+    2) Do shallow active blockcommit .
+    """
+    def prepare_lvm():
+        """
+        Create lvm as snap path and convert to qcow2 format
+        """
+        path = []
+        for i in range(1, lvm_num+1):
+            source_path = '/dev/%s/%s' % (disk_obj.vg_name, lv_name+str(i))
+            lv_utils.lv_create(vg_name, lv_name+str(i), vol_size)
+            # Change lv to qcow2 format.
+            libvirt.create_local_disk("file", source_path, vol_size,
+                                      disk_format="qcow2")
+            path.append(source_path)
+        return path
+
+    def setup_test():
+        """
+        Prepare specific type disk and create snapshots.
+       """
+        test_obj.new_image_path = disk_obj.add_vm_disk(disk_type, disk_dict)
+        prepare_lvm()
+
+        if not vm.is_alive():
+            vm.start()
+        vm.wait_for_login().close()
+
+        test_obj.tmp_dir = "/dev/%s/%s" % (vg_name, lv_name)
+        test_obj.prepare_snapshot(start_num=1, snap_num=snap_nums+1,
+                                  option=snap_option, extra=extra_option)
+        check_obj.check_backingchain_from_vmxml(disk_type, test_obj.new_dev,
+                                                test_obj.snap_path_list[::-1] +
+                                                [test_obj.new_image_path])
+
+    def run_test():
+        """
+        Do blockcommit and check backingchain result
+        """
+        session = vm.wait_for_login()
+        status, _ = session.cmd_status_output("which sha256sum")
+        if status:
+            test.error("Not find sha256sum command on guest.")
+        ret, expected_md5 = session.cmd_status_output("sha256sum %s" %
+                                                      "/dev/"+test_obj.new_dev)
+        options = ''
+        for i in range(1, commit_times+1):
+            if test_scenario == "shallow_active":
+                options = commit_options
+            elif test_scenario == "shallow_inactive":
+                options = commit_options % (test_obj.tmp_dir + str(i))
+
+            LOG.debug("The %d times to do blockcommit", i)
+            virsh.blockcommit(vm.name, test_obj.new_dev, options,
+                              ignore_status=False, debug=True)
+
+            expected_chain_index = params.get('expected_chain_%s' % i)
+            expected_chain = test_obj.convert_expected_chain(
+                expected_chain_index)
+            check_obj.check_backingchain_from_vmxml(disk_type, test_obj.new_dev,
+                                                    expected_chain)
+        check_obj.check_hash_list(["/dev/"+test_obj.new_dev], [expected_md5], session)
+        session.close()
+
+    def teardown_test():
+        """
+        Clean data.
+        """
+        test_obj.backingchain_common_teardown()
+
+        bkxml.sync()
+        disk_obj.cleanup_disk_preparation(disk_type)
+
+    vm_name = params.get("main_vm")
+    disk_dict = eval(params.get('disk_dict', '{}'))
+    commit_options = params.get('commit_options')
+    test_scenario = params.get('test_scenario')
+    snap_option = params.get('snap_option')
+    extra_option = params.get('extra_option')
+    disk_type = params.get('disk_type')
+    commit_times = int(params.get('commit_times'))
+    snap_nums = int(params.get('snap_nums'))
+    lvm_num = int(params.get('lvm_num'))
+    vg_name, lv_name, vol_size = 'vg0', 'lv', '200M'
+
+    vm = env.get_vm(vm_name)
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+
+    # Create object
+    test_obj = blockcommand_base.BlockCommand(test, vm, params)
+    check_obj = check_functions.Checkfunction(test, vm, params)
+    disk_obj = disk_base.DiskBase(test, vm, params)
+
+    try:
+        setup_test()
+        run_test()
+
+    finally:
+        teardown_test()

--- a/provider/backingchain/blockcommand_base.py
+++ b/provider/backingchain/blockcommand_base.py
@@ -72,23 +72,30 @@ class BlockCommand(object):
         # Update vm disk
         libvirt.set_vm_disk(self.vm, self.params)
 
-    def prepare_snapshot(self, snap_num=3, option='--disk-only'):
+    def prepare_snapshot(self, start_num=0, snap_num=3,
+                         snap_path="", option='--disk-only', extra=''):
         """
         Prepare domain snapshot
 
+        :params start_num: snap path start index
         :params snap_num: snapshot number, default value is 3
+        :params snap_path: path of snap
         :params option: option to create snapshot, default value is '--disk-only'
+        :params extra: extra option to create snap
         """
         # Create backing chain
-        for i in range(snap_num):
-            snap_option = "%s %s --diskspec %s,file=%s" % \
-                          ('snap%d' % i, option, self.new_dev,
-                           self.tmp_dir + 'snap%d' % i)
+        for i in range(start_num, snap_num):
+            if not snap_path:
+                path = self.tmp_dir + '%d' % i
+            else:
+                path = snap_path
+            snap_option = "%s %s --diskspec %s,file=%s%s" % \
+                          ('snap%d' % i, option, self.new_dev, path, extra)
 
             virsh.snapshot_create_as(self.vm.name, snap_option,
                                      ignore_status=False,
                                      debug=True)
-            self.snap_path_list.append(self.tmp_dir + 'snap%d' % i)
+            self.snap_path_list.append(path)
             self.snap_name_list.append('snap%d' % i)
 
     def convert_expected_chain(self, expected_chain_index):


### PR DESCRIPTION
  add case for backingchain modular redesign: blockcommit with all block chain
     **VIRT-293510:** Do shallow active/inactive blockcommit with all block disks in chain

  Signed-off-by: nanli <nanli@redhat.com>

**Two scenarios:**
1. Do shallow inactive blockcommit : **Failed**, Expected chain is incorrect , confirmed with meina and she filed this bug [2094205](https://bugzilla.redhat.com/show_bug.cgi?id=2094205 ), 
```
 avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockcommit.all_block_chain.shallow_inactive
 (1/1) backingchain.blockcommit.all_block_chain.shallow_inactive: FAIL: Expect source file to be ['/dev/vg0/lv4', '/dev/vg0/lv3', '/dev/vg0/lv2', '/dev/vg0/lv0'], but got ['/dev/vg0/lv4', '/dev/vg0/lv3', '/dev/vg0/lv2', '/dev/vg0/lv1', '/dev/vg0/lv0'] (59.34 s)
```
2. Do shallow active blockcommit : **PASS**
```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockcommit.all_block_chain.shallow_active
 (1/1) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.all_block_chain.shallow_active: PASS (61.09 s)
```





