### PR TITLE
Remove allow_output_check option

### DIFF
--- a/libvirt/tests/src/multifunction.py
+++ b/libvirt/tests/src/multifunction.py
@@ -175,7 +175,7 @@ def attach_additional_device(vm_name, disksize, targetdev, params):
     logging.info("Attaching disk...")
     disk_path = os.path.join(data_dir.get_tmp_dir(), targetdev)
     cmd = "qemu-img create %s %s" % (disk_path, disksize)
-    ret = process.run(cmd, shell=True, allow_output_check='combined')
+    ret = process.run(cmd, shell=True)
     status, output = ret.exit_status, ret.stdout_text.strip()
     if status:
         return (False, output)


### PR DESCRIPTION
This option is removed in beee20f45cbe63b9a6c70a344c1b13097243151d and not work.

Current multifunction test script specifies allow_output_check argument for avocado.utils.process.run() function.
However, this argument was removed in the following patch. So the script always errors because of the type mismatch.
