### PR TITLE
sriov: Add a case to test vIOMMU device's alias

### DIFF
--- a/libvirt/tests/cfg/sriov/vIOMMU/sriov_iommu_alias.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/sriov_iommu_alias.cfg
@@ -1,0 +1,17 @@
+- sriov.vIOMMU.iommu.alias:
+    type = sriov_iommu_alias
+    enable_guest_iommu = "yes"
+    func_supported_since_libvirt_ver = (8, 7, 0)
+    start_vm = "no"
+    only x86_64
+    variants:
+        - virtio:
+            iommu_dict = {'model': 'virtio'}
+            iommu_has_addr = "yes"
+        - intel:
+            iommu_dict = {'model': 'intel', 'driver': {'intremap': 'on', 'caching_mode': 'on', 'eim': 'on', 'iotlb': 'on', 'aw_bits': '48'}}
+            iommu_has_addr = "no"
+    variants:
+        - auto_gen:
+        - customized:
+            alias = {'name': 'ua-c1e12b91-175f-4436-b0d5-d7481de40f14'}

--- a/libvirt/tests/src/sriov/vIOMMU/sriov_iommu_alias.py
+++ b/libvirt/tests/src/sriov/vIOMMU/sriov_iommu_alias.py
@@ -1,0 +1,51 @@
+from provider.sriov import sriov_base
+
+from virttest.libvirt_xml import vm_xml
+
+
+def run(test, params, env):
+    """
+    Test alias support for iommu device
+    """
+    def check_xml(vm, exp_alias, iommu_pci_addr):
+        """
+        Check iommu device's xml
+
+        :param vm: The VM object
+        :param exp_alias: The expected alias
+        :param iommu_has_addr: Whether the iommu device should have 'address'
+        """
+        cur_iommu = vm_xml.VMXML.new_from_dumpxml(vm.name)\
+            .devices.by_device_tag("iommu")
+        if not cur_iommu:
+            test.fail("Unalbe to get iommu device!")
+        iommu_attrs = cur_iommu[0].fetch_attrs()
+        test.log.debug("iommu_attrs: %s", iommu_attrs)
+
+        if iommu_attrs['alias']['name'] != exp_alias:
+            test.fail("Got incorrect 'alias', it should be {}, but got {}!"
+                      .format(iommu_attrs['alias']['name'], exp_alias))
+        found = True if iommu_attrs.get("address") else False
+        if iommu_pci_addr != found:
+            test.fail("Got incorrect 'address', the iommu device should{} have"
+                      "address.".format('' if iommu_pci_addr else ' not'))
+
+    alias = eval(params.get("alias", "{}"))
+    iommu_dict = eval(params.get('iommu_dict', '{}'))
+    if alias:
+        iommu_dict.update({'alias': alias})
+        exp_alias = alias['name']
+    else:
+        exp_alias = "iommu0"
+    iommu_has_addr = "yes" == params.get("iommu_has_addr", "no")
+
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    vm = env.get_vm(vm_name)
+    sriov_test_obj = sriov_base.SRIOVTest(vm, test, params)
+
+    try:
+        sriov_test_obj.setup_iommu_test(iommu_dict=iommu_dict)
+        vm.start()
+        check_xml(vm, exp_alias, iommu_has_addr)
+    finally:
+        sriov_test_obj.teardown_default()

--- a/provider/sriov/sriov_base.py
+++ b/provider/sriov/sriov_base.py
@@ -372,9 +372,6 @@ class SRIOVTest(object):
         """
         iommu_dict = dargs.get('iommu_dict', {})
         test_scenario = dargs.get('test_scenario', '')
-        br_dict = dargs.get('br_dict', "{'source': {'bridge': 'br0'}}")
-        brg_dict = {'pf_name': self.pf_name,
-                    'bridge_name': br_dict['source']['bridge']}
         dev_type = dargs.get("dev_type", "interface")
 
         self.setup_default(**dargs)
@@ -383,6 +380,9 @@ class SRIOVTest(object):
             libvirt_virtio.add_iommu_dev(self.vm, iommu_dict)
 
         if test_scenario == "failover":
+            br_dict = dargs.get('br_dict', "{'source': {'bridge': 'br0'}}")
+            brg_dict = {'pf_name': self.pf_name,
+                        'bridge_name': br_dict['source']['bridge']}
             self.test.log.info("TEST_SETUP: Create host bridge.")
             utils_sriov.add_or_del_connection(brg_dict)
             self.test.log.info("TEST_SETUP: Add bridge interface.")
@@ -397,10 +397,11 @@ class SRIOVTest(object):
         :param dargs: Other test keywords
         """
         test_scenario = dargs.get('test_scenario', '')
-        br_dict = dargs.get('br_dict', "{'source': {'bridge': 'br0'}}")
-        brg_dict = {'pf_name': self.pf_name,
-                    'bridge_name': br_dict['source']['bridge']}
+
         self.teardown_default(**dargs)
         if test_scenario == 'failover':
+            br_dict = dargs.get('br_dict', "{'source': {'bridge': 'br0'}}")
+            brg_dict = {'pf_name': self.pf_name,
+                        'bridge_name': br_dict['source']['bridge']}
             self.test.log.info("TEST_TEARDOWN: Remove host bridge.")
             utils_sriov.add_or_del_connection(brg_dict, is_del=True)


### PR DESCRIPTION
This PR adds:
- VIRT-294976: [vIOMMU] Add alias support for iommu device

Signed-off-by: Yingshun Cui <yicui@redhat.com>

Depends on:
- https://github.com/avocado-framework/avocado-vt/pull/3552
- https://github.com/avocado-framework/avocado-vt/pull/3553

**Test results:**
```
 (1/4) type_specific.io-github-autotest-libvirt.sriov.vIOMMU.iommu.alias.auto_gen.virtio: PASS (19.06 s)
 (2/4) type_specific.io-github-autotest-libvirt.sriov.vIOMMU.iommu.alias.auto_gen.intel: PASS (19.31 s)
 (3/4) type_specific.io-github-autotest-libvirt.sriov.vIOMMU.iommu.alias.customized.virtio: PASS (19.22 s)
 (4/4) type_specific.io-github-autotest-libvirt.sriov.vIOMMU.iommu.alias.customized.intel: PASS (19.15 s)
```
