### PR TITLE
migration: Fixup no 'qemuProcessHandleMigrationStatus' issue

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -299,7 +299,7 @@
                     libvirtd_conf_type_dest = "virtproxyd"
                     log_conf_dict = '{"log_level": "1", "log_filters": "\"1:*\"", "log_outputs": "\"1:file:${log_outputs}\""}'
                     log_conf_type = "virtqemud"
-                    log_conf_dest_dict = '{r"log_level\s*=.*": 'log_level=1', r"log_outputs\s*=.*": 'log_outputs="1:file:${log_outputs}"'}'
+                    log_conf_dest_dict = '{r"log_level\s*=.*": 'log_level=1', r"log_filters\s*=.*": 'log_filters="1:*"', r"log_outputs\s*=.*": 'log_outputs="1:file:${log_outputs}"'}'
                     log_conf_type_dest = "virtqemud"
                     check_log_interval = "yes"
                     variants:


### PR DESCRIPTION
The log filters on the remote hosts was configed incorrectly,
Fix the issue in this PR.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Before the fix:**
` (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_options_shared.positive_test.check_event.event_without_postcopy.without_postcopy: FAIL: The string 'qemuProcessHandleMigrationStatus' is not included in /var/log/libvirt/libvirtd.log (160.71 s)
`
**After the fix:**
` (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_options_shared.positive_test.check_event.event_without_postcopy.without_postcopy: PASS (165.31 s)
`