### PR TITLE
migration: Fix service name error

### DIFF
--- a/libvirt/tests/cfg/migration/memory_copy_mode/migration_memory_copy_mode_precopy.cfg
+++ b/libvirt/tests/cfg/migration/memory_copy_mode/migration_memory_copy_mode_precopy.cfg
@@ -35,7 +35,7 @@
             action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: \'1\'", "func_param": "params"}]'
             variants:
                 - p2p:
-                    service_to_check = "virtqemud"
+                    service_to_check = "virtqemud|libvirtd"
                     virsh_migrate_options = '--live --p2p --verbose'
                 - non_p2p:
                     service_to_check = "virsh"


### PR DESCRIPTION
We need to check 'libvirtd' service on RHEL 8. So update it.

Signed-off-by: cliping <lcheng@redhat.com>
