### PR TITLE
virtual_networks: Increase trafic for comparing iface stat between host and guest

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_stat.py
+++ b/libvirt/tests/src/virtual_network/iface_stat.py
@@ -137,9 +137,10 @@ def run(test, params, env):
         if case == 'compare':
 
             def _collect_and_compare_stat(vm_name, session, **virsh_args):
-                session.cmd('curl -O https://avocado-project.org/data/'
-                            'assets/jeos/27/jeos-27-64.qcow2.xz -L',
-                            timeout=240)
+                for _ in range(3):
+                    session.cmd('curl -O https://avocado-project.org/data/'
+                                'assets/jeos/27/jeos-27-64.qcow2.xz -L',
+                                timeout=240)
                 host_iface_stat = get_host_iface_stat(vm_name,
                                                       iface_target_dev,
                                                       **virsh_args)


### PR DESCRIPTION
When the traffic is too small, the ratio of iface stat data between host ande guest may be relatively large, increasing the traffic and making the data used for comparison more reliable.

Before:
```
FAIL 1-type_specific.io-github-autotest-libvirt.virtual_network.iface_stat.compare.ethernet_type.managed_no.tap -> TestFail: Iface stat of host and vm should be close.
```

After:
```
PASS 1-type_specific.io-github-autotest-libvirt.virtual_network.iface_stat.compare.ethernet_type.managed_no.tap
```