### PR TITLE
misc -> virsh_event: enable crash_panic test for aarch64

### DIFF
--- a/libvirt/tests/cfg/event/virsh_event.cfg
+++ b/libvirt/tests/cfg/event/virsh_event.cfg
@@ -40,12 +40,15 @@
                             signal = 'SIGTERM'
                             events_list = "shutdown"
                         - crash_panic:
-                            no aarch64
                             only test_events
                             events_list = "crash"
                             panic_model = 'isa'
                             addr_type = 'isa'
                             addr_iobase = '0x505'
+                            aarch64:
+                              func_supported_since_libvirt_ver = (9, 1, 0)
+                              panic_model = "pvpanic"
+                              addr_type = "pci"
                         - domrename:
                             only test_events
                             events_list = "domrename"

--- a/libvirt/tests/src/event/virsh_event.py
+++ b/libvirt/tests/src/event/virsh_event.py
@@ -301,6 +301,7 @@ def run(test, params, env):
                     expected_events_list.append("'lifecycle' for %s:"
                                                 " Stopped Shutdown")
                 elif event == "crash":
+                    libvirt_version.is_libvirt_feature_supported(params)
                     if not vmxml.xmltreefile.find('devices').findall('panic'):
                         # Set panic device
                         panic_dev = Panic()


### PR DESCRIPTION
aarch64 supports panic since libvirt-9.1.0

Result:
```
PASS 1-type_specific.io-github-autotest-libvirt.virsh.event.positive_test.virsh_event.test_events.lifecycle_events.crash_panic.no_timeout.loop
```