### PR TITLE
v2v: fix some errors for RHEL8.7

### DIFF
--- a/v2v/tests/cfg/v2v_options.cfg
+++ b/v2v/tests/cfg/v2v_options.cfg
@@ -285,7 +285,7 @@
                     only output_mode.libvirt
                     checkpoint = compress
                     new_vm_name = ${main_vm}_compress
-                    v2v_options = -of qcow2 --oo compressed -on ${new_vm_name}
+                    v2v_options = -of qcow2 --compressed -on ${new_vm_name}
                 - empty_nic_source:
                     only input_mode.none
                     only output_mode.none

--- a/v2v/tests/src/function_test_esx.py
+++ b/v2v/tests/src/function_test_esx.py
@@ -756,6 +756,10 @@ def run(test, params, env):
         if 'root' in checkpoint and 'ask' in checkpoint:
             v2v_params['v2v_opts'] += ' --root ask'
             v2v_params['custom_inputs'] = params.get('choice', '2')
+            # The log check fixes in following version.
+            v2v_fix_ver = '[virt-v2v-2.0.7-1,)'
+            if not utils_v2v.multiple_versions_compare(v2v_fix_ver):
+                params['expect_msg'] = ''
         if 'root' in checkpoint and 'ask' not in checkpoint:
             root_option = params.get('root_option')
             v2v_params['v2v_opts'] += ' --root %s' % root_option

--- a/v2v/tests/src/function_test_xen.py
+++ b/v2v/tests/src/function_test_xen.py
@@ -283,7 +283,7 @@ def run(test, params, env):
             params['img_path'] = data_dir.get_tmp_dir() + '/%s.img' % vm_name
             if checkpoint == 'xvda_disk':
                 v2v_params['input_mode'] = 'disk'
-                v2v_params['hypervisor'] = 'kvm'
+                params['hypervisor'] = v2v_params['hypervisor'] = 'kvm'
                 v2v_params.update({'input_file': params['img_path']})
             # Copy remote image to local with scp
             remote.scp_from_remote(xen_host, 22, xen_host_user,


### PR DESCRIPTION
1) replace '-oo compressed' with '--compressed' to compatible with
   RHEL8.
2) update the hypervisor to 'kvm' in params.
3) skip log check on RHEL8.7

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>
