### PR TITLE
guestfs_add: Add a trailing newline when retreive contents

### DIFF
--- a/libguestfs/tests/guestfs_add.py
+++ b/libguestfs/tests/guestfs_add.py
@@ -190,7 +190,7 @@ def run(test, params, env):
             session = vm.wait_for_login()
             session.cmd("mount %s /mnt" % root)
             try:
-                login_wrote_text = session.cmd_output("cat /mnt/guestfs_temp",
+                login_wrote_text = session.cmd_output("cat /mnt/guestfs_temp; echo",
                                                       timeout=5)
             except aexpect.ShellTimeoutError as detail:
                 # written content with guestfs.write won't contain line break


### PR DESCRIPTION
The cmd_output function in aexpect module trim the last line because it
includes shell prompt.
https://github.com/avocado-framework/aexpect/blob/master/aexpect/client.py#L1202

In this test, the content of guestfs_temp has only one line and it doesn't
include newline at the end. So, the cat output is followed by the next
prompt in one line and trimmed in remove_last_nonempty_line function.
Because of this, the file content seems to be empty and test fails.

This patch adds additional newline after the cat command so that the
contents of the file is not trimmed by the remove_last_nonempty_line
function.

Before the fix:
`(25/32) type_specific.io-github-autotest-libvirt.guestfs_add.normal_test.add_disk:  FAIL: {'write_content': 'Write content to file successfully.', 'cat_writed': 'Cat content of file successfully.', 'login_to_check': 'Login to check failed:'} (27.64 s)`

After the fix:
` (25/32) type_specific.io-github-autotest-libvirt.guestfs_add.normal_test.add_disk:  PASS (26.57 s)`
