### PR TITLE
svirt: Enable selinux_relabel test for aarch64

### DIFF
--- a/libvirt/tests/cfg/svirt/selinux_relabel.cfg
+++ b/libvirt/tests/cfg/svirt/selinux_relabel.cfg
@@ -12,6 +12,8 @@
             serial_attrs_sources_seclabels = [{'attrs': {'model': 'selinux', 'relabel': 'yes'}, 'label': '${serial_label}'}, {'attrs': {'model': 'dac', 'relabel': 'yes'}, 'label': 'test:test'}]
             serial_attrs_sources = [{'attrs': ${serial_attrs_sources_attrs}, 'seclabels': ${serial_attrs_sources_seclabels}}]
             serial_attrs = {'sources': ${serial_attrs_sources}, 'type_name': 'unix', 'target_type': 'isa-serial', 'target_model': 'isa-serial'}
+            aarch64:
+                serial_attrs = {'sources': ${serial_attrs_sources}, 'type_name': 'unix', 'target_type': 'system-serial', 'target_model': 'pl011'}
             channel_attrs_sources_attrs = {'mode': 'bind', 'path': '${channel_path}'}
             channel_attrs_sources_seclabels = [{'attrs': {'model': 'selinux', 'relabel': 'yes'}, 'label': '${channel_label}'}]
             channel_attrs_sources = [{'attrs': ${channel_attrs_sources_attrs}, 'seclabels': ${channel_attrs_sources_seclabels}}]


### PR DESCRIPTION
The serial->target->type for character device on aarch64 is `system-serial`, and the usable model for system-serial is `pl011`.

Test Result:
```
# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio selinux_relabel.unix_socket --vt-connect-uri qemu:///system                                                                                                                
JOB ID     : db93bc13c4d164747f77442c71e119923c5a7c7c
JOB LOG    : /root/avocado/job-results/job-2022-11-03T03.32-db93bc1/job.log
 (1/1) type_specific.io-github-autotest-libvirt.selinux_relabel.unix_socket: PASS (5.50 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/avocado/job-results/job-2022-11-03T03.32-db93bc1/results.html
JOB TIME   : 5.86 s
```

Signed-off-by: Hu Shuai <hus.fnst@fujitsu.com>