### PR TITLE
chardev: add case for prevent muti console connection

### DIFF
--- a/libvirt/tests/cfg/chardev/virsh_console_operation/prevent_multiple_console.cfg
+++ b/libvirt/tests/cfg/chardev/virsh_console_operation/prevent_multiple_console.cfg
@@ -1,0 +1,33 @@
+- chardev.prevent_multiple_console:
+    type = prevent_multiple_console
+    start_vm = 'no'
+    chardev_type = "pty"
+    access_cmd = "virsh console %s"
+    force_cmd = "virsh console %s  --force"
+    port = 0
+    error_msg = "Active console session exists for this domain"
+    variants dev:
+        - console:
+            chardev = "console"
+            variants:
+                - virtio_target:
+                    target_type = "virtio"
+                    device_dict = "{'type_name':'${chardev_type}','target_type':'${target_type}', 'target_port':'${port}'}"
+        - serial:
+            chardev = "serial"
+            variants:
+                - pci_target:
+                    no s390-virtio
+                    target_type = pci-serial
+                    target_model = pci-serial
+                    device_dict = "{'type_name':'${chardev_type}','target_type':'${target_type}','target_model':'${target_model}', 'target_port':'${port}'}"
+                - isa_target:
+                    target_type = isa-serial
+                    target_model = isa-serial
+                    aarch64:
+                        target_type = system-serial
+                        target_model = pl011
+                    s390x:
+                        target_type = sclp-serial
+                        target_model = sclpconsole
+                    device_dict = "{'type_name':'${chardev_type}','target_model':'${target_model}','target_type':'${target_type}', 'target_port':'${port}'}"

--- a/libvirt/tests/src/chardev/virsh_console_operation/prevent_multiple_console.py
+++ b/libvirt/tests/src/chardev/virsh_console_operation/prevent_multiple_console.py
@@ -1,0 +1,109 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright Redhat
+#
+#   SPDX-License-Identifier: GPL-2.0
+
+#   Author: Nan Li <nanli@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import re
+
+import aexpect
+
+from virttest import utils_test
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+
+
+def run(test, params, env):
+    """
+    Verify that multiple console connections are prevented and user can
+     force disconnect the existing connection.
+    """
+
+    def setup_test():
+        """
+        Make sure remove all other serial/console devices before test.
+        """
+        test.log.info("Setup env: Remove console and serial")
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        vmxml.remove_all_device_by_type('console')
+        vmxml.remove_all_device_by_type('serial')
+        vmxml.sync()
+
+    def run_test():
+        """
+        1) Start guest with chardev.
+        2) Connect to console device.
+        3) Connect to console device with another terminal.
+        4) Connect to the chardev with --force parameter.
+        """
+        test.log.info("TEST_STEP1: Start vm with chardev")
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        libvirt_vmxml.modify_vm_device(
+            vmxml=vmxml, dev_type=chardev, dev_dict=device_dict)
+        vm.start()
+        vm.wait_for_login().close()
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        test.log.debug("The vmxml after start vm is:\n %s", vmxml)
+
+        test.log.info("TEST_STEP2: Connect to vm with virsh console vm_name")
+        access_session = aexpect.ShellSession("sudo -s")
+        status = utils_test.libvirt.verify_virsh_console(
+            access_session, params.get('username'), params.get('password'),
+            debug=True)
+        if not status:
+            test.fail("Expect virsh console success but got failed ")
+
+        test.log.info("TEST_STEP3: Connect with duplicated console session")
+        new_session = aexpect.ShellSession(access_cmd % vm_name)
+        try:
+            status = utils_test.libvirt.verify_virsh_console(
+                new_session, params.get('username'), params.get('password'),
+                debug=True)
+            if status:
+                test.fail("Expect virsh console failed with '%s', but success" % error_msg)
+        except Exception as detail:
+            if not re.search(error_msg, str(detail)):
+                test.fail("Duplicated console session should get '%s' "
+                          "but got:\n%s" % (error_msg, str(detail)))
+        new_session.close()
+
+        test.log.info("TEST_STEP4: Connect to the chardev with --force")
+        new_session = aexpect.ShellSession(force_cmd % vm_name)
+        force_status = utils_test.libvirt.verify_virsh_console(
+            new_session, params.get('username'), params.get('password'),
+            debug=True)
+        if not force_status:
+            test.fail("Expect force console session should succeed, "
+                      "but failed.")
+        new_session.close()
+        access_session.close()
+
+    def teardown_test():
+        """
+        Clean data.
+        """
+        if vm.is_alive():
+            vm.destroy(gracefully=False)
+        bkxml.sync()
+
+    vm_name = params.get("main_vm")
+    force_cmd = params.get('force_cmd')
+    chardev = params.get('chardev')
+    access_cmd = params.get('access_cmd')
+    error_msg = params.get('error_msg')
+    device_dict = eval(params.get('device_dict', '{}'))
+
+    vm = env.get_vm(vm_name)
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+
+    try:
+        setup_test()
+        run_test()
+
+    finally:
+        teardown_test()


### PR DESCRIPTION
     VIRT-296963: prevent multiple console connections
Signed-off-by: nanli <nanli@redhat.com>

```

avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 chardev.prevent_multiple_console

 (1/3) type_specific.io-github-autotest-libvirt.chardev.prevent_multiple_console.console.virtio_target: PASS (55.46 s)
 (2/3) type_specific.io-github-autotest-libvirt.chardev.prevent_multiple_console.serial.pci_target: PASS (52.18 s)
 (3/3) type_specific.io-github-autotest-libvirt.chardev.prevent_multiple_console.serial.isa_target: PASS (51.63 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0

```

Depend on https://github.com/avocado-framework/avocado-vt/pull/3706 