### PR TITLE
Automate test case:resize a block size

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockresize.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_blockresize.cfg
@@ -33,7 +33,12 @@
                     resize_value = "1m"
                 - gigabyte:
                     resize_value = "1g"
-
+                - B900:
+                    resize_value = "900B"
+                    only raw_type
+                - B600:
+                    resize_value = "600B"
+                    only raw_type
         - error_test:
             status_error = "yes"
             variants:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockresize.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockresize.py
@@ -1,3 +1,4 @@
+import math
 import os
 import re
 import logging as log
@@ -142,6 +143,9 @@ def run(test, params, env):
             value_return_by_qemu_img = re.search(r'virtual size:\s+(\d+(\.\d+)?)+\s?G', output).group(1)
             if value != int(float(value_return_by_qemu_img)):
                 test.fail("initial image size in config is not equals to value returned by qemu-img info")
+        elif resize_value[-1] == "B":
+            value = int(resize_value[:-1]) / 1000
+            expected_size = math.ceil(value) * 1024
         else:
             test.error("Unknown scale value")
 


### PR DESCRIPTION
Resize a block size to a value that's not a multiple of 1024,
and actual size need align with a multiple of 1024

Signed-off-by: chunfuwen <chwen@redhat.com>
