### PR TITLE
Add new network case of user type interface

### DIFF
--- a/libvirt/tests/cfg/virtual_network/connectivity/connectivity_check_user_interface.cfg
+++ b/libvirt/tests/cfg/virtual_network/connectivity/connectivity_check_user_interface.cfg
@@ -1,0 +1,60 @@
+- virtual_network.connectivity_check.user_interface:
+    type = connectivity_check_user_interface
+    func_supported_since_libvirt_ver = (9, 0, 0)
+    host_iface =
+    outside_ip = 'www.redhat.com'
+    start_vm = no
+    timeout = 240
+    iface_type = 'user'
+    vm_ping_outside = pass
+    vm_ping_host_public = pass
+    variants user_type:
+        - root_user:
+            test_user = root
+            virsh_uri = 'qemu:///system'
+        - non_root_user:
+            test_user = USER.EXAMPLE
+            test_passwd = PASSWORD.EXAMPLE
+            unpr_vm_name = UNPRIVILEGED_VM.EXAMPLE
+            virsh_uri = 'qemu+ssh://${test_user}@localhost/session'
+    variants:
+        - positive_test:
+            expect_error = no
+            vm_iface = eno1
+            variants:
+                - default:
+                    iface_attrs = {'model': 'virtio', 'type_name': 'user', 'acpi': {'index': '1'}, }
+                    ipv4_addr = 10.0.2.15
+                    ipv4_prefix = 24
+                    ipv4_default_gw = 10.0.2.2
+                    nameserver = 10.0.2.3
+                - customized_ip:
+                    variants:
+                        - no_prefix:
+                            iface_attrs = {'model': 'virtio', 'type_name': 'user', 'acpi': {'index': '1'}, 'ips': [{'address': '100.100.100.20', 'family': 'ipv4'}, {'address': '2001:db8:ac10:fd01::', 'family': 'ipv6'}]}
+                            ipv4_addr = \d+.0.2.15
+                            ipv4_prefix = 8
+                            ipv6_addr = 2001:db8:ac10:fd01:.+
+                            ipv6_prefix = 64
+                            ipv4_default_gw = \d+.0.2.2
+                            nameserver = \d+.0.2.3
+                        - with_prefix:
+                            iface_attrs = {'model': 'virtio', 'type_name': 'user', 'acpi': {'index': '1'}, 'ips': [{'address': '100.100.100.20', 'family': 'ipv4', 'prefix': '24'}, {'address': '2001:db8:ac10:fd01::', 'family': 'ipv6', 'prefix': '64'}]}
+                            ipv4_addr = 100.100.100.15
+                            ipv4_default_gw = 100.100.100.2
+                            nameserver = 100.100.100.3
+        - negative_test:
+            expect_error = yes
+            variants:
+                - multi_addr_ipv4:
+                    iface_attrs = {'model': 'virtio', 'type_name': 'user', 'ips': [{'address': '172.17.2.0', 'family': 'ipv4', 'prefix': '24'}, {'address': '100.17.2.0', 'family': 'ipv4', 'prefix': '24'}, {'address': '2001:db8:ac10:fd01::', 'family': 'ipv6', 'prefix': '64'}]}
+                    err_msg = Only one IPv4 address per interface is allowed
+                - multi_addr_ipv6:
+                    iface_attrs = {'model': 'virtio', 'type_name': 'user', 'ips': [{'address': '172.17.2.0', 'family': 'ipv4', 'prefix': '24'}, {'address': '2001:db8:ac10:fd01::', 'family': 'ipv6', 'prefix': '64'}, {'address': '2001:db8:ac10:fd03::', 'family': 'ipv6', 'prefix': '64'}]}
+                    err_msg = Only one IPv6 address per interface is allowed
+                - invalid_prefix_2:
+                    iface_attrs = {'model': 'virtio', 'type_name': 'user', 'ips': [{'address': '172.17.2.0', 'family': 'ipv4', 'prefix': '2'}, {'address': '2001:db8:ac10:fd01::', 'family': 'ipv6', 'prefix': '64'}]}
+                    err_msg = invalid prefix, must be in range of 4-27
+                - invalid_prefix_28:
+                    iface_attrs = {'model': 'virtio', 'type_name': 'user', 'ips': [{'address': '172.17.2.0', 'family': 'ipv4', 'prefix': '28'}, {'address': '2001:db8:ac10:fd01::', 'family': 'ipv6', 'prefix': '64'}]}
+                    err_msg = invalid prefix, must be in range of 4-27

--- a/libvirt/tests/src/virtual_network/connectivity/connectivity_check_user_interface.py
+++ b/libvirt/tests/src/virtual_network/connectivity/connectivity_check_user_interface.py
@@ -1,0 +1,143 @@
+import logging
+import re
+
+import aexpect
+from virttest import libvirt_version
+from virttest import remote
+from virttest import utils_net
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_unprivileged
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+from provider.virtual_network import network_base
+from provider.virtual_network import passt
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+
+def check_val(expect, actual, info, test):
+    """
+    Check whether actual value meets expectation
+
+    :param expect: expect value
+    :param actual: actual value
+    :param info: output info if not matched
+    :param test: test instance
+    """
+    if expect is None:
+        return
+    match = False
+    if '+' in expect:
+        match = re.search(expect, actual)
+    elif 'nameserver' in info:
+        match = expect in actual
+    else:
+        match = expect == actual
+    if match:
+        LOG.debug(f'{info} match. Expect {expect}, got {actual}')
+    else:
+        test.fail(f'{info} not match. Expect {expect}, but got {actual}')
+
+
+def run(test, params, env):
+    """
+    Connectivity check of user type interface
+    """
+    libvirt_version.is_libvirt_feature_supported(params)
+
+    expect_error = 'yes' == params.get('expect_error', 'no')
+    err_msg = params.get('err_msg')
+    virsh_uri = params.get('virsh_uri')
+    root = 'root_user' == params.get('user_type', '')
+    if root:
+        vm_name = params.get('main_vm')
+        vm = env.get_vm(vm_name)
+        virsh_ins = virsh
+    else:
+        vm_name = params.get('unpr_vm_name')
+        test_user = params.get('test_user', '')
+        test_passwd = params.get('test_passwd', '')
+        unpr_vm_args = {
+            'username': params.get('username'),
+            'password': params.get('password'),
+        }
+        vm = libvirt_unprivileged.get_unprivileged_vm(vm_name, test_user,
+                                                      test_passwd,
+                                                      **unpr_vm_args)
+        virsh_ins = virsh.VirshPersistent(uri=virsh_uri)
+        host_session = aexpect.ShellSession('su')
+        remote.VMManager.set_ssh_auth(host_session, 'localhost', test_user,
+                                      test_passwd)
+        host_session.close()
+
+    host_ip = utils_net.get_host_ip_address(ip_ver='ipv4')
+    params['host_ip_v6'] = host_ip_v6 = utils_net.get_host_ip_address(
+        ip_ver='ipv6')
+    iface_attrs = eval(params.get('iface_attrs'))
+    vm_iface = params.get('vm_iface', 'eno1')
+    outside_ip = params.get('outside_ip')
+    host_iface = params.get('host_iface')
+    host_iface = host_iface if host_iface else utils_net.get_net_if(
+        state='UP')[0]
+
+    ipv4_addr = params.get('ipv4_addr')
+    ipv4_prefix = params.get('ipv4_prefix')
+    ipv6_addr = params.get('ipv6_addr')
+    ipv6_prefix = params.get('ipipv6_prefixv4_addr')
+    ipv4_default_gw = params.get('ipv4_default_gw')
+    nameserver = params.get('nameserver')
+
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name,
+                                                   virsh_instance=virsh_ins)
+    bkxml = vmxml.copy()
+
+    try:
+        vmxml.del_device('interface', by_tag=True)
+        vmxml.sync(virsh_instance=virsh_ins)
+        iface = libvirt_vmxml.create_vm_device_by_type(
+            'interface', iface_attrs)
+        vmxml.add_device(iface)
+        define_result = virsh.define(vmxml.xml, debug=True, uri=virsh_uri)
+        libvirt.check_exit_status(define_result, expect_error)
+
+        if expect_error:
+            libvirt.check_result(define_result, expected_fails=err_msg)
+            return
+
+        LOG.debug(virsh_ins.dumpxml(vm_name).stdout_text)
+        vm.start()
+
+        session = vm.wait_for_serial_login(timeout=60)
+        LOG.debug(session.cmd_output('ip addr'))
+        vm_ipv4, vm_ipv4_pfx = passt.get_iface_ip_and_prefix(vm_iface, session)
+        LOG.debug(f'vm ipv4 address and prefix: {vm_ipv4} {vm_ipv4_pfx}')
+        check_val(ipv4_addr, vm_ipv4, 'vm ipv4', test)
+        check_val(ipv4_prefix, str(vm_ipv4_pfx), 'vm ipv4 prefix', test)
+
+        if ipv6_addr:
+            vm_ipv6, vm_ipv6_pfx = passt.get_iface_ip_and_prefix(
+                vm_iface, session, ip_ver='ipv6')[0]
+            LOG.debug(f'vm ipv6 address and prefix: {vm_ipv6} {vm_ipv6_pfx}')
+            check_val(ipv6_addr, vm_ipv6, 'vm ipv6', test)
+            check_val(ipv6_prefix, str(vm_ipv6_pfx), 'vm ipv6 prefix', test)
+
+        default_gw_v4 = utils_net.get_default_gateway(
+            session=session, ip_ver='ipv4', force_dhcp=True)
+        LOG.debug(f'vm default gateway ipv4: {default_gw_v4}')
+        check_val(ipv4_default_gw, default_gw_v4, 'default ipv4 gateway', test)
+        vm_nameserver = utils_net.get_guest_nameserver(session)
+        check_val(nameserver, vm_nameserver, 'vm nameserver', test)
+
+        ips = {
+            'outside_ip': outside_ip,
+            'host_public_ip': host_ip,
+        }
+        network_base.ping_check(params, ips, session, force_ipv4=True)
+        session.close()
+        vm.destroy()
+    finally:
+        bkxml.sync(virsh_instance=virsh_ins)
+        if not root:
+            del virsh_ins


### PR DESCRIPTION
- VIRT-296211 - [user][slirp] Check connectivity for user type interface

Test result:
```
 (01/14) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.user_interface.positive_test.default.root_user: PASS (137.02 s)
 (02/14) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.user_interface.positive_test.default.non_root_user: PASS (59.25 s)
 (03/14) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.user_interface.positive_test.customized_ip.no_prefix.root_user: PASS (197.48 s)
 (04/14) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.user_interface.positive_test.customized_ip.no_prefix.non_root_user: PASS (59.80 s)
 (05/14) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.user_interface.positive_test.customized_ip.with_prefix.root_user: PASS (197.18 s)
 (06/14) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.user_interface.positive_test.customized_ip.with_prefix.non_root_user: PASS (60.17 s)
 (07/14) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.user_interface.negative_test.multi_addr_ipv4.root_user: PASS (7.33 s)
 (08/14) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.user_interface.negative_test.multi_addr_ipv4.non_root_user: PASS (13.12 s)
 (09/14) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.user_interface.negative_test.multi_addr_ipv6.root_user: PASS (7.37 s)
 (10/14) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.user_interface.negative_test.multi_addr_ipv6.non_root_user: PASS (13.12 s)
 (11/14) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.user_interface.negative_test.invalid_prefix_2.root_user: PASS (7.32 s)
 (12/14) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.user_interface.negative_test.invalid_prefix_2.non_root_user: PASS (13.20 s)
 (13/14) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.user_interface.negative_test.invalid_prefix_28.root_user: PASS (7.26 s)
 (14/14) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.user_interface.negative_test.invalid_prefix_28.non_root_user: PASS (13.11 s)
RESULTS    : PASS 14 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2023-08-08T03.54-bbf42cb/results.html
JOB TIME   : 794.34 s
```