### PR TITLE
Fix utils_misc.wait_for(get_vol) immediate return issue if get_vol() return None firstly

### DIFF
--- a/libvirt/tests/src/virtual_disks/at_dt_iscsi_disk.py
+++ b/libvirt/tests/src/virtual_disks/at_dt_iscsi_disk.py
@@ -223,7 +223,8 @@ def run(test, params, env):
                     return None
 
             # Wait for a while so that we can get the volume info
-            vol_info = utils_misc.wait_for(get_vol, 10)
+            utils_misc.wait_for(lambda: get_vol() is not None, 10)
+            vol_info = get_vol()
             if vol_info:
                 vol_name, vol_path = vol_info
             else:


### PR DESCRIPTION
    Fix utils_misc.wait_for(get_vol) immediate return issue if get_vol() return None firstly
    
    utils_misc.wait_for(get_vol()) is used to get volume information until timeout is met or correctly returned
    In terms of utils_misc.wait_for(), first parameter should not be None, otherwise
    one error "NoneType' object is not callable" wil be thrown out, and the loop for that will be terminated 


Signed-off-by: chunfuwen <chwen@redhat.com>

