### PR TITLE
Add "--nvram" to the virsh.remove_domain()

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_network.py
+++ b/libvirt/tests/src/virtual_network/iface_network.py
@@ -1233,7 +1233,7 @@ TIMEOUT 3"""
         if vm.is_alive():
             vm.destroy(gracefully=False)
         for vms in vms_list:
-            virsh.remove_domain(vms.name, "--remove-all-storage")
+            virsh.remove_domain(vms.name, "--remove-all-storage --nvram")
         logging.info("Restoring network...")
         if net_name == "default":
             netxml_backup.sync()

--- a/libvirt/tests/src/virtual_network/iface_options.py
+++ b/libvirt/tests/src/virtual_network/iface_options.py
@@ -1121,11 +1121,11 @@ def run(test, params, env):
             # Restore vhost_net driver
             process.system("modprobe vhost_net", shell=True)
         if unprivileged_user:
-            virsh.remove_domain(vm_name, **virsh_dargs)
+            virsh.remove_domain(vm_name, "--nvram", **virsh_dargs)
             process.run('rm -f %s' % dst_disk, shell=True)
         if additional_vm:
             virsh.remove_domain(additional_vm.name,
-                                "--remove-all-storage")
+                                "--remove-all-storage --nvram")
             # Kill all omping server process on host
             process.system("pidof omping && killall omping",
                            ignore_status=True, shell=True)


### PR DESCRIPTION
For OVMF guest, without the "--nvram" option, domain can not be
removed successfully. Then the domain will be kept and it may
interfere futher cases.

Signed-off-by: Yalan Zhang <yalzhang@redhat.com>

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [ ] Description of the cases
- [ ] Links of libvirt features, libvirt bugs or case IDs
- [ ] Test results

## If the PR is bug cases
- [ ] Bug descriptions or bug links
- [ ] Test results

## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
