### PR TITLE
virsh_cpu_compare_xml:Fix error of parsing invalid test xml

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_compare_xml.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_cpu_compare_xml.py
@@ -92,13 +92,8 @@ def get_invalid_xml(data_xml):
     :return: The instance of VMCPUXML
     """
     invalid_xml = vm_xml.VMCPUXML()
-    with open(data_xml.xml, "r") as data_f, \
-            open(invalid_xml.xml, "w") as new_f:
-        # Discard line with <?xml
-        data_f.readline()
-        new_f.write("<host>{}</host>".format(data_f.read()))
-    # Reload xml content
-    invalid_xml.xmltreefile.parse(invalid_xml.xml)
+    data_xml_content = data_xml.xmltreefile.get_element_string('.')
+    invalid_xml.xml = f'<host>{data_xml_content}</host>'
     return invalid_xml
 
 


### PR DESCRIPTION

Test result:
```
 (1/1) type_specific.io-github-autotest-libvirt.virsh.cpu_compare_xml.cpu_xml.invalid_test: PASS (42.98 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2023-02-15T22.26-29d039d/results.html
JOB TIME   : 44.44 s
```