### PR TITLE
Libguestfs: virt file or inspect operations

### DIFF
--- a/libguestfs/tests/virt_file_operations.py
+++ b/libguestfs/tests/virt_file_operations.py
@@ -75,7 +75,7 @@ def test_virt_tar_in(test, vm, params):
         test.fail(str(detail))
 
     try:
-        output = session.cmd_output("cat %s" % path, timeout=5)
+        output = session.cmd_output("cat %s; echo" % path, timeout=5)
         logging.debug(output)
         vm.destroy()
         vm.wait_for_shutdown()
@@ -203,7 +203,7 @@ def test_virt_copy_in(test, vm, params):
         test.fail(str(detail))
 
     try:
-        output = session.cmd_output("cat %s" % path, timeout=5)
+        output = session.cmd_output("cat %s; echo" % path, timeout=5)
         logging.debug(output)
         vm.destroy()
         vm.wait_for_shutdown()

--- a/libguestfs/tests/virt_file_operations.py
+++ b/libguestfs/tests/virt_file_operations.py
@@ -267,7 +267,7 @@ def test_virt_copy_out(test, vm, params):
             test.fail("Catted file do not match.")
 
 
-def run_virt_file_operations(test, params, env):
+def run(test, params, env):
     """
     Test libguestfs with file commands: virt-tar-in, virt-tar-out,
                                         virt-copy-in, virt-copy-out

--- a/libguestfs/tests/virt_inspect_operations.py
+++ b/libguestfs/tests/virt_inspect_operations.py
@@ -170,7 +170,7 @@ def test_inspect_get(test, vm, params):
         test.fail(fail_info)
 
 
-def run_virt_inspect_operations(test, params, env):
+def run(test, params, env):
     """
     Test libguestfs with virt-inspect command.
     """


### PR DESCRIPTION
Includes two patches for virt_file_operations and virt_inspect_operations test.


**libguestfs: Fix entry points for virt_file_operations and virt_inspect_operations**

- virt_file_operations and virt_inspect_operations has wrong entry point function.

**virt_fil_operations: Add a trailing newline when retreive contents**

- This is same fix as PR#4468

**Before applying the patch**

```
 (1/3) type_specific.io-github-autotest-libvirt.virt_file_operations.tar_in: STARTED
 (1/3) type_specific.io-github-autotest-libvirt.virt_file_operations.tar_in: ERROR: Missing test entry point (4.08 s)
 (2/3) type_specific.io-github-autotest-libvirt.virt_file_operations.tar_in: STARTED
 (2/3) type_specific.io-github-autotest-libvirt.virt_file_operations.tar_in: ERROR: Missing test entry point (4.11 s)
 (3/3) type_specific.io-github-autotest-libvirt.virt_inspect_operations.inspect_get: STARTED
 (3/3) type_specific.io-github-autotest-libvirt.virt_inspect_operations.inspect_get: ERROR: Missing test entry point (4.08 s)
```

**After the first patch applied**

```
 (1/3) type_specific.io-github-autotest-libvirt.virt_file_operations.tar_in: STARTED
 (1/3) type_specific.io-github-autotest-libvirt.virt_file_operations.tar_in: FAIL: File content is not match. (27.34 s)
 (2/3) type_specific.io-github-autotest-libvirt.virt_file_operations.tar_in: STARTED
 (2/3) type_specific.io-github-autotest-libvirt.virt_file_operations.tar_in: FAIL: File content is not match. (27.18 s)
 (3/3) type_specific.io-github-autotest-libvirt.virt_inspect_operations.inspect_get: STARTED
 (3/3) type_specific.io-github-autotest-libvirt.virt_inspect_operations.inspect_get: PASS (33.62 s)
```

**After the both patches are applied**

```
 (1/3) type_specific.io-github-autotest-libvirt.virt_file_operations.tar_in: STARTED
 (1/3) type_specific.io-github-autotest-libvirt.virt_file_operations.tar_in: PASS (27.02 s)
 (2/3) type_specific.io-github-autotest-libvirt.virt_file_operations.tar_in: STARTED
 (2/3) type_specific.io-github-autotest-libvirt.virt_file_operations.tar_in: PASS (26.87 s)
 (3/3) type_specific.io-github-autotest-libvirt.virt_inspect_operations.inspect_get: STARTED
 (3/3) type_specific.io-github-autotest-libvirt.virt_inspect_operations.inspect_get: PASS (33.67 s)
```
