### PR TITLE
migration: specify log_filters as "1:*" of some case

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -298,7 +298,7 @@
                     libvirtd_conf_type = "virtproxyd"
                     libvirtd_conf_dest_dict = '{r"keepalive_interval\s*=.*": 'keepalive_interval=-1', }'
                     libvirtd_conf_type_dest = "virtproxyd"
-                    log_conf_dict = '{"log_level": "1", "log_outputs": "\"1:file:${log_outputs}\""}'
+                    log_conf_dict = '{"log_level": "1", "log_filters": "\"1:*\"", "log_outputs": "\"1:file:${log_outputs}\""}'
                     log_conf_type = "virtqemud"
                     log_conf_dest_dict = '{r"log_level\s*=.*": 'log_level=1', r"log_outputs\s*=.*": 'log_outputs="1:file:${log_outputs}"'}'
                     log_conf_type_dest = "virtqemud"


### PR DESCRIPTION
Signed-off-by: Hu Shuai <hus.fnst@fujitsu.com>

The default log_filters is "2:\*" if the `log_level` is not assigned with `libvirtd_debug_level`.
Specify `log_filters` as "1:\*" to get the debug log "qemuProcessHandleMigrationStatus" in /var/log/libvirt/libvirtd.log

Before:
```
# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-pci virsh.migrate_options_shared.positive_test.check_event.event_without_postcopy.without_postcopy --vt-connect-uri qemu:///system                                                                                                                                                                                                                                                                                                          
JOB ID     : a1a4c9cf6e55031741a7e0d73b510944590088af                                                                                                                                                                                         
JOB LOG    : /var/lib/avocado/job-results/job-2022-06-23T05.20-a1a4c9c/job.log                                                                                                                                                                
 (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_options_shared.positive_test.check_event.event_without_postcopy.without_postcopy: FAIL: The string 'qemuProcessHandleMigrationStatus' is not included in /var/log/libvirt/libvirtd.log (229.94 s)                                                                               
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0                         
JOB HTML   : /var/lib/avocado/job-results/job-2022-06-23T05.20-a1a4c9c/results.html                                                      
JOB TIME   : 230.73 s
```

After:
```
# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-pci virsh.migrate_options_shared.positive_test.check_event.event_without_postcopy.without_postcopy --vt-connect-uri qemu:///system                                                                       
JOB ID     : 795681f6d55b78a389debb6315c7ad9d7a551241
JOB LOG    : /var/lib/avocado/job-results/job-2022-06-23T05.35-795681f/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_options_shared.positive_test.check_event.event_without_postcopy.without_postcopy: PASS (238.60 s)                                                                              
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-06-23T05.35-795681f/results.html
JOB TIME   : 239.40 s
```
