### PR TITLE
libvirt_ap_passthrough: new test case to verify autostart of crypto device

### DIFF
--- a/libvirt/tests/cfg/passthrough/ap/libvirt_ap_passthrough_autostart.cfg
+++ b/libvirt/tests/cfg/passthrough/ap/libvirt_ap_passthrough_autostart.cfg
@@ -1,0 +1,5 @@
+- libvirt_ap_passthrough_autostart:
+    type = libvirt_ap_passthrough_autostart
+    only s390-virtio
+    kvm_module_parameters = 'nested=1'
+    start_vm = no

--- a/libvirt/tests/src/passthrough/ap/libvirt_ap_passthrough.py
+++ b/libvirt/tests/src/passthrough/ap/libvirt_ap_passthrough.py
@@ -11,23 +11,10 @@
 #
 # Copyright: Red Hat Inc. 2020
 # Author: Sebastian Mitterle <smitterl@redhat.com>
-
-import logging as log
-
-from virttest import virsh
-from virttest.utils_zcrypt import CryptoDeviceInfoBuilder, \
-    APMaskHelper, MatrixDevice, load_vfio_ap, unload_vfio_ap
 from virttest.libvirt_xml.vm_xml import VMXML
-from virttest.libvirt_xml.devices import hostdev
-from virttest.utils_misc import wait_for
 
-# minimal supported hwtype
-MIN_HWTYPE = 10
-
-
-# Using as lower capital is not the best way to do, but this is just a
-# workaround to avoid changing the entire file.
-logging = log.getLogger('avocado.' + __name__)
+from provider.vfio.mdev_handlers import MdevHandler
+from provider.vfio import ap
 
 
 def run(test, params, env):
@@ -43,64 +30,28 @@ def run(test, params, env):
     vmxml_backup = VMXML.new_from_inactive_dumpxml(vm_name)
 
     plug = params.get("plug")
-    mask_helper = None
-    matrix_dev = None
+    handler = None
 
     try:
+        handler = MdevHandler.from_type("vfio_ap-passthrough")
         if plug == "cold" and vm.is_alive():
             vm.destroy()
         if plug == "hot" and vm.is_dead():
             vm.start()
             vm.wait_for_login()
 
-        load_vfio_ap()
+        handler.create_nodedev()
 
-        info = CryptoDeviceInfoBuilder.get()
-        logging.debug("Host lszcrypt got %s", info)
-
-        if not info.entries or int(info.domains[0].hwtype) < MIN_HWTYPE:
-            test.error("vfio-ap requires at least HWTYPE %s." % MIN_HWTYPE)
-
-        devices = [info.domains[0]]
-        mask_helper = APMaskHelper.from_infos(devices)
-        matrix_dev = MatrixDevice.from_infos(devices)
-
-        hostdev_xml = hostdev.Hostdev()
-        hostdev_xml.mode = "subsystem"
-        hostdev_xml.model = "vfio-ap"
-        hostdev_xml.type = "mdev"
-        uuid = matrix_dev.uuid
-        hostdev_xml.source = hostdev_xml.new_source(**{"uuid": uuid})
-        hostdev_xml.xmltreefile.write()
-
-        logging.debug("Attaching %s", hostdev_xml.xmltreefile)
-        virsh.attach_device(vm_name, hostdev_xml.xml, flagstr="--current",
-                            ignore_status=False)
+        ap.attach_hostdev(vm_name, handler.matrix_dev.uuid)
 
         if plug == "cold":
             vm.start()
 
         session = vm.wait_for_login()
 
-        def verify_passed_through():
-            guest_info = CryptoDeviceInfoBuilder.get(session)
-            logging.debug("Guest lszcrypt got %s", guest_info)
-            if guest_info.domains:
-                default_driver_on_host = devices[0].driver
-                driver_in_guest = guest_info.domains[0].driver
-                logging.debug("Expecting default drivers from host and guest"
-                              " to be the same: { host: %s, guest: %s }",
-                              default_driver_on_host, driver_in_guest)
-                return default_driver_on_host == driver_in_guest
-            return False
+        handler.check_device_present_inside_guest(session)
 
-        if not wait_for(verify_passed_through, timeout=60, step=10):
-            test.fail("Crypto domain not attached correctly in guest."
-                      " Please, check the test log for details.")
     finally:
         vmxml_backup.sync()
-        if matrix_dev:
-            matrix_dev.unassign_all()
-        if mask_helper:
-            mask_helper.return_to_host_all()
-        unload_vfio_ap()
+        if handler:
+            handler.clean_up()

--- a/libvirt/tests/src/passthrough/ap/libvirt_ap_passthrough_autostart.py
+++ b/libvirt/tests/src/passthrough/ap/libvirt_ap_passthrough_autostart.py
@@ -1,0 +1,77 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2022
+# Author: Sebastian Mitterle <smitterl@redhat.com>
+from avocado.core.exceptions import TestFail
+
+from virttest.libvirt_xml.vm_xml import VMXML
+from virttest.utils_misc import cmd_status_output
+from virttest.utils_zcrypt import load_vfio_ap
+
+from provider.vfio import ap
+from provider.vfio.mdev_handlers import MdevHandler
+
+
+def confirm_device_is_running(uuid, session=None):
+    """
+    Confirm that a mediated device is running.
+
+    :param uuid: The UUID of the mediated device.
+    :param session: A guest session. If not None, the command will
+                    be executed on the host.
+    :raises TestFail: if the device isn't running.
+    """
+    cmd = "mdevctl list -u %s" % uuid
+    err, out = cmd_status_output(cmd, shell=True, session=session)
+    if uuid not in out:
+        raise TestFail("Mediated device UUID(%s) not listed in output:"
+                       " %s. Exit code: %s" % (uuid, out, err))
+
+
+def run(test, params, env):
+    """
+    Tests that vfio-ap passthrough configurations can autostart
+
+    1. Pass device through into guest
+    2. Inside guest create a persistent autostart configuration
+    3. Reboot the guest and confirm the device is running
+    """
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    vmxml_backup = VMXML.new_from_inactive_dumpxml(vm_name)
+
+    handler = None
+
+    try:
+        handler = MdevHandler.from_type("vfio_ap-passthrough")
+
+        handler.create_nodedev()
+        ap.attach_hostdev(vm_name, handler.matrix_dev.uuid)
+        vm.start()
+
+        session = vm.wait_for_login()
+
+        load_vfio_ap(session)
+        domain_info = ".".join([handler.devices[0].card,
+                                handler.devices[0].domain])
+        uuid = ap.create_autostart_mediated_device(domain_info, session)
+        confirm_device_is_running(uuid, session)
+        session.close()
+
+        vm.reboot()
+        session = vm.wait_for_login()
+        confirm_device_is_running(uuid, session)
+        session.close()
+    finally:
+        vmxml_backup.sync()
+        if handler:
+            handler.clean_up()

--- a/provider/vfio/ap.py
+++ b/provider/vfio/ap.py
@@ -1,0 +1,69 @@
+import logging as log
+from uuid import uuid4
+
+from avocado.core.exceptions import TestError
+from virttest import virsh
+from virttest.libvirt_xml.devices import hostdev
+from virttest.utils_misc import cmd_status_output
+
+LOG = log.getLogger('avocado.' + __name__)
+
+
+def attach_hostdev(vm_name, uuid):
+    """
+    Prepare device XML and attach it to the VM
+    in its current state
+
+    :param vm_name: The name of the VM
+    :param uuid: The UUID of the mediated device
+    """
+
+    hostdev_xml = hostdev.Hostdev()
+    hostdev_dict = {
+                    'type_name': 'mdev',
+                    'model': 'vfio-ap',
+                    'mode': 'subsystem',
+                    'type': 'mdev',
+                    'source': {
+                                'untyped_address': {'uuid': uuid}}}
+    hostdev_xml.setup_attrs(**hostdev_dict)
+    hostdev_xml.xmltreefile.write()
+    LOG.debug("Attaching %s", hostdev_xml.xmltreefile)
+    virsh.attach_device(vm_name, hostdev_xml.xml, flagstr="--current",
+                        ignore_status=False)
+
+
+def create_autostart_mediated_device(domain_info, session=None):
+    """
+    Creates the full persistent device configuration, using mdevctl,
+    sets it autostart and starts it.
+
+    :param domain_info: The crypto domain identifier as listed by lszcrypt
+                        CARD.DOMAIN e.g. 02.002b
+    :param session: If given run the commands in the VM session
+    :return uuid: The mediated device' UUID
+    """
+    card_domain = domain_info.split(".")
+
+    card_domain_10 = [int(x, 16) for x in card_domain]
+    cmd = "chzdev -t ap apmask=-%s aqmask=-%s" % tuple(card_domain_10)
+    err, out = cmd_status_output(cmd, shell=True, session=session)
+    if err:
+        raise TestError("Couldn't set device assignment: %s" % out)
+    _, out = cmd_status_output("lszdev -t ap", shell=True, session=session)
+    LOG.debug(out)
+
+    uuid = str(uuid4())
+    card_domain_16 = ["0x%s" % x for x in card_domain]
+    cmds = ["mdevctl define -p matrix -t vfio_ap-passthrough -u %s" % uuid,
+            "mdevctl modify -u %s -a" % uuid,
+            ("mdevctl modify -u %s"
+             " --addattr assign_adapter --value %s" % (uuid, card_domain_16[0])),
+            ("mdevctl modify -u %s"
+             " --addattr assign_domain --value %s" % (uuid, card_domain_16[1])),
+            "mdevctl start -u %s" % uuid]
+    for cmd in cmds:
+        err, out = cmd_status_output(cmd, shell=True, session=session)
+        if err:
+            raise TestError("Couldn't configure mediated device: %s" % out)
+    return uuid

--- a/provider/vfio/mdev_handlers.py
+++ b/provider/vfio/mdev_handlers.py
@@ -1,0 +1,239 @@
+"""
+This module contains classes and functions for handling mediated devices
+"""
+import logging
+
+from time import sleep
+from uuid import uuid4
+
+from avocado.core.exceptions import TestError
+from avocado.core.exceptions import TestFail
+
+from virttest import virsh
+from virttest.utils_misc import wait_for
+from virttest.utils_zcrypt import CryptoDeviceInfoBuilder, \
+    APMaskHelper, MatrixDevice, load_vfio_ap, unload_vfio_ap
+
+from provider.vfio import ccw
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+
+class MdevHandler(object):
+    """ Base class for mdev type specific implementations """
+
+    def create_nodedev(self, api="nodedev"):
+        """
+        Creates the mdev and returns its name
+
+        :param api: The name of the API to use. Mediated devices can
+                    be created e.g. via:
+                        - sysfs
+                        - mdevctl
+                        - nodedev
+                    An implementer should raise a TestError if
+                    a specific method is not supported.
+        """
+        raise NotImplementedError()
+
+    def get_target_address(self):
+        """ Returns a target address to use for hostdev """
+        raise NotImplementedError()
+
+    def check_device_present_inside_guest(self, session):
+        """
+        Checks if the host device is present inside the guest
+
+        :param session: guest session
+        """
+        raise NotImplementedError()
+
+    def clean_up(self):
+        """ Stops the mediated device and returns resources to the host """
+        raise NotImplementedError()
+
+    @staticmethod
+    def from_type(mdev_type):
+        """
+        Creates implementing instance for mdev_type
+
+        :param mdev_type: The mediated device type as by nodedev API
+        """
+        if mdev_type == "vfio_ccw-io":
+            return CcwMdevHandler()
+        if mdev_type == "vfio_ap-passthrough":
+            return ApMdevHandler()
+        else:
+            raise TestError("Test doesn't know how to handle %s." % mdev_type)
+
+
+def get_first_mdev_nodedev_name():
+    """
+    Returns the first nodedev of type mdev known to libvirt
+
+    :return: the first listed mdev node device
+    """
+    result = virsh.nodedev_list(cap="mdev", debug=True)
+    device_names = result.stdout.strip().splitlines()
+    if result.exit_status or len(device_names) == 0:
+        raise TestError("Couldn't create nodedev. %s. %s." %
+                        (result.stderr, result.stdout))
+    return device_names[0]
+
+
+class CcwMdevHandler(MdevHandler):
+    """ Class implementing test methods for vfio_ccw-io """
+
+    def __init__(self):
+        self.uuid = None
+        self.chpids = None
+        self.schid = None
+        self.target_address = None
+        self.expected_device_address = None
+        self.device_id = None
+        self.session = None
+
+    def create_nodedev(self, api="mdevctl"):
+        """
+        Creates a mediated device of a specific type
+        and returns its name from libvirt.
+
+        :return: name of mdev device as node device
+        """
+        if api != "mdevctl":
+            raise TestError("Handling mdev via '%s' is not implemented." % api)
+
+        self.schid, self.chpids = ccw.get_device_info()
+        self.device_id, _ = ccw.get_first_device_identifiers(self.chpids, None)
+        ccw.set_override(self.schid)
+        self.uuid = str(uuid4())
+        ccw.start_device(self.uuid, self.schid)
+
+        return get_first_mdev_nodedev_name()
+
+    def get_target_address(self):
+        """
+        Returns a valid target device address
+
+        :return: hostdev target address
+        """
+        self.target_address = "address.type=ccw,address.cssid=0xfe,address.ssid=0x0,address.devno=0x1111"
+        self.expected_device_address = "0.0.1111"
+        return self.target_address
+
+    def check_device_present_inside_guest(self, session):
+        """
+        Fails the test if the device can't be found inside the guest.
+
+        :param session: guest session
+        :raises: TestFail if device not found
+        """
+        self.session = session
+        device, _ = ccw.get_first_device_identifiers(self.chpids, session)
+        if device != self.expected_device_address:
+            raise TestFail("Couldn't find device inside guest."
+                           "Expected address %s, found %s." %
+                           (self.expected_device_address, device))
+        LOG.debug("Device was found inside guest with"
+                  " expected id %s." % device)
+
+    def clean_up(self):
+        """
+        Returns the mdev resources to the host.
+        """
+        if self.session:
+            self.session.close()
+        if self.uuid:
+            ccw.stop_device(self.uuid)
+        if self.schid:
+            ccw.unset_override(self.schid)
+            # need to sleep to avoid issue with setting device offline
+            # adding a wait_for would likely be more complicated
+            sleep(1)
+        if self.device_id:
+            ccw.set_device_offline(self.device_id)
+
+
+class ApMdevHandler(MdevHandler):
+    """ Class implementing test methods for vfio_ap-passthrough """
+
+    def __init__(self):
+        self.mask_helper = None
+        self.matrix_dev = None
+        self.session = None
+        self.devices = None
+        # minimal supported hwtype
+        self.MIN_HWTYPE = 10
+        self.vfio_ap_loaded = None
+
+    def create_nodedev(self, api="sysfs"):
+        """
+        Creates a mediated device of a specific type
+        and returns its name from libvirt.
+
+        :return: name of mdev device as node device
+        """
+        if api != "sysfs":
+            raise TestError("Handling mdev via '%s' is not implemented." % api)
+
+        load_vfio_ap()
+        self.vfio_ap_loaded = True
+
+        info = CryptoDeviceInfoBuilder.get()
+        LOG.debug("Host lszcrypt got %s", info)
+
+        if not info.entries or int(info.domains[0].hwtype) < self.MIN_HWTYPE:
+            raise TestError("vfio-ap requires at least HWTYPE %s." % self.MIN_HWTYPE)
+
+        self.devices = [info.domains[0]]
+        self.mask_helper = APMaskHelper.from_infos(self.devices)
+        self.matrix_dev = MatrixDevice.from_infos(self.devices)
+
+        return get_first_mdev_nodedev_name()
+
+    def get_target_address(self):
+        """
+        Returns a valid target device address
+
+        :return: hostdev target address
+        """
+        # AP devices don't have the target address //hostdev/address
+        return None
+
+    def check_device_present_inside_guest(self, session):
+        """
+        Fails the test if the device can't be found inside the guest.
+
+        :param session: guest session
+        :raises: TestFail if device not found
+        """
+        self.session = session
+
+        def verify_passed_through():
+            guest_info = CryptoDeviceInfoBuilder.get(session)
+            LOG.debug("Guest lszcrypt got %s", guest_info)
+            if guest_info.domains:
+                default_driver_on_host = self.devices[0].driver
+                driver_in_guest = guest_info.domains[0].driver
+                LOG.debug("Expecting default drivers from host and guest"
+                          " to be the same: { host: %s, guest: %s }",
+                          default_driver_on_host, driver_in_guest)
+                return default_driver_on_host == driver_in_guest
+            return False
+
+        if not wait_for(verify_passed_through, timeout=60, step=10):
+            raise TestFail("Crypto domain not attached correctly in guest."
+                           " Please, check the test log for details.")
+
+    def clean_up(self):
+        """
+        Returns the mdev resources to the host.
+        """
+        if self.session:
+            self.session.close()
+        if self.matrix_dev:
+            self.matrix_dev.unassign_all()
+        if self.mask_helper:
+            self.mask_helper.return_to_host_all()
+        if self.vfio_ap_loaded:
+            unload_vfio_ap()

--- a/virttools/tests/src/virt_install/hostdev_mdev.py
+++ b/virttools/tests/src/virt_install/hostdev_mdev.py
@@ -1,121 +1,12 @@
 import logging
 
-from time import sleep
-from uuid import uuid4
 from avocado.core.exceptions import TestError
-from avocado.core.exceptions import TestFail
-from provider.vfio import ccw
+from provider.vfio.mdev_handlers import MdevHandler
 from virttest.libvirt_xml.vm_xml import VMXML
 from virttest.utils_misc import cmd_status_output
 from virttest import virsh
 
 LOG = logging.getLogger('avocado.' + __name__)
-
-
-class MdevHandler(object):
-    """ Base class for mdev type specific implementations """
-
-    def create_nodedev(self):
-        """ Creates the mdev and returns its name """
-        raise NotImplementedError()
-
-    def get_target_address(self):
-        """ Returns a target address to use for hostdev """
-        raise NotImplementedError()
-
-    def check_device_present_inside_guest(self, session):
-        """
-        Checks if the host device is present inside the guest
-
-        :param session: guest session
-        """
-        raise NotImplementedError()
-
-    def clean_up(self):
-        """ Stops the mediated device and returns resources to the host """
-        raise NotImplementedError()
-
-    @staticmethod
-    def from_type(mdev_type):
-        """
-        Creates implementing instance for mdev_type
-
-        :param mdev_type: The mediated device type as by nodedev API
-        """
-        if mdev_type == "vfio_ccw-io":
-            return CcwMdevHandler()
-        else:
-            raise TestError("Test doesn't know how to handle %s." % mdev_type)
-
-
-class CcwMdevHandler(MdevHandler):
-    """ Class implementing test methods for vfio_ccw-io """
-
-    def __init__(self):
-        self.uuid = None
-        self.chpids = None
-        self.schid = None
-        self.target_address = None
-        self.expected_device_address = None
-        self.device_id = None
-        self.session = None
-
-    def create_nodedev(self):
-        """
-        Creates a mediated device of a specific type
-        and returns its name from libvirt.
-
-        :return: name of mdev device as node device
-        """
-        self.schid, self.chpids = ccw.get_device_info()
-        self.device_id, _ = ccw.get_first_device_identifiers(self.chpids, None)
-        ccw.set_override(self.schid)
-        self.uuid = str(uuid4())
-        ccw.start_device(self.uuid, self.schid)
-
-        return get_first_mdev_nodedev_name()
-
-    def get_target_address(self):
-        """
-        Returns a valid target device address
-
-        :return: hostdev target address
-        """
-        self.target_address = "address.type=ccw,address.cssid=0xfe,address.ssid=0x0,address.devno=0x1111"
-        self.expected_device_address = "0.0.1111"
-        return self.target_address
-
-    def check_device_present_inside_guest(self, session):
-        """
-        Fails the test if the device can't be found inside the guest.
-
-        :param session: guest session
-        :raises: TestFail if device not found
-        """
-        self.session = session
-        device, _ = ccw.get_first_device_identifiers(self.chpids, session)
-        if device != self.expected_device_address:
-            raise TestFail("Couldn't find device inside guest."
-                           "Expected address %s, found %s." %
-                           (self.expected_device_address, device))
-        LOG.debug("Device was found inside guest with"
-                  " expected id %s." % device)
-
-    def clean_up(self):
-        """
-        Returns the mdev resources to the host.
-        """
-        if self.session:
-            self.session.close()
-        if self.uuid:
-            ccw.stop_device(self.uuid)
-        if self.schid:
-            ccw.unset_override(self.schid)
-            # need to sleep to avoid issue with setting device offline
-            # adding a wait_for would likely be more complicated
-            sleep(1)
-        if self.device_id:
-            ccw.set_device_offline(self.device_id)
 
 
 def get_disk_for_import(vmxml):


### PR DESCRIPTION
With [s390-tools v2.22.0](https://github.com/ibm-s390-linux/s390-tools/releases/tag/v2.22.0) crypto passthrough device configurations are now easily persisted.
Add a test case to confirm that the configuration is restored at reboot and that therefore a mediated device is autostarted.

For this the code was refactored:
1. Move `MdevHandler` classes from existing virttools test case into new module under `provider` for re-use in new libvirt test case.
2. Create a new `ApMdevHandler`, refactor existing AP passthrough test case to use it instead.
3. Create new test case.

This change depends on https://github.com/avocado-framework/avocado-vt/pull/3472