### PR TITLE
numa_memory_spread: Make sure enough memory for guest

### DIFF
--- a/libvirt/tests/src/numa/numa_memory_spread.py
+++ b/libvirt/tests/src/numa/numa_memory_spread.py
@@ -79,12 +79,12 @@ def prepare_host_for_test(params, test):
                   format(numa_memory['nodeset'], nodeset_size))
     logging.debug('Memory available on a neighbour node {} is {}'.
                   format(neighbour, nodeset_nb_size))
-    # Increase a size by 50% of neighbour node
-    oversize = int(nodeset_size + 0.5 * nodeset_nb_size)
+    # Increase a size by 25% of neighbour node
+    oversize = int(nodeset_size + 0.25 * nodeset_nb_size)
     # Decrease nodeset size by 25%
     undersize = int(nodeset_size * 0.25)
-    # Memory to eat is a whole nodeset + 10% of neighbour size
-    memory_to_eat = int(nodeset_size + 0.1 * nodeset_nb_size)
+    # Memory to eat is a whole nodeset + 5% of neighbour size
+    memory_to_eat = int(nodeset_size + 0.05 * nodeset_nb_size)
     nodeset_string = '{},{}'.format(online_nodes[0], neighbour)
     process.run("swapoff -a", shell=True)
 
@@ -246,6 +246,8 @@ def run(test, params, env):
         nodeset_string = constants[5]
         # Prepare VM XML
         prepare_vm_xml_for_test(vm_name, numa_memory, oversize, undersize)
+        # Drop caches first to make sure host has enough memory
+        utils_memory.drop_caches()
         # Start the VM
         virsh.start(vm_name, ignore_status=False, debug=True)
         session = vm.wait_for_login()


### PR DESCRIPTION
1. Decrease memory size from the neighbour
2. Drop caches first to make sure host has enough memory

Before:
```
ERROR| ERROR 1-type_specific.io-github-autotest-libvirt.numa_memory_spread.positive_test.default -> CmdError: Command '/usr/bin/virsh start avocado-vt-vm1 ' failed.
stdout: b'\n'
stderr: b"error: Failed to start domain 'avocado-vt-vm1'\nerror: internal error: qemu unexpectedly closed the monitor: 2023-07-03T08:21:57.926073Z qemu-kvm: cannot set up guest memory 'mach-virt.ram': Cannot allocate memory\n"
```

After:
```
INFO | PASS 1-type_specific.io-github-autotest-libvirt.numa_memory_spread.positive_test.default
```