### PR TITLE
add case for detach input device with alias

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
@@ -62,6 +62,21 @@
             detach_rng_type = "rng"
             rng_dict = {"rng_model": "virtio","backend":{"backend_model":"random", "backend_dev":"/dev/urandom"}}
             detach_check_xml = "<rng"
+        - input:
+            only live,config
+            variants:
+                - keyboard:
+                    detach_input_type = "keyboard"
+                    detach_check_xml = "<input type='${detach_input_type}' bus='usb'>"
+                    input_dict = {"type_name":"${detach_input_type}","input_bus": "usb"}
+                - mouse:
+                    detach_input_type = "mouse"
+                    detach_check_xml = "<input type='${detach_input_type}' bus='virtio'>"
+                    input_dict = {"type_name":"${detach_input_type}","input_bus": "virtio"}
+                - passthrough:
+                    detach_input_type = "passthrough"
+                    detach_check_xml = "<input type='${detach_input_type}' bus='virtio'>"
+                    input_dict = {"type_name":"${detach_input_type}","input_bus": "virtio", "source_evdev":"/dev/input/event3"}
     variants:
         - live:
             detach_alias_options = "--live"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
@@ -60,6 +60,9 @@ def run(test, params, env):
     # rng params
     rng_type = params.get("detach_rng_type")
     rng_dict = eval(params.get('rng_dict', '{}'))
+    # input params
+    input_type = params.get("detach_input_type")
+    input_dict = eval(params.get('input_dict', '{}'))
 
     device_alias = "ua-" + str(uuid.uuid4())
 
@@ -209,6 +212,17 @@ def run(test, params, env):
         rng_dict.update({"alias": {"name": device_alias}})
         libvirt_vmxml.modify_vm_device(vmxml=vmxml,
                                        dev_type='rng', dev_dict=rng_dict)
+
+        if not vm.is_alive():
+            vm.start()
+        vm.wait_for_login(timeout=240).close()
+
+        attach_device = False
+
+    if input_type:
+        input_dict.update({"alias": {"name": device_alias}})
+        libvirt_vmxml.modify_vm_device(vmxml, "input",
+                                       dev_dict=input_dict)
 
         if not vm.is_alive():
             vm.start()


### PR DESCRIPTION
    RHEL-148234: Device can also be detached by 'virsh detach-device-alias' cmd. Test the following various input device by this cmd.

Signed-off-by: nanli <nanli@redhat.com>

Test result:
```
/usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35  virsh.detach_device_alias..input

 (1/6) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.input.keyboard: PASS (93.34 s)
 (2/6) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.input.mouse: PASS (93.09 s)
 (3/6) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.input.passthrough: PASS (92.17 s)
 (4/6) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.config.input.keyboard: PASS (91.08 s)
 (5/6) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.config.input.mouse: PASS (90.54 s)
 (6/6) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.config.input.passthrough: PASS (91.15 s)
```
