### PR TITLE
Fix permission issue caused by tpm device when disable dynamic_ownership

### DIFF
--- a/libvirt/tests/cfg/svirt/dac_start_destroy.cfg
+++ b/libvirt/tests/cfg/svirt/dac_start_destroy.cfg
@@ -7,6 +7,7 @@
     dac_start_destroy_disk_label = "107:107"
     dac_start_destroy_host_selinux = "enforcing"
     vars_path = "/var/lib/libvirt/qemu/nvram/avocado-vt-vm1_VARS.fd"
+    swtpm_lib = "/var/lib/swtpm-localca"
     variants:
         - with_qemu_conf:
             variants:


### PR DESCRIPTION
Signed-off-by: Yan Fu <yafu@redhat.com>

# Format of PR title < sub-system: summary >
e.g
*virsh_migrate: Fix unsupported direct socket mode issue*

# Check lists by category
## If the PR is new cases
- [ ] Description of the cases
- [ ] Links of libvirt features, libvirt bugs or case IDs
- [ ] Test results

## If the PR is bug cases
- [ ] Bug descriptions or bug links
- [ ] Test results

## If the PR is a trivial fix
It it is the fix of typos, comments or documents, the description of PR could be skipped.
