### PR TITLE
migration: Update migration parameter

### DIFF
--- a/libvirt/tests/cfg/migration_with_copy_storage/network_data_transport/tls_destination.cfg
+++ b/libvirt/tests/cfg/migration_with_copy_storage/network_data_transport/tls_destination.cfg
@@ -29,13 +29,14 @@
     nfs_mount_dir =
     custom_pki_path = "/etc/pki/qemu"
     qemu_tls = "yes"
-    server_cn = "copy-storage-test.com.cn"
+    server_cn = "ENTER.YOUR.EXAMPLE.SERVER_CN"
     client_cn = "ENTER.YOUR.EXAMPLE.CLIENT_CN"
     err_msg = "Certificate does not match the hostname"
     status_error = "yes"
     migrate_again = "yes"
     test_case = "tls_destination"
-    virsh_migrate_extra = "--tls"
+    virsh_migrate_extra = "--tls --migrateuri tcp://${server_ip}"
+    set_ip_addr = "no"
 
     variants:
         - p2p:
@@ -49,8 +50,9 @@
             copy_storage_option = "--copy-storage-inc"
     variants:
         - correct_value:
-            virsh_migrate_extra_mig_again = "--tls --tls-destination ${server_cn}"
+            virsh_migrate_extra_mig_again = "--tls --tls-destination ${server_cn} --migrateuri tcp://${server_ip}"
         - wrong_value:
+            server_cn = "copy-storage-test.com.cn"
             migrate_again_status_error = "yes"
-            virsh_migrate_extra_mig_again = "--tls --tls-destination fake${server_cn}"
+            virsh_migrate_extra_mig_again = "--tls --tls-destination fake${server_cn} --migrateuri tcp://${server_ip}"
             err_msg_again = "Certificate does not match the hostname"

--- a/libvirt/tests/cfg/migration_with_copy_storage/network_data_transport/tls_wrong_cert_configurations.cfg
+++ b/libvirt/tests/cfg/migration_with_copy_storage/network_data_transport/tls_wrong_cert_configurations.cfg
@@ -31,6 +31,7 @@
     status_error = "yes"
     test_case = "wrong_cert_configuration"
     virsh_migrate_extra = "--tls"
+    set_ip_address = "no"
 
     variants:
         - p2p:


### PR DESCRIPTION
If there is no '--migrateuri' parameter, we will not get the expected error message. So update it.