### PR TITLE
virtual_disks: stabilize tests that check a new disk was added

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/startup_policy.cfg
+++ b/libvirt/tests/cfg/virtual_disks/startup_policy.cfg
@@ -65,6 +65,7 @@
                             aarch64:
                                 disk_target_bus = "scsi"
                         - floppy:
+                            no s390-virtio
                             device_type = "floppy"
                             target_dev = "fda"
                             disk_target_bus = "fdc"
@@ -78,6 +79,7 @@
                                     target_dev = "vdb"
                                     disk_target_bus = "virtio"
                                 - sata_bus:
+                                    no s390-virtio
                                     target_dev = "sdb"
                                     disk_target_bus = "sata"
             variants:


### PR DESCRIPTION
Depends on https://github.com/avocado-framework/avocado-vt/pull/3729

Partition names under /cat/partitions might change
between boots, causing tests to fail in those cases.

Use instead information under /dev/disk/by-path.

Note, that pci disks might be listed twice, e.g.

'virtio-pci-0000:04:00.0-part1' and 'pci-0000:04:00.0-part1'.

Furthermore,

virtual_disk_ndb: remove unused parameter

startupPolicy: disable floppy, sata - not available on s390x