### PR TITLE
Add test case for searching avc errors in audit log

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_start.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_start.cfg
@@ -36,6 +36,8 @@
                 - force-boot:
                     no lxc
                     vs_opt = "--force-boot"
+                - audit_log_search:
+                    audit_log_search_string = "AVC"
         - status_error_yes:
             status_error = "yes"
             variants:


### PR DESCRIPTION
Automation of RHEL-133902.

This case simply starts a VM and looks for messages in audit.log that with avc label (SElinux permission checks).

```
# avocado run --vt-type libvirt virsh..audit_log_search
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : 63b27e4d4bda86717749c36d0217ce4321d310d0
JOB LOG    : /var/lib/avocado/job-results/job-2022-09-06T10.44-63b27e4/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.start.status_error_no.audit_log_search: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.virsh.start.status_error_no.audit_log_search: PASS (7.58 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-09-06T10.44-63b27e4/results.html
JOB TIME   : 9.68 s
```

- [x] Description of the cases
- [x] Links of libvirt features, libvirt bugs or case IDs
- [x] Test results
