### PR TITLE
chardev_pcie: Update controller index for modify_vm_device

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_device_alias.cfg
@@ -12,10 +12,11 @@
                     detach_hostdev_type = "scsi"
                 - pci:
                     detach_hostdev_type = "pci"
+                    index = 35
                     aarch64:
                       pci_filter = "Host bridge"
                     detach_hostdev_managed = "yes"
-                    controller_dict = {'type': 'pci', 'model': 'pcie-to-pci-bridge','index':'35'}
+                    controller_dict = {'type': 'pci', 'model': 'pcie-to-pci-bridge','index':'${index}'}
                     no s390-virtio
         - controller:
             detach_controller_type = "scsi"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
@@ -157,7 +157,8 @@ def run(test, params, env):
                     test.cancel("Host does not support iommu")
                 libvirt_vmxml.modify_vm_device(vmxml=vmxml,
                                                dev_type='controller',
-                                               dev_dict=controller_dict)
+                                               dev_dict=controller_dict,
+                                               index=int(params.get("index")))
 
                 pci_id = utils_misc.get_full_pci_id(
                     utils_misc.get_pci_id_using_filter(pci_filter)[-1])


### PR DESCRIPTION
To avoid affecting other controllers, just modify the controller device defined in controller_dict.

Test Results:
```
 (1/3) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.live.hostdev.pci: PASS (57.93 s)
 (2/3) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.config.hostdev.pci: PASS (49.33 s)
 (3/3) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.current.hostdev.pci: PASS (58.68 s)
```