### PR TITLE
libvirt_rng.multiple_rng: run socat on all archs

### DIFF
--- a/libvirt/tests/src/libvirt_rng.py
+++ b/libvirt/tests/src/libvirt_rng.py
@@ -629,7 +629,7 @@ def run(test, params, env):
                 cmd = "cat /dev/random | nc -4 -l localhost 1024"
                 bgjob = utils_misc.AsyncJob(cmd)
 
-            if all([guest_arch == 'x86_64', random_source, params.get("backend_type") == "udp", test_guest_dump]):
+            if all([random_source, params.get("backend_type") == "udp", test_guest_dump]):
                 if not utils_package.package_install("socat"):
                     test.error("Failed to install socat on host")
                 cmd1 = "cat /dev/urandom|nc -l 127.0.0.1 1235"


### PR DESCRIPTION
The multiple_rng tests set up an edg with udp. However, no source is available. For x86_64 there was a fix by providing a source with socat. Enable this for all architectures.