### PR TITLE
Add "--nvram" to virsh.remove_domain()

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_network.py
+++ b/libvirt/tests/src/virtual_network/iface_network.py
@@ -1233,7 +1233,7 @@ TIMEOUT 3"""
         if vm.is_alive():
             vm.destroy(gracefully=False)
         for vms in vms_list:
-            virsh.remove_domain(vms.name, "--remove-all-storage")
+            virsh.remove_domain(vms.name, "--remove-all-storage --nvram")
         logging.info("Restoring network...")
         if net_name == "default":
             netxml_backup.sync()


### PR DESCRIPTION
When undefine an ovmf guest, it needs the option "--nvram". Otherwise
the guest will not be removed successfully.

Signed-off-by: Yalan Zhang <yalzhang@redhat.com>