### PR TITLE
Move actions related to tpm lib's permissions to provider

### DIFF
--- a/libvirt/tests/src/svirt/dac/dac_seclabel_overall_domain.py
+++ b/libvirt/tests/src/svirt/dac/dac_seclabel_overall_domain.py
@@ -10,6 +10,8 @@ from virttest.libvirt_xml.vm_xml import VMXML
 from virttest.utils_libvirt import libvirt_disk
 from virttest.utils_test import libvirt
 
+from provider.security import security_base
+
 
 def update_qemu_conf(vmxml, qemu_conf, seclabel_relabel, qemu_conf_user_group,
                      qemu_conf_user, qemu_conf_group=None):
@@ -59,37 +61,6 @@ def create_user(user):
     return added_user
 
 
-def set_tpm_perms(vmxml, params):
-    """
-    Set the perms of swtpm lib to allow other users to write in the dir.
-
-    :param vmxml: The vmxml object
-    :param params: Dictionary with the test parameters
-    """
-    swtpm_lib = params.get("swtpm_lib")
-    swtpm_perms_file = params.get("swtpm_perms_file")
-    if vmxml.devices.by_device_tag('tpm'):
-        cmd = "getfacl -R %s > %s" % (swtpm_lib, swtpm_perms_file)
-        process.run(cmd, ignore_status=True, shell=True)
-        cmd = "chmod -R 777 %s" % swtpm_lib
-        process.run(cmd, ignore_status=False, shell=True)
-
-
-def restore_tpm_perms(vmxml, params):
-    """
-    Restore the perms of swtpm lib.
-
-    :param vmxml: The vmxml object
-    :param params: Dictionary with the test parameters
-    """
-    swtpm_perms_file = params.get("swtpm_perms_file")
-    if vmxml.devices.by_device_tag('tpm'):
-        if os.path.isfile(swtpm_perms_file):
-            cmd = "setfacl --restore=%s" % swtpm_perms_file
-            process.run(cmd, ignore_status=True, shell=True)
-            os.unlink(swtpm_perms_file)
-
-
 def run(test, params, env):
     """
     Test overall domain dac <seclabel> can work correctly.
@@ -130,7 +101,7 @@ def run(test, params, env):
     seclabel_relabel = seclabel_attr.get("relabel") == "yes"
 
     try:
-        set_tpm_perms(vmxml, params)
+        security_base.set_tpm_perms(vmxml, params)
         if seclabel_attr.get("label"):
             qemu_conf_user = seclabel_attr.get("label").split(":")[0]
             if len(seclabel_attr.get("label").split(":")) >= 2:
@@ -197,4 +168,4 @@ def run(test, params, env):
         if added_user:
             process.run("userdel -r %s" % added_user,
                         ignore_status=False, shell=True)
-        restore_tpm_perms(vmxml, params)
+        security_base.restore_tpm_perms(vmxml, params)

--- a/provider/security/security_base.py
+++ b/provider/security/security_base.py
@@ -1,0 +1,34 @@
+import os
+
+from avocado.utils import process
+
+
+def set_tpm_perms(vmxml, params):
+    """
+    Set the perms of swtpm lib to allow other users to write in the dir.
+
+    :param vmxml: The vmxml object
+    :param params: Dictionary with the test parameters
+    """
+    swtpm_lib = params.get("swtpm_lib")
+    swtpm_perms_file = params.get("swtpm_perms_file")
+    if vmxml.devices.by_device_tag('tpm'):
+        cmd = "getfacl -R %s > %s" % (swtpm_lib, swtpm_perms_file)
+        process.run(cmd, ignore_status=True, shell=True)
+        cmd = "chmod -R 777 %s" % swtpm_lib
+        process.run(cmd, ignore_status=False, shell=True)
+
+
+def restore_tpm_perms(vmxml, params):
+    """
+    Restore the perms of swtpm lib.
+
+    :param vmxml: The vmxml object
+    :param params: Dictionary with the test parameters
+    """
+    swtpm_perms_file = params.get("swtpm_perms_file")
+    if vmxml.devices.by_device_tag('tpm'):
+        if os.path.isfile(swtpm_perms_file):
+            cmd = "setfacl --restore=%s" % swtpm_perms_file
+            process.run(cmd, ignore_status=True, shell=True)
+            os.unlink(swtpm_perms_file)


### PR DESCRIPTION
It could be called by other tests.

Test results:
 (1/1) type_specific.io-github-autotest-libvirt.svirt.dac.seclabel.overall_domain.enable_dynamic_ownership.static.without_qemu_conf_user_group.107_plus.relabel_yes.without_img_chown: PASS (9.91 s)
