### PR TITLE
migration: Remove check drive-mirror/nbd-server

### DIFF
--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -2011,13 +2011,9 @@ def run(test, params, env):
             logging.info(output)
 
         target_image_source = test_dict.get("target_image_source", disk_source)
-        # Do not create target image when qemu supports drive-mirror
-        # and nbd-server, but need create a specific pool.
         no_create_pool = test_dict.get("no_create_pool", "no")
         try:
-            if ((utils_misc.is_qemu_capability_supported("drive-mirror") or
-                 libvirt_version.version_compare(5, 3, 0)) and
-                    utils_misc.is_qemu_capability_supported("nbd-server")):
+            if libvirt_version.version_compare(5, 3, 0):
                 support_precreation = True
         except exceptions.TestError as e:
             logging.debug(e)


### PR DESCRIPTION
Don't need to check drive-mirror and nbd-server in live storage migration now. So update script.

Signed-off-by: cliping <lcheng@redhat.com>