### PR TITLE
PCIe: pcie-root-port invalid name

### DIFF
--- a/libvirt/tests/cfg/backingchain/with_disk_attributes_test/commit_pull_with_disk_driver_attributes.cfg
+++ b/libvirt/tests/cfg/backingchain/with_disk_attributes_test/commit_pull_with_disk_driver_attributes.cfg
@@ -1,0 +1,25 @@
+- backingchain.with_disk_attributes_test.with_driver_attributes:
+    type = commit_pull_with_disk_driver_attributes
+    start_vm = "no"
+    common_options = " --wait --verbose"
+    target_disk = "vda"
+    driver_element = "driver"
+    snap_num = 4
+    variants:
+        - with_copy_on_read:
+            driver_dict = {"${driver_element}": {"copy_on_read": "on"}}
+        - with_cache_discard:
+            driver_dict = {"${driver_element}": {"cache": "none", "discard": "unmap"}}
+        - with_detect_zeroes:
+            driver_dict = {"${driver_element}": {"detect_zeroes": "unmap"}}
+        - with_metadata_cache:
+            with_metadata_cache = "yes"
+            driver_element = "driver_metadatacache"
+            driver_include = {"driver": {"name": "qemu", "type":"qcow2"}}
+            driver_dict = {"${driver_element}": {"max_size": 1024, "max_size_unit": "bytes"}, **${driver_include}}
+    variants block_cmd:
+        - blockcommit:
+            blockcommit_options = " --active --pivot"
+        - blockpull:
+            snap_option = " --disk-only"
+            snap_disk_dict = {"disk_name": "${target_disk}", **${driver_dict}}

--- a/libvirt/tests/cfg/controller/pcie_root_port_controller.cfg
+++ b/libvirt/tests/cfg/controller/pcie_root_port_controller.cfg
@@ -19,3 +19,12 @@
                 - controllers_same_chassis_different_port:
                     second_controller_model = "pcie-root-port"
                     second_controller_target = "{'chassis':1,'port':'0x4'}"
+                - index_equals_address_bus:
+                    test_define_only = "yes"
+                    controller_address = '{"type": "pci", "domain": "0x0000", "bus": "0x01", "slot": "0x1", "function":"0x0"}'
+                    failure_message = ".*The device at PCI address .* cannot be plugged into the PCI controller with index='.*'. It requires a controller that accepts a pcie-root-port.*"
+                - index_less_than_address_bus:
+                    bus_offset = 1
+                    test_define_only = "yes"
+                    controller_address = '{"type": "pci", "domain": "0x0000", "bus": "0x02", "slot": "0x1", "function":"0x0"}'
+                    failure_message = ".*a PCI slot is needed to connect a PCI controller model='pcie-root-port', but none is available, and it cannot be automatically added.*"

--- a/libvirt/tests/cfg/migration/migrate_service_control.cfg
+++ b/libvirt/tests/cfg/migration/migrate_service_control.cfg
@@ -40,7 +40,7 @@
                 - kill_qemu_on_dst:
                     service_name = "qemu-kvm"
                     service_on_dst = "yes"
-                    err_msg = 'qemu unexpectedly closed the monitor|domain is no longer running|Domain not found'
+                    err_msg = 'qemu unexpectedly closed the monitor|domain is no longer running|Domain not found|Unable to write to socket: Bad file descriptor'
                 - kill_libvirtd_on_src:
                     service_name = "libvirtd"
                     err_msg = 'End of file while reading data: Input/output error'

--- a/libvirt/tests/cfg/numa/guest_numa.cfg
+++ b/libvirt/tests/cfg/numa/guest_numa.cfg
@@ -70,7 +70,7 @@
                              variants:
                                  - 2M:
                                      hugepage_size_0 = "2048"
-                                     page_num_0 = "256"
+                                     page_num_0 = "512"
                                      page_nodenum_0 = "1"
                                      pseries:
                                         page_nodenum_0 = "0"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
@@ -62,6 +62,21 @@
             detach_rng_type = "rng"
             rng_dict = {"rng_model": "virtio","backend":{"backend_model":"random", "backend_dev":"/dev/urandom"}}
             detach_check_xml = "<rng"
+        - input:
+            only live,config
+            variants:
+                - keyboard:
+                    detach_input_type = "keyboard"
+                    detach_check_xml = "<input type='${detach_input_type}' bus='usb'>"
+                    input_dict = {"type_name":"${detach_input_type}","input_bus": "usb"}
+                - mouse:
+                    detach_input_type = "mouse"
+                    detach_check_xml = "<input type='${detach_input_type}' bus='virtio'>"
+                    input_dict = {"type_name":"${detach_input_type}","input_bus": "virtio"}
+                - passthrough:
+                    detach_input_type = "passthrough"
+                    detach_check_xml = "<input type='${detach_input_type}' bus='virtio'>"
+                    input_dict = {"type_name":"${detach_input_type}","input_bus": "virtio", "source_evdev":"/dev/input/event3"}
     variants:
         - live:
             detach_alias_options = "--live"

--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_nvme.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_nvme.cfg
@@ -1,0 +1,21 @@
+- virtual_disks.nvme:
+    type = virtual_disks_nvme
+    take_regular_screendumps = "no"
+    start_vm = "no"
+    target_format = "raw"
+    type_name = "nvme"
+    driver_type = 'raw'
+    device_type = "disk"
+    target_dev = "vdb"
+    target_bus = "virtio"
+    status_error = "no"
+    define_error = "no"
+    pkgs_host = "pciutils"
+    variants:
+        - attach_nvme:
+            source_attrs = "{'type':'pci', 'managed':'yes', 'namespace':'1', 'index':'1'}"
+    variants:
+        - coldplug:
+            virt_device_hotplug = "no"
+        - hotplug:
+            virt_device_hotplug = "yes"

--- a/libvirt/tests/src/backingchain/blockcopy/blockcopy_with_disk_driver_attributes.py
+++ b/libvirt/tests/src/backingchain/blockcopy/blockcopy_with_disk_driver_attributes.py
@@ -24,8 +24,8 @@ def run(test, params, env):
         Prepare active domain
         """
         test.log.info("TEST_SETUP: Start guest and prepare disk.")
-        global xml_file
-        xml_file = libvirt_vmxml.create_vm_device_by_type("disk", disk_dict).xml
+        global disk_xml
+        disk_xml = libvirt_vmxml.create_vm_device_by_type("disk", disk_dict)
         test_obj.backingchain_common_setup()
 
     def run_test():
@@ -34,7 +34,7 @@ def run(test, params, env):
         """
         test.log.info("TEST_STEP1: Do blockcopy.")
         virsh.blockcopy(vm_name, device,
-                        blockcopy_options.format(xml_file),
+                        blockcopy_options.format(disk_xml.xml),
                         ignore_status=False,
                         debug=True)
 

--- a/libvirt/tests/src/backingchain/with_disk_attributes_test/commit_pull_with_disk_driver_attributes.py
+++ b/libvirt/tests/src/backingchain/with_disk_attributes_test/commit_pull_with_disk_driver_attributes.py
@@ -1,0 +1,108 @@
+from virttest import virsh
+from virttest.libvirt_xml import snapshot_xml
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+from provider.backingchain import blockcommand_base
+
+
+def run(test, params, env):
+    """
+    Do blockcommit/blockpull with different attributes of driver elements.
+    1) Prepare a running guest with the follow driver elements and create snapshots:
+    - copy_on_read='on'
+    - cache and discard
+    - detect_zeroes
+    - metadata_cache ->max_size
+    2) Do blockcommit/blockpull and check dumpxml.
+    """
+
+    def setup_test():
+        """
+        Prepare a running guest with different driver elements and create snapshots.
+        """
+        test.log.info("Setup env: prepare a running guest and snap chain.")
+        if block_cmd == "blockpull" and with_metadata_cache:
+            test_obj.backingchain_common_setup()
+            prepare_snapshot()
+        else:
+            libvirt_vmxml.modify_vm_device(vmxml, 'disk', driver_dict)
+            test_obj.backingchain_common_setup(create_snap=True, snap_num=snap_num)
+
+    def run_test():
+        """
+        Do blockcommit/blockpull for the guest with different driver attributes
+        """
+        test.log.info("TEST_STEP1: Do blockcommit/blockpull")
+        if block_cmd == "blockcommit":
+            virsh.blockcommit(vm_name, target_disk, common_options+blockcommit_options,
+                              ignore_status=False, debug=True)
+        elif block_cmd == "blockpull":
+            virsh.blockpull(vm_name, target_disk, common_options,
+                            ignore_status=False, debug=True)
+        test.log.info("TEST_STEP2: Check driver attributes in dumpxml.")
+        check_attributes()
+
+    def teardown_test():
+        """
+        Clean up the test environment.
+        """
+        # Clean up the snapshots
+        libvirt.clean_up_snapshots(vm_name)
+        bkxml.sync()
+
+    def prepare_snapshot():
+        """
+        Create a snapshot with snapshot xml
+        """
+        snap_xml = snapshot_xml.SnapshotXML()
+        disk_obj = snap_xml.SnapDiskXML()
+        disk_obj.setup_attrs(**snap_disk_dict)
+        snap_xml.set_disks([disk_obj])
+        snap_file = snap_xml.xml
+        snap_options = " %s %s" % (snap_file, snap_option)
+        snapshot_result = virsh.snapshot_create(vm_name, snap_options,
+                                                ignore_status=False, debug=True)
+
+    def check_attributes():
+        """
+        Check the disk attributes in dumpxml
+        """
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        test.log.debug("The guest xml is: %s" % vmxml)
+        disk = vmxml.get_devices("disk")[0]
+        cur_dict = disk.fetch_attrs()[driver_element]
+        pre_dict = driver_dict[driver_element]
+        for key, value in pre_dict.items():
+            if cur_dict.get(key) != value:
+                test.fail("Driver XML compare fails. It should be '%s', but "
+                          "got '%s'" % (pre_dict, cur_dict))
+        else:
+            test.log.debug("Can get the expected attributes '%s'" % cur_dict)
+
+    # Process cartesian parameters
+    vm_name = params.get("main_vm")
+    target_disk = params.get('target_disk')
+    disk_type = params.get("disk_type")
+    common_options = params.get("common_options")
+    snap_num = int(params.get("snap_num"))
+    block_cmd = params.get("block_cmd")
+    blockcommit_options = params.get("blockcommit_options", "")
+    snap_option = params.get("snap_option")
+    snap_disk_dict = eval(str(params.get("snap_disk_dict", "{}")))
+    driver_dict = eval(params.get("driver_dict", "{}"))
+    with_metadata_cache = params.get("with_metadata_cache", "no") == "yes"
+    driver_element = params.get("driver_element")
+
+    vm = env.get_vm(vm_name)
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+
+    test_obj = blockcommand_base.BlockCommand(test, vm, params)
+
+    try:
+        setup_test()
+        run_test()
+    finally:
+        teardown_test()

--- a/libvirt/tests/src/controller/pcie_root_port_controller.py
+++ b/libvirt/tests/src/controller/pcie_root_port_controller.py
@@ -1,8 +1,10 @@
-import logging
 import ast
+import logging
 
+from virttest import virsh
 from virttest.libvirt_xml import vm_xml
-from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_libvirt import libvirt_vmxml, libvirt_pcicontr
+from virttest.utils_test import libvirt
 
 
 LOG = logging.getLogger('avocado.' + __name__)
@@ -17,28 +19,24 @@ def setup_test(params):
     controller_model = params.get("controller_model")
     controller_target = ast.literal_eval(params.get("controller_target"))
     second_controller_model = params.get("second_controller_model")
-    second_controller_target = ast.literal_eval(params.get("second_controller_target"))
+    second_controller_target = ast.literal_eval(
+        params.get("second_controller_target", "{}"))
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(params.get("main_vm", "avocado-vt-vm1"))
-    index = 0
 
     vmxml.remove_all_device_by_type("controller")
 
+    index = 0
     contr_dict = {"type": "pci", "model": "pcie-root", "index": index}
     libvirt_vmxml.modify_vm_device(vmxml, "controller", contr_dict, index)
 
     index += 1
-    contr_dict = {'type': 'pci',
-                  'model': controller_model,
-                  "index": index,
-                  'target': controller_target}
+    contr_dict = create_controller_dict(controller_model, controller_target, index)
     libvirt_vmxml.modify_vm_device(vmxml, "controller", contr_dict, index)
 
-    index += 1
     if second_controller_model and second_controller_target:
-        contr_dict = {'type': 'pci',
-                      'model': second_controller_model,
-                      "index": index,
-                      'target': second_controller_target}
+        index += 1
+        contr_dict = create_controller_dict(second_controller_model,
+                                            second_controller_target, index)
         libvirt_vmxml.modify_vm_device(vmxml, "controller", contr_dict, index)
 
     vmxml.sync()
@@ -52,18 +50,74 @@ def execute_test(vm, test, params):
     :param test: Avocado test object
     :param params: Test parameters object
     """
-    status_error = params.get("status_error") == "yes"
-    LOG.debug("Starting VM with XML:\n%s", vm_xml.VMXML.new_from_dumpxml(vm.name))
-    try:
-        vm.start()
-    except Exception as exc:
-        if status_error:
-            LOG.info("VM failed to start as expected.")
-        else:
-            test.fail("VM failed to start, reason: %s" % exc)
+    test_define_only = params.get("test_define_only") == "yes"
+    if test_define_only:
+        vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm.name)
+        check_define_vm(vmxml, params, test)
     else:
-        if vm.is_alive() and status_error:
-            test.fail("VM started sucessfully, but shouldn't.")
+        status_error = params.get("status_error") == "yes"
+        LOG.debug("Starting VM with XML:\n%s", vm_xml.VMXML.new_from_dumpxml(vm.name))
+        try:
+            vm.start()
+        except Exception as exc:
+            if status_error:
+                LOG.info("VM failed to start as expected.")
+            else:
+                test.fail("VM failed to start, reason: %s" % exc)
+        else:
+            if vm.is_alive() and status_error:
+                test.fail("VM started sucessfully, but shouldn't.")
+
+
+def create_controller_dict(model, target, index, address=None):
+    """
+    Creates a dictionary for PCI controller.
+
+    :param model: String, Controller model
+    :param target: Dictionary, Controller target
+    :param index: Int, controller index value
+    :param address: Dict, optional, device address example: {'attrs': {'bus': 0x01}}
+    :returns Built in dictionary, prepared to be added to VM XML
+    """
+    contr_dict = {'type': 'pci',
+                  'model': model,
+                  "index": index,
+                  'target': target}
+    if address:
+        contr_dict.update({"address": address})
+    return contr_dict
+
+
+def check_define_vm(vmxml, params, test):
+    """
+    Alternate function for checking and finishing the test.
+    Checks only if VM define action was successful instead of VM start.
+
+    :param vmxml: VM XML object
+    :param params: Test parameters object
+    :param test: Avocado test object
+    """
+    model = params.get("controller_model")
+    target = params.get("controller_target")
+    address = ast.literal_eval(params.get("controller_address", "{}"))
+    bus_offset = int(params.get("bus_offset", 0))
+    status_error = params.get("status_error") == "yes"
+    failure_message = params.get("failure_message")
+    max_indexes = libvirt_pcicontr.get_max_contr_indexes(vmxml, 'pci', model, 1)
+    index = max_indexes[0] + 1
+    address["bus"] = hex(index + bus_offset)
+    contr_dict = {'controller_type': 'pci',
+                  'controller_model': model,
+                  "controller_index": index,
+                  'controller_target': target,
+                  "controller_addr": str(address)}
+    contr_object = libvirt.create_controller_xml(contr_dict)
+    vmxml.add_device(contr_object)
+    cmd_result = virsh.define(vmxml.xml)
+    if failure_message:
+        libvirt.check_result(cmd_result, [failure_message])
+    else:
+        libvirt.check_exit_status(cmd_result, status_error)
 
 
 def cleanup_test(vm, vmxml_backup):
@@ -88,11 +142,12 @@ def run(test, params, env):
     :params params: Object containing parameters of a test from cfg file
     :params env: Environment object from Avocado framework
     """
-
     vm = env.get_vm(params.get("main_vm", "avocado-vt-vm1"))
     vmxml_backup = vm_xml.VMXML.new_from_dumpxml(vm.name)
+    test_define_only = params.get("test_define_only")
 
-    setup_test(params)
+    if not test_define_only:
+        setup_test(params)
     try:
         execute_test(vm, test, params)
     finally:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
@@ -60,6 +60,9 @@ def run(test, params, env):
     # rng params
     rng_type = params.get("detach_rng_type")
     rng_dict = eval(params.get('rng_dict', '{}'))
+    # input params
+    input_type = params.get("detach_input_type")
+    input_dict = eval(params.get('input_dict', '{}'))
 
     device_alias = "ua-" + str(uuid.uuid4())
 
@@ -209,6 +212,17 @@ def run(test, params, env):
         rng_dict.update({"alias": {"name": device_alias}})
         libvirt_vmxml.modify_vm_device(vmxml=vmxml,
                                        dev_type='rng', dev_dict=rng_dict)
+
+        if not vm.is_alive():
+            vm.start()
+        vm.wait_for_login(timeout=240).close()
+
+        attach_device = False
+
+    if input_type:
+        input_dict.update({"alias": {"name": device_alias}})
+        libvirt_vmxml.modify_vm_device(vmxml, "input",
+                                       dev_dict=input_dict)
 
         if not vm.is_alive():
             vm.start()

--- a/libvirt/tests/src/virtual_disks/virtual_disks_nvme.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_nvme.py
@@ -1,0 +1,152 @@
+import logging
+import platform
+import shutil
+import time
+
+from avocado.utils import process
+
+from virttest import utils_disk
+from virttest import utils_misc
+from virttest import virsh
+from virttest import virt_vm
+
+from virttest.libvirt_xml import vm_xml, xcepts
+from virttest.utils_libvirt import libvirt_disk
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+
+def run(test, params, env):
+    """
+    Test nvme virtual.
+
+    1.Prepare a vm with nvme type disk
+    2.Attach the virtual disk to the vm
+    3.Start vm
+    4.Check the disk in vm
+    5.Detach nvme device
+    """
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+
+    def get_new_disks(old_partitions):
+        """
+        Get new virtual disks in VM after disk plug.
+
+        :param old_partitions: already existing partitions in VM
+        :return: New disks/partitions in VM
+        """
+        session = None
+        try:
+            session = vm.wait_for_login()
+            if platform.platform().count('ppc64'):
+                time.sleep(10)
+            added_partitions = utils_disk.get_added_parts(session, old_partitions)
+            LOG.debug("Newly added partition(s) is: %s", added_partitions)
+            return added_partitions
+        except Exception as err:
+            test.fail("Error happens when get new disk: %s" % str(err))
+        finally:
+            if session:
+                session.close()
+
+    def get_usable_nvme_pci_address():
+        """
+        Get usable nvme device pci address
+        return: usable nvme pci address in Dict
+        """
+        lspci_output = process.run(
+            "lspci | grep -i 'Non-Volatile memory controller'",
+            timeout=10, ignore_status=True, verbose=False, shell=True)
+        # Expected output look something like below:
+        # 17:00.0 Non-Volatile memory controller
+        if lspci_output.exit_status != 0:
+            test.cancel("Failed to execute lspci on host with output:{}".format(lspci_output))
+        pci_address = lspci_output.stdout_text.strip().split()[0].split(":")
+        address_dict = {}
+        address_dict.update({'domain': '0x0000'})
+        address_dict.update({'bus': '0x{}'.format(pci_address[0])})
+        address_dict.update({'slot': '0x{}'.format(pci_address[1].split('.')[0])})
+        address_dict.update({'function': '0x{}'.format(pci_address[1].split('.')[1])})
+        return address_dict
+
+    def create_customized_disk(params, pci_address):
+        """
+        Create one customized disk with related attributes
+
+        :param params: dict wrapped with params
+        :param pci_address: pci address in dict format
+        """
+        type_name = params.get("type_name")
+        disk_device = params.get("device_type")
+        device_target = params.get("target_dev")
+        device_bus = params.get("target_bus")
+        device_format = params.get("target_format")
+
+        customized_disk = libvirt_disk.create_primitive_disk_xml(
+            type_name, disk_device,
+            device_target, device_bus,
+            device_format, None, None)
+
+        source_dict = eval(params.get("source_attrs"))
+        disk_src_dict = {"attrs": source_dict}
+        disk_source = customized_disk.new_disk_source(**disk_src_dict)
+        disk_source.address = pci_address
+        customized_disk.source = disk_source
+        LOG.debug("create customized xml: %s", customized_disk)
+        return customized_disk
+
+    hotplug = "yes" == params.get("virt_device_hotplug")
+    pkgs_host = params.get("pkgs_host", "")
+
+    # Get disk partitions info before hot/cold plug virtual disk
+    if vm.is_dead():
+        vm.start()
+    session = vm.wait_for_login()
+    old_partitions = utils_disk.get_parts_list(session)
+    session.close()
+    vm.destroy(gracefully=False)
+
+    # Backup vm xml
+    vmxml_backup = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    vmxml = vmxml_backup.copy()
+
+    try:
+        # install essential package in host
+        if not shutil.which('lspci'):
+            test.error("package {} not installed, please install them before testing".format(pkgs_host))
+
+        pci_addr_in_dict = get_usable_nvme_pci_address()
+
+        device_obj = create_customized_disk(params, pci_addr_in_dict)
+        if not hotplug:
+            vmxml.add_device(device_obj)
+            vmxml.sync()
+        vm.start()
+        vm.wait_for_login().close()
+        if hotplug:
+            virsh.attach_device(vm_name, device_obj.xml, flagstr="--live",
+                                ignore_status=False, debug=True)
+    except virt_vm.VMStartError as details:
+        test.fail("VM failed to start."
+                  "Error: %s" % str(details))
+    except xcepts.LibvirtXMLError as xml_error:
+        test.fail("VM failed to define"
+                  "Error: %s" % str(xml_error))
+    else:
+        utils_misc.wait_for(lambda: get_new_disks(old_partitions), 20)
+        new_disks = get_new_disks(old_partitions)
+        if len(new_disks) != 1:
+            test.fail("Attached 1 virtual disk but got %s." % len(new_disks))
+        new_disk = new_disks[0]
+        if platform.platform().count('ppc64'):
+            time.sleep(10)
+        if not libvirt_disk.check_virtual_disk_io(vm, new_disk):
+            test.fail("Cannot operate the newly added disk in vm.")
+        virsh.detach_device(vm_name, device_obj.xml, flagstr="--live",
+                            debug=True, ignore_status=False)
+    finally:
+        if vm.is_alive():
+            vm.destroy(gracefully=False)
+        # Restoring vm
+        vmxml_backup.sync()

--- a/libvirt/tests/src/virtual_network/iface_options.py
+++ b/libvirt/tests/src/virtual_network/iface_options.py
@@ -287,7 +287,8 @@ def run(test, params, env):
         ret = process.run(cmd, shell=True)
         logging.debug("Command line %s", ret.stdout_text)
         if test_vhost_net:
-            if not ret.stdout_text.count("vhost=on") and not rm_vhost_driver:
+            if not re.search('"vhost":true|vhost=on', ret.stdout_text) \
+                    and not rm_vhost_driver:
                 test.fail("Can't see vhost options in"
                           " qemu-kvm command line")
 

--- a/spell.ignore
+++ b/spell.ignore
@@ -679,6 +679,7 @@ numanode
 numastat
 numatune
 nvdimm
+nvme
 nvram
 nwfilter
 objs


### PR DESCRIPTION
This PR adds checks for PCIe root port controller with invalid name. The check should fail.
Automation of VIRT-47650
