### PR TITLE
Adding backslashes to avoid that regex tries to interpret "\s" as "s"

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_from_native.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_from_native.py
@@ -34,7 +34,7 @@ def run(test, params, env):
         pid = vm.get_pid()
         cmdline = process.run("cat -v /proc/%d/cmdline" % pid).stdout_text
         cmdline = re.sub(r'\^@', ' ', cmdline)
-        cmdline_tmp = re.sub(r'\s-drive\s[^\s]+', '\s', cmdline)
+        cmdline_tmp = re.sub(r'\\\s-drive\\\s[^\\\s]+', '\\\s', cmdline)
 
         # Libvirt requires the binary path for domxml-from-native to succeed
         # /proc/pid/cmdline would give qemu cmdline with binary without


### PR DESCRIPTION
This below code looks for what's behind a literal \ and tries to replace it by the proper non-ascii character. As s is not in ESCAPES dictionary so the KeyError exception gets triggered !
```
        else:
            try:
                this = chr(ESCAPES[this][1])
            except KeyError:
                if c in ASCIILETTERS:
                    raise s.error('bad escape %s' % this, len(this))
```
Error : 
bad escape \s at position 0 
Solution :
\\\ are added to make it understand as \\\s/\\\s- .
For reference : "https://github.com/python/cpython/commit/9bd85b83f66d31e39282244e455275bd9cd91bb1#diff-a0fc71db3d118bcf5fa27a2eb5d4e9c5" 
Signed-off-by :Anushree Mathur [anushree.mathur@linux.vnet.ibm.com](mailto:anushree.mathur@linux.vnet.ibm.com)