### PR TITLE
fix qemu-img --backingchain hung error

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockcommit/blockcommit_conventional_chain.cfg
+++ b/libvirt/tests/cfg/backingchain/blockcommit/blockcommit_conventional_chain.cfg
@@ -37,5 +37,6 @@
             auth_key = "EXAMPLE_AUTH_KEY"
             auth_user = "EXAMPLE_AUTH_USER"
             image_path = "EXAMPLE_IMAGE_PATH"
+            client_name = "EXAMPLE_CLIENT_NAME"
             sec_dict = {"secret_ephemeral": "no", "secret_private": "yes", "description": "secret_desc_for_backingchain", "usage": "ceph", "usage_name": "cephlibvirt"}
             disk_dict = {"type_name":"network", "target":{"dev": "${target_disk}", "bus": "virtio"}, "driver": {"name": "qemu", "type":"raw"}}

--- a/libvirt/tests/src/backingchain/blockcommit/blockcommit_conventional_chain.py
+++ b/libvirt/tests/src/backingchain/blockcommit/blockcommit_conventional_chain.py
@@ -1,5 +1,7 @@
 import logging
 
+from avocado.utils import process
+
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_libvirt import libvirt_disk
@@ -85,7 +87,8 @@ def run(test, params, env):
 
         bkxml.sync()
         disk_obj.cleanup_disk_preparation(disk_type)
-
+        if disk_type == "rbd_with_auth":
+            process.run("rm -f %s" % params.get('keyfile'))
     # Process cartesian parameters
     vm_name = params.get("main_vm")
     target_disk = params.get('target_disk')

--- a/provider/virtual_disk/disk_base.py
+++ b/provider/virtual_disk/disk_base.py
@@ -196,8 +196,13 @@ class DiskBase(object):
         mon_host = params.get("mon_host")
         new_image_path = params.get("image_path")
         auth_username = params.get("auth_user")
+        client_name = params.get("client_name")
 
         ceph.create_config_file(mon_host)
+        params.update(
+            {'keyfile': ceph.create_keyring_file(client_name, auth_key)})
+        LOG.debug('Create key file :%s' % params.get('keyfile'))
+
         libvirt_secret.clean_up_secrets()
         sec_uuid = libvirt_secret.create_secret(sec_dict=sec_dict)
         virsh.secret_set_value(sec_uuid, auth_key, debug=True)


### PR DESCRIPTION
   rbd disk qemu-img hung for long time due to no keyring
Signed-off-by: nanli <nanli@redhat.com>

```
/usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockcommit.conventional_chain.rbd_with_auth_disk  --vt-connect-uri qemu:///system
 (1/4)backingchain.blockcommit.conventional_chain.rbd_with_auth_disk.mid_to_mid: PASS (34.56 s)
 (2/4)backingchain.blockcommit.conventional_chain.rbd_with_auth_disk.top_to_base: PASS (32.09 s)
 (3/4)backingchain.blockcommit.conventional_chain.rbd_with_auth_disk.top_to_mid: PASS (32.21 s)
 (4/4)backingchain.blockcommit.conventional_chain.rbd_with_auth_disk.mid_to_base: PASS (32.81 s)
```
