### PR TITLE
v2v: add TC "Clear error msg when no vpx username"

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -836,9 +836,18 @@
             only esx_80
             version_required = "[virt-v2v-1.42.0-22.el8_8,)"
             main_vm = VM_NAME_ESX80_MULTI_SPEC_V2V_EXAMPLE
+        - no_vpx_username:
+            only esx_80
+            only it_default
+            only negative_test
+            version_required = "[libvirt-9.3.0-1.el9,)"
+            main_vm = VM_NAME_NON_ADMIN_V2V_EXAMPLE
+            msg_content = 'virt-v2v: error: exception: libvirt: VIR_ERR_AUTH_FAILED: VIR_FROM_AUTH: authentication failed: Username request failed'
+            expect_msg = yes
+            vpx_no_username = True
     variants:
         - positive_test:
             status_error = 'no'
         - negative_test:
             status_error = 'yes'
-            only option_root.single,invalid_rhv_pem,no-copy-illegal,system_rhv_pem.unset,logs.open_source,keys.invalid,invalid_mac_ip,block_dev.small,no_space,inodes.less_inodes,windows.external_poweroff,must_ip,no_ovirtsdk4_pkg,vddk_errors_41_disks,invalid_vddk_thumbprint
+            only option_root.single,invalid_rhv_pem,no-copy-illegal,system_rhv_pem.unset,logs.open_source,keys.invalid,invalid_mac_ip,block_dev.small,no_space,inodes.less_inodes,windows.external_poweroff,must_ip,no_ovirtsdk4_pkg,vddk_errors_41_disks,invalid_vddk_thumbprint,no_vpx_username


### PR DESCRIPTION
Refer bz#2181235

And refer https://github.com/avocado-framework/avocado-vt/pull/3725/ 