### PR TITLE
virt_sysprep: check ssh v2 public key instead of v1

### DIFF
--- a/libguestfs/tests/virt_sysprep.py
+++ b/libguestfs/tests/virt_sysprep.py
@@ -35,7 +35,7 @@ def run(test, params, env):
             session.cmd("touch /var/mail/tmp")
             tmp_hostname = "%stmp" % sysprep_hostname
             session.cmd("hostname %s" % tmp_hostname)
-            o_ssh = session.cmd_output("cd /etc/ssh && cat ssh_host_key.pub")
+            o_ssh = session.cmd_output("cd /etc/ssh && cat ssh_host_rsa_key.pub")
 
             # Confirm the file/hostname has been created/modified
             log_out = session.cmd_output("cd /var/log/ && ls | grep tmp.log")
@@ -112,7 +112,7 @@ def run(test, params, env):
             log_out = session.cmd_output("cd /var/log/ && ls | grep tmp.log")
             mail_out = session.cmd_output("cd /var/mail && ls | grep tmp")
             hname_out = session.cmd_output("hostname")
-            ssh_out = session.cmd_output("cd /etc/ssh && cat ssh_host_key.pub")
+            ssh_out = session.cmd_output("cd /etc/ssh && cat ssh_host_rsa_key.pub")
             session.close()
             vm.destroy()
             if (log_out.strip() or mail_out.strip() or


### PR DESCRIPTION
"ssh_host_key.pub" is a key file for SSHv1 protocol, that is deprecated
in 2017 and not exist in today's distributions.
Instead, "ssh_host_rsa_key.pub" should be used.

This test checks the contents of the key file to confirm virt-sysprep
command propery removes the key file. If the file doesn't exist,
this test cannot confirm the file deletion because the check always
return "No such file or directory" error.

Before the fix:
```
 (1/1) type_specific.io-github-autotest-libvirt.virt_sysprep.virt_clone.guest_target: FAIL: Test Failed! (71.12 s)

(session-avocado-vt-libguestfs_clone-09-01-16-30-06-LZ1s.log)
2022-09-01 16:30:07: cat: ssh_host_key.pub: No such file or directory

(session-avocado-vt-libguestfs_clone-09-01-16-30-27-GIK3.log)
2022-09-01 16:30:28: cat: ssh_host_key.pub: No such file or directory
```

After the fix:
```
 (1/1) type_specific.io-github-autotest-libvirt.virt_sysprep.virt_clone.guest_target: PASS (70.07 s)
```