### PR TITLE
virsh_detach_device_alias: fix for s390x

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
@@ -32,9 +32,13 @@
             detach_check_xml = "<target dev='vdd' bus='virtio'/>"
         - watchdog:
             only live,config
+            live:
+                no s390-virtio
             detach_watchdog_type = "watchdog"
             watchdog_dict = {"model_type":"i6300esb", "action":"poweroff"}
             detach_check_xml = "<watchdog"
+            s390-virtio:
+                watchdog_dict = {"model_type":"diag288", "action":"poweroff"}
         - network_interface:
             only live,config
             detach_interface_type = "network_interface"


### PR DESCRIPTION
1. Hotunplug of watchdog device not supported on s390x:
FAIL: error: Failed to detach device with alias
ua-50972fe1-44e0-48f8-9d34-416eb879d2a7\nerror: Operation not supported:
hot unplug of watchdog of model diag288 is not supported\n (29.81 s)
2. Fix the watchdog model for s390x, it's diag288.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>
