### PR TITLE
detach_device_alias: Enable detach input device with alias test for aarch64

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
@@ -8,6 +8,7 @@ from virttest import virsh
 from virttest import utils_misc
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.disk import Disk
+from virttest.libvirt_xml.devices.input import Input
 from virttest.libvirt_xml.devices.watchdog import Watchdog
 from virttest.utils_test import libvirt
 from virttest.utils_disk import get_scsi_info
@@ -224,8 +225,14 @@ def run(test, params, env):
         if input_type == "passthrough":
             event = process.run("ls /dev/input/event*", shell=True).stdout
             input_dict.update({"source_evdev": event.decode('utf-8').split()[0]})
-        libvirt_vmxml.modify_vm_device(vmxml, "input",
-                                       dev_dict=input_dict)
+
+        if not vmxml.get_devices(device_type="input"):
+            input_dev = Input(type_name=input_type)
+            input_dev.setup_attrs(**input_dict)
+            libvirt.add_vm_device(vmxml, input_dev)
+        else:
+            libvirt_vmxml.modify_vm_device(vmxml, "input",
+                                           dev_dict=input_dict)
 
         if not vm.is_alive():
             vm.start()


### PR DESCRIPTION
The default aarch64 guest doesn't have any input devices, so use 'libvirt.add_vm_device' to add the input device for deatch.

Test Result:
```
# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio virsh.detach_device_alias..input --vt-connect-uri qemu:///system
JOB ID     : b5c52484ef94dfb4e1556a62efe95388c18f021b
JOB LOG    : /var/lib/avocado/job-results/job-2023-02-13T02.08-b5c5248/job.log
 (1/6) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.input.keyboard: PASS (48.13 s)
 (2/6) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.input.mouse: PASS (54.81 s)
 (3/6) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.input.passthrough: PASS (54.46 s)
 (4/6) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.config.input.keyboard: PASS (47.03 s)
 (5/6) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.config.input.mouse: PASS (46.15 s)
 (6/6) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.config.input.passthrough: PASS (46.56 s)
RESULTS    : PASS 6 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2023-02-13T02.08-b5c5248/results.html
JOB TIME   : 297.60 s
```

Signed-off-by: Hu Shuai <hus.fnst@fujitsu.com>