### PR TITLE
migration: Update case for parallel migration

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -393,6 +393,7 @@
                                     only without_postcopy
                                     virsh_migrate_extra = "--comp-methods xbzrle --parallel --parallel-connections"
                                     parallel_cn_nums = 4
+                                    err_msg = "Compression method 'xbzrle' isn't supported with parallel migration"
                         - check_domstats:
                             asynch_migrate = "yes"
                             virsh_opt = ' -k0'

--- a/libvirt/tests/src/migration/migrate_options_shared.py
+++ b/libvirt/tests/src/migration/migrate_options_shared.py
@@ -1395,6 +1395,11 @@ def run(test, params, env):
         src_libvirt_file = libvirt_config.remove_key_for_modular_daemon(
             remove_dict)
 
+        if extra.count("xbzrle") and extra.count("parallel"):
+            if libvirt_version.version_compare(9, 4, 0):
+                asynch_migration = False
+                params.update({"status_error": "yes"})
+
         # Execute migration process
         if not asynch_migration:
             mig_result = do_migration(vm, dest_uri, options, extra)


### PR DESCRIPTION
In new libvirt version, compression method 'xbzrle' isn't supported with parallel migration. So update code.