### PR TITLE
svirt/umask_value: enable huge pages on s390x

### DIFF
--- a/libvirt/tests/cfg/svirt/umask_value/svirt_umask_files_accessed_by_qemu.cfg
+++ b/libvirt/tests/cfg/svirt/umask_value/svirt_umask_files_accessed_by_qemu.cfg
@@ -6,3 +6,5 @@
     target_hugepages = 1024
     aarch64:
         target_hugepages = 4
+    s390-virtio:
+        kvm_module_parameters = "hpage=1"


### PR DESCRIPTION
On s390x, huge pages are not enabled by default in RHEL. Add config parameter to reload module with huge pages support.