### PR TITLE
guest_os_booting: fix stateless xml don't match error

### DIFF
--- a/libvirt/tests/cfg/guest_os_booting/ovmf_firmware/ovmf_loader.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/ovmf_firmware/ovmf_loader.cfg
@@ -17,7 +17,7 @@
                     stateless  = "yes"
                     loader_path = "/usr/share/edk2/ovmf/OVMF.amdsev.fd"
                     loader_dict = {'os_firmware': 'efi', 'loader_stateless': 'yes'}
-                    loader_xpath = [{'element_attrs':[".//loader[@stateless='yes']"], 'text':'${loader_path}'}]
+                    loader_xpath = [{'element_attrs': ["./os/loader[@stateless='yes']"], 'text': '${loader_path}'}]
         - negative_test:
             variants:
                 - readonly_no:

--- a/libvirt/tests/src/guest_os_booting/ovmf_firmware/ovmf_loader.py
+++ b/libvirt/tests/src/guest_os_booting/ovmf_firmware/ovmf_loader.py
@@ -25,7 +25,7 @@ def run(test, params, env):
     """
     vm_name = params.get("main_vm")
     loader_dict = eval(params.get("loader_dict", "{}"))
-    loader_xpath = eval(params.get("loader_xpath", "{}"))
+    loader_xpath = eval(params.get("loader_xpath", "[]"))
     smm_state = params.get("smm_state", "off")
     error_msg = params.get("error_msg")
     incorrect_loader_path = params.get("incorrect_loader_path", "")
@@ -42,6 +42,7 @@ def run(test, params, env):
         # stateless='yes' only use for AMD test, so here we only check the dumpxml for it to avoid the machine issue
         if stateless:
             virsh.start(vm_name, debug=True)
+            vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
             libvirt_vmxml.check_guest_xml_by_xpaths(vmxml, loader_xpath)
         else:
             if use_file:


### PR DESCRIPTION
Now we get "TestFail: XML did not match text '/usr/share/edk2/ovmf/OVMF.amdsev.fd' for the xpath './/loader[@stateless='yes']" error for stateless test. This PR can fix it.