### PR TITLE
memory_snapshot_delete: fix version checking

### DIFF
--- a/libvirt/tests/cfg/snapshot/memory_snapshot_delete.cfg
+++ b/libvirt/tests/cfg/snapshot/memory_snapshot_delete.cfg
@@ -4,6 +4,7 @@
     start_vm = no
     snapshot_disk_list = "[{'disk_name': 'vda', 'disk_snapshot': 'no'}, {'disk_name': 'vdb', 'disk_snapshot': 'no'}]"
     snapshot_dict = {'description': 'Snapshot test', 'snap_name': '%s', 'mem_snap_type': 'external', 'mem_file': '%s'}
+    func_supported_since_libvirt_ver = (9, 0, 0)
     variants disk_format:
         - type_qcow2:
             disk_driver = {'driver': {'name': 'qemu', 'type': 'qcow2'}}

--- a/libvirt/tests/src/snapshot/memory_snapshot_delete.py
+++ b/libvirt/tests/src/snapshot/memory_snapshot_delete.py
@@ -14,6 +14,7 @@ Test cases about memory snapshot deletion
 import os
 
 from virttest import data_dir
+from virttest import libvirt_version
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 
@@ -119,6 +120,7 @@ def run(test, params, env):
     """
     Deletion test for memory only snapshot
     """
+    libvirt_version.is_libvirt_feature_supported(params)
     vm_name = params.get("main_vm")
     vm = env.get_vm(vm_name)
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)


### PR DESCRIPTION
libvirt version checking is missing.

Signed-off-by: Dan Zheng <dzheng@redhat.com>