### PR TITLE
tpm_device: fix UnboundLocalError

### DIFF
--- a/libvirt/tests/src/virtual_device/tpm_device.py
+++ b/libvirt/tests/src/virtual_device/tpm_device.py
@@ -790,7 +790,7 @@ def run(test, params, env):
             # Stop test when get expected failure
             return
         if vm_operate != "restart":
-            if not source_mode:
+            if source_attrs_str and not source_mode:
                 source_mode = 'connect'
             check_dumpxml(vm_name)
         if skip_start:


### PR DESCRIPTION
"if not source_mode, set as 'connect'" is added for invalid external vtpm testing. Modify to check it only when source_attrs_str exists.