### PR TITLE
Fix qemu command line output failure on s390x

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
@@ -1855,7 +1855,7 @@ def run(test, params, env):
                                                        "address", "devno").replace("0x", "")
                 dev_id_prefix = "fe.0."
 
-                cmd += (" | grep virtio-blk-ccw,devno=%s%s"
+                cmd += (" | grep virtio-blk-ccw.*devno.*%s%s"
                         % (dev_id_prefix, dev_devno))
 
             else:


### PR DESCRIPTION
Fix qemu command line output failure on s390x
qemu command is json format output, so need update it on s390x as well

Signed-off-by: chunfuwen <chwen@redhat.com>