### PR TITLE
fix blockcopy process num type changes to float

### DIFF
--- a/libvirt/tests/src/backingchain/blockcopy/blockcopy_with_conventional_chain.py
+++ b/libvirt/tests/src/backingchain/blockcopy/blockcopy_with_conventional_chain.py
@@ -53,7 +53,7 @@ def run(test, params, env):
         check_obj.check_mirror_exist(vm, target_disk, tmp_copy_path)
 
         if not utils_misc.wait_for(
-                lambda: libvirt.check_blockjob(vm_name, target_disk, "progress", "100"), 30):
+                lambda: libvirt.check_blockjob(vm_name, target_disk, "progress", "100(.00)?"), 30):
             test.fail("Blockcopy not finished for 30s")
         test.log.info("TEST_STEP3: Abort job with %s", execute_option)
         virsh.blockjob(vm_name, target_disk, execute_option,

--- a/libvirt/tests/src/backingchain/blockjob/blockjob_with_raw_option.py
+++ b/libvirt/tests/src/backingchain/blockjob/blockjob_with_raw_option.py
@@ -87,7 +87,7 @@ def run(test, params, env):
         test.log.info("Check if the job can be aborted successfully")
         if utils_misc.wait_for(
                 lambda: libvirt.check_blockjob(vm_name,
-                                               dev, "progress", "100"), 100):
+                                               dev, "progress", "100(.00)?"), 100):
             virsh.blockjob(vm_name, dev, options=' --pivot',
                            debug=True,
                            ignore_status=False)

--- a/libvirt/tests/src/backingchain/blockjob_options.py
+++ b/libvirt/tests/src/backingchain/blockjob_options.py
@@ -67,7 +67,7 @@ def run(test, params, env):
             # Abort job and check abort success.
             if utils_misc.wait_for(
                     lambda: libvirt.check_blockjob(vm_name,
-                                                   dev, "progress", "100"), 100):
+                                                   dev, "progress", "100(.00)?"), 100):
                 virsh.blockjob(vm_name, dev, options=' --pivot',
                                debug=True,
                                ignore_status=False)

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockcopy.py
@@ -185,7 +185,7 @@ def finish_job(vm_name, target, timeout):
         if utl.check_blockjob(vm_name, target, 'none', '0'):
             raise exceptions.TestFail("No blockjob find for '%s'" % target)
 
-        if utl.check_blockjob(vm_name, target, "progress", "100"):
+        if utl.check_blockjob(vm_name, target, "progress", "100(.00)?"):
             logging.debug("Block job progress up to 100%")
             break
         else:


### PR DESCRIPTION
  blockcopy process changes from 100% to 100.00%
Signed-off-by: nanli <nanli@redhat.com>

```

/usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockcopy.conventional_chain.file_disk.with_shallow backingchain.blockcopy.conventional_chain.file_disk.without_shallow backingchain.blockcopy.conventional_chain.block_disk.with_shallow backingchain.blockcopy.conventional_chain.block_disk.without_shallow backingchain.blockcopy.conventional_chain.rbd_with_auth_disk.with_shallow  backingchain.blockcopy.conventional_chain.rbd_with_auth_disk.without_shallow backingchain.blockjob.raw.raw_list backingchain.blockjob.options.option_raw backingchain.blockcopy.async_option.async

 (1/9) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.conventional_chain.file_disk.with_shallow: PASS (62.46 s)
 (2/9) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.conventional_chain.file_disk.without_shallow: PASS (61.33 s)
 (3/9) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.conventional_chain.block_disk.with_shallow: PASS (82.25 s)
 (4/9) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.conventional_chain.block_disk.without_shallow: PASS (79.01 s)
 (5/9) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.conventional_chain.rbd_with_auth_disk.with_shallow: PASS (61.69 s)
 (6/9) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.conventional_chain.rbd_with_auth_disk.without_shallow: PASS (63.15 s)
 (7/9) type_specific.io-github-autotest-libvirt.backingchain.blockjob.raw.raw_list: PASS (67.19 s)
 (8/9) type_specific.io-github-autotest-libvirt.backingchain.blockjob.options.option_raw: PASS (34.35 s)
 (9/9) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.async_option.async: PASS (55.19 s)



 (1/1) type_specific.io-github-autotest-libvirt.virsh.blockcopy.positive_test.non_acl.nfs_disk.dest_local.no_blockdev.shallow.pivot_option: PASS (113.28 s)
 (1/1) type_specific.io-github-autotest-libvirt.virsh.blockcopy.positive_test.non_acl.block_disk.disk_t.default.block_type.blockdev.shallow.no_option: PASS (197.32 s)


```
