### PR TITLE
svirt: Add a case about selinux

### DIFF
--- a/libvirt/tests/cfg/svirt/selinux/selinux_seclabel_overall_domain.cfg
+++ b/libvirt/tests/cfg/svirt/selinux/selinux_seclabel_overall_domain.cfg
@@ -1,0 +1,66 @@
+- svirt.selinux.seclabel.overall_domain:
+    type = selinux_seclabel_overall_domain
+    start_vm = "no"
+    variants:
+        - without_img_chcon:
+        - with_img_chcon:
+            only relabel_no
+            chcon_img = "system_u:object_r:svirt_image_t:s0"
+    variants:
+        - without_label:
+            variants:
+                - without_baselabel:
+                    static..relabel_no..without_label..without_img_chcon:
+                        status_error = "yes"
+                - baselabel_legit:
+                    only dynamic
+                    seclabel_attr_baselabel = "system_u:system_r:svirt_t:s0"
+                - baselabel_mess_MCS:
+                    only dynamic
+                    seclabel_attr_baselabel = "system_u:system_r:svirt_t:xxxxxx"
+                - baselabel_mess_t:
+                    only dynamic
+                    seclabel_attr_baselabel = "system_u:system_r:xxxxxx:s0"
+                    status_error = "yes"
+                - baselabel_mess_u_r:
+                    only dynamic
+                    seclabel_attr_baselabel = "xxxxxx:xxxxxx:svirt_t:s0"
+                - baselabel_invalid_str:
+                    only dynamic
+                    seclabel_attr_baselabel = "xxxxxx"
+                    status_error = "yes"
+        - label_MCS:
+            seclabel_attr_label = "system_u:system_r:svirt_t:s0:c450,c560"
+        - label_default:
+            seclabel_attr_label = "system_u:system_r:svirt_t:s0"
+            relabel_no..label_default..without_img_chcon:
+                status_error = "yes"
+        - label_invalid_t:
+            seclabel_attr_label = "system_u:system_r:xxxx:s0:c87,c520"
+            status_error = "yes"
+    variants:
+        - relabel_no:
+            seclabel_attr_relabel = "no"
+        - relabel_yes:
+            seclabel_attr_relabel = "yes"
+    variants:
+        - dynamic:
+            only relabel_yes..without_label
+            seclabel_attr_type = "dynamic"
+        - static:
+            no relabel_yes..without_label..without_baselabel, relabel_yes..label_MCS..with_img_chcon
+            no relabel_no..without_label, relabel_no..label_MCS, relabel_no..label_invalid_t
+            seclabel_attr_type = "static"
+    variants:
+        - model_none:
+            only dynamic..without_baselabel
+            seclabel_attr_model = "none"
+        - model_selinux:
+            seclabel_attr_model = "selinux"
+    variants:
+        - disable_security_driver:
+            only model_selinux..static..relabel_yes..label_MCS..without_img_chcon, model_selinux..dynamic..relabel_yes..without_baselabel
+            qemu_conf = {"security_driver": "\"none\""}
+            status_error = "yes"
+        - enable_security_driver:
+            qemu_conf = {"security_driver": "\"selinux\""}

--- a/libvirt/tests/src/svirt/selinux/selinux_seclabel_overall_domain.py
+++ b/libvirt/tests/src/svirt/selinux/selinux_seclabel_overall_domain.py
@@ -1,0 +1,89 @@
+import re
+
+from avocado.utils import process
+
+from virttest import virsh
+
+from virttest.libvirt_xml.vm_xml import VMXML
+from virttest.utils_libvirt import libvirt_disk
+from virttest.utils_test import libvirt
+
+
+def run(test, params, env):
+    """
+    Test overall domain selinux <seclabel> can work correctly.
+
+    1. Set VM xml and qemu.conf with proper security_driver.
+    2. Start VM with proper seclabel setting and check the context.
+    3. Destroy VM and check the xattr.
+    """
+
+    # Get general variables.
+    chcon_img = params.get("chcon_img")
+    qemu_conf = eval(params.get("qemu_conf", "{}"))
+    status_error = 'yes' == params.get("status_error", 'no')
+
+    xattr_selinux_str = params.get(
+        "xattr_selinux_str",
+        "trusted.libvirt.security.selinux=\"system_u:object_r:virt_image_t:s0\"")
+    xattr_dac_str = params.get("xattr_dac_str", "security.ref_dac=\"1\"")
+    qemu_conf_obj = None
+    backup_disks = []
+    # Get variables about VM and get a VM object and VMXML instance.
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    vmxml = VMXML.new_from_inactive_dumpxml(vm_name)
+    backup_xml = vmxml.copy()
+
+    seclabel_attr = {k.replace('seclabel_attr_', ''): int(v) if v.isdigit()
+                     else v for k, v in params.items()
+                     if k.startswith('seclabel_attr_')}
+    seclabel_relabel = seclabel_attr.get("relabel") == "yes"
+
+    try:
+        test.log.info("TEST_STEP: Update qemu.conf.")
+        qemu_conf_obj = libvirt.customize_libvirt_config(qemu_conf, "qemu")
+
+        if chcon_img:
+            for disk in list(vm.get_disk_devices().values()):
+                disk_path = disk['source']
+                backup_disks.append(disk_path)
+                process.run(f"chcon {chcon_img} {disk_path}", shell=True)
+
+        test.log.info("TEST_STEP: Update VM XML with %s.", seclabel_attr)
+        vmxml.set_seclabel([seclabel_attr])
+        vmxml.sync()
+        test.log.debug(VMXML.new_from_inactive_dumpxml(vm_name))
+
+        test.log.info("TEST_STEP: Start the VM.")
+        res = virsh.start(vm.name)
+        libvirt.check_exit_status(res, status_error)
+        if status_error:
+            return
+
+        test.log.info("TEST_STEP: Check the xattr of the vm image.")
+        vm_first_disk = libvirt_disk.get_first_disk_source(vm)
+        img_xattr = libvirt_disk.get_image_xattr(vm_first_disk)
+        if not re.findall(xattr_dac_str, img_xattr):
+            test.fail("Unable to get %s!" % xattr_dac_str)
+        if re.findall(xattr_selinux_str, img_xattr) == seclabel_relabel:
+            test.fail("It should%s contain %s!"
+                      % (' not' if seclabel_relabel else '', xattr_selinux_str))
+
+        test.log.info("TEST_STEP: Destroy the VM and check the xattr of image.")
+        vm.destroy(gracefully=False)
+        img_xattr = libvirt_disk.get_image_xattr(vm_first_disk)
+        if img_xattr:
+            test.fail("The xattr output should be cleaned up after VM shutdown!")
+
+    finally:
+        test.log.info("TEST_TEARDOWN: Recover test environment.")
+        if qemu_conf_obj:
+            libvirt.customize_libvirt_config(
+                None, "qemu", config_object=qemu_conf_obj,
+                is_recover=True)
+        if vm.is_alive():
+            vm.destroy(gracefully=False)
+        backup_xml.sync()
+        for path in backup_disks:
+            process.run(f"restorecon -v {path}", shell=True, verbose=True)


### PR DESCRIPTION
This PR adds:
    VIRT-296646: Start vm with overall domain selinux setting


**Test results:**
```
 (01/14) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.overall_domain.disable_security_driver.model_selinux.dynamic.relabel_yes.without_label.without_baselabel.without_img_chcon: PASS (11.08 s)
 (02/14) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.overall_domain.disable_security_driver.model_selinux.static.relabel_yes.label_MCS.without_img_chcon: PASS (11.12 s)
 (03/14) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.overall_domain.enable_security_driver.model_none.dynamic.relabel_yes.without_label.without_baselabel.without_img_chcon: PASS (13.24 s)
 (04/14) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.overall_domain.enable_security_driver.model_selinux.dynamic.relabel_yes.without_label.without_baselabel.without_img_chcon: PASS (13.19 s)
 (05/14) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.overall_domain.enable_security_driver.model_selinux.dynamic.relabel_yes.without_label.baselabel_legit.without_img_chcon:PASS (13.31 s)
 (06/14) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.overall_domain.enable_security_driver.model_selinux.dynamic.relabel_yes.without_label.baselabel_mess_MCS.without_img_chcon: PASS (13.41 s)
 (07/14) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.overall_domain.enable_security_driver.model_selinux.dynamic.relabel_yes.without_label.baselabel_mess_t.without_img_chcon: PASS (11.31 s)
 (08/14) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.overall_domain.enable_security_driver.model_selinux.dynamic.relabel_yes.without_label.baselabel_mess_u_r.without_img_chcon: PASS (13.33 s)
 (09/14) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.overall_domain.enable_security_driver.model_selinux.dynamic.relabel_yes.without_label.baselabel_invalid_str.without_img_chcon: PASS (11.25 s)
 (10/14) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.overall_domain.enable_security_driver.model_selinux.static.relabel_no.label_default.without_img_chcon: PASS (12.05 s)
 (11/14) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.overall_domain.enable_security_driver.model_selinux.static.relabel_no.label_default.with_img_chcon: PASS (13.41 s)
 (12/14) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.overall_domain.enable_security_driver.model_selinux.static.relabel_yes.label_MCS.without_img_chcon: PASS (15.91 s)
 (13/14) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.overall_domain.enable_security_driver.model_selinux.static.relabel_yes.label_default.without_img_chcon: PASS (13.34 s)
 (14/14) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.overall_domain.enable_security_driver.model_selinux.static.relabel_yes.label_invalid_t.without_img_chcon: PASS (11.20 s)
RESULTS    : PASS 14 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0

```