### PR TITLE
backingchain: Fix nbd server is not ready

### DIFF
--- a/provider/virtual_disk/disk_base.py
+++ b/provider/virtual_disk/disk_base.py
@@ -6,6 +6,7 @@ from avocado.utils import process
 
 from virttest import ceph
 from virttest import data_dir
+from virttest import utils_misc
 from virttest import virsh
 
 from virttest.libvirt_xml import pool_xml
@@ -181,6 +182,8 @@ class DiskBase(object):
                 image_path, image_format=device_format, port=nbd_server_port,
                 image_size=image_size, export_name=export_name, tls=tls_enabled)
             self.disk_backend.start_nbd_server()
+            utils_misc.wait_for(
+                lambda: process.system('netstat -nlp | grep %s ' % nbd_server_port, ignore_status=True, shell=True) == 0, 10)
 
             disk_dict.update(
                 {'source': {"attrs": {"protocol": "nbd",


### PR DESCRIPTION
Use `netstat` to make sure the nbd server is ready.

Before:
```
ERROR| ERROR 1-type_specific.io-github-autotest-libvirt.backingchain.blockcopy.dest_xml.nbd_disk.pivot_reuse_external -> CmdError: Command '/bin/virsh blockcopy avocado-vt-vm1 vdb  --pivot  --xml /tmp/xml_utils_temp_eg45andu.xml --transient-job --reuse-external --verbose --wait ' failed.
stdout: b'\n'
stderr: b"error: internal error: unable to execute QEMU command 'blockdev-add': Failed to connect to 'ampere***.com:10808': Connection refused\n"
additional_info: None
```

After:
```
INFO | PASS 1-type_specific.io-github-autotest-libvirt.backingchain.blockcopy.dest_xml.nbd_disk.pivot_reuse_external
```