### PR TITLE
snapshot: Make sure the guest boot successfully before snapshot-create-as

### DIFF
--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_edit.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_edit.py
@@ -22,6 +22,7 @@ def run(test, params, env):
     """
 
     vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
     status_error = params.get("status_error", "no")
     snap_desc = params.get("snapshot_edit_description")
     snap_cur = params.get("snapshot_edit_current", "")
@@ -127,6 +128,8 @@ def run(test, params, env):
 
     snapshot_oldlist = None
     try:
+        if params.get("start_vm") == "yes":
+            vm.wait_for_login().close()
         # Create disk snapshot before all to make the origin image clean
         logging.debug("Create snap-temp --disk-only")
         ret = virsh.snapshot_create_as(vm_name, "snap-temp --disk-only",


### PR DESCRIPTION
Make sure the guest boot successfully before creating snapshot, otherwise it may fail.

Before:
```
# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio virsh.snapshot_edit.positive_tests.edit_option_rename.edit_option_current_and_snapname.disk_snapshot.with_desc.disk_
snapshot --vt-connect-uri qemu:///system                                                                                                                                                                                                                                                                             
JOB ID     : 75dcc0e77481b4331486d35554502bb1934f06e9                                          
JOB LOG    : /var/lib/avocado/job-results/job-2022-07-06T05.09-75dcc0e/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.snapshot_edit.positive_tests.edit_option_rename.edit_option_current_and_snapname.disk_snapshot.with_desc.disk_snapshot: FAIL: Failed to create snapshot. Error:. (501.31 s)            
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0                                                                                                                                                             
JOB HTML   : /var/lib/avocado/job-results/job-2022-07-06T05.09-75dcc0e/results.html
JOB TIME   : 502.14 s
```
After:
```
# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio virsh.snapshot_edit.positive_tests.edit_option_rename.edit_option_current_and_snapname.disk_snapshot.with_desc.disk_snapshot --vt-connect-uri qemu:///system
JOB ID     : e14fb621471ecce592885d3190b575b58e36d88b
JOB LOG    : /var/lib/avocado/job-results/job-2022-07-06T07.59-e14fb62/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.snapshot_edit.positive_tests.edit_option_rename.edit_option_current_and_snapname.disk_snapshot.with_desc.disk_snapshot: PASS (34.13 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-07-06T07.59-e14fb62/results.html
JOB TIME   : 35.02 s
```
Signed-off-by: Hu Shuai <hus.fnst@fujitsu.com>

