### PR TITLE
Replaced 'or' with 'and' to Fix a wrong if condition

### DIFF
--- a/libvirt/tests/src/virsh_cmd/interface/virsh_iface_bridge.py
+++ b/libvirt/tests/src/virsh_cmd/interface/virsh_iface_bridge.py
@@ -83,7 +83,7 @@ def run(test, params, env):
     NW_status = NW_service.status()
     if NW_status is None:
         logging.debug("network service not found")
-        if (not utils_package.package_install('network-scripts') or
+        if (not utils_package.package_install('network-scripts') and
                 not utils_package.package_install('initscripts')):
             test.cancel("Failed to install network service")
     if NW_status is not True:


### PR DESCRIPTION
Signed-off-by: Kowshik Jois B S <kowsjois@linux.ibm.com>

Description:
- Here the test needs either of the packages to be installed.
- Since there is 'not' in the 'if' condition, it should have 'and' instead of 'or'.
- With the current code, it keeps looking for first one and prints the error message.
- It will never look at the second as first 'True' condition is sufficient for OR.