### PR TITLE
virtual_disks_multivms: fix image format

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_multivms.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_multivms.cfg
@@ -85,7 +85,7 @@
                     virt_disk_type = "file"
                     virt_disk_target = "vdb"
                     virt_disk_bus = "virtio"
-                    virt_disk_format = "qcow2"
+                    virt_disk_format = "raw"
         - vms_readonly_test:
             only coldplug
             virt_disk_test_readonly = "yes"


### PR DESCRIPTION
Shareable disks with qemu must have 'raw' format. 'qcow2' can often work but fill fail if host filesystem has blocksize 4096.