### PR TITLE
disk_base.py: fix blockcommit failed issue for block disk

### DIFF
--- a/provider/virtual_disk/disk_base.py
+++ b/provider/virtual_disk/disk_base.py
@@ -226,7 +226,7 @@ class DiskBase(object):
         """
         device_name = libvirt.setup_or_cleanup_iscsi(is_setup=True)
         lv_utils.vg_create(vg_name, device_name)
-        size = kwargs.get("size", "50M")
+        size = kwargs.get("size", "200M")
         if kwargs.get("size"):
             kwargs.pop("size")
         path = libvirt.create_local_disk("lvm", size=size, vgname=vg_name,


### PR DESCRIPTION
According to https://bugzilla.redhat.com/show_bug.cgi?id=2094205#c8:
We can't commit the contents of /dev/test/lv1 (libvirt-3-format, a qcow2 image of 300M) into /dev/test/lv0 (libvirt-1-format, a raw image of 200M) without first resizing the destination.
In test case, the lv0(raw) is 50M and the lv1(qcow2) is 200M, so update the size to be same.

Signed-off-by: Meina Li <meili@redhat.com>