### PR TITLE
fix none type get source file

### DIFF
--- a/provider/virtual_disk/disk_base.py
+++ b/provider/virtual_disk/disk_base.py
@@ -70,7 +70,8 @@ class DiskBase(object):
                                elem.find('source').get('name') or
                                elem.find('source').get('dev') or
                                elem.find('source').get('volume')
-                               for elem in backing_list]
+                               for elem in backing_list
+                               if elem.find("source") is not None]
                 source_list.insert(0, active_level_path)
                 break
 


### PR DESCRIPTION
  need skip to get source file if source tage is none
Signed-off-by: nanli <nanli@redhat.com>

```
Test result:

/usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockpull.conventional_chain.rbd_with_auth_disk.without_base --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.backingchain.blockpull.conventional_chain.rbd_with_auth_disk.without_base: PASS (64.00 s)
/usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockcopy.conventional_chain.rbd_with_auth_disk.without_shallow --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.conventional_chain.rbd_with_auth_disk.without_shallow: PASS (64.88 s)

```
