### PR TITLE
numa_topology_with_numa_distance: Enable test for aarch64

### DIFF
--- a/libvirt/tests/cfg/numa/guest_numa_topology/numa_topology_with_numa_distance.cfg
+++ b/libvirt/tests/cfg/numa/guest_numa_topology/numa_topology_with_numa_distance.cfg
@@ -4,6 +4,8 @@
     start_vm = "no"
     vcpu = 10
     cpu_mode = 'host-model'
+    aarch64:
+        cpu_mode = 'host-passthrough'
     numa_cell_0_distance = {'sibling': [{'id': '0', 'value': '10'}, {'id': '1', 'value': '21'}]}
     numa_cell_0 = {'unit': 'KiB', 'id': '0', 'memory': '1048576', 'distances': ${numa_cell_0_distance}, 'cpus': '0-1,4-9'}
     variants:


### PR DESCRIPTION
cpu model: aarch64 support host-passthrough

Test Result:
```
 (1/2) type_specific.io-github-autotest-libvirt.guest_numa_topology.numa_topology_with_numa_distance.symmetrical: PASS (105.10 s)
 (2/2) type_specific.io-github-autotest-libvirt.guest_numa_topology.numa_topology_with_numa_distance.asymmetrical: PASS (106.04 s)
```