### PR TITLE
backingchain: add case for blockjob with raw option

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockjob/blockjob_with_raw_option.cfg
+++ b/libvirt/tests/cfg/backingchain/blockjob/blockjob_with_raw_option.cfg
@@ -1,0 +1,8 @@
+- backingchain.blockjob.raw:
+    type = blockjob_with_raw_option
+    start_vm = 'yes'
+    disk = 'vda'
+    variants:
+        - raw_list:
+            option_value = ' --raw'
+            case_name = 'raw_list'

--- a/libvirt/tests/src/backingchain/blockjob/blockjob_with_raw_option.py
+++ b/libvirt/tests/src/backingchain/blockjob/blockjob_with_raw_option.py
@@ -1,0 +1,131 @@
+import os
+import time
+
+from virttest import virsh
+from virttest import utils_misc
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_disk
+from virttest.utils_libvirt import libvirt_misc
+from virttest.utils_test import libvirt
+
+from provider.backingchain import blockcommand_base
+
+
+def run(test, params, env):
+    """
+    Test blockjob with --raw option
+
+    """
+    def setup_raw_list():
+        """
+        Prepare running domain and do blockcopy
+        """
+        test.log.info("TEST_SETUP1:Start vm and clean exist copy file")
+        test_obj.backingchain_common_setup(remove_file=True,
+                                           file_path=tmp_copy_path)
+
+        test.log.info("TEST_SETUP2:Do blockcopy")
+        cmd = "blockcopy %s %s %s --wait --verbose --transient-job " \
+              "--bandwidth %s " % (vm_name, dev, tmp_copy_path, bandwidth)
+        virsh_session = virsh.VirshSession(virsh_exec=virsh.VIRSH_EXEC,
+                                           auto_close=True)
+        virsh_session.sendline(cmd)
+
+    def test_raw_list():
+        """
+        Do blockjob with raw option.
+
+        1) Do blockjob with raw option twice.
+        2) Check cur value is changing.
+        3) Execute with --pivot and check raw option return empty.
+        """
+        if not libvirt.check_blockjob(vm_name, dev, "progress", "100"):
+            _check_cur()
+            _abort_job()
+        else:
+            test.error('Blockcopy finished too fast, unable to check raw result,\
+             Please consider to reduce bandwith value to retest this case.')
+
+    def teardown_raw_list():
+        """
+        After blockcopy, clean file
+        """
+        # If some steps are broken by accident, execute --abort to
+        # stop blockcopy job
+        virsh.blockjob(vm_name, dev, options=' --abort', debug=True,
+                       ignore_status=True)
+
+        test_obj.clean_file(tmp_copy_path)
+        bkxml.sync()
+
+    def _check_cur():
+        """
+        Do twice blockjob --raw after blockcopy, and check the value of cur is
+        changed according to the progress of blockcopy.
+        """
+        test.log.info("TEST_STEP1: Do blockjob with --raw and check cur changed")
+        res_1 = virsh.blockjob(vm_name, dev, options=test_option, debug=True,
+                               ignore_status=False)
+        cur1 = libvirt_misc.convert_to_dict(res_1.stdout_text.strip(),
+                                            pattern=r'(\S+)=(\S+)')['cur']
+        time.sleep(1)
+        res_2 = virsh.blockjob(vm_name, dev, options=test_option, debug=True,
+                               ignore_status=False)
+        cur2 = libvirt_misc.convert_to_dict(res_2.stdout_text.strip(),
+                                            pattern=r'(\S+)=(\S+)')['cur']
+        test.log.info('cur1 is %s , cur2 is %s', cur1, cur2)
+
+        if int(cur1) >= int(cur2):
+            test.fail('Two times cur value is not changed according'
+                      ' to the progress of blockcopy.')
+
+    def _abort_job():
+        """
+        Abort the job and check if it's aborted successfully.
+        """
+        test.log.info("Check if the job can be aborted successfully")
+        if utils_misc.wait_for(
+                lambda: libvirt.check_blockjob(vm_name,
+                                               dev, "progress", "100"), 100):
+            virsh.blockjob(vm_name, dev, options=' --pivot',
+                           debug=True,
+                           ignore_status=False)
+        else:
+            test.fail("Blockjob timeout in 100 sec.")
+
+        test.log.info("TEST_STEP3: Check the output of 'blockjob --raw' "
+                      "after aborting the job")
+        result = virsh.blockjob(vm_name, dev, options=test_option,
+                                debug=True,
+                                ignore_status=False)
+        if result.stdout_text.strip():
+            test.fail("It should return empty after pivot, but get:%s",
+                      result.stdout_text.strip())
+
+    # Process cartesian parameters
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    case_name = params.get('case_name', 'blockjob')
+    test_option = params.get('option_value', '')
+    bandwidth = params.get('bandwidth', '1000')
+    dev = params.get('disk')
+    # Create object
+    test_obj = blockcommand_base.BlockCommand(test, vm, params)
+
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+    tmp_copy_path = os.path.join(os.path.dirname(
+        libvirt_disk.get_first_disk_source(vm)), "%s_blockcopy.img" % vm_name)
+    # MAIN TEST CODE ###
+    run_test = eval("test_%s" % case_name)
+    setup_test = eval("setup_%s" % case_name)
+    teardown_test = eval("teardown_%s" % case_name)
+
+    try:
+        # Execute test
+        setup_test()
+        run_test()
+
+    finally:
+        teardown_test()


### PR DESCRIPTION
   VIRT-293943: Do blockjob with --raw option
Signed-off-by: nanli <nanli@redhat.com>

**Test result:**

```
/usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockjob.raw.raw_list
JOB ID     : 3e0a0d8b0f43f0f33d9a9e58bea2c600b821a733
JOB LOG    : /root/avocado/job-results/job-2022-09-12T21.17-3e0a0d8/job.log
 (1/1) type_specific.io-github-autotest-libvirt.backingchain.blockjob.raw.raw_list: PASS (34.15 s)
```
