### PR TITLE
guest_numa: vm needs more memory to start

### DIFF
--- a/libvirt/tests/cfg/numa/guest_numa.cfg
+++ b/libvirt/tests/cfg/numa/guest_numa.cfg
@@ -4,17 +4,17 @@
     kill_vm = "yes"
     status_error = "no"
     vcpu_num = 4
-    max_mem = 1048576
+    max_mem = 2097152
     hugepage_force_allocate = "yes"
     numa_cells_with_memory_required = 2
     variants:
         - possitive_test:
              cell_id_0 = "0"
              cell_cpus_0 = "0-1"
-             cell_memory_0 = "524288"
+             cell_memory_0 = "1048576"
              cell_id_1 = "1"
              cell_cpus_1 = "2-3"
-             cell_memory_1 = "524288"
+             cell_memory_1 = "1048576"
              variants:
                  - numatune_mem:
                      memory_placement = "static"
@@ -25,8 +25,8 @@
                  - no_numatune_mem:
              variants:
                  - no_numatune_memnode:
-                     qemu_cmdline_numa_cell_0 = "node,nodeid=0,cpus=0-1,mem=512"
-                     qemu_cmdline_numa_cell_1 = "node,nodeid=1,cpus=2-3,mem=512"
+                     qemu_cmdline_numa_cell_0 = "node,nodeid=0,cpus=0-1,mem=1024"
+                     qemu_cmdline_numa_cell_1 = "node,nodeid=1,cpus=2-3,mem=1024"
                  - numatune_memnode:
                      memnode_nodeset_0 = 1
                      pseries:

--- a/libvirt/tests/src/numa/guest_numa.py
+++ b/libvirt/tests/src/numa/guest_numa.py
@@ -110,15 +110,15 @@ def run(test, params, env):
         if (machine_ver.startswith("pc-q35-rhel") and
                 machine_ver > 'pc-q35-rhel8.2.0' and
                 libvirt_version.version_compare(6, 4, 0)):
-            # Replace 'node,nodeid=0,cpus=0-1,mem=512' with
+            # Replace 'node,nodeid=0,cpus=0-1,mem=1024' with
             # 'node,nodeid=0,cpus=0-1,memdev=ram-node0'
-            # Replace 'node,nodeid=1,cpus=2-3,mem=512' with
+            # Replace 'node,nodeid=1,cpus=2-3,mem=1024' with
             # 'node,nodeid=1,cpus=2-3,memdev=ram-node1'
             for cmd in cmdline_list:
                 line = cmd['cmdline']
                 try:
                     node = line.split(',')[1][-1]
-                    cmd['cmdline'] = line.replace('mem=512',
+                    cmd['cmdline'] = line.replace('mem=1024',
                                                   'memdev=ram-node{}'.format(node))
                 # We can skip replacing, when the cmdline parameter is empty.
                 except IndexError:


### PR DESCRIPTION
Since qemu-kvm-7.2.0-1, the vm needs more memory to start. As RHEL offical web page says, 1G memory is too small. 1.5G is required at least. For convenient usage, we use 2G in test.

Signed-off-by: Dan Zheng <dzheng@redhat.com>