### PR TITLE
Fix s390x ccw passthrough read_write failure

### DIFF
--- a/libvirt/tests/src/passthrough/ccw/libvirt_ccw_passthrough_read_write.py
+++ b/libvirt/tests/src/passthrough/ccw/libvirt_ccw_passthrough_read_write.py
@@ -29,7 +29,11 @@ def run(test, params, env):
         if vm.is_alive():
             vm.destroy()
 
-        schid, chpids = ccw.get_device_info()
+        try:
+            schid, chpids = ccw.get_device_info()
+        except Exception as ex:
+            test.cancel("Failed to get device information: %s" % str(ex))
+
         uuid = str(uuid4())
 
         ccw.set_override(schid)


### PR DESCRIPTION
In some host, ccw device information may not be gotton,
in that case, just skip this case

Signed-off-by: chunfuwen <chwen@redhat.com>


