### PR TITLE
[incremental_backup] Fix failures for clean up checkpoints

### DIFF
--- a/libvirt/tests/src/incremental_backup/incremental_backup_push_mode.py
+++ b/libvirt/tests/src/incremental_backup/incremental_backup_push_mode.py
@@ -327,8 +327,11 @@ def run(test, params, env):
             test.fail("Backup job canceled: %s" % detail)
     finally:
         # Remove checkpoints
+        only_clean_checkpoint_metadata = not vm.is_alive()
+        if "expect_backup_canceled" in locals() and expect_backup_canceled:
+            only_clean_checkpoint_metadata = True
         utils_backup.clean_checkpoints(vm_name,
-                                       clean_metadata=not vm.is_alive())
+                                       clean_metadata=only_clean_checkpoint_metadata)
 
         if vm.is_alive():
             vm.destroy(gracefully=False)


### PR DESCRIPTION
For negative cases which intentionally destroy vm or kill qemu process during backup process, the checkpoints' metadata and qcow2 files' data could be inconsistent. And in this situation when case tries to cleanup checkpoints without '--metadata', error may happen. This fix is to delete chcekpoints with '--metadata' in the cleanup process for these negative cases.