### PR TITLE
Fix  virsh reboot failure case

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_reboot.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_reboot.py
@@ -149,11 +149,11 @@ def run(test, params, env):
                     status = -2
             # avoid the check if it is negative test
             if not status_error:
-                cmdoutput = ''
 
                 def _wait_for_reboot_up():
                     second_boot_time = boot_time()
                     is_rebooted = second_boot_time > first_boot_time
+                    global cmdoutput
                     cmdoutput = virsh.domstate(vm_ref, '--reason',
                                                ignore_status=True, debug=True)
                     domstate_status = cmdoutput.exit_status


### PR DESCRIPTION
Fix AttributeError: 'str' object has no attribute 'stderr when refering cmdoutput

Need set cmdoutput as global variable, otherwise it is not intialized by _wait_for_reboot_up function

Signed-off-by: chunfuwen <chwen@redhat.com>

