### PR TITLE
backingchain: add new test scenario for raw format

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockcommit/blockcommit_conventional_chain.cfg
+++ b/libvirt/tests/cfg/backingchain/blockcommit/blockcommit_conventional_chain.cfg
@@ -18,9 +18,13 @@
             top_image_suffix = 3
             expected_chain = "4>base"
     variants:
-        - file_disk:
+        - file_disk_qcow2:
             disk_type = "file"
             disk_dict = {"type_name":"${disk_type}", "target":{"dev": "${target_disk}", "bus": "virtio"}, "driver": {"name": "qemu", "type":"qcow2"}}
+        - file_disk_raw:
+            disk_type = "file"
+            disk_image_format = "raw"
+            disk_dict = {"type_name":"${disk_type}", "target":{"dev": "${target_disk}", "bus": "virtio"}, "driver": {"name": "qemu", "type":"raw"}}
         - block_disk:
             disk_type = "block"
             disk_dict = {"type_name":"${disk_type}", "target":{"dev": "${target_disk}", "bus": "virtio"}, "driver": {"name": "qemu", "type":"raw"}}

--- a/provider/virtual_disk/disk_base.py
+++ b/provider/virtual_disk/disk_base.py
@@ -120,8 +120,8 @@ class DiskBase(object):
                 size = kwargs.get("size", "50M")
                 if kwargs.get("size"):
                     kwargs.pop("size")
-                libvirt.create_local_disk("file", path=new_image_path,
-                                          size=size, disk_format="qcow2",
+                libvirt.create_local_disk("file", path=new_image_path, size=size,
+                                          disk_format=self.params.get("disk_image_format", 'qcow2'),
                                           **kwargs)
             disk_dict.update({'source': {'attrs': {'file': new_image_path}}})
 


### PR DESCRIPTION
This PR automate the new test scenario of raw guest image in: VIRT-292832 - Do blockcommit for conventional chain