### PR TITLE
remote_access: Remove redundant tls object

### DIFF
--- a/libvirt/tests/src/remote_access/remote_access.py
+++ b/libvirt/tests/src/remote_access/remote_access.py
@@ -515,12 +515,10 @@ def run(test, params, env):
         # change /etc/pki/libvirt/servercert.pem then
         # restart libvirt service on the remote host
         if tls_sanity_cert == "no" and ca_cn_new:
-            test_dict['ca_cn'] = ca_cn_new
-            test_dict['scp_new_cacert'] = 'no'
-            tls_obj_new = TLSConnection(test_dict)
-            test_dict['tls_obj_new'] = tls_obj_new
+            tls_obj.ca_cn = ca_cn_new
+            tls_obj.scp_new_cacert = "no"
             # only setup new CA and server
-            tls_obj_new.conn_setup(True, False)
+            tls_obj.conn_setup(True, False)
 
         # obtain and cache a ticket
         if kinit_pwd and sasl_type == 'gssapi' and auth_unix_rw == 'sasl':


### PR DESCRIPTION
The tls object has been [set up before](https://github.com/autotest/tp-libvirt/blob/master/libvirt/tests/src/remote_access/remote_access.py#L416), no need to [instantiate it again](https://github.com/autotest/tp-libvirt/blob/master/libvirt/tests/src/remote_access/remote_access.py#L520).

Creating a new tls object causes it to back up the conf file that was modified by the old tls object, making it ultimately impossible to restore the conf file to its original state.

Test Result:
(1/1) type_specific.io-github-autotest-libvirt.virsh.remote_with_tls.positive_testing.no_sanity_checks_and_no_verify: PASS (268.93 s)
(1/1) type_specific.io-github-autotest-libvirt.virsh.remote_with_tls.negative_testing.no_sanity_checks_without_no_verify: PASS (260.93 s)

Signed-off-by: Hu Shuai <hus.fnst@fujitsu.com>


