### PR TITLE
virsh_blockcopy: Make sure the guest boot successfully before snapshot-create

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
@@ -505,6 +505,11 @@ def run(test, params, env):
 
         :param snapshot_numbers_take: snapshot numbers.
         """
+        if params.get("start_vm") == "yes":
+            if not vm.is_alive():
+                vm.start()
+            vm.wait_for_login().close()
+
         for count in range(0, snapshot_numbers_take):
             snap_xml = snapshot_xml.SnapshotXML()
             snapshot_name = "blockcopy_snap"


### PR DESCRIPTION
If the guest starts, make sure it boot successfully before creating snapshot, otherwise it may fail.

Test Result:
(1/1) type_specific.io-github-autotest-libvirt.virsh.blockcopy.negative_test.shallow_raw.no_blockdev: PASS (36.29 s)

Signed-off-by: Hu Shuai <hus.fnst@fujitsu.com>