### PR TITLE
cpu: Fix vm login timeout issue

### DIFF
--- a/libvirt/tests/cfg/cpu/setvcpu.cfg
+++ b/libvirt/tests/cfg/cpu/setvcpu.cfg
@@ -4,9 +4,6 @@
     vcpu_placement = "static"
     vcpu_current = "1"
     maxvcpu = "8"
-    start_timeout = "60"
-    pseries:
-        start_timeout = '240'
     vcpus_hotpluggable = "{1,2,3,4,5,6,7}"
     variants:
         - positive_test:

--- a/libvirt/tests/src/cpu/setvcpu.py
+++ b/libvirt/tests/src/cpu/setvcpu.py
@@ -38,7 +38,7 @@ def run(test, params, env):
     vcpus_hotplug = eval(params.get("vcpus_hotpluggable", "{0}"))
     setvcpu_option = eval(params.get("setvcpu_option", "{}"))
     setvcpu_action = params.get("setvcpu_action", "")
-    start_timeout = int(params.get("start_timeout", "60"))
+    start_timeout = int(params.get("login_timeout", "60"))
     modify_non_hp_ol_vcpus = params.get("modify_non_hotpluggable_online", "no")
     check = params.get("check", "")
     err_msg = params.get("err_msg", "")


### PR DESCRIPTION
Update to use 'login_time' to avoid "Login timeout expired" issue.


**Before the fix:**
` (04/13) type_specific.io-github-autotest-libvirt.cpu.setvcpu.positive_test.hotplug.order: ERROR: Login timeout expired    (output: "exceeded 60 s timeout, last failure: Client said 'connection refused'    (output: 'ssh: connect to host 192.168.122.181 port 22: Connection refused\\n')") (77.87 s)`

**After the fix:**

```
 (01/13) type_specific.io-github-autotest-libvirt.cpu.setvcpu.positive_test.hotplug.enable_config: PASS (72.79 s)
 (02/13) type_specific.io-github-autotest-libvirt.cpu.setvcpu.positive_test.hotplug.disable: PASS (79.23 s)
 (03/13) type_specific.io-github-autotest-libvirt.cpu.setvcpu.positive_test.hotplug.disable_config: PASS (76.27 s)
 (04/13) type_specific.io-github-autotest-libvirt.cpu.setvcpu.positive_test.hotplug.order: PASS (94.46 s)
 (05/13) type_specific.io-github-autotest-libvirt.cpu.setvcpu.negative_test.hotplug.duplicate_vcpu.disable: PASS (73.99 s)
 (06/13) type_specific.io-github-autotest-libvirt.cpu.setvcpu.negative_test.hotplug.duplicate_vcpu.enable: PASS (78.14 s)
 (07/13) type_specific.io-github-autotest-libvirt.cpu.setvcpu.negative_test.hotplug.online_vcpu.disable: PASS (73.88 s)
 (08/13) type_specific.io-github-autotest-libvirt.cpu.setvcpu.negative_test.hotplug.noexist_vcpu.enable: PASS (75.12 s)
 (09/13) type_specific.io-github-autotest-libvirt.cpu.setvcpu.negative_test.hotplug.offline_vcpu.disable: PASS (75.78 s)
 (10/13) type_specific.io-github-autotest-libvirt.cpu.setvcpu.negative_test.hotplug.vcpu0.disable: PASS (81.03 s)
 (11/13) type_specific.io-github-autotest-libvirt.cpu.setvcpu.negative_test.hotplug.vcpu0.enable: PASS (78.95 s)
 (12/13) type_specific.io-github-autotest-libvirt.cpu.setvcpu.negative_test.hotplug_config.online_vcpu.disable: PASS (78.31 s)
 (13/13) type_specific.io-github-autotest-libvirt.cpu.setvcpu.negative_test.hotplug_config.online_vcpu.enable: PASS (72.79 s)

```
