### PR TITLE
fix cannot acquire state change lock

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockcommit.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockcommit.py
@@ -354,6 +354,12 @@ def run(test, params, env):
             options += "  --diskspec  %s,snapshot=external,file=%s" % (block_target, disk_external)
             virsh.snapshot_create_as(vm_name, options,
                                      ignore_status=False, debug=True)
+
+            if not utils_misc.wait_for(
+                    lambda: libvirt.check_blockjob(vm_name, block_target,
+                                                   "none"), 30, first=3):
+                test.fail("There should be no current block job")
+
             virsh.blockcommit(vm_name, block_target,
                               " --active --pivot ", ignore_status=False, debug=True)
             virsh.snapshot_delete(vm_name, tmp_snapshot_name, " --metadata")


### PR DESCRIPTION
  do several times blockcommit with pivot get lock error due to run too fast
Signed-off-by: nanli <nanli@redhat.com>

Before updated:
```
 /bin/virsh blockcommit avocado-vt-vm1 vda  --active --pivot '
2022-10-19 00:42:27,539 virsh            L1246 ERROR| Error taking VM avocado-vt-vm1 screenshot. 
You might have to set take_regular_screendumps=no on your tests.cfg config file Command
 '/bin/virsh -c 'qemu:///system' screenshot avocado-vt-vm1 /dev/shm/scrdump-2YIdQG-iter0.ppm' 
failed.stdout: b'\n'stderr: b'error: could not take a screenshot of avocado-vt-vm1\nerror: Timed out
 during operation: cannot acquire state change lock (held by monitor=remoteDispatchDomainBlockJobAbort)\n
'additional_info: None.  This will be the only logged error message.
2022-10-19 00:42:27,540 env_process      L1969 WARNI| VM 'avocado-vt-vm1' failed to produce a screendump
2022-10-19 00:42:43,248 ip_sniffing      L0060 DEBUG| Updated HWADDR (34:48:ed:f9:e2:20)<->(10.73.178.188) IP pair into address cache
2022-10-19 00:43:02,626 env_process      L1969 WARNI| VM 'avocado-vt-vm1' failed to produce a screendump
2022-10-19 00:43:37,713 env_process      L1969 WARNI| VM 'avocado-vt-vm1' failed to produce a screendump
2022-10-19 00:44:12,811 env_process      L1969 WARNI| VM 'avocado-vt-vm1' failed to produce a screendump
```

After updated
```
 /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 virsh.blockcommit.normal_test.single_chain.file_disk.local.no_ga.notimeout.shallow.top_active.with_pivot --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.virsh.blockcommit.normal_test.single_chain.file_disk.local.no_ga.notimeout.shallow.top_active.with_pivot: PASS (51.27 s)
```
