### PR TITLE
libvirt_mem.cfg: update the memory of numa cells to match ovmf guest

### DIFF
--- a/libvirt/tests/cfg/libvirt_mem.cfg
+++ b/libvirt/tests/cfg/libvirt_mem.cfg
@@ -86,6 +86,7 @@
                     page_size = 4
                     page_unit = "KiB"
                     node_mask = 0
+                    numa_cells = "{'id':'0','cpus':'0-1','memory':'1048576','unit':'KiB'} {'id':'1','cpus':'2-3','memory':'1048576','unit':'KiB'}"
                     memory_addr = "{'type':'dimm','slot':'1','base':'0x11f000000'}"
                 - hugepages:
                     test_qemu_cmd = "no"


### PR DESCRIPTION
libvirt_mem.cfg: update the memory of numa cells to match ovmf guest
Otherwise, the ovmf guest can't boot successfully.

Signed-off-by: Meina Li <meili@redhat.com>