### PR TITLE
virsh_pool_auth: fix authentication failure in iscsi pool

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/pool/virsh_pool_auth.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/pool/virsh_pool_auth.cfg
@@ -19,6 +19,7 @@
             iscsi_user = "rhat"
             iscsi_password = "rhatrhat"
             auth_type = "chap"
+            enable_authentication = "yes"
         - ceph_pool:
             pool_type = "rbd"
             pool_name = "test_ceph"

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool_auth.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool_auth.py
@@ -40,6 +40,7 @@ def run(test, params, env):
     iscsi_host = params.get("iscsi_host", "127.0.0.1")
     chap_user = params.get("iscsi_user")
     chap_passwd = params.get("iscsi_password")
+    enable_authentication = "yes" == params.get("enable_authentication", "no")
 
     # ceph options
     ceph_auth_user = params.get("ceph_auth_user")
@@ -118,7 +119,8 @@ def run(test, params, env):
                                                                is_login=False,
                                                                image_size=emulated_size,
                                                                chap_user=chap_user,
-                                                               chap_passwd=chap_passwd)
+                                                               chap_passwd=chap_passwd,
+                                                               enable_authentication=enable_authentication)
         return iscsi_target
 
     def check_auth_in_xml(dparams):


### PR DESCRIPTION
When testing the iscsi pool with auth, it need enable authentication=1 attribute when setup iscsi.

Signed-off-by: Meina Li <meili@redhat.com>