### PR TITLE
secret_disk: use EventTracker to wait for detach_device to complete

### DIFF
--- a/libvirt/tests/src/virsh_cmd/secret/virsh_secret_define_undefine.py
+++ b/libvirt/tests/src/virsh_cmd/secret/virsh_secret_define_undefine.py
@@ -171,7 +171,8 @@ def run(test, params, env):
             virsh.attach_device(vm_name, diskxml.xml,
                                 ignore_status=False, debug=True)
             virsh.detach_device(vm_name, diskxml.xml,
-                                ignore_status=False, debug=True)
+                                ignore_status=False, debug=True,
+                                wait_for_event=True, event_timeout=20)
 
         if undefine_acl:
             cmd_result = virsh.secret_undefine(uuid, **acl_dargs)


### PR DESCRIPTION
Device can not be hot unplugged immediately after hotplug.

Before:
```
ERROR 1-type_specific.io-github-autotest-libvirt.virsh.secret_define_undefine.normal_test.non_acl.ephemeral_yes.libvirtd_timeout -> CmdError: Command '/bin/virsh detach-device avocado-vt-vm1 /tmp/xml_utils_temp_yqqnkxc6.xml' failed.
stdout: b'\n'
stderr: b"error: Failed to detach device from /tmp/xml_utils_temp_yqqnkxc6.xml\nerror: internal error: unable to execute QEMU command 'device_del': Hot-unplug failed: guest is busy (power indicator blinking)\n"
additional_info: None
```

After:
```
PASS 1-type_specific.io-github-autotest-libvirt.virsh.secret_define_undefine.normal_test.non_acl.ephemeral_yes.libvirtd_timeout
```