### PR TITLE
migration: Fix rng issue

### DIFF
--- a/libvirt/tests/src/migration/migrate_with_virtual_devices.py
+++ b/libvirt/tests/src/migration/migrate_with_virtual_devices.py
@@ -6,6 +6,7 @@ from avocado.utils import process
 
 from virttest.libvirt_xml import vm_xml, xcepts
 from virttest.libvirt_xml.devices import rng
+from virttest.utils_libvirt import libvirt_vmxml
 from virttest.utils_test import libvirt
 from virttest import utils_misc
 from virttest import virsh, libvirt_version
@@ -201,6 +202,10 @@ class MigrationWithRng(MigrationVirtualDevicesBase):
         if self._vm_rng_mode() == 'client':
             self._create_tcp_rng_source(self.migrate_source_host,
                                         mode='server')
+
+        # Remove tpm device. Because tpm device also has a buitin rng device,
+        # after detaching rng device, we will still see /dev/hwrng in vm.
+        libvirt_vmxml.remove_vm_devices_by_type(self.main_vm, 'tpm')
 
         # Remove rng devices from vm xml definition
         self._remove_rng_from_vmxml(self.main_vm)

--- a/spell.ignore
+++ b/spell.ignore
@@ -1196,3 +1196,5 @@ Zhang
 stressapptest
 calc
 domdirtyrate
+hwrng
+buitin


### PR DESCRIPTION
Fix following issue:
  DeviceNotRemovedError: Error in phase POST_MIGRATE_BACK:Device
  rng is not removed from vm

tpm device also has a buitin rng device, so after detaching rng device, we can still see /dev/hwrng in vm. So need to remove tpm device from vm xml.

Signed-off-by: cliping <lcheng@redhat.com>