### PR TITLE
virsh_cpu_xml: fix to skip on not skylake

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_xml.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_xml.py
@@ -2,6 +2,8 @@ import logging as log
 import os
 import tempfile
 
+from avocado.utils import cpu
+
 from virttest import data_dir
 from virttest import libvirt_version
 from virttest import virsh               # pylint: disable=W0611
@@ -14,6 +16,20 @@ from virttest.utils_test import libvirt
 logging = log.getLogger('avocado.' + __name__)
 
 
+def check_support(params, test):
+    """
+    Check if current test case is suitable to run
+
+    :param params: dict of test parameters
+    :param test: test object
+    """
+    libvirt_version.is_libvirt_feature_supported(params)
+    file_path = params.get('file_path')
+    if file_path and 'skylake' in file_path:
+        if not cpu.cpu_has_flags(['mpx']) or cpu.cpu_has_flags(['avx512_vnni']):
+            test.cancel("The skylake host is required for this test")
+
+
 def run(test, params, env):
     """
     Run tests for {hypervisor_}cpu_{baseline,compare} with different xmls
@@ -23,7 +39,7 @@ def run(test, params, env):
         cpu xml within capabilities xml from two different hosts
         cpu xml within domain dumpxml from two different hosts
     """
-    libvirt_version.is_libvirt_feature_supported(params)
+    check_support(params, test)
     file_path = params.get('file_path')
     file_xml_declaration = params.get('file_xml_declaration')
     virsh_function = eval(params.get('virsh_function'))


### PR DESCRIPTION
Some cases require Skylake host to run. So this is to add the checking.

Signed-off-by: Dan Zheng <dzheng@redhat.com>