### PR TITLE
Fix test failure expectations when libvirtd is off

### DIFF
--- a/libvirt/tests/src/virsh_cmd/monitor/virsh_dominfo.py
+++ b/libvirt/tests/src/virsh_cmd/monitor/virsh_dominfo.py
@@ -1,8 +1,9 @@
 from virttest import ssh_key
 from virttest import virsh
 from virttest import utils_libvirtd
+import logging
 
-
+from provider import libvirt_version
 def run(test, params, env):
     """
     Test command: virsh dominfo.
@@ -64,7 +65,11 @@ def run(test, params, env):
     # check status_error
     if status_error == "yes":
         if status == 0 or err == "":
-            test.fail("Run successfully with wrong command!")
+            if libvirtd == "off" and libvirt_version.version_compare(5, 6, 0):
+                logging.info("From libvirt version 5.6.0 libvirtd is restarted "
+                             "and command should succeed")
+            else:
+                test.fail("Run successfully with wrong command!")
     elif status_error == "no":
         if status != 0 or output == "":
             test.fail("Run failed with right command")

--- a/temp_test
+++ b/temp_test
@@ -1,0 +1,5 @@
+Hi 
+hlkadfj
+kajfldjaf
+ka
+fdkdaks


### PR DESCRIPTION
libvirtd is restarted after issuing virsh commands from libvirt
version 5.6.0 on.