### PR TITLE
Add new cases of iface update

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_update.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_update.cfg
@@ -6,7 +6,7 @@
     variants:
         - positive_test:
             status_error = "no"
-            variants:
+            variants case:
                 - update_bandwidth:
                     new_iface_inbound = "{'average':'1000','peak':'5000','burst':'1024'}"
                     new_iface_outbound = "{'average':'128','peak':'256','burst':'256'}"
@@ -72,9 +72,26 @@
                 - update_coalesce:
                     iface_coalesce = {'max': 64}
                     new_iface_coalesce = {'max': 32}
+                - update_portgroup:
+                    bo_0 = {'average': '128', 'burst': '256', 'peak': '256'}
+                    bi_0 = {'average': '1000', 'burst': '5120', 'peak': '5000'}
+                    portgroup_0 = {'bandwidth_outbound': ${bo_0}, 'name': 'sales', 'bandwidth_inbound': ${bi_0}, 'default': 'yes'}
+                    bo_1 = {'average': '256', 'burst': '512', 'peak': '128'}
+                    bi_1 = {'average': '500', 'burst': '1024', 'peak': '1000'}
+                    portgroup_1 = {'bandwidth_outbound': ${bi_1}, 'name': 'engineering', 'bandwidth_inbound': ${bo_1}}
+                    net_attr_portgroups = [${portgroup_0}, ${portgroup_1}]
+                    net_attr_nat_port = {'start': '1024', 'end': '65535'}
+                    net_attr_bridge = {'name': 'virbr1', 'stp': 'on', 'delay': '0'}
+                    net_attr_ips = [{'dhcp_ranges': {'attrs': {'end': '192.168.100.254', 'start': '192.168.100.100'}}, 'address': '192.168.100.1'}]
+                    net_attr_forward = {'mode': 'nat'}
+                    net_attr_mac = "'52:54:00:cf:11:a0'"
+                    net_attr_uuid = "'a2ab8047-591e-4f95-80f6-ad47b518b9e0'"
+                    iface_source = "{'network': 'default'}"
+                    del_bandwidth = "yes"
+                    new_iface_source = "{'network':'default', 'portgroup': 'engineering'}"
         - negative_test:
             status_error = "yes"
-            variants:
+            variants case:
                 - update_alias:
                     new_iface_alias = "{'name': 'ua-82c8ae17-a501-466d-b14c-d002e324ee89'}"
                     expect_err_msg = "Operation not supported: cannot modify network device alias|operation forbidden: changing device alias is not allowed"
@@ -163,3 +180,8 @@
                                     new_iface_inbound = "{'average':'1000','peak':'5000','floor':'200','burst':'1024'}"
                                     new_iface_outbound = "{'average':'128','peak':'256','burst':'256'}"
                                     expect_err_msg = "has no inbound QoS set"
+                - update_driver_iommu_ast:
+                    vm_feature_append = {'ioapic': {'driver': 'qemu'}}
+                    expect_err_msg = "Operation not supported: cannot modify.* network device driver"
+                    iommu_attrs = {'model': 'intel', 'driver': {'intremap': 'on', 'caching_mode': 'on', 'eim': 'on', 'iotlb': 'on'}}
+                    new_iface_driver = {'iommu': 'on', 'ast': 'on'}


### PR DESCRIPTION
- RHEL7-99440:update portgroup of the interface for nat network
- RHEL-117419:update virtio driver attributes "iommu", "ats" (not support)

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>

Depends on:
- https://github.com/avocado-framework/avocado-vt/pull/3542
- https://github.com/avocado-framework/avocado-vt/pull/3543

Test result:
``` 
(1/2) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.positive_test.update_portgroup: PASS (12.41 s)
(2/2) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.negative_test.update_driver_iommu_ast: PASS (22.17 s)
```