### PR TITLE
Add case of memory

### DIFF
--- a/libvirt/tests/cfg/memory/memory_misc.cfg
+++ b/libvirt/tests/cfg/memory/memory_misc.cfg
@@ -27,7 +27,7 @@
                                 kvm_module_parameters = "hpage=1"
                         - memfd_backed:
                             mem_backing_attrs = {'hugepages': {}, 'source_type': 'memfd' ,'allocation': {'threads': '${threads_num}'}}
-                            qemu_check = '"qom-type":"memory-backend-memfd".*"prealloc-threads":${threads_num}'
+                            qemu_check = '"qom-type":"memory-backend-memfd".*"hugetlbsize":2097152.*"prealloc-threads":${threads_num}'
                         - ram_backed:
                             mem_backing_attrs = {'allocation': {'mode': 'immediate', 'threads': '${threads_num}'}}
                             qemu_check = '"qom-type":"memory-backend-ram".*"prealloc-threads":${threads_num}'
@@ -48,6 +48,13 @@
                             mem_backing_attrs = {'hugepages': {'pages': [{'unit': 'KiB', 'nodeset': '0,1', 'size': '${pagesize}'}]}, 'locked': True}
                             status_error = 'yes'
                             expect_msg = 'hugepages: node 0 not found'
+                - hp_from_2_numa_nodes:
+                    pagesize = 2048
+                    pagenum = 5120
+                    vm_attrs = {'max_mem_rt': 83886080, 'max_mem_rt_slots': 8, 'max_mem_rt_unit': 'KiB', 'memory': 20971520, 'memory_unit': 'KiB', 'current_mem': 20971520, 'current_mem_unit': 'KiB'}
+                    mem_backing_attrs = {'hugepages': {}}
+                    cpu_attrs = {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '19922944', 'unit': 'KiB', 'discard': 'yes'}]}
+                    mem_device_attrs = {'source': {'pagesize_unit': 'KiB', 'pagesize': 2048, 'nodemask': '0'}, 'mem_model': 'dimm', 'target': {'size': 1048576, 'node': 0, 'size_unit': 'KiB'}}
         - edit_mem:
             variants case:
                 - forbid_0:


### PR DESCRIPTION
- Start /destroy domain which is using hugepages from two numa node
- Verify property <hugepages/> works with source type=memfd

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>

Test result:

```
 (01/21) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.no_numa: CANCEL: This case is not supported by current libvirt. (6.61 s)
 (02/21) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.mem_lock.no_limit: PASS (9.35 s)
 (03/21) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.mem_lock.hard_limit: PASS (9.33 s)
 (04/21) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.prealloc_thread.file_backed: PASS (49.64 s)
 (05/21) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.prealloc_thread.memfd_backed: PASS (48.96 s)
 (06/21) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.prealloc_thread.ram_backed: PASS (47.33 s)
 (07/21) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.no_mem_backing: PASS (9.47 s)
 (08/21) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.nodeset_specified.nodeset_0: PASS (15.79 s)
 (09/21) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.nodeset_specified.nodeset_01: PASS (18.30 s)
 (10/21) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.hp_from_2_numa_nodes: PASS (14.16 s)
 (11/21) type_specific.io-github-autotest-libvirt.memory_misc.edit_mem.forbid_0.set_mem: PASS (6.81 s)
 (12/21) type_specific.io-github-autotest-libvirt.memory_misc.edit_mem.forbid_0.set_cur_mem: PASS (7.14 s)
 (13/21) type_specific.io-github-autotest-libvirt.memory_misc.edit_mem.forbid_0.set_with_numa: PASS (7.40 s)
 (14/21) type_specific.io-github-autotest-libvirt.memory_misc.edit_mem.mem_unit.1000M: PASS (50.18 s)
 (15/21) type_specific.io-github-autotest-libvirt.memory_misc.edit_mem.mem_unit.1024M: PASS (47.85 s)
 (16/21) type_specific.io-github-autotest-libvirt.memory_misc.edit_mem.mem_unit.1G: PASS (47.07 s)
 (17/21) type_specific.io-github-autotest-libvirt.memory_misc.dommemstat.disk_caches: PASS (47.88 s)
 (18/21) type_specific.io-github-autotest-libvirt.memory_misc.xml_check.smbios: PASS (9.52 s)
 (19/21) type_specific.io-github-autotest-libvirt.memory_misc.dimm.multiop: PASS (14.64 s)
 (20/21) type_specific.io-github-autotest-libvirt.memory_misc.audit_size.at_dt_mem: PASS (47.63 s)
 (21/21) type_specific.io-github-autotest-libvirt.memory_misc.managedsave.size_check: PASS (51.20 s)
RESULTS    : PASS 20 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 1
JOB HTML   : /var/lib/avocado/job-results/job-2022-09-30T02.34-2b29eef/results.html
JOB TIME   : 568.77 s
```