### PR TITLE
Add new case of interface update

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_update.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_update.cfg
@@ -89,6 +89,10 @@
                     iface_source = "{'network': 'default'}"
                     del_bandwidth = "yes"
                     new_iface_source = "{'network':'default', 'portgroup': 'engineering'}"
+                - update_boot_order:
+                    cold_update = 'yes'
+                    disk_boot = '1'
+                    new_iface_boot = '3'
         - negative_test:
             status_error = "yes"
             variants case:
@@ -181,7 +185,31 @@
                                     new_iface_outbound = "{'average':'128','peak':'256','burst':'256'}"
                                     expect_err_msg = "has no inbound QoS set"
                 - update_driver_iommu_ast:
-                    vm_feature_append = {'ioapic': {'driver': 'qemu'}}
                     expect_err_msg = "Operation not supported: cannot modify.* network device driver"
                     iommu_attrs = {'model': 'intel', 'driver': {'intremap': 'on', 'caching_mode': 'on', 'eim': 'on', 'iotlb': 'on'}}
                     new_iface_driver = {'iommu': 'on', 'ast': 'on'}
+                - update_boot_order:
+                    variants:
+                        - with_os_boot:
+                            new_iface_boot = '1'
+                            expect_err_msg = 'per-device boot elements cannot be used together with os/boot elements'
+                        - boot_order_occupied:
+                            disk_boot = '1'
+                            new_iface_boot = '1'
+                            expect_err_msg = 'boot order 1 is already used by another device'
+                        - invalid_value:
+                            expect_err_msg = 'Expected non-negative integer value'
+                            variants new_iface_boot:
+                                - 0:
+                                    expect_err_msg = 'Zero is not permitted'
+                                - s:
+                                - -6:
+                        - none_to_2:
+                            no vm_off
+                            disk_boot = '1'
+                            new_iface_boot = '2'
+                            expect_err_msg = 'cannot modify network device boot index setting'
+                    variants:
+                        - vm_on:
+                        - vm_off:
+                            cold_update = 'yes'


### PR DESCRIPTION
- VIRT-99433 - update boot order in interface

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>

Test result:
```
 (01/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.positive_test.update_bandwidth: PASS (10.21 s)
 (02/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.positive_test.update_link: PASS (48.32 s)
 (03/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.positive_test.update_link_with_rom: PASS (48.26 s)
 (04/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.positive_test.update_link_without_addr: PASS (47.46 s)
 (05/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.positive_test.update_link_diff_type: PASS (58.77 s)
 (06/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.positive_test.update_source: PASS (10.98 s)
 (07/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.positive_test.add_filter: PASS (11.34 s)
 (08/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.positive_test.add_filter_with_paramters: PASS (12.31 s)
 (09/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.positive_test.update_filter: PASS (18.89 s)
 (10/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.positive_test.update_filter_parameter: PASS (13.35 s)
 (11/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.positive_test.update_ignore_unsupported_features: PASS (31.35 s)
 (12/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.positive_test.del_filter: PASS (23.61 s)
 (13/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.positive_test.cold_update_alias: PASS (15.90 s)
 (14/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.positive_test.add_coalesce: PASS (10.27 s)
 (15/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.positive_test.del_coalesce: PASS (12.57 s)
 (16/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.positive_test.update_coalesce: PASS (11.40 s)
 (17/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.positive_test.update_portgroup: PASS (19.03 s)
 (18/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.positive_test.update_boot_order: PASS (17.83 s)
 (19/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.negative_test.update_alias: FAIL: The real error msg:'error: Failed to update device from /tmp/xml_utils_temp_3st2ero4.xml\nerror: device not found: no device found at address '0000:01:00.0' matching MAC address '52:54:00:12:e0:dc' and alias 'ua-82c8ae17-a501-466d-b14c-d002e324ee89'' does ... (10.38 s)
 (20/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.negative_test.update_alias_match_pci: FAIL: The real error msg:'error: Failed to update device from /tmp/xml_utils_temp__zbia0lf.xml\nerror: device not found: no device found at address '0000:01:00.0' matching MAC address '(<null>)' and alias 'ua-3e5d2629-8b0c-4320-9592-d67b0c343d27'' does not match... (17.61 s)
 (21/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.negative_test.update_alias_match_mac: FAIL: The real error msg:'error: Failed to update device from /tmp/xml_utils_temp_jbdgf9_9.xml\nerror: device not found: no device found at address '0000:01:00.0' matching MAC address '52:54:00:12:e0:dc' and alias 'ua-dd8ae3d4-3297-45b0-8366-d765aaef36c4'' does ... (17.69 s)
 (22/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.negative_test.update_queues: PASS (17.30 s)
 (23/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.negative_test.update_driver: PASS (10.67 s)
 (24/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.negative_test.update_model: PASS (19.13 s)
 (25/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.negative_test.update_rom: PASS (15.73 s)
 (26/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.negative_test.add_rom_enable: PASS (11.19 s)
 (27/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.negative_test.update_rom_enable: PASS (12.07 s)
 (28/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.negative_test.update_rom_and_address: PASS (18.95 s)
 (29/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.negative_test.del_rom_enable: FAIL: Run '/usr/bin/virsh update-device avocado-vt-vm1 /tmp/xml_utils_temp_ktr_zbt5.xml ' expect fail, but run successfully. (13.27 s)
 (30/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.negative_test.update_bandwidth: PASS (16.76 s)
 (31/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.negative_test.update_target: PASS (16.32 s)
 (32/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.negative_test.update_mtu.not_support: PASS (12.53 s)
 (33/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.negative_test.update_mtu.invalid_number: PASS (15.67 s)
 (34/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.negative_test.update_mtu.invalid_character: PASS (12.27 s)
 (35/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.negative_test.update_qos.average.negative_val: PASS (15.87 s)
 (36/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.negative_test.update_qos.average.huge_val: PASS (18.46 s)
 (37/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.negative_test.update_qos.average.missing: PASS (10.49 s)
 (38/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.negative_test.update_qos.network_qos.missing: PASS (18.04 s)
 (39/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.negative_test.update_driver_iommu_ast: PASS (19.71 s)
 (40/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.negative_test.update_boot_order.vm_on.os_boot: PASS (17.20 s)
 (41/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.negative_test.update_boot_order.vm_on.disk_boot: PASS (11.63 s)
 (42/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.negative_test.update_boot_order.vm_on.invalid_value.0: PASS (18.13 s)
 (43/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.negative_test.update_boot_order.vm_on.invalid_value.s: PASS (15.95 s)
 (44/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.negative_test.update_boot_order.vm_on.invalid_value.-6: PASS (11.29 s)
 (45/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.negative_test.update_boot_order.vm_on.none_to_2: PASS (18.97 s)
 (46/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.negative_test.update_boot_order.vm_off.os_boot: PASS (15.47 s)
 (47/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.negative_test.update_boot_order.vm_off.disk_boot: PASS (10.19 s)
 (48/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.negative_test.update_boot_order.vm_off.invalid_value.0: PASS (8.71 s)
 (49/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.negative_test.update_boot_order.vm_off.invalid_value.s: PASS (9.15 s)
 (50/50) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.negative_test.update_boot_order.vm_off.invalid_value.-6: PASS (16.16 s)
RESULTS    : PASS 46 | ERROR 0 | FAIL 4 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-10-28T00.08-49923d1/results.html
JOB TIME   : 898.82 s

The 4 failed tests were not caused by this change
```