### PR TITLE
memory: Enable test for aarch64

### DIFF
--- a/libvirt/tests/cfg/memory/memory_backing/lifecycle_for_hugepage.cfg
+++ b/libvirt/tests/cfg/memory/memory_backing/lifecycle_for_hugepage.cfg
@@ -1,5 +1,6 @@
 - memory.backing.lifecycle:
     type = lifecycle_for_hugepage
+    start_vm = "no"
     vm_nr_hugepages = 1024
     mount_size = "1048576"
     current_mem = 2097152
@@ -22,12 +23,21 @@
             variants:
                 - 4k:
                     no s390-virtio
+                    no kernelpagesize_64k
                     page_size = "4"
                     page_unit = "KiB"
                     memory_backing_dict = "'mb': {'hugepages': {'pages': [{'unit': '${page_unit}', 'size': '${page_size}'}]}}"
                     vm_attrs = {${memory_backing_dict}, 'memory_unit':'${mem_unit}','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}'}
                     HugePages_Free = "1024"
                     free_hugepages = "2"
+                - 64k:
+                    only kernelpagesize_64k
+                    page_size = "64"
+                    page_unit = "KiB"
+                    memory_backing_dict = "'mb': {'hugepages': {'pages': [{'unit': '${page_unit}', 'size': '${page_size}'}]}}"
+                    vm_attrs = {${memory_backing_dict}, 'memory_unit':'${mem_unit}','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}'}
+                    HugePages_Free = "4"
+                    free_hugepages = "1024"
                 - 1M:
                     only s390-virtio
                     memory_backing_dict = "'mb': {'hugepages': {}}"
@@ -36,12 +46,28 @@
                     free_hugepages = "0"
                 - 2M:
                     no s390-virtio
+                    no kernelpagesize_64k
                     memory_backing_dict = "'mb': {'hugepages': {}}"
                     vm_attrs = {${memory_backing_dict}, 'memory_unit':'${mem_unit}','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}'}
                     HugePages_Free = "0"
                     free_hugepages = "2"
+                - 2M:
+                    only kernelpagesize_64k
+                    page_size = "2"
+                    page_unit = "M"
+                    memory_backing_dict = "'mb': {'hugepages': {'pages': [{'unit': '${page_unit}', 'size': '${page_size}'}]}}"
+                    vm_attrs = {${memory_backing_dict}, 'memory_unit':'${mem_unit}','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}'}
+                    HugePages_Free = "4"
+                    free_hugepages = "0"
+                - 512M:
+                    only kernelpagesize_64k
+                    memory_backing_dict = "'mb': {'hugepages': {}}"
+                    vm_attrs = {${memory_backing_dict}, 'memory_unit':'${mem_unit}','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}'}
+                    HugePages_Free = "0"
+                    free_hugepages = "1024"
                 - 1G:
                     no s390-virtio
+                    no kernelpagesize_64k
                     page_size = "1"
                     page_unit = "G"
                     memory_backing_dict = "'mb': {'hugepages': {'pages': [{'unit': '${page_unit}', 'size': '${page_size}'}]}}"
@@ -60,4 +86,16 @@
                     memory_backing_dict = "'mb': {'hugepages': {}}"
                     vm_attrs = {${memory_backing_dict}, 'memory_unit':'${mem_unit}','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}'}
                     start_error = "unable to map backing store for guest RAM: Cannot allocate memory"
+            variants:
+                - kernelpagesize_4k:
+                    conf_pagesize = 4096
+                - kernelpagesize_64k:
+                    only aarch64
+                    conf_pagesize = 65536
+                    free_hugepages_cmd= "cat /sys/kernel/mm/hugepages/hugepages-2048kB/free_hugepages"
+                    vm_nr_hugepages = 4
+                    mount_size = "2048"
+                    target_hugepages = 1024
+                    set_pagesize = "2048"
+                    set_pagenum = 1024
 

--- a/libvirt/tests/src/memory/memory_backing/lifecycle_for_hugepage.py
+++ b/libvirt/tests/src/memory/memory_backing/lifecycle_for_hugepage.py
@@ -131,6 +131,11 @@ def run(test, params, env):
         hp_cfg = test_setup.HugePageConfig(params)
         hp_cfg.cleanup()
 
+    conf_pagesize = params.get("conf_pagesize")
+    kernel_pagesize = process.run("getconf PAGESIZE", shell=True).stdout_text.strip()
+    if kernel_pagesize != conf_pagesize:
+        test.cancel("The current test does not work with this kernel pagesize.")
+
     vm_name = params.get("main_vm")
     vm = env.get_vm(vm_name)
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)


### PR DESCRIPTION
For aarch64, the kernel pagesize for 8 is 64k. But for 9, both 4k and 64k are supported. Therefore, the huge pagesize supported on aarch64 will also vary based on the kernel pagesize.

Test Result on 8 (aarch64 + 64k kernel):
```
 (01/10) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.4k_kernel.4k: CANCEL: The current test does not work with this kernel pagesize. (39.94 s)
 (02/10) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.4k_kernel.2M: CANCEL: The current test does not work with this kernel pagesize. (37.67 s)
 (03/10) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.4k_kernel.1G: CANCEL: The current test does not work with this kernel pagesize. (37.78 s)
 (04/10) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.4k_kernel.0: CANCEL: The current test does not work with this kernel pagesize. (38.74 s)
 (05/10) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.4k_kernel.scarce_mem: CANCEL: The current test does not work with this kernel pagesize. (37.46 s)
 (06/10) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.64k_kernel.64k: PASS (83.39 s)
 (07/10) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.64k_kernel.2M: PASS (104.28 s)
 (08/10) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.64k_kernel.512M: PASS (90.05 s)
 (09/10) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.64k_kernel.0: PASS (12.39 s)
 (10/10) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.64k_kernel.scarce_mem: PASS (13.24 s)
```

Test Result on 9 (aarch64 + 4k kernel):
```
 (01/10) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.4k_kernel.4k: PASS (92.47 s)
 (02/10) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.4k_kernel.2M: PASS (108.10 s)
 (03/10) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.4k_kernel.1G: PASS (116.20 s)
 (04/10) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.4k_kernel.0: PASS (14.63 s)
 (05/10) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.4k_kernel.scarce_mem: PASS (16.71 s)
 (06/10) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.64k_kernel.64k: CANCEL: The current test does not work with this kernel pagesize. (55.68 s)
 (07/10) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.64k_kernel.2M: CANCEL: The current test does not work with this kernel pagesize. (43.11 s)
 (08/10) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.64k_kernel.512M: CANCEL: The current test does not work with this kernel pagesize. (43.05 s)
 (09/10) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.64k_kernel.0: CANCEL: The current test does not work with this kernel pagesize. (42.97 s)
 (10/10) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.64k_kernel.scarce_mem: CANCEL: The current test does not work with this kernel pagesize. (44.83 s)
```

Test Result on 8 (x86)
```
 (1/5) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.4k_kernel.4k: PASS (91.79 s)
 (2/5) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.4k_kernel.2M: PASS (102.07 s)
 (3/5) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.4k_kernel.1G: PASS (101.48 s)
 (4/5) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.4k_kernel.0: PASS (18.16 s)                    
 (5/5) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.4k_kernel.scarce_mem: PASS (18.85 s)
```