### PR TITLE
svirt_dac: Update serial_attrs to enable test for aarch64

### DIFF
--- a/libvirt/tests/cfg/svirt/dac/dac_seclabel_per_device.cfg
+++ b/libvirt/tests/cfg/svirt/dac/dac_seclabel_per_device.cfg
@@ -15,6 +15,8 @@
             serial_path = "/tmp/test1.sock"
             serial_attrs_sources_attrs = {"mode": "bind", "path": "${serial_path}"}
             serial_attrs = {'type_name': 'unix', 'target_type': 'pci-serial', 'target_model': 'pci-serial'}
+            aarch64:
+                serial_attrs = {'type_name': 'unix', 'target_type': 'system-serial', 'target_model': 'pl011'}
     variants:
         - relabel_no:
             seclabel_attr_relabel = "no"


### PR DESCRIPTION
The serial->target->type for character device on aarch64 is system-serial, and the usable model for system-serial is pl011.

Test Results:
The failed one is caused by a known issue.
```
 (1/4) type_specific.io-github-autotest-libvirt.svirt.dac.seclabel.per_device.relabel_yes.without_label.serial.cold_plug: FAIL: Run '/usr/bin/virsh start avocado-vt-vm1 ' expect fail, but run successfully. (5.89 s)
 (2/4) type_specific.io-github-autotest-libvirt.svirt.dac.seclabel.per_device.relabel_yes.with_label.s_qemu.serial.cold_plug: PASS (5.52 s)
 (3/4) type_specific.io-github-autotest-libvirt.svirt.dac.seclabel.per_device.relabel_yes.with_label.s_non_root.serial.cold_plug: PASS (5.56 s)
 (4/4) type_specific.io-github-autotest-libvirt.svirt.dac.seclabel.per_device.relabel_yes.with_label.none_existing_user.serial.cold_plug: PASS (5.39 s)
```