### PR TITLE
migration: Remove poweroff vm case

### DIFF
--- a/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_and_disruptive_and_recover.cfg
+++ b/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_and_disruptive_and_recover.cfg
@@ -56,8 +56,7 @@
             service_name = "qemu-kvm"
             service_on_dst = "yes"
             action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "virsh.domjobabort", "func_param": "'%s --postcopy' % params.get('migrate_main_vm')", "need_sleep_time": "5"}, {"func": "libvirt_service.kill_service", "func_param": "params", "need_sleep_time": "5"}, {"func": "set_migrate_speed_to_high", "func_param": "params"}, {"func": "do_migration", "func_param": "params"}]'
-        - poweroff_dest_vm:
+        - destroy_dest_vm:
             status_error = "yes"
             status_error_during_mig = "yes"
-            poweroff_vm_dest = "yes"
-            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "virsh.domjobabort", "func_param": "'%s --postcopy' % params.get('migrate_main_vm')", "need_sleep_time": "90"}, {"func": "poweroff_vm", "func_param": "params", "need_sleep_time": "3"}, {"func": "set_migrate_speed_to_high", "func_param": "params"}, {"func": "do_migration", "func_param": "params"}]'
+            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "virsh.domjobabort", "func_param": "'%s --postcopy' % params.get('migrate_main_vm')", "need_sleep_time": "5"}, {"func": "destroy_dest_vm", "func_param": "params", "need_sleep_time": "3"}, {"func": "set_migrate_speed_to_high", "func_param": "params"}, {"func": "do_migration", "func_param": "params"}]'

--- a/provider/migration/migration_base.py
+++ b/provider/migration/migration_base.py
@@ -620,3 +620,14 @@ def wait_for_unattended_mig(params):
     if remote_virsh_session and expected_event_target:
         dest_output = remote_virsh_session.get_stripped_output()
         check_output(dest_output, eval(expected_event_target), migration_obj.test)
+
+
+def destroy_dest_vm(params):
+    """
+    Destroy vm on dest
+
+    :param params: dict, get vm name and dest uri
+    """
+    dest_uri = params.get("virsh_migrate_desturi")
+    vm_name = params.get("main_vm")
+    virsh.destroy(vm_name, ignore_status=False, debug=True, uri=dest_uri)


### PR DESCRIPTION
1. Due to bug 2166856, we need remove poweroff_dest_vm case.
2. Add a new scenario to test destroy vm on dest.

Signed-off-by: cliping <lcheng@redhat.com>