### PR TITLE
virsh.detach_serial_device_alias: disable on s390

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_serial_device_alias.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_serial_device_alias.cfg
@@ -8,17 +8,19 @@
             serial_sources = path:/var/lib/libvirt/virt-test
             variants:
                 - isa-serial:
-                    no aarch64
+                    no aarch64, s390-virtio
                     target_type = isa-serial
                     hot_plugging_support = "no"
                 - pci-serial:
+                    no s390-virtio
                     target_type = pci-serial
         - serial_type_pty:
             serial_dev_type = pty
             variants:
                 - isa-serial:
-                    no aarch64
+                    no aarch64, s390-virtio
                     hot_plugging_support = "no"
                     target_type = isa-serial
                 - pci-serial:
+                    no s390-virtio
                     target_type = pci-serial


### PR DESCRIPTION
isa-serial and pci-serial are not available on s390x.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>