### PR TITLE
blockcommand_base: remove existed snap file

### DIFF
--- a/provider/backingchain/blockcommand_base.py
+++ b/provider/backingchain/blockcommand_base.py
@@ -91,6 +91,8 @@ class BlockCommand(object):
                 path = self.tmp_dir + '%d' % i
             else:
                 path = snap_path
+            if os.path.exists(path):
+                libvirt.delete_local_disk('file', path)
             snap_option = "%s %s --diskspec %s,file=%s%s" % \
                           ('snap%d' % i, option, self.new_dev, path, extra)
 


### PR DESCRIPTION
  if other cases not clean snap file successfully, existed file will
influence many cases
Signed-off-by: nanli <nanli@redhat.com>

**Test result:**

1. create existed snap file
2. run test 
3. passed
```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockpull.conventional_chain.rbd_with_auth_disk.with_base --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.backingchain.blockpull.conventional_chain.rbd_with_auth_disk.with_base: PASS (63.00 s)

```