### PR TITLE
virsh_boot.cfg: add a condition to remove nvram attribute

### DIFF
--- a/libvirt/tests/cfg/bios/virsh_boot.cfg
+++ b/libvirt/tests/cfg/bios/virsh_boot.cfg
@@ -170,6 +170,7 @@
                                 - zero:
                                     boot_order = 0
                         - readonly_no:
+                            with_nvram = "no"
                             readonly = "no"
                             checkpoint = 'Could not open .+: Permission denied|Could not reopen .+: Permission denied|error:.+Block node is read-only'
                         - no_readonly:


### PR DESCRIPTION
When testing readonly_no, it's better to only include loader attributes in os. Readonly_no is not an expected operation. So we'd better not to add much config in xml. Otherwise it will have unexpected error.