### PR TITLE
numa: make sure free memory is enough for memhog

### DIFF
--- a/libvirt/tests/src/numa/numa_memory_spread.py
+++ b/libvirt/tests/src/numa/numa_memory_spread.py
@@ -11,7 +11,7 @@ from virttest import utils_test
 from virttest import utils_package
 from virttest import virsh
 
-from virttest.staging.utils_memory import read_from_numastat
+from virttest.staging import utils_memory
 
 
 # Using as lower capital is not the best way to do, but this is just a
@@ -30,7 +30,7 @@ def get_qemu_total_for_nodes():
     result = process.run('pidof qemu-kvm', shell=True)
     pid = result.stdout_text
     # Get numastat output and look for Total
-    total = read_from_numastat(pid, "Total")
+    total = utils_memory.read_from_numastat(pid, "Total")
     logging.debug('Total memory taken by nodes:\n')
     for index in range(len(total)):
         logging.debug('\t\t\tnode{} : {}MB\n'.format(index, total[index]))
@@ -107,10 +107,9 @@ def prepare_guest_for_test(vm_name, session, test, oversize, memory_to_eat):
                   "command.".format(oversize))
 
     def _check_mem(memory_to_eat):
-        dommemstat_output = virsh.dommemstat(vm_name).stdout_text.strip()
-        actual_mem = re.search("actual (\d*)", dommemstat_output).groups()[0]
-        logging.debug("actual_mem is {}".format(actual_mem))
-        return int(actual_mem) > int(memory_to_eat)
+        free_mem = utils_memory.freememtotal(session)
+        logging.debug("free_mem is {}".format(free_mem))
+        return int(free_mem) > int(memory_to_eat)
     if not utils_misc.wait_for(lambda: _check_mem(memory_to_eat),
                                300, first=5):
         test.error("Failed to increase specific guest memory in time")


### PR DESCRIPTION
Before memhog, make sure free_mem is larger than memory_to_eat.
Actual_mem greater than memory_to_eat does not ensure memhog success.

Before:
```
ERROR| FAIL 1-type_specific.io-github-autotest-libvirt.numa_memory_spread.positive_test.default -> 
TestFail: Failed to run memhog:Shell command failed: 'memhog -r1 36081766k'    (status: 1,    output: 'numactl: mmap: Cannot allocate memory\n')
```
After:
```
INFO | PASS 1-type_specific.io-github-autotest-libvirt.numa_memory_spread.positive_test.default
```