### PR TITLE
virsh_attach_device: make sure device is ready before attaching a new device

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
@@ -8,6 +8,7 @@ import logging as log
 from string import ascii_lowercase
 import itertools
 import platform
+import time
 import aexpect
 
 from six import iteritems
@@ -367,6 +368,7 @@ class AttachDeviceBase(TestDeviceBase):
         if (cmdresult.exit_status == 0):
             if (cmdresult.stdout.strip().count('attached successfully') or
                     cmdresult.stderr.strip().count('attached successfully')):
+                time.sleep(3)
                 return True
         else:
             # See analyze_negative_results - expects return of true


### PR DESCRIPTION
/dev/vdX in guest may be inconsistent with disk->target@dev in XML, if the old device is not ready in guest before attaching a new device to the guest.

Before:
```
# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio virsh.attach_device.block.multi_virtio_file.with_alias.normal_test.hot_attach_hot_vm_current.name_ref.file_positional.domain_positional --vt-connect-uri qemu:///system
JOB ID : 98178aac2a79dc233e2ed45374cda6fc85a989a8 
JOB LOG : /var/lib/avocado/job-results/job-2022-10-12T14.22-98178aa/job.log 
 (1/1) type_specific.io-github-autotest-libvirt.virsh.attach_device.block.multi_virtio_file.with_alias.normal_test.hot_attach_hot_vm_current.name_ref.file_positional.domain_positional: FAIL: Positive pre-boot functionality test failed (285.12 s) 
RESULTS : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0 
JOB HTML : /var/lib/avocado/job-results/job-2022-10-12T14.22-98178aa/results.html 
JOB TIME : 286.19 s
```

After:
```
# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio virsh.attach_device.block.multi_virtio_file.with_alias.normal_test.hot_attach_hot_vm_current.name_ref.file_positional.domain_positional --vt-connect-uri qemu:///system                                                                
JOB ID     : a17c92bbbe012f399746c7d97a6a5caf70119d66
JOB LOG    : /var/lib/avocado/job-results/job-2022-10-17T03.12-a17c92b/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.attach_device.block.multi_virtio_file.with_alias.normal_test.hot_attach_hot_vm_current.name_ref.file_positional.domain_positional:  PASS (214.01 s)                                     
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-10-17T03.12-a17c92b/results.html
JOB TIME   : 215.10 s
```

Signed-off-by: Hu Shuai <hus.fnst@fujitsu.com>