### PR TITLE
tpm_device: add external vtpm tests

### DIFF
--- a/libvirt/tests/cfg/virtual_device/tpm_device.cfg
+++ b/libvirt/tests/cfg/virtual_device/tpm_device.cfg
@@ -122,6 +122,29 @@
                         - plain:
                         - encrypted:
                             prepare_secret = 'yes'
+                - external:
+                    func_supported_since_libvirt_ver = (9, 0, 0)
+                    backend_type = 'external'
+                    no pseries, s390-virtio
+                    q35:
+                        only tpm-crb_model
+                    aarch64:
+                        only tpm-tis_model
+                    no default_model
+                    source_attrs = {'type': 'unix', 'mode': 'connect', 'path': '/var/tmp/guest-swtpm.sock'}
+                    statedir = "/var/tmp/mytpm"
+                    swtpm_setup_path = '/usr/bin/swtpm_setup'
+                    swtpm_path = '/usr/bin/swtpm'
+                    variants:
+                        - start_vm:
+                            audit_cmd = ausearch -ts recent -m VIRT_RESOURCE| grep 'tpm-external'
+                            ausearch_check = 'reason=start.*device="/var/tmp/guest-swtpm.sock".*res=success'
+                        - suspend_resume:
+                            vm_operate = 'resume'
+                        - managedsave_start:
+                            vm_operate = 'managedsave'
+                        - restart_libvirtd:
+                            restart_libvirtd = 'yes'
             variants:
                 - tpm-tis_model:
                     only q35, aarch64


### PR DESCRIPTION
Do tests with external vtpm by start, suspend_resume, managedsave_start vm, and restart_libvirtd. Need to work with 
- https://github.com/avocado-framework/avocado-vt/pull/3658

To auto VIRT-296943.