### PR TITLE
Add network case of checking iface statistics

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_stat.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_stat.cfg
@@ -1,11 +1,21 @@
 - virtual_network.iface_stat:
     type = iface_stat
     start_vm = no
-    iface_name =
+    host_iface =
     variants case:
         - compare:
-            variants :
+            variants:
                 - direct_type:
+                    iface_type = direct
                     new_iface_source = {'dev': '%s', 'mode': 'bridge'}
                     new_iface_type = direct
                     new_iface_model = virtio
+                - ethernet_type:
+                    iface_type = ethernet
+                    variants:
+                        - managed_no:
+                            unpr_user = yes
+                            variants device_type:
+                                - tap:
+                                - macvtap:
+                    iface_attrs = {'acpi': {'index': '5'}, 'target': {'dev': tap_name, 'managed': 'no'}, 'model': 'virtio', 'type_name': 'ethernet'}

--- a/libvirt/tests/src/virtual_network/iface_stat.py
+++ b/libvirt/tests/src/virtual_network/iface_stat.py
@@ -1,21 +1,23 @@
 import datetime
-import logging as log
+import logging
 import re
+
+from avocado.utils import process
 
 from virttest import utils_misc
 from virttest import utils_net
 from virttest import virsh
 
 from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
 from virttest.utils_test import libvirt
 
+from provider.virtual_network import network_base
 
-# Using as lower capital is not the best way to do, but this is just a
-# workaround to avoid changing the entire file.
-logging = log.getLogger('avocado.' + __name__)
+LOG = logging.getLogger('avocado.' + __name__)
 
 
-def get_host_iface_stat(vm_name, iface):
+def get_host_iface_stat(vm_name, iface, **virsh_args):
     """
     Get iface stat on host
 
@@ -23,13 +25,13 @@ def get_host_iface_stat(vm_name, iface):
     :param iface: target iface to get stat of
     :return: iface stat
     """
-    logging.debug('Start at %s', datetime.datetime.now())
-    stat_host = virsh.domifstat(vm_name, iface, debug=True).stdout
+    LOG.debug('Start at %s', datetime.datetime.now())
+    stat_host = virsh.domifstat(vm_name, iface, debug=True, **virsh_args).stdout
     iface_info = stat_host.splitlines()
     iface_info = [line.replace(iface, '').strip()
                   for line in iface_info if iface in line]
     output = {line.split()[0]: int(line.split()[1]) for line in iface_info}
-    logging.info('Host iface stat: %s', output)
+    LOG.info('Host iface stat: %s', output)
 
     return output
 
@@ -42,9 +44,9 @@ def get_vm_iface_stat(session, iface):
     :param iface: target iface
     :return: iface stat in vm
     """
-    logging.debug('Start at %s', datetime.datetime.now())
+    LOG.debug('Start at %s', datetime.datetime.now())
     stat_vm = session.cmd('ifconfig %s' % iface)
-    logging.debug('Iface ifconfig in vm: %s', stat_vm)
+    LOG.debug('Iface ifconfig in vm: %s', stat_vm)
 
     def _get_info(pattern):
         """
@@ -69,11 +71,11 @@ def get_vm_iface_stat(session, iface):
     output['tx_errs'], output['tx_drop'] = _get_info(
         'TX errors (\d+)\s+dropped (\d+)')
 
-    logging.info('Iface stat in vm: %s', output)
+    LOG.info('Iface stat in vm: %s', output)
     return output
 
 
-def compare_iface_stat(vm_stat, host_stat, bar=0.2):
+def compare_iface_stat(vm_stat, host_stat, bar=0.1):
     """
     Compare iface stat between host and vm
 
@@ -85,7 +87,7 @@ def compare_iface_stat(vm_stat, host_stat, bar=0.2):
 
     flag = True
     if set(vm_stat.keys()) != set(host_stat.keys()):
-        logging.error('Iface info is not complete on host/vm.')
+        LOG.error('Iface info is not complete on host/vm.')
         return False
 
     for key in vm_stat.keys():
@@ -94,10 +96,13 @@ def compare_iface_stat(vm_stat, host_stat, bar=0.2):
             continue
         if delta == 0:
             continue
-        elif delta / max(vm_stat[key], host_stat[key]) > bar:
-            logging.error('Value of %s on vm (%s) and host (%s) are not close.',
+        else:
+            diff_ratio = delta / max(vm_stat[key], host_stat[key])
+            LOG.debug(f'Difference ratio of {key} is {diff_ratio}')
+            if diff_ratio > bar:
+                LOG.error('Value of %s on vm (%s) and host (%s) are not close.',
                           key, vm_stat[key], host_stat[key])
-            flag = False
+                flag = False
     return flag
 
 
@@ -107,42 +112,104 @@ def run(test, params, env):
     """
     vm_name = params.get('main_vm')
     case = params.get('case', '')
+    scenario = params.get('scenario', '')
     vm = env.get_vm(vm_name)
+    iface_type = params.get('iface_type', '')
+    rand_id = utils_misc.generate_random_string(3)
+    bridge_name = 'br_' + rand_id
+    device_type = params.get('device_type', '')
+    tap_name = device_type + '_' + rand_id
+    iface_attrs = eval(params.get('iface_attrs', '{}'))
+    unpr_user = 'unpr_user_' + rand_id if params.get('unpr_user') else ''
+    username = params.get('username')
+    password = params.get('password')
+    mac_addr = utils_net.generate_mac_address_simple()
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bk_xml = vmxml.copy()
 
-    bk_xml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    if unpr_user:
+        LOG.info(f'Create unprivileged user {unpr_user}')
+        process.run(f'useradd {unpr_user}', shell=True)
 
     try:
         if case == 'compare':
-            host_ifname = params.get("iface_name")
-            if not host_ifname:
-                host_ifname = utils_net.get_net_if(state="UP")[0]
-            iface_dict = {k.replace('new_iface_', ''): v
-                          for k, v in params.items() if k.startswith('new_iface_')}
-            iface_dict['source'] = iface_dict['source'] % host_ifname
 
-            logging.debug('iface_dict is %s', iface_dict)
-            libvirt.modify_vm_iface(vm_name, 'update_iface', iface_dict)
-            vm.start()
-
-            vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
-            iface = vmxml.devices.by_device_tag("interface")[0]
-            iface_mac = iface.mac_address
-            iface_target_dev = iface.target['dev']
-
-            session = vm.wait_for_serial_login(timeout=60)
-            iface_in_vm = utils_net.get_linux_ifname(session, iface_mac)
-            session.close()
-
-            def _collect_and_compare_stat():
-                session = vm.wait_for_serial_login(timeout=60)
-                session.cmd('ping www.redhat.com -4 -c 20')
-                host_iface_stat = get_host_iface_stat(vm_name, iface_target_dev)
+            def _collect_and_compare_stat(vm_name, session, **virsh_args):
+                session.cmd('curl -O https://download.fedoraproject.org/pub'
+                            '/fedora/linux/releases/37/Cloud/x86_64/images'
+                            '/Fedora-Cloud-Base-37-1.7.x86_64.qcow2 -L',
+                            timeout=240)
+                host_iface_stat = get_host_iface_stat(vm_name,
+                                                      iface_target_dev,
+                                                      **virsh_args)
                 vm_iface_stat = get_vm_iface_stat(session, iface_in_vm)
-                session.close()
-                return compare_iface_stat(vm_iface_stat, host_iface_stat,
-                                          bar=0.2)
+                if not compare_iface_stat(vm_iface_stat, host_iface_stat,
+                                          bar=0.1):
+                    test.fail('Iface stat of host and vm should be close.')
 
-            if not utils_misc.wait_for(_collect_and_compare_stat, timeout=240):
-                test.fail('Iface stat of host and vm should be close.')
+            host_iface = params.get("host_iface")
+            if not host_iface:
+                host_iface = utils_net.get_net_if(state="UP")[0]
+            if iface_type == 'direct':
+                iface_dict = {k.replace('new_iface_', ''): v
+                              for k, v in params.items()
+                              if k.startswith('new_iface_')}
+                iface_dict['source'] = iface_dict['source'] % host_iface
+
+                LOG.debug('iface_dict is %s', iface_dict)
+                libvirt.modify_vm_iface(vm_name, 'update_iface', iface_dict)
+                vm.start()
+
+                vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+                iface = vmxml.devices.by_device_tag("interface")[0]
+                iface_mac = iface.mac_address
+                iface_target_dev = iface.target['dev']
+
+                session = vm.wait_for_serial_login(timeout=60)
+                iface_in_vm = utils_net.get_linux_ifname(session, iface_mac)
+                _collect_and_compare_stat(vm_name, session)
+                session.close()
+
+            elif iface_type == 'ethernet':
+                if device_type == 'tap':
+                    utils_net.create_linux_bridge_tmux(bridge_name, host_iface)
+                    network_base.create_tap(tap_name, bridge_name, unpr_user)
+                elif device_type == 'macvtap':
+                    mac_addr = network_base.create_macvtap(tap_name, host_iface,
+                                                           unpr_user)
+                iface_attrs['mac_address'] = mac_addr
+
+                unpr_vmxml = network_base.prepare_vmxml_for_unprivileged_user(
+                    unpr_user, vmxml)
+                unpr_vmxml.del_device('interface', by_tag=True)
+                libvirt_vmxml.modify_vm_device(unpr_vmxml, 'interface',
+                                               iface_attrs)
+                network_base.define_vm_for_unprivileged_user(unpr_user,
+                                                             unpr_vmxml)
+                unpr_vm_name = unpr_vmxml.vm_name
+                virsh.start(unpr_vm_name, debug=True, ignore_status=False,
+                            unprivileged_user=unpr_user)
+                session = network_base.unprivileged_user_login(unpr_vm_name,
+                                                               unpr_user,
+                                                               username,
+                                                               password)
+                iface = unpr_vmxml.devices.by_device_tag("interface")[0]
+                iface_mac = iface.mac_address
+                iface_in_vm = utils_net.get_linux_ifname(session, iface_mac)
+                iface_target_dev = iface.target['dev']
+                _collect_and_compare_stat(unpr_vm_name, session,
+                                          unprivileged_user=unpr_user)
+                session.close()
+
     finally:
         bk_xml.sync()
+        if 'tap' in device_type:
+            virsh.destroy(unpr_vm_name, unprivileged_user=unpr_user, debug=True)
+            virsh.undefine(unpr_vm_name, options='--nvram',
+                           unprivileged_user=unpr_user, debug=True)
+            network_base.delete_tap(tap_name)
+            if device_type == 'tap':
+                utils_net.delete_linux_bridge_tmux(bridge_name, host_iface)
+        if unpr_user:
+            process.run(f'pkill -u {unpr_user};userdel -f -r {unpr_user}',
+                        shell=True, ignore_status=True)

--- a/provider/virtual_network/network_base.py
+++ b/provider/virtual_network/network_base.py
@@ -133,6 +133,8 @@ def create_macvtap(macvtap_name, iface, user):
     # Check if device owner is changed to unprivileged user
     process.run('ls -l %s' % device_path, shell=True)
 
+    return mac_addr
+
 
 def delete_tap(tap_name):
     """
@@ -224,9 +226,6 @@ def unprivileged_user_login(unpr_vm_name, unpr_user, username, password,
     :param timeout: timeout of login attempt
     :return: shell session instance of vm
     """
-    # Start vm as unprivileged user
-    virsh.start(unpr_vm_name, debug=True, ignore_status=False,
-                unprivileged_user=unpr_user)
     cmd = f"su - {unpr_user} -c 'virsh console {unpr_vm_name}'"
 
     session = aexpect.ShellSession(cmd)


### PR DESCRIPTION
- VIRT-296993: Get interface stats for a domain by domifstat - ethernet with managed=no

Test result:
```
 (1/3) type_specific.io-github-autotest-libvirt.virtual_network.iface_stat.compare.direct_type: PASS (86.62 s)
 (2/3) type_specific.io-github-autotest-libvirt.virtual_network.iface_stat.compare.ethernet_type.managed_no.tap: PASS (121.53 s)
 (3/3) type_specific.io-github-autotest-libvirt.virtual_network.iface_stat.compare.ethernet_type.managed_no.macvtap: FAIL: Iface stat of host and vm should be close. (101.03 s)
```
The failed case was caused by un-fixed bug