### PR TITLE
fix chardev get message failed

### DIFF
--- a/libvirt/tests/cfg/chardev/connection_and_operation/data_transfer.cfg
+++ b/libvirt/tests/cfg/chardev/connection_and_operation/data_transfer.cfg
@@ -28,21 +28,27 @@
                     device = "hvc0"
                     target_path = "/dev/hvc"
                     device_dict = "{'type_name':'${chardev_type}','sources': [{'attrs': {'path': '%s'}}],'target_type':'%s', 'alias': {'name': '%s'},'target_port':'${port}'}"
-                - serial_target:
-                    target_type = "serial"
-                    target_path = "/dev/ttyS"
-                    device_dict = "{'type_name':'${chardev_type}','sources': [{'attrs': {'path': '%s'}}],'target_type':'%s', 'alias': {'name': '%s'},'target_port':'${port}'}"
         - serial:
             chardev = "serial"
             target_path = "/dev/ttyS"
             variants:
                 - pci_target:
-                    target_type = "pci-serial"
-                    target_model = "pci-serial"
+                    no s390-virtio
+                    target_type = pci-serial
+                    target_model = pci-serial
+                    aarch64:
+                        target_type = system-serial
+                        target_model = pl011
                     device_dict = "{'type_name':'${chardev_type}','sources': [{'attrs': {'path': '%s'}}],'target_type':'%s', 'target_model':'${target_model}','target_port':'${port}','alias': {'name': '%s'}}"
                 - isa_target:
-                    target_type = "isa-serial"
-                    target_model = "isa-serial"
+                    target_type = isa-serial
+                    target_model = isa-serial
+                    aarch64:
+                        target_type = system-serial
+                        target_model = pl011
+                    s390x:
+                        target_type = sclp-serial
+                        target_model = sclpconsole
                     device_dict = "{'type_name':'${chardev_type}','sources': [{'attrs': {'path': '%s'}}],'target_type':'%s', 'target_model':'${target_model}','target_port':'${port}','alias': {'name': '%s'}}"
         - channel:
             chardev = "channel"

--- a/provider/chardev/chardev_base.py
+++ b/provider/chardev/chardev_base.py
@@ -9,6 +9,7 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 import re
 
+from avocado.core import exceptions
 from avocado.utils import process
 
 
@@ -28,7 +29,12 @@ def send_message(vm, send_on="host", send_msg="Test message", send_path=""):
         if not vm.is_alive():
             vm.start()
         session = vm.wait_for_login()
-        session.cmd_status_output("echo %s > %s " % (send_msg, send_path))
+        cmd = "echo %s > %s " % (send_msg, send_path)
+        status, stdout = session.cmd_status_output(cmd)
+        if status != 0:
+            raise exceptions.TestError("Error happened when executing "
+                                       "command:\n'%s', due to:\n'%s'"
+                                       % (cmd, stdout))
         session.close()
 
 


### PR DESCRIPTION
This pr did two things:
1. Remove console device and  serial target case, due to it's removed on polarion case
2. Not get transferred message  issue on x86

Before fixed

```
 avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 chardev.data_transfer.serial.pci_target.pipe --vt-connect-uri qemu:///system

 (1/1) type_specific.io-github-autotest-libvirt.chardev.data_transfer.serial.pci_target.pipe: FAIL: Check host msg failed due to . (139.78 s)
```

 After fixed
```

- avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 chardev.data_transfer --vt-connect-uri qemu:///system

 (1/8) type_specific.io-github-autotest-libvirt.chardev.data_transfer.console.virtio_target.file: PASS (148.72 s)
 (2/8) type_specific.io-github-autotest-libvirt.chardev.data_transfer.console.virtio_target.pipe: PASS (169.33 s)
 (3/8) type_specific.io-github-autotest-libvirt.chardev.data_transfer.serial.pci_target.file: PASS (134.27 s)
 (4/8) type_specific.io-github-autotest-libvirt.chardev.data_transfer.serial.pci_target.pipe: PASS (139.95 s)
 (5/8) type_specific.io-github-autotest-libvirt.chardev.data_transfer.serial.isa_target.file: PASS (134.71 s)
 (6/8) type_specific.io-github-autotest-libvirt.chardev.data_transfer.serial.isa_target.pipe: PASS (140.10 s)
 (7/8) type_specific.io-github-autotest-libvirt.chardev.data_transfer.channel.virtio_target.file: PASS (78.17 s)
 (8/8) type_specific.io-github-autotest-libvirt.chardev.data_transfer.channel.virtio_target.pipe: PASS (86.82 s)

- Run on 8.9 with this pr ,all passed ,job name: 8.9-runtest-x86_64-function-chardev_pcie/6/

```