### PR TITLE
virsh_boot: remove firmware efi

### DIFF
--- a/libvirt/tests/src/bios/virsh_boot.py
+++ b/libvirt/tests/src/bios/virsh_boot.py
@@ -19,6 +19,7 @@ from virttest.utils_test import libvirt as utlv
 from virttest.libvirt_xml.devices.controller import Controller
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.disk import Disk
+from virttest.utils_libvirt import libvirt_bios
 
 
 # Global test env cleanup variables
@@ -320,6 +321,7 @@ def apply_boot_options(vmxml, params, test):
     with_feature = params.get("with_feature", "no") == "yes"
 
     dict_os_attrs = {}
+
     # Set attributes of loader of VMOSXML
     if with_loader:
         logging.debug("Set os loader to test non-released os version without secure boot enabling")
@@ -674,12 +676,8 @@ def run(test, params, env):
     # Back VM XML
     vmxml_backup = vm_xml.VMXML.new_from_dumpxml(vm_name)
     vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
-    # Remove loader/nvram element if exist which may affect newly added same elements
-    for item in ["loader", "nvram"]:
-        if item in str(vmxml):
-            vmxml.xmltreefile.remove_by_xpath("/os/%s" % item, remove_all=True)
-            vmxml.sync()
 
+    vmxml.os = libvirt_bios.remove_bootconfig_items_from_vmos(vmxml.os)
     # Prepare a blank params to confirm if delete the configure at the end of the test
     ceph_cfg = ''
     keyring_file = ''

--- a/libvirt/tests/src/bios/virsh_boot_tseg.py
+++ b/libvirt/tests/src/bios/virsh_boot_tseg.py
@@ -1,12 +1,13 @@
 import logging as log
 
-from virttest import virsh
-from virttest import utils_package
-from virttest.libvirt_xml import vm_xml
-from virttest.utils_test import libvirt as utlv
-from virttest.libvirt_xml import xcepts
-
 from virttest import libvirt_version
+from virttest import utils_package
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.libvirt_xml import xcepts
+from virttest.utils_libvirt import libvirt_bios
+from virttest.utils_test import libvirt as utlv
 
 
 # Using as lower capital is not the best way to do, but this is just a
@@ -70,15 +71,11 @@ def run(test, params, env):
     # Back VM XML
     v_xml_backup = vm_xml.VMXML.new_from_dumpxml(vm_name)
     v_xml = vm_xml.VMXML.new_from_dumpxml(vm_name)
-    # Remove loader/nvram element if exist which may affect newly added same elements
-    for item in ["loader", "nvram"]:
-        if item in str(v_xml):
-            v_xml.xmltreefile.remove_by_xpath("/os/%s" % item, remove_all=True)
-            v_xml.sync()
 
     try:
         # Specify boot loader for OVMF
         if boot_type == 'ovmf':
+            v_xml.os = libvirt_bios.remove_bootconfig_items_from_vmos(v_xml.os)
             os_xml = v_xml.os
             os_xml.loader_type = loader_type
             os_xml.loader = loader

--- a/spell.ignore
+++ b/spell.ignore
@@ -251,6 +251,7 @@ dst
 du
 dumpxml
 ebtables
+efi
 eg
 els
 embeddedqemu


### PR DESCRIPTION
Remove firmware='efi' and nvram and loader elements in <os> because cases will add them

Depend on https://github.com/avocado-framework/avocado-vt/pull/3486

Signed-off-by: Dan Zheng <dzheng@redhat.com>
