### PR TITLE
Multifunction: Avoid GC for the diskxml object

### DIFF
--- a/libvirt/tests/src/multifunction.py
+++ b/libvirt/tests/src/multifunction.py
@@ -175,7 +175,7 @@ def attach_additional_device(vm_name, disksize, targetdev, params):
     logging.info("Attaching disk...")
     disk_path = os.path.join(data_dir.get_tmp_dir(), targetdev)
     cmd = "qemu-img create %s %s" % (disk_path, disksize)
-    ret = process.run(cmd, shell=True, allow_output_check='combined')
+    ret = process.run(cmd, shell=True)
     status, output = ret.exit_status, ret.stdout_text.strip()
     if status:
         return (False, output)

--- a/libvirt/tests/src/multifunction.py
+++ b/libvirt/tests/src/multifunction.py
@@ -151,7 +151,7 @@ def create_disk_xml(params):
     diskxml.target = {'dev': target_dev, 'bus': target_bus}
     diskxml.address = diskxml.new_disk_address(addr_type, attrs=addr_attr)
     logging.debug("Disk XML:\n%s", str(diskxml))
-    return diskxml.xml
+    return diskxml
 
 
 def device_exists(vm, target_dev):
@@ -185,12 +185,12 @@ def attach_additional_device(vm_name, disksize, targetdev, params):
     params['target_dev'] = targetdev
 
     # Create a file of device
-    xmlfile = create_disk_xml(params)
+    xmlobj = create_disk_xml(params)
 
     # To confirm attached device do not exist.
     virsh.detach_disk(vm_name, targetdev, extra="--config")
 
-    return virsh.attach_device(vm_name, xmlfile,
+    return virsh.attach_device(vm_name, xmlobj.xml,
                                flagstr="--config", debug=True)
 
 


### PR DESCRIPTION
The XML file to attach a disk is managed by the object named "diskxml" in
create_disk_xml function. But this function returns only diskxml.xml member,
it is a mere a string. So, the diskxml object lose its reference after
the function returning the value.
Because of this, diskxml object may be destroyed by the python gabage
collection.

If the diskxml object is destroyed, it removes related XML files in
its finalizer. It causes test failure with "No such file or directory"
error when it executes virsh attach-device command.

Before the fix:
```
(06/26) type_specific.io-github-autotest-libvirt.multifunction.set_type_pci.set_multifunction_on.single_device.function_0:  FAIL: Attach device vdb failed. (3.78 s)
```
After the fix:
```
(06/26) type_specific.io-github-autotest-libvirt.multifunction.set_type_pci.set_multifunction_on.single_device.function_0:  PASS (22.68 s)
```

This PR includes fix in https://github.com/autotest/tp-libvirt/pull/4462