### PR TITLE
Fix set_user_password failure

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_set_user_password.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_set_user_password.py
@@ -125,7 +125,7 @@ def run(test, params, env):
             # Del user
             if add_user:
                 session = vm.wait_for_login(timeout=30, username="root", password=ori_passwd)
-                cmd = "userdel -r %s" % set_user_name
+                cmd = "userdel -f -r %s" % set_user_name
                 status, output = session.cmd_status_output(cmd)
                 if status:
                     test.error("Deleting user '%s' got failed: '%s'" %


### PR DESCRIPTION
Fix set_user_password failure

After adding user user in guest, it also need delete the user at last but sometime it failed due to user is being used by other process, so add -f option when call userdel command

Signed-off-by: chunfuwen <chwen@redhat.com>

