### PR TITLE
watchdog: run tco tests only with q35 machine

### DIFF
--- a/libvirt/tests/cfg/virtual_device/watchdog.cfg
+++ b/libvirt/tests/cfg/virtual_device/watchdog.cfg
@@ -24,7 +24,7 @@
             model = "diag288"
             model_test = "yes"
         - model_tco:
-            no pseries
+            only q35
             model = "itco"
             func_supported_since_libvirt_ver = (9, 1, 0)
             variants:


### PR DESCRIPTION
Only supported on q35,

"error: unsupported configuration: itco model of watchdog is only part of q35 machine"