### PR TITLE
add case for detach rng with alias

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
@@ -40,6 +40,11 @@
             detach_interface_type = "network_interface"
             interface_dict = {"source": {'network':'default','bridge':'virbr0'},"target":{'dev': 'vnet0'}}
             detach_check_xml = "<interface"
+        - rng:
+            only live,config
+            detach_rng_type = "rng"
+            rng_dict = {"rng_model": "virtio","backend":{"backend_model":"random", "backend_dev":"/dev/urandom"}}
+            detach_check_xml = "<rng"
     variants:
         - live:
             detach_alias_options = "--live"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
@@ -55,6 +55,9 @@ def run(test, params, env):
     # interface params
     interface_type = params.get("detach_interface_type")
     interface_dict = eval(params.get('interface_dict', '{}'))
+    # rng params
+    rng_type = params.get("detach_rng_type")
+    rng_dict = eval(params.get('rng_dict', '{}'))
 
     device_alias = "ua-" + str(uuid.uuid4())
 
@@ -167,6 +170,17 @@ def run(test, params, env):
         interface_dict.update({"alias": {"name": device_alias}})
         libvirt_vmxml.modify_vm_device(
             vmxml=vmxml, dev_type='interface', dev_dict=interface_dict)
+
+        if not vm.is_alive():
+            vm.start()
+        vm.wait_for_login(timeout=240).close()
+
+        attach_device = False
+
+    if rng_type:
+        rng_dict.update({"alias": {"name": device_alias}})
+        libvirt_vmxml.modify_vm_device(vmxml=vmxml,
+                                       dev_type='rng', dev_dict=rng_dict)
 
         if not vm.is_alive():
             vm.start()


### PR DESCRIPTION
   RHEL-148239: Rng device can be detached by alias through 'virsh detach-device-alias' cmd
Signed-off-by: nanli <nanli@redhat.com>

**Test result**
```
/usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 virsh.detach_device_alias..rng
 (1/2) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.rng: PASS (33.60 s)
 (2/2) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.config.rng: PASS (24.11 s)
```
