### PR TITLE
virtio_transitional: directly use remove_bootconfig_item_from_vmos function

### DIFF
--- a/libvirt/tests/src/virtio_transitional/virtio_transitional_base.py
+++ b/libvirt/tests/src/virtio_transitional/virtio_transitional_base.py
@@ -1,4 +1,5 @@
 from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_bios
 from virttest.utils_test import libvirt
 
 
@@ -115,11 +116,5 @@ def remove_rhel6_nvram(vm_name):
     :param vm_name: VM name
     """
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
-    os_xml = vmxml.os
-    if os_xml.fetch_attrs().get('os_firmware') == 'efi':
-        os_xml.del_os_firmware()
-    os_xml.del_nvram()
-    os_xml.del_loader()
-    vmxml.os = os_xml
-    vmxml.xmltreefile.write()
+    vmxml.os = libvirt_bios.remove_bootconfig_items_from_vmos(vmxml.os)
     vmxml.sync("--nvram")


### PR DESCRIPTION
In remove_rhel6_nvram function of virtio_transitional_base.py, we can directly reuse libvirt_bios.remove_bootconfig_items_from_vmos(vmxml.os) to manage.