### PR TITLE
virtio_rng: Cold-plug/unplug a egd backend virtio-rng device - TCP connect/bind mode	

### DIFF
--- a/libvirt/tests/cfg/virtual_device/virtio_rng.cfg
+++ b/libvirt/tests/cfg/virtual_device/virtio_rng.cfg
@@ -3,6 +3,11 @@
    start_vm = no
 
    variants test_case:
-       - coldplug_unplug:
-           rng_device_dict = {"rng_model": "virtio", "backend": {"backend_model": "random", "backend_dev": "/dev/urandom"}}
+       - coldplug_unplug_random_backend:
            backend_dev = "/dev/urandom"
+           rng_device_dict = {"rng_model": "virtio", "backend": {"backend_model": "random", "backend_dev": "${backend_dev}"}}
+       - coldplug_unplug_egd_backend_connect_mode:
+           rng_port = "2345"
+           rng_device_dict = {"rng_model": "virtio", "backend": {"backend_model": "egd", "backend_type": "tcp", 'backend_dev': '\n        ', "source": [{"mode": "connect", "host": "localhost", "service": "${rng_port}", "tls": "no"}], "backend_protocol": "raw"}}
+       - coldplug_unplug_egd_backend_bind_mode:
+           rng_device_dict = {"rng_model": "virtio", "backend": {"backend_model": "egd", "backend_type": "tcp", 'backend_dev': '\n        ', "backend_protocol": "raw", "source": [{"mode": "bind", "host": "localhost", "service": "2345", "tls": "no"}]}}

--- a/libvirt/tests/src/virtual_device/virtio_rng.py
+++ b/libvirt/tests/src/virtual_device/virtio_rng.py
@@ -1,5 +1,6 @@
 import logging as log
 
+from virttest import utils_misc
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_libvirt import libvirt_vmxml
@@ -7,7 +8,7 @@ from virttest.utils_libvirt import libvirt_vmxml
 from provider.virtio_rng import check_points as virtio_provider
 
 logging = log.getLogger('avocado.' + __name__)
-
+locs = locals()
 
 def check_attached_rng_device(vm_name, rng_device_dict):
     """
@@ -37,7 +38,33 @@ def check_detached_rng_device(vm_name, test):
         test.fail("VM still has RNG device after detachment.")
 
 
-def setup_test(vm):
+def handle_connection_mode_fail(rng_port):
+    """
+    Starts a separate process feeding data to /dev/urandom and restarts vm.
+    The following code is just a first idea, untested
+    """
+    bgjob = utils_misc.AsyncJob(f"cat /dev/urandom | nc -l localhost -p {rng_port}")
+    return bgjob
+
+
+def create_attach_check_rng_device(vm_name, rng_device_dict):
+    rng_dev = libvirt_vmxml.create_vm_device_by_type(
+        "rng", rng_device_dict)
+    virsh.attach_device(vm_name, rng_dev.xml, flagstr="--config", debug=True)
+    check_attached_rng_device(vm_name, rng_device_dict)
+    return rng_dev
+
+
+def do_common_check_after_vm_start(vm_name, rng_dev, rng_device_dict, test, vm):
+    check_attached_rng_device(vm_name, rng_device_dict)
+    ssh_session = vm.wait_for_login()
+    virtio_provider.check_guest_dump(ssh_session)
+    ssh_session.close()
+    virsh.detach_device(vm_name, rng_dev.xml, flagstr="--config")
+    check_detached_rng_device(vm_name, test)
+
+
+def setup_basic(vm):
     """
     Function that prepares a test environment and guest.
 
@@ -49,7 +76,7 @@ def setup_test(vm):
     libvirt_vmxml.remove_vm_devices_by_type(vm, "rng")
 
 
-def execute_test(test, params, vm):
+def execute_basic(test, params, vm):
     """
     Function that runs the checks that are in the test
 
@@ -68,14 +95,15 @@ def execute_test(test, params, vm):
     check_attached_rng_device(vm_name, rng_device_dict)
 
     ssh_session = vm.wait_for_login()
-    virtio_provider.check_host(params.get("backend_dev"))
+    if params.get("backend_dev"):
+        virtio_provider.check_host(params.get("backend_dev"))
     virtio_provider.check_guest_dump(ssh_session)
     virsh.detach_device(vm_name, rng_dev.xml, flagstr="--config")
     check_detached_rng_device(vm_name, test)
     ssh_session.close()
 
 
-def cleanup_test(vmxml_backup, vm):
+def cleanup_basic(vmxml_backup, vm):
     """
     Remove the changes made by setup_test function
 
@@ -86,6 +114,58 @@ def cleanup_test(vmxml_backup, vm):
         vm.destroy(gracefully=False)
     logging.info("Restoring vm...")
     vmxml_backup.sync()
+
+
+def execute_coldplug_unplug_random_backend(test, params, vm):
+    execute_basic(test, params, vm)
+
+
+def execute_coldplug_unplug_egd_backend_connect_mode(test, params, vm):
+    """
+    Runs check according to
+    https://polarion.engineering.redhat.com/polarion/#/project/RHELVIRT/workitem?id=RHEL-112411
+    in connect mode.
+
+    :params test: The avocado test object
+    :params params: Parameters for the test
+    :params vm: The VM object
+    """
+    vm_name = params.get("main_vm")
+    rng_device_dict = eval(params.get("rng_device_dict"))
+    feed_process = None
+
+    rng_dev = create_attach_check_rng_device(vm_name, rng_device_dict)
+
+    try:
+        vm.start()
+    except:
+        feed_process = handle_connection_mode_fail(params.get("rng_port"))
+        vm.start()
+        pass
+    do_common_check_after_vm_start(vm_name, rng_dev, rng_device_dict, test, vm)
+
+    if feed_process:
+        feed_process.kill_func()
+
+
+def execute_coldplug_unplug_egd_backend_bind_mode(test, params, vm):
+    """
+    Runs check according to
+    https://polarion.engineering.redhat.com/polarion/#/project/RHELVIRT/workitem?id=RHEL-112411
+    in bind mode.
+
+    :params test: The avocado test object
+    :params params: Parameters for the test
+    :params vm: The VM object
+    """
+    vm_name = params.get("main_vm")
+    rng_device_dict = eval(params.get("rng_device_dict"))
+    rng_dev = create_attach_check_rng_device(vm_name, rng_device_dict)
+
+    vm.start()
+    check_attached_rng_device(vm_name, rng_device_dict)
+
+    do_common_check_after_vm_start(vm_name, rng_dev, rng_device_dict, test, vm)
 
 
 def run(test, params, env):
@@ -99,6 +179,15 @@ def run(test, params, env):
     vm_name = params.get("main_vm")
     vm = env.get_vm(vm_name)
     vmxml_backup = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+
+    test_case = params.get("test_case", "")
+    module_fields = dir(__import__(__name__))
+    setup_test = (eval(f"setup_{test_case}") if f"setup_{test_case}"
+    in module_fields else setup_basic)
+    execute_test = (eval(f"execute_{test_case}") if f"execute_{test_case}"
+    in module_fields else execute_basic)
+    cleanup_test = (eval(f"cleanup_{test_case}") if f"cleanup_{test_case}"
+    in locals() else cleanup_basic)
 
     try:
         setup_test(vm)


### PR DESCRIPTION
WIP: Code cleanup and documentation still needs to be done, however this is a feature complete code
Also CI job name needs to be changed

This commit adds automated version of polarion case RHEL-112411. It
tests Rng device type egd coldplugging and unplugging. Both bind mode
and connect mode are tested.

https://polarion.engineering.redhat.com/polarion/#/project/RHELVIRT/workitem?id=RHEL-112411

```
# avocado run --vt-type libvirt virtio_rng
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : e65494bfaf6c4a2ae7d325847ca2857e5905d22a
JOB LOG    : /root/avocado/job-results/job-2022-07-15T21.47-e65494b/job.log
 (1/3) type_specific.io-github-autotest-libvirt.virtio_rng.coldplug_unplug_random_backend: STARTED
 (1/3) type_specific.io-github-autotest-libvirt.virtio_rng.coldplug_unplug_random_backend: PASS (22.32 s)
 (2/3) type_specific.io-github-autotest-libvirt.virtio_rng.coldplug_unplug_egd_backend_connect_mode: STARTED
 (2/3) type_specific.io-github-autotest-libvirt.virtio_rng.coldplug_unplug_egd_backend_connect_mode: PASS (59.14 s)
 (3/3) type_specific.io-github-autotest-libvirt.virtio_rng.coldplug_unplug_egd_backend_bind_mode: STARTED
 (3/3) type_specific.io-github-autotest-libvirt.virtio_rng.coldplug_unplug_egd_backend_bind_mode: PASS (83.75 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/avocado/job-results/job-2022-07-15T21.47-e65494b/results.html
JOB TIME   : 172.47 s
```
# Check lists by category
## If the PR is new cases
- [x] Description of the cases
- [x] Links of libvirt features, libvirt bugs or case IDs
- [x] Test results
