### PR TITLE
graphics_functional: Remove remote-viewer checkpoint

### DIFF
--- a/libvirt/tests/cfg/graphics/graphics_functional.cfg
+++ b/libvirt/tests/cfg/graphics/graphics_functional.cfg
@@ -79,7 +79,6 @@
                                     listen_address = '2001:b8:ca2:2::1'
                                     network_dhcp_start = '2001:b8:ca2:2:1::10'
                                     network_dhcp_end = '2001:b8:ca2:2:1::ff'
-                                    remote_viewer_check = 'yes'
                                     rv_log_str = "main channel: opened"
                                 - network_route:
                                     spice_network_type = 'route'
@@ -87,7 +86,6 @@
                                     listen_address = '2001:b8:ca2:2::2'
                                     network_dhcp_start = '2001:b8:ca2:2:1::10'
                                     network_dhcp_end = '2001:b8:ca2:2:1::ff'
-                                    remote_viewer_check = 'yes'
                                     rv_log_str = "main channel: opened"
                             net_name = "virt_test_${spice_network_type}"
                         - defaultMode_secure:
@@ -161,7 +159,6 @@
                             insecure_channels = main
                             spice_listen_type = 'none'
                         - set_passwd:
-                            remote_viewer_check = 'yes'
                             graphic_passwd = 'redhat'
                             rv_log_str = "main channel: opened"
                             variants:
@@ -292,7 +289,6 @@
                                     listen_address = '2001:b8:ca2:2::1'
                                     network_dhcp_start = '2001:b8:ca2:2:1::10'
                                     network_dhcp_end = '2001:b8:ca2:2:1::ff'
-                                    remote_viewer_check = 'yes'
                                     rv_log_str = "desktop resize"
                                 - network_route:
                                     vnc_network_type = 'route'
@@ -300,7 +296,6 @@
                                     listen_address = '2001:b8:ca2:2::1'
                                     network_dhcp_start = '2001:b8:ca2:2:1::10'
                                     network_dhcp_end = '2001:b8:ca2:2:1::ff'
-                                    remote_viewer_check = 'yes'
                                     rv_log_str = "desktop resize"
                             net_name = 'virt-test-${vnc_network_type}'
                         - vnc_tls_enabled:
@@ -327,7 +322,6 @@
                                  - non_existing_vnc_secret_uuid:
                                      vnc_secret_uuid = "non_exist"
                         - set_passwd:
-                            remote_viewer_check = 'yes'
                             graphic_passwd = 'redhat'
                             rv_log_str = "desktop resize"
                             variants:


### PR DESCRIPTION
This checkpoint is covered in qemu test cases. So remove it.

Signed-off-by: cliping <lcheng@redhat.com>