### PR TITLE
sriov: Add a plug_unplug case

### DIFF
--- a/libvirt/tests/cfg/sriov/plug_unplug/sriov_attach_detach_device_after_restarting_service.cfg
+++ b/libvirt/tests/cfg/sriov/plug_unplug/sriov_attach_detach_device_after_restarting_service.cfg
@@ -1,0 +1,14 @@
+- sriov.plug_unplug.attach_detach_device_after_restarting_service:
+    type = sriov_attach_detach_device_after_restarting_service
+    start_vm = "no"
+    network_dict = {'forward': {'mode': 'hostdev', 'managed': 'yes'}, 'name': 'hostnet', 'vf_list': [{'type_name': 'pci', 'attrs': vf_pci_addr}, {'type_name': 'pci', 'attrs': vf_pci_addr2}], 'uuid': 'e6ddbb96-5be5-494d-92f0-f7473e185876'}
+    pre_iface_dict = {'type_name': 'network', 'source': {'network': 'hostnet'}}
+
+    only x86_64
+    variants dev_type:
+        - hostdev_interface:
+            iface_dict = {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr2}, 'driver': {'driver_attr': {'name': 'vfio'}}, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}, 'mac_address': mac_addr}
+        - hostdev_device:
+            hostdev_dict = {'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': vf_pci_addr2}, 'managed': 'yes'}
+        - network_interface:
+            iface_dict = {'type_name': 'network', 'source': {'network': 'hostnet'}, 'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}

--- a/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_device_after_restarting_service.py
+++ b/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_device_after_restarting_service.py
@@ -1,0 +1,58 @@
+from provider.sriov import sriov_base
+
+from virttest import utils_libvirtd
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+
+
+def run(test, params, env):
+    """
+    Add one more hostdev interface/device after restarting libvirtd
+    """
+    def setup_test():
+        """
+        Setup test
+        """
+        sriov_test_obj.setup_default(network_dict=network_dict)
+        test.log.info("TEST_SETUP: Start a vm with an interface, pointing to a "
+                      "hostdev network.")
+        libvirt_vmxml.modify_vm_device(
+            vm_xml.VMXML.new_from_inactive_dumpxml(vm_name),
+            'interface', pre_iface_dict)
+        vm.start()
+        vm.wait_for_serial_login(timeout=240).close()
+
+    def run_test():
+        """
+        Add one more hostdev interface/device after restarting libvirtd to
+        a guest with an existing interface(point to a hostdev network)
+        """
+        test.log.info("TEST_STEP1: Restart libvirtd")
+        utils_libvirtd.Libvirtd("virtqemud").restart()
+
+        test.log.info("TEST_STEP2: Attach a hostdev interface/device to VM")
+        iface_dev = sriov_test_obj.create_iface_dev(dev_type, iface_dict)
+        virsh.attach_device(vm.name, iface_dev.xml, debug=True,
+                            ignore_errors=False)
+
+        test.log.info("TEST_STEP3: Detach the hostdev interface/device")
+        virsh.detach_device(vm.name, iface_dev.xml, debug=True,
+                            ignore_errors=False)
+
+    dev_type = params.get("dev_type", "")
+    pre_iface_dict = eval(params.get("pre_iface_dict", "{}"))
+
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    vm = env.get_vm(vm_name)
+    sriov_test_obj = sriov_base.SRIOVTest(vm, test, params)
+
+    iface_dict = sriov_test_obj.parse_iface_dict()
+    network_dict = sriov_test_obj.parse_network_dict()
+    try:
+        setup_test()
+        run_test()
+
+    finally:
+        sriov_test_obj.teardown_default(network_dict=network_dict)

--- a/provider/sriov/sriov_base.py
+++ b/provider/sriov/sriov_base.py
@@ -123,8 +123,11 @@ class SRIOVTest(object):
             self.pf_pci, session=self.session)
         self.vf_pci = utils_sriov.get_vf_pci_id(
             self.pf_pci, session=self.session)
+        self.vf_pci2 = utils_sriov.get_vf_pci_id(
+            self.pf_pci, 1, session=self.session)
         self.pf_pci_addr = utils_sriov.pci_to_addr(self.pf_pci)
         self.vf_pci_addr = utils_sriov.pci_to_addr(self.vf_pci)
+        self.vf_pci_addr2 = utils_sriov.pci_to_addr(self.vf_pci2)
         self.pf_name = self.pf_info.get('iface')
         self.vf_name = utils_sriov.get_iface_name(
             self.vf_pci, session=self.session)
@@ -149,6 +152,7 @@ class SRIOVTest(object):
         mac_addr = utils_net.generate_mac_address_simple()
         pf_pci_addr = self.pf_pci_addr
         vf_pci_addr = self.vf_pci_addr
+        vf_pci_addr2 = self.vf_pci_addr2
         pf_name = self.pf_name
         vf_name = self.vf_name
         if self.params.get('iface_dict'):
@@ -158,6 +162,8 @@ class SRIOVTest(object):
                 del pf_pci_addr['type']
             if vf_pci_addr.get('type'):
                 del vf_pci_addr['type']
+            if vf_pci_addr2.get('type'):
+                del vf_pci_addr2['type']
             iface_dict = eval(self.params.get('hostdev_dict', '{}'))
 
         self.test.log.debug("iface_dict: %s.", iface_dict)
@@ -170,6 +176,7 @@ class SRIOVTest(object):
         :return: The updated network dict
         """
         vf_pci_addr = self.vf_pci_addr
+        vf_pci_addr2 = self.vf_pci_addr2
         pf_name = self.pf_name
         vf_name = self.vf_name
         net_forward_pf = str({'dev': pf_name})


### PR DESCRIPTION
This PR adds:
    VIRT-294721: Add one more hostdev interface/device after
        restarting libvirtd

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Test results:**
```
 (1/3) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_after_restarting_service.hostdev_interface: PASS (57.11 s)
 (2/3) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_after_restarting_service.hostdev_device: PASS (56.89 s)
 (3/3) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_after_restarting_service.network_interface: PASS (57.34 s)

```