### PR TITLE
memory_misc: Enable memorybacking nodeset tests for aarch64

### DIFF
--- a/libvirt/tests/cfg/memory/memory_misc.cfg
+++ b/libvirt/tests/cfg/memory/memory_misc.cfg
@@ -39,6 +39,8 @@
                     mem_device_attrs = {'source': {'pagesize_unit': 'KiB', 'pagesize': 2048, 'nodemask': '0'}, 'mem_model': 'dimm', 'target': {'size': 131072, 'node': 1, 'size_unit': 'KiB'}}
                 - nodeset_specified:
                     pagesize = 1048576
+                    aarch64:
+                        pagesize = 524288
                     pagenum = 10
                     variants scenario:
                         - nodeset_0:


### PR DESCRIPTION
the hugepage for aarch64 are 2048/524288/16777216

Test Result:
```
# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio memory_misc.memorybacking.nodeset_specified --vt-connect-uri qemu:///system                                                                                  
JOB ID     : d3451cb6400c53f365ddf4c953f7c1e5ea3a32f2                                                                                                                                                                                        
JOB LOG    : /var/lib/avocado/job-results/job-2022-10-08T05.45-d3451cb/job.log                                                                                                                                                               
 (1/2) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.nodeset_specified.nodeset_0: PASS (4.30 s)                                                                                                                         
 (2/2) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.nodeset_specified.nodeset_01: PASS (4.95 s)                                                                                                                        
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0                                                                                                                                                            
JOB HTML   : /var/lib/avocado/job-results/job-2022-10-08T05.45-d3451cb/results.html                                                                                                                                                          
JOB TIME   : 9.60 s
```

Signed-off-by: Hu Shuai <hus.fnst@fujitsu.com>