### PR TITLE
numa_topology_with_hugepage: Enable test for aarch64

### DIFF
--- a/libvirt/tests/cfg/numa/guest_numa_topology/numa_topology_with_hugepage.cfg
+++ b/libvirt/tests/cfg/numa/guest_numa_topology/numa_topology_with_hugepage.cfg
@@ -5,30 +5,55 @@
     max_mem_value = "'max_mem_rt': 8388608, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB'"
     target_hugepages_2M = 500
     target_hugepages_1G = 1
-    hugepage_path_1G = '/dev/hugepages1G'
     hugepage_path_2M = '/dev/hugepages'
+    hugepage_path_1G = '/dev/hugepages1G'
     pat_in_qemu_cmdline = '-object {"qom-type":".*","id":"ram-node0","mem-path":"%s","prealloc":true,"size":%d} .* -object {"qom-type":".*","id":"ram-node1",%s%s"size":%d}'
     variants hp_size:
         - 2M:
             mem_value = "'memory': 2097152, 'memory_unit': 'KiB'"
             vm_numa_node0_mem = 1024000
-            vm_numa_node1_mem = 1073152            
+            vm_numa_node1_mem = 1073152
             memory_backing = {'hugepages': {'pages': [{'size': '2048', 'unit': 'KiB', 'nodeset': '0'}]}}
         - 1G:
+            no kernelpagesize_64k
             mem_value = "'memory': 2121728, 'memory_unit': 'KiB'"
             vm_numa_node0_mem = 1048576
-            vm_numa_node1_mem = 1073152            
+            vm_numa_node1_mem = 1073152
             memory_backing = {'hugepages': {'pages': [{'size': '1048576', 'unit': 'KiB', 'nodeset': '0'}]}}
-        - 2M_1G:
+        - 512M:
+            only kernelpagesize_64k
+            mem_value = "'memory': 2121728, 'memory_unit': 'KiB'"
+            vm_numa_node0_mem = 1048576
+            vm_numa_node1_mem = 1073152
+            memory_backing = {'hugepages': {'pages': [{'size': '524288', 'unit': 'KiB', 'nodeset': '0'}]}}
+        - 2M_512M:
+            only kernelpagesize_64k
             mem_value = "'memory': 2072576, 'memory_unit': 'KiB'"
             vm_numa_node0_mem = 1024000
-            vm_numa_node1_mem = 1048576            
+            vm_numa_node1_mem = 1048576
+            memory_backing = {'hugepages': {'pages': [{'size': '512', 'unit': 'M', 'nodeset': '1'}, {'size': '2', 'unit': 'M', 'nodeset': '0'}]}}
+        - 2M_1G:
+            no kernelpagesize_64k
+            mem_value = "'memory': 2072576, 'memory_unit': 'KiB'"
+            vm_numa_node0_mem = 1024000
+            vm_numa_node1_mem = 1048576
             memory_backing = {'hugepages': {'pages': [{'size': '1', 'unit': 'G', 'nodeset': '1'}, {'size': '2', 'unit': 'M', 'nodeset': '0'}]}}
         - scarce_mem:
             mem_value = "'memory': 2097152, 'memory_unit': 'KiB'"
             vm_numa_node0_mem = 1048576
             vm_numa_node1_mem = 1048576
-            memory_backing = {'hugepages': {'pages': [{'size': '2048', 'unit': 'KiB', 'nodeset': '0'}]}}    
+            memory_backing = {'hugepages': {'pages': [{'size': '2048', 'unit': 'KiB', 'nodeset': '0'}]}}
+    variants:
+        - kernelpagesize_64k:
+            only aarch64
+            conf_pagesize = 65536
+            hugepage_path_2M = '/dev/hugepages2M'
+            hugepage_path_512M = '/dev/hugepages'
+            target_hugepages_512M = 2
+        - kernelpagesize_4k:
+            conf_pagesize = 4096
     current_mem_value = ${mem_value}
     numa_cell = "'numa_cell': [{'cpus': '0-1', 'memory': '${vm_numa_node0_mem}'}, {'cpus': '2-3', 'memory': '${vm_numa_node1_mem}'}]"
     vm_attrs = {${max_mem_value}, ${mem_value}, ${current_mem_value}, 'vcpu': 4, 'cpu': {'mode': 'host-model', ${numa_cell}}}
+    aarch64:
+        vm_attrs = {${max_mem_value}, ${mem_value}, ${current_mem_value}, 'vcpu': 4, 'cpu': {'mode': 'host-passthrough', ${numa_cell}}}


### PR DESCRIPTION
The support hugepage sizes on aarch64 are 2M, 512M and 16G, and the default pagesize is 512M.

Test Result:
```
 (1/4) type_specific.io-github-autotest-libvirt.guest_numa_topology.numa_topology_with_hugepage.2M: PASS (46.30 s)
 (2/4) type_specific.io-github-autotest-libvirt.guest_numa_topology.numa_topology_with_hugepage.512M: PASS (44.99 s)
 (3/4) type_specific.io-github-autotest-libvirt.guest_numa_topology.numa_topology_with_hugepage.2M_512M: PASS (49.47 s)
 (4/4) type_specific.io-github-autotest-libvirt.guest_numa_topology.numa_topology_with_hugepage.scarce_mem: PASS (13.97 s)
```