### PR TITLE
iothread: new case for thread pool

### DIFF
--- a/libvirt/tests/cfg/cpu/iothread.cfg
+++ b/libvirt/tests/cfg/cpu/iothread.cfg
@@ -14,6 +14,25 @@
                         - both_iothread_id_num:
                             iothread_ids = "2 4 6 8"
                             iothread_num = "5"
+                - defaultiothread_config:
+                    start_vm = "yes"
+                    func_supported_since_libvirt_ver = (8, 5, 0)
+                    vm_attrs = {'defaultiothread': {'thread_pool_min': '8', 'thread_pool_max': '16'}}
+                - thread_pool:
+                    iothread_num = "4"
+                    iothreadset_id = "4"
+                    thread_pool_min = "1"
+                    thread_pool_max = "120"
+                    iothreadset_val = "--thread-pool-min ${thread_pool_min} --thread-pool-max ${thread_pool_max}"
+                    test_operations = "iothreadset"
+                    func_supported_since_libvirt_ver = (8, 5, 0)
+                    variants:
+                        - shutoff_vm:
+                            cmd_options = '--config'
+                        - live_vm:
+                            start_vm = "yes"
+                            pre_vm_stats = "running"
+                            cmd_options = ''
                 - iothreadpin:
                     pre_vm_stats = "running"
                     iothread_ids = "1"
@@ -24,6 +43,7 @@
                     restart_libvirtd = "yes"
                     test_operations = "iothreaddel,iothreadpin,iothreadadd"
                 - iothread_poll:
+                    pre_vm_stats = "running"
                     restart_libvirtd = "yes"
                     restart_vm = "yes"
                     iothread_ids = "1"


### PR DESCRIPTION
Add new case for below scenarios:
 - VM can start with defaultiothread element
 - iothreadset can work with --thread-pool-min and --thread-pool-max
   when vm is shutoff or running
ID: VIRT-294819 , VIRT-294820

Signed-off-by: Dan Zheng <dzheng@redhat.com>

