### PR TITLE
migration: Remove nvram for rhel6 guest

### DIFF
--- a/libvirt/tests/src/migration/migrate_with_legacy_guest.py
+++ b/libvirt/tests/src/migration/migrate_with_legacy_guest.py
@@ -136,6 +136,14 @@ def run(test, params, env):
                 libvirt.modify_vm_iface(vm_name, "update_iface", iface_dict)
             if not check_disk:
                 params["disk_model"] = "virtio-transitional"
+        if 'rhel6' in params.get("shortname"):
+            vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+            os_xml = vmxml.os
+            os_xml.del_nvram()
+            os_xml.del_loader()
+            vmxml.os = os_xml
+            vmxml.xmltreefile.write()
+            vmxml.sync("--nvram")
         if set_crypto_policy:
             utils_conn.update_crypto_policy(set_crypto_policy)
 


### PR DESCRIPTION
The nvram settings should be removed for rhel6 guest.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Test results:**
```
 (17/38) type_specific.io-github-autotest-libvirt.virsh.migrate_with_legacy_guest.test_interface.rhel6_guest.virtio_transitional: PASS (188.88 s)
 (18/38) type_specific.io-github-autotest-libvirt.virsh.migrate_with_legacy_guest.test_disk.with_virtio_scsi.disk_raw.rhel6_guest.unspecified_model: PASS (245.39 s)
 (19/38) type_specific.io-github-autotest-libvirt.virsh.migrate_with_legacy_guest.test_disk.with_virtio_blk.disk_qcow2.rhel6_guest.virtio_transitional: PASS (244.68 s)
 (20/38) type_specific.io-github-autotest-libvirt.virsh.migrate_with_legacy_guest.test_memballoon.rhel6_guest.virtio_transitional: PASS (198.04 s)
 (21/38) type_specific.io-github-autotest-libvirt.virsh.migrate_with_legacy_guest.test_rng.rhel6_guest.virtio_transitional: PASS (188.09 s)

```