### PR TITLE
chardev: add case for chardev with log file

### DIFF
--- a/libvirt/tests/cfg/chardev/log/chardev_with_log_file.cfg
+++ b/libvirt/tests/cfg/chardev/log/chardev_with_log_file.cfg
@@ -1,0 +1,18 @@
+- chardev.log:
+    type = chardev_with_log_file
+    start_vm = 'no'
+    log_file = "/var/log/libvirt/chardev_test.log"
+    variants:
+        - console:
+            chardev = "console"
+            check_cmd = "uname -r"
+            variants console_type:
+                - pty:
+                    chardev_type = "pty"
+                    device_dict = "{'type_name':'${chardev_type}','log_file': {'file': '${log_file}', 'append':'off'}}"
+                - unix:
+                    chardev_type = 'unix'
+                    source_mode = "bind"
+                    source_path = "/tmp/foo"
+                    access_cmd = "socat stdin unix-connect:${source_path}"
+                    device_dict = "{'type_name':'${chardev_type}','log_file': {'file': '${log_file}', 'append':'off'}, 'sources': [{'attrs': {'path': '${source_path}', 'mode':'${source_mode}'}}]}"

--- a/libvirt/tests/src/chardev/log/chardev_with_log_file.py
+++ b/libvirt/tests/src/chardev/log/chardev_with_log_file.py
@@ -1,0 +1,92 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright Redhat
+#
+#   SPDX-License-Identifier: GPL-2.0
+
+#   Author: Nan Li <nanli@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import aexpect
+import os
+
+from virttest import utils_test
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+
+def run(test, params, env):
+    """
+    Verify data send through chardev can be correctly logged into log file
+    """
+
+    def setup_test():
+        """
+        Prepare a vm with the *only* console device.
+        """
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        vmxml.remove_all_device_by_type("console")
+        vmxml.remove_all_device_by_type("serial")
+        libvirt_vmxml.modify_vm_device(
+            vmxml=vmxml, dev_type=chardev, dev_dict=device_dict)
+
+    def run_test():
+        """
+        1) Connect to the device using suitable client
+        2) Login to the guest from client, run some commands
+        3) Check log file.
+        """
+        test.log.info("TEST_STEP1: Connect to the device")
+        vm.start()
+        vm.wait_for_login().close()
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        test.log.debug("The vmxml after start vm is:\n %s", vmxml)
+
+        test.log.info("TEST_STEP2: Check append value in guest.")
+        access_session = aexpect.ShellSession(access_cmd)
+        utils_test.libvirt.virsh_console_login(
+            access_session, params.get('username'), params.get('password'),
+            debug=True, timeout=20)
+
+        access_session.cmd_output(check_cmd)
+        test.log.debug("Sent cmd: %s", check_cmd)
+
+        test.log.info("TEST_STEP3: Check log file")
+        vm_session = vm.wait_for_login()
+        kernel_version = vm_session.cmd_output(check_cmd)
+        test.log.debug("Get expected kernel version '%s' " % kernel_version)
+        vm_session.close()
+
+        libvirt.check_logfile("%s\n%s" % (check_cmd, kernel_version), log_file)
+
+    def teardown_test():
+        """
+        Clean data.
+        """
+        if vm.is_alive():
+            vm.destroy(gracefully=False)
+        bkxml.sync()
+
+        if os.path.exists(log_file):
+            os.remove(log_file)
+
+    vm_name = params.get("main_vm")
+    device_dict = eval(params.get('device_dict', '{}'))
+
+    access_cmd = params.get('access_cmd', "virsh console %s --force" % vm_name)
+    chardev = params.get('chardev')
+    log_file = params.get('log_file')
+    check_cmd = params.get('check_cmd')
+
+    vm = env.get_vm(vm_name)
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+
+    try:
+        setup_test()
+        run_test()
+
+    finally:
+        teardown_test()


### PR DESCRIPTION
  VIRT-296959:chardev with log file
Signed-off-by: nanli <nanli@redhat.com>
```

 avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 chardev.log

 (1/2) type_specific.io-github-autotest-libvirt.chardev.log.console.pty: PASS (52.07 s)
 (2/2) type_specific.io-github-autotest-libvirt.chardev.log.console.unix: PASS (52.49 s)

```

Depend on https://github.com/avocado-framework/avocado-vt/pull/3717 