### PR TITLE
sriov: Add a case to check various flags

### DIFF
--- a/libvirt/tests/cfg/sriov/plug_unplug/sriov_attach_detach_device_with_flags.cfg
+++ b/libvirt/tests/cfg/sriov/plug_unplug/sriov_attach_detach_device_with_flags.cfg
@@ -1,0 +1,30 @@
+- sriov.plug_unplug.attach_detach_device_with_flags:
+    type = sriov_attach_detach_device_with_flags
+    only x86_64
+
+    variants:
+        - offline_domain:
+            start_vm = 'no'
+        - running_domain:
+            start_vm = 'yes'
+    variants flagstr:
+        - live:
+            expr_active_xml_changes = "yes"
+            offline_domain:
+                status_error = "yes"
+        - current:
+            offline_domain:
+                expr_inactive_xml_changes = "yes"
+            running_domain:
+                 expr_active_xml_changes = "yes"
+        - config:
+            expr_inactive_xml_changes = "yes"
+        - persistent:
+            expr_inactive_xml_changes = "yes"
+            running_domain:
+                expr_active_xml_changes = "yes"
+    variants dev_type:
+        - hostdev_interface:
+            iface_dict = {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}}
+        - hostdev_device:
+            hostdev_dict = {'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': vf_pci_addr}, 'managed': 'yes'}

--- a/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_device_with_flags.py
+++ b/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_device_with_flags.py
@@ -1,0 +1,123 @@
+from provider.sriov import check_points
+from provider.sriov import sriov_base
+
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vfio
+from virttest.utils_test import libvirt
+
+
+def run(test, params, env):
+    """
+    Attach/detach-device a hostdev interface or device with various flags
+    """
+    def get_vm_hostdev(device_type):
+        """
+        Get VM hostdev device/interface
+
+        :param device_type: Device type
+        :return: The first VM hostdev device or interface
+        """
+        try:
+            vm_hostdev = vm_xml.VMXML.new_from_dumpxml(vm.name)\
+                .devices.by_device_tag(device_type)[0]
+        except IndexError:
+            vm_hostdev = vm_xml.VMXML.new_from_inactive_dumpxml(vm.name)\
+                .devices.by_device_tag(device_type)[0]
+        return vm_hostdev
+
+    def check_hostdev_xml(vmxml, device_type, status_error=False):
+        """
+        Check VM hostdev xml info
+
+        :param vmxml: The vmxml object
+        :param device_type: Device type
+        :param status_error: Whether a hostdev interface/device should exist,
+            defaults to False
+        """
+        vm_hostdevs = vmxml.devices.by_device_tag(device_type)
+        if status_error != (len(vm_hostdevs) == 1):
+            test.fail("Got incorrect hostdev device/interface number: %d!"
+                      % len(vm_hostdevs))
+        if status_error:
+            vm_hostdev_dict = vm_hostdevs[0].fetch_attrs()
+            test.log.debug("hostdev device/interface: %s", vm_hostdev_dict)
+            if vm_hostdev_dict.get('driver'):
+                if vm_hostdev_dict['driver']['driver_attr']['name'] != 'vfio':
+                    test.fail("The driver name should be 'vfio'!")
+
+    def check_vm_xml(vm, device_type, params, status_error=False):
+        """
+        Check VM xml info
+
+        :param vm: VM object
+        :param device_type: Device type
+        :param params: Dictionary with the test parameters
+        :param status_error: Whether a hostdev interface/device should exist,
+            defaults to False
+        """
+        if params.get('expr_active_xml_changes', 'no') == "yes":
+            test.log.debug("checking active vm xml after attaching hostdev.")
+            check_hostdev_xml(
+                vm_xml.VMXML.new_from_dumpxml(vm.name), device_type, status_error)
+        if params.get('expr_inactive_xml_changes', 'no') == "yes":
+            test.log.debug("checking inactive vm xml after attaching hostdev.")
+            check_hostdev_xml(
+                vm_xml.VMXML.new_from_inactive_dumpxml(vm.name), device_type,
+                status_error)
+
+    def run_test():
+        """
+        Attach/detach-device a hostdev interface or device with
+        various flags(--live/config/persistent/current) for vm states(shutoff,
+        running).
+        """
+        if start_vm and not vm.is_alive():
+            vm.start()
+            vm_session = vm.wait_for_login()
+
+        libvirt_vfio.check_vfio_pci(sriov_test_obj.vf_pci, True)
+
+        test.log.info("TEST_STEP1: Attach a hostdev interface/device to VM")
+        iface_dev = sriov_test_obj.create_iface_dev(dev_type, iface_dict)
+        result = virsh.attach_device(vm.name, iface_dev.xml, flagstr=flagstr,
+                                     debug=True)
+        libvirt.check_exit_status(result, status_error)
+        if status_error:
+            return
+
+        test.log.info("TEST_STEP2: Check VM xml.")
+        check_vm_xml(vm, device_type, params, True)
+        if 'vm_session' in locals():
+            check_points.check_vm_network_accessed(vm_session)
+
+        test.log.info("TEST_STEP3: Detach the hostdev interface/device")
+        vm_hostdev = get_vm_hostdev(device_type)
+        wait_for_event = True if vm.is_alive() and not flagstr.count('config') \
+            else False
+        virsh.detach_device(vm.name, vm_hostdev.xml, debug=True,
+                            flagstr=flagstr, ignore_errors=False,
+                            wait_for_event=wait_for_event, event_timeout=15)
+
+        test.log.info("TEST_STEP4: Check VM xml.")
+        check_vm_xml(vm, device_type, params)
+
+    dev_type = params.get("dev_type", "")
+    flagstr = params.get('flagstr')
+    if flagstr:
+        flagstr = "--%s" % flagstr
+    start_vm = "yes" == params.get("start_vm")
+    status_error = "yes" == params.get("status_error")
+
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    vm = env.get_vm(vm_name)
+    sriov_test_obj = sriov_base.SRIOVTest(vm, test, params)
+
+    iface_dict = sriov_test_obj.parse_iface_dict()
+    device_type = "hostdev" if dev_type == "hostdev_device" else "interface"
+    try:
+        sriov_test_obj.setup_default()
+        run_test()
+    finally:
+        sriov_test_obj.teardown_default()

--- a/provider/sriov/sriov_base.py
+++ b/provider/sriov/sriov_base.py
@@ -240,6 +240,7 @@ class SRIOVTest(object):
         self.test.log.info("TEST_SETUP: Clear up the existing VM "
                            "interface(s) before testing.")
         libvirt_vmxml.remove_vm_devices_by_type(self.vm, 'interface')
+        libvirt_vmxml.remove_vm_devices_by_type(self.vm, 'hostdev')
         if network_dict:
             self.test.log.info("TEST_SETUP: Create new network.")
             libvirt_network.create_or_del_network(network_dict)


### PR DESCRIPTION
This PR adds:
    VIRT-294697 - Attach/detach-device a hostdev interface or device
        with various flags for vm states

Signed-off-by: Yingshun Cui <yicui@redhat.com>

**Test results:**
 (01/16) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_with_flags.hostdev_interface.live.offline_domain: PASS (21.48 s)
 (02/16) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_with_flags.hostdev_interface.live.running_domain: PASS (34.71 s)
 (03/16) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_with_flags.hostdev_interface.current.offline_domain: PASS (22.94 s)
 (04/16) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_with_flags.hostdev_interface.current.running_domain: PASS (34.70 s)
 (05/16) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_with_flags.hostdev_interface.config.offline_domain: PASS (22.68 s)
 (06/16) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_with_flags.hostdev_interface.config.running_domain: PASS (27.03 s)
 (07/16) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_with_flags.hostdev_interface.persistent.offline_domain: PASS (22.87 s)
 (08/16) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_with_flags.hostdev_interface.persistent.running_domain: PASS (35.22 s)
 (09/16) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_with_flags.hostdev_device.live.offline_domain: PASS (21.76 s)
 (10/16) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_with_flags.hostdev_device.live.running_domain: PASS (34.71 s)
 (11/16) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_with_flags.hostdev_device.current.offline_domain: PASS (22.64 s)
 (12/16) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_with_flags.hostdev_device.current.running_domain: PASS (34.60 s)
 (13/16) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_with_flags.hostdev_device.config.offline_domain: PASS (22.77 s)
 (14/16) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_with_flags.hostdev_device.config.running_domain: PASS (27.10 s)
 (15/16) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_with_flags.hostdev_device.persistent.offline_domain: PASS (22.82 s)
 (16/16) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_with_flags.hostdev_device.persistent.running_domain: PASS (35.28 s)
RESULTS    : PASS 16 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-08-31T22.14-ab15863/results.html
