### PR TITLE
memory_misc: disable test on s390x

### DIFF
--- a/libvirt/tests/cfg/memory/memory_misc.cfg
+++ b/libvirt/tests/cfg/memory/memory_misc.cfg
@@ -141,6 +141,7 @@
         - managedsave:
             variants case:
                 - size_check:
+                    no s390-virtio
                     vmxml_max_mem_rt_slots = 16
                     vmxml_max_mem_rt_unit = 'KiB'
                     vmxml_max_mem_rt = 55600128


### PR DESCRIPTION
memory_misc..size_check requires memory hotplug which is not available on s390x.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>