### PR TITLE
backingchain: slow down the process of blockcommit to check for allocation changes

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockcommit/check_allocation_watermark_during_blockcommit.cfg
+++ b/libvirt/tests/cfg/backingchain/blockcommit/check_allocation_watermark_during_blockcommit.cfg
@@ -9,10 +9,10 @@
     virsh_opt = " -k0"
     variants case:
         - inactive_layer:
-            commit_option = "--top ${target_disk}[3] --base ${target_disk}[1] --wait --verbose"
+            commit_option = "--top ${target_disk}[3] --base ${target_disk}[1] --wait --verbose --bandwidth 10"
             commit_success_msg = "Commit complete"
         - active_layer:
-            commit_option = " --wait --verbose --pivot "
+            commit_option = " --wait --verbose --pivot --bandwidth 10"
             commit_success_msg = "Successfully pivoted"
     variants:
         - file_disk:

--- a/libvirt/tests/src/backingchain/blockcommit/check_allocation_watermark_during_blockcommit.py
+++ b/libvirt/tests/src/backingchain/blockcommit/check_allocation_watermark_during_blockcommit.py
@@ -84,6 +84,7 @@ def run(test, params, env):
                 test.fail("%s should keep changing during blockcommit %s." % (
                     disappear_alloc, virsh_session.get_stripped_output()))
             alloc_dict = alloc_new_dict
+            time.sleep(1)
 
         test.log.info("TEST_STEP3: Check %s should disappear" % disappear_alloc)
         if utils_misc.wait_for(lambda: commit_success_msg in


### PR DESCRIPTION
The blockcommit runs too fast with the default set, limiting the bandwidth to 10 MiB/s in order to observe the allocation change process.