### PR TITLE
Fix iscsi_direct_pool failure due to enable_authentication = "yes"

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/at_dt_iscsi_disk.cfg
+++ b/libvirt/tests/cfg/virtual_disks/at_dt_iscsi_disk.cfg
@@ -58,7 +58,6 @@
                     pool_type = "iscsi"
                     enable_authentication = "yes"
                 - iscsi_direct_pool:
-                    enable_authentication = "yes"
                     pool_type = "iscsi-direct"
                     iscsi_initiator = "iqn.2019-07.com.example:client"
         - block_disk:


### PR DESCRIPTION
Fix iscsi_direct_pool failure due to enable_authentication = "yes"

This partly responds to the change brought by https://github.com/autotest/tp-libvirt/pull/4678/files

Signed-off-by: chunfuwen <chwen@redhat.com>