### PR TITLE
svirt: Add a case about per-device selinux setting

### DIFF
--- a/libvirt/tests/cfg/svirt/selinux/selinux_seclabel_per_device.cfg
+++ b/libvirt/tests/cfg/svirt/selinux/selinux_seclabel_per_device.cfg
@@ -1,0 +1,40 @@
+- svirt.selinux.seclabel.per_device:
+    type = selinux_seclabel_per_device
+    start_vm = "no"
+    seclabel_attr_model = "selinux"
+
+    variants test_scenario:
+        - cold_plug:
+        - hot_plug:
+    variants test_device:
+        - disk:
+            disk_attrs_target = {'dev': 'vdb', 'bus': 'virtio'}
+            disk_attrs_driver = {'name': 'qemu', 'type': 'qcow2', 'cache': 'none'}
+            disk_attrs = {'device': 'disk', 'driver': ${disk_attrs_driver}, 'target': ${disk_attrs_target}}
+        - serial:
+            serial_path = "/tmp/test1.sock"
+            serial_attrs_sources_attrs = {"mode": "bind", "path": "${serial_path}"}
+            serial_attrs = {'type_name': 'unix', 'target_type': 'pci-serial', 'target_model': 'pci-serial'}
+    variants:
+        - relabel_no:
+            seclabel_attr_relabel = "no"
+            disk:
+                status_error = "yes"
+        - relabel_yes:
+            seclabel_attr_relabel = "yes"
+            variants:
+                - without_label:
+                   status_error = "yes"
+                - label_legit:
+                    seclabel_attr_label = "system_u:object_r:svirt_image_t:s0"
+                - label_MCS:
+                    seclabel_attr_label = "system_u:object_r:svirt_image_t:s0:c182,c308"
+                    disk:
+                        status_error = "yes"
+                - label_default:
+                    seclabel_attr_label = "unconfined_u:object_r:virt_image_t:s0"
+                    disk:
+                        status_error = "yes"
+                - label_invalid_fmt:
+                    status_error = "yes"
+                    seclabel_attr_label = "xxxx.test.test.s0"

--- a/libvirt/tests/src/svirt/selinux/selinux_seclabel_per_device.py
+++ b/libvirt/tests/src/svirt/selinux/selinux_seclabel_per_device.py
@@ -1,0 +1,101 @@
+import os
+
+from avocado.utils import process
+
+from virttest import data_dir
+from virttest import virsh
+
+from virttest.libvirt_xml import xcepts
+from virttest.libvirt_xml.vm_xml import VMXML
+from virttest.utils_libvirt import libvirt_disk
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+
+def get_dev_dict(device_type, params):
+    """
+    Get device settings
+
+    :param device_type: device type, eg. disk
+    :param params: Test Dictionary with the test parameters
+    :return: Device attrs and it's seclabel attrs
+    """
+    seclabel_attr = {k.replace('seclabel_attr_', ''): int(v) if v.isdigit()
+                     else v for k, v in params.items()
+                     if k.startswith('seclabel_attr_')}
+
+    if device_type == "disk":
+        new_image_path = data_dir.get_data_dir() + '/test.img'
+        libvirt_disk.create_disk("file", new_image_path, disk_format="qcow2")
+        dev_dict = eval(params.get("disk_attrs", "{}"))
+        dev_dict.update({'source': {'attrs': {'file': new_image_path},
+                                    'seclabels': [seclabel_attr]}})
+    else:
+        dev_dict = eval(params.get("serial_attrs", "{}"))
+        dev_dict.update({'sources': [{"attrs": eval(
+            params.get("serial_attrs_sources_attrs", "{}")),
+                                      'seclabels': [seclabel_attr]}]})
+    return dev_dict, seclabel_attr
+
+
+def run(test, params, env):
+    """
+    Start VM or hotplug a device with per-device selinux <seclabel> setting
+
+    :param test: test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment
+    """
+    test_device = params.get("test_device")
+    test_scenario = params.get("test_scenario")
+    status_error = 'yes' == params.get("status_error", 'no')
+
+    source_path = None
+
+    # Get variables about VM and get a VM object and VMXML instance.
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    vmxml = VMXML.new_from_inactive_dumpxml(vm_name)
+    backup_xml = vmxml.copy()
+
+    dev_dict, seclabel_attr = get_dev_dict(test_device, params)
+    test.log.debug("The device setting will be updated to %s.", dev_dict)
+    try:
+        if test_scenario != "hot_plug":
+            test.log.info("TEST_STEP: Start VM with per-device dac setting.")
+            try:
+                libvirt_vmxml.modify_vm_device(vmxml, test_device, dev_dict)
+            except xcepts.LibvirtXMLError as details:
+                if not status_error:
+                    test.fail(details)
+            test.log.debug("VM XML: %s.", VMXML.new_from_inactive_dumpxml(vm_name))
+            res = virsh.start(vm.name)
+        else:
+            test.log.info("TEST_STEP: Hot plug a device with dac setting.")
+            if test_device == 'serial':
+                controller_dict = {'model': 'pcie-to-pci-bridge'}
+                libvirt_vmxml.modify_vm_device(vmxml, "controller", controller_dict, 50)
+            vm.start()
+            vm.wait_for_login().close()
+
+            dev_obj = libvirt_vmxml.create_vm_device_by_type(test_device, dev_dict)
+            dev_obj.setup_attrs(**dev_dict)
+            res = virsh.attach_device(vm.name, dev_obj.xml, debug=True)
+        libvirt.check_exit_status(res, status_error)
+
+        if seclabel_attr.get("label") and not status_error:
+            source_path = dev_dict['source']['attrs']['file'] \
+                if test_device == "disk" else params.get(
+                "serial_path", "/tmp/test1.sock")
+            test.log.info("TEST_STEP: Check the selinux context of '%s'.",
+                          source_path)
+
+            expr_dev_context = ':'.join(seclabel_attr.get("label").split(':')[:4])
+            label_output = process.run("ls -lZ %s" % source_path, shell=True)
+            libvirt.check_result(label_output, expected_match=expr_dev_context)
+    finally:
+        test.log.info("TEST_TEARDOWN: Recover test environment.")
+        backup_xml.sync()
+
+        if source_path and os.path.exists(source_path):
+            os.remove(source_path)


### PR DESCRIPTION
This PR adds:
    VIRT-296954 - Start vm or hotplug with per-device selinux <seclabel> setting


**Test results:** Failed cases are due to a known issue.
```
 (01/24) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.per_device.relabel_no.disk.cold_plug: PASS (8.38 s)
 (02/24) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.per_device.relabel_no.disk.hot_plug: PASS (47.28 s)
 (03/24) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.per_device.relabel_no.serial.cold_plug: PASS (8.81 s)
 (04/24) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.per_device.relabel_no.serial.hot_plug: PASS (47.14 s)
 (05/24) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.per_device.relabel_yes.without_label.disk.cold_plug: FAIL: Run '/usr/bin/virsh start avocado-vt-vm1 ' expect fail, but run successfully. (9.30 s)
 (06/24) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.per_device.relabel_yes.without_label.disk.hot_plug: FAIL: Run '/usr/bin/virsh attach-device avocado-vt-vm1 /tmp/xml_utils_temp_x2v1grx3.xml' expect fail, but run successfully. (48.06 s)
 (07/24) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.per_device.relabel_yes.without_label.serial.cold_plug: FAIL: Run '/usr/bin/virsh start avocado-vt-vm1 ' expect fail, but run successfully. (9.06 s)
 (08/24) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.per_device.relabel_yes.without_label.serial.hot_plug: FAIL: Run '/usr/bin/virsh attach-device avocado-vt-vm1 /tmp/xml_utils_temp_zv9t4q85.xml' expect fail, but run successfully. (48.70 s)
 (09/24) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.per_device.relabel_yes.label_legit.disk.cold_plug: PASS (8.89 s)
 (10/24) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.per_device.relabel_yes.label_legit.disk.hot_plug: PASS (48.87 s)
 (11/24) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.per_device.relabel_yes.label_legit.serial.cold_plug: PASS (8.92 s)
 (12/24) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.per_device.relabel_yes.label_legit.serial.hot_plug: PASS (48.18 s)
 (13/24) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.per_device.relabel_yes.label_MCS.disk.cold_plug: PASS (8.45 s)
 (14/24) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.per_device.relabel_yes.label_MCS.disk.hot_plug: PASS (47.47 s)
 (15/24) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.per_device.relabel_yes.label_MCS.serial.cold_plug: PASS (8.82 s)
 (16/24) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.per_device.relabel_yes.label_MCS.serial.hot_plug: PASS (48.33 s)
 (17/24) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.per_device.relabel_yes.label_default.disk.cold_plug: PASS (8.64 s)
 (18/24) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.per_device.relabel_yes.label_default.disk.hot_plug: PASS (47.55 s)
 (19/24) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.per_device.relabel_yes.label_default.serial.cold_plug: PASS (8.83 s)
 (20/24) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.per_device.relabel_yes.label_default.serial.hot_plug: PASS (49.29 s)
 (21/24) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.per_device.relabel_yes.label_invalid_fmt.disk.cold_plug: PASS (8.53 s)
 (22/24) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.per_device.relabel_yes.label_invalid_fmt.disk.hot_plug: PASS (47.77 s)
 (23/24) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.per_device.relabel_yes.label_invalid_fmt.serial.cold_plug: PASS (8.56 s)
 (24/24) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.per_device.relabel_yes.label_invalid_fmt.serial.hot_plug: PASS (48.21 s)

```