### PR TITLE
virtual_disk: Wait for partition to be ready before mkfs

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_multivms.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multivms.py
@@ -9,6 +9,7 @@ from virttest import data_dir
 from virttest import virt_vm
 from virttest import virsh
 from virttest import remote
+from virttest import utils_disk
 from virttest import utils_misc
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
@@ -151,6 +152,8 @@ def run(test, params, env):
             # Format the disk and make the file system.
             libvirt.mk_label(disk_source)
             libvirt.mk_part(disk_source, size="10M")
+            if not utils_misc.wait_for(lambda: "%s1" % disk_source.split("/")[-1] in utils_disk.get_parts_list(), timeout=5):
+                test.fail("Partition %s1 can not be ready" % disk_source)
             libvirt.mkfs("%s1" % disk_source, "ext3")
             disk_source += "1"
             disks.append({"format": disk_format,


### PR DESCRIPTION
Wait for the partition to be ready before making a file system on it.

Before:
```
ERROR 1-type_specific.io-github-autotest-libvirt.virtual_disks.multivms.coldplug.vms_sharable_test.block_type -> CmdError: Command 'mkfs.ext3 -F /dev/sdb1 ' failed
```
After:
```
PASS 1-type_specific.io-github-autotest-libvirt.virtual_disks.multivms.coldplug.vms_sharable_test.block_type
```