### PR TITLE
libvirtd.py: Fix arguments error

### DIFF
--- a/libvirt/tests/src/libvirtd/libvirtd.py
+++ b/libvirt/tests/src/libvirtd/libvirtd.py
@@ -63,7 +63,7 @@ def test_check_journal(libvirtd, params, test):
     output = msg_queue.get()
     # Check error message in journal
     if re.search(error_msg_in_journal, output):
-        test.fail("Found error message during libvirtd restarting: %s", output)
+        test.fail("Found error message during libvirtd restarting: %s" % output)
     else:
         logging.info("Not found error message during libvirtd restarting.")
 


### PR DESCRIPTION
Signed-off-by: Liu Yiding <liuyd.fnst@fujitsu.com>

Before:
```
(1/1) type_specific.io-github-autotest-libvirt.libvirtd.libvirtd.check_journal: ERROR: fail() takes from 1 to 2 positional arguments but 3 were given (51.13 s)
```

Now:
```
(1/1) type_specific.io-github-autotest-libvirt.libvirtd.libvirtd.check_journal: FAIL: Found error message during libvirtd restarting: -- Logs begin at Sun 2022-09-18 01:59:29 EDT. --\nSep 18 23:19:02 fujitsu-fx700-01-n00.2a2m.lab.eng.bos.redhat.com polkitd[1433]: Registered Authentication Agent for unix-process:271941:9410687 (system bus na... (54.07 s)
```