### PR TITLE
Add version check for direct type interface

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_stat.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_stat.cfg
@@ -6,6 +6,7 @@
         - compare:
             variants:
                 - direct_type:
+                    func_supported_since_libvirt_ver = (9, 2, 0)
                     iface_type = direct
                     new_iface_source = {'dev': '%s', 'mode': 'bridge'}
                     new_iface_type = direct
@@ -17,5 +18,7 @@
                             unpr_user = yes
                             variants device_type:
                                 - tap:
+                                    func_supported_since_libvirt_ver = (8, 0, 0)
                                 - macvtap:
+                                    func_supported_since_libvirt_ver = (9, 2, 0)
                     iface_attrs = {'acpi': {'index': '5'}, 'target': {'dev': tap_name, 'managed': 'no'}, 'model': 'virtio', 'type_name': 'ethernet'}

--- a/libvirt/tests/src/virtual_network/iface_stat.py
+++ b/libvirt/tests/src/virtual_network/iface_stat.py
@@ -7,6 +7,7 @@ from avocado.utils import process
 from virttest import utils_misc
 from virttest import utils_net
 from virttest import virsh
+from virttest import libvirt_version
 
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_libvirt import libvirt_vmxml
@@ -110,6 +111,7 @@ def run(test, params, env):
     """
     Test iface stat
     """
+    libvirt_version.is_libvirt_feature_supported(params)
     vm_name = params.get('main_vm')
     case = params.get('case', '')
     scenario = params.get('scenario', '')


### PR DESCRIPTION
For direct type interface, the bug fixed since libvirt 9.2.0. Add the version check for it.