### PR TITLE
Configure libvirtd_debug_filters to adapt to new change

### DIFF
--- a/libvirt/tests/cfg/numa/numa_memory.cfg
+++ b/libvirt/tests/cfg/numa/numa_memory.cfg
@@ -5,6 +5,7 @@
     status_error = "no"
     libvirtd_debug_file = "/var/log/libvirt/daemon.log"
     libvirtd_debug_level = "1"
+    libvirtd_debug_filters = "1:*"
     variants:
         - possitive_test:
              variants:

--- a/libvirt/tests/cfg/numa/numa_memory_migrate.cfg
+++ b/libvirt/tests/cfg/numa/numa_memory_migrate.cfg
@@ -6,6 +6,7 @@
     take_regular_screendumps = "no"
     libvirtd_debug_file = "/var/log/libvirt/daemon.log"
     libvirtd_debug_level = "1"
+    libvirtd_debug_filters = "1:*"
     variants:
         - mem_auto:
             memory_placement = "auto"


### PR DESCRIPTION
libvirtd_debug_filters should be configured if we set log level
lower than default.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>
