### PR TITLE
fix numa invalid test with hard code

### DIFF
--- a/libvirt/tests/cfg/numa/guest_numa_node_tuning/invalid_nodeset_of_numa_memory_binding.cfg
+++ b/libvirt/tests/cfg/numa/guest_numa_node_tuning/invalid_nodeset_of_numa_memory_binding.cfg
@@ -1,7 +1,8 @@
 - guest_numa_node_tuning.invalid_nodeset:
     type = invalid_nodeset_of_numa_memory_binding
     start_vm = "no"
-    error_msg = "unsupported configuration: NUMA node 2 is unavailable"
+    error_msg = "unsupported configuration: NUMA node %s is unavailable"
+    error_msg_1 = "Invalid value '%s' for 'cpuset.mems': Invalid argument"
     variants tuning:
         - strict:
             tuning_mode = "strict"
@@ -12,16 +13,13 @@
         - restrictive:
             tuning_mode = "restrictive"
             define_err = " 'restrictive' mode is required in memory element when mode is 'restrictive' in memnode element"
-    variants node_set:
-        - partially_inexistent:
-            nodeset = "1-2"
-            error_msg_1 = "Invalid value '${nodeset}' for 'cpuset.mems': Invalid argument"
-        - totally_inexistent:
-            nodeset = "2-3"
     variants binding:
         - host:
-            vm_attrs = {'numa_memory': {'mode': "${tuning_mode}",'nodeset': "${nodeset}"}}
+            vm_attrs = {'numa_memory': {'mode': "${tuning_mode}",'nodeset': "%s"}}
         - guest:
             cell_id = 0
             numa_attr = "'cpu': {'numa_cell': [{'id': ${cell_id}, 'cpus': '0-1', 'memory': '2097152', 'unit': 'KiB'}]}"
-            vm_attrs = {${numa_attr},'numa_memnode': [{'cellid':"${cell_id}",'mode': "${tuning_mode}",'nodeset':"${nodeset}"}]}
+            vm_attrs = {${numa_attr},'numa_memnode': [{'cellid':"${cell_id}",'mode': "${tuning_mode}",'nodeset':"%s"}]}
+    variants node_set:
+        - partially_inexistent:
+        - totally_inexistent:


### PR DESCRIPTION
RH9 & RH8 test result
```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35  guest_numa_node_tuning.invalid_nodeset

 (01/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.partially_inexistent.host.strict: PASS (7.14 s)
 (02/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.partially_inexistent.host.interleave: PASS (7.13 s)
 (03/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.partially_inexistent.host.preferred: PASS (7.22 s)
 (04/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.partially_inexistent.host.restrictive: PASS (7.17 s)
 (05/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.partially_inexistent.guest.strict: PASS (7.27 s)
 (06/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.partially_inexistent.guest.interleave: PASS (7.24 s)
 (07/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.partially_inexistent.guest.preferred: PASS (7.17 s)
 (08/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.partially_inexistent.guest.restrictive: PASS (7.91 s)
 (09/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.totally_inexistent.host.strict: PASS (9.64 s)
 (10/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.totally_inexistent.host.interleave: PASS (7.17 s)
 (11/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.totally_inexistent.host.preferred: PASS (7.22 s)
 (12/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.totally_inexistent.host.restrictive: PASS (7.24 s)
 (13/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.totally_inexistent.guest.strict: PASS (7.23 s)
 (14/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.totally_inexistent.guest.interleave: PASS (10.40 s)
 (15/16) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.invalid_nodeset.totally_inexistent.guest.preferred: PASS (7.17 s)

```