### PR TITLE
Fix input device failures due to element order change

### DIFF
--- a/libvirt/tests/src/virtual_device/input_devices.py
+++ b/libvirt/tests/src/virtual_device/input_devices.py
@@ -27,7 +27,7 @@ def run(test, params, env):
         """
         Check whether the added devices are shown in the guest xml
         """
-        pattern = "<input bus=\"%s\" type=\"%s\">" % (bus_type, input_type)
+        pattern = "<input type=\"%s\" bus=\"%s\">" % (input_type, bus_type)
         if with_packed:
             pattern = "<driver packed=\"%s\"" % (driver_packed)
         logging.debug('Searching for %s in vm xml', pattern)


### PR DESCRIPTION
Fix input device failures due to element order change
After avocado-vt PR:3615 integated, the input element order changed, so need change matched pattern accordingly