### PR TITLE
add case for backingchain modular design: blockpull convention chain

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockpull/blockpull_conventional_chain.cfg
+++ b/libvirt/tests/cfg/backingchain/blockpull/blockpull_conventional_chain.cfg
@@ -1,0 +1,28 @@
+- backingchain.blockpull.conventional_chain:
+    type = blockpull_conventional_chain
+    start_vm = "yes"
+    pull_options = " --wait --verbose"
+    target_disk = "vdb"
+    variants:
+        - with_base:
+            base_image_suffix = 1
+            expected_chain = "4>1>base"
+        - without_base:
+            expected_chain = "4"
+    variants:
+        - file_disk:
+            disk_type = "file"
+            disk_dict = {"type_name":"${disk_type}", "target":{"dev": "${target_disk}", "bus": "virtio"}, "driver": {"name": "qemu", "type":"qcow2"}}
+        - block_disk:
+            disk_type = "block"
+            disk_dict = {"type_name":"${disk_type}", "target":{"dev": "${target_disk}", "bus": "virtio"}, "driver": {"name": "qemu", "type":"raw"}}
+        - rbd_with_auth_disk:
+            disk_type = "rbd_with_auth"
+            disk_source_protocol = "rbd"
+            mon_host = "EXAMPLE_MON_HOST"
+            auth_key = "EXAMPLE_AUTH_KEY"
+            auth_user = "EXAMPLE_AUTH_USER"
+            image_path = "EXAMPLE_IMAGE_PATH"
+            client_name = "EXAMPLE_CLIENT_NAME"
+            sec_dict = {"secret_ephemeral": "no", "secret_private": "yes", "description": "secret_desc_for_backingchain", "usage": "ceph", "usage_name": "cephlibvirt"}
+            disk_dict = {"type_name":"network", "target":{"dev": "${target_disk}", "bus": "virtio"}, "driver": {"name": "qemu", "type":"raw"}}

--- a/libvirt/tests/src/backingchain/blockpull/blockpull_conventional_chain.py
+++ b/libvirt/tests/src/backingchain/blockpull/blockpull_conventional_chain.py
@@ -1,0 +1,100 @@
+import logging
+
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_disk
+
+from provider.backingchain import blockcommand_base
+from provider.backingchain import check_functions
+from provider.virtual_disk import disk_base
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+
+def run(test, params, env):
+    """
+    Do blockpull for conventional chain.
+
+    1) Prepare different type disk and snap chain
+        disk types: file, block, network(rbd with auth)
+    2) Do blockpull:
+        without --base
+        with --base
+    3) Check result:
+        Check vmxml chain and hash value of new device
+    """
+
+    def setup_test():
+        """
+        Prepare specific type disk and create snapshots.
+       """
+        test_obj.new_image_path = disk_obj.add_vm_disk(disk_type, disk_dict)
+
+        if not vm.is_alive():
+            vm.start()
+        vm.wait_for_login().close()
+        test_obj.prepare_snapshot(snap_num=4)
+
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        LOG.debug('After do snapshots, vmxml is:\n%s', vmxml)
+
+    def run_test():
+        """
+        Do blockpull and check backingchain result , hash value
+        """
+        if base_index:
+            # with --base option scenario
+            base_option = " --base %s" % test_obj.snap_path_list[int(base_index) - 1]
+        else:
+            # without --base option scenario
+            base_option = " "
+
+        session = vm.wait_for_login()
+        status, _ = session.cmd_status_output("which sha256sum")
+        if status:
+            test.error("Not find sha256sum command on guest.")
+        ret, expected_hash = session.cmd_status_output("sha256sum %s" %
+                                                       "/dev/"+test_obj.new_dev)
+
+        virsh.blockpull(vm.name, target_disk, pull_options+base_option,
+                        ignore_status=False, debug=True)
+
+        expected_chain = test_obj.convert_expected_chain(expected_chain_index)
+        check_obj.check_backingchain_from_vmxml(disk_type, test_obj.new_dev,
+                                                expected_chain)
+        check_obj.check_hash_list(["/dev/"+test_obj.new_dev], [expected_hash], session)
+        session.close()
+
+    def teardown_test():
+        """
+        Clean data.
+        """
+        test_obj.backingchain_common_teardown()
+
+        bkxml.sync()
+        disk_obj.cleanup_disk_preparation(disk_type)
+
+    # Process cartesian parameters
+    vm_name = params.get("main_vm")
+    target_disk = params.get('target_disk')
+    disk_type = params.get('disk_type')
+    disk_dict = eval(params.get('disk_dict', '{}'))
+    pull_options = params.get('pull_options')
+    expected_chain_index = params.get('expected_chain')
+    base_index = params.get('base_image_suffix')
+    vm = env.get_vm(vm_name)
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+
+    # Create object
+    test_obj = blockcommand_base.BlockCommand(test, vm, params)
+    check_obj = check_functions.Checkfunction(test, vm, params)
+    disk_obj = disk_base.DiskBase(test, vm, params)
+    test_obj.original_disk_source = libvirt_disk.get_first_disk_source(vm)
+
+    try:
+        setup_test()
+        run_test()
+
+    finally:
+        teardown_test()

--- a/provider/backingchain/check_functions.py
+++ b/provider/backingchain/check_functions.py
@@ -53,7 +53,8 @@ class Checkfunction(object):
                                elem.find('source').get('name') or
                                elem.find('source').get('dev') or
                                elem.find('source').get('volume')
-                               for elem in backing_list]
+                               for elem in backing_list
+                               if elem.find('source') is not None]
                 source_list.insert(0, active_level_path)
                 break
 


### PR DESCRIPTION
  VIRT-294004: Do blockpull for conventional chain
Signed-off-by: nanli <nanli@redhat.com>

**Test result:**
```
[root@dell-per730-59 ~]# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockpull.conventional_chain
 (1/6) type_specific.io-github-autotest-libvirt.backingchain.blockpull.conventional_chain.file_disk.with_base: PASS (20.72 s)
 (2/6) type_specific.io-github-autotest-libvirt.backingchain.blockpull.conventional_chain.file_disk.without_base: PASS (22.02 s)
 (3/6) type_specific.io-github-autotest-libvirt.backingchain.blockpull.conventional_chain.block_disk.with_base: PASS (44.13 s)
 (4/6) type_specific.io-github-autotest-libvirt.backingchain.blockpull.conventional_chain.block_disk.without_base: PASS (44.78 s)
 (5/6) type_specific.io-github-autotest-libvirt.backingchain.blockpull.conventional_chain.rbd_with_auth_disk.with_base: PASS (39.20 s)
 (6/6) type_specific.io-github-autotest-libvirt.backingchain.blockpull.conventional_chain.rbd_with_auth_disk.without_base: 

```

**Other related:**
```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockcommit.base_image_exist_backingfile

 (1/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.base_image_exist_backingfile.file_disk.file_backing.mid_to_mid: PASS (24.51 s)
 (2/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.base_image_exist_backingfile.file_disk.file_backing.top_to_base: PASS (30.00 s)
 (3/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.base_image_exist_backingfile.file_disk.file_backing.top_to_mid: PASS (30.23 s)
 (4/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.base_image_exist_backingfile.file_disk.file_backing.mid_to_base: PASS (30.68 s)
 (5/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.base_image_exist_backingfile.file_disk.block_backing.mid_to_mid: PASS (43.87 s)
 (6/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.base_image_exist_backingfile.file_disk.block_backing.top_to_base: PASS (44.55 s)
 (7/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.base_image_exist_backingfile.file_disk.block_backing.top_to_mid: PASS (44.40 s)
 (8/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.base_image_exist_backingfile.file_disk.block_backing.mid_to_base: PASS (45.00 s)

 (1/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.base_image_exist_backingfile.block_disk.file_backing.mid_to_mid: PASS (46.09 s)
 (2/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.base_image_exist_backingfile.block_disk.file_backing.top_to_base: PASS (45.57 s)
 (3/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.base_image_exist_backingfile.block_disk.file_backing.top_to_mid: PASS (45.59 s)
 (4/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.base_image_exist_backingfile.block_disk.file_backing.mid_to_base: PASS (46.06 s)
 (5/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.base_image_exist_backingfile.block_disk.block_backing.mid_to_mid: PASS (44.26 s)
 (6/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.base_image_exist_backingfile.block_disk.block_backing.top_to_base: PASS (44.65 s)
 (7/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.base_image_exist_backingfile.block_disk.block_backing.top_to_mid: PASS (44.85 s)
 (8/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.base_image_exist_backingfile.block_disk.block_backing.mid_to_base: PASS (44.46 s)


avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockcommit.all_block_chain.shallow_active
 (1/1) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.all_block_chain.shallow_active: PASS (41.86 s)

avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockcopy_options.positive_test.shallow_and_reuse_external
 (1/4) type_specific.io-github-autotest-libvirt.backingchain.blockcopy_options.positive_test.shallow_and_reuse_external.file_disk.pivot_after_blockcopy: PASS (23.45 s)
 (2/4) type_specific.io-github-autotest-libvirt.backingchain.blockcopy_options.positive_test.shallow_and_reuse_external.file_disk.abort_after_blockcopy: PASS (31.82 s)
 (3/4) type_specific.io-github-autotest-libvirt.backingchain.blockcopy_options.positive_test.shallow_and_reuse_external.block_disk.pivot_after_blockcopy: PASS (44.92 s)
 (4/4) type_specific.io-github-autotest-libvirt.backingchain.blockcopy_options.positive_test.shallow_and_reuse_external.block_disk.abort_after_blockcopy: PASS (45.19 s)

avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockcommit.conventional_chain

 (01/20) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.file_disk.mid_to_mid: PASS (21.43 s)
 (02/20) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.file_disk.top_to_base: PASS (28.44 s)
 (03/20) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.file_disk.top_to_mid: PASS (28.17 s)
 (04/20) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.file_disk.mid_to_base: PASS (28.59 s)
 (05/20) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.block_disk.mid_to_mid: PASS (43.52 s)
 (06/20) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.block_disk.top_to_base: PASS (44.26 s)
 (07/20) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.block_disk.top_to_mid: PASS (44.26 s)
 (08/20) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.block_disk.mid_to_base: PASS (44.61 s)
 (09/20) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.volume_disk.mid_to_mid: PASS (28.89 s)
 (10/20) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.volume_disk.top_to_base: PASS (28.72 s)
 (11/20) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.volume_disk.top_to_mid: PASS (29.14 s)
 (12/20) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.volume_disk.mid_to_base: PASS (29.11 s)
 (13/20) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.nfs_disk.mid_to_mid: PASS (79.71 s)
 (14/20) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.nfs_disk.top_to_base: PASS (21.87 s)
 (15/20) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.nfs_disk.top_to_mid: PASS (29.10 s)
 (16/20) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.nfs_disk.mid_to_base: PASS (29.67 s)


```