### PR TITLE
Fix the mcast test case

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_options.py
+++ b/libvirt/tests/src/virtual_network/iface_options.py
@@ -445,7 +445,11 @@ def run(test, params, env):
         if not utils_package.package_install(["omping"]):
             test.error("Failed to install omping"
                        " on host")
-        cmd = ("iptables -F;omping -m %s %s" %
+        # open udp port 4321 on host for omping multicast on host
+        # if firewalld is inactive, it will return with "FirewallD is not running"
+        # if firewalld is active, it will open udp port 4321
+        cmd = ("iptables -F; firewall-cmd --add-port=4321/udp;"
+               "omping -m %s %s" %
                (src_addr, "192.168.122.1 %s" %
                 ' '.join(list(vms_ip_dict.values()))))
         # Run a backgroup job waiting for connection of client
@@ -457,7 +461,8 @@ def run(test, params, env):
             if not utils_package.package_install(["omping"], vms_sess_dict[vms]):
                 test.error("Failed to install omping"
                            " on guest")
-            cmd = ("iptables -F; omping -c 5 -T 5 -m %s %s" %
+            cmd = ("iptables -F; firewall-cmd --add-port=4321/udp; "
+                   "omping -c 5 -T 5 -m %s %s" %
                    (src_addr, "192.168.122.1 %s" %
                     vms_ip_dict[vms]))
             ret, output = vms_sess_dict[vms].cmd_status_output(cmd)


### PR DESCRIPTION
To receive multicast packet, the guest and host must have the udp port 4321 open if firewalld is active. Otherwise, the multicast packet will be blocked.

Signed-off-by: yalzhang