### PR TITLE
Newly add new cases to cover bochs video model

### DIFF
--- a/libvirt/tests/cfg/virtual_device/video_devices.cfg
+++ b/libvirt/tests/cfg/virtual_device/video_devices.cfg
@@ -52,6 +52,9 @@
                                 - vga_default_size:
                                     only vga
                                     default_mem_size = 16384
+                                - bochs_default_size:
+                                    only bochs
+                                    default_mem_size = 16384
                                 - specified_size:
                                     variants:
                                         - power_of_2:
@@ -111,6 +114,9 @@
                         - virtio:
                             primary_video_model = virtio
                             no mem_test
+                        - bochs:
+                            primary_video_model = bochs
+                            only no_secondary_video..model_test.default no_secondary_video..vram..bochs_default_size
         - negative_test:
             status_error = "yes"
             variants:

--- a/libvirt/tests/src/virtual_device/video_devices.py
+++ b/libvirt/tests/src/virtual_device/video_devices.py
@@ -112,6 +112,8 @@ def run(test, params, env):
         if is_primary or is_primary is None:
             if model_type == "vga":
                 pattern = r"-device.*VGA"
+            elif model_type == "bochs":
+                pattern = r"-device.*bochs-display"
             else:
                 pattern = r"-device.*%s-vga" % model_type
             if guest_arch == 's390x':
@@ -183,6 +185,9 @@ def run(test, params, env):
         if mem_type == "vram" and model_type == "vga":
             cmd_mem_size = str(int(mem_size)//1024)
             pattern = r"-device.*VGA.*vgamem_mb\W{1,2}%s" % cmd_mem_size
+        if mem_type == "vram" and model_type == "bochs":
+            cmd_mem_size = str(int(mem_size)*1024)
+            pattern = r"-device.*bochs.*vgamem\W{1,2}%s" % cmd_mem_size
         if mem_type == "vgamem":
             cmd_mem_size = str(int(mem_size)//1024)
             pattern = r"-device.*qxl-vga.*vgamem_mb\W{1,2}%s" % cmd_mem_size


### PR DESCRIPTION
Newly add new cases to cover bochs video model

default_heads and vram default_size attributes are covered

Signed-off-by: chunfuwen <chwen@redhat.com>

