### PR TITLE
sriov: Add 2 network cases

### DIFF
--- a/libvirt/tests/cfg/sriov/network/sriov_check_net_info_by_network_lifecycle_cmds.cfg
+++ b/libvirt/tests/cfg/sriov/network/sriov_check_net_info_by_network_lifecycle_cmds.cfg
@@ -1,0 +1,6 @@
+- sriov.network.check_net_info_by_network_lifecycle_cmds:
+    type = sriov_check_net_info_by_network_lifecycle_cmds
+    only x86_64
+    start_vm = "no"
+    network_dict = {'forward': {'mode': 'hostdev', 'managed': 'yes'}, 'name': 'hostnet', 'vf_list': [{'type_name': 'pci', 'attrs': vf_pci_addr}], 'uuid': 'e6ddbb96-5be5-494d-92f0-f7473e185876'}
+    network_update_dict = {'portgroups': [{'name': 'dontpanic'}]}

--- a/libvirt/tests/cfg/sriov/network/sriov_define_or_start_network_with_pf_addr.cfg
+++ b/libvirt/tests/cfg/sriov/network/sriov_define_or_start_network_with_pf_addr.cfg
@@ -1,0 +1,6 @@
+- sriov.network.define_or_start_network_with_pf_addr:
+    type = sriov_define_or_start_network_with_pf_addr
+    only x86_64
+    start_vm = "no"
+    err_msg = "SR-IOV Virtual Function"    
+    network_dict = {'forward': {'mode': 'hostdev', 'managed': 'yes'}, 'name': 'hostnet', 'vf_list': [{'type_name': 'pci', 'attrs': pf_pci_addr}], 'uuid': 'e6ddbb96-5be5-494d-92f0-f7473e185876'}

--- a/libvirt/tests/src/sriov/network/sriov_check_net_info_by_network_lifecycle_cmds.py
+++ b/libvirt/tests/src/sriov/network/sriov_check_net_info_by_network_lifecycle_cmds.py
@@ -1,0 +1,91 @@
+import copy
+import os
+
+from provider.sriov import sriov_base
+
+from virttest import virsh
+from virttest import utils_libvirtd
+
+from virttest.libvirt_xml import network_xml
+
+VIRSH_ARGS = {'debug': True, 'ignore_status': False}
+
+
+def run(test, params, env):
+    """
+    Check net info
+    """
+    def run_test():
+        """
+        Check net info by network lifecycle commands:
+            net-define/undefine/create
+            net-destroy/start
+            net-dumpxml
+            net-info
+            net-update
+            net-autostart
+            net-list
+        """
+        test.log.info("TEST_STEP1: Create hostdev network from xml.")
+        virsh.net_create(net_dev.xml, **VIRSH_ARGS)
+        test.log.info("TEST_STEP2: Check net info by virsh command.")
+        virsh.net_info(network_name, **VIRSH_ARGS)
+        test.log.info("TEST_STEP3: Update the net.")
+        virsh.net_update(network_name, "add", net_update_section,
+                         net_update_xml, **VIRSH_ARGS)
+        test.log.info("TEST_STEP4: Dump net xml and check it.")
+        cur_net = network_xml.NetworkXML().new_from_net_dumpxml(network_name).fetch_attrs()
+        if cur_net != network_update_dict:
+            test.fail("Network XML compare fails! It should be '%s', but "
+                      "got '%s'" % (network_update_dict, cur_net))
+        virsh.net_destroy(network_name, **VIRSH_ARGS)
+
+        test.log.info("TEST_STEP5: Define network by virsh command.")
+        virsh.net_define(net_dev.xml, **VIRSH_ARGS)
+        test.log.info("TEST_STEP6: Start the network.")
+        virsh.net_start(network_name, **VIRSH_ARGS)
+        virsh.net_destroy(network_name, **VIRSH_ARGS)
+
+        test.log.info("TEST_STEP7: Autostart the network.")
+        virsh.net_autostart(network_name, **VIRSH_ARGS)
+        if os.path.exists('/run/libvirt/network/autostarted'):
+            os.remove('/run/libvirt/network/autostarted')
+        utils_libvirtd.Libvirtd("virtnetworkd").restart()
+        net_state = virsh.net_state_dict()
+        if net_state.get(network_name) and all(net_state.get(network_name).values()):
+            test.log.info("Check net info PASS!")
+        else:
+            test.fail("Unable to get correct net info in %s." % net_state)
+        test.log.info("TEST_STEP8: Destroy the network.")
+        virsh.net_destroy(network_name, **VIRSH_ARGS)
+        test.log.info("TEST_STEP9: Undefine the network.")
+        virsh.net_undefine(network_name, **VIRSH_ARGS)
+
+    def cleanup_test():
+        """
+        Test cleanup
+        """
+        net_state = virsh.net_state_dict()
+        if net_state.get(network_name):
+            if net_state.get(network_name).get('active'):
+                virsh.net_destroy(network_name, debug=True)
+            if net_state.get(network_name).get('persistent'):
+                virsh.net_undefine(network_name, debug=True)
+
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    vm = env.get_vm(vm_name)
+    net_update_section = params.get("net_update_section", "portgroup")
+    net_update_xml = params.get("net_update_xml", '''"<portgroup name='dontpanic'/>"''')
+    network_update_dict = eval(params.get("network_update_dict", "{}"))
+    sriov_test_obj = sriov_base.SRIOVTest(vm, test, params)
+    network_dict = sriov_test_obj.parse_network_dict()
+    network_update_dict.update(copy.deepcopy(network_dict))
+    test.log.debug(network_update_dict)
+    test.log.debug(network_dict)
+    network_name = network_dict['name']
+    net_dev = network_xml.NetworkXML()
+    net_dev.setup_attrs(**network_dict)
+    try:
+        run_test()
+    finally:
+        cleanup_test()

--- a/libvirt/tests/src/sriov/network/sriov_define_or_start_network_with_pf_addr.py
+++ b/libvirt/tests/src/sriov/network/sriov_define_or_start_network_with_pf_addr.py
@@ -1,0 +1,40 @@
+from provider.sriov import sriov_base
+
+from virttest import virsh
+
+from virttest.libvirt_xml import network_xml
+from virttest.utils_test import libvirt
+
+VIRSH_ARGS = {'debug': True}
+
+
+def run(test, params, env):
+    """
+    Check net info
+    """
+    def run_test():
+        """
+        Libvirt forbid to define or start 'hostdev' network which contains PF
+        pci address
+        """
+        test.log.info("TEST_STEP1: Try to define network with PF pci address.")
+        result = virsh.net_define(net_dev.xml, **VIRSH_ARGS)
+        libvirt.check_result(result, err_msg)
+        test.log.info("TEST_STEP2: Try to create network with PF pci address.")
+        result = virsh.net_create(net_dev.xml, **VIRSH_ARGS)
+        libvirt.check_result(result, err_msg)
+
+    err_msg = params.get("err_msg")
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    vm = env.get_vm(vm_name)
+    sriov_test_obj = sriov_base.SRIOVTest(vm, test, params)
+    network_dict = sriov_test_obj.parse_network_dict()
+    network_name = network_dict['name']
+    net_dev = network_xml.NetworkXML()
+    net_dev.setup_attrs(**network_dict)
+    try:
+        run_test()
+
+    finally:
+        virsh.net_destroy(network_name, debug=True)
+        virsh.net_undefine(network_name, debug=True)

--- a/provider/sriov/sriov_base.py
+++ b/provider/sriov/sriov_base.py
@@ -177,6 +177,7 @@ class SRIOVTest(object):
         """
         vf_pci_addr = self.vf_pci_addr
         vf_pci_addr2 = self.vf_pci_addr2
+        pf_pci_addr = self.pf_pci_addr
         pf_name = self.pf_name
         vf_name = self.vf_name
         net_forward_pf = str({'dev': pf_name})


### PR DESCRIPTION
This PR adds:
    1. VIRT-294816: Define or start 'hostdev' network which
        contains PF pci addresses
    2. VIRT-293136: Check net info by network lifecycle cmds

Signed-off-by: Yingshun Cui <yicui@redhat.com>

**Test results:**
```
(1/2) type_specific.io-github-autotest-libvirt.sriov.network.check_net_info_by_network_lifecycle_cmds: PASS (21.84 s)
 (2/2) type_specific.io-github-autotest-libvirt.sriov.network.define_or_start_network_with_pf_addr: PASS (20.98 s)
```