### PR TITLE
Memory : Fix incorrect block size on arm

### DIFF
--- a/libvirt/tests/cfg/memory/memory_attach_device.cfg
+++ b/libvirt/tests/cfg/memory/memory_attach_device.cfg
@@ -9,12 +9,12 @@
     variants test_case:
         - virtio_mem:
             no pseries
-            set_num_huge_pages = 1000
             required_kernel = [5.14.0,)
             guest_required_kernel = [5.8.0,)
             func_supported_since_libvirt_ver = (8, 0, 0)
             func_supported_since_qemu_kvm_ver = (6, 2, 0)
             vm_attrs = {'max_mem_rt': 10485760, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB', 'vcpu': 4, 'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '1048576', 'unit': 'KiB'}]}}
+            mem_device_attrs = {'mem_model': 'virtio-mem', 'target': {'requested_unit': 'KiB', 'size': 262144, 'node': 0, 'size_unit': 'KiB', 'requested_size': 131072, 'block_unit': 'KiB', 'block_size': 2048}}
             aarch64:
                 vm_attrs = {'max_mem_rt': 10485760, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB', 'vcpu': 4, 'cpu': {'mode': 'host-passthrough', 'numa_cell': [{'id': '0', 'cpus': '0-3', 'memory': '524288', 'unit': 'KiB'}]}}
-            mem_device_attrs = {'mem_model': 'virtio-mem', 'target': {'requested_unit': 'KiB', 'size': 262144, 'node': 0, 'size_unit': 'KiB', 'requested_size': 131072, 'block_unit': 'KiB', 'block_size': 2048}, 'source': {'pagesize_unit': 'KiB', 'pagesize': 2048, 'nodemask': '0'}}
+                mem_device_attrs = {'mem_model': 'virtio-mem', 'target': {'requested_unit': 'KiB', 'size': 1048576, 'node': 0, 'size_unit': 'KiB', 'requested_size': 524288, 'block_unit': 'KiB', 'block_size': 524288}}

--- a/libvirt/tests/cfg/memory/memory_update_device.cfg
+++ b/libvirt/tests/cfg/memory/memory_update_device.cfg
@@ -5,7 +5,6 @@
     variants test_case:
         - virtio_mem:
             no pseries
-            set_num_huge_pages = 1000
             required_kernel = [5.14.0,)
             guest_required_kernel = [5.8.0,)
             func_supported_since_libvirt_ver = (8, 0, 0)
@@ -13,7 +12,7 @@
             vm_attrs = {'max_mem_rt': 10485760, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB', 'vcpu': 4, 'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '1048576', 'unit': 'KiB'}]}}
             aarch64:
                 vm_attrs = {'max_mem_rt': 10485760, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB', 'vcpu': 4, 'cpu': {'mode': 'host-passthrough', 'numa_cell': [{'id': '0', 'cpus': '0-3', 'memory': '524288', 'unit': 'KiB'}]}}
-            mem_device_attrs = {'mem_model': 'virtio-mem', 'target': {'requested_unit': 'KiB', 'size': 262144, 'node': 0, 'size_unit': 'KiB', 'requested_size': 131072, 'block_unit': 'KiB', 'block_size': 2048}, 'source': {'pagesize_unit': 'KiB', 'pagesize': 2048, 'nodemask': '0'}}
-            requested_size = 160MiB
+                mem_device_attrs = {'mem_model': 'virtio-mem', 'target': {'requested_unit': 'KiB', 'size': 1048576, 'node': 0, 'size_unit': 'KiB', 'requested_size': 524288, 'block_unit': 'KiB', 'block_size': 524288}}
+            requested_size = 1048576KiB
             check_log_str = "MEMORY_DEVICE_SIZE_CHANGE.*virtiomem"
             virsh_opts = "--alias %s --requested-size ${requested_size}"

--- a/libvirt/tests/src/memory/memory_attach_device.py
+++ b/libvirt/tests/src/memory/memory_attach_device.py
@@ -1,15 +1,16 @@
+import time
+
 from virttest import libvirt_version
 from virttest import utils_misc
 from virttest import virsh
 
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.memory import Memory
-from virttest.staging import utils_memory
 from virttest.utils_libvirt import libvirt_vmxml
 from virttest.utils_version import VersionInterval
 
+
 VIRSH_ARGS = {'debug': True, 'ignore_status': False}
-ORG_HP = utils_memory.get_num_huge_pages()
 
 
 def run(test, params, env):
@@ -56,9 +57,6 @@ def run(test, params, env):
         """
         Setup vmxml for test
         """
-        set_num_huge_pages = params.get("set_num_huge_pages")
-        if set_num_huge_pages:
-            utils_memory.set_num_huge_pages(int(set_num_huge_pages))
 
         libvirt_vmxml.remove_vm_devices_by_type(vm, 'memory')
         vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
@@ -83,6 +81,7 @@ def run(test, params, env):
         virsh.attach_device(vm_name, mem_device.xml, flagstr=options,
                             debug=True, ignore_status=False)
 
+        time.sleep(10)
         if not vm.is_alive():
             vm.start()
             vm.wait_for_login().close()
@@ -111,8 +110,6 @@ def run(test, params, env):
         """
         Clean up environment
         """
-        if utils_memory.get_num_huge_pages() != ORG_HP:
-            utils_memory.set_num_huge_pages(ORG_HP)
 
     # Variable assignment
     test_case = params.get('test_case', '')

--- a/libvirt/tests/src/memory/memory_update_device.py
+++ b/libvirt/tests/src/memory/memory_update_device.py
@@ -6,13 +6,11 @@ from virttest import virsh
 
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.memory import Memory
-from virttest.staging import utils_memory
 from virttest.utils_test import libvirt
 from virttest.utils_libvirt import libvirt_vmxml
 from virttest.utils_version import VersionInterval
 
 VIRSH_ARGS = {'debug': True, 'ignore_status': False}
-ORG_HP = utils_memory.get_num_huge_pages()
 
 
 def run(test, params, env):
@@ -59,10 +57,6 @@ def run(test, params, env):
         """
         Setup vmxml for test
         """
-        set_num_huge_pages = params.get("set_num_huge_pages")
-        if set_num_huge_pages:
-            utils_memory.set_num_huge_pages(int(set_num_huge_pages))
-
         libvirt_vmxml.remove_vm_devices_by_type(vm, 'memory')
         vm_attrs = eval(params.get('vm_attrs', '{}'))
         vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
@@ -89,7 +83,8 @@ def run(test, params, env):
         test.log.debug("VM's memory before updating requested size: %s",
                        vm_mem_before)
 
-        test.log.info("TEST_STEP1: Update requested size for virtio-mem device.")
+        test.log.info(
+            "TEST_STEP1: Update requested size for virtio-mem device.")
         vmxml_cur = vm_xml.VMXML.new_from_dumpxml(vm_name)
         mem_dev = vmxml_cur.devices.by_device_tag("memory")[0]
         mem_dev_alias = mem_dev.fetch_attrs()['alias']['name']
@@ -114,7 +109,8 @@ def run(test, params, env):
         test.log.info("TEST_STEP3: Check 'MEMORY_DEVICE_SIZE_CHANGE' in "
                       "libvirtd/virtqemud log")
         log_file = utils_misc.get_path(test.debugdir, "libvirtd.log")
-        check_log_str = params.get("check_log_str", "MEMORY_DEVICE_SIZE_CHANGE")
+        check_log_str = params.get(
+            "check_log_str", "MEMORY_DEVICE_SIZE_CHANGE")
         libvirt.check_logfile(check_log_str, log_file)
 
         test.log.info("TEST STEP4: Check memory in the VM.")
@@ -131,9 +127,6 @@ def run(test, params, env):
         """
         Clean up environment
         """
-        if utils_memory.get_num_huge_pages() != ORG_HP:
-            utils_memory.set_num_huge_pages(ORG_HP)
-
     # Variable assignment
     test_case = params.get('test_case', '')
 


### PR DESCRIPTION
Fix memory device attachment and update errors.
The block size was too small, requiring a minimum of 524288KiB. 
This commit corrects the issue, allowing successful memory device 
attachment and updates.

Tested with libvirt version 9.5.0

**Results for x86_64** 
 **avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 memory_update_device.virtio_mem --vt-connect-uri qemu:///system**
JOB ID     : 270d985bae570287fd62983eeb9c661b13e36868
JOB LOG    : /var/lib/avocado/job-results/job-2023-10-23T03.12-270d985/job.log
 (1/1) type_specific.io-github-autotest-libvirt.memory_update_device.virtio_mem: PASS (89.62 s)
**RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0**
JOB HTML   : /var/lib/avocado/job-results/job-2023-10-23T03.12-270d985/results.html
JOB TIME   : 91.62 s

 **avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 memory_attach_device.virtio_mem.cold_plug --vt-connect-uri qemu:///system**
JOB ID     : 1b475552a9fee4f0efbc0acab56d2fe4559e591b
JOB LOG    : /var/lib/avocado/job-results/job-2023-10-23T03.18-1b47555/job.log
 (1/1) type_specific.io-github-autotest-libvirt.memory_attach_device.virtio_mem.cold_plug: PASS (87.82 s)
**RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0**
JOB HTML   : /var/lib/avocado/job-results/job-2023-10-23T03.18-1b47555/results.html
JOB TIME   : 89.61 s

**avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 memory_attach_device.virtio_mem.hot_plug --vt-connect-uri qemu:///system**
JOB ID     : 263d277e5fda66ccae8324a75e4eaf8eedb9e542
JOB LOG    : /var/lib/avocado/job-results/job-2023-10-23T03.21-263d277/job.log
 (1/1) type_specific.io-github-autotest-libvirt.memory_attach_device.virtio_mem.hot_plug: PASS (83.21 s)
**RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0**
JOB HTML   : /var/lib/avocado/job-results/job-2023-10-23T03.21-263d277/results.html
JOB TIME   : 84.92 s

**Results for aarch64:**
 **avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio memory_update_device.virtio_mem --vt-connect-uri qemu:///system**
Before fix:
 (1/1) type_specific.io-github-autotest-libvirt.memory_update_device.virtio_mem: ERROR: Command '/bin/virsh attach-device avocado-vt-vm1 /tmp/xml_utils_temp_qwvfgzbw.xml --config' failed.\nstdout: b'\n'\nstderr: b'error: Failed to attach device from /tmp/xml_utils_temp_qwvfgzbw.xml\nerror: block size too small, must be at least 524288KiB\n'\nad... (49.79 s)
After fix:
 (1/1) type_specific.io-github-autotest-libvirt.memory_update_device.virtio_mem: PASS (87.76 s)

 **avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio memory_attach_device.virtio_mem.cold_plug --vt-connect-uri qemu:///system**
Before fix:
 (1/1) type_specific.io-github-autotest-libvirt.memory_attach_device.virtio_mem.cold_plug: ERROR: Command '/usr/bin/virsh attach-device avocado-vt-vm1 /tmp/xml_utils_temp_6p00k16z.xml --config' failed.\nstdout: b'\n'\nstderr: b'error: Failed to attach device from /tmp/xml_utils_temp_6p00k16z.xml\nerror: block size too small, must be at least 524288KiB\n... (64.57 s)
After fix:
(1/1) type_specific.io-github-autotest-libvirt.memory_attach_device.virtio_mem.cold_plug: PASS (97.48 s)


 **avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio memory_attach_device.virtio_mem.hot_plug --vt-connect-uri qemu:///system**
 Before fix:
 (1/1) type_specific.io-github-autotest-libvirt.memory_attach_device.virtio_mem.hot_plug: ERROR: Command '/bin/virsh attach-device avocado-vt-vm1 /tmp/xml_utils_temp_09c3brgk.xml ' failed.\nstdout: b'\n'\nstderr: b'error: Failed to attach device from /tmp/xml_utils_temp_09c3brgk.xml\nerror: block size too small, must be at least 524288KiB\n'\nadditional... (112.82 s)
 After fix:
 (1/1) type_specific.io-github-autotest-libvirt.memory_attach_device.virtio_mem.hot_plug: PASS (95.58 s)

