### PR TITLE
virsh_restore: Fix variable not assignment

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_restore.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_restore.py
@@ -69,6 +69,7 @@ def run(test, params, env):
     vm_ref_uid = None
     vm_ref_gid = None
     qemu_conf = None
+    tmp_file = ""
 
     if unprivileged_user:
         if unprivileged_user.count('EXAMPLE'):


### PR DESCRIPTION
Fix local variable 'tmp_file' referenced before assignment

Before:
```
ERROR 1-type_specific.io-github-autotest-libvirt.virsh.restore.no_option -> UnboundLocalError: local variable 'tmp_file' referenced before assignment
```

After:
```
PASS 1-type_specific.io-github-autotest-libvirt.virsh.restore.no_option
```