### PR TITLE
virtio: update virtio pattern to virtio_attributes

### DIFF
--- a/libvirt/tests/cfg/virtio/virtio_page_per_vq.cfg
+++ b/libvirt/tests/cfg/virtio/virtio_page_per_vq.cfg
@@ -1,4 +1,4 @@
-- virtio.virtio_page_per_vq:
+- virtio_attributes.virtio_page_per_vq:
     type = virtio_page_per_vq
     start_vm = no
     driver_dict = {'driver': {'page_per_vq': 'on'}}


### PR DESCRIPTION
That because virtio pattern is not suitable when searching series of these cases to run.