### PR TITLE
Fix failure migrate_over_unix case

### DIFF
--- a/libvirt/tests/src/migration/migrate_over_unix.py
+++ b/libvirt/tests/src/migration/migrate_over_unix.py
@@ -78,6 +78,9 @@ def run(test, params, env):
             for idx in range(2, disk_num+1):
                 disk_path = os.path.join(os.path.dirname(blk_source),
                                          "test%s.img" % str(idx))
+                # Delete dirty disk if existed
+                if os.path.exists(disk_path):
+                    os.remove(disk_path)
                 # Create disk on local
                 libvirt_disk.create_disk("file", disk_format=disk_format,
                                          path=disk_path)


### PR DESCRIPTION
Fix failure in virsh.migrate_over_unix.positive_testing.with_copy_storage.default.multi_disks.p2p_live_migration.without_postcopy

test case failed at the beginning while calling utils_disk.linux_disk_check with below error message: Error: Partition(s) on /dev/vdb are being used
the root clause may come from reusing existed disk image with partitions

Signed-off-by: chunfuwen <chwen@redhat.com>

