### PR TITLE
virtio_transitional: Remove nvram setting for rhel6 guest

### DIFF
--- a/libvirt/tests/src/virtio_transitional/virtio_transitional_base.py
+++ b/libvirt/tests/src/virtio_transitional/virtio_transitional_base.py
@@ -106,3 +106,18 @@ def get_free_root_port(vm_name):
             libvirt.add_controller(vm_name, cntl_add)
             return "%0#4x" % int(index)
     return None
+
+
+def remove_rhel6_nvram(vm_name):
+    """
+    Remove nvram setting for rhel6 guest
+
+    :param vm_name: VM name
+    """
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    os_xml = vmxml.os
+    os_xml.del_nvram()
+    os_xml.del_loader()
+    vmxml.os = os_xml
+    vmxml.xmltreefile.write()
+    vmxml.sync("--nvram")

--- a/libvirt/tests/src/virtio_transitional/virtio_transitional_blk.py
+++ b/libvirt/tests/src/virtio_transitional/virtio_transitional_blk.py
@@ -15,6 +15,8 @@ from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import devices
 from virttest.utils_test import libvirt
 
+from src.virtio_transitional import virtio_transitional_base
+
 
 # Using as lower capital is not the best way to do, but this is just a
 # workaround to avoid changing the entire file.
@@ -254,6 +256,7 @@ def run(test, params, env):
                 'rhel6' in params.get("shortname")):
             iface_params = {'model': 'virtio-transitional'}
             libvirt.modify_vm_iface(vm_name, "update_iface", iface_params)
+            virtio_transitional_base.remove_rhel6_nvram(vm_name)
         libvirt.set_vm_disk(vm, params)
         if pci_bridge_index:
             v_xml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)

--- a/libvirt/tests/src/virtio_transitional/virtio_transitional_blk_negative.py
+++ b/libvirt/tests/src/virtio_transitional/virtio_transitional_blk_negative.py
@@ -12,6 +12,8 @@ from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import xcepts
 from virttest.utils_test import libvirt
 
+from src.virtio_transitional import virtio_transitional_base
+
 
 def run(test, params, env):
     """
@@ -39,6 +41,7 @@ def run(test, params, env):
                 'rhel6' in params.get("shortname")):
             iface_params = {'model': 'virtio-transitional'}
             libvirt.modify_vm_iface(vm_name, "update_iface", iface_params)
+            virtio_transitional_base.remove_rhel6_nvram(vm_name)
         try:
             libvirt.set_vm_disk(vm, params)
         except xcepts.LibvirtXMLError:

--- a/libvirt/tests/src/virtio_transitional/virtio_transitional_mem_balloon.py
+++ b/libvirt/tests/src/virtio_transitional/virtio_transitional_mem_balloon.py
@@ -12,6 +12,7 @@ from virttest import libvirt_version
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 
+from src.virtio_transitional import virtio_transitional_base
 
 # Using as lower capital is not the best way to do, but this is just a
 # workaround to avoid changing the entire file.
@@ -65,6 +66,8 @@ def run(test, params, env):
                 'rhel6' in params.get("shortname")):
             iface_params = {'model': 'virtio-transitional'}
             libvirt.modify_vm_iface(vm_name, "update_iface", iface_params)
+            # Remove nvram setting for rhel6 guest
+            virtio_transitional_base.remove_rhel6_nvram(vm_name)
         libvirt.set_vm_disk(vm, params)
         # The local variable "vmxml" will not be updated since set_vm_disk
         # sync with another dumped xml inside the function

--- a/libvirt/tests/src/virtio_transitional/virtio_transitional_nic.py
+++ b/libvirt/tests/src/virtio_transitional/virtio_transitional_nic.py
@@ -18,6 +18,8 @@ from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.interface import Interface
 
+from src.virtio_transitional import virtio_transitional_base
+
 
 # Using as lower capital is not the best way to do, but this is just a
 # workaround to avoid changing the entire file.
@@ -290,6 +292,9 @@ def run(test, params, env):
         if not os.path.exists(target_path):
             download.get_file(guest_src_url, target_path)
         params["blk_source_name"] = target_path
+    if (params["os_variant"] == 'rhel6' or
+            'rhel6' in params.get("shortname")):
+        virtio_transitional_base.remove_rhel6_nvram(vm_name)
     if set_crypto_policy:
         utils_conn.update_crypto_policy(set_crypto_policy)
 

--- a/libvirt/tests/src/virtio_transitional/virtio_transitional_rng.py
+++ b/libvirt/tests/src/virtio_transitional/virtio_transitional_rng.py
@@ -13,6 +13,7 @@ from virttest import libvirt_version
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 
+from src.virtio_transitional import virtio_transitional_base
 
 # Using as lower capital is not the best way to do, but this is just a
 # workaround to avoid changing the entire file.
@@ -153,11 +154,12 @@ def run(test, params, env):
                 .get_controllers('pci', 'pcie-to-pci-bridge')[0]
         pci_bridge_index = '%0#4x' % int(pci_bridge.get("index"))
 
-        # Update nic and vm disks
+        # Update nic/nvram and vm disks
         if (params["os_variant"] == 'rhel6' or
                 'rhel6' in params.get("shortname")):
             iface_params = {'model': 'virtio-transitional'}
             libvirt.modify_vm_iface(vm_name, "update_iface", iface_params)
+            virtio_transitional_base.remove_rhel6_nvram(vm_name)
         libvirt.set_vm_disk(vm, params)
         # vmxml will not be updated since set_vm_disk
         # sync with another dumped xml inside the function

--- a/libvirt/tests/src/virtio_transitional/virtio_transitional_serial.py
+++ b/libvirt/tests/src/virtio_transitional/virtio_transitional_serial.py
@@ -13,6 +13,8 @@ from virttest.utils_test import libvirt
 from virttest.libvirt_xml.devices.channel import Channel
 from virttest.libvirt_xml.devices.console import Console
 
+from src.virtio_transitional import virtio_transitional_base
+
 
 def run(test, params, env):
     """
@@ -113,6 +115,7 @@ def run(test, params, env):
         iface_params = {'model': 'virtio-transitional'}
         libvirt.modify_vm_iface(vm_name, "update_iface", iface_params)
         libvirt.set_vm_disk(vm, params)
+        virtio_transitional_base.remove_rhel6_nvram(vm_name)
         # vmxml will not be updated since set_vm_disk
         # sync with another dumped xml inside the function
         vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)

--- a/libvirt/tests/src/virtio_transitional/virtio_transitional_vsock.py
+++ b/libvirt/tests/src/virtio_transitional/virtio_transitional_vsock.py
@@ -86,6 +86,8 @@ def run(test, params, env):
             # rhel6 guest to make it works for login
             iface_params = {'model': 'virtio-transitional'}
             libvirt.modify_vm_iface(vm_name, "update_iface", iface_params)
+            # Remove nvram for rhel6 guest
+            virtio_transitional_base.remove_rhel6_nvram(vm_name)
         libvirt.set_vm_disk(vm, params)
         if hotplug:
             file_arg = vsock_xml.xml


### PR DESCRIPTION
The rhel6 guest should not be configured with nvram options, so
removing it in this PR.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Test results:**
```
05/38) type_specific.io-github-autotest-libvirt.virtio_transitional_rng.rhel6_guest.default.boot_test.virtio_transitional: PASS (49.53 s)
 (06/38) type_specific.io-github-autotest-libvirt.virtio_transitional_rng.rhel6_guest.default.hotplug_test.virtio_transitional: PASS (113.63 s)
 (07/38) type_specific.io-github-autotest-libvirt.virtio_transitional_rng.rhel6_guest.with_pcie_to_pci_bridge.boot_test.virtio: PASS (115.00 s)
 (08/38) type_specific.io-github-autotest-libvirt.virtio_transitional_rng.rhel6_guest.with_pcie_to_pci_bridge.boot_test.virtio_transitional: PASS (123.79 s)
 (09/38) type_specific.io-github-autotest-libvirt.virtio_transitional_rng.rhel6_guest.with_pcie_to_pci_bridge.hotplug_test.virtio: PASS (111.76 s)
 (10/38) type_specific.io-github-autotest-libvirt.virtio_transitional_rng.rhel6_guest.with_pcie_to_pci_bridge.hotplug_test.virtio_transitional: PASS (107.29 s)
 (11/38) type_specific.io-github-autotest-libvirt.virtio_transitional_nic.rhel6_guest.virtio_transitional.boot_test: PASS (112.05 s)
 (12/38) type_specific.io-github-autotest-libvirt.virtio_transitional_nic.rhel6_guest.virtio_transitional.hotplug.attach_device_test: FAIL: error: Failed to attach device from /tmp/xml_utils_temp_mm1ghxw8.xml\nerror: internal error: unable to execute QEMU command 'netdev_add': File descriptor named '(null)' has not been found\n (123.58 s)
 (13/38) type_specific.io-github-autotest-libvirt.virtio_transitional_nic.rhel6_guest.virtio_transitional.hotplug.attach_interface_test: FAIL: error: Failed to attach interface\nerror: internal error: unable to execute QEMU command 'netdev_add': File descriptor named '(null)' has not been found\n (120.43 s)
 (14/38) type_specific.io-github-autotest-libvirt.virtio_transitional_nic.rhel6_guest.virtio_transitional.hotplug.coldplug_test: PASS (295.73 s)
 (15/38) type_specific.io-github-autotest-libvirt.virtio_transitional_nic.rhel6_guest.virtio_transitional.save_restore: PASS (132.83 s)
 (16/38) type_specific.io-github-autotest-libvirt.virtio_transitional_mem_balloon.rhel6_guest.virtio_transitional: PASS (114.57 s)
(22/38) type_specific.io-github-autotest-libvirt.virtio_transitional_blk.rhel6_guest.default.with_virtio_blk.boot_test.virtio_transitional: PASS (38.91 s)
 (23/38) type_specific.io-github-autotest-libvirt.virtio_transitional_blk.rhel6_guest.default.with_virtio_blk.hotplug_test.virtio_transitional: PASS (106.62 s)
 (24/38) type_specific.io-github-autotest-libvirt.virtio_transitional_blk.rhel6_guest.default.with_virtio_blk.coldplug_test.virtio_transitional: PASS (161.19 s)
 (25/38) type_specific.io-github-autotest-libvirt.virtio_transitional_blk.rhel6_guest.default.with_virtio_blk.snapshot_test.virtio_transitional: PASS (115.50 s)
 (26/38) type_specific.io-github-autotest-libvirt.virtio_transitional_blk.rhel6_guest.default.with_virtio_scsi.boot_test.virtio_transitional: PASS (107.19 s)
 (27/38) type_specific.io-github-autotest-libvirt.virtio_transitional_blk.rhel6_guest.default.with_virtio_scsi.hotplug_test.virtio_transitional: PASS (112.12 s)
 (28/38) type_specific.io-github-autotest-libvirt.virtio_transitional_blk.rhel6_guest.default.with_virtio_scsi.hotplug_scsi_controller.virtio_transitional: PASS (103.26 s)
 (29/38) type_specific.io-github-autotest-libvirt.virtio_transitional_blk.rhel6_guest.with_pcie_to_pci_bridge.with_virtio_blk.boot_test.virtio: PASS (107.77 s)
 (30/38) type_specific.io-github-autotest-libvirt.virtio_transitional_blk.rhel6_guest.with_pcie_to_pci_bridge.with_virtio_blk.boot_test.virtio_transitional: PASS (104.59 s)
test-libvirt.virtio_transitional_blk.rhel6_guest.with_pcie_to_pci_bridge.with_virtio_blk.hotplug_test.virtio: PASS (112.21 s)
specific.io-github-autotest-libvirt.virtio_transitional_blk.rhel6_guest.with_pcie_to_pci_bridge.with_virtio_blk.hotplug_test.virtio_transitional: PASS (114.73 s)
 (33/38) type_specific.io-github-autotest-libvirt.virtio_transitional_blk.rhel6_guest.with_pcie_to_pci_bridge.with_virtio_scsi.boot_test.virtio: PASS (107.15 s)
 (34/38) type_specific.io-github-autotest-libvirt.virtio_transitional_blk.rhel6_guest.with_pcie_to_pci_bridge.with_virtio_scsi.boot_test.virtio_transitional: PASS (107.33 s)
 (35/38) type_specific.io-github-autotest-libvirt.virtio_transitional_blk.rhel6_guest.with_pcie_to_pci_bridge.with_virtio_scsi.hotplug_test.virtio: PASS (109.42 s)
 (36/38) type_specific.io-github-autotest-libvirt.virtio_transitional_blk.rhel6_guest.with_pcie_to_pci_bridge.with_virtio_scsi.hotplug_test.virtio_transitional: PASS (111.87 s)
 (37/38) type_specific.io-github-autotest-libvirt.virtio_transitional_blk.rhel6_guest.with_pcie_to_pci_bridge.with_virtio_scsi.hotplug_scsi_controller.virtio: PASS (111.20 s)
 (38/38) type_specific.io-github-autotest-libvirt.virtio_transitional_blk.rhel6_guest.with_pcie_to_pci_bridge.with_virtio_scsi.hotplug_scsi_controller.virtio_transitional: PASS (112.47 s)

```