### PR TITLE
migration: Fix issue about no expected string in log file

### DIFF
--- a/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_tls.cfg
+++ b/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_tls.cfg
@@ -26,7 +26,6 @@
     migrate_desturi_port = "16509"
     migrate_desturi_type = "tcp"
     virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
-    enable_libvirtd_debug_log = "no"
     transport_type = "tls"
     variants:
         - p2p:
@@ -48,7 +47,7 @@
             server_cn = "ENTER.YOUR.EXAMPLE.SERVER_CN"
             client_cn = "ENTER.YOUR.EXAMPLE.CLIENT_CN"
             set_remote_libvirtd_log = "yes"
-            libvirtd_file_path = "/etc/libvirt/virtqemud.conf"
+            libvirtd_file_type = "virtqemud"
             libvirtd_debug_level = "1"
             libvirtd_debug_filters = "1:*"
             check_str_local_log = '"dir":"/etc/pki/qemu","endpoint":"client","verify-peer":true'
@@ -65,6 +64,7 @@
             status_error = "yes"
             migrate_again = "yes"
             migrate_speed = "8796093022207"
+            enable_libvirtd_debug_log = "no"
             variants:
                 - correct_value:
                     virsh_migrate_extra_mig_again = "--tls --tls-destination ${server_cn}"


### PR DESCRIPTION
Add 'log_filters' on remote host.

Signed-off-by: cliping <lcheng@redhat.com>