### PR TITLE
backingchain:add case for blockcopy wth different dest xml

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockcopy/blockcopy_with_different_dest_xml.cfg
+++ b/libvirt/tests/cfg/backingchain/blockcopy/blockcopy_with_different_dest_xml.cfg
@@ -1,0 +1,39 @@
+- backingchain.blockcopy.dest_xml:
+    type = blockcopy_with_different_dest_xml
+    basic_option = " --xml {} --transient-job --reuse-external --verbose --wait"
+    source_disk_type = "file"
+    target_disk = "vdb"
+    func_supported_since_libvirt_ver = (5, 1, 0)
+    source_disk_dict = {"type_name":"${source_disk_type}", "target":{"dev": "${target_disk}", "bus": "virtio"}, "driver": {"name": "qemu", "type":"qcow2"}}
+    image_size = "500M"
+    variants operation:
+        - finish_reuse_external:
+            operation = "finish"
+            blockcopy_option = " --finish ${basic_option}"
+        - pivot_reuse_external:
+            operation = "pivot"
+            blockcopy_option = " --pivot ${basic_option}"
+    variants:
+        - file_disk:
+            dest_disk_type = "file"
+            dest_disk_dict = {"type_name":"${dest_disk_type}", "target":{"dev": "${target_disk}", "bus": "virtio"}, "driver": {"name": "qemu", "type":"qcow2"}}
+        - block_disk:
+            dest_disk_type = "block"
+            dest_disk_dict = {"type_name":"${dest_disk_type}", "target":{"dev": "${target_disk}", "bus": "virtio"}, "driver": {"name": "qemu", "type":"raw"}}
+        - rbd_with_auth_disk:
+            dest_disk_type = "rbd_with_auth"
+            mon_host = "EXAMPLE_MON_HOST"
+            auth_key = "EXAMPLE_AUTH_KEY"
+            auth_user = "EXAMPLE_AUTH_USER"
+            image_path = "EXAMPLE_IMAGE_PATH"
+            client_name = "EXAMPLE_CLIENT_NAME"
+            rbd_image_size = "${image_size}"
+            sec_dict = {"secret_ephemeral": "no", "secret_private": "yes", "description": "sec_desc", "usage": "ceph", "usage_name": "cephlibvirt"}
+            dest_disk_dict = {"type_name":"network", "target":{"dev": "${target_disk}", "bus": "scsi"}, "driver": {"name": "qemu", "type":"raw"}}
+        - nbd_disk:
+            dest_disk_type = "nbd"
+            nbd_server_port = "10808"
+            enable_tls = "yes"
+            export_name = "nbd_disk_export_name"
+            device_format = "raw"
+            dest_disk_dict = {"type_name":"network", "device":"disk","target":{"dev": "${target_disk}", "bus": "scsi"}, "driver": {"name": "qemu", "type":"raw"}}

--- a/libvirt/tests/src/backingchain/blockcopy/blockcopy_with_different_dest_xml.py
+++ b/libvirt/tests/src/backingchain/blockcopy/blockcopy_with_different_dest_xml.py
@@ -1,0 +1,104 @@
+from virttest import data_dir
+from virttest import libvirt_version
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_test import libvirt
+
+from provider.backingchain import blockcommand_base
+from provider.backingchain import check_functions
+from provider.virtual_disk import disk_base
+
+
+def run(test, params, env):
+    """
+    Test blockcopy to target disk with different dest xml
+    1) Prepare an running guest and different dest xml.
+    2) Do blockcopy with xml
+    4) Check result
+    """
+
+    def setup_test():
+        """
+        Prepare disk and dest xml
+        """
+        test.log.info("TEST_SETUP: Prepare disk and dest xml.")
+        test_obj.new_image_path = disk_obj.add_vm_disk(
+            source_disk_type, source_disk_dict, size=image_size)
+        test_obj.backingchain_common_setup()
+
+        if dest_disk_type == "file":
+            dest_image = data_dir.get_data_dir() + "/images/dest.img"
+            libvirt.create_local_disk("file", path=dest_image,
+                                      size=image_size, disk_format="qcow2")
+        else:
+            dest_image = ''
+        global dest_obj, new_xml_path
+        dest_obj, new_xml_path = disk_obj.prepare_disk_obj(
+            dest_disk_type, dest_disk_dict, new_image_path=dest_image,
+            size=image_size)
+
+    def run_test():
+        """
+        Test blockcopy.
+        """
+        test.log.info("TEST_STEP1: Do blockcopy with dest xml.")
+        virsh.blockcopy(vm_name, target_disk,
+                        blockcopy_option.format(dest_obj.xml),
+                        ignore_status=False,
+                        debug=True)
+
+        test.log.info("TEST_STEP2: Check result and backingchain.")
+        if operation == "finish":
+            check_obj.check_backingchain_from_vmxml(dest_disk_type, target_disk,
+                                                    [test_obj.new_image_path])
+        elif operation == "pivot":
+            if dest_disk_type == "nbd":
+                expected_path = export_name
+            else:
+                expected_path = new_xml_path
+
+            check_obj.check_backingchain_from_vmxml(dest_disk_type, target_disk,
+                                                    [expected_path])
+
+    def teardown_test():
+        """
+        Clean env
+        """
+        test.log.info("TEST_TEARDOWN: Clean up env.")
+        test_obj.backingchain_common_teardown()
+        bkxml.sync()
+
+        disk_obj.cleanup_disk_preparation(dest_disk_type)
+        disk_obj.cleanup_disk_preparation(source_disk_type)
+
+    libvirt_version.is_libvirt_feature_supported(params)
+
+    # Process cartesian parameters
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    target_disk = params.get('target_disk')
+    operation = params.get('operation')
+    image_size = params.get('image_size')
+    export_name = params.get('export_name', '')
+    dest_disk_type = params.get('dest_disk_type')
+    source_disk_type = params.get('source_disk_type')
+    source_disk_dict = eval(params.get('source_disk_dict', '{}'))
+    dest_disk_dict = eval(params.get('dest_disk_dict', '{}'))
+    blockcopy_option = params.get('blockcopy_option')
+
+    # Create object
+    test_obj = blockcommand_base.BlockCommand(test, vm, params)
+    disk_obj = disk_base.DiskBase(test, vm, params)
+    check_obj = check_functions.Checkfunction(test, vm, params)
+
+    # Get vm xml
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+
+    try:
+        setup_test()
+        run_test()
+
+    finally:
+        teardown_test()


### PR DESCRIPTION
   VIRT-294410: Do blockcopy with different dest XML
Signed-off-by: nanli <nanli@redhat.com>

```

 /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockcopy.dest_xml
 (1/8) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.dest_xml.file_disk.finish_reuse_external: PASS (45.10 s)
 (2/8) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.dest_xml.file_disk.pivot_reuse_external: PASS (46.90 s)
 (3/8) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.dest_xml.block_disk.finish_reuse_external: PASS (63.41 s)
 (4/8) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.dest_xml.block_disk.pivot_reuse_external: -ujPASS (64.71 s)
 (5/8) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.dest_xml.rbd_with_auth_disk.finish_reuse_external: PASS (48.02 s)
 (6/8) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.dest_xml.rbd_with_auth_disk.pivot_reuse_external: PASS (46.32 s)
 (7/8) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.dest_xml.nbd_disk.finish_reuse_external: PASS (49.41 s)
 (8/8) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.dest_xml.nbd_disk.pivot_reuse_external: PASS (49.33 s)

```