### PR TITLE
Replace nvram_template with nvram_attrs

### DIFF
--- a/libvirt/tests/src/bios/boot_integration.py
+++ b/libvirt/tests/src/bios/boot_integration.py
@@ -54,7 +54,7 @@ def prepare_boot_xml(vmxml, params):
         nvram = params.get("nvram", "")
         nvram_template = params.get("template", "")
         dict_os_attrs.update({"nvram": nvram})
-        dict_os_attrs.update({"nvram_template": nvram_template})
+        dict_os_attrs.update({"nvram_attrs": {"template": nvram_template}})
 
     # Set Seabios special attributes
     if boot_type == "seabios":

--- a/libvirt/tests/src/bios/virsh_boot.py
+++ b/libvirt/tests/src/bios/virsh_boot.py
@@ -359,7 +359,7 @@ def apply_boot_options(vmxml, params, test):
         nvram = nvram.replace("<VM_NAME>", vm_name)
         dict_os_attrs.update({"nvram": nvram})
         if with_nvram_template:
-            dict_os_attrs.update({"nvram_template": template})
+            dict_os_attrs.update({"nvram_attrs": {"template": template}})
 
     vmxml.set_os_attrs(**dict_os_attrs)
 


### PR DESCRIPTION
According to xml updates of VMOSXML class

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>

Depends on:
- https://github.com/avocado-framework/avocado-vt/pull/3557