### PR TITLE
Fixup:chown of VARS.fd file to avoid permission issue

### DIFF
--- a/libvirt/tests/cfg/svirt/dac_nfs_save_restore.cfg
+++ b/libvirt/tests/cfg/svirt/dac_nfs_save_restore.cfg
@@ -18,6 +18,7 @@
     file_mode = 438
     pre_file = "yes"
     pre_file_name = "dac_nfs_file"
+    vars_path = "/var/lib/libvirt/qemu/nvram/avocado-vt-vm1_VARS.fd"
     variants:
         - root_squash:
             export_options= "rw,root_squash"

--- a/libvirt/tests/cfg/svirt/dac_start_destroy.cfg
+++ b/libvirt/tests/cfg/svirt/dac_start_destroy.cfg
@@ -6,6 +6,7 @@
     kill_vm_on_error = "yes"
     dac_start_destroy_disk_label = "107:107"
     dac_start_destroy_host_selinux = "enforcing"
+    vars_path = "/var/lib/libvirt/qemu/nvram/avocado-vt-vm1_VARS.fd"
     variants:
         - with_qemu_conf:
             variants:

--- a/libvirt/tests/src/svirt/dac_nfs_save_restore.py
+++ b/libvirt/tests/src/svirt/dac_nfs_save_restore.py
@@ -1,4 +1,5 @@
 import os
+import pwd
 import logging as log
 
 from avocado.core import exceptions
@@ -111,6 +112,18 @@ def run(test, params, env):
                 os.chown(disk_path, 0, 0)
             elif qemu_user == "qemu":
                 os.chown(disk_path, 107, 107)
+
+        # Change ownership of VARS.fd file
+        if dynamic_ownership is False:
+            vars_path = None
+            if vmxml.os.xmltreefile.find('nvram') is not None:
+                vars_path = vmxml.os.nvram
+            elif vmxml.os.fetch_attrs().get('os_firmware') == 'efi':
+                vars_path = params.get('vars_path')
+
+            if vars_path is not None and os.path.exists(vars_path):
+                user_info = pwd.getpwnam(qemu_user)
+                os.chown(vars_path, user_info.pw_uid, user_info.pw_gid)
 
         # Set selinux of host.
         utils_selinux.set_status(host_sestatus)

--- a/libvirt/tests/src/svirt/dac_start_destroy.py
+++ b/libvirt/tests/src/svirt/dac_start_destroy.py
@@ -232,6 +232,22 @@ def run(test, params, env):
             vmxml.sync()
             logging.debug("updated domain xml is: %s" % vmxml.xmltreefile)
 
+        # Change ownership of VARS.fd file
+        if dynamic_ownership is False:
+            vars_path = None
+            if vmxml.os.xmltreefile.find('nvram') is not None:
+                vars_path = vmxml.os.nvram
+            elif vmxml.os.fetch_attrs().get('os_firmware') == 'efi':
+                vars_path = params.get('vars_path')
+
+            if vars_path is not None and os.path.exists(vars_path):
+                if qemu_user.isdigit():
+                    uid, gid = int(qemu_user), int(qemu_group)
+                else:
+                    user_info = pwd.getpwnam(qemu_user)
+                    uid, gid = user_info.pw_uid, user_info.pw_gid
+                os.chown(vars_path, uid, gid)
+
         # Start VM to check the qemu process and image.
         try:
             libvirtd.restart()


### PR DESCRIPTION
Ownership will not be changed dynamically when 'dynamic_ownership'
is disabled. Therefore the ownership of certain files should be
maintained manually to avoid permission issue.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>
