### PR TITLE
Add passt case of transferring file

### DIFF
--- a/libvirt/tests/cfg/virtual_network/passt/passt_transfer_file.cfg
+++ b/libvirt/tests/cfg/virtual_network/passt/passt_transfer_file.cfg
@@ -1,0 +1,47 @@
+- virtual_network.passt.transfer_file:
+    type = passt_transfer_file
+    func_supported_since_libvirt_ver = (9, 0, 0)
+    host_iface =
+    outside_ip = 'www.redhat.com'
+    start_vm = no
+    variants user_type:
+        - root_user:
+            test_user = root
+            user_id = 107
+            virsh_uri = 'qemu:///system'
+            log_dir = /run/user/${user_id}
+            socket_dir = f'/run/libvirt/qemu/passt/'
+        - non_root_user:
+            test_user = USER.EXAMPLE
+            test_passwd = PASSWORD.EXAMPLE
+            user_id = 
+            unpr_vm_name = UNPRIVILEGED_VM.EXAMPLE
+            virsh_uri = 'qemu+ssh://${test_user}@localhost/session'
+            socket_dir = f'/run/user/{user_id}/libvirt/qemu/run/passt/'
+    variants:
+        - ip_portfw:
+            alias = {'alias': {'name': 'ua-c87b89ff-b769-4abc-921f-30d42d7aec5b'}}
+            backend = {'type': 'passt'}
+            ips = {'ips': [{'address': '172.17.2.4', 'family': 'ipv4', 'prefix': '24'}, {'address': '2001:db8:ac10:fd01::20', 'family': 'ipv6'}]}
+            port = 41339
+            portForward_0 = {'attrs': {'proto': 'tcp'}, 'ranges': [{'start': '${port}'}]}
+            portForwards = {'portForwards': [${portForward_0}]}
+            iface_attrs = {'model': 'virtio', 'acpi': {'index': '1'}, **${ips}, 'backend': ${backend}, 'source': {'dev': '${host_iface}'}, **${alias}, 'type_name': 'user', **${portForwards}}
+            ipv6_prefix = 128
+            vm_iface = eno1
+    variants file_size:
+        - 10M:
+            bs = 1M
+        - 1G:
+            bs = 100M
+    test_file = /tmp/${file_size}_file
+    rec_file = out_${file_size}
+    cmd_create_file = dd if=/dev/urandom bs=${bs} count=10 > ${test_file}
+    cmd_listen = f'socat -u {prot}-LISTEN:{port},reuseaddr OPEN:${rec_file},create'
+    cmd_transfer = f'socat -u FILE:${test_file} {prot}:{addr}:{port}'
+    variants direction:
+        - host_to_vm:
+        - vm_to_host:
+    variants ip_ver:
+        - ipv4:
+        - ipv6:

--- a/libvirt/tests/src/virtual_network/passt/passt_transfer_file.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_transfer_file.py
@@ -1,0 +1,191 @@
+import logging
+import os
+import shutil
+import time
+
+import aexpect
+from avocado.utils import process
+from virttest import libvirt_version
+from virttest import remote
+from virttest import utils_net
+from virttest import utils_selinux
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.staging import service
+from virttest.utils_libvirt import libvirt_unprivileged
+
+from provider.virtual_network import passt
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+VIRSH_ARGS = {'debug': True, 'ignore_status': False}
+IPV6_LENGTH = 128
+
+
+def transfer_host_to_vm(session, prot, ip_ver, params, test):
+    """
+    Test file transfer from host to vm via socat
+
+    :param session: vm session
+    :param prot: protocol
+    :param ip_ver: ip version
+    :param params: test params
+    :param test: test instance
+    """
+    test_file = params.get('test_file')
+    rec_file = params.get('rec_file')
+    cmd_create_file = params.get('cmd_create_file')
+    port = params.get('port')
+    cmd_listen = eval(params.get('cmd_listen'))
+    process.run(cmd_create_file, shell=True)
+    md5 = process.run(f'md5sum {test_file}',
+                      shell=True).stdout_text.split()[0]
+    LOG.debug(f'MD5 of sent file: {md5}')
+    session.sendline('systemctl stop firewalld')
+    session.sendline(cmd_listen)
+    time.sleep(5)
+    addr = 'localhost' if ip_ver == 'ipv4' else '[::1]'
+    cmd_transfer = eval(params.get('cmd_transfer'))
+    process.run(cmd_transfer, shell=True)
+
+    if session.cmd_status(f'test -a {rec_file}') != 0:
+        test.fail(f'VM did not recieve {rec_file}')
+    vm_file_md5 = session.cmd_output(f'md5sum {rec_file}')
+    vm_file_md5 = vm_file_md5.split()[0]
+    LOG.debug(f'MD5 of recieved file: {vm_file_md5}')
+    try:
+        if md5 == vm_file_md5:
+            LOG.debug('MD5 check PASS')
+        else:
+            test.fail('MD5 of files from host and vm NOT match')
+    finally:
+        session.cmd(f'rm {rec_file} -f')
+
+
+def transfer_vm_to_host(session, prot, ip_ver, vm_iface, firewalld,
+                        params, test):
+    """
+    Test file transfer from vm to host via socat
+
+    :param session: vm session
+    :param prot: protocol
+    :param ip_ver: ip version
+    :param vm_iface: interface of vm
+    :param firewalld: firewalld service instance
+    :param params: test params
+    :param test: test instance
+    """
+    test_file = params.get('test_file')
+    rec_file = params.get('rec_file')
+    cmd_create_file = params.get('cmd_create_file')
+    force_dhcp = True if ip_ver == 'ipv4' else False
+    vm_default_gw = utils_net.get_default_gateway(session=session,
+                                                  ip_ver=ip_ver,
+                                                  force_dhcp=force_dhcp)
+    addr = vm_default_gw if ip_ver == 'ipv4' \
+        else f'[{vm_default_gw}%{vm_iface}]'
+    firewalld.stop()
+    port = passt.get_free_port()
+    cmd_listen = eval(params.get('cmd_listen'))
+    cmd_transfer = eval(params.get('cmd_transfer'))
+    session.cmd(cmd_create_file)
+    md5_output = session.cmd_output(f'md5sum {test_file}')
+    LOG.debug(md5_output)
+    md5 = md5_output.split()[0]
+    LOG.debug(f'MD5 of sent file: {md5}')
+    host_session = aexpect.ShellSession('su')
+    host_session.sendline(cmd_listen)
+    session.cmd(cmd_transfer)
+    host_session.close()
+    if not os.path.exists(rec_file):
+        test.fail(f'HOST did not recieve {rec_file}')
+    host_file_md5 = process.run(
+        f'md5sum {rec_file}', shell=True).stdout_text.split()[0]
+    LOG.debug(f'MD5 of recieved file: {host_file_md5}')
+    try:
+        if md5 == host_file_md5:
+            LOG.debug('MD5 check PASS')
+        else:
+            test.fail('MD5 of files from host and vm NOT match')
+    finally:
+        os.remove(rec_file)
+
+
+def run(test, params, env):
+    """
+    Test file transfer between host and vm with passt backend interface
+    """
+    libvirt_version.is_libvirt_feature_supported(params)
+    root = 'root_user' == params.get('user_type', '')
+    if root:
+        vm_name = params.get('main_vm')
+        vm = env.get_vm(vm_name)
+        virsh_ins = virsh
+        log_dir = params.get('log_dir')
+        user_id = params.get('user_id')
+    else:
+        vm_name = params.get('unpr_vm_name')
+        test_user = params.get('test_user', '')
+        test_passwd = params.get('test_passwd', '')
+        user_id = passt.get_user_id(test_user)
+        unpr_vm_args = {
+            'username': params.get('username'),
+            'password': params.get('password'),
+        }
+        vm = libvirt_unprivileged.get_unprivileged_vm(vm_name, test_user,
+                                                      test_passwd,
+                                                      **unpr_vm_args)
+        uri = f'qemu+ssh://{test_user}@localhost/session'
+        virsh_ins = virsh.VirshPersistent(uri=uri)
+        host_session = aexpect.ShellSession('su')
+        remote.VMManager.set_ssh_auth(host_session, 'localhost', test_user,
+                                      test_passwd)
+        host_session.close()
+
+    iface_attrs = eval(params.get('iface_attrs'))
+    params['socket_dir'] = socket_dir = eval(params.get('socket_dir'))
+    params['proc_checks'] = proc_checks = eval(params.get('proc_checks', '{}'))
+    vm_iface = params.get('vm_iface', 'eno1')
+    host_iface = params.get('host_iface')
+    host_iface = host_iface if host_iface else utils_net.get_net_if(
+        state="UP")[0]
+    log_file = f'/run/user/{user_id}/passt.log'
+    iface_attrs['backend']['logFile'] = log_file
+    iface_attrs['source']['dev'] = host_iface
+    direction = params.get('direction')
+    ip_ver = params.get('ip_ver')
+
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name,
+                                                   virsh_instance=virsh_ins)
+    bkxml = vmxml.copy()
+
+    selinux_status = passt.ensure_selinux_enforcing()
+    passt.check_socat_installed()
+
+    firewalld = service.Factory.create_service("firewalld")
+    try:
+        if root:
+            passt.make_log_dir(user_id, log_dir)
+
+        passt.vm_add_iface(vmxml, iface_attrs, virsh_ins)
+        vm.start()
+        LOG.debug(virsh_ins.dumpxml(vm_name).stdout_text)
+
+        session = vm.wait_for_serial_login(timeout=60)
+        passt.check_default_gw(session)
+
+        prot = 'TCP' if ip_ver == 'ipv4' else 'TCP6'
+        if direction == 'host_to_vm':
+            transfer_host_to_vm(session, prot, ip_ver, params, test)
+        if direction == 'vm_to_host':
+            transfer_vm_to_host(session, prot, ip_ver, vm_iface, firewalld,
+                                params, test)
+    finally:
+        firewalld.start()
+        vm.destroy()
+        bkxml.sync(virsh_instance=virsh_ins)
+        if root:
+            shutil.rmtree(log_dir)
+        else:
+            del virsh_ins
+        utils_selinux.set_status(selinux_status)

--- a/spell.ignore
+++ b/spell.ignore
@@ -773,6 +773,7 @@ prepended
 priveledge
 proc
 propoer
+prot
 proto
 Prudhvi
 ps
@@ -901,6 +902,7 @@ SMT
 snaplist
 snapname
 snapshotname
+socat
 socketscount
 sourse
 Sparsify


### PR DESCRIPTION
- VIRT-297076: [user][passt] Passt backend interface - transfter a file between guest and host through tcp4/6

Test result:
 (01/16) type_specific.io-github-autotest-libvirt.virtual_network.passt.transfer_file.ipv4.host_to_vm.10M.ip_portfw.root_user: PASS (153.82 s)
 (02/16) type_specific.io-github-autotest-libvirt.virtual_network.passt.transfer_file.ipv4.host_to_vm.10M.ip_portfw.non_root_user: PASS (84.61 s)
 (03/16) type_specific.io-github-autotest-libvirt.virtual_network.passt.transfer_file.ipv4.host_to_vm.1G.ip_portfw.root_user: PASS (225.39 s)
 (04/16) type_specific.io-github-autotest-libvirt.virtual_network.passt.transfer_file.ipv4.host_to_vm.1G.ip_portfw.non_root_user: PASS (90.43 s)
 (05/16) type_specific.io-github-autotest-libvirt.virtual_network.passt.transfer_file.ipv4.vm_to_host.10M.ip_portfw.root_user: PASS (198.97 s)
 (06/16) type_specific.io-github-autotest-libvirt.virtual_network.passt.transfer_file.ipv4.vm_to_host.10M.ip_portfw.non_root_user: PASS (63.44 s)
 (07/16) type_specific.io-github-autotest-libvirt.virtual_network.passt.transfer_file.ipv4.vm_to_host.1G.ip_portfw.root_user: PASS (210.92 s)
 (08/16) type_specific.io-github-autotest-libvirt.virtual_network.passt.transfer_file.ipv4.vm_to_host.1G.ip_portfw.non_root_user: PASS (73.10 s)
 (09/16) type_specific.io-github-autotest-libvirt.virtual_network.passt.transfer_file.ipv6.host_to_vm.10M.ip_portfw.root_user: PASS (212.76 s)
 (10/16) type_specific.io-github-autotest-libvirt.virtual_network.passt.transfer_file.ipv6.host_to_vm.10M.ip_portfw.non_root_user: PASS (76.12 s)
 (11/16) type_specific.io-github-autotest-libvirt.virtual_network.passt.transfer_file.ipv6.host_to_vm.1G.ip_portfw.root_user: PASS (233.61 s)
 (12/16) type_specific.io-github-autotest-libvirt.virtual_network.passt.transfer_file.ipv6.host_to_vm.1G.ip_portfw.non_root_user: PASS (86.65 s)
 (13/16) type_specific.io-github-autotest-libvirt.virtual_network.passt.transfer_file.ipv6.vm_to_host.10M.ip_portfw.root_user: PASS (138.04 s)
 (14/16) type_specific.io-github-autotest-libvirt.virtual_network.passt.transfer_file.ipv6.vm_to_host.10M.ip_portfw.non_root_user: PASS (65.30 s)
 (15/16) type_specific.io-github-autotest-libvirt.virtual_network.passt.transfer_file.ipv6.vm_to_host.1G.ip_portfw.root_user: PASS (207.20 s)
 (16/16) type_specific.io-github-autotest-libvirt.virtual_network.passt.transfer_file.ipv6.vm_to_host.1G.ip_portfw.non_root_user: PASS (74.14 s)