### PR TITLE
fix the block disk size use hard code

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockcopy/blockcopy_with_backingfile.cfg
+++ b/libvirt/tests/cfg/backingchain/blockcopy/blockcopy_with_backingfile.cfg
@@ -18,7 +18,7 @@
                     create_snap_option = " --disk-only --no-metadata --diskspec vda,snapshot=no"
                 - block_disk:
                     disk_type = "block"
-                    disk_size = "50M"
+                    disk_size = "100M"
                     backing_fmt = "raw"
                     disk_dict = {"type_name":"${disk_type}", "target":{"dev": "${target_disk}", "bus": "virtio"}, "driver": {"name": "qemu", "type":"raw"}}
                     create_snap_option = " --no-metadata --reuse-external --disk-only"

--- a/libvirt/tests/src/backingchain/blockcopy/blockcopy_with_backingfile.py
+++ b/libvirt/tests/src/backingchain/blockcopy/blockcopy_with_backingfile.py
@@ -37,8 +37,8 @@ def run(test, params, env):
         snap_path = ""
         if disk_type == "block":
             snap_path = libvirt.create_local_disk(
-                "lvm", size="100M", vgname=disk_obj.vg_name, lvname=lv1)
-            cmd = "qemu-img create -f qcow2 %s 100M" % snap_path
+                "lvm", size=disk_size, vgname=disk_obj.vg_name, lvname=lv1)
+            cmd = "qemu-img create -f qcow2 %s %s" % (snap_path, disk_size)
             process.run(cmd, shell=True, verbose=True)
 
         test.log.info("TEST_STEP1: Prepare snap chain :%s", test_obj.snap_path_list)
@@ -97,7 +97,7 @@ def run(test, params, env):
                                       size=disk_size, disk_format="qcow2")
         elif disk_type == 'block':
             test_obj.copy_image = libvirt.create_local_disk(
-                "lvm", size="100M", vgname=disk_obj.vg_name, lvname=lv3)
+                "lvm", size=disk_size, vgname=disk_obj.vg_name, lvname=lv3)
 
         create_backing_cmd = "qemu-img create -f qcow2 -F %s -b %s %s" % (
             backing_fmt, test_obj.copy_image, tmp_copy_path)


### PR DESCRIPTION
    block disk size should use same variable in src and dst image
Signed-off-by: nanli <nanli@redhat.com>

**Test result:**
```
 /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockcopy.blockcopy_with_backingfile.shallow_and_reuse_external..block_disk
 (1/2) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.blockcopy_with_backingfile.shallow_and_reuse_external.block_disk.pivot_after_blockcopy: PASS (251.49 s)
 (2/2) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.blockcopy_with_backingfile.shallow_and_reuse_external.block_disk.abort_after_blockcopy: PASS (250.57 s)

```