### PR TITLE
add case for blockcopy conventional chain

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockcopy/blockcopy_with_conventional_chain.cfg
+++ b/libvirt/tests/cfg/backingchain/blockcopy/blockcopy_with_conventional_chain.cfg
@@ -1,0 +1,31 @@
+- backingchain.blockcopy.conventional_chain:
+    type = blockcopy_with_conventional_chain
+    start_vm = "yes"
+    target_disk = "vdb"
+    snap_num = 4
+    execute_option = "--pivot"
+    snap_extra = " -diskspec vda,snapshot=no"
+    variants:
+        - with_shallow:
+            blockcopy_option = " --shallow --transient-job"
+            expected_chain = "copy_file>3>2>1>base"
+        - without_shallow:
+            blockcopy_option = " --transient-job"
+            expected_chain = "copy_file"
+    variants:
+        - file_disk:
+            disk_type = "file"
+            disk_dict = {"type_name":"${disk_type}", "target":{"dev": "${target_disk}", "bus": "virtio"}, "driver": {"name": "qemu", "type":"qcow2"}}
+        - block_disk:
+            disk_type = "block"
+            disk_dict = {"type_name":"${disk_type}", "target":{"dev": "${target_disk}", "bus": "virtio"}, "driver": {"name": "qemu", "type":"raw"}}
+        - rbd_with_auth_disk:
+            disk_type = "rbd_with_auth"
+            disk_source_protocol = "rbd"
+            mon_host = "EXAMPLE_MON_HOST"
+            auth_key = "EXAMPLE_AUTH_KEY"
+            auth_user = "EXAMPLE_AUTH_USER"
+            image_path = "EXAMPLE_IMAGE_PATH"
+            client_name = "EXAMPLE_CLIENT_NAME"
+            sec_dict = {"secret_ephemeral": "no", "secret_private": "yes", "description": "secret_desc_for_backingchain", "usage": "ceph", "usage_name": "cephlibvirt"}
+            disk_dict = {"type_name":"network", "target":{"dev": "${target_disk}", "bus": "virtio"}, "driver": {"name": "qemu", "type":"raw"}}

--- a/libvirt/tests/src/backingchain/blockcopy/blockcopy_with_conventional_chain.py
+++ b/libvirt/tests/src/backingchain/blockcopy/blockcopy_with_conventional_chain.py
@@ -1,0 +1,113 @@
+import os
+
+from virttest import utils_misc
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_disk
+from virttest.utils_test import libvirt
+
+from provider.backingchain import blockcommand_base
+from provider.backingchain import check_functions
+from provider.virtual_disk import disk_base
+
+
+def run(test, params, env):
+    """
+    Test blockcopy with conventional chain.
+
+    1) Prepare an running guest.
+    2) Create snap.
+    3) Do blockcopy with shallow/no shallow.
+    4) Check hash value and chain value.
+    """
+
+    def setup_test():
+        """
+        Prepare expected disk type, snapshots, blockcopy path.
+        """
+        test.log.info("TEST_SETUP:Prepare new disk and snapchain.")
+        test_obj.new_image_path = disk_obj.add_vm_disk(disk_type, disk_dict)
+
+        if not vm.is_alive():
+            vm.start()
+        vm.wait_for_login().close()
+
+        test_obj.prepare_snapshot(snap_num=snap_num,
+                                  extra=snap_extra)
+
+    def run_test():
+        """
+        Do blockcopy and abort job ,than check hash and vmxml chain
+        """
+        session = vm.wait_for_login()
+        expected_hash = test_obj.get_hash_value(session,
+                                                "/dev/" + test_obj.new_dev)
+
+        test.log.info("TEST_STEP1: Do blockcopy and abort job")
+        virsh.blockcopy(vm_name, target_disk, tmp_copy_path,
+                        options=blockcopy_options, ignore_status=False,
+                        debug=True)
+
+        test.log.info("TEST_STEP2: Check expected chain and hash value")
+        check_obj.check_mirror_exist(vm, target_disk, tmp_copy_path)
+
+        if not utils_misc.wait_for(
+                lambda: libvirt.check_blockjob(vm_name, target_disk, "progress", "100"), 30):
+            test.fail("Blockcopy not finished for 30s")
+        test.log.info("TEST_STEP3: Abort job with %s", execute_option)
+        virsh.blockjob(vm_name, target_disk, execute_option,
+                       ignore_status=False, debug=True)
+
+        test.log.info("TEST_STEP4: Check expected chain and hash value ")
+        test_obj.copy_image = tmp_copy_path
+        expected_chain = test_obj.convert_expected_chain(expected_chain_index)
+        check_obj.check_backingchain_from_vmxml(disk_type, target_disk, expected_chain)
+
+        check_obj.check_hash_list(["/dev/" + test_obj.new_dev], [expected_hash],
+                                  session)
+        session.close()
+
+    def teardown_test():
+        """
+        Clean env
+        """
+        test.log.info("TEST_TEARDOWN: Clean up env.")
+        test_obj.backingchain_common_teardown()
+        bkxml.sync()
+        disk_obj.cleanup_disk_preparation(disk_type)
+
+        if os.path.exists(tmp_copy_path):
+            os.remove(tmp_copy_path)
+        if os.path.exists(test_obj.new_image_path):
+            os.remove(test_obj.new_image_path)
+
+    # Process cartesian parameters
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    target_disk = params.get('target_disk')
+    disk_type = params.get("disk_type")
+    disk_dict = eval(params.get('disk_dict', '{}'))
+    execute_option = params.get("execute_option")
+    blockcopy_options = params.get('blockcopy_option')
+    snap_extra = params.get("snap_extra", "")
+    snap_num = int(params.get("snap_num", 4))
+    expected_chain_index = params.get("expected_chain", "")
+
+    # Create object
+    test_obj = blockcommand_base.BlockCommand(test, vm, params)
+    check_obj = check_functions.Checkfunction(test, vm, params)
+    disk_obj = disk_base.DiskBase(test, vm, params)
+    # Get vm xml
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+    test_obj.original_disk_source = libvirt_disk.get_first_disk_source(vm)
+    tmp_copy_path = os.path.join(os.path.dirname(
+        libvirt_disk.get_first_disk_source(vm)), "%s_blockcopy.img" % vm_name)
+
+    try:
+        # Execute test
+        setup_test()
+        run_test()
+
+    finally:
+        teardown_test()

--- a/provider/backingchain/blockcommand_base.py
+++ b/provider/backingchain/blockcommand_base.py
@@ -115,6 +115,8 @@ class BlockCommand(object):
                 expected_chain.append(self.new_image_path)
             elif i == 'backing_file':
                 expected_chain.append(self.backing_file)
+            elif i == 'copy_file':
+                expected_chain.append(self.copy_image)
             else:
                 expected_chain.append(self.snap_path_list[int(i) - 1])
         LOG.debug("Expected chain is : %s", expected_chain)

--- a/provider/backingchain/check_functions.py
+++ b/provider/backingchain/check_functions.py
@@ -219,3 +219,29 @@ class Checkfunction(object):
                 self.test.fail("File:%s hash :%s is different from hash before "
                                "blockcommit:%s" % (item, current_hash,
                                                    item_list[index]))
+
+    def check_mirror_exist(self, vm, device, image_path):
+        """
+        Check mirror tag exist and correct source file
+
+        :param vm: the vm object
+        :param device: device name
+        :param image_path: image path
+        """
+        # Check exist mirror tag.
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm.name)
+        disk_list = vmxml.get_disk_all()[device]
+        if not disk_list.find('mirror'):
+            self.test.fail('No mirror tag in current domain xml :%s' % vmxml)
+        else:
+            # Check file in mirror should be new path
+            mirror_file = disk_list.find('mirror').get('file')
+            if mirror_file != image_path:
+                self.test.fail('Current mirror tag file:%s is not same as:%s' %
+                               (mirror_file, image_path))
+            # Check file in mirror >source > file should be new path
+            mirror_source_file = disk_list.find('mirror'). \
+                find('source').get('file')
+            if mirror_source_file != image_path:
+                self.test.fail('Current source tag file:%s is not same as:%s' %
+                               (mirror_source_file, image_path))


### PR DESCRIPTION
    VIRT-294083:Do blockcopy after creating external snapshots with different disk types:

Signed-off-by: nanli <nanli@redhat.com>

```
 /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35  backingchain.blockcopy.conventional_chain
 (1/6) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.conventional_chain.file_disk.with_shallow: PASS (31.57 s)
 (2/6) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.conventional_chain.file_disk.without_shallow: PASS (33.63 s)
 (3/6) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.conventional_chain.block_disk.with_shallow: PASS (61.19 s)
 (4/6) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.conventional_chain.block_disk.without_shallow: PASS (52.78 s)
 (5/6) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.conventional_chain.rbd_with_auth_disk.with_shallow: PASS (42.01 s)
 (6/6) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.conventional_chain.rbd_with_auth_disk.without_shallow: PASS (42.04 s)

```