### PR TITLE
Exportfs command not found error fixing!

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domblkerror.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domblkerror.py
@@ -14,6 +14,7 @@ from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.disk import Disk
 from virttest.staging.service import Factory
+from virttest.utils_package import package_install
 
 
 # Using as lower capital is not the best way to do, but this is just a
@@ -27,6 +28,9 @@ def run(test, params, env):
     1. unspecified error
     2. no space
     """
+    # Install nfs-utils package.
+    if not package_install("nfs-utils"):
+        test.cancel("Need nfs-utils package for exportfs command, can't install it")
 
     if not virsh.has_help_command('domblkerror'):
         test.cancel("This version of libvirt does not support domblkerror "

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_restore.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_restore.py
@@ -15,7 +15,7 @@ from virttest import libvirt_version
 
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
-
+from virttest.utils_package import package_install
 
 # Using as lower capital is not the best way to do, but this is just a
 # workaround to avoid changing the entire file.
@@ -33,6 +33,10 @@ def run(test, params, env):
     4.Recover test environment.
     5.Confirm the test result.
     """
+    # Install nfs-utils package.
+    if not package_install("nfs-utils"):
+        test.cancel("Need nfs-utils package for exportfs command, can't install it")
+
     def check_file_own(file_path, exp_uid, exp_gid):
         """
         Check the uid and gid of file_path


### PR DESCRIPTION
Some tests require "exportfs" command which comes with the "nfs-utils" package so this patch will check if the nfs-utils package is installed else it will install that package, so the following error won't occur:

Error: Command 'exportfs' could not be found in any of the PATH dirs: ['/bin', '/root/.local/bin', '/root/bin', '/sbin', '/usr/bin', '/usr/libexec', '/usr/local/bin', '/usr/local/sbin', '/usr/sbin', '/usr/share/Modules/bin'] .
Signed-off-by :Anushree Mathur <anushree.mathur@linux.vnet.ibm.com>