### PR TITLE
Add new case of memory and replace logging with test.log

### DIFF
--- a/libvirt/tests/cfg/memory/memory_misc.cfg
+++ b/libvirt/tests/cfg/memory/memory_misc.cfg
@@ -98,3 +98,16 @@
                     ausearch_check_1 = 'old-mem=%d new-mem=%d.*res=success.*\n.*old-mem=%d new-mem=%d.*res=success'
                     ausearch_check_2 = 'old-mem=%d new-mem=%d.*res=failed'
                     ausearch_check_3 = 'old-mem=%d new-mem=%d.*res=success'
+        - managedsave:
+            variants case:
+                - size_check:
+                    vmxml_max_mem_rt_slots = 16
+                    vmxml_max_mem_rt_unit = 'KiB'
+                    vmxml_max_mem_rt = 55600128
+                    vmxml_memory_unit = 'KiB'
+                    vmxml_memory = 3145728
+                    vmxml_current_mem_unit = 'KiB'
+                    vmxml_current_mem = 3045728
+                    vmxml_vcpu = 4
+                    numa_node_size = 2048000
+                    cpu_attrs = {'numa_cell': [{'id': '0', 'cpus': '0,2', 'memory': '${numa_node_size}', 'unit': 'KiB'}, {'id': '1', 'cpus': '1,3', 'memory': '${numa_node_size}', 'unit': 'KiB'}]}


### PR DESCRIPTION
- Check the memory balloon size after restoring a managed save guest

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>
