### PR TITLE
v2v:fix 9.3 functional testing for failed TC

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -819,7 +819,7 @@
             version_required = "[nbdkit-1.30.8-1,)"
             main_vm = VM_NAME_ESX70_RHEL8_V2V_EXAMPLE
             vddk_thumbprint = 'AA:2B:AD'
-            msg_content_yes = "nbdkit: vddk[1]: error: Please verify whether the "thumbprint" parameter"
+            msg_content_yes = "error: Please verify whether the "thumbprint" parameter"
         - non_admin_user:
             only esx_80
             main_vm = VM_NAME_NON_ADMIN_V2V_EXAMPLE


### PR DESCRIPTION
Fix failed TC.

 (1/1) type_specific.io-github-autotest-libvirt.function_test_esx.negative_test.invalid_vddk_thumbprint.esx_70.rhev.rhv_upload.it_vddk.vpx_uri: PASS (79.71 s)
