### PR TITLE
add case for memory access mode

### DIFF
--- a/libvirt/tests/cfg/memory/memory_backing/memory_access_mode.cfg
+++ b/libvirt/tests/cfg/memory/memory_backing/memory_access_mode.cfg
@@ -1,0 +1,60 @@
+- memory.backing.access_mode:
+    type = memory_access_mode
+    set_pagesize = 2048
+    set_pagenum = 1024
+    numa_mem = 2097152
+    start_vm = no
+    qemu_monitor_option = '--hmp'
+    qemu_monitor_cmd = 'info memdev'
+    pattern_share = "share:\s*{}"
+    mem_backend = "memory backend: ram-node0"
+    variants source:
+        - file:
+            source_type = 'file'
+            source_attr = "'source_type':'${source_type}'"
+            source_path = {'element_attrs': ['./memoryBacking/source/[@type="${source_type}"]']}
+        - anonymous:
+            source_type = 'anonymous'
+            source_attr = "'source_type':'${source_type}'"
+            source_path = {'element_attrs': ['./memoryBacking/source/[@type="${source_type}"]']}
+        - memfd:
+            source_type = 'memfd'
+            source_attr = "'source_type':'${source_type}'"
+            source_path = {'element_attrs': ['./memoryBacking/source/[@type="${source_type}"]']}
+        - no_source:
+    variants mem_access:
+        - mem_access_private:
+            mem_access_mode = 'private'
+            mem_acccess_attr = "'access_mode':'${mem_access_mode}'"
+            mem_access_path = {'element_attrs': ['./memoryBacking/access/[@mode="${mem_access_mode}"]']}
+        - mem_access_shared:
+            mem_access_mode = 'shared'
+            mem_acccess_attr = "'access_mode':'${mem_access_mode}'"
+            mem_access_path = {'element_attrs': ['./memoryBacking/access/[@mode="${mem_access_mode}"]']}
+        - mem_access_default:
+    variants numa_access:
+        - numa_access_private:
+            numa_access_mode = 'private'
+            numa_attrs = {'vcpu': 4,'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-3', 'memory': '${numa_mem}', 'unit': 'KiB', 'memAccess':'${numa_access_mode}'}]}}
+            numa_access_path = {'element_attrs': ['./cpu/numa/cell/[@memAccess="${numa_access_mode}"]', './cpu/numa/cell/[@memory="${numa_mem}"]']}
+        - numa_access_shared:
+            numa_access_mode = 'shared'
+            numa_attrs = {'vcpu': 4,'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-3', 'memory': '${numa_mem}', 'unit': 'KiB', 'memAccess':'${numa_access_mode}'}]}}
+            numa_access_path = {'element_attrs': ['./cpu/numa/cell/[@memAccess="${numa_access_mode}"]', './cpu/numa/cell/[@memory="${numa_mem}"]']}
+        - numa_access_default:
+            numa_attrs = {'vcpu': 4,'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-3', 'memory': '${numa_mem}', 'unit': 'KiB'}]}}
+        - no_numa:
+            mem_backend = "memory backend: pc.ram"
+    variants mem_pagesize:
+        - without_hugepage:
+        - with_hugepage:
+            no anonymous
+            hugepages_attr = "'hugepages': {}"
+            hugepages_path = {'element_attrs': ['./memoryBacking/hugepages']}
+    variants:
+        - memory_allocation:
+            mem_unit = "KiB"
+            current_mem_unit = "KiB"
+            current_mem = "2097152"
+            mem_value = "2097152"
+            mem_attrs = {'memory_unit':'${mem_unit}','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}'}

--- a/libvirt/tests/src/memory/memory_backing/memory_access_mode.py
+++ b/libvirt/tests/src/memory/memory_backing/memory_access_mode.py
@@ -1,0 +1,233 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright Redhat
+#
+#   SPDX-License-Identifier: GPL-2.0
+
+#   Author: Nan Li <nanli@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import re
+
+from virttest import virsh
+from virttest import test_setup
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_test import libvirt
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_libvirt import libvirt_memory
+
+
+def get_vm_attrs(test, params):
+    """
+    Get vm attrs.
+
+    :param test: test object
+    :param params: VM param
+    :return vm_attrs: expected vm attrs dict.
+    """
+    source_attr = params.get("source_attr", "")
+    hugepages_attr = params.get("hugepages_attr", "")
+    mem_acccess_attr = params.get("mem_acccess_attr", "")
+    numa_attrs = eval(params.get("numa_attrs", '{}'))
+    mem_attrs = eval(params.get("mem_attrs", "{}"))
+
+    mb_value = ""
+    for item in [source_attr, mem_acccess_attr, hugepages_attr]:
+        if item != "":
+            mb_value = mb_value + item + ","
+    vm_attrs = eval("{'mb':{%s}}" % mb_value[:-1])
+    if numa_attrs:
+        vm_attrs.update(numa_attrs)
+    vm_attrs.update(mem_attrs)
+    test.log.debug("Get current vm attrs is :%s" % vm_attrs)
+
+    return vm_attrs
+
+
+def get_expected_xpath(test, params):
+    """
+    Get expected xpath.
+
+    :param test: test object
+    :param params: VM param
+    :return expect_xpath: Get xpath according to the cfg file.
+    """
+    expect_xpath = []
+
+    source_path = params.get("source_path", '')
+    hugepages_path = params.get("hugepages_path", '')
+    mem_access_path = params.get("mem_access_path", '')
+    numa_access_path = params.get("numa_access_path", '')
+
+    for xpath in [source_path, hugepages_path, mem_access_path,
+                  numa_access_path]:
+        if xpath != "":
+            expect_xpath.append(eval(xpath))
+    test.log.debug("Get expected xpath: %s", expect_xpath)
+    return expect_xpath
+
+
+def get_qemu_cmd_line(params):
+    """
+    Get expected qemu cmd line.
+
+    :param params: VM param
+    :return qemu_cmd: Get expected qemu cmd according to the scenarios.
+    """
+    existed_line, not_existed_line = [], []
+    numa_access = params.get("numa_access")
+    mem_access = params.get("mem_access")
+    mem_pagesize = params.get("mem_pagesize")
+
+    if mem_access == "mem_access_default" and \
+            numa_access in ["numa_access_default", "no_numa"] and \
+            mem_pagesize == "without_hugepage":
+        existed_line += ['"qom-type":"memory-backend-ram"']
+        not_existed_line += ['"mem-path":"/var/lib/libvirt/qemu/ram/']
+
+    elif mem_pagesize == "with_hugepage":
+        existed_line += ['"qom-type":"memory-backend-file"',
+                         '"mem-path":"/dev/hugepages/libvirt/qemu/']
+
+    elif (mem_access in ["mem_access_private", "mem_access_shared",
+                         "mem_access_default"] and
+          numa_access in ["numa_access_private", "numa_access_shared"]
+          and mem_pagesize == "without_hugepage"):
+
+        existed_line += ['"qom-type":"memory-backend-file"',
+                         '"mem-path":"/var/lib/libvirt/qemu/ram/']
+    elif (mem_access in ["mem_access_private", "mem_access_shared"]
+          and numa_access == "numa_access_default" and
+          mem_pagesize == "without_hugepage"):
+
+        existed_line += ['"qom-type":"memory-backend-file"',
+                         '"mem-path":"/var/lib/libvirt/qemu/ram/']
+
+    elif (mem_access in ["mem_access_private", "mem_access_shared"] and
+          numa_access == "no_numa" and mem_pagesize == "without_hugepage"):
+
+        existed_line += ['"qom-type":"memory-backend-file"',
+                         '"mem-path":"/var/lib/libvirt/qemu/ram/']
+
+    qemu_cmd = {True: existed_line, False: not_existed_line}
+
+    return qemu_cmd
+
+
+def get_access_mode(params):
+    """
+    Get expected access mode according to the scenarios.
+
+    :param params: VM param
+    :return: share value.
+    """
+    share = "false"
+    numa_access = params.get("numa_access")
+    mem_access = params.get("mem_access")
+    source = params.get("source")
+
+    if numa_access == "numa_access_shared":
+        share = "true"
+
+    elif mem_access == "mem_access_shared" and \
+            numa_access in ["numa_access_default", "no_numa"]:
+        share = "true"
+
+    elif source == "memfd" and mem_access == "mem_access_default" and \
+            numa_access in ["numa_access_default", "no_numa"]:
+        share = "true"
+
+    return share
+
+
+def run(test, params, env):
+    """
+    1. Verify memory access setting takes effect
+    2. Verify the numa topology access setting takes effect
+    against memory backing setting
+    """
+
+    def setup_test():
+        """
+        Setup pagesize
+        """
+        hp_cfg.set_kernel_hugepages(set_pagesize, set_pagenum)
+
+    def run_test():
+        """
+        Define vm and check msg
+        Start vm and check config
+        Check the qemu cmd line
+        Check the access mode
+        Login the guest and consume the guest memory
+        """
+        test.log.info("TEST_STEP1: Define vm and check result")
+        vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+        vm_attrs = get_vm_attrs(test, params)
+        vmxml.setup_attrs(**vm_attrs)
+        test.log.debug("Define vm with %s." % vmxml)
+        virsh.undefine(vm.name, debug=True)
+        virsh.define(vmxml.xml, debug=True, ignore_status=False)
+
+        test.log.info("TEST_STEP2: Start vm")
+        vm.start()
+
+        test.log.info("TEST_STEP3: Check xml config")
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        libvirt_vmxml.check_guest_xml_by_xpaths(vmxml, get_expected_xpath(test, params))
+
+        if params.get("source") == "no_source":
+            test.log.info("TEST_STEP4: Check the qemu cmd line")
+            for existed, item_list in get_qemu_cmd_line(params).items():
+                for item in item_list:
+                    libvirt.check_qemu_cmd_line(item, expect_exist=existed)
+                    test.log.debug("Check %s exist", item)
+
+        test.log.info("TEST_STEP5: Check the memory allocated")
+        share_value = get_access_mode(params)
+        pattern = pattern_share.format(share_value)
+
+        ret = virsh.qemu_monitor_command(vm_name,
+                                         qemu_monitor_cmd,
+                                         qemu_monitor_option).stdout_text.strip()
+        test.log.debug("Get qemu-monitor-command cmd result:\n%s", ret)
+        if not re.search(pattern, ret[ret.index(mem_backend):]):
+            test.fail("Expect '%s' exist, but not found." % pattern)
+        else:
+            test.log.debug("Check '%s' PASS.", pattern)
+
+        test.log.info("TEST_STEP6: Consume the guest memory")
+        session = vm.wait_for_login()
+        status, output = libvirt_memory.consume_vm_freememory(session)
+        if status:
+            test.fail("Fail to consume guest memory. Got error:%s" % output)
+        session.close()
+
+    def teardown_test():
+        """
+        Clean data.
+        """
+        test.log.info("TEST_TEARDOWN: Clean up env.")
+        bkxml.sync()
+        hp_cfg.cleanup()
+
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+    pattern_share = params.get('pattern_share')
+    mem_backend = params.get("mem_backend")
+    qemu_monitor_cmd = params.get('qemu_monitor_cmd')
+    qemu_monitor_option = params.get('qemu_monitor_option')
+    set_pagesize = params.get("set_pagesize")
+    set_pagenum = params.get("set_pagenum")
+
+    hp_cfg = test_setup.HugePageConfig(params)
+
+    try:
+        setup_test()
+        run_test()
+
+    finally:
+        teardown_test()


### PR DESCRIPTION
    Memory access mode
Signed-off-by: nanli <nanli@redhat.com>
```

[root@dell-per320-02 tp-libvirt]#  avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 memory.backing.access_mode
 (01/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_private.mem_access_private.file: PASS (82.70 s)
 (02/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_private.mem_access_private.anonymous: PASS (83.02 s)
 (03/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_private.mem_access_private.memfd: PASS (81.78 s)
 (04/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_private.mem_access_private.no_source: PASS (82.77 s)
 (05/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_private.mem_access_shared.file: PASS (82.37 s)
 (06/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_private.mem_access_shared.anonymous: PASS (83.99 s)
 (07/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_private.mem_access_shared.memfd: PASS (84.99 s)
 (08/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_private.mem_access_shared.no_source: PASS (77.48 s)
 (09/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_private.mem_access_default.file: PASS (86.36 s)
 (10/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_private.mem_access_default.anonymous: PASS (84.97 s)
 (11/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_private.mem_access_default.memfd: PASS (82.05 s)
 (12/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_private.mem_access_default.no_source: PASS (82.38 s)
 (13/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_shared.mem_access_private.file: PASS (102.39 s)
 (14/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_shared.mem_access_private.anonymous: PASS (102.33 s)
 (15/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_shared.mem_access_private.memfd: PASS (81.49 s)
 (16/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_shared.mem_access_private.no_source: PASS (102.79 s)
 (17/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_shared.mem_access_shared.file: PASS (101.28 s)
 (18/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_shared.mem_access_shared.anonymous: PASS (101.18 s)
 (19/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_shared.mem_access_shared.memfd: PASS (83.01 s)
 (20/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_shared.mem_access_shared.no_source: PASS (103.90 s)
 (21/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_shared.mem_access_default.file: PASS (99.26 s)
 (22/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_shared.mem_access_default.anonymous: PASS (101.09 s)
 (23/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_shared.mem_access_default.memfd: PASS (81.69 s)
 (24/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_shared.mem_access_default.no_source: PASS (106.57 s)
 (25/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_default.mem_access_private.file: PASS (81.00 s)
 (26/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_default.mem_access_private.anonymous: PASS (72.91 s)
 (27/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_default.mem_access_private.memfd: PASS (93.73 s)
 (28/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_default.mem_access_private.no_source: PASS (83.21 s)
 (29/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_default.mem_access_shared.file: PASS (100.56 s)
 (30/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_default.mem_access_shared.anonymous: PASS (101.44 s)
 (31/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_default.mem_access_shared.memfd: PASS (82.31 s)
 (32/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_default.mem_access_shared.no_source: PASS (99.37 s)
 (33/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_default.mem_access_default.file: PASS (82.53 s)
 (34/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_default.mem_access_default.anonymous: PASS (78.88 s)
 (35/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_default.mem_access_default.memfd: PASS (83.10 s)
 (36/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_default.mem_access_default.no_source: PASS (79.36 s)
 (37/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.no_numa.mem_access_private.file: PASS (85.03 s)
 (38/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.no_numa.mem_access_private.anonymous: PASS (81.97 s)
 (39/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.no_numa.mem_access_private.memfd: PASS (84.20 s)
 (40/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.no_numa.mem_access_private.no_source: PASS (83.64 s)
 (41/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.no_numa.mem_access_shared.file: PASS (101.18 s)
 (42/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.no_numa.mem_access_shared.anonymous: PASS (99.80 s)
 (43/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.no_numa.mem_access_shared.memfd: PASS (81.82 s)
 (44/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.no_numa.mem_access_shared.no_source: PASS (104.30 s)
 (45/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.no_numa.mem_access_default.file: PASS (82.17 s)
 (46/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.no_numa.mem_access_default.anonymous: PASS (79.04 s)
 (47/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.no_numa.mem_access_default.memfd: PASS (82.46 s)
 (48/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.no_numa.mem_access_default.no_source: PASS (77.53 s)
 (49/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_private.mem_access_private.file: PASS (80.46 s)
 (50/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_private.mem_access_private.memfd: PASS (80.15 s)
 (51/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_private.mem_access_private.no_source: PASS (79.24 s)
 (52/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_private.mem_access_shared.file: PASS (80.96 s)
 (53/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_private.mem_access_shared.memfd: PASS (79.59 s)
 (54/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_private.mem_access_shared.no_source: PASS (78.16 s)
 (55/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_private.mem_access_default.file: PASS (78.09 s)
 (56/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_private.mem_access_default.memfd: PASS (81.37 s)
 (57/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_private.mem_access_default.no_source: PASS (79.52 s)
 (58/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_shared.mem_access_private.file: PASS (78.89 s)
 (59/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_shared.mem_access_private.memfd: PASS (76.72 s)
 (60/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_shared.mem_access_private.no_source: PASS (82.59 s)
 (61/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_shared.mem_access_shared.file: PASS (79.61 s)
 (62/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_shared.mem_access_shared.memfd: PASS (78.70 s)
 (63/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_shared.mem_access_shared.no_source: PASS (80.05 s)
 (64/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_shared.mem_access_default.file: PASS (79.64 s)
 (65/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_shared.mem_access_default.memfd: PASS (79.64 s)
 (66/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_shared.mem_access_default.no_source: PASS (77.34 s)
 (67/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_default.mem_access_private.file: PASS (81.59 s)
 (68/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_default.mem_access_private.memfd: PASS (79.39 s)
 (69/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_default.mem_access_private.no_source: PASS (79.21 s)
 (70/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_default.mem_access_shared.file: PASS (79.54 s)
 (71/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_default.mem_access_shared.memfd: PASS (78.82 s)
 (72/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_default.mem_access_shared.no_source: PASS (80.67 s)
 (73/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_default.mem_access_default.file: PASS (78.75 s)
 (74/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_default.mem_access_default.memfd: PASS (79.32 s)
 (75/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_default.mem_access_default.no_source: PASS (81.05 s)
 (76/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.no_numa.mem_access_private.file: PASS (78.55 s)
 (77/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.no_numa.mem_access_private.memfd: PASS (78.63 s)
 (78/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.no_numa.mem_access_private.no_source: PASS (80.91 s)
 (79/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.no_numa.mem_access_shared.file: PASS (87.82 s)
 (80/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.no_numa.mem_access_shared.memfd: PASS (79.40 s)
 (81/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.no_numa.mem_access_shared.no_source: PASS (79.93 s)
 (82/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.no_numa.mem_access_default.file: PASS (77.53 s)
 (83/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.no_numa.mem_access_default.memfd: PASS (82.01 s)
 (84/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.no_numa.mem_access_default.no_source: PASS (80.94 s)
RESULTS    : PASS 84 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 7126.28 s
```