### PR TITLE
numa_various_numa_topology_settings: Enable test for aarch64

### DIFF
--- a/libvirt/tests/cfg/numa/guest_numa_topology/various_numa_topology_settings.cfg
+++ b/libvirt/tests/cfg/numa/guest_numa_topology/various_numa_topology_settings.cfg
@@ -6,8 +6,11 @@
     memory_backing = {'hugepages': {}}
     qemu_monitor_option = '--hmp'
     qemu_monitor_cmd = 'info memdev'    
-    cpu_mode = 'host-model'    
+    cpu_mode = 'host-model'
     target_hugepages = 1024
+    aarch64:
+        cpu_mode = 'host-passthrough'
+        target_hugepages = 32
     hugepage_size = 2048
     numa_cell_0 = {'id': '0', 'memory': '1048576', 'cpus': '0-1'}
     numa_cell_1 = {'id': '1', 'memory': '1048576', 'cpus': '2-3'}


### PR DESCRIPTION
Enable tests for aarch64 with the following changes:
  1. cpu model: aarch64 support host-passthrough
  2. target_hugepages: Reduce the number of huge pages to 32, because the default pagesize of aarc64 is 512M, creating 1024 hugepages requires a lot of free memory on the machine

Test Results are as follows, the 3 cases that still fail should be other issues which failed on x86 too.
```
 (01/16) type_specific.io-github-autotest-libvirt.guest_numa_topology.various_numa_topology_settings.discard_none.memaccess_none: PASS (42.42 s)
 (02/16) type_specific.io-github-autotest-libvirt.guest_numa_topology.various_numa_topology_settings.discard_none.memaccess_shared: PASS (46.75 s)
 (03/16) type_specific.io-github-autotest-libvirt.guest_numa_topology.various_numa_topology_settings.discard_none.memaccess_private: PASS (44.96 s)
 (04/16) type_specific.io-github-autotest-libvirt.guest_numa_topology.various_numa_topology_settings.discard_none.memaccess_invalid: PASS (12.12 s)
 (05/16) type_specific.io-github-autotest-libvirt.guest_numa_topology.various_numa_topology_settings.discard_yes.memaccess_none: PASS (46.22 s)
 (06/16) type_specific.io-github-autotest-libvirt.guest_numa_topology.various_numa_topology_settings.discard_yes.memaccess_shared: PASS (46.63 s)
 (07/16) type_specific.io-github-autotest-libvirt.guest_numa_topology.various_numa_topology_settings.discard_yes.memaccess_private: PASS (44.85 s)
 (08/16) type_specific.io-github-autotest-libvirt.guest_numa_topology.various_numa_topology_settings.discard_yes.memaccess_invalid: PASS (12.27 s)
 (09/16) type_specific.io-github-autotest-libvirt.guest_numa_topology.various_numa_topology_settings.discard_no.memaccess_none: FAIL: Expecting '"?discard-data"?(=|:)(no|false|off)' does exist in qemu command line, but  notfound (47.32 s)                                                                               
 (10/16) type_specific.io-github-autotest-libvirt.guest_numa_topology.various_numa_topology_settings.discard_no.memaccess_shared: FAIL: Expecting '"?discard-data"?(=|:)(no|false|off)' does exist in qemu command line, but  notfound (44.70 s)                                                                             
 (11/16) type_specific.io-github-autotest-libvirt.guest_numa_topology.various_numa_topology_settings.discard_no.memaccess_private: FAIL: Expecting '"?discard-data"?(=|:)(no|false|off)' does exist in qemu command line, but  notfound (44.77 s)                                                                            
 (12/16) type_specific.io-github-autotest-libvirt.guest_numa_topology.various_numa_topology_settings.discard_no.memaccess_invalid: PASS (10.26 s)
 (13/16) type_specific.io-github-autotest-libvirt.guest_numa_topology.various_numa_topology_settings.discard_invalid.memaccess_none: PASS (12.67 s)
 (14/16) type_specific.io-github-autotest-libvirt.guest_numa_topology.various_numa_topology_settings.discard_invalid.memaccess_shared: PASS (12.45 s)
 (15/16) type_specific.io-github-autotest-libvirt.guest_numa_topology.various_numa_topology_settings.discard_invalid.memaccess_private: PASS (12.55 s)
 (16/16) type_specific.io-github-autotest-libvirt.guest_numa_topology.various_numa_topology_settings.discard_invalid.memaccess_invalid: PASS (12.52 s)
```