### PR TITLE
sriov: Add a checkpoint to check ping latency

### DIFF
--- a/libvirt/tests/cfg/sriov/vm_lifecycle/sriov_vm_lifecycle_reboot.cfg
+++ b/libvirt/tests/cfg/sriov/vm_lifecycle/sriov_vm_lifecycle_reboot.cfg
@@ -19,6 +19,8 @@
                     variants test_scenario:
                         - managed_yes:
                             iface_dict = {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}, 'driver': {'driver_attr': {'name': 'vfio'}}, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}, 'mac_address': mac_addr}
+                            iface_dict2 = {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr2}, 'driver': {'driver_attr': {'name': 'vfio'}}}
+                            check_ping_time = "yes"
                         - managed_no:
                             iface_dict = {'managed': 'no', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}, 'alias': {'name': 'ua-89cbe690-6c6c-4f2f-adac-5826fe52ea74'}}
                         - without_managed:

--- a/provider/sriov/check_points.py
+++ b/provider/sriov/check_points.py
@@ -137,6 +137,7 @@ def check_vm_network_accessed(vm_session, ping_count=3, ping_timeout=5,
         the string "ICMP echo request"
     :param ping_dest: Ping destination address
     :raise: test.fail when ping fails.
+    :return: Output of ping command
     """
     if not ping_dest:
         ping_dest = sriov_base.get_ping_dest(vm_session)
@@ -163,6 +164,7 @@ def check_vm_network_accessed(vm_session, ping_count=3, ping_timeout=5,
                 exceptions.TestFail("Get incorrect tcpdump output: {}, it "
                                     "should include '{}'."
                                     .format(output, pat_str))
+    return o
 
 
 def check_vm_iface_num(session, exp_num, timeout=10, first=0.0):


### PR DESCRIPTION
This PR adds a 2 vfs hostdev interfaces to check ping latency.


**Test results:**
```
 (01/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.hostdev_interface.vf_address.managed_yes.with_iommu: PASS (292.15 s)
 (02/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.hostdev_interface.vf_address.managed_yes.without_iommu: PASS (127.93 s)
 (03/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.hostdev_interface.vf_address.managed_no.without_iommu: PASS (101.33 s)
 (04/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.hostdev_interface.vf_address.without_managed.without_iommu: PASS (101.20 s)
 (05/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.hostdev_interface.vf_address.vlan.without_iommu: PASS (87.90 s)
 (06/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.hostdev_interface.vf_address.failover.with_iommu: PASS (305.14 s)
 (07/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.hostdev_device.vf_address.managed_yes.with_iommu: PASS (243.94 s)
 (08/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.hostdev_device.vf_address.managed_yes.without_iommu: PASS (99.64 s)
 (09/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.hostdev_device.vf_address.managed_no.without_iommu: PASS (100.11 s)
 (10/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.hostdev_device.pf_address.managed_yes.without_iommu: PASS (106.19 s)
 (11/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.hostdev_device.pf_address.managed_no.without_iommu: PASS (129.14 s)
 (12/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.network_interface.network.pf_name.hostdev.managed_no.without_iommu: PASS (102.14 s)
 (13/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.network_interface.network.pf_name.hostdev.managed_yes.without_iommu: PASS (100.98 s)
 (14/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.network_interface.network.pf_name.hostdev.without_managed.without_iommu: PASS (102.59 s)
 (15/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.network_interface.network.vf_address.hostdev.managed_yes.without_iommu: PASS (102.17 s)
 (16/16) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.network_interface.network.vf_address.hostdev.without_managed.without_iommu: PASS (103.22 s)

```