### PR TITLE
svirt_umask_value: Enable test for aarch64

### DIFF
--- a/libvirt/tests/cfg/svirt/umask_value/svirt_umask_files_accessed_by_qemu.cfg
+++ b/libvirt/tests/cfg/svirt/umask_value/svirt_umask_files_accessed_by_qemu.cfg
@@ -4,3 +4,5 @@
     umask_value = '027'
     mem_backing_attrs = {'hugepages': {}}
     target_hugepages = 1024
+    aarch64:
+        target_hugepages = 4


### PR DESCRIPTION
Reduce the target_hugepages to 4, because the default pagesize of aarc64 is 512M

Before:
```
ERROR 1-type_specific.io-github-autotest-libvirt.svirt.umask.files_accessed_by_qemu -> ValueError: Cannot set the kernel hugepage setting to the target value of 1024 hugepages.
```

After:
```
PASS 1-type_specific.io-github-autotest-libvirt.svirt.umask.files_accessed_by_qemu
```