### PR TITLE
fix remove incorrect snap file

### DIFF
--- a/provider/backingchain/blockcommand_base.py
+++ b/provider/backingchain/blockcommand_base.py
@@ -91,7 +91,7 @@ class BlockCommand(object):
                 path = self.tmp_dir + '%d' % i
             else:
                 path = snap_path
-            if os.path.exists(path):
+            if os.path.exists(path) and "reuse" not in option:
                 libvirt.delete_local_disk('file', path)
             snap_option = "%s %s --diskspec %s,file=%s%s" % \
                           ('snap%d' % i, option, self.new_dev, path, extra)


### PR DESCRIPTION
  for reuse type snap, snap file should not be cleaned
Signed-off-by: nanli <nanli@redhat.com>

```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockcopy.blockcopy_with_backingfile.shallow_and_reuse_external.block_disk.pivot_after_blockcopy --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.blockcopy_with_backingfile.shallow_and_reuse_external.block_disk.pivot_after_blockcopy: PASS (214.67 s)
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockcommit.all_block_chain.shallow_active --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.all_block_chain.shallow_active: PASS (212.73 s)

```
