### PR TITLE
virsh_iothreadpin: new case for disallowed cpuset

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_iothreadpin.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_iothreadpin.cfg
@@ -3,7 +3,6 @@
     iothread_command = "iothreadpin"
     iothread_pre_vm_state = "null"
     iothread_vm_ref = "name"
-    iothread_extra_param = ""
     iothread_options = ""
     iothreadids = "2 1"
     # The format of iothreadpins is IOTHEADID:CPUSET
@@ -44,5 +43,15 @@
             variants:
                 - invalid_cpulist:
                     cpuset = "a"
+                - disallowed_cpuset:
+                    func_supported_since_libvirt_ver = (8, 1, 0)
+                    iothreadids = ""
+                    iothreadpins = ""
+                    iothreads = ""
+                    iothread_id = ""
+                    disallowed_cpuset = "yes"
+                    add_iothread_id = '3'
+                    error_msg = 'cannot set CPU affinity on process.*:\s*Invalid argument'
                 - readonly:
+                    cpuset = "1"
                     readonly = "yes"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_iothreadpin.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_iothreadpin.py
@@ -1,9 +1,14 @@
 import logging as log
 
 from avocado.core import exceptions
+from avocado.utils import cpu
+from avocado.utils import process
 
+
+from virttest import libvirt_version
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
+from virttest.libvirt_xml import xcepts
 from virttest.utils_test import libvirt
 
 
@@ -12,7 +17,7 @@ from virttest.utils_test import libvirt
 logging = log.getLogger('avocado.' + __name__)
 
 
-def get_xmlinfo(vm_name, options):
+def get_iothreadpins(vm_name, options):
     """
     Get some iothreadpins info from the guests xml
     Returns:
@@ -23,7 +28,114 @@ def get_xmlinfo(vm_name, options):
     else:
         xml_info = vm_xml.VMXML.new_from_dumpxml(vm_name)
     logging.debug("domxml: %s", xml_info)
-    return xml_info.cputune.iothreadpins
+    try:
+        return xml_info.cputune.iothreadpins
+    except xcepts.LibvirtXMLNotFoundError:
+        return None
+
+
+def setup_vmxml_before_start(vmxml, params):
+    """
+    Configure vm xml using given parameters
+
+    :param vmxml: vm xml
+    :param params: dict for the test
+    """
+    iothreads = params.get("iothreads")
+    iothreadids = params.get("iothreadids")
+    iothreadpins = params.get("iothreadpins")
+
+    if iothreadids:
+        ids_xml = vm_xml.VMIothreadidsXML()
+        ids_xml.iothread = iothreadids.split()
+        vmxml.iothreadids = ids_xml
+    if iothreadpins:
+        cputune_xml = vm_xml.VMCPUTuneXML()
+        io_pins = []
+        for pins in iothreadpins.split():
+            thread, cpu = pins.split(':')
+            io_pins.append({"iothread": thread,
+                            "cpuset": cpu})
+        cputune_xml.iothreadpins = io_pins
+        vmxml.cputune = cputune_xml
+    if iothreads:
+        vmxml.iothreads = int(iothreads)
+    logging.debug("Pre-test xml is %s", vmxml)
+    vmxml.sync()
+
+
+def get_dom_option(vm, vm_ref):
+    """
+    Get the domain option for iothreadpin
+
+    :param vm: vm object
+    :param vm_ref:  vm reference
+    :return: str, vm name or domain id or domain uuid or others
+    """
+    domid = vm.get_id()  # only valid for running
+    domuuid = vm.get_uuid()
+
+    if vm_ref == "name":
+        dom_option = vm.name
+    elif vm_ref == "id":
+        dom_option = domid
+    elif vm_ref == "uuid":
+        dom_option = domuuid
+    else:
+        dom_option = vm_ref
+
+    return dom_option
+
+
+def process_cpuset(params, test):
+    """
+    Process cpuset value for some specific tests
+
+    :param params: dict for testing
+    :param test: test object
+    :return: int, cpuset to be used for iothreadpin
+    """
+    cpuset = params.get("cpuset")
+    disallowed_cpuset = params.get('disallowed_cpuset', 'no') == 'yes'
+
+    if disallowed_cpuset:
+        # Set cpuset to the first cpu id just for testing
+        cpuset_cpus_path = '/sys/fs/cgroup/machine.slice/cpuset.cpus'
+        logging.debug("Set allowed cpuset to %s", cpuset_cpus_path)
+        online_cpu_list = cpu.online_list()
+        if cpu.online_count() == 1:
+            test.cancel("At least 2 online cpus are needed for this test case.")
+
+        cmd = "echo %d > %s" % (online_cpu_list[0], cpuset_cpus_path)
+        process.run(cmd, ignore_status=False, shell=True)
+        cpuset = online_cpu_list[1]
+
+    return cpuset
+
+
+def verify_test_disallowed_cpuset(vm_name, options, test):
+    """
+    Verify the test for disallowed cpuset case and iothreadpin info should
+    not exist
+
+    :param vm_name: vm name
+    :param options: iothreadpin options
+    :param test: test object
+    :raises: test.fail if iothreadpin info still exists in dumpxml
+    """
+
+    def _check_iothreadpins():
+        iothreadpins = get_iothreadpins(vm_name, options)
+        if iothreadpins:
+            test.fail("iothreadpin info '%s' in guest xml is not expected" % iothreadpins)
+        else:
+            logging.debug("iothreadpins info does not exist as expected")
+
+    _check_iothreadpins()
+    virsh_dargs = {"debug": True, "ignore_status": False}
+    virsh.managedsave(vm_name, **virsh_dargs)
+    virsh.start(vm_name, **virsh_dargs)
+    _check_iothreadpins()
 
 
 def run(test, params, env):
@@ -36,25 +148,17 @@ def run(test, params, env):
     3.Recover test environment.
     4.Confirm the test result.
     """
-
+    libvirt_version.is_libvirt_feature_supported(params)
     vm_name = params.get("main_vm")
     vm = env.get_vm(vm_name)
     pre_vm_state = params.get("iothread_pre_vm_state")
     command = params.get("iothread_command", "iothread")
     options = params.get("iothread_options")
-    vm_ref = params.get("iothread_vm_ref", "name")
-    iothreads = params.get("iothreads", 4)
-    iothread_id = params.get("iothread_id", "6")
-    cpuset = params.get("cpuset", "1")
     status_error = "yes" == params.get("status_error")
-    iothreadids = params.get("iothreadids")
-    iothreadpins = params.get("iothreadpins")
-    try:
-        iothreads = int(iothreads)
-    except ValueError:
-        # 'iothreads' may not invalid number in negative tests
-        logging.debug("Can't convert %s to integer type", iothreads)
-
+    add_iothread_id = params.get("add_iothread_id")
+    iothread_id = params.get("iothread_id")
+    disallowed_cpuset = params.get("disallowed_cpuset")
+    error_msg = params.get("error_msg")
     # Save original configuration
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     orig_config_xml = vmxml.copy()
@@ -69,55 +173,38 @@ def run(test, params, env):
                 raise exceptions.TestSkipError("The current libvirt version"
                                                " doesn't support '%s' option"
                                                % item)
-        # Set iothreads first
-        if iothreadids:
-            ids_xml = vm_xml.VMIothreadidsXML()
-            ids_xml.iothread = iothreadids.split()
-            vmxml.iothreadids = ids_xml
-        if iothreadpins:
-            cputune_xml = vm_xml.VMCPUTuneXML()
-            io_pins = []
-            for pins in iothreadpins.split():
-                thread, cpu = pins.split(':')
-                io_pins.append({"iothread": thread,
-                                "cpuset": cpu})
-            cputune_xml.iothreadpins = io_pins
-            vmxml.cputune = cputune_xml
-        vmxml.iothreads = iothreads
-        logging.debug("Pre-test xml is %s", vmxml)
-        vmxml.sync()
 
+        setup_vmxml_before_start(vmxml, params)
         # Restart, unless that's not our test
         if not vm.is_alive():
             vm.start()
         vm.wait_for_login()
 
-        domid = vm.get_id()  # only valid for running
-        domuuid = vm.get_uuid()
+        dom_option = get_dom_option(vm, params.get("iothread_vm_ref"))
 
         if pre_vm_state == "shut off" and vm.is_alive():
             vm.destroy()
 
-        # Run test
-        if vm_ref == "name":
-            dom_option = vm_name
-        elif vm_ref == "id":
-            dom_option = domid
-        elif vm_ref == "uuid":
-            dom_option = domuuid
-        else:
-            dom_option = vm_ref
-
-        virsh_dargs = {"debug": True, "ignore_status": True}
+        virsh_dargs = {"debug": True}
         if "yes" == params.get("readonly", "no"):
             virsh_dargs.update({"readonly": True})
+
+        cpuset = process_cpuset(params, test)
+        if add_iothread_id:
+            iothread_id = add_iothread_id
+            virsh.iothreadadd(dom_option, add_iothread_id, debug=True, ignore_status=False)
         ret = virsh.iothreadpin(dom_option, iothread_id, cpuset,
                                 options, **virsh_dargs)
-        libvirt.check_exit_status(ret, status_error)
+        if error_msg:
+            libvirt.check_result(ret, expected_fails=error_msg)
+        else:
+            libvirt.check_exit_status(ret, status_error)
+        if disallowed_cpuset:
+            verify_test_disallowed_cpuset(vm_name, options, test)
 
         if not status_error:
             # Check domainxml
-            iothread_info = get_xmlinfo(vm_name, options)
+            iothread_info = get_iothreadpins(vm_name, options)
             logging.debug("iothreadinfo: %s", iothread_info)
             for info in iothread_info:
                 if info["iothread"] == iothread_id and info["cpuset"] == cpuset:


### PR DESCRIPTION
Case ID: VIRT-292858
Pin iothread to invalid cpuset fails, and vm xml is not impacted.

Signed-off-by: Dan Zheng <dzheng@redhat.com>
