### PR TITLE
Fix serial console failure on s390x

### DIFF
--- a/libvirt/tests/cfg/serial/serial_pty_log.cfg
+++ b/libvirt/tests/cfg/serial/serial_pty_log.cfg
@@ -12,6 +12,10 @@
                 target_type = system-serial
                 target_model = pl011
                 boot_prompt = 'localhost login'
+            s390x:
+                target_type = sclp-serial
+                target_model = sclpconsole
+                boot_prompt = 'localhost login'
             stdio_handler = 'file'
         - logd:
             serial_dev_type = pty
@@ -21,5 +25,9 @@
             aarch64:
                 target_type = system-serial
                 target_model = pl011
+                boot_prompt = 'localhost login'
+            s390x:
+                target_type = sclp-serial
+                target_model = sclpconsole
                 boot_prompt = 'localhost login'
             stdio_handler = 'logd'


### PR DESCRIPTION
Fix serial console failure on s390x

on s390x, serial console need configure target type='sclp-serial'and  model name='sclpconsole'

Signed-off-by: chunfuwen <chwen@redhat.com>
