### PR TITLE
memory_misc: Fix some cases on s390x

### DIFF
--- a/libvirt/tests/cfg/memory/memory_misc.cfg
+++ b/libvirt/tests/cfg/memory/memory_misc.cfg
@@ -23,6 +23,8 @@
                         - file_backed:
                             mem_backing_attrs = {'hugepages': {}, 'allocation': {'threads': '${threads_num}'}}
                             qemu_check = '"qom-type":"memory-backend-file".*"prealloc-threads":${threads_num}'
+                            s390-virtio:
+                                kvm_module_parameters = "hpage=1"
                         - memfd_backed:
                             mem_backing_attrs = {'hugepages': {}, 'source_type': 'memfd' ,'allocation': {'threads': '${threads_num}'}}
                             qemu_check = '"qom-type":"memory-backend-memfd".*"prealloc-threads":${threads_num}'
@@ -30,6 +32,7 @@
                             mem_backing_attrs = {'allocation': {'mode': 'immediate', 'threads': '${threads_num}'}}
                             qemu_check = '"qom-type":"memory-backend-ram".*"prealloc-threads":${threads_num}'
                 - no_mem_backing:
+                    no s390-virtio
                     vm_attrs = {'max_mem_rt': 2124800, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB', 'memory': 1155072, 'memory_unit': 'KiB', 'current_mem': 1048576, 'current_mem_unit': 'KiB', 'vcpu': 16}
                     numa_node_size = 512000
                     cpu_attrs = {'numa_cell': [{'id': '0', 'cpus': '0-7', 'memory': '${numa_node_size}', 'unit': 'KiB'}, {'id': '1', 'cpus': '8-15', 'memory': '${numa_node_size}', 'unit': 'KiB'}]}
@@ -43,6 +46,7 @@
                             error_msg = 'Memory size must be specified via <memory> or in the <numa> configuration'
                         - set_cur_mem:
                         - set_with_numa:
+                            no s390-virtio
                             numa_cells = [{'id': '0', 'cpus': '0-1', 'memory': '512000', 'unit': 'KiB'}, {'id': '1', 'cpus': '2-3', 'memory': '512000', 'unit': 'KiB', 'memAccess': 'shared'}]
                             vcpu = 4
         - dommemstat:


### PR DESCRIPTION
A) On s390x, there's no NUMA support; disable the test cases.
B) Per default, hugepage support might not be enabled; set
config option to enable it.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>