### PR TITLE
Fix virtual_disks dasd failure on s390x

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_dasd.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_dasd.py
@@ -108,6 +108,17 @@ def attach_disk(vm_name, target, path):
     virsh.attach_disk(vm_name, path, target, source_info, ignore_status=False)
 
 
+def detach_disk(vm_name, target):
+    """
+    Detaches the target disk
+
+    :param vm_name: VM name
+    :param target: //target@dev, e.g. 'vdb'
+    """
+
+    virsh.detach_disk(vm_name, target, ignore_status=False)
+
+
 def check_dasd_partition_table(session, device_target):
     """
     Checks that the partition table can be read
@@ -143,7 +154,10 @@ def run(test, params, env):
 
         session = vm.wait_for_login()
         check_dasd_partition_table(session, TARGET)
+        detach_disk(vm_name, TARGET)
     finally:
+        if vm.is_alive():
+            vm.destroy(gracefully=False)
         # sync will release attached disk, precondition for disablement
         backup_xml.sync()
         global TEST_DASD_ID


### PR DESCRIPTION
Fix virtual_disks dasd failure on s390x
Sometimes, this case failed in process of disabling dasd So it can enchance this situation by adding explicitly detach disk and gracefully shutdown VM before disabling dasd

Signed-off-by: chunfuwen <chwen@redhat.com>