### PR TITLE
sriov: Update to attach an interface after the vm is fully started

### DIFF
--- a/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_device_with_flags.py
+++ b/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_device_with_flags.py
@@ -73,9 +73,12 @@ def run(test, params, env):
         various flags(--live/config/persistent/current) for vm states(shutoff,
         running).
         """
-        if start_vm and not vm.is_alive():
-            vm.start()
-            vm_session = vm.wait_for_login()
+        if start_vm:
+            if not vm.is_alive():
+                vm.start()
+            vm.cleanup_serial_console()
+            vm.create_serial_console()
+            vm_session = vm.wait_for_serial_login(timeout=240)
 
         libvirt_vfio.check_vfio_pci(sriov_test_obj.vf_pci, True)
 
@@ -89,7 +92,7 @@ def run(test, params, env):
 
         test.log.info("TEST_STEP2: Check VM xml.")
         check_vm_xml(vm, device_type, params, True)
-        if 'vm_session' in locals():
+        if 'vm_session' in locals() and not flagstr.count('config'):
             check_points.check_vm_network_accessed(vm_session)
 
         test.log.info("TEST_STEP3: Detach the hostdev interface/device")

--- a/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_interface_with_flags.py
+++ b/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_interface_with_flags.py
@@ -51,8 +51,11 @@ def run(test, params, env):
         """
         Attach hostdev type interface to a guest and detach it.
         """
-        if start_vm and not vm.is_alive():
-            vm.start()
+        if start_vm:
+            if not vm.is_alive():
+                vm.start()
+            vm.cleanup_serial_console()
+            vm.create_serial_console()
             vm_session = vm.wait_for_serial_login(timeout=240)
 
         mac_addr = utils_net.generate_mac_address_simple()
@@ -73,7 +76,7 @@ def run(test, params, env):
         test.log.info("TEST_STEP3: Check VM xml after attaching a host device.")
         check_vm_xml(vm, params, iface_dict)
 
-        if 'vm_session' in locals():
+        if 'vm_session' in locals() and not flagstr.count('config'):
             check_points.check_vm_network_accessed(vm_session)
 
         test.log.info("TEST_STEP4: Detach the hostdev interface.")


### PR DESCRIPTION
Correct the previous condition for accessing the vm. And the serial session needs to be recreated in some cases, update the code accordingly.

Signed-off-by: Yingshun Cui <yicui@redhat.com>



**Test results:**
```
 (01/26) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_interface_with_flags.no_option.offline_domain: PASS (22.31 s)
 (02/26) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_interface_with_flags.no_option.running_domain: PASS (74.78 s)
 (03/26) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_interface_with_flags.live.offline_domain: PASS (22.21 s)
 (04/26) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_interface_with_flags.live.running_domain: PASS (56.14 s)
 (05/26) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_interface_with_flags.current.offline_domain: PASS (23.17 s)
 (06/26) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_interface_with_flags.current.running_domain: PASS (61.26 s)
 (07/26) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_interface_with_flags.config.offline_domain: PASS (23.01 s)
 (08/26) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_interface_with_flags.config.running_domain: PASS (53.36 s)
 (09/26) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_interface_with_flags.persistent.offline_domain: PASS (23.12 s)
 (10/26) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_interface_with_flags.persistent.running_domain: PASS (60.27 s)
 (11/26) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_with_flags.hostdev_interface.live.offline_domain: PASS (22.32 s)
 (12/26) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_with_flags.hostdev_interface.live.running_domain: PASS (61.17 s)
 (13/26) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_with_flags.hostdev_interface.current.offline_domain: PASS (23.53 s)
 (14/26) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_with_flags.hostdev_interface.current.running_domain: PASS (60.44 s)
 (15/26) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_with_flags.hostdev_interface.config.offline_domain: PASS (23.35 s)
 (16/26) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_with_flags.hostdev_interface.config.running_domain: PASS (54.64 s)
 (17/26) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_with_flags.hostdev_interface.persistent.offline_domain: PASS (23.36 s)
 (18/26) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_with_flags.hostdev_interface.persistent.running_domain: PASS (61.74 s)
 (19/26) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_with_flags.hostdev_device.live.offline_domain: PASS (22.35 s)
 (20/26) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_with_flags.hostdev_device.live.running_domain: PASS (60.27 s)
 (21/26) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_with_flags.hostdev_device.current.offline_domain: PASS (23.42 s)
 (22/26) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_with_flags.hostdev_device.current.running_domain: PASS (59.85 s)
 (23/26) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_with_flags.hostdev_device.config.offline_domain: PASS (23.34 s)
 (24/26) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_with_flags.hostdev_device.config.running_domain: PASS (54.32 s)
 (25/26) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_with_flags.hostdev_device.persistent.offline_domain: PASS (23.32 s)
 (26/26) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_with_flags.hostdev_device.persistent.running_domain: PASS (58.81 s)

```