### PR TITLE
Fix virsh console case failure on s390x

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_console.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_console.py
@@ -198,7 +198,7 @@ def run(test, params, env):
 
     # PAPR guests don't usually have a true serial device (ttyS0),
     # they only have the hypervisor console (/dev/hvc0)
-    if 'ppc64' in platform.machine():
+    if 'ppc64' in platform.machine() or 's390x' in platform.machine():
         params["console_device"] = 'hvc0'
 
     update_console = params.get("update_console", "yes")


### PR DESCRIPTION
Fix virsh console case failure on s390x

this is brittle test, which failed often on s390x
this may be caused by the fact that ttyS0 doesn't refer to a true serial device on PAPR guest

Signed-off-by: chunfuwen <chwen@redhat.com>