### PR TITLE
Draft: filesystem_device: remove numa cells

### DIFF
--- a/libvirt/tests/src/virtual_device/filesystem_device.py
+++ b/libvirt/tests/src/virtual_device/filesystem_device.py
@@ -327,6 +327,11 @@ def run(test, params, env):
             vmxml.sync()
             numa_no = None
             if with_numa:
+                vm_cpu = vmxml.cpu
+                vm_cpu.remove_numa_cells()
+                vmxml['cpu'] = vm_cpu
+                vmxml.sync()
+
                 numa_no = vmxml.vcpu // vcpus_per_cell if vmxml.vcpu != 1 else 1
             vm_xml.VMXML.set_vm_vcpus(vmxml.vm_name, vmxml.vcpu, numa_number=numa_no)
             vm_xml.VMXML.set_memoryBacking_tag(vmxml.vm_name, access_mode="shared",


### PR DESCRIPTION
The tests fail when numa cells are already
present in the guest xml because vm_xml.set_vm_vcpus will construct a wrong attributes dict:

[{'xmltreefile': None, 'validates': None, 'xml': <_io.FileIO name='/tmp/xml_utils_temp_1ju8k73s.xml' mode='rb+' closefd=True>, 'virsh': <module 'virttest.virsh' from
'/var/ci/libvirt-ci/runtest/avocado-vt/avocado-vt/virttest/virsh.py'>}]

...leading to error

    TypeError: Attributes values should be str-type of int-type.

Remove the numa cells and leave it to set_vm_vcpus to add them according to input. It will then create the correct dict

[{'cpus': '0-1', 'id': '0', 'memory': '2097152'}]