### PR TITLE
numa: Add version check for discard and emulator tests

### DIFF
--- a/libvirt/tests/cfg/numa/guest_numa_node_tuning/memory_binding_with_emulator_thread.cfg
+++ b/libvirt/tests/cfg/numa/guest_numa_node_tuning/memory_binding_with_emulator_thread.cfg
@@ -1,4 +1,5 @@
 - guest_numa_node_tuning.memory_binding_with_emulator_thread:
+    func_supported_since_libvirt_ver = (9, 3, 0)
     type = memory_binding_with_emulator_thread
     take_regular_screendumps = no
     start_vm = "no"    

--- a/libvirt/tests/cfg/numa/guest_numa_topology/various_numa_topology_settings.cfg
+++ b/libvirt/tests/cfg/numa/guest_numa_topology/various_numa_topology_settings.cfg
@@ -1,4 +1,5 @@
 - guest_numa_topology.various_numa_topology_settings:
+    func_supported_since_libvirt_ver = (9, 3, 0)
     type = various_numa_topology_settings
     take_regular_screendumps = no
     start_vm = "no"

--- a/libvirt/tests/src/numa/guest_numa_node_tuning/memory_binding_with_emulator_thread.py
+++ b/libvirt/tests/src/numa/guest_numa_node_tuning/memory_binding_with_emulator_thread.py
@@ -240,6 +240,7 @@ def run(test, params, env):
     """
     Test for numa memory binding with emulator thread pin
     """
+    libvirt_version.is_libvirt_feature_supported(params)
     vm_name = params.get("main_vm")
     vm = env.get_vm(vm_name)
     numatest_obj = numa_base.NumaTest(vm, params, test)

--- a/libvirt/tests/src/numa/guest_numa_topology/various_numa_topology_settings.py
+++ b/libvirt/tests/src/numa/guest_numa_topology/various_numa_topology_settings.py
@@ -10,6 +10,7 @@
 
 import re
 
+from virttest import libvirt_version
 from virttest import test_setup
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
@@ -166,6 +167,7 @@ def teardown_default(test_obj):
 
 
 def run(test, params, env):
+    libvirt_version.is_libvirt_feature_supported(params)
     vm_name = params.get("main_vm")
     vm = env.get_vm(vm_name)
     numatest_obj = numa_base.NumaTest(vm, params, test)


### PR DESCRIPTION
Test on 8 & 9, when set discrad as no, their behavior is different.
on 9.3, the discard-data is false in the qemu cmd line
on 8.9, no discard-data para in the qemu cmd line
    
 Has confirmed with feature owner, both behavior have the same effect.

Before fix on 8:
```
FAIL 1-type_specific.io-github-autotest-libvirt.guest_numa_topology.various_numa_topology_settings.discard_no.memaccess_none -> TestFail: Expecting 'discard-data' does exist in qemu command line, but  notfound
```

After fix on 8.
```
 (1/4) type_specific.io-github-autotest-libvirt.guest_numa_topology.various_numa_topology_settings.discard_no.memaccess_none: PASS (48.29 s)
 (2/4) type_specific.io-github-autotest-libvirt.guest_numa_topology.various_numa_topology_settings.discard_no.memaccess_shared: PASS (51.14 s)
 (3/4) type_specific.io-github-autotest-libvirt.guest_numa_topology.various_numa_topology_settings.discard_no.memaccess_private: PASS (50.82 s)
 (4/4) type_specific.io-github-autotest-libvirt.guest_numa_topology.various_numa_topology_settings.discard_no.memaccess_invalid: PASS (12.10 s)
```