### PR TITLE
svirt: Add a case about nfs storage

### DIFF
--- a/libvirt/tests/cfg/svirt/shared_storage/svirt_nfs_disk.cfg
+++ b/libvirt/tests/cfg/svirt/shared_storage/svirt_nfs_disk.cfg
@@ -1,0 +1,18 @@
+- svirt.shared_storage.nfs_disk:
+    type = svirt_nfs_disk
+    start_vm = no
+    storage_type = nfs
+    local_boolean_varible = 'virt_use_nfs'
+    setup_local_nfs = "yes"
+    variants:
+        - root_squash:
+            export_options= "rw,root_squash"
+        - no_root_squash:
+            export_options= "rw,no_root_squash,sync"
+    variants:
+        - virt_use_nfs_on:
+            root_squash:
+                status_error = "no"
+        - virt_use_nfs_off:
+            only no_root_squash
+            local_boolean_value = "off"

--- a/libvirt/tests/src/svirt/shared_storage/svirt_nfs_disk.py
+++ b/libvirt/tests/src/svirt/shared_storage/svirt_nfs_disk.py
@@ -1,0 +1,45 @@
+import os
+
+from virttest import data_dir
+from virttest import virsh
+
+from virttest.libvirt_xml.vm_xml import VMXML
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+
+def run(test, params, env):
+    """
+    Test svirt works correctly for nfs storage.
+    """
+    status_error = 'yes' == params.get("status_error", 'no')
+
+    # Get variables about VM and get a VM object and VMXML instance.
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    vmxml = VMXML.new_from_inactive_dumpxml(vm_name)
+    backup_xml = vmxml.copy()
+
+    try:
+        test.log.info("TEST_STEP: Update disk xml.")
+        disk_img = os.path.basename(vm.get_first_disk_devices()['source'])
+        disk_dict = {'source': {'attrs': {'file': os.path.join(
+            params.get("nfs_mount_dir"), disk_img)}}}
+        libvirt_vmxml.modify_vm_device(vmxml, 'disk', disk_dict)
+        test.log.debug(f"VM xml after updating disk: {VMXML.new_from_dumpxml(vm_name)}")
+
+        test.log.info("TEST_STEP: Start the VM.")
+        if vm.is_alive():
+            vm.destroy()
+        res = virsh.start(vm.name, debug=True)
+        libvirt.check_exit_status(res, status_error)
+        if status_error:
+            return
+
+        test.log.info("TEST_STEP: Save and restore the VM.")
+        save_path = os.path.join(data_dir.get_tmp_dir(), 'test.save')
+        virsh.save(vm_name, save_path, debug=True, ignore_status=False)
+        virsh.restore(save_path, debug=True, ignore_status=False)
+    finally:
+        test.log.info("TEST_TEARDOWN: Recover test environment.")
+        backup_xml.sync()


### PR DESCRIPTION
This pr adds:
    VIRT-296978 [sVirt]Start vm with different virt_use_nfs
        settings and no_root_squash/root_squash nfs storage

**Depends on:**
- https://github.com/avocado-framework/avocado-vt/pull/3703
- https://github.com/avocado-framework/avocado-vt/pull/3704

**Test results:**
```

 (1/3) type_specific.io-github-autotest-libvirt.svirt.shared_storage.nfs_disk.virt_use_nfs_on.root_squash: PASS (10.61 s)
 (2/3) type_specific.io-github-autotest-libvirt.svirt.shared_storage.nfs_disk.virt_use_nfs_on.no_root_squash: PASS (13.54 s)
 (3/3) type_specific.io-github-autotest-libvirt.svirt.shared_storage.nfs_disk.virt_use_nfs_off.no_root_squash: PASS (10.71 s)

```
