### PR TITLE
migration: Fix issue about migration speed

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -463,6 +463,7 @@
                             without_postcopy:
                                 actions_during_migration = "suspendvm"
                             with_postcopy:
+                                low_speed = "10"
                                 actions_during_migration = "suspendvm,setmigratepostcopy"
                         - pause_vm_before_migration:
                             pause_vm_before_migration = "yes"


### PR DESCRIPTION
Set migrate speed to low value, then we can run 'virsh
 migrate-postcopy' during migration.