### PR TITLE
guest_os_booting: Add a case of migration

### DIFF
--- a/libvirt/tests/cfg/guest_os_booting/migration/migration_boot.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/migration/migration_boot.cfg
@@ -1,0 +1,31 @@
+- guest_os_booting.migration.boot:
+    type = migration_boot
+    # Migrating non-started VM causes undefined behavior
+    start_vm = yes
+    # Console output can only be monitored via virsh console output
+    only_pty = True
+    take_regular_screendumps = no
+    # Options to pass to virsh migrate command before <domain> <desturi>
+    virsh_migrate_options = ""
+    # Extra options to pass after <domain> <desturi>
+    virsh_migrate_extra = ""
+    # SSH connection time out
+    ssh_timeout = 60
+    migration_setup = "yes"
+    storage_type = 'nfs'
+    setup_local_nfs = 'yes'
+    disk_type = "file"
+    disk_source_protocol = "netfs"
+    mnt_path_name = ${nfs_mount_dir}
+    image_convert = 'no'
+    virsh_migrate_dest_state = "running"
+    virsh_migrate_src_state = "shut off"
+    virsh_migrate_options = "--p2p --live --verbose  --persistent"
+    virsh_migrate_desturi = "qemu+ssh://${migrate_dest_host}/system"
+    virsh_migrate_connect_uri = "qemu:///system"
+    variants:
+        - os_dev:
+            os_attrs_boots = ['hd', 'cdrom', 'network']
+        - boot_order:
+            disk_boot_idx = 1
+            iface_dict = {'boot': 2}

--- a/libvirt/tests/src/guest_os_booting/migration/migration_boot.py
+++ b/libvirt/tests/src/guest_os_booting/migration/migration_boot.py
@@ -1,0 +1,69 @@
+from virttest.libvirt_xml import vm_xml
+
+from provider.migration import base_steps
+from provider.guest_os_booting import guest_os_booting_base
+
+
+def run(test, params, env):
+    """
+    Migrate vm with boot elements.
+
+    :param test: test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    def update_vm_xml(vm, params):
+        """
+        Update VM xml
+
+        :param vm: VM object
+        :param params: Dictionary with the test parameters
+        """
+        iface_dict = eval(params.get("iface_dict", "{}"))
+        os_attrs_boots = eval(params.get('os_attrs_boots', '[]'))
+        vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm.name)
+
+        if os_attrs_boots:
+            os_attrs = {'boots': os_attrs_boots}
+            vmxml.setup_attrs(os=os_attrs)
+        else:
+            vm_os = vmxml.os
+            vm_os.del_boots()
+            vmxml.os = vm_os
+            xml_devices = vmxml.devices
+            if iface_dict:
+                iface_obj = xml_devices.by_device_tag('interface')[0]
+                iface_obj.setup_attrs(**iface_dict)
+            vmxml.devices = xml_devices
+            disk_attrs = xml_devices.by_device_tag('disk')[0].fetch_attrs()
+            vmxml.set_boot_order_by_target_dev(
+                disk_attrs['target']['dev'], params.get('disk_boot_idx'))
+        vmxml.xmltreefile.write()
+        test.log.debug(f"vmxml after updating: {vmxml}")
+        vmxml.sync()
+
+    def setup_test():
+        """
+        Test setup
+        """
+        update_vm_xml(vm, params)
+        migration_obj.setup_default()
+
+    vm_name = guest_os_booting_base.get_vm(params)
+    vm = env.get_vm(vm_name)
+
+    migration_obj = base_steps.MigrationBase(test, vm, params)
+
+    try:
+        setup_test()
+        test.log.info("TEST_STEP: Migrate the VM to the target host.")
+        migration_obj.run_migration()
+        migration_obj.verify_default()
+
+        test.log.info("TEST_STEP: Migrate back the VM to the source host.")
+        migration_obj.run_migration_back()
+        dargs = {"check_disk_on_dest": "no"}
+        migration_obj.migration_test.post_migration_check([vm], dargs)
+
+    finally:
+        migration_obj.cleanup_default()

--- a/provider/migration/base_steps.py
+++ b/provider/migration/base_steps.py
@@ -275,7 +275,6 @@ class MigrationBase(object):
         dest_uri = self.params.get("virsh_migrate_desturi")
         vm_name = self.params.get("migrate_main_vm")
 
-        time.sleep(25)
         func_returns = dict(self.migration_test.func_ret)
         self.migration_test.func_ret.clear()
         self.test.log.debug("Migration returns function results:%s", func_returns)


### PR DESCRIPTION
This PR adds:
    VIRT-297947: Migrate vm with boot element


**Test results:**
```
 (1/2) type_specific.io-github-autotest-libvirt.guest_os_booting.migration.boot.os_dev: PASS (171.11 s)
 (2/2) type_specific.io-github-autotest-libvirt.guest_os_booting.migration.boot.boot_order: PASS (171.39 s)
```
