### PR TITLE
virtio_rng: Cold-plug/unplug a egd backend virtio-rng device - TCP connect/bind mode	

### DIFF
--- a/libvirt/tests/cfg/virtual_device/virtio_rng.cfg
+++ b/libvirt/tests/cfg/virtual_device/virtio_rng.cfg
@@ -3,6 +3,11 @@
    start_vm = no
 
    variants test_case:
-       - coldplug_unplug:
-           rng_device_dict = {"rng_model": "virtio", "backend": {"backend_model": "random", "backend_dev": "/dev/urandom"}}
+       - coldplug_unplug_random_backend:
            backend_dev = "/dev/urandom"
+           rng_device_dict = {"rng_model": "virtio", "backend": {"backend_model": "random", "backend_dev": "${backend_dev}"}}
+       - coldplug_unplug_egd_tcp_connect_mode:
+           rng_port = "2345"
+           rng_device_dict = {"rng_model": "virtio", "backend": {"backend_model": "egd", "backend_type": "tcp", "source": [{"mode": "connect", "host": "localhost", "service": "${rng_port}", "tls": "no"}], "backend_protocol": "raw"}}
+       - coldplug_unplug_egd_tcp_bind_mode:
+           rng_device_dict = {"rng_model": "virtio", "backend": {"backend_model": "egd", "backend_type": "tcp", "backend_protocol": "raw", "source": [{"mode": "bind", "host": "localhost", "service": "2345", "tls": "no"}]}}

--- a/libvirt/tests/src/virtual_device/virtio_rng.py
+++ b/libvirt/tests/src/virtual_device/virtio_rng.py
@@ -1,26 +1,33 @@
 import logging as log
 
+from avocado.utils import process
+
+from virttest import utils_misc
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_libvirt import libvirt_vmxml
+from virttest.virt_vm import VMStartError
+from virttest.staging import service
 
 from provider.virtio_rng import check_points as virtio_provider
 
 logging = log.getLogger('avocado.' + __name__)
 
 
-def check_attached_rng_device(vm_name, rng_device_dict):
+def check_attached_rng_device(vm_name, rng_device_dict, remove_keys=None):
     """
     Make sure the XML contains all information required by the test after
     the VM is started.
 
     :params vm_name: Name of the virtual machine to test
     :params rng_device_dict: Dictionary containing data that should be
+    :params remove_keys: Array of keys that should be removed when doing
+    the check
     in VM rng
     """
 
     vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
-    virtio_provider.comp_rng_xml(vmxml, rng_device_dict)
+    virtio_provider.comp_rng_xml(vmxml, rng_device_dict, remove_keys)
 
 
 def check_detached_rng_device(vm_name, test):
@@ -37,7 +44,60 @@ def check_detached_rng_device(vm_name, test):
         test.fail("VM still has RNG device after detachment.")
 
 
-def setup_test(vm):
+def handle_connection_mode_fail(rng_port):
+    """
+    Starts a separate process feeding data rng device in vm and restarts vm.
+
+    :param rng_port: Port where we should listen for connections from VM
+    :return: Background job feeding data to the opened port
+    """
+    # The second grep filters the grep process itself, otherwise the cmd would
+    # always be successful, because it would match at least one process,
+    # the grep process
+    cmd = 'ps aux | grep "*. /sbin/rngd -f -r /dev/urandom -o /dev/random" | grep -v grep'
+    result = process.run(cmd, shell=True, ignore_status=True)
+    if result.exit_status == 0:
+        rngd_service = service.Factory.create_service("rngd")
+        rngd_service.stop()
+    bgjob = utils_misc.AsyncJob(f"cat /dev/urandom | nc -l localhost {rng_port}")
+    return bgjob
+
+
+def create_attach_check_rng_device(vm_name, rng_device_dict, remove_keys=None):
+    """
+    Creates, attaches, and checks rng device.
+
+    :param vm_name: Name of the VM where the device should be attached.
+    :param rng_device_dict: Rng device dictionary from which the device should
+    be created
+    :param remove_keys:  Array of keys that should be removed from dict
+    :return: Rng device that was created according to  rng_device_dict
+    """
+    rng_dev = libvirt_vmxml.create_vm_device_by_type(
+        "rng", rng_device_dict)
+    virsh.attach_device(vm_name, rng_dev.xml, flagstr="--config", debug=True)
+    check_attached_rng_device(vm_name, rng_device_dict, remove_keys)
+    return rng_dev
+
+
+def do_common_check_after_vm_start(vm_name, rng_dev, rng_device_dict, test, vm):
+    """
+    Contains most common steps we do after we start the VM.
+
+    :param vm_name: Name of VM we're working with
+    :param rng_dev: Random number generator device object
+    :param rng_device_dict: A device dict that was used to create rng device in previous step
+    :param test: Test object from avocado
+    :param vm: VM object from avocado
+    """
+    ssh_session = vm.wait_for_login()
+    virtio_provider.check_guest_dump(ssh_session)
+    ssh_session.close()
+    virsh.detach_device(vm_name, rng_dev.xml, flagstr="--config")
+    check_detached_rng_device(vm_name, test)
+
+
+def setup_basic(vm):
     """
     Function that prepares a test environment and guest.
 
@@ -49,7 +109,7 @@ def setup_test(vm):
     libvirt_vmxml.remove_vm_devices_by_type(vm, "rng")
 
 
-def execute_test(test, params, vm):
+def execute_basic(test, params, vm):
     """
     Function that runs the checks that are in the test
 
@@ -59,23 +119,17 @@ def execute_test(test, params, vm):
     """
     vm_name = params.get("main_vm")
     rng_device_dict = eval(params.get("rng_device_dict"))
-    rng_dev = libvirt_vmxml.create_vm_device_by_type(
-        "rng", rng_device_dict)
-    virsh.attach_device(vm_name, rng_dev.xml, flagstr="--config", debug=True)
-    check_attached_rng_device(vm_name, rng_device_dict)
+    rng_dev = create_attach_check_rng_device(vm_name, rng_device_dict)
 
     vm.start()
     check_attached_rng_device(vm_name, rng_device_dict)
 
-    ssh_session = vm.wait_for_login()
-    virtio_provider.check_host(params.get("backend_dev"))
-    virtio_provider.check_guest_dump(ssh_session)
-    virsh.detach_device(vm_name, rng_dev.xml, flagstr="--config")
-    check_detached_rng_device(vm_name, test)
-    ssh_session.close()
+    if params.get("backend_dev"):
+        virtio_provider.check_host(params.get("backend_dev"))
+    do_common_check_after_vm_start(vm_name, rng_dev, rng_device_dict, test, vm)
 
 
-def cleanup_test(vmxml_backup, vm):
+def cleanup_basic(vmxml_backup, vm):
     """
     Remove the changes made by setup_test function
 
@@ -86,6 +140,57 @@ def cleanup_test(vmxml_backup, vm):
         vm.destroy(gracefully=False)
     logging.info("Restoring vm...")
     vmxml_backup.sync()
+
+
+def execute_coldplug_unplug_egd_tcp_connect_mode(test, params, vm):
+    """
+    Runs check according to connect mode definitions in cfg file.
+
+    :params test: The avocado test object
+    :params params: Parameters for the test
+    :params vm: The VM object
+    """
+    vm_name = params.get("main_vm")
+    rng_device_dict = eval(params.get("rng_device_dict"))
+    feed_process = None
+
+    rng_dev = create_attach_check_rng_device(vm_name, rng_device_dict,
+                                             remove_keys=["backend_dev"])
+
+    try:
+        vm.start()
+    except VMStartError as error:
+        logging.debug(f"VMXML during expected failure to start:\n{vm_xml.VMXML.new_from_dumpxml(vm_name)}")
+        rng_port = params.get("rng_port")
+        if f"Failed to connect to 'localhost:{rng_port}': Connection refused" in str(error):
+            feed_process = handle_connection_mode_fail(rng_port)
+            vm.start()
+        else:
+            test.fail(f"Unexpected error during VM startup, error: {error}")
+    check_attached_rng_device(vm_name, rng_device_dict, remove_keys=["backend_dev"])
+    do_common_check_after_vm_start(vm_name, rng_dev, rng_device_dict, test, vm)
+
+    if feed_process:
+        feed_process.kill_func()
+
+
+def execute_coldplug_unplug_egd_tcp_bind_mode(test, params, vm):
+    """
+    Runs check according to bind mode definitions in cfg file.
+
+    :params test: The avocado test object
+    :params params: Parameters for the test
+    :params vm: The VM object
+    """
+    vm_name = params.get("main_vm")
+    rng_device_dict = eval(params.get("rng_device_dict"))
+    rng_dev = create_attach_check_rng_device(vm_name, rng_device_dict,
+                                             remove_keys=["backend_dev"])
+
+    vm.start()
+    check_attached_rng_device(vm_name, rng_device_dict, remove_keys=["backend_dev"])
+
+    do_common_check_after_vm_start(vm_name, rng_dev, rng_device_dict, test, vm)
 
 
 def run(test, params, env):
@@ -99,6 +204,14 @@ def run(test, params, env):
     vm_name = params.get("main_vm")
     vm = env.get_vm(vm_name)
     vmxml_backup = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+
+    test_case = params.get("test_case", "")
+    setup_test = (eval(f"setup_{test_case}") if f"setup_{test_case}"
+                  in globals() else setup_basic)
+    execute_test = (eval(f"execute_{test_case}") if f"execute_{test_case}"
+                    in globals() else execute_basic)
+    cleanup_test = (eval(f"cleanup_{test_case}") if f"cleanup_{test_case}"
+                    in globals() else cleanup_basic)
 
     try:
         setup_test(vm)

--- a/provider/virtio_rng/check_points.py
+++ b/provider/virtio_rng/check_points.py
@@ -44,17 +44,35 @@ def check_host(backend_dev):
                         " on host, command output: %s" % ret.stdout_text)
 
 
-def comp_rng_xml(vmxml, rng_dict, status_error=False):
+def remove_key(dictionary, key):
+    """
+    Helper function that goes recursively through a dictionary removing
+    the designated key.
+
+    :param dictionary: Dict to go through
+    :param key: The key to remove
+    """
+    for dict_key in dictionary:
+        if isinstance(dictionary[dict_key], dict):
+            remove_key(dictionary[dict_key], key)
+    dictionary.pop(key, None)
+
+
+def comp_rng_xml(vmxml, rng_dict, remove_keys=None, status_error=False):
     """
     Compare rng xml from VM xml to rng dictionary on all attributes.
 
     :params vmxml: Vmxml object from where the device should be taken
     :params rng_dict: Rng device dictionary to compare
+    :params remove_keys: Array of keys to remove from VM XML before comparison
     :params status_error: Set to True if you expect the test to fail
     :raises Exception: Exception in case the test fails
     """
     rng_device = vmxml.get_devices("rng")[0]
     rng_dev_attributes = rng_device.fetch_attrs()
+    if remove_keys:
+        for key in remove_keys:
+            remove_key(rng_dev_attributes, key)
     for key, val, in rng_dict.items():
         if rng_dev_attributes[key] != val and status_error is False:
             raise Exception("Device XML value: '%s' does not match"


### PR DESCRIPTION
This commit adds automated version of polarion case RHEL-112411. It
tests Rng device type egd coldplugging and unplugging. Both bind mode
and connect mode are tested.

Feature: virtio_rng

```
# avocado run --vt-type libvirt virtio_rng
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : e65494bfaf6c4a2ae7d325847ca2857e5905d22a
JOB LOG    : /root/avocado/job-results/job-2022-07-15T21.47-e65494b/job.log
 (1/3) type_specific.io-github-autotest-libvirt.virtio_rng.coldplug_unplug_random_backend: STARTED
 (1/3) type_specific.io-github-autotest-libvirt.virtio_rng.coldplug_unplug_random_backend: PASS (22.32 s)
 (2/3) type_specific.io-github-autotest-libvirt.virtio_rng.coldplug_unplug_egd_backend_connect_mode: STARTED
 (2/3) type_specific.io-github-autotest-libvirt.virtio_rng.coldplug_unplug_egd_backend_connect_mode: PASS (59.14 s)
 (3/3) type_specific.io-github-autotest-libvirt.virtio_rng.coldplug_unplug_egd_backend_bind_mode: STARTED
 (3/3) type_specific.io-github-autotest-libvirt.virtio_rng.coldplug_unplug_egd_backend_bind_mode: PASS (83.75 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/avocado/job-results/job-2022-07-15T21.47-e65494b/results.html
JOB TIME   : 172.47 s
```
# Check lists by category
## If the PR is new cases
- [x] Description of the cases
- [x] Links of libvirt features, libvirt bugs or case IDs
- [x] Test results
