### PR TITLE
sriov: Add a negative lifecycle case

### DIFF
--- a/libvirt/tests/cfg/sriov/vm_lifecycle/sriov_vm_lifecycle_start_negative.cfg
+++ b/libvirt/tests/cfg/sriov/vm_lifecycle/sriov_vm_lifecycle_start_negative.cfg
@@ -1,0 +1,38 @@
+- sriov.vm_lifecycle.start.negative:
+    type = sriov_vm_lifecycle_start_negative
+    start_vm = "no"
+    status_error = "yes"
+    only x86_64
+    variants dev_type:
+        - hostdev_interface:
+            variants test_scenario:
+                - vlan_trunk:
+                    iface_dict = {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}, 'vlan': {'tags': [{'id': '42'}, {'id': '47'}], 'trunk': 'yes'}}
+                    err_msg = "vlan trunking is not supported"
+                - inactive_pf:
+                    iface_dict = {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}}
+                    err_msg = "PF is not online"
+                - inactive_network:
+                    iface_dict = {'mac_address': mac_addr, 'type_name': 'network', 'source': {'network': 'hostdev_net'}}
+                    network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev"}', 'vf_list_attrs': vf_list_attrs}
+                    err_msg = "network.*is not active"
+                - pf_address:
+                    iface_dict = {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': pf_pci_addr}}
+                    err_msg = "supported on SR-IOV Virtual Functions only"
+                - unsupported_virtualport:
+                    iface_dict = {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}, 'virtualport': {'parameters': {'profileid': 'finance'}, 'type': '802.1Qbh'}}
+                    err_msg = "PortProfileRequest"
+                - unassigned_address:
+                    iface_dict = {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'attrs': vf_pci_addr}, 'address': {'attrs':{'type': 'unassigned'}}}
+                    err_msg = "is supported only for hostdev"
+                    define_err = "yes"
+                - iommu_without_caching:
+                    iommu_dict = {'driver': {'intremap': 'on'}, 'model': 'intel'}
+                    iface_dict = {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}}
+                    err_msg = "iommu to enable"
+        - hostdev_device:
+            variants test_scenario:
+                - iommu_without_caching:
+                    iommu_dict = {'driver': {'intremap': 'on'}, 'model': 'intel'}
+                    hostdev_dict = {'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': vf_pci_addr}, 'managed': 'yes'}
+                    err_msg = "iommu to enable"

--- a/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_start_negative.py
+++ b/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_start_negative.py
@@ -1,0 +1,59 @@
+from provider.sriov import sriov_base
+
+from virttest import utils_net
+from virttest import virsh
+
+from virttest.utils_test import libvirt
+
+
+def run(test, params, env):
+    """
+    Start vm with a hostdev device or hostdev interface(negative)
+    """
+    def run_test():
+        """
+        Start vm with an interface/device of hostdev type
+        """
+        if test_scenario == "inactive_pf":
+            utils_net.Interface(sriov_test_obj.pf_name).down()
+        elif test_scenario == "inactive_network":
+            virsh.net_destroy(network_dict['net_name'], debug=True)
+
+        test.log.info("TEST_STEP1: Attach a hostdev interface/device to VM")
+        iface_dev = sriov_test_obj.create_iface_dev(dev_type, iface_dict)
+        result = virsh.attach_device(vm_name, iface_dev.xml, flagstr="--config",
+                                     debug=True)
+        libvirt.check_exit_status(result, define_err)
+        if define_err:
+            if err_msg:
+                libvirt.check_result(result, err_msg)
+            return
+
+        test.log.info("TEST_STEP2: Start the VM")
+        result = virsh.start(vm.name, debug=True)
+        libvirt.check_exit_status(result, True)
+        if err_msg:
+            libvirt.check_result(result, err_msg)
+
+    dev_type = params.get("dev_type", "")
+    test_scenario = params.get("test_scenario")
+
+    define_err = "yes" == params.get("define_err")
+    err_msg = params.get("err_msg")
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    vm = env.get_vm(vm_name)
+    sriov_test_obj = sriov_base.SRIOVTest(vm, test, params)
+    test_dict = sriov_test_obj.parse_iommu_test_params()
+    iface_dict = sriov_test_obj.parse_iface_dict()
+    network_dict = sriov_test_obj.parse_network_dict()
+    try:
+        if test_dict['iommu_dict']:
+            sriov_test_obj.setup_iommu_test(**test_dict)
+        else:
+            sriov_test_obj.setup_default(network_dict=network_dict)
+        run_test()
+
+    finally:
+        if test_scenario == "inactive_pf":
+            utils_net.Interface(sriov_test_obj.pf_name).up()
+        sriov_test_obj.teardown_default(network_dict=network_dict)


### PR DESCRIPTION
VIRT-293914 - Start vm with hostdev interface/device - some negative scenarios

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**depends on:** https://github.com/avocado-framework/avocado-vt/pull/3456
**Test results:**
```
 (1/8) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start.negative.hostdev_interface.vlan_trunk: PASS (16.39 s)
 (2/8) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start.negative.hostdev_interface.inactive_pf: PASS (16.50 s)
 (3/8) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start.negative.hostdev_interface.inactive_network: PASS (17.02 s)
 (4/8) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start.negative.hostdev_interface.pf_address: PASS (16.43 s)
 (5/8) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start.negative.hostdev_interface.unsupported_virtualport: PASS (16.25 s)
 (6/8) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start.negative.hostdev_interface.unassigned_address: PASS (16.27 s)
 (7/8) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start.negative.hostdev_interface.iommu_without_caching: PASS (18.98 s)
 (8/8) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start.negative.hostdev_device.iommu_without_caching: PASS (18.72 s)

```