### PR TITLE
Fix virtual network multivms failure due to dhclient

### DIFF
--- a/spell.ignore
+++ b/spell.ignore
@@ -189,6 +189,7 @@ dev's
 devs
 df
 dhcp
+dhcp-client
 diag
 dict's
 dicts


### PR DESCRIPTION
dhclient may not be installed as default on some arch guest, e.g s390x
virtual network multivms need dhclient, so add some logic to install dhclient package

Signed-off-by: chunfuwen <chwen@redhat.com>
