### PR TITLE
guest_os_booting: change to select vm based on different guest

### DIFF
--- a/libvirt/tests/cfg/guest_os_booting/ovmf_firmware/ovmf_firmware_feature.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/ovmf_firmware/ovmf_firmware_feature.cfg
@@ -11,12 +11,13 @@
             variants:
                 - enable_secure_boot:
                     firmware_dict = {'os_firmware': 'efi', 'firmware': {'feature': [{'enabled': 'yes', 'name': 'enrolled-keys'}, {'enabled': 'yes', 'name': 'secure-boot'}]}}
-                    firmware_xpath = [{'element_attrs': ["./os/nvram[@template='${nvram_template}']"]}, {'element_attrs': ["./os/loader[@secure='yes']"], 'text': '${loader_path}'}]
+                    firmware_xpath = [{'element_attrs': ["./os/nvram[@template='${nvram_template}']"]}, {'element_attrs': ["./os/loader[@type='pflash']"], 'text': '${loader_path}'}]
                 - disable_secure_boot:
                     nvram_template = "/usr/share/edk2/ovmf/OVMF_VARS.fd"
                     firmware_dict = {'os_firmware': 'efi', 'firmware': {'feature': [{'enabled': 'no', 'name': 'enrolled-keys'}, {'enabled': 'yes', 'name': 'secure-boot'}]}}
-                    firmware_xpath = [{'element_attrs': ["./os/nvram[@template='${nvram_template}']"]}, {'element_attrs': ["./os/loader[@secure='yes']"], 'text': '${loader_path}'}]
+                    firmware_xpath = [{'element_attrs': ["./os/nvram[@template='${nvram_template}']"]}, {'element_attrs': ["./os/loader[@type='pflash']"], 'text': '${loader_path}'}]
                 - not_support_secure_boot:
+                    func_supported_since_libvirt_ver = (9, 0, 0)
                     loader_path = "/usr/share/edk2/ovmf/OVMF_CODE.fd"
                     nvram_template = "/usr/share/edk2/ovmf/OVMF_VARS.fd"
                     firmware_dict = {'os_firmware': 'efi', 'firmware': {'feature': [{'enabled': 'no', 'name': 'enrolled-keys'}, {'enabled': 'no', 'name': 'secure-boot'}]}}

--- a/libvirt/tests/cfg/guest_os_booting/ovmf_firmware/ovmf_smm.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/ovmf_firmware/ovmf_smm.cfg
@@ -15,6 +15,7 @@
                     smm_xpath = [{'element_attrs':[".//tseg[@unit='B']"], 'text':'${smm_tseg_size}'}]
                 - smm_off:
                     smm_state = "off"
+                    func_supported_since_libvirt_ver = (9, 0, 0) # for loader_path
                     loader_path = "/usr/share/edk2/ovmf/OVMF_CODE.fd"
                     nvram_path = "/var/lib/libvirt/qemu/nvram/nvram_VARS.fd"
                     nvram_template = "/usr/share/edk2/ovmf/OVMF_VARS.fd"

--- a/libvirt/tests/cfg/guest_os_booting/seabios_firmware/seabios_loader.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/seabios_firmware/seabios_loader.cfg
@@ -4,6 +4,7 @@
     loader_path = "/usr/share/seabios/bios-256k.bin"
     loader_type = "rom"
     loader_dict = {'loader_type': '%s', 'loader': '%s'}
+    firmware_type = "seabios"
     variants:
         - positive_test:
             variants:

--- a/libvirt/tests/src/guest_os_booting/ovmf_firmware/ovmf_firmware_feature.py
+++ b/libvirt/tests/src/guest_os_booting/ovmf_firmware/ovmf_firmware_feature.py
@@ -7,6 +7,7 @@
 
 #   Author: Meina Li <meili@redhat.com>
 #
+from virttest import libvirt_version
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import xcepts
 from virttest.utils_libvirt import libvirt_vmxml
@@ -19,12 +20,13 @@ def run(test, params, env):
     1) Prepare a guest with related firmware feature.
     2) Start and boot the guest.
     """
-    vm_name = params.get("main_vm")
+    vm_name = guest_os.get_vm(params)
     firmware_dict = eval(params.get("firmware_dict", "{}"))
     firmware_xpath = eval(params.get("firmware_xpath", "[]"))
     error_msg = params.get("error_msg", "")
     firmware_type = params.get("firmware_type")
     status_error = "yes" == params.get("status_error", "no")
+    libvirt_version.is_libvirt_feature_supported(params)
 
     vm = env.get_vm(vm_name)
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)

--- a/libvirt/tests/src/guest_os_booting/ovmf_firmware/ovmf_loader.py
+++ b/libvirt/tests/src/guest_os_booting/ovmf_firmware/ovmf_loader.py
@@ -24,7 +24,7 @@ def run(test, params, env):
     1) Prepare a guest with related os loader xml.
     2) Start and boot the guest.
     """
-    vm_name = params.get("main_vm")
+    vm_name = guest_os.get_vm(params)
     firmware_type = params.get("firmware_type")
     loader_dict = eval(params.get("loader_dict", "{}"))
     loader_xpath = eval(params.get("loader_xpath", "[]"))

--- a/libvirt/tests/src/guest_os_booting/ovmf_firmware/ovmf_nvram.py
+++ b/libvirt/tests/src/guest_os_booting/ovmf_firmware/ovmf_nvram.py
@@ -17,7 +17,7 @@ def run(test, params, env):
     1) Prepare a guest with related nvram elements.
     2) Start and boot the guest.
     """
-    vm_name = params.get("main_vm")
+    vm_name = guest_os.get_vm(params)
     firmware_type = params.get("firmware_type")
     smm_state = params.get("smm_state", "off")
     error_msg = params.get("error_msg", "")

--- a/libvirt/tests/src/guest_os_booting/ovmf_firmware/ovmf_smm.py
+++ b/libvirt/tests/src/guest_os_booting/ovmf_firmware/ovmf_smm.py
@@ -7,6 +7,7 @@
 
 #   Author: Meina Li <meili@redhat.com>
 #
+from virttest import libvirt_version
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import xcepts
 from virttest.utils_libvirt import libvirt_bios
@@ -21,13 +22,14 @@ def run(test, params, env):
     1) Prepare a guest with related smm elements.
     2) Start and boot the guest.
     """
-    vm_name = params.get("main_vm")
+    vm_name = guest_os.get_vm(params)
     smm_state = params.get("smm_state")
     smm_tseg_size = params.get("smm_tseg_size", "")
     smm_xpath = eval(params.get("smm_xpath", "{}"))
     error_msg = params.get("error_msg")
     firmware_type = params.get("firmware_type")
     loader_dict = eval(params.get("loader_dict", "{}"))
+    libvirt_version.is_libvirt_feature_supported(params)
 
     vm = env.get_vm(vm_name)
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)

--- a/libvirt/tests/src/guest_os_booting/seabios_firmware/seabios_loader.py
+++ b/libvirt/tests/src/guest_os_booting/seabios_firmware/seabios_loader.py
@@ -21,7 +21,7 @@ def run(test, params, env):
     1) Prepare a guest with related os loader xml.
     2) Start and boot the guest.
     """
-    vm_name = params.get("main_vm")
+    vm_name = guest_os.get_vm(params)
     loader_type = params.get("loader_type", "rom")
     loader_path = params.get("loader_path")
     loader_dict = eval(params.get("loader_dict", "{}") % (loader_type, loader_path))


### PR DESCRIPTION
Seabios guest and uefi guest use different guest xml and guest images. To select guest automatically, we use a new function get_vm() from provider to supoort it.