### PR TITLE
virtual_disk: Wait for device is ready on guest after attach-device

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_scsi3_persistent_reservation.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_scsi3_persistent_reservation.py
@@ -10,6 +10,7 @@ from avocado.utils import service
 from virttest import virt_vm
 from virttest import virsh
 from virttest import utils_disk
+from virttest import utils_misc
 
 from virttest.utils_test import libvirt
 
@@ -244,10 +245,9 @@ def run(test, params, env):
                 result = virsh.attach_device(vm_name, disk_xml.xml,
                                              ignore_status=True, debug=True)
                 libvirt.check_exit_status(result)
-            new_parts = get_delta_parts(vm, old_parts)
-            if len(new_parts) != 1:
-                logging.error("Expected 1 dev added but has %s" % len(new_parts))
-            new_part = new_parts[0]
+            if not utils_misc.wait_for(lambda: len(get_delta_parts(vm, old_parts)) == 1, timeout=5):
+                test.fail("Expected 1 dev added but has %s" % len(get_delta_parts(vm, old_parts)))
+            new_part = get_delta_parts(vm, old_parts)[0]
             check_pr_cmds(vm, new_part)
             result = virsh.detach_device(vm_name, disk_xml.xml,
                                          ignore_status=True, debug=True, wait_for_event=True)


### PR DESCRIPTION
The device may not be ready on guest immediately after attaching device, just wait at most 5 seconds here.

Before:
```
# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio virtual_disks.scsi3_persistent_reservation.reservations_managed.hotplug_disk.enable_auth.auth_usage.auth_out_source --vt-connect-uri qemu:///system
JOB ID     : b73830db6845b986fae86339cff1be363fcf9b4f
JOB LOG    : /var/lib/avocado/job-results/job-2022-11-03T11.18-b73830d/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_disks.scsi3_persistent_reservation.reservations_managed.hotplug_disk.enable_auth.auth_usage.auth_out_source:  ERROR: list index out of range (65.69 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-11-03T11.18-b73830d/results.html
JOB TIME   : 66.18 s
```

After:
```
# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio virtual_disks.scsi3_persistent_reservation.reservations_managed.hotplug_disk.enable_auth.auth_usage.auth_out_source --vt-connect-uri qemu:///system                                                                        
JOB ID     : 6036e69162d2dffe0a5f1b506c1f7a008d3b6768
JOB LOG    : /var/lib/avocado/job-results/job-2022-11-04T05.23-6036e69/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virtual_disks.scsi3_persistent_reservation.reservations_managed.hotplug_disk.enable_auth.auth_usage.auth_out_source: PASS (69.03 s)                                                          
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-11-04T05.23-6036e69/results.html
JOB TIME   : 69.51 s
```

Signed-off-by: Hu Shuai <hus.fnst@fujitsu.com>