### PR TITLE
fix relative path secret missed issue

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockcommit/blockcommit_relative_path.cfg
+++ b/libvirt/tests/cfg/backingchain/blockcommit/blockcommit_relative_path.cfg
@@ -48,4 +48,5 @@
             auth_user = "EXAMPLE_AUTH_USER"
             image_path = "EXAMPLE_IMAGE_PATH"
             client_name = "EXAMPLE_CLIENT_NAME"
+            sec_dict = {"secret_ephemeral": "no", "secret_private": "yes", "description": "secret_desc_for_backingchain", "usage": "ceph", "usage_name": "cephlibvirt"}
             disk_dict = {"device": "disk", "type_name": "file","target": {"dev": "${target_disk}", "bus": "virtio"},"driver": {"name": "qemu", "type": "qcow2"},"source": {"attrs": {"file": "%s"}},"backingstore": {"type": "file", "format":{'type': "qcow2"},"source": {"attrs": {"file": "%s"}},"backingstore":{"type": "file","format": {'type': "qcow2"},"source": {"attrs": {"file": "%s"}},"backingstore":{"type": "network","format": {'type': "raw"},"source": {'attrs': {'protocol': "rbd", "name": "%s"},"host": {"name":"${mon_host}"},"auth": {"auth_user": "${auth_user}","secret_usage": "cephlibvirt","secret_type": "ceph"}}}}}}

--- a/libvirt/tests/cfg/backingchain/blockpull/blockpull_relative_path.cfg
+++ b/libvirt/tests/cfg/backingchain/blockpull/blockpull_relative_path.cfg
@@ -34,5 +34,6 @@
             auth_user = "EXAMPLE_AUTH_USER"
             image_path = "EXAMPLE_IMAGE_PATH"
             client_name = "EXAMPLE_CLIENT_NAME"
+            sec_dict = {"secret_ephemeral": "no", "secret_private": "yes", "description": "secret_desc_for_backingchain", "usage": "ceph", "usage_name": "cephlibvirt"}
             disk_dict = {"device": "disk", "type_name": "file","target": {"dev": "${target_disk}", "bus": "virtio"},"driver": {"name": "qemu", "type": "qcow2"},"source": {"attrs": {"file": "%s"}},"backingstore": {"type": "file", "format":{'type': "qcow2"},"source": {"attrs": {"file": "%s"}},"backingstore":{"type": "file","format": {'type': "qcow2"},"source": {"attrs": {"file": "%s"}},"backingstore":{"type": "network","format": {'type': "raw"},"source": {'attrs': {'protocol': "rbd", "name": "%s"},"host": {"name":"${mon_host}"},"auth": {"auth_user": "${auth_user}","secret_usage": "cephlibvirt","secret_type": "ceph"}}}}}}
             expected_chain = '3>2>base'

--- a/libvirt/tests/src/backingchain/blockcommit/blockcommit_relative_path.py
+++ b/libvirt/tests/src/backingchain/blockcommit/blockcommit_relative_path.py
@@ -5,6 +5,7 @@ from avocado.utils import process
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_libvirt import libvirt_disk
+from virttest.utils_libvirt import libvirt_secret
 from virttest.utils_test import libvirt
 
 from provider.backingchain import blockcommand_base
@@ -35,7 +36,12 @@ def run(test, params, env):
         test.log.info("TEST_SETUP1: Prepare relative path and new disk.")
         test_obj.new_image_path, _ = disk_obj.prepare_relative_path(disk_type)
 
-        disk_dict, kwargs = _get_disk_param()
+        disk_dict, sec_dict, kwargs = _get_disk_param()
+        if disk_type == 'rbd_with_auth':
+            libvirt_secret.clean_up_secrets()
+            sec_uuid = libvirt_secret.create_secret(sec_dict=sec_dict)
+            virsh.secret_set_value(sec_uuid, auth_key, debug=True)
+
         disk_obj.add_vm_disk(disk_type, disk_dict,
                              new_image_path=test_obj.new_image_path, **kwargs)
 
@@ -96,7 +102,8 @@ def run(test, params, env):
             pvt.cleanup_pool(**params)
             process.run("rm -rf %s" % pool_target)
 
-        if disk_type == 'rbd_with_auth_disk':
+        if disk_type == 'rbd_with_auth':
+            libvirt_secret.clean_up_secrets()
             process.run("rm -f %s" % params.get("keyfile"))
             cmd = ("rbd -m {0} info {1} && rbd -m {0} rm {1}".format(
                 mon_host, rbd_source_name))
@@ -108,6 +115,7 @@ def run(test, params, env):
 
         :return disk_dict and **kwargs
         """
+        sec_dict = eval(params.get("sec_dict", "{}"))
         kwargs = {}
         if disk_type == "rbd_with_auth":
             kwargs.update({'no_update_dict': True})
@@ -118,7 +126,7 @@ def run(test, params, env):
         else:
             disk_dict = eval(params.get("disk_dict", "{}"))
 
-        return disk_dict, kwargs
+        return disk_dict, sec_dict, kwargs
 
     def _pre_vm_state():
         if not vm.is_alive():
@@ -162,6 +170,7 @@ def run(test, params, env):
     base_index = params.get('base_image_suffix')
     virsh_opt = params.get('virsh_opt')
     pool_target = params.get('pool_target')
+    auth_key = params.get('auth_key')
 
     test_scenario = params.get('test_scenario')
     vm_state = params.get('vm_state')


### PR DESCRIPTION
  Need to create secret before add relative path to disk
Signed-off-by: nanli <nanli@redhat.com>

```
Test error before  updated:
ERROR: VM 'avocado-vt-vm1' failed to start: error: Failed to start domain 'avocado-vt-vm1'\nerror: 
Secret not found: no secret with matching usage 'cephlibvirt' 

```
Test result:
 ```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockpull.relative_path
 (1/3) type_specific.io-github-autotest-libvirt.backingchain.blockpull.relative_path.file_disk.keep_relative: PASS (28.28 s)
 (2/3) type_specific.io-github-autotest-libvirt.backingchain.blockpull.relative_path.block_disk.keep_relative: PASS (51.52 s)
 (3/3) type_specific.io-github-autotest-libvirt.backingchain.blockpull.relative_path.rbd_with_auth_disk.keep_relative: PASS (33.62 s)

 avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockcommit.relative_path --vt-connect-uri qemu:///system
 (1/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.file_disk.keep_relative.active.vm_started: PASS (43.48 s)
 (2/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.file_disk.keep_relative.active.vm_paused: PASS (44.59 s)
 (3/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.file_disk.keep_relative.inactive.vm_started: PASS (44.16 s)
 (4/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.file_disk.keep_relative.inactive.vm_paused: PASS (43.44 s)
 (5/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.block_disk.keep_relative.active.vm_started: PASS (72.76 s)
 (6/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.block_disk.keep_relative.active.vm_paused: PASS (71.86 s)
 (7/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.rbd_with_auth_disk.keep_relative.active.vm_started: PASS (49.24 s)
 (8/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.rbd_with_auth_disk.keep_relative.active.vm_paused: PASS (46.13 s)


```