### PR TITLE
add case for invalid memory value

### DIFF
--- a/libvirt/tests/cfg/mem/memory_allocation/memory_invalid_value.cfg
+++ b/libvirt/tests/cfg/mem/memory_allocation/memory_invalid_value.cfg
@@ -1,0 +1,44 @@
+- memory.allocation.invalid_value:
+    type = memory_invalid_value
+    mem_value = 2097152
+    mem_unit = 'KiB'
+    current_mem = 2097152
+    current_mem_unit = 'KiB'
+    max_mem_slots = 16
+    max_mem = 15242880
+    max_mem_unit = 'KiB'
+    numa_mem = 1048576
+    start_vm = no
+    variants num:
+        - zero:
+            value = 0
+        - minus:
+            value = -1
+            status_error = "yes"
+            minus_error_msg = "Invalid value '${value}' for element or attribute "
+    variants mem_config:
+        - memory:
+            vm_attrs = {'memory':${value},'memory_unit':'${mem_unit}','current_mem':${current_mem},'current_mem_unit':"${current_mem_unit}"}
+            error_msg = "Memory size must be specified via <memory> or in the <numa> configuration"
+            status_error = "yes"
+        - current_memory:
+            start_vm_error = "no"
+            status_error = "no"
+            xpaths_list = [{'element_attrs':[".//currentMemory[@unit='${current_mem_unit}']"],'text':'${current_mem}'}]
+            vm_attrs = {'current_mem':${value},'current_mem_unit':"${current_mem_unit}",'memory':${mem_value},'memory_unit':'${mem_unit}'}
+        - mam_memory:
+            vm_attrs = {'max_mem_rt': ${value}, 'max_mem_rt_slots': ${max_mem_slots}, 'max_mem_rt_unit': "${max_mem_unit}",'memory_unit':"${mem_unit}",'memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}','vcpu': 4,'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '${numa_mem}', 'unit': 'KiB'},{'id':'1','cpus': '2-3','memory':'${numa_mem}','unit':'KiB'}]}}
+            error_msg = "both maximum memory size and memory slot count must be specified"
+            status_error = "yes"
+        - numa:
+            xpaths_list = [{'element_attrs':[".//cell[@id='0']"], 'text':'${value}'}, {'element_attrs':[".//memory[@unit='${mem_unit}']"], 'text':'${numa_mem}'}, {'element_attrs':[".//currentMemory[@unit='${current_mem_unit}']"], 'text':'${numa_mem}'}]
+            vm_attrs = {'max_mem_rt': ${max_mem}, 'max_mem_rt_slots': ${max_mem_slots}, 'max_mem_rt_unit': "${max_mem_unit}",'memory_unit':"${mem_unit}",'memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}','vcpu': 4,'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '${value}', 'unit': 'KiB'},{'id':'1','cpus': '2-3','memory':'${numa_mem}','unit':'KiB'}]}}
+            start_vm_error = "yes"
+            status_error = "no"
+            start_error_msg = "property 'size' of memory-backend-ram doesn't take value '${value}'"
+        - mixed_mem:
+            xpaths_list = [{'element_attrs':[".//memory[@unit='${mem_unit}']"], 'text':'${mem_value}'}, {'element_attrs':[".//currentMemory[@unit='${current_mem_unit}']"], 'text':'${current_mem}'}]
+            vm_attrs = {'memory':${value},'current_mem':${value},'max_mem_rt': ${max_mem}, 'max_mem_rt_slots': ${max_mem_slots}, 'max_mem_rt_unit': "${max_mem_unit}",'memory_unit':"${mem_unit}",'current_mem_unit':'${current_mem_unit}','vcpu': 4,'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '${numa_mem}', 'unit': 'KiB'},{'id':'1','cpus': '2-3','memory':'${numa_mem}','unit':'KiB'}]}}
+            start_vm_error = "no"
+            status_error = "no"
+

--- a/libvirt/tests/src/mem/memory_allocation/memory_invalid_value.py
+++ b/libvirt/tests/src/mem/memory_allocation/memory_invalid_value.py
@@ -1,0 +1,77 @@
+
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_test import libvirt
+from virttest.utils_libvirt import libvirt_vmxml
+
+
+def run(test, params, env):
+    """
+    Verify libvirt forbids invalid memory value
+
+    1.value: Zero/Minus
+    2.mem type: Memory/currentMemory/maxMemory/numa
+                mem currentMem numa mixed
+    """
+    def setup_test():
+        pass
+
+    def run_test():
+        """
+        Define vm and check msg
+        Start vm and check config
+        """
+        test.log.info("TEST_STEP1: Define vm and check result")
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        vmxml.setup_attrs(**vm_attrs)
+        test.log.debug("Define vm with %s." % vmxml)
+        cmd_result = virsh.define(vmxml.xml, debug=True)
+        if num == "minus":
+            libvirt.check_result(cmd_result, minus_error_msg)
+        elif num == "zero":
+            if error_msg:
+                libvirt.check_result(cmd_result, error_msg)
+            else:
+                test.log.info("TEST_STEP2: Check xml after define")
+                check_mem_config()
+                test.log.info("TEST_STEP3: Check start vm get correct result")
+                res = virsh.start(vm_name)
+                libvirt.check_exit_status(res, start_vm_error)
+                if start_error_msg:
+                    libvirt.check_result(res, start_error_msg)
+
+    def teardown_test():
+        """
+        Clean data.
+        """
+        test.log.info("TEST_TEARDOWN: Clean up env.")
+        bkxml.sync()
+
+    def check_mem_config():
+        """
+        Check current mem device config
+        """
+        vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+        test.log.debug('111111111111111111111:%s', vmxml)
+        libvirt_vmxml.check_guest_xml_by_xpaths(vmxml, xpaths_list)
+
+    vm_name = params.get("main_vm")
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+
+    error_msg = params.get("error_msg", "")
+    minus_error_msg = params.get("minus_error_msg", "")
+    start_error_msg = params.get("start_error_msg", "")
+
+    num = params.get("num")
+    xpaths_list = eval(params.get("xpaths_list", '{}'))
+    vm_attrs = eval(params.get("vm_attrs"))
+    start_vm_error = "yes" == params.get("start_vm_error", "no")
+
+    try:
+        setup_test()
+        run_test()
+
+    finally:
+        teardown_test()


### PR DESCRIPTION
   VIRT-297062:  invalid memory value

```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 memory.allocation.invalid_value
 (01/10) type_specific.io-github-autotest-libvirt.memory.allocation.invalid_value.memory.zero: PASS (4.92 s)
 (02/10) type_specific.io-github-autotest-libvirt.memory.allocation.invalid_value.memory.minus: PASS (4.82 s)
 (03/10) type_specific.io-github-autotest-libvirt.memory.allocation.invalid_value.current_memory.zero: PASS (5.83 s)
 (04/10) type_specific.io-github-autotest-libvirt.memory.allocation.invalid_value.current_memory.minus: PASS (4.85 s)
 (05/10) type_specific.io-github-autotest-libvirt.memory.allocation.invalid_value.mam_memory.zero: PASS (5.02 s)
 (06/10) type_specific.io-github-autotest-libvirt.memory.allocation.invalid_value.mam_memory.minus: PASS (4.97 s)
 (07/10) type_specific.io-github-autotest-libvirt.memory.allocation.invalid_value.numa.zero: PASS (4.95 s)
 (08/10) type_specific.io-github-autotest-libvirt.memory.allocation.invalid_value.numa.minus: PASS (5.01 s)
 (09/10) type_specific.io-github-autotest-libvirt.memory.allocation.invalid_value.mixed_mem.zero: PASS (5.74 s)
 (10/10) type_specific.io-github-autotest-libvirt.memory.allocation.invalid_value.mixed_mem.minus: PASS (5.59 s)
RESULTS    : PASS 9 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2023-04-16T08.25-b7d576b/results.html
JOB TIME   : 53.10 s

```