### PR TITLE
virtual_network: make interface selection configurable

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_stat.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_stat.cfg
@@ -1,6 +1,7 @@
 - virtual_network.iface_stat:
     type = iface_stat
     start_vm = no
+    iface_name =
     variants case:
         - compare:
             variants :

--- a/libvirt/tests/cfg/virtual_network/iface_unprivileged.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_unprivileged.cfg
@@ -8,6 +8,7 @@
     remote_ip = "www.google.com"
     ping_count = 3
     ping_timeout = 10
+    iface_name =
     variants:
         - precreated:
             case = 'precreated'

--- a/libvirt/tests/cfg/virtual_network/virtual_network_multivms.cfg
+++ b/libvirt/tests/cfg/virtual_network/virtual_network_multivms.cfg
@@ -7,6 +7,7 @@
     expect_ping_out = 'yes'
     expect_ping_vm = 'yes'
     out_ip = www.redhat.com
+    iface_name =
     variants:
         - port_isolated:
             feature = 'port_isolated'

--- a/libvirt/tests/src/virtual_network/iface_stat.py
+++ b/libvirt/tests/src/virtual_network/iface_stat.py
@@ -111,7 +111,9 @@ def run(test, params, env):
 
     try:
         if case == 'compare':
-            host_ifname = utils_net.get_net_if(state="UP")[0]
+            host_ifname = params.get("iface_name")
+            if not host_ifname:
+                host_ifname = utils_net.get_net_if(state="UP")[0]
             iface_dict = {k.replace('new_iface_', ''): v
                           for k, v in params.items() if k.startswith('new_iface_')}
             iface_dict['source'] = iface_dict['source'] % host_ifname

--- a/libvirt/tests/src/virtual_network/iface_unprivileged.py
+++ b/libvirt/tests/src/virtual_network/iface_unprivileged.py
@@ -63,7 +63,9 @@ def run(test, params, env):
     user_vm_name = params.get('user_vm_name', 'non_root_vm')
     bridge_name = params.get('bridge_name', 'test_br0') + rand_id
     device_type = params.get('device_type', '')
-    iface_name = utils_net.get_net_if(state="UP")[0]
+    iface_name = params.get("iface_name")
+    if not iface_name:
+        iface_name = utils_net.get_net_if(state="UP")[0]
     tap_name = params.get('tap_name', 'mytap0') + rand_id
     macvtap_name = params.get('macvtap_name', 'mymacvtap0') + rand_id
     remote_ip = params.get('remote_ip')

--- a/libvirt/tests/src/virtual_network/virtual_network_multivms.py
+++ b/libvirt/tests/src/virtual_network/virtual_network_multivms.py
@@ -182,7 +182,9 @@ def run(test, params, env):
     rand_id = '_' + utils_misc.generate_random_string(3)
     resume_vm = 'yes' == params.get('resume_vm', 'no')
     bridge_name = params.get('bridge_name', 'test_br0') + rand_id
-    iface_name = utils_net.get_net_if(state="UP")[0]
+    iface_name = params.get("iface_name")
+    if not iface_name:
+        iface_name = utils_net.get_net_if(state="UP")[0]
     test_net = feature + rand_id
     bridge_created = False
 


### PR DESCRIPTION
Currently, the several tests select the first host interface. In order to allow for testing with a specific interface in other test environments allow for value to be configured. Don't assign a value in the cfg in order to keep legacy behavior.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>