### PR TITLE
sriov: Add cases about managedsave and unmanaged

### DIFF
--- a/libvirt/tests/cfg/sriov/vm_lifecycle/sriov_vm_lifecycle_managedsave.cfg
+++ b/libvirt/tests/cfg/sriov/vm_lifecycle/sriov_vm_lifecycle_managedsave.cfg
@@ -1,0 +1,19 @@
+- sriov.vm_lifecycle.managedsave:
+    type = sriov_vm_lifecycle_managedsave
+    start_vm = "no"
+    status_error = "yes"
+    err_msg = "Operation not supported"
+    only x86_64
+    variants dev_type:
+        - hostdev_interface:
+            variants dev_source:
+                - vf_address:
+                    variants:
+                        - managed_yes:
+                            iface_dict = {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}}
+        - hostdev_device:
+            variants dev_source:
+                - vf_address:
+                    variants:
+                        - managed_yes:
+                            hostdev_dict = {'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': vf_pci_addr}, 'managed': 'yes'}

--- a/libvirt/tests/cfg/sriov/vm_lifecycle/sriov_vm_lifecycle_unmanaged.cfg
+++ b/libvirt/tests/cfg/sriov/vm_lifecycle/sriov_vm_lifecycle_unmanaged.cfg
@@ -1,0 +1,47 @@
+- sriov.vm_lifecycle.unmanaged:
+    type = sriov_vm_lifecycle_unmanaged
+    status_error = "yes"
+    err_msg = "Unmanaged PCI device.*must be manually detached from the host"
+
+    only x86_64
+    variants dev_type:
+        - hostdev_interface:
+            variants dev_source:
+                - vf_address:
+                    variants:
+                        - managed_no:
+                            iface_dict = {'managed': 'no', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
+                        - without_managed:
+                            iface_dict = {'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
+        - hostdev_device:
+            variants dev_source:
+                - vf_address:
+                    variants:
+                        - managed_no:
+                            hostdev_dict = {'alias': {'name': 'ua-1bcbabff-f022-4d4f-ae8c-13f2d3a07906'}, 'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': vf_pci_addr}, 'managed': 'no'}
+                - pf_address:
+                    variants:
+                        - managed_no:
+                            hostdev_dict = {'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': pf_pci_addr}, 'managed': 'no'}
+        - network_interface:
+            variants dev_source:
+                - network:
+                    variants net_source:
+                        - pf_name:
+                            variants:
+                                - managed_no:
+                                    iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
+                                    network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev", "managed": "no"}', 'net_forward_pf': net_forward_pf}
+                                - without_managed:
+                                    iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
+                                    network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev"}', 'net_forward_pf': net_forward_pf}
+                        - vf_address:
+                            variants:
+                                - without_managed:
+                                    iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
+                                    network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev"}', 'vf_list_attrs': vf_list_attrs}
+    variants test_scenario:
+        - cold_plug:
+            start_vm = 'no'
+        - hot_plug:
+            start_vm = 'yes'

--- a/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_managedsave.py
+++ b/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_managedsave.py
@@ -1,0 +1,56 @@
+from provider.sriov import sriov_base
+
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_test import libvirt
+
+
+def run(test, params, env):
+    """
+    Managedsave vm with a hostdev interface/device
+    """
+    def run_test():
+        """
+        Managedsave vm with a hostdev interface/device is not supported
+
+        1) Start the VM
+        2) Managedsave the VM and check the error message
+        """
+
+        test.log.info("TEST_STEP1: Attach a hostdev interface/device to VM")
+        iface_dev = sriov_test_obj.create_iface_dev(dev_type, iface_dict)
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        libvirt.add_vm_device(vmxml, iface_dev)
+
+        test.log.info("TEST_STEP2: Start the VM")
+        vm.start()
+        vm.cleanup_serial_console()
+        vm.create_serial_console()
+        vm.wait_for_serial_login(timeout=240).close()
+
+        test.log.info("TEST_STEP3: Managedsave the vm")
+        result = virsh.managedsave(vm.name, debug=True)
+        libvirt.check_exit_status(result, status_error)
+        if err_msg:
+            libvirt.check_result(result, err_msg)
+
+    dev_type = params.get("dev_type", "")
+
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    vm = env.get_vm(vm_name)
+    status_error = "yes" == params.get("status_error", "yes")
+    err_msg = params.get("err_msg")
+    sriov_test_obj = sriov_base.SRIOVTest(vm, test, params)
+
+    iface_dict = sriov_test_obj.parse_iface_dict()
+
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    orig_config_xml = vmxml.copy()
+
+    try:
+        sriov_test_obj.setup_default()
+        run_test()
+
+    finally:
+        sriov_test_obj.teardown_default(orig_config_xml)

--- a/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_unmanaged.py
+++ b/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_unmanaged.py
@@ -1,0 +1,60 @@
+from provider.sriov import sriov_base
+
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vfio
+from virttest.utils_test import libvirt
+
+
+def run(test, params, env):
+    """
+    Start vm with interface/hostdev with managed=no or ignored
+    """
+    def run_test():
+        """
+        Cold/hot plug an interface/hostdev with managed=no or ignored
+
+        1) Cold/hot plug an interface/hostdev with managed=no or ignored
+        2) Check driver of the device
+        """
+
+        test.log.info("TEST_STEP1: Attach a hostdev interface/device to VM")
+        at_options = '' if vm.is_alive() else '--config'
+        iface_dev = sriov_test_obj.create_iface_dev(dev_type, iface_dict)
+        result = virsh.attach_device(vm_name, iface_dev.xml, flagstr=at_options,
+                                     debug=True)
+        if at_options:
+            result = virsh.start(vm_name, debug=True)
+        libvirt.check_exit_status(result, status_error)
+        if error_msg:
+            libvirt.check_result(result, error_msg)
+
+        test.log.info("TEST_STEP2: Check if the VM is not using VF.")
+        libvirt_vfio.check_vfio_pci(dev_pci, True)
+
+    dev_type = params.get("dev_type", "")
+    dev_source = params.get("dev_source", "")
+    test_scenario = params.get("test_scenario", "")
+    status_error = "yes" == params.get("status_error", "no")
+    error_msg = params.get("error_msg")
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    vm = env.get_vm(vm_name)
+    sriov_test_obj = sriov_base.SRIOVTest(vm, test, params)
+    iface_dict = sriov_test_obj.parse_iface_dict()
+    network_dict = sriov_test_obj.parse_network_dict()
+    if dev_type == "hostdev_device" and dev_source.startswith("pf"):
+        dev_pci = sriov_test_obj.pf_pci
+    else:
+        dev_pci = sriov_test_obj.vf_pci
+    test_dict = {"network_dict": network_dict}
+
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    orig_config_xml = vmxml.copy()
+
+    try:
+        sriov_test_obj.setup_default(**test_dict)
+        run_test()
+
+    finally:
+        sriov_test_obj.teardown_default(orig_config_xml, **test_dict)


### PR DESCRIPTION
This PR adds:
    1. VIRT-293788 - Start vm with hostdev interface/device with
        managed=no or ignored
    2. VIRT-293133 - Managedsave vm with a hostdev interface/device

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Test results:**
```
 (1/2) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.managedsave.hostdev_interface.vf_address.managed_yes: PASS (42.46 s)
 (2/2) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.managedsave.hostdev_device.vf_address.managed_yes: PASS (41.79 s)
 (01/14) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.unmanaged.cold_plug.hostdev_interface.vf_address.managed_no: PASS (15.35 s)
 (02/14) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.unmanaged.cold_plug.hostdev_interface.vf_address.without_managed: PASS (15.54 s)
 (03/14) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.unmanaged.cold_plug.hostdev_device.vf_address.managed_no: PASS (15.57 s)
 (04/14) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.unmanaged.cold_plug.hostdev_device.pf_address.managed_no: PASS (17.94 s)
 (05/14) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.unmanaged.cold_plug.network_interface.network.pf_name.managed_no: PASS (15.97 s)
 (06/14) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.unmanaged.cold_plug.network_interface.network.pf_name.without_managed: PASS (16.03 s)
 (07/14) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.unmanaged.cold_plug.network_interface.network.vf_address.without_managed: PASS (16.14 s)
 (08/14) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.unmanaged.hot_plug.hostdev_interface.vf_address.managed_no: PASS (18.30 s)
 (09/14) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.unmanaged.hot_plug.hostdev_interface.vf_address.without_managed: PASS (18.16 s)
 (10/14) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.unmanaged.hot_plug.hostdev_device.vf_address.managed_no: PASS (18.01 s)
 (11/14) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.unmanaged.hot_plug.hostdev_device.pf_address.managed_no: PASS (17.98 s)
 (12/14) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.unmanaged.hot_plug.network_interface.network.pf_name.managed_no: PASS (18.52 s)
 (13/14) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.unmanaged.hot_plug.network_interface.network.pf_name.without_managed: PASS (18.49 s)
 (14/14) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.unmanaged.hot_plug.network_interface.network.vf_address.without_managed: PASS (18.56 s)
```

