### PR TITLE
virtual_network/connectivity: fix test case for s390x

### DIFF
--- a/libvirt/tests/cfg/virtual_network/connectivity/connectivity_check_bridge_interface.cfg
+++ b/libvirt/tests/cfg/virtual_network/connectivity/connectivity_check_bridge_interface.cfg
@@ -8,6 +8,8 @@
     vm_ping_host_public = pass
     vm_ping_ep_vm = pass
     host_ping_vm = pass
+    host_iface =
+    iface_in_vm =
     variants scenario:
         - default:
             linux_br:
@@ -50,6 +52,8 @@
                     iface_attrs_driver = {'driver_attr': {'queues': '4'}}
                     iface_attrs_model = virtio
                     iface_attrs_acpi = {'index': '5'}
+                    s390-virtio:
+                        iface_attrs_acpi =
     variants bridge_type:
         - linux_br:
         - ovs_br:

--- a/libvirt/tests/src/virtual_network/connectivity/connectivity_check_bridge_interface.py
+++ b/libvirt/tests/src/virtual_network/connectivity/connectivity_check_bridge_interface.py
@@ -28,7 +28,7 @@ def parse_attrs(target, params):
     """
     attrs = {k.replace(target + '_', ''): int(v) if v.isdigit()
              else eval(v) if v[0] in '{[' else v
-             for k, v in params.items() if k.startswith(target)}
+             for k, v in params.items() if v and k.startswith(target)}
     LOG.debug(f'{target}: {attrs}')
     return attrs
 
@@ -49,6 +49,7 @@ def run(test, params, env):
     iface_attrs['source']['bridge'] = bridge_name
     vm_attrs = eval(params.get('vm_attrs', '{}'))
     nwfilter_attrs = parse_attrs('nwfilter_attrs', params)
+    iface_in_vm = params.get('iface_in_vm', 'eno')
 
     host_iface = params.get('host_iface')
     host_iface = host_iface if host_iface else utils_net.get_net_if(
@@ -95,7 +96,6 @@ def run(test, params, env):
 
         network_base.ping_check(params, ips_v4, session, force_ipv4=True)
 
-        iface_in_vm = 'eno'
         if 'acpi' in iface_attrs:
             iface_in_vm += iface_attrs['acpi']['index']
             check_cmd = 'ip l'

--- a/libvirt/tests/src/virtual_network/connectivity/connectivity_check_bridge_interface_unprivileged.py
+++ b/libvirt/tests/src/virtual_network/connectivity/connectivity_check_bridge_interface_unprivileged.py
@@ -35,6 +35,8 @@ def run(test, params, env):
     unpr_user = params.get('unpr_user', 'test_unpr') + rand_id
 
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    LOG.debug("Remove 'dac' security driver for unprivileged user")
+    vmxml.del_seclabel(by_attr=[('model', 'dac')])
 
     try:
         utils_net.create_linux_bridge_tmux(linux_bridge, host_iface)


### PR DESCRIPTION
1. On s390x, ACPI is not available.
2. Remove DAC security driver for unprivileged user if present as it
is not supported for those users.
3. Allow for configuration of host and guest interface names.