### PR TITLE
migration: Fix failed to get domain

### DIFF
--- a/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_by_domjobabort_and_recover.cfg
+++ b/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_by_domjobabort_and_recover.cfg
@@ -65,6 +65,7 @@
         - dname:
             dname_value = "guest-new-name"
             virsh_migrate_extra = "--dname ${dname_value}"
+            virsh_migrate_extra_mig_again = "--timeout 4 --timeout-postcopy --postcopy --postcopy-resume --dname ${dname_value}"
         - xml:
             update_xml_title = "Update title in xml"
         - persistent:


### PR DESCRIPTION
Need to set '--dname' parameter in migration again process. So add
 a parameter.