### PR TITLE
Fix pid check issue

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_network.py
+++ b/libvirt/tests/src/virtual_network/iface_network.py
@@ -952,7 +952,9 @@ TIMEOUT 3"""
                 run_dnsmasq_default_test("dhcp-range", "192.168.122.2,192.168.122.254,255.255.252.0")
             # check the left part in dnsmasq conf
             run_dnsmasq_default_test("strict-order", name=net_name)
-            if libvirt_version.version_compare(6, 0, 0):
+            if libvirt_version.version_compare(8, 6, 0):
+                run_dnsmasq_default_test("pid-file", "/var/run/libvirt/network/%s.pid" % net_name, name=net_name)
+            elif libvirt_version.version_compare(6, 0, 0):
                 run_dnsmasq_default_test("pid-file", "/run/libvirt/network/%s.pid" % net_name, name=net_name)
             else:
                 run_dnsmasq_default_test("pid-file", "/var/run/libvirt/network/%s.pid" % net_name, name=net_name)


### PR DESCRIPTION
local run pass with updated content
JOB ID     : 6e020abc4e178e0d6f53bbf09d5a982637f947ef
JOB LOG    : /root/avocado/job-results/job-2023-10-12T04.34-6e020ab/job.log
 (1/7) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.dnsmasq_test.net_dns_forward: STARTED
 (1/7) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.dnsmasq_test.net_dns_forward: PASS (35.73 s)
 (2/7) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.dnsmasq_test.net_domain: STARTED
 (2/7) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.dnsmasq_test.net_domain: PASS (35.29 s)
 (3/7) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.dnsmasq_test.net_netmask: STARTED
 (3/7) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.dnsmasq_test.net_netmask: PASS (35.76 s)
 (4/7) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.dnsmasq_test.net_forwarder_full: STARTED
 (4/7) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.dnsmasq_test.net_forwarder_full: PASS (34.75 s)
 (5/7) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.dnsmasq_test.net_forwarder_domain: STARTED
 (5/7) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.dnsmasq_test.net_forwarder_domain: PASS (36.28 s)
 (6/7) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.dnsmasq_test.net_forwarder_mix: STARTED
 (6/7) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.dnsmasq_test.net_forwarder_mix: PASS (35.77 s)
 (7/7) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.dnsmasq_test.disable_dns: STARTED
 (7/7) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.dnsmasq_test.disable_dns: PASS (35.79 s)
RESULTS    : PASS 7 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/avocado/job-results/job-2023-10-12T04.34-6e020ab/results.html
JOB TIME   : 257.40 s