### PR TITLE
migration: Set migration speed to more low value

### DIFF
--- a/libvirt/tests/cfg/migration/memory_copy_mode/migration_memory_copy_mode_postcopy.cfg
+++ b/libvirt/tests/cfg/migration/memory_copy_mode/migration_memory_copy_mode_postcopy.cfg
@@ -28,7 +28,6 @@
     virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
     stress_package = "stress"
     stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20s"
-
     variants:
         - p2p:
             virsh_migrate_options = '--live --p2p --verbose'

--- a/libvirt/tests/cfg/migration/memory_copy_mode/migration_memory_copy_mode_precopy.cfg
+++ b/libvirt/tests/cfg/migration/memory_copy_mode/migration_memory_copy_mode_precopy.cfg
@@ -29,10 +29,13 @@
 
     variants test_case:
         - default:
-            migrate_speed = "20"
+            migrate_speed = "10"
+            stress_package = "stress"
+            stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20s"
             port_to_check = "16509"
             check_local_port = "yes"
-            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: \'1\'", "func_param": "params"}]'
+            migrate_speed_high = '8796093022207'
+            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: \'1\'", "func_param": "params"}, {"func": "set_migrate_speed_to_high", "func_param": "params"}]'
             variants:
                 - p2p:
                     service_to_check = "virtqemud"

--- a/libvirt/tests/cfg/migration/migration_efficiency/migration_zerocopy.cfg
+++ b/libvirt/tests/cfg/migration/migration_efficiency/migration_zerocopy.cfg
@@ -31,8 +31,11 @@
     libvirtd_debug_filters = "1:*"
     check_str_local_log = '"capability":"zero-copy-send","state":true'
     func_supported_since_libvirt_ver = (8, 0, 0)
-    action_during_mig = '[{"func": "check_qemu_mem_lock_hard_limit", "after_event": "iteration: '1'", "func_param": 'params'}]'
-
+    action_during_mig = '[{"func": "check_qemu_mem_lock_hard_limit", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "set_migrate_speed_to_high", "func_param": "params"}]'
+    migrate_speed_high = '8796093022207'
+    migrate_speed = "5"
+    stress_package = "stress"
+    stress_args = "--cpu 8 --io 8 --vm 4 --vm-bytes 128M --timeout 20s"
     variants:
         - p2p:
             virsh_migrate_options = '--live --p2p --verbose'
@@ -40,10 +43,7 @@
             virsh_migrate_options = '--live --verbose'
     variants:
         - with_precopy:
-            migrate_speed = "5"
         - with_postcopy:
-            stress_package = "stress"
-            stress_args = "--cpu 8 --io 8 --vm 4 --vm-bytes 128M --timeout 20s"
             postcopy_options = '--postcopy --timeout 10 --timeout-postcopy'
     variants:
         - with_memtune:

--- a/libvirt/tests/cfg/migration/migration_efficiency/migration_zerocopy_abort.cfg
+++ b/libvirt/tests/cfg/migration/migration_efficiency/migration_zerocopy_abort.cfg
@@ -30,7 +30,9 @@
     status_error = "yes"
     migrate_again = "yes"
     migrate_again_status_error = "no"
-
+    migrate_speed = "5"
+    stress_package = "stress"
+    stress_args = "--cpu 8 --io 8 --vm 4 --vm-bytes 256M --timeout 20s"
     variants:
         - p2p:
             virsh_migrate_options = '--live --p2p --verbose'
@@ -38,10 +40,7 @@
             virsh_migrate_options = '--live --verbose'
     variants:
         - with_precopy:
-            migrate_speed = "5"
         - with_postcopy:
-            stress_package = "stress"
-            stress_args = "--cpu 8 --io 8 --vm 4 --vm-bytes 256M --timeout 20s"
             postcopy_options = '--postcopy --timeout 10 --timeout-postcopy'
     variants test_case:
         - with_memtune:

--- a/libvirt/tests/cfg/migration/migration_efficiency/migration_zerocopy_unsupported_feature_combinations.cfg
+++ b/libvirt/tests/cfg/migration/migration_efficiency/migration_zerocopy_unsupported_feature_combinations.cfg
@@ -27,7 +27,6 @@
     migrate_desturi_type = "tcp"
     virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
     func_supported_since_libvirt_ver = (8, 0, 0)
-
     variants:
         - p2p:
             virsh_migrate_options = '--live --p2p --verbose'

--- a/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_tcp.cfg
+++ b/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_tcp.cfg
@@ -27,7 +27,9 @@
     migrate_desturi_type = "tcp"
     virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
     qemu_conf_path = "/etc/libvirt/qemu.conf"
-
+    migrate_speed = "10"
+    stress_package = "stress"
+    stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20s"
     variants:
         - p2p:
             virsh_migrate_options = '--live --p2p --verbose'
@@ -35,17 +37,14 @@
             virsh_migrate_options = '--live --verbose'
     variants:
         - with_precopy:
-            migrate_speed = "10"
         - with_postcopy:
-            stress_package = "stress"
-            stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20s"
             postcopy_options = '--postcopy --timeout 10 --timeout-postcopy'
     variants test_case:
         - default:
-            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: \'1\'", "func_param": "params"}]'
+            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: \'1\'", "func_param": "params"}, {"func": "set_migrate_speed_to_high", "func_param": "params"}]'
         - migration_host:
             no with_postcopy
-            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}]'
+            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "set_migrate_speed_to_high", "func_param": "params"}]'
             ipv6_addr_des = "ENTER.YOUR.IPv6.DESTINATION"
             server_cn = "ENTER.YOUR.EXAMPLE.SERVER_CN"
             variants:

--- a/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_tcp_listen_address.cfg
+++ b/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_tcp_listen_address.cfg
@@ -28,7 +28,8 @@
     virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
     migrate_speed = "8"
     ipv6_addr_des = "ENTER.YOUR.IPv6.DESTINATION"
-
+    stress_package = "stress"
+    stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20s"
     variants:
         - p2p:
             virsh_migrate_options = '--live --p2p --verbose'
@@ -37,7 +38,7 @@
     variants:
         - migrateuri_ipv4_and_listen_address_ipv4:
             virsh_migrate_extra = "--migrateuri tcp://${migrate_dest_host} --listen-address ${migrate_dest_host}"
-            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: \'1\'", "func_param": "params"}]'
+            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: \'1\'", "func_param": "params"}, {"func": "set_migrate_speed_to_high", "func_param": "params"}]'
         - migrateuri_ipv4_and_listen_address_ipv6:
             ipv6_config = "yes"
             status_error = "yes"
@@ -45,17 +46,17 @@
             virsh_migrate_extra = "--migrateuri tcp://${migrate_dest_host} --listen-address [${ipv6_addr_des}]"
         - migrateuri_ipv6_and_listen_address_ipv6:
             ipv6_config = "yes"
-            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: \'1\'", "func_param": "params"}]'
+            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: \'1\'", "func_param": "params"}, {"func": "set_migrate_speed_to_high", "func_param": "params"}]'
             virsh_migrate_extra = "--migrateuri tcp://[${ipv6_addr_des}] --listen-address [${ipv6_addr_des}]"
         - migrateuri_ipv4_and_listen_address_all_ipv6:
-            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: \'1\'", "func_param": "params"}]'
+            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: \'1\'", "func_param": "params"}, {"func": "set_migrate_speed_to_high", "func_param": "params"}]'
             virsh_migrate_extra = "--migrateuri tcp://${migrate_dest_host} --listen-address ::"
         - migrateuri_ipv6_and_listen_address_all_ipv6:
             ipv6_config = "yes"
-            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: \'1\'", "func_param": "params"}]'
+            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: \'1\'", "func_param": "params"}, {"func": "set_migrate_speed_to_high", "func_param": "params"}]'
             virsh_migrate_extra = "--migrateuri tcp://[${ipv6_addr_des}] --listen-address ::"
         - migrateuri_ipv4_and_listen_address_all_ipv4:
-            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: \'1\'", "func_param": "params"}]'
+            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: \'1\'", "func_param": "params"}, {"func": "set_migrate_speed_to_high", "func_param": "params"}]'
             virsh_migrate_extra = "--migrateuri tcp://${migrate_dest_host} --listen-address 0.0.0.0"
         - migrateuri_ipv6_and_listen_address_all_ipv4:
             status_error = "yes"

--- a/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_tcp_migrateuri.cfg
+++ b/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_tcp_migrateuri.cfg
@@ -27,7 +27,8 @@
     migrate_desturi_type = "tcp"
     virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
     migrate_speed = "5"
-
+    stress_package = "stress"
+    stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20s"
     variants:
         - p2p:
             virsh_migrate_options = '--live --p2p --verbose'
@@ -35,21 +36,21 @@
             virsh_migrate_options = '--live --verbose'
     variants:
         - dest_host_ipv4:
-            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}]'
+            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "set_migrate_speed_to_high", "func_param": "params"}]'
             virsh_migrate_extra = "--migrateuri tcp://${migrate_dest_host}"
         - dest_host_ipv6:
             ipv6_config = "yes"
             ipv6_addr_des = "ENTER.YOUR.IPv6.DESTINATION"
-            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}]'
+            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "set_migrate_speed_to_high", "func_param": "params"}]'
             virsh_migrate_extra = "--migrateuri tcp://[${ipv6_addr_des}]"
         - dest_host_ipv4_with_port:
-            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}]'
+            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "set_migrate_speed_to_high", "func_param": "params"}]'
             port_to_check = "49158"
             virsh_migrate_extra = "--migrateuri tcp://${migrate_dest_host}:${port_to_check}"
         - dest_host_ipv6_with_port:
             ipv6_config = "yes"
             ipv6_addr_des = "ENTER.YOUR.IPv6.DESTINATION"
-            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}]'
+            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "set_migrate_speed_to_high", "func_param": "params"}]'
             port_to_check = "49158"
             virsh_migrate_extra = "--migrateuri tcp://[${ipv6_addr_des}]:${port_to_check}"
         - invalid_ip_addr:

--- a/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_tls.cfg
+++ b/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_tls.cfg
@@ -28,6 +28,9 @@
     virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
     enable_libvirtd_debug_log = "no"
     transport_type = "tls"
+    migrate_speed = "10"
+    stress_package = "stress"
+    stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20s"
     variants:
         - p2p:
             virsh_migrate_options = '--live --p2p --verbose'
@@ -35,10 +38,7 @@
             virsh_migrate_options = '--live --verbose'
     variants:
         - with_precopy:
-            migrate_speed = "10"
         - with_postcopy:
-            stress_package = "stress"
-            stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20s"
             postcopy_options = '--postcopy --timeout 10 --timeout-postcopy'
     variants test_case:
         - default:
@@ -53,7 +53,7 @@
             libvirtd_debug_filters = "1:*"
             check_str_local_log = '"dir":"/etc/pki/qemu","endpoint":"client","verify-peer":true'
             check_str_remote_log = '"dir":"/etc/pki/qemu","endpoint":"server","verify-peer":true'
-            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: \'1\'", "func_param": "params"}]'
+            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: \'1\'", "func_param": "params"}, {"func": "set_migrate_speed_to_high", "func_param": "params"}]'
         - tls_destination:
             no with_postcopy
             custom_pki_path = "/etc/pki/qemu"

--- a/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_tunnelled.cfg
+++ b/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_tunnelled.cfg
@@ -21,12 +21,13 @@
     server_pwd = "${migrate_dest_pwd}"
     status_error = "no"
     check_network_accessibility_after_mig = "yes"
-    migrate_speed = "20"
+    migrate_speed = "10"
     virsh_migrate_options = '--live --p2p --verbose'
-    action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: \'1\'", "func_param": "params"}]'
+    action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: \'1\'", "func_param": "params"}, {"func": "set_migrate_speed_to_high", "func_param": "params"}]'
     virsh_migrate_extra = "--tunnelled"
     expected_network_conn_num = "0"
-
+    stress_package = "stress"
+    stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20s"
     variants desturi_protocol:
         - desturi_tls:
             migrate_desturi_port = "16514"

--- a/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_unix_proxy.cfg
+++ b/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_unix_proxy.cfg
@@ -21,7 +21,9 @@
     server_pwd = "${migrate_dest_pwd}"
     status_error = "no"
     check_network_accessibility_after_mig = "yes"
-
+    migrate_speed = "10"
+    stress_package = "stress"
+    stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20s"
     variants:
         - p2p:
             virsh_migrate_options = '--live --p2p --verbose'
@@ -29,10 +31,7 @@
             virsh_migrate_options = '--live --verbose'
     variants:
         - with_precopy:
-            migrate_speed = "10"
         - with_postcopy:
-            stress_package = "stress"
-            stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20s"
             postcopy_options = '--postcopy --timeout 10 --timeout-postcopy'
     variants test_case:
         - default:
@@ -49,4 +48,4 @@
             check_socket_num = "yes"
             expected_socket_num = "2"
             check_port_or_network_conn_num = "no"
-            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: \'1\'", "func_param": 'params'}]'
+            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: \'1\'", "func_param": 'params'}, {"func": "set_migrate_speed_to_high", "func_param": "params"}]'

--- a/provider/migration/migration_base.py
+++ b/provider/migration/migration_base.py
@@ -236,10 +236,10 @@ def set_migrate_speed_to_high(params):
     :param params: dict, used to setup the connection
     """
     vm_name = params.get("migrate_main_vm")
-    migrate_speed_high = params.get("migrate_speed_high")
+    migrate_speed_high = params.get("migrate_speed_high", "8796093022207")
     postcopy_options = params.get("postcopy_options")
 
-    mode = 'both' if '--postcopy' in postcopy_options else 'precopy'
+    mode = 'both' if postcopy_options else 'precopy'
     MigrationTest().control_migrate_speed(vm_name, int(migrate_speed_high), mode)
 
 


### PR DESCRIPTION
If migration finish too fast, we cann't check port and ip during
 migration. So update migration speed.
