### PR TITLE
numa_memory: Check appropriate error messages for aarch64

### DIFF
--- a/libvirt/tests/cfg/numa/numa_memory.cfg
+++ b/libvirt/tests/cfg/numa/numa_memory.cfg
@@ -48,6 +48,8 @@
                  - out_range:
                      memory_nodeset = "200-300"
                      err_msg = "NUMA node.*unavailable"
+                     aarch64:
+                       err_msg = "Numerical result out of range"
                      variants:
                          - strict:
                              memory_mode = "strict"


### PR DESCRIPTION
For aarch64, if the nodeset is out of range, the error message is "Numerical result out of range" when starting the vm.

Before:
```
# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio numa_memory.negative_test.out_range.strict --vt-connect-uri qemu:///system                                                                                                        
JOB ID     : 100758afd818d602b89d8ad126f420d6b7644616                                                                                                                                                                                        
JOB LOG    : /var/lib/avocado/job-results/job-2022-12-02T04.21-100758a/job.log                                                                                                                                                               
 (1/1) type_specific.io-github-autotest-libvirt.numa_memory.negative_test.out_range.strict: FAIL: Expect should fail with one of ['NUMA node.*unavailable'], but failed with:\nerror: Failed to start domain 'avocado-vt-vm1'\nerror: Unable t
o write to '/sys/fs/cgroup/cpuset/machine.slice/machine-qemu\x2d1\x2davocado\x2dvt\x2dvm1.scope/libvirt/emulator/cpus... (5.97 s)                                                                                                            
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-12-02T04.21-100758a/results.html
JOB TIME   : 6.34 s
```

After:
```
# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio numa_memory.negative_test.out_range.strict --vt-connect-uri qemu:///system                                                                                                     
JOB ID     : 54c645bf28d7c62c1e41d007df5af9fddd2b9651
JOB LOG    : /var/lib/avocado/job-results/job-2022-12-02T04.44-54c645b/job.log
 (1/1) type_specific.io-github-autotest-libvirt.numa_memory.negative_test.out_range.strict: PASS (5.71 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-12-02T04.44-54c645b/results.html
JOB TIME   : 6.08 s
```

Signed-off-by: Hu Shuai <hus.fnst@fujitsu.com>