### PR TITLE
add case for lifecycle with memory allocation

### DIFF
--- a/libvirt/tests/cfg/mem/memory_allocation/lifecycle_with_memory_allocation.cfg
+++ b/libvirt/tests/cfg/mem/memory_allocation/lifecycle_with_memory_allocation.cfg
@@ -1,0 +1,28 @@
+- memory.allocation.lifecycle:
+    type = lifecycle_with_memory_allocation
+    mem_value = 2097152
+    mem_unit = 'KiB'
+    current_mem = 1843200
+    current_mem_unit = 'KiB'
+    max_mem_slots = 16
+    max_mem = 15242880
+    max_mem_unit = 'KiB'
+    numa_mem = 1048576
+    variants case:
+        - positive_test:
+            variants mem_config:
+                - without_maxmemory:
+                    expect_xpath = [{'element_attrs':[".//memory[@unit='${mem_unit}']"],'text':'${mem_value}'},{'element_attrs':[".//currentMemory[@unit='${current_mem_unit}']"],'text':'${current_mem}'}]
+                    vm_attrs = {'memory_unit':'${mem_unit}','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':"${current_mem_unit}"}
+                - with_numa:
+                    max_mem = 15360000
+                    expect_xpath = [{'element_attrs':[".//maxMemory[@slots='${max_mem_slots}']",".//maxMemory[@unit='${max_mem_unit}']"],'text':'${max_mem}'},{'element_attrs':[".//currentMemory[@unit='${current_mem_unit}']"],'text':'${current_mem}'},{'element_attrs':[".//cell[@id='0']"],'text':'${numa_mem}'}, {'element_attrs':[".//cell[@id='1']"],'text':'${numa_mem}'}]
+                    numa_attr = "'vcpu': 4,'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '${numa_mem}', 'unit': 'KiB'},{'id':'1','cpus': '2-3','memory':'${numa_mem}','unit':'KiB'}]}"
+                    max_mem_attr = "${numa_attr}, 'max_mem_rt': ${max_mem}, 'max_mem_rt_slots': ${max_mem_slots}, 'max_mem_rt_unit': '${max_mem_unit}'"
+                    vm_attrs = {${max_mem_attr},'memory_unit':"${mem_unit}",'memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}'}
+        - negative_test:
+            variants mem_config:
+                - with_maxmemory:
+                    max_mem_attr = "'max_mem_rt': ${max_mem}, 'max_mem_rt_slots': ${max_mem_slots}, 'max_mem_rt_unit': '${max_mem_unit}'"
+                    vm_attrs = {${max_mem_attr},'memory_unit':'${mem_unit}','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}'}
+                    error_msg = "At least one numa node has to be configured when enabling memory hotplug"

--- a/libvirt/tests/src/mem/memory_allocation/lifecycle_with_memory_allocation.py
+++ b/libvirt/tests/src/mem/memory_allocation/lifecycle_with_memory_allocation.py
@@ -1,0 +1,177 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright Redhat
+#
+#   SPDX-License-Identifier: GPL-2.0
+
+#   Author: Nan Li <nanli@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+import os
+
+from virttest import virsh
+from virttest import utils_libvirtd
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_test import libvirt
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_libvirt import libvirt_misc
+
+
+def run(test, params, env):
+    """
+    Verify memory allocation settings take effect during the life cycle of guest vm.
+
+    Scenario:
+    1:without max memory
+    2:with max memory
+    3:with numa topology
+    """
+
+    def run_positive_test():
+        """
+        Start guest
+        Check the qemu cmd line
+        Check the memory size with virsh dominfo cmd
+        """
+        test.log.info("TEST_STEP1: Define and start vm")
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        vmxml.setup_attrs(**vm_attrs)
+        vmxml.sync()
+
+        if not vm.is_alive():
+            vm.start()
+        vm.wait_for_login().close()
+
+        test.log.info("TEST_STEP2: Check dominfo and qemu cmd line")
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        test.log.debug("After start vm, get vmxml is :%s", vmxml)
+        check_dominfo()
+        check_qemu_cmdline()
+
+        test.log.info("TEST_STEP3:Check vm reboot and memory config")
+        virsh.reboot(vm_name, ignore_status=False, debug=True)
+        vm.wait_for_login().close()
+        check_mem_config()
+
+        test.log.info("TEST_STEP4:Check vm suspend & resume and memory config")
+        virsh.suspend(vm_name, ignore_status=False, debug=True)
+        virsh.resume(vm_name, ignore_status=False, debug=True)
+        vm.wait_for_login().close()
+        check_mem_config()
+
+        test.log.info("TEST_STEP5:Check vm save & restore and memory config")
+        if os.path.exists(save_file):
+            os.remove(save_file)
+        virsh.save(vm_name, save_file, ignore_status=False, debug=True)
+        virsh.restore(save_file, ignore_status=False, debug=True)
+        vm.wait_for_login().close()
+        check_mem_config()
+
+        test.log.info("TEST_STEP6:Check vm managedsave,start and memory config")
+        virsh.managedsave(vm_name, ignore_status=False, debug=True)
+        vm.start()
+        vm.wait_for_login().close()
+        check_mem_config()
+
+        test.log.info("TEST_STEP7:Check libvirtd restart and memory config")
+        libvirtd = utils_libvirtd.Libvirtd()
+        libvirtd.restart()
+        vm.wait_for_login().close()
+        check_mem_config()
+
+        test.log.info("TEST_STEP8: Destroy vm ")
+        virsh.destroy(vm_name, ignore_status=False, debug=True)
+
+    def teardown_positive_test():
+        """
+        Clean data.
+        """
+        test.log.info("TEST_TEARDOWN: Clean up env.")
+        if os.path.exists(save_file):
+            os.remove(save_file)
+        vm.undefine(options='--nvram --managed-save')
+        bkxml.sync()
+
+    def run_negative_test():
+        """
+        Define vm and check result.
+        """
+        test.log.info("TEST_STEP1: Define vm with maxMemory and no numa")
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        vmxml.setup_attrs(**vm_attrs)
+        test.log.debug("Define vm with %s.", vmxml)
+
+        cmd_result = virsh.define(vmxml.xml, debug=True)
+
+        test.log.info("TEST_STEP2: Check error message")
+        libvirt.check_result(cmd_result, error_msg)
+
+    def teardown_negative_test():
+        """
+        Clean data.
+        """
+        test.log.info("TEST_TEARDOWN: Clean up env.")
+        bkxml.sync()
+
+    def check_qemu_cmdline():
+        """
+        Check expected memory value in qemu cmd line.
+        """
+        expected_str = ""
+        if mem_config == "without_maxmemory":
+            expected_str = r"-m %s" % str(int(mem_value/1024))
+        elif mem_config == "with_numa":
+            expected_str = r"-m size=%dk,slots=%d,maxmem=%dk" % (
+                int(mem_value), max_mem_slots, int(max_mem))
+
+        libvirt.check_qemu_cmd_line(expected_str)
+
+    def check_dominfo():
+        """
+        Check current memory value and memory value in virsh dominfo result
+        """
+        result = virsh.dominfo(
+            vm_name, ignore_status=False, debug=True).stdout_text.strip()
+        dominfo_dict = libvirt_misc.convert_to_dict(
+            result, pattern=r'(\S+ \S+):\s+(\S+)')
+
+        if dominfo_dict["Max memory"] != str(mem_value):
+            test.fail("Memory value should be %s instead of %s " % (
+                mem_value, dominfo_dict["Max memory"]))
+        if dominfo_dict["Used memory"] != str(current_mem):
+            test.fail("Current memory should be %s instead of %s " % (
+                current_mem, dominfo_dict["Used memory"]))
+
+    def check_mem_config():
+        """
+        Check current mem device config
+        """
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        libvirt_vmxml.check_guest_xml_by_xpaths(vmxml, expect_xpath)
+
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+
+    case = params.get("case")
+    error_msg = params.get("error_msg")
+    mem_value = int(params.get("mem_value"))
+    current_mem = int(params.get("current_mem"))
+    max_mem_slots = int(params.get("max_mem_slots"))
+    max_mem = int(params.get("max_mem"))
+    mem_config = params.get("mem_config")
+    expect_xpath = eval(params.get("expect_xpath", '{}'))
+    vm_attrs = eval(params.get("vm_attrs"))
+    save_file = "/tmp/%s.save" % vm_name
+
+    run_test = eval("run_%s" % case)
+    teardown_test = eval("teardown_%s" % case)
+
+    try:
+        run_test()
+
+    finally:
+        teardown_test()

--- a/spell.ignore
+++ b/spell.ignore
@@ -617,6 +617,7 @@ multipathd
 multiqueue
 multitimes
 namespace
+nanli
 nano
 nat
 nbd


### PR DESCRIPTION
    VIRT-297048: Life cycle with memory allocation
Signed-off-by: nanli <nanli@redhat.com>

```
 /usr/bin/python /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 memory.allocation.lifecycle

 (1/3) type_specific.io-github-autotest-libvirt.memory.allocation.lifecycle.positive_test.without_maxmemory: PASS (122.21 s)
 (2/3) type_specific.io-github-autotest-libvirt.memory.allocation.lifecycle.positive_test.with_numa: PASS (119.04 s)
 (3/3) type_specific.io-github-autotest-libvirt.memory.allocation.lifecycle.negative_test.with_maxmemory: PASS (7.00 s)


```