### PR TITLE
libvirt_rng: add test case with invalid XML

### DIFF
--- a/libvirt/tests/cfg/libvirt_rng.cfg
+++ b/libvirt/tests/cfg/libvirt_rng.cfg
@@ -56,6 +56,12 @@
                     only device_assign
                     with_packed = "yes"
                     driver_packed = "on"
+                - invalid_address:
+                    address = "domain=0x9999 bus=0x00 slot=0x00 function=0x0"
+                    expected_create_error = "Invalid PCI address"
+                - invalid_model:
+                    rng_model = virtio-abc
+                    expected_create_error = "RNG model"
         - backend_udp:
             backend_model = "egd"
             backend_type = "udp"


### PR DESCRIPTION
1. In the past, libvirtd crashed on invalid address.
Checking error message on invalid address setting
confirms libvirtd handles this correctly.

2. Check error message on invalid model.
