### PR TITLE
Add network case of start with different model type

### DIFF
--- a/libvirt/tests/cfg/virtual_network/elements_and_attributes/element_model.cfg
+++ b/libvirt/tests/cfg/virtual_network/elements_and_attributes/element_model.cfg
@@ -1,0 +1,34 @@
+- virtual_network.elements_and_attributes.model:
+    type = element_model
+    start_vm = no
+    timeout = 240
+    outside_ip = 'www.redhat.com'
+    host_iface =
+    vm_ping_outside = pass
+    aarch64:
+        only virtio, virtio-non-transitional, test
+    pseries:
+        only virtio, virtio-non-transitional, test
+    s390x:
+        only virtio, test
+    variants model_type:
+        - default:
+            iface_driver = 8139cp
+            pci_model = pcie-to-pci-bridge
+        - virtio:
+            iface_driver = virtio_net
+            pci_model = pcie-root-port
+        - e1000e:
+            iface_driver = e1000e
+            pci_model = pcie-root-port
+        - rtl8139:
+            iface_driver = 8139cp
+            pci_model = pcie-to-pci-bridge
+        - virtio-non-transitional:
+            iface_driver = virtio_net
+            pci_model = pcie-root-port
+        - test:
+            status_error = yes
+            err_msg = is not a valid device model name
+    iface_attrs = {'source': {'network': 'default'}, 'model': '${model_type}', 'type_name': 'network', 'acpi': {'index': '1'}}
+    vm_iface = eno1

--- a/libvirt/tests/src/virtual_network/elements_and_attributes/element_model.py
+++ b/libvirt/tests/src/virtual_network/elements_and_attributes/element_model.py
@@ -1,0 +1,89 @@
+import logging
+
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+from provider.virtual_network import network_base
+
+VIRSH_ARGS = {'ignore_status': False, 'debug': True}
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+
+def run(test, params, env):
+    """
+    Test 'model' element of interface
+    """
+    vm_name = params.get('main_vm')
+    vm = env.get_vm(vm_name)
+    outside_ip = params.get('outside_ip')
+    status_error = 'yes' == params.get('status_error', 'no')
+    err_msg = params.get('err_msg')
+    pci_model = params.get('pci_model')
+    iface_attrs = eval(params.get('iface_attrs', '{}'))
+    vm_iface = params.get('vm_iface')
+    iface_driver = params.get('iface_driver')
+    model_type = params.get('model_type')
+    if model_type == 'default':
+        iface_attrs.pop('model')
+
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+
+    try:
+        vmxml.del_device('interface', by_tag=True)
+        libvirt_vmxml.modify_vm_device(vmxml, 'interface', iface_attrs)
+
+        LOG.debug(f'VMXML of {vm_name}:\n{virsh.dumpxml(vm_name).stdout_text}')
+
+        if status_error:
+            start_result = virsh.start(vm_name, debug=True)
+            libvirt.check_exit_status(start_result, status_error)
+            if err_msg:
+                libvirt.check_result(start_result, expected_fails=err_msg)
+            return
+
+        vm.start()
+        virsh.domiflist(vm_name, **VIRSH_ARGS)
+        iflist = libvirt.get_interface_details(vm_name)
+        LOG.debug(f'iflist of vm: {iflist}')
+        iface_info = iflist[0]
+        model_type = 'rtl8139' if model_type == 'default' else model_type
+        if iface_info['model'] == model_type:
+            LOG.debug('Model check of domiflist: PASS')
+        else:
+            test.fail(f'Expect interface model {model_type}, '
+                      f'but got {iface_info["model"]}')
+
+        session = vm.wait_for_serial_login()
+
+        eth_output = session.cmd_output(f'ethtool -i {vm_iface} | grep driver')
+        LOG.debug(eth_output)
+        msg = f'Found expected driver "{iface_driver}" in ethtool output'
+        if iface_driver in eth_output:
+            LOG.debug(msg)
+        else:
+            test.fail('Not ' + msg)
+
+        ips = {'outside_ip': outside_ip}
+        network_base.ping_check(params, ips, session, force_ipv4=True)
+        session.close()
+
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        iface = vmxml.get_devices('interface')[0]
+        LOG.debug(f'Interface xml after vm started:\n{iface}')
+        ctrl_index = int(iface.fetch_attrs()['address']['attrs']['bus'], 16)
+        controllers = vmxml.get_devices('controller')
+        iface_controller = [c for c in controllers if c.type == 'pci' and
+                            c.index == str(ctrl_index)][0]
+        LOG.debug(f'Controller xml:\n{iface_controller}')
+
+        if iface_controller.model == pci_model:
+            LOG.debug('XML controller model check: PASS')
+        else:
+            test.fail(f'Expect pci model: {pci_model}, '
+                      f'and got {iface_controller.model}')
+    finally:
+        bkxml.sync()


### PR DESCRIPTION
- VIRT-296241 - [model] Start vm with different model type

test result:
```
 (1/7) type_specific.io-github-autotest-libvirt.virtual_network.elements_and_attributes.model.default: PASS (50.65 s)
 (2/7) type_specific.io-github-autotest-libvirt.virtual_network.elements_and_attributes.model.virtio: PASS (82.76 s)
 (3/7) type_specific.io-github-autotest-libvirt.virtual_network.elements_and_attributes.model.e1000e: PASS (49.61 s)
 (4/7) type_specific.io-github-autotest-libvirt.virtual_network.elements_and_attributes.model.rtl8139: PASS (83.27 s)
 (5/7) type_specific.io-github-autotest-libvirt.virtual_network.elements_and_attributes.model.virtio-transitional: PASS (50.79 s)
 (6/7) type_specific.io-github-autotest-libvirt.virtual_network.elements_and_attributes.model.virtio-non-transitional: PASS (81.69 s)
 (7/7) type_specific.io-github-autotest-libvirt.virtual_network.elements_and_attributes.model.test: PASS (6.50 s)
RESULTS    : PASS 7 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```