### PR TITLE
numa: add case for invalid nodeset of numa memory binding

### DIFF
--- a/libvirt/tests/cfg/numa/numa_node_tuning/invalid_nodeset_of_numa_memory_binding.cfg
+++ b/libvirt/tests/cfg/numa/numa_node_tuning/invalid_nodeset_of_numa_memory_binding.cfg
@@ -1,0 +1,25 @@
+- guest_numa_node_tuning.invalid_nodeset:
+    type = invalid_nodeset_of_numa_memory_binding
+    start_vm = "no"
+    error_msg = "error: unsupported configuration: NUMA node 2 is unavailable"
+    variants tuning:
+        - strict:
+            tuning_mode = "strict"
+        - interleave:
+            tuning_mode = "interleave"
+        - preferred:
+            tuning_mode = "preferred"
+        - restrictive:
+            tuning_mode = "restrictive"
+    variants node_set:
+        - partially_inexistent:
+            nodeset = "1-2"
+        - totally_inexistent:
+            nodeset = "2-3"
+    variants binding:
+        - host:
+            vm_attrs = {'numa_memory': {'mode': "${tuning_mode}",'nodeset': "${nodeset}"}}
+        - guest:
+            cell_id = 0
+            numa_attr = "'cpu': {'numa_cell': [{'id': ${cell_id}, 'cpus': '0-1', 'memory': '2097152', 'unit': 'KiB'}]}"
+            vm_attrs = {${numa_attr},'numa_memnode': [{'cellid':"${cell_id}",'mode': "${tuning_mode}",'nodeset':"${nodeset}"}]}

--- a/libvirt/tests/src/numa/numa_node_tuning/invalid_nodeset_of_numa_memory_binding.py
+++ b/libvirt/tests/src/numa/numa_node_tuning/invalid_nodeset_of_numa_memory_binding.py
@@ -1,0 +1,70 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright Redhat
+#
+#   SPDX-License-Identifier: GPL-2.0
+
+#   Author: Nan Li <nanli@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import re
+
+from virttest import virt_vm
+
+from virttest.libvirt_xml import vm_xml
+
+
+def run(test, params, env):
+    """
+    Verify that error msg prompts when starting a guest vm with
+    invalid nodeset of numa memory binding
+    """
+
+    def setup_test():
+        """
+        Prepare init xml
+        """
+        test.log.info("TEST_SETUP: Set hugepage and guest boot ")
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        vmxml.setup_attrs(**vm_attrs)
+        vmxml.sync()
+
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        test.log.debug("The init xml is:\n%s", vmxml)
+
+    def run_test():
+        """
+        Start vm and check result
+        """
+        test.log.info("TEST_STEP1: Start vm and check result")
+        try:
+            vm.start()
+            if vm.is_alive():
+                test.fail("Guest state should not be running")
+        except virt_vm.VMStartError as detail:
+            if not re.search(error_msg, str(detail)):
+                test.fail("Expect '%s' in '%s' " % (error_msg, str(detail)))
+            else:
+                test.log.debug("Got '%s' in '%s'" % (error_msg, detail))
+
+    def teardown_test():
+        """
+        Clean data.
+        """
+        test.log.info("TEST_TEARDOWN: Clean up env.")
+        bkxml.sync()
+
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+
+    vm_attrs = eval(params.get("vm_attrs"))
+    error_msg = params.get("error_msg")
+
+    try:
+        setup_test()
+        run_test()
+
+    finally:
+        teardown_test()


### PR DESCRIPTION
   VIRT-297676: Invalid nodeset of numa memory binding settings
Signed-off-by: nanli <nanli@redhat.com>

Two cases failed : restrictive mode , guest binding get error ,confirmed with lcong: due to bz#2208946, bz#2185184, bz#2138150

```
 avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35  guest_numa_node_tuning.invalid_nodeset

 (01/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.host.partially_inexistent.strict: PASS (5.43 s)
 (02/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.host.partially_inexistent.interleave: PASS (5.92 s)
 (03/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.host.partially_inexistent.preferred: PASS (5.78 s)
 (04/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.host.partially_inexistent.restrictive: PASS (5.68 s)
 (05/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.host.totally_inexistent.strict: PASS (5.70 s)
 (06/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.host.totally_inexistent.interleave: PASS (5.47 s)
 (07/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.host.totally_inexistent.preferred: PASS (5.69 s)
 (08/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.host.totally_inexistent.restrictive: PASS (5.84 s)
 (09/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.guest.partially_inexistent.strict: PASS (6.78 s)
 (10/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.guest.partially_inexistent.interleave: PASS (5.93 s)
 (11/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.guest.partially_inexistent.preferred: PASS (5.67 s)
 (12/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.guest.partially_inexistent.restrictive: ERROR: Failed to define avocado-vt-vm1 for reason:\nerror: Failed to define domain from /tmp/xml_utils_temp_gl1rr8ih.xml\nerror: XML error: 'restrictive' mode is required in memory element when mode is 'restrictive' in memnode element\n (5.63 s)
 (13/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.guest.totally_inexistent.strict: PASS (5.76 s)
 (14/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.guest.totally_inexistent.interleave: PASS (5.90 s)
 (15/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.guest.totally_inexistent.preferred: PASS (5.76 s)
 (16/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.guest.totally_inexistent.restrictive: ERROR: Failed to define avocado-vt-vm1 for reason:\nerror: Failed to define domain from /tmp/xml_utils_temp_a0ppk2kn.xml\nerror: XML error: 'restrictive' mode is required in memory element when mode is 'restrictive' in memnode element\n (5.46 s)
RESULTS    : PASS 14 | ERROR 2 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2023-06-16T02.08-e5778dc/results.html
JOB TIME   : 93.51 s

```