### PR TITLE
virtiofs : add case for restart service after config shared memory

### DIFF
--- a/libvirt/tests/cfg/virtual_device/filesystem_device.cfg
+++ b/libvirt/tests/cfg/virtual_device/filesystem_device.cfg
@@ -86,6 +86,14 @@
                     bug_url = "https://bugzilla.redhat.com/show_bug.cgi?id=1940276"
                     destroy_start = "yes"
                     stress_script = "#!/usr/bin/python3;import os;while True:;    os.open("%s/moo", os.O_CREAT | os.O_RDWR);    os.unlink("%s/moo");"
+                - restart_service:
+                    only file_backed
+                    func_supported_since_libvirt_ver = (9, 2, 0)
+                    setup_mem = True
+                    source_dir = "/var/tmp/mount_tag0"
+                    dev_type = "filesystem"
+                    vm_attrs = {'mb': {"source_type":"file", 'access_mode': 'shared'}}
+                    fs_dict = {'accessmode':'passthrough', 'driver': {'type': 'virtiofs', 'queue':'512'}, 'source':{'dir': '${source_dir}'}, "target": {'dir': 'mount_tag0'}, 'binary': {'path': '/usr/libexec/virtiofsd', 'xattr': 'on','cache_mode':'none','lock_posix':'off','flock':'off'}}
         - coldplug_coldunplug:
             only xattr_on.flock_off.lock_posix_off.cache_mode_none..one_fs
             coldplug = "yes"


### PR DESCRIPTION
    VIRT-298224: Verify the libvirt can identify shared memory after restart libvirtd/virtqemud
```

avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 virtual_devices.filesystem_device.positive_test.file_backed.lifecycle.restart_service.fs_test.xattr_on.flock_off.lock_posix_off.cache_mode_none.thread_pool_noset.one_fs.one_guest

 (1/1) type_specific.io-github-autotest-libvirt.virtual_devices.filesystem_device.positive_test.file_backed.lifecycle.restart_service.fs_test.xattr_on.flock_off.lock_posix_off.cache_mode_none.thread_pool_noset.one_fs.one_guest: PASS (39.41 s)

```