### PR TITLE
incremental_backup: Fix backup job not canceled issue

### DIFF
--- a/libvirt/tests/cfg/incremental_backup/incremental_backup_push_mode.cfg
+++ b/libvirt/tests/cfg/incremental_backup/incremental_backup_push_mode.cfg
@@ -33,11 +33,13 @@
                         - destroy_vm:
                             only original_disk_local.coldplug_disk.backup_to_raw.backup_to_block
                             expect_backup_canceled = "yes"
-                            original_disk_size = "1000M"
+                            original_disk_size = "5000M"
+                            dd_count = "4000"
                         - kill_qemu:
                             only original_disk_local.hotplug_disk.backup_to_qcow2.backup_to_block
                             expect_backup_canceled = "yes"
-                            original_disk_size = "1000M"
+                            original_disk_size = "5000M"
+                            dd_count = "4000"
                 - positive_test:
     variants:
         - backup_to_qcow2:

--- a/libvirt/tests/src/incremental_backup/incremental_backup_push_mode.py
+++ b/libvirt/tests/src/incremental_backup/incremental_backup_push_mode.py
@@ -253,10 +253,7 @@ def run(test, params, env):
             backup_options = backup_xml.xml + " " + checkpoint_xml.xml
 
             # Create some data in vdb
-            dd_count = "1"
-            if expect_backup_canceled:
-                # Generate more data to extend the backup job duration
-                dd_count = "100"
+            dd_count = params.get("dd_count", "1")
             dd_seek = str(backup_index * 10 + 10)
             dd_bs = "1M"
             session = vm.wait_for_login()


### PR DESCRIPTION
Based on #3625, genereate 1000M data to slow down backup process.

Before:
```
# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio incremental_backup.push_mode.original_disk_local.coldplug_disk.backup_to_raw.backup_to_block.negative_test.
destroy_vm --vt-connect-uri qemu:///system 
JOB ID     : 7c24f41ead0d1ef8af78c55e43e4e31f61cfbedd                                                                                                                                                                                        
JOB LOG    : /var/lib/avocado/job-results/job-2022-12-05T04.29-7c24f41/job.log                                                                                                                                                               
 (1/1) type_specific.io-github-autotest-libvirt.incremental_backup.push_mode.original_disk_local.coldplug_disk.backup_to_raw.backup_to_block.negative_test.destroy_vm:  FAIL: Backup job should be canceled but not. (58.63 s)               
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-12-05T04.29-7c24f41/results.html
JOB TIME   : 59.00 s
```

After:
```
# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio incremental_backup.push_mode.original_disk_local.coldplug_disk.backup_to_raw.backup_to_block.negative_test.
destroy_vm --vt-connect-uri qemu:///system                                                                     
JOB ID     : 98858526f36f5ada5418ca065ec41c1d056dc9ab
JOB LOG    : /var/lib/avocado/job-results/job-2022-12-05T04.43-9885852/job.log
 (1/1) type_specific.io-github-autotest-libvirt.incremental_backup.push_mode.original_disk_local.coldplug_disk.backup_to_raw.backup_to_block.negative_test.destroy_vm: PASS (72.87 s)                                                        
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-12-05T04.43-9885852/results.html
JOB TIME   : 73.24 s
```

Signed-off-by: Hu Shuai <hus.fnst@fujitsu.com>