### PR TITLE
v2v: fix firmware check issue

### DIFF
--- a/provider/v2v_vmcheck_helper.py
+++ b/provider/v2v_vmcheck_helper.py
@@ -630,11 +630,6 @@ class VMChecker(object):
                     ".//*[@model='virtio-transitional']") or root.findall(".//*[@type='virtio-transitional']"):
                 self.log_err(err_msg)
 
-        LOG.info("Checking firware='efi' existing in VM XML")
-        if bootinfo == 'uefi' and not root.findall("./os[@firmware='efi']"):
-            err_msg = "Checking firmware='efi' existing failed"
-            self.log_err(err_msg)
-
         if self.vsock_check_enabled() and self.is_vsock_supported(self.os_version):
             self.check_xml('./devices/vsock')
 

--- a/v2v/tests/cfg/specific_kvm.cfg
+++ b/v2v/tests/cfg/specific_kvm.cfg
@@ -261,6 +261,11 @@
             only source_xen
             os_version = 'WINDOWS_ROOT_OS_VERSION_V2V_EXAMPLE'
             main_vm = 'WINDOWS_ROOT_VM_NAME_V2V_EXAMPLE'
+        - vmware_os_firmware:
+            only esx.esx_70
+            boottype = 2
+            checkpoint = vmware_os_firmware
+            main_vm = 'VM_UEFI_GUEST_V2V_EXAMPLE'
     variants:
         - positive_test:
             status_error = 'no'


### PR DESCRIPTION
The old firmware check is as a public checkpoint, but in fact, not all VMs have that attribute. And the original test case and bug only report the attribute should be show in xml only for vmware guests.

So I moved the check for all test cases and put it into a specific test case.

Signed-off-by: Xiaodai Wang <xiaodwan@redhat.com>