### PR TITLE
migration: Add case for memory compression

### DIFF
--- a/libvirt/tests/cfg/migration/migration_performance_tuning/migration_memory_compression.cfg
+++ b/libvirt/tests/cfg/migration/migration_performance_tuning/migration_memory_compression.cfg
@@ -1,0 +1,48 @@
+- migration.migration_performance_tuning.migration_memory_compression:
+    type = migration_performance_tuning
+    migration_setup = 'yes'
+    storage_type = 'nfs'
+    setup_local_nfs = 'yes'
+    disk_type = "file"
+    disk_source_protocol = "netfs"
+    mnt_path_name = ${nfs_mount_dir}
+    # Console output can only be monitored via virsh console output
+    only_pty = True
+    take_regular_screendumps = no
+    # Extra options to pass after <domain> <desturi>
+    virsh_migrate_extra = ''
+    # SSH connection time out
+    ssh_timeout = 60
+    # Local URI
+    virsh_migrate_connect_uri = 'qemu:///system'
+    virsh_migrate_dest_state = "running"
+    virsh_migrate_src_state = "shut off"
+    image_convert = 'no'
+    server_ip = "${migrate_dest_host}"
+    server_user = "root"
+    server_pwd = "${migrate_dest_pwd}"
+    status_error = "no"
+    check_network_accessibility_after_mig = "yes"
+    migrate_desturi_port = "16509"
+    migrate_desturi_type = "tcp"
+    virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
+    check_compression_list = '["Compression cache", "Compressed data", "Compressed pages", "Compression cache misses", "Compression overflows"]'
+    test_case = "memory_compression"
+    variants:
+        - p2p:
+            virsh_migrate_options = '--live --p2p --verbose'
+        - non_p2p:
+            virsh_migrate_options = '--live --verbose'
+    variants:
+        - with_precopy:
+        - with_postcopy:
+            postcopy_options = '--postcopy --timeout 10 --timeout-postcopy'
+    variants:
+        - default_compression:
+            virsh_migrate_extra = "--compressed"
+        - xbzrle_compression_and_default_cache_size:
+            cache_size = "67108864"
+            virsh_migrate_extra = "--compressed --comp-methods xbzrle"
+        - xbzrle_compression_and_specified_cache_size:
+            cache_size = "536870912"
+            virsh_migrate_extra = "--compressed --comp-methods xbzrle --comp-xbzrle-cache ${cache_size}"

--- a/libvirt/tests/src/migration/migration_performance_tuning/migration_performance_tuning.py
+++ b/libvirt/tests/src/migration/migration_performance_tuning/migration_performance_tuning.py
@@ -21,6 +21,26 @@ def run(test, params, env):
         virsh.migrate_setmaxdowntime(vm_name, "100", debug=True)
         migration_obj.setup_connection()
 
+    def verify_memory_compression():
+        """
+        Verify for memory compression
+
+        """
+        cache_size = params.get("cache_size")
+        check_compression_list = eval(params.get("check_compression_list"))
+        test.log.debug("Start verify compression cache.")
+        ret = virsh.domjobinfo(vm_name, extra=" --completed", debug=True, ignore_status=True)
+        if ret.exit_status:
+            test.fail("Failed to get domjobinfo --completed: %s" % ret.stderr)
+        jobinfo = ret.stdout_text
+        for name in check_compression_list:
+            if name not in jobinfo:
+                test.fail("Not found '%s' in domjobinfo." % name)
+        if cache_size:
+            comp_info = "Compression cache: %.3f MiB" % (int(cache_size)/(1024*1024))
+            if comp_info not in jobinfo:
+                test.fail("Not found '%s' in domjobinfo." % comp_info)
+
     test_case = params.get('test_case', '')
     vm_name = params.get("migrate_main_vm")
 


### PR DESCRIPTION
VIRT-293935 - VM live migration - memory compression(--compressed)

Signed-off-by: cliping <lcheng@redhat.com>
