### PR TITLE
Fix virtual_network reconnect_tap case failures 

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_network.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_network.cfg
@@ -163,7 +163,7 @@
                             net2_dhcp_end_ipv4 = '192.168.150.254'
                         - reconnect_tap:
                             reconnect_tap = "yes"
-                            test_ipv6_address = "no"
+                            test_ipv6_address = "yes"
                             test_ipv4_address = "no"
                             variants:
                                 - default:


### PR DESCRIPTION
On some lab, when start ipv6 network, it may fail as below: virsh net-start nattest
error: Failed to start network nattest
error: internal error: Check the host setup: interface enc1 has kernel autoconfigured IPv6 routes and enabling forwarding  without accept_ra set to 2 will cause the kernel to flush them, breaking networking.

Refer to https://github.com/autotest/tp-libvirt/blob/master/libvirt/tests/src/virtual_network/iface_network.py#L694, it need enable test_ipv6_address=yes to enforce accept_ra set to 2

Signed-off-by: chunfuwen <chwen@redhat.com>