### PR TITLE
cpu: fix several tests on s390x

### DIFF
--- a/libvirt/tests/cfg/cpu/vcpu_misc.cfg
+++ b/libvirt/tests/cfg/cpu/vcpu_misc.cfg
@@ -32,6 +32,7 @@
                     expected_str_after_startup = 'mode="host-passthrough"'
                     customize_cpu_features = "yes"
                 - with_maxphysaddr:
+                    no s390-virtio
                     func_supported_since_libvirt_ver = (9, 3, 0)                    
                     maxphysaddr = {'mode': 'passthrough', 'limit':'%d'}
                     expected_qemuline = "host-phys-bits-limit=%s"

--- a/libvirt/tests/cfg/cpu/vm_features.cfg
+++ b/libvirt/tests/cfg/cpu/vm_features.cfg
@@ -62,6 +62,7 @@
         - negative_test:
             variants:
                 - hyperv:
+                    no pseries, s390-virtio, aarch64
                     variants:
                         - features_not_in_domcapabilities:
                             func_supported_since_libvirt_ver = (9, 0, 0)

--- a/libvirt/tests/src/cpu/vcpu_metrics.py
+++ b/libvirt/tests/src/cpu/vcpu_metrics.py
@@ -126,6 +126,8 @@ def setup_with_unprivileged_user(vm, params, test):
     interface_attrs = eval(params.get('interface_attrs', '{}'))
     vmxml = vm_xml.VMXML.new_from_dumpxml(vm.name)
     params['backup_vmxml'] = vmxml.copy()
+    test.log.debug("Remove 'dac' security driver for unprivileged user")
+    vmxml.del_seclabel(by_attr=[('model', 'dac')])
     libvirt_vmxml.modify_vm_device(vmxml, 'interface', interface_attrs)
     boot_disk = vmxml.devices.by_device_tag('disk')[0]
     first_disk_source = boot_disk.fetch_attrs()['source']['attrs']['file']


### PR DESCRIPTION
vm_features: disable for unsupported archs

Hyper-V is not supported on these architectures, as was already indicated for positive_tests.
Disable the negative_tests, too.

vcpu_misc: disable test for maxphysaddr on s390x

CPU maximum physical address bits specification is not supported for 's390x' architecture

vcpu_metrics: remove seclabel for unprivileged user

seclable dac model is not available for unprivileged users, remove it.