### PR TITLE
Add case to cover start virtlogd with specified configuration file

### DIFF
--- a/libvirt/tests/cfg/daemon/conf_file/qemu_conf/set_virtlogd.cfg
+++ b/libvirt/tests/cfg/daemon/conf_file/qemu_conf/set_virtlogd.cfg
@@ -32,8 +32,57 @@
                 - disabled_virtlogd:
                     expected_result = virtlogd_disabled
                     start_vm = no
+                - specific_config_file:
+                    expected_result = virtlogd_specific_config_file_enable
+                    virtlogd_config_file = "/etc/sysconfig/virtlogd"
+                    virtlogd_config_bak_file = "/etc/sysconfig/virtlogd.bak"
+                    virtlogd_config_file_new = "/etc/libvirt/virtlogd-new.conf"
+                    virtlogd_config_file_alternative_new = "/var/log/libvirt/virtlogd-new.log"
+                    start_vm = no
+                - specific_timeout:
+                    expected_result = virtlogd_specific_timeout
+                    virtlogd_config_file = "/etc/sysconfig/virtlogd"
+                    virtlogd_config_bak_file = "/etc/sysconfig/virtlogd.bak"
+                    virtlogd_config_file_new = "/etc/libvirt/virtlogd-new.conf"
+                    start_vm = no
+                - record_qenu_crash_log:
+                    expected_result = record_qenu_crash_log
+                    crash_information = "unable to map backing store for guest RAM: Cannot allocate memory"
+                    start_vm = no
+                - stop_virtlogd:
+                    expected_result = stop_virtlogd
+                    start_vm = no
+                - default_max_size_max_backups:
+                    expected_result = default_max_size_max_backups
+                    max_backups = 3
+                    start_vm = no
+                - recreate_qemu_log:
+                    expected_result = recreate_qemu_log
+                    start_vm = no
+                - opened_fd_of_qemu_log_file:
+                    expected_result = opened_fd_of_qemu_log_file
+                    start_vm = no
+                - vm_destroy_log_into_qemu_log_file:
+                    expected_result = vm_destroy_log_into_qemu_log_file
+                    start_vm = no
+                - start_vm_twice_log_into_qemu_log_file:
+                    expected_result = start_vm_twice_log_into_qemu_log_file
+                    start_vm = no
+                - record_save_restore_guest_log:
+                    expected_result = record_save_restore_guest_log
+                    start_vm = no
+                    save_vm_path = "/tmp/test1.save"
         - negative_test:
             variants:
                 - invalid:
                     expected_result = unbootable
                     stdio_handler = 'invalid'
+                - invalid_virtlogd_conf:
+                    start_vm = no
+                    expected_result = 'invalid_virtlogd_conf'
+                    max_clients = 'invalid'
+                    variants:
+                        - reload_virtlogd:
+                            action = "reload"
+                        - restart_virtlogd:
+                            action = "restart"


### PR DESCRIPTION
    Add cases to cover start virtlogd with various config
    
     VIRT-xx: virtlogd can be started with specified config by configuring VIRTLOGD_ARGS="--config /etc/libvirt/virtlogd-new.conf"
    in  /etc/sysconfig/virtlogd
    
    VIRT-xx: [virtlogd][-t | --timeout] Start virtlogd with --timeout <SECONDS> and without active guests
    
    VIRT-xx: [virtlogd] [Reload] [negative] Virtlogd.service reload failed with invalid configuration
    
    VIRT-xx: [virtlogd][Stop] Stop virtlogd service when guest is running
    
    VIRT-xx: [virtlogd]Check qemu log when guest fails to start due to "qemu process exits" error
    
    VIRT-xx: [virtlogd] Start virtlogd with default max_size and max_backups

  VIRT-xx: [virtlogd]Remove the qemu log file when guest is running
VIRT-xx: [virtlogd] [start] [negative] Virtlogd.serivce start failed with invalid configuration
    VIRT-xx: [virtlogd] Check opened FDs of qemu log file when guest is running and destroyed
    
    VIRT-xx: [virtlogd] Check qemu log when guest shuts down
    
    VIRT-xx: [virtlogd] Check qemu log when guest starts for the second time
