### PR TITLE
Fix domain_life_cycle.undefine_domain.positive.wipe_storage case failure

### DIFF
--- a/libvirt/tests/cfg/domain_life_cycle/create_destroy_domain.cfg
+++ b/libvirt/tests/cfg/domain_life_cycle/create_destroy_domain.cfg
@@ -36,7 +36,6 @@
                     variants test_scenario:
                         - wipe_storage:
                             target_device = "vdb"
-                            source_file_path = "/var/lib/libvirt/images/wipe_storage.qcow2"
                         - convert_persistent_to_transient:
         - reset_domain:
             variants:

--- a/libvirt/tests/src/domain_life_cycle/create_destroy_domain.py
+++ b/libvirt/tests/src/domain_life_cycle/create_destroy_domain.py
@@ -18,6 +18,7 @@ from avocado.utils import process
 
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
+from virttest.libvirt_xml import pool_xml
 from virttest.utils_test import libvirt
 from virttest.utils_libvirt import libvirt_disk
 
@@ -190,7 +191,9 @@ def add_wiping_storage_disk(params):
     vm_name = params.get("main_vm")
     xml_dump = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
 
-    source_file_path = params.get("source_file_path")
+    p_xml = pool_xml.PoolXML.new_from_dumpxml("images")
+    source_file_path = os.path.join(p_xml.target_path, "wipe.img")
+    params.update({"source_file_path": source_file_path})
     libvirt.create_local_disk("file", source_file_path, 1,
                               disk_format="qcow2")
     virsh.pool_refresh("images")


### PR DESCRIPTION
Fix domain_life_cycle.undefine_domain.positive.wipe_storage case failure

"images" pool path may be changed by CI, rather than default:/var/lib/libvirt/images

So it need dynamically get path,then create volume under that