### PR TITLE
virtual_device: use EventTracker to wait for detach_device to complete

### DIFF
--- a/libvirt/tests/src/virtual_device/vsock.py
+++ b/libvirt/tests/src/virtual_device/vsock.py
@@ -271,7 +271,9 @@ def run(test, params, env):
                     vm.name, vsock_dev.alias['name'], ignore_status=False,
                     debug=True, wait_for_event=True, event_timeout=20)
             else:
-                result = virsh.detach_device(vm_name, vsock_dev.xml, debug=True)
+                result = virsh.detach_device(
+                    vm_name, vsock_dev.xml, debug=True,
+                    wait_for_event=True, event_timeout=20)
             utils_test.libvirt.check_exit_status(result, expect_error=False)
             utils_misc.wait_for(_detach_completed, timeout=20)
             vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)


### PR DESCRIPTION
Device can not be hot unplugged immediately after hotplug.

Before:
```
# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio vsock.normal_test.hotplug.nop.auto_cid --vt-connect-uri qemu:///system                                                                                                            
JOB ID     : 43d3c455478606cf39b44ee8f05b2b1c7301b003                                                                                                                                                                                         
JOB LOG    : /var/lib/avocado/job-results/job-2022-10-17T04.12-43d3c45/job.log                                                                                                                                                                
 (1/1) type_specific.io-github-autotest-libvirt.vsock.normal_test.hotplug.nop.auto_cid: FAIL: error: Failed to detach device from /tmp/xml_utils_temp__0pjfaxj.xml\nerror: internal error: unable to execute QEMU command 'device_del': Hot-un
plug failed: guest is busy (power indicator blinking)\n (27.35 s)                                                                                                                                                                            
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0                                                                                                                                                            
JOB HTML   : /var/lib/avocado/job-results/job-2022-10-17T04.12-43d3c45/results.html                                                                                                                                                          
JOB TIME   : 27.74 s
```

After:
```
# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio vsock.normal_test.hotplug.nop.auto_cid --vt-connect-uri qemu:///system                                                                                                             
JOB ID     : 324e8fc3df5339f98cf9716935383a6b11900ef8
JOB LOG    : /var/lib/avocado/job-results/job-2022-10-17T04.19-324e8fc/job.log
 (1/1) type_specific.io-github-autotest-libvirt.vsock.normal_test.hotplug.nop.auto_cid: PASS (33.78 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-10-17T04.19-324e8fc/results.html
JOB TIME   : 34.16 s
```

Signed-off-by: Hu Shuai <hus.fnst@fujitsu.com>