### PR TITLE
[guest_resource_control] Add cases to check negative cfs_quota values

### DIFF
--- a/libvirt/tests/cfg/guest_resource_control/control_cgroup.cfg
+++ b/libvirt/tests/cfg/guest_resource_control/control_cgroup.cfg
@@ -146,7 +146,11 @@
                     virsh_cmd_param = "vcpu_quota"
                     variants:
                         - positive:
-                            virsh_cmd_param_value = "80000"
+                          variants:
+				- value_positive:
+				  virsh_cmd_param_value = "80000"
+				- value_negative:
+				  virsh_cmd_param_value = "-111"
                         - negative:
                             status_error = "yes"
                             variants:
@@ -166,7 +170,11 @@
                     virsh_cmd_param = "emulator_quota"
                     variants:
                         - positive:
-                            virsh_cmd_param_value = "80000"
+                          variants:
+				- value_positive:
+				  virsh_cmd_param_value = "80000"
+				- value_negative:
+				  virsh_cmd_param_value = "-222"
                         - negative:
                             status_error = "yes"
                             variants:
@@ -186,7 +194,11 @@
                     virsh_cmd_param = "global_quota"
                     variants:
                         - positive:
-                            virsh_cmd_param_value = "80000"
+                          variants:
+				- value_positive:
+				  virsh_cmd_param_value = "80000"
+				- value_negative:
+				  virsh_cmd_param_value = "-333"
                         - negative:
                             status_error = "yes"
                             variants:
@@ -206,7 +218,11 @@
                     virsh_cmd_param = "iothread_quota"
                     variants:
                         - positive:
-                            virsh_cmd_param_value = "80000"
+                          variants:
+				- value_positive:
+				  virsh_cmd_param_value = "80000"
+				- value_negative:
+				  virsh_cmd_param_value = "-444"
                         - negative:
                             status_error = "yes"
                             variants:


### PR DESCRIPTION
cfs_quota params can be set as negative values, which means it's unlimited. After bz2037998 fixed, we'll need to add cases to check them.

Signed-off-by: Yi Sun <yisun@redhat.com>