### PR TITLE
memory_attach_device: Enable test for aarch64

### DIFF
--- a/libvirt/tests/cfg/memory/memory_attach_device.cfg
+++ b/libvirt/tests/cfg/memory/memory_attach_device.cfg
@@ -15,4 +15,6 @@
             func_supported_since_libvirt_ver = (8, 0, 0)
             func_supported_since_qemu_kvm_ver = (6, 2, 0)
             vm_attrs = {'max_mem_rt': 10485760, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB', 'vcpu': 4, 'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '524288', 'unit': 'KiB'}]}}
+            aarch64:
+                vm_attrs = {'max_mem_rt': 10485760, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB', 'vcpu': 4, 'cpu': {'mode': 'host-passthrough', 'numa_cell': [{'id': '0', 'cpus': '0-3', 'memory': '524288', 'unit': 'KiB'}]}}
             mem_device_attrs = {'mem_model': 'virtio-mem', 'target': {'requested_unit': 'KiB', 'size': 262144, 'node': 0, 'size_unit': 'KiB', 'requested_size': 131072, 'block_unit': 'KiB', 'block_size': 2048}, 'source': {'pagesize_unit': 'KiB', 'pagesize': 2048, 'nodemask': '0'}}


### PR DESCRIPTION
Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Test rt.
```
 (1/2) type_specific.io-github-autotest-libvirt.memory_attach_device.virtio_mem.cold_plug: STARTED
 (1/2) type_specific.io-github-autotest-libvirt.memory_attach_device.virtio_mem.cold_plug: PASS (94.16 s)
 (2/2) type_specific.io-github-autotest-libvirt.memory_attach_device.virtio_mem.hot_plug: STARTED
 (2/2) type_specific.io-github-autotest-libvirt.memory_attach_device.virtio_mem.hot_plug: PASS (94.20 s)
```
