### PR TITLE
External snapshot deletion failure modification!

### DIFF
--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_disk.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_disk.py
@@ -422,7 +422,7 @@ def run(test, params, env):
             session.close()
 
         # Test delete snapshot without "--metadata", delete external disk
-        # snapshot will fail for now.
+        # External snapshot deletion support added in libvirt_version >= 9.0.0
         # Only do this when snapshot create succeed which filtered in cfg file.
         if snapshot_del_test:
             if snapshot_name:
@@ -439,7 +439,7 @@ def run(test, params, env):
                             test.fail("Snapshot xml file %s missing"
                                       % snap_xml_path)
                 else:
-                    if status_error:
+                    if (not libvirt_version.version_compare(9, 0, 0)) and status_error:
                         err_msg = "Snapshot delete succeed but expect fail."
                         test.fail(err_msg)
                     else:


### PR DESCRIPTION
In libvirt version lesser than 9.0.0 external snapshot deletion was unsupported, but the testcase is failing now with the error message as "Snapshot delete succeed but expect fail" because the deletion is supported now with external disk.
For reference : https://libvirt.org/news.html#v9-0-0-2023-01-16
Signed-off-by: Anushree Mathur <anushree.mathur@linux.vnet.ibm.com>