### PR TITLE
numa_memory_spread: extend timeout for memhog

### DIFF
--- a/libvirt/tests/src/numa/numa_memory_spread.py
+++ b/libvirt/tests/src/numa/numa_memory_spread.py
@@ -202,7 +202,7 @@ def make_memory_spread(test, vm, session, memory_to_eat, memhog_rt):
     """
     def run_memhog(test, session, test_memory, memhog_rt):
         try:
-            session.cmd('memhog -r1 {}k'.format(test_memory), timeout=120)
+            session.cmd('memhog -r1 {}k'.format(test_memory), timeout=1200)
         except Exception as err:
             memhog_rt["err"] = str(err)
     # Start consuming memory


### PR DESCRIPTION
Now the memory of some servers has exceeded 500G, so the memory that the guest needs to consume can reach about 300G in this case. Because across numa nodes, sometimes 120s is not enough for memhog.

Result:
```
# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio numa_memory_spread.positive_test.default --vt-connect-uri qemu:///system
JOB ID     : 7c064d9195c45cb96992e94be5b6351ab7018329
JOB LOG    : /root/avocado/job-results/job-2022-10-19T03.04-7c064d9/job.log
 (1/1) type_specific.io-github-autotest-libvirt.numa_memory_spread.positive_test.default: PASS (369.98 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/avocado/job-results/job-2022-10-19T03.04-7c064d9/results.html
JOB TIME   : 370.60 s
```

Signed-off-by: Hu Shuai <hus.fnst@fujitsu.com>