### PR TITLE
guest_os_booting: fix the unsupported version issues

### DIFF
--- a/libvirt/tests/cfg/guest_os_booting/ovmf_firmware/ovmf_loader.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/ovmf_firmware/ovmf_loader.cfg
@@ -15,6 +15,7 @@
                     loader_dict = {'loader': '${loader_path}', 'nvram': '${nvram_path}', 'nvram_attrs': {'template': '${nvram_template}'}, 'secure': 'no', 'loader_readonly': 'yes', 'loader_type': 'pflash'}
                 - stateless_yes:
                     stateless  = "yes"
+                    func_supported_since_libvirt_ver = (8, 6, 0)
                     loader_path = "/usr/share/edk2/ovmf/OVMF.amdsev.fd"
                     loader_dict = {'os_firmware': 'efi', 'loader_stateless': 'yes'}
                     loader_xpath = [{'element_attrs': ["./os/loader[@stateless='yes']"], 'text': '${loader_path}'}]

--- a/libvirt/tests/src/guest_os_booting/ovmf_firmware/ovmf_loader.py
+++ b/libvirt/tests/src/guest_os_booting/ovmf_firmware/ovmf_loader.py
@@ -10,6 +10,7 @@
 
 import os
 
+from virttest import libvirt_version
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_libvirt import libvirt_vmxml
@@ -31,6 +32,7 @@ def run(test, params, env):
     incorrect_loader_path = params.get("incorrect_loader_path", "")
     use_file = "yes" == params.get("use_file", "no")
     stateless = "yes" == params.get("stateless", "no")
+    libvirt_version.is_libvirt_feature_supported(params)
 
     vm = env.get_vm(vm_name)
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)

--- a/provider/guest_os_booting/guest_os_booting_base.py
+++ b/provider/guest_os_booting/guest_os_booting_base.py
@@ -52,7 +52,7 @@ def check_vm_startup(vm, vm_name, error_msg):
     :params vm: vm object
     :params vm_name: the name of guest
     """
-    ret = virsh.start(vm_name, "--reset-nvram", timeout=30, debug=True)
+    ret = virsh.start(vm_name, timeout=30, debug=True)
     vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
     libvirt.check_result(ret, expected_fails=error_msg)
     if not error_msg:


### PR DESCRIPTION
    Fix two version issues in this PR:
    1) --reset-nvram option is not supported in RHEL8 but we need to test
       this auto case. So don't use it in the test steps.
    2) The stateless is supported from libvirt-8.6.0. So test it from this
       version.