### PR TITLE
numa: add case for auto mem placement with incompatible host nodeset

### DIFF
--- a/libvirt/tests/cfg/numa/numa_node_tuning/auto_mem_placement_with_incompatible_host_nodeset.cfg
+++ b/libvirt/tests/cfg/numa/numa_node_tuning/auto_mem_placement_with_incompatible_host_nodeset.cfg
@@ -1,0 +1,17 @@
+- guest_numa_node_tuning.incompatible_host_nodeset:
+    type = auto_mem_placement_with_incompatible_host_nodeset
+    start_vm = "no"
+    nodeset = "0"
+    placement = "auto"
+    expected_xpaths =  [{'element_attrs': [".//memory[@mode='%s']", ".//memory[@placement='${placement}']"]}]
+    error_msg = "XML document failed to validate against schema"
+    success_msg = "Domain '%s' XML configuration edited"
+    variants:
+        - strict:
+            tuning_mode = "strict"
+        - interleave:
+            tuning_mode = "interleave"
+        - preferred:
+            tuning_mode = "preferred"
+        - restrictive:
+            tuning_mode = "restrictive"

--- a/libvirt/tests/src/numa/numa_node_tuning/auto_mem_placement_with_incompatible_host_nodeset.py
+++ b/libvirt/tests/src/numa/numa_node_tuning/auto_mem_placement_with_incompatible_host_nodeset.py
@@ -1,0 +1,96 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright Redhat
+#
+#   SPDX-License-Identifier: GPL-2.0
+
+#   Author: Nan Li <nanli@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import aexpect
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+
+
+def run(test, params, env):
+    """
+    Verify that:
+    1) nodeset setting is ignored when auto memory placement is defined
+    2) error prompts for mixing nodeset and auto memory placement settings
+    """
+
+    def setup_test():
+        """
+        Prepare init xml
+        """
+        test.log.info("TEST_SETUP: Define guest")
+        vm_attrs = {'numa_memory': {'mode': tuning_mode,
+                                    'placement': placement,
+                                    'nodeset': nodeset}}
+
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        vmxml.setup_attrs(**vm_attrs)
+        vmxml.sync()
+
+    def run_test():
+        """
+        Start vm and check result
+        """
+        test.log.info("TEST_STEP1: Check xml")
+        vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+        test.log.debug("Get related xml:\n%s", vmxml)
+        libvirt_vmxml.check_guest_xml_by_xpaths(
+            vmxml, eval(expected_xpaths % tuning_mode))
+
+        test.log.info("TEST_STEP2: Edit gust and turn off validation")
+        session = aexpect.ShellSession("sudo -s")
+        session.sendline("virsh edit %s" % vm_name)
+        test.log.debug("virsh edit cmd is:'%s'", edit_cmd)
+        session.sendline(edit_cmd)
+        session.send('\x1b')
+        session.send('ZZ')
+        _, text = session.read_until_any_line_matches(
+            [r"%s" % error_msg], timeout=10, internal_timeout=1)
+        test.log.debug("Checked '%s' exists in '%s'", (error_msg, text))
+        test.log.debug("Input 'i' to turn off validation")
+        session.sendline('i')
+
+        test.log.info("TEST_STEP3: Check xml again")
+        _, text = session.read_until_any_line_matches(
+            [r"%s" % (success_msg % vm_name)], timeout=10, internal_timeout=1)
+        session.close()
+        test.log.debug("Checked '%s' exists in '%s'", (success_msg % vm_name,
+                                                       text))
+
+        vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+        libvirt_vmxml.check_guest_xml_by_xpaths(
+            vmxml, eval(expected_xpaths % tuning_mode))
+
+    def teardown_test():
+        """
+        Clean data.
+        """
+        test.log.info("TEST_TEARDOWN: Clean up env.")
+        bkxml.sync()
+
+    vm_name = params.get("main_vm")
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+
+    error_msg = params.get("error_msg")
+    success_msg = params.get("success_msg")
+    tuning_mode = params.get("tuning_mode")
+    placement = params.get("placement")
+    nodeset = params.get("nodeset")
+    expected_xpaths = params.get("expected_xpaths", '{}')
+    default_cmd = r":%s/memory mode='{}'/memory mode='{}' nodeset='{}'".format(
+        tuning_mode, tuning_mode, nodeset)
+    edit_cmd = params.get("edit_cmd", default_cmd)
+
+    try:
+        setup_test()
+        run_test()
+
+    finally:
+        teardown_test()


### PR DESCRIPTION
    VIRT-297679: Auto memory placement with incompatible host nodeset binding
Signed-off-by: nanli <nanli@redhat.com>
```
[root@dell-per750-31 tp-libvirt]# rpm -q libvirt
libvirt-8.0.0-22.module+el8.9.0+19544+b3045133.x86_64

 [root@dell-per730-59 tp-libvirt]# rpm -q libvirt
libvirt-9.5.0-0rc1.1.el9.x86_64

avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 guest_numa_node_tuning.incompatible_host_nodeset

 (1/4) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.strict: PASS (7.19 s)
 (2/4) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.interleave: PASS (7.20 s)
 (3/4) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.preferred: PASS (7.02 s)
 (4/4) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.restrictive: PASS (7.28 s)

```