### PR TITLE
virtual_interface: Update memory settings

### DIFF
--- a/libvirt/tests/cfg/virtual_interface/hotplug_mem.cfg
+++ b/libvirt/tests/cfg/virtual_interface/hotplug_mem.cfg
@@ -2,6 +2,14 @@
     type = hotplug_mem
     start_vm = no
 
+    current_mem = 2
+    current_mem_unit = 'GiB'
+    cpu_setting = {'numa_cell': [{'id': '0', 'cpus': '0-3', 'memory': '1', 'unit': 'GiB'}, {'id': '1', 'cpus': '4-7', 'memory': '1', 'unit': 'GiB'}]}
+    max_mem_rt = 6291456
+    max_mem_rt_unit = 'K'
+    max_mem_rt_slots = 32
+    vcpu = 8
+
     variants dev_type:
         - vdpa:
             only x86_64
@@ -19,12 +27,12 @@
             hostdev_dict = {'type': 'pci', 'mode': 'subsystem', 'managed': 'yes', 'source': {'untyped_address': %s}}
     variants test_scenario:
         - at_memory_to_vm_with_iface:
-            vm_attrs = {'max_mem_rt': 6291456, 'max_mem_rt_slots': 32, 'max_mem_rt_unit': 'K', 'current_mem':1048576, 'current_mem_unit': 'KiB','vcpu': 8, 'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-3', 'memory': '524288', 'unit': 'KiB'}, {'id': '1', 'cpus': '4-7', 'memory': '524288', 'unit': 'KiB'}]}}
+            vm_attrs = {'max_mem_rt': ${max_mem_rt}, 'max_mem_rt_slots': ${max_mem_rt_slots}, 'max_mem_rt_unit': '${max_mem_rt_unit}', 'current_mem': ${current_mem}, 'current_mem_unit': '${current_mem_unit}','vcpu': ${vcpu}, 'cpu': ${cpu_setting}}
             mem_dict = {'mem_model': 'dimm', 'target': {'size': 1, 'size_unit': 'G', 'node': 0}}
         - at_memory_to_vm_with_iface_and_locked_mem:
-            vm_attrs = {'max_mem_rt': 6291456, 'max_mem_rt_slots': 32, 'max_mem_rt_unit': 'K', 'current_mem':1048576, 'current_mem_unit': 'KiB','vcpu': 8,'memtune':{'hard_limit': 10485760, 'hard_limit_unit': 'KiB'}, 'mb': {'locked': True}, 'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-3', 'memory': '524288', 'unit': 'KiB'}, {'id': '1', 'cpus': '4-7', 'memory': '524288', 'unit': 'KiB'}]}}
+            vm_attrs = {'max_mem_rt': ${max_mem_rt}, 'max_mem_rt_slots': ${max_mem_rt_slots}, 'max_mem_rt_unit': '${max_mem_rt_unit}', 'current_mem': ${current_mem}, 'current_mem_unit': '${current_mem_unit}','vcpu': ${vcpu},'memtune':{'hard_limit': 10485760, 'hard_limit_unit': 'KiB'}, 'mb': {'locked': True}, 'cpu': ${cpu_setting}}
             mem_dict = {'mem_model': 'dimm', 'target': {'size': 1, 'size_unit': 'G', 'node': 0}}
         - at_iface_and_memory:
-            vm_attrs = {'max_mem_rt': 6291456, 'max_mem_rt_slots': 32, 'max_mem_rt_unit': 'K', 'current_mem':1048576, 'current_mem_unit': 'KiB','vcpu': 8, 'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-3', 'memory': '524288', 'unit': 'KiB'}, {'id': '1', 'cpus': '4-7', 'memory': '524288', 'unit': 'KiB'}]}}
+            vm_attrs = {'max_mem_rt': ${max_mem_rt}, 'max_mem_rt_slots': ${max_mem_rt_slots}, 'max_mem_rt_unit': '${max_mem_rt_unit}', 'current_mem': ${current_mem}, 'current_mem_unit': '${current_mem_unit}','vcpu': ${vcpu}, 'cpu': ${cpu_setting}}
             mem_dict1 = {'mem_model': 'dimm', 'target': {'size': 256, 'size_unit': 'M', 'node': 0}}
             mem_dict2 = {'mem_model': 'dimm', 'target': {'size': 256, 'size_unit': 'M', 'node': 1}}


### PR DESCRIPTION
Update vm settings to avoid memory allocation issues.

Signed-off-by: Yingshun Cui <yicui@redhat.com>

Test results:
 ```
(1/3) type_specific.io-github-autotest-libvirt.iface.hotplug_mem.at_memory_to_vm_with_iface.hostdev: PASS (62.42 s)
 (2/3) type_specific.io-github-autotest-libvirt.iface.hotplug_mem.at_memory_to_vm_with_iface_and_locked_mem.hostdev: PASS (67.31 s)
 (3/3) type_specific.io-github-autotest-libvirt.iface.hotplug_mem.at_iface_and_memory.hostdev: PASS (82.78 s)
 (1/3) type_specific.io-github-autotest-libvirt.iface.hotplug_mem.at_memory_to_vm_with_iface.hostdev_device: PASS (61.46 s)
 (2/3) type_specific.io-github-autotest-libvirt.iface.hotplug_mem.at_memory_to_vm_with_iface_and_locked_mem.hostdev_device: PASS (62.99 s)
 (3/3) type_specific.io-github-autotest-libvirt.iface.hotplug_mem.at_iface_and_memory.hostdev_device: PASS (82.02 s)

```