### PR TITLE
sriov: Fix no interface issues

### DIFF
--- a/provider/sriov/check_points.py
+++ b/provider/sriov/check_points.py
@@ -63,7 +63,8 @@ def check_mac_addr(vm_session, vm_name, device_type, iface_dict):
     if device_type != 'interface' or not mac:
         LOG.warning("No need to check mac address.")
         return
-    iface = utils_net.get_linux_iface_info(mac, vm_session)
+    iface = utils_misc.wait_for(
+        lambda: utils_net.get_linux_iface_info(mac, vm_session), 120)
     if not iface:
         raise exceptions.TestFail("Unable to get VM interface with given mac "
                                   "address - %s!" % mac)

--- a/provider/sriov/sriov_base.py
+++ b/provider/sriov/sriov_base.py
@@ -76,7 +76,9 @@ def get_ping_dest(vm_session, mac_addr="", restart_network=False):
         if not utils_package.package_install('dhcp-client', session=vm_session):
             raise exceptions.TestFail("Failed to install dhcp-client on guest.")
         utils_net.restart_guest_network(vm_session)
-    vm_iface = utils_net.get_linux_ifname(vm_session, mac_addr)
+    vm_iface = utils_misc.wait_for(
+        lambda: utils_net.get_linux_ifname(vm_session, mac_addr),
+        timeout=240, first=10)
     if not vm_iface:
         raise exceptions.TestError("Unable to get VM's interface!")
     if isinstance(vm_iface, list):


### PR DESCRIPTION
Update to wait for some time before checking interface information to avoid no interface issues.

Signed-off-by: Yingshun Cui <yicui@redhat.com>

**Before the fix:**
` (1/1) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.network_interface.network.pf_name.managed_yes: FAIL: Unable to get VM interface with given mac address - 9a:4d:36:c1:77:26! (39.04 s)`


**After the fix:**
```
 (1/1) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.network_interface.network.pf_name.managed_yes: PASS (71.29 s)
 (1/1) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_interface_with_flags.live.running_domain: PASS (66.89 s)
```

