### PR TITLE
guest_agent: Add a case about domhostname

### DIFF
--- a/libvirt/tests/cfg/guest_agent/domhostname.cfg
+++ b/libvirt/tests/cfg/guest_agent/domhostname.cfg
@@ -1,0 +1,10 @@
+- guest_agent.domhostname:
+    type = domhostname
+
+    variants:
+        - domain_name:
+            domain_ref = "name"
+        - domain_ID:
+            domain_ref = "id"
+        - domain_UUID:
+            domain_ref = "uuid"

--- a/libvirt/tests/src/guest_agent/domhostname.py
+++ b/libvirt/tests/src/guest_agent/domhostname.py
@@ -1,0 +1,31 @@
+from virttest import virsh
+
+from virttest.utils_test import libvirt
+from virttest.libvirt_xml import vm_xml
+
+
+def run(test, params, env):
+    """
+    Get domain's hostname via guest agent
+    """
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    expr_hostname = params.get("expr_hostname", "myhostname")
+
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    backup_xml = vmxml.copy()
+
+    try:
+        vm.prepare_guest_agent()
+
+        test.log.info(f"TEST_STEP: Set VM's hostname to {expr_hostname}.")
+        vm_session = vm.wait_for_login()
+        vm_session.cmd("hostname %s" % expr_hostname)
+        domain_ref = vm.get_id() if params.get("domain_ref") == 'id' \
+            else eval('vm.%s' % params.get("domain_ref"))
+
+        test.log.info(f"TEST_STEP: Get VM's hostname via guest agent.")
+        res = virsh.domhostname(domain_ref, debug=True)
+        libvirt.check_result(res, expected_match=expr_hostname)
+    finally:
+        backup_xml.sync()


### PR DESCRIPTION
This PR adds:
    Get domain's hostname via guest agent


**Test results:**
```
(1/3) type_specific.io-github-autotest-libvirt.guest_agent.domhostname.domain_name: PASS (94.24 s)
 (2/3) type_specific.io-github-autotest-libvirt.guest_agent.domhostname.domain_ID: PASS (88.65 s)
 (3/3) type_specific.io-github-autotest-libvirt.guest_agent.domhostname.domain_UUID: PASS (89.79 s)
```

**Depends on:**
- https://github.com/avocado-framework/avocado-vt/pull/3701

