### PR TITLE
numa: increase the page_num_0 value for hugepages2M to fix failure

### DIFF
--- a/libvirt/tests/cfg/numa/guest_numa.cfg
+++ b/libvirt/tests/cfg/numa/guest_numa.cfg
@@ -70,7 +70,7 @@
                              variants:
                                  - 2M:
                                      hugepage_size_0 = "2048"
-                                     page_num_0 = "256"
+                                     page_num_0 = "512"
                                      page_nodenum_0 = "1"
                                      pseries:
                                         page_nodenum_0 = "0"


### PR DESCRIPTION
numa: increase the page_num_0 value for hugepages2M to fix failure
Otherwise the guest can't start because of the insufficient memory.

Signed-off-by: Meina Li <meili@redhat.com>