### PR TITLE
migration: Add cases about memory copy mode

### DIFF
--- a/libvirt/tests/cfg/migration/memory_copy_mode/migration_memory_copy_mode_postcopy.cfg
+++ b/libvirt/tests/cfg/migration/memory_copy_mode/migration_memory_copy_mode_postcopy.cfg
@@ -1,0 +1,51 @@
+- migration.migration_memory_copy_mode:
+    type = migration_memory_copy_mode 
+    migration_setup = 'yes'
+    storage_type = 'nfs'
+    setup_local_nfs = 'yes'
+    disk_type = "file"
+    disk_source_protocol = "netfs"
+    mnt_path_name = ${nfs_mount_dir}
+    # Console output can only be monitored via virsh console output
+    only_pty = True
+    take_regular_screendumps = no
+    # Extra options to pass after <domain> <desturi>
+    virsh_migrate_extra = ''
+    # SSH connection time out
+    ssh_timeout = 60
+    # Local URI
+    virsh_migrate_connect_uri = 'qemu:///system'
+    virsh_migrate_dest_state = "running"
+    virsh_migrate_src_state = "shut off"
+    image_convert = 'no'
+    server_ip = "${migrate_dest_host}"
+    server_user = "root"
+    server_pwd = "${migrate_dest_pwd}"
+    status_error = "no"
+    check_network_accessibility_after_mig = "yes"
+    migrate_desturi_port = "16509"
+    transport_type = "tcp"
+    virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
+    stress_package = "stress"
+    stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20s"
+
+    variants:
+        - p2p:
+            virsh_migrate_options = '--live --p2p --verbose'
+        - non_p2p:
+            virsh_migrate_options = '--live --verbose'
+    variants test_case:
+        - postcopy_migration:
+            variants:
+                - default_postcopy:
+                    postcopy_options = '--postcopy'
+                - migrate_postcopy:
+                    expected_event_src = 'Suspended Post-copy'
+                    postcopy_options = '--postcopy'
+                    action_during_mig = '[{"func": "virsh.migrate_postcopy", "after_event": "iteration: '1'", "func_param": "'%s' % params.get('migrate_main_vm')"}]'
+                - postcopy_after_precopy:
+                    expected_event_src = 'Suspended Post-copy'
+                    postcopy_options = '--postcopy --postcopy-after-precopy'
+                - timeout_postcopy:
+                    expected_event_src = 'Suspended Post-copy'
+                    postcopy_options = '--postcopy --timeout 10 --timeout-postcopy'

--- a/libvirt/tests/cfg/migration/memory_copy_mode/migration_memory_copy_mode_precopy.cfg
+++ b/libvirt/tests/cfg/migration/memory_copy_mode/migration_memory_copy_mode_precopy.cfg
@@ -1,0 +1,42 @@
+- migration.migration_memory_copy_mode.precopy:
+    type = migration_memory_copy_mode
+    migration_setup = 'yes'
+    storage_type = 'nfs'
+    setup_local_nfs = 'yes'
+    disk_type = "file"
+    disk_source_protocol = "netfs"
+    mnt_path_name = ${nfs_mount_dir}
+    # Console output can only be monitored via virsh console output
+    only_pty = True
+    take_regular_screendumps = no
+    # Extra options to pass after <domain> <desturi>
+    virsh_migrate_extra = ''
+    # SSH connection time out
+    ssh_timeout = 60
+    # Local URI
+    virsh_migrate_connect_uri = 'qemu:///system'
+    virsh_migrate_dest_state = "running"
+    virsh_migrate_src_state = "shut off"
+    image_convert = 'no'
+    server_ip = "${migrate_dest_host}"
+    server_user = "root"
+    server_pwd = "${migrate_dest_pwd}"
+    status_error = "no"
+    check_network_accessibility_after_mig = "yes"
+    migrate_desturi_port = "16509"
+    transport_type = "tcp"
+    virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
+
+    variants test_case:
+        - default:
+            migrate_speed = "20"
+            port_to_check = "16509"
+            check_local_port = "yes"
+            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: \'1\'", "func_param": "params"}]'
+            variants:
+                - p2p:
+                    service_to_check = "virtqemud"
+                    virsh_migrate_options = '--live --p2p --verbose'
+                - non_p2p:
+                    service_to_check = "virsh"
+                    virsh_migrate_options = '--live --verbose'

--- a/libvirt/tests/src/migration/memory_copy_mode/migration_memory_copy_mode.py
+++ b/libvirt/tests/src/migration/memory_copy_mode/migration_memory_copy_mode.py
@@ -1,0 +1,62 @@
+import re
+
+from virttest import libvirt_version
+from virttest import virsh
+
+from provider.migration import base_steps
+
+event_session = None
+
+
+def run(test, params, env):
+    """
+    Test live migration with precopy/postcopy.
+
+    :param test: test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    def setup_postcopy_migration():
+        """
+        Setup for postcopy migration
+        """
+        expected_event_src = params.get("expected_event_src")
+        if expected_event_src:
+            cmd = "event --loop --all"
+            global event_session
+            event_session = virsh.VirshSession(virsh_exec=virsh.VIRSH_EXEC,
+                                               auto_close=True)
+            event_session.sendline(cmd)
+        migration_obj.setup_connection()
+
+    def verify_postcopy_migration():
+        """
+        Verify for postcopy migration
+        """
+        expected_event_src = params.get("expected_event_src")
+        if expected_event_src:
+            global event_session
+            src_output = event_session.get_stripped_output()
+            test.log.debug("Event output on source: %s", src_output)
+            if not re.findall(expected_event_src, src_output):
+                test.fail("Unalbe to find event {}".format(expected_event_src))
+        migration_obj.verify_default()
+
+    libvirt_version.is_libvirt_feature_supported(params)
+
+    test_case = params.get('test_case', '')
+    vm_name = params.get("migrate_main_vm")
+
+    vm = env.get_vm(vm_name)
+    migration_obj = base_steps.MigrationBase(test, vm, params)
+    setup_test = eval("setup_%s" % test_case) if "setup_%s" % test_case in \
+        locals() else migration_obj.setup_connection
+    verify_test = eval("verify_%s" % test_case) if "verify_%s" % test_case in \
+        locals() else migration_obj.verify_default
+
+    try:
+        setup_test()
+        migration_obj.run_migration()
+        verify_test()
+    finally:
+        migration_obj.cleanup_connection()


### PR DESCRIPTION
    Add two cases:
    1. VIRT-293931 - VM live migration - precopy + p2p/non-p2p
    2. VIRT-293930 - VM live migration - postcopy

Signed-off-by: cliping <lcheng@redhat.com>
