### PR TITLE
migration: Add case to test port occupied by other app

### DIFF
--- a/libvirt/tests/cfg/migration/migration_performance_tuning/migration_parallel_connections.cfg
+++ b/libvirt/tests/cfg/migration/migration_performance_tuning/migration_parallel_connections.cfg
@@ -69,6 +69,7 @@
             virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
             server_cn = "ENTER.YOUR.EXAMPLE.SERVER_CN"
             client_cn = "ENTER.YOUR.EXAMPLE.CLIENT_CN"
+            set_ip_addr = "no"
         - unix:
             transport_type = "unix_proxy"
             service_to_check = " "

--- a/libvirt/tests/cfg/migration/migration_performance_tuning/migration_parallel_connections.cfg
+++ b/libvirt/tests/cfg/migration/migration_performance_tuning/migration_parallel_connections.cfg
@@ -69,7 +69,6 @@
             virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
             server_cn = "ENTER.YOUR.EXAMPLE.SERVER_CN"
             client_cn = "ENTER.YOUR.EXAMPLE.CLIENT_CN"
-            set_ip_addr = "no"
         - unix:
             transport_type = "unix_proxy"
             service_to_check = " "

--- a/libvirt/tests/cfg/migration/migration_uri/tcp_migration_port_allocation_port_occupied_by_other_app.cfg
+++ b/libvirt/tests/cfg/migration/migration_uri/tcp_migration_port_allocation_port_occupied_by_other_app.cfg
@@ -1,0 +1,39 @@
+- migration.migration_uri.tcp.migration_port_allocation.port_occupied_by_other_app:
+    type = tcp_migration_port_allocation_port_occupied_by_other_app
+    migration_setup = 'yes'
+    storage_type = 'nfs'
+    setup_local_nfs = 'yes'
+    disk_type = "file"
+    disk_source_protocol = "netfs"
+    mnt_path_name = ${nfs_mount_dir}
+    # Console output can only be monitored via virsh console output
+    only_pty = True
+    take_regular_screendumps = no
+    # Extra options to pass after <domain> <desturi>
+    virsh_migrate_extra = ''
+    # SSH connection time out
+    ssh_timeout = 60
+    # Local URI
+    virsh_migrate_connect_uri = 'qemu:///system'
+    virsh_migrate_dest_state = "running"
+    virsh_migrate_src_state = "shut off"
+    image_convert = 'no'
+    server_ip = "${migrate_dest_host}"
+    server_user = "root"
+    server_pwd = "${migrate_dest_pwd}"
+    status_error = "no"
+    check_network_accessibility_after_mig = "yes"
+    migrate_desturi_port = "16509"
+    migrate_desturi_type = "tcp"
+    virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
+    migrate_speed = "20"
+    stress_package = "stress"
+    stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20s"
+    port_to_check = "49153"
+    occupy_port_cmd = "nc -l -p 49152 &"
+    action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": "params"}, {"func": "set_migrate_speed_to_high", "func_param": "params"}]'
+    variants:
+        - p2p:
+            virsh_migrate_options = '--live --p2p --verbose'
+        - non_p2p:
+            virsh_migrate_options = '--live --verbose'

--- a/libvirt/tests/src/migration/migration_uri/tcp_migration_port_allocation_port_occupied_by_other_app.py
+++ b/libvirt/tests/src/migration/migration_uri/tcp_migration_port_allocation_port_occupied_by_other_app.py
@@ -1,0 +1,28 @@
+from virttest import remote
+
+from provider.migration import base_steps
+
+
+def run(test, params, env):
+    """
+    To verify that when migration port is occupied by other app, libvirt will
+    allocate the next available port to migration.
+
+    :param test: test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    vm_name = params.get("migrate_main_vm")
+    occupy_port_cmd = params.get("occupy_port_cmd")
+
+    vm = env.get_vm(vm_name)
+    migration_obj = base_steps.MigrationBase(test, vm, params)
+
+    try:
+        migration_obj.setup_connection()
+        remote.run_remote_cmd(occupy_port_cmd, params, ignore_status=False)
+        migration_obj.run_migration()
+        migration_obj.verify_default()
+    finally:
+        migration_obj.cleanup_connection()
+        remote.run_remote_cmd("pkill -9 nc", params)


### PR DESCRIPTION
VIRT-298371 - [VM migration] network data transport - TCP - migration
    port allocation - port occupied by other app