### PR TITLE
libvirt_rng: Ignore non-virtio rng device

### DIFF
--- a/libvirt/tests/cfg/libvirt_rng.cfg
+++ b/libvirt/tests/cfg/libvirt_rng.cfg
@@ -5,6 +5,9 @@
     status_error = no
     s390-virtio:
         set_virtio_current = yes
+    # Devices that might be present though not configured via <rng>.
+    # For example, devices that are provided by the CPU.
+    ignored_devices = s390-trng,trng,tpm-rng-0
     variants:
         - hotplug_unplug:
             only backend_rdm.default, backend_tcp, backend_udp, backend_builtin


### PR DESCRIPTION
The tests compare the number of available rng devices to confirm attachment. However, some sources can provide rng devices that are not virtio and can be ignored.

Instead of adding logic to the code that ignores one by one, change the code to provide a configurable list of devices that should be ignored.

The criterion to ignore the device 'tpm-rng-0' was its presence in the XML configuration. However, it should always be ignored.