### PR TITLE
Fix the permission denied issues for dac_per_disk_hotplug

### DIFF
--- a/libvirt/tests/cfg/svirt/dac_per_disk_hotplug.cfg
+++ b/libvirt/tests/cfg/svirt/dac_per_disk_hotplug.cfg
@@ -14,6 +14,8 @@
     target_dev = "vdf"
     target_bus = "virtio"
     driver_type = ${vol_format}
+    vars_path = "/var/lib/libvirt/qemu/nvram/avocado-vt-vm1_VARS.fd"
+    swtpm_lib = "/var/lib/swtpm-localca"
     variants:
         - dynamic_ownership_on:
             dynamic_ownership = "yes"


### PR DESCRIPTION
Two factors may cause the permission denied issues:
1.Start guest with existing nvram file when disable dynamic_ownership
2.Start guest with tpm device when disable dynamic_ownership

Signed-off-by: Yan Fu <yafu@redhat.com>

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [ ] Description of the cases
- [ ] Links of libvirt features, libvirt bugs or case IDs
- [ ] Test results

## If the PR is bug cases
- [ ] Bug descriptions or bug links
- [ ] Test results

## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
