### PR TITLE
memory: Enable test for aarch64

### DIFF
--- a/libvirt/tests/cfg/memory/memory_backing/hugepage_nodeset.cfg
+++ b/libvirt/tests/cfg/memory/memory_backing/hugepage_nodeset.cfg
@@ -11,6 +11,12 @@
     set_pagesize = "2048"
     set_pagenum = "1024"
     expect_str = "huge"
+    aarch64:
+        page_size = "524288"
+        current_mem = 1572864
+        mem_value = 1572864
+        set_pagesize = "524288"
+        set_pagenum = "4"
     variants:
         - nodeset_0:
             nodeset = "0"
@@ -24,6 +30,8 @@
         - with_numa:
             numa_size_1 = 1048576
             numa_size_2 = 1024000
+            aarch64:
+                numa_size_2 = 524288
             numa_cpu = {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '${numa_size_1}', 'unit': 'KiB'}, {'id': '1', 'cpus': '2-3', 'memory': '${numa_size_2}', 'unit': 'KiB'}]}
             vm_attrs = {${memory_backing_dict},"cpu":${numa_cpu},'vcpu': 4,'max_mem_rt_slots': 16,'memory_unit':"${mem_unit}",'memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}','max_mem_rt': 3145728, 'max_mem_rt_unit': "KiB"}
             expect_xpath = [{'element_attrs':[".//page[@size='${page_size}']", ".//page[@unit='${page_unit}']", ".//page[@nodeset='${nodeset}']"]}]
@@ -32,3 +40,5 @@
             vm_attrs = {${memory_backing_dict}, 'memory_unit':'${mem_unit}','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}'}
             expect_xpath = [{'element_attrs':[".//page[@size='${page_size}']", ".//page[@unit='${page_unit}']"]}]
             allocated_mem = "2072576"
+            aarch64:
+                allocated_mem = "1572864"


### PR DESCRIPTION
The default huge pagesize is 512M for aarch64.

Test Results:
```
 (1/4) type_specific.io-github-autotest-libvirt.memory.backing.nodeset.with_numa.nodeset_0: PASS (35.53 s)
 (2/4) type_specific.io-github-autotest-libvirt.memory.backing.nodeset.with_numa.nodeset_not_exist: PASS (9.59 s)
 (3/4) type_specific.io-github-autotest-libvirt.memory.backing.nodeset.without_numa.nodeset_0: PASS (40.35 s)
 (4/4) type_specific.io-github-autotest-libvirt.memory.backing.nodeset.without_numa.nodeset_not_exist: PASS (9.73 s)
```