### PR TITLE
guest_os_booting: Add a case of boot order

### DIFF
--- a/libvirt/tests/cfg/guest_os_booting/boot_order/boot_from_disk_device.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/boot_order/boot_from_disk_device.cfg
@@ -1,0 +1,29 @@
+- guest_os_booting.boot_order.disk_device:
+    type = boot_from_disk_device
+    start_vm = no
+    disk1_attrs_target = {'dev': 'vda', 'bus': 'virtio'}
+    variants:
+        - os_dev:
+            os_attrs_boots = ['hd']
+            disk1_attrs = {'target': ${disk1_attrs_target}}
+            variants:
+                - single_disk:
+                - multi_disks:
+                    disk1_img = "non-bootable.qcow2"
+                    disk2_attrs = {'target': {'dev': 'sda', 'bus': 'sata'}}
+                    status_error = "yes"
+        - disk_boot_order:
+            variants:
+                - single_disk:
+                    disk1_attrs = {'target': {'dev': 'sda', 'bus': 'scsi'}}
+                - multi_disks:
+                    disk1_img = "non-bootable.qcow2"
+                    disk1_attrs = {'target': ${disk1_attrs_target}}
+                    disk2_attrs = {'target': {'dev': 'sda', 'bus': 'scsi'}}
+                    seabios:
+                        status_error = "yes"
+    variants firmware_type:
+        - seabios:
+            only x86_64
+        - ovmf:
+            only q35

--- a/libvirt/tests/src/guest_os_booting/boot_order/boot_from_disk_device.py
+++ b/libvirt/tests/src/guest_os_booting/boot_order/boot_from_disk_device.py
@@ -1,0 +1,106 @@
+import copy
+import os
+
+from virttest import data_dir
+from virttest import remote
+
+from virttest.libvirt_xml import vm_xml
+from virttest.libvirt_xml.devices import disk
+from virttest.utils_libvirt import libvirt_disk
+from virttest.utils_libvirt import libvirt_vmxml
+
+from provider.guest_os_booting import guest_os_booting_base
+
+
+def parse_disks_attrs(vmxml, params):
+    """
+    Parse disk devices' attrs
+
+    :param vmxml: The vmxml object
+    :param params: Dictionary with the test parameters
+    :return: (Newly created disk image path, list of disk devices' attrs)
+    """
+    disk1_img = params.get('disk1_img')
+    disk_attrs_list = []
+    disk1_img_path = ""
+    disk_org_attrs = vmxml.devices.by_device_tag('disk')[0].fetch_attrs()
+    del disk_org_attrs['address']
+    if disk1_img:
+        disk1_img_path = os.path.join(data_dir.get_data_dir(), 'images',
+                                      disk1_img)
+        libvirt_disk.create_disk('file', disk1_img_path, disk_format='qcow2')
+        disk1_attrs = copy.deepcopy(disk_org_attrs)
+        disk1_attrs['source'] = {'attrs': {'file': disk1_img_path}}
+        disk_attrs_list.append(disk1_attrs)
+
+        disk_org_attrs.update(eval(params.get("disk2_attrs", "{}")))
+    else:
+        disk_org_attrs.update(eval(params.get("disk1_attrs", "{}")))
+    disk_attrs_list.append(disk_org_attrs)
+    return disk1_img_path, disk_attrs_list
+
+
+def update_vm_xml(vm, params, disk_attrs_list):
+    """
+    Update VM xml
+
+    :param vm: VM object
+    :param params: Dictionary with the test parameters
+    :param disk_attrs_list: List of disk devices' attrs
+    """
+    os_attrs_boots = eval(params.get('os_attrs_boots', '[]'))
+    libvirt_vmxml.remove_vm_devices_by_type(vm, 'disk')
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm.name)
+    if os_attrs_boots:
+        os_attrs = {'boots': os_attrs_boots}
+        vmxml.setup_attrs(os=os_attrs)
+    else:
+        vm_os = vmxml.os
+        vm_os.del_boots()
+        vmxml.os = vm_os
+
+    index = 0
+    for disk_attrs in disk_attrs_list:
+        disk_obj = disk.Disk(disk_attrs)
+        disk_obj.setup_attrs(**disk_attrs)
+        vmxml.add_device(disk_obj)
+        index += 1
+        if 'disk_boot_order' in params.get("shortname"):
+            vmxml.set_boot_order_by_target_dev(
+                disk_attrs['target']['dev'], index)
+    vmxml.xmltreefile.write()
+    vmxml.sync()
+
+
+def run(test, params, env):
+    """
+    Boot VM from disk devices
+    This case covers per-device(disk) boot elements and os/boot elements.
+    """
+    vm_name = guest_os_booting_base.get_vm(params)
+    status_error = "yes" == params.get("status_error", "no")
+    disk1_img_path = ""
+
+    vm = env.get_vm(vm_name)
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm.name)
+    bkxml = vmxml.copy()
+
+    try:
+        disk1_img_path, disk_attrs_list = parse_disks_attrs(vmxml, params)
+        update_vm_xml(vm, params, disk_attrs_list)
+        test.log.debug(vm_xml.VMXML.new_from_dumpxml(vm.name))
+
+        vm.start()
+        try:
+            vm.wait_for_serial_login().close()
+        except remote.LoginTimeoutError as detail:
+            if status_error:
+                test.log.debug("Found the expected error: %s", detail)
+            else:
+                test.fail(detail)
+
+    finally:
+        bkxml.sync()
+        if disk1_img_path and os.path.isfile(disk1_img_path):
+            test.log.debug(f"removing {disk1_img_path}")
+            os.remove(disk1_img_path)


### PR DESCRIPTION
This PR adds:
    VIRT-296938 - Boot vm from disk device


**Test results:**
```
(1/8) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.disk_device.seabios.os_dev.single_disk: PASS (33.51 s)
 (2/8) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.disk_device.seabios.os_dev.multi_disks: PASS (266.18 s)
 (3/8) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.disk_device.seabios.disk_boot_order.single_disk: PASS (31.62 s)
 (4/8) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.disk_device.seabios.disk_boot_order.multi_disks: PASS (266.57 s)
 (5/8) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.disk_device.ovmf.os_dev.single_disk: PASS (53.24 s)
 (6/8) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.disk_device.ovmf.os_dev.multi_disks: PASS (270.21 s)
 (7/8) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.disk_device.ovmf.disk_boot_order.single_disk: PASS (54.51 s)
 (8/8) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.disk_device.ovmf.disk_boot_order.multi_disks: PASS (55.45 s)
RESULTS    : PASS 8 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```
