### PR TITLE
virtual_disk: Fix nbd server is not ready

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_nbd.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_nbd.py
@@ -229,7 +229,7 @@ def run(test, params, env):
                         private_key_encrypt_passphrase=private_key_encrypt_passphrase, secret_uuid=secret_uuid)
         nbd.start_nbd_server()
         utils_misc.wait_for(
-            lambda: process.system('pgrep qemu-nbd', ignore_status=True, shell=True) == 0, 10)
+            lambda: process.system('netstat -nlp | grep %s ' % nbd_server_port, ignore_status=True, shell=True) == 0, 10)
         # Prepare disk source xml
         source_attrs_dict = {"protocol": "nbd", "tls": "%s" % tls_bit}
         if export_name:


### PR DESCRIPTION
Use `lsof` instead of `pgrep` to make sure the nbd server is really ready.

`pgrep` will always get the pid of `qemu-nbd` after the nbd server starts, whether or not the nbd server is really ready.
If the nbd server is not ready, the guest will fail to start.

Before:
```
# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio virtual_disks.nbd.coldplug.enable_tls.default.enable_export.domain_operate.snap_shot --vt-connect-uri qemu:
///system
JOB ID : e8dd2f15d799e088b3ca469964cf21fbd368e52e 
JOB LOG : /var/lib/avocado/job-results/job-2022-09-21T10.27-e8dd2f1/job.log 
(1/1) type_specific.io-github-autotest-libvirt.virtual_disks.nbd.coldplug.enable_tls.default.enable_export.domain_operate.snap_shot: FAIL: VM should start but failed: VM 'avocado-vt-vm1' failed to start: error: Failed to start domain 'avocado-vt-vm1'\nerror: internal error: process exited while connecting to monitor: 2022-09-21T14:27:48.296106Z qemu-kvm: -blockdev {"driver":"nbd","server":{"t... (30.68 s) 
RESULTS : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0 
JOB HTML : /var/lib/avocado/job-results/job-2022-09-21T10.27-e8dd2f1/results.html 
JOB TIME : 31.11 s

```

After:
```
# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio virtual_disks.nbd.coldplug.enable_tls.default.enable_export.domain_operate.snap_shot --vt-connect-uri qemu:
///system                                                                                                                                                                                                                                                                                                    
JOB ID     : 639a482d3c01c446f451c4efe70ee551e9be50d8                                                                                                                                                                                        
JOB LOG    : /var/lib/avocado/job-results/job-2022-09-25T22.44-639a482/job.log                                                                                                                                                               
 (1/1) type_specific.io-github-autotest-libvirt.virtual_disks.nbd.coldplug.enable_tls.default.enable_export.domain_operate.snap_shot: PASS (175.80 s)                                                                                        
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0                                                                                                                                                            
JOB HTML   : /var/lib/avocado/job-results/job-2022-09-25T22.44-639a482/results.html                                                                                                                                                          
JOB TIME   : 176.27 s
```


Signed-off-by: Hu Shuai <hus.fnst@fujitsu.com>