### PR TITLE
Adjust memory page size for Arm architecture

### DIFF
--- a/libvirt/tests/cfg/guest_os_booting/migration/migration_boot.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/migration/migration_boot.cfg
@@ -1,0 +1,31 @@
+- guest_os_booting.migration.boot:
+    type = migration_boot
+    # Migrating non-started VM causes undefined behavior
+    start_vm = yes
+    # Console output can only be monitored via virsh console output
+    only_pty = True
+    take_regular_screendumps = no
+    # Options to pass to virsh migrate command before <domain> <desturi>
+    virsh_migrate_options = ""
+    # Extra options to pass after <domain> <desturi>
+    virsh_migrate_extra = ""
+    # SSH connection time out
+    ssh_timeout = 60
+    migration_setup = "yes"
+    storage_type = 'nfs'
+    setup_local_nfs = 'yes'
+    disk_type = "file"
+    disk_source_protocol = "netfs"
+    mnt_path_name = ${nfs_mount_dir}
+    image_convert = 'no'
+    virsh_migrate_dest_state = "running"
+    virsh_migrate_src_state = "shut off"
+    virsh_migrate_options = "--p2p --live --verbose  --persistent"
+    virsh_migrate_desturi = "qemu+ssh://${migrate_dest_host}/system"
+    virsh_migrate_connect_uri = "qemu:///system"
+    variants:
+        - os_dev:
+            os_attrs_boots = ['hd', 'cdrom', 'network']
+        - boot_order:
+            disk_boot_idx = 1
+            iface_dict = {'boot': 2}

--- a/libvirt/tests/cfg/memory/memory_attach_device.cfg
+++ b/libvirt/tests/cfg/memory/memory_attach_device.cfg
@@ -9,12 +9,13 @@
     variants test_case:
         - virtio_mem:
             no pseries
-            set_num_huge_pages = 1000
+            #set_num_huge_pages = 1000
             required_kernel = [5.14.0,)
             guest_required_kernel = [5.8.0,)
             func_supported_since_libvirt_ver = (8, 0, 0)
             func_supported_since_qemu_kvm_ver = (6, 2, 0)
             vm_attrs = {'max_mem_rt': 10485760, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB', 'vcpu': 4, 'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '1048576', 'unit': 'KiB'}]}}
             aarch64:
-                vm_attrs = {'max_mem_rt': 10485760, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB', 'vcpu': 4, 'cpu': {'mode': 'host-passthrough', 'numa_cell': [{'id': '0', 'cpus': '0-3', 'memory': '524288', 'unit': 'KiB'}]}}
-            mem_device_attrs = {'mem_model': 'virtio-mem', 'target': {'requested_unit': 'KiB', 'size': 262144, 'node': 0, 'size_unit': 'KiB', 'requested_size': 131072, 'block_unit': 'KiB', 'block_size': 2048}, 'source': {'pagesize_unit': 'KiB', 'pagesize': 2048, 'nodemask': '0'}}
+                vm_attrs = {'max_mem_rt': 10485760, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB', 'vcpu': 4, 'cpu': {'mode': 'host-passthrough', 'numa_cell': [{'id': '0', 'cpus': '0-3', 'memory': '1048576', 'unit': 'KiB'}]}}
+            mem_device_attrs = {'mem_model': 'virtio-mem', 'target': {'requested_unit': 'KiB', 'size': 1048576, 'node': 0, 'size_unit': 'KiB', 'requested_size': 524288, 'block_unit': 'KiB', 'block_size': 524288}}
+           # , 'source': {'pagesize_unit': 'KiB', 'pagesize': 2048, 'nodemask': '0'}}

--- a/libvirt/tests/cfg/memory/memory_update_device.cfg
+++ b/libvirt/tests/cfg/memory/memory_update_device.cfg
@@ -13,7 +13,7 @@
             vm_attrs = {'max_mem_rt': 10485760, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB', 'vcpu': 4, 'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '1048576', 'unit': 'KiB'}]}}
             aarch64:
                 vm_attrs = {'max_mem_rt': 10485760, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB', 'vcpu': 4, 'cpu': {'mode': 'host-passthrough', 'numa_cell': [{'id': '0', 'cpus': '0-3', 'memory': '524288', 'unit': 'KiB'}]}}
-            mem_device_attrs = {'mem_model': 'virtio-mem', 'target': {'requested_unit': 'KiB', 'size': 262144, 'node': 0, 'size_unit': 'KiB', 'requested_size': 131072, 'block_unit': 'KiB', 'block_size': 2048}, 'source': {'pagesize_unit': 'KiB', 'pagesize': 2048, 'nodemask': '0'}}
-            requested_size = 160MiB
+            mem_device_attrs = {'mem_model': 'virtio-mem', 'target': {'requested_unit': 'KiB', 'size': 1048576, 'node': 0, 'size_unit': 'KiB', 'requested_size': 524288, 'block_unit': 'KiB', 'block_size': 524288}, 'source': {'pagesize_unit': 'KiB', 'pagesize': 524288, 'nodemask': '0'}}
+            requested_size = 1048576KiB
             check_log_str = "MEMORY_DEVICE_SIZE_CHANGE.*virtiomem"
             virsh_opts = "--alias %s --requested-size ${requested_size}"

--- a/libvirt/tests/cfg/sriov/vIOMMU/migration_iommu_device.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/migration_iommu_device.cfg
@@ -1,0 +1,56 @@
+- vIOMMU.migration.iommu_device:
+    type = migration_iommu_device
+    # Migrating non-started VM causes undefined behavior
+    start_vm = yes
+    # Console output can only be monitored via virsh console output
+    only_pty = True
+    take_regular_screendumps = no
+    # Options to pass to virsh migrate command before <domain> <desturi>
+    virsh_migrate_options = ""
+    # Extra options to pass after <domain> <desturi>
+    virsh_migrate_extra = ""
+    # SSH connection time out
+    ssh_timeout = 60
+    migration_setup = "yes"
+    storage_type = 'nfs'
+    setup_local_nfs = 'yes'
+    disk_type = "file"
+    disk_source_protocol = "netfs"
+    mnt_path_name = ${nfs_mount_dir}
+    image_convert = 'no'
+    virsh_migrate_dest_state = "running"
+    virsh_migrate_src_state = "shut off"
+    virsh_migrate_options = "--p2p --live --verbose  --persistent"
+    virsh_migrate_desturi = "qemu+ssh://${migrate_dest_host}/system"
+    virsh_migrate_connect_uri = "qemu:///system"
+    check_network_accessibility_after_mig = "yes"
+    disk_driver = {'name': 'qemu', 'type': 'qcow2', 'iommu': 'on'}
+    variants:
+        - virtio:
+            only q35, aarch64
+            func_supported_since_libvirt_ver = (8, 3, 0)
+            iommu_dict = {'model': 'virtio'}
+        - intel:
+            only q35
+            start_vm = "yes"
+            enable_guest_iommu = "yes"
+            iommu_dict = {'model': 'intel', 'driver': {'intremap': 'on', 'caching_mode': 'on', 'eim': 'on', 'iotlb': 'on', 'aw_bits': '48'}}
+        - smmuv3:
+            only aarch64
+            func_supported_since_libvirt_ver = (5, 5, 0)
+            iommu_dict = {'model': 'smmuv3'}
+    variants:
+        - virtio_muti_devices:
+            disk_dict = {'target': {'dev': 'vda', 'bus': 'virtio'}, 'device': 'disk', 'driver': ${disk_driver}}
+            video_dict = {'primary': 'yes', 'model_heads': '1', 'model_type': 'virtio', 'driver': {'iommu': 'on'}}
+            variants:
+                - vhost_on:
+                    interface_driver_name = "vhost"
+                - vhost_off:
+                    interface_driver_name = "qemu"
+            interface_driver = {'driver_attr': {'name': '${interface_driver_name}', 'iommu': 'on'}}
+            iface_dict = {'type_name': 'network', 'model': 'virtio', 'driver': ${interface_driver}, 'source': {'network': 'default'}}
+        - scsi_controller:
+            controller_dicts = [{'type': 'scsi', 'model': 'virtio-scsi','driver': {'iommu': 'on'}}]
+            disk_dict = {'target': {'dev': 'sda', 'bus': 'scsi'}}
+            cleanup_ifaces = no

--- a/libvirt/tests/src/guest_os_booting/migration/migration_boot.py
+++ b/libvirt/tests/src/guest_os_booting/migration/migration_boot.py
@@ -1,0 +1,69 @@
+from virttest.libvirt_xml import vm_xml
+
+from provider.migration import base_steps
+from provider.guest_os_booting import guest_os_booting_base
+
+
+def run(test, params, env):
+    """
+    Migrate vm with boot elements.
+
+    :param test: test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    def update_vm_xml(vm, params):
+        """
+        Update VM xml
+
+        :param vm: VM object
+        :param params: Dictionary with the test parameters
+        """
+        iface_dict = eval(params.get("iface_dict", "{}"))
+        os_attrs_boots = eval(params.get('os_attrs_boots', '[]'))
+        vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm.name)
+
+        if os_attrs_boots:
+            os_attrs = {'boots': os_attrs_boots}
+            vmxml.setup_attrs(os=os_attrs)
+        else:
+            vm_os = vmxml.os
+            vm_os.del_boots()
+            vmxml.os = vm_os
+            xml_devices = vmxml.devices
+            if iface_dict:
+                iface_obj = xml_devices.by_device_tag('interface')[0]
+                iface_obj.setup_attrs(**iface_dict)
+            vmxml.devices = xml_devices
+            disk_attrs = xml_devices.by_device_tag('disk')[0].fetch_attrs()
+            vmxml.set_boot_order_by_target_dev(
+                disk_attrs['target']['dev'], params.get('disk_boot_idx'))
+        vmxml.xmltreefile.write()
+        test.log.debug(f"vmxml after updating: {vmxml}")
+        vmxml.sync()
+
+    def setup_test():
+        """
+        Test setup
+        """
+        update_vm_xml(vm, params)
+        migration_obj.setup_default()
+
+    vm_name = guest_os_booting_base.get_vm(params)
+    vm = env.get_vm(vm_name)
+
+    migration_obj = base_steps.MigrationBase(test, vm, params)
+
+    try:
+        setup_test()
+        test.log.info("TEST_STEP: Migrate the VM to the target host.")
+        migration_obj.run_migration()
+        migration_obj.verify_default()
+
+        test.log.info("TEST_STEP: Migrate back the VM to the source host.")
+        migration_obj.run_migration_back()
+        dargs = {"check_disk_on_dest": "no"}
+        migration_obj.migration_test.post_migration_check([vm], dargs)
+
+    finally:
+        migration_obj.cleanup_default()

--- a/libvirt/tests/src/sriov/vIOMMU/migration_iommu_device.py
+++ b/libvirt/tests/src/sriov/vIOMMU/migration_iommu_device.py
@@ -1,0 +1,89 @@
+from virttest import libvirt_version
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+
+from provider.sriov import sriov_base
+from provider.migration import base_steps
+
+
+def run(test, params, env):
+    """
+    Test vm migration with iommu device
+    This case starts vm with different iommu device settings then migrate it
+    to and back to check network works well.
+    """
+    def check_iommu_xml(vm, params):
+        """
+        Check the iommu xml of the migrated vm
+
+        :param vm: VM object
+        :param params: Dictionary with the test parameters
+        """
+        iommu_dict = eval(params.get('iommu_dict', '{}'))
+        if not iommu_dict:
+            return
+        server_ip = params.get("server_ip")
+        server_user = params.get("server_user", "root")
+        server_pwd = params.get("server_pwd")
+        remote_virsh_dargs = {'remote_ip': server_ip,
+                              'remote_user': server_user,
+                              'remote_pwd': server_pwd,
+                              'unprivileged_user': None,
+                              'ssh_remote_auth': True}
+        virsh_session_remote = virsh.VirshPersistent(**remote_virsh_dargs)
+        migrated_vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(
+                vm.name, virsh_instance=virsh_session_remote)
+        vm_iommu = migrated_vmxml.devices.by_device_tag(
+            'iommu')[0].fetch_attrs()
+        for attr, value in iommu_dict.items():
+            if vm_iommu.get(attr) != value:
+                test.fail('iommu xml(%s) comparison failed.'
+                          'Expected "%s",got "%s".'
+                          % (attr, value, vm_iommu))
+
+    def setup_test():
+        """
+        Setup test
+        """
+        test.log.info("TEST_SETUP: Prepare a VM with different iommu devices.")
+        test_obj.setup_iommu_test(iommu_dict=iommu_dict,
+                                  cleanup_ifaces=cleanup_ifaces)
+        test_obj.prepare_controller()
+        test.log.debug(vm_xml.VMXML.new_from_dumpxml(vm.name))
+        for dev in ["disk", "video"]:
+            dev_dict = eval(params.get('%s_dict' % dev, '{}'))
+            if dev == "disk":
+                dev_dict = test_obj.update_disk_addr(dev_dict)
+            test.log.debug(dev_dict)
+            libvirt_vmxml.modify_vm_device(
+                vm_xml.VMXML.new_from_dumpxml(vm.name), dev, dev_dict)
+        if cleanup_ifaces:
+            libvirt_vmxml.modify_vm_device(
+                    vm_xml.VMXML.new_from_dumpxml(vm.name),
+                    "interface", iface_dict)
+        migration_obj.setup_default()
+
+    libvirt_version.is_libvirt_feature_supported(params)
+    cleanup_ifaces = "yes" == params.get("cleanup_ifaces", "yes")
+    iommu_dict = eval(params.get('iommu_dict', '{}'))
+    iface_dict = eval(params.get('iface_dict', '{}'))
+
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    vm = env.get_vm(vm_name)
+    test_obj = sriov_base.SRIOVTest(vm, test, params)
+    migration_obj = base_steps.MigrationBase(test, vm, params)
+
+    try:
+        setup_test()
+        test.log.info("TEST_STEP: Migrate the VM to the target host.")
+        migration_obj.run_migration()
+        migration_obj.verify_default()
+        check_iommu_xml(vm, params)
+
+        test.log.info("TEST_STEP: Migrate back the VM to the source host.")
+        migration_obj.run_migration_back()
+        migration_obj.migration_test.ping_vm(vm, params)
+    finally:
+        test_obj.teardown_iommu_test()

--- a/provider/migration/base_steps.py
+++ b/provider/migration/base_steps.py
@@ -275,7 +275,6 @@ class MigrationBase(object):
         dest_uri = self.params.get("virsh_migrate_desturi")
         vm_name = self.params.get("migrate_main_vm")
 
-        time.sleep(25)
         func_returns = dict(self.migration_test.func_ret)
         self.migration_test.func_ret.clear()
         self.test.log.debug("Migration returns function results:%s", func_returns)

--- a/provider/sriov/sriov_base.py
+++ b/provider/sriov/sriov_base.py
@@ -168,6 +168,9 @@ class SRIOVTest(object):
                     dev_attrs.update({'slot': self.dev_slot})
 
             disk_dict.update({"address": {'attrs': dev_attrs}})
+            if disk_dict['target']['bus'] == "scsi":
+                disk_dict['address']['attrs'].update({'type': 'drive'})
+
             if self.controller_dicts[-1]['model'] == 'pcie-root-port':
                 self.controller_dicts.pop()
         return disk_dict

--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -862,6 +862,14 @@
             luks_keys = LUKS_MAPPER_KEYS
             skip_vm_check = yes
             skip_reason = 'luks encryped, cannot boots up without password'
+        - default_vsphere:
+            only esx_80
+            main_vm = VM_NAME_NON_ADMIN_V2V_EXAMPLE
+            interaction_run = 'yes'
+            vpx_no_username = True
+            cmd_has_ip = 'no'
+            msg_content = 'administrator@vsphere.local'
+            expect_msg = yes
     variants:
         - positive_test:
             status_error = 'no'


### PR DESCRIPTION
In the context of Arm architecture, memory pages are different compared to x86. By default, x86 uses 2M memory pages, while Arm requires 512M memory pages.
This commit addresses an error related to attaching a device by adjusting the memory page size to 512M for Arm architecture. This change ensures compatibility and resolves the reported issue.

Test result for arm arch-
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : a74efc7fc3f3cd31c50b1e28743a2bf6366ff4a3
JOB LOG    : /var/lib/avocado/job-results/job-2023-09-11T03.22-a74efc7/job.log
 (1/1) type_specific.io-github-autotest-libvirt.memory_update_device.virtio_mem: PASS (72.93 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2023-09-11T03.22-a74efc7/results.html

Test result for x86:
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : 85eea8d991afd3c0fc1aca7b3102a7478bd6870e
JOB LOG    : /var/lib/avocado/job-results/job-2023-09-12T06.44-85eea8d/job.log
 (1/1) type_specific.io-github-autotest-libvirt.memory_update_device.virtio_mem: ERROR: VM 'avocado-vt-vm1' failed to start: error: Failed to start domain 'avocado-vt-vm1'\nerror: internal error: Unable to find any usable hugetlbfs mount for 524288 KiB(exit status: 1) (53.27 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2023-09-12T06.44-85eea8d/results.html
JOB TIME   : 53.73 s



