### PR TITLE
label_restore_rules: fix image format

### DIFF
--- a/libvirt/tests/src/svirt/label_restore_rules/label_restore_rules_disk_access_modes.py
+++ b/libvirt/tests/src/svirt/label_restore_rules/label_restore_rules_disk_access_modes.py
@@ -51,7 +51,7 @@ def run(test, params, env):
         disk_path = vm.get_first_disk_devices()['source']
         if disk_attrs.get("share"):
             disk_path = data_dir.get_data_dir() + '/test.img'
-            libvirt_disk.create_disk("file", disk_path, disk_format="qcow2")
+            libvirt_disk.create_disk("file", disk_path, disk_format="raw")
             disk_attrs.update({'source': {'attrs': {'file': disk_path}}})
             disk_index = 1
         org_label = process.run("ls -lZ %s | awk '{print $3,$4,$5}'"


### PR DESCRIPTION
Shareable disks with qemu must have 'raw' image format. 'qcow2' can often work but will fail if host filesystem has blocksize 4096.