### PR TITLE
managed_save: Open a new session to get pid of ping

### DIFF
--- a/provider/save/save_base.py
+++ b/provider/save/save_base.py
@@ -16,10 +16,11 @@ def pre_save_setup(vm):
     upsince = session.cmd_output('uptime --since').strip()
     LOG.debug(f'VM has been up since {upsince}')
     ping_cmd = 'ping 127.0.0.1'
+    # This session shouldn't be closed or it will kill ping
     session.sendline(ping_cmd + '&')
-    session.sendline()
-    pid_ping = session.cmd_output('pidof ping').strip().split()[-1]
-    # The session shouldn't be closed or it will kill ping
+    check_session = vm.wait_for_login()
+    pid_ping = check_session.cmd_output('pidof ping').strip().split()[-1]
+    check_session.close()
     LOG.debug(f'Pid of ping: {pid_ping}')
 
     return pid_ping, upsince


### PR DESCRIPTION
Before:
```
# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio save_and_restore.save_with_options.normal.paused_vm.no_opt --vt-connect-uri qemu:///system                                                                                                                                    
JOB ID     : 78cd70263ef5c782e60d786a4638d616ac298931                                                                                                                                                                                                                                                                        
JOB LOG    : /var/lib/avocado/job-results/job-2023-05-25T03.18-78cd702/job.log                                                                                                                                                                                                                                               
 (1/1) type_specific.io-github-autotest-libvirt.save_and_restore.save_with_options.normal.paused_vm.no_opt: ERROR: Timeout expired while waiting for shell command to complete: 'pidof ping'    (output: '[1] 2789\n[root@localhost ~]# 2789\n[root@localhost ~]# PING 127.0.0.1 (127.0.0.1) 56(84) bytes of data.\n64 bytes f
rom 127.0.0.1: icmp_seq=1 ttl=64 time=0.031 ms\n64 b... (85.11 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2023-05-25T03.18-78cd702/results.html                                                                                                                                                                                                                                          
JOB TIME   : 85.48 s
```
After:
```
# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio save_and_restore.save_with_options.normal.paused_vm.no_opt --vt-connect-uri qemu:///system                                                                            

JOB ID     : e94bb42574ff61d47873884754c04f5956d7f72a                                                                                               
JOB LOG    : /var/lib/avocado/job-results/job-2023-05-25T03.37-e94bb42/job.log                                                                                                                                                                                                                                               
 (1/1) type_specific.io-github-autotest-libvirt.save_and_restore.save_with_options.normal.paused_vm.no_opt: PASS (35.71 s)                                                                                                                                                                                                   
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0                                                                                                                                                                                                                                            
JOB HTML   : /var/lib/avocado/job-results/job-2023-05-25T03.37-e94bb42/results.html                                                                                                                                                                                                                                          
JOB TIME   : 36.08 s
```