### PR TITLE
numa_invalid_nodes: Update error message

### DIFF
--- a/libvirt/tests/cfg/numa/guest_numa_node_tuning/invalid_nodeset_of_numa_memory_binding.cfg
+++ b/libvirt/tests/cfg/numa/guest_numa_node_tuning/invalid_nodeset_of_numa_memory_binding.cfg
@@ -1,7 +1,7 @@
 - guest_numa_node_tuning.invalid_nodeset:
     type = invalid_nodeset_of_numa_memory_binding
     start_vm = "no"
-    error_msg = "error: unsupported configuration: NUMA node 2 is unavailable"
+    error_msg = "unsupported configuration: NUMA node 2 is unavailable"
     variants tuning:
         - strict:
             tuning_mode = "strict"


### PR DESCRIPTION
On 8, when testing for invalid nodeset with host numa nodes, it outputs "error : unsupported...".
There is a space between error and :, remove "error:" to fit tests on all releases.

Results as follows, the failed two cases are caused by a minor known bug, which won't fix on 8. And I have add them to the skiplist in ibvirt_ci.
```
 (01/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.host.partially_inexistent.strict: FAIL: Expect 'unsupported configuration: NUMA node 2 is unavailable' in 'VM 'avocado-vt-vm1' failed to start: error: Failed to start domain 'avocado-vt-vm1'\nerror: Invalid value '1-2' for 'cpuset.mems': Invalid argument(exit status: 1)'  (9.47 s)
 (02/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.host.partially_inexistent.interleave: PASS (17.13 s)
 (03/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.host.partially_inexistent.preferred: PASS (8.43 s)
 (04/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.host.partially_inexistent.restrictive: PASS (8.57 s)
 (05/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.host.totally_inexistent.strict: FAIL: Expect 'unsupported configuration: NUMA node 2 is unavailable' in 'VM 'avocado-vt-vm1' failed to start: error: Failed to start domain 'avocado-vt-vm1'\nerror: Invalid value '2-3' for 'cpuset.mems': Invalid argument(exit status: 1)'  (18.55 s)
 (06/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.host.totally_inexistent.interleave: PASS (8.48 s)
 (07/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.host.totally_inexistent.preferred: PASS (8.76 s)
 (08/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.host.totally_inexistent.restrictive: PASS (8.40 s)
 (09/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.guest.partially_inexistent.strict: PASS (7.94 s)
 (10/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.guest.partially_inexistent.interleave: PASS (7.87 s)
 (11/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.guest.partially_inexistent.preferred: PASS (17.00 s)
 (12/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.guest.partially_inexistent.restrictive: PASS (7.96 s)
 (13/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.guest.totally_inexistent.strict: PASS (8.07 s)
 (14/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.guest.totally_inexistent.interleave: PASS (8.15 s)
 (15/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.guest.totally_inexistent.preferred: PASS (7.99 s)
 (16/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.guest.totally_inexistent.restrictive: PASS (7.96 s)
```