### PR TITLE
sriov: Fix an issue of no rom file

### DIFF
--- a/provider/sriov/sriov_base.py
+++ b/provider/sriov/sriov_base.py
@@ -239,7 +239,12 @@ class SRIOVTest(object):
         rom_vendor_device = lspci_stdout[1:-1].replace(':', '') + '.rom'
         rom_file = os.path.join('/usr/share/ipxe', rom_vendor_device)
         if not os.path.exists(rom_file):
-            self.test.error("This test needs rom file: %s." % rom_file)
+            build_cmd = "git clone https://github.com/ipxe/ipxe.git;\
+                         pushd ipxe/src; make bin/{0}; cp bin/{0} {1}; popd; \
+                         rm -rf ipxe".format(rom_vendor_device, rom_file)
+            process.run(build_cmd, shell=True, verbose=True)
+            if not os.path.exists(rom_file):
+                self.test.error("This test needs rom file: %s." % rom_file)
         return rom_file
 
     def create_iface_dev(self, dev_type, iface_dict):


### PR DESCRIPTION
If there is no specific rom file, need to build from source code.

**Before the fix:**
` (1/1) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_special_situations.hostdev_interface.boot_order: ERROR: This test needs rom file: /usr/share/ipxe/8086154c.rom. (15.57 s)`

**After the fix:**
` (1/1) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device_special_situations.hostdev_interface.boot_order: PASS (265.74 s)
`