### PR TITLE
guest_os_booting: Add a case about resetting nvram

### DIFF
--- a/libvirt/tests/cfg/guest_os_booting/lifecycle/lifecycle_reset_nvram.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/lifecycle/lifecycle_reset_nvram.cfg
@@ -1,0 +1,17 @@
+- guest_os_booting.lifecycle.reset_nvram:
+    type = lifecycle_reset_nvram
+    start_vm = no
+    firmware_type = "ovmf"
+    func_supported_since_libvirt_ver = (8, 1, 0)
+    only q35
+ 
+    variants reset_action:
+        - create:
+        - start:
+            variants:
+                - @default:
+                - managedsave:
+                    pre_action = "managedsave"
+        - restore:
+            start_vm = "yes"
+            pre_action = "save"

--- a/libvirt/tests/src/guest_os_booting/lifecycle/lifecycle_reset_nvram.py
+++ b/libvirt/tests/src/guest_os_booting/lifecycle/lifecycle_reset_nvram.py
@@ -1,0 +1,64 @@
+import os
+
+from virttest import data_dir
+from virttest import libvirt_version
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+
+from provider.guest_os_booting import guest_os_booting_base
+
+VIRSH_ARGS = {'ignore_status': False, 'debug': True}
+
+
+def run(test, params, env):
+    """
+    Test'--reset-nvram' option can re-initialize NVRAM from its pristine
+    template.
+    """
+
+    libvirt_version.is_libvirt_feature_supported(params)
+    reset_action = params.get("reset_action")
+    reset_func = eval("virsh.%s" % reset_action)
+
+    vm_name = guest_os_booting_base.get_vm(params)
+    vm = env.get_vm(vm_name)
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm.name)
+    bkxml = vmxml.copy()
+
+    nvram_path = f"/var/lib/libvirt/qemu/nvram/{vm.name}_VARS.fd"
+    save_path = os.path.join(data_dir.get_tmp_dir(), vm.name + '.save')
+
+    try:
+        pre_action = params.get('pre_action')
+        if pre_action:
+            test.log.info("TEST_STEP: %s the VM.", pre_action)
+            pre_func = eval("virsh.%s" % pre_action)
+            if pre_action == "save":
+                pre_func_args = [vm.name, save_path]
+            else:
+                pre_func_args = [vm.name]
+            pre_func(*pre_func_args)
+
+        test.log.info("TEST_STEP: Erase nvram file contents.")
+        open(nvram_path, 'w').close()
+        st_size = os.stat(nvram_path).st_size
+        if st_size != 0:
+            test.fail("The size(%s) of the nvram file before resetting is "
+                      "incorrect!" % st_size)
+
+        test.log.info("TEST_STEP: Reset nvram file using %s function.",
+                      reset_action)
+        reset_opts = {"create": [vmxml.xml],
+                      "restore": [save_path],
+                      "start": [vm.name]}
+        reset_func(*reset_opts.get(reset_action), options="--reset-nvram",
+                   **VIRSH_ARGS)
+        st_size = os.stat(nvram_path).st_size
+        if st_size <= 0:
+            test.fail("The size(%s) of the nvram file after resetting is "
+                      "incorrect!" % st_size)
+
+    finally:
+        virsh.managedsave_remove(vm.name, debug=True)
+        bkxml.sync()


### PR DESCRIPTION
This PR adds:
    VIRT-297866: Reset NVRAM state of ovmf vm


**Test results:**
```
 (1/4) type_specific.io-github-autotest-libvirt.guest_os_booting.lifecycle.reset_nvram.create: PASS (9.99 s)
 (2/4) type_specific.io-github-autotest-libvirt.guest_os_booting.lifecycle.reset_nvram.start.default: PASS (10.07 s)
 (3/4) type_specific.io-github-autotest-libvirt.guest_os_booting.lifecycle.reset_nvram.start.managedsave: PASS (10.15 s)
 (4/4) type_specific.io-github-autotest-libvirt.guest_os_booting.lifecycle.reset_nvram.restore: PASS (88.42 s)
```
