### PR TITLE
Filter acpi network feature cases on s390x

### DIFF
--- a/libvirt/tests/cfg/virtual_network/network_misc.cfg
+++ b/libvirt/tests/cfg/virtual_network/network_misc.cfg
@@ -9,6 +9,7 @@
                     expect_str = ['libvirt (active)', 'target: ACCEPT', 'interfaces: .*%s' % br, 'services: dhcp dhcpv6 dns ssh tftp', 'protocols: icmp ipv6-icmp', 'rule priority="32767" reject']
         - iface_acpi:
             no ppc64le
+            no s390-virtio
             func_supported_since_libvirt_ver = (7, 3, 0)
             acpi_index = 13
             variants case:


### PR DESCRIPTION
Filter acpi network feature cases on s390x
virsh capabilities |grep acpi show acpi is not supported feature on s390x
so those related cases needed to be filter out in s390x

Signed-off-by: chunfuwen <chwen@redhat.com>

