### PR TITLE
Fix nvme case failure due to pre-existed partitions on nvme device

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_nvme.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_nvme.py
@@ -118,6 +118,10 @@ def run(test, params, env):
 
         pci_addr_in_dict = get_usable_nvme_pci_address()
 
+        # Delete partitions if exist on nvme device
+        process.run("sfdisk --delete  /dev/nvme[0-9]n[0-9]",
+                    timeout=10, ignore_status=True, verbose=True, shell=True)
+
         device_obj = create_customized_disk(params, pci_addr_in_dict)
         if not hotplug:
             vmxml.add_device(device_obj)


### PR DESCRIPTION
Fix nvme case failure due to pre-existed partitions on nvme device
clean up nvme device partitions before attaching to VM