### PR TITLE
Add case of save with options

### DIFF
--- a/libvirt/tests/cfg/save_and_restore/save_with_options.cfg
+++ b/libvirt/tests/cfg/save_and_restore/save_with_options.cfg
@@ -1,0 +1,33 @@
+- save_and_restore.save_with_options:
+    type = save_with_options
+    variants scenario:
+        - no_opt:
+            options = 
+        - verbose_opt:
+            options = --verbose
+            expect_msg = 'Save:\s\[100 %\]'
+        - running_opt:
+            options = --running
+            after_state = running
+        - paused_opt:
+            options = --paused
+            after_state = paused
+        - xml_opt:
+            options = --xml
+            description = 'Saving added description'
+        - bypass_cache_opt:
+            options = --bypass-cache
+            check_cmd = "while(true);do cat /proc/$(lsof -w {}|awk '/libvirt_i/{{print $2}}')/fdinfo/1 ;done"
+    variants:
+        - running_vm:
+            pre_state = running
+        - paused_vm:
+            no verbose_opt, xml_opt, bypass_cache_opt
+            pre_state = paused
+    variants mode:
+        - readonly:
+            only running_vm.no_opt
+            virsh_options = ' -r'
+            status_error = yes
+            error_msg = 'read only access prevents virDomainSave'
+        - normal:

--- a/libvirt/tests/src/save_and_restore/save_with_options.py
+++ b/libvirt/tests/src/save_and_restore/save_with_options.py
@@ -1,0 +1,112 @@
+import logging
+import os
+import re
+
+from avocado.utils import process
+
+from virttest import utils_misc
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_test import libvirt
+
+from provider.save import save_base
+
+LOG = logging.getLogger('avocado.test.' + __name__)
+VIRSH_ARGS = {'debug': True, 'ignore_status': False}
+
+
+def run(test, params, env):
+
+    vm_name = params.get('main_vm')
+    vm = env.get_vm(vm_name)
+
+    scenario = params.get('scenario', '')
+    status_error = "yes" == params.get('status_error', 'no')
+    error_msg = params.get('error_msg', '')
+    expect_msg = params.get('expect_msg', '')
+    timeout = params.get('timeout', 60)
+    virsh_options = params.get('virsh_options', '')
+    options = params.get('options', '')
+    pre_state = params.get('pre_state', 'running')
+    after_state = params.get('after_state', pre_state)
+    rand_id = utils_misc.generate_random_string(3)
+    save_path = f'/var/tmp/{vm_name}_{rand_id}.save'
+    check_cmd = params.get('check_cmd', '')
+    check_cmd = check_cmd.format(save_path) if check_cmd else check_cmd
+
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+
+    try:
+        pid_ping, upsince = save_base.pre_save_setup(vm)
+        if pre_state == 'paused':
+            virsh.suspend(vm_name, **VIRSH_ARGS)
+
+        if scenario == 'xml_opt':
+            alter_xml = vm_xml.VMXML.new_from_dumpxml(vm_name,
+                                                      options='--migratable')
+            description = params.get('description', '{}')
+            alter_xml.description = description
+            params['vm_description'] = description
+            LOG.debug(f"Modify description to {description}")
+            LOG.debug(f'XML for saving:\n{alter_xml}')
+            options += ' ' + alter_xml.xml
+
+        if scenario == 'bypass_cache_opt':
+            sp = process.SubProcess(check_cmd, shell=True)
+            sp.start()
+
+        save_result = virsh.save(vm_name, save_path, options=options,
+                                 debug=True, virsh_opt=virsh_options)
+        libvirt.check_exit_status(save_result, status_error)
+
+        if status_error:
+            libvirt.check_result(save_result, error_msg)
+            if vm.state() != pre_state:
+                test.fail(f'VM state should not changed since save failed.'
+                          f'VM should be {pre_state}, not {vm.state()}')
+            return
+        else:
+            if vm.state() != 'shut off':
+                test.fail(f'VM should be shut off after being successfully '
+                          f'saved, but current state is {vm.state()}')
+            if expect_msg:
+                save_output = save_result.stdout_text + save_result.stderr_text
+                if not re.search(expect_msg, save_output):
+                    test.fail(f'Expect content "{expect_msg}" not in output: '
+                              f'{save_output}')
+
+        if scenario == 'bypass_cache_opt':
+            output = sp.get_stdout().decode()
+            LOG.debug(f'bypass-cache check output:\n{output}')
+            sp.terminate()
+            if not re.search('flags:\s\d{2}4', output):
+                test.fail('bypass-cache check fail, please check log')
+
+        if scenario == 'xml_opt':
+            vmxml_save = vm_xml.VMXML()
+            vmxml_save.xml = virsh.save_image_dumpxml(save_path).stdout_text
+            if vmxml_save.description != params['vm_description']:
+                test.fail('VM description after save is incorrect')
+
+        virsh.restore(save_path, **VIRSH_ARGS)
+
+        if not utils_misc.wait_for(lambda: vm.state() == after_state,
+                                   timeout=timeout):
+            test.fail(f'VM should be {after_state} after restore, but current '
+                      f'state is {vm.state()}')
+
+        if vm.state() == 'paused':
+            virsh.resume(vm_name, **VIRSH_ARGS)
+
+        save_base.post_save_check(vm, pid_ping, upsince)
+
+        if scenario == 'xml_opt':
+            vmxml_after = vm_xml.VMXML.new_from_dumpxml(vm_name)
+            if vmxml_after.description != params['vm_description']:
+                test.fail('VM description after save-restore is incorrect')
+
+    finally:
+        bkxml.sync()
+        if os.path.exists(save_path):
+            os.remove(save_path)

--- a/provider/save/save_base.py
+++ b/provider/save/save_base.py
@@ -1,0 +1,52 @@
+import logging
+
+LOG = logging.getLogger('avocado.' + __name__)
+VIRSH_ARGS = {'debug': True, 'ignore_status': False}
+
+
+def pre_save_setup(vm):
+    """
+    Setup vm before save:
+    Start ping process and get uptime since when on vm
+
+    :param vm: vm instance
+    :return: a tuple of pid of ping and uptime since when
+    """
+    session = vm.wait_for_login()
+    upsince = session.cmd_output('uptime --since').strip()
+    LOG.debug(f'VM has been up since {upsince}')
+    ping_cmd = 'ping 127.0.0.1'
+    session.sendline(ping_cmd + '&')
+    session.sendline()
+    pid_ping = session.cmd_output('pidof ping').strip().split()[-1]
+    # The session shouldn't be closed or it will kill ping
+    LOG.debug(f'Pid of ping: {pid_ping}')
+
+    return pid_ping, upsince
+
+
+def post_save_check(vm, pid_ping, upsince):
+    """
+    Check vm status after save-restore:
+    Whether ping is still running, uptime since when is the same as before
+    save-restore.
+
+    :param vm: vm instance
+    :param pid_ping: pid of ping
+    :param upsince: uptime since when
+    """
+    session = vm.wait_for_login()
+    upsince_restore = session.cmd_output('uptime --since').strip()
+    LOG.debug(f'VM has been up (after restore) since {upsince_restore}')
+    LOG.debug(session.cmd_output(f'pidof ping'))
+    proc_info = session.cmd_output(f'ps -p {pid_ping} -o command').strip()
+    LOG.debug(proc_info)
+    LOG.debug(session.cmd_output(f'ps -ef|grep ping'))
+    session.close()
+
+    ping_cmd = 'ping 127.0.0.1'
+    if ping_cmd not in proc_info:
+        raise Exception('Cannot find running ping command after save-restore.')
+    if upsince_restore != upsince:
+        raise Exception(f'Uptime since {upsince_restore} is incorrect,'
+                        f'should be {upsince}')


### PR DESCRIPTION
- VIRT-296947: Save vm to file with various options

Depends on:
- https://github.com/avocado-framework/avocado-vt/pull/3649

Test result:
```
 (01/10) type_specific.io-github-autotest-libvirt.save.save_with_options.readonly.running.option.no_option: PASS (60.87 s)
 (02/10) type_specific.io-github-autotest-libvirt.save.save_with_options.normal.running.option.no_option: PASS (70.85 s)
 (03/10) type_specific.io-github-autotest-libvirt.save.save_with_options.normal.running.option.verbose: PASS (70.83 s)
 (04/10) type_specific.io-github-autotest-libvirt.save.save_with_options.normal.running.option.running: PASS (70.99 s)
 (05/10) type_specific.io-github-autotest-libvirt.save.save_with_options.normal.running.option.paused: PASS (71.10 s)
 (06/10) type_specific.io-github-autotest-libvirt.save.save_with_options.normal.running.option.xml: PASS (71.92 s)
 (07/10) type_specific.io-github-autotest-libvirt.save.save_with_options.normal.running.option.bypass-cache: PASS (70.34 s)
 (08/10) type_specific.io-github-autotest-libvirt.save.save_with_options.normal.paused.option.no_option: PASS (70.91 s)
 (09/10) type_specific.io-github-autotest-libvirt.save.save_with_options.normal.paused.option.running: PASS (70.11 s)
 (10/10) type_specific.io-github-autotest-libvirt.save.save_with_options.normal.paused.option.paused: PASS (70.86 s)
```