### PR TITLE
Bios: Add disk boot order element checks

### DIFF
--- a/libvirt/tests/cfg/bios/boot_order_seabios.cfg
+++ b/libvirt/tests/cfg/bios/boot_order_seabios.cfg
@@ -1,37 +1,39 @@
 - boot_order_seabios:
     type = boot_order_seabios
-    boot_ref = "dev"
-    boot_dev = "hd"
     disk_format = "qcow2"
     driver_name = "qemu"
     driver_type = "qcow2"
     only x86_64
-    target_bus = "sata"
-    target_dev = "sda"
+    target_bus = "virtio"
+    target_dev = "vda"
     variants:
         - boot_dev:
+           xml_boot_in_os = "yes"
            variants:
               - hd_dev:
+                  target_bus = "sata"
+                  target_dev = "sda"
                   boot_dev = "hd"
                   image_size = "1G"
-                  xml_boot_in_os = "yes"
         - boot_order:
+            xml_boot_in_os = "no"
             variants:
               - file_disk:
-                   xml_boot_in_os = "yes"
                    disk_device = "disk"
                    disk_type = "file"
     variants:
         - positive_test:
             status_error = "no"
             variants case:
-                - bootable_dev: 
+                - bootable_dev:
                     use_bootable_dev = "yes"
-        - negative_test: 
+        - negative_test:
             status_error = "yes"
             variants case:
                 - no_dev:
+                    only boot_dev
                 - unbootable_dev:
+                    only boot_dev
                     use_unbootable_dev = "yes"
                 - unbootable_dev_first:
                     use_unbootable_dev_first = "yes"

--- a/libvirt/tests/cfg/bios/boot_order_seabios.cfg
+++ b/libvirt/tests/cfg/bios/boot_order_seabios.cfg
@@ -6,28 +6,30 @@
     driver_name = "qemu"
     driver_type = "qcow2"
     only x86_64
+    target_bus = "sata"
+    target_dev = "sda"
     variants:
-        - hd:
-            boot_dev = "hd"
-            image_size = "1G"
+        - boot_dev:
+           variants:
+              - hd_dev:
+                  boot_dev = "hd"
+                  image_size = "1G"
+                  xml_boot_in_os = "yes"
+        - boot_order:
             variants:
-                - file_disk:
-                    disk_device = "disk"
-                    disk_type = "file"
-                    target_bus = "sata"
-                    target_dev = "sda"
+              - file_disk:
+                   xml_boot_in_os = "yes"
+                   disk_device = "disk"
+                   disk_type = "file"
     variants:
         - positive_test:
             status_error = "no"
-            variants:
-                - bootable_dev:
+            variants case:
+                - bootable_dev: 
                     use_bootable_dev = "yes"
-                - boot_order_element:
-                    use_bootable_dev = "yes"
-                    boot_order_bootable_first = "yes"
-        - negative_test:
+        - negative_test: 
             status_error = "yes"
-            variants:
+            variants case:
                 - no_dev:
                 - unbootable_dev:
                     use_unbootable_dev = "yes"
@@ -35,9 +37,3 @@
                     use_unbootable_dev_first = "yes"
                     target_dev = "sdb"
                     unbootable_target_dev = "sda"
-                - boot_order_element:
-                    use_unbootable_dev_first = "yes"
-                    boot_order_bootable_first = "no"
-                    target_dev = "sdb"
-                    unbootable_target_dev = "sda"
-                    status_error = "yes"

--- a/libvirt/tests/cfg/bios/boot_order_seabios.cfg
+++ b/libvirt/tests/cfg/bios/boot_order_seabios.cfg
@@ -22,6 +22,9 @@
             variants:
                 - bootable_dev:
                     use_bootable_dev = "yes"
+                - boot_order_element:
+                    use_bootable_dev = "yes"
+                    boot_order_bootable_first = "yes"
         - negative_test:
             status_error = "yes"
             variants:
@@ -32,3 +35,9 @@
                     use_unbootable_dev_first = "yes"
                     target_dev = "sdb"
                     unbootable_target_dev = "sda"
+                - boot_order_element:
+                    use_unbootable_dev_first = "yes"
+                    boot_order_bootable_first = "no"
+                    target_dev = "sdb"
+                    unbootable_target_dev = "sda"
+                    status_error = "yes"

--- a/libvirt/tests/src/bios/boot_order_seabios.py
+++ b/libvirt/tests/src/bios/boot_order_seabios.py
@@ -1,4 +1,5 @@
 import os
+import time
 
 from virttest.libvirt_xml import vm_xml
 from virttest.remote import LoginTimeoutError
@@ -32,6 +33,7 @@ def set_domain_disk(vm, vmxml, blk_source, params):
     use_unbootable_dev = "yes" == params.get("use_unbootable_dev", "no")
     use_unbootable_dev_first = "yes" == params.get("use_unbootable_dev_first", "no")
     boot_order_bootable_first = "yes" == params.get("boot_order_bootable_first")
+    xml_boot_in_os = "yes" == params.get("xml_boot_in_os", "yes")
 
     global unbootable_source
 
@@ -44,7 +46,8 @@ def set_domain_disk(vm, vmxml, blk_source, params):
     #Remove all disk and reacquire the vmxml
     libvirt_vmxml.remove_vm_devices_by_type(vm, device_type='disk')
     vmxml = vm_xml.VMXML.new_from_dumpxml(vm.name)
-    vmxml.remove_all_boots()
+    if not xml_boot_in_os:
+        vmxml.remove_all_boots()
 
     if use_unbootable_dev:
         device_path = os.path.dirname(blk_source)
@@ -53,7 +56,7 @@ def set_domain_disk(vm, vmxml, blk_source, params):
                                   'driver': {'name': driver_name, 'type': driver_type},
                                   'target': {'dev': unbootable_target_dev, 'bus': target_bus},
                                   'device': disk_device}
-        if not boot_order_bootable_first:
+        if not xml_boot_in_os and not boot_order_bootable_first:
             unbootable_disk_params["boot"] = 1
 
         libvirt.create_local_disk(disk_type, unbootable_source, image_size, disk_format)
@@ -66,10 +69,11 @@ def set_domain_disk(vm, vmxml, blk_source, params):
                                 'driver': {'name': driver_name, 'type': driver_type},
                                 'target': {'dev': target_dev, 'bus': target_bus},
                                 'device': disk_device}
-        if boot_order_bootable_first:
-            bootable_disk_params["boot"] = 1
-        else:
-            bootable_disk_params["boot"] = 2
+        if not xml_boot_in_os:
+            if boot_order_bootable_first:
+                bootable_disk_params["boot"] = 1
+            else:
+                bootable_disk_params["boot"] = 2
 
         libvirt_vmxml.modify_vm_device(vmxml=vmxml, dev_type='disk',
                                        dev_dict=bootable_disk_params, index=1)
@@ -102,14 +106,15 @@ def run(test, params, env):
     try:
         blk_source = vm.get_first_disk_devices()['source']
         set_domain_disk(vm, vmxml, blk_source, params)
+        test.log.debug(f"VM XML before start:\n{vm_xml.VMXML.new_from_dumpxml(vm_name)}")
         if not vm.is_alive():
             vm.start()
-            test.log.debug(f"VM XML after start:\n{vm_xml.VMXML.new_from_dumpxml(vm_name)}")
+            time.sleep(3)
         if not status_error:
             try:
                 vm.cleanup_serial_console()
                 vm.create_serial_console()
-                vm.wait_for_serial_login(timeout=15)
+                vm.wait_for_serial_login(timeout=60)
             except Exception as e:
                 test.fail(f"Test fail: {str(e)}")
             else:
@@ -118,7 +123,7 @@ def run(test, params, env):
             try:
                 vm.cleanup_serial_console()
                 vm.create_serial_console()
-                vm.wait_for_serial_login(timeout=15)
+                vm.wait_for_serial_login(timeout=60)
             except LoginTimeoutError as expected_e:
                 test.log.debug("Got expected error message: %s", str(expected_e))
             except Exception as e:

--- a/libvirt/tests/src/bios/boot_order_seabios.py
+++ b/libvirt/tests/src/bios/boot_order_seabios.py
@@ -104,11 +104,12 @@ def run(test, params, env):
         set_domain_disk(vm, vmxml, blk_source, params)
         if not vm.is_alive():
             vm.start()
+            test.log.debug(f"VM XML after start:\n{vm_xml.VMXML.new_from_dumpxml(vm_name)}")
         if not status_error:
             try:
                 vm.cleanup_serial_console()
                 vm.create_serial_console()
-                vm.wait_for_serial_login(timeout=60)
+                vm.wait_for_serial_login(timeout=15)
             except Exception as e:
                 test.fail(f"Test fail: {str(e)}")
             else:
@@ -117,7 +118,7 @@ def run(test, params, env):
             try:
                 vm.cleanup_serial_console()
                 vm.create_serial_console()
-                vm.wait_for_serial_login(timeout=60)
+                vm.wait_for_serial_login(timeout=15)
             except LoginTimeoutError as expected_e:
                 test.log.debug("Got expected error message: %s", str(expected_e))
             except Exception as e:


### PR DESCRIPTION
Add checks for disk boot order element to
libvirt/tests/src/bios/boot_order_ovmf.py. Positive and negative check
is added.

LIBVIRTAT-13216
VIRT-45997
```
# avocado run --vt-type libvirt boot_order_seabios..boot_order_element
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : e02186789f56f8d4a76dcd29bbc4477ed0ef1046
JOB LOG    : /root/avocado/job-results/job-2022-07-22T12.12-e021867/job.log
 (1/2) type_specific.io-github-autotest-libvirt.boot_order_seabios.positive_test.boot_order_element.hd.file_disk: STARTED
 (1/2) type_specific.io-github-autotest-libvirt.boot_order_seabios.positive_test.boot_order_element.hd.file_disk: PASS (20.28 s)
 (2/2) type_specific.io-github-autotest-libvirt.boot_order_seabios.negative_test.boot_order_element.hd.file_disk: STARTED
 (2/2) type_specific.io-github-autotest-libvirt.boot_order_seabios.negative_test.boot_order_element.hd.file_disk: PASS (96.18 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/avocado/job-results/job-2022-07-22T12.12-e021867/results.html
JOB TIME   : 123.81 s
```
# Check lists by category
## If the PR is new cases
- [x] Description of the cases
- [x] Links of libvirt features, libvirt bugs or case IDs
- [ ] Test results
