### PR TITLE
Revert "numa_memory: Check appropriate error messages for aarch64"

### DIFF
--- a/libvirt/tests/cfg/numa/numa_memory.cfg
+++ b/libvirt/tests/cfg/numa/numa_memory.cfg
@@ -48,8 +48,6 @@
                  - out_range:
                      memory_nodeset = "200-300"
                      err_msg = "NUMA node.*unavailable"
-                     aarch64:
-                       err_msg = "Numerical result out of range"
                      variants:
                          - strict:
                              memory_mode = "strict"


### PR DESCRIPTION
If the numa node setting is out of range, for aarch64, the error message should also be "NUMA node.*unavailable" which should be rasied in the configuration check.

When memory_mode is "strict" and memory_nodeset is out of range, the guest does not fail to start until it writes to cpuset.mems with the error message "Numerical result out of range", which should be a bug.