### PR TITLE
Fix the ovmf smm failure of inconsistency between os xml and smm status

### DIFF
--- a/libvirt/tests/src/guest_os_booting/ovmf_firmware/ovmf_smm.py
+++ b/libvirt/tests/src/guest_os_booting/ovmf_firmware/ovmf_smm.py
@@ -9,6 +9,7 @@
 #
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import xcepts
+from virttest.utils_libvirt import libvirt_bios
 from virttest.utils_libvirt import libvirt_vmxml
 
 from provider.guest_os_booting import guest_os_booting_base as guest_os
@@ -34,13 +35,16 @@ def run(test, params, env):
 
     try:
         try:
+            if smm_state == "off":
+                vmxml.os = libvirt_bios.remove_bootconfig_items_from_vmos(vmxml.os)
+                vmxml.sync()
             guest_os.prepare_smm_xml(vm_name, smm_state, smm_tseg_size)
         except xcepts.LibvirtXMLError as details:
             if error_msg and error_msg in str(details):
                 test.log.info("Get expected error message: %s.", error_msg)
                 return
             else:
-                test.fail("Failed to define the guest because error:%s", str(details))
+                test.fail("Failed to define the guest because error:%s" % str(details))
         if smm_state == "off":
             guest_os.prepare_os_xml(vm_name, loader_dict, firmware_type)
         vmxml = guest_os.check_vm_startup(vm, vm_name, error_msg)


### PR DESCRIPTION
When disabling the smm, the non-secure boot status should be configured. In fact, the guest still uses the secure boot. So it get error "Unable to find any firmware to satisfy 'efi'". Adjust the xml configuration here.