### PR TITLE
virtual_disk: Update fedore iso url

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_cdrom_device.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_cdrom_device.cfg
@@ -30,7 +30,7 @@
             source_protocol = "https"
             source_name = "EXAMPLE_HTTPS_ISO"
             source_host_name = "dl.fedoraproject.org"
-            default_iso_name = "/pub/fedora/linux/releases/34/Server/x86_64/iso/Fedora-Server-netinst-x86_64-34-1.2.iso"
+            default_iso_name = "/pub/fedora/linux/releases/38/Server/x86_64/iso/Fedora-Server-netinst-x86_64-38-1.6.iso"
             source_host_port = "443"
             backend_device = "https_cdrom_backend"
             only hotplug..positive_test


### PR DESCRIPTION
The iso address for fedora34 has been removed, update the iso address to fedora38.

Before:
```
FAIL 1-type_specific.io-github-autotest-libvirt.virtual_disks.cdrom_device.hotplug.https_cdrom_backend.positive_test -> TestFail: VM failed to start.Error: VM 'avocado-vt-vm1' failed to start: error: Failed to start domain 'avocado-vt-vm1'
error: internal error: qemu unexpectedly closed the monitor: 2023-05-29T12:49:25.076181Z qemu-kvm: -blockdev {"driver":"https","url":"https://dl.fedoraproject.org:443/pub/fedora/linux/releases/34/Server/x86_64/iso/Fedora-Server-netinst-x86_64-34-1.2.iso","node-name":"libvirt-1-storage","auto-read-only":true,"discard":"unmap"}: CURL: Error opening file: The requested URL returned error: 404 Not Found(exit status: 1)
```

After:
```
PASS 1-type_specific.io-github-autotest-libvirt.virtual_disks.cdrom_device.hotplug.https_cdrom_backend.positive_test
```