### PR TITLE
migration: Fix some issues

### DIFF
--- a/libvirt/tests/cfg/migration/guest_lifecycle_operations_during_migration/migration_poweroff_vm.cfg
+++ b/libvirt/tests/cfg/migration/guest_lifecycle_operations_during_migration/migration_poweroff_vm.cfg
@@ -25,7 +25,7 @@
     migrate_desturi_port = "16509"
     migrate_desturi_type = "tcp"
     virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
-    action_during_mig = '[{"func": "poweroff_src_vm", "after_event": "iteration: '1'", "func_param": "params"}]'
+    action_during_mig = '[{"func": "poweroff_vm", "after_event": "iteration: '1'", "func_param": "params"}]'
     err_msg = "error: operation failed: domain is not running"
     virsh_migrate_extra = "--bandwidth 10"
     test_case = "poweroff_vm"

--- a/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/no_paused_during_recover_migration.cfg
+++ b/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/no_paused_during_recover_migration.cfg
@@ -25,6 +25,7 @@
     migrate_desturi_port = "16509"
     migrate_desturi_type = "tcp"
     virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
+    func_supported_since_libvirt_ver = (8, 5, 0)
     variants:
         - p2p:
             virsh_migrate_options = '--live --p2p --verbose'

--- a/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_and_disruptive_and_recover.cfg
+++ b/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_and_disruptive_and_recover.cfg
@@ -31,6 +31,7 @@
     postcopy_options = "--timeout 4 --timeout-postcopy --postcopy"
     do_migration_during_mig = "yes"
     postcopy_options_during_mig = "--postcopy-resume"
+    func_supported_since_libvirt_ver = (8, 5, 0)
 
     variants:
         - p2p:

--- a/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_and_recover_and_disruptive.cfg
+++ b/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_and_recover_and_disruptive.cfg
@@ -30,6 +30,7 @@
     do_migration_during_mig = "yes"
     postcopy_options_during_mig = "--postcopy-resume"
     action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "virsh.domjobabort", "func_param": "'%s --postcopy' % params.get('migrate_main_vm')", "need_sleep_time": "5"}, {"func": "do_migration", "func_param": "params", "need_sleep_time": "5"}]'
+    func_supported_since_libvirt_ver = (8, 5, 0)
 
     variants:
         - p2p:
@@ -82,5 +83,5 @@
             tcp_config_list = '{"tcp_keepalive_probes": "9", "tcp_keepalive_intvl": "60", "tcp_retries1": "4", "tcp_retries2": "8", "tcp_fin_timeout": "2"}'
             recover_tcp_config_list = '{"tcp_keepalive_probes": "9", "tcp_keepalive_intvl": "75", "tcp_retries1": "3", "tcp_retries2": "15", "tcp_fin_timeout": "60"}'
         - pause_by_proxy_issue:
-            action_during_do_mig = '[{"func": "clear_pmsocat", "func_param": "params", "need_sleep_time": "5"}, {"func": "base_steps.recreate_conn_objs", "func_param": "params"}, "need_sleep_time": "10"]'
+            action_during_do_mig = '[{"func": "clear_pmsocat", "func_param": "params", "need_sleep_time": "5"}, {"func": "base_steps.recreate_conn_objs", "func_param": "params", "need_sleep_time": "10"}]'
             status_error_during_mig = "no"

--- a/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_and_recover_twice.cfg
+++ b/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_and_recover_twice.cfg
@@ -33,6 +33,7 @@
     test_case = "pause_and_recover_twice"
     status_error_during_mig = "yes"
     status_error_during_mig_twice = "no"
+    func_supported_since_libvirt_ver = (8, 5, 0)
 
     variants:
         - p2p:

--- a/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_by_domjobabort_and_recover.cfg
+++ b/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_by_domjobabort_and_recover.cfg
@@ -43,6 +43,7 @@
     dominfo_check = "Persistent:     no"
     expected_event_src = ["event 'lifecycle' for domain.*: Suspended Post-copy Error", "event 'lifecycle' for domain .*: Suspended Post-copy", "event 'lifecycle' for domain .*: Stopped Migrated", "event 'job-completed' for domain"]
     expected_event_target = ["event 'lifecycle' for domain.*: Resumed Post-copy Error", "event 'lifecycle' for domain.*: Resumed Post-copy", "event 'lifecycle' for domain.*: Resumed Migrated"]
+    func_supported_since_libvirt_ver = (8, 5, 0)
 
     variants:
         - p2p:

--- a/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_by_network_and_recover.cfg
+++ b/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_by_network_and_recover.cfg
@@ -45,6 +45,7 @@
     virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
     tcp_config_list = '{"tcp_keepalive_probes": "9", "tcp_keepalive_intvl": "60", "tcp_retries1": "4", "tcp_retries2": "8", "tcp_fin_timeout": "2"}'
     recover_tcp_config_list = '{"tcp_keepalive_probes": "9", "tcp_keepalive_intvl": "75", "tcp_retries1": "3", "tcp_retries2": "15", "tcp_fin_timeout": "60"}'
+    func_supported_since_libvirt_ver = (8, 5, 0)
 
     variants:
         - p2p:

--- a/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_by_proxy_and_recover.cfg
+++ b/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_by_proxy_and_recover.cfg
@@ -40,6 +40,7 @@
     dominfo_check = "Persistent:     no"
     expected_event_src = ["event 'lifecycle' for domain.*: Suspended Post-copy Error", "event 'lifecycle' for domain .*: Suspended Post-copy", "event 'lifecycle' for domain .*: Stopped Migrated", "event 'job-completed' for domain"]
     expected_event_target = ["event 'lifecycle' for domain.*: Resumed Post-copy Error", "event 'lifecycle' for domain.*: Resumed Post-copy", "event 'lifecycle' for domain.*: Resumed Migrated"]
+    func_supported_since_libvirt_ver = (8, 5, 0)
 
     variants:
         - p2p:

--- a/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/unattended_migration.cfg
+++ b/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/unattended_migration.cfg
@@ -33,6 +33,7 @@
     expected_src_state = "paused"
     dominfo_check = "Persistent:     no"
     status_error = "yes"
+    func_supported_since_libvirt_ver = (8, 5, 0)
 
     variants:
         - p2p:

--- a/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/unattended_migration_and_disruptive.cfg
+++ b/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/unattended_migration_and_disruptive.cfg
@@ -31,6 +31,7 @@
     service_name = "virtproxyd"
     service_on_dst = "yes"
     action_during_do_mig = '[{"func": "set_migrate_speed_to_high", "before_pause": "yes", "func_param": "params"}]'
+    func_supported_since_libvirt_ver = (8, 5, 0)
 
     variants:
         - p2p:

--- a/libvirt/tests/src/migration/destructive_operations_around_live_migration/migration_kill_libvirt_daemon.py
+++ b/libvirt/tests/src/migration/destructive_operations_around_live_migration/migration_kill_libvirt_daemon.py
@@ -1,6 +1,7 @@
 import json
 
 from virttest import libvirt_version
+from virttest import utils_split_daemons
 from virttest import virsh
 
 from virttest.utils_libvirt import libvirt_memory
@@ -82,6 +83,11 @@ def run(test, params, env):
     test_case = params.get('test_case', '')
     vm_name = params.get("migrate_main_vm")
     migrate_again = "yes" == params.get("migrate_again", "no")
+    service_name = params.get("service_name")
+
+    if service_name and service_name == "virtproxyd":
+        if not utils_split_daemons.is_modular_daemon():
+            test.cancel("This libvirt version doesn't support virtproxyd.")
 
     old_hard_limit = []
 

--- a/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/no_paused_during_recover_migration.py
+++ b/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/no_paused_during_recover_migration.py
@@ -1,3 +1,5 @@
+from virttest import libvirt_version
+
 from provider.migration import base_steps
 
 
@@ -9,6 +11,8 @@ def run(test, params, env):
     :param params: Dictionary with the test parameters
     :param env: Dictionary with test environment.
     """
+    libvirt_version.is_libvirt_feature_supported(params)
+
     vm_name = params.get("migrate_main_vm")
     migrate_again = "yes" == params.get("migrate_again", "no")
 

--- a/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/pause_and_disruptive_and_recover.py
+++ b/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/pause_and_disruptive_and_recover.py
@@ -1,3 +1,4 @@
+from virttest import libvirt_version
 from virttest import virsh
 
 from virttest.utils_test import libvirt
@@ -22,6 +23,8 @@ def run(test, params, env):
             virsh.destroy(vm_name, ignore_status=True, debug=True)
             virsh.start(vm_name, ignore_status=True, debug=True)
         migration_obj.cleanup_connection()
+
+    libvirt_version.is_libvirt_feature_supported(params)
 
     disruptive_operations = params.get("disruptive_operations")
     vm_name = params.get("migrate_main_vm")

--- a/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/pause_and_recover_and_disruptive.py
+++ b/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/pause_and_recover_and_disruptive.py
@@ -1,3 +1,5 @@
+from virttest import libvirt_version
+
 from virttest.utils_libvirt import libvirt_network
 
 from provider.migration import base_steps
@@ -31,6 +33,8 @@ def run(test, params, env):
         recover_tcp_config_list = eval(params.get("recover_tcp_config_list"))
         libvirt_network.change_tcp_config(recover_tcp_config_list)
         migration_obj.cleanup_connection()
+
+    libvirt_version.is_libvirt_feature_supported(params)
 
     vm_name = params.get("migrate_main_vm")
     disruptive_operations = params.get("disruptive_operations")

--- a/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/pause_and_recover_twice.py
+++ b/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/pause_and_recover_twice.py
@@ -1,3 +1,5 @@
+from virttest import libvirt_version
+
 from virttest.utils_libvirt import libvirt_network
 
 from provider.migration import base_steps
@@ -31,6 +33,8 @@ def run(test, params, env):
         recover_tcp_config_list = eval(params.get("recover_tcp_config_list"))
         libvirt_network.change_tcp_config(recover_tcp_config_list)
         migration_obj.cleanup_connection()
+
+    libvirt_version.is_libvirt_feature_supported(params)
 
     recover_failed_reason = params.get('recover_failed_reason', '')
     vm_name = params.get("migrate_main_vm")

--- a/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/pause_by_domjobabort_and_recover.py
+++ b/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/pause_by_domjobabort_and_recover.py
@@ -1,3 +1,4 @@
+from virttest import libvirt_version
 from virttest import virsh
 
 from virttest.libvirt_xml import vm_xml
@@ -96,6 +97,8 @@ def run(test, params, env):
 
         # Check event output
         migration_base.check_event_output(params, test, virsh_session, remote_virsh_session)
+
+    libvirt_version.is_libvirt_feature_supported(params)
 
     migration_options = params.get('migration_options', '')
     vm_name = params.get("migrate_main_vm")

--- a/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/pause_by_network_and_recover.py
+++ b/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/pause_by_network_and_recover.py
@@ -1,3 +1,4 @@
+from virttest import libvirt_version
 from virttest import virsh
 
 from virttest.utils_libvirt import libvirt_network
@@ -37,6 +38,8 @@ def run(test, params, env):
 
         # Check event output
         migration_base.check_event_output(params, test, virsh_session, remote_virsh_session)
+
+    libvirt_version.is_libvirt_feature_supported(params)
 
     vm_name = params.get("migrate_main_vm")
     migrate_again = "yes" == params.get("migrate_again", "no")

--- a/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/pause_by_proxy_and_recover.py
+++ b/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/pause_by_proxy_and_recover.py
@@ -1,3 +1,4 @@
+from virttest import libvirt_version
 from virttest import virsh
 
 from virttest.utils_test import libvirt
@@ -35,6 +36,8 @@ def run(test, params, env):
 
         # Check event output
         migration_base.check_event_output(params, test, virsh_session, remote_virsh_session)
+
+    libvirt_version.is_libvirt_feature_supported(params)
 
     vm_name = params.get("migrate_main_vm")
     migrate_again = "yes" == params.get("migrate_again", "no")

--- a/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/unattended_migration.py
+++ b/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/unattended_migration.py
@@ -1,3 +1,4 @@
+from virttest import libvirt_version
 from virttest import virsh
 
 from virttest.utils_libvirt import libvirt_network
@@ -77,6 +78,8 @@ def run(test, params, env):
         recover_tcp_config_list = eval(params.get("recover_tcp_config_list"))
         libvirt_network.change_tcp_config(recover_tcp_config_list)
         migration_obj.cleanup_connection()
+
+    libvirt_version.is_libvirt_feature_supported(params)
 
     vm_name = params.get("migrate_main_vm")
     make_unattended = params.get("make_unattended")

--- a/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/unattended_migration_and_disruptive.py
+++ b/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/unattended_migration_and_disruptive.py
@@ -1,3 +1,5 @@
+from virttest import libvirt_version
+
 from virttest.utils_libvirt import libvirt_network
 
 from provider.migration import base_steps
@@ -32,6 +34,8 @@ def run(test, params, env):
         recover_tcp_config_list = eval(params.get("recover_tcp_config_list"))
         libvirt_network.change_tcp_config(recover_tcp_config_list)
         migration_obj.cleanup_connection()
+
+    libvirt_version.is_libvirt_feature_supported(params)
 
     vm_name = params.get("migrate_main_vm")
     disruptive_operations = params.get("disruptive_operations")

--- a/provider/migration/migration_base.py
+++ b/provider/migration/migration_base.py
@@ -20,6 +20,7 @@ from virttest.utils_libvirt import libvirt_service   # pylint: disable=W0611
 from virttest.utils_test import libvirt_domjobinfo   # pylint: disable=W0611
 from virttest.utils_test import libvirt
 
+from provider.migration import base_steps            # pylint: disable=W0611
 
 # Using as lower capital is not the best way to do, but this is just a
 # workaround to avoid changing the entire file.
@@ -298,7 +299,10 @@ def execute_statistics_command(params):
     logging.debug("disks: %s", disks)
     debug_kargs = {'ignore_status': False, 'debug': True}
     for disk in list(disks.values()):
-        disk_source = disk.find('source').get('file')
+        if disk_type:
+            disk_source = disk.find('source').get('dev')
+        else:
+            disk_source = disk.find('source').get('file')
         disk_target = disk.find('target').get('dev')
         logging.debug("disk_source: %s", disk_source)
         logging.debug("disk_target: %s", disk_target)


### PR DESCRIPTION
1. libvirt support post-copy migration recovery since 8.5.0. So
add libvirt_version.is_libvirt_feature_supported() in some cases.
2. Fix NameError in migration_base.py.
    Error message: NameError: name 'base_steps' is not defined
3. Fix SyntaxError in pause_and_recover_and_disruptive.cfg.
    Error message: SyntaxError: invalid syntax 
4. Fix wrong function name in action_during_mig.

Signed-off-by: cliping <lcheng@redhat.com>