### PR TITLE
sriov: Add a case about nodedev

### DIFF
--- a/libvirt/tests/cfg/sriov/nodedev/sriov_reattach_detach_nodedev_in_use.cfg
+++ b/libvirt/tests/cfg/sriov/nodedev/sriov_reattach_detach_nodedev_in_use.cfg
@@ -1,0 +1,17 @@
+- sriov.nodedev.reattach_detach_nodedev_in_use:
+    type = sriov_reattach_detach_nodedev_in_use
+    start_vm = "no"
+    err_msg = "PCI device.* is in use by driver"
+    only x86_64
+
+    variants dev_type:
+        - hostdev_interface:
+            variants dev_name:
+                - vf:
+                    iface_dict = {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}, 'driver': {'driver_attr': {'name': 'vfio'}}}
+        - hostdev_device:
+            variants dev_name:
+                - vf:
+                    hostdev_dict = {'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': vf_pci_addr}, 'managed': 'yes'}
+                - pf:
+                    hostdev_dict = {'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': pf_pci_addr}, 'managed': 'yes'}

--- a/libvirt/tests/src/sriov/nodedev/sriov_reattach_detach_nodedev_in_use.py
+++ b/libvirt/tests/src/sriov/nodedev/sriov_reattach_detach_nodedev_in_use.py
@@ -1,0 +1,58 @@
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+from provider.sriov import check_points
+from provider.sriov import sriov_base
+
+
+def run(test, params, env):
+    """Test nodedev-detach or reattach when vf or PF is in use."""
+    def run_test():
+        """
+        Run nodedev-detach or reattach when vf or PF is in use.
+
+        1. start the vm with hostdev interface or device;
+        2. on the host, run nodedev-detach for the PF or VF, should fail
+        3. on the host, run nodedev-reattach for the PF or VF, should fail
+        4. check on the VM for network function, should works well.
+        """
+        test.log.info("TEST_STEP: Start the VM.")
+        dev_type = "interface" if 'interface' in params.get('dev_type') else "hostdev"
+        libvirt_vmxml.modify_vm_device(
+            vm_xml.VMXML.new_from_inactive_dumpxml(vm_name),
+            dev_type, iface_dict)
+        vm.start()
+        vm_session = vm.wait_for_serial_login(timeout=int(params.get('login_timeout')))
+
+        test.log.info("TEST_STEP: Detach nodedev %s.", dev_name)
+        result = virsh.nodedev_detach(dev_name, debug=True)
+        libvirt.check_result(result, err_msg)
+
+        test.log.info("TEST_STEP: Reattach nodedev %s.", dev_name)
+        result = virsh.nodedev_reattach(dev_name, debug=True)
+        libvirt.check_result(result, err_msg)
+
+        test.log.info("TEST_STEP: Check VM network accessibility.")
+        check_points.check_vm_network_accessed(vm_session)
+
+    dev_name = params.get("dev_name", "pf")
+    err_msg = params.get("err_msg", "PCI device.* is in use by driver")
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    vm = env.get_vm(vm_name)
+    sriov_test_obj = sriov_base.SRIOVTest(vm, test, params)
+    iface_dict = sriov_test_obj.parse_iface_dict()
+    if dev_name == "vf":
+        dev_name = sriov_test_obj.vf_dev_name
+    else:
+        dev_name = sriov_test_obj.pf_dev_name
+
+    try:
+        sriov_test_obj.setup_default()
+        run_test()
+
+    finally:
+        virsh.nodedev_reattach(dev_name, debug=True)
+        sriov_test_obj.teardown_default()


### PR DESCRIPTION
This PR adds:
   VIRT-293916: Run nodedev-detach or reattach when vf or PF is in use

Signed-off-by: Yingshun Cui <yicui@redhat.com>

**Test results:**
```
 (1/3) type_specific.io-github-autotest-libvirt.sriov.nodedev.reattach_detach_nodedev_in_use.hostdev_interface.vf: PASS (69.49 s)
 (2/3) type_specific.io-github-autotest-libvirt.sriov.nodedev.reattach_detach_nodedev_in_use.hostdev_device.vf: PASS (71.00 s)
 (3/3) type_specific.io-github-autotest-libvirt.sriov.nodedev.reattach_detach_nodedev_in_use.hostdev_device.pf: PASS (72.83 s)
```