### PR TITLE
guest_os_booting: Add negative test about boot order settings

### DIFF
--- a/libvirt/tests/cfg/guest_os_booting/boot_order/boot_order_setting_negative.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/boot_order/boot_order_setting_negative.cfg
@@ -1,0 +1,19 @@
+- guest_os_booting.boot_order.setting.negative:
+    type = boot_order_setting_negative
+    start_vm = no
+    err_msg = "Invalid value for attribute 'order' in element 'boot'"
+    variants:
+        - duplicate:
+            boot_index = '1'
+            iface_dict = {'boot': ${boot_index}}
+            err_msg = "used for more than one device"
+        - with_os_boots:
+            os_attrs_boots = ['hd']
+            boot_index = '1'
+            err_msg = "per-device boot elements cannot be used together with os/boot elements"
+        - minus:
+            boot_index = '-1'
+        - zero:
+            boot_index = '0'
+        - string:
+            boot_index = 'invalid'

--- a/libvirt/tests/src/guest_os_booting/boot_order/boot_order_setting_negative.py
+++ b/libvirt/tests/src/guest_os_booting/boot_order/boot_order_setting_negative.py
@@ -1,0 +1,49 @@
+from virttest.libvirt_xml import vm_xml
+from virttest.libvirt_xml import xcepts
+
+from provider.guest_os_booting import guest_os_booting_base
+
+
+def run(test, params, env):
+    """
+    Test boot order settings - negative
+    """
+    vm_name = guest_os_booting_base.get_vm(params)
+    iface_dict = eval(params.get("iface_dict", "{}"))
+    err_msg = params.get('err_msg', "Invalid value")
+
+    vm = env.get_vm(vm_name)
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm.name)
+    bkxml = vmxml.copy()
+
+    try:
+        os_attrs_boots = eval(params.get('os_attrs_boots', '[]'))
+        if os_attrs_boots:
+            os_attrs = {'boots': os_attrs_boots}
+            vmxml.setup_attrs(os=os_attrs)
+        else:
+            vm_os = vmxml.os
+            vm_os.del_boots()
+            vmxml.os = vm_os
+
+        xml_devices = vmxml.devices
+        if iface_dict:
+            iface_obj = xml_devices.by_device_tag('interface')[0]
+            iface_obj.setup_attrs(**iface_dict)
+        vmxml.devices = xml_devices
+        disk_attrs = xml_devices.by_device_tag('disk')[0].fetch_attrs()
+        vmxml.set_boot_order_by_target_dev(
+            disk_attrs['target']['dev'], params.get('boot_index'))
+        vmxml.xmltreefile.write()
+        test.log.debug(f"vmxml after updating: {vmxml}")
+        try:
+            vmxml.sync()
+        except xcepts.LibvirtXMLError as xml_error:
+            test.log.debug("Failed define vm as expected: %s.", str(xml_error))
+            if err_msg not in str(xml_error):
+                test.fail("Unable to get expected error: %s!" % xml_error)
+        else:
+            test.fail("It should Fail")
+
+    finally:
+        bkxml.sync()


### PR DESCRIPTION
This PR adds:
    VIRT-297200: [Negative] Define vm with invalid boot order


**Test results:**
```
 (1/5) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.setting.negative.duplicate: PASS (10.74 s)
 (2/5) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.setting.negative.with_os_boots: PASS (11.19 s)
 (3/5) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.setting.negative.minus: PASS (11.10 s)
 (4/5) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.setting.negative.zero: PASS (11.16 s)
 (5/5) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.setting.negative.string: PASS (11.73 s)
RESULTS    : PASS 5 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0

```