### PR TITLE
backingchain: add case for blockcopy with blockdev option

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockcopy/blockcopy_with_blockdev_option.cfg
+++ b/libvirt/tests/cfg/backingchain/blockcopy/blockcopy_with_blockdev_option.cfg
@@ -1,0 +1,37 @@
+- backingchain.blockcopy.blockdev_option:
+    type = blockcopy_with_blockdev_option
+    target_disk = "vdb"
+    snap_nums = 1
+    lvm_num = 3
+    variants:
+        - blockdev:
+            blockcopy_option = " --blockdev %s --transient-job --pivot"
+            expected_chain = "2"
+        - blockdev_and_shallow:
+            blockcopy_option = " --blockdev %s --transient-job --shallow --pivot"
+            expected_chain = "2>base"
+    variants:
+        - file_disk:
+            disk_type = "file"
+            disk_dict = {"type_name":"${disk_type}", "target":{"dev": "${target_disk}", "bus": "virtio"}, "driver": {"name": "qemu", "type":"qcow2"}}
+            create_snap_option = " --disk-only --no-metadata "
+            snap_extra = " --diskspec vda,snapshot=no"
+            file_snap_path = "/var/lib/libvirt/images/test.s1"
+        - block_disk:
+            disk_type = "block"
+            disk_dict = {"type_name":"${disk_type}", "target":{"dev": "${target_disk}", "bus": "virtio"}, "driver": {"name": "qemu", "type":"raw"}}
+            create_snap_option = " --disk-only --no-metadata "
+            snap_extra = ",stype=block --diskspec vda,snapshot=no"
+            pool_target = ""
+        - rbd_with_auth_disk:
+            disk_type = "rbd_with_auth"
+            disk_source_protocol = "rbd"
+            mon_host = "EXAMPLE_MON_HOST"
+            auth_key = "EXAMPLE_AUTH_KEY"
+            auth_user = "EXAMPLE_AUTH_USER"
+            image_path = "EXAMPLE_IMAGE_PATH"
+            client_name = "EXAMPLE_CLIENT_NAME"
+            create_snap_option = " --disk-only --no-metadata "
+            snap_extra = ",stype=block --diskspec vda,snapshot=no"
+            sec_dict = {"secret_ephemeral": "no", "secret_private": "yes", "description": "secret_desc_for_backingchain", "usage": "ceph", "usage_name": "cephlibvirt"}
+            disk_dict = {"type_name":"network", "target":{"dev": "${target_disk}", "bus": "virtio"}, "driver": {"name": "qemu", "type":"raw"}}

--- a/libvirt/tests/src/backingchain/blockcopy/blockcopy_with_blockdev_option.py
+++ b/libvirt/tests/src/backingchain/blockcopy/blockcopy_with_blockdev_option.py
@@ -1,0 +1,136 @@
+from avocado.utils import lv_utils
+from avocado.utils import process
+
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_disk
+from virttest.utils_test import libvirt
+
+from provider.backingchain import blockcommand_base
+from provider.backingchain import check_functions
+from provider.virtual_disk import disk_base
+
+
+def run(test, params, env):
+    """
+    Test blockcopy with blockdev option.
+
+    1) Prepare an running guest.
+    2) Create snap.
+    3) Do blockcopy with --blockdev shallow and no shallow
+    4) Check expected chain and disk hash
+    """
+
+    def setup_test():
+        """
+        Prepare active domain and snap chain
+        """
+        test.log.info("TEST_SETUP: Add disk and snap chain.")
+        test_obj.new_image_path = disk_obj.add_vm_disk(disk_type, disk_dict)
+        if not vm.is_alive():
+            vm.start()
+        vm.wait_for_login().close()
+
+        test_obj.lvm_list = _pre_lvm()
+        _do_snap(test_obj.lvm_list)
+
+    def run_test():
+        """
+        Test blockcopy with --blockdev option.
+        """
+        session = vm.wait_for_login()
+        expected_hash = test_obj.get_hash_value(session,
+                                                check_item="/dev/"+test_obj.new_dev)
+
+        test.log.info("TEST_STEP1: Do blockcopy.")
+        virsh.blockcopy(vm_name, device, blockcopy_options % test_obj.lvm_list[1],
+                        ignore_status=False,
+                        debug=True)
+
+        test.log.info("TEST_STEP2: Check backingchain and hash value.")
+        expected_chain = test_obj.convert_expected_chain(expected_chain_index)
+        check_obj.check_backingchain_from_vmxml(disk_type, device, expected_chain)
+
+        check_obj.check_hash_list(["/dev/"+test_obj.new_dev], [expected_hash],
+                                  session)
+        session.close()
+
+    def teardown_test():
+        """
+        Clean env
+        """
+        test.log.info("TEST_TEARDOWN: Clean up env.")
+        test_obj.backingchain_common_teardown()
+
+        bkxml.sync()
+        disk_obj.cleanup_block_disk_preparation(disk_obj.vg_name, lv_name+"1")
+
+        process.run("rm -f %s" % ("/dev/%s" % disk_obj.vg_name))
+        process.run("rm -f %s" % file_snap_path)
+
+    def _do_snap(lvm_list):
+        """
+        Create snap chain
+
+        :params lvm_list: lvm list
+        """
+        snap_path = file_snap_path
+        if disk_type == "block" or disk_type == "rbd_with_auth":
+            test_obj.tmp_dir = "/dev/%s/%s" % (vg_name, lv_name)
+            snap_path = lvm_list[0]
+
+        test_obj.prepare_snapshot(snap_num=snap_nums, snap_path=snap_path,
+                                  option=snap_option, extra=extra_option,
+                                  clean_snap_file=False)
+        test_obj.snap_path_list = test_obj.lvm_list
+
+    def _pre_lvm():
+        """
+        Create the left lvm as snap path, the first lvm is created by add_vm_disk code
+        """
+        if disk_type != "block":
+            # for block disk, volume group has been created in add_vm_disk()
+            # Need to create volume group for file/rbd disk
+            device_name = libvirt.setup_or_cleanup_iscsi(is_setup=True)
+            lv_utils.vg_create(vg_name, device_name)
+
+        path = []
+        for i in range(1, lvm_num):
+            source_path = '/dev/%s/%s' % (disk_obj.vg_name, lv_name + str(i))
+            lv_utils.lv_create(disk_obj.vg_name, lv_name + str(i), vol_size)
+            path.append(source_path)
+        return path
+
+    # Process cartesian parameters
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    device = params.get('target_disk')
+    disk_type = params.get('disk_type', '')
+    disk_dict = eval(params.get('disk_dict', '{}'))
+
+    lvm_num = int(params.get('lvm_num'))
+    snap_nums = int(params.get("snap_nums"))
+    file_snap_path = params.get("file_snap_path")
+    blockcopy_options = params.get('blockcopy_option')
+    snap_option = params.get('create_snap_option', '')
+    extra_option = params.get('snap_extra', '')
+    expected_chain_index = params.get('expected_chain')
+    # Create object
+    test_obj = blockcommand_base.BlockCommand(test, vm, params)
+    check_obj = check_functions.Checkfunction(test, vm, params)
+    disk_obj = disk_base.DiskBase(test, vm, params)
+
+    # Get vm xml
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+    test_obj.original_disk_source = libvirt_disk.get_first_disk_source(vm)
+    vg_name, lv_name, vol_size = 'vg0', 'lv', '300M'
+
+    try:
+        # Execute test
+        setup_test()
+        run_test()
+
+    finally:
+        teardown_test()
+        bkxml.sync()

--- a/provider/backingchain/blockcommand_base.py
+++ b/provider/backingchain/blockcommand_base.py
@@ -38,6 +38,7 @@ class BlockCommand(object):
         self.old_parts = []
         self.original_disk_source = ''
         self.backing_file = ''
+        self.lvm_list = []
 
     def prepare_iscsi(self):
         """
@@ -78,7 +79,8 @@ class BlockCommand(object):
         libvirt.set_vm_disk(self.vm, self.params)
 
     def prepare_snapshot(self, start_num=0, snap_num=3,
-                         snap_path="", option='--disk-only', extra=''):
+                         snap_path="", option='--disk-only', extra='',
+                         clean_snap_file=True):
         """
         Prepare domain snapshot
 
@@ -87,6 +89,7 @@ class BlockCommand(object):
         :params snap_path: path of snap
         :params option: option to create snapshot, default value is '--disk-only'
         :params extra: extra option to create snap
+        :params clean_snap_file: Clean snap file before create snap if True.
         """
         # Create backing chain
         for i in range(start_num, snap_num):
@@ -94,7 +97,7 @@ class BlockCommand(object):
                 path = self.tmp_dir + '%d' % i
             else:
                 path = snap_path
-            if os.path.exists(path) and "reuse" not in option:
+            if os.path.exists(path) and "reuse" not in option and clean_snap_file:
                 libvirt.delete_local_disk('file', path)
             snap_option = "%s %s --diskspec %s,file=%s%s" % \
                           ('snap%d' % i, option, self.new_dev, path, extra)

--- a/provider/virtual_disk/disk_base.py
+++ b/provider/virtual_disk/disk_base.py
@@ -98,7 +98,8 @@ class DiskBase(object):
                 if kwargs.get("size"):
                     kwargs.pop("size")
                 libvirt.create_local_disk("file", path=new_image_path,
-                                          size=size, disk_format="qcow2", **kwargs)
+                                          size=size, disk_format="qcow2",
+                                          **kwargs)
             disk_dict.update({'source': {'attrs': {'file': new_image_path}}})
 
         elif disk_type == 'block':
@@ -111,15 +112,18 @@ class DiskBase(object):
             if not new_image_path:
                 pool_name, new_image_path = self.create_volume_for_disk_path(
                     self.test, self.params, self.pool_name,
-                    self.pool_type, self.pool_target, self.emulated_image, **kwargs)
+                    self.pool_type, self.pool_target, self.emulated_image,
+                    **kwargs)
             disk_dict.update({'source': {'attrs': {'pool': self.pool_name,
                                                    'volume': new_image_path}}})
         elif disk_type == 'nfs':
             if not new_image_path:
-                nfs_res = libvirt.setup_or_cleanup_nfs(is_setup=True, is_mount=True)
+                nfs_res = libvirt.setup_or_cleanup_nfs(is_setup=True,
+                                                       is_mount=True)
                 new_image_path = nfs_res['mount_dir'] + '/test.img'
 
-                libvirt.create_local_disk("file", path=new_image_path, size='50M',
+                libvirt.create_local_disk("file", path=new_image_path,
+                                          size='50M',
                                           disk_format="qcow2", **kwargs)
             disk_dict.update({'source': {'attrs': {'file': new_image_path}}})
 
@@ -131,11 +135,11 @@ class DiskBase(object):
                 mon_host, auth_username, new_image_path = \
                     self.create_rbd_disk_path(self.params)
                 disk_dict.update({'source': {
-                        'attrs': {'protocol': "rbd", "name": new_image_path},
-                        "hosts": [{"name": mon_host}],
-                        "auth": {"auth_user": auth_username,
-                                 "secret_usage": "cephlibvirt",
-                                 "secret_type": "ceph"}}})
+                    'attrs': {'protocol': "rbd", "name": new_image_path},
+                    "hosts": [{"name": mon_host}],
+                    "auth": {"auth_user": auth_username,
+                             "secret_usage": "cephlibvirt",
+                             "secret_type": "ceph"}}})
 
         disk_xml = self.set_disk_xml(disk_dict)
         libvirt.add_vm_device(vmxml, disk_xml)
@@ -185,7 +189,8 @@ class DiskBase(object):
                                     pool_type='dir', pool_target='dir_pool',
                                     emulated_image='dir_pool_img',
                                     vol_name='vol_name', capacity='2G',
-                                    allocation='2G', volume_type='qcow2', **kwargs):
+                                    allocation='2G', volume_type='qcow2',
+                                    **kwargs):
         """
         Prepare volume type disk image path
 
@@ -294,8 +299,8 @@ class DiskBase(object):
             pool_name = self.create_pool_from_xml(pool_dict, source_dict)
             source_path = []
             for i in range(0, self.lv_num):
-                source = "/dev/%s/%s" % (pool_name, self.lv_name+str(i))
-                virsh.vol_create_as(self.lv_name+str(i), pool_name, "20M",
+                source = "/dev/%s/%s" % (pool_name, self.lv_name + str(i))
+                virsh.vol_create_as(self.lv_name + str(i), pool_name, "20M",
                                     "10M", "", debug=True)
                 libvirt.create_local_disk("file", source, "10M", "qcow2")
                 source_path.append(source)
@@ -305,7 +310,7 @@ class DiskBase(object):
 
         elif disk_type == "rbd_with_auth":
             origin_image = self._pre_rbd_origin_image()
-            dst_img, backing_list = libvirt_disk.\
+            dst_img, backing_list = libvirt_disk. \
                 make_relative_path_backing_files(self.vm,
                                                  pre_set_root_dir=self.base_dir,
                                                  origin_image=origin_image,
@@ -357,7 +362,8 @@ class DiskBase(object):
         pool.source = source_xml
 
         virsh.pool_define(pool.xml, debug=True, ignore_status=False)
-        virsh.pool_build(pool_name, options='--overwrite', debug=True, ignore_status=False)
+        virsh.pool_build(pool_name, options='--overwrite', debug=True,
+                         ignore_status=False)
         virsh.pool_start(pool_name, debug=True, ignore_status=False)
 
         return pool_name


### PR DESCRIPTION
   VIRT-294520: Do blockcopy with --blockdev option for different disk types
Signed-off-by: nanli <nanli@redhat.com>

**Test result:**
```
/usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35  backingchain.blockcopy.blockdev_option
 (1/6) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.blockdev_option.file_disk.blockdev: PASS (72.21 s)
 (2/6) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.blockdev_option.file_disk.blockdev_and_shallow: PASS (85.27 s)
 (3/6) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.blockdev_option.block_disk.blockdev: PASS (75.65 s)
 (4/6) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.blockdev_option.block_disk.blockdev_and_shallow: PASS (73.59 s)
 (5/6) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.blockdev_option.rbd_with_auth_disk.blockdev: PASS (79.84 s)
 (6/6) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.blockdev_option.rbd_with_auth_disk.blockdev_and_shallow: PASS (77.29 s)

```
