### PR TITLE
[incremental_backup] Add cases to delete snapshot among backup actions

### DIFF
--- a/libvirt/tests/cfg/incremental_backup/incremental_backup_backing_chain.cfg
+++ b/libvirt/tests/cfg/incremental_backup/incremental_backup_backing_chain.cfg
@@ -37,3 +37,8 @@
             variants blockcopy_reuse:
                 - reuse_external:
                 - not_reuse_external:
+        - snapshot-delete:
+            only libvirt_snapshot
+            variants delete_layer:
+                - active_layer:
+                - inactive_layer:


### PR DESCRIPTION
Previously we did blockcommit/blockpull/blockcopy among the backup actions to thet data integrity. And from libvirt-9.0.0, deleting external snapshots is supported. So we add 'snapshot-delete' in this script to cover this case.