### PR TITLE
virtual_devices: Sound dev default address slot

### DIFF
--- a/libvirt/tests/cfg/virtual_device/sound_device.cfg
+++ b/libvirt/tests/cfg/virtual_device/sound_device.cfg
@@ -18,6 +18,7 @@
             sound_model = ich6
         - sound_model_ich9:
             no pseries
+            slot_value = "0x1b"
             sound_model = ich9
     variants:
         - positive_test:

--- a/libvirt/tests/src/virtual_device/sound_device.py
+++ b/libvirt/tests/src/virtual_device/sound_device.py
@@ -47,6 +47,12 @@ def run(test, params, env):
                 test.fail("Can not find the %s codec xml for sound dev "
                           "in the guest xml file." % codec_type)
 
+        if sound_model == "ich9":
+            sound_devices = xml_after_adding_device.get_devices("sound")
+            for device in sound_devices:
+                if device.model_type == "ich9":
+                    check_device_address_slot(device, expected_address_slot_value)
+
     def check_qemu_cmd_line():
         """
         Check whether the added devices are shown in the qemu cmd line
@@ -78,11 +84,26 @@ def run(test, params, env):
                 test.fail("Can not find the %s codec for sound dev "
                           "in qemu cmd line." % codec_type)
 
+    def check_device_address_slot(sound_device, expected_value):
+        """
+        Checks if the address slot of a given sound_device has expected value.
+
+        :param sound_device: XML device object, the sound device to check
+        :param expected_value: String, value the device addr. slot should match
+        """
+        slot_value = sound_device.address["slot"]
+        if slot_value != expected_value:
+            test.fail(f"Expected address slot value '{expected_value}' but got"
+                      "'{slot_value}'")
+        else:
+            logging.info(f"Address slot value matches '{expected_value}'")
+
     vm_name = params.get("main_vm", "avocado-vt-vm1")
     vm = env.get_vm(vm_name)
 
     status_error = params.get("status_error", "no") == "yes"
     sound_model = params.get("sound_model")
+    expected_address_slot_value = params.get("slot_value")
 
     # AC97 sound model supported since 0.6.0
     if sound_model == "ac97":


### PR DESCRIPTION
This commit adds a check for ich9 sound device. When ich9 sound device is added it's address slot should be 0xb1 by default after VM start.

LIBVIRTAT-13557
VIRT-89396
```
[root@dell-per740-03 ~]# avocado run --vt-type libvirt virtual_devices.sound_device.positive_test.sound_model_ich9.codec_type_duplex
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : 6a740a6da99bcf757e6ea5bbd55377e4c73c3e30
JOB LOG    : /var/lib/avocado/job-results/job-2022-10-07T11.11-6a740a6/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_devices.sound_device.positive_test.sound_model_ich9.codec_type_duplex: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.virtual_devices.sound_device.positive_test.sound_model_ich9.codec_type_duplex: PASS (8.01 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-10-07T11.11-6a740a6/results.html
JOB TIME   : 10.49 s
```

# Check lists by category
## If the PR is new cases
- [x] Description of the cases
- [x] Links of libvirt features, libvirt bugs or case IDs
- [x] Test results