### PR TITLE
Virtio_transitional_vsock: fix a checking result change

### DIFF
--- a/libvirt/tests/cfg/virtio_transitional/virtio_transitional_vsock.cfg
+++ b/libvirt/tests/cfg/virtio_transitional/virtio_transitional_vsock.cfg
@@ -3,7 +3,7 @@
     no Windows
     start_vm = no
     addr_pattern = '\d\d:\d\d\.\d'
-    device_pattern = 'Communication controller: Red Hat.* Device'
+    device_pattern = 'Communication controller: Red Hat.* Device | Communication controller: Red Hat.* socket'
     variants:
         - virtio:
             virtio_model = "virtio"


### PR DESCRIPTION
After we start a guest with vsock, we'll get 
```
# lspci | grep Communication
03:00.0 Communication controller: Red Hat, Inc. Virtio console (rev 01)
07:00.0 Communication controller: Red Hat, Inc. Virtio socket (rev 01)
```
now. So update the script.