### PR TITLE
pcibridge: fix attach bus error

### DIFF
--- a/libvirt/tests/cfg/controller/pcibridge.cfg
+++ b/libvirt/tests/cfg/controller/pcibridge.cfg
@@ -97,8 +97,7 @@
                         - s_str:
                             slot = 'haha'
                             err_msg = "internal error: Cannot parse <address> 'slot' attribute|Invalid value for attribute 'slot'.*: '${slot}'"
-                    pci_br_kwargs = "{'index': '9'}"
-                    iface_kwargs = {'address': "{'type': 'pci', 'domain': '0x0000', 'bus': '0x09', 'slot': '${slot}', 'function': '0x0'}"}
+                    iface_kwargs = {'address': "{'type': 'pci', 'domain': '0x0000', 'bus': '%s', 'slot': '${slot}', 'function': '0x0'}"}
                 - index_v_bus:
                     only q35
                     case = 'index_v_bus_'

--- a/libvirt/tests/src/controller/pcibridge.py
+++ b/libvirt/tests/src/controller/pcibridge.py
@@ -228,6 +228,10 @@ def run(test, params, env):
 
             # Attach device with invalid slot to pcie-to-pci-bridge
             if case == 'attach_with_invalid_slot':
+                target_bus = cur_pci_br[0].index
+                target_bus = hex(int(target_bus))
+                iface_kwargs['address'] = iface_kwargs['address'] % target_bus
+                logging.debug('iface_kwargs is updated to: %s', iface_kwargs)
                 iface = create_iface(iface_model, iface_source, **iface_kwargs)
                 vmxml.add_device(iface)
                 result_to_check = virsh.define(vmxml.xml, debug=True)


### PR DESCRIPTION
Due to more controllers added, the fixed bus of the iface device is attached
to a wrong controller which makes attaching succeeded. This is to remove the
fixed bus info of iface device and get the desired index of pcie-to-pci-bridge
controller as target bus to attach.

Signed-off-by: Dan Zheng <dzheng@redhat.com>
