### PR TITLE
migration: Remove some redundant params

### DIFF
--- a/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_and_recover_and_disruptive.cfg
+++ b/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_and_recover_and_disruptive.cfg
@@ -56,9 +56,6 @@
             check_port_or_network_conn_num = "no"
     variants disruptive_operations:
         - poweroff_vm_dest:
-            migrate_desturi_port = "16509"
-            migrate_desturi_type = "tcp"
-            virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
             action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "virsh.domjobabort", "func_param": "'%s --postcopy' % params.get('migrate_main_vm')", "need_sleep_time": "90"}, {"func": "do_migration", "func_param": "params", "need_sleep_time": "10"}]'
             action_during_do_mig = '[{"func": "poweroff_vm", "before_pause": "yes", "func_param": "params", "need_sleep_time": "10"}]'
             status_error_during_mig = "yes"


### PR DESCRIPTION
Don't need to set 'virsh_migrate_destur = "qemu+tcp://${migrate_dest_host}/system"' for unix_proxy case.