### PR TITLE
fix remove existed copy image issue

### DIFF
--- a/libvirt/tests/src/backingchain/blockcopy/blockcopy_with_conventional_chain.py
+++ b/libvirt/tests/src/backingchain/blockcopy/blockcopy_with_conventional_chain.py
@@ -34,6 +34,7 @@ def run(test, params, env):
 
         test_obj.prepare_snapshot(snap_num=snap_num,
                                   extra=snap_extra)
+        test_obj.clean_file(tmp_copy_path)
 
     def run_test():
         """


### PR DESCRIPTION
  clean existed image before blockcopy

Signed-off-by: nanli <nanli@redhat.com>
```

/usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockcopy.conventional_chain.block_disk
 (1/2) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.conventional_chain.block_disk.with_shallow: PASS (71.45 s)
 (2/2) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.conventional_chain.block_disk.without_shallow: PASS (72.51 s)

```