### PR TITLE
Fix functional console invalid_chassisNr failure on 390x

### DIFF
--- a/libvirt/tests/src/controller/controller_functional.py
+++ b/libvirt/tests/src/controller/controller_functional.py
@@ -804,7 +804,7 @@ def run(test, params, env):
         if remove_nic:
             remove_devices(vm_xml, 'interface')
         # Get the max controller index in current vm xml
-        the_model = 'pci-root' if 'ppc' in platform.machine() else 'pcie-root-port'
+        the_model = 'pci-root' if any(['ppc' in platform.machine(), 's390x' in platform.machine()]) else 'pcie-root-port'
         if add_contrl_list:
             ret_indexes = libvirt_pcicontr.get_max_contr_indexes(vm_xml, 'pci', the_model)
             if ret_indexes and len(ret_indexes) > 0:


### PR DESCRIPTION
Fix functional console invalid_chassisNr failure

In s390x, it use pci_root controller model,otherwise it will return empty index

Signed-off-by: chunfuwen <chwen@redhat.com>

