### PR TITLE
Update seclabel attrs according to xml class update

### DIFF
--- a/libvirt/tests/cfg/svirt/selinux_relabel.cfg
+++ b/libvirt/tests/cfg/svirt/selinux_relabel.cfg
@@ -9,13 +9,13 @@
             channel_path = '/var/lib/libvirt/qemu/vm1.agent'
             channel_label = 'system_u:object_r:admin_home_t:s0'
             serial_attrs_sources_attrs = {'mode': 'bind', 'path': '${serial_path}'}
-            serial_attrs_sources_seclabels = [{'attrs': {'model': 'selinux', 'relabel': 'yes'}, 'label': '${serial_label}'}, {'attrs': {'model': 'dac', 'relabel': 'yes'}, 'label': 'test:test'}]
+            serial_attrs_sources_seclabels = [{'model': 'selinux', 'relabel': 'yes', 'label': '${serial_label}'}, {'model': 'dac', 'relabel': 'yes', 'label': 'test:test'}]
             serial_attrs_sources = [{'attrs': ${serial_attrs_sources_attrs}, 'seclabels': ${serial_attrs_sources_seclabels}}]
             serial_attrs = {'sources': ${serial_attrs_sources}, 'type_name': 'unix', 'target_type': 'isa-serial', 'target_model': 'isa-serial'}
             aarch64:
                 serial_attrs = {'sources': ${serial_attrs_sources}, 'type_name': 'unix', 'target_type': 'system-serial', 'target_model': 'pl011'}
             channel_attrs_sources_attrs = {'mode': 'bind', 'path': '${channel_path}'}
-            channel_attrs_sources_seclabels = [{'attrs': {'model': 'selinux', 'relabel': 'yes'}, 'label': '${channel_label}'}]
+            channel_attrs_sources_seclabels = [{'model': 'selinux', 'relabel': 'yes', 'label': '${channel_label}'}]
             channel_attrs_sources = [{'attrs': ${channel_attrs_sources_attrs}, 'seclabels': ${channel_attrs_sources_seclabels}}]
             channel_attrs_target = {'type': 'virtio', 'name': 'org.qemu.guest_agent.1'}
             channel_attrs = {'sources': ${channel_attrs_sources}, 'target': ${channel_attrs_target}, 'type_name': 'unix'}


### PR DESCRIPTION
Depends on:
- https://github.com/avocado-framework/avocado-vt/pull/3670

Test result:
 (1/1) type_specific.io-github-autotest-libvirt.selinux_relabel.unix_socket: PASS (6.85 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2023-04-22T22.55-86e29d0/results.html
JOB TIME   : 8.13 s
