### PR TITLE
fix memory case libvirt version issue

### DIFF
--- a/libvirt/tests/cfg/memory/memory_allocation/memory_invalid_value.cfg
+++ b/libvirt/tests/cfg/memory/memory_allocation/memory_invalid_value.cfg
@@ -30,6 +30,7 @@
         - mam_memory:
             vm_attrs = {'max_mem_rt': ${value}, 'max_mem_rt_slots': ${max_mem_slots}, 'max_mem_rt_unit': "${max_mem_unit}",'memory_unit':"${mem_unit}",'memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}','vcpu': 4,'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '${numa_mem}', 'unit': 'KiB'},{'id':'1','cpus': '2-3','memory':'${numa_mem}','unit':'KiB'}]}}
             error_msg = "both maximum memory size and memory slot count must be specified"
+            error_msg_2 = "maximum memory size must be specified when specifying number of memory slot"
             status_error = "yes"
         - numa:
             xpaths_list = [{'element_attrs':[".//cell[@id='0']"]}, {'element_attrs':[".//memory[@unit='${mem_unit}']"], 'text':'${numa_mem}'}, {'element_attrs':[".//currentMemory[@unit='${current_mem_unit}']"], 'text':'${numa_mem}'}]

--- a/libvirt/tests/src/memory/memory_allocation/lifecycle_with_memory_allocation.py
+++ b/libvirt/tests/src/memory/memory_allocation/lifecycle_with_memory_allocation.py
@@ -11,6 +11,7 @@
 import os
 
 from virttest import virsh
+from virttest import libvirt_version
 from virttest import utils_libvirtd
 
 from virttest.libvirt_xml import vm_xml
@@ -121,7 +122,10 @@ def run(test, params, env):
         """
         expected_str = ""
         if mem_config == "without_maxmemory":
-            expected_str = r"-m %s" % str(int(mem_value/1024))
+            if libvirt_version.version_compare(9, 5, 0):
+                expected_str = r"-m size=%sk" % mem_value
+            else:
+                expected_str = r"-m %s" % str(int(mem_value/1024))
         elif mem_config == "with_numa":
             expected_str = r"-m size=%dk,slots=%d,maxmem=%dk" % (
                 int(mem_value), max_mem_slots, int(max_mem))

--- a/libvirt/tests/src/memory/memory_allocation/memory_invalid_value.py
+++ b/libvirt/tests/src/memory/memory_allocation/memory_invalid_value.py
@@ -31,7 +31,12 @@ def run(test, params, env):
         if num == "minus":
             libvirt.check_result(cmd_result, minus_error_msg)
         elif num == "zero":
-            if error_msg:
+            if mem_config == "mam_memory":
+                if libvirt_version.version_compare(9, 5, 0):
+                    libvirt.check_result(cmd_result, error_msg_2)
+                else:
+                    libvirt.check_result(cmd_result, error_msg)
+            elif mem_config == "memory":
                 libvirt.check_result(cmd_result, error_msg)
             else:
                 test.log.info("TEST_STEP2: Check xml after define")
@@ -54,7 +59,6 @@ def run(test, params, env):
         Check current mem device config
         """
         vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
-        test.log.debug('111111111111111111111:%s', vmxml)
         libvirt_vmxml.check_guest_xml_by_xpaths(vmxml, xpaths_list)
 
     vm_name = params.get("main_vm")
@@ -62,6 +66,7 @@ def run(test, params, env):
     bkxml = vmxml.copy()
 
     error_msg = params.get("error_msg", "")
+    error_msg_2 = params.get("error_msg_2", "")
     minus_error_msg = params.get("minus_error_msg", "")
     start_error_msg = params.get("start_error_msg", "")
 


### PR DESCRIPTION
    Signed-off-by: nanli <nanli@redhat.com>

The first case
Before fix:

`  L0045 ERROR| avocado.core.exceptions.TestFail: Expecting '-m 2048' does exist in qemu command line, but  notfound`

After fix:
```

 [root@dell-per750-30 tp-libvirt]# rpm -q libvirt
libvirt-9.5.0-0rc1.1.el9.x86_64

 [root@dell-per750-30 tp-libvirt]# avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 memory.allocation.lifecycle.positive_test.without_maxmemory --vt-connect-uri qemu:///system

 (1/1) type_specific.io-github-autotest-libvirt.memory.allocation.lifecycle.positive_test.without_maxmemory: PASS (105.28 s)
```


```
[root@cloud-qe-05 tp-libvirt]# rpm -q libvirt
libvirt-8.0.0-21.module+el8.9.0+19166+e262ca96.x86_64
[root@cloud-qe-05 tp-libvirt]# avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 memory.allocation.lifecycle.positive_test.without_maxmemory --vt-connect-uri qemu:///system

 (1/1) type_specific.io-github-autotest-libvirt.memory.allocation.lifecycle.positive_test.without_maxmemory: PASS (137.06 s)

```