### PR TITLE
cpu: Remove cases about iothread 'poll-' value validation

### DIFF
--- a/libvirt/tests/cfg/cpu/iothread.cfg
+++ b/libvirt/tests/cfg/cpu/iothread.cfg
@@ -84,18 +84,6 @@
                     iothreadset_id = "1"
                     test_operations = "iothreadset"
                     variants:
-                        - invalid_value:
-                            val = 2147483648
-                            variants:
-                                - poll_max_ns:
-                                    iothreadset_val = "--poll-max-ns ${val} --poll-grow 2147483647 --poll-shrink 2147483647"
-                                    err_msg = "error: unsupported configuration: poll-max-ns \(${val}\) must be less than or equal to 2147483647"
-                                - poll_grow:
-                                    iothreadset_val = "--poll-max-ns 2147483647 --poll-grow ${val} --poll-shrink 2147483647"
-                                    err_msg = "error: unsupported configuration: poll-grow \(${val}\) must be less than or equal to 2147483647"
-                                - poll_shrink:
-                                    iothreadset_val = "--poll-max-ns 2147483647 --poll-grow 2147483647 --poll-shrink ${val}"
-                                    err_msg = "error: unsupported configuration: poll-shrink \(${val}\) must be less than or equal to 2147483647"
                         - invalid_string:
                             val = "abcd"
                             variants:


### PR DESCRIPTION
The type of iothread's 'poll*' attributes were changed from unsigned int to unsigned long long and the validation of iothread 'poll-' value were removed from codes, so deleting the related cases.