### PR TITLE
virsh_nodeinfo: skip on AMD

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_nodeinfo.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_nodeinfo.cfg
@@ -4,7 +4,7 @@
     start_vm = no
     virsh_node_options = ""
     status_error = "no"
-    variants:
+    variants test_case:
         - no_option:
             libvirtd = "on"
         - disable_enable_vcpu:

--- a/libvirt/tests/src/virsh_cmd/host/virsh_nodeinfo.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_nodeinfo.py
@@ -22,6 +22,18 @@ from virttest.staging import utils_memory
 logging = log.getLogger('avocado.' + __name__)
 
 
+def check_skip_case(params, test):
+    """
+    Check if the case should be run
+
+    :param params: dict, test parameters
+    :param test: test object
+    """
+    test_case = params.get('test_case')
+    if test_case == 'no_option' and cputils.get_vendor() == 'amd':
+        test.cancel("The case does not support AMD machine")
+
+
 def run(test, params, env):
     """
     Test the command virsh nodeinfo
@@ -236,6 +248,7 @@ def run(test, params, env):
                       "but found '%s'" % (int(cpus_nodeinfo_before),
                                           cpus_nodeinfo_after))
 
+    check_skip_case(params, test)
     # Prepare libvirtd service
 
     libvirtd = params.get("libvirtd", "on")


### PR DESCRIPTION
Skip a case on AMD machine because the cpu topology is different between Intel and AMD.



Signed-off-by: Dan Zheng <dzheng@redhat.com>