### PR TITLE
migration: Update the error messages

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -557,7 +557,7 @@
                             stress_in_vm = "yes"
                             stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M --timeout 70"
                             actions_during_migration = "killqemutarget"
-                            err_msg = "error: internal error: qemu unexpectedly closed the monitor|error: operation failed: domain is not running"
+                            err_msg = "error: internal error: qemu unexpectedly closed the monitor|error: operation failed: domain is not running|Domain not found"
                         - disable_keepalive:
                             only without_postcopy
                             break_network_connection = "yes"
@@ -606,7 +606,7 @@
                                     variants:
                                         - without_option:
                                             virsh_migrate_extra = "--tls"
-                                            err_msg = "error: internal error: qemu unexpectedly closed the monitor"
+                                            err_msg = "error: internal error: qemu unexpectedly closed the monitor|Domain not found"
                                         - empty_str:
                                             virsh_migrate_extra = "--tls --tls-destination ''"
                                             err_msg = "error: Failed to get option 'tls-destination': Option argument is empty"

--- a/libvirt/tests/cfg/migration/migrate_service_control.cfg
+++ b/libvirt/tests/cfg/migration/migrate_service_control.cfg
@@ -40,7 +40,7 @@
                 - kill_qemu_on_dst:
                     service_name = "qemu-kvm"
                     service_on_dst = "yes"
-                    err_msg = 'qemu unexpectedly closed the monitor|domain is no longer running'
+                    err_msg = 'qemu unexpectedly closed the monitor|domain is no longer running|Domain not found'
                 - kill_libvirtd_on_src:
                     service_name = "libvirtd"
                     err_msg = 'End of file while reading data: Input/output error'


### PR DESCRIPTION
The error messages are changed for some cases.

Signed-off-by: Yingshun Cui <yicui@redhat.com>

Before the fix:
` (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_options_shared.negative_test.p2p_migration.native_tls.tls_destination.without_option.without_postcopy: FAIL: Can not find the expected patterns 'error: internal error: qemu unexpectedly closed the monitor' in output 'error: Domain not found: no domain with matching uuid '045d1838-0204-41ab-936e-e77d1e5c3f94' (avocado-vt-vm1)' (193.68 s)
`
After the fix:
```
 (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_options_shared.negative_test.p2p_migration.kill_qemu_target.with_postcopy: PASS (146.83 s)
 (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_options_shared.negative_test.p2p_migration.native_tls.tls_destination.without_option.without_postcopy: PASS (193.27 s)
 (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_service_control.kill_service.kill_qemu_on_dst.p2p_live.without_postcopy: PASS (167.41 s)

```