### PR TITLE
libvirt_rng:Fix error when calling 'get_devices'

### DIFF
--- a/libvirt/tests/src/libvirt_rng.py
+++ b/libvirt/tests/src/libvirt_rng.py
@@ -430,7 +430,7 @@ def run(test, params, env):
 
         :param rng_dev: List of names of RNG devices
         """
-        if vm_xml.VMXML.get_devices("tpm"):
+        if vmxml.get_devices("tpm"):
             rng_dev.remove("tpm-rng-0")
         if "trng" in rng_dev:
             rng_dev.remove("trng")


### PR DESCRIPTION
The function get_devices is supposed to be called by a VMXML instance, not the class itself.