### PR TITLE
Add network case of connectivity check of udp tunnel iface

### DIFF
--- a/libvirt/tests/cfg/virtual_network/connectivity/connectivity_check_udp_tunnel_interface.cfg
+++ b/libvirt/tests/cfg/virtual_network/connectivity/connectivity_check_udp_tunnel_interface.cfg
@@ -1,0 +1,14 @@
+- virtual_network.connectivity_check.udp_tunnel_interface:
+    type = connectivity_check_udp_tunnel_interface
+    start_vm = no
+    vms = avocado-vt-vm1 vm2
+    source_port = 5558
+    vm_ip = 10.10.10.10
+    cli_vm_ip = 10.10.10.20
+    netmask = 24
+    source_port = 5558
+    local_port = 6667
+    source_attrs = {'address': '127.0.0.1', 'port': '${source_port}'}
+    local_attrs = {'address': '127.0.0.1', 'port': '${local_port}'}
+    iface_attrs = {'source': ${source_attrs}, 'model': 'virtio', 'source_local': ${local_attrs}, 'type_name': 'udp'}
+    cli_iface_attrs = {'source': ${local_attrs}, 'model': 'virtio', 'source_local': ${source_attrs}, 'type_name': 'udp'}

--- a/libvirt/tests/src/virtual_network/connectivity/connectivity_check_udp_tunnel_interface.py
+++ b/libvirt/tests/src/virtual_network/connectivity/connectivity_check_udp_tunnel_interface.py
@@ -1,0 +1,76 @@
+import logging
+
+from virttest import utils_net
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+
+from provider.virtual_network import network_base
+
+VIRSH_ARGS = {'ignore_status': False, 'debug': True}
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+
+def run(test, params, env):
+    """
+    Check connectivity for direct type interface
+    """
+    vm_name = params.get('main_vm')
+    vms = params.get('vms').split()
+    vm, cli_vm = (env.get_vm(vm_i) for vm_i in vms)
+
+    iface_attrs = eval(params.get('iface_attrs', '{}'))
+    cli_iface_attrs = eval(params.get('cli_iface_attrs', '{}'))
+    vm_ip = params.get('vm_ip')
+    cli_vm_ip = params.get('cli_vm_ip')
+    netmask = params.get('netmask')
+
+    bkxmls = list(map(vm_xml.VMXML.new_from_inactive_dumpxml, vms))
+
+    try:
+        vmxml, cli_vmxml = list(
+            map(vm_xml.VMXML.new_from_inactive_dumpxml, vms))
+        [vmxml_i.del_device('interface', by_tag=True) for vmxml_i in
+         [vmxml, cli_vmxml]]
+
+        [libvirt_vmxml.modify_vm_device(vmxml_i, 'interface', attrs)
+         for vmxml_i, attrs in [(vmxml, iface_attrs),
+                                (cli_vmxml, cli_iface_attrs)]]
+
+        [LOG.debug(f'VMXML of {vm_x}:\n{virsh.dumpxml(vm_x).stdout_text}')
+         for vm_x in vms]
+
+        [vm_i.start() for vm_i in [vm, cli_vm]]
+        session, cli_session = (vm_inst.wait_for_serial_login()
+                                for vm_inst in [vm, cli_vm])
+        mac, cli_mac = list(map(vm_xml.VMXML.get_first_mac_by_name, vms))
+
+        iface_info = utils_net.get_linux_iface_info(mac=mac, session=session)
+        cli_iface_info = utils_net.get_linux_iface_info(
+            mac=cli_mac, session=cli_session)
+
+        vm_iface, cli_vm_iface = (info['ifname'] for info in
+                                  (iface_info, cli_iface_info))
+        LOG.debug(f'interface name of server vm: {vm_iface}\n'
+                  f'client vm: {cli_vm_iface}')
+
+        network_base.set_static_ip(vm_iface, vm_ip, netmask, session)
+        network_base.set_static_ip(
+            cli_vm_iface, cli_vm_ip, netmask, cli_session)
+
+        status, _ = utils_net.ping(dest=cli_vm_ip, count=5,
+                                   timeout=10,
+                                   session=session,
+                                   force_ipv4=True,)
+        if status != 0:
+            test.fail('Ping from server to client failed')
+
+        status, _ = utils_net.ping(dest=vm_ip, count=5,
+                                   timeout=10,
+                                   session=cli_session,
+                                   force_ipv4=True,)
+        if status != 0:
+            test.fail('Ping from client to server failed')
+    finally:
+        [backup_xml.sync() for backup_xml in bkxmls]


### PR DESCRIPTION
- VIRT-296213 - [udp] Check connectivity of udp tunnel type interface

depends on:
- https://github.com/avocado-framework/avocado-vt/pull/3747
- https://github.com/autotest/tp-libvirt/pull/5130


test result:
 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.udp_tunnel_interface: PASS (80.72 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2023-08-25T05.50-98c927a/results.html
JOB TIME   : 82.13 s
