### PR TITLE
fix version issue for virtio-mem

### DIFF
--- a/libvirt/tests/cfg/memory/memory_devices/lifecycle_of_mixed_memory_devices.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/lifecycle_of_mixed_memory_devices.cfg
@@ -30,6 +30,11 @@
     virtio_mem_dict_1 = {'mem_model': 'virtio-mem', 'target': {'size': ${virtio_mem_target_size}, 'size_unit': 'KiB','node':0, 'block_unit':'KiB','block_size':2048,'requested_size':1048576, 'requested_unit':'KiB'}}
     variants:
         - mutiple_mem:
+            no s390-virtio
+            required_kernel = [5.14.0,)
+            guest_required_kernel = [5.8.0,)
+            func_supported_since_libvirt_ver = (8, 0, 0)
+            func_supported_since_qemu_kvm_ver = (6, 2, 0)
             dimm_dict_2 = {'mem_model': 'dimm', 'mem_access':'shared','mem_discard':'yes','target': {'size': ${dimm_target_dize}, 'size_unit': 'KiB','node':1}}
             nvdimm_dict_2 = {'mem_model': 'nvdimm', 'source': {"path":"${nvdimm_path_2}"}, 'target': {'size': ${nvdimm_target_dize}, 'size_unit': 'KiB','node':1, 'label':{'size':128, 'size_unit':'KiB'} }}
             virtio_mem_dict_2 = {'mem_model': 'virtio-mem','source': {"pagesize":${page_size}, "pagesize_unit":"KiB"}, 'target': {'size': 262144, 'size_unit': 'KiB','node':0, 'block_unit':'KiB','block_size':2048,'requested_size':262144, 'requested_unit':'KiB'}}


### PR DESCRIPTION
Before fixed

```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 memory.devices.lifecycle.mutiple_mem --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.memory.devices.lifecycle.mutiple_mem: ERROR: Failed to define avocado-vt-vm1 for reason:\nsetlocale: No such file or directory\nerror: Failed to define domain from /tmp/xml_utils_temp_6shka80q.xml\nerror: unsupported configuration: virtio-mem isn't supported by this QEMU binary\n (79.04 s)
```


 
After fixed

```

avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 memory.devices.lifecycle.mutiple_mem --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.memory.devices.lifecycle.mutiple_mem: CANCEL: Got host kernel version:4.18.0-499, which is not in [5.14.0,) (6.16 s)

```