### PR TITLE
virtual_devices: check lsof availability

### DIFF
--- a/libvirt/tests/src/virtual_device/filesystem_device.py
+++ b/libvirt/tests/src/virtual_device/filesystem_device.py
@@ -4,6 +4,7 @@ import time
 import threading
 
 from avocado.utils import process
+from avocado.utils import path as utils_path
 
 from virttest import virsh
 from virttest import utils_test
@@ -225,6 +226,9 @@ def run(test, params, env):
     host_hp_size = utils_memory.get_huge_page_size()
     backup_huge_pages_num = utils_memory.get_num_huge_pages()
     huge_pages_num = 0
+
+    if hotplug_unplug and not utils_path.find_command("lsof", default=False):
+        test.cancel("Lsof command is required to run test, but not installed")
 
     if len(vm_names) != guest_num:
         test.cancel("This test needs exactly %d vms." % guest_num)


### PR DESCRIPTION
Sometimes lsof is not installed on our hosts. To avoid errors further down the line, this PR adds a check to the test to see if lsof is installed and if not the test is cancelled.
```
(p3-ve) [root@yuggoth ~]# avocado run --vt-type libvirt virtual_devices.filesystem_device.positive_test.hugepages_backed.hotplug_unplug.detach_device_alias.stdio_handler.file.fs_test.xattr_on.flock_on.lock_posix_on.cache_mode_none.one_fs.one_guest
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : 3695aed91ea26b8fed71a5d242efdb94101710a0
JOB LOG    : /root/avocado/job-results/job-2022-08-09T19.52-3695aed/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_devices.filesystem_device.positive_test.hugepages_backed.hotplug_unplug.detach_device_alias.stdio_handler.file.fs_test.xattr_on.flock_on.lock_posix_on.cache_mode_none.one_fs.one_guest: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.virtual_devices.filesystem_device.positive_test.hugepages_backed.hotplug_unplug.detach_device_alias.stdio_handler.file.fs_test.xattr_on.flock_on.lock_posix_on.cache_mode_none.one_fs.one_guest: CANCEL: Lsof command is required to run test, but not installed (3.52 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 1
JOB HTML   : /root/avocado/job-results/job-2022-08-09T19.52-3695aed/results.html
JOB TIME   : 8.59 s
```

## If the PR is bug cases
- [x] Bug descriptions or bug links
- [x] Test results
