### PR TITLE
virtual_disk: Update disk image to enable test on aarch64

### DIFF
--- a/libvirt/tests/cfg/virtio/virtio_page_per_vq.cfg
+++ b/libvirt/tests/cfg/virtio/virtio_page_per_vq.cfg
@@ -12,6 +12,8 @@
     variants device_type:
         - disk:
             disk_image = '/var/lib/avocado/data/avocado-vt/images/jeos-27-x86_64.qcow2'
+            aarch64:
+                disk_image = '/var/lib/avocado/data/avocado-vt/images/jeos-27-aarch64.qcow2'
             driver_dict = {'driver': {'name': 'qemu', 'type': 'qcow2', 'page_per_vq': 'on'}}
             device_dict = {'device': 'disk', 'type_name': 'file', **${driver_dict}, 'source': {'attrs': {'file': '${disk_image}'}}, 'target': {'dev': 'vdb', 'bus': 'virtio'}}
         - controller:


### PR DESCRIPTION
The disk image should be jeos-27-aarch64.qcow2 on aarch64.

Test Result:
```
PASS 1-type_specific.io-github-autotest-libvirt.virtio_attributes.virtio_page_per_vq.disk.default_start
```