### PR TITLE
migration: Remove qemu command line checking

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -206,7 +206,6 @@
                     cmd_run_in_remote_host = "cat %s > ${remote_cat_file} &"
                     cmd_run_in_remote_host_1 = "cat ${remote_cat_file}|grep '${message_sent}'"
                     cmd_run_in_remote_host_2 = "rm -f ${remote_cat_file}"
-                    qemu_check = "-chardev pty,id=charchannel.*-device virtserialport.*chardev=charchannel.*name=${target_name}"
                 - htm:
                     qemu_check = 'cap-htm='
                     guest_xml_check_after_mig = 'htm state='


### PR DESCRIPTION
The checking operation is covered in libvirt upstream unit test. So
 remove it.

Signed-off-by: cliping <lcheng@redhat.com>
