### PR TITLE
passthrough/pci: add test for ISM device on s390x

### DIFF
--- a/libvirt/tests/cfg/passthrough/pci/ism_pci_passthrough.cfg
+++ b/libvirt/tests/cfg/passthrough/pci/ism_pci_passthrough.cfg
@@ -1,0 +1,7 @@
+- libvirt_pci_passthrough.ism:
+    only s390-virtio
+    type = ism_pci_passthrough
+    variants:
+        - happy_path:
+            start_vm = no
+            pci_dev = LIBVIRT_PCI_NAME

--- a/libvirt/tests/src/passthrough/pci/ism_pci_passthrough.py
+++ b/libvirt/tests/src/passthrough/pci/ism_pci_passthrough.py
@@ -1,0 +1,40 @@
+import logging as log
+
+from virttest.libvirt_xml.vm_xml import VMXML
+from virttest.libvirt_xml.nodedev_xml import NodedevXML
+
+
+logging = log.getLogger('avocado.' + __name__)
+
+
+def run(test, params, env):
+    """
+    Test for ISM device passthrough to libvirt guest.
+    """
+    # get the params from params
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    pci_dev = params.get("pci_dev", "pci_0000_00_00_0")
+    vmxml = VMXML.new_from_inactive_dumpxml(vm_name)
+    backup_xml = vmxml.copy()
+
+    try:
+        pci_xml = NodedevXML.new_from_dumpxml(pci_dev)
+        if "ism" != pci_xml.driver_name:
+            test.error("Device %s is not a ISM device: %s" % pci_xml)
+        pci_address = pci_xml.cap.get_address_dict()
+        vmxml.add_hostdev(pci_address)
+        vmxml.sync()
+
+        vm.start()
+        session = vm.wait_for_login()
+
+        output = session.cmd_output("lspci")
+        devices = output.split('\n')
+        if not len(devices) >= 1 or "ISM" not in devices[0]:
+            test.fail("Expected 1 ISM PCI device but got: %s" % output)
+    finally:
+        if session:
+            session.close()
+        vm.destroy()
+        backup_xml.sync()


### PR DESCRIPTION
ISM is a special device on s390x that can be passed through with vfio_pci. It's managed by libvirt as node device.

Add a test case that confirms that the device can be attached and is listed inside the guest.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>