### PR TITLE
virsh_detach_serial_device_alias: fix_early_unplug

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_detach_serial_device_alias.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_detach_serial_device_alias.py
@@ -121,6 +121,7 @@ def run(test, params, env):
         vm_xml.sync()
 
         vm.start()
+        vm.wait_for_login().close()
         check_vm_xml()
 
         # Hot detach device by its alias name.


### PR DESCRIPTION
Sometimes qemu-kvm process will crash when we unplug the serial device before vm is fully booted. This behavior is not reasonable. So we need to make sure the vm is fully booted and could be logged in.

Signed-off-by: Dan Zheng <dzheng@redhat.com>
