### PR TITLE
virttools: Change installation tree location

### DIFF
--- a/virttools/tests/cfg/virt_install/kernel_cmdline.cfg
+++ b/virttools/tests/cfg/virt_install/kernel_cmdline.cfg
@@ -8,5 +8,5 @@
             expected_status = 0
         - does_not_boot_with_long_commandline:
             # contains a kernel version that does not support long commandline
-            location = http://mirror.stream.centos.org/9-stream/BaseOS/s390x/os/
+            location = https://dl.fedoraproject.org/pub/fedora-secondary/releases/35/Everything/s390x/os/
             expected_status = 1


### PR DESCRIPTION
CentOS 9 now allows for long kernel command lines causing test failure. Use an older Fedora release instead.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>