### PR TITLE
svirt: Add a case about security confined options

### DIFF
--- a/libvirt/tests/cfg/svirt/qemu_conf/svirt_qemu_security_confined.cfg
+++ b/libvirt/tests/cfg/svirt/qemu_conf/svirt_qemu_security_confined.cfg
@@ -1,0 +1,23 @@
+- svirt.qemu_conf.security_confined:
+    type = svirt_qemu_security_confined
+    start_vm = "no"
+    variants:
+        - default_confined_0:
+            qemu_conf_security_default_confined = "0"
+        - default_confined_1:
+            qemu_conf_security_default_confined = "1"
+    variants:
+        - require_confined_0:
+            qemu_conf_security_require_confined = "0"
+        - require_confined_1:
+            qemu_conf_security_require_confined = "1"     
+    variants:
+        - seclabel_none:
+            seclabel_attr_type = "none"
+        - @default:
+    variants:
+        - positive_test:
+            only seclabel_none..require_confined_0, default..default_confined_1
+        - negative_test:
+            only seclabel_none..require_confined_1
+            status_error = yes

--- a/libvirt/tests/src/svirt/qemu_conf/svirt_qemu_security_confined.py
+++ b/libvirt/tests/src/svirt/qemu_conf/svirt_qemu_security_confined.py
@@ -1,0 +1,47 @@
+from virttest import virsh
+
+from virttest.libvirt_xml.vm_xml import VMXML
+from virttest.utils_test import libvirt
+
+
+def run(test, params, env):
+    """
+    Test security confined options in qemu.conf.
+    """
+
+    status_error = 'yes' == params.get("status_error", 'no')
+
+    # Get variables about VM and get a VM object and VMXML instance.
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    vmxml = VMXML.new_from_inactive_dumpxml(vm_name)
+    backup_xml = vmxml.copy()
+
+    seclabel_attr = {k.replace('seclabel_attr_', ''): int(v) if v.isdigit()
+                     else v for k, v in params.items()
+                     if k.startswith('seclabel_attr_')}
+    qemu_conf = {k.replace('qemu_conf_', ''): v for k, v in params.items()
+                 if k.startswith('qemu_conf_')}
+    qemu_conf_obj = None
+    try:
+        test.log.info("TEST_STEP: Enable qemu namespaces in qemu.conf.")
+        qemu_conf_obj = libvirt.customize_libvirt_config(qemu_conf, "qemu")
+
+        if seclabel_attr:
+            test.log.info("TEST_STEP: Update VM XML with %s.", seclabel_attr)
+            vmxml.set_seclabel([seclabel_attr])
+            vmxml.sync()
+            test.log.debug(f"vmxml: {vmxml}")
+
+        test.log.info("TEST_STEP: Start the VM.")
+        res = virsh.start(vm.name, debug=True)
+        libvirt.check_exit_status(res, status_error)
+
+    finally:
+        test.log.info("TEST_TEARDOWN: Recover test environment.")
+        backup_xml.sync()
+
+        if qemu_conf_obj:
+            libvirt.customize_libvirt_config(
+                None, "qemu", config_object=qemu_conf_obj,
+                is_recover=True)


### PR DESCRIPTION
This PR adds:
    virt-296975: Start vm with security confined options in qemu.conf


**Test results:**
```
 (1/6) type_specific.io-github-autotest-libvirt.svirt.qemu_conf.security_confined.positive_test.seclabel_none.require_confined_0.default_confined_0: |^[[PASS (10.49 s)
 (2/6) type_specific.io-github-autotest-libvirt.svirt.qemu_conf.security_confined.positive_test.seclabel_none.require_confined_0.default_confined_1: PASS (10.65 s)
 (3/6) type_specific.io-github-autotest-libvirt.svirt.qemu_conf.security_confined.positive_test.default.require_confined_0.default_confined_1: PASS (9.98 s)
 (4/6) type_specific.io-github-autotest-libvirt.svirt.qemu_conf.security_confined.positive_test.default.require_confined_1.default_confined_1: PASS (10.17 s)
 (5/6) type_specific.io-github-autotest-libvirt.svirt.qemu_conf.security_confined.negative_test.seclabel_none.require_confined_1.default_confined_0: PASS (9.33 s)
 (6/6) type_specific.io-github-autotest-libvirt.svirt.qemu_conf.security_confined.negative_test.seclabel_none.require_confined_1.default_confined_1: PASS (9.56 s)

```