### PR TITLE
Update the mount point to /tmp/mnt

### DIFF
--- a/libvirt/tests/src/nwfilter/nwfilter_vm_start.py
+++ b/libvirt/tests/src/nwfilter/nwfilter_vm_start.py
@@ -164,7 +164,8 @@ def run(test, params, env):
         if mount_noexec_tmp:
             device_name = utlv.setup_or_cleanup_iscsi(is_setup=True)
             utlv.mkfs(device_name, 'ext4')
-            cmd = "mount %s /tmp -o noexec,nosuid" % device_name
+            # update the tmp to /tmp/mnt since tmp directory is used for tpm device
+            cmd = "mkdir /tmp/mnt; mount %s /tmp/mnt -o noexec,nosuid" % device_name
             process.run(cmd, shell=True)
 
         if ipset_command:


### PR DESCRIPTION
As the /tpm directoy is also used for tpm device. Using /tmp as
mount point with noexec option will cause the vm failed to start.
Update the mount point to /tmp/mnt.

Signed-off-by: Yalan Zhang <yalzhang@redhat.com>