### PR TITLE
numa: add case for numa mem binding with offline cpu

### DIFF
--- a/libvirt/tests/cfg/numa/guest_numa_node_tuning/numa_mem_binding_with_offline_cpu.cfg
+++ b/libvirt/tests/cfg/numa/guest_numa_node_tuning/numa_mem_binding_with_offline_cpu.cfg
@@ -1,0 +1,29 @@
+- guest_numa_node_tuning.cpu_offline:
+    type = numa_mem_binding_with_offline_cpu
+    start_vm = "no"
+    cpu_index = 0
+    offline_node_index = 1
+    online = "1"
+    offline = "0"
+    err_msg = " 'restrictive' mode is required in memory element when mode is 'restrictive' in memnode element"
+    variants tuning:
+        - strict:
+            tuning_mode = "strict"
+        - interleave:
+            tuning_mode = "interleave"
+        - preferred:
+            tuning_mode = "preferred"
+        - restrictive:
+            tuning_mode = "restrictive"
+    variants node_set:
+        - related:
+            nodeset_index = "${offline_node_index}"
+        - unrelated:
+            nodeset_index = "0"
+    variants binding:
+        - host:
+            vm_attrs = {'numa_memory': {'mode': '${tuning_mode}','nodeset': '%s'}}
+        - guest:
+            cell_id = 0
+            numa_attr = "'cpu': {'numa_cell': [{'id': ${cell_id}, 'cpus': '0', 'memory': '2097152', 'unit': 'KiB'}]}"
+            vm_attrs = {${numa_attr},'numa_memnode': [{'cellid':'${cell_id}','mode': '${tuning_mode}','nodeset':'%s'}]}

--- a/libvirt/tests/src/numa/guest_numa_node_tuning/numa_mem_binding_with_offline_cpu.py
+++ b/libvirt/tests/src/numa/guest_numa_node_tuning/numa_mem_binding_with_offline_cpu.py
@@ -1,0 +1,116 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright Redhat
+#
+#   SPDX-License-Identifier: GPL-2.0
+
+#   Author: Nan Li <nanli@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+from avocado.utils import cpu
+
+from virttest import libvirt_cgroup
+from virttest import libvirt_version
+from virttest import utils_misc
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_test import libvirt
+
+
+def set_cpu_state(operate_cpu, set_value):
+    """
+    Set cpu online or offline
+
+    :params: operate_cpu: specific cpu index
+    :params: set_value: 1 for online, 0 for offline
+    """
+    if set_value == "0":
+        cpu.online(operate_cpu)
+    elif set_value == "1":
+        cpu.offline(operate_cpu)
+
+
+def run(test, params, env):
+    """
+    Verify numa tuned guest vm is not affected when cpu is offline
+    """
+
+    def setup_test():
+        """
+        Prepare init xml
+        """
+        numa_info = utils_misc.NumaInfo()
+        online_nodes = numa_info.get_online_nodes_withmem()
+        test.log.debug("Get online node with memory:%s", online_nodes)
+
+        node_cpus = numa_info.get_all_node_cpus()[
+            online_nodes[offline_node_index]].strip().split(' ')
+
+        params.update({'nodeset': online_nodes[nodeset_index]})
+        params.update({'off_cpu': node_cpus[cpu_index]})
+        set_cpu_state(params.get('off_cpu'), offline)
+        is_cgroupv2 = libvirt_cgroup.CgroupTest(None).is_cgroup_v2_enabled()
+        if not is_cgroupv2:
+            test.log.debug("Need to keep original value in cpuset file under "
+                           "cgroup v1 environment for later recovery")
+            default_cpuset = libvirt_cgroup.CgroupTest(None).\
+                get_cpuset_cpus(vm_name)
+            params.update({'default_cpuset': default_cpuset})
+
+    def run_test():
+        """
+        Start vm and check result
+        """
+        test.log.info("TEST_STEP1: Set hugepage and guest boot ")
+        vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+        vm_attrs_new = eval(vm_attrs % params['nodeset'])
+        vmxml.setup_attrs(**vm_attrs_new)
+
+        result = virsh.define(vmxml.xml, debug=True, ignore_status=True)
+        if libvirt_version.version_compare(9, 4, 0) and \
+                tuning == "restrictive" and binding == "guest":
+            libvirt.check_result(result, expected_fails=err_msg,
+                                 check_both_on_error=True)
+            return
+        else:
+            libvirt.check_exit_status(result)
+
+        vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+        test.log.debug("The new xml is:\n%s", vmxml)
+
+        test.log.info("TEST_STEP2: Start vm")
+        vm.start()
+
+    def teardown_test():
+        """
+        Clean data.
+        """
+        test.log.info("TEST_TEARDOWN: Clean up env.")
+        bkxml.sync()
+        is_cgroupv2 = libvirt_cgroup.CgroupTest(None).is_cgroup_v2_enabled()
+        if not is_cgroupv2:
+            test.log.debug("Reset cpuset file under cgroup v1 environment")
+            libvirt_cgroup.CgroupTest(None).set_cpuset_cpus(
+                params['default_cpuset'], vm_name)
+
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+
+    vm_attrs = params.get("vm_attrs")
+    nodeset_index = int(params.get('nodeset_index'))
+    offline_node_index = int(params.get('offline_node_index'))
+    cpu_index = int(params.get('cpu_index'))
+    offline = params.get("offline")
+    err_msg = params.get("err_msg")
+    tuning = params.get("tuning")
+    binding = params.get("binding")
+
+    try:
+        setup_test()
+        run_test()
+
+    finally:
+        teardown_test()


### PR DESCRIPTION
   VIRT-297677:Numa memory binding with offline cpu
Signed-off-by: nanli <nanli@redhat.com>

RHEL 9
```
[root@dell-per730-59 tp-libvirt]# rpm -q libvirt
libvirt-9.5.0-0rc1.1.el9.x86_64
[root@dell-per730-59 tp-libvirt]# avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35  guest_numa_node_tuning.cpu_offline
 (01/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.cpu_offline.host.related.strict: PASS (7.78 s)
 (02/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.cpu_offline.host.related.interleave: PASS (10.40 s)
 (03/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.cpu_offline.host.related.preferred: PASS (11.96 s)
 (04/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.cpu_offline.host.related.restrictive: PASS (11.92 s)
 (05/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.cpu_offline.host.unrelated.strict: PASS (12.72 s)
 (06/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.cpu_offline.host.unrelated.interleave: PASS (12.29 s)
 (07/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.cpu_offline.host.unrelated.preferred: PASS (12.71 s)
 (08/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.cpu_offline.host.unrelated.restrictive: PASS (12.68 s)
 (09/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.cpu_offline.guest.related.strict: PASS (13.04 s)
 (10/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.cpu_offline.guest.related.interleave: PASS (13.28 s)
 (11/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.cpu_offline.guest.related.preferred: PASS (13.03 s)
 (12/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.cpu_offline.guest.related.restrictive: PASS (12.84 s)
 (13/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.cpu_offline.guest.unrelated.strict: PASS (7.92 s)
 (14/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.cpu_offline.guest.unrelated.interleave: PASS (12.95 s)
 (15/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.cpu_offline.guest.unrelated.preferred: PASS (13.44 s)
 (16/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.cpu_offline.guest.unrelated.restrictive: PASS (12.11 s)

```
RHEL 8 
test on jenkins: -8.9-provision-x86_64-function-numa/19/