### PR TITLE
fix empty rbd source file

### DIFF
--- a/provider/virtual_disk/disk_base.py
+++ b/provider/virtual_disk/disk_base.py
@@ -125,7 +125,7 @@ class DiskBase(object):
             if no_secret:
                 disk_dict.update({'source': {'attrs': {'file': new_image_path}}})
             else:
-                mon_host, auth_username, _ = \
+                mon_host, auth_username, new_image_path = \
                     self.create_rbd_disk_path(self.params)
                 disk_dict.update({'source': {
                         'attrs': {'protocol': "rbd", "name": new_image_path},


### PR DESCRIPTION
   for rbd type in add_vm_disk func, missing source file if secret
Signed-off-by: nanli <nanli@redhat.com>

**Test result:**
```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35  backingchain..rbd_with_auth_disk
 (1/6) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.rbd_with_auth_disk.mid_to_mid: PASS (48.01 s)
 (2/6) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.rbd_with_auth_disk.top_to_base: PASS (115.00 s)
 (3/6) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.rbd_with_auth_disk.top_to_mid: PASS (77.50 s)
 (4/6) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.conventional_chain.rbd_with_auth_disk.mid_to_base: PASS (90.31 s)
 (5/6) type_specific.io-github-autotest-libvirt.backingchain.blockpull.conventional_chain.rbd_with_auth_disk.with_base: PASS (111.68 s)
 (6/6) type_specific.io-github-autotest-libvirt.backingchain.blockpull.conventional_chain.rbd_with_auth_disk.without_base: PASS (86.39 s)

```