### PR TITLE
hooks: use EventTracker to wait for detach_interface to complete

### DIFF
--- a/libvirt/tests/src/libvirt_hooks.py
+++ b/libvirt/tests/src/libvirt_hooks.py
@@ -392,13 +392,8 @@ def run(test, params, env):
             def is_detached_interface():
                 return len(vm_xml.VMXML.new_from_dumpxml(vm_name).get_devices("interface")) == interface_num
 
-            ret = virsh.detach_interface(vm_name, "network --mac %s" % mac_addr)
+            ret = virsh.detach_interface(vm_name, "network --mac %s" % mac_addr, wait_for_event=True)
             libvirt.check_exit_status(ret)
-            utils_misc.wait_for(is_detached_interface, timeout=50)
-            # Wait for timeout and if not succeeded, detach again (during testing, detaching interface failed from q35 VM for the first time when using this function)
-            if len(vm_xml.VMXML.new_from_dumpxml(vm_name).get_devices("interface")) != interface_num:
-                ret = virsh.detach_interface(vm_name, "network --mac %s" % mac_addr)
-                libvirt.check_exit_status(ret)
             if utils_misc.wait_for(is_detached_interface, timeout=50) is not True:
                 test.fail("Detaching interface failed.")
             if libvirt_version.version_compare(6, 0, 0):


### PR DESCRIPTION
Signed-off-by: Hu Shuai <hus.fnst@fujitsu.com>

Interface can not be hot unplugged immediately after hotplug. 
For q35 and i440fx, IMO no need to detach interface for a sceond time with EventTracker.

Before:
```
# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio libvirt_hooks.vm.network_t --vt-connect-uri qemu:///system                                                                                                                        
JOB ID     : 47a165e7530f21a279662ca11d2cd9572bd980c8                                                                                                              
JOB LOG    : /var/lib/avocado/job-results/job-2022-08-28T23.02-47a165e/job.log     
 (1/1) type_specific.io-github-autotest-libvirt.libvirt_hooks.vm.network_t: FAIL: Failed to check network hooks (30.21 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0                                                                                                                             
JOB HTML   : /var/lib/avocado/job-results/job-2022-08-28T23.02-47a165e/results.html                                                                                                   
JOB TIME   : 30.57 s
```
After:
```
# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio libvirt_hooks.vm.network_t --vt-connect-uri qemu:///system
JOB ID     : 5c6428452af097c6ddd80bef8c322709797460da
JOB LOG    : /var/lib/avocado/job-results/job-2022-08-29T04.21-5c64284/job.log
 (1/1) type_specific.io-github-autotest-libvirt.libvirt_hooks.vm.network_t: PASS (56.37 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-08-29T04.21-5c64284/results.html
JOB TIME   : 56.73 s
```

Test Results for q35 and i440fx:
```
# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 libvirt_hooks.vm.network_t --vt-connect-uri qemu:///system
JOB ID     : 10c8e779fb9c3805a071c218a9abb1cb6c90aadf
JOB LOG    : /var/lib/avocado/job-results/job-2022-08-29T04.28-10c8e77/job.log
 (1/1) type_specific.io-github-autotest-libvirt.libvirt_hooks.vm.network_t: PASS (58.18 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-08-29T04.28-10c8e77/results.html
JOB TIME   : 58.54 s

# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type i440fx libvirt_hooks.vm.network_t --vt-connect-uri qemu:///system
JOB ID     : 2b36d04f200f01c1da69e467962b60eff47ff6e3
JOB LOG    : /var/lib/avocado/job-results/job-2022-08-29T04.30-2b36d04/job.log
 (1/1) type_specific.io-github-autotest-libvirt.libvirt_hooks.vm.network_t: PASS (55.71 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-08-29T04.30-2b36d04/results.html
JOB TIME   : 56.07 s
```