### PR TITLE
remote_access: fix not assignment

### DIFF
--- a/libvirt/tests/src/remote_access/remote_access.py
+++ b/libvirt/tests/src/remote_access/remote_access.py
@@ -324,6 +324,7 @@ def run(test, params, env):
     ssh_config_path = test_dict.get("ssh_config_path")
     openssl_config_name = test_dict.get("openssl_config_name")
     ssh_config_backup_path = None
+    openssl_config_path = None
     if openssl_config_name:
         openssl_config_path = os.path.join(data_dir.get_tmp_dir(), openssl_config_name)
 


### PR DESCRIPTION
Fix below error:

UnboundLocalError: local variable 'openssl_config_path' referenced before assignment
It is similar to https://github.com/autotest/tp-libvirt/pull/4612

Signed-off-by: Dan Zheng <dzheng@redhat.com>