### PR TITLE
fix get correct log attr

### DIFF
--- a/libvirt/tests/cfg/chardev/log/chardev_with_log_file.cfg
+++ b/libvirt/tests/cfg/chardev/log/chardev_with_log_file.cfg
@@ -9,10 +9,10 @@
             variants console_type:
                 - pty:
                     chardev_type = "pty"
-                    device_dict = "{'type_name':'${chardev_type}','log_file': {'file': '${log_file}', 'append':'off'}}"
+                    device_dict = "{'type_name':'${chardev_type}','log': {'file': '${log_file}', 'append':'off'}}"
                 - unix:
                     chardev_type = 'unix'
                     source_mode = "bind"
                     source_path = "/tmp/foo"
                     access_cmd = "socat stdin unix-connect:${source_path}"
-                    device_dict = "{'type_name':'${chardev_type}','log_file': {'file': '${log_file}', 'append':'off'}, 'sources': [{'attrs': {'path': '${source_path}', 'mode':'${source_mode}'}}]}"
+                    device_dict = "{'type_name':'${chardev_type}','log': {'file': '${log_file}', 'append':'off'}, 'sources': [{'attrs': {'path': '${source_path}', 'mode':'${source_mode}'}}]}"


### PR DESCRIPTION
  log_file needs to be log
Signed-off-by: nanli <nanli@redhat.com>
```

avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 chardev.log

 (1/2) type_specific.io-github-autotest-libvirt.chardev.log.console.pty: PASS (49.88 s)
 (2/2) type_specific.io-github-autotest-libvirt.chardev.log.console.unix: PASS (49.88 s)

```