### PR TITLE
managed_save: Add version check for xpath_opt

### DIFF
--- a/libvirt/tests/cfg/save_and_restore/save_image_dumpxml.cfg
+++ b/libvirt/tests/cfg/save_and_restore/save_image_dumpxml.cfg
@@ -11,6 +11,7 @@
             check_sec = yes
             expect_graph_pw = yes
         - xpath_opt:
+            func_supported_since_libvirt_ver = (8, 5, 0)
             options = --xpath
             check_os = yes
             variants:

--- a/libvirt/tests/src/save_and_restore/save_image_dumpxml.py
+++ b/libvirt/tests/src/save_and_restore/save_image_dumpxml.py
@@ -1,6 +1,7 @@
 import logging
 import os
 
+from virttest import libvirt_version
 from virttest import utils_misc
 from virttest import virsh
 from virttest.libvirt_xml import base
@@ -61,6 +62,7 @@ def run(test, params, env):
     """
     Test virsh save-image-dumpxml with options
     """
+    libvirt_version.is_libvirt_feature_supported(params)
     vm_name = params.get('main_vm')
     vm = env.get_vm(vm_name)
 


### PR DESCRIPTION
libvirt support --xpath for `virsh save-image-dumpxml` since 8.5.0

Before:
```
 (1/2) type_specific.io-github-autotest-libvirt.save_and_restore.save_image_dumpxml.normal.xpath_opt.default: FAIL: error: command 'save-image-dumpxml' doesn't support option --xpath\n (26.26 s)
 (2/2) type_specific.io-github-autotest-libvirt.save_and_restore.save_image_dumpxml.normal.xpath_opt.wrap: FAIL: error: command 'save-image-dumpxml' doesn't support option --xpath\n (26.94 s)
```