### PR TITLE
numa_topology: skip dies related tests on aarch64

### DIFF
--- a/libvirt/tests/cfg/numa/guest_numa_topology/numa_topology_with_cpu_topology.cfg
+++ b/libvirt/tests/cfg/numa/guest_numa_topology/numa_topology_with_cpu_topology.cfg
@@ -1,4 +1,5 @@
 - guest_numa_topology.numa_topology_with_cpu_topology:
+    no aarch64
     type = numa_topology_with_cpu_topology
     take_regular_screendumps = no
     start_vm = "no"


### PR DESCRIPTION
dies is not supported on arm cpu topology