### PR TITLE
Fix virsh change-media failure after creating transient VM

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_change_media_matrix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_change_media_matrix.py
@@ -247,6 +247,7 @@ def run(test, params, env):
             if virsh.create(vmxml_for_test.xml, **virsh_dargs).exit_status:
                 vmxml_backup.define()
                 test.cancel("Can't create the domain")
+            vm.wait_for_login().close()
 
         # Libvirt will ignore --source when action is eject
         attach = True


### PR DESCRIPTION
Fix virsh change-media failure after creating transient VM

Change media operation need to be applied after VM completely booted
Fix this issue by adding check whether VM completely booted after transient VM is created

Signed-off-by: chunfuwen <chwen@redhat.com>

