### PR TITLE
block_job_commit_pull: Make sure the guest boot successfully before snapshot-create-as

### DIFF
--- a/libvirt/tests/src/backingchain/blockcommand.py
+++ b/libvirt/tests/src/backingchain/blockcommand.py
@@ -223,6 +223,7 @@ def run(test, params, env):
             vmxml.sync()
 
         vm.start()
+        vm.wait_for_login().close()
         logging.debug(virsh.dumpxml(vm_name))
 
         # Create backing chain


### PR DESCRIPTION
Make sure the guest boot successfully before creating snapshot, otherwise it may fail.

Test Results:
 (1/4) type_specific.io-github-autotest-libvirt.backingchain.blockcommand.blockpull.base_top.positive_test.file_disk.block_bk: PASS (59.95 s)
 (2/4) type_specific.io-github-autotest-libvirt.backingchain.blockcommand.blockpull.base_top.positive_test.block_disk.block_bk: PASS (63.87 s)
 (3/4) type_specific.io-github-autotest-libvirt.backingchain.blockcommand.blockcommit.base_top.positive_test.file_disk.block_bk: PASS (58.67 s)
 (4/4) type_specific.io-github-autotest-libvirt.backingchain.blockcommand.blockcommit.base_top.positive_test.block_disk.block_bk: PASS (63.64 s)

Signed-off-by: Hu Shuai <hus.fnst@fujitsu.com>
