### PR TITLE
blockjob_options: fix --async option failure with new checkpoint

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockjob_options.cfg
+++ b/libvirt/tests/cfg/backingchain/blockjob_options.cfg
@@ -11,3 +11,5 @@
             option_value = ' --async'
             case_name = 'blockjob_async'
             bandwidth = 1
+            event_cmd = " qemu-monitor-event %s --loop"
+            expected_event = "BLOCK_JOB_CANCELLED"


### PR DESCRIPTION
TestFail: After blockjob with --async, the blockcopy not aborted immediately, spent 6.51890412100056 seconds.
---Change "Check run time less than 2 seconds" to "Check BLOCK_JOB_CANCELLED event in qemu-monitor-event". Because the previous checkpoints were not rigorous in auto tests. This lead to the different results between manual and auto test. Manual case has already been updated.

error: invalid argument: disk vda does not have an active block job
---Update def teardown_blockjob_async() part. Because for blockjob with --async, no need to use --abort to cancel the block job again.


Signed-off-by: Meina Li <meili@redhat.com>
