### PR TITLE
migrate_options_shared: Increase low_speed for aarch64

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -409,6 +409,8 @@
                             break_network_connection = "yes"
                             asynch_migrate = "yes"
                             low_speed = "10"
+                            aarch64:
+                                low_speed = "50"
                             stress_in_vm = "yes"
                             stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M --timeout 70"
                             actions_during_migration = "drop_network_connection"


### PR DESCRIPTION
When the low_speed is too small, the migration process may get stuck at 99%.

Before:
```
ERROR 1-type_specific.io-github-autotest-libvirt.virsh.migrate_options_shared.positive_test.p2p_migration.disable_keepalive.on_both.without_postcopy -> TestError: No migration result is returned.
ERROR 1-type_specific.io-github-autotest-libvirt.virsh.migrate_options_shared.positive_test.p2p_migration.disable_keepalive.on_target.without_postcopy -> TestError: No migration result is returned.
```

After:
```
PASS 1-type_specific.io-github-autotest-libvirt.virsh.migrate_options_shared.positive_test.p2p_migration.disable_keepalive.on_both.without_postcopy
PASS 1-type_specific.io-github-autotest-libvirt.virsh.migrate_options_shared.positive_test.p2p_migration.disable_keepalive.on_target.without_postcopy
```