### PR TITLE
Fix virtual_disks set_rerror_policy_report case failure

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_rerror_policy.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_rerror_policy.cfg
@@ -10,7 +10,7 @@
     driver_type = 'raw'
     status_error = "no"
     define_error = "no"
-    error_msg = "blk_update_request: I/O error"
+    error_msg = "blk_update_request: I/O error|Buffer I/O error"
     variants:
         - validate_guest_act:
         - start_guest:

--- a/libvirt/tests/src/virtual_disks/virtual_disks_rerror_policy.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_rerror_policy.py
@@ -1,5 +1,6 @@
 import aexpect
 import logging
+import re
 import os
 
 from avocado.utils import process
@@ -110,7 +111,7 @@ def check_dmeg_and_domblkerror(params, vm, test, check_error_msg=True):
             session.cmd("dmesg -C")
             return False
         else:
-            return error_msg in output
+            return re.search(r'%s' % error_msg, output)
 
     result = _check_dmeg_msg(error_msg)
     if check_error_msg:


### PR DESCRIPTION
Fix virtual_disks set_rerror_policy_report case failure

the anticipated error message content has been changed, related python and cfg files are modified to adapt the change

Signed-off-by: chunfuwen <chwen@redhat.com>