### PR TITLE
passthrough/pci: teard down properly

### DIFF
--- a/libvirt/tests/src/passthrough/pci/ism_pci_passthrough.py
+++ b/libvirt/tests/src/passthrough/pci/ism_pci_passthrough.py
@@ -17,6 +17,7 @@ def run(test, params, env):
     pci_dev = params.get("pci_dev", "pci_0000_00_00_0")
     vmxml = VMXML.new_from_inactive_dumpxml(vm_name)
     backup_xml = vmxml.copy()
+    session = None
 
     try:
         pci_xml = NodedevXML.new_from_dumpxml(pci_dev)


### PR DESCRIPTION
The session variable needs to be initilized so that in case of a failure the conditional doesn't raise

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>