### PR TITLE
Fix blockpull failure due to low timeout value

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockpull.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockpull.py
@@ -354,7 +354,7 @@ def run(test, params, env):
             blockpull_options = "--wait --verbose"
 
         if with_timeout:
-            blockpull_options += " --timeout 1"
+            blockpull_options += " --timeout 5"
 
         if bandwidth:
             blockpull_options += " --bandwidth %s" % bandwidth


### PR DESCRIPTION
Fix blockpull failure due to low timeout value
In some extreme case, current timeout value:1 second is not enough, so blockpull operation will be aborted

Signed-off-by: chunfuwen <chwen@redhat.com>