### PR TITLE
cpu/iothread: add error message variant

### DIFF
--- a/libvirt/tests/cfg/cpu/iothread.cfg
+++ b/libvirt/tests/cfg/cpu/iothread.cfg
@@ -70,7 +70,7 @@
                             pseries, aarch64:
                                 iothreadpins = "2:300"
                             start_vm = "yes"
-                            err_msg = "Numerical result out of range"
+                            err_msg = "Numerical result out of range|Invalid argument"
                         - no_matchs_iothread:
                             define_error = "yes"
                             iothread_ids = "2"


### PR DESCRIPTION
On some systems the expected error message is different.