### PR TITLE
Draft: passt: fix test cases on s390x

### DIFF
--- a/libvirt/tests/cfg/virtual_network/passt/passt_attach_detach.cfg
+++ b/libvirt/tests/cfg/virtual_network/passt/passt_attach_detach.cfg
@@ -2,6 +2,7 @@
     type = passt_attach_detach
     func_supported_since_libvirt_ver = (9, 0, 0)
     host_iface =
+    host_iface_index =
     outside_ip = 'www.redhat.com'
     start_vm = no
     mtu = 65520
@@ -45,3 +46,6 @@
             conn_check_args_1 = ('TCP6', 'localhost', 31339, 41339, True, None)
             conn_check_args_2 = ('UDP4', 'localhost', 2025, 2025, True, None)
             conn_check_args_3 = ('UDP6', 'localhost', 2025, 2025, True, None)
+            s390-virtio:
+                vm_iface = enc1
+                iface_attrs = {'model': 'virtio', 'ips': ${ips}, 'backend': ${backend}, 'source': {'dev': '${host_iface}'}, 'alias': ${alias}, 'type_name': 'user', 'portForwards': ${portForwards}}

--- a/libvirt/tests/cfg/virtual_network/passt/passt_connectivity_between_2vms.cfg
+++ b/libvirt/tests/cfg/virtual_network/passt/passt_connectivity_between_2vms.cfg
@@ -41,3 +41,7 @@
             conn_check_args_1 = ('TCP6', server_default_gw_v6, vm_c_iface, 41335, 41335)
             conn_check_args_2 = ('UDP4', server_default_gw, None, 21335, 21335)
             conn_check_args_3 = ('UDP6', server_default_gw_v6, vm_c_iface, 21335, 21335)
+            s390-virtio:
+                vm_c_iface = enc1
+                iface_attrs = {'model': 'virtio', **${ips}, 'backend': ${backend}, 'source': {'dev': '${host_iface}'}, 'type_name': 'user', **${portForwards}}
+                iface_c_attrs = {'model': 'virtio', **${ips}, 'backend': ${backend}, 'source': {'dev': '${host_iface}'}, 'type_name': 'user'}

--- a/libvirt/tests/cfg/virtual_network/passt/passt_function.cfg
+++ b/libvirt/tests/cfg/virtual_network/passt/passt_function.cfg
@@ -22,6 +22,9 @@
             iface_attrs = {'model': 'virtio', 'acpi': {'index': '1'}, 'type_name': 'user', 'backend': {'type': 'passt'}, 'source': {'dev': '${host_iface}'}}
             vm_iface = eno1
             vm_ping_outside = pass
+            s390-virtio:
+                iface_attrs = {'model': 'virtio', 'type_name': 'user', 'backend': {'type': 'passt'}, 'source': {'dev': '${host_iface}'}}
+                vm_iface = enc1
         - ip_portfw:
             alias = {'name': 'ua-c87b89ff-b769-4abc-921f-30d42d7aec5b'}
             backend = {'type': 'passt'}
@@ -49,3 +52,6 @@
             conn_check_args_7 = ('UDP4', 'localhost', 2025, 2025, True, None)
             conn_check_args_8 = ('UDP6', host_ip_v6, 4431, 4432, True, None)
             conn_check_args_9 = ('UDP6', '::1', 4431, 4432, False, None)
+            s390-virtio:
+                iface_attrs = {'model': 'virtio', 'ips': ${ips}, 'backend': ${backend}, 'source': {'dev': '${host_iface}'}, 'alias': ${alias}, 'type_name': 'user', 'portForwards': ${portForwards}}
+                vm_iface = enc1

--- a/libvirt/tests/cfg/virtual_network/passt/passt_reconnect.cfg
+++ b/libvirt/tests/cfg/virtual_network/passt/passt_reconnect.cfg
@@ -40,3 +40,6 @@
             conn_check_args_1 = ('TCP6', 'localhost', 31339, 41339, True, None)
             conn_check_args_2 = ('UDP4', 'localhost', 2025, 2025, True, None)
             conn_check_args_3 = ('UDP6', 'localhost', 2025, 2025, True, None)
+            s390-virtio:
+                vm_iface = enc1
+                iface_attrs = {'model': 'virtio', **${ips}, 'backend': ${backend}, 'source': {'dev': '${host_iface}'}, **${alias}, 'type_name': 'user', **${portForwards}}

--- a/libvirt/tests/cfg/virtual_network/passt/passt_transfer_file.cfg
+++ b/libvirt/tests/cfg/virtual_network/passt/passt_transfer_file.cfg
@@ -29,6 +29,9 @@
             iface_attrs = {'model': 'virtio', 'acpi': {'index': '1'}, **${ips}, 'backend': ${backend}, 'source': {'dev': '${host_iface}'}, **${alias}, 'type_name': 'user', **${portForwards}}
             ipv6_prefix = 128
             vm_iface = eno1
+            s390-virtio:
+                vm_iface = enc1
+                iface_attrs = {'model': 'virtio', **${ips}, 'backend': ${backend}, 'source': {'dev': '${host_iface}'}, **${alias}, 'type_name': 'user', **${portForwards}}
     variants file_size:
         - 10M:
             bs = 1M

--- a/libvirt/tests/src/virtual_network/passt/passt_attach_detach.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_attach_detach.py
@@ -65,17 +65,18 @@ def run(test, params, env):
     scenario = params.get('scenario')
     virsh_uri = params.get('virsh_uri')
     add_iface = 'yes' == params.get('add_iface', 'no')
-    host_ip = utils_net.get_host_ip_address(ip_ver='ipv4')
-    host_ip_v6 = utils_net.get_host_ip_address(ip_ver='ipv6')
+    host_iface = params.get('host_iface')
+    host_iface = host_iface if host_iface else utils_net.get_net_if(
+        state="UP")[0]
+    host_iface_index = int(params.get('host_iface_index', 0))
+    host_ip = utils_net.get_ip_address_by_interface(host_iface, ip_ver='ipv4')
+    host_ip_v6 = utils_net.get_ip_address_by_interface(host_iface, ip_ver='ipv6')
     iface_attrs = eval(params.get('iface_attrs'))
     params['socket_dir'] = socket_dir = eval(params.get('socket_dir'))
     params['proc_checks'] = proc_checks = eval(params.get('proc_checks', '{}'))
     vm_iface = params.get('vm_iface', 'eno1')
     mtu = params.get('mtu')
     outside_ip = params.get('outside_ip')
-    host_iface = params.get('host_iface')
-    host_iface = host_iface if host_iface else utils_net.get_net_if(
-        state="UP")[0]
     log_file = f'/run/user/{user_id}/passt.log'
     iface_attrs['backend']['logFile'] = log_file
     iface_attrs['source']['dev'] = host_iface
@@ -124,9 +125,9 @@ def run(test, params, env):
                 test.fail(f'Logfile of passt "{log_file}" not created')
 
             session = vm.wait_for_serial_login(timeout=60)
-            passt.check_vm_ip(iface_attrs, session, host_iface)
+            passt.check_vm_ip(iface_attrs, session, host_iface, vm_iface)
             passt.check_vm_mtu(session, vm_iface, mtu)
-            passt.check_default_gw(session)
+            passt.check_default_gw(session, host_iface_index)
             passt.check_nameserver(session)
 
             ips = {
@@ -138,7 +139,8 @@ def run(test, params, env):
             firewalld.stop()
             LOG.debug(f'Service status of firewalld: {firewalld.status()}')
             passt.check_connection(vm, vm_iface,
-                                   ['TCP4', 'TCP6', 'UDP4', 'UDP6'])
+                                   ['TCP4', 'TCP6', 'UDP4', 'UDP6'],
+                                   host_iface_index)
 
             if 'portForwards' in iface_attrs:
                 passt.check_portforward(vm, host_ip, params)

--- a/libvirt/tests/src/virtual_network/passt/passt_reconnect.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_reconnect.py
@@ -109,7 +109,7 @@ def run(test, params, env):
             test.fail(f'Logfile of passt "{log_file}" not created')
 
         session = vm.wait_for_serial_login(timeout=60)
-        passt.check_vm_ip(iface_attrs, session, host_iface)
+        passt.check_vm_ip(iface_attrs, session, host_iface, vm_iface)
         passt.check_vm_mtu(session, vm_iface, mtu)
         passt.check_default_gw(session)
         passt.check_nameserver(session)


### PR DESCRIPTION
1. s390x doesn't have ACPI
2. s390x virtual interface name inside VM is encX
3. Remove unsupported DAC security driver for unprivileged user
   if present
4. Pass 'vm_iface' to 'passt.check_vm_ip' to avoid default value
   with wrong interface naming scheme
5. passt/check_nameserver: remove interface name from ipv6 entry as
   it might be different between host and guest
6. passt/check_default_gw: let us select which entry to choose because
   utils_net.get_default_gateway might return more than one, e.g. with
   multipath routes or when there's more than one interface on the host;
   same for passt/check_connection
7. passt/check_port_listen: only check for partial process user "'passt"
   because on x86_64 there's specializatoin 'passt.avx2' but on s390x it's
   just 'passt'
8. Don't use utils_net.get_host_ip_address because it doesn't let us choose
    which interface to get the ip address from; use utils_net.get_ip_address_by_interface
    instead
