### PR TITLE
virsh_cpu_stats: Fix comparison of floating point numbers

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_stats.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_stats.py
@@ -1,4 +1,5 @@
 import re
+import math
 import os.path
 import logging as log
 
@@ -210,15 +211,17 @@ def run(test, params, env):
 
             # check cgroup cpu_time > sum of cpu_time
             if end_num >= 0:
-                logging.debug("Check sum of cgroup cpu_time %d >= cpu_time %d",
+                # usage_percpu reports the CPU time in nanoseconds
+                sum_cgtime = sum_cgtime/1000000000
+                logging.debug("Check sum of cgroup cpu_time %0.9f >= cpu_time %0.9f",
                               sum_cgtime, sum_cputime)
-                if sum_cputime > sum_cgtime:
+                if not (math.isclose(sum_cgtime, sum_cputime) or sum_cgtime > sum_cputime):
                     test.fail("Check sum of cgroup cpu_time < sum "
                               "of output cpu_time")
 
             # check Total cpu_time >= sum of cpu_time when no options
             if get_noopt:
-                logging.debug("Check total time %d >= sum of output cpu_time"
-                              " %d", total_time, sum_cputime)
-                if total_time < sum_cputime:
+                logging.debug("Check total time %0.9f >= sum of output cpu_time"
+                              " %0.9f", total_time, sum_cputime)
+                if not (math.isclose(total_time, sum_cputime) or total_time > sum_cputime):
                     test.fail("total time < sum of output cpu_time")


### PR DESCRIPTION
It's better to use math.isclose() to check if the floating point numbers are equal, due to precision errors in floating point calculations.

Signed-off-by: Hu Shuai <hus.fnst@fujitsu.com>