### PR TITLE
iothread: fix var missing

### DIFF
--- a/libvirt/tests/cfg/cpu/iothread.cfg
+++ b/libvirt/tests/cfg/cpu/iothread.cfg
@@ -78,6 +78,7 @@
                             iothreadpins = "1:1"
                             err_msg = "error: unsupported configuration: Cannot find 'iothread' : 1"
                 - iothread_poll:
+                    pre_vm_stats = "running"
                     iothread_ids = "1 4 2"
                     iothread_num = "3"
                     iothreadset_id = "1"


### PR DESCRIPTION
In https://github.com/autotest/tp-libvirt/pull/4500, this vm state variable is missed for negative cases for thread poll test. This caused some cases fail.

Signed-off-by: Dan Zheng <dzheng@redhat.com>