### PR TITLE
backingchain: add case for blockpull with invalid base image

### DIFF
--- a/libvirt/tests/cfg/backingchain/negative_scenario/blockpull_with_invalid_base.cfg
+++ b/libvirt/tests/cfg/backingchain/negative_scenario/blockpull_with_invalid_base.cfg
@@ -1,0 +1,11 @@
+- backingchain.negative.blockpull.invalid_base:
+    type = blockpull_with_invalid_base
+    start_vm = "yes"
+    target_disk = "vda"
+    snap_num = 4
+    pull_options = "--base %s --wait --verbose"
+    error_msg = "error: invalid argument: could not find image "
+    variants case:
+        - active_as_base:
+        - not_existing_path:
+            not_exist_file = "/var/lib/libvirt/images/xxxx.img"

--- a/libvirt/tests/src/backingchain/negative_scenario/blockpull_with_invalid_base.py
+++ b/libvirt/tests/src/backingchain/negative_scenario/blockpull_with_invalid_base.py
@@ -1,0 +1,75 @@
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_test import libvirt
+
+from provider.backingchain import blockcommand_base
+
+
+def run(test, params, env):
+    """
+    Do blockpull with invalid base image
+
+    1) Prepare a running guest and snap chain.
+    2) Do blockpull
+        S1: Do blockpull with active image as base.
+        S2: Do blockpull with nonexist base image.
+    3) Check error
+    """
+
+    def setup_test():
+        """
+        Prepare running guest and create snap chain.
+       """
+        test.log.info("TEST_SETUP:Start vm and create snap chain")
+        test_obj.backingchain_common_setup(create_snap=True,
+                                           snap_num=snap_num)
+
+    def run_test():
+        """
+        Do blockpull with invalid base image
+        """
+        invalid_path = ""
+        if case == "active_as_base":
+            invalid_path = test_obj.snap_path_list[-1]
+        elif case == "not_existing_path":
+            invalid_path = not_exist_file
+
+        test.log.info("TEST_STEP:Do blockpull and check error message")
+        result = virsh.blockpull(vm.name, target_disk,
+                                 pull_options % invalid_path,
+                                 ignore_status=True,
+                                 debug=True)
+        libvirt.check_result(result, expected_fails=error_msg,
+                             check_both_on_error=True)
+
+    def teardown_test():
+        """
+        Clean data.
+        """
+        test.log.info("TEST_TEARDOWN: Clean up env.")
+        test_obj.backingchain_common_teardown()
+        bkxml.sync()
+
+    # Process cartesian parameters
+    vm_name = params.get("main_vm")
+    target_disk = params.get('target_disk')
+    case = params.get('case')
+    snap_num = int(params.get('snap_num'))
+    not_exist_file = params.get('not_exist_file')
+    pull_options = params.get('pull_options')
+    error_msg = params.get('error_msg')
+
+    vm = env.get_vm(vm_name)
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+
+    # Create object
+    test_obj = blockcommand_base.BlockCommand(test, vm, params)
+
+    try:
+        setup_test()
+        run_test()
+
+    finally:
+        teardown_test()


### PR DESCRIPTION
    VIRT-294591: Do blockpull with invalid base image
Signed-off-by: nanli <nanli@redhat.com>

Test result:
```

avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.negative.blockpull.invalid_base
 (1/2) type_specific.io-github-autotest-libvirt.backingchain.negative.blockpull.invalid_base.active_as_base: PASS (23.57 s)
 (2/2) type_specific.io-github-autotest-libvirt.backingchain.negative.blockpull.invalid_base.not_existing_path: PASS (19.72 s)
```