### PR TITLE
numa_memory_binding_setting: Enable tests for aarch64

### DIFF
--- a/libvirt/tests/cfg/numa/guest_numa_node_tuning/memory_binding_setting.cfg
+++ b/libvirt/tests/cfg/numa/guest_numa_node_tuning/memory_binding_setting.cfg
@@ -3,8 +3,14 @@
     take_regular_screendumps = no
     start_vm = "no"    
     mem_value = "'memory': 2072576, 'memory_unit': 'KiB'"
+    target_hugepages = "512"
+    cpu_mode = 'host-model'
+    aarch64:
+        mem_value = "'memory': 2097152, 'memory_unit': 'KiB'"
+        target_hugepages = "3"
+        cpu_mode = 'host-passthrough'
     current_mem_value = ${mem_value}
-    vm_attrs = {${mem_value}, ${current_mem_value}, 'cpu': {'mode': 'host-model'}}    
+    vm_attrs = {${mem_value}, ${current_mem_value}, 'cpu': {'mode': '${cpu_mode}'}}
     variants memory_binding_nodeset:
         - single_host_node:
             single_host_node = yes
@@ -22,7 +28,12 @@
     variants pagesize:
         - default_pagesize:
             only single_host_node
+            default_pagesize = 4
+            aarch64:
+                default_pagesize = 64
         - hugepage:
             memory_backing = {'hugepages': {}}
             expected_hugepage_size = 2048
+            aarch64:
+                expected_hugepage_size = 524288
     numa_memory = {'mode': '${mem_mode}', 'nodeset': '%s'}


### PR DESCRIPTION
The default hugepage pagesize is 512M on aarch64, do some changes to enable tests for it.

Results as follows, the failed cases are other known issues which failed on x86 too.
```
 (01/12) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.memory_binding_setting.default_pagesize.mem_mode_strict.single_host_node: PASS (41.44 s)
 (02/12) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.memory_binding_setting.default_pagesize.mem_mode_interleave.single_host_node: FAIL: Expect cpuset.mems in path '/sys/fs/cgroup/cpuset/machine.slice/machine-qemu\x2d1\x2davocado\x2dvt\x2dvm1.scope/libvirt/emulator/cpuset.mems' to be '', but found '0-1' (43.79 s)
 (03/12) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.memory_binding_setting.default_pagesize.mem_mode_preferred.single_host_node: FAIL: Expect cpuset.mems in path '/sys/fs/cgroup/cpuset/machine.slice/machine-qemu\x2d1\x2davocado\x2dvt\x2dvm1.scope/libvirt/emulator/cpuset.mems' to be '', but found '0-1' (44.58 s)
 (04/12) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.memory_binding_setting.default_pagesize.mem_mode_restrictive.single_host_node: FAIL: The numa_maps should not include 'N1=', but  found (43.82 s)
 (05/12) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.memory_binding_setting.hugepage.mem_mode_strict.single_host_node: PASS (10.59 s)
 (06/12) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.memory_binding_setting.hugepage.mem_mode_strict.multiple_host_nodes: PASS (48.65 s)
 (07/12) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.memory_binding_setting.hugepage.mem_mode_interleave.single_host_node: FAIL: Expect cpuset.mems in path '/sys/fs/cgroup/cpuset/machine.slice/machine-qemu\x2d1\x2davocado\x2dvt\x2dvm1.scope/libvirt/emulator/cpuset.mems' to be '', but found '0-1' (48.68 s)
 (08/12) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.memory_binding_setting.hugepage.mem_mode_interleave.multiple_host_nodes: FAIL: Expect cpuset.mems in path '/sys/fs/cgroup/cpuset/machine.slice/machine-qemu\x2d1\x2davocado\x2dvt\x2dvm1.scope/libvirt/emulator/cpuset.mems' to be '', but found '0-1' (50.70 s)
 (09/12) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.memory_binding_setting.hugepage.mem_mode_preferred.single_host_node: FAIL: Expect cpuset.mems in path '/sys/fs/cgroup/cpuset/machine.slice/machine-qemu\x2d1\x2davocado\x2dvt\x2dvm1.scope/libvirt/emulator/cpuset.mems' to be '', but found '0-1' (50.40 s)
 (10/12) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.memory_binding_setting.hugepage.mem_mode_preferred.multiple_host_nodes: PASS (10.39 s)
 (11/12) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.memory_binding_setting.hugepage.mem_mode_restrictive.single_host_node: FAIL: Expect should fail with one of unable to map backing store for guest RAM: Cannot allocate memory, but succeeded: Domain 'avocado-vt-vm1' started\n\n\n (44.93 s)
 (12/12) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.memory_binding_setting.hugepage.mem_mode_restrictive.multiple_host_nodes: PASS (46.11 s)
```