### PR TITLE
ras tests: remove deprecated allow_output_check switch

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_dump.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_dump.py
@@ -103,7 +103,7 @@ def run(test, params, env):
                 time.sleep(0.05)
                 continue
             cmd2 = "cat /proc/%s/fdinfo/1 |grep flags|awk '{print $NF}'" % output
-            ret = process.run(cmd2, allow_output_check='combined', shell=True)
+            ret = process.run(cmd2, shell=True)
             status, output = ret.exit_status, ret.stdout_text.strip()
             if status:
                 error = "Fail to get the flags of dumped file"
@@ -176,7 +176,7 @@ def run(test, params, env):
             return True
         else:
             file_cmd = "file %s" % dump_file
-            ret = process.run(file_cmd, allow_output_check='combined', shell=True)
+            ret = process.run(file_cmd, shell=True)
             status, output = ret.exit_status, ret.stdout_text.strip()
             if status:
                 logging.error("Fail to check dumped file %s", dump_file)


### PR DESCRIPTION
Newer version of avocado (>93) depreates use of allow_output_check with various process.<...> api's. Remove this switch to avoid test failures.

Signed-off-by: Kowshik Jois B S <kowsjois@linux.ibm.com>