### PR TITLE
virtual_network: disable ROM test cases for s390x

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_hotplug.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_hotplug.cfg
@@ -14,10 +14,12 @@
             err_msgs2 = "are mutually exclusive"
             variants:
                 - rom_bar_off:
+                    no s390-virtio
                     only at_device
                     iface_rom = "{'bar':'off'}"
                     err_msg_rom = "Hot-plugged device without ROM bar can't have an option ROM"
                 - rom_enable_no_bar_off:
+                    no s390-virtio
                     only at_device
                     iface_rom = "{'enabled':'no','bar':'off'}"
                     err_msg_rom = "ROM tuning is not supported when ROM is disabled"
@@ -27,11 +29,13 @@
                             start_vm = "no"
                             attach_option = "--persistent"
                 - rom_enable_no:
+                    no s390-virtio
                     only at_device
                     iface_num = '2'
                     iface_rom = "{'enabled':'no'}"
                     detach_device = "yes"
                 - rom_enable_yes:
+                    no s390-virtio
                     only at_device
                     iface_rom = "{'enabled':'yes','file':'/usr/share/ipxe/1af41000.rom','bar':'on'}"
                     detach_device = "yes"

--- a/libvirt/tests/cfg/virtual_network/iface_update.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_update.cfg
@@ -13,9 +13,11 @@
                 - update_link:
                     new_iface_link = "down"
                 - update_link_with_rom:
+                    no s390-virtio
                     iface_rom = "{'enabled':'yes','bar':'on','file':'/usr/share/qemu-kvm/%s-virtio.rom'}"
                     new_iface_link = "up"
                 - update_link_without_addr:
+                    no s390-virtio
                     iface_rom = "{'enabled':'yes','bar':'on','file':'/usr/share/qemu-kvm/%s-virtio.rom'}"
                     new_iface_link = "up"
                     del_address = "yes"
@@ -48,6 +50,7 @@
                     new_iface_filter_parameters = "[{'name': 'IP', 'value': '1.2.3.4'}, {'name': 'IP', 'value': '1.2.3.5'}]"
                     rules =  ["-p IPv4 --ip-src 1.2.3.4 -j RETURN", "-p IPv4 --ip-src 1.2.3.5 -j RETURN", "-p ARP --arp-ip-src 1.2.3.4 -j RETURN", "-p ARP --arp-ip-src 1.2.3.5 -j RETURN"]
                 - update_ignore_unsupported_features:
+                    no s390-virtio
                     iface_driver = "{'name':'vhost','txmode':'iothread','ioeventfd':'on','event_idx':'off','queues':'5','rx_queue_size':'256'}"
                     iface_driver_host = "{'csum':'off','gso':'off','tso4':'off','tso6':'off','ecn':'off','ufo':'off','mrg_rxbuf':'off'}"
                     iface_driver_guest = "{'csum':'off','tso4':'off','tso6':'off','ecn':'off','ufo':'off'}"
@@ -121,22 +124,27 @@
                     new_iface_model = "rtl8139"
                     expect_err_msg = "Operation not supported: cannot modify network device model from virtio to rtl8139"
                 - update_rom:
+                    no s390-virtio
                     new_iface_rom = "{'bar':'on','file':'/etc/fake/boot.bin'}"
                     expect_err_msg = "Operation not supported: cannot modify network device rom bar setting"
                 - add_rom_enable:
+                    no s390-virtio
                     new_iface_rom = "{'enabled':'yes'}"
                     expect_err_msg = "Operation not supported: cannot modify network device rom enabled setting"
                 - update_rom_enable:
+                    no s390-virtio
                     iface_rom = "{'enabled':'yes'}"
                     new_iface_rom = "{'enabled':'no'}"
                     expect_err_msg = "Operation not supported: cannot modify network device rom enabled setting"
                 - update_rom_and_address:
+                    no s390-virtio
                     iface_rom = "{'enabled':'yes','bar':'on','file':'/usr/share/qemu-kvm/%s-virtio.rom'}"
                     new_iface_rom = "{'enabled':'no'}"
                     del_address = "yes"
                     del_rom = "yes"
                     expect_err_msg = "Operation not supported: cannot modify network device rom enabled setting"
                 - del_rom_enable:
+                    no s390-virtio
                     iface_rom = "{'enabled':'yes'}"
                     del_rom = "yes"
                     expect_err_msg = "Operation not supported: cannot modify network device rom enabled setting"
@@ -185,6 +193,7 @@
                                     new_iface_outbound = "{'average':'128','peak':'256','burst':'256'}"
                                     expect_err_msg = "has no inbound QoS set"
                 - update_driver_iommu_ast:
+                    no s390-virtio
                     expect_err_msg = "Operation not supported: cannot modify.* network device driver"
                     iommu_attrs = {'model': 'intel', 'driver': {'intremap': 'on', 'caching_mode': 'on', 'eim': 'on', 'iotlb': 'on'}}
                     new_iface_driver = {'iommu': 'on', 'ast': 'on'}


### PR DESCRIPTION
s390x doesn't support ROM. Disable tests.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>