### PR TITLE
Add case of passt hotplug/unplug

### DIFF
--- a/libvirt/tests/cfg/virtual_network/passt/passt_attach_detach.cfg
+++ b/libvirt/tests/cfg/virtual_network/passt/passt_attach_detach.cfg
@@ -1,0 +1,47 @@
+- virtual_network.passt.attach_detach:
+    type = passt_attach_detach
+    func_supported_since_libvirt_ver = (9, 0, 0)
+    host_iface =
+    outside_ip = 'www.redhat.com'
+    start_vm = no
+    mtu = 65520
+    variants user_type:
+        - root_user:
+            test_user = root
+            user_id = 107
+            virsh_uri = 'qemu:///system'
+            log_dir = /run/user/${user_id}
+            socket_dir = f'/run/libvirt/qemu/passt/'
+        - non_root_user:
+            test_user = USER.EXAMPLE
+            test_passwd = PASSWORD.EXAMPLE
+            user_id = 
+            unpr_vm_name = UNPRIVILEGED_VM.EXAMPLE
+            virsh_uri = 'qemu+ssh://${test_user}@localhost/session'
+            socket_dir = f'/run/user/{user_id}/libvirt/qemu/run/passt/'
+    variants scenario:
+        - attach:
+        - detach:
+            add_iface = yes
+        - attach_detach:
+    variants:
+        - ip_portfw:
+            alias = {'name': 'ua-c87b89ff-b769-4abc-921f-30d42d7aec5b'}
+            backend = {'type': 'passt'}
+            ips = [{'address': '172.17.2.4', 'family': 'ipv4', 'prefix': '24'}, {'address': '2001:db8:ac10:fd01::20', 'family': 'ipv6'}]
+            portForward_0 = {'attrs': {'proto': 'tcp'}, 'ranges': [{'start': '31339', 'to': '41339'}]}
+            portForward_1 = {'attrs': {'proto': 'udp'}, 'ranges': [{'start': '2025'}]}
+            portForward_2 = {'attrs': {'proto': 'tcp', 'address': host_ip}, 'ranges': [{'start': '9000'}]}
+            portForwards = [${portForward_0}, ${portForward_1}, ${portForward_2}]
+            iface_attrs = {'model': 'virtio', 'acpi': {'index': '1'}, 'ips': ${ips}, 'backend': ${backend}, 'source': {'dev': '${host_iface}'}, 'alias': ${alias}, 'type_name': 'user', 'portForwards': ${portForwards}}
+            proc_checks = ['--tcp-ports 31339:41339', '--udp-ports 2025', f'--tcp-ports {host_ip}/9000']
+            ipv6_prefix = 128
+            vm_iface = eno1
+            vm_ping_outside = pass
+            vm_ping_host_public = pass
+            tcp_port_list = [9000, '*:31339']
+            udp_port_list = ['0.0.0.0:2025', '[::]:2025']
+            conn_check_args_0 = ('TCP4', 'localhost', 31339, 41339, True, None)
+            conn_check_args_1 = ('TCP6', 'localhost', 31339, 41339, True, None)
+            conn_check_args_2 = ('UDP4', 'localhost', 2025, 2025, True, None)
+            conn_check_args_3 = ('UDP6', 'localhost', 2025, 2025, True, None)

--- a/libvirt/tests/src/virtual_network/passt/passt_attach_detach.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_attach_detach.py
@@ -1,0 +1,210 @@
+import logging
+import os
+import shutil
+
+import aexpect
+from avocado.utils import process
+from virttest import libvirt_version
+from virttest import remote
+from virttest import utils_net
+from virttest import utils_selinux
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.staging import service
+from virttest.utils_libvirt import libvirt_unprivileged
+from virttest.utils_libvirt import libvirt_vmxml
+
+from provider.virtual_network import network_base
+from provider.virtual_network import passt
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+VIRSH_ARGS = {'debug': True, 'ignore_status': False}
+IPV6_LENGTH = 128
+
+
+def check_mac_in_domiflist(vm_name, mac, virsh_ins, test, expect=True):
+    domif = virsh_ins.domiflist(vm_name, **VIRSH_ARGS).stdout_text
+    found = mac in domif
+    msg = f'{"" if found else "Not"} Found mac {mac} of iface '\
+          f'from output of domiflist'
+    if found != expect:
+        test.fail(msg)
+
+
+def check_passt_pid_not_exist(test):
+    pid_passt = process.run('pidof passt',
+                            ignore_status=True).stdout_text.strip()
+    if pid_passt:
+        test.fail(f'Process of passt still exists: {pid_passt}')
+
+
+def run(test, params, env):
+    """
+    Test passt backend interface hotplug and hotunplug
+    """
+    libvirt_version.is_libvirt_feature_supported(params)
+    root = 'root_user' == params.get('user_type', '')
+    if root:
+        vm_name = params.get('main_vm')
+        vm = env.get_vm(vm_name)
+        virsh_ins = virsh
+        log_dir = params.get('log_dir')
+        user_id = params.get('user_id')
+    else:
+        vm_name = params.get('unpr_vm_name')
+        test_user = params.get('test_user', '')
+        test_passwd = params.get('test_passwd', '')
+        user_id = passt.get_user_id(test_user)
+        unpr_vm_args = {
+            'username': params.get('username'),
+            'password': params.get('password'),
+        }
+        vm = libvirt_unprivileged.get_unprivileged_vm(vm_name, test_user,
+                                                      test_passwd,
+                                                      **unpr_vm_args)
+        uri = f'qemu+ssh://{test_user}@localhost/session'
+        virsh_ins = virsh.VirshPersistent(uri=uri)
+        host_session = aexpect.ShellSession('su')
+        remote.VMManager.set_ssh_auth(host_session, 'localhost', test_user,
+                                      test_passwd)
+        host_session.close()
+
+    scenario = params.get('scenario')
+    virsh_uri = params.get('virsh_uri')
+    add_iface = 'yes' == params.get('add_iface', 'no')
+    host_ip = utils_net.get_host_ip_address(ip_ver='ipv4')
+    host_ip_v6 = utils_net.get_host_ip_address(ip_ver='ipv6')
+    iface_attrs = eval(params.get('iface_attrs'))
+    params['socket_dir'] = socket_dir = eval(params.get('socket_dir'))
+    params['proc_checks'] = proc_checks = eval(params.get('proc_checks', '{}'))
+    vm_iface = params.get('vm_iface', 'eno1')
+    mtu = params.get('mtu')
+    outside_ip = params.get('outside_ip')
+    host_iface = params.get('host_iface')
+    host_iface = host_iface if host_iface else utils_net.get_net_if(
+        state="UP")[0]
+    log_file = f'/run/user/{user_id}/passt.log'
+    iface_attrs['backend']['logFile'] = log_file
+    iface_attrs['source']['dev'] = host_iface
+
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name,
+                                                   virsh_instance=virsh_ins)
+    bkxml = vmxml.copy()
+
+    selinux_status = utils_selinux.get_status()
+    if selinux_status != 'enforcing':
+        utils_selinux.set_status('enforcing')
+
+    if not os.path.exists('/usr/bin/socat'):
+        test.error('This test requires to install socat')
+
+    firewalld = service.Factory.create_service("firewalld")
+    try:
+        if root:
+            if not os.path.exists(log_dir):
+                os.mkdir(log_dir)
+            os.chown(log_dir, int(user_id), int(user_id))
+
+        vmxml.del_device('interface', by_tag=True)
+        iface_device = libvirt_vmxml.create_vm_device_by_type('interface',
+                                                              iface_attrs)
+        LOG.debug(f'iface_device: {iface_device}')
+        if add_iface:
+            vmxml.add_device(iface_device)
+        vmxml.sync(virsh_instance=virsh_ins)
+        vm.start()
+
+        if 'attach' in scenario:
+            virsh_ins.attach_device(vm_name, iface_device.xml, **VIRSH_ARGS)
+            LOG.debug(virsh_ins.dumpxml(vm_name).stdout_text)
+
+            vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name,
+                                                  virsh_instance=virsh_ins)
+            iface_after_at = vmxml.get_devices(device_type='interface')[0]
+            LOG.debug(f'iface device after detach: {iface_after_at}')
+            iface_after_at.del_mac_address()
+            iface_after_at.del_address()
+            if iface_after_at != iface_device:
+                test.fail('iface xml changed after attach')
+
+            mac = vm.get_virsh_mac_address()
+            check_mac_in_domiflist(vm_name, mac, virsh_ins, test)
+
+            passt.check_proc_info(params, log_file, mac)
+
+            #   check the passt log
+            if not os.path.exists(log_file):
+                test.fail(f'Logfile of passt "{log_file}" not created')
+
+            session = vm.wait_for_serial_login(timeout=60)
+            passt.check_vm_ip(iface_attrs, session, host_iface)
+            passt.check_vm_mtu(session, vm_iface, mtu)
+            passt.check_default_gw(session)
+            passt.check_nameserver(session)
+
+            ips = {
+                'outside_ip': outside_ip,
+                'host_public_ip': host_ip,
+            }
+            network_base.ping_check(params, ips, session, force_ipv4=True)
+
+            firewalld.stop()
+            LOG.debug(f'Service status of firewalld: {firewalld.status()}')
+            passt.check_connection(vm, vm_iface,
+                                   ['TCP4', 'TCP6', 'UDP4', 'UDP6'])
+
+            if 'portForwards' in iface_attrs:
+                tcp_port_list = eval(params.get('tcp_port_list', '[]'))
+                tcp_port_list = [f'{host_ip}:{port}' if str(port).isdigit()
+                                 else port for port in tcp_port_list]
+                passt.check_port_listen(tcp_port_list, 'TCP', host_ip=host_ip)
+
+                udp_port_list = eval(params.get('udp_port_list', '[]'))
+                passt.check_port_listen(udp_port_list, 'UDP')
+
+                conn_check_list = []
+                for k, v in params.items():
+                    if k.startswith('conn_check_args_'):
+                        conn_check_list.append(eval(v))
+                LOG.debug(f'conn_check_list: {conn_check_list}')
+
+                passt.check_portforward_connetion(vm, conn_check_list,
+                                                  test_user=params.get(
+                                                      'test_user'))
+        if 'detach' not in scenario:
+            vm.destroy()
+            check_passt_pid_not_exist(test)
+            if os.listdir(socket_dir):
+                test.fail(f'Socket dir is not empty: {os.listdir(socket_dir)}')
+        else:
+            vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name,
+                                                  virsh_instance=virsh_ins)
+            LOG.debug(f'vmxml before detach:\n{vmxml}')
+            iface_to_detach = vmxml.get_devices('interface')[0]
+            mac = iface_to_detach.mac_address
+
+            virsh.detach_device(vm_name, iface_to_detach.xml,
+                                wait_for_event=True, event_timeout=15,
+                                uri=virsh_uri, **VIRSH_ARGS)
+
+            vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name,
+                                                  virsh_instance=virsh_ins)
+            LOG.debug(f'vmxml after detach: {vmxml}')
+            iface_after_detach = vmxml.get_devices('interface')
+            if iface_after_detach:
+                test.fail('Interface should be detached from vm, but it can '
+                          'still be found in vmxml')
+
+            check_mac_in_domiflist(vm_name, mac, virsh_ins, test, expect=False)
+            check_passt_pid_not_exist(test)
+
+    finally:
+        firewalld.start()
+        vm.destroy()
+        bkxml.sync(virsh_instance=virsh_ins)
+        if root:
+            shutil.rmtree(log_dir)
+        else:
+            del virsh_ins
+        utils_selinux.set_status(selinux_status)


### PR DESCRIPTION
- VIRT-297073 - [user][passt] Passt backend interface - hotplug/unplug

Depends on:
- https://github.com/avocado-framework/avocado-vt/pull/3667
- https://github.com/avocado-framework/avocado-vt/pull/3668
- https://github.com/avocado-framework/avocado-vt/pull/3673
- https://github.com/avocado-framework/avocado-vt/pull/3676

Test result:
 (1/6) type_specific.io-github-autotest-libvirt.virtual_network.passt.attach_detach.ip_portfw.attach.root_user: PASS (341.87 s)
 (2/6) type_specific.io-github-autotest-libvirt.virtual_network.passt.attach_detach.ip_portfw.attach.non_root_user: PASS (267.66 s)
 (3/6) type_specific.io-github-autotest-libvirt.virtual_network.passt.attach_detach.ip_portfw.detach.root_user: PASS (169.29 s)
 (4/6) type_specific.io-github-autotest-libvirt.virtual_network.passt.attach_detach.ip_portfw.detach.non_root_user: PASS (32.64 s)
 (5/6) type_specific.io-github-autotest-libvirt.virtual_network.passt.attach_detach.ip_portfw.attach_detach.root_user: PASS (407.98 s)
 (6/6) type_specific.io-github-autotest-libvirt.virtual_network.passt.attach_detach.ip_portfw.attach_detach.non_root_user: PASS (272.67 s)
RESULTS    : PASS 6 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2023-04-27T04.39-7708e61/results.html
JOB TIME   : 1493.59 s
