### PR TITLE
svirt: Add cases about lable restore rules

### DIFF
--- a/libvirt/tests/cfg/svirt/label_restore_rules/label_restore_rules_disk_access_modes.cfg
+++ b/libvirt/tests/cfg/svirt/label_restore_rules/label_restore_rules_disk_access_modes.cfg
@@ -1,0 +1,20 @@
+- svirt.label_restore_rules.disk_access_modes:
+    type = label_restore_rules_disk_access_modes
+    start_vm = "no"
+    dac_seclabel_attr_model = "dac"
+    dac_seclabel_attr_label = "qemu:qemu"
+    selinux_seclabel_attr_model = "selinux"
+
+    variants:
+        - readonly:
+            disk_attrs = {'readonly': True}
+            selinux_seclabel_attr_label = "system_u:object_r:virt_content_t:s0"
+            label_restored = "no"
+        - shareable:
+            disk_attrs = {'share': True, 'target': {'dev': 'vdd', 'bus': 'virtio'}, 'device': 'disk', 'type_name': 'file'}
+            selinux_seclabel_attr_label = "system_u:object_r:svirt_image_t:s0"
+            label_restored = "no"
+        - non_shareable:
+            disk_attrs = {'share': False, 'readonly': False}
+            selinux_seclabel_attr_label = "system_u:object_r:svirt_image_t:s0:c[0-1023]:c[0-1023]"
+            label_restored = "yes"

--- a/libvirt/tests/cfg/svirt/label_restore_rules/label_restore_rules_on_failed_start.cfg
+++ b/libvirt/tests/cfg/svirt/label_restore_rules/label_restore_rules_on_failed_start.cfg
@@ -1,0 +1,4 @@
+- svirt.label_restore_rules.on_failed_start:
+    type = label_restore_rules_on_failed_start
+    start_vm = "no"
+    error_msg = "SELinux label on.*already in use"

--- a/libvirt/tests/src/svirt/label_restore_rules/label_restore_rules_disk_access_modes.py
+++ b/libvirt/tests/src/svirt/label_restore_rules/label_restore_rules_disk_access_modes.py
@@ -1,0 +1,85 @@
+import os
+
+from avocado.utils import process
+from virttest import data_dir
+from virttest.libvirt_xml.vm_xml import VMXML
+from virttest.utils_libvirt import libvirt_disk
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+
+def get_seclabel_attrs(params):
+    """Get seclabel settings
+
+    :param params: Test Dictionary with the test parameters
+    :return: seclabel attrs and the expected label setting
+    """
+    dac_seclabel_attr = {k.replace('dac_seclabel_attr_', ''): int(v)
+                         if v.isdigit()
+                         else v for k, v in params.items()
+                         if k.startswith('dac_seclabel_attr_')}
+    selinux_seclabel_attr = {k.replace('selinux_seclabel_attr_', ''): int(v)
+                             if v.isdigit()
+                             else v for k, v in params.items()
+                             if k.startswith('selinux_seclabel_attr_')}
+    expr_label = " ".join(dac_seclabel_attr['label'].split(":") +
+                          [':'.join(selinux_seclabel_attr['label']
+                                    .split(':')[:4])])
+
+    return [dac_seclabel_attr, selinux_seclabel_attr], expr_label
+
+
+def run(test, params, env):
+    """
+    Check svirt label and restore rules for different disk access modes
+
+    :param test: test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment
+    """
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+
+    disk_attrs = eval(params.get("disk_attrs", "{}"))
+    disk_index = 0
+    seclabel_attrs, expr_label = get_seclabel_attrs(params)
+
+    vmxml = VMXML.new_from_inactive_dumpxml(vm_name)
+    backup_xml = vmxml.copy()
+    try:
+        test.log.info("TEST_SETUP: Prepare a VM with the proper access mode disk.")
+        disk_path = vm.get_first_disk_devices()['source']
+        if disk_attrs.get("share"):
+            disk_path = data_dir.get_data_dir() + '/test.img'
+            libvirt_disk.create_disk("file", disk_path, disk_format="qcow2")
+            disk_attrs.update({'source': {'attrs': {'file': disk_path}}})
+            disk_index = 1
+        org_label = process.run("ls -lZ %s | awk '{print $3,$4,$5}'"
+                                % disk_path, shell=True).stdout_text.strip()
+        libvirt_vmxml.modify_vm_device(vmxml, "disk", disk_attrs,
+                                       index=disk_index)
+
+        test.log.info("TEST_STEP: Update VM XML with %s.", seclabel_attrs)
+        vmxml.set_seclabel(seclabel_attrs)
+        vmxml.sync()
+        vm.start()
+        test.log.debug(VMXML.new_from_dumpxml(vm_name))
+
+        test.log.info("TEST_STEP: Check the label of disk image after the VM "
+                      "starts.")
+        label_output = process.run("ls -lZ %s" % disk_path, shell=True)
+        libvirt.check_result(label_output, expected_match=expr_label)
+
+        test.log.info("TEST_STEP: Check the label of disk image after "
+                      "destroying the VM.")
+        vm.destroy()
+        if params.get("label_restored") == "yes":
+            expr_label = org_label
+        test.log.debug(expr_label)
+        label_output2 = process.run("ls -lZ %s" % disk_path, shell=True)
+        libvirt.check_result(label_output2, expected_match=expr_label)
+    finally:
+        test.log.info("TEST_TEARDOWN: Recover test environment.")
+        backup_xml.sync()
+        if disk_attrs.get("share") and os.path.exists(disk_path):
+            os.remove(disk_path)

--- a/libvirt/tests/src/svirt/label_restore_rules/label_restore_rules_on_failed_start.py
+++ b/libvirt/tests/src/svirt/label_restore_rules/label_restore_rules_on_failed_start.py
@@ -1,0 +1,54 @@
+import re
+
+from virttest import utils_misc
+from virttest import virsh
+
+from virttest.libvirt_xml.vm_xml import VMXML
+from virttest.utils_libvirt import libvirt_disk
+from virttest.utils_test import libvirt
+
+
+def run(test, params, env):
+    """
+    Check the xattr of resource file when guest fails to start.
+
+    :param test: test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment
+    """
+    error_msg = params.get("error_msg")
+    xattr_selinux_str = params.get("xattr_selinux_str",
+                                   "trusted.libvirt.security.ref_selinux=\"1\"")
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    vmxml = VMXML.new_from_inactive_dumpxml(vm_name)
+    backup_xml = vmxml.copy()
+    disk_path = vm.get_first_disk_devices()['source']
+    vm2_name = vm.name + '_' + utils_misc.generate_random_string(3)
+    try:
+        test.log.info("TEST_STEP: Start a VM and check the xattr of disk image.")
+        vm.start()
+        img_xattr = libvirt_disk.get_image_xattr(disk_path)
+        if not re.findall(xattr_selinux_str, img_xattr):
+            test.fail("Unable to get %s!" % xattr_selinux_str)
+
+        test.log.info("TEST_STEP: Start another VM using the same image with "
+                      "the first VM.")
+        vmxml2 = VMXML.new_from_inactive_dumpxml(vm_name)
+        vmxml2.setup_attrs(**{'vm_name': vm2_name})
+        vmxml2.del_uuid()
+        virsh.define(vmxml2.xml, debug=True, ignore_status=False)
+
+        result = virsh.start(vm2_name, debug=True)
+        libvirt.check_result(result, error_msg)
+
+        test.log.info("TEST_STEP: Check the xattr of disk image")
+        img_xattr = libvirt_disk.get_image_xattr(disk_path)
+        if not re.findall(xattr_selinux_str, img_xattr):
+            test.fail("Unable to get %s!" % xattr_selinux_str)
+
+    finally:
+        test.log.info("TEST_TEARDOWN: Recover test environment.")
+        backup_xml.sync()
+        if 'vmxml2' in locals():
+            vmxml2.undefine()


### PR DESCRIPTION
This PR adds:
    VIRT-296956 - Check svirt label and restore rules for different
        disk access modes
    VIRT-296957 - Start two guests using the same image

**Test results**
```
 (1/4) type_specific.io-github-autotest-libvirt.svirt.label_restore_rules.on_failed_start: PASS (9.43 s)
 (2/4) type_specific.io-github-autotest-libvirt.svirt.label_restore_rules.disk_access_modes.readonly: PASS (42.63 s)
 (3/4) type_specific.io-github-autotest-libvirt.svirt.label_restore_rules.disk_access_modes.shareable: PASS (58.14 s)
 (4/4) type_specific.io-github-autotest-libvirt.svirt.label_restore_rules.disk_access_modes.non_shareable: PASS (50.18 s)

```