### PR TITLE
selinux_seclabel_per_device: set correct device for s390x

### DIFF
--- a/libvirt/tests/cfg/svirt/selinux/selinux_seclabel_per_device.cfg
+++ b/libvirt/tests/cfg/svirt/selinux/selinux_seclabel_per_device.cfg
@@ -19,6 +19,8 @@
             serial_attrs = {'type_name': 'unix', 'target_type': 'pci-serial', 'target_model': 'pci-serial'}
             aarch64:
                 serial_attrs = {'type_name': 'unix', 'target_type': 'system-serial', 'target_model': 'pl011'}
+            s390-virtio:
+                serial_attrs = {'type_name': 'unix', 'target_type': 'sclp-serial', 'target_model': 'sclpconsole'}
     variants:
         - relabel_no:
             seclabel_attr_relabel = "no"


### PR DESCRIPTION
Default serial device on s390x should be sclpconsole.