### PR TITLE
fix memory xml not match

### DIFF
--- a/libvirt/tests/cfg/memory/memory_allocation/lifecycle_with_memory_allocation.cfg
+++ b/libvirt/tests/cfg/memory/memory_allocation/lifecycle_with_memory_allocation.cfg
@@ -16,7 +16,7 @@
                     vm_attrs = {'memory_unit':'${mem_unit}','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':"${current_mem_unit}"}
                 - with_numa:
                     max_mem = 15360000
-                    expect_xpath = [{'element_attrs':[".//maxMemory[@slots='${max_mem_slots}']",".//maxMemory[@unit='${max_mem_unit}']"],'text':'${max_mem}'},{'element_attrs':[".//currentMemory[@unit='${current_mem_unit}']"],'text':'${current_mem}'},{'element_attrs':[".//cell[@id='0']"],'text':'${numa_mem}'}, {'element_attrs':[".//cell[@id='1']"],'text':'${numa_mem}'}]
+                    expect_xpath = [{'element_attrs':[".//maxMemory[@slots='${max_mem_slots}']",".//maxMemory[@unit='${max_mem_unit}']"],'text':'${max_mem}'},{'element_attrs':[".//currentMemory[@unit='${current_mem_unit}']"],'text':'${current_mem}'},{'element_attrs':[".//cell[@memory='${numa_mem}']",".//cell[@id='0']"]}, {'element_attrs':[".//cell[@memory='${numa_mem}']",".//cell[@id='1']"]}]
                     numa_attr = "'vcpu': 4,'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '${numa_mem}', 'unit': 'KiB'},{'id':'1','cpus': '2-3','memory':'${numa_mem}','unit':'KiB'}]}"
                     max_mem_attr = "${numa_attr}, 'max_mem_rt': ${max_mem}, 'max_mem_rt_slots': ${max_mem_slots}, 'max_mem_rt_unit': '${max_mem_unit}'"
                     vm_attrs = {${max_mem_attr},'memory_unit':"${mem_unit}",'memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}'}

--- a/libvirt/tests/cfg/memory/memory_allocation/memory_invalid_value.cfg
+++ b/libvirt/tests/cfg/memory/memory_allocation/memory_invalid_value.cfg
@@ -9,6 +9,7 @@
     max_mem_unit = 'KiB'
     numa_mem = 1048576
     start_vm = no
+    func_supported_since_libvirt_ver = (9, 0, 0)
     variants num:
         - zero:
             value = 0
@@ -31,7 +32,7 @@
             error_msg = "both maximum memory size and memory slot count must be specified"
             status_error = "yes"
         - numa:
-            xpaths_list = [{'element_attrs':[".//cell[@id='0']"], 'text':'${value}'}, {'element_attrs':[".//memory[@unit='${mem_unit}']"], 'text':'${numa_mem}'}, {'element_attrs':[".//currentMemory[@unit='${current_mem_unit}']"], 'text':'${numa_mem}'}]
+            xpaths_list = [{'element_attrs':[".//cell[@id='0']"]}, {'element_attrs':[".//memory[@unit='${mem_unit}']"], 'text':'${numa_mem}'}, {'element_attrs':[".//currentMemory[@unit='${current_mem_unit}']"], 'text':'${numa_mem}'}]
             vm_attrs = {'max_mem_rt': ${max_mem}, 'max_mem_rt_slots': ${max_mem_slots}, 'max_mem_rt_unit': "${max_mem_unit}",'memory_unit':"${mem_unit}",'memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}','vcpu': 4,'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '${value}', 'unit': 'KiB'},{'id':'1','cpus': '2-3','memory':'${numa_mem}','unit':'KiB'}]}}
             start_vm_error = "yes"
             status_error = "no"

--- a/libvirt/tests/src/memory/memory_allocation/memory_invalid_value.py
+++ b/libvirt/tests/src/memory/memory_allocation/memory_invalid_value.py
@@ -1,5 +1,6 @@
 
 from virttest import virsh
+from virttest import libvirt_version
 
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
@@ -65,11 +66,14 @@ def run(test, params, env):
     start_error_msg = params.get("start_error_msg", "")
 
     num = params.get("num")
+    mem_config = params.get("mem_config")
     xpaths_list = eval(params.get("xpaths_list", '{}'))
     vm_attrs = eval(params.get("vm_attrs"))
     start_vm_error = "yes" == params.get("start_vm_error", "no")
 
     try:
+        if num == "zero" and mem_config == "numa":
+            libvirt_version.is_libvirt_feature_supported(params)
         setup_test()
         run_test()
 


### PR DESCRIPTION
**First case:** 
Before fixed
```
 avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 memory.allocation.invalid_value.numa.zero --vt-connect-uri qemu:///system

 (1/1) type_specific.io-github-autotest-libvirt.memory.allocation.invalid_value.numa.zero: FAIL: XML did not match text '0' for the xpath './/cell[@id='0']' (8.01 s)

```
After fixed, lcong has confirmed that the test should cancel if libvirt version <9.0  for zero &numa scenario

```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 memory.allocation.invalid_value.numa.zero --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.memory.allocation.invalid_value.numa.zero: CANCEL: This libvirt version doesn't support this function. (7.36 s)

```

