### PR TITLE
Fix virtual_disks multidisk multi_queue failure on 390x

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
@@ -1081,6 +1081,10 @@ def run(test, params, env):
             # Ignore errors here
             session.cmd("dracut --force --add-drivers '%s'"
                         % add_disk_driver, timeout=360)
+            # In terms of s390x, additional step is needed for normal guest
+            # boot, see https://bugzilla.redhat.com/show_bug.cgi?id=2214147
+            if arch == 's390x':
+                session.cmd("zipl")
         session.close()
         vm.shutdown()
 


### PR DESCRIPTION
Fix virtual_disks.multidisks.coldplug.multi_disks_test.disk_virtio_scsi_multi_queue fail

In terms of s390x arch, additional step is needed for normal guest boot

See more details from https://bugzilla.redhat.com/show_bug.cgi?id=2214147