### PR TITLE
tpm_device: add invalid xml test for external vtpm

### DIFF
--- a/libvirt/tests/cfg/virtual_device/tpm_device.cfg
+++ b/libvirt/tests/cfg/virtual_device/tpm_device.cfg
@@ -242,3 +242,40 @@
                                     active_pcr_banks = 'sha384'
                                     vm_operate = 'managedsave'
                                     pcrbank_change = 'sha256'
+                - external:
+                    func_supported_since_libvirt_ver = (9, 0, 0)
+                    backend_type = 'external'
+                    no pseries, s390-virtio
+                    q35:
+                        tpm_model = 'tpm-crb'
+                    aarch64:
+                        tpm_model = 'tpm-tis'
+                    variants:
+                        - source_type:
+                            xml_errmsg = "XML error: missing external TPM backend source type"
+                            variants:
+                                - nonexist:
+                                    source_attrs = {'mode': 'connect', 'path': '/var/tmp/guest-swtpm.sock'}
+                                - empty:
+                                    source_attrs = {'type': '', 'mode': 'connect', 'path': '/var/tmp/guest-swtpm.sock'}
+                                - invalid:
+                                    source_attrs = {'type': 'unixaa', 'mode': 'connect', 'path': '/var/tmp/guest-swtpm.sock'}
+                                    xml_errmsg = "unsupported configuration: unknown backend source type 'unixaa' for external TPM"
+                        - source_mode:
+                            variants:
+                                - nonexist:
+                                    source_attrs = {'type': 'unix', 'path': '/var/tmp/guest-swtpm.sock'}
+                                    skip_start = 'yes'
+                                - empty:
+                                    source_attrs = {'type': 'unix', 'mode': '', 'path': '/var/tmp/guest-swtpm.sock'}
+                                    xml_errmsg = "XML error: Invalid value for attribute 'mode' in element 'source': ''"
+                                - invalid:
+                                    source_attrs = {'type': 'unix', 'mode': 'bind', 'path': '/var/tmp/guest-swtpm.sock'}
+                                    xml_errmsg = "XML error: only 'connect' mode is supported for external TPM device"
+                        - source_path:
+                            variants:
+                                - nonexist:
+                                    source_attrs = {'type': 'unix', 'mode': 'connect'}
+                                    xml_errmsg = "error: XML error: missing socket path for external TPM device"
+                                - empty:
+                                    source_attrs = {'type': 'unix', 'mode': 'connect', 'path': ''}


### PR DESCRIPTION
Add invalid xml test for external vtpm, including nonexist, empty and invalid values for source_type, source_mode and source_socket.
To auto VIRT-296945.