### PR TITLE
v2v: add a variant to control the vsock checking

### DIFF
--- a/provider/v2v_vmcheck_helper.py
+++ b/provider/v2v_vmcheck_helper.py
@@ -634,7 +634,7 @@ class VMChecker(object):
                     ".//*[@model='virtio-transitional']") or root.findall(".//*[@type='virtio-transitional']"):
                 self.log_err(err_msg)
 
-        if self.is_vsock_supported(self.os_version):
+        if self.vsock_check_enabled() and self.is_vsock_supported(self.os_version):
             self.check_xml('./devices/vsock')
 
     def check_xml(self, xpath, existence=True):
@@ -696,7 +696,7 @@ class VMChecker(object):
         # https://wiki.qemu.org/Features/VirtIORNG
         if compare_version(FEATURE_SUPPORT['virtio_rng'], kernel_version):
             virtio_devs.append("Virtio RNG")
-        if self.is_vsock_supported(self.os_version):
+        if self.vsock_check_enabled() and self.is_vsock_supported(self.os_version):
             virtio_devs.append("Virtio socket")
         LOG.info("Virtio devices checking list: %s", virtio_devs)
         for dev in virtio_devs:
@@ -935,6 +935,12 @@ class VMChecker(object):
         elif has_genid == 'no':
             if re.search(r'genid', self.vmxml):
                 self.log_err('Unexpected genid in xml')
+
+    def vsock_check_enabled(self):
+        """
+        Check if vsock should be checked for VM.
+        """
+        return self.params.get('enable_vsock_check', 'no') == 'yes'
 
     def is_vsock_supported(self, os_version):
         """

--- a/v2v/tests/cfg/convert_vm_to_libvirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_libvirt.cfg
@@ -7,6 +7,7 @@
     remote_preprocess = "no"
     only dest_libvirt
     v2v_debug = on
+    enable_vsock_check = yes
 
     username = "root"
     password = GENERAL_GUEST_PASSWORD


### PR DESCRIPTION
Whether a VM suppots vsock or not depends on the vm's kernel, it's
difficult in our script to check it and not necessary. For most of
cases, the vsock check can be ignored except the matrix and acceptance
and signoff testing.

So we can enabled the check in convert_vm_to_libvirt but other files
to avoid unexpected vsock checking failure.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>