### PR TITLE
virtual_network: Add 2 cases about rss and tftp

### DIFF
--- a/libvirt/tests/cfg/virtual_interface/interface_update_device_negative.cfg
+++ b/libvirt/tests/cfg/virtual_interface/interface_update_device_negative.cfg
@@ -1,0 +1,13 @@
+- iface.update_device.negative:
+    type = interface_update_device_negative
+    start_vm = "yes"
+    virsh_opt = "no_option"
+    variants:
+        - driver:
+            variants:
+                - rss:
+                    func_supported_since_libvirt_ver = (8, 4, 0)
+                    status_error = "yes"
+                    error_msg = "device driver attributes"
+                    pre_iface_dict = {'driver': {'driver_attr': {'queues': '4'}}}
+                    iface_dict = {'driver': {'driver_attr': {'queues': '4', 'rss': 'on', 'rss_hash_report': 'on'}}}

--- a/libvirt/tests/cfg/virtual_network/address/virtual_network_address_tftp.cfg
+++ b/libvirt/tests/cfg/virtual_network/address/virtual_network_address_tftp.cfg
@@ -1,0 +1,7 @@
+- virtual_network.address.tftp:
+    type = virtual_network_address_tftp
+    start_vm = "no"
+    func_supported_since_libvirt_ver = (8, 5, 0)
+    network_dict = {'bridge': {'name': 'virbr1', 'stp': 'on', 'delay': '0'},  'forward': {'mode': 'nat'}, 'ips': [{'address': '192.168.120.1', 'netmask': '255.255.255.0', 'tftp_root': tftp_root}], 'nat_port': {'start': '1024', 'end': '65535'}, 'name': 'net_boot'}
+    error_msg = "tftpboot inaccessible: No such file or directory"
+    dnsmasq_setting = "enable-tftp"

--- a/libvirt/tests/src/virtual_interface/interface_update_device_negative.py
+++ b/libvirt/tests/src/virtual_interface/interface_update_device_negative.py
@@ -1,0 +1,32 @@
+from provider.interface import interface_base
+
+from virttest import libvirt_version
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+
+
+def run(test, params, env):
+    """
+    Update an interface by update-device(negative)
+    """
+    libvirt_version.is_libvirt_feature_supported(params)
+
+    pre_iface_dict = eval(params.get("pre_iface_dict", "{}"))
+    start_vm = "yes" == params.get("start_vm", "no")
+
+    vm_name = params.get('main_vm')
+    vm = env.get_vm(vm_name)
+
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    backup_vmxml = vmxml.copy()
+
+    try:
+        if pre_iface_dict:
+            libvirt_vmxml.modify_vm_device(vmxml, 'interface', pre_iface_dict)
+        if start_vm and not vm.is_alive():
+            vm.start()
+            vm.wait_for_login(timeout=240).close()
+        test.log.info("TEST_STEP: Update interface device.")
+        interface_base.update_iface_device(vm, params)
+    finally:
+        backup_vmxml.sync()

--- a/libvirt/tests/src/virtual_network/address/virtual_network_address_tftp.py
+++ b/libvirt/tests/src/virtual_network/address/virtual_network_address_tftp.py
@@ -1,0 +1,65 @@
+import os
+
+from avocado.utils import process
+
+from virttest import libvirt_version
+from virttest import utils_misc
+from virttest import virsh
+from virttest.libvirt_xml import network_xml
+from virttest.utils_test import libvirt
+
+
+def run(test, params, env):
+    """
+    Enable tftp service for the network without dhcp
+    """
+    def run_test():
+        """
+        Test tftp server function via libvirt network
+        1. Prepare a network xml with tftp setting
+        2. Define and start the network when there is no tftp_root dir
+        3. Create tftp_root dir and start the network again
+        4. Check dnsmasq config file and tftp server
+        """
+        test.log.info("TEST_STEP1: Prepare a network xml with tftp settting.")
+        net_obj = network_xml.NetworkXML()
+        net_obj.setup_attrs(**network_dict)
+        test.log.debug("Network created: %s.", net_obj)
+        net_obj.define()
+
+        test.log.info("TEST_STEP2: Remove tftp_root dir and start the network.")
+        if os.path.exists(tftp_root):
+            utils_misc.safe_rmdir(tftp_root)
+        result = virsh.net_start(net_name, debug=True)
+        libvirt.check_exit_status(result, True)
+        libvirt.check_result(result, error_msg)
+
+        test.log.info("TEST_STEP3: Create tftp_root dir and start the network.")
+        os.makedirs(tftp_root)
+        net_obj.start()
+
+        test.log.info("TEST_STEP4: Check dnsmasq config.")
+        net_conf = '/var/lib/libvirt/dnsmasq/%s.conf' % net_name
+        with open(net_conf, 'r') as fd:
+            lines = fd.read()
+        dnsmasq_setting = params.get("dnsmasq_setting", "enable-tftp")
+        if not lines.count(dnsmasq_setting):
+            test.fail("Unable to get '%s' from %s." % (dnsmasq_setting, lines))
+
+        test.log.info("TEST_STEP5: Check tftp service is running.")
+        process.run('netstat -anu | grep ":69 "', shell=True)
+
+    libvirt_version.is_libvirt_feature_supported(params)
+
+    error_msg = params.get("error_msg")
+    tftp_root = '/var/lib/tftpboot'
+    network_dict = eval(params.get("network_dict"))
+    net_name = network_dict.get('name')
+
+    try:
+        run_test()
+    finally:
+        if os.path.exists(tftp_root):
+            utils_misc.safe_rmdir(tftp_root)
+        virsh.net_destroy(net_name, debug=True)
+        virsh.net_undefine(net_name, debug=True)


### PR DESCRIPTION
This PR adds 2 network cases:
    1. VIRT-294611: Enable tftp service for the network without dhcp
    2. VIRT-294448: update the virtio driver attributes "rss" "rss-report"

Signed-off-by: Yingshun Cui <yicui@redhat.com>
`Test results:
````
 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.address.tftp: PASS (7.85 s)
 (1/1) type_specific.io-github-autotest-libvirt.iface.update_device.negative.driver.rss: PASS (8.89 s)
```
