### PR TITLE
virtio_transitional_blk: Fix up "No such file or directory" issue

### DIFF
--- a/libvirt/tests/src/virtio_transitional/virtio_transitional_blk.py
+++ b/libvirt/tests/src/virtio_transitional/virtio_transitional_blk.py
@@ -168,11 +168,12 @@ def run(test, params, env):
 
         v_xml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
         slot = get_free_slot(pci_bridge_index, v_xml)
-        disk_xml = _generate_disk_xml()
-        attach(disk_xml, device_target, plug_method)
+        disk_dev = devices.disk.Disk("file")
+        disk_dev.xml = _generate_disk_xml()
+        attach(disk_dev.xml, device_target, plug_method)
         if plug_method == "cold":
-            disk_xml = _generate_disk_xml()
-        detach(disk_xml, device_target, plug_method)
+            disk_dev.xml = _generate_disk_xml()
+        detach(disk_dev.xml, device_target, plug_method)
         if not utils_misc.wait_for(
                 lambda: not libvirt.device_exists(vm, device_target),
                 detect_time):


### PR DESCRIPTION
Update to use disk device object to avoid "No such file or
directory" issue.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Before the fix:**
` (1/1) type_specific.io-github-autotest-libvirt.virtio_transitional_blk.rhel6_guest.default.with_virtio_blk.hotplug_test.virtio_transitional: ERROR: [Errno 2] No such file or directory: '/tmp/xml_utils_temp_d6el8jm5.xml' (165.39 s)
`

**After the fix:**
 `(1/1) type_specific.io-github-autotest-libvirt.virtio_transitional_blk.rhel6_guest.default.with_virtio_blk.hotplug_test.virtio_transitional: PASS (163.12 s)`

