### PR TITLE
memory: fix several tests on s390x

### DIFF
--- a/libvirt/tests/cfg/memory/memory_allocation/define_value_unit.cfg
+++ b/libvirt/tests/cfg/memory/memory_allocation/define_value_unit.cfg
@@ -74,6 +74,7 @@
             vm_attrs = {'memory_unit':'${mem_unit}','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':"${current_mem_unit}"}
             xpaths = [[{'element_attrs':['.//memory[@unit="${default_unit}"]'],'text':'%s'}],[{'element_attrs':['.//currentMemory[@unit="${default_unit}"]'],'text':'%s'}]]
         - with_numa:
+            no s390-virtio
             numa_cpu = {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '${mem_value}', 'unit': '${mem_unit}'}]}
             vm_attrs = {'max_mem_rt': ${max_mem}, 'max_mem_rt_slots': ${max_mem_slots}, 'max_mem_rt_unit': "${max_mem_unit}",'memory_unit':"${mem_unit}",'memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}',"cpu":${numa_cpu}}
             xpaths = [[{'element_attrs':['.//memory[@unit="${default_unit}"]'],'text':'%s'}],[{'element_attrs':['.//currentMemory[@unit="${default_unit}"]'],'text':'%s'}],[{'element_attrs':['.//maxMemory[@unit="${default_unit}"]'],'text':'%s'}],[{'element_attrs':['.//cell[@unit="${default_unit}"]','.//cell[@memory="%s"]']}]]

--- a/libvirt/tests/cfg/memory/memory_allocation/memory_allocation_config_modification.cfg
+++ b/libvirt/tests/cfg/memory/memory_allocation/memory_allocation_config_modification.cfg
@@ -20,6 +20,7 @@
                 - without_numa:
                     vm_attrs = {'memory_unit':'${mem_unit}','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':"${current_mem_unit}"}
                 - with_numa:
+                    no s390-virtio
                     numa_attrs = "'vcpu': 4,'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '${numa_mem}', 'unit': 'KiB'},{'id':'1','cpus': '2-3','memory':'${numa_mem}','unit':'KiB'}]}"
                     vm_attrs = {${numa_attrs},'max_mem_rt': ${max_mem}, 'max_mem_rt_slots': ${max_mem_slots}, 'max_mem_rt_unit': "${max_mem_unit}",'memory_unit':"${mem_unit}",'memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}'}
                     maxmem_error = "initial memory size of a domain with NUMA nodes cannot be modified with this API"

--- a/libvirt/tests/cfg/memory/memory_backing/lifecycle_for_hugepage.cfg
+++ b/libvirt/tests/cfg/memory/memory_backing/lifecycle_for_hugepage.cfg
@@ -10,22 +10,38 @@
     set_pagesize ="1048576"
     set_pagenum = "2"
     free_hugepages_cmd= "cat /sys/kernel/mm/hugepages/hugepages-1048576kB/free_hugepages"
+    s390-virtio:
+        free_hugepages_cmd= "cat /sys/kernel/mm/hugepages/hugepages-1024kB/free_hugepages"
+        set_pagesize = "1024"
+        mount_size = "1024"
+        set_pagenum = "2048"
+        vm_nr_hugepages = 2048
+        kvm_module_parameters =
     variants:
         - memory_hugepage:
             variants:
                 - 4k:
+                    no s390-virtio
                     page_size = "4"
                     page_unit = "KiB"
                     memory_backing_dict = "'mb': {'hugepages': {'pages': [{'unit': '${page_unit}', 'size': '${page_size}'}]}}"
                     vm_attrs = {${memory_backing_dict}, 'memory_unit':'${mem_unit}','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}'}
                     HugePages_Free = "1024"
                     free_hugepages = "2"
+                - 1M:
+                    only s390-virtio
+                    memory_backing_dict = "'mb': {'hugepages': {}}"
+                    vm_attrs = {${memory_backing_dict}, 'memory_unit':'${mem_unit}','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}'}
+                    HugePages_Free = "0"
+                    free_hugepages = "0"
                 - 2M:
+                    no s390-virtio
                     memory_backing_dict = "'mb': {'hugepages': {}}"
                     vm_attrs = {${memory_backing_dict}, 'memory_unit':'${mem_unit}','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}'}
                     HugePages_Free = "0"
                     free_hugepages = "2"
                 - 1G:
+                    no s390-virtio
                     page_size = "1"
                     page_unit = "G"
                     memory_backing_dict = "'mb': {'hugepages': {'pages': [{'unit': '${page_unit}', 'size': '${page_size}'}]}}"

--- a/libvirt/tests/cfg/virtio/virtio_page_per_vq.cfg
+++ b/libvirt/tests/cfg/virtio/virtio_page_per_vq.cfg
@@ -3,6 +3,7 @@
     start_vm = no
     driver_dict = {'driver': {'page_per_vq': 'on'}}
     ping_outside = 'www.google.com'
+    no s390-virtio
     variants:
         - default_start:
         - hotplug:

--- a/libvirt/tests/src/memory/memory_backing/lifecycle_for_hugepage.py
+++ b/libvirt/tests/src/memory/memory_backing/lifecycle_for_hugepage.py
@@ -116,7 +116,7 @@ def run(test, params, env):
         status, stdout = session.cmd_status_output("swapoff -a; memhog %s" % (
                 mem_free - 204800))
         if status:
-            raise test.fail("Failed to consume memory:%s", stdout)
+            raise test.fail("Failed to consume memory:%s" % stdout)
 
         virsh.destroy(vm.name, **VIRSH_ARGS)
 


### PR DESCRIPTION
memory..define_value_unit: disable numa tests on s390x

There's no NUMA on s390x. Disable tests.

memory_backing/lifecycel_for_hugepage: fix tests on s390x

On s390x, supported huge page size for KVM is 1M.
Also, add kvm_module_parameters which allow to set 'hpage=1' to enable hugepage support in CI.

memory_allocation_config: disable numa test on s390x

No NUMA on s390x, disable test.

virtio.virtio_page_per_vq: disable on s390x

virtio-balloon-ccw doesn't support the page-per-vq property. Disable test.