### PR TITLE
chardev_pcie: Create USB controller manually for aarch64

### DIFF
--- a/libvirt/tests/src/virtio/virtio_page_per_vq.py
+++ b/libvirt/tests/src/virtio/virtio_page_per_vq.py
@@ -1,4 +1,6 @@
 import os
+import platform
+
 from virttest import libvirt_version
 from virttest import utils_net
 from virttest import virsh
@@ -28,6 +30,12 @@ def run(test, params, env):
         :params vmxml: the vm xml
         """
         vmxml.remove_all_device_by_type(device_type)
+        # For now, arm can not create USB controller automatically.
+        if device_type == "controller" and platform.machine() == 'aarch64':
+            usb_controller = Controller("controller")
+            usb_controller.type = "usb"
+            usb_controller.model = 'qemu-xhci'
+            vmxml.add_device(usb_controller)
         vmxml.sync()
         # Need to use shared memory for filesystem device
         if device_type == "filesystem":


### PR DESCRIPTION
For now, arm can not create USB controller automatically.

When the device_type is controller, all controllers will be deleted, including the USB controller here. However, arm can not create USB controller automatically now. So it will fail to define the guest then.

Before:
```
ERROR 1-type_specific.io-github-autotest-libvirt.virtio_attributes.virtio_page_per_vq.controller.serial.default_start -> LibvirtXMLError: Failed to define avocado-vt-vm1 for reason:
error: Failed to define domain from /tmp/xml_utils_temp_05fpu947.xml
error: unsupported configuration: USB is disabled for this domain, but USB devices are present in the domain XML
```

After:
```
PASS 1-type_specific.io-github-autotest-libvirt.virtio_attributes.virtio_page_per_vq.controller.serial.default_start
```