### PR TITLE
fix source image and dst image have different size

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockcopy/blockcopy_with_backingfile.cfg
+++ b/libvirt/tests/cfg/backingchain/blockcopy/blockcopy_with_backingfile.cfg
@@ -13,10 +13,12 @@
             variants:
                 - file_disk:
                     disk_type = "file"
+                    disk_size = "500M"
                     disk_dict = {"type_name":"${disk_type}", "target":{"dev": "${target_disk}", "bus": "virtio"}, "driver": {"name": "qemu", "type":"qcow2"}}
                     create_snap_option = " --disk-only --no-metadata --diskspec vda,snapshot=no"
                 - block_disk:
                     disk_type = "block"
+                    disk_size = "50M"
                     backing_fmt = "raw"
                     disk_dict = {"type_name":"${disk_type}", "target":{"dev": "${target_disk}", "bus": "virtio"}, "driver": {"name": "qemu", "type":"raw"}}
                     create_snap_option = " --no-metadata --reuse-external --disk-only"

--- a/libvirt/tests/src/backingchain/blockcopy/blockcopy_with_backingfile.py
+++ b/libvirt/tests/src/backingchain/blockcopy/blockcopy_with_backingfile.py
@@ -28,7 +28,8 @@ def run(test, params, env):
         Prepare expected disk type, snapshots, blockcopy path.
         """
         test.log.info("TEST_SETUP: Start setup.")
-        test_obj.new_image_path = disk_obj.add_vm_disk(disk_type, disk_dict)
+        test_obj.new_image_path = disk_obj.add_vm_disk(disk_type, disk_dict,
+                                                       size=disk_size)
         if not vm.is_alive():
             vm.start()
         vm.wait_for_login().close()
@@ -91,8 +92,9 @@ def run(test, params, env):
         if disk_type == 'file':
             test_obj.copy_image = data_dir.get_data_dir() + \
                                   '/copy_dst_base_image.qcow2'
+            # "Source and target image needs to have same sizes"
             libvirt.create_local_disk('file', test_obj.copy_image,
-                                      size='500M', disk_format="qcow2")
+                                      size=disk_size, disk_format="qcow2")
         elif disk_type == 'block':
             test_obj.copy_image = libvirt.create_local_disk(
                 "lvm", size="100M", vgname=disk_obj.vg_name, lvname=lv3)
@@ -114,6 +116,7 @@ def run(test, params, env):
     create_snap_option = params.get("create_snap_option")
     snap_extra = params.get("snap_extra", "")
     backing_fmt = params.get("backing_fmt", "qcow2")
+    disk_size = params.get("disk_size")
     # Create object
     test_obj = blockcommand_base.BlockCommand(test, vm, params)
     check_obj = check_functions.Checkfunction(test, vm, params)


### PR DESCRIPTION
    source and target image needs to have same sizes
Signed-off-by: nanli <nanli@redhat.com>


**Test result on x86 :**
```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockcopy.blockcopy_with_backingfile --vt-connect-uri qemu:///system
 (1/4) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.blockcopy_with_backingfile.shallow_and_reuse_external.file_disk.pivot_after_blockcopy: PASS (49.26 s)
 (2/4) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.blockcopy_with_backingfile.shallow_and_reuse_external.file_disk.abort_after_blockcopy: PASS (49.70 s)
 (3/4) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.blockcopy_with_backingfile.shallow_and_reuse_external.block_disk.pivot_after_blockcopy: PASS (249.73 s)
 (4/4) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.blockcopy_with_backingfile.shallow_and_reuse_external.block_disk.abort_after_blockcopy
PASS (246.65 s)
```