### PR TITLE
guest_resoure_control: Fix regexp for getting first nvme disk

### DIFF
--- a/libvirt/tests/src/guest_resource_control/control_cgroup.py
+++ b/libvirt/tests/src/guest_resource_control/control_cgroup.py
@@ -39,7 +39,7 @@ def run(test, params, env):
         first_disk = ""
         disks = utils_disk.get_parts_list()
         for disk in disks:
-            pattern = re.compile('[0-9]+')
+            pattern = re.compile('p[0-9]+') if 'nvme' in disk else re.compile('[0-9]+')
             if not pattern.findall(disk):
                 first_disk = disk
                 break


### PR DESCRIPTION
The current regexp can not used for getting nvme disk, so update the regexp.

https://github.com/avocado-framework/avocado-vt/pull/3724 fix the behaviour in guest.

Before:
```
ERROR| ERROR 1-type_specific.io-github-autotest-libvirt.guest_resource_control.control_cgroup.vm_running.hot.blkiotune.weight.positive -> CmdError: Command 'cat /sys/block//queue/scheduler' failed.
stdout: b''
stderr: b'cat: /sys/block//queue/scheduler: No such file or directory\n'
additional_info: None
```
After:
```
INFO | PASS 1-type_specific.io-github-autotest-libvirt.guest_resource_control.control_cgroup.vm_running.hot.blkiotune.weight.positive
```