### PR TITLE
sriov: Add a case about attaching a hostdev interface from network

### DIFF
--- a/libvirt/tests/cfg/sriov/plug_unplug/sriov_attach_detach_interface_from_network.cfg
+++ b/libvirt/tests/cfg/sriov/plug_unplug/sriov_attach_detach_interface_from_network.cfg
@@ -1,0 +1,5 @@
+- sriov.plug_unplug.attach_detach_interface_from_network:
+    type = sriov_attach_detach_interface_from_network
+    start_vm = "no"
+    network_dict = {'forward': {'mode': 'hostdev', 'managed': 'yes'}, 'name': 'hostdev_net', 'vf_list': [{'type_name': 'pci', 'attrs': vf_pci_addr}]}
+    only x86_64

--- a/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_interface_from_network.py
+++ b/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_interface_from_network.py
@@ -1,0 +1,50 @@
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vfio
+
+from provider.sriov import check_points
+from provider.sriov import sriov_base
+
+
+def run(test, params, env):
+    """
+    Attach interface to guest from a hostdev network
+    """
+    def run_test():
+        """
+        Attach interface to guest from a hostdev network and detach it.
+        """
+        test.log.info("TEST_STEP1: Start the VM")
+        vm.start()
+        vm_session = vm.wait_for_serial_login(timeout=240)
+
+        test.log.info("TEST_STEP2: Attach a hostdev interface to VM")
+        opts = "network %s" % network_dict['name']
+        virsh.attach_interface(vm.name, opts, debug=True,
+                               ignore_status=False)
+
+        check_points.check_vm_network_accessed(vm_session)
+
+        test.log.info("TEST_STEP3: Detach the hostdev interface.")
+        virsh.detach_interface(vm.name, "hostdev", debug=True,
+                               ignore_status=False, wait_for_event=True)
+        cur_hostdevs = vm_xml.VMXML.new_from_dumpxml(vm.name)\
+            .devices.by_device_tag("interface")
+        if cur_hostdevs:
+            test.fail("Got hostdev interface(%s) after detaching the "
+                      "device!" % cur_hostdevs)
+
+        libvirt_vfio.check_vfio_pci(sriov_test_obj.vf_pci, True)
+
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    vm = env.get_vm(vm_name)
+    sriov_test_obj = sriov_base.SRIOVTest(vm, test, params)
+    network_dict = sriov_test_obj.parse_network_dict()
+
+    try:
+        sriov_test_obj.setup_default(network_dict=network_dict)
+        run_test()
+
+    finally:
+        sriov_test_obj.teardown_default(network_dict=network_dict)


### PR DESCRIPTION
This PR adds:
    VIRT-292861: Attach-interface to guest from a hostdev network

Signed-off-by: Yingshun Cui <yicui@redhat.com>

` (1/1) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_interface_from_network: PASS (81.56 s)
`