### PR TITLE
sriov: Add a case of attaching hostdev device or interface

### DIFF
--- a/libvirt/tests/cfg/sriov/plug_unplug/sriov_attach_detach_device.cfg
+++ b/libvirt/tests/cfg/sriov/plug_unplug/sriov_attach_detach_device.cfg
@@ -1,0 +1,55 @@
+- sriov.plug_unplug.attach_detach_device:
+    type = sriov_attach_detach_device
+    start_vm = "no"
+
+    only x86_64
+    variants dev_type:
+        - hostdev_interface:
+            variants dev_source:
+                - vf_address:
+                    variants:
+                        - managed_yes:
+                            iface_dict = {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}, 'driver': {'driver_attr': {'name': 'vfio'}}, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}, 'mac_address': mac_addr}
+                        - managed_no:
+                            iface_dict = {'managed': 'no', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
+                        - without_managed:
+                            iface_dict = {'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
+                        - vlan:
+                            iface_dict = {'type_name': 'hostdev', 'vlan': {'tags': [{'id': '42'}]}, 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}, 'managed': 'yes', 'driver': {'driver_attr': {'name': 'vfio'}}, 'mac_address': mac_addr}
+        - hostdev_device:
+            variants dev_source:
+                - vf_address:
+                    variants:
+                        - managed_yes:
+                            hostdev_dict = {'alias': {'name': 'ua-1bcbabff-f022-4d4f-ae8c-13f2d3a07906'}, 'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': vf_pci_addr}, 'managed': 'yes'}
+                        - managed_no:
+                            hostdev_dict = {'alias': {'name': 'ua-1bcbabff-f022-4d4f-ae8c-13f2d3a07906'}, 'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': vf_pci_addr}, 'managed': 'no'}
+                - pf_address:
+                    variants:
+                        - managed_yes:
+                            hostdev_dict = {'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': pf_pci_addr}, 'managed': 'yes'}
+                        - managed_no:
+                            hostdev_dict = {'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': pf_pci_addr}, 'managed': 'no'}
+        - network_interface:
+            variants dev_source:
+                - network:
+                    variants net_source:
+                        - pf_name:
+                            variants:
+                                - managed_no:
+                                    iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
+                                    network_dict = {"name":'hostdev_net','forward': {'mode': 'hostdev', 'managed': 'no'}, 'pf': {'dev': pf_name}}
+                                - managed_yes:
+                                    iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
+                                    network_dict = {"name":'hostdev_net','forward': {'mode': 'hostdev', 'managed': 'yes'}, 'pf': {'dev': pf_name}}
+                                - without_managed:
+                                    iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
+                                    network_dict = {"name":'hostdev_net','forward': {'mode': 'hostdev'}, 'pf': {'dev': pf_name}}
+                        - vf_address:
+                            variants:
+                                - managed_yes:
+                                    iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
+                                    network_dict = {'forward': {'mode': 'hostdev', 'managed': 'yes'}, 'name': 'hostdev_net', 'vf_list': [{'type_name': 'pci', 'attrs': vf_pci_addr}]}
+                                - without_managed:
+                                    iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
+                                    network_dict = {'forward': {'mode': 'hostdev'}, 'name': 'hostdev_net', 'vf_list': [{'type_name': 'pci', 'attrs': vf_pci_addr}]}

--- a/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_device.py
+++ b/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_device.py
@@ -1,0 +1,91 @@
+from provider.sriov import sriov_base
+from provider.sriov import check_points
+
+from virttest import utils_misc
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vfio
+
+
+def run(test, params, env):
+    """
+    Attach/detach-device a hostdev interface or device to/from guest
+    """
+    def run_test():
+        """
+        Live hotplug/unplug an interface/device of hostdev type to/from guest,
+        and test the network function.
+        """
+        test.log.info("TEST_STEP1: Start the VM")
+        vm.start()
+        vm_session = vm.wait_for_serial_login(timeout=240)
+
+        test.log.info("TEST_STEP2: Attach a hostdev interface/device to VM")
+        iface_dev = sriov_test_obj.create_iface_dev(dev_type, iface_dict)
+        virsh.attach_device(vm.name, iface_dev.xml, debug=True,
+                            ignore_errors=False)
+
+        test.log.info("TEST_STEP3: Check hostdev xml after VM startup")
+        if dev_type == "network_interface":
+            iface_dict.update({'type_name': 'hostdev'})
+        check_points.comp_hostdev_xml(vm, device_type, iface_dict)
+
+        test.log.info("TEST_STEP4: Check hostdev information - mac, "
+                      "vlan, network accessibility and so on")
+        check_points.check_mac_addr(
+            vm_session, vm.name, device_type, iface_dict)
+
+        if 'vlan' in iface_dict:
+            check_points.check_vlan(sriov_test_obj.pf_name, iface_dict)
+        else:
+            check_points.check_vm_network_accessed(vm_session)
+
+        test.log.info("TEST_STEP5: Detach the hostdev interface/device.")
+        vm_hostdev = vm_xml.VMXML.new_from_dumpxml(vm.name)\
+            .devices.by_device_tag(device_type)[0]
+        virsh.detach_device(vm.name, vm_hostdev.xml, debug=True,
+                            ignore_errors=False)
+        cur_hostdevs = vm_xml.VMXML.new_from_dumpxml(vm.name)\
+            .devices.by_device_tag(device_type)
+        if cur_hostdevs:
+            test.fail("Got hostdev interface/device(%s) after detaching the "
+                      "device!" % cur_hostdevs)
+
+        if not utils_misc.wait_for(
+            lambda: libvirt_vfio.check_vfio_pci(
+                dev_pci, not managed_disabled, True), 10, 5):
+            test.fail("Got incorrect driver!")
+        if managed_disabled:
+            virsh.nodedev_reattach(dev_name, debug=True, ignore_errors=False)
+            libvirt_vfio.check_vfio_pci(dev_pci, True)
+
+    dev_type = params.get("dev_type", "")
+    dev_source = params.get("dev_source", "")
+
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    vm = env.get_vm(vm_name)
+    sriov_test_obj = sriov_base.SRIOVTest(vm, test, params)
+    if dev_type == "hostdev_device" and dev_source.startswith("pf"):
+        dev_name = sriov_test_obj.pf_dev_name
+        dev_pci = sriov_test_obj.pf_pci
+    else:
+        dev_name = sriov_test_obj.vf_dev_name
+        dev_pci = sriov_test_obj.vf_pci
+
+    iface_dict = sriov_test_obj.parse_iface_dict()
+    network_dict = sriov_test_obj.parse_network_dict()
+    managed_disabled = iface_dict.get('managed') != "yes" or \
+        (network_dict and network_dict.get('managed') != "yes")
+    device_type = "hostdev" if dev_type == "hostdev_device" else "interface"
+
+    try:
+        sriov_test_obj.setup_default(dev_name=dev_name,
+                                     managed_disabled=managed_disabled,
+                                     network_dict=network_dict)
+        run_test()
+
+    finally:
+        sriov_test_obj.teardown_default(
+            managed_disabled=managed_disabled,
+            dev_name=dev_name, network_dict=network_dict)


### PR DESCRIPTION
VIRT-292850: Attach/detach-device a hostdev interface or device to/from guest

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Depends on:** https://github.com/avocado-framework/avocado-vt/pull/3498
**Test results:**
```
 (01/13) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.hostdev_interface.vf_address.managed_yes: PASS (63.01 s)
 (02/13) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.hostdev_interface.vf_address.managed_no: PASS (64.92 s)
 (03/13) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.hostdev_interface.vf_address.without_managed: PASS (62.97 s)
 (04/13) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.hostdev_interface.vf_address.vlan: PASS (60.14 s)
 (05/13) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.hostdev_device.vf_address.managed_yes: PASS (63.16 s)
 (06/13) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.hostdev_device.vf_address.managed_no: PASS (84.17 s)
 (07/13) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.hostdev_device.pf_address.managed_yes: PASS (72.72 s)
 (08/13) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.hostdev_device.pf_address.managed_no: PASS (75.32 s)
 (09/13) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.network_interface.network.pf_name.managed_no: PASS (65.25 s)
 (10/13) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.network_interface.network.pf_name.managed_yes: PASS (65.42 s)
 (11/13) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.network_interface.network.pf_name.without_managed: PASS (63.97 s)
 (12/13) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.network_interface.network.vf_address.managed_yes: PASS (63.81 s)
 (13/13) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.network_interface.network.vf_address.without_managed: PASS (63.78 s)
```
