### PR TITLE
fix input case  Unexpected address virtio-mouse error

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
@@ -9,6 +9,7 @@ from virttest import utils_misc
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.disk import Disk
 from virttest.libvirt_xml.devices.watchdog import Watchdog
+from virttest.libvirt_xml.devices.input import Input
 from virttest.utils_test import libvirt
 from virttest.utils_disk import get_scsi_info
 from virttest.utils_libvirt import libvirt_vmxml
@@ -220,12 +221,16 @@ def run(test, params, env):
         attach_device = False
 
     if input_type:
+        vmxml.remove_all_device_by_type('input')
         input_dict.update({"alias": {"name": device_alias}})
         if input_type == "passthrough":
             event = process.run("ls /dev/input/event*", shell=True).stdout
             input_dict.update({"source_evdev": event.decode('utf-8').split()[0]})
-        libvirt_vmxml.modify_vm_device(vmxml, "input",
-                                       dev_dict=input_dict)
+
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        input_obj = Input(type_name=input_type)
+        input_obj.setup_attrs(**input_dict)
+        libvirt.add_vm_device(vmxml, input_obj)
 
         if not vm.is_alive():
             vm.start()


### PR DESCRIPTION
Signed-off-by: nanli <nanli@redhat.com>


 Fix two errors:
```
VMStartError: VM 'avocado-vt-vm1' failed to start: error: Failed to start domain 'avocado-vt-vm1'error: internal error: Unexpected address type for 'virtio-mouse'(exit status: 1)&#10;

TypeError: __init__() missing 1 required positional argument: 'type_name'&#10;


```



```

[root@dell-per730-66 tp-libvirt]# avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 virsh.detach_device_alias..input --vt-connect-uri qemu:///system

 (1/6) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.input.keyboard: PASS (107.54 s)
 (2/6) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.input.mouse: PASS (110.84 s)
 (3/6) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.input.passthrough: PASS (106.98 s)
 (4/6) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.config.input.keyboard: PASS (105.84 s)
 (5/6) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.config.input.mouse: PASS (105.92 s)
 (6/6) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.config.input.passthrough: PASS (104.74 s)

```