### PR TITLE
migration: Fix check_established error

### DIFF
--- a/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_by_domjobabort_and_recover.cfg
+++ b/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_by_domjobabort_and_recover.cfg
@@ -62,6 +62,7 @@
         - migrateuri:
             port_to_check = "49153"
             virsh_migrate_extra = "--migrateuri tcp://${migrate_dest_host}:${port_to_check} --listen-address ${migrate_dest_host} "
+            action_during_mig_again = '[{"func": "do_common_check", "before_pause": "yes", "func_param": "params"}, {"func": "libvirt_network.check_established", "func_param": 'params'}, {"func": "set_migrate_speed_to_high", "before_pause": "yes", "func_param": "params"}]'
         - dname:
             dname_value = "guest-new-name"
             virsh_migrate_extra = "--dname ${dname_value}"

--- a/provider/migration/migration_base.py
+++ b/provider/migration/migration_base.py
@@ -489,8 +489,6 @@ def do_common_check(params):
     migration_obj = params.get("migration_obj")
     vm_name = params.get("main_vm")
 
-    if migration_options == "migrateuri":
-        libvirt_network.check_established(params)
     if migration_options == "postcopy_bandwidth" and second_bandwidth:
         libvirt_domjobinfo.check_domjobinfo(migration_obj.vm, params)
 


### PR DESCRIPTION
Executing the domain job abort operation during the migration
process will interrupt the established connection. So for
migrateuri case, checking for "ESTABLISHED" with the netstat
command in do_common_check() fails. We can check established
during migration again.

Signed-off-by: cliping <lcheng@redhat.com>