### PR TITLE
Update the vm.undefine() to adapt to ovmf guest

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_interface_matrix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_detach_interface_matrix.py
@@ -228,7 +228,7 @@ def run(test, params, env):
             raise exceptions.TestSkipError("Can't pause the domain")
     elif pre_vm_state == "transient":
         logging.info("Creating %s..." % vm_name)
-        vm.undefine()
+        vm.undefine(options='--nvram')
         if virsh.create(backup_xml.xml,
                         **virsh_dargs).exit_status:
             backup_xml.define()


### PR DESCRIPTION
Update the vm.undefine() to vm.undefine(options='--nvram') to
adapt to ovmf guest. And it works well for pc guest, too.

Signed-off-by: Yalan Zhang <yalzhang@redhat.com>