### PR TITLE
blockcommit relative: update new disk xml with backingstore

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockcommit/blockcommit_relative_path.cfg
+++ b/libvirt/tests/cfg/backingchain/blockcommit/blockcommit_relative_path.cfg
@@ -48,4 +48,4 @@
             auth_user = "EXAMPLE_AUTH_USER"
             image_path = "EXAMPLE_IMAGE_PATH"
             client_name = "EXAMPLE_CLIENT_NAME"
-            disk_dict = {"device":"disk","type_name":"file", "target":{"dev": "${target_disk}", "bus": "virtio"}, "driver": {"name": "qemu", "type":"qcow2"}}
+            disk_dict = {"device": "disk", "type_name": "file","target": {"dev": "${target_disk}", "bus": "virtio"},"driver": {"name": "qemu", "type": "qcow2"},"source": {"attrs": {"file": "%s"}},"backingstore": {"type": "file", "format":{'type': "qcow2"},"source": {"attrs": {"file": "%s"}},"backingstore":{"type": "file","format": {'type': "qcow2"},"source": {"attrs": {"file": "%s"}},"backingstore":{"type": "network","format": {'type': "raw"},"source": {'attrs': {'protocol': "rbd", "name": "%s"},"host": {"name":"${mon_host}"},"auth": {"auth_user": "${auth_user}","secret_usage": "cephlibvirt","secret_type": "ceph"}}}}}}


### PR DESCRIPTION
  feature owner update the case content, which needs to update origin rbd disk xml
Signed-off-by: nanli <nanli@redhat.com>
**depend on**: https://github.com/autotest/tp-libvirt/pull/4455 

**Test result:**

```
/usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockcommit.relative_path
JOB ID     : 94c87c681abd922f2d8d5365af77dbffec5169cf
JOB LOG    : /root/avocado/job-results/job-2022-09-08T19.45-94c87c6/job.log
 (1/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.file_disk.keep_relative.active.vm_started: PASS (12.56 s)
 (2/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.file_disk.keep_relative.active.vm_paused: PASS (13.20 s)
 (3/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.file_disk.keep_relative.inactive.vm_started: PASS (14.99 s)
 (4/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.file_disk.keep_relative.inactive.vm_paused: PASS (13.70 s)
 (5/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.block_disk.keep_relative.active.vm_started: PASS (35.88 s)
 (6/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.block_disk.keep_relative.active.vm_paused: PASS (39.39 s)
 (7/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.rbd_with_auth_disk.keep_relative.active.vm_started: PASS (15.75 s)
 (8/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.rbd_with_auth_disk.keep_relative.active.vm_paused: PASS (14.31 s)
```
