### PR TITLE
add case for detach hostdev-pci with alias

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
@@ -2,11 +2,17 @@
     type = virsh_detach_device_alias
     variants:
         - hostdev:
-            detach_hostdev_type = "usb"
             detach_hostdev_managed = "no"
             detach_check_xml = "<hostdev"
-            s390-virtio, aarch64:
-                detach_hostdev_type = "scsi"
+            variants:
+                - usb:
+                    detach_hostdev_type = "usb"
+                - scsi:
+                    detach_hostdev_type = "scsi"
+                - pci:
+                    detach_hostdev_type = "pci"
+                    detach_hostdev_managed = "yes"
+                    controller_dict = {'type': 'pci', 'model': 'pcie-to-pci-bridge','index':'35'}
         - controller:
             detach_controller_type = "scsi"
             detach_controller_mode = "virtio-scsi"
@@ -63,3 +69,4 @@
             detach_alias_options = "--config"
         - current:
             detach_alias_options = "--current"
+

--- a/libvirt/tests/src/sriov/capabilities/sriov_capabilities_iommu_support.py
+++ b/libvirt/tests/src/sriov/capabilities/sriov_capabilities_iommu_support.py
@@ -12,7 +12,7 @@ def run(test, params, env):
     res = re.search("iommu=on", kernel_cmd)
     if not res:
         test.error("iommu should be enabled in kernel cmd line - "
-                   "'%s'." % res)
+                   "'%s'." % kernel_cmd)
     cap_xml = capability_xml.CapabilityXML()
     if cap_xml.get_iommu().get('support') != 'yes':
         test.fail("IOMMU is disabled in capabilities: %s. "

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
@@ -1,4 +1,5 @@
 import os
+import re
 import uuid
 import logging as log
 
@@ -37,6 +38,7 @@ def run(test, params, env):
     # hostdev device params
     hostdev_type = params.get("detach_hostdev_type", "")
     hostdev_managed = params.get("detach_hostdev_managed")
+    controller_dict = eval(params.get('controller_dict', '{}'))
     # controller params
     contr_type = params.get("detach_controller_type")
     contr_model = params.get("detach_controller_mode")
@@ -98,13 +100,30 @@ def run(test, params, env):
     vm.wait_for_login()
 
     if hostdev_type:
-        if hostdev_type in ["usb", "scsi"]:
+        if hostdev_type in ["usb", "scsi", "pci"]:
             if hostdev_type == "usb":
                 pci_id = get_usb_info()
             elif hostdev_type == "scsi":
                 source_disk = libvirt.create_scsi_disk(scsi_option="",
                                                        scsi_size="8")
                 pci_id = get_scsi_info(source_disk)
+            elif hostdev_type == "pci":
+                libvirt_vmxml.modify_vm_device(vmxml=vmxml,
+                                               dev_type='controller',
+                                               dev_dict=controller_dict)
+                kernel_cmd = utils_misc.get_ker_cmd()
+                res = re.search("iommu=on", kernel_cmd)
+                if not res:
+                    test.error("iommu should be enabled in kernel "
+                               "cmd line - '%s'." % kernel_cmd)
+
+                pci_id = utils_misc.get_full_pci_id(
+                    utils_misc.get_pci_id_using_filter('')[-1])
+
+                if not vm.is_alive():
+                    vm.start()
+                vm.wait_for_login()
+
             device_xml = libvirt.create_hostdev_xml(pci_id=pci_id,
                                                     dev_type=hostdev_type,
                                                     managed=hostdev_managed,


### PR DESCRIPTION
  RHEL-148233: Device can also be detached by 'virsh detach-device-alias' cmd
Signed-off-by: nanli <nanli@redhat.com>
Depends on : https://github.com/avocado-framework/avocado-vt/pull/3576 

**Test result:**
```
/usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 virsh.detach_device_alias..hostdev.pci
 (1/3) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.hostdev.pci: PASS (93.61 s)
 (2/3) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.config.hostdev.pci: PASS (90.11 s)
 (3/3) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.current.hostdev.pci: PASS (93.19 s)

/usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 virsh.detach_device_alias..hostdev.scsi
 (1/3) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.hostdev.scsi: PASS (45.04 s)
 (2/3) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.config.hostdev.scsi: PASS (48.68 s)
 (3/3) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.current.hostdev.scsi: PASS (50.28 s)

/usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 virsh.detach_device_alias..hostdev.usb

 (1/3) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.hostdev.usb: PASS (45.60 s)
 (2/3) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.config.hostdev.usb: PASS (48.01 s)
 (3/3) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.current.hostdev.usb: PASS (51.88 s)

```