### PR TITLE
numa: Fix options for `virsh numatune`

### DIFF
--- a/libvirt/tests/src/numa/numa_memory_migrate.py
+++ b/libvirt/tests/src/numa/numa_memory_migrate.py
@@ -41,7 +41,7 @@ def run(test, params, env):
             raise exceptions.TestFail("nodes memory usage not expected.")
 
     vm_name = params.get("main_vm")
-    options = params.get("options", "live")
+    options = params.get("options", "--live")
     vm = env.get_vm(vm_name)
     backup_xml = libvirt_xml.VMXML.new_from_dumpxml(vm_name)
 


### PR DESCRIPTION
"live" --> "--live"

Before:
```
 (1/2) type_specific.io-github-autotest-libvirt.numa_memory_migrate.mem_auto: ERROR: Command '/usr/bin/virsh numatune avocado-vt-vm1 live --nodeset 0' failed.\nstdout: b'\n'\nstderr: b'error: Invalid mode: live\n'\nadditional_info: None (40.23 s)
 (2/2) type_specific.io-github-autotest-libvirt.numa_memory_migrate.mem_nodeset: ERROR: Command '/usr/bin/virsh numatune avocado-vt-vm1 live --nodeset 1' failed.\nstdout: b'\n'\nstderr: b'error: Invalid mode: live\n'\nadditional_info: None (44.94 s)
```

After:
```
 (1/2) type_specific.io-github-autotest-libvirt.numa_memory_migrate.mem_auto: PASS (41.97 s)
 (2/2) type_specific.io-github-autotest-libvirt.numa_memory_migrate.mem_nodeset: PASS (39.74 s)
```