### PR TITLE
console: Enable detach_device_alias of hostdev pci test for aarch64

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
@@ -11,6 +11,8 @@
                     detach_hostdev_type = "scsi"
                 - pci:
                     detach_hostdev_type = "pci"
+                    aarch64:
+                      pci_filter = "Host bridge"
                     detach_hostdev_managed = "yes"
                     controller_dict = {'type': 'pci', 'model': 'pcie-to-pci-bridge','index':'35'}
                     no s390-virtio


### PR DESCRIPTION
For aarch64, no kernel cmd line for iommu. We can use "virsh capabilities | grep iommu" to check whether the host supports iommu. If the 'support' value is 'yes', there is no need to check the kernel cmd line.

And for aarch64, only 'Host bridge' PCI device can be used for hostdev_pci.

Results:
```
# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio virsh.detach_device_alias..hostdev.pci --vt-connect-uri qemu:///system
JOB ID     : 33936c1ec60061cd59828f5d709ccc04801e67c2
JOB LOG    : /var/lib/avocado/job-results/job-2023-01-09T23.18-33936c1/job.log
 (1/3) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.hostdev.pci: PASS (54.33 s)
 (2/3) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.config.hostdev.pci: PASS (47.85 s)
 (3/3) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.current.hostdev.pci: PASS (53.73 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2023-01-09T23.18-33936c1/results.html
JOB TIME   : 156.33 s
```

Signed-off-by: Hu Shuai <hus.fnst@fujitsu.com>