### PR TITLE
sriov: Fixup an issue due to error message change

### DIFF
--- a/libvirt/tests/cfg/sriov/vm_lifecycle/sriov_vm_lifecycle_managedsave.cfg
+++ b/libvirt/tests/cfg/sriov/vm_lifecycle/sriov_vm_lifecycle_managedsave.cfg
@@ -2,7 +2,7 @@
     type = sriov_vm_lifecycle_managedsave
     start_vm = "no"
     status_error = "yes"
-    err_msg = "cannot migrate.*domain.*(VFIO device doesn't support|with.*hostdev)"
+    err_msg = "cannot migrate.*domain.*(VFIO.*migration|with.*hostdev)"
     only x86_64
     variants dev_type:
         - hostdev_interface:


### PR DESCRIPTION
Update error message to handle the latest change.


**Test result:**
` (1/1) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.managedsave.hostdev_device.vf_address.managed_yes: PASS (49.74 s)`
