### PR TITLE
fix 100 percent match issue

### DIFF
--- a/libvirt/tests/src/backingchain/blockjob/blockjob_pivot_after_irregular_operations.py
+++ b/libvirt/tests/src/backingchain/blockjob/blockjob_pivot_after_irregular_operations.py
@@ -41,7 +41,7 @@ def run(test, params, env):
         test.log.info("TEST_STEP2: Do blockjob with pivot")
         if not utils_misc.wait_for(
                 lambda: libvirt.check_blockjob(vm_name, target_disk,
-                                               "progress", "100"), 2):
+                                               "progress", "100(.00)?"), 2):
 
             result = virsh.blockjob(vm_name, target_disk,
                                     options=pivot_option, debug=True,

--- a/libvirt/tests/src/backingchain/blockjob/blockjob_with_raw_option.py
+++ b/libvirt/tests/src/backingchain/blockjob/blockjob_with_raw_option.py
@@ -40,7 +40,7 @@ def run(test, params, env):
         2) Check cur value is changing.
         3) Execute with --pivot and check raw option return empty.
         """
-        if not libvirt.check_blockjob(vm_name, dev, "progress", "100"):
+        if not libvirt.check_blockjob(vm_name, dev, "progress", "100(.00)?"):
             _check_cur()
             _abort_job()
         else:

--- a/libvirt/tests/src/backingchain/blockjob_options.py
+++ b/libvirt/tests/src/backingchain/blockjob_options.py
@@ -48,7 +48,7 @@ def run(test, params, env):
         4) Execute with --pivot and check raw option return empty
         """
         # Confirm blockcopy not finished.
-        if not libvirt.check_blockjob(vm_name, dev, "progress", "100"):
+        if not libvirt.check_blockjob(vm_name, dev, "progress", "100(.00)?"):
             res_1 = virsh.blockjob(vm_name, dev, options=test_option, debug=True,
                                    ignore_status=False)
             cur1 = libvirt_misc.convert_to_dict(res_1.stdout_text.strip(),

--- a/libvirt/tests/src/backingchain/negative_scenario/blockcopy_with_invalid_destination.py
+++ b/libvirt/tests/src/backingchain/negative_scenario/blockcopy_with_invalid_destination.py
@@ -111,7 +111,7 @@ def run(test, params, env):
         2)Destroy guest
         3)Check the xattr of the destination file.
         """
-        if not libvirt.check_blockjob(vm_name, target_disk, "progress", "100"):
+        if not libvirt.check_blockjob(vm_name, target_disk, "progress", "100(.00)?"):
             _check_xattr(tmp_copy_path, msg_before_destroy)
 
             test.log.info("TEST_STEP3: Destroy guest and check image xattr "

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockjob.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockjob.py
@@ -24,7 +24,7 @@ def finish_job(vm_name, target, timeout, test):
     """
     job_time = 0
     while job_time < timeout:
-        if utl.check_blockjob(vm_name, target, "progress", "100"):
+        if utl.check_blockjob(vm_name, target, "progress", "100(.00)?"):
             logging.debug("Block job progress up to 100%.")
             break
         else:

--- a/libvirt/tests/src/virtual_disks/virtual_disks_metadatacache.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_metadatacache.py
@@ -38,7 +38,7 @@ def test_blockcopy_operation(vm_name, disk_path, disk_format,
                     options=blockcopy_option,
                     debug=True, ignore_status=False)
     #Check job finished
-    if not utils_misc.wait_for(lambda: libvirt.check_blockjob(vm_name, device_target, "progress", "100"), 300):
+    if not utils_misc.wait_for(lambda: libvirt.check_blockjob(vm_name, device_target, "progress", "100(.00)?"), 300):
         test.fail("Blockjob timeout in 300 sec.")
     # Check max size value in mirror part
     blk_mirror = ("mirror type='file' file='%s' "


### PR DESCRIPTION
  100% turns to be 100.00%
Signed-off-by: nanli <nanli@redhat.com>

```

avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35  backingchain.blockjob.pivot virsh.blockjob.positive_test.pivot_option backingchain.blockjob.raw backingchain.blockcopy.invalid_destination..absolute_path

 (1/5) type_specific.io-github-autotest-libvirt.backingchain.blockjob.pivot.before_finish: PASS (49.32 s)
 (2/5) type_specific.io-github-autotest-libvirt.backingchain.blockjob.pivot.delete_copy_file: PASS (57.49 s)
 (3/5) type_specific.io-github-autotest-libvirt.virsh.blockjob.positive_test.pivot_option: PASS (60.29 s)
 (4/5) type_specific.io-github-autotest-libvirt.backingchain.blockjob.raw.raw_list: PASS (69.64 s)
 (5/5) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.invalid_destination.absolute_path: PASS (48.29 s)

```