### PR TITLE
Set swtpm_user/swtpm_group in qemu.conf if dynamic_ownership='0' 

### DIFF
--- a/libvirt/tests/src/svirt/dac_nfs_disk.py
+++ b/libvirt/tests/src/svirt/dac_nfs_disk.py
@@ -137,11 +137,14 @@ def run(test, params, env):
 
         # set qemu conf
         qemu_conf.user = qemu_user
-        qemu_conf.group = qemu_user
+        qemu_conf.group = qemu_group
         if dynamic_ownership:
             qemu_conf.dynamic_ownership = 1
         else:
             qemu_conf.dynamic_ownership = 0
+            if vmxml.devices.by_device_tag('tpm') is not None:
+                qemu_conf.swtpm_user = qemu_user
+                qemu_conf.swtpm_group = qemu_group
         logging.debug("the qemu.conf content is: %s", qemu_conf)
         libvirtd.restart()
 


### PR DESCRIPTION
… dynamic_ownership='0'

Ownership of swtpm.socket will not be chaneged dynamically when dynamic_ownership='0'.
So need to set swtpm_user/swtpm_group the same with user/group in qemu.conf to avoid the
permission issue.

Signed-off-by: Yan Fu <yafu@redhat.com>

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [ ] Description of the cases
- [ ] Links of libvirt features, libvirt bugs or case IDs
- [ ] Test results

## If the PR is bug cases
- [ ] Bug descriptions or bug links
- [ ] Test results

## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
