### PR TITLE
hotplug: add case for detach channel with alias

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
@@ -17,14 +17,21 @@
             detach_redirdev_bus = "usb"
             detach_check_xml = "<redirdev"
         - channel:
-            no pseries
-            detach_channel_type = "spicevmc"
-            detach_channel_target = "{'target_type':'virtio', 'target_name':'com.redhat.spice.0'}"
-            detach_check_xml = "<channel type='spicevmc'>"
-            s390-virtio:
-                detach_channel_type = "pty"
-                detach_channel_target = "{'target_type':'virtio', 'target_name':'some.virtio.serial.port.name'}"
-                detach_check_xml = "<channel type='pty'>"
+            variants:
+                - spicevmc:
+                    only x86_64
+                    detach_channel_type = "spicevmc"
+                    channel_dict = "{'target':{'type':'virtio', 'name':'com.redhat.spice.0'}}"
+                    detach_check_xml = "<channel type='spicevmc'>"
+                - pty:
+                    detach_channel_type = "pty"
+                    channel_dict = "{'target':{'type':'virtio', 'name':'arbitrary.virtio.serial.port.name'}}"
+                    detach_check_xml = "<channel type='pty'>"
+                - unix:
+                    only live,config
+                    detach_channel_type = "unix"
+                    channel_dict = "{'target':{'type':'virtio', 'name':'org.qemu.guest_agent.0'}}"
+                    detach_check_xml = "<channel type='unix'>"
         - virtual_disk:
             only live,config
             detach_virtual_disk_type = "virtual_disk"


### PR DESCRIPTION
  RHEL-148235: Device can also be detached by 'virsh detach-device-alias' cmd.
Signed-off-by: nanli <nanli@redhat.com>

**Test result:**
```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 virsh.detach_device_alias..channel
 (1/6) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.channel.spicevmc: PASS (49.72 s)
 (2/6) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.channel.pty: PASS (62.11 s)
 (3/6) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.channel.unix: PASS (61.41 s)
 (4/6) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.config.channel.spicevmc: PASS (60.02 s)
 (5/6) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.config.channel.pty: PASS (60.34 s)
 (6/6) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.config.channel.unix: PASS (60.70 s)

```