### PR TITLE
Fixup:Increase memory size to avoid start up failure

### DIFF
--- a/libvirt/tests/cfg/memory/memory_attach_device.cfg
+++ b/libvirt/tests/cfg/memory/memory_attach_device.cfg
@@ -14,7 +14,7 @@
             guest_required_kernel = [5.8.0,)
             func_supported_since_libvirt_ver = (8, 0, 0)
             func_supported_since_qemu_kvm_ver = (6, 2, 0)
-            vm_attrs = {'max_mem_rt': 10485760, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB', 'vcpu': 4, 'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '524288', 'unit': 'KiB'}]}}
+            vm_attrs = {'max_mem_rt': 10485760, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB', 'vcpu': 4, 'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '1048576', 'unit': 'KiB'}]}}
             aarch64:
                 vm_attrs = {'max_mem_rt': 10485760, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB', 'vcpu': 4, 'cpu': {'mode': 'host-passthrough', 'numa_cell': [{'id': '0', 'cpus': '0-3', 'memory': '524288', 'unit': 'KiB'}]}}
             mem_device_attrs = {'mem_model': 'virtio-mem', 'target': {'requested_unit': 'KiB', 'size': 262144, 'node': 0, 'size_unit': 'KiB', 'requested_size': 131072, 'block_unit': 'KiB', 'block_size': 2048}, 'source': {'pagesize_unit': 'KiB', 'pagesize': 2048, 'nodemask': '0'}}

--- a/libvirt/tests/cfg/memory/memory_update_device.cfg
+++ b/libvirt/tests/cfg/memory/memory_update_device.cfg
@@ -10,10 +10,10 @@
             guest_required_kernel = [5.8.0,)
             func_supported_since_libvirt_ver = (8, 0, 0)
             func_supported_since_qemu_kvm_ver = (6, 2, 0)
-            vm_attrs = {'max_mem_rt': 10485760, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB', 'vcpu': 4, 'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '524288', 'unit': 'KiB'}]}}
+            vm_attrs = {'max_mem_rt': 10485760, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB', 'vcpu': 4, 'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '1048576', 'unit': 'KiB'}]}}
             aarch64:
                 vm_attrs = {'max_mem_rt': 10485760, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB', 'vcpu': 4, 'cpu': {'mode': 'host-passthrough', 'numa_cell': [{'id': '0', 'cpus': '0-3', 'memory': '524288', 'unit': 'KiB'}]}}
             mem_device_attrs = {'mem_model': 'virtio-mem', 'target': {'requested_unit': 'KiB', 'size': 262144, 'node': 0, 'size_unit': 'KiB', 'requested_size': 131072, 'block_unit': 'KiB', 'block_size': 2048}, 'source': {'pagesize_unit': 'KiB', 'pagesize': 2048, 'nodemask': '0'}}
-            requested_size = 80MiB
+            requested_size = 160MiB
             check_log_str = "MEMORY_DEVICE_SIZE_CHANGE.*virtiomem"
             virsh_opts = "--alias %s --requested-size ${requested_size}"


### PR DESCRIPTION
The old memory size is lower than system requirements which would cause start up failure.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>