### PR TITLE
virtual_devices/input_device: fix test with_packed

### DIFF
--- a/libvirt/tests/src/virtual_device/input_devices.py
+++ b/libvirt/tests/src/virtual_device/input_devices.py
@@ -33,7 +33,9 @@ def run(test, params, env):
                 ".//input[@bus='%s']" % bus_type
                 ]
         if with_packed:
-            expected.append(".//driver[@packed='%s']" % driver_packed)
+            expected = [
+                    ".//driver[@packed='%s']" % driver_packed
+                    ]
         logging.debug('Searching vm xml for values %s', expected)
         xml_after_adding_device = VMXML.new_from_dumpxml(vm_name)
         logging.debug('xml_after_adding_device:\n%s', xml_after_adding_device)


### PR DESCRIPTION
9b616bc893e086fd096811185e3ee56f6ba01b7e introduced a new function to check input XML without considering the order. However, the test expectation for `with_packed` was accidentally changed erroneously. The test now verifies correctly that `<driver packed='on'/>` is present.