### PR TITLE
virtual_devices/video_devices: disable unsupported cases on s390x

### DIFF
--- a/libvirt/tests/cfg/virtual_device/video_devices.cfg
+++ b/libvirt/tests/cfg/virtual_device/video_devices.cfg
@@ -105,16 +105,20 @@
                 - primary_video:
                     variants:
                         - qxl:
+                            no s390-virtio
                             primary_video_model = qxl
                         - vga:
+                            no s390-virtio
                             primary_video_model = vga
                         - cirrus:
+                            no s390-virtio
                             primary_video_model = cirrus
                             no mem_test
                         - virtio:
                             primary_video_model = virtio
                             no mem_test
                         - bochs:
+                            no s390-virtio
                             primary_video_model = bochs
                             only no_secondary_video..model_test.default no_secondary_video..vram..bochs_default_size
         - negative_test:


### PR DESCRIPTION
s390x only supports virtio-gpu.