### PR TITLE
virsh_domdirtyrate_calc: no dirty-ring on s390 and aarch64

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domdirtyrate_calc.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domdirtyrate_calc.cfg
@@ -21,6 +21,7 @@
                     func_supported_since_libvirt_ver = (8, 1, 0)
                     unsupported_err_msg = "domdirtyrate-calc supports --mode since 8.1.0"
                 - dirty_ring_mode:
+                    no s390-virtio, aarch64
                     mode = "dirty-ring"
                     dirty_ring_size = 4096
                     func_supported_since_libvirt_ver = (8, 1, 0)


### PR DESCRIPTION
dirty-ring is not enabled on s390x and aarch64 so far in qemu-kvm.

Signed-off-by: Dan Zheng <dzheng@redhat.com>