### PR TITLE
add case for detach redirected usb with alias

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
@@ -19,9 +19,15 @@
             detach_check_xml = "<controller type='scsi' index='%s' model='virtio-scsi'>"
         - redirdev:
             no s390-virtio pseries
-            detach_redirdev_type = "spicevmc"
             detach_redirdev_bus = "usb"
             detach_check_xml = "<redirdev"
+            variants:
+                - spicevmc:
+                    detach_redirdev_type = "spicevmc"
+                - tcp:
+                    detach_redirdev_type = "tcp"
+                    port = '4000'
+                    redir_params = "{'source':'{"mode":"connect","host":"localhost","service":"${port}", "tls":"no"}'}"
         - channel:
             variants:
                 - spicevmc:


### PR DESCRIPTION
    RHEL-148240: Detach redirected usb device by alias
Signed-off-by: nanli <nanli@redhat.com>

 ```
/usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 virsh.detach_device_alias..redirdev
 (1/3) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.redirdev.spicevmc: PASS (29.31 s)
 (2/3) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.config.redirdev.spicevmc: PASS (33.57 s)
 (3/3) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.current.redirdev.spicevmc: PASS (34.34 s)

(1/3) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.redirdev.tcp: PASS (48.93 s)
 (2/3) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.config.redirdev.tcp: PASS (51.25 s)
 (3/3) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.current.redirdev.tcp: PASS (53.34 s)


```