### PR TITLE
libvirt_rng: fix incompatible param type

### DIFF
--- a/libvirt/tests/cfg/libvirt_rng.cfg
+++ b/libvirt/tests/cfg/libvirt_rng.cfg
@@ -58,7 +58,7 @@
                     with_packed = "yes"
                     driver_packed = "on"
                 - invalid_address:
-                    address = "domain=0x9999 bus=0x00 slot=0x00 function=0x0"
+                    address = "{ 'domain': '0x9999', 'bus': '0x00', 'slot': '0x00', 'function': '0x0'}"
                     expected_create_error = "Invalid PCI address"
                 - invalid_model:
                     rng_model = virtio-abc

--- a/libvirt/tests/src/libvirt_rng.py
+++ b/libvirt/tests/src/libvirt_rng.py
@@ -161,7 +161,7 @@ def run(test, params, env):
                                           "").split()
         backend_protocol = dparams.get("backend_protocol")
         rng_alias = dparams.get("rng_alias")
-        device_address = dparams.get_dict("address", "")
+        device_address = dparams.get("address")
         vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
         rng_xml = rng.Rng()
         rng_xml.rng_model = rng_model
@@ -185,7 +185,7 @@ def run(test, params, env):
         if with_packed:
             rng_xml.driver = dict(packed=driver_packed)
         if device_address:
-            rng_xml.address = rng_xml.new_rng_address(**{"attrs": device_address})
+            rng_xml.address = rng_xml.new_rng_address(**{"attrs": ast.literal_eval(device_address)})
 
         logging.debug("Rng xml: %s", rng_xml)
         if get_xml:


### PR DESCRIPTION
4cc1a3b3c3c7acd921341e719ae4167078617d25 introduced a new parameter but the type was incompatible for the multiple_rng test variant.