### PR TITLE
vdpa: Add a case to check mem_lock limit

### DIFF
--- a/libvirt/tests/cfg/virtual_interface/locked_memory_check/mem_lock_limit_multiple_mixed_interfaces.cfg
+++ b/libvirt/tests/cfg/virtual_interface/locked_memory_check/mem_lock_limit_multiple_mixed_interfaces.cfg
@@ -1,0 +1,14 @@
+- iface.locked_memory_check.mixed_interfaces:
+    type = mem_lock_limit_multiple_mixed_interfaces
+    start_vm = no
+    variants dev_type:
+        - vdpa:
+            only x86_64
+            func_supported_since_libvirt_ver = (8, 10, 0)
+            vm_attrs = {'max_mem_rt': 6291456, 'max_mem_rt_slots': 32, 'max_mem_rt_unit': 'K', 'current_mem':2, 'current_mem_unit': 'GiB','vcpu': 8, 'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-3', 'memory': '1', 'unit': 'GiB'}, {'id': '1', 'cpus': '4-7', 'memory': '1', 'unit': 'GiB'}]}}
+            iface_dict = {"source": {'dev':'/dev/vhost-vdpa-0'}}
+            iface_dict2 = {"source": {'dev':'/dev/vhost-vdpa-1'}}
+    variants test_scenario:
+        - cold_plug:
+            hostdev_dict = {'mode': 'subsystem', 'type': 'pci', 'managed': 'yes'}
+        - hot_plug:

--- a/libvirt/tests/src/virtual_interface/locked_memory_check/mem_lock_limit_multiple_mixed_interfaces.py
+++ b/libvirt/tests/src/virtual_interface/locked_memory_check/mem_lock_limit_multiple_mixed_interfaces.py
@@ -1,0 +1,130 @@
+from virttest import utils_vdpa
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_memory
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+from provider.interface import interface_base
+from provider.sriov import sriov_base
+
+
+def run(test, params, env):
+    """
+    Check the mem_lock limit when there is a hostdev and vDPA interface together.
+    """
+    def setup_test(dev_type):
+        """
+        Set up test.
+
+        1) Remove interface devices and iommu device
+        2) Set VM attrs
+        3) Add an vDPA interface
+
+        :param dev_type: interface type
+        """
+        test.log.info("TEST_SETUP: Remove iommu and interface devices.")
+        libvirt_vmxml.remove_vm_devices_by_type(vm, 'interface')
+        libvirt_vmxml.remove_vm_devices_by_type(vm, 'iommu')
+
+        test.log.info("TEST_SETUP: Update VM attrs.")
+        vm_attrs = eval(params.get('vm_attrs', '{}'))
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        vmxml.setup_attrs(**vm_attrs)
+        vmxml.sync()
+        test.log.debug("Updated VM xml: %s.",
+                       vm_xml.VMXML.new_from_dumpxml(vm_name))
+
+        test.log.info("TEST_SETUP: Add an interface to the VM.")
+        iface_dict = eval(params.get('iface_dict', "{'source': {'dev':'/dev/vhost-vdpa-0'}}"))
+        iface_dev = interface_base.create_iface(dev_type, iface_dict)
+        libvirt.add_vm_device(vm_xml.VMXML.new_from_dumpxml(vm_name), iface_dev)
+        test.log.debug("VM xml afater updating ifaces: %s.",
+                       vm_xml.VMXML.new_from_dumpxml(vm_name))
+
+        if test_scenario == "cold_plug":
+            test.log.info("TEST_SETUP: Attach hostdev device to the VM.")
+            hostdev_dict = eval(params.get("hostdev_dict", "{}"))
+            sriov_test_obj.vf_pci_addr.pop("type")
+            hostdev_dict.update(
+                {'source': {'untyped_address': sriov_test_obj.vf_pci_addr}})
+            libvirt_vmxml.modify_vm_device(
+                vm_xml.VMXML.new_from_dumpxml(vm_name), "hostdev", hostdev_dict)
+
+    def run_test(dev_type):
+        """
+        Check the locked memory for the vm with hostdev and vDPA interfaces.
+
+        1. The locked memory will be "1G + current memory * ${num of vDPA interface}";
+        2. All hostdev interfaces will share one memory space, so the locked
+            memory will be "current memory(for hostdev interfaces) + current
+            memory * num of vDPA interface (for vDPA) + 1G";
+        """
+        test.log.info("TEST_STEP: Start the vm with a vDPA interface.")
+        vm.start()
+        vm.wait_for_serial_login(timeout=240).close()
+
+        new_vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        iface_no = len(new_vmxml.devices.by_device_tag("hostdev")) + len(new_vmxml.devices.by_device_tag("interface"))
+        expr_memlock = libvirt_memory.normalize_mem_size(
+            new_vmxml.get_current_mem(),
+            new_vmxml.get_current_mem_unit()) * iface_no + 1073741824
+        if not libvirt_memory.comp_memlock(expr_memlock):
+            test.fail("Unalbe to get correct MEMLOCK after VM startup!")
+
+        if test_scenario == "cold_plug":
+            return
+        test.log.info("TEST_STEP: Hotplug a hostdev interface.")
+        virsh.attach_interface(vm.name, "hostdev --managed %s" % sriov_test_obj.vf_pci,
+                               debug=True, ignore_status=False)
+        new_vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        expr_memlock = libvirt_memory.normalize_mem_size(
+            new_vmxml.get_current_mem(),
+            new_vmxml.get_current_mem_unit()) * 2 + 1073741824
+        if not libvirt_memory.comp_memlock(expr_memlock):
+            test.fail("Unalbe to get correct MEMLOCK after attaching a hostdev "
+                      "interface!")
+
+        test.log.info("TEST_STEP: Hotplug another hostdev interface.")
+        virsh.attach_interface(vm.name, "hostdev --managed %s" % sriov_test_obj.vf_pci2,
+                               debug=True, ignore_status=False)
+        if not libvirt_memory.comp_memlock(expr_memlock):
+            test.fail("Unalbe to get correct MEMLOCK after attaching a hostdev "
+                      "interface!")
+
+        test.log.info("TEST_STEP: Add one more vDPA interface.")
+        iface2 = interface_base.create_iface(
+            dev_type, eval(params.get(
+                'iface_dict2', "{'source': {'dev':'/dev/vhost-vdpa-1'}}")))
+        virsh.attach_device(vm_name, iface2.xml, **virsh_args)
+
+        new_vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        expr_memlock = libvirt_memory.normalize_mem_size(
+            new_vmxml.get_current_mem(),
+            new_vmxml.get_current_mem_unit()) * 3 + 1073741824
+        if not libvirt_memory.comp_memlock(expr_memlock):
+            test.fail("Unalbe to get correct MEMLOCK after attaching the 2nd "
+                      "vDPA interface device!")
+
+    # Variable assignment
+    dev_type = params.get('dev_type', 'vdpa')
+    test_scenario = params.get("test_scenario")
+    virsh_args = {'debug': True, 'ignore_status': False}
+    vm_name = params.get('main_vm')
+    vm = env.get_vm(vm_name)
+
+    vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+    backup_vmxml = vmxml.copy()
+    sriov_test_obj = sriov_base.SRIOVTest(vm, test, params)
+
+    try:
+        pf_pci = utils_vdpa.get_vdpa_pci()
+        test_env_obj = utils_vdpa.VDPAOvsTest(pf_pci)
+        test_env_obj.setup()
+        setup_test(dev_type)
+        run_test(dev_type)
+
+    finally:
+        backup_vmxml.sync()
+        test_env_obj.cleanup()


### PR DESCRIPTION
This PR adds:
    VIRT-296323 - Check the mem_lock limit when there is a hostdev
        and vdpa interface together

Signed-off-by: Yingshun Cui <yicui@redhat.com>

**Test results:**
 ```
(1/2) type_specific.io-github-autotest-libvirt.iface.locked_memory_check.mixed_interfaces.cold_plug.vdpa: PASS (95.65 s)
 (2/2) type_specific.io-github-autotest-libvirt.iface.locked_memory_check.mixed_interfaces.hot_plug.vdpa: PASS (97.20 s)

```