### PR TITLE
virsh_attach_detach_disk: Fix "No more available PCI slots" error

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_disk.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_attach_detach_disk.cfg
@@ -136,6 +136,8 @@
                     at_dt_disk_at_options =  " --targetbus scsi"
                     at_dt_disk_address = " scsi:00.00.0"
                     at_dt_disk_address2 = " scsi:01.00.0"
+                    aarch64:
+                        reset_pci_controllers_nums = 'yes'
                 - twice_multifunction:
                     only attach_disk
                     qemu_file_lock = '2.9.0'


### PR DESCRIPTION
The default PCI slots are not enough to attach two new disks for aarch64.

Before:
```
# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio virsh.attach_detach_disk.attach_disk.normal_test.twice_same_target_diff_scsi_address --vt-connect-uri qemu:///system                                                                          
JOB ID     : 6b6068fe17033d499a82bc464fcad8e3286cbf3c                                           
JOB LOG    : /var/lib/avocado/job-results/job-2022-10-12T00.08-6b6068f/job.log                                                                                                        
 (1/1) type_specific.io-github-autotest-libvirt.virsh.attach_detach_disk.attach_disk.normal_test.twice_same_target_diff_scsi_address: ERROR: Command '/usr/bin/virsh attach-disk --domain avocado-vt-vm1 --source /var/lib/avocado/data/avocad
o-vt/attach.img --target sdb  --targetbus scsi --address  scsi:01.00.0' failed.\nstdout: b'\n'\nstderr: b'error: Failed to attach disk\nerror: internal error: No more available PCI slots (64.34 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-10-12T00.08-6b6068f/results.html                                                                      
JOB TIME   : 65.23 s
```

After:
```
# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio virsh.attach_detach_disk.attach_disk.normal_test.twice_same_target_diff_scsi_address --vt-connect-uri qemu:///system                                                              
JOB ID     : ac18a57944d0072d65ba6f14664b1a7edc58ec28
JOB LOG    : /var/lib/avocado/job-results/job-2022-10-12T03.57-ac18a57/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.attach_detach_disk.attach_disk.normal_test.twice_same_target_diff_scsi_address: PASS (68.13 s)                                                                                         
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-10-12T03.57-ac18a57/results.html
JOB TIME   : 69.02 s
```


Signed-off-by: Hu Shuai <hus.fnst@fujitsu.com>