### PR TITLE
Fix failures to get expected messages in filesystem on s390x

### DIFF
--- a/libvirt/tests/src/conf_file/sysconfig_libvirt_guests/libvirt_guests.py
+++ b/libvirt/tests/src/conf_file/sysconfig_libvirt_guests/libvirt_guests.py
@@ -320,7 +320,7 @@ def run(test, params, env):
         # host shutdown. The purpose can also be fulfilled by restart the
         # libvirt-guests service.
         libvirt_guests_service.restart()
-        time.sleep(10)
+        time.sleep(30)
         output = tail_messages.get_output()
         logging.debug("Get messages in /var/log/messages: %s" % output)
 


### PR DESCRIPTION
Fix failures to get expected messages in filesystem

Extend sleep more time to allow get more messages from /var/log/messages

Signed-off-by: chunfuwen <chwen@redhat.com>