### PR TITLE
ovmf_loader: add the libvirt support version

### DIFF
--- a/libvirt/tests/cfg/guest_os_booting/ovmf_firmware/ovmf_loader.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/ovmf_firmware/ovmf_loader.cfg
@@ -23,6 +23,7 @@
         - negative_test:
             variants:
                 - readonly_no:
+                    func_supported_since_libvirt_ver = (9, 5, 0)
                     loader_dict = {'secure': 'yes', 'loader_readonly': 'no', 'loader_type': 'pflash', 'loader': '${loader_path}'}
                     error_msg = "Could not open .+: Permission denied"
                 - type_rom:


### PR DESCRIPTION
Readonly_os issue has been fixed in bug 2196178. So add the libvirt support version.