### PR TITLE
PCIe: pcie-root-port invalid name

### DIFF
--- a/libvirt/tests/cfg/controller/pcie_root_port_controller.cfg
+++ b/libvirt/tests/cfg/controller/pcie_root_port_controller.cfg
@@ -30,6 +30,9 @@
                 - controllers_same_chassis_different_port:
                     second_controller_model = "pcie-root-port"
                     second_controller_target = "{'chassis':1,'port':'0x4'}"
+                - model_name_invalid:
+                    test_define_only = "yes"
+                    controller_model = "dmi-to-pci-bridge"
                 - index_equals_address_bus:
                     test_define_only = "yes"
                     controller_address = '{"type": "pci", "domain": "0x0000", "bus": "0x01", "slot": "0x1", "function":"0x0"}'


### PR DESCRIPTION
This PR adds checks for PCIe root port controller with invalid name. The check should fail. Automation of VIRT-47650