### PR TITLE
iface_options:Fix error of cannot find vhost options

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_options.py
+++ b/libvirt/tests/src/virtual_network/iface_options.py
@@ -287,7 +287,8 @@ def run(test, params, env):
         ret = process.run(cmd, shell=True)
         logging.debug("Command line %s", ret.stdout_text)
         if test_vhost_net:
-            if not ret.stdout_text.count("vhost=on") and not rm_vhost_driver:
+            if not re.search('"vhost":true|vhost=on', ret.stdout_text) \
+                    and not rm_vhost_driver:
                 test.fail("Can't see vhost options in"
                           " qemu-kvm command line")
 


### PR DESCRIPTION
The output of qemu command has been upgraded to json format, therefore the searching target should be updated as well.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>