### PR TITLE
fix numa case invalid message

### DIFF
--- a/libvirt/tests/cfg/numa/guest_numa_node_tuning/invalid_nodeset_of_numa_memory_binding.cfg
+++ b/libvirt/tests/cfg/numa/guest_numa_node_tuning/invalid_nodeset_of_numa_memory_binding.cfg
@@ -15,6 +15,7 @@
     variants node_set:
         - partially_inexistent:
             nodeset = "1-2"
+            error_msg_1 = "Invalid value '${nodeset}' for 'cpuset.mems': Invalid argument"
         - totally_inexistent:
             nodeset = "2-3"
     variants binding:


### PR DESCRIPTION
Due to bug won't be fixed and feature owner updated the polarion  case


```
 avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 guest_numa_node_tuning.invalid_nodeset.
 (01/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.host.partially_inexistent.strict: PASS (6.23 s)
 (02/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.host.partially_inexistent.interleave: PASS (6.22 s)
 (03/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.host.partially_inexistent.preferred: PASS (6.23 s)
 (04/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.host.partially_inexistent.restrictive: PASS (6.26 s)
 (05/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.host.totally_inexistent.strict: PASS (6.25 s)
 (06/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.host.totally_inexistent.interleave: PASS (6.27 s)
 (07/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.host.totally_inexistent.preferred: PASS (6.24 s)
 (08/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.host.totally_inexistent.restrictive: PASS (9.00 s)
 (09/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.guest.partially_inexistent.strict: PASS (6.25 s)
 (10/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.guest.partially_inexistent.interleave: PASS (6.25 s)
 (11/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.guest.partially_inexistent.preferred: PASS (6.27 s)
 (12/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.guest.partially_inexistent.restrictive: PASS (6.77 s)
 (13/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.guest.totally_inexistent.strict: PASS (8.90 s)
 (14/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.guest.totally_inexistent.interleave: PASS (6.27 s)
 (15/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.guest.totally_inexistent.preferred: PASS (6.29 s)
 (16/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.guest.totally_inexistent.restrictive: PASS (6.86 s)

```