### PR TITLE
PCIe: pcie-root-port chassis and port checks

### DIFF
--- a/libvirt/tests/cfg/controller/pcie_root_port_controller.cfg
+++ b/libvirt/tests/cfg/controller/pcie_root_port_controller.cfg
@@ -1,0 +1,21 @@
+- pcie_root_port_controller:
+    type = pcie_root_port_controller
+    start_vm = "no"
+    controller_model = "pcie-root-port"
+    controller_target = '{"chassis":1,"port":"0x8"}'
+    variants:
+        - positive_test:
+            status_error = "no"
+            variants:
+                - controllers_different_chassis_same_port:
+                    second_controller_model = "pcie-root-port"
+                    second_controller_target = "{'chassis':2,'port':'0x8'}"
+        - negative_test:
+            status_error = "yes"
+            variants:
+                - controllers_same_chassis_same_port:
+                    second_controller_model = "pcie-root-port"
+                    second_controller_target = "{'chassis':1,'port':'0x8'}"
+                - controllers_same_chassis_different_port:
+                    second_controller_model = "pcie-root-port"
+                    second_controller_target = "{'chassis':1,'port':'0x4'}"

--- a/libvirt/tests/src/controller/pcie_root_port_controller.py
+++ b/libvirt/tests/src/controller/pcie_root_port_controller.py
@@ -1,0 +1,99 @@
+import logging
+import ast
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+
+def setup_test(params):
+    """
+    Perform step needed before test can be executed.
+
+    :param params: Test parameters object
+    """
+    controller_model = params.get("controller_model")
+    controller_target = ast.literal_eval(params.get("controller_target"))
+    second_controller_model = params.get("second_controller_model")
+    second_controller_target = ast.literal_eval(params.get("second_controller_target"))
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(params.get("main_vm", "avocado-vt-vm1"))
+    index = 0
+
+    vmxml.remove_all_device_by_type("controller")
+
+    contr_dict = {"type": "pci", "model": "pcie-root", "index": index}
+    libvirt_vmxml.modify_vm_device(vmxml, "controller", contr_dict, index)
+
+    index += 1
+    contr_dict = {'type': 'pci',
+                  'model': controller_model,
+                  "index": index,
+                  'target': controller_target}
+    libvirt_vmxml.modify_vm_device(vmxml, "controller", contr_dict, index)
+
+    index += 1
+    if second_controller_model and second_controller_target:
+        contr_dict = {'type': 'pci',
+                      'model': second_controller_model,
+                      "index": index,
+                      'target': second_controller_target}
+        libvirt_vmxml.modify_vm_device(vmxml, "controller", contr_dict, index)
+
+    vmxml.sync()
+
+
+def execute_test(vm, test, params):
+    """
+    Perform the checks that make the case.
+
+    :param vm: VM object from avocado
+    :param test: Avocado test object
+    :param params: Test parameters object
+    """
+    status_error = params.get("status_error") == "yes"
+    LOG.debug("Starting VM with XML:\n%s", vm_xml.VMXML.new_from_dumpxml(vm.name))
+    try:
+        vm.start()
+    except Exception as exc:
+        if status_error:
+            LOG.info("VM failed to start as expected.")
+        else:
+            test.fail("VM failed to start, reason: %s" % exc)
+    else:
+        if vm.is_alive() and status_error:
+            test.fail("VM started sucessfully, but shouldn't.")
+
+
+def cleanup_test(vm, vmxml_backup):
+    """
+    Reconfigure the environment back to the state if was in before test setup.
+
+    :param vm: VM object of the VM we're operating on
+    :param vmxml_backup: Backup vmxml to restore to
+    """
+    LOG.info("Start cleanup")
+    if vm.is_alive():
+        vm.destroy()
+    LOG.info("Restore the VM XML")
+    vmxml_backup.sync()
+
+
+def run(test, params, env):
+    """
+    Function executed by avocado. Similar to "main" function of a module.
+
+    :params test: Test object of Avocado framework
+    :params params: Object containing parameters of a test from cfg file
+    :params env: Environment object from Avocado framework
+    """
+
+    vm = env.get_vm(params.get("main_vm", "avocado-vt-vm1"))
+    vmxml_backup = vm_xml.VMXML.new_from_dumpxml(vm.name)
+
+    setup_test(params)
+    try:
+        execute_test(vm, test, params)
+    finally:
+        cleanup_test(vm, vmxml_backup)


### PR DESCRIPTION
This PR adds checks for target chassis and ports for PCIe controllers.

VIRT-55416
```
 [root@dell-per740xd-25 ~]# avocado run --vt-type libvirt pcie_controllers.positive_tests.controllers_different_chassis_same_port.hotplug_off pcie_controllers.negative_tests.controllers_same_chassis_same_port.hotplug_off pcie_controllers.negative_tests.controllers_same_chassis_different_port.hotplug_off
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : 590302295e207d3a946f0e78348ecc0ba4086b69
JOB LOG    : /var/lib/avocado/job-results/job-2022-10-20T05.10-5903022/job.log
 (1/3) type_specific.io-github-autotest-libvirt.pcie_controllers.positive_tests.controllers_different_chassis_same_port.hotplug_off: STARTED
 (1/3) type_specific.io-github-autotest-libvirt.pcie_controllers.positive_tests.controllers_different_chassis_same_port.hotplug_off: PASS (68.74 s)
 (2/3) type_specific.io-github-autotest-libvirt.pcie_controllers.negative_tests.controllers_same_chassis_same_port.hotplug_off: STARTED
 (2/3) type_specific.io-github-autotest-libvirt.pcie_controllers.negative_tests.controllers_same_chassis_same_port.hotplug_off: PASS (37.27 s)
 (3/3) type_specific.io-github-autotest-libvirt.pcie_controllers.negative_tests.controllers_same_chassis_different_port.hotplug_off: STARTED
 (3/3) type_specific.io-github-autotest-libvirt.pcie_controllers.negative_tests.controllers_same_chassis_different_port.hotplug_off: PASS (37.29 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-10-20T05.10-5903022/results.html
JOB TIME   : 146.97 s
```