### PR TITLE
npiv: fix a 'no available lun' issue

### DIFF
--- a/libvirt/tests/src/npiv/npiv_hostdev_passthrough.py
+++ b/libvirt/tests/src/npiv/npiv_hostdev_passthrough.py
@@ -110,6 +110,8 @@ def run(test, params, env):
         if not online_hbas:
             test.cancel("NO ONLINE HBAs!")
         first_online_hba = online_hbas[0]
+        # enable multipath service
+        process.run("mpathconf --enable", shell=True)
         # create vhba based on the first online hba
         old_vhbas = utils_npiv.find_hbas("vhba")
         logging.debug("Original online vHBAs: %s", old_vhbas)
@@ -117,8 +119,6 @@ def run(test, params, env):
                 {"nodedev_parent": first_online_hba,
                  "scsi_wwnn": scsi_wwnn,
                  "scsi_wwpn": scsi_wwpn})
-        # enable multipath service
-        process.run("mpathconf --enable", shell=True)
         if not utils_misc.wait_for(lambda: utils_npiv.is_vhbas_added(old_vhbas),
                                    timeout=_TIMEOUT):
             test.fail("vhba not successfully created")


### PR DESCRIPTION
Previously the mpathconf was enabled after vhba created and multipathd restarted. This caused mpath dev not show up in time. With this fix, the sequence is correct to be:
1. enable mpathconf > 2. restart multipathd And new device will be show up in time.

Signed-off-by: Yi Sun <yisun@redhat.com>