### PR TITLE
v2v: fix some script errors on rhel9.1

### DIFF
--- a/provider/v2v_vmcheck_helper.py
+++ b/provider/v2v_vmcheck_helper.py
@@ -597,16 +597,12 @@ class VMChecker(object):
             self.log_err(err_msg)
 
         LOG.info("Checking boot os info in VM XML")
-        chipset, bootinfo, secboot = self.get_expected_boottype(self.boottype)
+        chipset, bootinfo, _ = self.get_expected_boottype(self.boottype)
 
         chip_pattern = r"machine='pc-%s" % ('q35' if chipset ==
                                             'q35' else 'i440fx')
         if bootinfo == 'uefi':
-            boot_pattern = r"secure='%s' type='pflash'" % (
-                'yes' if secboot else 'no')
-            # v2v doesn't support secure boot to ovirt
-            if self.target == "ovirt":
-                boot_pattern = boot_pattern.replace('yes', 'no')
+            boot_pattern = r"type='pflash'"
         else:
             boot_pattern = None
 

--- a/v2v/tests/cfg/convert_vm_to_libvirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_libvirt.cfg
@@ -65,7 +65,7 @@
                     os_version = "DEBIAN_VERSION"
                 - ubuntu_lts:
                     only source_esx.esx_67, source_esx.esx_70
-                    os_short_id = "ubuntu18.04"
+                    os_short_id = "UBUNTU_LTS_SHORT_ID"
                     os_version = "UBUNTU_LTS_VERSION"
                 - sles12sp4:
                     only source_esx.esx_67, source_esx.esx_70
@@ -78,9 +78,9 @@
                     only source_esx.esx_67, source_esx.esx_70
                     os_short_id = "OPENSUSE_LATEST_SHORT_ID"
                     os_version = "OPENSUSE_LATEST_VERSION"
-                - opensuse15_1:
+                - opensuse15_4:
                     only source_esx.esx_67, source_esx.esx_70
-                    os_version = "opensuse15.1"
+                    os_version = "opensuse15.4"
         - windows:
             no pv
             os_type = "windows"

--- a/v2v/tests/cfg/convert_vm_to_ovirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_ovirt.cfg
@@ -112,9 +112,9 @@
                 - opensuse_latest:
                     only source_esx.esx_67, source_esx.esx_70
                     os_version = "OPENSUSE_LATEST_VERSION"
-                - opensuse15_1:
+                - opensuse15_4:
                     only source_esx.esx_67, source_esx.esx_70
-                    os_version = "opensuse15.1"
+                    os_version = "opensuse15.4"
         - windows:
             no pv
             os_type = "windows"

--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -230,7 +230,6 @@
             libguestfs_backend = 'direct'
         - local_storage:
             only esx_70
-            boottype = 3
             main_vm = "VM_NAME_ESX_LOCALSTORAGE_V2V_EXAMPLE"
         - multiple_disks:
             only esx_70

--- a/v2v/tests/cfg/v2v_options.cfg
+++ b/v2v/tests/cfg/v2v_options.cfg
@@ -281,8 +281,8 @@
                     example_file = /DISK_IMAGE_PATH_V2V_EXAMPLE/MACHINE_READABLE_V2V_EXAMPLE
                     in_man = 'colours-option'
                 - compress:
-                    only input_mode.libvirt.kvm.default
                     only output_mode.libvirt
+                    only input_mode.libvirt.esx.esx_67
                     checkpoint = compress
                     new_vm_name = ${main_vm}_compress
                     v2v_options = -of qcow2 --compressed -on ${new_vm_name}

--- a/v2v/tests/src/specific_kvm.py
+++ b/v2v/tests/src/specific_kvm.py
@@ -712,18 +712,12 @@ def run(test, params, env):
                 'devices').find('graphics').get('type')
             params['vm_machine'] = ori_vm_xml.xmltreefile.find(
                 './os/type').get('machine')
-            # Inactive xml only has firmware attribute. There is no way
-            # to determine whether it's secure or not.
             uefi_firmware = ori_vm_xml_root.find('./os[@firmware="efi"]')
             if uefi_firmware is not None:
-                # If convert to local kvm host, set it to 3 which is default in RHEL.
-                params['boottype'] = 3 if target == 'libvirt' else 2
-            # This detection is not conflict with above detection. In different libvirt
-            # and qemu versions, the configuration is different. There is no good way to
-            # check the boot type.
-            element_loader = ori_vm_xml_root.find('./os/loader[@type="pflash"]')
-            if element_loader is not None:
-                params['boottype'] = 2 if element_loader.get('secure') == 'no' else 3
+                # No good way to determine whether it's secure boot or not.
+                # So the check is skipped. There is no difference between
+                # 2 and 3.
+                params['boottype'] = 2
 
         backup_xml = None
         # Only kvm guest's xml needs to be backup currently


### PR DESCRIPTION
1) update some guests' configuration
2) Remove security check when boot firmare is UEFI.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com