### PR TITLE
Handling polkit based testcase failures!

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_restore.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_restore.py
@@ -7,6 +7,7 @@ import pwd
 import grp
 
 from avocado.utils import process
+from avocado.utils import distro
 
 from virttest import virsh
 from virttest import data_dir
@@ -71,6 +72,7 @@ def run(test, params, env):
     qemu_conf = None
     tmp_file = ""
 
+    detected_distro = distro.detect()
     if unprivileged_user:
         if unprivileged_user.count('EXAMPLE'):
             unprivileged_user = 'testacl'
@@ -79,6 +81,11 @@ def run(test, params, env):
         if params.get('setup_libvirt_polkit') == 'yes':
             test.cancel("API acl test not supported in current"
                         " libvirt version.")
+    #After RHEL8.2 Polkit rules expanded,default domain name is avocado-vt-vm1
+    if unprivileged_user == 'testacl' and vm_name != "avocado-vt-vm1":
+        if detected_distro.name == "rhel" and int(detected_distro.version) > 8.2:
+            test.cancel("Domain name expected in polkit rules is avocado-vt-vm1")
+
     try:
         if "--xml" in extra_param:
             vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name, options="--migratable")

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_suspend.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_suspend.py
@@ -1,3 +1,5 @@
+from avocado.utils import distro
+
 from virttest import virsh
 from virttest import libvirt_version
 from virttest.utils_test import libvirt
@@ -23,6 +25,7 @@ def run(test, params, env):
     status_error = params.get("status_error", "no")
     suspend_readonly = "yes" == params.get("suspend_readonly", "no")
 
+    detected_distro = distro.detect()
     uri = params.get("virsh_uri")
     unprivileged_user = params.get('unprivileged_user')
     if unprivileged_user:
@@ -38,7 +41,10 @@ def run(test, params, env):
         if params.get('setup_libvirt_polkit') == 'yes':
             test.cancel("API acl test not supported in current libvirt "
                         "version.")
-
+    #After RHEL8.2 polkit rules expanded,default domain name is avocado-vt-vm1
+    if unprivileged_user == 'testacl' and vm_name != "avocado-vt-vm1":
+        if detected_distro.name == "rhel" and int(detected_distro.version) > 8.2:
+            test.cancel("Domain name expected in polkit rules is avocado-vt-vm1")
     # Run test case
     if vm_ref == "id":
         vm_ref = domid


### PR DESCRIPTION
After RHEL version 8.2 polkit rules got expanded and default expected name in polkit rule is avocado-vt-vm1.If domain name is given as anything else other than avocado-vt-vm1, testcase will fail. So cancelling the testcases with proper message after checking condition for rhel version, domain name and user!
Signed-off-by: Anushree Mathur <anushree.mathur@linux.vnet.ibm.com>