### PR TITLE
guest_os_booting: Add a case of booting vm without a bootable device

### DIFF
--- a/libvirt/tests/cfg/guest_os_booting/negative/boot_without_bootable_devices.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/negative/boot_without_bootable_devices.cfg
@@ -1,0 +1,4 @@
+- guest_os_booting.boot_without_bootable_devices:
+    type = boot_from_cdrom_device
+    start_vm = no
+    remove_device_types = ["disk", "interface"]

--- a/libvirt/tests/src/guest_os_booting/negative/boot_without_bootable_devices.py
+++ b/libvirt/tests/src/guest_os_booting/negative/boot_without_bootable_devices.py
@@ -1,0 +1,33 @@
+from virttest import remote
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+
+from provider.guest_os_booting import guest_os_booting_base
+
+
+def run(test, params, env):
+    """
+    Test whether VM without a bootable disk cannot boot
+    """
+    vm_name = guest_os_booting_base.get_vm(params)
+    remove_devices = eval(params.get("remove_device_types", "[]"))
+    vm = env.get_vm(vm_name)
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm.name)
+    bkxml = vmxml.copy()
+
+    try:
+        test.log.info("TEST_SETUP: Remove disk device and interface device.")
+        for dev in remove_devices:
+            libvirt_vmxml.remove_vm_devices_by_type(vm, dev)
+
+        test.log.info("TEST_STEP: Check if VM is working.")
+        vm.start()
+        try:
+            vm.wait_for_serial_login().close()
+        except remote.LoginTimeoutError as detail:
+            test.log.debug("Found the expected error: %s", detail)
+        else:
+            test.fail("VM without bootable devices should be inaccessible!")
+    finally:
+        test.log.info("TEST_TEARDOWN: Recover test environment.")
+        bkxml.sync()


### PR DESCRIPTION
This PR adds:
    VIRT-297948 - Boot vm without any bootable devices

**Test results:**
` (2/2) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_without_bootable_devices: PASS (48.18 s)
`