### PR TITLE
backingchain: add case for blockcopy with different qcow2 properities

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockcopy/blockcopy_with_different_qcow2_properties.cfg
+++ b/libvirt/tests/cfg/backingchain/blockcopy/blockcopy_with_different_qcow2_properties.cfg
@@ -1,0 +1,31 @@
+- backingchain.blockcopy.image_properties:
+    type = blockcopy_with_different_qcow2_properties
+    target_disk = "vdb"
+    disk_type = "file"
+    snap_num = 1
+    blockcopy_option = " --wait --verbose --transient-job --pivot"
+    snap_extra = " --no-metadata --diskspec vda,snapshot=no"
+    copy_image = "/tmp/copy.qcow2"
+    image_path = "/var/lib/libvirt/images/test.qcow2"
+    image_format = "qcow2"
+    image_size = "500M"
+    variants property:
+        - extended_l2_and_cluster_size:
+            cluster_size = "2M"
+            extended_l2_value = "on"
+            expected_extended_l2 = "true"
+            property_command = "cluster_size=${cluster_size},extended_l2=${extended_l2_value}"
+            image_extras = "-o ${property_command}"
+   variants:
+        - not_encrypt_disk:
+            enable_encrypt_disk = "no"
+            disk_dict = {"type_name":"${disk_type}", "target":{"dev": "${target_disk}", "bus": "virtio"}, "driver": {"name": "qemu", "type":"qcow2"}}
+        - encrypt_disk:
+            enable_encrypt_disk = "yes"
+            sec_private = "yes"
+            private_key_password = "EXAMPLE_PWD"
+            disk_format = "luks"
+            image_extras = " --object secret,id=sec0,data=redhat -f qcow2 -o encrypt.format=luks,encrypt.key-secret=sec0,${property_command}"
+            sec_dict = {"secret_ephemeral": "no", "secret_private": "yes", "description": "sec", "usage": "volume", "volume": "/path/to/luks-sample"}
+            secret_disk_dict = {'type_name': "${disk_type}",'target': {"dev": "${target_disk}", "bus": "virtio"},'driver': {"name": "qemu", "type": "qcow2"},'source':{'encryption':{"encryption": 'luks',"secret": {"type": "passphrase"}}}}
+

--- a/libvirt/tests/src/backingchain/blockcopy/blockcopy_with_different_qcow2_properties.py
+++ b/libvirt/tests/src/backingchain/blockcopy/blockcopy_with_different_qcow2_properties.py
@@ -1,0 +1,117 @@
+import re
+
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_test import libvirt
+
+from provider.backingchain import blockcommand_base
+from provider.backingchain import check_functions
+from provider.virtual_disk import disk_base
+
+
+def run(test, params, env):
+    """
+    Do blockcopy with different qcow2 properties
+
+    1) Prepare image with properties and snap chain
+    2) Do blockcopy.
+    3) Check result.
+    """
+
+    def setup_test():
+        """
+        Prepare image with properties and snap chain
+        """
+        test.log.info("SETUP:Prepare image with properties and snap chain")
+        libvirt.create_local_disk("file", path=image_path, size=image_size,
+                                  disk_format=image_format, extra=image_extras)
+        check_property(image_path, property_item)
+
+        prepare_disk()
+        test_obj.backingchain_common_setup(create_snap=True,
+                                           snap_num=1, extra=snap_extra)
+        check_property(test_obj.snap_path_list[0], property_item)
+
+    def run_test():
+        """
+        Do blockcopy.
+        """
+        test.log.info("TEST_STEP1:Do blockcopy.")
+        virsh.blockcopy(vm_name, target_disk, copy_image,
+                        options=blockcopy_option,
+                        ignore_status=False,
+                        debug=True)
+
+        test.log.info("TEST_STEP2:Check properties after blockcopy.")
+        check_property(copy_image, property_item)
+
+    def teardown_test():
+        """
+        Clean data.
+        """
+        test.log.info("TEST_TEARDOWN: Clean up env.")
+        test_obj.backingchain_common_teardown()
+        test_obj.clean_file(copy_image)
+        test_obj.clean_file(image_path)
+
+        bkxml.sync()
+
+    def check_property(path, property_item):
+        """
+        Check the property value
+
+        :param path: The image path.
+        :param property_item: The property you want to check.
+        """
+        if property_item == "extended_l2_and_cluster_size":
+            check_obj.check_image_info(path, 'extended l2',
+                                       expected_extended_l2)
+
+            cluster_size_value = int(re.findall(r"\d+", cluster_size)[0])*1024*1024
+            check_obj.check_image_info(path, 'csize',
+                                       cluster_size_value)
+
+    def prepare_disk():
+        """
+        Prepare encryption or normal disk.
+        """
+        if encryption_disk:
+            test_obj.prepare_secret_disk(image_path, secret_disk_dict)
+        else:
+            test_obj.new_image_path = disk_obj.add_vm_disk(
+                disk_type, disk_dict, new_image_path=image_path)
+
+    # Process cartesian parameters
+    vm_name = params.get("main_vm")
+    target_disk = params.get('target_disk')
+    disk_type = params.get('disk_type')
+    disk_dict = eval(params.get('disk_dict', '{}'))
+    blockcopy_option = params.get('blockcopy_option')
+    secret_disk_dict = eval(params.get("secret_disk_dict", '{}'))
+    snap_extra = params.get('snap_extra')
+    image_extras = params.get('image_extras')
+    image_format = params.get('image_format')
+    image_path = params.get('image_path')
+    image_size = params.get('image_size')
+    copy_image = params.get('copy_image')
+    property_item = params.get('property')
+    cluster_size = params.get('cluster_size')
+    expected_extended_l2 = params.get('expected_extended_l2')
+    encryption_disk = params.get('enable_encrypt_disk', 'no') == "yes"
+
+    vm = env.get_vm(vm_name)
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+
+    # Create object
+    test_obj = blockcommand_base.BlockCommand(test, vm, params)
+    check_obj = check_functions.Checkfunction(test, vm, params)
+    disk_obj = disk_base.DiskBase(test, vm, params)
+
+    try:
+        setup_test()
+        run_test()
+
+    finally:
+        teardown_test()

--- a/provider/backingchain/blockcommand_base.py
+++ b/provider/backingchain/blockcommand_base.py
@@ -256,6 +256,8 @@ class BlockCommand(object):
         vmxml.devices = vmxml.devices.append(new_disk)
         vmxml.xmltreefile.write()
         vmxml.sync()
+        vmxml = vm_xml.VMXML.new_from_dumpxml(self.vm.name)
+        self.test.log.debug("Current vm xml is :%s", vmxml)
 
     @staticmethod
     def clean_file(file_path):


### PR DESCRIPTION
    VIRT-294532: Check qcow2 properties after blockcopy
Signed-off-by: nanli <nanli@redhat.com>

Test result:
```
/usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockcopy.image_properties
JOB LOG    : /var/lib/avocado/job-results/job-2022-11-21T21.04-9076fbe/job.log
 (1/2) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.image_properties.not_encrypt_disk.extended_l2_and_cluster_size: PASS (65.97 s)
 (2/2) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.image_properties.encrypt_disk.extended_l2_and_cluster_size: PASS (62.87 s)
```