### PR TITLE
Fix travis CI failure on python3.7 due to importlib-metadata

### DIFF
--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -7,3 +7,4 @@ simplejson==3.8.1
 inspektor==0.5.2
 pylint==2.11.1
 pyenchant
+importlib-metadata==4.13.0; python_version == '3.7'


### PR DESCRIPTION
Signed-off-by: chunfuwen <chwen@redhat.com>