### PR TITLE
PCIe Controller, pcie-root-port with index <= bus

### DIFF
--- a/libvirt/tests/cfg/controller/pcie_root_port_controller.cfg
+++ b/libvirt/tests/cfg/controller/pcie_root_port_controller.cfg
@@ -19,3 +19,12 @@
                 - controllers_same_chassis_different_port:
                     second_controller_model = "pcie-root-port"
                     second_controller_target = "{'chassis':1,'port':'0x4'}"
+                - index_equals_address_bus:
+                    test_define_only = "yes"
+                    controller_address = '{"type": "pci", "domain": "0x0000", "bus": "0x01", "slot": "0x1", "function":"0x0"}'
+                    failure_message = ".*The device at PCI address .* cannot be plugged into the PCI controller with index='.*'. It requires a controller that accepts a pcie-root-port.*"
+                - index_less_than_address_bus:
+                    bus_offset = 1
+                    test_define_only = "yes"
+                    controller_address = '{"type": "pci", "domain": "0x0000", "bus": "0x02", "slot": "0x1", "function":"0x0"}'
+                    failure_message = ".*a PCI slot is needed to connect a PCI controller model='pcie-root-port', but none is available, and it cannot be automatically added.*"

--- a/libvirt/tests/src/controller/pcie_root_port_controller.py
+++ b/libvirt/tests/src/controller/pcie_root_port_controller.py
@@ -1,8 +1,10 @@
-import logging
 import ast
+import logging
 
+from virttest import virsh
 from virttest.libvirt_xml import vm_xml
-from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_libvirt import libvirt_vmxml, libvirt_pcicontr
+from virttest.utils_test import libvirt
 
 
 LOG = logging.getLogger('avocado.' + __name__)
@@ -17,28 +19,24 @@ def setup_test(params):
     controller_model = params.get("controller_model")
     controller_target = ast.literal_eval(params.get("controller_target"))
     second_controller_model = params.get("second_controller_model")
-    second_controller_target = ast.literal_eval(params.get("second_controller_target"))
+    second_controller_target = ast.literal_eval(
+        params.get("second_controller_target", "{}"))
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(params.get("main_vm", "avocado-vt-vm1"))
-    index = 0
 
     vmxml.remove_all_device_by_type("controller")
 
+    index = 0
     contr_dict = {"type": "pci", "model": "pcie-root", "index": index}
     libvirt_vmxml.modify_vm_device(vmxml, "controller", contr_dict, index)
 
     index += 1
-    contr_dict = {'type': 'pci',
-                  'model': controller_model,
-                  "index": index,
-                  'target': controller_target}
+    contr_dict = create_controller_dict(controller_model, controller_target, index)
     libvirt_vmxml.modify_vm_device(vmxml, "controller", contr_dict, index)
 
-    index += 1
     if second_controller_model and second_controller_target:
-        contr_dict = {'type': 'pci',
-                      'model': second_controller_model,
-                      "index": index,
-                      'target': second_controller_target}
+        index += 1
+        contr_dict = create_controller_dict(second_controller_model,
+                                            second_controller_target, index)
         libvirt_vmxml.modify_vm_device(vmxml, "controller", contr_dict, index)
 
     vmxml.sync()
@@ -52,18 +50,74 @@ def execute_test(vm, test, params):
     :param test: Avocado test object
     :param params: Test parameters object
     """
-    status_error = params.get("status_error") == "yes"
-    LOG.debug("Starting VM with XML:\n%s", vm_xml.VMXML.new_from_dumpxml(vm.name))
-    try:
-        vm.start()
-    except Exception as exc:
-        if status_error:
-            LOG.info("VM failed to start as expected.")
-        else:
-            test.fail("VM failed to start, reason: %s" % exc)
+    test_define_only = params.get("test_define_only") == "yes"
+    if test_define_only:
+        vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm.name)
+        check_define_vm(vmxml, params, test)
     else:
-        if vm.is_alive() and status_error:
-            test.fail("VM started sucessfully, but shouldn't.")
+        status_error = params.get("status_error") == "yes"
+        LOG.debug("Starting VM with XML:\n%s", vm_xml.VMXML.new_from_dumpxml(vm.name))
+        try:
+            vm.start()
+        except Exception as exc:
+            if status_error:
+                LOG.info("VM failed to start as expected.")
+            else:
+                test.fail("VM failed to start, reason: %s" % exc)
+        else:
+            if vm.is_alive() and status_error:
+                test.fail("VM started sucessfully, but shouldn't.")
+
+
+def create_controller_dict(model, target, index, address=None):
+    """
+    Creates a dictionary for PCI controller.
+
+    :param model: String, Controller model
+    :param target: Dictionary, Controller target
+    :param index: Int, controller index value
+    :param address: Dict, optional, device address example: {'attrs': {'bus': 0x01}}
+    :returns Built in dictionary, prepared to be added to VM XML
+    """
+    contr_dict = {'type': 'pci',
+                  'model': model,
+                  "index": index,
+                  'target': target}
+    if address:
+        contr_dict.update({"address": address})
+    return contr_dict
+
+
+def check_define_vm(vmxml, params, test):
+    """
+    Alternate function for checking and finishing the test.
+    Checks only if VM define action was successful instead of VM start.
+
+    :param vmxml: VM XML object
+    :param params: Test parameters object
+    :param test: Avocado test object
+    """
+    model = params.get("controller_model")
+    target = params.get("controller_target")
+    address = ast.literal_eval(params.get("controller_address", "{}"))
+    bus_offset = int(params.get("bus_offset", 0))
+    status_error = params.get("status_error") == "yes"
+    failure_message = params.get("failure_message")
+    max_indexes = libvirt_pcicontr.get_max_contr_indexes(vmxml, 'pci', model, 1)
+    index = max_indexes[0] + 1
+    address["bus"] = hex(index + bus_offset)
+    contr_dict = {'controller_type': 'pci',
+                  'controller_model': model,
+                  "controller_index": index,
+                  'controller_target': target,
+                  "controller_addr": str(address)}
+    contr_object = libvirt.create_controller_xml(contr_dict)
+    vmxml.add_device(contr_object)
+    cmd_result = virsh.define(vmxml.xml)
+    if failure_message:
+        libvirt.check_result(cmd_result, [failure_message])
+    else:
+        libvirt.check_exit_status(cmd_result, status_error)
 
 
 def cleanup_test(vm, vmxml_backup):
@@ -88,11 +142,12 @@ def run(test, params, env):
     :params params: Object containing parameters of a test from cfg file
     :params env: Environment object from Avocado framework
     """
-
     vm = env.get_vm(params.get("main_vm", "avocado-vt-vm1"))
     vmxml_backup = vm_xml.VMXML.new_from_dumpxml(vm.name)
+    test_define_only = params.get("test_define_only")
 
-    setup_test(params)
+    if not test_define_only:
+        setup_test(params)
     try:
         execute_test(vm, test, params)
     finally:


### PR DESCRIPTION
This commit adds 2 checks that check a situation where pcie-root-port controller index number should be over the bus number it is attached to.

Automation of VIRT-54001
```
[root@dell-per740xd-25 ~]# avocado run --vt-type libvirt pcie_controllers.negative_tests.index_equal_to_bus.hotplug_off pcie_controllers.negative_tests.index_less_than_bus.hotplug_off
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : c0e309a258c30ac8c3e14f2487d050a4ec4b5323
JOB LOG    : /var/lib/avocado/job-results/job-2022-10-20T09.25-c0e309a/job.log
 (1/2) type_specific.io-github-autotest-libvirt.pcie_controllers.negative_tests.index_equal_to_bus.hotplug_off: STARTED
 (1/2) type_specific.io-github-autotest-libvirt.pcie_controllers.negative_tests.index_equal_to_bus.hotplug_off: PASS (37.56 s)
 (2/2) type_specific.io-github-autotest-libvirt.pcie_controllers.negative_tests.index_less_than_bus.hotplug_off: STARTED
 (2/2) type_specific.io-github-autotest-libvirt.pcie_controllers.negative_tests.index_less_than_bus.hotplug_off: PASS (38.73 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-10-20T09.25-c0e309a/results.html
JOB TIME   : 79.39 s
```