### PR TITLE
virsh_nodedev_dumpxml: add check for s390x device css

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_dumpxml_chain.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_dumpxml_chain.cfg
@@ -8,3 +8,8 @@
             only s390-virtio
             checks = '[{"capability/block": r"/dev/dasd"},{"driver/name": r"dasd"},{"driver/name": r"(io_subchannel|vfio_ccw)"}]'
             chain_start_device_pattern = "block_dasd"
+        - device_type_css:
+            only s390-virtio
+            checks = '[{"capability/channel_dev_addr/devno": r"0x[\w\d]{4}"}]'
+            chain_start_device_pattern = "css_0_0_[\w\d]{4}"
+            

--- a/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_dumpxml_chain.py
+++ b/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_dumpxml_chain.py
@@ -80,5 +80,6 @@ def get_device(nodedev_list, pattern):
     """
     for dev_id in nodedev_list:
         if re.search(pattern, dev_id):
+            logging.debug("Selected %s", dev_id)
             return dev_id
     return None


### PR DESCRIPTION
If the kernel supports it, the css device' attribute "dev_buis" that idenditifes the actual device attached to the channel is displayed in the nodedev xml.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>