### PR TITLE
guest_numa.cfg: fix boot failed issue with hugepages2M

### DIFF
--- a/libvirt/tests/cfg/numa/guest_numa.cfg
+++ b/libvirt/tests/cfg/numa/guest_numa.cfg
@@ -65,6 +65,8 @@
                      qemu_cmdline_numa_cell_1 = "node,nodeid=1,cpus=2-3,memdev=ram-node1"
                      variants:
                          - per_node:
+                             cell_memory_0 = "1048576"
+                             cell_memory_1 = "1048576"
                              variants:
                                  - 2M:
                                      hugepage_size_0 = "2048"
@@ -74,8 +76,6 @@
                                         page_nodenum_0 = "0"
                                  - 1G:
                                      max_mem = "2097152"
-                                     cell_memory_0 = "1048576"
-                                     cell_memory_1 = "1048576"
                                      vmpage_size_0 = "1048576"
                                      hugepage_size_0 = "1048576"
                                      page_num_0 = "1"
@@ -84,8 +84,6 @@
                                         page_nodenum_0 = "0"
                                  - 16M:
                                      max_mem = "2097152"
-                                     cell_memory_0 = "1048576"
-                                     cell_memory_1 = "1048576"
                                      vmpage_size_0 = "16384"
                                      hugepage_size_0 = "16384"
                                      page_num_0 = "65"


### PR DESCRIPTION
In ovmf guest, the memory is recommended to use 2G but not 1G.  Otherwise the guest can't boot. So here also update the hugepages2M test to 2G.

Signed-off-by: Meina Li <meili@redhat.com>