### PR TITLE
sriov: Fix an AttributeError

### DIFF
--- a/libvirt/tests/cfg/sriov/vm_lifecycle/direct_passthrough_vm_lifecycle_start_destroy.cfg
+++ b/libvirt/tests/cfg/sriov/vm_lifecycle/direct_passthrough_vm_lifecycle_start_destroy.cfg
@@ -20,4 +20,4 @@
                             variants:
                                 - @default:
                                     iface_dict = {'mac_address': mac_addr, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}, 'type_name': 'network', 'source': {'network': 'macvtap-passthrough'}}
-                                    network_dict = {"net_name":'macvtap-passthrough',"net_forward": '{"mode": "passthrough", "dev": "%s"}' % vf_name, "forward_iface": vf_name}
+                                    network_dict = {'name': 'macvtap-passthrough', 'forward': {'mode': 'passthrough', 'dev': vf_name}, 'forward_interface': [{'dev': vf_name}]}

--- a/libvirt/tests/src/sriov/vm_lifecycle/direct_passthrough_vm_lifecycle_start_destroy.py
+++ b/libvirt/tests/src/sriov/vm_lifecycle/direct_passthrough_vm_lifecycle_start_destroy.py
@@ -41,7 +41,7 @@ def run(test, params, env):
 
         if network_dict:
             libvirt_network.check_network_connection(
-                network_dict.get("net_name"), 1)
+                network_dict.get("name"), 1)
 
         test.log.info("TEST_STEP5: Destroy VM")
         vm.destroy(gracefully=False)
@@ -49,7 +49,7 @@ def run(test, params, env):
         test.log.info("TEST_STEP6: Check environment recovery - mac, vlan ")
         if network_dict:
             libvirt_network.check_network_connection(
-                network_dict.get("net_name"), 0)
+                network_dict.get("name"), 0)
 
         check_points.check_vlan(sriov_test_obj.pf_name, iface_dict, True)
 


### PR DESCRIPTION
Fix "no attribute" issue.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Test result:**
_Before the fix:_
` (1/1) type_specific.io-github-autotest-libvirt.direct_passthrough.vm_lifecycle.start_destroy.network_interface.network.vf_name.default: ERROR: Cannot set attribute "net_name" to <class 'virttest.libvirt_xml.network_xml.NetworkXML'> object.There is no such attribute. (15.15 s)
`

_After the fix:_
` (1/1) type_specific.io-github-autotest-libvirt.direct_passthrough.vm_lifecycle.start_destroy.network_interface.network.vf_name.default: PASS (74.22 s)
`