### PR TITLE
svirt: Change nfs settings from global to test case specific

### DIFF
--- a/libvirt/tests/cfg/svirt/shared_storage/svirt_nfs_disk.cfg
+++ b/libvirt/tests/cfg/svirt/shared_storage/svirt_nfs_disk.cfg
@@ -4,6 +4,11 @@
     storage_type = nfs
     local_boolean_varible = 'virt_use_nfs'
     setup_local_nfs = "yes"
+    nfs_mount_src = "/var/lib/avocado/data/avocado-vt/images"
+    nfs_mount_dir = "/var/lib/libvirt/nfs_dir"
+    nfs_mount_options = "rw"
+    export_ip = "*"
+    export_dir = "/var/lib/avocado/data/avocado-vt/images"
     status_error = "yes"
     variants:
         - root_squash:


### PR DESCRIPTION
Enable nfs settings in svirt_nfs_disk case so as not to affect other cases.