### PR TITLE
pcibridge.py: update the method of login guest to fix timeout

### DIFF
--- a/libvirt/tests/src/controller/pcibridge.py
+++ b/libvirt/tests/src/controller/pcibridge.py
@@ -345,8 +345,7 @@ def run(test, params, env):
                 libvirt.check_exit_status(result_start_vm)
 
                 # Login to make sure vm is actually started
-                vm.create_serial_console()
-                vm.wait_for_serial_login().close()
+                vm.wait_for_login().close()
 
                 logging.debug(virsh.dumpxml(vm_name))
 


### PR DESCRIPTION
Several pcibridge related cases may failed because of "LoginTimeoutError: Login timeout expired" sometimes. The failure may be related to serial port which be occupied  or others. So change it from vm.wait_for_serial_login().close() to vm.wait_for_login().close() to check if it can resolve the failure.