### PR TITLE
virsh_detach_device_alias: fix for s390x

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
@@ -78,11 +78,15 @@
                     detach_input_type = "keyboard"
                     detach_check_xml = "<input type='${detach_input_type}' bus='usb'>"
                     input_dict = {"type_name":"${detach_input_type}","input_bus": "usb"}
+                    s390-virtio:
+                        detach_check_xml = "<input type='${detach_input_type}' bus='virtio'>"
+                        input_dict = {"type_name":"${detach_input_type}","input_bus": "virtio"}
                 - mouse:
                     detach_input_type = "mouse"
                     detach_check_xml = "<input type='${detach_input_type}' bus='virtio'>"
                     input_dict = {"type_name":"${detach_input_type}","input_bus": "virtio"}
                 - passthrough:
+                    no s390-virtio
                     detach_input_type = "passthrough"
                     detach_check_xml = "<input type='${detach_input_type}' bus='virtio'>"
                     input_dict = {"type_name":"${detach_input_type}","input_bus": "virtio"}

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
@@ -268,7 +268,6 @@ def run(test, params, env):
             event = process.run("ls /dev/input/event*", shell=True).stdout
             input_dict.update({"source_evdev": event.decode('utf-8').split()[0]})
 
-        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
         input_obj = Input(type_name=input_type)
         input_obj.setup_attrs(**input_dict)
         libvirt.add_vm_device(vmxml, input_obj)


### PR DESCRIPTION
keyboard is virtio, passthrough not available on s390x

Also, fix an issue where the VM ends up with two input devices if it already had one because it read the xml again after removing it.