### PR TITLE
virsh_blockcommit: create file with random contents for error test

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blockcommit.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blockcommit.py
@@ -534,7 +534,8 @@ def run(test, params, env):
             make_relative_path_backing_files(pre_set_root_dir)
             blk_source_folder = create_reuse_external_snapshots(pre_set_root_dir)
         else:
-            make_disk_snapshot(postfix_n, snapshot_take, check_snapshot_tree, check_image_file_in_vm)
+            is_create_image_file_in_vm = True if status_error else check_image_file_in_vm
+            make_disk_snapshot(postfix_n, snapshot_take, check_snapshot_tree, is_create_image_file_in_vm)
 
         basename = os.path.basename(blk_source)
         diskname = basename.split(".")[0]


### PR DESCRIPTION
The error test executes two blockcommit jobs and expects the second to fail because the first hasn't finished yet. Sometimes, the first job would finish too fast. Instead of touching a file, create one with random content, reusing existing test logic. Hopefully, this will cause blockcommits to take longer.