### PR TITLE
virsh.emulatorpin: add alternative error msg for negative test

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_emulatorpin.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_emulatorpin.cfg
@@ -133,7 +133,7 @@
                                                     err_msg = 'CPU.*in cpulist.*exceed the maxcpu'
                                                 - set_by_xml:
                                                     set_emulatorpin_by_xml = "yes"
-                                                    err_msg = 'cannot set CPU affinity on process.*: Invalid argument|result out of range'
+                                                    err_msg = 'cannot set CPU affinity on process.*: Invalid argument|result out of range|Invalid value.*cpuset.cpus.*: Invalid argument'
                                     variants:
                                         - emulatorpin_options:
                                             variants:


### PR DESCRIPTION
On s390x, there's a different but valid error message. Expect the message alternatively on failure.