### PR TITLE
fix missing ceph config file

### DIFF
--- a/libvirt/tests/src/backingchain/blockcommit/blockcommit_relative_path.py
+++ b/libvirt/tests/src/backingchain/blockcommit/blockcommit_relative_path.py
@@ -104,6 +104,7 @@ def run(test, params, env):
 
         if disk_type == 'rbd_with_auth':
             libvirt_secret.clean_up_secrets()
+            process.run("rm -f %s" % params.get("configfile"))
             process.run("rm -f %s" % params.get("keyfile"))
             cmd = ("rbd -m {0} info {1} && rbd -m {0} rm {1}".format(
                 mon_host, rbd_source_name))

--- a/libvirt/tests/src/backingchain/blockpull/blockpull_relative_path.py
+++ b/libvirt/tests/src/backingchain/blockpull/blockpull_relative_path.py
@@ -82,6 +82,7 @@ def run(test, params, env):
 
         if disk_type == 'rbd_with_auth':
             libvirt_secret.clean_up_secrets()
+            process.run("rm -f %s" % params.get("configfile"))
             process.run("rm -f %s" % params.get("keyfile"))
             cmd = ("rbd -m {0} info {1} && rbd -m {0} rm {1}".format(
                 mon_host, rbd_source_name))

--- a/provider/virtual_disk/disk_base.py
+++ b/provider/virtual_disk/disk_base.py
@@ -326,8 +326,11 @@ class DiskBase(object):
         new_image_path = self.params.get("image_path")
         auth_key = self.params.get("auth_key")
         client_name = self.params.get("client_name")
+
+        self.params.update({'configfile': ceph.create_config_file(mon_host)})
         self.params.update(
             {'keyfile': ceph.create_keyring_file(client_name, auth_key)})
+        LOG.debug('Create ceph key file and config file')
 
         process.run("mkdir %s" % (self.base_dir + "/c"))
         cmd = "cd %s && qemu-img create -f qcow2 -F raw -o " \


### PR DESCRIPTION
   blockcommit and blockpull relative case miss the ceph config file
Signed-off-by: nanli <nanli@redhat.com>
```

/usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockcommit.relative_path.rbd_with_auth_disk.keep_relative.active --vt-connect-uri qemu:///system
(1/2) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.rbd_with_auth_disk.keep_relative.active.vm_started: PASS (32.47 s)
(2/2) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.rbd_with_auth_disk.keep_relative.active.vm_paused: PASS (35.32 s)

```