### PR TITLE
Refactor code to use create_or_del_network

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_network.cfg
+++ b/libvirt/tests/cfg/migration/migrate_network.cfg
@@ -28,12 +28,12 @@
         - ovs_br:
             only without_postcopy
             ovs_bridge_name = "ovsbr0"
-            network_dict = {"net_name": "ovs-net", "net_forward": '{"mode": "bridge"}',"net_bridge": '{"name": "${ovs_bridge_name}"}', "net_virtualport": "openvswitch"}
+            network_dict = {'bridge': {'name': '${ovs_bridge_name}'}, 'forward': {'mode': 'bridge'}, 'name': 'ovs-net', 'virtualport_type': 'openvswitch'}
             iface_dict = {"type": "network", "source": "{'network': 'ovs-net'}","model": "virtio"}
         - direct:
             direct_mode = "yes"
             target_vm_name = "avocado-vt-remote-vm1"
-            network_dict = {"net_name": "direct-macvtap", "net_forward": '{"mode": "bridge"}'}
+            network_dict = {'forward': {'mode': 'bridge'}, 'name': 'direct-macvtap'}
             iface_dict = {"type": "network", "source": "{'network': 'direct-macvtap'}","model": "virtio"}
             macvtap_cmd = "ip l |grep macvtap |sed 's/.*macvtap\([0-9]\+\).*.*/\1/'"
             target_vm_ip_cmd = "arp -a | grep  %s | sed 's/.*(\(.*\)).*/\1/g'"

--- a/libvirt/tests/cfg/sriov/failover/sriov_failover_abort_migration.cfg
+++ b/libvirt/tests/cfg/sriov/failover/sriov_failover_abort_migration.cfg
@@ -37,8 +37,8 @@
             migrate_speed = "8"
     variants dev_type:
         - hostdev_interface:
-            br_network_dict = {"net_name":'host_bridge',"net_forward": '{"mode": "bridge"}', 'net_bridge': '{"name": "${br_name}"}'}
-            network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev", "managed": "yes"}', 'net_forward_pf': net_forward_pf}
+            br_network_dict = {'bridge': {'name': '${br_name}'}, 'forward': {'mode': 'bridge'}, 'name': 'host_bridge'}
+            network_dict = {"name":'hostdev_net','forward': {'mode': 'hostdev', 'managed': 'yes'}, 'pf': {'dev': pf_name}}
             br_dict = {'teaming': {'type': 'persistent'}, 'mac_address': mac_addr, 'type_name': 'network', 'alias': {'name': "${alias_name}"}, 'source': {'network': 'host_bridge'}, 'model': 'virtio'}
             iface_dict = {'teaming': {'type': 'transient', 'persistent': "${alias_name}"}, 'mac_address': mac_addr, 'type_name': 'network', 'source': {'network': 'hostdev_net'}}
         - hostdev_device:

--- a/libvirt/tests/cfg/sriov/failover/sriov_failover_migration.cfg
+++ b/libvirt/tests/cfg/sriov/failover/sriov_failover_migration.cfg
@@ -38,8 +38,8 @@
             postcopy_options = '--postcopy --timeout 10 --timeout-postcopy'
     variants dev_type:
         - hostdev_interface:
-            br_network_dict = {"net_name":'host_bridge',"net_forward": '{"mode": "bridge"}', 'net_bridge': '{"name": "${br_name}"}'}
-            network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev", "managed": "yes"}', 'net_forward_pf': net_forward_pf}
+            br_network_dict = {'bridge': {'name': '${br_name}'}, 'forward': {'mode': 'bridge'}, 'name': 'host_bridge'}
+            network_dict = {"name":'hostdev_net','forward': {'mode': 'hostdev', 'managed': 'yes'}, 'pf': {'dev': pf_name}}
             br_dict = {'teaming': {'type': 'persistent'}, 'mac_address': mac_addr, 'type_name': 'network', 'alias': {'name': "${alias_name}"}, 'source': {'network': 'host_bridge'}, 'model': 'virtio'}
             iface_dict = {'teaming': {'type': 'transient', 'persistent': "${alias_name}"}, 'mac_address': mac_addr, 'type_name': 'network', 'source': {'network': 'hostdev_net'}}
         - hostdev_device:

--- a/libvirt/tests/cfg/sriov/vm_lifecycle/sriov_vm_lifecycle_reboot.cfg
+++ b/libvirt/tests/cfg/sriov/vm_lifecycle/sriov_vm_lifecycle_reboot.cfg
@@ -52,20 +52,20 @@
                                     variants test_scenario:
                                         - managed_no:
                                             iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
-                                            network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev", "managed": "no"}', 'net_forward_pf': net_forward_pf}
+                                            network_dict = {"name":'hostdev_net','forward': {'mode': 'hostdev', 'managed': 'no'}, 'pf': {'dev': pf_name}}
                                         - managed_yes:
                                             iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
-                                            network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev", "managed": "yes"}', 'net_forward_pf': net_forward_pf}
+                                            network_dict = {"name":'hostdev_net','forward': {'mode': 'hostdev', 'managed': 'yes'}, 'pf': {'dev': pf_name}}
                                         - without_managed:
                                             iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
-                                            network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev"}', 'net_forward_pf': net_forward_pf}
+                                            network_dict = {"name":'hostdev_net','forward': {'mode': 'hostdev'}, 'pf': {'dev': pf_name}}
                         - vf_address:
                             variants network_mode:
                                 - hostdev:
                                     variants test_scenario:
                                         - managed_yes:
                                             iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
-                                            network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev", "managed": "yes"}', 'vf_list_attrs': vf_list_attrs}
+                                            network_dict = {'forward': {'mode': 'hostdev', 'managed': 'yes'}, 'name': 'hostdev_net', 'vf_list': [{'type_name': 'pci', 'attrs': vf_pci_addr}]}
                                         - without_managed:
                                             iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
-                                            network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev"}', 'vf_list_attrs': vf_list_attrs}
+                                            network_dict = {'forward': {'mode': 'hostdev'}, 'name': 'hostdev_net', 'vf_list': [{'type_name': 'pci', 'attrs': vf_pci_addr}]}

--- a/libvirt/tests/cfg/sriov/vm_lifecycle/sriov_vm_lifecycle_start_destroy.cfg
+++ b/libvirt/tests/cfg/sriov/vm_lifecycle/sriov_vm_lifecycle_start_destroy.cfg
@@ -38,18 +38,18 @@
                             variants:
                                 - managed_no:
                                     iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
-                                    network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev", "managed": "no"}', 'net_forward_pf': net_forward_pf}
+                                    network_dict = {"name":'hostdev_net','forward': {'mode': 'hostdev', 'managed': 'no'}, 'pf': {'dev': pf_name}}
                                 - managed_yes:
                                     iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
-                                    network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev", "managed": "yes"}', 'net_forward_pf': net_forward_pf}
+                                    network_dict = {"name":'hostdev_net','forward': {'mode': 'hostdev', 'managed': 'yes'}, 'pf': {'dev': pf_name}}
                                 - without_managed:
                                     iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
-                                    network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev"}', 'net_forward_pf': net_forward_pf}
+                                    network_dict = {"name":'hostdev_net','forward': {'mode': 'hostdev'}, 'pf': {'dev': pf_name}}
                         - vf_address:
                             variants:
                                 - managed_yes:
                                     iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
-                                    network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev", "managed": "yes"}', 'vf_list_attrs': vf_list_attrs}
+                                    network_dict = {'forward': {'mode': 'hostdev', 'managed': 'yes'}, 'name': 'hostdev_net', 'vf_list': [{'type_name': 'pci', 'attrs': vf_pci_addr}]}
                                 - without_managed:
                                     iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
-                                    network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev"}', 'vf_list_attrs': vf_list_attrs}
+                                    network_dict = {'forward': {'mode': 'hostdev'}, 'name': 'hostdev_net', 'vf_list': [{'type_name': 'pci', 'attrs': vf_pci_addr}]}

--- a/libvirt/tests/cfg/sriov/vm_lifecycle/sriov_vm_lifecycle_start_negative.cfg
+++ b/libvirt/tests/cfg/sriov/vm_lifecycle/sriov_vm_lifecycle_start_negative.cfg
@@ -14,7 +14,7 @@
                     err_msg = "PF is not online"
                 - inactive_network:
                     iface_dict = {'mac_address': mac_addr, 'type_name': 'network', 'source': {'network': 'hostdev_net'}}
-                    network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev"}', 'vf_list_attrs': vf_list_attrs}
+                    network_dict = {'forward': {'mode': 'hostdev'}, 'name': 'hostdev_net', 'vf_list': [{'type_name': 'pci', 'attrs': vf_pci_addr}]}
                     err_msg = "network.*is not active"
                 - pf_address:
                     iface_dict = {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': pf_pci_addr}}

--- a/libvirt/tests/cfg/sriov/vm_lifecycle/sriov_vm_lifecycle_suspend_resume.cfg
+++ b/libvirt/tests/cfg/sriov/vm_lifecycle/sriov_vm_lifecycle_suspend_resume.cfg
@@ -52,20 +52,20 @@
                                     variants test_scenario:
                                         - managed_no:
                                             iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
-                                            network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev", "managed": "no"}', 'net_forward_pf': net_forward_pf}
+                                            network_dict = {"name":'hostdev_net','forward': {'mode': 'hostdev', 'managed': 'no'}, 'pf': {'dev': pf_name}}
                                         - managed_yes:
                                             iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
-                                            network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev", "managed": "yes"}', 'net_forward_pf': net_forward_pf}
+                                            network_dict = {"name":'hostdev_net','forward': {'mode': 'hostdev', 'managed': 'yes'}, 'pf': {'dev': pf_name}}
                                         - without_managed:
                                             iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
-                                            network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev"}', 'net_forward_pf': net_forward_pf}
+                                            network_dict = {"name":'hostdev_net','forward': {'mode': 'hostdev'}, 'pf': {'dev': pf_name}}
                         - vf_address:
                             variants network_mode:
                                 - hostdev:
                                     variants test_scenario:
                                         - managed_yes:
                                             iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
-                                            network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev", "managed": "yes"}', 'vf_list_attrs': vf_list_attrs}
+                                            network_dict = {'forward': {'mode': 'hostdev', 'managed': 'yes'}, 'name': 'hostdev_net', 'vf_list': [{'type_name': 'pci', 'attrs': vf_pci_addr}]}
                                         - without_managed:
                                             iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
-                                            network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev"}', 'vf_list_attrs': vf_list_attrs}
+                                            network_dict = {'forward': {'mode': 'hostdev'}, 'name': 'hostdev_net', 'vf_list': [{'type_name': 'pci', 'attrs': vf_pci_addr}]}

--- a/libvirt/tests/cfg/sriov/vm_lifecycle/sriov_vm_lifecycle_unmanaged.cfg
+++ b/libvirt/tests/cfg/sriov/vm_lifecycle/sriov_vm_lifecycle_unmanaged.cfg
@@ -31,15 +31,15 @@
                             variants:
                                 - managed_no:
                                     iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
-                                    network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev", "managed": "no"}', 'net_forward_pf': net_forward_pf}
+                                    network_dict = {"name":'hostdev_net','forward': {'mode': 'hostdev', 'managed': 'no'}, 'pf': {'dev': pf_name}}
                                 - without_managed:
                                     iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
-                                    network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev"}', 'net_forward_pf': net_forward_pf}
+                                    network_dict = {"name":'hostdev_net','forward': {'mode': 'hostdev'}, 'pf': {'dev': pf_name}}
                         - vf_address:
                             variants:
                                 - without_managed:
                                     iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
-                                    network_dict = {"net_name":'hostdev_net',"net_forward": '{"mode": "hostdev"}', 'vf_list_attrs': vf_list_attrs}
+                                    network_dict = {'forward': {'mode': 'hostdev'}, 'name': 'hostdev_net', 'vf_list': [{'type_name': 'pci', 'attrs': vf_pci_addr}]}
     variants test_scenario:
         - cold_plug:
             start_vm = 'no'

--- a/libvirt/tests/src/migration/migrate_network.py
+++ b/libvirt/tests/src/migration/migrate_network.py
@@ -100,10 +100,10 @@ def run(test, params, env):
         :param runner: Command runner
         :return: Updated network dict
         """
-        if net_dict.get("net_name", "") == "direct-macvtap":
+        if net_dict.get("name", "") == "direct-macvtap":
             logging.info("Updating network iface name")
             iface_name = utils_net.get_net_if(runner=runner, state="UP")[0]
-            net_dict.update({"forward_iface": iface_name})
+            net_dict.update({'forward_interface': [{'dev': iface_name}]})
         else:
             # TODO: support other types
             logging.info("No need to update net_dict. We only support to "

--- a/libvirt/tests/src/sriov/scalability/sriov_scalability_max_vfs.py
+++ b/libvirt/tests/src/sriov/scalability/sriov_scalability_max_vfs.py
@@ -31,9 +31,9 @@ def create_network(net_name, pf_name, params):
     :param pf_name: PF device
     :param params: The parameters dict
     """
-    net_dict = {"net_name": net_name,
-                "net_forward": params.get("net_forward"),
-                "net_forward_pf": '{"dev": "%s"}' % pf_name
+    net_dict = {"name": net_name,
+                "forward": eval(params.get("net_forward")),
+                "pf": {"dev": pf_name}
                 }
     libvirt_network.create_or_del_network(net_dict)
 
@@ -113,7 +113,7 @@ def run(test, params, env):
         net_info = get_net_dict(pf_info)
         for pf_dev in net_info:
             libvirt_network.create_or_del_network(
-                        {"net_name": net_info[pf_dev]}, True)
+                        {"name": net_info[pf_dev]}, True)
 
     def run_test():
         """

--- a/libvirt/tests/src/sriov/sriov_managed.py
+++ b/libvirt/tests/src/sriov/sriov_managed.py
@@ -43,9 +43,11 @@ def run(test, params, env):
         """
         Create VF pool
         """
-        net_hostdev_dict = {"net_name": params.get("net_name"),
-                            "net_forward": params.get("net_forward"),
-                            "vf_list_attrs": "[%s]" % utils_sriov.pci_to_addr(vf_pci)}
+        net_hostdev_dict = {"name": params.get("net_name"),
+                            "forward": eval(params.get("net_forward")),
+                            'vf_list': [{'type_name': 'pci',
+                                         'attrs': utils_sriov.pci_to_addr(vf_pci)}]
+                            }
         libvirt_network.create_or_del_network(net_hostdev_dict)
 
     def check_vm_iface_managed(vm_name, iface_dict):
@@ -153,5 +155,5 @@ def run(test, params, env):
             vm.destroy(gracefully=False)
         orig_config_xml.sync()
         libvirt_network.create_or_del_network(
-            {"net_name": params.get("net_name")}, True)
+            {"name": params.get("net_name")}, True)
         virsh.nodedev_reattach(dev_name, debug=True)

--- a/libvirt/tests/src/sriov/sriov_vf_pool.py
+++ b/libvirt/tests/src/sriov/sriov_vf_pool.py
@@ -25,14 +25,13 @@ def create_network(params):
     """
     Create VF pool
     """
-    net_dict = {"net_name": params.get("net_name"),
-                "net_forward": params.get("net_forward")}
+    net_dict = {"name": params.get("net_name"),
+                "forward": eval(params.get("net_forward"))}
     net_forward_pf = "yes" == params.get("net_forward_pf")
     if net_forward_pf:
-        net_dict.update(
-            {"net_forward_pf": '{"dev": "%s"}' % params.get("pf_name")})
+        net_dict.update({'pf': {'dev': params.get("pf_name")}})
     else:
-        net_dict.update({"forward_iface": params.get("vf_iface")})
+        net_dict.update({"forward_interface": [{"dev": params.get("vf_iface")}]})
     libvirt_network.create_or_del_network(net_dict)
 
 
@@ -167,4 +166,4 @@ def run(test, params, env):
             vm.destroy(gracefully=False)
         orig_config_xml.sync()
         libvirt_network.create_or_del_network(
-            {"net_name": params.get("net_name")}, True)
+            {"name": params.get("net_name")}, True)

--- a/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_start_destroy.py
+++ b/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_start_destroy.py
@@ -46,7 +46,7 @@ def run(test, params, env):
 
         if network_dict:
             libvirt_network.check_network_connection(
-                network_dict.get("net_name"), 1)
+                network_dict.get("name"), 1)
 
         test.log.info("TEST_STEP5: Destroy VM")
         vm.destroy(gracefully=False)
@@ -55,7 +55,7 @@ def run(test, params, env):
                       "vlan")
         if network_dict:
             libvirt_network.check_network_connection(
-                network_dict.get("net_name"), 0)
+                network_dict.get("name"), 0)
 
         check_points.check_vlan(sriov_test_obj.pf_name, iface_dict, True)
 

--- a/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_start_negative.py
+++ b/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_start_negative.py
@@ -19,7 +19,7 @@ def run(test, params, env):
         if test_scenario == "inactive_pf":
             utils_net.Interface(sriov_test_obj.pf_name).down()
         elif test_scenario == "inactive_network":
-            virsh.net_destroy(network_dict['net_name'], debug=True)
+            virsh.net_destroy(network_dict['name'], debug=True)
 
         test.log.info("TEST_STEP1: Attach a hostdev interface/device to VM")
         iface_dev = sriov_test_obj.create_iface_dev(dev_type, iface_dict)


### PR DESCRIPTION
Update configurations and scripts to use the updated create_or_del_network().

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Depends on:**
https://github.com/avocado-framework/avocado-vt/pull/3498
**Test results:**
```
 (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_network.ovs_br.without_postcopy: PASS (597.36 s)
 (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_network.direct.fake_macvtap_exists_dest.with_postcopy: PASS (262.05 s)
 (01/88) type_specific.io-github-autotest-libvirt.sriov.vf_pool.active.at_dt.macvtap_passthrough: PASS (56.22 s)
 (02/88) type_specific.io-github-autotest-libvirt.sriov.vf_pool.active.connection.macvtap_passthrough: PASS (56.57 s)
 (03/88) type_specific.io-github-autotest-libvirt.sriov.vf_pool.active.connection.hostdev: PASS (59.64 s)
 (04/88) type_specific.io-github-autotest-libvirt.sriov.vf_pool.inactive.at_dt.macvtap_passthrough: PASS (64.26 s)
 (05/88) type_specific.io-github-autotest-libvirt.sriov.managed.networks.managed_no: PASS (138.13 s)
 (06/88) type_specific.io-github-autotest-libvirt.sriov.managed.networks.default: PASS (199.69 s)
 (07/88) type_specific.io-github-autotest-libvirt.sriov.managed.device_hotplug.managed_no: PASS (55.45 s)
 (08/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.iommu.at_dt_hostdev.hostdev_interface.managed_yes: PASS (271.62 s)
 (09/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.iommu.at_dt_hostdev.hostdev_interface.failover: PASS (251.56 s)
 (10/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.iommu.at_dt_hostdev.hostdev_device.managed_yes: PASS (266.20 s)
(14/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.unmanaged.cold_plug.hostdev_interface.vf_address.managed_no: PASS (22.16 s)
 (15/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.unmanaged.cold_plug.hostdev_interface.vf_address.without_managed: PASS (21.92 s)
 (16/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.unmanaged.cold_plug.hostdev_device.vf_address.managed_no: PASS (22.12 s)
 (17/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.unmanaged.cold_plug.hostdev_device.pf_address.managed_no: PASS (22.09 s)
 (18/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.unmanaged.cold_plug.network_interface.network.pf_name.managed_no: PASS (22.48 s)
 (19/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.unmanaged.cold_plug.network_interface.network.pf_name.without_managed: PASS (22.34 s)
 (20/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.unmanaged.cold_plug.network_interface.network.vf_address.without_managed: PASS (24.94 s)
 (21/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.unmanaged.hot_plug.hostdev_interface.vf_address.managed_no: PASS (25.55 s)
 (22/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.unmanaged.hot_plug.hostdev_interface.vf_address.without_managed: PASS (25.48 s)
 (23/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.unmanaged.hot_plug.hostdev_device.vf_address.managed_no: PASS (25.43 s)
 (24/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.unmanaged.hot_plug.hostdev_device.pf_address.managed_no: PASS (25.69 s)
 (25/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.unmanaged.hot_plug.network_interface.network.pf_name.managed_no: PASS (26.13 s)
 (26/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.unmanaged.hot_plug.network_interface.network.pf_name.without_managed: PASS (26.06 s)
 (27/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.unmanaged.hot_plug.network_interface.network.vf_address.without_managed: PASS (26.08 s)
 (28/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.hostdev_interface.vf_address.managed_yes.with_iommu: PASS (231.01 s)
 (29/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.hostdev_interface.vf_address.managed_yes.without_iommu: PASS (85.43 s)
 (30/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.hostdev_interface.vf_address.managed_no.without_iommu: PASS (84.84 s)
 (31/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.hostdev_interface.vf_address.without_managed.without_iommu: PASS (84.69 s)
 (32/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.hostdev_interface.vf_address.vlan.without_iommu: PASS (80.98 s)
 (33/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.hostdev_interface.vf_address.failover.with_iommu: PASS (261.21 s)
 (34/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.hostdev_device.vf_address.managed_yes.with_iommu: PASS (219.11 s)
 (35/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.hostdev_device.vf_address.managed_yes.without_iommu: PASS (84.30 s)
 (36/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.hostdev_device.vf_address.managed_no.without_iommu: PASS (86.22 s)
 (37/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.hostdev_device.pf_address.managed_yes.without_iommu: PASS (99.56 s)
 (38/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.hostdev_device.pf_address.managed_no.without_iommu: PASS (98.00 s)
 (39/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.network_interface.network.pf_name.hostdev.managed_no.without_iommu: PASS (84.84 s)
 (40/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.network_interface.network.pf_name.hostdev.managed_yes.without_iommu: PASS (84.42 s)
 (41/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.network_interface.network.pf_name.hostdev.without_managed.without_iommu: PASS (85.11 s)
 (42/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.network_interface.network.vf_address.hostdev.managed_yes.without_iommu: PASS (85.04 s)
 (43/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.network_interface.network.vf_address.hostdev.without_managed.without_iommu: PASS (84.72 s)
 (44/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.suspend_resume.hostdev_interface.vf_address.managed_yes.with_iommu: PASS (208.59 s)
 (45/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.suspend_resume.hostdev_interface.vf_address.managed_yes.without_iommu: PASS (58.51 s)
 (46/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.suspend_resume.hostdev_interface.vf_address.managed_no.without_iommu: PASS (58.77 s)
 (47/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.suspend_resume.hostdev_interface.vf_address.without_managed.without_iommu: PASS (61.00 s)
 (48/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.suspend_resume.hostdev_interface.vf_address.vlan.without_iommu: PASS (57.06 s)
 (49/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.suspend_resume.hostdev_interface.vf_address.failover.with_iommu: PASS (236.83 s)
 (50/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.suspend_resume.hostdev_device.vf_address.managed_yes.with_iommu: PASS (198.04 s)
 (51/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.suspend_resume.hostdev_device.vf_address.managed_yes.without_iommu: PASS (58.54 s)
 (52/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.suspend_resume.hostdev_device.vf_address.managed_no.without_iommu: PASS (61.43 s)
 (53/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.suspend_resume.hostdev_device.pf_address.managed_yes.without_iommu: PASS (71.63 s)
 (54/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.suspend_resume.hostdev_device.pf_address.managed_no.without_iommu: PASS (70.83 s)
 (55/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.suspend_resume.network_interface.network.pf_name.hostdev.managed_no.without_iommu: PASS (59.48 s)
 (56/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.suspend_resume.network_interface.network.pf_name.hostdev.managed_yes.without_iommu: PASS (59.62 s)
 (57/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.suspend_resume.network_interface.network.pf_name.hostdev.without_managed.without_iommu: PASS (59.31 s)
 (58/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.suspend_resume.network_interface.network.vf_address.hostdev.managed_yes.without_iommu: PASS (60.23 s)
 (59/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.suspend_resume.network_interface.network.vf_address.hostdev.without_managed.without_iommu: PASS (59.29 s)
 (60/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.managedsave.hostdev_interface.vf_address.managed_yes: PASS (55.25 s)
 (61/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.managedsave.hostdev_device.vf_address.managed_yes: PASS (60.65 s)
 (62/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.exclusive_check.offline_domain.hostdev_interface.hostdev_interface: PASS (37.62 s)
 (63/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.exclusive_check.offline_domain.hostdev_interface.hostdev_device: PASS (36.44 s)
 (64/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.exclusive_check.offline_domain.hostdev_device.hostdev_interface: PASS (37.68 s)
 (65/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.exclusive_check.offline_domain.hostdev_device.hostdev_device: PASS (37.62 s)
 (66/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start_destroy.hostdev_interface.vf_address.managed_yes: PASS (63.66 s)
 (67/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start_destroy.hostdev_interface.vf_address.managed_no: PASS (63.84 s)
 (68/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start_destroy.hostdev_interface.vf_address.without_managed: PASS (64.17 s)
 (69/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start_destroy.hostdev_interface.vf_address.vlan: PASS (62.07 s)
 (70/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start_destroy.hostdev_device.vf_address.managed_yes: PASS (63.49 s)
 (71/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start_destroy.hostdev_device.vf_address.managed_no: PASS (63.70 s)
 (72/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start_destroy.hostdev_device.pf_address.managed_yes: PASS (76.74 s)
 (73/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start_destroy.hostdev_device.pf_address.managed_no: PASS (78.89 s)
 (74/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start_destroy.network_interface.network.pf_name.managed_no: PASS (64.90 s)
 (75/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start_destroy.network_interface.network.pf_name.managed_yes: PASS (65.15 s)
 (76/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start_destroy.network_interface.network.pf_name.without_managed: PASS (64.99 s)
 (77/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start_destroy.network_interface.network.vf_address.managed_yes: PASS (65.16 s)
 (78/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start_destroy.network_interface.network.vf_address.without_managed: PASS (66.25 s)
 (79/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start.negative.hostdev_interface.vlan_trunk: PASS (22.18 s)
 (80/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start.negative.hostdev_interface.inactive_pf: PASS (22.31 s)
 (81/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start.negative.hostdev_interface.inactive_network: PASS (22.69 s)
 (82/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start.negative.hostdev_interface.pf_address: PASS (22.02 s)
 (83/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start.negative.hostdev_interface.unsupported_virtualport: PASS (22.18 s)
 (84/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start.negative.hostdev_interface.unassigned_address: PASS (21.93 s)
 (85/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start.negative.hostdev_interface.iommu_without_caching: PASS (24.61 s)
 (86/88) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.start.negative.hostdev_device.iommu_without_caching: PASS (24.62 s)
 (88/88) type_specific.io-github-autotest-libvirt.sriov.scalability.max_vfs: PASS (878.08 s)

```