### PR TITLE
virsh_connect: Fix client_ip parameter issue

### DIFF
--- a/libvirt/tests/src/virsh_cmd/virsh_connect.py
+++ b/libvirt/tests/src/virsh_cmd/virsh_connect.py
@@ -193,6 +193,8 @@ def run(test, params, env):
         elif transport == "tcp":
             tcp_connection = utils_conn.TCPConnection(server_ip=server_ip,
                                                       server_pwd=server_pwd,
+                                                      client_ip=client_ip,
+                                                      client_pwd=client_pwd,
                                                       tcp_port=tcp_port)
             tcp_connection.conn_setup()
 


### PR DESCRIPTION
Fix following issue:
  ConnLoginError: Got a error when login to CLIENT.IP.Error: Host
  terminates during login to client.

Signed-off-by: cliping <lcheng@redhat.com>