### PR TITLE
Update the tx_queue_size parameter

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_bridge.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_bridge.cfg
@@ -32,7 +32,7 @@
             iface_source = "{'network':'host_bridge'}"
             iface_alias = "ua-ad4acfc8-2ed4-43d4-9481-18a7d8e11b4f"
         - multiqueues:
-            iface_driver = '{"queues": "4", "rx_queue_size": "1024", "tx_queue_size": "512", "name": "vhost" }'
+            iface_driver = '{"queues": "4", "rx_queue_size": "1024", "tx_queue_size": "256", "name": "vhost" }'
             iface_model = "virtio"
             variants:
                 - start:

--- a/libvirt/tests/cfg/virtual_network/iface_options.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_options.cfg
@@ -25,11 +25,11 @@
                 - driver_page_per_vq:
                     no s390-virtio
                     func_supported_since_libvirt_ver = (7, 9, 0)
-                    iface_driver = "{'queues':'5','page_per_vq':'on','tx_queue_size':'1024','rx_queue_size':'1024'}"
+                    iface_driver = "{'queues':'5','page_per_vq':'on','tx_queue_size':'256','rx_queue_size':'1024'}"
                     variants:
                         - on:
                         - off:
-                            iface_driver = "{'queues':'5','page_per_vq':'off','tx_queue_size':'1024','rx_queue_size':'1024'}"
+                            iface_driver = "{'queues':'5','page_per_vq':'off','tx_queue_size':'256','rx_queue_size':'1024'}"
                         - attach_device:
                             change_iface_options = "no"
                             test_iface_option_cmd = "no"
@@ -120,7 +120,7 @@
                     ovs_br_name = "ovsbr0"
                     vhostuser_names = "vhost-user1"
                     need_vhostuser_env = "yes"
-                    iface_driver = "{'name':'vhost','queues':'5','rx_queue_size':'1024','tx_queue_size':'1024'}"
+                    iface_driver = "{'name':'vhost','queues':'5','rx_queue_size':'1024','tx_queue_size':'256'}"
                     expect_tx_size = "256"
                     change_iface_options = "yes"
                     test_iface_option_xml = "yes"
@@ -228,7 +228,7 @@
                     variants test_type:
                         - queue_size_check:
                             iface_source = "{'type':'unix','path':'/var/run/openvswitch/vhost-user1','mode':'client'}"
-                            iface_driver = "{'name':'qemu','queues':'5','rx_queue_size':'1024','tx_queue_size':'1024'}"
+                            iface_driver = "{'name':'qemu','queues':'5','rx_queue_size':'1024','tx_queue_size':'256'}"
                             check_guest_trans = "yes"
                         - multi_queue:
                             vcpu_num = "16"


### PR DESCRIPTION
After qemu bug 2040509, qemu changed the bahavior when checking the tx_queue_size value. Only for vdpa and vhostuser, the tx_queue_size more than 256 are supported. For other types, it will report error. Before this bug, qemu will ignore the unsupported setting and start the vm anyway and always keep tx_queue_size as 256 in the VM. This may be supported in the future, refer to
https://issues.redhat.com/browse/RHEL-1139. Update this parameter setting as it is not critical for this case.