### PR TITLE
Cancelling all the testcases for virsh iface-*

### DIFF
--- a/libvirt/tests/src/virsh_cmd/interface/virsh_iface.py
+++ b/libvirt/tests/src/virsh_cmd/interface/virsh_iface.py
@@ -3,6 +3,7 @@ import logging as log
 
 from avocado.utils import process
 from avocado.utils import path as utils_path
+from avocado.utils import distro
 
 from virttest import utils_net
 from virttest import virsh
@@ -127,6 +128,12 @@ def run(test, params, env):
     device by default. You can specify the interface which you want, but be
     careful.
     """
+    """
+    Cancelling testcase if distro version is rhel 9 and above
+    """
+    detected_distro = distro.detect()
+    if detected_distro.name == "rhel" and int(detected_distro.version) >= 9:
+        test.cancel("virsh iface-* commands are unsupported in rhel 9")
 
     iface_name = params.get("iface_name", "ENTER.BRIDGE.NAME")
     iface_xml = params.get("iface_xml")

--- a/libvirt/tests/src/virsh_cmd/interface/virsh_iface_bridge.py
+++ b/libvirt/tests/src/virsh_cmd/interface/virsh_iface_bridge.py
@@ -2,7 +2,7 @@ import os
 import logging as log
 
 from avocado.utils import process
-
+from avocado.utils import distro
 from avocado.utils import path as utils_path
 
 from virttest import utils_net
@@ -27,6 +27,12 @@ def run(test, params, env):
     (1) Bridge an existing network device(iface-bridge).
     (2) Unbridge a network device(iface-unbridge).
     """
+    """
+    Cancelling the testcase if distro version is rhel 9 and above
+    """
+    detected_distro = distro.detect()
+    if detected_distro.name == "rhel" and int(detected_distro.version) >= 9:
+        test.cancel("virsh iface-* commands are unsupported in rhel 9")
 
     bridge_name = params.get("bridge_name")
     ping_ip = params.get("ping_ip", "")

--- a/libvirt/tests/src/virsh_cmd/interface/virsh_iface_edit.py
+++ b/libvirt/tests/src/virsh_cmd/interface/virsh_iface_edit.py
@@ -5,6 +5,7 @@ import logging as log
 import aexpect
 
 from avocado.utils import process
+from avocado.utils import distro
 
 from virttest import remote
 from virttest import data_dir
@@ -58,6 +59,11 @@ def run(test, params, env):
 
     Edit interface start mode in this case.
     """
+    """Cancelling testcase if distro version is rhel 9 and above"""
+    detected_distro = distro.detect()
+    if detected_distro.name == "rhel" and int(detected_distro.version) >= 9:
+        test.cancel("virsh iface-* commands are unsupported in rhel 9")
+
     iface_name = params.get("iface_name", "lo")
     status_error = "yes" == params.get("status_error", "no")
     if not libvirt.check_iface(iface_name, "exists", "--all"):

--- a/libvirt/tests/src/virsh_cmd/interface/virsh_iface_list.py
+++ b/libvirt/tests/src/virsh_cmd/interface/virsh_iface_list.py
@@ -8,6 +8,7 @@ import logging as log
 import re
 
 from avocado.utils import process, astring
+from avocado.utils import distro
 from virttest import virsh
 
 
@@ -33,6 +34,11 @@ def run(test, params, env):
     (3) Get interface MAC address by interface name
     (4) Get interface name by interface MAC address
     """
+    """Cancelling testcase if distro version is rhel 9 and above"""
+    detected_distro = distro.detect()
+    if detected_distro.name == "rhel" and int(detected_distro.version) >= 9:
+        test.cancel("virsh iface-* commands are unsupported in rhel 9")
+
     vm_name = params.get("main_vm")
     vm = env.get_vm(vm_name)
     opt = params.get('opt', '')

--- a/libvirt/tests/src/virsh_cmd/interface/virsh_iface_trans.py
+++ b/libvirt/tests/src/virsh_cmd/interface/virsh_iface_trans.py
@@ -5,6 +5,7 @@ import logging as log
 from avocado.utils import process
 from avocado.utils import path as utils_path
 from avocado.core import exceptions
+from avocado.utils import distro
 
 from virttest import virsh
 from virttest import utils_libvirtd
@@ -195,6 +196,12 @@ def run(test, params, env):
            2.3.1 begin and commit testing with libvirtd restart
            2.3.2 begin and rollback testing with libvirtd restart
     """
+    """
+    Cancelling testcase if distro version is rhel 9 and above
+    """
+    detected_distro = distro.detect()
+    if detected_distro.name == "rhel" and int(detected_distro.version) >= 9:
+        test.cancel("virsh iface-* commands are unsupported in rhel 9")
 
     if not utils_package.package_install(["mlocate"]):
         test.cancel("Failed to install dependency package mlocate"


### PR DESCRIPTION
Cancelling all the testcases regarding virsh iface-* for distro version rhel 9 and above as it is unsupported now in rhel 9!
Documentation for Reference : https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/considerations_in_adopting_rhel_9/assembly_virtualization_considerations-in-adopting-rhel-9
Signed-off-by: Anushree Mathur <anushree.mathur@linux.vnet.ibm.com>