### PR TITLE
migration: Fix undefine with nvram

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate.py
@@ -87,7 +87,7 @@ def run(test, params, env):
                 vm.destroy(gracefully=False)
 
                 if vm.is_persistent():
-                    vm.undefine()
+                    vm.undefine(options='--nvram')
 
         except Exception as detail:
             logging.error("Cleaning up destination failed.\n%s", detail)
@@ -1356,7 +1356,7 @@ def run(test, params, env):
         # Simple sync cannot be used here, because the vm may not exists and
         # it cause the sync to fail during the internal backup.
         vm.destroy()
-        vm.undefine()
+        vm.undefine(options='--nvram')
         orig_config_xml.define()
 
         if src_libvirt_file:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_copy_storage.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_copy_storage.py
@@ -312,7 +312,7 @@ def run(test, params, env):
             src_libvirt_file.restore()
 
         if disks_count and vm.name == new_vm_name:
-            vm.undefine()
+            vm.undefine(options='--nvram')
         for disk in added_disks_list:
             if disk_type == 'file':
                 utlv.delete_local_disk(disk_type, disk)

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_option_mix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_option_mix.py
@@ -42,7 +42,7 @@ def run(test, params, env):
         if vm.is_alive():
             vm.destroy()
         if vm.is_persistent():
-            vm.undefine()
+            vm.undefine(options='--nvram')
 
         # Restore vm connect_uri
         vm.connect_uri = uri_bak
@@ -222,7 +222,7 @@ def run(test, params, env):
             vm_xml_backup.define()
         elif src_vm_cfg == "transient" and vm.is_persistent():
             logging.debug("Make src vm transient")
-            vm.undefine()
+            vm.undefine(options='--nvram')
 
         # Prepare for postcopy migration: install and run stress in VM
         if postcopy and src_vm_status == "running":

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_setmaxdowntime.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_setmaxdowntime.py
@@ -74,7 +74,7 @@ def cleanup_dest(vm, src_uri, dest_uri):
     vm.connect_uri = dest_uri
     if vm.exists():
         if vm.is_persistent():
-            vm.undefine()
+            vm.undefine(options='--nvram')
         if vm.is_alive():
             vm.destroy()
     # Set connect uri back to local uri

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migration.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migration.py
@@ -47,7 +47,7 @@ def cleanup_vm(vm_list, vmxml_dict, migration_obj, src_uri, dest_uri):
     for vm in vm_list:
         migration_obj.cleanup_dest_vm(vm, src_uri, dest_uri)
         if vm.exists() and vm.is_persistent():
-            vm.undefine()
+            vm.undefine(options='--nvram')
         if vm.is_alive():
             vm.destroy()
     for key in vmxml_dict.keys():


### PR DESCRIPTION
Add '--nvram' option to avoid 'cannot undefine domain with nvram' error.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
```
Before the fix: After 'migrate_option_mix.persistent.no_persistent_xml.no_xml.no_dname.no_undefinesource.src_vm_running.src_vm_transient.graphic_passwd.p2p.precopy.live' is executed, the test VM(avocado-vt-vm1) is not deleted on the target machine: 
# virsh list --all
 Id   Name                    State
----------------------------------------
 -    avocado-vt-remote-vm1   shut off
 -    avocado-vt-vm1          shut off


After the fix: The VM is deleted.
# virsh list --all
 Id   Name                    State
----------------------------------------
 -    avocado-vt-remote-vm1   shut off

```