### PR TITLE
Improve compatibility by filtering serial device operations

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_serial_device_alias.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_detach_serial_device_alias.cfg
@@ -12,7 +12,7 @@
                     target_type = isa-serial
                     hot_plugging_support = "no"
                 - pci-serial:
-                    no s390-virtio
+                    no aarch64, s390-virtio
                     target_type = pci-serial
         - serial_type_pty:
             serial_dev_type = pty
@@ -22,5 +22,5 @@
                     hot_plugging_support = "no"
                     target_type = isa-serial
                 - pci-serial:
-                    no s390-virtio
+                    no aarch64, s390-virtio
                     target_type = pci-serial


### PR DESCRIPTION
Previously, an error occurred when attempting to hot-plug or unplug serial devices on the arm64 architecture. This is due to the lack of support for these operations on arm64.
To resolve this issue, this commit refactors the configuration file to exclude hot-plugging and unplugging of serial devices specifically for arm64. By doing so, we ensure better compatibility and prevent unknown errors.