### PR TITLE
virtual_disk: wait for the disk be ready in guest

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
@@ -1626,6 +1626,7 @@ def run(test, params, env):
                 if len(device_attach_error) > i:
                     disk_attach_error = "yes" == device_attach_error[i]
                 libvirt.check_exit_status(ret, disk_attach_error)
+                time.sleep(3)
             if attach_ccw_address_at_dt_disk:
                 attach_option = device_attach_option[0].replace('--live', '--config')
                 ret = virsh.attach_disk(vm_name, disks[0]["source"],


### PR DESCRIPTION
sleep 3s to wait for the disk be ready after attaching the disk to guest

Before:
```
FAIL 1-type_specific.io-github-autotest-libvirt.virtual_disks.multidisks.coldplug.single_disk_test.disk_readonly_nfs_cdrom.coldplug_with_at_dt_disk -> TestFail: Checking disk readonly option failed
```

After:
```
PASS 1-type_specific.io-github-autotest-libvirt.virtual_disks.multidisks.coldplug.single_disk_test.disk_readonly_nfs_cdrom.coldplug_with_at_dt_disk
```