### PR TITLE
Fixup:add config for direct type interface to fix ping failure

### DIFF
--- a/libvirt/tests/cfg/virtual_network/connectivity/connectivity_check_direct_interface.cfg
+++ b/libvirt/tests/cfg/virtual_network/connectivity/connectivity_check_direct_interface.cfg
@@ -24,4 +24,4 @@
             vm_ping_ep_vm = fail
             host_ping_vm = fail
             host_ping_outside = pass
-    iface_attrs = {'type_name': 'direct', 'model': 'virtio', 'source': {'dev': host_iface, 'mode': '${source_mode}'}}
+    iface_attrs = {'type_name': 'direct', 'trustGuestRxFilters': 'yes',  'model': 'virtio', 'source': {'dev': host_iface, 'mode': '${source_mode}'}}


### PR DESCRIPTION
Depends on:
- https://github.com/avocado-framework/avocado-vt/pull/3735

Test result:
 (1/3) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.direct_interface.br: PASS (95.44 s)
 (2/3) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.direct_interface.private: PASS (99.22 s)
 (3/3) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.direct_interface.vepa: PASS (99.79 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2023-08-06T23.09-9cb66e4/results.html
JOB TIME   : 295.92 s
