### PR TITLE
vm_features: add case using features in domcap

### DIFF
--- a/libvirt/tests/cfg/cpu/vm_features.cfg
+++ b/libvirt/tests/cfg/cpu/vm_features.cfg
@@ -1,5 +1,6 @@
 - vm_features:
     type = vm_features
+    take_regular_screendumps = no
     start_vm = 'no'
     variants:
         - positive_test:
@@ -7,18 +8,24 @@
                 - hyperv:
                     no pseries, s390-virtio, aarch64
                     variants:
+                        - features_in_domcapabilities:
+                            func_supported_since_libvirt_ver = (9, 0, 0)
+                            features_from_domcap = 'in'
                         - tlbflush:
-                            hyperv_attr = {'relaxed': 'on', 'vapic': 'on', 'vpindex': 'on', 'tlbflush': 'on'}
+                            func_supported_since_libvirt_ver = (5, 0, 0)
+                            hyperv_attr = {'relaxed': {'state': 'on'}, 'vapic': {'state': 'on'}, 'vpindex': {'state': 'on'}, 'tlbflush': {'state': 'on'}}
                         - frequencies:
-                            hyperv_attr = {'relaxed': 'on', 'vapic': 'on', 'vpindex': 'on', 'frequencies': 'on'}
+                            func_supported_since_libvirt_ver = (5, 0, 0)
+                            hyperv_attr = {'relaxed': {'state': 'on'}, 'vapic': {'state': 'on'}, 'vpindex': {'state': 'on'}, 'frequencies': {'state': 'on'}}
                         - reenlightenment:
-                            hyperv_attr = {'reenlightenment': 'on'}
+                            func_supported_since_libvirt_ver = (5, 0, 0)
+                            hyperv_attr = {'reenlightenment': {'state': 'on'}}
                         - relaxed:
                             variants:
                                 - enable:
-                                    hyperv_attr={'relaxed': 'on'}
+                                    hyperv_attr={'relaxed': {'state': 'on'}}
                                 - disable:
-                                    hyperv_attr={'relaxed': 'off'}
+                                    hyperv_attr={'relaxed': {'state': 'on'}}
                 - pmu:
                     no pseries, s390-virtio
                     variants:
@@ -44,6 +51,7 @@
                             hidden_attr={'kvm_hidden_state': 'off'}
                 - kvm_poll_control:
                     no pseries, aarch64, s390x
+                    func_supported_since_libvirt_ver = (6, 10, 0)
                     variants:
                         - enable:
                             kvm_poll_control_attr = {'kvm_poll_control': 'on'}
@@ -51,3 +59,12 @@
                         - disable:
                             kvm_poll_control_attr = {'kvm_poll_control': 'off'}
                             qemu_exclude = 'kvm-poll-control=on'
+        - negative_test:
+            variants:
+                - hyperv:
+                    variants:
+                        - features_not_in_domcapabilities:
+                            func_supported_since_libvirt_ver = (9, 0, 0)
+                            status_error = 'yes'
+                            all_possible_hyperv_features = ['relaxed', 'vapic', 'spinlocks', 'vpindex', 'runtime', 'synic', 'stimer', 'reset', 'vendor_id', 'frequencies', 'reenlightenment', 'tlbflush', 'ipi', 'evmcs', 'avic']
+                            features_from_domcap = 'not in'

--- a/libvirt/tests/src/cpu/vm_features.py
+++ b/libvirt/tests/src/cpu/vm_features.py
@@ -8,9 +8,10 @@ from virttest import libvirt_version
 from virttest import utils_package
 from virttest import utils_misc
 from virttest import virsh
+from virttest.libvirt_xml import domcapability_xml
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
-
+from virttest.libvirt_xml import xcepts
 
 # Using as lower capital is not the best way to do, but this is just a
 # workaround to avoid changing the entire file.
@@ -57,10 +58,98 @@ def check_cmd_in_guest(cmd_in_guest, vm_session, params, test):
     logging.debug("Checking in check_cmd_in_guest() is successful.")
 
 
+def get_hyperv_features_in_domcapabilities():
+    """
+    Get all supported hyperv features on the host
+
+    :return: list, the feature name list
+    """
+    domcapa_xml = domcapability_xml.DomCapabilityXML()
+    features = domcapa_xml.get_features()
+    if not features.hyperv_supported == 'yes':
+        return None
+    for enum_node in features.get_hyperv_enums():
+        if enum_node.name != 'features':
+            continue
+        return [enum_item.value for enum_item in enum_node.values]
+
+
+def update_hyperv_features(vmxml, hyperv_attr, test):
+    """
+    Update specified hyperv features in vmxml
+    Sample hyperv_attr: {'relaxed': {'state': 'on'}, 'spinlocks'： {'state': 'on', 'retries': '4096'}}
+
+    :param vmxml: VMXML instance
+    :param hyperv_attr: dict, hyperv features and attributes
+    :param test: test object
+    """
+    vmxml_features = vmxml.features
+    if not vmxml_features:
+        vmxml_features = vm_xml.VMFeaturesXML()
+    try:
+        if vmxml_features.get_hyperv():
+            vmxml_features.del_hyperv()
+    except xcepts.LibvirtXMLNotFoundError:
+        test.log.debug("There is no <hyperv> in old vm xml")
+    features_hyperv = vm_xml.VMFeaturesHypervXML()
+    features_hyperv.setup_attrs(**hyperv_attr)
+    vmxml_features.set_hyperv(features_hyperv)
+    vmxml.features = vmxml_features
+
+
+def add_required_timer(vmxml, timer_attrs):
+    """
+    Add clock configuration in vmxml
+
+    :param vmxml: VMXML instance
+    :param timer_attrs: dict, timer attributes
+    """
+    vm_clock = vmxml.clock
+    clock_timers = vm_clock.timers
+    new_timer = vm_xml.VMClockXML.TimerXML()
+    new_timer.setup_attrs(**timer_attrs)
+    clock_timers.append(new_timer)
+    vm_clock.timers = clock_timers
+    vmxml.clock = vm_clock
+
+
+def assemble_hyperv_feature_list(feature_list, params, test):
+    """
+    Assemble a hyperv feature dict
+
+    :param feature_list: list, name list of hyperv features
+    :param params: dict, test parameters
+    :param test: test object
+
+    :return: dict, hyperv features
+    """
+    hyperv_attr = {}
+    for one_feature in feature_list:
+        if one_feature == 'spinlocks':
+            hyperv_attr.update({one_feature: {'state': 'on', 'retries': '4096'}})
+        elif one_feature == 'stimer':
+            hyperv_attr.update({one_feature: {'state': 'on', 'direct': {'state': 'on'}}})
+        elif one_feature == 'vendor_id':
+            hyperv_attr.update({one_feature: {'state': 'on', 'value': 'KVM Hv'}})
+        else:
+            hyperv_attr.update({one_feature: {'state': 'on'}})
+    if params.get('features_from_domcap') == 'not in':
+        feature_names = eval(params.get('all_possible_hyperv_features'))
+        difference_set = set(feature_names).difference(set(feature_list))
+        test.log.debug("Get hyperv features gap: %s", difference_set)
+        if difference_set:
+            hyperv_attr.update({list(difference_set)[0]: {'state': 'on'}})
+        else:
+            test.cancel("Can not find an unsupported hyperv feature on the host.")
+    test.log.debug("Get assembled hyperv features:\n%s", hyperv_attr)
+    return hyperv_attr
+
+
 def run(test, params, env):
     """
     Test vm features
     """
+    libvirt_version.is_libvirt_feature_supported(params)
     vm_name = params.get('main_vm')
     vm = env.get_vm(vm_name)
 
@@ -73,34 +162,25 @@ def run(test, params, env):
     qemu_exclude = params.get('qemu_exclude', '')
     cmd_in_guest = params.get('cmd_in_guest')
     pkgs = params.get('pkgs')
+    features_from_domcap = params.get('features_from_domcap')
+    status_error = params.get('status_error') == 'yes'
 
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     bkxml = vmxml.copy()
     vm_session = None
     try:
-
-        # Set hyperv attribs if there're attribs to set
+        # Set hyperv features if there're features to set
+        if features_from_domcap:
+            feature_list = get_hyperv_features_in_domcapabilities()
+            if not feature_list:
+                test.cancel("Can not find any supported hyperv features")
+            if 'stimer' in feature_list:
+                add_required_timer(vmxml, {'name': 'hypervclock', 'present': 'yes'})
+            hyperv_attr = assemble_hyperv_feature_list(feature_list, params, test)
         if hyperv_attr:
-            if set(hyperv_attr.keys()).intersection(('tlbflush',
-                                                     'frequencies',
-                                                     'reenlightenment')):
-
-                # Compare libvirt version to decide if test is valid
-                if not libvirt_version.version_compare(5, 0, 0):
-                    test.cancel('This version of libvirt does\'nt support '
-                                'the setting: %r' % hyperv_attr)
-
-            vm_xml.VMXML.set_vm_features(
-                vm_name,
-                **{'hyperv_%s_state' % key: value
-                   for key, value in hyperv_attr.items()}
-            )
-
-        if kvm_poll_control_attr:
-            if not libvirt_version.version_compare(6, 10, 0):
-                test.cancel('This version of libvirt does not support'
-                            ' kvm poll-control')
-
+            update_hyperv_features(vmxml, hyperv_attr, test)
+            vmxml.sync()
+            test.log.debug('Before starting, vm xml:\n%s', vm_xml.VMXML.new_from_inactive_dumpxml(vm_name))
         # Set feature attrs
         test_attrs = [pmu_attr, pvspinlock_attr, kvm_poll_control_attr, hidden_attr]
         [vm_xml.VMXML.set_vm_features(vm_name, **fea_attr)
@@ -109,7 +189,7 @@ def run(test, params, env):
         # Test vm start
         try:
             ret = virsh.start(vm_name, debug=True)
-            libvirt.check_exit_status(ret)
+            libvirt.check_exit_status(ret, status_error)
         except exceptions.TestFail as details:
             if re.search(r"host doesn\'t support paravirtual spinlocks",
                          str(details)):
@@ -117,8 +197,8 @@ def run(test, params, env):
             else:
                 test.fail('VM failed to start:\n%s' % details)
         vm_session = vm.wait_for_login()
-        install_pkgs(vm_session, pkgs, test)
-        if hyperv_attr:
+
+        if hyperv_attr and not features_from_domcap:
             # Check hyperv settings in qemu command line
             for attr in hyperv_attr:
                 if libvirt_version.version_compare(5, 6, 0):
@@ -152,6 +232,8 @@ def run(test, params, env):
                 test.fail('Unexpected "%s" was found '
                           'in qemu command line' % qemu_exclude)
         if cmd_in_guest:
+            if pkgs:
+                install_pkgs(vm_session, pkgs, test)
             cmd_params = {'hidden_attr': hidden_attr}
             check_cmd_in_guest(cmd_in_guest, vm_session, cmd_params, test)
 


### PR DESCRIPTION
This is to test all supported hyperv features in domcapabilities can be used to start the vm. And if unsupported hyperv feature is used to start the vm, the vm will fail to start.

Case ID: VIRT-296852

Signed-off-by: Dan Zheng <dzheng@redhat.com>
