### PR TITLE
driver_page_per_vq as one network driver attribute is not supported on s390-virtio

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_options.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_options.cfg
@@ -23,6 +23,7 @@
                 - driver_txmode_timer:
                     iface_driver = "{'txmode':'timer'}"
                 - driver_page_per_vq:
+                    no s390-virtio
                     func_supported_since_libvirt_ver = (7, 9, 0)
                     iface_driver = "{'queues':'5','page_per_vq':'on','tx_queue_size':'1024','rx_queue_size':'1024'}"
                     variants:


### PR DESCRIPTION
driver_page_per_vq as one network driver attribute is purposedly for  vdpa device

and it is still not supported on s390-virtio,
therefore Vm with this network setting fail to launch with below error:
Property 'virtio-net-ccw.page-per-vq' not found

Signed-off-by: chunfuwen <chwen@redhat.com>

