### PR TITLE
migration: Add case about pause/recover migration

### DIFF
--- a/libvirt/tests/cfg/migration/destructive_operations_around_live_migration/migration_kill_libvirt_daemon.cfg
+++ b/libvirt/tests/cfg/migration/destructive_operations_around_live_migration/migration_kill_libvirt_daemon.cfg
@@ -26,7 +26,7 @@
     migrate_desturi_port = "16509"
     migrate_desturi_type = "tcp"
     virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
-    action_during_mig = '[{"func": "kill_libvirt_daemon", "after_event": "iteration: \'1\'", "func_param": "params"}]'
+    action_during_mig = '[{"func": "libvirt_service.kill_service", "after_event": "iteration: \'1\'", "func_param": "params"}]'
     migrate_again_status_error = 'no'
     migrate_again = 'yes'
     check_migration_params = '{"xbzrle-cache-size": "67108864", "multifd-channels": "2", "cpu-throttle-initial": "20", "cpu-throttle-increment": "10"}'
@@ -45,12 +45,15 @@
             virsh_migrate_options = '--live --verbose'
     variants:
         - with_precopy:
-    variants kill_daemon:
+    variants:
         - kill_src_virtqemud:
+            service_name = "libvirtd"
         - kill_dest_virtqemud:
+            service_name = "libvirtd"
+            service_on_dst = "yes"
         - kill_dest_virtproxyd:
-        - kill_src_libvirtd:
-        - kill_dest_libvirtd:
+            service_name = "virtproxyd"
+            service_on_dst = "yes"
     variants test_case:
         - parallel_option:
             virsh_migrate_extra = "--parallel --parallel-connections 5"
@@ -58,7 +61,7 @@
         - zerocopy_option:
             virsh_migrate_extra = "--parallel --zerocopy"
             virsh_migrate_extra_mig_again = "--parallel --zerocopy"
-            action_during_mig = '[{"func": "check_qemu_mem_lock_hard_limit", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "kill_libvirt_daemon", "func_param": "params"}]'
+            action_during_mig = '[{"func": "check_qemu_mem_lock_hard_limit", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "libvirt_service.kill_service", "func_param": "params"}]'
         - xbzrle_option:
             virsh_migrate_extra = "--compressed --comp-methods xbzrle --comp-xbzrle-cache 134217728"
             virsh_migrate_extra_mig_again = "--compressed --comp-methods xbzrle"

--- a/libvirt/tests/cfg/migration/migrate_service_control.cfg
+++ b/libvirt/tests/cfg/migration/migrate_service_control.cfg
@@ -28,7 +28,7 @@
             vm_state_after_abort = "{'source': 'running', 'target': 'nonexist'}"
             migrate_speed = 10
             status_error = 'yes'
-            action_during_mig = '[{"func": "utils_misc.kill_service", "after_event": "migration-iteration", "before_event": "Suspended Migrated", "func_param": "params"}]'
+            action_during_mig = '[{"func": "libvirt_service.kill_service", "after_event": "migration-iteration", "before_event": "Suspended Migrated", "func_param": "params"}]'
             migrate_again = 'yes'
             migrate_again_status_error = 'no'
             expected_image_ownership = 'qemu:qemu'

--- a/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_tls.cfg
+++ b/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_tls.cfg
@@ -64,7 +64,6 @@
             status_error = "yes"
             migrate_again = "yes"
             migrate_speed = "8796093022207"
-            enable_libvirtd_debug_log = "no"
             variants:
                 - correct_value:
                     virsh_migrate_extra_mig_again = "--tls --tls-destination ${server_cn}"

--- a/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_and_recover_and_disruptive.cfg
+++ b/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_and_recover_and_disruptive.cfg
@@ -1,0 +1,86 @@
+- migration.pause_postcopy_migration_and_recover.pause_and_recover_and_disruptive:
+    type = pause_and_recover_and_disruptive
+    migration_setup = 'yes'
+    storage_type = 'nfs'
+    setup_local_nfs = 'yes'
+    disk_type = "file"
+    disk_source_protocol = "netfs"
+    mnt_path_name = ${nfs_mount_dir}
+    # Console output can only be monitored via virsh console output
+    only_pty = True
+    take_regular_screendumps = no
+    # Extra options to pass after <domain> <desturi>
+    virsh_migrate_extra = ''
+    # SSH connection time out
+    ssh_timeout = 60
+    # Local URI
+    virsh_migrate_connect_uri = 'qemu:///system'
+    virsh_migrate_dest_state = "running"
+    virsh_migrate_src_state = "shut off"
+    image_convert = 'no'
+    server_ip = "${migrate_dest_host}"
+    server_user = "root"
+    server_pwd = "${migrate_dest_pwd}"
+    check_network_accessibility_after_mig = "yes"
+    status_error = "no"
+    migrate_speed = "5"
+    stress_package = "stress"
+    stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20s"
+    postcopy_options = "--timeout 4 --timeout-postcopy --postcopy --postcopy-bandwidth 5"
+    do_migration_during_mig = "yes"
+    postcopy_options_during_mig = "--postcopy-resume"
+    action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "virsh.domjobabort", "func_param": "'%s --postcopy' % params.get('migrate_main_vm')", "need_sleep_time": "5"}, {"func": "do_migration", "func_param": "params", "need_sleep_time": "5"}]'
+
+    variants:
+        - p2p:
+            virsh_migrate_options = '--live --p2p --verbose'
+        - non_p2p:
+            virsh_migrate_options = '--live --verbose'
+    variants:
+        - tcp:
+            migrate_desturi_port = "16509"
+            migrate_desturi_type = "tcp"
+            virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
+            transport_type = "tcp"
+        - unix_proxy:
+            transport_type = "unix_proxy"
+            desturi_socket_path = "/tmp/desturi-socket"
+            migrateuri_socket_path = "/var/lib/libvirt/qemu/migrateuri-socket"
+            disks_uri_socket_path = "/var/lib/libvirt/qemu/disks-uri-socket"
+            migrate_desturi_type = "unix_proxy"
+            virsh_migrate_desturi = "qemu+unix:///system?socket=${desturi_socket_path}"
+            virsh_migrate_migrateuri = "unix://${migrateuri_socket_path}"
+            virsh_migrate_disks_uri = "unix://${disks_uri_socket_path}"
+            virsh_migrate_extra = "--migrateuri ${virsh_migrate_migrateuri}"
+            check_port_or_network_conn_num = "no"
+    variants disruptive_operations:
+        - poweroff_vm_dest:
+            migrate_desturi_port = "16509"
+            migrate_desturi_type = "tcp"
+            virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
+            service_name = "libvirtd"
+            service_on_dst = "yes"
+            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "virsh.domjobabort", "func_param": "'%s --postcopy' % params.get('migrate_main_vm')", "need_sleep_time": "90"}, {"func": "do_migration", "func_param": "params", "need_sleep_time": "90"}]'
+            action_during_do_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "libvirt_service.kill_service", "func_param": "params"}, {"func": "poweroff_vm", "func_param": "params"}, {"func": "do_migration", "func_param": "params"}]'
+            status_error_during_mig = "yes"
+            poweroff_vm_dest = "yes"
+        - unattended_mig:
+            service_name = "libvirtd"
+            service_on_dst = "yes"
+            action_during_do_mig = '[{"func": "libvirt_service.kill_service", "before_pause": "yes", "func_param": "params", "need_sleep_time": "10"}]'
+            status_error_during_mig = "yes"
+        - pause_by_domjobabort:
+            action_during_do_mig = '[{"func": "virsh.domjobabort", "before_pause": "yes", "func_param": "'%s --postcopy' % params.get('migrate_main_vm')"}, {"func": "resume_migration_again", "func_param": "params"}]'
+            status_error_during_mig = "no"
+        - pause_by_network_issue:
+            port_to_check = "49152"
+            virsh_migrate_extra = "--migrateuri tcp://${migrate_dest_host}:${port_to_check} --listen-address ${migrate_dest_host}"
+            firewall_rule_on_dest = "ipv4 filter INPUT 0 -p tcp --dport ${port_to_check} -j DROP"
+            firewall_rule_on_src = "ipv4 filter INPUT 0 -p tcp --sport ${port_to_check} -j DROP"
+            action_during_do_mig = '[{"func": "libvirt_network.setup_firewall_rule", "func_param": "params", "need_sleep_time": "10"}, {"func": "libvirt_network.cleanup_firewall_rule", "func_param": "params", "need_sleep_time": "90"}]'
+            status_error_during_mig = "no"
+            tcp_config_list = '{"tcp_keepalive_probes": "9", "tcp_keepalive_intvl": "60", "tcp_retries1": "4", "tcp_retries2": "8", "tcp_fin_timeout": "2"}'
+            recover_tcp_config_list = '{"tcp_keepalive_probes": "9", "tcp_keepalive_intvl": "75", "tcp_retries1": "3", "tcp_retries2": "15", "tcp_fin_timeout": "60"}'
+        - pause_by_proxy_issue:
+            action_during_do_mig = '[{"func": "clear_pmsocat", "func_param": "params", "need_sleep_time": "5"}, {"func": "base_steps.recreate_conn_objs", "func_param": "params"}, "need_sleep_time": "10"]'
+            status_error_during_mig = "no"

--- a/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_and_recover_twice.cfg
+++ b/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_and_recover_twice.cfg
@@ -1,0 +1,67 @@
+- migration.pause_postcopy_migration_and_recover.pause_and_recover_twice:
+    type = pause_and_recover_twice
+    migration_setup = 'yes'
+    storage_type = 'nfs'
+    setup_local_nfs = 'yes'
+    disk_type = "file"
+    disk_source_protocol = "netfs"
+    mnt_path_name = ${nfs_mount_dir}
+    # Console output can only be monitored via virsh console output
+    only_pty = True
+    take_regular_screendumps = no
+    # Extra options to pass after <domain> <desturi>
+    virsh_migrate_extra = ''
+    # SSH connection time out
+    ssh_timeout = 60
+    # Local URI
+    virsh_migrate_connect_uri = 'qemu:///system'
+    virsh_migrate_dest_state = "running"
+    virsh_migrate_src_state = "shut off"
+    image_convert = 'no'
+    server_ip = "${migrate_dest_host}"
+    server_user = "root"
+    server_pwd = "${migrate_dest_pwd}"
+    check_network_accessibility_after_mig = "yes"
+    status_error = "no"
+    migrate_speed = "5"
+    stress_package = "stress"
+    stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20s"
+    postcopy_options = "--timeout 4 --timeout-postcopy --postcopy"
+    do_migration_during_mig = "yes"
+    postcopy_options_during_mig = "--postcopy-resume"
+    err_msg = "job 'migration in' failed in post-copy phase"
+    test_case = "pause_and_recover_twice"
+    status_error_during_mig = "yes"
+    status_error_during_mig_twice = "no"
+
+    variants:
+        - p2p:
+            virsh_migrate_options = '--live --p2p --verbose'
+        - non_p2p:
+            virsh_migrate_options = '--live --verbose'
+    variants recover_failed_reason:
+        - network_issue:
+            port_to_check = "49154"
+            virsh_migrate_extra = "--migrateuri tcp://${migrate_dest_host}:${port_to_check} --listen-address ${migrate_dest_host}"
+            firewall_rule_on_dest = "ipv4 filter INPUT 0 -p tcp --dport ${port_to_check} -j DROP"
+            firewall_rule_on_src = "ipv4 filter INPUT 0 -p tcp --sport ${port_to_check} -j DROP"
+            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "virsh.domjobabort", "func_param": "'%s --postcopy' % params.get('migrate_main_vm')", "need_sleep_time": "5"}, {"func": "libvirt_network.setup_firewall_rule", "func_param": "params"}, {"func": "do_migration", "func_param": "params", "need_sleep_time": "90"}, {"func": "libvirt_network.cleanup_firewall_rule", "func_param": "params", "need_sleep_time": "5"}, {"func": "resume_migration_again", "func_param": "params", "need_sleep_time": "5"}]'
+            migrate_desturi_port = "16509"
+            migrate_desturi_type = "tcp"
+            virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
+            err_msg_during_mig = "unable to connect to server at.*: Connection timed out"
+            tcp_config_list = '{"tcp_keepalive_probes": "9", "tcp_keepalive_intvl": "60", "tcp_retries1": "4", "tcp_retries2": "8", "tcp_fin_timeout": "2"}'
+            recover_tcp_config_list = '{"tcp_keepalive_probes": "9", "tcp_keepalive_intvl": "75", "tcp_retries1": "3", "tcp_retries2": "15", "tcp_fin_timeout": "60"}'
+        - proxy_issue:
+            transport_type = "unix_proxy"
+            desturi_socket_path = "/tmp/desturi-socket"
+            migrateuri_socket_path = "/var/lib/libvirt/qemu/migrateuri-socket"
+            disks_uri_socket_path = "/var/lib/libvirt/qemu/disks-uri-socket"
+            migrate_desturi_type = "unix_proxy"
+            virsh_migrate_desturi = "qemu+unix:///system?socket=${desturi_socket_path}"
+            virsh_migrate_migrateuri = "unix://${migrateuri_socket_path}"
+            virsh_migrate_disks_uri = "unix://${disks_uri_socket_path}"
+            virsh_migrate_extra = "--migrateuri ${virsh_migrate_migrateuri}"
+            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "virsh.domjobabort", "func_param": "'%s --postcopy' % params.get('migrate_main_vm')", "need_sleep_time": "5"}, {"func": "clear_pmsocat", "func_param": "params"}, {"func": "do_migration", "func_param": "params", "need_sleep_time": "60"}, {"func": "base_steps.recreate_conn_objs", "func_param": "params"}, {"func": "resume_migration_again", "func_param": "params"}]'
+            check_port_or_network_conn_num = "no"
+            err_msg_during_mig = "Failed to connect socket to .*: Connection refused"

--- a/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_by_domjobabort_and_recover.cfg
+++ b/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_by_domjobabort_and_recover.cfg
@@ -1,0 +1,83 @@
+- migration.pause_postcopy_migration_and_recover.pause_by_domjobabort_and_recover:
+    type = pause_by_domjobabort_and_recover
+    migration_setup = 'yes'
+    storage_type = 'nfs'
+    setup_local_nfs = 'yes'
+    disk_type = "file"
+    disk_source_protocol = "netfs"
+    mnt_path_name = ${nfs_mount_dir}
+    # Console output can only be monitored via virsh console output
+    only_pty = True
+    take_regular_screendumps = no
+    # Extra options to pass after <domain> <desturi>
+    virsh_migrate_extra = ''
+    # SSH connection time out
+    ssh_timeout = 60
+    # Local URI
+    virsh_migrate_connect_uri = 'qemu:///system'
+    virsh_migrate_dest_state = "running"
+    virsh_migrate_src_state = "shut off"
+    image_convert = 'no'
+    server_ip = "${migrate_dest_host}"
+    server_user = "root"
+    server_pwd = "${migrate_dest_pwd}"
+    check_network_accessibility_after_mig = "yes"
+    migrate_desturi_port = "16509"
+    migrate_desturi_type = "tcp"
+    virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
+    status_error = "yes"
+    migrate_speed = "5"
+    stress_package = "stress"
+    stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20s"
+    postcopy_options = "--timeout 4 --timeout-postcopy --postcopy"
+    action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "virsh.domjobabort", "func_param": "'%s --postcopy' % params.get('migrate_main_vm')", "need_sleep_time": "5"}, {"func": "do_common_check", "func_param": "params"}]'
+    migrate_again = 'yes'
+    migrate_again_status_error = 'no'
+    action_during_mig_again = '[{"func": "do_common_check", "before_pause": "yes", "func_param": "params"}, {"func": "set_migrate_speed_to_high", "before_pause": "yes", "func_param": "params"}]'
+    virsh_migrate_extra_mig_again = "--timeout 4 --timeout-postcopy --postcopy --postcopy-resume"
+    postcopy_resume_migration = "yes"
+    migrate_speed_high = "1048576"
+    err_msg = "job 'migration in' failed in post-copy phase"
+    expected_dest_state = "running"
+    expected_src_state = "paused"
+    dominfo_check = "Persistent:     no"
+    expected_event_src = ["event 'lifecycle' for domain.*: Suspended Post-copy Error", "event 'lifecycle' for domain .*: Suspended Post-copy", "event 'lifecycle' for domain .*: Stopped Migrated", "event 'job-completed' for domain"]
+    expected_event_target = ["event 'lifecycle' for domain.*: Resumed Post-copy Error", "event 'lifecycle' for domain.*: Resumed Post-copy", "event 'lifecycle' for domain.*: Resumed Migrated"]
+
+    variants:
+        - p2p:
+            virsh_migrate_options = '--live --p2p --verbose'
+        - non_p2p:
+            virsh_migrate_options = '--live --verbose'
+    variants network_data_transport:
+        - tcp:
+        - tls:
+            transport_type = "tls"
+            qemu_tls = "yes"
+            custom_pki_path = "/etc/pki/qemu"
+            server_cn = "ENTER.YOUR.EXAMPLE.SERVER_CN"
+            client_cn = "ENTER.YOUR.EXAMPLE.CLIENT_CN"
+    variants migration_options:
+        - migrateuri:
+            port_to_check = "49153"
+            virsh_migrate_extra = "--migrateuri tcp://${migrate_dest_host}:${port_to_check} --listen-address ${migrate_dest_host} "
+        - dname:
+            dname_value = "guest-new-name"
+            virsh_migrate_extra = "--dname ${dname_value}"
+        - xml:
+            update_xml_title = "Update title in xml"
+        - persistent:
+            update_persist_title = "Update title in persist xml"
+            dominfo_check = "Persistent:     yes"
+        - undefinesource:
+            virsh_migrate_extra = "--undefinesource --persistent"
+            virsh_migrate_src_state = "failed to get domain"
+            dominfo_check = "Persistent:     yes"
+        - postcopy_bandwidth:
+            initiating_bandwidth = "5"
+            second_bandwidth = "10"
+            jobinfo_item = "Memory bandwidth:"
+            diff_rate = '0.5'
+            compare_to_value = ${second_bandwidth}
+            postcopy_options = "--postcopy-bandwidth ${initiating_bandwidth} --timeout 4 --timeout-postcopy --postcopy"
+        - no_options:

--- a/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_by_network_and_recover.cfg
+++ b/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_by_network_and_recover.cfg
@@ -1,0 +1,73 @@
+- migration.pause_postcopy_migration_and_recover.pause_by_network_and_recover:
+    type = pause_by_network_and_recover
+    migration_setup = 'yes'
+    storage_type = 'nfs'
+    setup_local_nfs = 'yes'
+    disk_type = "file"
+    disk_source_protocol = "netfs"
+    mnt_path_name = ${nfs_mount_dir}
+    # Console output can only be monitored via virsh console output
+    only_pty = True
+    take_regular_screendumps = no
+    # Extra options to pass after <domain> <desturi>
+    virsh_migrate_extra = ''
+    # SSH connection time out
+    ssh_timeout = 60
+    # Local URI
+    virsh_migrate_connect_uri = 'qemu:///system'
+    virsh_migrate_dest_state = "running"
+    virsh_migrate_src_state = "shut off"
+    image_convert = 'no'
+    server_ip = "${migrate_dest_host}"
+    server_user = "root"
+    server_pwd = "${migrate_dest_pwd}"
+    check_network_accessibility_after_mig = "yes"
+    status_error = "yes"
+    migrate_speed = "1"
+    stress_package = "stress"
+    stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20s"
+    postcopy_options = "--timeout 4 --timeout-postcopy --postcopy --postcopy-bandwidth 1"
+    action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "libvirt_network.setup_firewall_rule", "func_param": "params", "need_sleep_time": "5"}, {"func": "do_common_check", "func_param": "params", "need_sleep_time": "90"}, {"func": "libvirt_network.cleanup_firewall_rule", "func_param": "params"}]'
+    migrate_again = 'yes'
+    migrate_again_status_error = 'no'
+    action_during_mig_again = '[{"func": "do_common_check", "before_pause": "yes", "func_param": "params"}, {"func": "set_migrate_speed_to_high", "before_pause": "yes", "func_param": "params"}]'
+    virsh_migrate_extra_mig_again = "--timeout 4 --timeout-postcopy --postcopy --postcopy-resume"
+    postcopy_resume_migration = "yes"
+    migrate_speed_high = "1048576"
+    err_msg = "migration out job: post-copy phase failed"
+    expected_dest_state = "running"
+    expected_src_state = "paused"
+    dominfo_check = "Persistent:     no"
+    expected_event_src = ["event 'lifecycle' for domain.*: Suspended Post-copy Error", "event 'lifecycle' for domain .*: Suspended Post-copy", "event 'lifecycle' for domain .*: Stopped Migrated", "event 'job-completed' for domain"]
+    expected_event_target = ["event 'lifecycle' for domain.*: Resumed Post-copy Error", "event 'lifecycle' for domain.*: Resumed Post-copy", "event 'lifecycle' for domain.*: Resumed Migrated"]
+    migrate_desturi_port = "16509"
+    migrate_desturi_type = "tcp"
+    virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
+    tcp_config_list = '{"tcp_keepalive_probes": "9", "tcp_keepalive_intvl": "60", "tcp_retries1": "4", "tcp_retries2": "8", "tcp_fin_timeout": "2"}'
+    recover_tcp_config_list = '{"tcp_keepalive_probes": "9", "tcp_keepalive_intvl": "75", "tcp_retries1": "3", "tcp_retries2": "15", "tcp_fin_timeout": "60"}'
+
+    variants:
+        - p2p:
+            virsh_migrate_options = '--live --p2p --verbose'
+        - non_p2p:
+            virsh_migrate_options = '--live --verbose'
+    variants network_data_transport:
+        - tcp:
+            transport_type = "tcp"
+        - tls:
+            transport_type = "tls"
+            qemu_tls = "yes"
+            custom_pki_path = "/etc/pki/qemu"
+            server_cn = "ENTER.YOUR.EXAMPLE.SERVER_CN"
+            client_cn = "ENTER.YOUR.EXAMPLE.CLIENT_CN"
+    variants :
+        - qemu_layer:
+            port_to_check = "49155"
+            virsh_migrate_extra = "--migrateuri tcp://${migrate_dest_host}:${port_to_check} --listen-address ${migrate_dest_host}"
+            firewall_rule_on_dest = "ipv4 filter INPUT 0 -p tcp --dport ${port_to_check} -j DROP"
+            firewall_rule_on_src = "ipv4 filter INPUT 0 -p tcp --sport ${port_to_check} -j DROP"
+            err_msg = "job 'migration in' failed in post-copy phase"
+        - libvirt_layer:
+            firewall_rule_on_dest = "ipv4 filter INPUT 0 -p tcp --dport ${migrate_desturi_port} -j DROP"
+            firewall_rule_on_src = "ipv4 filter INPUT 0 -p tcp --sport ${migrate_desturi_port} -j DROP"
+            err_msg = "internal error: client socket is closed"

--- a/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_by_proxy_and_recover.cfg
+++ b/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_by_proxy_and_recover.cfg
@@ -1,0 +1,60 @@
+- migration.pause_postcopy_migration_and_recover.pause_by_proxy_and_recover:
+    type = pause_by_proxy_and_recover
+    migration_setup = 'yes'
+    storage_type = 'nfs'
+    setup_local_nfs = 'yes'
+    disk_type = "file"
+    disk_source_protocol = "netfs"
+    mnt_path_name = ${nfs_mount_dir}
+    # Console output can only be monitored via virsh console output
+    only_pty = True
+    take_regular_screendumps = no
+    # Extra options to pass after <domain> <desturi>
+    virsh_migrate_extra = ''
+    # SSH connection time out
+    ssh_timeout = 60
+    # Local URI
+    virsh_migrate_connect_uri = 'qemu:///system'
+    virsh_migrate_dest_state = "running"
+    virsh_migrate_src_state = "shut off"
+    image_convert = 'no'
+    server_ip = "${migrate_dest_host}"
+    server_user = "root"
+    server_pwd = "${migrate_dest_pwd}"
+    check_network_accessibility_after_mig = "yes"
+    status_error = "yes"
+    migrate_speed = "5"
+    stress_package = "stress"
+    stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20s"
+    postcopy_options = "--timeout 4 --timeout-postcopy --postcopy --postcopy-bandwidth 5"
+    action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "clear_pmsocat", "func_param": "params", "need_sleep_time": "60"}, {"func": "do_common_check", "func_param": "params", "need_sleep_time": "5"}, {"func": "base_steps.recreate_conn_objs", "func_param": "params"}]'
+    migrate_again = 'yes'
+    migrate_again_status_error = 'no'
+    action_during_mig_again = '[{"func": "do_common_check", "before_pause": "yes", "func_param": "params"}, {"func": "set_migrate_speed_to_high", "before_pause": "yes", "func_param": "params"}]'
+    virsh_migrate_extra_mig_again = "--timeout 4 --timeout-postcopy --postcopy --postcopy-resume"
+    postcopy_resume_migration = "yes"
+    migrate_speed_high = "1048576"
+    err_msg = "migration out job: post-copy phase failed|internal error: client socket is closed"
+    expected_dest_state = "running"
+    expected_src_state = "paused"
+    dominfo_check = "Persistent:     no"
+    expected_event_src = ["event 'lifecycle' for domain.*: Suspended Post-copy Error", "event 'lifecycle' for domain .*: Suspended Post-copy", "event 'lifecycle' for domain .*: Stopped Migrated", "event 'job-completed' for domain"]
+    expected_event_target = ["event 'lifecycle' for domain.*: Resumed Post-copy Error", "event 'lifecycle' for domain.*: Resumed Post-copy", "event 'lifecycle' for domain.*: Resumed Migrated"]
+
+    variants:
+        - p2p:
+            virsh_migrate_options = '--live --p2p --verbose'
+        - non_p2p:
+            virsh_migrate_options = '--live --verbose'
+    variants:
+        - unix_proxy:
+            transport_type = "unix_proxy"
+            desturi_socket_path = "/tmp/desturi-socket"
+            migrateuri_socket_path = "/var/lib/libvirt/qemu/migrateuri-socket"
+            disks_uri_socket_path = "/var/lib/libvirt/qemu/disks-uri-socket"
+            migrate_desturi_type = "unix_proxy"
+            virsh_migrate_desturi = "qemu+unix:///system?socket=${desturi_socket_path}"
+            virsh_migrate_migrateuri = "unix://${migrateuri_socket_path}"
+            virsh_migrate_disks_uri = "unix://${disks_uri_socket_path}"
+            virsh_migrate_extra = "--migrateuri ${virsh_migrate_migrateuri}"
+            check_port_or_network_conn_num = "no"

--- a/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/unattended_migration.cfg
+++ b/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/unattended_migration.cfg
@@ -1,0 +1,77 @@
+- migration.pause_postcopy_migration_and_recover.unattended_migration:
+    type = unattended_migration
+    migration_setup = 'yes'
+    storage_type = 'nfs'
+    setup_local_nfs = 'yes'
+    disk_type = "file"
+    disk_source_protocol = "netfs"
+    mnt_path_name = ${nfs_mount_dir}
+    # Console output can only be monitored via virsh console output
+    only_pty = True
+    take_regular_screendumps = no
+    # Extra options to pass after <domain> <desturi>
+    virsh_migrate_extra = ''
+    # SSH connection time out
+    ssh_timeout = 60
+    # Local URI
+    virsh_migrate_connect_uri = 'qemu:///system'
+    virsh_migrate_dest_state = "running"
+    virsh_migrate_src_state = "shut off"
+    image_convert = 'no'
+    server_ip = "${migrate_dest_host}"
+    server_user = "root"
+    server_pwd = "${migrate_dest_pwd}"
+    check_network_accessibility_after_mig = "yes"
+    migrate_desturi_port = "16509"
+    migrate_desturi_type = "tcp"
+    virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
+    migrate_speed = "5"
+    stress_package = "stress"
+    stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20s"
+    postcopy_options = "--timeout 4 --timeout-postcopy --postcopy --postcopy-bandwidth 5"
+    expected_dest_state = "running"
+    expected_src_state = "paused"
+    dominfo_check = "Persistent:     no"
+    status_error = "yes"
+
+    variants:
+        - p2p:
+            virsh_migrate_options = '--live --p2p --verbose'
+        - non_p2p:
+            virsh_migrate_options = '--live --verbose'
+    variants make_unattended:
+        - kill_src_virtqemud:
+            expected_event_src = ["event 'lifecycle' for domain .*: Suspended Post-copy"]
+            expected_event_src_2 = ["event 'lifecycle' for domain .*: Stopped Migrated", "event 'job-completed' for domain"]
+            expected_event_target = ["event 'lifecycle' for domain.*: Resumed Post-copy", "event 'lifecycle' for domain.*: Resumed Migrated"]
+            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "check_event_before_unattended", "func_param": "params"}, {"func": "libvirt_service.kill_service", "func_param": "params"}, {"func": "do_common_check", "func_param": "params", "need_sleep_time": "5"}, {"func": "wait_for_unattended_mig", "func_param": "params"}]'
+            service_name = "libvirtd"
+        - kill_dest_virtqemud:
+            expected_event_src = ["event 'lifecycle' for domain .*: Suspended Post-copy Error", "event 'lifecycle' for domain .*: Suspended Post-copy", "event 'lifecycle' for domain .*: Stopped Migrated", "event 'job-completed' for domain"]
+            expected_event_target = ["event 'lifecycle' for domain.*: Resumed Post-copy"]
+            expected_event_target_2 = ["event 'lifecycle' for domain.*: Resumed Migrated"]
+            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "check_event_before_unattended", "func_param": "params"}, {"func": "libvirt_service.kill_service", "func_param": "params"}, {"func": "do_common_check", "func_param": "params", "need_sleep_time": "5"}, {"func": "wait_for_unattended_mig", "func_param": "params"}]'
+            service_name = "libvirtd"
+            service_on_dst = "yes"
+        - kill_dest_virtproxyd:
+            expected_event_src = ["event 'lifecycle' for domain .*: Suspended Post-copy"]
+            expected_event_src_2 = ["event 'lifecycle' for domain .*: Stopped Migrated", "event 'job-completed' for domain"]
+            expected_event_target = ["event 'lifecycle' for domain.*: Resumed Post-copy", "event 'lifecycle' for domain.*: Resumed Migrated"]
+            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "check_event_before_unattended", "func_param": "params"}, {"func": "libvirt_service.kill_service", "func_param": "params"}, {"func": "do_common_check", "func_param": "params", "need_sleep_time": "5"}, {"func": "wait_for_unattended_mig", "func_param": "params"}]'
+            service_name = "virtproxyd"
+            service_on_dst = "yes"
+        - network_issue_libvirt_layer:
+            firewall_rule_on_dest = "ipv4 filter INPUT 0 -p tcp --dport ${migrate_desturi_port} -j DROP"
+            firewall_rule_on_src = "ipv4 filter INPUT 0 -p tcp --sport ${migrate_desturi_port} -j DROP"
+            expected_event_src = ["event 'lifecycle' for domain .*: Suspended Post-copy"]
+            expected_event_src_2 = ["event 'lifecycle' for domain .*: Stopped Migrated", "event 'job-completed' for domain"]
+            expected_event_target = ["event 'lifecycle' for domain.*: Resumed Post-copy", "event 'lifecycle' for domain.*: Resumed Migrated"]
+            tcp_config_list = '{"tcp_keepalive_probes": "9", "tcp_keepalive_intvl": "60", "tcp_retries1": "4", "tcp_retries2": "8", "tcp_fin_timeout": "2"}'
+            recover_tcp_config_list = '{"tcp_keepalive_probes": "9", "tcp_keepalive_intvl": "75", "tcp_retries1": "3", "tcp_retries2": "15", "tcp_fin_timeout": "60"}'
+            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "check_event_before_unattended", "func_param": "params"}, {"func": "libvirt_network.setup_firewall_rule", "func_param": "params"}, {"func": "do_common_check", "func_param": "params", "need_sleep_time": "90"}, {"func": "wait_for_unattended_mig", "func_param": "params"}, {"func": "libvirt_network.cleanup_firewall_rule", "func_param": "params"}]'
+    variants migration_options:
+        - with_undefinesource_persistent:
+            virsh_migrate_extra = "--undefinesource --persistent"
+            dominfo_check = "Persistent:     yes"
+            virsh_migrate_src_state = "failed to get domain"
+        - without_undefinesource_persistent:

--- a/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/unattended_migration_and_disruptive.cfg
+++ b/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/unattended_migration_and_disruptive.cfg
@@ -1,0 +1,84 @@
+- migration.pause_postcopy_migration_and_recover.unattended_migration_and_disruptive:
+    type = unattended_migration_and_disruptive
+    migration_setup = 'yes'
+    storage_type = 'nfs'
+    setup_local_nfs = 'yes'
+    disk_type = "file"
+    disk_source_protocol = "netfs"
+    mnt_path_name = ${nfs_mount_dir}
+    # Console output can only be monitored via virsh console output
+    only_pty = True
+    take_regular_screendumps = no
+    # Extra options to pass after <domain> <desturi>
+    virsh_migrate_extra = ''
+    # SSH connection time out
+    ssh_timeout = 60
+    # Local URI
+    virsh_migrate_connect_uri = 'qemu:///system'
+    virsh_migrate_dest_state = "running"
+    virsh_migrate_src_state = "shut off"
+    image_convert = 'no'
+    server_ip = "${migrate_dest_host}"
+    server_user = "root"
+    server_pwd = "${migrate_dest_pwd}"
+    check_network_accessibility_after_mig = "yes"
+    migrate_speed = "5"
+    stress_package = "stress"
+    stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20s"
+    postcopy_options = "--timeout 4 --timeout-postcopy --postcopy --postcopy-bandwidth 5"
+    do_migration_during_mig = "yes"
+    postcopy_options_during_mig = "--postcopy-resume"
+    service_name = "virtproxyd"
+    service_on_dst = "yes"
+    action_during_do_mig = '[{"func": "set_migrate_speed_to_high", "before_pause": "yes", "func_param": "params"}]'
+
+    variants:
+        - p2p:
+            virsh_migrate_options = '--live --p2p --verbose'
+        - non_p2p:
+            virsh_migrate_options = '--live --verbose'
+    variants disruptive_operations:
+        - poweroff_vm_dest:
+            migrate_desturi_port = "16509"
+            migrate_desturi_type = "tcp"
+            virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
+            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "libvirt_service.kill_service", "func_param": "params", "need_sleep_time": "90"}, {"func": "poweroff_vm", "func_param": "params"}, {"func": "do_migration", "func_param": "params"}]'
+            migrate_speed = "1"
+            postcopy_options = "--timeout 4 --timeout-postcopy --postcopy --postcopy-bandwidth 1"
+            status_error = "no"
+            status_error_during_mig = "yes"
+            poweroff_vm_dest = "yes"
+        - pause_by_domjobabort:
+            migrate_desturi_port = "16509"
+            migrate_desturi_type = "tcp"
+            virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
+            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "libvirt_service.kill_service", "func_param": "params", "need_sleep_time": "5"}, {"func": "virsh.domjobabort", "func_param": "'%s --postcopy' % params.get('migrate_main_vm')"}, {"func": "do_migration", "func_param": "params"}]'
+            status_error = "no"
+            status_error_during_mig = "no"
+        - pause_by_network:
+            migrate_desturi_port = "16509"
+            migrate_desturi_type = "tcp"
+            virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
+            port_to_check = "49152"
+            virsh_migrate_extra = "--migrateuri tcp://${migrate_dest_host}:${port_to_check} --listen-address ${migrate_dest_host}"
+            firewall_rule_on_dest = "ipv4 filter INPUT 0 -p tcp --dport ${port_to_check} -j DROP"
+            firewall_rule_on_src = "ipv4 filter INPUT 0 -p tcp --sport ${port_to_check} -j DROP"
+            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "libvirt_service.kill_service", "func_param": "params"}, {"func": "libvirt_network.setup_firewall_rule", "func_param": "params", "need_sleep_time": "5"}, {"func": "libvirt_network.cleanup_firewall_rule", "func_param": "params", "need_sleep_time": "90"}, {"func": "do_migration", "func_param": "params", "need_sleep_time": "10"}]'
+            status_error = "no"
+            status_error_during_mig = "no"
+            tcp_config_list = '{"tcp_keepalive_probes": "9", "tcp_keepalive_intvl": "60", "tcp_retries1": "4", "tcp_retries2": "8", "tcp_fin_timeout": "2"}'
+            recover_tcp_config_list = '{"tcp_keepalive_probes": "9", "tcp_keepalive_intvl": "75", "tcp_retries1": "3", "tcp_retries2": "15", "tcp_fin_timeout": "60"}'
+        - pause_by_proxy:
+            transport_type = "unix_proxy"
+            desturi_socket_path = "/tmp/desturi-socket"
+            migrateuri_socket_path = "/var/lib/libvirt/qemu/migrateuri-socket"
+            disks_uri_socket_path = "/var/lib/libvirt/qemu/disks-uri-socket"
+            migrate_desturi_type = "unix_proxy"
+            virsh_migrate_desturi = "qemu+unix:///system?socket=${desturi_socket_path}"
+            virsh_migrate_migrateuri = "unix://${migrateuri_socket_path}"
+            virsh_migrate_disks_uri = "unix://${disks_uri_socket_path}"
+            virsh_migrate_extra = "--migrateuri ${virsh_migrate_migrateuri}"
+            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "clear_pmsocat", "func_param": "params", "need_sleep_time": "60"}, {"func": "base_steps.recreate_conn_objs", "func_param": "params"}, {"func": "do_migration", "func_param": "params"}]'
+            check_port_or_network_conn_num = "no"
+            status_error = "no"
+            status_error_during_mig = "no"

--- a/libvirt/tests/src/migration/migrate_service_control.py
+++ b/libvirt/tests/src/migration/migrate_service_control.py
@@ -8,8 +8,6 @@ from virttest import libvirt_vm
 from virttest import migration
 from virttest import virsh
 from virttest import libvirt_version
-from virttest import remote
-from virttest import utils_libvirtd
 
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
@@ -124,16 +122,6 @@ def run(test, params, env):
 
         if kill_service:
             check_image_ownership(vm_name, expected_image_ownership, test)
-            if service_name == "libvirtd":
-                if service_on_dst:
-                    remote_session = remote.wait_for_login('ssh', server_ip, '22',
-                                                           server_user, server_pwd,
-                                                           r"[\#\$]\s*$")
-                    service_name = utils_libvirtd.Libvirtd(session=remote_session).service_name
-                    remote_session.close()
-                else:
-                    service_name = utils_libvirtd.Libvirtd().service_name
-                params.update({'service_name': service_name})
 
         if migrate_speed:
             mode = 'both' if '--postcopy' in postcopy_options else 'precopy'

--- a/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/pause_and_recover_and_disruptive.py
+++ b/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/pause_and_recover_and_disruptive.py
@@ -1,0 +1,52 @@
+from virttest.utils_libvirt import libvirt_network
+
+from provider.migration import base_steps
+
+
+def run(test, params, env):
+    """
+    Do postcopy migration, then pause it, then recover migration. Before
+    recovery finishes, do disruptive operations.
+
+    :param test: test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    def setup_pause_by_network():
+        """
+        Setup for pause_by_network
+
+        """
+        test.log.info("Setup for pause_by_network")
+        tcp_config_list = eval(params.get("tcp_config_list"))
+        libvirt_network.change_tcp_config(tcp_config_list)
+        migration_obj.setup_connection()
+
+    def cleanup_pause_by_network():
+        """
+        Cleanup for pause_by_network
+
+        """
+        test.log.info("Cleanup for pause_by_network")
+        recover_tcp_config_list = eval(params.get("recover_tcp_config_list"))
+        libvirt_network.change_tcp_config(recover_tcp_config_list)
+        migration_obj.cleanup_connection()
+
+    vm_name = params.get("migrate_main_vm")
+    disruptive_operations = params.get("disruptive_operations")
+
+    vm = env.get_vm(vm_name)
+    migration_obj = base_steps.MigrationBase(test, vm, params)
+    params.update({"migration_obj": migration_obj})
+
+    setup_test = eval("setup_%s" % disruptive_operations) if "setup_%s" % disruptive_operations in \
+        locals() else migration_obj.setup_connection
+    cleanup_test = eval("cleanup_%s" % disruptive_operations) if "cleanup_%s" % disruptive_operations in \
+        locals() else migration_obj.cleanup_connection
+
+    try:
+        setup_test()
+        migration_obj.run_migration()
+        migration_obj.verify_default()
+    finally:
+        cleanup_test()

--- a/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/pause_and_recover_twice.py
+++ b/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/pause_and_recover_twice.py
@@ -1,0 +1,53 @@
+from virttest.utils_libvirt import libvirt_network
+
+from provider.migration import base_steps
+
+
+def run(test, params, env):
+    """
+    Test postcopy migration, then pause it, then recover it and make recovery
+    fail, then recover it again.
+
+    :param test: test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    def setup_network_issue():
+        """
+        Setup for network issue
+
+        """
+        test.log.info("Setup for network issue")
+        tcp_config_list = eval(params.get("tcp_config_list"))
+        libvirt_network.change_tcp_config(tcp_config_list)
+        migration_obj.setup_connection()
+
+    def cleanup_network_issue():
+        """
+        Cleanup for network issue
+
+        """
+        test.log.info("Cleanup for network issue")
+        recover_tcp_config_list = eval(params.get("recover_tcp_config_list"))
+        libvirt_network.change_tcp_config(recover_tcp_config_list)
+        migration_obj.cleanup_connection()
+
+    recover_failed_reason = params.get('recover_failed_reason', '')
+    vm_name = params.get("migrate_main_vm")
+
+    vm = env.get_vm(vm_name)
+    migration_obj = base_steps.MigrationBase(test, vm, params)
+    params.update({"migration_obj": migration_obj})
+
+    setup_test = eval("setup_%s" % recover_failed_reason) if "setup_%s" % recover_failed_reason in \
+        locals() else migration_obj.setup_connection
+    cleanup_test = eval("cleanup_%s" % recover_failed_reason) if "cleanup_%s" % recover_failed_reason in \
+        locals() else migration_obj.cleanup_connection
+
+    try:
+        setup_test()
+        migration_obj.setup_connection()
+        migration_obj.run_migration()
+        migration_obj.verify_default()
+    finally:
+        cleanup_test()

--- a/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/pause_by_domjobabort_and_recover.py
+++ b/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/pause_by_domjobabort_and_recover.py
@@ -1,0 +1,124 @@
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_test import libvirt
+
+from provider.migration import base_steps
+from provider.migration import migration_base
+
+
+def run(test, params, env):
+    """
+    Test postcopy migration, then pause migration by "virsh domjobabort --postcopy", then recover migration.
+
+    :param test: test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    def setup_persistent():
+        """
+        Setup for persistent option
+
+        """
+        test.log.info("Setup for persistent option.")
+        extra = params.get("virsh_migrate_extra")
+        update_persist_title = params.get("update_persist_title")
+        tmp_xml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name, "--security-info")
+        tmp_xml.title = update_persist_title
+        extra = "%s --persistent --persistent-xml=%s" % (extra, tmp_xml.xml)
+        params.update({"virsh_migrate_extra": extra})
+        migration_obj.setup_connection()
+
+    def setup_xml():
+        """
+        Setup for xml option
+
+        """
+        test.log.info("Setup for xml option.")
+        extra = params.get("virsh_migrate_extra")
+        update_xml_title = params.get("update_xml_title")
+
+        migration_obj.setup_connection()
+        tmp_xml = vm_xml.VMXML.new_from_dumpxml(vm_name, "--security-info --migratable")
+        tmp_xml.title = update_xml_title
+        extra = "%s --xml=%s" % (extra, tmp_xml.xml)
+        params.update({"virsh_migrate_extra": extra})
+
+    def verify_test():
+        """
+        Verify steps
+
+        """
+        dest_uri = params.get("virsh_migrate_desturi")
+        dominfo_check = params.get("dominfo_check")
+        migration_options = params.get("migration_options")
+        dname_value = params.get("dname_value")
+
+        test.log.info("Verify for pause_by_domjobabort_and_recover.")
+        # check domain persistence
+        if dominfo_check:
+            if migration_options == "dname":
+                dominfo = virsh.dominfo(dname_value, ignore_status=True, debug=True, uri=dest_uri)
+            else:
+                dominfo = virsh.dominfo(vm_name, ignore_status=True, debug=True, uri=dest_uri)
+            libvirt.check_result(dominfo, expected_match=dominfo_check)
+
+        # check qemu-guest-agent command
+        if migration_options == "dname":
+            result = virsh.domtime(dname_value, ignore_status=True, debug=True, uri=dest_uri)
+        else:
+            result = virsh.domtime(vm_name, ignore_status=True, debug=True, uri=dest_uri)
+        libvirt.check_exit_status(result)
+
+        if migration_options == "undefinesource":
+            virsh_migrate_src_state = params.get("virsh_migrate_src_state")
+            func_returns = dict(migration_obj.migration_test.func_ret)
+            migration_obj.migration_test.func_ret.clear()
+            test.log.debug("Migration returns function results:%s", func_returns)
+            if int(migration_obj.migration_test.ret.exit_status) == 0:
+                migration_obj.migration_test.post_migration_check([vm], params,
+                                                                  dest_uri=dest_uri)
+                result = virsh.domstate(vm_name, extra="--reason", uri=migration_obj.src_uri, debug=True)
+                libvirt.check_result(result, expected_fails=virsh_migrate_src_state)
+        elif migration_options == "dname":
+            virsh_migrate_dest_state = params.get("virsh_migrate_dest_state")
+            func_returns = dict(migration_obj.migration_test.func_ret)
+            migration_obj.migration_test.func_ret.clear()
+            test.log.debug("Migration returns function results:%s", func_returns)
+            if int(migration_obj.migration_test.ret.exit_status) == 0:
+                migration_obj.migration_test.post_migration_check([vm], params, dest_uri=dest_uri)
+                result = virsh.domstate(vm_name, extra="--reason", uri=migration_obj.src_uri, debug=True)
+                libvirt.check_result(result)
+                result = virsh.domstate(dname_value, extra="--reason", uri=dest_uri, debug=True)
+                libvirt.check_result(result)
+        else:
+            migration_obj.verify_default()
+
+        # Check event output
+        migration_base.check_event_output(params, test, virsh_session, remote_virsh_session)
+
+    migration_options = params.get('migration_options', '')
+    vm_name = params.get("migrate_main_vm")
+    migrate_again = "yes" == params.get("migrate_again", "no")
+
+    virsh_session = None
+    remote_virsh_session = None
+
+    vm = env.get_vm(vm_name)
+    migration_obj = base_steps.MigrationBase(test, vm, params)
+    params.update({"migration_obj": migration_obj})
+
+    setup_test = eval("setup_%s" % migration_options) if "setup_%s" % migration_options in \
+        locals() else migration_obj.setup_connection
+
+    try:
+        base_steps.setup_network_data_transport(params)
+        setup_test()
+        # Monitor event on source/target host
+        virsh_session, remote_virsh_session = migration_base.monitor_event(params)
+        migration_obj.run_migration()
+        if migrate_again:
+            migration_obj.run_migration_again()
+        verify_test()
+    finally:
+        migration_obj.cleanup_connection()

--- a/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/pause_by_network_and_recover.py
+++ b/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/pause_by_network_and_recover.py
@@ -1,0 +1,65 @@
+from virttest import virsh
+
+from virttest.utils_libvirt import libvirt_network
+from virttest.utils_test import libvirt
+
+from provider.migration import base_steps
+from provider.migration import migration_base
+
+
+def run(test, params, env):
+    """
+    Test postcopy migration, then pause migration by network issue, then recover migration.
+
+    :param test: test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    def verify_test():
+        """
+        Verify steps
+
+        """
+        dest_uri = params.get("virsh_migrate_desturi")
+        dominfo_check = params.get("dominfo_check")
+
+        test.log.info("Verify for pause_and_network_and_recover.")
+        # check domain persistence
+        if dominfo_check:
+            dominfo = virsh.dominfo(vm_name, ignore_status=True, debug=True, uri=dest_uri)
+            libvirt.check_result(dominfo, expected_match=dominfo_check)
+
+        # check qemu-guest-agent command
+        result = virsh.domtime(vm_name, ignore_status=True, debug=True, uri=dest_uri)
+        libvirt.check_exit_status(result)
+
+        migration_obj.verify_default()
+
+        # Check event output
+        migration_base.check_event_output(params, test, virsh_session, remote_virsh_session)
+
+    vm_name = params.get("migrate_main_vm")
+    migrate_again = "yes" == params.get("migrate_again", "no")
+    tcp_config_list = eval(params.get("tcp_config_list"))
+    recover_tcp_config_list = eval(params.get("recover_tcp_config_list"))
+
+    virsh_session = None
+    remote_virsh_session = None
+
+    vm = env.get_vm(vm_name)
+    migration_obj = base_steps.MigrationBase(test, vm, params)
+    params.update({"migration_obj": migration_obj})
+
+    try:
+        base_steps.setup_network_data_transport(params)
+        libvirt_network.change_tcp_config(tcp_config_list)
+        migration_obj.setup_connection()
+        # Monitor event on source/target host
+        virsh_session, remote_virsh_session = migration_base.monitor_event(params)
+        migration_obj.run_migration()
+        if migrate_again:
+            migration_obj.run_migration_again()
+        verify_test()
+    finally:
+        libvirt_network.change_tcp_config(recover_tcp_config_list)
+        migration_obj.cleanup_connection()

--- a/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/pause_by_proxy_and_recover.py
+++ b/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/pause_by_proxy_and_recover.py
@@ -1,0 +1,58 @@
+from virttest import virsh
+
+from virttest.utils_test import libvirt
+
+from provider.migration import base_steps
+from provider.migration import migration_base
+
+
+def run(test, params, env):
+    """
+    Test postcopy migration, then pause migration by UNIX proxy issue, then recover migration.
+
+    :param test: test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    def verify_test():
+        """
+        Verify for pause_by_proxy_and_recover
+
+        """
+        dest_uri = params.get("virsh_migrate_desturi")
+        dominfo_check = params.get("dominfo_check")
+
+        # check domain persistence
+        if dominfo_check:
+            dominfo = virsh.dominfo(vm_name, ignore_status=True, debug=True, uri=dest_uri)
+            libvirt.check_result(dominfo, expected_match=dominfo_check)
+
+        # check qemu-guest-agent command
+        result = virsh.domtime(vm_name, ignore_status=True, debug=True, uri=dest_uri)
+        libvirt.check_exit_status(result)
+
+        migration_obj.verify_default()
+
+        # Check event output
+        migration_base.check_event_output(params, test, virsh_session, remote_virsh_session)
+
+    vm_name = params.get("migrate_main_vm")
+    migrate_again = "yes" == params.get("migrate_again", "no")
+
+    virsh_session = None
+    remote_virsh_session = None
+
+    vm = env.get_vm(vm_name)
+    migration_obj = base_steps.MigrationBase(test, vm, params)
+    params.update({"migration_obj": migration_obj})
+
+    try:
+        migration_obj.setup_connection()
+        # Monitor event on source/target host
+        virsh_session, remote_virsh_session = migration_base.monitor_event(params)
+        migration_obj.run_migration()
+        if migrate_again:
+            migration_obj.run_migration_again()
+        verify_test()
+    finally:
+        migration_obj.cleanup_connection()

--- a/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/unattended_migration.py
+++ b/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/unattended_migration.py
@@ -1,0 +1,105 @@
+from virttest import virsh
+
+from virttest.utils_libvirt import libvirt_network
+from virttest.utils_test import libvirt
+
+from provider.migration import base_steps
+from provider.migration import migration_base
+
+
+def run(test, params, env):
+    """
+    Test postcopy migration, then make migration become "unattended migration".
+    Then wait for unattended migration to finish..
+
+    :param test: test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    def setup_kill_src_virtqemud():
+        """
+        Setup for kill_src_virtqemud
+
+        """
+        test.log.info("Setup for kill_src_virtqemud.")
+        virsh_migrate_options = params.get("virsh_migrate_options")
+        status_error = "yes" == params.get("status_error", "no")
+        if "--p2p" not in virsh_migrate_options:
+            # In kill_src_virtqemud.non_p2p case, migration result status is 0. And stdout contains
+            # "Migration: [  3 %]error: Disconnected from qemu:///system due to end of file0 %]".
+            # So need to set status_error to 'no'.
+            params.update({"status_error": "no"})
+        migration_obj.setup_connection()
+
+    def setup_network_issue_libvirt_layer():
+        """
+        Setup for network_issue_libvirt_layer
+
+        """
+        test.log.info("Setup for network_issue_libvirt_layer.")
+        tcp_config_list = eval(params.get("tcp_config_list"))
+        libvirt_network.change_tcp_config(tcp_config_list)
+        migration_obj.setup_connection()
+
+    def verify_test():
+        """
+        Verify steps
+
+        """
+        dest_uri = params.get("virsh_migrate_desturi")
+        dominfo_check = params.get("dominfo_check")
+        migration_options = params.get("migration_options")
+
+        # check domain persistence
+        if dominfo_check:
+            dominfo = virsh.dominfo(vm_name, ignore_status=True, debug=True, uri=dest_uri)
+            libvirt.check_result(dominfo, expected_match=dominfo_check)
+
+        if migration_options == "with_undefinesource_persistent":
+            virsh_migrate_src_state = params.get("virsh_migrate_src_state")
+            func_returns = dict(migration_obj.migration_test.func_ret)
+            migration_obj.migration_test.func_ret.clear()
+            test.log.debug("Migration returns function results:%s", func_returns)
+            if not libvirt.check_vm_state(vm_name, virsh_migrate_src_state, uri=migration_obj.src_uri):
+                test.fail("Migrated VMs failed to be in %s state at source" % virsh_migrate_src_state)
+            if int(migration_obj.migration_test.ret.exit_status) == 0:
+                migration_obj.migration_test.post_migration_check([vm], params,
+                                                                  dest_uri=dest_uri)
+        else:
+            migration_obj.verify_default()
+
+    def cleanup_network_issue_libvirt_layer():
+        """
+        Cleanup for network_issue_libvirt_layer
+
+        """
+        test.log.info("Cleanup for network_issue_libvirt_layer")
+        recover_tcp_config_list = eval(params.get("recover_tcp_config_list"))
+        libvirt_network.change_tcp_config(recover_tcp_config_list)
+        migration_obj.cleanup_connection()
+
+    vm_name = params.get("migrate_main_vm")
+    make_unattended = params.get("make_unattended")
+
+    virsh_session = None
+    remote_virsh_session = None
+
+    vm = env.get_vm(vm_name)
+    migration_obj = base_steps.MigrationBase(test, vm, params)
+    params.update({"migration_obj": migration_obj})
+
+    setup_test = eval("setup_%s" % make_unattended) if "setup_%s" % make_unattended in \
+        locals() else migration_obj.setup_connection
+    cleanup_test = eval("cleanup_%s" % make_unattended) if "cleanup_%s" % make_unattended in \
+        locals() else migration_obj.cleanup_connection
+
+    try:
+        setup_test()
+        # Monitor event on source/target host
+        virsh_session, remote_virsh_session = migration_base.monitor_event(params)
+        params.update({"virsh_session": virsh_session})
+        params.update({"remote_virsh_session": remote_virsh_session})
+        migration_obj.run_migration()
+        verify_test()
+    finally:
+        cleanup_test()

--- a/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/unattended_migration_and_disruptive.py
+++ b/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/unattended_migration_and_disruptive.py
@@ -1,0 +1,53 @@
+from virttest.utils_libvirt import libvirt_network
+
+from provider.migration import base_steps
+
+
+def run(test, params, env):
+    """
+    Do postcopy migration, then make migration become "unattended migration".
+    Then do disruptive operations during unattended migration. Then try to
+    recover migration.
+
+    :param test: test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    def setup_pause_by_network():
+        """
+        Setup for pause_by_network
+
+        """
+        test.log.info("Setup for pause_by_network.")
+        tcp_config_list = eval(params.get("tcp_config_list"))
+        libvirt_network.change_tcp_config(tcp_config_list)
+        migration_obj.setup_connection()
+
+    def cleanup_pause_by_network():
+        """
+        Cleanup for pause_by_network
+
+        """
+        test.log.info("Cleanup for pause_by_network")
+        recover_tcp_config_list = eval(params.get("recover_tcp_config_list"))
+        libvirt_network.change_tcp_config(recover_tcp_config_list)
+        migration_obj.cleanup_connection()
+
+    vm_name = params.get("migrate_main_vm")
+    disruptive_operations = params.get("disruptive_operations")
+
+    vm = env.get_vm(vm_name)
+    migration_obj = base_steps.MigrationBase(test, vm, params)
+    params.update({"migration_obj": migration_obj})
+
+    setup_test = eval("setup_%s" % disruptive_operations) if "setup_%s" % disruptive_operations in \
+        locals() else migration_obj.setup_connection
+    cleanup_test = eval("cleanup_%s" % disruptive_operations) if "cleanup_%s" % disruptive_operations in \
+        locals() else migration_obj.cleanup_connection
+
+    try:
+        setup_test()
+        migration_obj.run_migration()
+        migration_obj.verify_default()
+    finally:
+        cleanup_test()


### PR DESCRIPTION
VIRT-294698 - [postcopy]VM live migration - pause migration by domjobabort->recover it
VIRT-294701 - [postcopy]VM live migration - pause migration due to network issue->recover it
VIRT-294700 - [postcopy]VM live migration - pause migration due to proxy issue->recover it - UNIX+proxy transport
VIRT-294703 - [postcopy]VM live migration - pause migration->recover it and failed->recover it
VIRT-294699 - [postcopy]VM live migration - make migration become unattended migration
VIRT-294708 - [postcopy]VM live migration - make migration become unattended migration->do disruptive operations during unattended migration

Signed-off-by: cliping <lcheng@redhat.com>