### PR TITLE
Fix test failure expectations when libvirtd is off

### DIFF
--- a/libvirt/tests/src/virsh_cmd/monitor/virsh_dominfo.py
+++ b/libvirt/tests/src/virsh_cmd/monitor/virsh_dominfo.py
@@ -1,3 +1,5 @@
+import logging
+from virttest import libvirt_version
 from virttest import ssh_key
 from virttest import virsh
 from virttest import utils_libvirtd
@@ -64,7 +66,11 @@ def run(test, params, env):
     # check status_error
     if status_error == "yes":
         if status == 0 or err == "":
-            test.fail("Run successfully with wrong command!")
+            if libvirtd == "off" and libvirt_version.version_compare(5, 6, 0):
+                logging.info("From libvirt version 5.6.0 libvirtd is restarted "
+                             "and command should succeed")
+            else:
+                test.fail("Run successfully with wrong command!")
     elif status_error == "no":
         if status != 0 or output == "":
             test.fail("Run failed with right command")


### PR DESCRIPTION
libvirtd is restarted after issuing virsh commands from libvirt version 5.6.0 on.

Signed-off-by: Anushree Mathur <anushree.mathur2@ibm.com>