### PR TITLE
fix negative case error message

### DIFF
--- a/libvirt/tests/cfg/backingchain/negative_scenario/blockcommit_invalid_top_base.cfg
+++ b/libvirt/tests/cfg/backingchain/negative_scenario/blockcommit_invalid_top_base.cfg
@@ -9,11 +9,13 @@
                 - blockcommit_directly:
                     top_image_suffix = "origin_source_file"
                     err_msg = "error: invalid argument: top '{0}' in chain for '${target_disk}' has no backing file"
+                    err_msg_2 = "could not find base image in chain for '${target_disk}'"
                 - after_pivot:
                     pivot = "--wait --verbose --active --pivot"
                     commit_option = " --active"
                     top_image_suffix = "origin_source_file"
                     err_msg = "error: invalid argument: top '{0}' in chain for '${target_disk}' has no backing file"
+                    err_msg_2 = "could not find base image in chain for '${target_disk}'"
         - same_image:
             top_image_suffix = 2
             base_image_suffix = 2

--- a/libvirt/tests/src/backingchain/negative_scenario/blockcommit_invalid_top_base.py
+++ b/libvirt/tests/src/backingchain/negative_scenario/blockcommit_invalid_top_base.py
@@ -81,7 +81,7 @@ def run(test, params, env):
 
         if case == "same_image":
             replace_msg = test_obj.snap_path_list[int(top_index) - 1]
-        libvirt.check_result(result, err_msg.format(replace_msg))
+        libvirt.check_result(result, [err_msg.format(replace_msg), err_msg_2])
 
     # Process cartesian parameters
     vm_name = params.get("main_vm")
@@ -89,6 +89,7 @@ def run(test, params, env):
     pivot = params.get('pivot')
     snap_num = int(params.get('snap_num'))
     err_msg = params.get('err_msg')
+    err_msg_2 = params.get('err_msg_2')
     top_index = params.get('top_image_suffix', '')
     base_index = params.get('base_image_suffix', '')
     commit_option = params.get('commit_option', '')


### PR DESCRIPTION
    error msg needs to be updated
Confirm with meina and  use this two error msgs

Signed-off-by: nanli <nanli@redhat.com>

before

`TestFail: Expect should fail with one of [&quot;error: invalid argument: top '/var/lib/avocado/data/avocado-vt/images/jeos-27-x86_64.qcow2' in chain for 'vda' has no backing file&quot;], but failed with:error: invalid argument: could not find base image in chain for 'vda'&#10;`

fixed 
```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.negative.blockcommit.invalid_top_base.no_backing --vt-connect-uri qemu:///system
 (1/2) type_specific.io-github-autotest-libvirt.backingchain.negative.blockcommit.invalid_top_base.no_backing.blockcommit_directly: PASS (37.52 s)
 (2/2) type_specific.io-github-autotest-libvirt.backingchain.negative.blockcommit.invalid_top_base.no_backing.after_pivot: PASS (37.52 s)
```
