### PR TITLE
virtual_interface: Add cases about vdpa interface

### DIFF
--- a/libvirt/tests/cfg/virtual_interface/connectivity_check.cfg
+++ b/libvirt/tests/cfg/virtual_interface/connectivity_check.cfg
@@ -19,11 +19,21 @@
                     only mellanox
                     required_kernel = [5.14.0,)
                     func_supported_since_libvirt_ver = (8, 0, 0)
-                    driver_queues = "8"
+                    driver_queues = 8
                     vdpa_mgmt_tool_extra = "max_vqp ${driver_queues}"
-                    iface_dict = {'model': 'virtio', 'source': {'dev': '/dev/vhost-vdpa-0'}, 'type_name': 'vdpa', 'driver': {'driver_attr': {'queues': ${driver_queues}}}, 'mac_address': mac_addr}
+                    iface_dict = {'model': 'virtio', 'source': {'dev': '/dev/vhost-vdpa-0'}, 'type_name': 'vdpa', 'driver': {'driver_attr': {'queues': '${driver_queues}'}}, 'mac_address': mac_addr}
                     variants:
                         - vcpu_gt_queues:
                             vm_attrs = {'vcpu': 4}
                         - vcpu_lt_queues:
                             vm_attrs = {'vcpu': 16}
+                        - boot:
+                            iface_dict = {'model': 'virtio', 'source': {'dev': '/dev/vhost-vdpa-0'}, 'type_name': 'vdpa', 'driver': {'driver_attr': {'queues': '${driver_queues}'}}, 'boot': '2', 'mac_address': mac_addr}
+                            disk_boot = 1
+                        - page_per_vq:
+                            enable_guest_iommu = "yes"
+                            expr_multiplier = '00001000'
+                            iface_dict = {'model': 'virtio', 'source': {'dev': '/dev/vhost-vdpa-0'}, 'type_name': 'vdpa', 'driver': {'driver_attr': {'queues': '${driver_queues}', 'page_per_vq': 'on'}}, 'mac_address': mac_addr}
+                        - multi_ifaces:
+                            func_supported_since_libvirt_ver = (8, 7, 0)
+                            iface_dict2 = {'model': 'virtio', 'source': {'dev': '/dev/vhost-vdpa-1'}, 'type_name': 'vdpa', 'driver': {'driver_attr': {'queues': '${driver_queues}'}}}

--- a/libvirt/tests/cfg/virtual_interface/locked_memory_check/mem_lock_limit_multiple_vdpa_interfaces.cfg
+++ b/libvirt/tests/cfg/virtual_interface/locked_memory_check/mem_lock_limit_multiple_vdpa_interfaces.cfg
@@ -1,0 +1,13 @@
+- iface.locked_memory_check.multiple_interfaces:
+    type = mem_lock_limit_multiple_vdpa_interfaces
+    start_vm = no
+    variants dev_type:
+        - vdpa:
+            only x86_64
+            func_supported_since_libvirt_ver = (8, 7, 0)
+            vm_attrs = {'max_mem_rt': 6291456, 'max_mem_rt_slots': 32, 'max_mem_rt_unit': 'K', 'current_mem':2, 'current_mem_unit': 'GiB','vcpu': 8, 'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-3', 'memory': '1', 'unit': 'GiB'}, {'id': '1', 'cpus': '4-7', 'memory': '1', 'unit': 'GiB'}]}}
+            iface_dict = {"source": {'dev':'/dev/vhost-vdpa-0'}}
+            iface_dict2 = {"source": {'dev':'/dev/vhost-vdpa-1'}}
+            iface_dict3 = {"source": {'dev':'/dev/vhost-vdpa-2'}}
+            mem_dict1 = {'mem_model': 'dimm', 'target': {'size': 1, 'size_unit': 'G', 'node': 0}}
+            mem_dict2 = {'mem_model': 'dimm', 'target': {'size': 1, 'size_unit': 'G', 'node': 1}}

--- a/libvirt/tests/src/virtual_interface/locked_memory_check/mem_lock_limit_multiple_vdpa_interfaces.py
+++ b/libvirt/tests/src/virtual_interface/locked_memory_check/mem_lock_limit_multiple_vdpa_interfaces.py
@@ -1,0 +1,157 @@
+from avocado.utils import process
+
+from virttest import libvirt_version
+from virttest import utils_vdpa
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_memory
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+from provider.interface import interface_base
+
+
+def run(test, params, env):
+    """Hotplug memory with interface."""
+    def setup_test(dev_type):
+        """
+        Set up test.
+
+        1) Remove interface devices
+        2) Set VM attrs
+        3) Add an interface
+
+        :param dev_type: interface type
+        """
+        libvirt_vmxml.remove_vm_devices_by_type(vm, 'interface')
+
+        vm_attrs = eval(params.get('vm_attrs', '{}'))
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        vmxml.setup_attrs(**vm_attrs)
+        vmxml.sync()
+        test.log.debug("Updated VM xml: %s.",
+                       vm_xml.VMXML.new_from_dumpxml(vm_name))
+
+        iface_dict = eval(params.get('iface_dict', "{'source': {'dev':'/dev/vhost-vdpa-0'}}"))
+        iface_dev = interface_base.create_iface(dev_type, iface_dict)
+        libvirt.add_vm_device(vm_xml.VMXML.new_from_dumpxml(vm_name), iface_dev)
+        test.log.debug("VM xml afater updating ifaces: %s.",
+                       vm_xml.VMXML.new_from_dumpxml(vm_name))
+
+    def run_test(dev_type):
+        """
+        Check the locked memory for the vm with multiple vDPA interfaces.
+
+        1. The locked memory will be 1G + current memory * ${num of vDPA interface};
+        2. Hot unplug the vDPA interface or Memory device will not decrease
+            the locked memory;
+        3. When hotplug a vDPA interface, the locked memory will not increase
+            if there is enough locked memory(>=1G + current memory * ${num of vDPA interface});
+        4. No error or fail in the qemu log.
+        """
+        test.log.info("TEST_STEP1: Start the vm with a vDPA interface.")
+        vm.start()
+        vm.wait_for_serial_login(timeout=240).close()
+
+        qemu_log = "/var/log/libvirt/qemu/%s.log" % vm.name
+        process.run("echo > {}".format(qemu_log), shell=True)
+        new_vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+
+        expr_memlock = libvirt_memory.normalize_mem_size(
+            new_vmxml.get_current_mem(),
+            new_vmxml.get_current_mem_unit()) + 1073741824
+        if not libvirt_memory.comp_memlock(expr_memlock):
+            test.fail("Unalbe to get correct MEMLOCK after VM startup!")
+
+        test.log.info("TEST_STEP2: Hotplug memory device.")
+        mem_dict1 = eval(params.get('mem_dict1', '{}'))
+        mem_dev = libvirt_vmxml.create_vm_device_by_type("memory", mem_dict1)
+        virsh.attach_device(vm_name, mem_dev.xml, **virsh_args)
+
+        new_vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        expr_memlock = libvirt_memory.normalize_mem_size(
+            new_vmxml.get_current_mem(),
+            new_vmxml.get_current_mem_unit()) + 1073741824
+        if not libvirt_memory.comp_memlock(expr_memlock):
+            test.fail("Unalbe to get correct MEMLOCK after attaching a memory "
+                      "device!")
+
+        test.log.info("TEST_STEP3: Add one more vDPA interface.")
+        iface2 = interface_base.create_iface(dev_type, eval(params.get('iface_dict2', "{'source': {'dev':'/dev/vhost-vdpa-1'}}")))
+        virsh.attach_device(vm_name, iface2.xml, **virsh_args)
+
+        new_vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        expr_memlock = libvirt_memory.normalize_mem_size(
+            new_vmxml.get_current_mem(),
+            new_vmxml.get_current_mem_unit()) * 2 + 1073741824
+        if not libvirt_memory.comp_memlock(expr_memlock):
+            test.fail("Unalbe to get correct MEMLOCK after attaching the 2nd "
+                      "interface device!")
+
+        test.log.info("TEST_STEP4: Hotplut one more memory device.")
+        mem_dict2 = eval(params.get('mem_dict2', '{}'))
+        mem_dev2 = libvirt_vmxml.create_vm_device_by_type("memory", mem_dict2)
+        virsh.attach_device(vm_name, mem_dev2.xml, **virsh_args)
+
+        new_vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        expr_memlock = libvirt_memory.normalize_mem_size(
+            new_vmxml.get_current_mem(),
+            new_vmxml.get_current_mem_unit()) * 2 + 1073741824
+        if not libvirt_memory.comp_memlock(expr_memlock):
+            test.fail("Unalbe to get correct MEMLOCK after attaching the 2nd "
+                      "interface device!")
+
+        test.log.info("TEST_STEP5: Detach a memory device and vDPA interface.")
+        memxml = vm_xml.VMXML.new_from_dumpxml(vm_name).get_devices('memory')[-1]
+        virsh.detach_device(vm_name, memxml.xml, debug=True)
+        if not libvirt_memory.comp_memlock(expr_memlock):
+            test.fail("Unalbe to get correct MEMLOCK after detaching a memory device!")
+
+        iface = vm_xml.VMXML.new_from_dumpxml(vm_name).get_devices('interface')[-1]
+        virsh.detach_device(vm_name, iface.xml,
+                            wait_for_event=True,
+                            **virsh_args)
+        if not libvirt_memory.comp_memlock(expr_memlock):
+            test.fail("Unalbe to get correct MEMLOCK after detaching a vDPA interface!")
+
+        test.log.info("TEST_STEP6: Hotplug a vDPA interface.")
+        virsh.attach_device(vm_name, iface.xml, **virsh_args)
+        if not libvirt_memory.comp_memlock(expr_memlock):
+            test.fail("Unalbe to get correct MEMLOCK after re-attaching a vDPA interface!")
+
+        test.log.info("TEST_STEP7: Hotplug one more vDPA interface.")
+        iface3 = interface_base.create_iface(dev_type, eval(params.get('iface_dict3', "{'source': {'dev':'/dev/vhost-vdpa-2'}}")))
+        virsh.attach_device(vm_name, iface3.xml, **virsh_args)
+
+        new_vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        expr_memlock = libvirt_memory.normalize_mem_size(
+            new_vmxml.get_current_mem(),
+            new_vmxml.get_current_mem_unit()) * 3 + 1073741824
+        if not libvirt_memory.comp_memlock(expr_memlock):
+            test.fail("Unalbe to get correct MEMLOCK after attaching the 3rd "
+                      "interface device!")
+
+        test.log.info("TEST_STEP8: Check qemu log.")
+        libvirt.check_logfile("fail|error", qemu_log, str_in_log=False)
+
+    libvirt_version.is_libvirt_feature_supported(params)
+    # Variable assignment
+    dev_type = params.get('dev_type', 'vdpa')
+    virsh_args = {'debug': True, 'ignore_status': False}
+    vm_name = params.get('main_vm')
+    vm = env.get_vm(vm_name)
+
+    vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+    backup_vmxml = vmxml.copy()
+
+    try:
+        pf_pci = utils_vdpa.get_vdpa_pci()
+        test_env_obj = utils_vdpa.VDPAOvsTest(pf_pci)
+        test_env_obj.setup()
+        setup_test(dev_type)
+        run_test(dev_type)
+
+    finally:
+        backup_vmxml.sync()
+        test_env_obj.cleanup()


### PR DESCRIPTION
This PR adds:
    1. VIRT-296166 - hotplug/unplug memory and multiple vdpa interfaces
    2. Add 3 scenarios into connectivity_check test - boot order,
        page_per_vq and mutiqueue and multiple vdpa interfaces

Signed-off-by: Yingshun Cui <yicui@yicui.nay.csb>
Depends:
- https://github.com/avocado-framework/avocado-vt/pull/3598
- https://github.com/avocado-framework/avocado-vt/pull/3600

Test results: 
```
 (1/7) type_specific.io-github-autotest-libvirt.iface.locked_memory_check.multiple_interfaces.vdpa: FAIL: The string 'fail|error' is included in /var/log/libvirt/qemu/avocado-vt-vm1.log (90.23 s)
 (2/7) type_specific.io-github-autotest-libvirt.iface.connectivity_check.vdpa.default.mellanox: PASS (124.59 s)
 (3/7) type_specific.io-github-autotest-libvirt.iface.connectivity_check.vdpa.driver_queues.vcpu_gt_queues.mellanox: PASS (128.42 s)
 (4/7) type_specific.io-github-autotest-libvirt.iface.connectivity_check.vdpa.driver_queues.vcpu_lt_queues.mellanox: PASS (129.46 s)
 (5/7) type_specific.io-github-autotest-libvirt.iface.connectivity_check.vdpa.driver_queues.boot.mellanox: PASS (127.84 s)
 (6/7) type_specific.io-github-autotest-libvirt.iface.connectivity_check.vdpa.driver_queues.page_per_vq.mellanox: PASS (128.12 s)
 (7/7) type_specific.io-github-autotest-libvirt.iface.connectivity_check.vdpa.driver_queues.multi_ifaces.mellanox: PASS (137.93 s)

```
NOTE: The failure is caused by a known issue.