### PR TITLE
memory_update_device: Enable test on aarch64

### DIFF
--- a/libvirt/tests/cfg/memory/memory_update_device.cfg
+++ b/libvirt/tests/cfg/memory/memory_update_device.cfg
@@ -11,6 +11,8 @@
             func_supported_since_libvirt_ver = (8, 0, 0)
             func_supported_since_qemu_kvm_ver = (6, 2, 0)
             vm_attrs = {'max_mem_rt': 10485760, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB', 'vcpu': 4, 'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '524288', 'unit': 'KiB'}]}}
+            aarch64:
+                vm_attrs = {'max_mem_rt': 10485760, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB', 'vcpu': 4, 'cpu': {'mode': 'host-passthrough', 'numa_cell': [{'id': '0', 'cpus': '0-3', 'memory': '524288', 'unit': 'KiB'}]}}
             mem_device_attrs = {'mem_model': 'virtio-mem', 'target': {'requested_unit': 'KiB', 'size': 262144, 'node': 0, 'size_unit': 'KiB', 'requested_size': 131072, 'block_unit': 'KiB', 'block_size': 2048}, 'source': {'pagesize_unit': 'KiB', 'pagesize': 2048, 'nodemask': '0'}}
             requested_size = 80MiB
             check_log_str = "MEMORY_DEVICE_SIZE_CHANGE.*virtiomem"

--- a/libvirt/tests/src/memory/memory_update_device.py
+++ b/libvirt/tests/src/memory/memory_update_device.py
@@ -74,6 +74,8 @@ def run(test, params, env):
 
         virsh.attach_device(vm_name, mem_device.xml, flagstr='--config',
                             debug=True, ignore_status=False)
+        test.log.debug("vmxml is {}".format(vm_xml.VMXML.
+                                            new_from_dumpxml(vm_name)))
 
     def run_test_virtio_mem():
         """
@@ -101,6 +103,9 @@ def run(test, params, env):
         expr_requested_size = int(float(utils_misc.normalize_data_size(
             params.get("requested_size", '80Mib'), order_magnitude='K')))
         for check_item in ['requested_size', 'current_size']:
+            test.log.debug("Expected size is {}, Actual size is {}".
+                           format(expr_requested_size,
+                                  getattr(mem_dev.target, check_item)))
             if getattr(mem_dev.target, check_item) != expr_requested_size:
                 test.fail("Incorrect %s! It should be %s, but got %s."
                           % (check_item, expr_requested_size,


### PR DESCRIPTION
Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

```
# avocado run --vt-type libvirt --vt-arch aarch64 --vt-machine-type arm64-mmio memory_update_device.virtio_mem
JOB ID     : 63f5a58222b3464e341fcb5ad1e73ac41ecc3da6
JOB LOG    : /root/avocado/job-results/job-2022-06-24T04.56-63f5a58/job.log
 (1/1) type_specific.io-github-autotest-libvirt.memory_update_device.virtio_mem: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.memory_update_device.virtio_mem: PASS (109.37 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/avocado/job-results/job-2022-06-24T04.56-63f5a58/results.html
JOB TIME   : 113.73 s
```
