### PR TITLE
migration: Add a scenario to test zlib compression

### DIFF
--- a/libvirt/tests/cfg/migration/migration_performance_tuning/migration_zerocopy_unsupported_feature_combinations.cfg
+++ b/libvirt/tests/cfg/migration/migration_performance_tuning/migration_zerocopy_unsupported_feature_combinations.cfg
@@ -62,14 +62,22 @@
             migrate_again = "yes"
             migrate_again_status_error = "no"
             virsh_migrate_extra_mig_again = "--zerocopy --parallel"
-        - zerocopy_and_parallel_and_compression:
+        - zerocopy_and_parallel_and_mt_compression:
             virsh_migrate_extra = "--zerocopy --parallel --compressed --comp-methods mt"
             err_msg = "Zero copy only available for non-compressed non-TLS multifd migration|Multifd is not compatible with compress|Compression method 'mt' isn't supported with parallel migration"
             migrate_again = "yes"
             migrate_again_status_error = "no"
             virsh_migrate_extra_mig_again = "--zerocopy --parallel"
-        - zerocopy_and_parallel_and_xbzrle:
+        - zerocopy_and_parallel_and_xbzrle_compression:
             virsh_migrate_extra = "--zerocopy --parallel --compressed --comp-methods xbzrle"
+            err_msg = "Zero copy only available for non-compressed non-TLS multifd migration|Compression method 'xbzrle' isn't supported with parallel migration"
+            migrate_again = "yes"
+            migrate_again_status_error = "no"
+            virsh_migrate_extra_mig_again = "--zerocopy --parallel"
+        - zerocopy_and_parallel_and_zlib_compression:
+            virsh_migrate_extra = "--zerocopy --parallel --compressed --comp-methods zlib"
+            func_supported_since_libvirt_ver = (9, 4, 0)
+            err_msg = "Zero copy only available for non-compressed non-TLS multifd migration"
             migrate_again = "yes"
             migrate_again_status_error = "no"
             virsh_migrate_extra_mig_again = "--zerocopy --parallel"


### PR DESCRIPTION
To test 'zerocopy + parallel + zlib compression'.

Case update:
VIRT-XXXX - VM live migration - zerocopy - unsupported feature combinations