### PR TITLE
migration: Add case about network bandwidth

### DIFF
--- a/libvirt/tests/cfg/migration/migration_resource_limit/migration_postcopy_bandwidth.cfg
+++ b/libvirt/tests/cfg/migration/migration_resource_limit/migration_postcopy_bandwidth.cfg
@@ -1,0 +1,63 @@
+- migration.migration_resource_limit.migration_postcopy_bandwidth:
+    type = migration_bandwidth
+    migration_setup = 'yes'
+    storage_type = 'nfs'
+    setup_local_nfs = 'yes'
+    disk_type = "file"
+    disk_source_protocol = "netfs"
+    mnt_path_name = ${nfs_mount_dir}
+    # Console output can only be monitored via virsh console output
+    only_pty = True
+    take_regular_screendumps = no
+    # Extra options to pass after <domain> <desturi>
+    virsh_migrate_extra = ''
+    # SSH connection time out
+    ssh_timeout = 60
+    # Local URI
+    virsh_migrate_connect_uri = 'qemu:///system'
+    virsh_migrate_dest_state = "running"
+    virsh_migrate_src_state = "shut off"
+    image_convert = 'no'
+    server_ip = "${migrate_dest_host}"
+    server_user = "root"
+    server_pwd = "${migrate_dest_pwd}"
+    status_error = "no"
+    check_network_accessibility_after_mig = "yes"
+    migrate_desturi_port = "16509"
+    migrate_desturi_type = "tcp"
+    virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
+    stress_package = "stress"
+    stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20s"
+    postcopy_bandwidth = "10"
+    jobinfo_item = "Memory bandwidth:"
+    diff_rate = '0.7'
+    compare_to_value = "${postcopy_bandwidth}"
+    libvirtd_file_type = "virtqemud"
+    libvirtd_debug_level = "1"
+    libvirtd_debug_filters = "1:*"
+    expected_event_src = ["Suspended Post-copy"]
+    check_str_local_log = 'migrate-set-parameters.*max-postcopy-bandwidth":10485760'
+
+    variants:
+        - p2p:
+            virsh_migrate_options = '--live --p2p --verbose'
+        - non_p2p:
+            virsh_migrate_options = '--live --verbose'
+    variants:
+        - with_postcopy:
+            postcopy_options = '--postcopy'
+    variants test_case:
+        - default_bandwidth:
+            compare_to_value = "8796093022207"
+            diff_rate = '0'
+            check_str_local_log = '.*"max-postcopy-bandwidth":9223372036853727232'
+            action_during_mig = '[{"func": "check_domjobinfo_during_mig", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "virsh.migrate_postcopy", "func_param": "'%s' % params.get('migrate_main_vm')"}, {"func": "check_domjobinfo_during_mig", "func_param": "params"}, {"func": "set_migrate_speed_to_high", "func_param": "params"}]'
+        - set_bandwidth_when_vm_running:
+            action_during_mig = '[{"func": "virsh.migrate_postcopy", "after_event": "iteration: '1'", "func_param": "'%s' % params.get('migrate_main_vm')"}, {"func": "check_domjobinfo_during_mig", "func_param": "params", "need_sleep_time": "5"}, {"func": "set_migrate_speed_to_high", "func_param": "params"}]'
+        - set_bandwidth_when_initiating_live_migration:
+            postcopy_options = '--postcopy --postcopy-bandwidth ${postcopy_bandwidth}'
+            action_during_mig = '[{"func": "virsh.migrate_postcopy", "after_event": "iteration: '1'", "func_param": "'%s' % params.get('migrate_main_vm')", "need_sleep_time": "3"}, {"func": "check_domjobinfo_during_mig", "func_param": "params", "need_sleep_time": "5"}, {"func": "set_migrate_speed_to_high", "func_param": "params"}]'
+        - set_bandwidth_during_live_migration_precopy_phase:
+            action_during_mig = '[{"func": "set_bandwidth", "after_event": "iteration: '1'", "func_param": "params"}, {"func": "virsh.migrate_postcopy", "func_param": "'%s' % params.get('migrate_main_vm')"}, {"func": "check_domjobinfo_during_mig", "func_param": "params", "need_sleep_time": "5"}, {"func": "set_migrate_speed_to_high", "func_param": "params"}]'
+        - set_bandwidth_during_live_migration_postcopy_phase:
+            action_during_mig = '[{"func": "virsh.migrate_postcopy", "after_event": "iteration: '1'", "func_param": "'%s' % params.get('migrate_main_vm')"}, {"func": "set_bandwidth", "func_param": "params"}, {"func": "check_domjobinfo_during_mig", "func_param": "params", "need_sleep_time": "5"}, {"func": "set_migrate_speed_to_high", "func_param": "params"}]'

--- a/libvirt/tests/cfg/migration/migration_resource_limit/migration_precopy_and_postcopy_bandwidth.cfg
+++ b/libvirt/tests/cfg/migration/migration_resource_limit/migration_precopy_and_postcopy_bandwidth.cfg
@@ -1,5 +1,5 @@
-- migration.migration_performance_tuning.migration_precopy_bandwidth:
-    type = migration_precopy_bandwidth
+- migration.migration_resource_limit.migration_precopy_and_postcopy_bandwidth:
+    type = migration_bandwidth
     migration_setup = 'yes'
     storage_type = 'nfs'
     setup_local_nfs = 'yes'
@@ -28,13 +28,19 @@
     virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
     stress_package = "stress"
     stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20s"
-    action_during_mig = '[{"func": "check_domjobinfo_during_mig", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "set_migrate_speed_to_high", "func_param": "params"}]'
-    domjob_ignore_status = "True"
+    domjob_ignore_status = "False"
     jobinfo_item = "Memory bandwidth:"
-    diff_rate = '0.5'
-    compare_to_value = "10"
-    check_str_local_log = 'migrate-set-parameters.*"max-bandwidth":10485760'
-    precopy_bandwidth = "${compare_to_value}"
+    diff_rate = '0.7'
+    libvirtd_file_type = "virtqemud"
+    libvirtd_debug_level = "1"
+    libvirtd_debug_filters = "1:*"
+    expected_event_src = ["Suspended Post-copy"]
+    check_str_local_log = 'migrate-set-parameters.*max-bandwidth":5242880'
+    check_postcopy_log = 'migrate-set-parameters.*max-postcopy-bandwidth":10485760'
+    precopy_bandwidth = "5"
+    postcopy_bandwidth = "10"
+    compare_to_value = "${postcopy_bandwidth}"
+    action_during_mig = '[{"func": "check_domjobinfo_precopy", "after_event": "iteration: '1'", "func_param": "params"}, {"func": "virsh.migrate_postcopy", "func_param": "'%s' % params.get('migrate_main_vm')"}, {"func": "check_domjobinfo_during_mig", "func_param": "params"}, {"func": "set_migrate_speed_to_high", "func_param": "params"}]'
 
     variants:
         - p2p:
@@ -42,16 +48,9 @@
         - non_p2p:
             virsh_migrate_options = '--live --verbose'
     variants:
-        - with_precopy:
+        - with_postcopy:
+            postcopy_options = '--postcopy'
     variants test_case:
-        - default_bandwidth:
-            compare_to_value = "8796093022207"
-            diff_rate = '0'
-            check_str_local_log = 'migrate-set-parameters.*"max-bandwidth":9223372036853727232'
-        - set_bandwidth_when_vm_shutoff:
         - set_bandwidth_when_vm_running:
-            migrate_speed = "${precopy_bandwidth}"
         - set_bandwidth_when_initiating_live_migration:
-            virsh_migrate_extra = "--bandwidth ${precopy_bandwidth}"
-        - set_bandwidth_during_live_migration:
-            action_during_mig = '[{"func": "set_bandwidth", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "check_domjobinfo_during_mig", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "set_migrate_speed_to_high", "func_param": "params"}]'
+            postcopy_options = '--bandwidth ${precopy_bandwidth} --postcopy --postcopy-bandwidth ${postcopy_bandwidth}'

--- a/libvirt/tests/src/migration/migration_performance_tuning/migration_precopy_bandwidth.py
+++ b/libvirt/tests/src/migration/migration_performance_tuning/migration_precopy_bandwidth.py
@@ -22,7 +22,7 @@ def run(test, params, env):
         test.log.debug("Setup bandwidth when vm shutoff.")
         migrate_desturi_port = params.get("migrate_desturi_port")
         migrate_desturi_type = params.get("migrate_desturi_type", "tcp")
-        compared_value = params.get("compared_value")
+        precopy_bandwidth = params.get("precopy_bandwidth")
 
         migration_obj.conn_list.append(migration_base.setup_conn_obj(migrate_desturi_type, params, test))
         migration_obj.remote_add_or_remove_port(migrate_desturi_port)
@@ -30,7 +30,7 @@ def run(test, params, env):
         if vm.is_alive():
             vm.destroy()
         virsh_args = {"debug": True, "ignore_status": False}
-        virsh.migrate_setspeed(vm_name, compared_value, **virsh_args)
+        virsh.migrate_setspeed(vm_name, precopy_bandwidth, **virsh_args)
         virsh.migrate_getspeed(vm_name, debug=True)
         vm.start()
         vm.wait_for_login().close()

--- a/libvirt/tests/src/migration/migration_resource_limit/migration_bandwidth.py
+++ b/libvirt/tests/src/migration/migration_resource_limit/migration_bandwidth.py
@@ -1,0 +1,70 @@
+from virttest import virsh
+
+from virttest.utils_test import libvirt
+
+from provider.migration import base_steps
+from provider.migration import migration_base
+
+
+def run(test, params, env):
+    """
+    Test network bandwidth - postcopy.
+
+    :param test: test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    def setup_default_bandwidth():
+        """
+        Setup for default_bandwidth
+
+        """
+        compare_to_value = params.get("compare_to_value")
+
+        test.log.debug("Setup for default_bandwidth.")
+        migration_obj.setup_connection()
+        speed = virsh.migrate_getspeed(vm_name, debug=True).stdout.strip()
+        if compare_to_value != speed:
+            test.fail("Default bandwidth is not 0.")
+
+    def setup_set_bandwidth_when_vm_running():
+        """
+        Setup bandwidth when vm running
+
+        """
+        test.log.debug("Setup bandwidth when vm running.")
+        migration_obj.setup_connection()
+        migration_base.set_bandwidth(params)
+
+    def verify_test():
+        """
+        Verify steps
+
+        """
+        check_postcopy_log = params.get("check_postcopy_log")
+        log_file = params.get("libvirtd_debug_file")
+
+        test.log.debug("Verify steps.")
+        migration_obj.verify_default()
+        if check_postcopy_log:
+            libvirt.check_logfile(check_postcopy_log, log_file)
+        migration_base.check_event_output(params, test, virsh_session)
+
+    test_case = params.get('test_case', '')
+    vm_name = params.get("migrate_main_vm")
+
+    virsh_session = None
+
+    vm = env.get_vm(vm_name)
+    params.update({'vm_obj': vm})
+    migration_obj = base_steps.MigrationBase(test, vm, params)
+    setup_test = eval("setup_%s" % test_case) if "setup_%s" % test_case in \
+        locals() else migration_obj.setup_connection
+
+    try:
+        virsh_session, _ = migration_base.monitor_event(params)
+        setup_test()
+        migration_obj.run_migration()
+        verify_test()
+    finally:
+        migration_obj.cleanup_connection()

--- a/provider/migration/migration_base.py
+++ b/provider/migration/migration_base.py
@@ -417,18 +417,37 @@ def check_domjobinfo_during_mig(params):
     libvirt_domjobinfo.check_domjobinfo(vm, params)
 
 
-def set_bandwidth_during_mig(params):
+def check_domjobinfo_precopy(params):
     """
-    Set bandwidth during migration
+    During precopy phase of live migration, check domjobinfo
 
-    :param params: dict, get vm name and compared value
+    :param params: dict, get vm object
+    """
+    vm = params.get("vm_obj")
+    precopy_bandwidth = params.get("precopy_bandwidth")
+    compare_to_value = params.get("compare_to_value")
+
+    params.update({"compare_to_value": precopy_bandwidth})
+    libvirt_domjobinfo.check_domjobinfo(vm, params)
+
+
+def set_bandwidth(params):
+    """
+    Set bandwidth
+
+    :param params: dict, get vm name, postcopy bandwidth and precopy bandwidth
     """
     vm_name = params.get("migrate_main_vm")
-    compared_value = params.get("compared_value")
+    postcopy_bandwidth = params.get("postcopy_bandwidth")
+    precopy_bandwidth = params.get("precopy_bandwidth")
 
     virsh_args = {"debug": True, "ignore_status": False}
-    virsh.migrate_setspeed(vm_name, compared_value, **virsh_args)
-    virsh.migrate_getspeed(vm_name, debug=True)
+    if postcopy_bandwidth:
+        virsh.migrate_setspeed(vm_name, postcopy_bandwidth, extra="--postcopy", **virsh_args)
+        virsh.migrate_getspeed(vm_name, extra="--postcopy", debug=True)
+    if precopy_bandwidth:
+        virsh.migrate_setspeed(vm_name, precopy_bandwidth, **virsh_args)
+        virsh.migrate_getspeed(vm_name, debug=True)
 
 
 def check_vm_status_during_mig(params):


### PR DESCRIPTION
1. VIRT-293956 - [VM migration] network bandwidth - postcopy
2. VIRT-293957 - [VM migration] network bandwidth - precopy+postcopy
3. Fix a parameter error. We need to use 'compare_to_value'
parameter in libvirt_domjobinfo.check_domjobinfo().