### PR TITLE
virsh_attach_device: Update scsi controller on ppc vms to support scsi hotplug

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
@@ -19,7 +19,6 @@ from virttest import virt_vm, virsh, remote, utils_misc, data_dir
 from virttest.libvirt_xml import xcepts
 from virttest.libvirt_xml.vm_xml import VMXML
 from virttest.utils_libvirt import libvirt_pcicontr
-from virttest.libvirt_xml.devices.controller import Controller
 
 # TODO: Move all these helper classes someplace else
 
@@ -934,8 +933,8 @@ def update_controllers_ppc(vm_name, vmxml):
     machine = platform.machine().lower()
     if 'ppc64le' in machine:
         # Remove old scsi controller, replace with virtio-scsi controller
-         device_bus = 'scsi'
-         if not vmxml.get_controllers(device_bus, 'virtio-scsi'):
+        device_bus = 'scsi'
+        if not vmxml.get_controllers(device_bus, 'virtio-scsi'):
             vmxml.del_controller(device_bus)
             ppc_controller = Controller('controller')
             ppc_controller.type = device_bus


### PR DESCRIPTION
The code deletes the scsi controller but not replacing with "virtio-scsi" due
to which VM boots fails.

Reference - commit 1473a1a

The comment "Remove old scsi controller, replace with virtio-scsi controller"
is inaccurate. The code is removing the old controller, but it is not
replacing it with anything. It seems to be assuming that libvirt will default
to adding a virtio-scsi controller, but that is not the case. libvirt defaults
to the spapr-vscsi controller on ppc64le, not virtio-scsi. So
update_controllers_ppc should instead explicitly add a virtio-scsi controller.

Signed-off-by: Seeteena Thoufeek s1seetee@linux.vnet.ibm.com

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [x] Description of the cases
- [x] Links of libvirt features, libvirt bugs or case IDs
- [x] Test results

## If the PR is bug cases
- [x] Bug descriptions or bug links
- [x] Test results

## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
