### PR TITLE
numa: Fix small typo

### DIFF
--- a/libvirt/tests/cfg/numa/guest_numa_node_tuning/auto_memory_incompatible_guest_binding.cfg
+++ b/libvirt/tests/cfg/numa/guest_numa_node_tuning/auto_memory_incompatible_guest_binding.cfg
@@ -11,7 +11,7 @@
     current_mem_value = ${mem_value}
     cpu_mode = 'host-model'
     aarch64:
-        cpu_mode = 'host-pathrough'
+        cpu_mode = 'host-passthrough'
     only q35, aarch64
     variants auto_placement:
         - vcpu_auto:


### PR DESCRIPTION
host-pathrough --> host-passthrough

Test Results:
```
 (01/20) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_incompatible_guest_binding.memnode_strict.vcpu_auto: PASS (7.12 s)
 (02/20) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_incompatible_guest_binding.memnode_strict.mem_mode_strict: PASS (7.03 s)
 (03/20) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_incompatible_guest_binding.memnode_strict.mem_mode_interleave: PASS (7.23 s)                                                                                                                                                            
 (04/20) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_incompatible_guest_binding.memnode_strict.mem_mode_preferred: PASS (8.90 s)                                                                                                                                                             
 (05/20) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_incompatible_guest_binding.memnode_strict.mem_mode_restrictive: PASS (7.22 s)                                                                                                                                                           
 (06/20) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_incompatible_guest_binding.memnode_interleave.vcpu_auto: PASS (8.75 s)
 (07/20) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_incompatible_guest_binding.memnode_interleave.mem_mode_strict: PASS (7.17 s)                                                                                                                                                            
 (08/20) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_incompatible_guest_binding.memnode_interleave.mem_mode_interleave: PASS (8.83 s)                                                                                                                                                        
 (09/20) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_incompatible_guest_binding.memnode_interleave.mem_mode_preferred: PASS (7.13 s)                                                                                                                                                         
 (10/20) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_incompatible_guest_binding.memnode_interleave.mem_mode_restrictive: PASS (8.17 s)                                                                                                                                                       
 (11/20) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_incompatible_guest_binding.memnode_preferred.vcpu_auto: PASS (7.11 s)
 (12/20) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_incompatible_guest_binding.memnode_preferred.mem_mode_strict: PASS (8.76 s)                                                                                                                                                             
 (13/20) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_incompatible_guest_binding.memnode_preferred.mem_mode_interleave: PASS (7.13 s)                                                                                                                                                         
 (14/20) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_incompatible_guest_binding.memnode_preferred.mem_mode_preferred: PASS (9.08 s)                                                                                                                                                          
 (15/20) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_incompatible_guest_binding.memnode_preferred.mem_mode_restrictive: PASS (7.09 s)                                                                                                                                                        
 (16/20) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_incompatible_guest_binding.memnode_restrictive.vcpu_auto: PASS (9.04 s)
 (17/20) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_incompatible_guest_binding.memnode_restrictive.mem_mode_strict: PASS (7.32 s)                                                                                                                                                           
 (18/20) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_incompatible_guest_binding.memnode_restrictive.mem_mode_interleave: PASS (9.32 s)                                                                                                                                                       
 (19/20) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_incompatible_guest_binding.memnode_restrictive.mem_mode_preferred: PASS (7.12 s)                                                                                                                                                        
 (20/20) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_incompatible_guest_binding.memnode_restrictive.mem_mode_restrictive: PASS (8.72 s)
```