### PR TITLE
virsh_detach_device_alias: fix watchdog test case

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
@@ -52,9 +52,10 @@
                 no s390-virtio
             detach_watchdog_type = "watchdog"
             watchdog_dict = {"model_type":"i6300esb", "action":"poweroff"}
-            detach_check_xml = "<watchdog"
+            detach_check_xml = "<watchdog model='i6300esb'"
             s390-virtio:
                 watchdog_dict = {"model_type":"diag288", "action":"poweroff"}
+                detach_check_xml = "<watchdog model='diag288'"
         - network_interface:
             only live,config
             detach_interface_type = "network_interface"


### PR DESCRIPTION
Newer libvirt versions add watchdog 'itco' always in certain cases resulting in an additional watchdog element and test failure.

Update the checked substring to match only the removed watchdog.