### PR TITLE
fix check hash function error msg

### DIFF
--- a/provider/backingchain/check_functions.py
+++ b/provider/backingchain/check_functions.py
@@ -198,7 +198,7 @@ class Checkfunction(object):
             if current_hash != hash_list[index]:
                 self.test.fail("File:%s hash :%s is different from hash before "
                                "blockcommit:%s" % (item, current_hash,
-                                                   item_list[index]))
+                                                   hash_list[index]))
 
     def check_mirror_exist(self, vm, device, image_path):
         """


### PR DESCRIPTION
Return correct error message   

```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type s390-virtio backingchain.blockcommit.shallow_option.file_disk.snap_type.disk_only --vt-connect-uri qemu:///system

 (1/1) backingchain.blockcommit.shallow_option.file_disk.snap_type.disk_only: 
FAIL: File:/dev/vdb hash :8565a714dca840f8652c5bae9249ab05f5fb5a4f9f13fbe23304b10f68252da2  /dev/vdb\n is
 different from hash before **blockcommit:test:old hash** (64.27 s)
```