### PR TITLE
domain_lifecycle: check reboot event from inside guest

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_event.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_event.cfg
@@ -57,6 +57,10 @@
                 - reboot_event:
                     event_name = "reboot"
                     events_list = "reset"
+                - reboot_from_console:
+                    only virsh_event
+                    events_list = "reboot_from_console"
+                    event_all_option = "yes"
                 - tunable_event1:
                     event_name = "tunable"
                     events_list = "emulatorpin"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
@@ -330,6 +330,14 @@ def run(test, params, env):
                 elif event == "reset":
                     virsh.reset(dom.name, **virsh_dargs)
                     expected_events_list.append("'reboot' for %s")
+                elif event == "reboot_from_console":
+                    session = dom.wait_for_login()
+                    try:
+                        session.cmd("shutdown -r now")
+                    except ShellProcessTerminatedError:
+                        logging.info("Shell terminated as host restarts as expected.")
+                    session.close()
+                    expected_events_list.append("'reboot' for %s")
                 elif event == "vcpupin":
                     virsh.vcpupin(dom.name, '0', '0', **virsh_dargs)
                     expected_events_list.append("'tunable' for %s:"


### PR DESCRIPTION
This commit adds new test scenario to virsh_event where host is rebooted
via a console command and reboot event is checked to be present.

LIBVIRTAT-13464
VIRT-12705
```
# avocado run --vt-type libvirt virsh.event.positive_test.virsh_event.test_events.reboot_from_console.no_timeout.loop
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : 40d0f5d54f7f84335c4bba2b513b4580d18f413c
JOB LOG    : /var/lib/avocado/job-results/job-2022-09-13T11.07-40d0f5d/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.event.positive_test.virsh_event.test_events.reboot_from_console.no_timeout.loop: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.virsh.event.positive_test.virsh_event.test_events.reboot_from_console.no_timeout.loop: PASS (83.65 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-09-13T11.07-40d0f5d/results.html
JOB TIME   : 85.20 s
```

# Check lists by category
## If the PR is new cases
- [x] Description of the cases
- [x] Links of libvirt features, libvirt bugs or case IDs
- [x] Test results