### PR TITLE
sriov: Add 3 cases

### DIFF
--- a/libvirt/tests/cfg/sriov/scalability/sriov_scalability_max_vf.cfg
+++ b/libvirt/tests/cfg/sriov/scalability/sriov_scalability_max_vf.cfg
@@ -1,0 +1,5 @@
+- sriov.scalability.max_vfs:
+    type = sriov_scalability_max_vfs
+    start_vm = "no"
+    vf_no = 63
+    net_forward = {"mode": "hostdev", "managed": "yes"}

--- a/libvirt/tests/cfg/sriov/sriov_scalability.cfg
+++ b/libvirt/tests/cfg/sriov/sriov_scalability.cfg
@@ -1,7 +1,0 @@
-- sriov.scalability:
-    type = sriov_scalability
-    start_vm = "no"
-    variants test_case:
-        - max_vfs:
-            vf_no = 63
-            net_forward = {"mode": "hostdev", "managed": "yes"}

--- a/libvirt/tests/cfg/sriov/vm_lifecycle/sriov_vm_lifecycle_exclusive_check_offline_domain.cfg
+++ b/libvirt/tests/cfg/sriov/vm_lifecycle/sriov_vm_lifecycle_exclusive_check_offline_domain.cfg
@@ -1,0 +1,26 @@
+- sriov.vm_lifecycle.exclusive_check.offline_domain:
+    type = sriov_vm_lifecycle_exclusive_check_offline_domain
+    start_vm = "no"
+    only x86_64
+    variants dev_type:
+        - hostdev_interface:
+            iface_dict = {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}}
+            variants dev_type2:
+                - hostdev_interface:
+                    iface_dict2 = ${iface_dict}
+                    define_err = "yes"
+                    err_msg = "Hostdev already exists"
+                - hostdev_device:
+                    hostdev_dict2 = {'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': pf_pci_addr}, 'managed': 'yes'}
+                    err_msg = "interface of PCI device"               
+        - hostdev_device:
+            hostdev_dict = {'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': vf_pci_addr}, 'managed': 'yes'}
+            variants dev_type2:
+                - hostdev_interface:
+                    iface_dict2 = {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}}
+                    define_err = "yes"
+                    err_msg = "Hostdev already exists"
+                - hostdev_device:
+                    hostdev_dict2 = ${hostdev_dict}
+                    define_err = "yes"
+                    err_msg = "Hostdev already exists"

--- a/libvirt/tests/cfg/sriov/vm_lifecycle/sriov_vm_lifecycle_exclusive_check_running_domain.cfg
+++ b/libvirt/tests/cfg/sriov/vm_lifecycle/sriov_vm_lifecycle_exclusive_check_running_domain.cfg
@@ -1,0 +1,17 @@
+- sriov.vm_lifecycle.exclusive_check.running_domain:
+    type = sriov_vm_lifecycle_exclusive_check_running_domain
+    vms = "ENTER.YOUR.VM1 ENTER.YOUR.VM2"
+    start_vm = "no"
+    only x86_64
+    dev_type = "hostdev_interface"
+    iface_dict = {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}}
+    err_msg = "in use by driver"
+
+    variants test_scenario:
+        - start_2nd_vm:
+            dev_type2 = hostdev_interface
+            iface_dict2 = ${iface_dict}
+        - assigned_VF_to_host: 
+        - hotplug:
+            dev_type2 = "hostdev_device"
+            hostdev_dict2 = {'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': vf_pci_addr}, 'managed': 'yes'}

--- a/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_exclusive_check_offline_domain.py
+++ b/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_exclusive_check_offline_domain.py
@@ -1,0 +1,59 @@
+from provider.sriov import sriov_base
+
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.libvirt_xml import xcepts
+from virttest.utils_test import libvirt
+
+
+def run(test, params, env):
+    """
+    Confirm a device occupied can not be used by others
+    """
+    def run_test():
+        test.log.info("TEST_STEP1: Attach a hostdev interface/device to VM")
+        iface_dev = sriov_test_obj.create_iface_dev(dev_type, iface_dict)
+        libvirt.add_vm_device(vm_xml.VMXML.new_from_dumpxml(vm_name), iface_dev)
+        test.log.info("TEST_STEP2: Start the VM")
+        iface_dev2 = sriov_test_obj.create_iface_dev(dev_type2, iface_dict2)
+        try:
+            libvirt.add_vm_device(vm_xml.VMXML.new_from_dumpxml(vm_name), iface_dev2)
+        except xcepts.LibvirtXMLError as details:
+            if define_err and err_msg:
+                if not str(details).count(err_msg):
+                    test.fail("Incorrect error message, it should be '{}', but "
+                              "got '{}'.".format(err_msg, details))
+            else:
+                test.fail(details)
+        else:
+            if define_err:
+                test.fail("Defining the VM should fail, but run successfully!")
+            test.log.info("TEST_STEP2: Start the VM")
+            result = virsh.start(vm.name, debug=True)
+            libvirt.check_exit_status(result, True)
+            if err_msg:
+                libvirt.check_result(result, err_msg)
+
+    dev_type = params.get("dev_type", "")
+    dev_type2 = params.get("dev_type2", "")
+
+    define_err = "yes" == params.get("define_err")
+    err_msg = params.get("err_msg")
+
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    vm = env.get_vm(vm_name)
+    sriov_test_obj = sriov_base.SRIOVTest(vm, test, params)
+    iface_dict = sriov_test_obj.parse_iface_dict()
+
+    test_dict = {'iface_dict': params.get("iface_dict2"),
+                 'hostdev_dict': params.get("hostdev_dict2")}
+    sriov_test_obj2 = sriov_base.SRIOVTest(vm, test, test_dict)
+    iface_dict2 = sriov_test_obj2.parse_iface_dict()
+
+    try:
+        sriov_test_obj.setup_default()
+        run_test()
+
+    finally:
+        sriov_test_obj.teardown_default()

--- a/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_exclusive_check_running_domain.py
+++ b/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_exclusive_check_running_domain.py
@@ -1,0 +1,146 @@
+from provider.sriov import check_points
+from provider.sriov import sriov_base
+
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_test import libvirt
+
+
+def run(test, params, env):
+    """
+    Confirm a device occupied can not be used by others
+    """
+    def coldplug_iface():
+        """
+        Cold plug a hostdev interface to VM
+        """
+        if test_scenario in ['start_2nd_vm', 'hotplug']:
+            if len(vm_list) != 2:
+                test.cancel('More or less than 2 vms is currently unsupported')
+        test.log.info("TEST_STEP1: Attach a hostdev interface/device to VM")
+        iface_dev = sriov_test_obj.create_iface_dev(dev_type, iface_dict)
+        virsh.attach_device(vm.name, iface_dev.xml, flagstr="--config",
+                            debug=True, ignore_status=False)
+
+    def get_vm_session(vm):
+        """
+        Get VM's session
+
+        :param vm: VM object
+        :return: The session of VM
+        """
+        vm.start()
+        vm.cleanup_serial_console()
+        vm.create_serial_console()
+        return vm.wait_for_serial_login(timeout=240)
+
+    def run_start_2nd_vm():
+        """
+        Try to start other VM with the same VF device
+        """
+        sriov_test_obj2 = sriov_base.SRIOVTest(vm, test, test_dict)
+        iface_dict2 = sriov_test_obj2.parse_iface_dict()
+
+        coldplug_iface()
+        vm_session = get_vm_session(vm)
+
+        vm2 = vm_list[1]
+        test.log.info("TEST_STEP2: Attach the same VF device to VM2.")
+        iface_dev2 = sriov_test_obj.create_iface_dev(dev_type2, iface_dict2)
+        virsh.attach_device(vm2.name, iface_dev2.xml,
+                            flagstr="--config", debug=True, ignore_status=False)
+
+        test.log.info("TEST_STEP2: Start VM2")
+        result = virsh.start(vm2.name, debug=True)
+        libvirt.check_exit_status(result, True)
+        if err_msg:
+            libvirt.check_result(result, err_msg)
+        check_points.check_vm_network_accessed(vm_session)
+
+    def run_assigned_VF_to_host():
+        """
+        Try to attach the assigned VF to host
+        """
+        coldplug_iface()
+        vm_session = get_vm_session(vm)
+
+        test.log.info("TEST_STEP2: Detach the VF device.")
+        result = virsh.nodedev_detach(sriov_test_obj.vf_dev_name, debug=True)
+        libvirt.check_exit_status(result, True)
+        if err_msg:
+            libvirt.check_result(result, err_msg)
+
+        test.log.info("TEST_STEP2: Reattach the VF device.")
+        result = virsh.nodedev_reattach(sriov_test_obj.vf_dev_name, debug=True)
+        libvirt.check_exit_status(result, True)
+        if err_msg:
+            libvirt.check_result(result, err_msg)
+
+        check_points.check_vm_network_accessed(vm_session)
+
+    def run_hotplug():
+        """
+        Try to hotplug the VF to another running VM or itself
+        """
+        def check_hostdev_attach(vm, iface_dev):
+            """
+            Attach a hostdev iface/device and check the result
+
+            :param vm: VM object
+            :param iface_dev: Interface device object
+            """
+            result = virsh.attach_device(vm.name, iface_dev.xml,
+                                         debug=True)
+            libvirt.check_exit_status(result, True)
+            if err_msg:
+                libvirt.check_result(result, err_msg)
+
+        sriov_test_obj2 = sriov_base.SRIOVTest(vm, test, test_dict)
+        iface_dict2 = sriov_test_obj2.parse_iface_dict()
+        coldplug_iface()
+
+        vm_session = get_vm_session(vm)
+
+        vm2 = vm_list[1]
+        vm2.start()
+        vm2.wait_for_serial_login(timeout=240).close()
+
+        iface_dev = sriov_test_obj.create_iface_dev(dev_type, iface_dict)
+        iface_dev2 = sriov_test_obj.create_iface_dev(dev_type2, iface_dict2)
+
+        test.log.info("TEST_STEP2: Attach a hostdev interface/device to another "
+                      "running VM and itself")
+        for vm_obj in [vm, vm2]:
+            for iface_dev_obj in [iface_dev, iface_dev2]:
+                check_hostdev_attach(vm_obj, iface_dev_obj)
+
+        check_points.check_vm_network_accessed(vm_session)
+
+    dev_type = params.get("dev_type", "")
+    dev_type2 = params.get("dev_type2", "")
+
+    err_msg = params.get("err_msg")
+    test_scenario = params.get("test_scenario", "")
+    run_test = eval("run_%s" % test_scenario)
+    vms = params.get('vms').split()
+    vm_list = [env.get_vm(v_name) for v_name in vms]
+    vm = vm_list[0]
+    sriov_test_obj = sriov_base.SRIOVTest(vm, test, params)
+    iface_dict = sriov_test_obj.parse_iface_dict()
+
+    test_dict = {'iface_dict': params.get("iface_dict2"),
+                 'hostdev_dict': params.get("hostdev_dict2")}
+
+    if len(vm_list) >= 2:
+        vm2_xml_backup = vm_xml.VMXML.new_from_inactive_dumpxml(vm_list[1].name)
+
+    try:
+        sriov_test_obj.setup_default()
+        run_test()
+
+    finally:
+        if "vm2_xml_backup" in locals():
+            vm2_xml_backup.sync()
+        sriov_test_obj.teardown_default()
+        if test_scenario == "assigned_VF_to_host":
+            virsh.nodedev_reattach(sriov_test_obj.vf_dev_name, debug=True)


### PR DESCRIPTION
This PR adds:
    1. VIRT-293953 - Confirm a device occupied can not be used by others
    2. VIRT-293915 - Start vm with 2 interfaces which need exclusive
        access to the device(negative)
    3. VIRT-293919 - Test maximum hostdev interfaces on the vm

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Test results:**
 ```
(1/1) type_specific.io-github-autotest-libvirt.sriov.scalability.max_vfs: PASS (214.15 s)
 (1/7) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.exclusive_check.offline_domain.hostdev_interface.hostdev_interface: PASS (26.61 s)
 (2/7) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.exclusive_check.offline_domain.hostdev_interface.hostdev_device: PASS (27.14 s)
 (3/7) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.exclusive_check.offline_domain.hostdev_device.hostdev_interface: PASS (26.28 s)
 (4/7) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.exclusive_check.offline_domain.hostdev_device.hostdev_device: PASS (26.50 s)
 (5/7) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.exclusive_check.running_domain.start_2nd_vm: PASS (54.40 s)
 (6/7) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.exclusive_check.running_domain.assigned_VF_to_host: PASS (46.43 s)
 (7/7) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.exclusive_check.running_domain.hotplug: PASS (79.08 s)

```