### PR TITLE
virsh_blockcommit.py: fix case which is hard to get expected result

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockcommit.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockcommit.py
@@ -656,8 +656,7 @@ def run(test, params, env):
 
         if with_active_commit:
             # inactive commit follow active commit will fail with bug 1135339
-            cmd = "virsh blockcommit %s %s --active --pivot" % (vm_name,
-                                                                blk_target)
+            cmd = "virsh blockcommit %s %s --active" % (vm_name, blk_target)
             cmd_session = aexpect.ShellSession(cmd)
 
         if backing_file_relative_path:


### PR DESCRIPTION
When we remove --pivot option in virsh blockommit, the blockjob will always have an active job there. Then we can get the expected error info in this negative scenario. But if we use --pivot option, it may execute so quickly that it's hard to get error info, we can only get: ......expect fail, but run successfully. 

Signed-off-by: Meina Li <meili@redhat.com>