### PR TITLE
Fix managed save and restore failure on s390x

### DIFF
--- a/libvirt/tests/src/save_and_restore/save_to_block.py
+++ b/libvirt/tests/src/save_and_restore/save_to_block.py
@@ -58,7 +58,7 @@ def run(test, params, env):
         if vm.state() != 'running':
             test.fail(f'VM should be running after restore, not {vm.state()}')
 
-        avc_denied = process.run('grep avc -i /var/log/audit/audit.log',
+        avc_denied = process.run("grep -E 'avc:.*denied' /var/log/audit/audit.log",
                                  ignore_status=True).stdout_text.strip()
         if avc_denied:
             test.fail(f'Got avc denied:\n{avc_denied}')


### PR DESCRIPTION
Fix managed save and restore failure on s390x

on s390x, it may grep msg='avc',but not denied message, so this case will be marked as failure
By updating grep message to 'avc:.*denied' to avoid this happening