### PR TITLE
virtaul_disk: Update regrex for alias_plus_boot_order

### DIFF
--- a/libvirt/tests/src/scsi/scsi_device.py
+++ b/libvirt/tests/src/scsi/scsi_device.py
@@ -233,9 +233,17 @@ def check_scsi_device_boot_order(test, params, env):
     """
     vm_name = params.get("main_vm")
 
-    match_alias_plus_boot_order1 = '"%s","bootindex":%s' % (params.get("alias_name_1"), params.get("boot_order_1"))
+    match_alias_plus_boot_order1 = '("%s","bootindex":%s)|(%s,bootindex=%s)'\
+                                   % (params.get("alias_name_1"),
+                                      params.get("boot_order_1"),
+                                      params.get("alias_name_1"),
+                                      params.get("boot_order_1"))
     libvirt.check_qemu_cmd_line(match_alias_plus_boot_order1)
-    match_alias_plus_boot_order2 = '"%s","bootindex":%s' % (params.get("alias_name_2"), params.get("boot_order_2"))
+    match_alias_plus_boot_order2 = '("%s","bootindex":%s)|(%s,bootindex=%s)'\
+                                   % (params.get("alias_name_2"),
+                                      params.get("boot_order_2"),
+                                      params.get("alias_name_2"),
+                                      params.get("boot_order_2"))
     libvirt.check_qemu_cmd_line(match_alias_plus_boot_order2)
     LOG.debug('boot order dumpxml:\n')
     LOG.debug(vm_xml.VMXML.new_from_dumpxml(vm_name))


### PR DESCRIPTION
Test on 8.0.0, the output of qemu_cmd_line is different, so update the regrex match to fit the test on 8.0.0

Before:
```
FAIL 1-type_specific.io-github-autotest-libvirt.scsi_device_manipulate.coldplug.scsi_hostdev.positive.boot_order -> TestFail: Expecting '"ua-alias_hostdev1","bootindex":2' does exist in qemu command line, but  notfound
```
After:
```
PASS 1-type_specific.io-github-autotest-libvirt.scsi_device_manipulate.coldplug.scsi_hostdev.positive.boot_order
```