### PR TITLE
fix blockcommit low speed

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockcommit/check_allocation_watermark_during_blockcommit.cfg
+++ b/libvirt/tests/cfg/backingchain/blockcommit/check_allocation_watermark_during_blockcommit.cfg
@@ -9,7 +9,7 @@
     virsh_opt = " -k0"
     variants case:
         - inactive_layer:
-            commit_option = "--top ${target_disk}[3] --base ${target_disk}[1] --wait --verbose 10"
+            commit_option = "--top ${target_disk}[3] --base ${target_disk}[1] --wait --verbose"
             commit_success_msg = "Commit complete"
         - active_layer:
             commit_option = " --wait --verbose --pivot "


### PR DESCRIPTION
  blockcommit too fast and failed to check the allocation changed
Signed-off-by: nanli <nanli@redhat.com>

```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockcommit.allocation_watermark --vt-connect-uri qemu:///system
 (1/4) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.allocation_watermark.file_disk.inactive_layer: PASS (128.69 s)
 (2/4) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.allocation_watermark.file_disk.active_layer: PASS (68.03 s)
 (3/4) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.allocation_watermark.block_disk.inactive_layer: PASS (86.75 s)
 (4/4) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.allocation_watermark.block_disk.active_layer: PASS (88.38 s)

```