### PR TITLE
sriov: Update to check if the vm interface exists

### DIFF
--- a/provider/sriov/sriov_base.py
+++ b/provider/sriov/sriov_base.py
@@ -77,6 +77,8 @@ def get_ping_dest(vm_session, mac_addr="", restart_network=False):
             raise exceptions.TestFail("Failed to install dhcp-client on guest.")
         utils_net.restart_guest_network(vm_session)
     vm_iface = utils_net.get_linux_ifname(vm_session, mac_addr)
+    if not vm_iface:
+        raise exceptions.TestError("Unable to get VM's interface!")
     if isinstance(vm_iface, list):
         iface_name = vm_iface[0]
     else:


### PR DESCRIPTION
VM interface may not exist due to a bug in some cases.

Signed-off-by: Yingshun Cui <yicui@redhat.com>

Test result: This case failed due to a bug.
` (1/1) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.hostdev_device.pf_address.managed_yes: ERROR: Unable to get VM's interface! (49.62 s)`
