### PR TITLE
deprecate existed rbd image

### DIFF
--- a/libvirt/tests/src/backingchain/blockcommit/blockcommit_relative_path.py
+++ b/libvirt/tests/src/backingchain/blockcommit/blockcommit_relative_path.py
@@ -103,12 +103,7 @@ def run(test, params, env):
             process.run("rm -rf %s" % pool_target)
 
         if disk_type == 'rbd_with_auth':
-            libvirt_secret.clean_up_secrets()
-            process.run("rm -f %s" % params.get("configfile"))
-            process.run("rm -f %s" % params.get("keyfile"))
-            cmd = ("rbd -m {0} info {1} && rbd -m {0} rm {1}".format(
-                mon_host, rbd_source_name))
-            process.run(cmd, ignore_status=True, shell=True)
+            disk_obj.cleanup_disk_preparation(disk_type)
 
     def _get_disk_param():
         """

--- a/libvirt/tests/src/backingchain/blockpull/blockpull_relative_path.py
+++ b/libvirt/tests/src/backingchain/blockpull/blockpull_relative_path.py
@@ -81,12 +81,7 @@ def run(test, params, env):
             process.run("rm -rf %s" % pool_target)
 
         if disk_type == 'rbd_with_auth':
-            libvirt_secret.clean_up_secrets()
-            process.run("rm -f %s" % params.get("configfile"))
-            process.run("rm -f %s" % params.get("keyfile"))
-            cmd = ("rbd -m {0} info {1} && rbd -m {0} rm {1}".format(
-                mon_host, rbd_source_name))
-            process.run(cmd, ignore_status=True, shell=True)
+            disk_obj.cleanup_disk_preparation(disk_type)
 
     def get_relative_path():
         """


### PR DESCRIPTION
   create rbd image for backingchain case instead of using existed rbd image

Signed-off-by: nanli <nanli@redhat.com>

Test result:

relative path case
```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockcommit.relative_path  --vt-connect-uri qemu:///system
 (1/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.file_disk.keep_relative.active.vm_started: PASS (40.36 s)
 (2/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.file_disk.keep_relative.active.vm_paused: PASS (42.28 s)
 (3/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.file_disk.keep_relative.inactive.vm_started: PASS (41.35 s)
 (4/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.file_disk.keep_relative.inactive.vm_paused: PASS (40.81 s)
 (5/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.block_disk.keep_relative.active.vm_started: PASS (80.68 s)
 (6/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.block_disk.keep_relative.active.vm_paused: PASS (81.71 s)
 (7/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.rbd_with_auth_disk.keep_relative.active.vm_started: PASS (51.21 s)
 (8/8) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.rbd_with_auth_disk.keep_relative.active.vm_paused: PASS (42.25 s)

avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockpull.relative_path  --vt-connect-uri qemu:///system
 (1/3) type_specific.io-github-autotest-libvirt.backingchain.blockpull.relative_path.file_disk.keep_relative: PASS (39.73 s)
 (2/3) type_specific.io-github-autotest-libvirt.backingchain.blockpull.relative_path.block_disk.keep_relative: PASS (81.10 s)
 (3/3) type_specific.io-github-autotest-libvirt.backingchain.blockpull.relative_path.rbd_with_auth_disk.keep_relative: PASS (41.35 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0


```