### PR TITLE
timer_management: Remove hpet related cases.

### DIFF
--- a/libvirt/tests/cfg/timer_management.cfg
+++ b/libvirt/tests/cfg/timer_management.cfg
@@ -85,9 +85,6 @@
                 - kvmclock:
                     # Support hypervisor: qemu
                     timer_name = 'kvmclock'
-                - hpet:
-                    # Support hypervisor: libxl, xen, qemu
-                    timer_name = "hpet"
                 - pit:
                     # Support hypervisor: qemu
                     timer_name = 'pit'
@@ -98,8 +95,6 @@
                     variants:
                         - pit_rtc:
                             timer_name = 'pit,rtc'
-                        - hpet_tsc:
-                            timer_name = 'hpet,tsc'
                 - tsc:
                     # Support hypervisor: libxml,qemu
                     timer_name = "tsc"


### PR DESCRIPTION
After modifying the logic in qemu code,it cannot create HPET device, and hpet is disabled by default, so remove the cases.