### PR TITLE
Add network case of element sndbuf

### DIFF
--- a/libvirt/tests/cfg/virtual_network/elements_and_attributes/element_sndbuf.cfg
+++ b/libvirt/tests/cfg/virtual_network/elements_and_attributes/element_sndbuf.cfg
@@ -1,0 +1,11 @@
+- virtual_network.elements_and_attributes.sndbuf:
+    type = element_sndbuf
+    start_vm = no
+    timeout = 240
+    outside_ip = 'www.redhat.com'
+    vm_ping_outside = pass
+    variants sndbuf:
+        - 0:
+        - 1600:
+        - 1800:
+    iface_attrs = {'type_name': 'network', 'source': {'network': 'default'}, 'model': 'virtio', 'tune': {'sndbuf': ${sndbuf}}}

--- a/libvirt/tests/src/virtual_network/elements_and_attributes/element_sndbuf.py
+++ b/libvirt/tests/src/virtual_network/elements_and_attributes/element_sndbuf.py
@@ -1,0 +1,43 @@
+import logging
+
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+from provider.virtual_network import network_base
+
+VIRSH_ARGS = {'ignore_status': False, 'debug': True}
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+
+def run(test, params, env):
+    """
+    Test 'sndbuf' element of interface
+    """
+    vm_name = params.get('main_vm')
+    vm = env.get_vm(vm_name)
+    outside_ip = params.get('outside_ip')
+    iface_attrs = eval(params.get('iface_attrs', '{}'))
+    sndbuf = int(params.get('sndbuf'))
+
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+
+    try:
+        vmxml.del_device('interface', by_tag=True)
+        libvirt_vmxml.modify_vm_device(vmxml, 'interface', iface_attrs)
+        LOG.debug(f'VMXML of {vm_name}:\n{virsh.dumpxml(vm_name).stdout_text}')
+
+        vm.start()
+        session = vm.wait_for_serial_login()
+
+        libvirt.check_qemu_cmd_line(f'"sndbuf":{sndbuf}')
+
+        ips = {'outside_ip': outside_ip}
+        network_base.ping_check(params, ips, session, force_ipv4=True)
+        session.close()
+
+    finally:
+        bkxml.sync()

--- a/spell.ignore
+++ b/spell.ignore
@@ -909,6 +909,7 @@ SMT
 snaplist
 snapname
 snapshotname
+sndbuf
 socat
 socketscount
 sourse


### PR DESCRIPTION
- VIRT-296263 - [sndbuf] Start vm with sndbuf setting and check the qemu cmd line

Depends on
- https://github.com/avocado-framework/avocado-vt/pull/3773

Test result:
 (1/3) type_specific.io-github-autotest-libvirt.virtual_network.elements_and_attributes.sndbuf.0: PASS (43.64 s)
 (2/3) type_specific.io-github-autotest-libvirt.virtual_network.elements_and_attributes.sndbuf.1600: PASS (46.42 s)
 (3/3) type_specific.io-github-autotest-libvirt.virtual_network.elements_and_attributes.sndbuf.1800: PASS (42.93 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
