### PR TITLE
guest_os_booting: fix loader/nvram script to use firmware_type

### DIFF
--- a/libvirt/tests/cfg/guest_os_booting/ovmf_firmware/ovmf_loader.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/ovmf_firmware/ovmf_loader.cfg
@@ -3,6 +3,7 @@
     start_vm = no
     loader_path = "/usr/share/edk2/ovmf/OVMF_CODE.secboot.fd"
     smm_state = "on"
+    firmware_type = "ovmf"
     only q35
     variants:
         - positive_test:

--- a/libvirt/tests/cfg/guest_os_booting/ovmf_firmware/ovmf_nvram.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/ovmf_firmware/ovmf_nvram.cfg
@@ -4,6 +4,7 @@
     smm_state = "on"
     loader_path = "/usr/share/edk2/ovmf/OVMF_CODE.secboot.fd"
     nvram_dict = {'secure': 'yes', 'loader_readonly': 'yes', 'loader_type': 'pflash', 'loader': '${loader_path}', 'nvram_attrs': {'template': '%s'}}
+    firmware_type = "ovmf"
     only q35
     variants:
         - positive_test:

--- a/libvirt/tests/src/guest_os_booting/ovmf_firmware/ovmf_loader.py
+++ b/libvirt/tests/src/guest_os_booting/ovmf_firmware/ovmf_loader.py
@@ -25,6 +25,7 @@ def run(test, params, env):
     2) Start and boot the guest.
     """
     vm_name = params.get("main_vm")
+    firmware_type = params.get("firmware_type")
     loader_dict = eval(params.get("loader_dict", "{}"))
     loader_xpath = eval(params.get("loader_xpath", "[]"))
     smm_state = params.get("smm_state", "off")
@@ -40,7 +41,7 @@ def run(test, params, env):
 
     try:
         guest_os.prepare_smm_xml(vm_name, smm_state, "")
-        vmxml = guest_os.prepare_os_xml(vm_name, loader_dict)
+        vmxml = guest_os.prepare_os_xml(vm_name, loader_dict, firmware_type)
         # stateless='yes' only use for AMD test, so here we only check the dumpxml for it to avoid the machine issue
         if stateless:
             virsh.start(vm_name, debug=True)

--- a/libvirt/tests/src/guest_os_booting/ovmf_firmware/ovmf_nvram.py
+++ b/libvirt/tests/src/guest_os_booting/ovmf_firmware/ovmf_nvram.py
@@ -18,6 +18,7 @@ def run(test, params, env):
     2) Start and boot the guest.
     """
     vm_name = params.get("main_vm")
+    firmware_type = params.get("firmware_type")
     smm_state = params.get("smm_state", "off")
     error_msg = params.get("error_msg", "")
     template_path = params.get("template_path", "")
@@ -32,7 +33,7 @@ def run(test, params, env):
 
     try:
         guest_os.prepare_smm_xml(vm_name, smm_state, smm_size=None)
-        guest_os.prepare_os_xml(vm_name, nvram_dict)
+        guest_os.prepare_os_xml(vm_name, nvram_dict, firmware_type)
         guest_os.check_vm_startup(vm, vm_name, error_msg)
     finally:
         bkxml.sync()


### PR DESCRIPTION
To distinguish ovmf and seabios in test, we add a new variable firmware_type. Here update this variable to previous merged loader/nvram script.