### PR TITLE
guest_numa.py: cancel test when out of memory for host

### DIFF
--- a/libvirt/tests/src/numa/guest_numa.py
+++ b/libvirt/tests/src/numa/guest_numa.py
@@ -321,9 +321,13 @@ def run(test, params, env):
                     node_dict = i.copy()
                     node_dict['num'] = node_val
                     backup_list.append(node_dict)
-                    hp_cl.set_node_num_huge_pages(i['num'],
-                                                  i['nodenum'],
-                                                  i['size'])
+                    try:
+                        hp_cl.set_node_num_huge_pages(i['num'],
+                                                      i['nodenum'],
+                                                      i['size'])
+                    except ValueError as details:
+                        if "please check if the node has enough memory" in str(details):
+                            test.cancel(str(details))
                     node_val_after_set = hp_cl.get_node_num_huge_pages(i['nodenum'],
                                                                        i['size'])
                     if node_val_after_set < int(i['num']):


### PR DESCRIPTION
In gating, rhel.guest_numa.possitive_test.hugepage.per_node.2M.topology.numatune_memnode.m_strict.numatune_mem will fail when the host has not enough memory for node1. It may affectthe gating result. So  decided to cancel it in that case。

Signed-off-by: Meina Li <meili@redhat.com>