### PR TITLE
Add new case of memory test

### DIFF
--- a/libvirt/tests/cfg/memory/memory_misc.cfg
+++ b/libvirt/tests/cfg/memory/memory_misc.cfg
@@ -57,6 +57,14 @@
                     mem_backing_attrs = {'hugepages': {}}
                     cpu_attrs = {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '19922944', 'unit': 'KiB', 'discard': 'yes'}]}
                     mem_device_attrs = {'source': {'pagesize_unit': 'KiB', 'pagesize': 2048, 'nodemask': '0'}, 'mem_model': 'dimm', 'target': {'size': 1048576, 'node': 0, 'size_unit': 'KiB'}}
+                - mount_hp_running_vm:
+                    pagesize = 2048
+                    hp_path = '/dev/hugepages1G'
+                    vm_attrs = {'vcpu': 4, 'max_mem_rt': 15242880, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB'}
+                    numa_node_size = 1048576
+                    cpu_attrs = {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '${numa_node_size}', 'unit': 'KiB'}, {'id': '1', 'cpus': '2-3', 'memory': '${numa_node_size}', 'unit': 'KiB'}]}
+                    mem_backing_attrs = {'hugepages': {'pages': [{'unit': 'KiB', 'size': '${pagesize}'}]}}
+                    mem_device_attrs = {'source': {'pagesize': 1048576, 'pagesize_unit': 'KiB'}, 'mem_model': 'dimm', 'target': {'size': 1048576, 'node': 0, 'size_unit': 'KiB'}}
         - edit_mem:
             variants case:
                 - forbid_0:


### PR DESCRIPTION
- VIRT-295935 - Mount 1G hugepage path for a running guest vm backed by 2M hugepage memory - bug2123196

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>

Test result:
```
<domain type='kvm' id='1'>
...
  <maxMemory slots='16' unit='KiB'>15243264</maxMemory>
  <memory unit='KiB'>3145728</memory>
  <currentMemory unit='KiB'>3145728</currentMemory>
  <memoryBacking>
    <hugepages>
      <page size='2048' unit='KiB'/>
    </hugepages>
  </memoryBacking>
  <vcpu placement='static'>4</vcpu>
...
  <cpu mode='custom' match='exact' check='full'>
    <model fallback='forbid'>Haswell-noTSX-IBRS</model>
    <vendor>Intel</vendor>
    <feature policy='require' name='vme'/>
...
    <numa>
      <cell id='0' cpus='0-1' memory='1048576' unit='KiB'/>
      <cell id='1' cpus='2-3' memory='1048576' unit='KiB'/>
    </numa>
  </cpu>

...

    <memory model='dimm'>
      <source>
        <nodemask>0-1</nodemask>
        <pagesize unit='KiB'>1048576</pagesize>
      </source>
      <target>
        <size unit='KiB'>1048576</size>
        <node>0</node>
      </target>
      <alias name='dimm0'/>
      <address type='dimm' slot='0' base='0x100000000'/>
    </memory>
  </devices>
...
</domain>


Attempting to log into 'avocado-vt-vm1' (timeout 240s)
avocado-vt-vm1 alive now. Used to failed to get register info from guest 1 times
Updated HWADDR (52:54:00:c3:78:12)<->(192.168.122.118) IP pair into address cache
Found/Verified IP 192.168.122.118 for VM avocado-vt-vm1 NIC 0
[stderr] DEBUG:aexpect.client:Sending command: swapoff -a

[stderr] DEBUG:aexpect.client:Sending command: echo $?

[stderr] DEBUG:aexpect.client:Sending command: grep MemFree /proc/meminfo

Free mem on vm: 2341748
[stderr] DEBUG:aexpect.client:Sending command: memhog 2186M

[stderr] DEBUG:aexpect.client:Sending command: echo $?

Destroying VM
Trying to shutdown VM with shell command
Shutdown command sent; waiting for VM to go down...
VM is down
Running 'systemctl restart virtqemud'
Command 'systemctl restart virtqemud' finished with 0 after 0.056063294s
Running virsh command: start avocado-vt-vm1 
Running '/usr/bin/virsh start avocado-vt-vm1 '
[stdout] Domain 'avocado-vt-vm1' started
[stdout] 
Command '/usr/bin/virsh start avocado-vt-vm1 ' finished with 0 after 1.371994181s
status: 0
stdout: Domain 'avocado-vt-vm1' started
stderr: 
Undefine VM avocado-vt-vm1
....
PASS 1-type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.hp_vm_restart

```