### PR TITLE
libvirt_scsi_hostdev: Reduce the size of create disk

### DIFF
--- a/libvirt/tests/src/libvirt_scsi_hostdev.py
+++ b/libvirt/tests/src/libvirt_scsi_hostdev.py
@@ -84,7 +84,7 @@ def run(test, params, env):
         logging.info("hostdev xml is: %s", hostdev_xml)
         return hostdev_xml
 
-    def prepare_iscsi_lun(emulated_img="emulated-iscsi", img_size='1G'):
+    def prepare_iscsi_lun(emulated_img="emulated-iscsi", img_size='100M'):
         """
         Prepare iscsi lun
 
@@ -108,7 +108,7 @@ def run(test, params, env):
                                                                portal_ip="127.0.0.1")
         return iscsi_target, lun_num
 
-    def prepare_local_scsi(emulated_img="emulated-iscsi", img_size='1G'):
+    def prepare_local_scsi(emulated_img="emulated-iscsi", img_size='100M'):
         """
         Prepare a local scsi device
 


### PR DESCRIPTION
The disk is too large to cause timeout for guest io checking: [stderr] DEBUG:aexpect.client:[192.168.122.64] Sending command: fdisk -l /dev/sdb && mkfs.ext4 -F /dev/sdb && mkdir -p sdb && mount /dev/sdb sdb && echo teststring > sdb/testfile && umount sdb

Error happens when check disk io in vm: Timeout expired while waiting for shell command to complete: 'fdisk -l /dev/sdb && mkfs.ext4 -F /dev/sdb && mkdir -p sdb && mount /dev/sdb sdb && echo teststring > sdb/testfile && umount sdb'

Reduce them from 1G to 100M.