### PR TITLE
auto_memory_nodeset_placement: add adaption to cgroup v1 for cupset.m…

### DIFF
--- a/libvirt/tests/src/numa/guest_numa_node_tuning/auto_memory_nodeset_placement.py
+++ b/libvirt/tests/src/numa/guest_numa_node_tuning/auto_memory_nodeset_placement.py
@@ -114,7 +114,7 @@ def verify_cgroup_mem_binding(test_obj):
     """
     mem_mode = test_obj.params.get('mem_mode')
     nodeset = test_obj.params.get('nodeset')
-    online_nodes = libvirt_numa.parse_numa_nodeset_to_str('x-y', test_obj.params.get('online_nodes'))
+    online_nodes = libvirt_numa.parse_numa_nodeset_to_str('x-y', test_obj.online_nodes)
     vcpu_placement = eval(test_obj.params.get('vm_attrs')).get('placement')
     vm_pid = test_obj.vm.get_pid()
     cg = libvirt_cgroup.CgroupTest(vm_pid)

--- a/libvirt/tests/src/numa/guest_numa_node_tuning/auto_memory_nodeset_placement.py
+++ b/libvirt/tests/src/numa/guest_numa_node_tuning/auto_memory_nodeset_placement.py
@@ -27,6 +27,7 @@ from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 from virttest.utils_libvirt import libvirt_vmxml
 from virttest.utils_libvirt import libvirt_misc
+from virttest.utils_libvirt import libvirt_numa
 
 from provider.numa import numa_base
 
@@ -113,6 +114,7 @@ def verify_cgroup_mem_binding(test_obj):
     """
     mem_mode = test_obj.params.get('mem_mode')
     nodeset = test_obj.params.get('nodeset')
+    online_nodes = libvirt_numa.parse_numa_nodeset_to_str('x-y', test_obj.params.get('online_nodes'))
     vcpu_placement = eval(test_obj.params.get('vm_attrs')).get('placement')
     vm_pid = test_obj.vm.get_pid()
     cg = libvirt_cgroup.CgroupTest(vm_pid)
@@ -134,15 +136,15 @@ def verify_cgroup_mem_binding(test_obj):
         elif (vcpu_placement == 'auto' and
                 mem_mode in ['interleave', 'preferred'] and
                 not nodeset):
-            expected_nodeset = ''
+            expected_nodeset = '' if is_cgroup2 else online_nodes
         elif vcpu_placement != 'auto' and mem_mode == 'none':
-            expected_nodeset = ''
+            expected_nodeset = '' if is_cgroup2 else online_nodes
         elif vcpu_placement == 'auto' and mem_mode == 'none':
             expected_nodeset = test_obj.params['nodeset_numad']
         elif mem_mode in ['strict', 'restrictive'] and nodeset:
             expected_nodeset = nodeset
         elif mem_mode in ['interleave', 'preferred'] and nodeset:
-            expected_nodeset = ''
+            expected_nodeset = '' if is_cgroup2 else online_nodes
         if cpuset_mems != expected_nodeset:
             test_obj.test.fail("Expect cpuset.mems=%s, but "
                                "found %s" % (expected_nodeset, cpuset_mems))

--- a/provider/numa/numa_base.py
+++ b/provider/numa/numa_base.py
@@ -35,6 +35,8 @@ class NumaTest(object):
         if status != 0:
             test.error("Failed to get information from %s", cmd)
         self.host_numa_info = utils_misc.NumaInfo()
+        self.online_nodes = self.host_numa_info.get_online_nodes().copy()
+        self.params['online_nodes'] = self.online_nodes
         self.online_nodes_withmem = self.host_numa_info.get_online_nodes_withmem()
         self.all_usable_numa_nodes = self.online_nodes_withmem.copy()
         self.virsh_dargs = {'ignore_status': False, 'debug': True}

--- a/provider/numa/numa_base.py
+++ b/provider/numa/numa_base.py
@@ -36,7 +36,6 @@ class NumaTest(object):
             test.error("Failed to get information from %s", cmd)
         self.host_numa_info = utils_misc.NumaInfo()
         self.online_nodes = self.host_numa_info.get_online_nodes().copy()
-        self.params['online_nodes'] = self.online_nodes
         self.online_nodes_withmem = self.host_numa_info.get_online_nodes_withmem()
         self.all_usable_numa_nodes = self.online_nodes_withmem.copy()
         self.virsh_dargs = {'ignore_status': False, 'debug': True}


### PR DESCRIPTION
testing results on rhel8 with cgroup v1:
(01/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_defined.mem_mode_strict.vcpu_auto: PASS (28.80 s)
 (02/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_defined.mem_mode_strict.vcpu_static: PASS (27.80 s)
 (03/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_defined.mem_mode_interleave.vcpu_auto: PASS (28.92 s)
 (04/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_defined.mem_mode_interleave.vcpu_static: PASS (26.82 s)
 (05/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_defined.mem_mode_preferred.vcpu_auto: PASS (29.32 s)
 (06/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_defined.mem_mode_preferred.vcpu_static: PASS (26.89 s)
 (07/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_defined.mem_mode_restrictive.vcpu_auto: PASS (29.00 s)
 (08/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_defined.mem_mode_restrictive.vcpu_static: PASS (26.98 s)
 (09/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_undefined.mem_mode_none.vcpu_auto: PASS (28.93 s)
 (10/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_undefined.mem_mode_none.vcpu_static: PASS (26.79 s)
 (11/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_undefined.mem_mode_strict.vcpu_auto: PASS (29.84 s)
 (12/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_undefined.mem_mode_strict.vcpu_static: PASS (7.01 s)
 (13/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_undefined.mem_mode_interleave.vcpu_auto: PASS (28.93 s)
 (14/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_undefined.mem_mode_interleave.vcpu_static: PASS (6.94 s)
 (15/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_undefined.mem_mode_preferred.vcpu_auto: PASS (28.99 s)
 (16/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_undefined.mem_mode_preferred.vcpu_static: PASS (6.82 s)
 (17/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_undefined.mem_mode_restrictive.vcpu_auto: PASS (28.79 s)
 (18/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_undefined.mem_mode_restrictive.vcpu_static: PASS (6.89 s)
 (19/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.with_iothread.nodeset_defined.mem_mode_strict.vcpu_auto: PASS (29.39 s)
 (20/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.with_iothread.nodeset_defined.mem_mode_strict.vcpu_static: PASS (27.21 s)
 (21/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.with_iothread.nodeset_defined.mem_mode_interleave.vcpu_auto: PASS (29.23 s)
 (22/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.with_iothread.nodeset_defined.mem_mode_interleave.vcpu_static: PASS (27.22 s)
 (23/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.with_iothread.nodeset_defined.mem_mode_preferred.vcpu_auto: PASS (29.23 s)
 (24/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.with_iothread.nodeset_defined.mem_mode_preferred.vcpu_static: PASS (27.30 s)
 (25/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.with_iothread.nodeset_defined.mem_mode_restrictive.vcpu_auto: PASS (29.59 s)
 (26/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.with_iothread.nodeset_defined.mem_mode_restrictive.vcpu_static: PASS (27.23 s)
 (27/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.with_iothread.nodeset_undefined.mem_mode_none.vcpu_auto: PASS (29.30 s)
 (28/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.with_iothread.nodeset_undefined.mem_mode_none.vcpu_static: PASS (27.27 s)
 (29/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.with_iothread.nodeset_undefined.mem_mode_strict.vcpu_auto: PASS (29.39 s)
 (30/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.with_iothread.nodeset_undefined.mem_mode_strict.vcpu_static: PASS (6.92 s)
 (31/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.with_iothread.nodeset_undefined.mem_mode_interleave.vcpu_auto: PASS (29.30 s)
 (32/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.with_iothread.nodeset_undefined.mem_mode_interleave.vcpu_static: PASS (6.83 s)
 (33/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.with_iothread.nodeset_undefined.mem_mode_preferred.vcpu_auto: PASS (29.40 s)
 (34/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.with_iothread.nodeset_undefined.mem_mode_preferred.vcpu_static: PASS (6.96 s)
 (35/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.with_iothread.nodeset_undefined.mem_mode_restrictive.vcpu_auto: PASS (29.43 s)
 (36/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.with_iothread.nodeset_undefined.mem_mode_restrictive.vcpu_static: PASS (6.83 s)
RESULTS    : PASS 36 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/Code/testbase/job-results/job-2023-09-25T21.48-de51c75/results.html
JOB TIME   : 855.22 s