### PR TITLE
fix numa node check and version issue

### DIFF
--- a/libvirt/tests/cfg/numa/guest_numa_node_tuning/invalid_nodeset_of_numa_memory_binding.cfg
+++ b/libvirt/tests/cfg/numa/guest_numa_node_tuning/invalid_nodeset_of_numa_memory_binding.cfg
@@ -11,6 +11,7 @@
             tuning_mode = "preferred"
         - restrictive:
             tuning_mode = "restrictive"
+            define_err = " 'restrictive' mode is required in memory element when mode is 'restrictive' in memnode element"
     variants node_set:
         - partially_inexistent:
             nodeset = "1-2"


### PR DESCRIPTION
    Signed-off-by: nanli <nanli@redhat.com>


```


avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 guest_numa_node_tuning.invalid_nodeset --vt-connect-uri qemu:///system
 (01/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.host.partially_inexistent.strict: FAIL: Expect 'unsupported configuration: NUMA node 2 is unavailable' in 'VM 'avocado-vt-vm1' failed to start: setlocale: No such file or directory\nerror: Failed to start domain 'avocado-vt-vm1'\nerror: Invalid value '1-2' for 'cpuset.mems': Invalid argument(exit... (5.88 s)
 (02/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.host.partially_inexistent.interleave: PASS (5.58 s)
 (03/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.host.partially_inexistent.preferred: PASS (5.49 s)
 (04/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.host.partially_inexistent.restrictive: FAIL: Expect 'unsupported configuration: NUMA node 2 is unavailable' in 'VM 'avocado-vt-vm1' failed to start: setlocale: No such file or directory\nerror: Failed to start domain 'avocado-vt-vm1'\nerror: Invalid value '1-2' for 'cpuset.mems': Invalid argument(exit... (5.87 s)
 (05/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.host.totally_inexistent.strict: FAIL: Expect 'unsupported configuration: NUMA node 2 is unavailable' in 'VM 'avocado-vt-vm1' failed to start: setlocale: No such file or directory\nerror: Failed to start domain 'avocado-vt-vm1'\nerror: Invalid value '2-3' for 'cpuset.mems': Invalid argument(exit... (5.86 s)
 (06/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.host.totally_inexistent.interleave: PASS (5.64 s)
 (07/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.host.totally_inexistent.preferred: PASS (5.49 s)
 (08/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.host.totally_inexistent.restrictive: FAIL: Expect 'unsupported configuration: NUMA node 2 is unavailable' in 'VM 'avocado-vt-vm1' failed to start: setlocale: No such file or directory\nerror: Failed to start domain 'avocado-vt-vm1'\nerror: Invalid value '2-3' for 'cpuset.mems': Invalid argument(exit... (5.86 s)
 (09/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.guest.partially_inexistent.strict: PASS (5.26 s)
 (10/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.guest.partially_inexistent.interleave: PASS (5.34 s)
 (11/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.guest.partially_inexistent.preferred: PASS (5.37 s)
 (12/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.guest.partially_inexistent.restrictive: PASS (5.34 s)
 (13/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.guest.totally_inexistent.strict: PASS (5.24 s)
 (14/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.guest.totally_inexistent.interleave: PASS (5.32 s)
 (15/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.guest.totally_inexistent.preferred: PASS (5.33 s)
 (16/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.guest.totally_inexistent.restrictive: PASS (5.28 s)
```


Failed scenarios: 
  Host/Guest * strict/restrictive due to bug , id: 