### PR TITLE
virt_install.hostdev: set required --osinfo value

### DIFF
--- a/virttools/tests/src/virt_install/hostdev_mdev.py
+++ b/virttools/tests/src/virt_install/hostdev_mdev.py
@@ -159,6 +159,7 @@ def virt_install_with_hostdev(vm_name, mdev_nodedev, target_address, disk_path):
            " --hostdev %s,%s"
            " --disk %s"
            " --vcpus 2 --memory 2048"
+           " --osinfo detect=on,require=off"
            " --nographics --noautoconsole" %
            (vm_name, mdev_nodedev, target_address, disk_path))
     err, out = cmd_status_output(cmd, shell=True, verbose=True)


### PR DESCRIPTION
Since v4.0.0 virt_install requires --osinfo in most cases, so
the test failed since that version. https://github.com/virt-manager/virt-manager/releases/tag/v4.0.0

Add commandline arguments to set previous behavior.
I confirmed this works with v3.2.0, too.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>
