### PR TITLE
Fix wrong guest pid

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_options.py
+++ b/libvirt/tests/src/virtual_network/iface_options.py
@@ -283,7 +283,7 @@ def run(test, params, env):
         :raise avocado.core.exceptions.TestFail: if commandline doesn't match
         :return: None
         """
-        cmd = ("ps -ef | grep %s | grep -v grep " % vm_name)
+        cmd = ("ps -ef | grep %s | grep qemu-kvm | grep -v grep " % vm_name)
         ret = process.run(cmd, shell=True)
         logging.debug("Command line %s", ret.stdout_text)
         if test_vhost_net:


### PR DESCRIPTION
There is an additional swtpm process which has the guest's name.
So the cmd can not get the correct guest pid anymore, update the
cmd to be more accurate.

Signed-off-by: Yalan Zhang <yalzhang@redhat.com>