### PR TITLE
numa: Fix comparison of numa_nodeset

### DIFF
--- a/libvirt/tests/src/numa/numa_config_with_auto_placement.py
+++ b/libvirt/tests/src/numa/numa_config_with_auto_placement.py
@@ -205,7 +205,7 @@ def check_cgget_output(test, expected_value):
             cmd = 'cat /sys/fs/cgroup/cpuset/machine.slice/{}/libvirt/{}/cpuset.mems'.format(slice_line, item)
 
         result = process.run(cmd, shell=True, ignore_status=False, verbose=True)
-        if int(expected_value) != int(result.stdout_text):
+        if expected_value != result.stdout_text.strip():
             test.fail('{} is not found in the cpuset.mems file'.format(expected_value))
 
 


### PR DESCRIPTION
The guest memory may be bound to multiple nodes such as 0-1 or 0-3. It is inappropriate to convert the value of nodeset to int type for comparison.

Before:
```
# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio numa_config_with_auto_placement.memory_bind --vt-connect-uri qemu:///system                                                                                                       
JOB ID     : 8f484000b04d2fbc84620f261f996c01cbffe205
JOB LOG    : /var/lib/avocado/job-results/job-2023-02-07T00.38-8f48400/job.log
 (1/1) type_specific.io-github-autotest-libvirt.numa_config_with_auto_placement.memory_bind: FAIL: Unexpected failure during the test: invalid literal for int() with base 10: '0-3' (67.72 s)                                               
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2023-02-07T00.38-8f48400/results.html
JOB TIME   : 68.48 s
```

After:
```
# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio numa_config_with_auto_placement.memory_bind --vt-connect-uri qemu:///system                                                                                                        
JOB ID     : 78b9bb84eb7fd342695165d83e22b265691f67ff
JOB LOG    : /var/lib/avocado/job-results/job-2023-02-07T01.44-78b9bb8/job.log
 (1/1) type_specific.io-github-autotest-libvirt.numa_config_with_auto_placement.memory_bind: PASS (72.93 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2023-02-07T01.44-78b9bb8/results.html
JOB TIME   : 73.64 s
```

Signed-off-by: Hu Shuai <hus.fnst@fujitsu.com>