### PR TITLE
add case for concurrent block operation

### DIFF
--- a/libvirt/tests/cfg/backingchain/negative_scenario/do_concurrent_operation.cfg
+++ b/libvirt/tests/cfg/backingchain/negative_scenario/do_concurrent_operation.cfg
@@ -1,0 +1,28 @@
+- backingchain.concurrent_operation:
+    type = do_concurrent_operation
+    target_disk = "vdb"
+    virsh_opt = " -k0"
+    error_msg = "error: block copy still active: disk '${target_disk}' already in active block job"
+    variants case:
+        - during_blockcopy:
+            blockcopy_options = " --wait --verbose %s --transient-job 1"
+            commit_option = " --active --wait --verbose --shallow --pivot --keep-relative"
+            pull_option = " --wait --verbose --base ${target_disk}[2]"
+        - during_blockcommit:
+            blockcommit_options = " --active --wait --verbose --keep-relative --bytes 1"
+            pull_option = " --wait --verbose --base ${target_disk}[2]"
+            commit_option = " --wait --verbose --top %s --base %s --keep-relative"
+    variants:
+        - file_disk:
+            disk_type = "file"
+            disk_dict = {"type_name":"${disk_type}", "target":{"dev": "${target_disk}", "bus": "virtio"}, "driver": {"name": "qemu", "type":"qcow2"}}
+        - block_disk:
+            disk_type = "block"
+            pool_name = "vg0"
+            pool_target = "/dev/${pool_name}"
+            pool_type = "logical"
+            pool_name = "vg0"
+            emulated_image = "emulated-image"
+            disk_dict = {"type_name":"${disk_type}", "target":{"dev": "${target_disk}", "bus": "virtio"}, "driver": {"name": "qemu", "type":"qcow2"}}
+            pool_dict = {"pool_type":"${pool_type}", "name":"${pool_name}", "target_path":"${pool_target}"}
+            source_dict = {"device_path":"%s", "vg_name":"${pool_name}"}

--- a/libvirt/tests/src/backingchain/negative_scenario/do_concurrent_operation.py
+++ b/libvirt/tests/src/backingchain/negative_scenario/do_concurrent_operation.py
@@ -1,0 +1,139 @@
+import os
+
+from avocado.utils import process
+
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_test import libvirt
+
+from provider.backingchain import blockcommand_base
+from provider.virtual_disk import disk_base
+
+
+def run(test, params, env):
+    """
+    Do concurrent blockcommit/blockpull/blockcopy with relative path:
+
+    1) Prepare a guest with snapshots in relative path.
+    2) Do concurrent blockcommit/blockpull/blockcopy
+    3) Check result.
+    """
+
+    def setup_test():
+        """
+        Prepare disk and relative path.
+        """
+        test.log.info("TEST_SETUP:Prepare relative path")
+
+        test_obj.new_image_path, _ = disk_obj.prepare_relative_path(
+            disk_type)
+        disk_obj.add_vm_disk(disk_type, disk_dict,
+                             new_image_path=test_obj.new_image_path,
+                             size="800M")
+
+        test_obj.backingchain_common_setup(remove_file=True, file_path=copy_path)
+
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm.name)
+        test.log.debug('vmxml after starting is:%s', vmxml)
+        test_obj.snap_path_list = disk_obj.get_source_list(vmxml, disk_type,
+                                                           test_obj.new_dev)[1:]
+
+    def test_during_blockcopy():
+        """
+        Do blockcommit and blockpull during blockcopy
+        """
+        test.log.info("TEST_STEP1: Do blockcommit/blockpull during blockcopy")
+        virsh_session = virsh.VirshSession(virsh_exec=virsh.VIRSH_EXEC,
+                                           auto_close=True)
+        cmd = "blockcopy %s %s %s" % (vm_name, target_disk,
+                                      blockcopy_options % copy_path)
+        virsh_session.sendline(cmd)
+        test.log.debug("Do blockcopy by: %s", cmd)
+
+        ret = virsh.blockcommit(vm.name, target_disk, commit_option,
+                                debug=True, virsh_opt=virsh_opt)
+        libvirt.check_result(ret, expected_fails=error_msg,
+                             check_both_on_error=True)
+
+        ret = virsh.blockpull(vm.name, target_disk, pull_option,
+                              debug=True, virsh_opt=virsh_opt)
+        libvirt.check_result(ret, expected_fails=error_msg,
+                             check_both_on_error=True)
+
+    def test_during_blockcommit():
+        """
+        Do blockcommit and blockpull during blockcommit
+        """
+
+        test.log.info("TEST_STEP1: Do blockcommit/blockpull during blockcommit")
+        virsh_session = virsh.VirshSession(virsh_exec=virsh.VIRSH_EXEC,
+                                           auto_close=True)
+        cmd = " blockcommit %s %s %s" % (vm_name, target_disk,
+                                         blockcommit_options)
+        virsh_session.sendline(cmd)
+        test.log.debug("Do blockcommit by: %s", cmd)
+
+        ret = virsh.blockcommit(vm.name, target_disk,
+                                commit_option % (test_obj.snap_path_list[0],
+                                                 test_obj.snap_path_list[2]),
+                                debug=True, virsh_opt=virsh_opt)
+
+        libvirt.check_result(ret, expected_fails=error_msg,
+                             check_both_on_error=True)
+
+        ret = virsh.blockpull(vm.name, target_disk, pull_option,
+                              debug=True, virsh_opt=virsh_opt)
+        libvirt.check_result(ret, expected_fails=error_msg,
+                             check_both_on_error=True)
+
+    def teardown_test():
+        """
+        Clean env
+        """
+        test.log.info("TEST_TEARDOWN: Clean up env.")
+        bkxml.sync()
+        test_obj.clean_file(copy_path)
+
+        for folder in [chr(letter) for letter in
+                       range(ord('a'), ord('a') + 4)]:
+            rm_cmd = "rm -rf %s" % os.path.join(disk_obj.base_dir, folder)
+            process.run(rm_cmd, shell=True)
+
+        if disk_type == 'block':
+            pvt = libvirt.PoolVolumeTest(test, params)
+            pvt.cleanup_pool(**params)
+            process.run("rm -rf %s" % pool_target)
+
+    # Process cartesian parameters
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    case = params.get("case")
+    target_disk = params.get("target_disk")
+    disk_type = params.get("disk_type")
+    disk_dict = eval(params.get('disk_dict', '{}'))
+
+    virsh_opt = params.get("virsh_opt")
+    blockcopy_options = params.get("blockcopy_options")
+    blockcommit_options = params.get("blockcommit_options")
+
+    commit_option = params.get("commit_option")
+    pull_option = params.get("pull_option")
+    error_msg = params.get("error_msg")
+    pool_target = params.get("pool_target")
+
+    test_obj = blockcommand_base.BlockCommand(test, vm, params)
+    disk_obj = disk_base.DiskBase(test, vm, params)
+
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+    copy_path = os.path.join(disk_obj.base_dir, "copy.img")
+
+    run_test = eval("test_%s" % case)
+
+    try:
+        setup_test()
+        run_test()
+
+    finally:
+        teardown_test()


### PR DESCRIPTION
    VIRT-294613:  Do concurrent block operations with relative path
Signed-off-by: nanli <nanli@redhat.com>
```

/usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.concurrent_operation

 (1/4) type_specific.io-github-autotest-libvirt.backingchain.concurrent_operation.file_disk.during_blockcopy: PASS (46.46 s)
 (2/4) type_specific.io-github-autotest-libvirt.backingchain.concurrent_operation.file_disk.during_blockcommit: PASS (65.00 s)
 (3/4) type_specific.io-github-autotest-libvirt.backingchain.concurrent_operation.block_disk.during_blockcopy: PASS (101.02 s)
 (4/4) type_specific.io-github-autotest-libvirt.backingchain.concurrent_operation.block_disk.during_blockcommit: PASS (95.44 s)
```