### PR TITLE
libvirtd_conf/unix_sock.py: fix function call error

### DIFF
--- a/libvirt/tests/src/conf_file/libvirtd_conf/unix_sock.py
+++ b/libvirt/tests/src/conf_file/libvirtd_conf/unix_sock.py
@@ -161,7 +161,7 @@ def run(test, params, env):
         # with 'virsh list'. This will fail if socket file location
         # changed. We solve this by bypassing the checking part.
         else:
-            restarted = libvirtd.libvirtd.restart()
+            restarted = utils_libvirtd.libvirtd_restart()
 
         if not restarted:
             if expected_result != 'unbootable':


### PR DESCRIPTION
'Libvirtd' object has no attribute 'libvirtd'

Signed-off-by: gjw <guojingwei@inspur.com>