### PR TITLE
migration: Update error message

### DIFF
--- a/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_tls_wrong_cert_configuration.cfg
+++ b/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_tls_wrong_cert_configuration.cfg
@@ -42,10 +42,10 @@
     variants cert_configuration:
         - no_client_cert_on_src:
             cert_path = "${custom_pki_path}/client-cert.pem"
-            err_msg = "operation failed: job 'migration out' failed: Cannot write to TLS channel: Input/output error|unable to execute QEMU command 'object-add': Unable to access credentials ${cert_path}"
+            err_msg = "Cannot write to TLS channel: Input/output error|unable to execute QEMU command 'object-add': Unable to access credentials ${cert_path}"
         - no_server_cert_on_target:
             cert_path = "${custom_pki_path}/server-cert.pem"
             err_msg = "unable to execute QEMU command 'object-add': Unable to access credentials ${cert_path}"
         - wrong_hostname_in_cert:
             server_cn = "test.com.cn"
-            err_msg = "qemu-kvm: Cannot read from TLS channel: Input/output error|operation failed: job 'migration out' failed: Certificate does not match the hostname|Domain not found: no domain with matching uuid"
+            err_msg = "qemu-kvm: Cannot read from TLS channel: Input/output error|Certificate does not match the hostname|Domain not found: no domain with matching uuid"


### PR DESCRIPTION
Fix following issue:
  TestFail: Can not find the expected patterns 'operation failed:
  job 'migration out' failed: Cannot write to TLS channel:
  Input/output error|unable to execute QEMU command
  'object-add': Unable to access credentials
  /etc/pki/qemu/client-cert.pem' in output 'error: operation
  failed: migration out job: Cannot write to TLS channel:
  Input/output error'

Signed-off-by: cliping <lcheng@redhat.com>