### PR TITLE
Backingchain: add new case for blockcopy with granularity and buf-size

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockcopy/blockcopy_with_granularity_buf_size_option.cfg
+++ b/libvirt/tests/cfg/backingchain/blockcopy/blockcopy_with_granularity_buf_size_option.cfg
@@ -1,0 +1,38 @@
+- backingchain.blockcopy.granularity_buf_size:
+    type = blockcopy_with_granularity_buf_size_option
+    target_disk = "vdb"
+    disk_type = "file"
+    disk_dict = {"type_name":"${disk_type}", "target":{"dev": "${target_disk}", "bus": "virtio"}, "driver": {"name": "qemu", "type":"qcow2"}}
+    blockcopy_option = " --wait --verbose --transient-job"
+    snap_num = 1
+    variants:
+        - positive_test:
+            status_error = "no"
+            abort_option = " --pivot"
+            variants:
+                - granularity:
+                    blockcopy_option += " --granularity"
+                    test_size = 512
+                    expected_log = "granularity=0x200"
+                - buf_size:
+                    blockcopy_option += " --buf-size"
+                    test_size = 100
+                    expected_log = "buf_size=100"
+        - negative_test:
+            status_error = "yes"
+            variants:
+                - granularity:
+                    blockcopy_option += " --granularity"
+                    variants:
+                        - little_than_512B:
+                            test_size = 4
+                            error_msg = "expects a value in range \[512B, 64MB\]"
+                        - more_than_64MB:
+                            test_size = 134217728
+                            error_msg = "expects a value in range \[512B, 64MB\]"
+                        - not_power_of_2:
+                            test_size = 1234
+                            error_msg = "granularity must be power of 2"
+                        - not_a_int:
+                            test_size = -512
+                            error_msg = "is malformed or out of range"

--- a/libvirt/tests/src/backingchain/blockcopy/blockcopy_with_granularity_buf_size_option.py
+++ b/libvirt/tests/src/backingchain/blockcopy/blockcopy_with_granularity_buf_size_option.py
@@ -1,0 +1,120 @@
+import os
+
+from virttest import data_dir
+from virttest import virsh
+from virttest import utils_libvirtd
+from virttest import utils_misc
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_test import libvirt
+from virttest.utils_libvirt import libvirt_disk
+
+from provider.backingchain import blockcommand_base
+from provider.virtual_disk import disk_base
+
+
+def run(test, params, env):
+    """
+    Do blockcopy with granularity/buf-size options
+
+    1) Prepare disk and snap chain
+        disk type: file
+    2) Do blockcopy:
+        --granularity
+        --buf-size
+    3) Check result
+    """
+
+    def setup_test():
+        """
+        Prepare running domain and snapshot
+        """
+        test.log.info("Setup env: prepare running vm and snapshot")
+        test_obj.new_image_path = disk_obj.add_vm_disk(disk_type, disk_dict)
+        test_obj.backingchain_common_setup(create_snap=True, snap_num=snap_num)
+
+    def run_test():
+        """
+        Do blockcopy with granularity/buf-size options
+        Check result
+        """
+        test.log.info("TEST_STEP1: Do blockcopy ")
+        blockcopy_options = f'{blockcopy_option} {test_size}'
+        test_obj.copy_image = data_dir.get_data_dir() + '/rhel.copy'
+        result = virsh.blockcopy(vm_name, target_disk, test_obj.copy_image,
+                                 options=blockcopy_options, debug=True)
+        _check_result(result)
+
+    def check_libvirt_log():
+        """
+        Check if expected information can be found in libvirtd log.
+        """
+        if not os.path.exists(libvirtd_log_file):
+            test.fail("Expected VM log file: %s not exists" % libvirtd_log_file)
+        result = utils_misc.wait_for(lambda: libvirt.check_logfile(expected_log, libvirtd_log_file), timeout=20)
+        if not result:
+            test.fail("Can't get expected log %s in %s" % (expected_log, libvirtd_log_file))
+
+    def _check_result(result):
+        """
+        Check the result
+        """
+        libvirt.check_exit_status(result, status_error)
+        if not status_error:
+            check_libvirt_log()
+            # Pivot the blockcopy process
+            virsh.blockjob(vm_name, target_disk, options=abort_option,
+                           debug=True, ignore_status=False)
+        else:
+            if error_msg:
+                libvirt.check_result(result, error_msg)
+
+    def teardown_test():
+        """
+        Clean the test environment
+        """
+        test.log.info("TEST_TEARDOWN: Clean up env.")
+        # clean up snapshot
+        test_obj.backingchain_common_teardown()
+        # clean up disk image and copy image
+        test_obj.clean_file(test_obj.new_image_path)
+        test_obj.clean_file(test_obj.copy_image)
+        # Restore libvirtd conf and restart libvirtd/virtqemud
+        libvirtd_conf.restore()
+        utils_libvirtd.libvirtd_restart()
+        if libvirtd_log_file and os.path.exists(libvirtd_log_file):
+            os.unlink(libvirtd_log_file)
+        bkxml.sync()
+
+    # Process cartesian parameters
+    vm_name = params.get("main_vm")
+    target_disk = params.get('target_disk')
+    disk_type = params.get("disk_type")
+    disk_dict = eval(params.get("disk_dict", "{}"))
+    abort_option = params.get("abort_option")
+    snap_num = int(params.get("snap_num"))
+    expected_log = params.get("expected_log")
+    blockcopy_option = params.get("blockcopy_option")
+    test_size = params.get("test_size")
+    error_msg = params.get("error_msg", "")
+    status_error = params.get("status_error", "no") == "yes"
+
+    vm = env.get_vm(vm_name)
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+
+    # Create object
+    test_obj = blockcommand_base.BlockCommand(test, vm, params)
+    disk_obj = disk_base.DiskBase(test, vm, params)
+    test_obj.original_disk_source = libvirt_disk.get_first_disk_source(vm)
+
+    # Prepare libvirt log
+    libvirtd_log_file = os.path.join(test.debugdir, "libvirtd.log")
+    libvirtd_conf_dict = {"log_filters": '"3:json 1:libvirt 1:qemu"',
+                          "log_outputs": '"1:file:%s"' % libvirtd_log_file}
+    libvirtd_conf = libvirt.customize_libvirt_config(libvirtd_conf_dict)
+
+    try:
+        setup_test()
+        run_test()
+    finally:
+        teardown_test()


### PR DESCRIPTION
Automate case:
VIRT-294528 - Do blockcopy with --buf-size or --granularity option

Test Result:
```
# avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockcopy.granularity_buf-size
JOB ID     : ffed7c03cfc3ddc3854e759efa45ca09631a5d6e
JOB LOG    : /var/lib/avocado/job-results/job-2022-10-28T03.06-ffed7c0/job.log
 (1/6) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.granularity_buf-size.positive_test.granularity: PASS (72.31 s)
 (2/6) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.granularity_buf-size.positive_test.buf-size: PASS (76.59 s)
 (3/6) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.granularity_buf-size.negative_test.granularity.little_than_512B: PASS (75.35 s)
 (4/6) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.granularity_buf-size.negative_test.granularity.more_than_64MB: PASS (76.22 s)
 (5/6) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.granularity_buf-size.negative_test.granularity.not_power_of_2: PASS (74.25 s)
 (6/6) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.granularity_buf-size.negative_test.granularity.not_a_int: PASS (75.06 s)
RESULTS    : PASS 6 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-10-28T03.06-ffed7c0/results.html
JOB TIME   : 452.63 s
```

Signed-off-by: root <root@lenovo-sr630-05.lab.eng.pek2.redhat.com>