### PR TITLE
backingchain: add case for blockpull with relative path

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockpull/blockpull_relative_path.cfg
+++ b/libvirt/tests/cfg/backingchain/blockpull/blockpull_relative_path.cfg
@@ -1,0 +1,38 @@
+- backingchain.blockpull.relative_path:
+    type = blockpull_relative_path
+    target_disk = "vdb"
+    virsh_opt = " -k0"
+    start_vm = "yes"
+    base_dir = "/var/lib/libvirt/images"
+    variants test_scenario:
+        - keep_relative:
+            pull_options = " --wait --verbose --keep-relative"
+            base_image_suffix = 3
+            expected_chain = '3>base'
+    variants:
+        - file_disk:
+            pull_times = 3
+            disk_type = "file"
+            disk_dict = {"type_name":"${disk_type}", "target":{"dev": "${target_disk}", "bus": "virtio"}, "driver": {"name": "qemu", "type":"qcow2"}}
+        - block_disk:
+            pull_times = 3
+            disk_type = "block"
+            disk_dict = {"type_name":"${disk_type}", "target":{"dev": "${target_disk}", "bus": "virtio"}, "driver": {"name": "qemu", "type":"qcow2"}}
+            snap_extra = ",stype=block --diskspec vda,snapshot=no"
+            pool_type = "logical"
+            pool_name = "vg0"
+            emulated_image = "emulated-iscsi"
+            pool_target = "/dev/${pool_name}"
+            pool_dict = {"pool_type":"logical", "name":"${pool_name}", "target_path":"${pool_target}"}
+            source_dict = {"device_path":"%s", "vg_name":"${pool_name}"}
+        - rbd_with_auth_disk:
+            pull_times = 2
+            disk_type = "rbd_with_auth"
+            disk_source_protocol = "rbd"
+            mon_host = "EXAMPLE_MON_HOST"
+            auth_key = "EXAMPLE_AUTH_KEY"
+            auth_user = "EXAMPLE_AUTH_USER"
+            image_path = "EXAMPLE_IMAGE_PATH"
+            client_name = "EXAMPLE_CLIENT_NAME"
+            disk_dict = {"device": "disk", "type_name": "file","target": {"dev": "${target_disk}", "bus": "virtio"},"driver": {"name": "qemu", "type": "qcow2"},"source": {"attrs": {"file": "%s"}},"backingstore": {"type": "file", "format":{'type': "qcow2"},"source": {"attrs": {"file": "%s"}},"backingstore":{"type": "file","format": {'type': "qcow2"},"source": {"attrs": {"file": "%s"}},"backingstore":{"type": "network","format": {'type': "raw"},"source": {'attrs': {'protocol': "rbd", "name": "%s"},"host": {"name":"${mon_host}"},"auth": {"auth_user": "${auth_user}","secret_usage": "cephlibvirt","secret_type": "ceph"}}}}}}
+            expected_chain = '3>2>base'

--- a/libvirt/tests/src/backingchain/blockpull/blockpull_relative_path.py
+++ b/libvirt/tests/src/backingchain/blockpull/blockpull_relative_path.py
@@ -1,0 +1,150 @@
+import os
+
+from avocado.utils import process
+
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_disk
+from virttest.utils_test import libvirt
+
+from provider.backingchain import blockcommand_base
+from provider.backingchain import check_functions
+from provider.virtual_disk import disk_base
+
+
+def run(test, params, env):
+    """
+    Do blockpull with relative path.
+
+    1) Prepare different type disk and relative path
+        disk types: file, block, network(rbd with auth)
+    2) Set vm status
+        running VM
+    3) Do blockpull
+        Do blockpull with --keep-relative continuously
+    4) Check result
+    """
+
+    def setup_test():
+        """
+        Prepare specific type disk and relative path.
+        """
+        test.log.info("TEST_SETUP1: Prepare relative path and new disk.")
+        test_obj.new_image_path, _ = disk_obj.prepare_relative_path(disk_type)
+
+        disk_dict, kwargs = get_disk_param()
+        disk_obj.add_vm_disk(disk_type, disk_dict,
+                             new_image_path=test_obj.new_image_path, **kwargs)
+
+        test.log.info("TEST_SETUP2: Start vm and get relative path.")
+        if not vm.is_alive():
+            vm.start()
+        vm.wait_for_login().close()
+
+        get_relative_path()
+
+    def test_keep_relative():
+        """
+        Do blockpull and check backingchain result
+        """
+        test.log.info("TEST_STEP1: Do blockpull.")
+        do_several_blockpull()
+
+        test.log.info("TEST_STEP2: Check backingchain.")
+        expected_chain = test_obj.convert_expected_chain(expected_chain_index)[::-1]
+        check_obj.check_backingchain_from_vmxml(disk_type, test_obj.new_dev,
+                                                expected_chain)
+
+    def teardown_test():
+        """
+        Clean data.
+        """
+        test.log.info("TEST_TEARDOWN: Recover test enviroment.")
+
+        test_obj.backingchain_common_teardown()
+        bkxml.sync()
+
+        for folder in [chr(letter) for letter in
+                       range(ord('a'), ord('a') + 4)]:
+            rm_cmd = "rm -rf %s" % os.path.join(disk_obj.base_dir, folder)
+            process.run(rm_cmd, shell=True)
+
+        if disk_type == 'block':
+            pvt = libvirt.PoolVolumeTest(test, params)
+            pvt.cleanup_pool(**params)
+            process.run("rm -rf %s" % pool_target)
+
+        if disk_type == 'rbd_with_auth_disk':
+            process.run("rm -f %s" % params.get("keyfile"))
+            cmd = ("rbd -m {0} info {1} && rbd -m {0} rm {1}".format(
+                mon_host, rbd_source_name))
+            process.run(cmd, ignore_status=True, shell=True)
+
+    def get_relative_path():
+        """
+        Get relative path.
+        """
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        test_obj.snap_path_list = disk_obj.get_source_list(vmxml, disk_type,
+                                                           test_obj.new_dev)[1:]
+        test.log.info("After start vm with relative path, "
+                      "The xml is:\n%s", vmxml)
+
+    def get_disk_param():
+        """
+        Get the param value according to different type disk.
+
+        :return disk_dict and **kwargs
+        """
+        kwargs = {}
+        if disk_type == "rbd_with_auth":
+            kwargs.update({'no_update_dict': True})
+            relative = test_obj.get_relative_path(test_obj.new_image_path)
+
+            disk_dict = eval(params.get('disk_dict', '{}')
+                             % (relative[0], relative[1], relative[2], relative[3]))
+        else:
+            disk_dict = eval(params.get("disk_dict", "{}"))
+
+        return disk_dict, kwargs
+
+    def do_several_blockpull():
+        """
+        Do several times blockpull
+        """
+        for i in range(0, pull_times):
+            base_option = " --base %s" % test_obj.snap_path_list[i]
+            virsh.blockpull(vm.name, test_obj.new_dev, base_option + pull_options,
+                            ignore_status=False, debug=True,
+                            virsh_opt=virsh_opt)
+
+    vm_name = params.get("main_vm")
+    disk_type = params.get('disk_type')
+    pull_options = params.get('pull_options')
+    expected_chain_index = params.get('expected_chain')
+    virsh_opt = params.get('virsh_opt')
+    pool_target = params.get('pool_target')
+
+    test_scenario = params.get('test_scenario')
+    pull_times = int(params.get('pull_times'))
+    mon_host = params.get('mon_host', '')
+    rbd_source_name = params.get('image_path', '')
+
+    vm = env.get_vm(vm_name)
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+
+    # Create object
+    test_obj = blockcommand_base.BlockCommand(test, vm, params)
+    check_obj = check_functions.Checkfunction(test, vm, params)
+    disk_obj = disk_base.DiskBase(test, vm, params)
+    test_obj.original_disk_source = libvirt_disk.get_first_disk_source(vm)
+
+    run_test = eval("test_%s" % test_scenario)
+
+    try:
+        setup_test()
+        run_test()
+
+    finally:
+        teardown_test()

--- a/provider/virtual_disk/disk_base.py
+++ b/provider/virtual_disk/disk_base.py
@@ -121,9 +121,9 @@ class DiskBase(object):
             disk_dict.update({'source': {'attrs': {'file': new_image_path}}})
 
         elif disk_type == 'rbd_with_auth':
-            no_secret = kwargs.get("no_secret")
-            if no_secret:
-                disk_dict.update({'source': {'attrs': {'file': new_image_path}}})
+            no_update_dict = kwargs.get("no_update_dict")
+            if no_update_dict:
+                pass
             else:
                 mon_host, auth_username, _ = \
                     self.create_rbd_disk_path(self.params)
@@ -322,10 +322,11 @@ class DiskBase(object):
             {'keyfile': ceph.create_keyring_file(client_name, auth_key)})
 
         process.run("mkdir %s" % (self.base_dir + "/c"))
-        origin_image = self.base_dir + '/c/c'
-        cmd = "qemu-img create -f qcow2 -F raw -o " \
-              "backing_file=rbd:%s:mon_host=%s %s" % (new_image_path,
-                                                      mon_host, origin_image)
+        cmd = "cd %s && qemu-img create -f qcow2 -F raw -o " \
+              "backing_file=rbd:%s:mon_host=%s %s" % (self.base_dir+"/c",
+                                                      new_image_path,
+                                                      mon_host, "c")
+        origin_image = "../c/c"
         process.run(cmd, ignore_status=False, shell=True)
 
         return origin_image


### PR DESCRIPTION
    VIRT-294062: Do blockpull with --keep-relative and relative path continuously
Signed-off-by: nanli <nanli@redhat.com>

**Test result:**

```
/usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockpull.relative_path
 (1/3) type_specific.io-github-autotest-libvirt.backingchain.blockpull.relative_path.file_disk.keep_relative.inactive: PASS (14.69 s)
 (2/3) type_specific.io-github-autotest-libvirt.backingchain.blockpull.relative_path.block_disk.keep_relative.inactive: PASS (36.06 s)
 (3/3) type_specific.io-github-autotest-libvirt.backingchain.blockpull.relative_path.rbd_with_auth_disk.keep_relative.inactive: ERROR: Command '/usr/bin/virsh -k0 blockpull avocado-vt-vm1 vdb  --base /var/lib/libvirt/images/c/c --wait --verbose --keep-relative' failed.\nstdout: b'\n'\nstderr: b"error: Requested operation is not valid: can't keep relative backing relationship\n"\nadditional_... (14.42 s)
```

