### PR TITLE
Fix event block threshold failure due to mkfs.ex4 command timeout

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_event.py
@@ -377,7 +377,7 @@ def run(test, params, env):
                     virsh.domblkthreshold(vm_name, 'vdb', '100M')
                     session = dom.wait_for_login()
                     session.cmd("mkfs.ext4 /dev/vdb && mount /dev/vdb /mnt && ls /mnt && "
-                                "dd if=/dev/urandom of=/mnt/bigfile bs=1M count=300 && sync")
+                                "dd if=/dev/urandom of=/mnt/bigfile bs=1M count=300 && sync", timeout=90)
                     time.sleep(5)
                     session.close()
                     expected_events_list.append("'block-threshold' for %s:"


### PR DESCRIPTION
Fix event block threshold failure due to mkfs.ex4 command timeout
During the testing, it need send mkfs.ex4 to Vm, but timeout happen So extend command timeout value to 90 seconds

Signed-off-by: chunfuwen <chwen@redhat.com>