### PR TITLE
sriov: Add a case about virtio iommu

### DIFF
--- a/libvirt/tests/cfg/sriov/vIOMMU/sriov_virtio_iommu_with_addtional_attributes.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/sriov_virtio_iommu_with_addtional_attributes.cfg
@@ -1,0 +1,16 @@
+- sriov.vIOMMU.virtio_iommu.addtional_attributes:
+    type = sriov_virtio_iommu_with_addtional_attributes
+    start_vm = "no"
+    enable_guest_iommu = "yes"
+    err_msg = "iommu model 'virtio' doesn't support additional attributes"
+    func_supported_since_libvirt_ver = (8, 7, 0)
+    only x86_64
+    variants:
+        - caching_mode:
+            iommu_dict = {'driver': {'caching_mode': 'on'}, 'model': 'virtio'}
+        - eim:
+            iommu_dict = {'driver': {'eim': 'on'}, 'model': 'virtio'}
+        - iotlb:
+            iommu_dict = {'driver': {'iotlb': 'on'}, 'model': 'virtio'}
+        - aw_bits:
+            iommu_dict = {'driver': {'aw_bits': '48'}, 'model': 'virtio'}

--- a/libvirt/tests/src/sriov/vIOMMU/sriov_virtio_iommu_with_addtional_attributes.py
+++ b/libvirt/tests/src/sriov/vIOMMU/sriov_virtio_iommu_with_addtional_attributes.py
@@ -1,0 +1,29 @@
+from provider.sriov import sriov_base
+
+from virttest.libvirt_xml import xcepts
+from virttest.utils_libvirt import libvirt_virtio
+
+
+def run(test, params, env):
+    """
+    virtio iommu do not support any additional attributes
+    """
+    err_msg = params.get("err_msg")
+    iommu_dict = eval(params.get('iommu_dict', '{}'))
+
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    vm = env.get_vm(vm_name)
+    sriov_test_obj = sriov_base.SRIOVTest(vm, test, params)
+
+    try:
+        libvirt_virtio.add_iommu_dev(vm, iommu_dict)
+    except xcepts.LibvirtXMLError as details:
+        if err_msg:
+            test.log.debug("Check '%s' in %s.", err_msg, details)
+            if not str(details).count(err_msg):
+                test.fail("Incorrect error message, it should be '{}', but "
+                          "got '{}'.".format(err_msg, details))
+    else:
+        test.fail("Defining the VM should fail, but run successfully!")
+    finally:
+        sriov_test_obj.teardown_default()


### PR DESCRIPTION
This PR adds:
    - VIRT-294974 [virtio iommu] Test virtio iommu with addtional
attributes(unsuppoted)

Signed-off-by: Yingshun Cui <yicui@redhat.com>
**Test results:**
 ```
(1/4) type_specific.io-github-autotest-libvirt.sriov.vIOMMU.virtio_iommu.addtional_attributes.caching_mode: PASS (16.28 s)
 (2/4) type_specific.io-github-autotest-libvirt.sriov.vIOMMU.virtio_iommu.addtional_attributes.eim: PASS (16.37 s)
 (3/4) type_specific.io-github-autotest-libvirt.sriov.vIOMMU.virtio_iommu.addtional_attributes.iotlb: PASS (16.45 s)
 (4/4) type_specific.io-github-autotest-libvirt.sriov.vIOMMU.virtio_iommu.addtional_attributes.aw_bits: PASS (16.88 s)

```