### PR TITLE
bios: Boot order for OVMF guest with dev=hd

### DIFF
--- a/libvirt/tests/cfg/bios/boot_order_ovmf.cfg
+++ b/libvirt/tests/cfg/bios/boot_order_ovmf.cfg
@@ -8,16 +8,37 @@
     start_vm = "no"
     only x86_64
     variants:
-        - bootable_first:
+        - boot_dev:
+            xml_boot_in_os = "yes"
+            target_bus = "sata"
+            target_dev = "sda"
             variants:
-                - boot_order_element:
+                - hd_dev:
+                    boot_dev = "hd"
+                    image_size = "1G"
+        - boot_order:
+            xml_boot_in_os = "no"
+            variants:
+                - file_disk:
+    variants:
+        - positive_test:
+            status_error = "no"
+            variants:
+                - bootable_dev:
                     use_bootable_dev = "yes"
                     boot_order_bootable_first = "yes"
                     target_dev = "sda"
-        - bootable_second:
-            variants:
-                - boot_order_element:
+                - unbootable_dev_first:
+                    only boot_dev
                     use_unbootable_dev_first = "yes"
                     boot_order_bootable_first = "no"
                     unbootable_target_dev = "sda"
                     target_dev = "sdb"
+        - negative_test:
+            status_error = "yes"
+            variants:
+                - no_dev:
+                    only boot_dev
+                - unbootable_dev:
+                    only boot_dev
+                    use_unbootable_dev = "yes"


### PR DESCRIPTION
This PR adds script for automating VIRT-45958. It checks boot
element in <os> part of VMXML. The device is always hd.

```
avocado run --vt-type libvirt boot_order_ovmf..boot_dev
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : 9bf86fd8dcf208a7a4ec64da4b827d507a6c4c6c
JOB LOG    : /var/lib/avocado/job-results/job-2022-08-31T08.48-9bf86fd/job.log
 (1/4) type_specific.io-github-autotest-libvirt.boot_order_ovmf.positive_test.bootable_dev.boot_dev.hd_dev: STARTED
 (1/4) type_specific.io-github-autotest-libvirt.boot_order_ovmf.positive_test.bootable_dev.boot_dev.hd_dev: PASS (75.95 s)
 (2/4) type_specific.io-github-autotest-libvirt.boot_order_ovmf.positive_test.unbootable_dev_first.boot_dev.hd_dev: STARTED
 (2/4) type_specific.io-github-autotest-libvirt.boot_order_ovmf.positive_test.unbootable_dev_first.boot_dev.hd_dev: FAIL: Test fail: Login timeout expired    (output: 'exceeded 240 s timeout') (302.26 s)
 (3/4) type_specific.io-github-autotest-libvirt.boot_order_ovmf.negative_test.no_dev.boot_dev.hd_dev: STARTED
 (3/4) type_specific.io-github-autotest-libvirt.boot_order_ovmf.negative_test.no_dev.boot_dev.hd_dev: PASS (274.76 s)
 (4/4) type_specific.io-github-autotest-libvirt.boot_order_ovmf.negative_test.unbootable_dev.boot_dev.hd_dev: STARTED
 (4/4) type_specific.io-github-autotest-libvirt.boot_order_ovmf.negative_test.unbootable_dev.boot_dev.hd_dev: PASS (293.64 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-08-31T08.48-9bf86fd/results.html
JOB TIME   : 950.20 s
```

# Check lists by category
## If the PR is new cases
- [x] Description of the cases
- [x] Links of libvirt features, libvirt bugs or case IDs
- [x] Test results