### PR TITLE
rhel6_guest: Remove efi os_firmware

### DIFF
--- a/libvirt/tests/src/migration/migrate_with_legacy_guest.py
+++ b/libvirt/tests/src/migration/migrate_with_legacy_guest.py
@@ -139,6 +139,8 @@ def run(test, params, env):
         if 'rhel6' in params.get("shortname"):
             vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
             os_xml = vmxml.os
+            if os_xml.fetch_attrs().get('os_firmware') == 'efi':
+                os_xml.del_os_firmware()
             os_xml.del_nvram()
             os_xml.del_loader()
             vmxml.os = os_xml

--- a/libvirt/tests/src/virtio_transitional/virtio_transitional_base.py
+++ b/libvirt/tests/src/virtio_transitional/virtio_transitional_base.py
@@ -116,6 +116,8 @@ def remove_rhel6_nvram(vm_name):
     """
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     os_xml = vmxml.os
+    if os_xml.fetch_attrs().get('os_firmware') == 'efi':
+        os_xml.del_os_firmware()
     os_xml.del_nvram()
     os_xml.del_loader()
     vmxml.os = os_xml


### PR DESCRIPTION
The rhel6 guest should not be configured with efi os_firmware.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Test results:**
```
 (1/1) type_specific.io-github-autotest-libvirt.virtio_transitional_mem_balloon.rhel6_guest.virtio_transitional: PASS (163.84 s)
 (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_with_legacy_guest.test_interface.rhel6_guest.virtio_transitional: PASS (194.41 s)

```