### PR TITLE
virsh_save/restore: improve tear down

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_restore.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_restore.py
@@ -216,3 +216,5 @@ def run(test, params, env):
                 export_dir=params.get("export_dir"), rm_export_dir=False)
         if setup_iscsi:
             libvirt.setup_or_cleanup_iscsi(False)
+        if os.path.exists(tmp_file):
+            os.remove(tmp_file)

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_save.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_save.py
@@ -155,3 +155,5 @@ def run(test, params, env):
     finally:
         if vm.is_paused():
             virsh.resume(vm_name)
+        if os.path.exists(savefile):
+            os.remove(savefile)


### PR DESCRIPTION
If save.file exists, remove it. If not, it can lead to test errors "Permission denied" or "right command failed" and similar issues.