### PR TITLE
sriov: Update error message for managedsave cases

### DIFF
--- a/libvirt/tests/cfg/sriov/vm_lifecycle/sriov_vm_lifecycle_managedsave.cfg
+++ b/libvirt/tests/cfg/sriov/vm_lifecycle/sriov_vm_lifecycle_managedsave.cfg
@@ -2,7 +2,7 @@
     type = sriov_vm_lifecycle_managedsave
     start_vm = "no"
     status_error = "yes"
-    err_msg = "Operation not supported"
+    err_msg = "cannot migrate.*domain.*(VFIO device doesn't support|with.*hostdev)"
     only x86_64
     variants dev_type:
         - hostdev_interface:


### PR DESCRIPTION
The error message was updated recently, so update it.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
```
 (1/2) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.managedsave.hostdev_interface.vf_address.managed_yes: PASS (54.94 s)
 (2/2) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.managedsave.hostdev_device.vf_address.managed_yes: PASS (55.06 s)
```
