### PR TITLE
dac_seclabel_per_device: fix serial config

### DIFF
--- a/libvirt/tests/cfg/svirt/dac/dac_seclabel_per_device.cfg
+++ b/libvirt/tests/cfg/svirt/dac/dac_seclabel_per_device.cfg
@@ -19,6 +19,8 @@
             serial_attrs = {'type_name': 'unix', 'target_type': 'pci-serial', 'target_model': 'pci-serial'}
             aarch64:
                 serial_attrs = {'type_name': 'unix', 'target_type': 'system-serial', 'target_model': 'pl011'}
+            s390-virtio:
+                serial_attrs = {'type_name': 'unix', 'target_type': 'sclp-serial', 'target_model': 'sclpconsole'}
     variants:
         - relabel_no:
             seclabel_attr_relabel = "no"


### PR DESCRIPTION
On s390x, the default serial device is sclpconsole.