### PR TITLE
 PCIe Controller, invalid root_port_controller index

### DIFF
--- a/libvirt/tests/cfg/controller/pcie_root_port_controller.cfg
+++ b/libvirt/tests/cfg/controller/pcie_root_port_controller.cfg
@@ -36,9 +36,21 @@
                 - index_equals_address_bus:
                     test_define_only = "yes"
                     controller_address = '{"type": "pci", "domain": "0x0000", "bus": "0x01", "slot": "0x1", "function":"0x0"}'
-                    failure_message = ".*The device at PCI address .* cannot be plugged into the PCI controller with index='.*'. It requires a controller that accepts a pcie-root-port.*"
+                    failure_message = ".*The device at PCI address .* cannot be plugged into the PCI controller with index='.*'. It requires a controller that accepts a pcie\-root\-port.*"
                 - index_less_than_address_bus:
                     bus_offset = 1
                     test_define_only = "yes"
                     controller_address = '{"type": "pci", "domain": "0x0000", "bus": "0x02", "slot": "0x1", "function":"0x0"}'
-                    failure_message = ".*a PCI slot is needed to connect a PCI controller model='pcie-root-port', but none is available, and it cannot be automatically added.*"
+                    failure_message = ".*a PCI slot is needed to connect a PCI controller model='pcie\-root\-port', but none is available, and it cannot be automatically added.*"
+                - controller_index_zero:
+                    test_define_only = "yes"
+                    controller_index = 0
+                    failure_message = "XML error: Multiple 'pci' controllers with index '0'"
+                - controller_index_too_high:
+                    test_define_only = "yes"
+                    controller_index = 256
+                    failure_message = "internal error: a PCI slot is needed to connect a PCI controller model='pcie\-root\-port', but none is available, and it cannot be automatically added"
+                - controller_index_invalid:
+                    test_define_only = "yes"
+                    controller_index = xxx
+                    failure_message = "Invalid value for attribute 'index' in element 'controller': 'xxx'. Expected integer value|internal error: Cannot parse controller index xxx"


### PR DESCRIPTION
This commit adds a new test scenarios where invalid PCIe
root_port_controller index is tested to produde VM define command
failure.
    
VIRT-47643