### PR TITLE
migration: Add case about specified tls hostname

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_storage.cfg
+++ b/libvirt/tests/cfg/migration/migrate_storage.cfg
@@ -43,6 +43,16 @@
                     server_info_ip = "192.168.10.123"
                     virsh_migrate_extra = "--tls --migrateuri tcp://${migrate_dest_host}"
                     err_msg = "Certificate does not match the hostname"
+                - specified_tls_hostname:
+                    only copy_storage_all
+                    func_supported_since_libvirt_ver = (8, 2, 0)
+                    virsh_migrate_extra = "--tls --migrateuri tcp://${migrate_dest_host}"
+                    err_msg = "Certificate does not match the hostname"
+                    migrate_again = 'yes'
+                    status_error = 'yes'
+                    server_info_ip = "192.168.10.123"
+                    migrate_again_status_error = 'no'
+                    virsh_migrate_extra_mig_again = "--tls --tls-destination ${server_cn} --migrateuri tcp://${migrate_dest_host}"
         - migrateuri:
             only copy_storage_all
             check_disks_port = "yes"

--- a/libvirt/tests/src/migration/migrate_storage.py
+++ b/libvirt/tests/src/migration/migrate_storage.py
@@ -218,6 +218,9 @@ def run(test, params, env):
             if cancel_migration:
                 action_during_mig = None
             extra_args["status_error"] = "no"
+            if params.get("virsh_migrate_extra_mig_again"):
+                extra = params.get("virsh_migrate_extra_mig_again")
+                extra = "{} {}".format(extra, copy_storage_option)
             migration_test.do_migration(vms, None, dest_uri, 'orderly',
                                         options, thread_timeout=1200,
                                         ignore_status=True,


### PR DESCRIPTION
RHEL-196405 - [Migration][tls][tls-destination] Migrate vm with
 copy storage - Native TLS(--tls) - with specified tls hostname

Signed-off-by: cliping <lcheng@redhat.com>