### PR TITLE
Fix nbd server is not completely started

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_nbd.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_nbd.py
@@ -10,6 +10,7 @@ from virttest import remote
 from virttest import virt_vm
 from virttest import virsh
 from virttest import utils_disk
+from virttest import utils_misc
 from virttest import libvirt_version
 from virttest.utils_test import libvirt
 from virttest.utils_nbd import NbdExport
@@ -227,6 +228,8 @@ def run(test, params, env):
                         tls=tls_enabled, deleteExisted=deleteExisted,
                         private_key_encrypt_passphrase=private_key_encrypt_passphrase, secret_uuid=secret_uuid)
         nbd.start_nbd_server()
+        utils_misc.wait_for(
+            lambda: process.system('pgrep qemu-nbd', ignore_status=True, shell=True) == 0, 10)
         # Prepare disk source xml
         source_attrs_dict = {"protocol": "nbd", "tls": "%s" % tls_bit}
         if export_name:


### PR DESCRIPTION
Fix nbd server is not completely started
In some extreme case, disk device may be consumed just after start nbd server
But at this time, nbd server may be not ready

Here use utils_misc.wait_for to allow ndb server more robust for readiness

Signed-off-by: chunfuwen <chwen@redhat.com>
