### PR TITLE
Add case of Check the connectivity for direct type interface

### DIFF
--- a/libvirt/tests/cfg/virtual_network/connectivity/connectivity_check_direct_interface.cfg
+++ b/libvirt/tests/cfg/virtual_network/connectivity/connectivity_check_direct_interface.cfg
@@ -1,0 +1,27 @@
+- virtual_network.connectivity_check.direct_interface:
+    type = connectivity_check_direct_interface
+    start_vm = no
+    vms = avocado-vt-vm1 vm2
+    outside_ip = 'www.redhat.com'
+    host_iface =
+    variants source_mode:
+        - br:
+            source_mode = bridge
+            vm_ping_outside = pass
+            vm_ping_host_public = fail
+            vm_ping_ep_vm = pass
+            host_ping_vm = fail
+            host_ping_outside = pass
+        - private:
+            vm_ping_outside = pass
+            vm_ping_host_public = fail
+            vm_ping_ep_vm = fail
+            host_ping_vm = fail
+            host_ping_outside = pass
+        - vepa:
+            vm_ping_outside = pass
+            vm_ping_host_public = fail
+            vm_ping_ep_vm = fail
+            host_ping_vm = fail
+            host_ping_outside = pass
+    iface_attrs = {'type_name': 'direct', 'model': 'virtio', 'source': {'dev': host_iface, 'mode': '${source_mode}'}}

--- a/libvirt/tests/src/virtual_network/connectivity/connectivity_check_direct_interface.py
+++ b/libvirt/tests/src/virtual_network/connectivity/connectivity_check_direct_interface.py
@@ -1,0 +1,62 @@
+import logging
+
+from virttest import utils_net
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+
+from provider.virtual_network import network_base
+
+VIRSH_ARGS = {'ignore_status': False, 'debug': True}
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+
+def run(test, params, env):
+    """
+    Check connectivity for direct type interface
+    """
+    vm_name = params.get('main_vm')
+    vms = params.get('vms').split()
+    vm, ep_vm = (env.get_vm(vm_i) for vm_i in vms)
+    outside_ip = params.get('outside_ip')
+    host_iface = params.get('host_iface')
+    host_iface = host_iface if host_iface else utils_net.get_net_if(
+        state="UP")[0]
+    iface_attrs = eval(params.get('iface_attrs', '{}'))
+
+    bkxmls = list(map(vm_xml.VMXML.new_from_inactive_dumpxml, vms))
+
+    try:
+        vmxml, ep_vmxml = list(
+            map(vm_xml.VMXML.new_from_inactive_dumpxml, vms))
+        [vmxml_i.del_device('interface', by_tag=True) for vmxml_i in
+         [vmxml, ep_vmxml]]
+        [libvirt_vmxml.modify_vm_device(vmxml_i, 'interface', iface_attrs)
+         for vmxml_i in [vmxml, ep_vmxml]]
+
+        [LOG.debug(f'VMXML of {vm_x}:\n{virsh.dumpxml(vm_x).stdout_text}')
+         for vm_x in vms]
+
+        [vm_i.start() for vm_i in [vm, ep_vm]]
+        session, ep_session = (vm_inst.wait_for_serial_login()
+                               for vm_inst in [vm, ep_vm])
+        mac, ep_mac = list(map(vm_xml.VMXML.get_first_mac_by_name, vms))
+
+        ips_v4 = network_base.get_test_ips(session, mac, ep_session, ep_mac,
+                                           net_name=None,
+                                           ip_ver='ipv4')
+        ips_v6 = network_base.get_test_ips(session, mac, ep_session, ep_mac,
+                                           net_name=None,
+                                           ip_ver='ipv6')
+        ips_v4['outside_ip'] = outside_ip
+        ping_check_args = {'host_ping_outside': {'interface': host_iface}}
+
+        network_base.ping_check(params, ips_v4, session, force_ipv4=True,
+                                **ping_check_args)
+        network_base.ping_check(params, ips_v6, session, force_ipv4=False,
+                                **ping_check_args)
+
+    finally:
+        [backup_xml.sync() for backup_xml in bkxmls]


### PR DESCRIPTION
- VIRT-296210: [direct] Check the connectivity for direct type interface - bridge, vepa, private

Depends on:
- https://github.com/autotest/tp-libvirt/pull/4804

Test result:
```
 (1/3) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.direct_interface.br: PASS (143.20 s)
 (2/3) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.direct_interface.private: PASS (150.08 s)
 (3/3) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.direct_interface.vepa: PASS (147.00 s)
```