### PR TITLE
Fix the issues about flock/posix

### DIFF
--- a/libvirt/tests/cfg/virtual_device/filesystem_device.cfg
+++ b/libvirt/tests/cfg/virtual_device/filesystem_device.cfg
@@ -4,8 +4,8 @@
     vms = "avocado-vt-vm1"
     start_vm = no
     cache_mode = "none"
-    lock_posix = "on"
-    flock = "on"
+    lock_posix = "off"
+    flock = "off"
     virtiofsd_path = "/usr/libexec/virtiofsd"
     queue_size = "512"
     driver_type = "virtiofs"
@@ -32,13 +32,13 @@
                 - two_guests:
                     vms = "avocado-vt-vm1 avocado-vt-vm2"
                     guest_num = 2
-                    only nop.fs_test.xattr_on.flock_on.lock_posix_on.cache_mode_none.one_fs, hotplug_unplug..fs_test.xattr_on.flock_on.lock_posix_on.cache_mode_none.one_fs
+                    only nop.fs_test.xattr_on.flock_off.lock_posix_off.cache_mode_none.one_fs, hotplug_unplug..fs_test.xattr_on.flock_off.lock_posix_off.cache_mode_none.one_fs
             variants:
                 - one_fs:
                     fs_num = 1
                 - multiple_fs:
                     fs_num = 2
-                    only xattr_on.flock_on.lock_posix_on.cache_mode_none
+                    only xattr_on.flock_off.lock_posix_off.cache_mode_none
             variants:
                 - cache_mode_none:
                     cache_mode = "none"
@@ -67,9 +67,9 @@
         - nop:
         - socket_file_checking:
             socket_file_checking = "yes"
-            only xattr_on.flock_on.lock_posix_on.cache_mode_none, externally_launched_fs_test 
+            only xattr_on.flock_off.lock_posix_off.cache_mode_none, externally_launched_fs_test
         - lifecycle:
-            only xattr_on.flock_on.lock_posix_on.cache_mode_none.one_fs
+            only xattr_on.flock_off.lock_posix_off.cache_mode_none.one_fs
             variants:
                 - suspend_resume:
                     suspend_resume = "yes"
@@ -82,14 +82,14 @@
                     destroy_start = "yes"
                     stress_script = "#!/usr/bin/python3;import os;while True:;    os.open("%s/moo", os.O_CREAT | os.O_RDWR);    os.unlink("%s/moo");"
         - coldplug_coldunplug:
-            only xattr_on.flock_on.lock_posix_on.cache_mode_none.one_fs
+            only xattr_on.flock_off.lock_posix_off.cache_mode_none.one_fs
             coldplug = "yes"
         - hotplug_unplug:
             hotplug_unplug = "yes"
             variants:
                 - detach_device_alias:
                     detach_device_alias = "yes"
-                    only xattr_on.flock_on.lock_posix_on.cache_mode_none
+                    only xattr_on.flock_off.lock_posix_off.cache_mode_none
                     variants:
                         - stdio_handler:
                             variants:
@@ -114,7 +114,7 @@
                       with_hugepages = no
                       with_memfd = yes
         - negative_test:
-            only fs_test.xattr_on.flock_on.lock_posix_on.cache_mode_none.one_fs.one_guest
+            only fs_test.xattr_on.flock_off.lock_posix_off.cache_mode_none.one_fs.one_guest
             status_error = "yes"
             variants:
                 - invalid_queue_size:


### PR DESCRIPTION
1) As shown in https://bugzilla.redhat.com/show_bug.cgi?id=2057882#c9,
posix/flock is not supported, some import scenarios in only tested when
posix/flock=on before, and these scenarios have be added into skiplist.
We should change posix/flock to off in these scenarios.

2) If I run the cases on my local machine, there would be a process of
avocado contains "virtiofsd". If one just grep the first process of
virtiofsd, it is not the virtiofsd process itself.

Signed-off-by: Lili Zhu <lizhu@redhat.com>
