### PR TITLE
backingchain: Update the disk attribute according to the modification of avocado-vt

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockcopy/blockcopy_with_disk_driver_attributes.cfg
+++ b/libvirt/tests/cfg/backingchain/blockcopy/blockcopy_with_disk_driver_attributes.cfg
@@ -7,5 +7,5 @@
                 image_path = "/tmp/backingchain_copy.img"
                 unit = "bytes"
                 max_size = 1024
-                disk_dict = {"type_name":"file", "target":{"dev": "${target_disk}", "bus": "virtio"}, "drivermetadata":{"metadata_cache":{'max_size':'${max_size}', 'max_size_unit':'${unit}'}},"driver": {"name": "qemu", "type":"qcow2"}, 'source': {'attrs': {'file': '${image_path}','index':'3'}}}
+                disk_dict = {"type_name":"file", "target":{"dev": "${target_disk}", "bus": "virtio"}, "driver_metadatacache":{"max_size":${max_size}, "max_size_unit":"${unit}"}, "driver": {"name": "qemu", "type":"qcow2"}, 'source': {'attrs': {'file': '${image_path}','index':'3'}}}
                 blockcopy_option = " --xml {} --transient-job --wait --verbose --pivot"


### PR DESCRIPTION
"drivermetadata" has been changed to "driver_metadatacache" since [#avocado-framework/avocado-vt-3573](https://github.com/avocado-framework/avocado-vt/pull/3573/commits/156ba0e2f506ff01282c39d67c753ef83c9e141a)

Before:
```
# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio backingchain.blockcopy.disk.driver_attr.metadata_cache --vt-connect-uri qemu:///sy
stem                                                              
JOB ID     : 66b5fb14ffd695765627d446e384bfd1114df5df
JOB LOG    : /var/lib/avocado/job-results/job-2022-12-28T02.29-66b5fb1/job.log
 (1/1) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.disk.driver_attr.metadata_cache: ERROR: Cannot set attribute "drivermetadata" to <class 'virttest.libvirt_xml.devices.disk.Disk'> object.There is no such attribute. (5
.42 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-12-28T02.29-66b5fb1/results.html
JOB TIME   : 5.80 s
```

After:
```
# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio backingchain.blockcopy.disk.driver_attr.metadata_cache --vt-connect-uri qemu:///sy
stem                                                                     
JOB ID     : 3991019a8372df9f01f16ee497bb1193456521f1
JOB LOG    : /var/lib/avocado/job-results/job-2022-12-28T02.30-3991019/job.log
 (1/1) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.disk.driver_attr.metadata_cache: PASS (27.70 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2022-12-28T02.30-3991019/results.html
JOB TIME   : 28.07 s
```

Signed-off-by: Hu Shuai <hus.fnst@fujitsu.com>