### PR TITLE
Disable osinfo detect in virt-install

### DIFF
--- a/libvirt/tests/src/svirt/svirt_virt_install.py
+++ b/libvirt/tests/src/svirt/svirt_virt_install.py
@@ -70,6 +70,7 @@ def run(test, params, env):
             cmd += ",relabel=%s" % sec_relabel
 
         cmd += " --noautoconsole --graphics vnc --video %s" % video_model
+        cmd += " --osinfo detect=on,require=off"
         process.run(cmd, timeout=600, ignore_status=True)
 
         def _vm_alive():


### PR DESCRIPTION
--osinfo/--os-variant is required after virt-install-4.* in default,
So disable osinfo detect to get the old behavior back.

Signed-off-by: Yan Fu <yafu@redhat.com>

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [ ] Description of the cases
- [ ] Links of libvirt features, libvirt bugs or case IDs
- [ ] Test results

## If the PR is bug cases
- [ ] Bug descriptions or bug links
- [ ] Test results

## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
