### PR TITLE
[minor fix] virsh_nodecpumap: Remove unused func turn_off_on_cpu

### DIFF
--- a/libvirt/tests/src/virsh_cmd/host/virsh_nodecpumap.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_nodecpumap.py
@@ -158,28 +158,6 @@ def check_result(result, option, status_error, test):
             test.fail("Online cpu is not expected")
 
 
-def turn_off_on_cpu(cpu, off, test):
-    """
-    Turn off/on cpu
-    :param cpu: CPU name like 'cpu3'
-    :param off: Turn off or turn on the cpu.
-                True means off, False means on
-    :param test: The test object
-    :return: Success or raise exception
-    """
-
-    if off:
-        logging.debug("Turn off %s", cpu)
-        cmd = "echo 0 > %s/%s/online" % (SYSFS_SYSTEM_PATH, cpu)
-    else:
-        logging.debug("Turn on %s", cpu)
-        cmd = "echo 1 > %s/%s/online" % (SYSFS_SYSTEM_PATH, cpu)
-
-    ret = process.run(cmd, shell=True, ignore_status=True)
-    if ret.exit_status:
-        test.fail("Failed to set cpu: %s" % ret.stderr_text)
-
-
 def run(test, params, env):
     """
     Test the command virsh nodecpumap


### PR DESCRIPTION
This test has used cpu.online/offline, turn_off_on_cpu is unused.

```
 (1/4) type_specific.io-github-autotest-libvirt.virsh.nodecpumap.no_option: STARTED
 (1/4) type_specific.io-github-autotest-libvirt.virsh.nodecpumap.no_option: PASS (6.18 s)
 (2/4) type_specific.io-github-autotest-libvirt.virsh.nodecpumap.pretty_option: STARTED
 (2/4) type_specific.io-github-autotest-libvirt.virsh.nodecpumap.pretty_option: PASS (6.17 s)
 (3/4) type_specific.io-github-autotest-libvirt.virsh.nodecpumap.unexpect_option: STARTED
 (3/4) type_specific.io-github-autotest-libvirt.virsh.nodecpumap.unexpect_option: PASS (6.09 s)
 (4/4) type_specific.io-github-autotest-libvirt.virsh.nodecpumap.cpu_off_on: STARTED
 (4/4) type_specific.io-github-autotest-libvirt.virsh.nodecpumap.cpu_off_on: PASS (6.73 s)
```

