### PR TITLE
backingchain: add case for blockcommit with invalid top base

### DIFF
--- a/libvirt/tests/cfg/backingchain/negative_scenario/blockcommit_invalid_top_base.cfg
+++ b/libvirt/tests/cfg/backingchain/negative_scenario/blockcommit_invalid_top_base.cfg
@@ -1,0 +1,22 @@
+- backingchain.negative.blockcommit.invalid_top_base:
+    type = blockcommit_invalid_top_base
+    start_vm = "yes"
+    target_disk = "vda"
+    snap_num = 4
+    variants case:
+        - no_backing:
+            variants:
+                - blockcommit_directly:
+                    top_image_suffix = "origin_source_file"
+                    err_msg = "error: invalid argument: top '{0}' in chain for '${target_disk}' has no backing file"
+                - after_pivot:
+                    pivot = "--wait --verbose --active --pivot"
+                    commit_option = " --active"
+                    top_image_suffix = "origin_source_file"
+                    err_msg = "error: invalid argument: top '{0}' in chain for '${target_disk}' has no backing file"
+        - same_image:
+            top_image_suffix = 2
+            base_image_suffix = 2
+            err_msg = "error: invalid argument: could not find image '{0}' beneath '{0}' in chain for 'vda'"
+        - top_without_active:
+            err_msg = "error: invalid argument: commit of '${target_disk}' active layer requires active flag"

--- a/libvirt/tests/src/backingchain/negative_scenario/blockcommit_invalid_top_base.py
+++ b/libvirt/tests/src/backingchain/negative_scenario/blockcommit_invalid_top_base.py
@@ -1,0 +1,110 @@
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_disk
+from virttest.utils_test import libvirt
+
+from provider.backingchain import blockcommand_base
+
+
+def run(test, params, env):
+    """
+    Do blockcommit for invalid top or base option.
+
+    1) Prepare started guest and snap chain
+    2) Do blockcommit:
+        S1: Do blockcommit when image has no backing file
+        S2: Do blockcommit using same image.
+        S3: Do blockcommit from top without --active.
+    3) Check error message
+    """
+
+    def setup_test():
+        """
+        Prepare specific type disk and create snapshots.
+       """
+
+        test_obj.backingchain_common_setup(create_snap=True,
+                                           snap_num=snap_num)
+
+    def run_test():
+        """
+        Do blockcommit
+        """
+        test.log.info("TEST_STEP1: Get option ")
+        top_option, base_option = _get_options()
+
+        if params.get("pivot"):
+            virsh.blockcommit(vm_name, target_disk, pivot,
+                              ignore_status=False, debug=True)
+
+        test.log.info("TEST_STEP2: Do blockcommit with error operation")
+        result = virsh.blockcommit(vm_name, target_disk,
+                                   top_option+base_option+commit_option,
+                                   ignore_status=True, debug=True)
+
+        test.log.info("TEST_STEP3: Check correct error msg after blockcommit")
+        _check_result(result)
+
+    def teardown_test():
+        """
+        Clean data.
+        """
+        test.log.info("TEST_TEARDOWN: Clean env")
+        test_obj.backingchain_common_teardown()
+
+        bkxml.sync()
+
+    def _get_options():
+        """
+        Get top, base, commit options
+
+        :return: return the top and base option
+        """
+        top_option, base_option = '', ''
+        if top_index.isnumeric():
+            top_option = "--top %s" % test_obj.snap_path_list[int(top_index)-1]
+        elif top_index == "origin_source_file":
+            top_option = "--top %s" % origin_source_file
+
+        if base_index:
+            base_option = " --base %s" % test_obj.snap_path_list[int(base_index)-1]
+
+        return top_option, base_option
+
+    def _check_result(result):
+        """
+        Check blockcommit result
+
+        :param result: The blockcommit result.
+        """
+        replace_msg = origin_source_file
+
+        if case == "same_image":
+            replace_msg = test_obj.snap_path_list[int(top_index) - 1]
+        libvirt.check_result(result, err_msg.format(replace_msg))
+
+    # Process cartesian parameters
+    vm_name = params.get("main_vm")
+    target_disk = params.get('target_disk')
+    pivot = params.get('pivot')
+    snap_num = int(params.get('snap_num'))
+    err_msg = params.get('err_msg')
+    top_index = params.get('top_image_suffix', '')
+    base_index = params.get('base_image_suffix', '')
+    commit_option = params.get('commit_option', '')
+    case = params.get('case', '')
+
+    vm = env.get_vm(vm_name)
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+
+    # Create object
+    test_obj = blockcommand_base.BlockCommand(test, vm, params)
+    origin_source_file = libvirt_disk.get_first_disk_source(vm)
+
+    try:
+        setup_test()
+        run_test()
+
+    finally:
+        teardown_test()

--- a/provider/backingchain/blockcommand_base.py
+++ b/provider/backingchain/blockcommand_base.py
@@ -157,6 +157,24 @@ class BlockCommand(object):
                 if 'snap' in sf:
                     process.run('rm -f %s/%s' % (image_path, sf))
 
+    def backingchain_common_setup(self, create_snap=False, **kwargs):
+        """
+        Setup step for backingchain test
+
+        :param create_snap: create snap flag, will create if True.
+        :param **kwargs: Key words for setup,
+        """
+        if not self.vm.is_alive():
+            self.vm.start()
+        self.vm.wait_for_login().close()
+
+        if create_snap:
+            self.prepare_snapshot(**kwargs)
+
+        remove_file = kwargs.get("remove_file")
+        if remove_file:
+            self.clean_file(kwargs.get("file_path"))
+
     def prepare_secret_disk(self, image_path, secret_disk_dict=None):
         """
         Add secret disk for domain.
@@ -187,3 +205,12 @@ class BlockCommand(object):
         vmxml.devices = vmxml.devices.append(new_disk)
         vmxml.xmltreefile.write()
         vmxml.sync()
+
+    @staticmethod
+    def clean_file(file_path):
+        """
+        Clean file
+        :params file_path: the path of file to delete
+        """
+        if os.path.exists(file_path):
+            os.remove(file_path)


### PR DESCRIPTION
    VIRT-294581:Do blockcommit with invalid top/base image
Signed-off-by: nanli <nanli@redhat.com>

```
[root@dell-per740-33 avocado-vt]# avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.negative.blockcommit.invalid_top_base

 (1/4) type_specific.io-github-autotest-libvirt.backingchain.negative.blockcommit.invalid_top_base.no_backing.blockcommit_directly: PASS (49.00 s)
 (2/4) type_specific.io-github-autotest-libvirt.backingchain.negative.blockcommit.invalid_top_base.no_backing.after_pivot: PASS (57.33 s)
 (3/4) type_specific.io-github-autotest-libvirt.backingchain.negative.blockcommit.invalid_top_base.same_image: PASS (50.78 s)
 (4/4) type_specific.io-github-autotest-libvirt.backingchain.negative.blockcommit.invalid_top_base.top_without_active: PASS (51.31 s)
RESULTS    : PASS 4 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-08-09T22.09-76bec48/results.html
JOB TIME   : 209.72 s

```