### PR TITLE
CPU: Update params setting of test out_of_range for aarch64

### DIFF
--- a/libvirt/tests/cfg/cpu/iothread.cfg
+++ b/libvirt/tests/cfg/cpu/iothread.cfg
@@ -47,7 +47,7 @@
                             iothread_ids = "1"
                             iothread_num = "2"
                             iothreadpins = "2:100"
-                            pseries:
+                            pseries, aarch64:
                                 iothreadpins = "2:300"
                             start_vm = "yes"
                             err_msg = "Numerical result out of range"


### PR DESCRIPTION
Some aarch64 hosts have more cpus, 100 is not enough to be out of range.

Signed-off-by: Hu Shuai <hus.fnst@fujitsu.com>
