### PR TITLE
svirt: Fix incorrect 'status_error' issue

### DIFF
--- a/libvirt/tests/cfg/svirt/shared_storage/svirt_nfs_disk.cfg
+++ b/libvirt/tests/cfg/svirt/shared_storage/svirt_nfs_disk.cfg
@@ -4,6 +4,7 @@
     storage_type = nfs
     local_boolean_varible = 'virt_use_nfs'
     setup_local_nfs = "yes"
+    status_error = "yes"
     variants:
         - root_squash:
             export_options= "rw,root_squash"
@@ -11,7 +12,7 @@
             export_options= "rw,no_root_squash,sync"
     variants:
         - virt_use_nfs_on:
-            root_squash:
+            no_root_squash:
                 status_error = "no"
         - virt_use_nfs_off:
             only no_root_squash


### PR DESCRIPTION
`Test results:` 
```
(1/3) type_specific.io-github-autotest-libvirt.svirt.shared_storage.nfs_disk.virt_use_nfs_on.root_squash: PASS (7.47 s)
 (2/3) type_specific.io-github-autotest-libvirt.svirt.shared_storage.nfs_disk.virt_use_nfs_on.no_root_squash: PASS (9.65 s)
 (3/3) type_specific.io-github-autotest-libvirt.svirt.shared_storage.nfs_disk.virt_use_nfs_off.no_root_squash: PASS (7.58 s)

```