### PR TITLE
svirt: Add a case about per-device dac

### DIFF
--- a/libvirt/tests/cfg/svirt/dac/dac_seclabel_per_device.cfg
+++ b/libvirt/tests/cfg/svirt/dac/dac_seclabel_per_device.cfg
@@ -1,0 +1,38 @@
+- svirt.dac.seclabel.per_device:
+    type = dac_seclabel_per_device
+    start_vm = "no"
+    seclabel_attr_model = "dac"
+
+    variants test_scenario:
+        - cold_plug:
+        - hot_plug:
+    variants test_device:
+        - disk:
+            disk_attrs_target = {'dev': 'vdb', 'bus': 'virtio'}
+            disk_attrs_driver = {'name': 'qemu', 'type': 'qcow2', 'cache': 'none'}
+            disk_attrs = {'device': 'disk', 'driver': ${disk_attrs_driver}, 'target': ${disk_attrs_target}}
+        - serial:
+            serial_path = "/tmp/test1.sock"
+            serial_attrs_sources_attrs = {"mode": "bind", "path": "${serial_path}"}
+            serial_attrs = {'type_name': 'unix', 'target_type': 'pci-serial', 'target_model': 'pci-serial'}
+    variants:
+        - relabel_no:
+            seclabel_attr_relabel = "no"
+            disk:
+                status_error = "yes"
+        - relabel_yes:
+            seclabel_attr_relabel = "yes"
+            variants:
+                - without_label:
+                   status_error = "yes"
+                - with_label:
+                    variants:
+                        - s_qemu:
+                            seclabel_attr_label = "qemu:qemu"
+                        - s_non_root:
+                            seclabel_attr_label = "test:test"
+                            disk:
+                                status_error = "yes"
+                        - none_existing_user:
+                            status_error = "yes"
+                            seclabel_attr_label = "non-user:qemu"

--- a/libvirt/tests/src/svirt/dac/dac_seclabel_per_device.py
+++ b/libvirt/tests/src/svirt/dac/dac_seclabel_per_device.py
@@ -1,0 +1,116 @@
+import os
+import pwd
+
+from avocado.utils import process
+
+from virttest import data_dir
+from virttest import virsh
+
+from virttest.libvirt_xml import xcepts
+from virttest.libvirt_xml.vm_xml import VMXML
+from virttest.utils_libvirt import libvirt_disk
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+
+def get_dev_dict(device_type, params):
+    """Get device settings
+
+    :param device_type: device type, eg. disk
+    :param params: Test Dictionary with the test parameters
+    :return: Device attrs and it's seclabel attrs
+    """
+    seclabel_attr = {k.replace('seclabel_attr_', ''): int(v) if v.isdigit()
+                     else v for k, v in params.items()
+                     if k.startswith('seclabel_attr_')}
+
+    if device_type == "disk":
+        new_image_path = data_dir.get_data_dir() + '/test.img'
+        libvirt_disk.create_disk("file", new_image_path, disk_format="qcow2")
+        dev_dict = eval(params.get("disk_attrs", "{}"))
+        dev_dict.update({'source': {'attrs': {'file': new_image_path},
+                                    'seclabels': [seclabel_attr]}})
+    else:
+        dev_dict = eval(params.get("serial_attrs", "{}"))
+        dev_dict.update({'sources': [{"attrs": eval(
+            params.get("serial_attrs_sources_attrs", "{}")),
+                                      'seclabels': [seclabel_attr]}]})
+    return dev_dict, seclabel_attr
+
+
+def run(test, params, env):
+    """
+    Start VM or hotplug a device with per-device dac <seclabel> setting
+
+    :param test: test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment
+    """
+    test_device = params.get("test_device")
+    test_scenario = params.get("test_scenario")
+    # Get general variables.
+    added_user = None
+    source_path = None
+
+    # Get variables about VM and get a VM object and VMXML instance.
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    vmxml = VMXML.new_from_inactive_dumpxml(vm_name)
+    backup_xml = vmxml.copy()
+
+    status_error = 'yes' == params.get("status_error", 'no')
+
+    dev_dict, seclabel_attr = get_dev_dict(test_device, params)
+    test.log.debug(dev_dict)
+
+    try:
+        if seclabel_attr.get("label") and not status_error:
+            user = seclabel_attr.get("label").split(":")[0]
+            if user not in [x.pw_name for x in pwd.getpwall()]:
+                process.run("useradd %s" % user, shell=True, verbose=True)
+                added_user = user
+
+        if test_scenario != "hot_plug":
+            test.log.info("TEST_STEP: Start VM with per-device dac setting.")
+            try:
+                libvirt_vmxml.modify_vm_device(vmxml, test_device, dev_dict)
+            except xcepts.LibvirtXMLError as details:
+                if not status_error:
+                    test.fail(details)
+            test.log.debug("VM XML: %s.", VMXML.new_from_inactive_dumpxml(vm_name))
+            res = virsh.start(vm.name)
+        else:
+            test.log.info("TEST_STEP: Hot plug a device with dac setting.")
+            if test_device == 'serial':
+                controller_dict = {'model': 'pcie-to-pci-bridge'}
+                libvirt_vmxml.modify_vm_device(vmxml, "controller", controller_dict, 50)
+            vm.start()
+            vm.wait_for_login().close()
+
+            dev_obj = libvirt_vmxml.create_vm_device_by_type(test_device, dev_dict)
+            dev_obj.setup_attrs(**dev_dict)
+            res = virsh.attach_device(vm.name, dev_obj.xml, debug=True)
+        libvirt.check_exit_status(res, status_error)
+
+        if seclabel_attr.get("label") and not status_error:
+            source_path = dev_dict['source']['attrs']['file'] \
+                if test_device == "disk" else params.get(
+                "serial_path", "/tmp/test1.sock")
+            test.log.info("TEST_STEP: Check ownership of '%s'.", source_path)
+            stat_re = os.lstat(source_path)
+            test.log.debug(stat_re)
+            usr = seclabel_attr.get("label").split(":")[0]
+            if [stat_re.st_uid, stat_re.st_gid] != [
+               pwd.getpwnam(usr).pw_uid, pwd.getpwnam(usr).pw_gid]:
+                test.fail("Incorrect ownership of source file!")
+
+    finally:
+        test.log.info("TEST_TEARDOWN: Recover test environment.")
+        vm.destroy(gracefully=False)
+        backup_xml.sync()
+
+        if added_user:
+            process.run("userdel -r %s" % added_user,
+                        ignore_status=False, shell=True)
+        if source_path and os.path.exists(source_path):
+            os.remove(source_path)


### PR DESCRIPTION
This PR adds a case:
    Start vm or hotplug with per-device dac <seclabel> setting


**Test results:** Failures of relabel_yes.without_label are caused by a known issue.
```
 (01/20) type_specific.io-github-autotest-libvirt.svirt.dac.seclabel.per_device.relabel_no.disk.cold_plug: PASS (8.52 s)
 (02/20) type_specific.io-github-autotest-libvirt.svirt.dac.seclabel.per_device.relabel_no.disk.hot_plug: PASS (47.52 s)
 (03/20) type_specific.io-github-autotest-libvirt.svirt.dac.seclabel.per_device.relabel_no.serial.cold_plug: PASS (9.02 s)
 (04/20) type_specific.io-github-autotest-libvirt.svirt.dac.seclabel.per_device.relabel_no.serial.hot_plug: PASS (47.48 s)
 (05/20) type_specific.io-github-autotest-libvirt.svirt.dac.seclabel.per_device.relabel_yes.without_label.disk.cold_plug: FAIL: Run '/usr/bin/virsh start avocado-vt-vm1 ' expect fail, but run successfully. (9.52 s)
 (06/20) type_specific.io-github-autotest-libvirt.svirt.dac.seclabel.per_device.relabel_yes.without_label.disk.hot_plug: FAIL: Run '/usr/bin/virsh attach-device avocado-vt-vm1 /tmp/xml_utils_temp_qns6uw0n.xml' expect fail, but run successfully. (47.25 s)
 (07/20) type_specific.io-github-autotest-libvirt.svirt.dac.seclabel.per_device.relabel_yes.without_label.serial.cold_plug: FAIL: Run '/usr/bin/virsh start avocado-vt-vm1 ' expect fail, but run successfully. (9.51 s)
 (08/20) type_specific.io-github-autotest-libvirt.svirt.dac.seclabel.per_device.relabel_yes.without_label.serial.hot_plug: FAIL: Run '/usr/bin/virsh attach-device avocado-vt-vm1 /tmp/xml_utils_temp_b0tygp7e.xml' expect fail, but run successfully. (49.98 s)
 (09/20) type_specific.io-github-autotest-libvirt.svirt.dac.seclabel.per_device.relabel_yes.with_label.s_qemu.disk.cold_plug: PASS (9.12 s)
 (10/20) type_specific.io-github-autotest-libvirt.svirt.dac.seclabel.per_device.relabel_yes.with_label.s_qemu.disk.hot_plug: PASS (46.88 s)
 (11/20) type_specific.io-github-autotest-libvirt.svirt.dac.seclabel.per_device.relabel_yes.with_label.s_qemu.serial.cold_plug: PASS (9.09 s)
 (12/20) type_specific.io-github-autotest-libvirt.svirt.dac.seclabel.per_device.relabel_yes.with_label.s_qemu.serial.hot_plug: PASS (49.67 s)
 (13/20) type_specific.io-github-autotest-libvirt.svirt.dac.seclabel.per_device.relabel_yes.with_label.s_non_root.disk.cold_plug: PASS (8.75 s)
 (14/20) type_specific.io-github-autotest-libvirt.svirt.dac.seclabel.per_device.relabel_yes.with_label.s_non_root.disk.hot_plug: PASS (46.76 s)
 (15/20) type_specific.io-github-autotest-libvirt.svirt.dac.seclabel.per_device.relabel_yes.with_label.s_non_root.serial.cold_plug: PASS (8.95 s)
 (16/20) type_specific.io-github-autotest-libvirt.svirt.dac.seclabel.per_device.relabel_yes.with_label.s_non_root.serial.hot_plug: PASS (49.66 s)
 (17/20) type_specific.io-github-autotest-libvirt.svirt.dac.seclabel.per_device.relabel_yes.with_label.none_existing_user.disk.cold_plug: PASS (8.76 s)
 (18/20) type_specific.io-github-autotest-libvirt.svirt.dac.seclabel.per_device.relabel_yes.with_label.none_existing_user.disk.hot_plug: PASS (46.84 s)
 (19/20) type_specific.io-github-autotest-libvirt.svirt.dac.seclabel.per_device.relabel_yes.with_label.none_existing_user.serial.cold_plug: PASS (8.82 s)
 (20/20) type_specific.io-github-autotest-libvirt.svirt.dac.seclabel.per_device.relabel_yes.with_label.none_existing_user.serial.hot_plug: PASS (48.56 s)

```