### PR TITLE
Fix channel functional case failure on 390x

### DIFF
--- a/libvirt/tests/cfg/channel/channel_functional.cfg
+++ b/libvirt/tests/cfg/channel/channel_functional.cfg
@@ -36,6 +36,7 @@
                     channel_address_type = 'virtio-serial'
                     channel_address_controller = '0'
                     channel_address_bus = '0'
+                    no s390-virtio
         - negative_tests:
             variants:
                 - target_not_set:


### PR DESCRIPTION
Fix channel functional case failure

channel.functional.positive_tests.auto_gen_port.pty_type, this case will attach channel device with channel type="spicevmc", which is not supported on s390x, so filter out this case on s390x

Signed-off-by: chunfuwen <chwen@redhat.com>
