### PR TITLE
backingchain: fix allocation_watermark issue in aarch

### DIFF
--- a/libvirt/tests/src/backingchain/blockcommit/check_allocation_watermark_during_blockcommit.py
+++ b/libvirt/tests/src/backingchain/blockcommit/check_allocation_watermark_during_blockcommit.py
@@ -75,6 +75,7 @@ def run(test, params, env):
         test.log.debug("blockcommit cmd: %s", cmd)
 
         alloc_dict = {}
+        time.sleep(5)
         for i in range(0, 2):
             alloc_new_dict = get_alloc_result()
             test.log.debug('Current alloc dict is:%s, last alloc dict is :%s',


### PR DESCRIPTION
In aarch, we usually get "TestFail: block.4.allocation should keep changing during blockcommit" failure. This may caused by the faster execution time than x86 and then the data has not changed. So add a time delay.