### PR TITLE
daemon/check after remove package: fix in case of dependencies

### DIFF
--- a/libvirt/tests/src/daemon/check_daemon_after_remove_pkgs.py
+++ b/libvirt/tests/src/daemon/check_daemon_after_remove_pkgs.py
@@ -46,7 +46,7 @@ def run(test, params, env):
             test.error("Failed to remove libvirt packages on guest")
 
         for daemon in daemons:
-            cmd = "systemctl -a | grep %s" % daemon
+            cmd = "systemctl -a | grep %s | grep -v not-found" % daemon
             if not session.cmd_status(cmd):
                 test.fail("%s still exists after removing libvirt pkgs" % daemon)
 


### PR DESCRIPTION
The libvirt daemon might be reference by other services in their unit files. E.g. RHEL 8 has the kvm-setup.service on some archs.

In these cases the daemon will still be listed but as 'not-found'. This is correct.

Update the test case to allow for this case.