### PR TITLE
kernel_panic:Replace exception call type

### DIFF
--- a/libvirt/tests/src/kernel_panic.py
+++ b/libvirt/tests/src/kernel_panic.py
@@ -50,7 +50,7 @@ def run(test, params, env):
     try:
         vm.verify_kernel_crash()
         status = 1  # bad
-    except virt_vm.VMDeadKernelCrashError:
+    except virt_vm.VMKernelCrashError:
         status = 0  # good
 
     # Restore environment to stable state


### PR DESCRIPTION
Since the exception type in verify_kernel_crash is updated, 
the exception called by cases is updated synchronously.

ID: 2179829
Signed-off-by: zhenyzha [zhenyzha@redhat.com](mailto:zhenyzha@redhat.com)