### PR TITLE
sriov: Add a negative test about attaching/detaching hostdev

### DIFF
--- a/libvirt/tests/cfg/sriov/plug_unplug/sriov_attach_detach_device_with_unsupported_settings.cfg
+++ b/libvirt/tests/cfg/sriov/plug_unplug/sriov_attach_detach_device_with_unsupported_settings.cfg
@@ -1,0 +1,19 @@
+- sriov.plug_unplug.attach_detach_device_with_unsupported_settings:
+    type = sriov_attach_detach_device_with_unsupported_settings
+    start_vm = "no"
+
+    only x86_64
+    variants dev_type:
+        - hostdev_interface:
+            variants test_scenario:
+                - inactive_pf:
+                    iface_dict = {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}}
+                    err_msg = "PF is not online"
+                - unassigned_address:
+                    func_supported_since_libvirt_ver = (6, 0, 0)
+                    iface_dict = {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'attrs': vf_pci_addr}, 'address': {'attrs':{'type': 'unassigned'}}}
+                    err_msg = "is supported only for hostdev"
+                - dup_alias:
+                    pre_iface_dict = {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
+                    iface_dict = {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr2}, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
+                    err_msg = "Duplicate ID|non unique alias detected"

--- a/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_device_with_unsupported_settings.py
+++ b/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_device_with_unsupported_settings.py
@@ -1,0 +1,67 @@
+from virttest import utils_net
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+from provider.sriov import sriov_base
+
+
+def run(test, params, env):
+    """
+    Attach-device of hostdev type to guest with unsupported settings
+    """
+    def setup_test():
+        """
+        Setup test
+        """
+        sriov_test_obj.setup_default()
+        if test_scenario == "inactive_pf":
+            utils_net.Interface(sriov_test_obj.pf_name).down()
+        elif test_scenario == "dup_alias":
+            test.log.info("TEST_SETUP: Attach an interface.")
+            vf_pci_addr = sriov_test_obj.vf_pci_addr
+            pre_iface_dict = eval(params.get("pre_iface_dict", "{}"))
+            libvirt_vmxml.modify_vm_device(
+                vm_xml.VMXML.new_from_inactive_dumpxml(vm_name),
+                'interface', pre_iface_dict)
+
+    def run_test():
+        """
+        Attach-device of hostdev type to guest for special scenarios - negative
+        """
+        test.log.info("TEST_SETUP1: Start a vm.")
+        vm.start()
+        vm.wait_for_serial_login(timeout=240).close()
+
+        test.log.info("TEST_STEP2: Attach a hostdev interface/device to VM")
+        iface_dev = sriov_test_obj.create_iface_dev(dev_type, iface_dict)
+        result = virsh.attach_device(vm_name, iface_dev.xml, debug=True)
+        libvirt.check_result(result, err_msg)
+        if test_scenario == "dup_alias":
+            host_dev = vm_xml.VMXML.new_from_dumpxml(vm.name)\
+                .devices.by_device_tag("interface")[0]
+            test.log.info("TEST_STEP3: Detach the first hostdev interface.")
+            virsh.detach_device(vm_name, host_dev.xml, wait_for_event=True,
+                                debug=True, ignore_status=False)
+
+            test.log.info("TEST_STEP4: Attach the second hostdev interface again.")
+            virsh.attach_device(vm_name, iface_dev.xml, debug=True,
+                                ignore_status=False)
+
+    dev_type = params.get("dev_type", "")
+    test_scenario = params.get("test_scenario")
+    err_msg = params.get("err_msg")
+
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    vm = env.get_vm(vm_name)
+    sriov_test_obj = sriov_base.SRIOVTest(vm, test, params)
+    iface_dict = sriov_test_obj.parse_iface_dict()
+    try:
+        setup_test()
+        run_test()
+    finally:
+        if test_scenario == "inactive_pf":
+            utils_net.Interface(sriov_test_obj.pf_name).up()
+        sriov_test_obj.teardown_default()


### PR DESCRIPTION
This PR adds:
    VIRT-293237 - Attach-device of hostdev type to guest with
        unsupported settings

Signed-off-by: Yingshun Cui <yicui@redhat.com>

**Test results:**
```

 (1/3) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_with_unsupported_settings.hostdev_interface.inactive_pf: PASS (61.90 s)
 (2/3) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_with_unsupported_settings.hostdev_interface.unassigned_address: PASS (54.49 s)
 (3/3) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_with_unsupported_settings.hostdev_interface.dup_alias: PASS (59.48 s)

```