### PR TITLE
v2v: fix 8.9 func TC "v2v_options..log_check"

### DIFF
--- a/v2v/tests/cfg/v2v_options.cfg
+++ b/v2v/tests/cfg/v2v_options.cfg
@@ -104,8 +104,8 @@
                             vpx_dc = ${vpx_dc}
                             esx_ip = ${esx_hostname}
                             variants:
-                                - esx_60:
-                                    only source_esx.esx_60
+                                - esx_70:
+                                    only source_esx.esx_70
                                     variants:
                                         - log_check:
                                             main_vm = "VM_NAME_ESX_DEFAULT_V2V_EXAMPLE"


### PR DESCRIPTION
Original VM is inaccessible and esx6.0 is out of service. update to esx7.0 vm.