### PR TITLE
sriov: Correct virsh commands' ignore_status

### DIFF
--- a/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_device.py
+++ b/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_device.py
@@ -24,7 +24,7 @@ def run(test, params, env):
         test.log.info("TEST_STEP2: Attach a hostdev interface/device to VM")
         iface_dev = sriov_test_obj.create_iface_dev(dev_type, iface_dict)
         virsh.attach_device(vm.name, iface_dev.xml, debug=True,
-                            ignore_errors=False)
+                            ignore_status=False)
 
         test.log.info("TEST_STEP3: Check hostdev xml after VM startup")
         if dev_type == "network_interface":
@@ -45,7 +45,7 @@ def run(test, params, env):
         vm_hostdev = vm_xml.VMXML.new_from_dumpxml(vm.name)\
             .devices.by_device_tag(device_type)[0]
         virsh.detach_device(vm.name, vm_hostdev.xml, debug=True,
-                            ignore_errors=False)
+                            ignore_status=False)
         cur_hostdevs = vm_xml.VMXML.new_from_dumpxml(vm.name)\
             .devices.by_device_tag(device_type)
         if cur_hostdevs:
@@ -57,7 +57,7 @@ def run(test, params, env):
                 dev_pci, not managed_disabled, True), 10, 5):
             test.fail("Got incorrect driver!")
         if managed_disabled:
-            virsh.nodedev_reattach(dev_name, debug=True, ignore_errors=False)
+            virsh.nodedev_reattach(dev_name, debug=True, ignore_status=False)
             libvirt_vfio.check_vfio_pci(dev_pci, True)
 
     dev_type = params.get("dev_type", "")

--- a/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_device_after_restarting_service.py
+++ b/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_device_after_restarting_service.py
@@ -35,11 +35,11 @@ def run(test, params, env):
         test.log.info("TEST_STEP2: Attach a hostdev interface/device to VM")
         iface_dev = sriov_test_obj.create_iface_dev(dev_type, iface_dict)
         virsh.attach_device(vm.name, iface_dev.xml, debug=True,
-                            ignore_errors=False)
+                            ignore_status=False)
 
         test.log.info("TEST_STEP3: Detach the hostdev interface/device")
         virsh.detach_device(vm.name, iface_dev.xml, debug=True,
-                            ignore_errors=False)
+                            ignore_status=False)
 
     dev_type = params.get("dev_type", "")
     pre_iface_dict = eval(params.get("pre_iface_dict", "{}"))

--- a/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_device_with_flags.py
+++ b/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_device_with_flags.py
@@ -97,7 +97,7 @@ def run(test, params, env):
         wait_for_event = True if vm.is_alive() and not flagstr.count('config') \
             else False
         virsh.detach_device(vm.name, vm_hostdev.xml, debug=True,
-                            flagstr=flagstr, ignore_errors=False,
+                            flagstr=flagstr, ignore_status=False,
                             wait_for_event=wait_for_event, event_timeout=15)
 
         test.log.info("TEST_STEP4: Check VM xml.")

--- a/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_start_destroy.py
+++ b/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_start_destroy.py
@@ -64,7 +64,7 @@ def run(test, params, env):
                 dev_pci, not managed_disabled, True), 10, 5):
             test.fail("Got incorrect driver!")
         if managed_disabled:
-            virsh.nodedev_reattach(dev_name, debug=True, ignore_errors=False)
+            virsh.nodedev_reattach(dev_name, debug=True, ignore_status=False)
             libvirt_vfio.check_vfio_pci(dev_pci, True)
         check_points.check_mac_addr_recovery(
             sriov_test_obj.pf_name, device_type, iface_dict)

--- a/provider/sriov/sriov_base.py
+++ b/provider/sriov/sriov_base.py
@@ -254,7 +254,7 @@ class SRIOVTest(object):
             libvirt_network.create_or_del_network(network_dict)
 
         if managed_disabled:
-            virsh.nodedev_detach(dev_name, debug=True, ignore_errors=False)
+            virsh.nodedev_detach(dev_name, debug=True, ignore_status=False)
 
     def teardown_default(self, **dargs):
         """
@@ -275,7 +275,7 @@ class SRIOVTest(object):
             utils_libvirtd.Libvirtd().restart()
             self.orig_config_xml.sync()
         if managed_disabled:
-            virsh.nodedev_reattach(dev_name, debug=True, ignore_errors=False)
+            virsh.nodedev_reattach(dev_name, debug=True, ignore_status=False)
         if network_dict:
             libvirt_network.create_or_del_network(network_dict, True)
 


### PR DESCRIPTION
The 'ignore_status' was incorrectly passed as 'ignore_error'.

Signed-off-by: Yingshun Cui <yicui@redhat.com>
```
 (1/3) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_after_restarting_service.hostdev_interface: PASS (66.10 s)
 (2/3) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_after_restarting_service.hostdev_device: PASS (58.36 s)
 (3/3) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_after_restarting_service.network_interface: PASS (59.13 s)


```