### PR TITLE
fix hash value issue

### DIFF
--- a/provider/backingchain/blockcommand_base.py
+++ b/provider/backingchain/blockcommand_base.py
@@ -115,7 +115,7 @@ class BlockCommand(object):
             self.snap_path_list.append(path)
             self.snap_name_list.append(name)
 
-            if not utils_misc.wait_for(lambda: os.path.exists(path), 10, first=2):
+            if not utils_misc.wait_for(lambda: os.path.exists(path), 10, first=5):
                 self.test.error("%s should be in snapshot list" % snap_name)
 
     def convert_expected_chain(self, expected_chain_index):


### PR DESCRIPTION
 wait time between creating snap steps
Signed-off-by: nanli <nanli@redhat.com>

```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type s390-virtio backingchain.blockcommit.with_bandwith.positive_test.bandwith_mb backingchain.blockcommit.delete_option.file_disk.mid_to_base backingchain.blockcopy.conventional_chain.file_disk.with_shallow backingchain.blockcopy.blockcopy_with_backingfile.shallow_and_reuse_external.file_disk.pivot_after_blockcopy  --vt-connect-uri qemu:///system

 (1/4) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.with_bandwith.positive_test.bandwith_mb: PASS (35.61 s)
 (2/4) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.delete_option.file_disk.mid_to_base: PASS (38.72 s)
 (3/4) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.conventional_chain.file_disk.with_shallow: PASS (39.11 s)
 (4/4) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.blockcopy_with_backingfile.shallow_and_reuse_external.file_disk.pivot_after_blockcopy: PASS (26.71 s)

```
```

avocado run --vt-type libvirt --test-runner=runner --vt-machine-type s390-virtio backingchain.blockcommit.delete_option.file_disk.mid_to_mid backingchain.blockcommit.delete_option.file_disk.top_to_base backingchain.blockcommit.delete_option.file_disk.top_to_mid backingchain.blockcommit.delete_option.file_disk.mid_to_base backingchain.blockcommit.base_image_exist_backingfile.file_disk.file_backing.mid_to_mid backingchain.blockcommit.base_image_exist_backingfile.file_disk.file_backing.top_to_base backingchain.blockcopy.blockcopy_with_backingfile.shallow_and_reuse_external.file_disk.pivot_after_blockcopy backingchain.blockresize.positive_test.raw_image.size_g backingchain.blockresize.positive_test.raw_image.size_b backingchain.blockresize.positive_test.raw_image.size_mb backingchain.blockcommit.shallow_option.file_disk.snap_type.reuse_external backingchain.blockcommit.shallow_option.file_disk.snap_type.disk_only

 (01/12) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.delete_option.file_disk.mid_to_mid: PASS (39.41 s)
 (02/12) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.delete_option.file_disk.top_to_base: PASS (39.11 s)
 (03/12) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.delete_option.file_disk.top_to_mid: PASS (38.20 s)
 (04/12) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.delete_option.file_disk.mid_to_base: PASS (39.58 s)
 (05/12) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.base_image_exist_backingfile.file_disk.file_backing.mid_to_mid: PASS (40.28 s)
 (06/12) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.base_image_exist_backingfile.file_disk.file_backing.top_to_base: PASS (40.00 s)
 (07/12) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.blockcopy_with_backingfile.shallow_and_reuse_external.file_disk.pivot_after_blockcopy: PASS (27.54 s)
 (08/12) type_specific.io-github-autotest-libvirt.backingchain.blockresize.positive_test.raw_image.size_g: PASS (32.44 s)
 (09/12) type_specific.io-github-autotest-libvirt.backingchain.blockresize.positive_test.raw_image.size_b: PASS (32.01 s)
 (10/12) type_specific.io-github-autotest-libvirt.backingchain.blockresize.positive_test.raw_image.size_mb: PASS (31.42 s)
 (11/12) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.shallow_option.file_disk.snap_type.reuse_external: PASS (18.47 s)
 (12/12) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.shallow_option.file_disk.snap_type.disk_only: PASS (38.64 s)

```