### PR TITLE
virsh_start: Just check the audit log generated in this case

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_start.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_start.py
@@ -16,14 +16,14 @@ from virttest import libvirt_version
 logging = log.getLogger('avocado.' + __name__)
 
 
-def check_audit_log(test, audit_log_search_string):
+def check_audit_log(test, audit_log_search_string, start_date, start_time):
     """
     Run ausearch and look for audit_log_search_string.
 
     :param test: Test object for utility functions
     :param audit_log_search_string: String describing ausearch criteria
     """
-    cmd = f"ausearch  -m {audit_log_search_string}"
+    cmd = f"ausearch -m {audit_log_search_string} --start {start_date} {start_time}"
     cmd_result = process.run(cmd, shell=True, ignore_status=True)
     if cmd_result.exit_status == 0:
         test.fail(f"Unexpectedly found '{audit_log_search_string}'"
@@ -45,6 +45,8 @@ def run(test, params, env):
     vm_ref = params.get("vm_ref", "vm1")
     opt = params.get("vs_opt", "")
     audit_log_search_string = params.get("audit_log_search_string")
+    start_date = process.run("date +%x", ignore_status=True, shell=True).stdout_text.strip()
+    start_time = process.run("date +%H:%M:%S", ignore_status=True, shell=True).stdout_text.strip()
     service_mgr = service.ServiceManager()
 
     # Backup for recovery.
@@ -172,7 +174,7 @@ def run(test, params, env):
                               "but it is restored from a"
                               " managedsave.")
             elif audit_log_search_string:
-                check_audit_log(test, audit_log_search_string)
+                check_audit_log(test, audit_log_search_string, start_date, start_time)
             else:
                 if status_error == "no" and not vm.is_alive() and pre_operation != "remote":
                     test.fail("VM was started but it is not alive.")


### PR DESCRIPTION
'ausearch -m AVC' will search the entire audit log for AVC errors, here use the `--start` parameter to check only the logs generated for this case.

Test Result:
```
# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio virsh.start.status_error_no.audit_log_search --vt-connect-uri qemu:///system
JOB ID     : 63480cd2f7f3c4c47e513d0fc78f247960a772b1
JOB LOG    : /var/lib/avocado/job-results/job-2022-11-07T02.50-63480cd/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.start.status_error_no.audit_log_search: PASS (5.11 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-11-07T02.50-63480cd/results.html
JOB TIME   : 5.51 s
```

Signed-off-by: Hu Shuai <hus.fnst@fujitsu.com>