### PR TITLE
migration: Update memory compression case

### DIFF
--- a/libvirt/tests/cfg/migration/migration_performance_tuning/migration_memory_compression.cfg
+++ b/libvirt/tests/cfg/migration/migration_performance_tuning/migration_memory_compression.cfg
@@ -28,6 +28,7 @@
     virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
     check_compression_list = '["Compression cache", "Compressed data", "Compressed pages", "Compression cache misses", "Compression overflows"]'
     test_case = "memory_compression"
+
     variants:
         - p2p:
             virsh_migrate_options = '--live --p2p --verbose'
@@ -40,9 +41,21 @@
     variants:
         - default_compression:
             virsh_migrate_extra = "--compressed"
-        - xbzrle_compression_and_default_cache_size:
-            cache_size = "67108864"
-            virsh_migrate_extra = "--compressed --comp-methods xbzrle"
-        - xbzrle_compression_and_specified_cache_size:
-            cache_size = "536870912"
-            virsh_migrate_extra = "--compressed --comp-methods xbzrle --comp-xbzrle-cache ${cache_size}"
+        - xbzrle_compression:
+            variants:
+                - default_cache_size:
+                    cache_size = "67108864"
+                    virsh_migrate_extra = "--compressed --comp-methods xbzrle"
+                - specified_cache_size:
+                    cache_size = "536870912"
+                    variants setting_method:
+                        - virsh_option:
+                            virsh_migrate_extra = "--compressed --comp-methods xbzrle --comp-xbzrle-cache ${cache_size}"
+                        - set_by_migrate_compcache_and_then_do_migration:
+                            virsh_migrate_extra = "--compressed --comp-methods xbzrle"
+                        - do_migration_and_then_set_by_migrate_compcache:
+                            stress_package = "stress"
+                            stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 30s"
+                            migrate_speed = "15"
+                            virsh_migrate_extra = "--compressed --comp-methods xbzrle"
+                            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "virsh.migrate_compcache", "func_param": "'%s --size ${cache_size}' % params.get('migrate_main_vm')"}]'

--- a/libvirt/tests/src/migration/migration_performance_tuning/migration_performance_tuning.py
+++ b/libvirt/tests/src/migration/migration_performance_tuning/migration_performance_tuning.py
@@ -34,6 +34,18 @@ def run(test, params, env):
             params.update({"virsh_migrate_extra": extra})
         migration_obj.setup_connection()
 
+    def setup_memory_compression():
+        """
+        Setup for memory compression
+
+        """
+        test.log.info("Setup for memory compression.")
+        setting_method = params.get("setting_method")
+        cache_size = params.get("cache_size")
+        migration_obj.setup_connection()
+        if setting_method == "set_by_migrate_compcache_and_then_do_migration":
+            virsh.migrate_compcache(vm_name, cache_size, debug=True, ignore_status=False)
+
     def verify_memory_compression():
         """
         Verify for memory compression


### PR DESCRIPTION
Add new scenario:
  1. Start migration, then set cache size by "virsh migrate-compcache <domain> <n>".
  2. Set cache size by "virsh migrate-compcache <domain> <n>", then do migration with option "--compressed --comp-methods xbzrle".