### PR TITLE
sriov: Add a case

### DIFF
--- a/libvirt/tests/cfg/sriov/plug_unplug/sriov_attach_interface_to_vm_with_vf.cfg
+++ b/libvirt/tests/cfg/sriov/plug_unplug/sriov_attach_interface_to_vm_with_vf.cfg
@@ -1,0 +1,6 @@
+- sriov.plug_unplug.attach_interface_to_vm_with_vf:
+    type = sriov_attach_interface_to_vm_with_vf
+    start_vm = "no"
+    network_dict = {'forward': {'mode': 'hostdev', 'managed': 'yes'}, 'name': 'hostnet', 'vf_list': [{'type_name': 'pci', 'attrs': vf_pci_addr}, {'type_name': 'pci', 'attrs': vf_pci_addr2}]}
+    pre_iface_dict = {'type_name': 'network', 'source': {'network': 'hostnet'}}
+    only x86_64

--- a/libvirt/tests/src/sriov/plug_unplug/sriov_attach_interface_to_vm_with_vf.py
+++ b/libvirt/tests/src/sriov/plug_unplug/sriov_attach_interface_to_vm_with_vf.py
@@ -1,0 +1,54 @@
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+
+from provider.sriov import sriov_base
+
+
+def run(test, params, env):
+    """
+    Alternatively hotplug other interface and hostdev interface while the guest
+    contains VF
+    """
+    def setup_test():
+        """
+        Setup test
+        """
+        sriov_test_obj.setup_default(network_dict=network_dict)
+        test.log.info("TEST_SETUP: Start a vm with an interface, pointing to a "
+                      "hostdev network.")
+        libvirt_vmxml.modify_vm_device(
+            vm_xml.VMXML.new_from_inactive_dumpxml(vm.name),
+            'interface', pre_iface_dict)
+        vm.start()
+        vm.wait_for_serial_login(timeout=240).close()
+
+    def run_test():
+        """
+        Attach virtual interface whose source is default network while the guest
+        contains VF
+        """
+        test.log.info("TEST_STEP1: Attach-interface to the VM.")
+        virsh.attach_interface(vm.name, virsh_opts, debug=True,
+                               ignore_status=False)
+        cur_ifaces = vm_xml.VMXML.new_from_dumpxml(vm.name)\
+            .devices.by_device_tag("interface")
+        if len(cur_ifaces) != 2:
+            test.fail("VM's interface number is %d, it should be 2." % len(cur_ifaces))
+        if cur_ifaces[1].get_source().get('network') != "default":
+            test.fail("Incorrect network!")
+
+    pre_iface_dict = eval(params.get("pre_iface_dict", "{}"))
+    virsh_opts = params.get("virsh_opts", "network default --model virtio")
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    vm = env.get_vm(vm_name)
+    sriov_test_obj = sriov_base.SRIOVTest(vm, test, params)
+
+    network_dict = sriov_test_obj.parse_network_dict()
+    try:
+        setup_test()
+        run_test()
+
+    finally:
+        sriov_test_obj.teardown_default(network_dict=network_dict)


### PR DESCRIPTION
This PR adds a case(VIRT-294712) to attach a hostdev interface while the guest contains VF.

Signed-off-by: Yingshun Cui <yicui@redhat.com>

**Test results:**
```
 (1/1) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_interface_to_vm_with_vf: PASS (51.24 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-11-09T01.15-ff4aba7/results.html
```
