### PR TITLE
fix rm folder error

### DIFF
--- a/libvirt/tests/src/backingchain/blockcopy/blockcopy_with_blockdev_option.py
+++ b/libvirt/tests/src/backingchain/blockcopy/blockcopy_with_blockdev_option.py
@@ -65,7 +65,7 @@ def run(test, params, env):
         bkxml.sync()
         disk_obj.cleanup_block_disk_preparation(disk_obj.vg_name, lv_name+"1")
 
-        process.run("rm -f %s" % ("/dev/%s" % disk_obj.vg_name))
+        process.run("rm -rf %s" % ("/dev/%s" % disk_obj.vg_name))
         process.run("rm -f %s" % file_snap_path)
 
     def _do_snap(lvm_list):


### PR DESCRIPTION
 rm f folder in rhel8.8 get error, need rm rf
Signed-off-by: nanli <nanli@redhat.com>


```
Get error while rm folder on    rhel 8.8 : d 'rm -f /dev/vg0' failed.\nstdout: b''\nstderr: 
b"rm: cannot remove '/dev/vg0': Is a directory\n"\


Test result after updated:
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockcopy.blockdev_option.file_disk.blockdev --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.blockdev_option.file_disk.blockdev: PASS (46.62 s)

```