### PR TITLE
svirt: Fix a permission issue

### DIFF
--- a/libvirt/tests/src/svirt/umask_value/svirt_umask_files_accessed_by_qemu.py
+++ b/libvirt/tests/src/svirt/umask_value/svirt_umask_files_accessed_by_qemu.py
@@ -4,6 +4,7 @@ import shutil
 from avocado.utils import process
 
 from virttest import test_setup
+from virttest import utils_libvirtd
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.vm_xml import VMXML
 
@@ -28,6 +29,7 @@ def run(test, params, env):
         test.log.info(f"TEST_STEP: Delete {hp_path} and create hugepages in the host.")
         if os.path.exists(hp_path):
             shutil.rmtree(hp_path)
+            utils_libvirtd.Libvirtd().restart()
         hp_cfg = test_setup.HugePageConfig(params)
         hp_cfg.set_hugepages()
 


### PR DESCRIPTION
Update to restart libvirtd to avoid permission issue.


**Before the fix:**
`VMStartError: VM 'avocado-vt-vm1' failed to start: error: Failed to start domain 'avocado-vt-vm1'error: internal error: qemu unexpectedly closed the monitor: 2023-06-25T08:38:19.273408Z qemu-kvm: can't open backing store /dev/hugepages/libvirt/qemu/2-avocado-vt-vm1 for guest RAM: Permission denied(exit status: 1)&#10;`

**After the fix:**
` (1/1) type_specific.io-github-autotest-libvirt.svirt.umask.files_accessed_by_qemu:PASS (21.09 s)
`