### PR TITLE
Fix static check failure in travics ci

### DIFF
--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -6,4 +6,5 @@ virtualenv==1.9.1
 simplejson==3.8.1
 inspektor==0.5.2
 pylint==2.11.1
+pycodestyle==2.8.0
 pyenchant


### PR DESCRIPTION
Fix static check failure in travics ci
inspekt checkall --disable-style E501,E265,W601,W605,E402,E722,E741 --no-license-check will fail
it need roll back pycodestyle==2.8.0 to fix it

Signed-off-by: chunfuwen <chwen@redhat.com>

