### PR TITLE
virsh_detach_device_alias: fix watchdog device checking

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
@@ -1,5 +1,6 @@
 - virsh.detach_device_alias:
     type = virsh_detach_device_alias
+    take_regular_screendumps = no
     variants:
         - hostdev:
             detach_hostdev_managed = "no"
@@ -58,10 +59,8 @@
                 no s390-virtio
             detach_watchdog_type = "watchdog"
             watchdog_dict = {"model_type":"i6300esb", "action":"poweroff"}
-            detach_check_xml = "<watchdog model='i6300esb'"
             s390-virtio:
                 watchdog_dict = {"model_type":"diag288", "action":"poweroff"}
-                detach_check_xml = "<watchdog model='diag288'"
         - network_interface:
             only live,config
             detach_interface_type = "network_interface"


### PR DESCRIPTION
A new watchdog device with model="itco" is added to vm xml by libvirt automatically. So this is to align with this change that the checking method for watchdog device should be changed.


Signed-off-by: Dan Zheng <dzheng@redhat.com>