### PR TITLE
ccw: Enable DASD device selection via configuration

### DIFF
--- a/libvirt/tests/cfg/passthrough/ccw/libvirt_ccw_passthrough.cfg
+++ b/libvirt/tests/cfg/passthrough/ccw/libvirt_ccw_passthrough.cfg
@@ -1,6 +1,7 @@
 - libvirt_ccw_passthrough:
     type = libvirt_ccw_passthrough
     only s390-virtio
+    devid =
     variants:
         - happy_path:
         - device_removal:

--- a/libvirt/tests/cfg/passthrough/ccw/libvirt_ccw_passthrough_read_write.cfg
+++ b/libvirt/tests/cfg/passthrough/ccw/libvirt_ccw_passthrough_read_write.cfg
@@ -1,5 +1,6 @@
 - libvirt_ccw_passthrough.read_write:
     type = libvirt_ccw_passthrough_read_write
     only s390-virtio
+    devid =
     variants:
         - happy_path:

--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_dasd.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_dasd.cfg
@@ -1,6 +1,6 @@
 - virtual_disks.dasd:
     type = virtual_disks_dasd
     only s390-virtio
+    devid =
     variants:
         - read_native_partition_table:
-

--- a/libvirt/tests/src/passthrough/ccw/libvirt_ccw_passthrough.py
+++ b/libvirt/tests/src/passthrough/ccw/libvirt_ccw_passthrough.py
@@ -21,6 +21,7 @@ def run(test, params, env):
     backup_xml = vmxml.copy()
 
     device_removal_case = "yes" == params.get("device_removal_case", "no")
+    devid = params.get("devid")
     schid = None
     uuid = None
     chpids = None
@@ -31,7 +32,7 @@ def run(test, params, env):
         if vm.is_alive():
             vm.destroy()
 
-        schid, chpids = ccw.get_device_info()
+        schid, chpids = ccw.get_device_info(devid)
         uuid = str(uuid4())
 
         ccw.set_override(schid)

--- a/libvirt/tests/src/passthrough/ccw/libvirt_ccw_passthrough_read_write.py
+++ b/libvirt/tests/src/passthrough/ccw/libvirt_ccw_passthrough_read_write.py
@@ -19,6 +19,7 @@ def run(test, params, env):
     vmxml = VMXML.new_from_inactive_dumpxml(vm_name)
     backup_xml = vmxml.copy()
 
+    devid = params.get("devid")
     schid = None
     uuid = None
     chpids = None
@@ -29,7 +30,7 @@ def run(test, params, env):
         if vm.is_alive():
             vm.destroy()
 
-        schid, chpids = ccw.get_device_info()
+        schid, chpids = ccw.get_device_info(devid)
         uuid = str(uuid4())
 
         ccw.set_override(schid)

--- a/provider/vfio/ccw.py
+++ b/provider/vfio/ccw.py
@@ -299,16 +299,23 @@ def assure_preconditions():
                                    "driverctl"])
 
 
-def get_device_info():
+def get_device_info(devid=None):
     """
-    Gets the device info for passthrough
+    Gets the device info for passthrough.
+    It selects a device that's safely removable if devid
+    is not given.
 
+    :param devid: The ccw device id, e.g. 0.0.5000
     :return: Subchannel and Channel path ids (schid, chpids)
     """
 
     paths = SubchannelPaths()
     paths.get_info()
-    device = paths.get_first_unused_and_safely_removable()
+    device = None
+    if devid:
+        device = paths.get_device(devid)
+    else:
+        device = paths.get_first_unused_and_safely_removable()
     schid = device[paths.HEADER["Subchan."]]
     chpids = device[paths.HEADER["CHPIDs"]]
     return schid, chpids

--- a/provider/vfio/mdev_handlers.py
+++ b/provider/vfio/mdev_handlers.py
@@ -93,7 +93,7 @@ class CcwMdevHandler(MdevHandler):
         self.device_id = None
         self.session = None
 
-    def create_nodedev(self, api="mdevctl"):
+    def create_nodedev(self, api="mdevctl", devid=None):
         """
         Creates a mediated device of a specific type
         and returns its name from libvirt.
@@ -103,7 +103,7 @@ class CcwMdevHandler(MdevHandler):
         if api != "mdevctl":
             raise TestError("Handling mdev via '%s' is not implemented." % api)
 
-        self.schid, self.chpids = ccw.get_device_info()
+        self.schid, self.chpids = ccw.get_device_info(devid)
         self.device_id, _ = ccw.get_first_device_identifiers(self.chpids, None)
         ccw.set_override(self.schid)
         self.uuid = str(uuid4())

--- a/virttools/tests/cfg/virt_install/hostdev_mdev.cfg
+++ b/virttools/tests/cfg/virt_install/hostdev_mdev.cfg
@@ -4,3 +4,4 @@
         - check_present_inside_guest:
             only s390-virtio
             mdev_type = vfio_ccw-io
+            devid =

--- a/virttools/tests/src/virt_install/hostdev_mdev.py
+++ b/virttools/tests/src/virt_install/hostdev_mdev.py
@@ -71,6 +71,7 @@ def run(test, params, env):
     vm = env.get_vm(vm_name)
     vmxml = VMXML.new_from_inactive_dumpxml(vm_name)
     mdev_type = params.get("mdev_type", "vfio_ccw-io")
+    devid = params.get("devid")
     handler = None
 
     try:
@@ -78,7 +79,7 @@ def run(test, params, env):
         vm.undefine()
         handler = MdevHandler.from_type(mdev_type)
         disk = get_disk_for_import(vmxml)
-        mdev_nodedev = handler.create_nodedev()
+        mdev_nodedev = handler.create_nodedev(devid=devid)
         target_address = handler.get_target_address()
 
         virt_install_with_hostdev(vm_name, mdev_nodedev, target_address, disk)


### PR DESCRIPTION
Depends on https://github.com/avocado-framework/avocado-vt/pull/3606

Tests relied on a function in avocado-vt to select a device for testing based on certain assumptions.

Add a parameter to the configurations in order to overwrite that selection and choose a device manually.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>