### PR TITLE
default_dac_check: fix hugepage setup on s390x

### DIFF
--- a/libvirt/tests/cfg/svirt/default_dac_check.cfg
+++ b/libvirt/tests/cfg/svirt/default_dac_check.cfg
@@ -6,6 +6,9 @@
             umask = "027"
             huge_pages = "yes"
             check_type = "hugepage_file"
+            s390-virtio:
+                kvm_module_parameters = "hpage=1"
+                page_size = 1024
         - default_dir:
             check_type = "default_dir"
         - socket_file:

--- a/libvirt/tests/src/svirt/default_dac_check.py
+++ b/libvirt/tests/src/svirt/default_dac_check.py
@@ -73,7 +73,7 @@ def run(test, params, env):
         drop_caches()
         # Set umask
         process.run("umask %s" % umask, ignore_status=False, shell=True)
-        setup_hugepages(2048, 2000)
+        setup_hugepages(page_size, 2000)
         modify_domain_xml(vmxml)
         # Start guest
         vm.start()
@@ -105,6 +105,7 @@ def run(test, params, env):
     start_vm = ("yes" == params.get("start_vm", "no"))
     umask = params.get("umask", "022")
     huge_pages = ('yes' == params.get("huge_pages", "yes"))
+    page_size = int(params.get("page_size", "2048"))
     check_type = params.get("check_type")
 
     vm = env.get_vm(vm_name)


### PR DESCRIPTION
On s390x, huge pages are size 1M. Also, the support is not enabled by default on RHEL.

Set parameter `page_size` maintaining legacy behavior by setting default value `2048`.
Enable kvm module reload with huge page support on s390x.