### PR TITLE
Fix virtual_network.iface_network.net_forward.route_test case failure

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_network.py
+++ b/libvirt/tests/src/virtual_network/iface_network.py
@@ -1061,6 +1061,8 @@ TIMEOUT 3"""
                 start_clone_vm = virsh.start(vm_clone, debug=True)
                 libvirt.check_exit_status(start_clone_vm)
             else:
+                if vm.is_dead():
+                    vm.start()
                 if serial_login:
                     session = vm.wait_for_serial_login(username=username,
                                                        password=password)


### PR DESCRIPTION
Fix virtual_network.iface_network.net_forward.route_test case failure

In terms of this case, occasionally, it failed on s390x platform with below eror message:
VMDeadError: VM is dead    reason: Domain avocado-vt-vm1 is inactive

Signed-off-by: chunfuwen <chwen@redhat.com>

