### PR TITLE
virsh_cpu_xml: Change cpu xml back to original file for negative test

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_cpu_xml.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_cpu_xml.cfg
@@ -56,7 +56,7 @@
                 - xml_declaration:
                     no cpu_baseline
                     file_xml_declaration = "<?xml version='1.0' encoding='UTF-8'?>"
-                    file_path = '../../../deps/domcapabilities.xml'
+                    file_path = '../../../deps/capabilities.xml'
                     s390-virtio:
                         file_path = '../../../deps/negative_domcapabilities_s390x.xml'
             variants:


### PR DESCRIPTION
Change the cpu definition xml back to original file to get the expected error message for the negative test.

Signed-off-by: Hu Shuai <hus.fnst@fujitsu.com>