### PR TITLE
remote_access: fix UnboundLocalError

### DIFF
--- a/libvirt/tests/src/remote_access/remote_access.py
+++ b/libvirt/tests/src/remote_access/remote_access.py
@@ -323,6 +323,7 @@ def run(test, params, env):
     test_alias = test_dict.get("test_alias")
     ssh_config_path = test_dict.get("ssh_config_path")
     openssl_config_name = test_dict.get("openssl_config_name")
+    ssh_config_backup_path = None
     if openssl_config_name:
         openssl_config_path = os.path.join(data_dir.get_tmp_dir(), openssl_config_name)
 


### PR DESCRIPTION
Fix below error:
- UnboundLocalError: local variable 'ssh_config_backup_path' referenced before assignment

Signed-off-by: Dan Zheng <dzheng@redhat.com>