### PR TITLE
guest_agent: Add a case of attaching invalid device xml

### DIFF
--- a/libvirt/tests/cfg/guest_agent/guest_agent.cfg
+++ b/libvirt/tests/cfg/guest_agent/guest_agent.cfg
@@ -12,6 +12,11 @@
         - customize_source_path:
             src_path = '/test/agent'
             con_label = "system_u:object_r:qemu_var_run_t:s0"
+        - hotplug_ga_without_tgt_type:
+            only ga_started
+            hotplug_ga_without_tgt_type = "yes"
+            loop_time = 10
+            dev_dict = {'address': {'type': 'virtio-serial'}, 'sources': [{'attrs': {'mode': 'bind'}}], 'type_name': 'unix'}
     variants:
         - ga_started:
             start_ga = "yes"
@@ -21,6 +26,7 @@
         - positive:
             status_error = "no"
             only ga_started
+            no hotplug_ga_without_tgt_type
         - negative:
             status_error = "yes"
-            only ga_stopped
+            only ga_stopped, hotplug_ga_without_tgt_type


### PR DESCRIPTION
This PR adds:
    VIRT-87354 - Hotplug guest agent char device without target type


**Test result:**
` (1/1) type_specific.io-github-autotest-libvirt.guest_agent.negative.ga_started.hotplug_ga_without_tgt_type: PASS (63.07 s)`

