### PR TITLE
libvirt_rng: remove flakiness for tcp bind mode

### DIFF
--- a/libvirt/tests/src/libvirt_rng.py
+++ b/libvirt/tests/src/libvirt_rng.py
@@ -641,11 +641,6 @@ def run(test, params, env):
             # Wait guest to enter boot stage
             time.sleep(3)
 
-            # Feed the tcp random device some data
-            if test_guest_dump and params.get("backend_type") == "tcp":
-                cmd = "cat /dev/random | nc -4 localhost 1024"
-                bgjob = utils_misc.AsyncJob(cmd)
-
             if attach_rng:
                 ret = virsh.attach_device(vm_name, rng_xml.xml,
                                           flagstr=attach_options,
@@ -660,6 +655,11 @@ def run(test, params, env):
                 # Start the VM.
                 if start_error:
                     test.fail("VM started unexpectedly")
+
+            # Feed the tcp random device some data
+            if test_guest_dump and params.get("backend_type") == "tcp":
+                cmd = "cat /dev/random | nc -4 localhost 1024"
+                bgjob = utils_misc.AsyncJob(cmd)
 
             # Add udp random server to feed aarch64 guest to speed up boot
             # https://bugzilla.redhat.com/show_bug.cgi?id=1983544


### PR DESCRIPTION
Sometimes,

 libvirt_rng.backend_tcp.bind_mode.hotplug_unplug.positive.persistent

fails.

The test provides entropy to the tcp backend via netcat

 nc -4 localhost 1024

However, this command will immediately exit if nothing listens on that port.
The test will hotplug an egd device which listens. However, if netcat is issued before the listener is active then netcat will exit and that egd device doesn't receive entropy during the boot. Therefore the boot will wait and the test can't log into the console.

Change execution order to make sure the entropy is provided, that is, first hotplug the listener, then send data with netcat.

I assume that on environments where the test passes, the bgjob is started shortly after device is attached, and that this is possible because it's started asynchronously because it uses the class AsyncJob.