### PR TITLE
save_with_options:Update target pattern to search for

### DIFF
--- a/libvirt/tests/cfg/save_and_restore/save_with_options.cfg
+++ b/libvirt/tests/cfg/save_and_restore/save_with_options.cfg
@@ -5,7 +5,7 @@
             options = 
         - verbose_opt:
             options = --verbose
-            expect_msg = 'Save:\s\[100 %\]'
+            expect_msg = 'Save:\s\[100.*%\]'
         - running_opt:
             options = --running
             after_state = running


### PR DESCRIPTION
Output updated from 100 % to 100.00 %

Test result:
PASS 1-type_specific.io-github-autotest-libvirt.save_and_restore.save_with_options.normal.running_vm.verbose_opt