### PR TITLE
ap_passthrough: add hw hotplug test

### DIFF
--- a/libvirt/tests/cfg/passthrough/ap/libvirt_ap_passthrough.cfg
+++ b/libvirt/tests/cfg/passthrough/ap/libvirt_ap_passthrough.cfg
@@ -2,8 +2,8 @@
     type = libvirt_ap_passthrough
     only s390-virtio
     variants:
-        - hotplug:
+        - hostdev_hotplug:
             plug = hot
-        - coldplug:
+        - hostdev_coldplug:
             plug = cold
 

--- a/libvirt/tests/cfg/passthrough/ap/libvirt_ap_passthrough_autostart.cfg
+++ b/libvirt/tests/cfg/passthrough/ap/libvirt_ap_passthrough_autostart.cfg
@@ -1,4 +1,4 @@
-- libvirt_ap_passthrough_autostart:
+- libvirt_ap_passthrough.autostart:
     type = libvirt_ap_passthrough_autostart
     only s390-virtio
     kvm_module_parameters = 'nested=1'

--- a/libvirt/tests/cfg/passthrough/ap/libvirt_ap_passthrough_hotplug.cfg
+++ b/libvirt/tests/cfg/passthrough/ap/libvirt_ap_passthrough_hotplug.cfg
@@ -1,0 +1,5 @@
+- libvirt_ap_passthrough.hw_hotplug:
+    type = libvirt_ap_passthrough_hotplug
+    only s390-virtio
+    kvm_module_parameters = 'nested=1'
+    start_vm = no

--- a/libvirt/tests/src/passthrough/ap/libvirt_ap_passthrough_hotplug.py
+++ b/libvirt/tests/src/passthrough/ap/libvirt_ap_passthrough_hotplug.py
@@ -1,0 +1,163 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2022
+# Author: Sebastian Mitterle <smitterl@redhat.com>
+import logging as log
+from time import sleep
+
+from avocado.core.exceptions import TestError, TestFail
+from virttest.libvirt_xml.vm_xml import VMXML
+from virttest.utils_misc import cmd_status_output
+from virttest.utils_zcrypt import load_vfio_ap
+
+from provider.vfio.mdev_handlers import MdevHandler
+from provider.vfio import ap
+
+REFRESH_INTERVAL_SEC = 5
+
+
+logging = log.getLogger("avocado." + __name__)
+
+
+def create_mdev(session, domain_info):
+    """
+    Loads the vfio_ap and creates a mediated device
+    with the first available domain set for passthrough
+
+    :param session: guest session
+    :param domain_info: CARD.DOMAIN id of the crypto device
+    """
+    load_vfio_ap(session)
+    return ap.create_mediated_device(domain_info, session=session)
+
+
+def wait_for_refresh():
+    """
+    Sleep for the time needed for the crypto device info
+    to be refreshed in the guest.
+    """
+    sleep(REFRESH_INTERVAL_SEC)
+
+
+def make_device_available(domain_info, uuid):
+    """
+    On the host assigns adapter and domain so that it becomes
+    available in the guest
+    :param domain_info: CARD.DOMAIN to be assigned
+    :param uuid: The mediated device' UUID
+    """
+
+    path = get_mediated_device_path(uuid)
+    adapter, domain = domain_info.split(".")
+    cmds = ["echo 0x%s > %s/assign_adapter" % (adapter, path),
+            "echo 0x%s > %s/assign_domain" % (domain, path),
+            "echo 0x%s > %s/assign_control_domain" % (domain, path)]
+    for cmd in cmds:
+        err, out = cmd_status_output(cmd, shell=True, verbose=True)
+        if err:
+            raise TestError("Couldn't set attribute: %s" % out)
+    return
+
+
+def make_device_unavailable(domain_info, uuid):
+    """
+    On the host unassign adapter and domain so that it becomes
+    unavailable in the guest
+    :param domain_info: CARD.DOMAIN to be assigned
+    :param uuid: The mediated device' UUID
+    """
+
+    path = get_mediated_device_path(uuid)
+    adapter, domain = domain_info.split(".")
+    cmds = ["echo 0x%s > %s/unassign_adapter" % (adapter, path),
+            "echo 0x%s > %s/unassign_domain" % (domain, path),
+            "echo 0x%s > %s/unassign_control_domain" % (domain, path)]
+    for cmd in cmds:
+        err, out = cmd_status_output(cmd, shell=True, verbose=True)
+        if err:
+            raise TestError("Couldn't set attribute: %s" % out)
+    return
+
+
+def get_mediated_device_path(uuid):
+    """
+    Returns the mediated device path in the sysfs
+
+    :param uuid: The mediated device' UUID
+    """
+    return "/sys/devices/vfio_ap/matrix/%s" % uuid
+
+
+def assert_guest_matrix_is(session, uuid, expected=""):
+    """
+    Reads the guest matrix in the mediated device and fails if it's not as expected
+    :param session: If given, we assert in the guest
+    :param uuid: The UUID of the mediated device
+    :param expected: The expected attribute content as string
+    """
+
+    path = "%s/guest_matrix" % get_mediated_device_path(uuid)
+    cmd = "cat %s" % path
+    err, out = cmd_status_output(cmd, shell=True, session=session, verbose=True)
+    if err:
+        raise TestError("Couldn't read path %s: %s" % (path, out))
+    actual = out.strip()
+    if expected != actual:
+        raise TestFail("Expected: %s\nGot: %s" % (expected, actual))
+
+
+def run(test, params, env):
+    """
+    Verify that passthrough can be configured
+    for vfio_ap and device availability is updated
+    depending on the availability of crypto devices.
+    Both, host and guest kernel need to support crypto
+    device hotplug for vfio_ap for this test.
+    """
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    vmxml_backup = VMXML.new_from_inactive_dumpxml(vm_name)
+
+    handler = None
+    session = None
+
+    try:
+        host_handler = MdevHandler.from_type("vfio_ap-passthrough")
+        host_handler.create_blank_nodedev()
+        host_uuid = host_handler.matrix_dev.uuid
+
+        entry = [x for x in host_handler.devices if x.domain][0]
+        domain_info = ".".join([entry.card, entry.domain])
+
+        ap.attach_hostdev(vm_name, host_handler.matrix_dev.uuid)
+        vm.start()
+        session = vm.wait_for_login()
+
+        ap.set_crypto_device_refresh_interval(session, REFRESH_INTERVAL_SEC)
+
+        guest_uuid = create_mdev(session, domain_info)
+        assert_guest_matrix_is(session, guest_uuid, expected="")
+
+        make_device_available(domain_info, host_uuid)
+        wait_for_refresh()
+        assert_guest_matrix_is(session, guest_uuid, expected=domain_info)
+
+        make_device_unavailable(domain_info, host_uuid)
+        wait_for_refresh()
+        assert_guest_matrix_is(session, guest_uuid, expected="")
+
+    finally:
+        if session:
+            session.close()
+        vmxml_backup.sync()
+        if host_handler:
+            host_handler.clean_up()

--- a/provider/vfio/mdev_handlers.py
+++ b/provider/vfio/mdev_handlers.py
@@ -191,6 +191,22 @@ class ApMdevHandler(MdevHandler):
 
         return get_first_mdev_nodedev_name()
 
+    def create_blank_nodedev(self):
+        """
+        Creates a mediated device for vfio_ap but doesn't assign
+        anything to the matrix yet.
+        """
+
+        load_vfio_ap()
+        self.vfio_ap_loaded = True
+        info = CryptoDeviceInfoBuilder.get()
+        LOG.debug("Host lszcrypt got %s", info)
+
+        self.devices = info.domains
+        self.mask_helper = APMaskHelper.from_infos(self.devices)
+
+        self.matrix_dev = MatrixDevice()
+
     def get_target_address(self):
         """
         Returns a valid target device address

--- a/spell.ignore
+++ b/spell.ignore
@@ -1022,6 +1022,7 @@ umask
 umount
 umounted
 un
+unassign
 unbridge
 Unbridge
 Unclassifed


### PR DESCRIPTION
1. Tidy up libvirt_ap_passthrough test types and names to be more
   consistent.
2. Create new test to confirm crypto devices can be hot plugged and
   unplugged if set up on a mediated device. As we can't modify the
   available crypto devices on an LPAR or z/VM, the test case
   creates a mediated device on the host to control device availability
   for a KVM guest. It creates another mediated device in that guest
   to confirm that the guest_matrix is updated. Therefore, both host
   and guest kernel need to support vfio_ap hotplug.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>