### PR TITLE
pcie, new case for invalid PCIe slots

### DIFF
--- a/libvirt/tests/cfg/controller/pcie_root_port_controller.cfg
+++ b/libvirt/tests/cfg/controller/pcie_root_port_controller.cfg
@@ -13,6 +13,17 @@
         - negative_test:
             status_error = "yes"
             variants:
+                - device_slot_invalid:
+                    test_define_only = "yes"
+                    interface_slot = "a"
+                    minimal_interface_dict = '{"source": {"network": "default"}}'
+                    failure_message = "Invalid value for attribute 'slot' in element 'address': 'a'. Expected .*integer value"
+                - device_slot_wrong_number:
+                    test_define_only = "yes"
+                    interface_slot_type = "hex"
+                    interface_slot = 1
+                    minimal_interface_dict = '{"source": {"network": "default"}}'
+                    failure_message = "Invalid PCI address .* slot must be <= 0"
                 - controllers_same_chassis_same_port:
                     second_controller_model = "pcie-root-port"
                     second_controller_target = "{'chassis':1,'port':'0x8'}"

--- a/libvirt/tests/src/controller/pcie_root_port_controller.py
+++ b/libvirt/tests/src/controller/pcie_root_port_controller.py
@@ -22,12 +22,16 @@ def setup_test(params):
     second_controller_target = ast.literal_eval(
         params.get("second_controller_target", "{}"))
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(params.get("main_vm", "avocado-vt-vm1"))
+    test_define_only = params.get("test_define_only") == "yes"
 
     vmxml.remove_all_device_by_type("controller")
 
     index = 0
     contr_dict = {"type": "pci", "model": "pcie-root", "index": index}
     libvirt_vmxml.modify_vm_device(vmxml, "controller", contr_dict, index)
+
+    if test_define_only:
+        return
 
     index += 1
     contr_dict = create_controller_dict(controller_model, controller_target, index)
@@ -97,15 +101,22 @@ def check_define_vm(vmxml, params, test):
     :param params: Test parameters object
     :param test: Avocado test object
     """
+    LOG.info("Checking VM in define only mode.")
     model = params.get("controller_model")
     target = params.get("controller_target")
     address = ast.literal_eval(params.get("controller_address", "{}"))
     bus_offset = int(params.get("bus_offset", 0))
     status_error = params.get("status_error") == "yes"
     failure_message = params.get("failure_message")
+    minimal_interface_dict = ast.literal_eval(params.get("minimal_interface_dict", "{}"))
+    interface_slot = params.get("interface_slot", 0)
+    interface_slot_type = params.get("interface_slot_type", "int")
+    if interface_slot_type == "hex":
+        interface_slot = hex(int(interface_slot))
     max_indexes = libvirt_pcicontr.get_max_contr_indexes(vmxml, 'pci', model, 1)
     index = max_indexes[0] + 1
-    address["bus"] = hex(index + bus_offset)
+    if address:
+        address["bus"] = hex(index + bus_offset)
     contr_dict = {'controller_type': 'pci',
                   'controller_model': model,
                   "controller_index": index,
@@ -113,11 +124,36 @@ def check_define_vm(vmxml, params, test):
                   "controller_addr": str(address)}
     contr_object = libvirt.create_controller_xml(contr_dict)
     vmxml.add_device(contr_object)
+    if minimal_interface_dict:
+        interface_dict = customize_interface_dict(minimal_interface_dict,
+                                                  interface_bus=hex(index),
+                                                  interface_slot=interface_slot)
+        vmxml.devices = vmxml.devices.append(interface_dict)
+
     cmd_result = virsh.define(vmxml.xml)
     if failure_message:
         libvirt.check_result(cmd_result, [failure_message])
     else:
         libvirt.check_exit_status(cmd_result, status_error)
+
+
+def customize_interface_dict(minimal_dict, interface_bus=None, interface_slot=None):
+    """
+    Update interface dictionary and prepare it for adding to VM XML.
+
+    :param minimal_dict: Dictionary with interface values from config file
+    :param interface bus: Optional value for address bus
+    :param interface_slot: Optional value for address slot to update
+    """
+    if interface_bus or interface_slot:
+        interface_address = {"attrs": {}}
+        if interface_bus:
+            interface_address["attrs"].update({"bus": interface_bus})
+        if interface_slot:
+            interface_address["attrs"].update({"slot": interface_slot})
+        minimal_dict.update({"address": interface_address})
+    iface = libvirt_vmxml.create_vm_device_by_type("interface", minimal_dict)
+    return iface
 
 
 def cleanup_test(vm, vmxml_backup):


### PR DESCRIPTION
This case adds checks for devices attached to PCIe controller that have
slot number bigger than one or something else than a number.
    
VIRT-48333