### PR TITLE
fix input detach error

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
@@ -76,7 +76,7 @@
                 - passthrough:
                     detach_input_type = "passthrough"
                     detach_check_xml = "<input type='${detach_input_type}' bus='virtio'>"
-                    input_dict = {"type_name":"${detach_input_type}","input_bus": "virtio", "source_evdev":"/dev/input/event3"}
+                    input_dict = {"type_name":"${detach_input_type}","input_bus": "virtio"}
     variants:
         - live:
             detach_alias_options = "--live"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
@@ -221,6 +221,9 @@ def run(test, params, env):
 
     if input_type:
         input_dict.update({"alias": {"name": device_alias}})
+        if input_type == "passthrough":
+            event = process.run("ls /dev/input/event*", shell=True).stdout
+            input_dict.update({"source_evdev": event.decode('utf-8').split()[0]})
         libvirt_vmxml.modify_vm_device(vmxml, "input",
                                        dev_dict=input_dict)
 


### PR DESCRIPTION
  Need to get event on host
Signed-off-by: nanli <nanli@redhat.com>
```

avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 virsh.detach_device_alias..input --vt-connect-uri qemu:///system

 (1/6) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.input.keyboard: PASS (174.82 s)
 (2/6) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.input.mouse: PASS (167.48 s)
 (3/6) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.input.passthrough: PASS (167.37 s)
 (4/6) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.config.input.keyboard: PASS (165.34 s)
 (5/6) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.config.input.mouse: PASS (163.62 s)
 (6/6) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.config.input.passthrough: PASS (166.02 s)

```