### PR TITLE
Fix remote access case failures due to auth_pwd not set properly

### DIFF
--- a/libvirt/tests/cfg/remote_access/remote_with_unix.cfg
+++ b/libvirt/tests/cfg/remote_access/remote_with_unix.cfg
@@ -76,6 +76,7 @@
                     su_user = "bob"
                     adduser_cmd = "useradd ${su_user}"
                     deluser_cmd = "userdel -r ${su_user}"
+                    auth_pwd = ${remote_pwd}
                     main_vm = "avocado-vt-vm1"
                     virsh_cmd = "start"
                     patterns_virsh_cmd = ".*Domain\s*\'?${main_vm}\'?\s*started\s*.*"
@@ -90,6 +91,7 @@
                     su_user = "bob"
                     adduser_cmd = "useradd ${su_user}"
                     deluser_cmd = "userdel -r ${su_user}"
+                    auth_pwd = ${remote_pwd}
                     main_vm = "avocado-vt-vm1"
                     virsh_cmd = "start"
                     patterns_virsh_cmd = ".*Domain\s*\'?${main_vm}\'?\s*started\s*.*"


### PR DESCRIPTION
  Fix remote access case failures due to auth_pwd not set properly

  In remote_access cases, sometime it need send auth_pwd to remote host.
  But auth_pwd parameter may be not defined in cfg file ,so it return None in some cases
  Therefore, TypeError: unsupported operand type(s) for +: 'NoneType' and 'str can be found
    
  Signed-off-by: chunfuwen <chwen@redhat.com>

