### PR TITLE
memory_binding_setting: fix incorrect exception message

### DIFF
--- a/libvirt/tests/src/numa/guest_numa_node_tuning/memory_binding_setting.py
+++ b/libvirt/tests/src/numa/guest_numa_node_tuning/memory_binding_setting.py
@@ -255,17 +255,17 @@ def teardown_default(test_obj):
     if test_obj.params.get('memory_backing'):
         expected_hugepage_size = test_obj.params.get('expected_hugepage_size')
         hpc = test_obj.params.get('hp_config_obj')
-        all_nodes = test_obj.online_nodes_withmem
-        hpc.set_node_num_huge_pages('0', all_nodes[0], expected_hugepage_size)
-        test_obj.test.log.debug("Get first node hugepage is "
-                                "%d", hpc.get_node_num_huge_pages(all_nodes[0],
-                                                                  expected_hugepage_size))
-        hpc.set_node_num_huge_pages('0', all_nodes[1], expected_hugepage_size)
-        test_obj.test.log.debug("Get second node hugepage is "
-                                "%d", hpc.get_node_num_huge_pages(all_nodes[1],
-                                                                  expected_hugepage_size))
-
-        test_obj.test.log.debug("Step: hugepage is deallocated")
+        if hpc:
+            all_nodes = test_obj.online_nodes_withmem
+            hpc.set_node_num_huge_pages('0', all_nodes[0], expected_hugepage_size)
+            test_obj.test.log.debug("Get first node hugepage is "
+                                    "%d", hpc.get_node_num_huge_pages(all_nodes[0],
+                                                                      expected_hugepage_size))
+            hpc.set_node_num_huge_pages('0', all_nodes[1], expected_hugepage_size)
+            test_obj.test.log.debug("Get second node hugepage is "
+                                    "%d", hpc.get_node_num_huge_pages(all_nodes[1],
+                                                                      expected_hugepage_size))
+            test_obj.test.log.debug("Step: hugepage is deallocated")
 
     test_obj.test.log.debug("Step: teardown is done")
 


### PR DESCRIPTION
The first exception message is below:
`avocado.core.exceptions.TestCancel: Expect 2 numa nodes at least, but found 1.`
But the final exception message is below.
`AttributeError: 'NoneType' object has no attribute 'set_node_num_huge_pages'`

The first exception is root cause , but overwritten by the final one. This is because insufficient handling in teardown function.
This patch is a simple fix for this issue.