### PR TITLE
input_devices, virsh_boot_sysinfo: improve xml check

### DIFF
--- a/libvirt/tests/src/bios/virsh_boot_sysinfo.py
+++ b/libvirt/tests/src/bios/virsh_boot_sysinfo.py
@@ -122,12 +122,19 @@ def run(test, params, env):
         if not status_error:
             # Check result in dumpxml and qemu cmdline
             if with_file:
-                expect_xml_line = "<entry file=\"%s\" name=\"%s\" />" % (entry_file, entry_name)
+                xpaths = [
+                        ".//entry[@file='%s']" % entry_file,
+                        ".//entry[@name='%s']" % entry_name
+                        ]
+                text = None
                 expect_qemu_line = "-fw_cfg name=%s,file=%s" % (entry_name, entry_file)
             if with_value:
-                expect_xml_line = "<entry name=\"%s\">%s</entry>" % (entry_name, value_string)
+                xpaths = [
+                        ".//entry[@name='%s']" % entry_name
+                        ]
+                text = value_string
                 expect_qemu_line = "-fw_cfg name=%s,string=%s" % (entry_name, value_string)
-            libvirt.check_dumpxml(vm, expect_xml_line)
+            libvirt.check_xpaths(vmxml, xpaths, text)
             libvirt.check_qemu_cmd_line(expect_qemu_line)
 
             # Check result in guest

--- a/libvirt/tests/src/virtual_device/input_devices.py
+++ b/libvirt/tests/src/virtual_device/input_devices.py
@@ -5,6 +5,7 @@ import platform
 
 from virttest.libvirt_xml.devices.input import Input
 from virttest.libvirt_xml.vm_xml import VMXML
+from virttest.utils_test import libvirt
 from virttest import virsh
 
 from virttest import libvirt_version
@@ -27,15 +28,16 @@ def run(test, params, env):
         """
         Check whether the added devices are shown in the guest xml
         """
-        pattern = "<input type=\"%s\" bus=\"%s\">" % (input_type, bus_type)
+        expected = [
+                ".//input[@type='%s']" % input_type,
+                ".//input[@bus='%s']" % bus_type
+                ]
         if with_packed:
-            pattern = "<driver packed=\"%s\"" % (driver_packed)
-        logging.debug('Searching for %s in vm xml', pattern)
+            expected.append(".//driver[@packed='%s']" % driver_packed)
+        logging.debug('Searching vm xml for values %s', expected)
         xml_after_adding_device = VMXML.new_from_dumpxml(vm_name)
         logging.debug('xml_after_adding_device:\n%s', xml_after_adding_device)
-        if pattern not in str(xml_after_adding_device):
-            test.fail("Can not find the %s input device xml "
-                      "in the guest xml file." % input_type)
+        libvirt.check_xpaths(xml_after_adding_device, expected)
 
     def check_qemu_cmd_line():
         """


### PR DESCRIPTION
Depends on https://github.com/avocado-framework/avocado-vt/pull/3632

XML attributes are unordered. Therefore, checking multiple values
as strings can fail. Use XPath expressions instead.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>