### PR TITLE
vDPA: Add 3 cases into connectivity_check test

### DIFF
--- a/libvirt/tests/cfg/virtual_interface/connectivity_check.cfg
+++ b/libvirt/tests/cfg/virtual_interface/connectivity_check.cfg
@@ -19,11 +19,21 @@
                     only mellanox
                     required_kernel = [5.14.0,)
                     func_supported_since_libvirt_ver = (8, 0, 0)
-                    driver_queues = "8"
+                    driver_queues = 8
                     vdpa_mgmt_tool_extra = "max_vqp ${driver_queues}"
-                    iface_dict = {'model': 'virtio', 'source': {'dev': '/dev/vhost-vdpa-0'}, 'type_name': 'vdpa', 'driver': {'driver_attr': {'queues': ${driver_queues}}}, 'mac_address': mac_addr}
+                    iface_dict = {'model': 'virtio', 'source': {'dev': '/dev/vhost-vdpa-0'}, 'type_name': 'vdpa', 'driver': {'driver_attr': {'queues': '${driver_queues}'}}, 'mac_address': mac_addr}
                     variants:
                         - vcpu_gt_queues:
                             vm_attrs = {'vcpu': 4}
                         - vcpu_lt_queues:
                             vm_attrs = {'vcpu': 16}
+                        - boot:
+                            iface_dict = {'model': 'virtio', 'source': {'dev': '/dev/vhost-vdpa-0'}, 'type_name': 'vdpa', 'driver': {'driver_attr': {'queues': '${driver_queues}'}}, 'boot': '2', 'mac_address': mac_addr}
+                            disk_boot = 1
+                        - page_per_vq:
+                            enable_guest_iommu = "yes"
+                            expr_multiplier = '00001000'
+                            iface_dict = {'model': 'virtio', 'source': {'dev': '/dev/vhost-vdpa-0'}, 'type_name': 'vdpa', 'driver': {'driver_attr': {'queues': '${driver_queues}', 'page_per_vq': 'on'}}, 'mac_address': mac_addr}
+                        - multi_ifaces:
+                            func_supported_since_libvirt_ver = (8, 7, 0)
+                            iface_dict2 = {'model': 'virtio', 'source': {'dev': '/dev/vhost-vdpa-1'}, 'type_name': 'vdpa', 'driver': {'driver_attr': {'queues': '${driver_queues}'}}}


### PR DESCRIPTION
This PR adds 3 scenarios:
    1. vdpa interface which has boot order and multiqueue setting
    2. vdpa interface with page_per_vq and multiqueue
    3. multiple vdpa interfaces

Signed-off-by: Yingshun Cui <yicui@redhat.com>


**Test results:**
 ```
(1/6) type_specific.io-github-autotest-libvirt.iface.connectivity_check.vdpa.default.mellanox: PASS (107.83 s)
 (2/6) type_specific.io-github-autotest-libvirt.iface.connectivity_check.vdpa.driver_queues.vcpu_gt_queues.mellanox: PASS (109.48 s)
 (3/6) type_specific.io-github-autotest-libvirt.iface.connectivity_check.vdpa.driver_queues.vcpu_lt_queues.mellanox: PASS (111.02 s)
 (4/6) type_specific.io-github-autotest-libvirt.iface.connectivity_check.vdpa.driver_queues.boot.mellanox: PASS (110.87 s)
 (5/6) type_specific.io-github-autotest-libvirt.iface.connectivity_check.vdpa.driver_queues.page_per_vq.mellanox: PASS (108.98 s)
 (6/6) type_specific.io-github-autotest-libvirt.iface.connectivity_check.vdpa.driver_queues.multi_ifaces.mellanox: PASS (120.07 s)
```
