### PR TITLE
Add new case of attaching iface

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_attach_detach.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_attach_detach.cfg
@@ -1,0 +1,24 @@
+- virtual_network.iface_attach_detach:
+    type = iface_attach_detach
+    start_vm = no
+    variants case:
+        - boot_order:
+            boot_order = '1'
+            status_error = 'yes'
+            attach_cmd = 'attach_device'
+            variants pre_vm_state:
+                - hot:
+                - cold:
+                    virsh_options = ' --config'
+            variants scenario:
+                - with_os_boot:
+                    error_msg = 'per-device boot elements cannot be used together with os/boot elements'
+                - with_boot_disk:
+                    error_msg = 'boot order 1 is already used by another device'
+                - unsupported_value:
+                    variants boot_order:
+                        - -1:
+                            error_msg = 'Expected .*integer value'
+                        - ss:
+                            error_msg = 'Expected .*integer value'
+            iface_attrs = {'boot': '${boot_order}'}

--- a/libvirt/tests/src/virtual_network/iface_attach_detach.py
+++ b/libvirt/tests/src/virtual_network/iface_attach_detach.py
@@ -1,0 +1,69 @@
+import logging
+
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.libvirt_xml.devices import interface
+from virttest.utils_test import libvirt
+
+LOG = logging.getLogger('avocado.' + __name__)
+VIRSH_ARGS = {'debug': True, 'ignore_status': False}
+
+
+def modify_iface(vm_name, index=0, **attrs):
+    vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+    xml_devices = vmxml.devices
+
+    try:
+        iface_index = xml_devices.index(
+            xml_devices.by_device_tag("interface")[index])
+        iface = xml_devices[iface_index]
+    except IndexError:
+        iface = interface.Interface()
+
+    iface.setup_attrs(**attrs)
+    LOG.debug('iface after modification: %s', iface)
+
+    return iface
+
+
+def run(test, params, env):
+    """
+    Test attaching/detaching interface
+    """
+    def test_boot_order():
+        pre_vm_state = params.get('pre_vm_state', '')
+        iface_pre_at = modify_iface(vm_name, **iface_attrs)
+
+        if scenario == 'with_boot_disk':
+            libvirt.change_boot_order(vm_name, 'disk', '1')
+        if pre_vm_state == 'hot':
+            vm.start()
+
+        LOG.debug('vm xml is :%s\n', virsh.dumpxml(vm_name).stdout_text)
+        test_result = virsh.attach_device(vm_name, iface_pre_at.xml,
+                                          flagstr=virsh_options, debug=True)
+        libvirt.check_exit_status(test_result, status_error)
+        libvirt.check_result(test_result, expected_fails=error_msg)
+
+    # Variables assignment
+    vm_name = params.get('main_vm')
+    vm = env.get_vm(vm_name)
+
+    case = params.get('case', '')
+    scenario = params.get('scenario', '')
+    status_error = 'yes' == params.get('status_error', 'no')
+    error_msg = params.get('error_msg', '')
+    bk_vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+
+    iface_attrs = eval(params.get('iface_attrs', '{}'))
+    virsh_options = params.get('virsh_options', '')
+    vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+
+    # Get test function
+    test_func = eval('test_%s' % case)
+
+    try:
+        test_func()
+
+    finally:
+        bk_vmxml.sync()


### PR DESCRIPTION
- VIRT-110831 - hotplug an interface with boot order

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>

Test result:
```
 (1/8) type_specific.io-github-autotest-libvirt.virtual_network.iface_attach_detach.boot_order.with_os_boot.hot: PASS (9.78 s)
 (2/8) type_specific.io-github-autotest-libvirt.virtual_network.iface_attach_detach.boot_order.with_os_boot.cold: PASS (14.03 s)
 (3/8) type_specific.io-github-autotest-libvirt.virtual_network.iface_attach_detach.boot_order.with_boot_disk.hot: PASS (10.26 s)
 (4/8) type_specific.io-github-autotest-libvirt.virtual_network.iface_attach_detach.boot_order.with_boot_disk.cold: PASS (16.71 s)
 (5/8) type_specific.io-github-autotest-libvirt.virtual_network.iface_attach_detach.boot_order.unsupported_value.-1.hot: PASS (8.96 s)
 (6/8) type_specific.io-github-autotest-libvirt.virtual_network.iface_attach_detach.boot_order.unsupported_value.-1.cold: PASS (8.37 s)
 (7/8) type_specific.io-github-autotest-libvirt.virtual_network.iface_attach_detach.boot_order.unsupported_value.ss.hot: PASS (8.83 s)
 (8/8) type_specific.io-github-autotest-libvirt.virtual_network.iface_attach_detach.boot_order.unsupported_value.ss.cold: PASS (15.21 s)

```