### PR TITLE
memory_misc: Enable managedsave test for aarch64

### DIFF
--- a/libvirt/tests/cfg/memory/memory_misc.cfg
+++ b/libvirt/tests/cfg/memory/memory_misc.cfg
@@ -111,3 +111,7 @@
                     vmxml_vcpu = 4
                     numa_node_size = 2048000
                     cpu_attrs = {'numa_cell': [{'id': '0', 'cpus': '0,2', 'memory': '${numa_node_size}', 'unit': 'KiB'}, {'id': '1', 'cpus': '1,3', 'memory': '${numa_node_size}', 'unit': 'KiB'}]}
+                    aarch64:
+                        vmxml_memory = 3145760
+                        vmxml_current_mem = 3045760
+                        cpu_attrs = {'mode': 'host-passthrough', 'numa_cell': [{'id': '0', 'cpus': '0,2', 'memory': '${numa_node_size}', 'unit': 'KiB'}, {'id': '1', 'cpus': '1,3', 'memory': '${numa_node_size}', 'unit': 'KiB'}]}


### PR DESCRIPTION
Signed-off-by: Hu Shuai <hus.fnst@fujitsu.com>

Enable managedsave test for rhel8.7 aarch64:
1. Set cpu mode as host-passthrough for aarch64.
2. Update currentMemory to a multiple of 64 as the pagesize of rhel8.7 aarch64 is 64 KiB.

Test result:
(1/1) type_specific.io-github-autotest-libvirt.memory_misc.managedsave.size_check: PASS (47.40 s)