### PR TITLE
libvirtd: Ignore PVR err str for aarch64

### DIFF
--- a/libvirt/tests/cfg/libvirtd/libvirtd.cfg
+++ b/libvirt/tests/cfg/libvirtd/libvirtd.cfg
@@ -7,5 +7,7 @@
         - check_journal:
             error_msg_in_journal = "error|failed"
             error_msg_in_log = "error :"
+            aarch64:
+                ignore_log_err_msg = "Cannot find CPU model with PVR"
             libvirtd_debug_file = '/var/log/libvirt/libvirtd.log'
             libvirtd_debug_level = '1'

--- a/libvirt/tests/src/libvirtd/libvirtd.py
+++ b/libvirt/tests/src/libvirtd/libvirtd.py
@@ -45,6 +45,7 @@ def test_check_journal(libvirtd, params, test):
     libvirtd_debug_file = params.get("libvirtd_debug_file")
     error_msg_in_journal = params.get("error_msg_in_journal")
     error_msg_in_log = params.get("error_msg_in_log")
+    ignore_log_err_msg = params.get("ignore_log_err_msg", "")
 
     utils_libvirtd.Libvirtd("libvirtd-tls.socket").stop()
     utils_libvirtd.Libvirtd("libvirtd-tcp.socket").stop()
@@ -68,7 +69,8 @@ def test_check_journal(libvirtd, params, test):
         logging.info("Not found error message during libvirtd restarting.")
 
     # Check error messages in libvirtd log
-    libvirt.check_logfile(error_msg_in_log, libvirtd_debug_file, False)
+    libvirt.check_logfile(error_msg_in_log, libvirtd_debug_file,
+                          False, ignore_str=ignore_log_err_msg)
 
 
 def run(test, params, env):


### PR DESCRIPTION
The PVR err is output during CPU detection for ARM. Which was caused by the
missing cpu xml in libvirt/src/cpu_map.

CPU detection will (in some cases) report the host CPU in host capabilities,
but that's it. It's not very useful so we could ignore the PVR err.
Otherwise we need to add all arm cpu to libvirt/src/cpu_map.

Ref: https://listman.redhat.com/archives/libvir-list/2022-August/234040.html

Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

