### PR TITLE
migration: Add a case about wrong cert configuration

### DIFF
--- a/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_tls_wrong_cert_configuration.cfg
+++ b/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_tls_wrong_cert_configuration.cfg
@@ -1,0 +1,50 @@
+- migration.migration_uri.network_data_transport.tls.wrong_cert_configuration:
+    type = migration_network_data_transport_tls
+    migration_setup = 'yes'
+    storage_type = 'nfs'
+    setup_local_nfs = 'yes'
+    disk_type = "file"
+    disk_source_protocol = "netfs"
+    mnt_path_name = ${nfs_mount_dir}
+    # Console output can only be monitored via virsh console output
+    only_pty = True
+    take_regular_screendumps = no
+    # Extra options to pass after <domain> <desturi>
+    virsh_migrate_extra = ''
+    # SSH connection time out
+    ssh_timeout = 60
+    # Local URI
+    virsh_migrate_connect_uri = 'qemu:///system'
+    virsh_migrate_dest_state = "running"
+    virsh_migrate_src_state = "shut off"
+    image_convert = 'no'
+    server_ip = "${migrate_dest_host}"
+    server_user = "root"
+    server_pwd = "${migrate_dest_pwd}"
+    status_error = "no"
+    check_network_accessibility_after_mig = "yes"
+    migrate_desturi_port = "16509"
+    transport_type = "tcp"
+    virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
+    custom_pki_path = "/etc/pki/qemu"
+    qemu_tls = "yes"
+    status_error = "yes"
+    virsh_migrate_extra = "--tls"
+    server_cn = "ENTER.YOUR.EXAMPLE.SERVER_CN"
+    client_cn = "ENTER.YOUR.EXAMPLE.CLIENT_CN"
+    test_case = "wrong_cert_configuration"
+    variants:
+        - p2p:
+            virsh_migrate_options = '--live --p2p --verbose'
+        - non_p2p:
+            virsh_migrate_options = '--live --verbose'
+    variants cert_configuration:
+        - no_client_cert_on_src:
+            cert_path = "${custom_pki_path}/client-cert.pem"
+            err_msg = "operation failed: job 'migration out' failed: Cannot write to TLS channel: Input/output error|unable to execute QEMU command 'object-add': Unable to access credentials ${cert_path}"
+        - no_server_cert_on_target:
+            cert_path = "${custom_pki_path}/server-cert.pem"
+            err_msg = "unable to execute QEMU command 'object-add': Unable to access credentials ${cert_path}"
+        - wrong_hostname_in_cert:
+            server_cn = "test.com.cn"
+            err_msg = "qemu-kvm: Cannot read from TLS channel: Input/output error|operation failed: job 'migration out' failed: Certificate does not match the hostname|Domain not found: no domain with matching uuid"

--- a/libvirt/tests/src/migration/migration_uri/migration_network_data_transport_tls.py
+++ b/libvirt/tests/src/migration/migration_uri/migration_network_data_transport_tls.py
@@ -1,5 +1,8 @@
+from avocado.utils import process
+
 from virttest import libvirt_remote
 from virttest import libvirt_version
+from virttest import remote
 
 from virttest.utils_test import libvirt
 from virttest.utils_libvirt import libvirt_config
@@ -80,6 +83,23 @@ def run(test, params, env):
                                                  is_recover=True,
                                                  extra_params=params,
                                                  config_object=obj)
+
+    def setup_wrong_cert_configuration():
+        """
+        Setup for wrong cert configuration
+
+        """
+        cert_configuration = params.get("cert_configuration", '')
+        custom_pki_path = params.get("custom_pki_path")
+        cert_path = params.get("cert_path")
+
+        test.log.info("Setup for wrong cert configuration.")
+        migration_obj.setup_connection()
+        cmd = "rm -f %s" % cert_path
+        if cert_configuration == "no_client_cert_on_src":
+            process.run(cmd, shell=True)
+        elif cert_configuration == "no_server_cert_on_target":
+            remote.run_remote_cmd(cmd, params, ignore_status=False)
 
     libvirt_version.is_libvirt_feature_supported(params)
 


### PR DESCRIPTION
VIRT-293985 - VM live migration - network data transport - TLS - wrong cert configuration

Signed-off-by: cliping <lcheng@redhat.com>
