### PR TITLE
passt:replace session funtion cmd_output with cmd

### DIFF
--- a/libvirt/tests/src/virtual_network/passt/passt_function.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_function.py
@@ -138,7 +138,7 @@ def run(test, params, env):
                                               test_user=params.get('test_user'))
 
         vm_sess = vm.wait_for_serial_login(timeout=60)
-        vm_sess.cmd_output('systemctl start firewalld')
+        vm_sess.cmd('systemctl start firewalld')
         vm.destroy()
 
         pid_passt = process.run('pidof passt',

--- a/provider/virtual_network/passt.py
+++ b/provider/virtual_network/passt.py
@@ -288,7 +288,7 @@ def check_portforward_connetion(vm, check_list, test_user=None):
     :param test_user: unprivileged user if any, defaults to None
     """
     vm_sess = vm.wait_for_serial_login(timeout=60)
-    vm_sess.cmd_output('systemctl stop firewalld')
+    vm_sess.cmd('systemctl stop firewalld')
     vm_sess.close()
     cmd_create_sess = f'su - {test_user}' if test_user else 'su'
 


### PR DESCRIPTION
Calling cmd_output instead of cmd was a workaround since the status of command could not be found then. Drop this workaround since the problem is fixed.

Depends on:
- https://github.com/avocado-framework/avocado-vt/pull/3695