### PR TITLE
pcibridge: fix incorrect index

### DIFF
--- a/libvirt/tests/cfg/controller/pcibridge.cfg
+++ b/libvirt/tests/cfg/controller/pcibridge.cfg
@@ -16,9 +16,9 @@
                             pci_br_has_device = 'yes'
                             sound_dev_model_type = 'ich6'
                             sound_dev_address = "{'type': 'pci', 'domain': '0x0000', 'bus': '0x0%s', 'slot': '0x02', 'function': '0x0'}"
-                            iface_kwargs = {'address': "{'type': 'pci', 'domain': '0x0000', 'bus':'%s', 'slot': '0x05', 'function': '0x0'}"}
+                            iface_kwargs = {'address': "{'type': 'pci', 'domain': '0x0000', 'bus':'%s', 'slot': '0x07', 'function': '0x0'}"}
                         - no_device:
-                            iface_kwargs = {'address': "{'type': 'pci', 'domain': '0x0000', 'bus':'%s', 'slot': '0x05', 'function': '0x0'}"}
+                            iface_kwargs = {'address': "{'type': 'pci', 'domain': '0x0000', 'bus':'%s', 'slot': '0x07', 'function': '0x0'}"}
 
                     variants:
                         - pcie_to_pci_br:

--- a/libvirt/tests/src/controller/pcibridge.py
+++ b/libvirt/tests/src/controller/pcibridge.py
@@ -152,7 +152,7 @@ def run(test, params, env):
             logging.debug('address: %s', new_iface_kwargs['address'])
             iface = create_iface(iface_model, iface_source, **new_iface_kwargs)
             mac = iface.mac_address
-
+            logging.debug('Before attaching %s\n', virsh.dumpxml(vm_name))
             result = virsh.attach_device(vm_name, iface.xml, debug=True)
             libvirt.check_exit_status(result)
 
@@ -164,7 +164,7 @@ def run(test, params, env):
             iface_list = [
                 iface for iface in xml_after_attach.get_devices('interface')
                 if iface.mac_address == mac and
-                int(iface.address['attrs']['bus'], 16) == int(pci_br_index, 16)
+                int(iface.address['attrs']['bus'], 16) == int(pci_br_index)
             ]
 
             logging.debug('iface list after attach: %s', iface_list)


### PR DESCRIPTION
Fix 2 problems:
 - slot is occupied by other devices (pci-bridge controller)
 - index number should be in decimal, not hex.

Signed-off-by: Dan Zheng <dzheng@redhat.com>
