### PR TITLE
migration: Fix undefine vm issue

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_option_mix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_migrate_option_mix.py
@@ -222,7 +222,7 @@ def run(test, params, env):
             vm_xml_backup.define()
         elif src_vm_cfg == "transient" and vm.is_persistent():
             logging.debug("Make src vm transient")
-            vm.undefine(options='--nvram')
+            vm.undefine(options='--keep-nvram')
 
         # Prepare for postcopy migration: install and run stress in VM
         if postcopy and src_vm_status == "running":


### PR DESCRIPTION
Define and start a UEFI vm, then undefine vm with --nvram, then do live migration will fail. A workaround is undefine vm with --keep-nvram.

Signed-off-by: cliping <lcheng@redhat.com>