### PR TITLE
migration: Add cases for zerocopy migration

### DIFF
--- a/libvirt/tests/cfg/migration/memory_copy_mode/migration_memory_copy_mode_postcopy.cfg
+++ b/libvirt/tests/cfg/migration/memory_copy_mode/migration_memory_copy_mode_postcopy.cfg
@@ -24,7 +24,7 @@
     status_error = "no"
     check_network_accessibility_after_mig = "yes"
     migrate_desturi_port = "16509"
-    transport_type = "tcp"
+    migrate_desturi_type = "tcp"
     virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
     stress_package = "stress"
     stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20s"

--- a/libvirt/tests/cfg/migration/memory_copy_mode/migration_memory_copy_mode_precopy.cfg
+++ b/libvirt/tests/cfg/migration/memory_copy_mode/migration_memory_copy_mode_precopy.cfg
@@ -24,7 +24,7 @@
     status_error = "no"
     check_network_accessibility_after_mig = "yes"
     migrate_desturi_port = "16509"
-    transport_type = "tcp"
+    migrate_desturi_type = "tcp"
     virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
 
     variants test_case:

--- a/libvirt/tests/cfg/migration/migration_efficiency/migration_zerocopy.cfg
+++ b/libvirt/tests/cfg/migration/migration_efficiency/migration_zerocopy.cfg
@@ -1,0 +1,57 @@
+- migration_efficiency.migration_zerocopy:
+    type = migration_zerocopy
+    migration_setup = 'yes'
+    storage_type = 'nfs'
+    setup_local_nfs = 'yes'
+    disk_type = "file"
+    disk_source_protocol = "netfs"
+    mnt_path_name = ${nfs_mount_dir}
+    # Console output can only be monitored via virsh console output
+    only_pty = True
+    take_regular_screendumps = no
+    # Extra options to pass after <domain> <desturi>
+    virsh_migrate_extra = ''
+    # SSH connection time out
+    ssh_timeout = 60
+    # Local URI
+    virsh_migrate_connect_uri = 'qemu:///system'
+    virsh_migrate_dest_state = "running"
+    virsh_migrate_src_state = "shut off"
+    image_convert = 'no'
+    server_ip = "${migrate_dest_host}"
+    server_user = "root"
+    server_pwd = "${migrate_dest_pwd}"
+    status_error = "no"
+    check_network_accessibility_after_mig = "yes"
+    migrate_desturi_port = "16509"
+    migrate_desturi_type = "tcp"
+    virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
+    libvirtd_file_path = "/etc/libvirt/virtqemud.conf"
+    libvirtd_debug_level = "1"
+    libvirtd_debug_filters = "1:*"
+    check_str_local_log = '"capability":"zero-copy-send","state":true'
+    func_supported_since_libvirt_ver = (8, 0, 0)
+    action_during_mig = '[{"func": "check_qemu_mem_lock_hard_limit", "after_event": "iteration: '1'", "func_param": 'params'}]'
+
+    variants:
+        - p2p:
+            virsh_migrate_options = '--live --p2p --verbose'
+        - non_p2p:
+            virsh_migrate_options = '--live --verbose'
+    variants:
+        - with_precopy:
+            migrate_speed = "5"
+        - with_postcopy:
+            stress_package = "stress"
+            stress_args = "--cpu 8 --io 8 --vm 4 --vm-bytes 128M --timeout 20s"
+            postcopy_options = '--postcopy --timeout 10 --timeout-postcopy'
+    variants:
+        - with_memtune:
+            hard_limit = 10485760
+            vm_attrs = {'memtune': {'hard_limit': ${hard_limit}, 'hard_limit_unit': 'KiB'}}
+        - without_memtune:
+    variants:
+        - zerocopy_and_parallel_and_tcp_transport:
+            virsh_migrate_extra = "--zerocopy --parallel"
+        - zerocopy_and_parallel_and_auto_converge:
+            virsh_migrate_extra = "--zerocopy --parallel --auto-converge"

--- a/libvirt/tests/cfg/migration/migration_efficiency/migration_zerocopy_abort.cfg
+++ b/libvirt/tests/cfg/migration/migration_efficiency/migration_zerocopy_abort.cfg
@@ -1,5 +1,5 @@
-- migration.vm_configuration_and_status:
-    type = migration_vm_configuration_and_status
+- migration_efficiency.migration_zerocopy_abort:
+    type = migration_zerocopy
     migration_setup = 'yes'
     storage_type = 'nfs'
     setup_local_nfs = 'yes'
@@ -15,24 +15,36 @@
     ssh_timeout = 60
     # Local URI
     virsh_migrate_connect_uri = 'qemu:///system'
-    virsh_migrate_dest_state = "running"
-    virsh_migrate_src_state = "shut off"
     image_convert = 'no'
     server_ip = "${migrate_dest_host}"
     server_user = "root"
     server_pwd = "${migrate_dest_pwd}"
-    status_error = "no"
     check_network_accessibility_after_mig = "yes"
     migrate_desturi_port = "16509"
     migrate_desturi_type = "tcp"
     virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
+    func_supported_since_libvirt_ver = (8, 0, 0)
+    action_during_mig = '[{"func": "check_qemu_mem_lock_hard_limit", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "virsh.domjobabort", "func_param": "'%s' % params.get('migrate_main_vm')"}]'
+    virsh_migrate_extra = "--zerocopy --parallel"
+    check_hard_limit = "yes"
+    status_error = "yes"
+    migrate_again = "yes"
+    migrate_again_status_error = "no"
 
     variants:
         - p2p:
             virsh_migrate_options = '--live --p2p --verbose'
         - non_p2p:
             virsh_migrate_options = '--live --verbose'
+    variants:
+        - with_precopy:
+            migrate_speed = "5"
+        - with_postcopy:
+            stress_package = "stress"
+            stress_args = "--cpu 8 --io 8 --vm 4 --vm-bytes 256M --timeout 20s"
+            postcopy_options = '--postcopy --timeout 10 --timeout-postcopy'
     variants test_case:
-        - suspend_target_vm:
-            check_dest_state = "paused"
-            virsh_migrate_extra = "--suspend"
+        - with_memtune:
+            hard_limit = 10485760
+            vm_attrs = {'memtune': {'hard_limit': ${hard_limit}, 'hard_limit_unit': 'KiB'}}
+        - without_memtune:

--- a/libvirt/tests/cfg/migration/migration_efficiency/migration_zerocopy_unsupported_feature_combinations.cfg
+++ b/libvirt/tests/cfg/migration/migration_efficiency/migration_zerocopy_unsupported_feature_combinations.cfg
@@ -1,0 +1,76 @@
+- migration_efficiency.migration_zerocopy_unsupported_feature_combinations:
+    type = migration_zerocopy
+    migration_setup = 'yes'
+    storage_type = 'nfs'
+    setup_local_nfs = 'yes'
+    disk_type = "file"
+    disk_source_protocol = "netfs"
+    mnt_path_name = ${nfs_mount_dir}
+    # Console output can only be monitored via virsh console output
+    only_pty = True
+    take_regular_screendumps = no
+    # Extra options to pass after <domain> <desturi>
+    virsh_migrate_extra = ''
+    # SSH connection time out
+    ssh_timeout = 60
+    # Local URI
+    virsh_migrate_connect_uri = 'qemu:///system'
+    virsh_migrate_dest_state = "running"
+    virsh_migrate_src_state = "shut off"
+    image_convert = 'no'
+    server_ip = "${migrate_dest_host}"
+    server_user = "root"
+    server_pwd = "${migrate_dest_pwd}"
+    status_error = "yes"
+    check_network_accessibility_after_mig = "yes"
+    migrate_desturi_port = "16509"
+    migrate_desturi_type = "tcp"
+    virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
+    func_supported_since_libvirt_ver = (8, 0, 0)
+
+    variants:
+        - p2p:
+            virsh_migrate_options = '--live --p2p --verbose'
+        - non_p2p:
+            virsh_migrate_options = '--live --verbose'
+    variants:
+        - zerocopy_and_parallel:
+            status_error = "no"
+            virsh_migrate_extra = "--zerocopy --parallel"
+        - zerocopy_and_non_parallel:
+            virsh_migrate_extra = "--zerocopy"
+            err_msg = "zero-copy is only available for parallel migration"
+            migrate_again = "yes"
+            migrate_again_status_error = "no"
+            virsh_migrate_extra_mig_again = "--zerocopy --parallel"
+        - zerocopy_and_parallel_and_unix:
+            transport_type = "unix_proxy"
+            migrateuri_socket_path = "/var/lib/libvirt/qemu/migrateuri-socket"
+            virsh_migrate_migrateuri = "unix://${migrateuri_socket_path}"
+            virsh_migrate_extra = "--zerocopy --parallel --migrateuri ${virsh_migrate_migrateuri}"
+            err_msg = "job 'migration out' failed: Zero copy send feature not detected in host kernel"
+            migrate_again = "yes"
+            migrate_again_status_error = "no"
+            virsh_migrate_extra_mig_again = "--zerocopy --parallel"
+        - zerocopy_and_parallel_and_tls:
+            transport_type = "tls"
+            custom_pki_path = "/etc/pki/qemu"
+            qemu_tls = "yes"
+            server_cn = "ENTER.YOUR.EXAMPLE.SERVER_CN"
+            client_cn = "ENTER.YOUR.EXAMPLE.CLIENT_CN"
+            virsh_migrate_extra = "--zerocopy --parallel --tls"
+            err_msg = "job 'migration out' failed: Requested Zero Copy feature is not available: Invalid argument"
+            migrate_again = "yes"
+            migrate_again_status_error = "no"
+            virsh_migrate_extra_mig_again = "--zerocopy --parallel"
+        - zerocopy_and_parallel_and_compression:
+            virsh_migrate_extra = "--zerocopy --parallel --compressed --comp-methods mt"
+            err_msg = "Zero copy only available for non-compressed non-TLS multifd migration"
+            migrate_again = "yes"
+            migrate_again_status_error = "no"
+            virsh_migrate_extra_mig_again = "--zerocopy --parallel"
+        - zerocopy_and_parallel_and_xbzrle:
+            virsh_migrate_extra = "--zerocopy --parallel --compressed --comp-methods xbzrle"
+            migrate_again = "yes"
+            migrate_again_status_error = "no"
+            virsh_migrate_extra_mig_again = "--zerocopy --parallel"

--- a/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_tcp.cfg
+++ b/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_tcp.cfg
@@ -24,7 +24,7 @@
     status_error = "no"
     check_network_accessibility_after_mig = "yes"
     migrate_desturi_port = "16509"
-    transport_type = "tcp"
+    migrate_desturi_type = "tcp"
     virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
     qemu_conf_path = "/etc/libvirt/qemu.conf"
 

--- a/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_tcp_listen_address.cfg
+++ b/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_tcp_listen_address.cfg
@@ -24,7 +24,7 @@
     status_error = "no"
     check_network_accessibility_after_mig = "yes"
     migrate_desturi_port = "16509"
-    transport_type = "tcp"
+    migrate_desturi_type = "tcp"
     virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
     migrate_speed = "8"
     ipv6_addr_des = "ENTER.YOUR.IPv6.DESTINATION"

--- a/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_tcp_migrateuri.cfg
+++ b/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_tcp_migrateuri.cfg
@@ -24,7 +24,7 @@
     status_error = "no"
     check_network_accessibility_after_mig = "yes"
     migrate_desturi_port = "16509"
-    transport_type = "tcp"
+    migrate_desturi_type = "tcp"
     virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
     migrate_speed = "5"
 

--- a/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_tls.cfg
+++ b/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_tls.cfg
@@ -24,10 +24,10 @@
     status_error = "no"
     check_network_accessibility_after_mig = "yes"
     migrate_desturi_port = "16509"
-    transport_type = "tcp"
+    migrate_desturi_type = "tcp"
     virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
     enable_libvirtd_debug_log = "no"
-
+    transport_type = "tls"
     variants:
         - p2p:
             virsh_migrate_options = '--live --p2p --verbose'

--- a/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_tls_migrate_tls_force.cfg
+++ b/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_tls_migrate_tls_force.cfg
@@ -24,7 +24,7 @@
     status_error = "no"
     check_network_accessibility_after_mig = "yes"
     migrate_desturi_port = "16509"
-    transport_type = "tcp"
+    migrate_desturi_type = "tcp"
     virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
     custom_pki_path = "/etc/pki/qemu"
     qemu_tls = "yes"
@@ -51,6 +51,7 @@
             migrate_again_status_error = "no"
             err_msg = "Requested operation is not valid: this libvirtd instance allows migration only with VIR_MIGRATE_TLS flag"
             virsh_migrate_extra_mig_again = "--tls"
+            transport_type_again = "tls"
         - disable_src_enable_dest:
             qemu_conf_src = '{"migrate_tls_force": "0"}'
             qemu_conf_dest = '{r".*migrate_tls_force\s*=.*": "migrate_tls_force=1"}'
@@ -59,6 +60,7 @@
             migrate_again_status_error = "no"
             err_msg = "Requested operation is not valid: this libvirtd instance allows migration only with VIR_MIGRATE_TLS flag"
             virsh_migrate_extra_mig_again = "--tls"
+            transport_type_again = "tls"
         - enable_src_and_dest:
             qemu_conf_src = '{"migrate_tls_force": "1"}'
             qemu_conf_dest = '{r".*migrate_tls_force\s*=.*": "migrate_tls_force=1"}'
@@ -67,6 +69,7 @@
             migrate_again_status_error = "no"
             err_msg = "Requested operation is not valid: this libvirtd instance allows migration only with VIR_MIGRATE_TLS flag"
             virsh_migrate_extra_mig_again = "--tls"
+            transport_type_again = "tls"
         - disable_src_and_dest:
             qemu_conf_src = '{"migrate_tls_force": "0"}'
             qemu_conf_dest = '{r".*migrate_tls_force\s*=.*": "migrate_tls_force=0"}'

--- a/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_tunnelled.cfg
+++ b/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_tunnelled.cfg
@@ -30,12 +30,12 @@
     variants desturi_protocol:
         - desturi_tls:
             migrate_desturi_port = "16514"
-            transport_type = "tls"
+            migrate_desturi_type = "tls"
             virsh_migrate_desturi = "qemu+tls://${migrate_dest_host}/system"
         - desturi_tcp:
             migrate_desturi_port = "16509"
-            transport_type = "tcp"
+            migrate_desturi_type = "tcp"
             virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
         - desturi_ssh:
-            transport_type = "ssh"
+            migrate_desturi_type = "ssh"
             virsh_migrate_desturi = "qemu+ssh://${migrate_dest_host}/system"

--- a/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_unix_proxy.cfg
+++ b/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_unix_proxy.cfg
@@ -41,6 +41,7 @@
             desturi_socket_path = "/tmp/desturi-socket"
             migrateuri_socket_path = "/var/lib/libvirt/qemu/migrateuri-socket"
             disks_uri_socket_path = "/var/lib/libvirt/qemu/disks-uri-socket"
+            migrate_desturi_type = "unix_proxy"
             virsh_migrate_desturi = "qemu+unix:///system?socket=${desturi_socket_path}"
             virsh_migrate_migrateuri = "unix://${migrateuri_socket_path}"
             virsh_migrate_disks_uri = "unix://${disks_uri_socket_path}"

--- a/libvirt/tests/src/migration/migration_efficiency/migration_zerocopy.py
+++ b/libvirt/tests/src/migration/migration_efficiency/migration_zerocopy.py
@@ -1,0 +1,96 @@
+from virttest import libvirt_version
+
+from virttest.libvirt_xml import vm_xml
+
+from virttest.utils_libvirt import libvirt_memory
+
+from provider.migration import base_steps
+
+
+def run(test, params, env):
+    """
+    Test live migration - zero-copy.
+
+    :param test: test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    def setup_with_memtune():
+        """
+        Setup with memtune
+
+        """
+        test.log.debug("Setup for with memtune.")
+        hard_limit = params.get("hard_limit")
+        if hard_limit:
+            params.update({'expect_hard_limit': hard_limit})
+        test.log.info("hard limit: %s", hard_limit)
+        vm_attrs = eval(params.get('vm_attrs', '{}'))
+
+        if check_hard_limit:
+            old_hard_limit.append(libvirt_memory.get_qemu_process_memlock_hard_limit())
+
+        if vm_attrs:
+            vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+            vmxml.setup_attrs(**vm_attrs)
+            vmxml.sync()
+            test.log.info("Updated VM xml: %s", vm_xml.VMXML.new_from_dumpxml(vm_name))
+
+        migration_obj.setup_connection()
+
+    def setup_without_memtune():
+        """
+        Setup without memtune
+
+        """
+        test.log.debug("Setup for without memtune.")
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        cur_mem = vmxml.current_mem
+        test.log.info("VM current memory: %s", cur_mem)
+        params.update({'expect_hard_limit': cur_mem})
+
+        if check_hard_limit:
+            old_hard_limit.append(libvirt_memory.get_qemu_process_memlock_hard_limit())
+
+        migration_obj.setup_connection()
+
+    def migration_test_again():
+        """
+        Migration again
+
+        """
+        if check_hard_limit:
+            if not vm.is_alive():
+                vm.connect_uri = migration_obj.src_uri
+                vm.start()
+                vm.wait_for_login().close()
+            new_hard_limit = libvirt_memory.get_qemu_process_memlock_hard_limit()
+            test.log.debug("old hard limit: %s", old_hard_limit[0])
+            test.log.debug("new hard limit: %s", new_hard_limit)
+            if new_hard_limit != old_hard_limit[0]:
+                test.fail("Check qemu process memlock hard limit failed.")
+
+        migration_obj.run_migration_again()
+
+    libvirt_version.is_libvirt_feature_supported(params)
+
+    test_case = params.get('test_case', '')
+    vm_name = params.get("migrate_main_vm")
+    migrate_again = "yes" == params.get("migrate_again", "no")
+    check_hard_limit = "yes" == params.get("check_hard_limit", "no")
+
+    old_hard_limit = []
+
+    vm = env.get_vm(vm_name)
+    migration_obj = base_steps.MigrationBase(test, vm, params)
+    setup_test = eval("setup_%s" % test_case) if "setup_%s" % test_case in \
+        locals() else migration_obj.setup_connection
+
+    try:
+        setup_test()
+        migration_obj.run_migration()
+        if migrate_again:
+            migration_test_again()
+        migration_obj.verify_default()
+    finally:
+        migration_obj.cleanup_connection()

--- a/provider/migration/base_steps.py
+++ b/provider/migration/base_steps.py
@@ -231,16 +231,18 @@ class MigrationBase(object):
 
         """
         transport_type = self.params.get("transport_type")
-        extra = self.params.get("virsh_migrate_extra")
+        transport_type_again = self.params.get("transport_type_again")
         migrate_desturi_port = self.params.get("migrate_desturi_port")
+        migrate_desturi_type = self.params.get("migrate_desturi_type", "tcp")
 
-        if transport_type:
+        if migrate_desturi_type:
+            self.conn_list.append(migration_base.setup_conn_obj(migrate_desturi_type, self.params, self.test))
+
+        if transport_type and transport_type != migrate_desturi_type:
             self.conn_list.append(migration_base.setup_conn_obj(transport_type, self.params, self.test))
 
-        if self.params.get("virsh_migrate_extra_mig_again"):
-            extra += self.params.get("virsh_migrate_extra_mig_again")
-        if '--tls' in extra:
-            self.conn_list.append(migration_base.setup_conn_obj('tls', self.params, self.test))
+        if transport_type_again and transport_type_again not in [transport_type, migrate_desturi_type]:
+            self.conn_list.append(migration_base.setup_conn_obj(transport_type_again, self.params, self.test))
 
         if migrate_desturi_port:
             self.remote_add_or_remove_port(migrate_desturi_port)

--- a/provider/migration/migration_base.py
+++ b/provider/migration/migration_base.py
@@ -3,11 +3,14 @@ import types
 import re
 import signal                                        # pylint: disable=W0611
 
+from avocado.core import exceptions
+
 from virttest import virsh                           # pylint: disable=W0611
 from virttest import utils_misc                      # pylint: disable=W0611
 from virttest import utils_libvirtd                  # pylint: disable=W0611
 from virttest import utils_conn
 
+from virttest.utils_libvirt import libvirt_memory
 from virttest.utils_libvirt import libvirt_network   # pylint: disable=W0611
 from virttest.migration import MigrationTest
 from virttest.libvirt_xml import vm_xml
@@ -262,3 +265,14 @@ def execute_statistics_command(params):
         virsh.domblkinfo(vm_name, disk_source, **debug_kargs)
         virsh.domstats(vm_name, **debug_kargs)
         virsh.dommemstat(vm_name, **debug_kargs)
+
+
+def check_qemu_mem_lock_hard_limit(params):
+    """
+    Check qemu process memlock hard limit
+
+    """
+    expect_hard_limit = params.get("expect_hard_limit")
+    output = libvirt_memory.get_qemu_process_memlock_hard_limit()
+    if int(output) != int(expect_hard_limit) * 1024:
+        raise exceptions.TestFail("'%s' is not matched expect hard limit '%s'" % (output, expect_hard_limit))


### PR DESCRIPTION
    1. VIRT-294637 - VM live migration - zerocopy - unsupported feature combinations
    2. VIRT-294640 - VM live migration - zerocopy
    3. VIRT-294638 - VM live migration - zerocopy - abort migration

Signed-off-by: cliping <lcheng@redhat.com>
