### PR TITLE
svirt_start_destroy:Fix permission issue with tpm device

### DIFF
--- a/libvirt/tests/cfg/svirt/svirt_start_destroy.cfg
+++ b/libvirt/tests/cfg/svirt/svirt_start_destroy.cfg
@@ -7,6 +7,7 @@
     # Label for VM.
     svirt_start_destroy_vm_sec_label = "system_u:system_r:svirt_t:s0:c87,c520"
     svirt_start_destroy_host_selinux = "enforcing"
+    swtpm_dir = '/var/lib/swtpm-localca'
     variants:
         - with_qemu_conf:
             variants:


### PR DESCRIPTION
Test result:

>  (1/2) type_specific.io-github-autotest-libvirt.svirt_start_destroy.positive_test.off_destroy.d_svirt_img_s0.no_baselabel.relabel_no.st_none.multi_model.with_qemu_conf.unconfined: PASS (11.27 s)
>  (2/2) type_specific.io-github-autotest-libvirt.svirt_start_destroy.positive_test.off_destroy.d_svirt_img_s0.no_baselabel.relabel_no.st_none.multi_model.without_qemu_conf: PASS (11.20 s)
> 