### PR TITLE
migration: Add case to test copy storage synchronous writes

### DIFF
--- a/libvirt/tests/cfg/migration_with_copy_storage/performance_tuning/copy_storage_synchronous_writes.cfg
+++ b/libvirt/tests/cfg/migration_with_copy_storage/performance_tuning/copy_storage_synchronous_writes.cfg
@@ -1,0 +1,44 @@
+- migration_with_copy_storage.performance_tuning.copy_storage_synchronous_writes:
+    type = copy_storage_synchronous_writes
+    migration_setup = 'yes'
+    # Console output can only be monitored via virsh console output
+    only_pty = True
+    take_regular_screendumps = no
+    # Extra options to pass after <domain> <desturi>
+    virsh_migrate_extra = ''
+    # SSH connection time out
+    ssh_timeout = 60
+    # Local URI
+    virsh_migrate_connect_uri = 'qemu:///system'
+    virsh_migrate_dest_state = "running"
+    virsh_migrate_src_state = "shut off"
+    image_convert = 'no'
+    server_ip = "${migrate_dest_host}"
+    server_user = "root"
+    server_pwd = "${migrate_dest_pwd}"
+    client_ip = "${migrate_source_host}"
+    client_user = "root"
+    client_pwd = "${migrate_source_pwd}"
+    status_error = "yes"
+    check_network_accessibility_after_mig = "yes"
+    migrate_desturi_port = "16509"
+    migrate_desturi_type = "tcp"
+    virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
+    setup_nfs = "no"
+    nfs_mount_dir =
+    server_cn = "ENTER.YOUR.EXAMPLE.SERVER_CN"
+    client_cn = "ENTER.YOUR.EXAMPLE.CLIENT_CN"
+    status_error = "no"
+    virsh_migrate_extra = "--copy-storage-synchronous-writes"
+    func_supported_since_libvirt_ver = (8, 0, 0)
+
+    variants:
+        - p2p:
+            virsh_migrate_options = '--live --p2p --verbose'
+        - non_p2p:
+            virsh_migrate_options = '--live --verbose'
+    variants:
+        - copy_storage_all:
+            copy_storage_option = "--copy-storage-all"
+        - copy_storage_inc:
+            copy_storage_option = "--copy-storage-inc"

--- a/libvirt/tests/src/migration_with_copy_storage/performance_tuning/copy_storage_synchronous_writes.py
+++ b/libvirt/tests/src/migration_with_copy_storage/performance_tuning/copy_storage_synchronous_writes.py
@@ -1,0 +1,39 @@
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright Red Hat
+#
+#   SPDX-License-Identifier: GPL-2.0
+
+#   Author: Liping Cheng<lcheng@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+from virttest import libvirt_version
+
+from provider.migration import base_steps
+
+
+def run(test, params, env):
+    """
+    To verify that libvirt can enable synchronous writes of vm disks during
+    migration.
+
+    :param test: test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    libvirt_version.is_libvirt_feature_supported(params)
+
+    vm_name = params.get("migrate_main_vm")
+    vm = env.get_vm(vm_name)
+    migration_obj = base_steps.MigrationBase(test, vm, params)
+
+    try:
+        migration_obj.setup_connection()
+        base_steps.prepare_disks_remote(params, vm)
+        migration_obj.run_migration()
+        migration_obj.verify_default()
+    finally:
+        migration_obj.cleanup_connection()
+        base_steps.cleanup_disks_remote(params, vm)

--- a/spell.ignore
+++ b/spell.ignore
@@ -110,6 +110,7 @@ chardev
 chardevs
 checksum
 checksums
+Cheng
 chipset
 chmod
 chnaged
@@ -487,6 +488,7 @@ kvm
 KVM
 kwargs
 lan
+lcheng
 lchown
 libexec
 libguestfs
@@ -505,6 +507,7 @@ libvrtd
 lifecycle
 Lifecycle
 linux
+Liping
 localhost
 localvm
 lockspace


### PR DESCRIPTION
VIRT-297902 - VM live migration with copy storage - synchronous writes of vm disks(--copy-storage-synchronous-writes)