### PR TITLE
add case for blockpull with backingfile

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockpull/blockpull_base_image_exist_backingfile.cfg
+++ b/libvirt/tests/cfg/backingchain/blockpull/blockpull_base_image_exist_backingfile.cfg
@@ -1,0 +1,27 @@
+- backingchain.blockpull.base_image_exist_backingfile:
+    type = blockpull_base_image_exist_backingfile
+    start_vm = "yes"
+    pull_options = " --wait --verbose"
+    target_disk = "vdb"
+    snap_num = 4
+    snap_extra = " --diskspec vda,snapshot=no"
+    variants:
+        - with_base:
+            base_image_suffix = 1
+            expected_chain = "4>1>base>backing_file"
+        - without_base:
+            expected_chain = "4"
+    variants:
+        - file_backing:
+            backing_file_type = "file"
+            backing_format = "qcow2"
+        - block_backing:
+            backing_file_type = "block"
+            backing_format = "raw"
+    variants:
+        - file_disk:
+            disk_type = "file"
+            disk_dict = {"type_name":"${disk_type}", "target":{"dev": "${target_disk}", "bus": "virtio"}, "driver": {"name": "qemu", "type":"qcow2"}}
+        - block_disk:
+            disk_type = "block"
+            disk_dict = {"type_name":"${disk_type}", "target":{"dev": "${target_disk}", "bus": "virtio"}, "driver": {"name": "qemu", "type":"qcow2"}}

--- a/libvirt/tests/src/backingchain/blockpull/blockpull_base_image_exist_backingfile.py
+++ b/libvirt/tests/src/backingchain/blockpull/blockpull_base_image_exist_backingfile.py
@@ -13,65 +13,55 @@ LOG = logging.getLogger('avocado.' + __name__)
 
 def run(test, params, env):
     """
-    Do blockcommit when the guest image has backing file
+       Do blockpull when the guest image has backing file
 
-    1) Prepare different type disk and snap chain
-        File disk image which has file backing file
-        File disk image which has block backing file
-        Block disk image which has file backing file
-        Block disk image which has block backing file
-    2) Do blockcommit:
-        from middle to middle
-        from top to base
-        from top to middle
-        from middle to base
-    3) Check result:
-        md5 of file in vm are correct
-        vm is alive
-    """
+       1) Prepare different type disk and snap chain
+           File disk image which has file backing file
+           File disk image which has block backing file
+           Block disk image which has file backing file
+           Block disk image which has block backing file
+       2) Do blockpull
+           with --base
+           without --base
+       3) Check result
+           md5 of device in vm is correct
+       """
 
     def setup_test():
         """
         Prepare specific type disk and create snapshots.
        """
+        test.log.info('Setup env: Prepare backingfile and snap chain')
         based_image, test_obj.backing_file = disk_obj.prepare_backing_file(
             disk_type, backing_file_type, backing_format)
 
-        test_obj.new_image_path = disk_obj.add_vm_disk(
-            disk_type, disk_dict, new_image_path=based_image)
+        test_obj.new_image_path = disk_obj.add_vm_disk(disk_type, disk_dict,
+                                                       new_image_path=based_image)
 
         if not vm.is_alive():
             vm.start()
         vm.wait_for_login().close()
-        test_obj.prepare_snapshot(snap_num=4)
-        check_obj.check_backingchain(test_obj.snap_path_list[::-1])
-
+        test_obj.prepare_snapshot(snap_num=snap_num, extra=snap_extra)
         vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
-        LOG.debug("After create snapshots ,the vmxml is:\n%s", vmxml)
+        LOG.debug("After create snapshots, the vmxml is:\n%s", vmxml)
 
     def run_test():
         """
-        Do blockcommit and check backingchain result , file hash value
+        Do blockpull and check backingchain result , hash value
         """
-        top_option = " --top %s" % test_obj.snap_path_list[int(top_index)-1]\
-            if top_index else " --pivot"
         if base_index:
-            # this scenario is from middle to middle and from top to middle
-            base_option = " --base %s" % test_obj.snap_path_list[int(base_index) - 1]
-        elif top_option.split()[-1] == test_obj.snap_path_list[-1]:
-            # this scenario is from top to base
-            base_option = " --pivot"
+            # with --base option scenario
+            base_option = " --base %s" % test_obj.snap_path_list[int(base_index)-1]
         else:
-            # this scenario is from middle to base
+            # without --base option scenario
             base_option = " "
 
         session = vm.wait_for_login()
-        expected_hash = test_obj.get_hash_value(session,
-                                                "/dev/"+test_obj.new_dev)
+        expected_hash = test_obj.get_hash_value(session, "/dev/"+test_obj.new_dev)
 
-        virsh.blockcommit(vm.name, target_disk,
-                          commit_options+top_option+base_option,
-                          ignore_status=False, debug=True)
+        test.log.info("TEST_STEP: Do blockpull")
+        virsh.blockpull(vm.name, target_disk, base_option+pull_options,
+                        ignore_status=False, debug=True)
 
         expected_chain = test_obj.convert_expected_chain(expected_chain_index)
         check_obj.check_backingchain_from_vmxml(disk_type, test_obj.new_dev,
@@ -79,35 +69,30 @@ def run(test, params, env):
         check_obj.check_hash_list(["/dev/"+test_obj.new_dev], [expected_hash], session)
         session.close()
 
-        if not vm.is_alive():
-            test.fail("The vm should be alive after blockcommit, "
-                      "but it's in %s state." % vm.state)
-
     def teardown_test():
         """
         Clean data.
         """
         test.log.info("TEST_TEARDOWN: Recover test enviroment.")
         test_obj.backingchain_common_teardown()
-
         bkxml.sync()
 
         disk_obj.cleanup_disk_preparation(disk_type)
         if backing_file_type == 'block' and disk_type == 'file':
             disk_obj.cleanup_block_disk_preparation(disk_obj.vg_name,
                                                     disk_obj.lv_backing)
-
     # Process cartesian parameters
     vm_name = params.get("main_vm")
     disk_type = params.get('disk_type')
+    disk_dict = eval(params.get('disk_dict', '{}'))
     target_disk = params.get('target_disk')
     backing_file_type = params.get('backing_file_type')
     backing_format = params.get('backing_format')
-    disk_dict = eval(params.get('disk_dict', '{}'))
-    commit_options = params.get('commit_options')
+    pull_options = params.get('pull_options')
     expected_chain_index = params.get('expected_chain')
-    top_index = params.get('top_image_suffix')
     base_index = params.get('base_image_suffix')
+    snap_num = int(params.get('snap_num'))
+    snap_extra = params.get('snap_extra')
 
     vm = env.get_vm(vm_name)
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)

--- a/provider/virtual_disk/disk_base.py
+++ b/provider/virtual_disk/disk_base.py
@@ -1,6 +1,7 @@
 import logging
 
-from avocado.utils import lv_utils, process
+from avocado.utils import lv_utils
+from avocado.utils import process
 
 from virttest import ceph
 from virttest import data_dir
@@ -39,6 +40,7 @@ class DiskBase(object):
         self.pool_target = params.get("pool_target", 'dir_pool')
         self.emulated_image = params.get("emulated_image", 'dir_pool_img')
         self.base_dir = params.get("base_dir", "/var/lib/libvirt/images")
+        self.lv_backing = 'lv1'
         self.new_image_path = ''
         self.path_list = ''
 
@@ -357,3 +359,33 @@ class DiskBase(object):
         virsh.pool_start(pool_name, debug=True, ignore_status=False)
 
         return pool_name
+
+    def prepare_backing_file(self, disk_type, backing_file_type, backing_format):
+        """
+        Prepare backing file
+        """
+        based_image, backing_file = '', ''
+
+        if disk_type == 'file':
+            based_image = data_dir.get_data_dir()+'/based.qcow2'
+            if backing_file_type == 'file':
+                backing_file = data_dir.get_data_dir()+'/backing.qcow2'
+                libvirt.create_local_disk('file', backing_file,
+                                          size='200M', disk_format="qcow2")
+            if backing_file_type == 'block':
+                backing_file = self.create_lvm_disk_path(self.vg_name, self.lv_backing)
+
+        elif disk_type == 'block':
+            based_image = self.create_lvm_disk_path(self.vg_name, self.lv_name)
+            if backing_file_type == 'file':
+                backing_file = data_dir.get_data_dir() + '/backing.qcow2'
+                libvirt.create_local_disk('file', backing_file, '200M', "qcow2")
+            if backing_file_type == 'block':
+                backing_file = libvirt.create_local_disk(
+                    "lvm", size="10M", vgname=self.vg_name, lvname=self.lv_backing)
+
+        backing_cmd = "qemu-img create -f qcow2 -b %s -F %s %s" % (
+            backing_file, backing_format, based_image)
+        process.run(backing_cmd, shell=True, verbose=True)
+        return based_image, backing_file
+


### PR DESCRIPTION
   VIRT-294012: Do blockpull when the guest image has backing file
Signed-off-by: nanli <nanli@redhat.com>

**Test result:**
```
 avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockpull
 (1/8) type_specific.io-github-autotest-libvirt.backingchain.blockpull.base_image_exist_backingfile.file_disk.file_backing.with_base: PASS (33.76 s)
 (2/8) type_specific.io-github-autotest-libvirt.backingchain.blockpull.base_image_exist_backingfile.file_disk.file_backing.without_base: PASS (34.03 s)
 (3/8) type_specific.io-github-autotest-libvirt.backingchain.blockpull.base_image_exist_backingfile.file_disk.block_backing.with_base: PASS (53.76 s)
 (4/8) type_specific.io-github-autotest-libvirt.backingchain.blockpull.base_image_exist_backingfile.file_disk.block_backing.without_base: PASS (55.86 s)
 (5/8) type_specific.io-github-autotest-libvirt.backingchain.blockpull.base_image_exist_backingfile.block_disk.file_backing.with_base: PASS (61.96 s)
 (6/8) type_specific.io-github-autotest-libvirt.backingchain.blockpull.base_image_exist_backingfile.block_disk.file_backing.without_base: PASS (56.22 s)
 (7/8) type_specific.io-github-autotest-libvirt.backingchain.blockpull.base_image_exist_backingfile.block_disk.block_backing.with_base: PASS (58.55 s)
 (8/8) type_specific.io-github-autotest-libvirt.backingchain.blockpull.base_image_exist_backingfile.block_disk.block_backing.without_base: PASS (55.64 s)
```
**Influenced other case**
```
 avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockcommit.base_image_exist_backingfile.file_disk.block_backing
 (1/4) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.base_image_exist_backingfile.file_disk.block_backing.mid_to_mid: PASS (49.98 s)
 (2/4) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.base_image_exist_backingfile.file_disk.block_backing.top_to_base: PASS (54.46 s)
 (3/4) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.base_image_exist_backingfile.file_disk.block_backing.top_to_mid: PASS (52.88 s)
 (4/4) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.base_image_exist_backingfile.file_disk.block_backing.mid_to_base: PASS (55.52 s)

/usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockcommit.base_image_exist_backingfile.file_disk.file_backing
 (1/4) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.base_image_exist_backingfile.file_disk.file_backing.mid_to_mid: PASS (34.11 s)
 (2/4) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.base_image_exist_backingfile.file_disk.file_backing.top_to_base: PASS (33.27 s)
 (3/4) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.base_image_exist_backingfile.file_disk.file_backing.top_to_mid: PASS (32.87 s)
 (4/4) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.base_image_exist_backingfile.file_disk.file_backing.mid_to_base: PASS (33.48 s)


```