### PR TITLE
backingchain: fix s390x issue by using correct guest disk to check

### DIFF
--- a/libvirt/tests/src/backingchain/blockcommit/blockcommit_all_block_chain.py
+++ b/libvirt/tests/src/backingchain/blockcommit/blockcommit_all_block_chain.py
@@ -59,7 +59,7 @@ def run(test, params, env):
         Do blockcommit and check backingchain result
         """
         session = vm.wait_for_login()
-        expected_md5 = test_obj.get_hash_value(session, "/dev/"+test_obj.new_dev)
+        expected_md5, check_disk = test_obj.get_hash_value(session, "/dev/"+test_obj.new_dev)
 
         options = ''
         for i in range(1, commit_times+1):
@@ -77,7 +77,7 @@ def run(test, params, env):
                 expected_chain_index)
             check_obj.check_backingchain_from_vmxml(disk_type, test_obj.new_dev,
                                                     expected_chain)
-        check_obj.check_hash_list(["/dev/"+test_obj.new_dev], [expected_md5], session)
+        check_obj.check_hash_list([check_disk], [expected_md5], session)
         session.close()
 
     def teardown_test():

--- a/libvirt/tests/src/backingchain/blockcommit/blockcommit_base_image_exist_backingfile.py
+++ b/libvirt/tests/src/backingchain/blockcommit/blockcommit_base_image_exist_backingfile.py
@@ -66,8 +66,8 @@ def run(test, params, env):
             base_option = " "
 
         session = vm.wait_for_login()
-        expected_hash = test_obj.get_hash_value(session,
-                                                "/dev/"+test_obj.new_dev)
+        expected_hash, check_disk = test_obj.get_hash_value(session,
+                                                            "/dev/"+test_obj.new_dev)
 
         virsh.blockcommit(vm.name, target_disk,
                           commit_options+top_option+base_option,
@@ -76,7 +76,7 @@ def run(test, params, env):
         expected_chain = test_obj.convert_expected_chain(expected_chain_index)
         check_obj.check_backingchain_from_vmxml(disk_type, test_obj.new_dev,
                                                 expected_chain)
-        check_obj.check_hash_list(["/dev/"+test_obj.new_dev], [expected_hash], session)
+        check_obj.check_hash_list([check_disk], [expected_hash], session)
         session.close()
 
         if not vm.is_alive():

--- a/libvirt/tests/src/backingchain/blockcommit/blockcommit_conventional_chain.py
+++ b/libvirt/tests/src/backingchain/blockcommit/blockcommit_conventional_chain.py
@@ -58,8 +58,8 @@ def run(test, params, env):
             base_option = " "
 
         session = vm.wait_for_login()
-        expected_hash = test_obj.get_hash_value(session,
-                                                "/dev/"+test_obj.new_dev)
+        expected_hash, check_disk = test_obj.get_hash_value(session,
+                                                            "/dev/"+test_obj.new_dev)
         virsh.blockcommit(vm.name, target_disk,
                           commit_options+top_option+base_option,
                           ignore_status=False, debug=True)
@@ -67,7 +67,7 @@ def run(test, params, env):
         expected_chain = test_obj.convert_expected_chain(expected_chain_index)
         check_obj.check_backingchain_from_vmxml(disk_type, test_obj.new_dev,
                                                 expected_chain)
-        check_obj.check_hash_list(["/dev/"+test_obj.new_dev], [expected_hash], session)
+        check_obj.check_hash_list([check_disk], [expected_hash], session)
         session.close()
 
         if not vm.is_alive():

--- a/libvirt/tests/src/backingchain/blockcommit/blockcommit_with_delete_option.py
+++ b/libvirt/tests/src/backingchain/blockcommit/blockcommit_with_delete_option.py
@@ -56,7 +56,7 @@ def run(test, params, env):
             base_option = " "
 
         session = vm.wait_for_login()
-        expected_hash = test_obj.get_hash_value(session, "/dev/"+test_obj.new_dev)
+        expected_hash, check_disk = test_obj.get_hash_value(session, "/dev/"+test_obj.new_dev)
 
         test.log.info("TEST_STEP2: Do blockcommit ")
         virsh.blockcommit(vm.name, target_disk,
@@ -72,7 +72,7 @@ def run(test, params, env):
                 test.fail("%s should be deleted after blockcommit with "
                           "delete option" % deleted_snap)
 
-        check_obj.check_hash_list(["/dev/"+test_obj.new_dev], [expected_hash], session)
+        check_obj.check_hash_list([check_disk], [expected_hash], session)
         session.close()
 
     def teardown_test():

--- a/libvirt/tests/src/backingchain/blockcommit/blockcommit_with_keep_overlay.py
+++ b/libvirt/tests/src/backingchain/blockcommit/blockcommit_with_keep_overlay.py
@@ -40,15 +40,15 @@ def run(test, params, env):
         """
         test.log.info("TEST_STEP1: Get top or base option and hash value.")
         session = vm.wait_for_login()
-        expected_hash = test_obj.get_hash_value(session,
-                                                check_item="/dev/"+test_obj.new_dev)
+        expected_hash, check_disk = test_obj.get_hash_value(session,
+                                                            check_item="/dev/"+test_obj.new_dev)
         top_option, base_option = _get_options()
 
         test.log.info("TEST_STEP2: Do bloccommit.")
         res = virsh.blockcommit(vm.name, target_disk,
                                 commit_options+top_option+base_option, debug=True)
         _check_blockcommit_result(res)
-        check_obj.check_hash_list(["/dev/"+test_obj.new_dev], [expected_hash], session)
+        check_obj.check_hash_list([check_disk], [expected_hash], session)
 
         session.close()
 

--- a/libvirt/tests/src/backingchain/blockcommit/blockcommit_with_shallow_option.py
+++ b/libvirt/tests/src/backingchain/blockcommit/blockcommit_with_shallow_option.py
@@ -45,7 +45,7 @@ def run(test, params, env):
         """
         test.log.info("TEST_STEP1: Get hash value for %s", test_obj.new_dev)
         session = vm.wait_for_login()
-        expected_hash = test_obj.get_hash_value(session, "/dev/"+test_obj.new_dev)
+        expected_hash, check_disk = test_obj.get_hash_value(session, "/dev/"+test_obj.new_dev)
 
         test.log.info("TEST_STEP2: Do blockcommit with %s", commit_options)
         virsh.blockcommit(vm.name, target_disk, commit_options,
@@ -59,7 +59,7 @@ def run(test, params, env):
         expected_chain = test_obj.convert_expected_chain(expected_chain_index)
         check_obj.check_backingchain_from_vmxml(disk_type, test_obj.new_dev,
                                                 expected_chain)
-        check_obj.check_hash_list(["/dev/"+test_obj.new_dev], [expected_hash], session)
+        check_obj.check_hash_list([check_disk], [expected_hash], session)
         session.close()
 
     def teardown_test():

--- a/libvirt/tests/src/backingchain/blockcopy/blockcopy_with_backingfile.py
+++ b/libvirt/tests/src/backingchain/blockcopy/blockcopy_with_backingfile.py
@@ -52,7 +52,7 @@ def run(test, params, env):
         Do blockcopy and abort job ,than check hash and vmxml chain
         """
         session = vm.wait_for_login()
-        expected_hash = test_obj.get_hash_value(session, "/dev/"+device)
+        expected_hash, check_disk = test_obj.get_hash_value(session, "/dev/"+device)
         test.log.info("TEST_STEP3:Do blockcopy")
         virsh.blockcopy(vm_name, device, tmp_copy_path,
                         options=blockcopy_options, ignore_status=False,
@@ -67,7 +67,7 @@ def run(test, params, env):
         elif execute_option == "--pivot":
             expected_chain = [tmp_copy_path, test_obj.copy_image]
         check_obj.check_backingchain_from_vmxml(disk_type, device, expected_chain)
-        check_obj.check_hash_list(["/dev/" + test_obj.new_dev], [expected_hash],
+        check_obj.check_hash_list([check_disk], [expected_hash],
                                   session)
         session.close()
 

--- a/libvirt/tests/src/backingchain/blockcopy/blockcopy_with_blockdev_option.py
+++ b/libvirt/tests/src/backingchain/blockcopy/blockcopy_with_blockdev_option.py
@@ -39,8 +39,8 @@ def run(test, params, env):
         Test blockcopy with --blockdev option.
         """
         session = vm.wait_for_login()
-        expected_hash = test_obj.get_hash_value(session,
-                                                check_item="/dev/"+test_obj.new_dev)
+        expected_hash, check_disk = test_obj.get_hash_value(session,
+                                                            check_item="/dev/"+test_obj.new_dev)
 
         test.log.info("TEST_STEP1: Do blockcopy.")
         virsh.blockcopy(vm_name, device, blockcopy_options % test_obj.lvm_list[1],
@@ -51,7 +51,7 @@ def run(test, params, env):
         expected_chain = test_obj.convert_expected_chain(expected_chain_index)
         check_obj.check_backingchain_from_vmxml(disk_type, device, expected_chain)
 
-        check_obj.check_hash_list(["/dev/"+test_obj.new_dev], [expected_hash],
+        check_obj.check_hash_list([check_disk], [expected_hash],
                                   session)
         session.close()
 

--- a/libvirt/tests/src/backingchain/blockcopy/blockcopy_with_conventional_chain.py
+++ b/libvirt/tests/src/backingchain/blockcopy/blockcopy_with_conventional_chain.py
@@ -41,8 +41,8 @@ def run(test, params, env):
         Do blockcopy and abort job ,than check hash and vmxml chain
         """
         session = vm.wait_for_login()
-        expected_hash = test_obj.get_hash_value(session,
-                                                "/dev/" + test_obj.new_dev)
+        expected_hash, check_disk = test_obj.get_hash_value(session,
+                                                            "/dev/" + test_obj.new_dev)
 
         test.log.info("TEST_STEP1: Do blockcopy and abort job")
         virsh.blockcopy(vm_name, target_disk, tmp_copy_path,
@@ -64,7 +64,7 @@ def run(test, params, env):
         expected_chain = test_obj.convert_expected_chain(expected_chain_index)
         check_obj.check_backingchain_from_vmxml(disk_type, target_disk, expected_chain)
 
-        check_obj.check_hash_list(["/dev/" + test_obj.new_dev], [expected_hash],
+        check_obj.check_hash_list([check_disk], [expected_hash],
                                   session)
         session.close()
 

--- a/libvirt/tests/src/backingchain/blockpull/blockpull_base_image_exist_backingfile.py
+++ b/libvirt/tests/src/backingchain/blockpull/blockpull_base_image_exist_backingfile.py
@@ -52,7 +52,8 @@ def run(test, params, env):
             base_option = " "
 
         session = vm.wait_for_login()
-        expected_hash = test_obj.get_hash_value(session, "/dev/"+test_obj.new_dev)
+        expected_hash, check_disk = test_obj.get_hash_value(session,
+                                                            "/dev/" + test_obj.new_dev)
 
         test.log.info("TEST_STEP: Do blockpull")
         virsh.blockpull(vm.name, target_disk, base_option+pull_options,
@@ -61,7 +62,7 @@ def run(test, params, env):
         expected_chain = test_obj.convert_expected_chain(expected_chain_index)
         check_obj.check_backingchain_from_vmxml(disk_type, test_obj.new_dev,
                                                 expected_chain)
-        check_obj.check_hash_list(["/dev/"+test_obj.new_dev], [expected_hash], session)
+        check_obj.check_hash_list([check_disk], [expected_hash], session)
         session.close()
 
     def teardown_test():

--- a/libvirt/tests/src/backingchain/blockpull/blockpull_conventional_chain.py
+++ b/libvirt/tests/src/backingchain/blockpull/blockpull_conventional_chain.py
@@ -50,15 +50,15 @@ def run(test, params, env):
             base_option = " "
 
         session = vm.wait_for_login()
-        expected_hash = test_obj.get_hash_value(session,
-                                                "/dev/" + test_obj.new_dev)
+        expected_hash, check_disk = test_obj.get_hash_value(session,
+                                                            "/dev/" + test_obj.new_dev)
         virsh.blockpull(vm.name, target_disk, pull_options+base_option,
                         ignore_status=False, debug=True)
 
         expected_chain = test_obj.convert_expected_chain(expected_chain_index)
         check_obj.check_backingchain_from_vmxml(disk_type, test_obj.new_dev,
                                                 expected_chain)
-        check_obj.check_hash_list(["/dev/"+test_obj.new_dev], [expected_hash], session)
+        check_obj.check_hash_list([check_disk], [expected_hash], session)
         session.close()
 
     def teardown_test():

--- a/provider/backingchain/blockcommand_base.py
+++ b/provider/backingchain/blockcommand_base.py
@@ -192,11 +192,19 @@ class BlockCommand(object):
         if status:
             self.test.error("Not find sha256sum command on guest.")
 
+        # If the target disk we tested changes to bootable disk in guest, then get another disk
+        if check_item in session.cmd_output("df -h"):
+            lsblk_cmd = "lsblk -l | grep -i disk | awk '{print $1}'"
+            disk_list = session.cmd_output(lsblk_cmd).split()
+            target_disk = check_item.split('/')[-1]
+            disk_list.remove(target_disk)
+            check_item = "/dev/" + disk_list[0]
+
         ret, expected_hash = session.cmd_status_output("sha256sum %s" % check_item)
         if ret:
             self.test.error("Get sha256sum value failed")
 
-        return expected_hash
+        return expected_hash, check_item
 
     def backingchain_common_teardown(self):
         """


### PR DESCRIPTION
In s390x, the disk drive number vdb will be changed but not a stable one. So the hash checking will check the bootable disk but not the tested disk. That will cause different hash value contrast. This PR can be fixed to check test disks.