### PR TITLE
serial_pty_log: fix log decode failure

### DIFF
--- a/libvirt/tests/src/serial/serial_functional.py
+++ b/libvirt/tests/src/serial/serial_functional.py
@@ -122,8 +122,7 @@ class Console(aexpect.ShellSession):
                 address + '.out',
                 os.O_RDONLY | os.O_CREAT | os.O_NONBLOCK)
         elif console_type == 'file':
-            self.read_fd = open(address,
-                                'r')
+            self.read_fd = open(address, 'r', errors='ignore')
 
     def _tcp_thread(self):
         """

--- a/libvirt/tests/src/serial/serial_pty_log.py
+++ b/libvirt/tests/src/serial/serial_pty_log.py
@@ -24,7 +24,7 @@ def check_pty_log_file(file_path, boot_prompt):
     :return: True or False according the result of finding
     """
 
-    with open(file_path) as fp:
+    with open(file_path, errors='ignore') as fp:
         contents = fp.read()
     logging.debug("The contents of log file are : %s" % contents)
     ret = contents.find(boot_prompt)


### PR DESCRIPTION
When booting OVMF guest, there are some un-decoded special characters in the
console log which caused file reading failed. So the solution is to add this
error='ignore' parameter in order to not raise the error like below:
`UnicodeDecodeError: 'utf-8' codec can't decode byte 0xd9 in position 0: unexpected end of data`

The ignoring will not impact some key strings matched in the log.

Signed-off-by: Dan Zheng <dzheng@redhat.com>
