### PR TITLE
memory: add case for hugepage nodeset

### DIFF
--- a/libvirt/tests/cfg/memory/memory_backing/hugepage_nodeset.cfg
+++ b/libvirt/tests/cfg/memory/memory_backing/hugepage_nodeset.cfg
@@ -1,0 +1,34 @@
+- memory.backing.nodeset:
+    type = hugepage_nodeset
+    no s390-virtio
+    start_vm = no
+    page_size = "2048"
+    page_unit = "KiB"
+    current_mem = 2072576
+    mem_value = 2072576
+    mem_unit = "KiB"
+    current_mem_unit = "KiB"
+    set_pagesize = "2048"
+    set_pagenum = "1024"
+    expect_str = "huge"
+    variants:
+        - nodeset_0:
+            nodeset = "0"
+            memory_backing_dict = "'mb': {'hugepages': {'pages': [{'unit': '${page_unit}', 'size': '${page_size}','nodeset':'${nodeset}'}]}}"
+        - nodeset_not_exist:
+            nodeset = "0,2"
+            memory_backing_dict = "'mb': {'hugepages': {'pages': [{'unit': '${page_unit}', 'size': '${page_size}','nodeset':'${nodeset}'}]}}"
+            with_numa_error = "error: hugepages: node 2 not found"
+            without_numa_error = "error: hugepages: node 0 not found"
+    variants config:
+        - with_numa:
+            numa_size_1 = 1048576
+            numa_size_2 = 1024000
+            numa_cpu = {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '${numa_size_1}', 'unit': 'KiB'}, {'id': '1', 'cpus': '2-3', 'memory': '${numa_size_2}', 'unit': 'KiB'}]}
+            vm_attrs = {${memory_backing_dict},"cpu":${numa_cpu},'vcpu': 4,'max_mem_rt_slots': 16,'memory_unit':"${mem_unit}",'memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}','max_mem_rt': 3145728, 'max_mem_rt_unit': "KiB"}
+            expect_xpath = [{'element_attrs':[".//page[@size='${page_size}']", ".//page[@unit='${page_unit}']", ".//page[@nodeset='${nodeset}']"]}]
+            allocated_mem = "1048576"
+        - without_numa:
+            vm_attrs = {${memory_backing_dict}, 'memory_unit':'${mem_unit}','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}'}
+            expect_xpath = [{'element_attrs':[".//page[@size='${page_size}']", ".//page[@unit='${page_unit}']"]}]
+            allocated_mem = "2072576"

--- a/libvirt/tests/src/memory/memory_backing/hugepage_nodeset.py
+++ b/libvirt/tests/src/memory/memory_backing/hugepage_nodeset.py
@@ -1,0 +1,141 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright Redhat
+#
+#   SPDX-License-Identifier: GPL-2.0
+
+#   Author: Nannan Li <nanli@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+import re
+
+from avocado.utils import process
+
+from virttest import test_setup
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_test import libvirt
+from virttest.utils_libvirt import libvirt_vmxml
+
+
+def check_numa_maps(test, params, result):
+    """
+    Check the numa maps result
+
+    :param params: dict of test parameters
+    :param test: test object
+    :param result: Numa maps result
+    """
+    numa_node_mem = []
+    kernel_pagesize = []
+    set_pagesize = int(params.get("set_pagesize"))
+    allocated_mem = params.get("allocated_mem")
+    expect_str = params.get("expect_str")
+    test.log.debug("Get numa maps result is :%s", result)
+
+    for item in result.split():
+        if re.search(r'N(\d+)', item):
+            numa_node_mem.append(int(item.split('=')[1]))
+        elif item.startswith("kernelpagesize_kB"):
+            kernel_pagesize.append(item.split('=')[1])
+
+    if len(kernel_pagesize) > 1:
+        test.fail("Kernel pagesize value number should be 1 instead of %s"
+                  % (len(kernel_pagesize)))
+
+    huge = result.split()[3]
+    if huge != expect_str:
+        test.fail("Expect get '%s', but got '%s'" % (expect_str, huge))
+
+    if sum(numa_node_mem)*set_pagesize != int(allocated_mem):
+        test.fail("Expect numa node mem get %s, but got %s" % (
+            allocated_mem, sum(numa_node_mem)*set_pagesize))
+
+    if int(kernel_pagesize[0]) != set_pagesize:
+        test.fail("Kernel pagesize get from numa_maps should be %s intead of %s"
+                  % (set_pagesize, kernel_pagesize[0]))
+
+
+def run(test, params, env):
+    """
+    1.Verify nodeset config affect the huge page memory allocation
+    2.Verify error msg prompts with not existent nodeset
+    """
+
+    def setup_test():
+        """
+        Allocate hugepage memory
+        """
+        test.log.info("TEST_SETUP: Allocate hugepage memory")
+        hp_cfg = test_setup.HugePageConfig(params)
+        hp_cfg.set_kernel_hugepages(set_pagesize, set_pagenum)
+
+    def run_test():
+        """
+        Define guest, check xml, check memory
+        """
+        test.log.info("TEST_SETUP1: Define guest")
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        vmxml.setup_attrs(**vm_attrs)
+        result = virsh.define(vmxml.xml, debug=True)
+
+        if globals()["config_error"]:
+            if not re.search(globals()["config_error"], result.stderr_text):
+                test.fail("Define guest should get error %s instead of %s" % (
+                    globals()["config_error"], result))
+            else:
+                return
+        else:
+            libvirt.check_exit_status(result)
+
+        test.log.info("TEST_SETUP2: Check xml")
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        test.log.debug("The new xml is:\n%s", vmxml)
+        libvirt_vmxml.check_guest_xml_by_xpaths(vmxml, expect_xpath)
+
+        test.log.info("TEST_STEP3: Start vm")
+        if not vm.is_alive():
+            vm.start()
+        vm.wait_for_login().close()
+
+        test.log.info("TEST_STEP4: Check memory")
+        pid = process.run('pidof qemu-kvm', shell=True).stdout_text.strip()
+        test.log.debug("Get qemu-kvm pid:%s", pid)
+
+        address = process.run('grep -B1 %s /proc/%s/smaps' % (
+            allocated_mem, pid), shell=True).stdout_text.split("-")[0]
+        test.log.debug("Get address:%s", address)
+
+        result = process.run('grep %s /proc/%s/numa_maps' % (address, pid), shell=True).stdout_text
+        check_numa_maps(test, params, result)
+
+    def teardown_test():
+        """
+        Clean data.
+        """
+        test.log.info("TEST_TEARDOWN: Clean up env.")
+        bkxml.sync()
+        hugepage = test_setup.HugePageConfig(params)
+        hugepage.cleanup()
+
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+    vm_attrs = eval(params.get('vm_attrs', '{}'))
+
+    allocated_mem = params.get('allocated_mem')
+    set_pagesize = params.get("set_pagesize")
+    set_pagenum = params.get("set_pagenum")
+    expect_xpath = eval(params.get("expect_xpath"))
+    config = params.get("config")
+    globals()["config_error"] = params.get("%s_error" % config, None)
+
+    try:
+        setup_test()
+        run_test()
+
+    finally:
+        teardown_test()

--- a/spell.ignore
+++ b/spell.ignore
@@ -618,6 +618,7 @@ multipathd
 multiqueue
 multitimes
 namespace
+Nannan
 nanli
 nano
 nat


### PR DESCRIPTION
    add case for hugepage nodeset
       VIRT-297167: Huge page nodeset

```

 /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 memory.backing.nodeset

 (1/4) type_specific.io-github-autotest-libvirt.memory.backing.nodeset.with_numa.nodeset_0: PASS (54.20 s)
 (2/4) type_specific.io-github-autotest-libvirt.memory.backing.nodeset.with_numa.nodeset_not_exist: PASS (24.68 s)
 (3/4) type_specific.io-github-autotest-libvirt.memory.backing.nodeset.without_numa.nodeset_0: PASS (56.44 s)
 (4/4) type_specific.io-github-autotest-libvirt.memory.backing.nodeset.without_numa.nodeset_not_exist: PASS (17.07 s)

```