### PR TITLE
fix set_disk_xml function duplicate

### DIFF
--- a/provider/virtual_disk/disk_base.py
+++ b/provider/virtual_disk/disk_base.py
@@ -8,9 +8,9 @@ from virttest import data_dir
 from virttest import virsh
 from virttest.libvirt_xml import pool_xml
 from virttest.libvirt_xml import vm_xml
-from virttest.libvirt_xml.devices.disk import Disk
 from virttest.utils_test import libvirt
 from virttest.utils_libvirt import libvirt_disk
+from virttest.utils_libvirt import libvirt_vmxml
 from virttest.utils_libvirt import libvirt_secret
 
 LOG = logging.getLogger('avocado.' + __name__)
@@ -141,7 +141,7 @@ class DiskBase(object):
                              "secret_usage": "cephlibvirt",
                              "secret_type": "ceph"}}})
 
-        disk_xml = self.set_disk_xml(disk_dict)
+        disk_xml = libvirt_vmxml.create_vm_device_by_type("disk", disk_dict)
         libvirt.add_vm_device(vmxml, disk_xml)
 
         vmxml = vm_xml.VMXML.new_from_dumpxml(self.vm.name)
@@ -259,19 +259,6 @@ class DiskBase(object):
         virsh.secret_set_value(sec_uuid, auth_key, debug=True)
 
         return mon_host, auth_username, new_image_path
-
-    @staticmethod
-    def set_disk_xml(disk_dict):
-        """
-        Set vm disk xml by disk dict.
-
-        :params disk_dict: dict to get disk xml
-        :return: disk xml
-        """
-        new_disk = Disk()
-        new_disk.setup_attrs(**disk_dict)
-
-        return new_disk
 
     def prepare_relative_path(self, disk_type, **kwargs):
         """


### PR DESCRIPTION
   set_disk_xml function duplicate with create_vm_device_by_type
Signed-off-by: nanli <nanli@redhat.com>

**Test result:**
```

 [root@dell-per740-07 tp-libvirt]# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockcommit.keep_overlay
 (1/2) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.keep_overlay.positive_test.active: PASS (66.15 s)
 (2/2) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.keep_overlay.negative_test.inactive: PASS (64.75 s)

```
```
/usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockcommit.base_image_exist_backingfile.file_disk
 (1/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.base_image_exist_backingfile.file_disk.file_backing.mid_to_mid: PASS (66.17 s)
 (2/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.base_image_exist_backingfile.file_disk.file_backing.top_to_base: PASS (65.06 s)
 (3/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.base_image_exist_backingfile.file_disk.file_backing.top_to_mid: PASS (66.80 s)
 (4/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.base_image_exist_backingfile.file_disk.file_backing.mid_to_base: PASS (65.45 s)
 (5/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.base_image_exist_backingfile.file_disk.block_backing.mid_to_mid: PASS (71.80 s)
 (6/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.base_image_exist_backingfile.file_disk.block_backing.top_to_base: PASS (79.84 s)
 (7/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.base_image_exist_backingfile.file_disk.block_backing.top_to_mid: PASS (80.55 s)
 (8/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.base_image_exist_backingfile.file_disk.block_backing.mid_to_base: PASS (78.37 s)



```