### PR TITLE
numa_memory: fix incorrect numa node usage

### DIFF
--- a/libvirt/tests/cfg/numa/numa_memory.cfg
+++ b/libvirt/tests/cfg/numa/numa_memory.cfg
@@ -23,11 +23,13 @@
                      variants:
                          - node1:
                              no interleave
-                             memory_nodeset = "0"
+                             # 'x' stands for a numa node pattern, like 1. The value will be dynamically determined
+                             memory_nodeset = x
                              can_be_dynamic = "yes"
                          - node2:
                              no preferred
-                             memory_nodeset = "0-1"
+                             # 'x-y' stands for a numa node pattern, like 0-3. The value will be dynamically determined
+                             memory_nodeset = x-y
                              can_be_dynamic = "yes"
              variants:
                  - no_vcpu:
@@ -53,6 +55,6 @@
                          - interleave:
                              memory_mode = "interleave"
                  - preferred_multi:
-                     memory_nodeset = "0-1"
+                     memory_nodeset = "x-y"
                      memory_mode = "preferred"
                      can_be_dynamic = "yes"


### PR DESCRIPTION
On special numa hosts, the numa node with memory is not continous. So we need to adjust the usable numa node for test instead of using hardcoded numa node.

Signed-off-by: Dan Zheng <dzheng@redhat.com>