### PR TITLE
PCIe contr, invalid pcie-root-port target chassis

### DIFF
--- a/libvirt/tests/cfg/controller/pcie_root_port_controller.cfg
+++ b/libvirt/tests/cfg/controller/pcie_root_port_controller.cfg
@@ -54,3 +54,17 @@
                     test_define_only = "yes"
                     controller_index = xxx
                     failure_message = "Invalid value for attribute 'index' in element 'controller': 'xxx'. Expected integer value|internal error: Cannot parse controller index xxx"
+                - chassis_less_than_valid:
+                    test_define_only = "yes"
+                    controller_target = '{"chassis":-1,"port":"0x8"}'
+                    failure_message = "XML error: Invalid value for attribute 'chassis' in element 'target': '-1'. Expected non-negative value"
+                    func_supported_since_libvirt_ver = (8, 8, 0)
+                    unsupported_err_msg = "Chassis value -1 behaves incorrectly in libvirt version less than 8.8.0"
+                - chassis_greater_than_valid:
+                    test_define_only = "yes"
+                    controller_target = '{"chassis":256,"port":"0x8"}'
+                    failure_message = "PCI controller chassis '256' out of range - must be 0-255"
+                - chassis_invalid:
+                    test_define_only = "yes"
+                    controller_target = '{"chassis":"a","port":"0x8"}'
+                    failure_message = "XML error: Invalid value for attribute 'chassis' in element 'target': 'a'. Expected integer value"

--- a/libvirt/tests/src/controller/pcie_root_port_controller.py
+++ b/libvirt/tests/src/controller/pcie_root_port_controller.py
@@ -1,6 +1,7 @@
 import ast
 import logging
 
+from virttest import libvirt_version
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_libvirt import libvirt_vmxml, libvirt_pcicontr
@@ -79,6 +80,7 @@ def create_controller_dict(model, target, index, address=None):
                   'target': target}
     if address:
         contr_dict.update({"address": address})
+    LOG.debug("Created controller %s", contr_dict)
     return contr_dict
 
 
@@ -196,6 +198,7 @@ def run(test, params, env):
     :params params: Object containing parameters of a test from cfg file
     :params env: Environment object from Avocado framework
     """
+    libvirt_version.is_libvirt_feature_supported(params)
     vm = env.get_vm(params.get("main_vm", "avocado-vt-vm1"))
     vmxml_backup = vm_xml.VMXML.new_from_dumpxml(vm.name)
     test_define_only = params.get("test_define_only")


### PR DESCRIPTION
This PR adds test cases for testing invalid values of chassis attribute of target element of pcie-root-port device. All cases are negative tests.

VIRT-47653