### PR TITLE
Update case save_with_formats

### DIFF
--- a/libvirt/tests/cfg/save_and_restore/save_with_formats.cfg
+++ b/libvirt/tests/cfg/save_and_restore/save_with_formats.cfg
@@ -6,7 +6,12 @@
     variants:
         - positive_test:
             status_error = no
-            save_formats = raw lzop gzip bzip2 xz
+            variants save_format:
+                - raw:
+                - lzop:
+                - gzip:
+                - bzip2:
+                - xz:
         - negative_test:
             status_error = yes
             variants save_format:

--- a/libvirt/tests/src/save_and_restore/save_with_formats.py
+++ b/libvirt/tests/src/save_and_restore/save_with_formats.py
@@ -14,34 +14,41 @@ LOG = logging.getLogger('avocado.test.' + __name__)
 VIRSH_ARGS = {'debug': True, 'ignore_status': False}
 
 
-def save_with_format(save_format, test, params, env):
+def run(test, params, env):
     """
-    Run virsh save with given format
-
-    :param save_format: format to save with
-    :param test: test instance
-    :param params: test params
-    :param env: test env
-    :return: dict-type data of duration and image size
+    Test virsh save with different formats
     """
     vm_name = params.get('main_vm')
     vm = env.get_vm(vm_name)
 
+    status_error = "yes" == params.get('status_error', 'no')
+    error_msg = params.get('error_msg', '')
     log_file = params.get('libvirtd_debug_file')
+    save_format = params.get('save_format')
     rand_id = '_' + utils_misc.generate_random_string(3)
-    save_path = f'/root/{vm_name}_{save_format}_{rand_id}.save'
-
-    qemu_conf = utils_config.LibvirtQemuConfig()
-    libvirtd = utils_libvirtd.Libvirtd()
-    qemu_conf.save_image_format = save_format
-    libvirtd.restart()
+    save_path = f'/var/tmp/{vm_name}_{rand_id}.save'
+    check_cmd = params.get('check_cmd', '')
+    check_cmd = check_cmd.format(save_path) if check_cmd else check_cmd
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
 
     try:
+        qemu_conf = utils_config.LibvirtQemuConfig()
+        libvirtd = utils_libvirtd.Libvirtd()
+        qemu_conf.save_image_format = save_format
+        libvirtd.restart()
+
+        vm.start()
         pid_ping, upsince = save_base.pre_save_setup(vm)
+
         save_result = virsh.save(vm_name, save_path, debug=True)
+        libvirt.check_exit_status(save_result, status_error)
+        if status_error:
+            libvirt.check_result(save_result, error_msg)
+            return
+
         duration = save_result.duration
         LOG.debug(f'Duration of {format}: {duration}')
-
         img_size = int(utils_misc.get_image_info(save_path)['dsize'])
         LOG.debug(f'Image size of {format}: {img_size}')
 
@@ -56,60 +63,6 @@ def save_with_format(save_format, test, params, env):
             libvirt.check_logfile(log_pattern, log_file)
 
         save_base.post_save_check(vm, pid_ping, upsince)
-
-        return {'duration': duration, 'img_size': img_size}
-
-    finally:
-        if os.path.exists(save_path):
-            os.remove(save_path)
-        qemu_conf.restore()
-        libvirtd.restart()
-
-
-def run(test, params, env):
-    """
-    Test virsh save with different formats and compare duration and image size
-    """
-    vm_name = params.get('main_vm')
-    vm = env.get_vm(vm_name)
-
-    status_error = "yes" == params.get('status_error', 'no')
-    error_msg = params.get('error_msg', '')
-    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
-    bkxml = vmxml.copy()
-    save_formats = params.get('save_formats', '').split()
-    rand_id = '_' + utils_misc.generate_random_string(3)
-    save_path = f'/var/tmp/{vm_name}_{rand_id}.save'
-    check_cmd = params.get('check_cmd', '')
-    check_cmd = check_cmd.format(save_path) if check_cmd else check_cmd
-
-    try:
-        vm.start()
-        if not status_error:
-            save_info = {}
-            for save_format in save_formats:
-                save_info[save_format] = save_with_format(save_format, test,
-                                                          params, env)
-            [LOG.debug(f"Duration of format {f} is {save_info[f]['duration']}")
-             for f in save_formats]
-            [LOG.debug(f"Image size of format {f} is {save_info[f]['img_size']}"
-                       ) for f in save_formats]
-            duration_list = [save_info[f]['duration'] for f in save_formats]
-            if sorted(duration_list) != duration_list:
-                test.fail(
-                    'The order of time cost is not correct, please check log')
-            img_size_list = [save_info[f]['img_size'] for f in save_formats]
-            if sorted(img_size_list, reverse=True) != img_size_list:
-                test.fail(
-                    'The order of image size is not correct, please check log')
-        else:
-            save_format = params.get('save_format')
-            qemu_conf = utils_config.LibvirtQemuConfig()
-            libvirtd = utils_libvirtd.Libvirtd()
-            qemu_conf.save_image_format = save_format
-            libvirtd.restart()
-            save_result = virsh.save(vm_name, save_path, debug=True)
-            libvirt.check_result(save_result, error_msg)
 
     finally:
         bkxml.sync()

--- a/provider/save/save_base.py
+++ b/provider/save/save_base.py
@@ -49,12 +49,13 @@ def post_save_check(vm, pid_ping, upsince):
     LOG.debug(session.cmd_output(f'ps -ef|grep ping'))
     session.close()
 
+    if upsince_restore != upsince:
+        raise exceptions.TestWarn(f'Uptime since {upsince_restore} is '
+                                  f'incorrect, should be {upsince}')
     ping_cmd = 'ping 127.0.0.1'
     if ping_cmd not in proc_info:
-        raise Exception('Cannot find running ping command after save-restore.')
-    if upsince_restore != upsince:
-        raise Exception(f'Uptime since {upsince_restore} is incorrect,'
-                        f'should be {upsince}')
+        raise exceptions.TestFail('Cannot find running ping command '
+                                  'after save-restore.')
 
 
 def check_ownership(path, uid, gid):


### PR DESCRIPTION
- VIRT-296947: skipping time cost and file size comparison, and need to split case to several separate cases for each format.
- Don't fail test if uptime check failed

Test result:
```
 (1/6) type_specific.io-github-autotest-libvirt.save_and_restore.save_with_formats.positive_test.raw: PASS (50.00 s)
 (2/6) type_specific.io-github-autotest-libvirt.save_and_restore.save_with_formats.positive_test.lzop: PASS (49.70 s)
 (3/6) type_specific.io-github-autotest-libvirt.save_and_restore.save_with_formats.positive_test.gzip: PASS (71.65 s)
 (4/6) type_specific.io-github-autotest-libvirt.save_and_restore.save_with_formats.positive_test.bzip2: PASS (118.37 s)
 (5/6) type_specific.io-github-autotest-libvirt.save_and_restore.save_with_formats.positive_test.xz: PASS (128.29 s)
 (6/6) type_specific.io-github-autotest-libvirt.save_and_restore.save_with_formats.negative_test.abc: PASS (40.21 s)
RESULTS    : PASS 6 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```