### PR TITLE
virsh_managedsave:Fail test if timeout when waiting for certain vm state

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_managedsave.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_managedsave.py
@@ -198,7 +198,10 @@ def run(test, params, env):
         """
         Wait for vm state is ready.
         """
-        utils_misc.wait_for(lambda: vm.state() == vm_state, 10)
+        timeout = 120
+        if not utils_misc.wait_for(lambda: vm.state() == vm_state, timeout):
+            test.fail(f'Wait {timeout}s for vm to be {vm_state} and failed.'
+                      f'Current VM state is {vm.state()}')
 
     def check_guest_flags(bash_cmd, flags):
         """


### PR DESCRIPTION
Test should not proceed if vm has not been expected state, or test result would be incorrect.

With 10s as timeout:
```
FAIL 1-type_specific.io-github-autotest-libvirt.virsh.managedsave.functional_test.bypass_cache -> TestFail: Wait 10s for vm to be shut off and failed.Current VM state is paused
```

With 120s as timeout:
```
PASS 1-type_specific.io-github-autotest-libvirt.virsh.managedsave.functional_test.bypass_cache
```