### PR TITLE
migration: Fix recover postcopy migration error

### DIFF
--- a/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_and_recover_and_disruptive.cfg
+++ b/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_and_recover_and_disruptive.cfg
@@ -71,7 +71,7 @@
             action_during_do_mig = '[{"func": "libvirt_service.kill_service", "before_pause": "yes", "func_param": "params", "need_sleep_time": "10"}]'
             status_error_during_mig = "yes"
         - pause_by_domjobabort:
-            action_during_do_mig = '[{"func": "virsh.domjobabort", "before_pause": "yes", "func_param": "'%s --postcopy' % params.get('migrate_main_vm')"}, {"func": "resume_migration_again", "func_param": "params"}]'
+            action_during_do_mig = '[{"func": "virsh.domjobabort", "before_pause": "yes", "func_param": "'%s --postcopy' % params.get('migrate_main_vm')", "need_sleep_time": "20"}, {"func": "resume_migration_again", "before_pause": "yes", "func_param": "params", "need_sleep_time": "10"}]'
             status_error_during_mig = "no"
         - pause_by_network_issue:
             port_to_check = "49152"


### PR DESCRIPTION
Need add time sleep before virsh.domjobabort() for recover postcopy
 migration.