### PR TITLE
tpm_device: use tpm_testsuite_url to download

### DIFF
--- a/libvirt/tests/cfg/virtual_device/tpm_device.cfg
+++ b/libvirt/tests/cfg/virtual_device/tpm_device.cfg
@@ -4,6 +4,7 @@
     loader = "/usr/share/edk2/ovmf/OVMF_CODE.secboot.fd"
     nvram = "/var/lib/libvirt/qemu/nvram/<VM_NAME>_VARS.fd"
     uefi_disk_url = "EXAMPLE_UEFI_DISK_URL"
+    tpm_testsuite_url = "EXAMPLE_TPM_TESTSUITE_URL"
     no s390-virtio
     variants:
         - normal_test:


### PR DESCRIPTION
Use tpm_testsuite_url instead to download from internal
server. It will speed up downloads. And we can manage test suite
updating to required version at specific time after manual test
succeed, which are all transparent to tp-libvirt code.

Signed-off-by: Yanqiu Zhang <yanqzhan@redhat.com>
