### PR TITLE
numa_memory: add checkpoints for VMStartError

### DIFF
--- a/libvirt/tests/cfg/numa/numa_memory.cfg
+++ b/libvirt/tests/cfg/numa/numa_memory.cfg
@@ -47,6 +47,7 @@
              variants:
                  - out_range:
                      memory_nodeset = "200-300"
+                     err_msg = "NUMA node.*unavailable"
                      variants:
                          - strict:
                              memory_mode = "strict"
@@ -56,5 +57,6 @@
                              memory_mode = "interleave"
                  - preferred_multi:
                      memory_nodeset = "x-y"
+                     err_msg = "NUMA memory tuning.*'preferred' mode only supports single node"
                      memory_mode = "preferred"
                      can_be_dynamic = "yes"

--- a/libvirt/tests/src/numa/numa_memory.py
+++ b/libvirt/tests/src/numa/numa_memory.py
@@ -299,11 +299,15 @@ def run(test, params, env):
         except virt_vm.VMStartError as e:
             # Starting VM failed.
             if status_error:
+                err_msg = params.get('err_msg')
+                if err_msg:
+                    utils_test.libvirt.check_status_output(e.status,
+                                                           output=e.reason,
+                                                           expected_fails=err_msg)
                 return
             else:
                 test.fail("Test failed in positive case.\n "
                           "error: %s\n%s" % (e, bug_url))
-
         # Check qemu process numa memory usage
         memory_status, qemu_cpu = utils_test.qemu.get_numa_status(
             host_numa_node,


### PR DESCRIPTION
When vm fails to start, we should check the error message which are included in the manual test cases.

Signed-off-by: Dan Zheng <dzheng@redhat.com>