### PR TITLE
guestfs_block_operations/guestfs_volume_operations: Fix argument for function calls

### DIFF
--- a/libguestfs/tests/guestfs_block_operations.py
+++ b/libguestfs/tests/guestfs_block_operations.py
@@ -170,7 +170,7 @@ def test_blockdev_ro(test, vm, params):
     params['libvirt_domain'] = vt.newvm.name
     params['gf_inspector'] = True
     gf = utils_test.libguestfs.GuestfishTools(params)
-    part_num = prepare_attached_device(gf, device_in_gf)
+    part_num = prepare_attached_device(test, gf, device_in_gf)
     part_name = "%s%s" % (device_in_gf, part_num)
 
     mkfs_result = gf.mkfs("ext3", part_name)
@@ -261,7 +261,7 @@ def test_blockdev_rw(test, vm, params):
     params['libvirt_domain'] = vt.newvm.name
     params['gf_inspector'] = True
     gf = utils_test.libguestfs.GuestfishTools(params)
-    part_num = prepare_attached_device(gf, device_in_gf)
+    part_num = prepare_attached_device(test, gf, device_in_gf)
     part_name = "%s%s" % (device_in_gf, part_num)
     part_name_in_vm = "%s%s" % (device_in_vm, part_num)
 

--- a/libguestfs/tests/guestfs_volume_operations.py
+++ b/libguestfs/tests/guestfs_volume_operations.py
@@ -126,7 +126,7 @@ def test_rename_vol_group(test, vm, params):
     params['libvirt_domain'] = vt.newvm.name
     params['gf_inspector'] = True
     gf = utils_test.libguestfs.GuestfishTools(params)
-    part_name = prepare_attached_device(gf, device_in_gf)
+    part_name = prepare_attached_device(test, gf, device_in_gf)
 
     groupname = params.get("gf_volume_group_name", "VolGroupTest")
     vgcreate_result = gf.vgcreate(groupname, part_name)
@@ -204,7 +204,7 @@ def test_remove_vol_group(test, vm, params):
     params['libvirt_domain'] = vt.newvm.name
     params['gf_inspector'] = True
     gf = utils_test.libguestfs.GuestfishTools(params)
-    part_name = prepare_attached_device(gf, device_in_gf)
+    part_name = prepare_attached_device(test, gf, device_in_gf)
 
     groupname = params.get("gf_volume_group_name", "VolGroupTest")
     vgcreate_result = gf.vgcreate(groupname, part_name)
@@ -265,7 +265,7 @@ def test_create_volume(test, vm, params):
     params['libvirt_domain'] = vt.newvm.name
     params['gf_inspector'] = True
     gf = utils_test.libguestfs.GuestfishTools(params)
-    part_name = prepare_attached_device(gf, device_in_gf)
+    part_name = prepare_attached_device(test, gf, device_in_gf)
 
     groupname = params.get("gf_volume_group_name", "VolGroupTest")
     vgcreate_result = gf.vgcreate(groupname, part_name)
@@ -369,7 +369,7 @@ def test_delete_volume(test, vm, params):
     params['libvirt_domain'] = vt.newvm.name
     params['gf_inspector'] = True
     gf = utils_test.libguestfs.GuestfishTools(params)
-    part_name = prepare_attached_device(gf, device_in_gf)
+    part_name = prepare_attached_device(test, gf, device_in_gf)
 
     groupname = params.get("gf_volume_group_name", "VolGroupTest")
     vgcreate_result = gf.vgcreate(groupname, part_name)
@@ -453,7 +453,7 @@ def test_shrink_volume(test, vm, params):
     params['libvirt_domain'] = vt.newvm.name
     params['gf_inspector'] = True
     gf = utils_test.libguestfs.GuestfishTools(params)
-    part_name = prepare_attached_device(gf, device_in_gf)
+    part_name = prepare_attached_device(test, gf, device_in_gf)
 
     groupname = params.get("gf_volume_group_name", "VolGroupTest")
     vgcreate_result = gf.vgcreate(groupname, part_name)
@@ -606,7 +606,7 @@ def test_expand_volume(test, vm, params):
     params['libvirt_domain'] = vt.newvm.name
     params['gf_inspector'] = True
     gf = utils_test.libguestfs.GuestfishTools(params)
-    part_name = prepare_attached_device(gf, device_in_gf)
+    part_name = prepare_attached_device(test, gf, device_in_gf)
 
     groupname = params.get("gf_volume_group_name", "VolGroupTest")
     vgcreate_result = gf.vgcreate(groupname, part_name)

--- a/libguestfs/tests/guestfs_volume_operations.py
+++ b/libguestfs/tests/guestfs_volume_operations.py
@@ -530,7 +530,7 @@ def test_shrink_volume(test, vm, params):
             if not re.search(mountpoint, str(output)):
                 raise utils_test.libguestfs.VTMountError("df", output)
         output = session.cmd_output("dd if=/dev/zero of=%s bs=1M "
-                                    "count=%s" % (file_path, dd_size1),
+                                    "count=%s" % (file_path, int(dd_size1)),
                                     timeout=5)
         logging.debug(output)
         md51 = session.cmd_output("md5sum %s" % file_path)
@@ -682,7 +682,7 @@ def test_expand_volume(test, vm, params):
             if not re.search(mountpoint, str(output)):
                 raise utils_test.libguestfs.VTMountError("df", output)
         output = session.cmd_output("dd if=/dev/zero of=%s bs=1M "
-                                    "count=%s" % (file_path, dd_size1),
+                                    "count=%s" % (file_path, int(dd_size1)),
                                     timeout=5)
         logging.debug(output)
         md51 = session.cmd_output("md5sum %s" % file_path)


### PR DESCRIPTION
Includes two patches for guestfs_block_operations and guestfs_volume_operations test.

**guestfs_block_operations/guestfs_volume_operations: Fix argument for function call**

In guestfs_block_operations and guestfs_volume_operations, 
prepare_attached_device function requires three arguments.
However, in some line, it is called with only two arguments.
It causes TypeError during the test.

**guestfs_volume_operations: Cast dd size to integer**

`dd_size1` is a float value because it is calicurated as `int(volumesize) / 2`, 
for example "25.0". Such value is not acceptable for dd command.
Cast to integer is needed.


Before the patch `guestfs_block_operations/guestfs_volume_operations: Fix argument for function call`:
```
 (10/32) type_specific.io-github-autotest-libvirt.guestfs_block_operations.blockdev_ro:  ERROR: prepare_attached_device() missing 1 required positional argument: 'device' (113.54 s)
...
 (28/32) type_specific.io-github-autotest-libvirt.guestfs_volume_operations.create_volume:  ERROR: prepare_attached_device() missing 1 required positional argument: 'device' (113.61 s)
...
 (30/32) type_specific.io-github-autotest-libvirt.guestfs_volume_operations.expand_volume:  ERROR: prepare_attached_device() missing 1 required positional argument: 'device' (113.78 s)
```

Before the patch `guestfs_volume_operations: Cast dd size to integer`:
```
 (30/32) type_specific.io-github-autotest-libvirt.guestfs_volume_operations.expand_volume:  FAIL: Get md5 failed. (48.62 s)

(session-log)
2022-08-31 16:41:55: [root@avocado-vt-guestfish ~]#
2022-08-31 16:41:55: dd: invalid number: 25.0
2022-08-31 16:41:55: [root@avocado-vt-guestfish ~]#
2022-08-31 16:41:56: md5sum: /mnt/test_expand_volume.img: No such file or directory
```

After the both patch:
```
 (10/32) type_specific.io-github-autotest-libvirt.guestfs_block_operations.blockdev_ro:  PASS (25.53 s)
...
 (28/32) type_specific.io-github-autotest-libvirt.guestfs_volume_operations.create_volume:  PASS (43.84 s)
...
 (30/32) type_specific.io-github-autotest-libvirt.guestfs_volume_operations.expand_volume:  PASS (47.42 s)
```
