### PR TITLE
svirt: Update serial_attrs to enable test for aarch64

### DIFF
--- a/libvirt/tests/cfg/svirt/selinux/selinux_seclabel_per_device.cfg
+++ b/libvirt/tests/cfg/svirt/selinux/selinux_seclabel_per_device.cfg
@@ -15,6 +15,8 @@
             serial_path = "/tmp/test1.sock"
             serial_attrs_sources_attrs = {"mode": "bind", "path": "${serial_path}"}
             serial_attrs = {'type_name': 'unix', 'target_type': 'pci-serial', 'target_model': 'pci-serial'}
+            aarch64:
+                serial_attrs = {'type_name': 'unix', 'target_type': 'system-serial', 'target_model': 'pl011'}
     variants:
         - relabel_no:
             seclabel_attr_relabel = "no"


### PR DESCRIPTION
The serial->target->type for character device on aarch64 is system-serial, and the usable model for system-serial is pl011.