### PR TITLE
Filter out pcie-pci-bridge controller type on s390x

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
@@ -13,6 +13,7 @@
                     detach_hostdev_type = "pci"
                     detach_hostdev_managed = "yes"
                     controller_dict = {'type': 'pci', 'model': 'pcie-to-pci-bridge','index':'35'}
+                    no s390-virtio
         - controller:
             detach_controller_type = "scsi"
             detach_controller_mode = "virtio-scsi"


### PR DESCRIPTION
Filter out pcie-pci-bridge controller type on s390x
unsupported configuration: the 'pcie-pci-bridge' device is not supported by this QEMU binary on s390x

Signed-off-by: chunfuwen <chwen@redhat.com>