### PR TITLE
Fix iface security model dac not available issue

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_unprivileged.py
+++ b/libvirt/tests/src/virtual_network/iface_unprivileged.py
@@ -197,6 +197,8 @@ def run(test, params, env):
             upu_vmxml.devices = all_devices
             logging.debug(upu_vmxml)
 
+            # Remove seclabel model="dac" since unprivileged user doesn't support this feature
+            upu_vmxml.del_seclabel([('model', 'dac'), ('relabel', 'yes')])
             # Define updated xml
             shutil.copyfile(upu_vmxml.xml, new_xml_path)
             upu_vmxml.xml = new_xml_path


### PR DESCRIPTION
If define Security driver model 'dac' in vm.xml,  seclabel model="dac" under unprivileged user is not supported

Therefore, one error: unsupported configuration: Security driver model 'dac' is not available will be thrown

Fixing the issue by removing seclabel model="dac" since unprivileged user doesn't support this feature

Signed-off-by: chunfuwen <chwen@redhat.com>

