### PR TITLE
Add case of connectivity check of mcast interface

### DIFF
--- a/libvirt/tests/cfg/virtual_network/connectivity/connectivity_check_mcast_interface.cfg
+++ b/libvirt/tests/cfg/virtual_network/connectivity/connectivity_check_mcast_interface.cfg
@@ -1,0 +1,10 @@
+- virtual_network.connectivity_check.mcast_interface:
+    type = connectivity_check_mcast_interface
+    start_vm = no
+    vms = avocado-vt-vm1 vm2
+    mcast_addr = 230.144.17.1
+    iface_m_attrs = {'source': {'address': '${mcast_addr}', 'port': '5558'}, 'model': 'virtio', 'type_name': 'mcast'}
+    iface_attrs = {'source': {'network': 'default'}, 'model': 'virtio', 'type_name': 'network'}
+    variants:
+        - default:
+            expect_msg = 'unicast, xmt/rcv/%loss = \d+/\d+/0%.*\n.*multicast, xmt/rcv/%loss = \d+/\d+/0%'

--- a/libvirt/tests/src/virtual_network/connectivity/connectivity_check_mcast_interface.py
+++ b/libvirt/tests/src/virtual_network/connectivity/connectivity_check_mcast_interface.py
@@ -1,0 +1,92 @@
+import logging
+import re
+from avocado.utils import process
+
+from virttest import utils_net
+from virttest import utils_package
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+VIRSH_ARGS = {'ignore_status': False, 'debug': True}
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+
+def run(test, params, env):
+    """
+    Check connectivity for mcast interface
+    """
+    vm_name = params.get('main_vm')
+    vms = params.get('vms').split()
+    vm, vm_c = (env.get_vm(vm_i) for vm_i in vms)
+
+    mcast_addr = params.get('mcast_addr')
+    iface_attrs = eval(params.get('iface_attrs', '{}'))
+    iface_m_attrs = eval(params.get('iface_m_attrs', '{}'))
+    expect_msg = params.get('expect_msg')
+
+    bkxmls = list(map(vm_xml.VMXML.new_from_inactive_dumpxml, vms))
+
+    try:
+        vmxml, vmxml_c = list(map(vm_xml.VMXML.new_from_inactive_dumpxml, vms))
+
+        vmxml.del_device('interface', by_tag=True)
+        vmxml_c.del_device('interface', by_tag=True)
+
+        iface = libvirt_vmxml.create_vm_device_by_type(
+            'interface', iface_attrs)
+        iface_m = libvirt_vmxml.create_vm_device_by_type('interface',
+                                                         iface_m_attrs)
+
+        for vmxml_i in (vmxml, vmxml_c):
+            for iface_i in (iface, iface_m):
+                libvirt.add_vm_device(vmxml_i, iface_i)
+
+        [LOG.debug(f'VMXML of {vm_x}:\n{virsh.dumpxml(vm_x).stdout_text}')
+         for vm_x in vms]
+
+        [vm_i.start() for vm_i in [vm, vm_c]]
+
+        netstat_out = process.run('netstat -g').stdout_text
+        if mcast_addr not in netstat_out:
+            test.fail(f'Not found "{mcast_addr}" in netstat output')
+
+        session = vm.wait_for_serial_login()
+        session_c = vm_c.wait_for_serial_login()
+
+        if any([not utils_package.package_install('omping', sess)
+                for sess in (session, session_c)]):
+            test.error('Failed to install "omping" in vms.')
+
+        ip, ip_c = [vm_i.get_address() for vm_i in [vm, vm_c]]
+
+        LOG.debug(session.cmd_output('ip a'))
+        LOG.debug(session_c.cmd_output('ip a'))
+
+        # Build omping command
+        ip_suf, ip_suf_c = (ip_i.split('.')[-1] for ip_i in (ip, ip_c))
+        ip_pre = ip.replace(f'.{ip_suf}', '')
+        omping_cmd = f'omping -m {mcast_addr} {ip_pre}.{{{ip_suf},{ip_suf_c}}}'
+
+        # omping from vm to vm_c
+        session.cmd('systemctl stop firewalld')
+        status, output = utils_net.raw_ping(omping_cmd, 5, session,
+                                            output_func=LOG.debug)
+        if 'response message never received' not in output:
+            test.fail('omping should fail with remote vm firewalld on')
+
+        # Keep omping process alive on vm then omping from vm_c to vm
+        session.sendline(omping_cmd)
+        session_c.cmd('systemctl stop firewalld')
+        status_c, output_c = utils_net.raw_ping(omping_cmd, 5, session_c,
+                                                output_func=LOG.debug)
+        if not re.search(expect_msg, output_c):
+            test.fail(f'Not found "{expect_msg}" in output of omping')
+
+        session.close()
+        session_c.close()
+
+    finally:
+        [backup_xml.sync() for backup_xml in bkxmls]


### PR DESCRIPTION
- VIRT-294957 - [mcast] Check connectivity of mcast type interface

test result:
 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.mcast_interface.default: PASS (108.24 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2023-08-31T23.33-6281078/results.html
JOB TIME   : 109.69 s

