### PR TITLE
migration: Fix wrong vm state on source

### DIFF
--- a/libvirt/tests/cfg/migration/guest_lifecycle_operations_during_migration/migration_poweroff_vm.cfg
+++ b/libvirt/tests/cfg/migration/guest_lifecycle_operations_during_migration/migration_poweroff_vm.cfg
@@ -24,11 +24,14 @@
     check_network_accessibility_after_mig = "yes"
     migrate_desturi_port = "16509"
     migrate_desturi_type = "tcp"
+    stress_package = "stress"
+    stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20s"
     virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
-    action_during_mig = '[{"func": "poweroff_vm", "after_event": "iteration: '1'", "func_param": "params"}]'
+    action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "poweroff_vm", "func_param": "params", "need_sleep_time": "70"}]'
     err_msg = "error: operation failed: domain is not running"
-    virsh_migrate_extra = "--bandwidth 10"
+    virsh_migrate_extra = "--bandwidth 5"
     test_case = "poweroff_vm"
+
     variants:
         - p2p:
             virsh_migrate_options = '--live --p2p --verbose'
@@ -38,5 +41,6 @@
         - with_precopy:
             virsh_migrate_src_state = "shut off"
         - with_postcopy:
-            postcopy_options = '--postcopy --timeout 10 --timeout-postcopy --postcopy-bandwidth 10'
+            postcopy_options = '--postcopy --timeout 10 --timeout-postcopy --postcopy-bandwidth 5'
             virsh_migrate_src_state = "paused"
+            poweroff_vm_dest = "yes"

--- a/libvirt/tests/src/migration/guest_lifecycle_operations_during_migration/migration_poweroff_vm.py
+++ b/libvirt/tests/src/migration/guest_lifecycle_operations_during_migration/migration_poweroff_vm.py
@@ -54,7 +54,7 @@ def run(test, params, env):
             test.log.info("Guest don't exist on destination.")
         if not libvirt.check_vm_state(vm.name, vm_state_src, uri=migration_obj.src_uri):
             test.fail("Migrated VM failed to be in %s state at source" % vm_state_src)
-        test.log.info("Guest state is '%s' at source is as expected", vm_state_dest)
+        test.log.info("Guest state is '%s' at source is as expected", vm_state_src)
         migration_obj.verify_default()
 
     test_case = params.get('test_case', '')
@@ -62,6 +62,7 @@ def run(test, params, env):
 
     vm = env.get_vm(vm_name)
     migration_obj = base_steps.MigrationBase(test, vm, params)
+    params.update({"migration_obj": migration_obj})
     setup_test = eval("setup_%s" % test_case) if "setup_%s" % test_case in \
         locals() else migration_obj.setup_connection
     verify_test = eval("verify_%s" % test_case) if "verify_%s" % test_case in \

--- a/provider/migration/migration_base.py
+++ b/provider/migration/migration_base.py
@@ -251,17 +251,14 @@ def poweroff_vm(params):
 
     if poweroff_vm_dest:
         dest_uri = params.get("virsh_migrate_desturi")
-        backup_uri, migration_obj.vm.connect_uri = migration_obj.vm.connect_uri, dest_uri
         migration_obj.vm.cleanup_serial_console()
+        backup_uri, migration_obj.vm.connect_uri = migration_obj.vm.connect_uri, dest_uri
         migration_obj.vm.create_serial_console()
         remote_vm_session = migration_obj.vm.wait_for_serial_login(timeout=120)
         remote_vm_session.cmd("poweroff", ignore_all_errors=True)
         remote_vm_session.close()
         migration_obj.vm.cleanup_serial_console()
         migration_obj.vm.connect_uri = backup_uri
-        vm_state_src = params.get("virsh_migrate_src_state", "shut off")
-        if not libvirt.check_vm_state(migration_obj.vm.name, vm_state_src, uri=migration_obj.src_uri):
-            raise exceptions.TestFail("Migrated VM failed to be in %s state at source" % vm_state_src)
     else:
         vm_session = params.get("vm_session")
         vm_session.cmd("poweroff", ignore_all_errors=True)


### PR DESCRIPTION
For postcopy, we should send 'poweroff' command to dest host. Fix following issue:
  TestFail: Migrated VM failed to be in paused state at source

Signed-off-by: cliping <lcheng@redhat.com>