### PR TITLE
Fix for domifstat and domblkstat when libvirtd is off

### DIFF
--- a/libvirt/tests/src/virsh_cmd/monitor/virsh_domblkstat.py
+++ b/libvirt/tests/src/virsh_cmd/monitor/virsh_domblkstat.py
@@ -1,6 +1,10 @@
+import logging as log
 from virttest import virsh
 from virttest import libvirt_xml
 from virttest import utils_libvirtd
+from virttest import libvirt_version
+
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):
@@ -61,7 +65,11 @@ def run(test, params, env):
     # check status_error
     if status_error == "yes":
         if status == 0 or err == "":
-            test.fail("Run successfully with wrong command!")
+            if libvirt_version.version_compare(5, 6, 0):
+                logging.info("From libvirt version 5.6.0 libvirtd is "
+                             "restarted and command should succeed")
+            else:
+                test.fail("Run successfully with wrong command!")
     elif status_error == "no":
         if status != 0 or output == "":
             test.fail("Run failed with right command")

--- a/libvirt/tests/src/virsh_cmd/monitor/virsh_domifstat.py
+++ b/libvirt/tests/src/virsh_cmd/monitor/virsh_domifstat.py
@@ -1,9 +1,13 @@
+import logging as log
 from xml.dom.minidom import parseString
 
 from avocado.utils import process
 
 from virttest import virsh
 from virttest import utils_libvirtd
+from virttest import libvirt_version
+
+logging = log.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):
@@ -82,7 +86,11 @@ def run(test, params, env):
     # check status_error
     if status_error == "yes":
         if status == 0:
-            test.fail("Run successfully with wrong command!")
+            if libvirt_version.version_compare(5, 6, 0):
+                logging.info("From libvirt version 5.6.0 libvirtd is "
+                             "restarted and command should succeed")
+            else:
+                test.fail("Run successfully with wrong command!")
     elif status_error == "no":
         if status != 0:
             test.fail("Run failed with right command")


### PR DESCRIPTION
Signed-off-by: Kowshik Jois B S <kowsjois@linux.ibm.com>

Description: libvirtd is restarted after issuing virsh commands from libvirt version 5.6.0 on.
Hence need to fix test expectations when libvirtd is off