### PR TITLE
managadsave: Update the check method of flag to adapt to all platforms

### DIFF
--- a/libvirt/tests/cfg/save_and_restore/save_with_options.cfg
+++ b/libvirt/tests/cfg/save_and_restore/save_with_options.cfg
@@ -17,7 +17,7 @@
             description = 'Saving added description'
         - bypass_cache_opt:
             options = --bypass-cache
-            check_cmd = "while(true);do cat /proc/$(lsof -w {}|awk '/libvirt_i/{{print $2}}')/fdinfo/1 ;done"
+            check_cmd = "while(true); do [ -e {} ] && cat /proc/$(lsof -w {}|awk '/libvirt_i/{{print $2}}')/fdinfo/1 ;done"
     variants:
         - running_vm:
             pre_state = running


### PR DESCRIPTION
The bypass cache flag O_DIRECT is arch based.

Before:
```
# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio save_and_restore.save_with_options.normal.running_vm.bypass_cache_opt --vt-connect-uri qemu:///system                                                                                                                                                     
JOB ID     : 35cf7eb01f03bdbfbea6b30085e1adc85b8fb2df                                                                                                                                 
JOB LOG    : /var/lib/avocado/job-results/job-2023-05-26T03.49-35cf7eb/job.log                                                                                     
 (1/1) type_specific.io-github-autotest-libvirt.save_and_restore.save_with_options.normal.running_vm.bypass_cache_opt: FAIL: bypass-cache check fail, please check log (27.45 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0                     
JOB HTML   : /var/lib/avocado/job-results/job-2023-05-26T03.49-35cf7eb/results.html                                                                                                                                                                              
JOB TIME   : 27.82 s
```
After:
```
# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio save_and_restore.save_with_options.normal.running_vm.bypass_cache_opt --vt-connect-uri qemu:///system                                                                                                                                                                                                                   
JOB ID     : 0fc51cea31ee0ef69ce3c79725f9216c45eb9e9b
JOB LOG    : /var/lib/avocado/job-results/job-2023-05-26T04.19-0fc51ce/job.log
 (1/1) type_specific.io-github-autotest-libvirt.save_and_restore.save_with_options.normal.running_vm.bypass_cache_opt: PASS (37.84 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2023-05-26T04.19-0fc51ce/results.html
JOB TIME   : 38.22 s
```