### PR TITLE
add case for memmory allocation freepagereporting config

### DIFF
--- a/libvirt/tests/cfg/memory/memory_ballon/memory_balloon_freepagereporting_config.cfg
+++ b/libvirt/tests/cfg/memory/memory_ballon/memory_balloon_freepagereporting_config.cfg
@@ -1,0 +1,34 @@
+- memory.balloon.freepagereporting:
+    type = memory_balloon_freepagereporting_config
+    start_vm = no
+    set_mem = 1945600
+    mem_unit = "KiB"
+    current_mem_unit = "KiB"
+    current_mem = "2097152"
+    mem_value = "2097152"
+    set_used_mem = "1843200"
+    dominfo_check = "Max memory:(\s+)${mem_value} KiB\nUsed memory:(\s+)${set_used_mem} KiB"
+    variants:
+        - virtio_model:
+            memballoon_model = "virtio"
+        - virtio_trans_model:
+            memballoon_model = "virtio-transitional"
+        - virtio_non_trans_model:
+            memballoon_model = "virtio-non-transitional"
+    variants fg_config:
+        - fg_undefined:
+            fg_set = ''
+            fg_attr = ""
+            diff_value = 51200
+        - fg_off:
+            fg_set = "off"
+            fg_attr = ",'freepage_reporting':'${fg_set}'"
+            diff_value = 51200
+        - fg_on:
+            fg_set = "on"
+            fg_attr = ",'freepage_reporting':'${fg_set}'"
+            diff_value = 819200
+    device_dict = "{'model':'${memballoon_model}' ${fg_attr}}"
+    variants:
+        - memory_allocation:
+            mem_attrs = {'memory_unit':'${mem_unit}','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}'}

--- a/libvirt/tests/src/memory/memory_ballon/memory_balloon_freepagereporting_config.py
+++ b/libvirt/tests/src/memory/memory_ballon/memory_balloon_freepagereporting_config.py
@@ -1,0 +1,145 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright Redhat
+#
+#   SPDX-License-Identifier: GPL-2.0
+
+#   Author: Nannan Li<nanli@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import re
+import time
+
+from virttest import virsh
+from virttest import utils_misc
+
+from virttest.libvirt_xml import vm_xml
+from virttest.libvirt_xml.devices import memballoon
+from virttest.staging import utils_memory
+from virttest.utils_libvirt import libvirt_memory
+from virttest.utils_test import libvirt
+
+
+def run(test, params, env):
+    """
+    Verify the free page reporting takes effect with various memory balloon models
+
+    Scenario:
+    1.memory balloon models: virtio, virtio-transitional, virtio-non-transitional.
+    2.free page reporting: undefined, on, off
+    3.mem config: mem, current mem.
+    """
+
+    def get_memory_statistics():
+        """
+        Get memory statistics by virsh dommemstat
+        :return: rss mem value in result.
+        """
+        for wait in range(0, 6):
+            # wait for max 30s to check dommemstat result.
+            time.sleep(5)
+
+            res = virsh.dommemstat(vm_name, ignore_status=False,
+                                   debug=True).stdout_text
+            if re.findall(r'rss (\d+)', res):
+                break
+
+        rss_mem = int(re.findall(r'rss (\d+)', res)[0])
+        return rss_mem
+
+    def run_test():
+        """
+        Define and start guest
+        Check memTotal and memory allocation
+        """
+        test.log.info("TEST_STEP1: Define guest")
+        vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+
+        vmxml.del_device('memballoon', by_tag=True)
+        mem_balloon = memballoon.Memballoon()
+        mem_balloon.setup_attrs(**device_dict)
+        vmxml.devices = vmxml.devices.append(mem_balloon)
+
+        vmxml.setup_attrs(**mem_attrs)
+        vmxml.sync()
+
+        test.log.info("TEST_STEP2: Start guest ")
+        if not vm.is_alive():
+            vm.start()
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        test.log.debug("After start vm, get xml is:\n%s", vmxml)
+
+        test.log.info("TEST_STEP3: Login the guest and get guest free memory")
+        session = vm.wait_for_login()
+        free_mem = utils_memory.freememtotal(session)
+        session.close()
+        test.log.debug('Get free mem in guest', free_mem)
+
+        test.log.info("TEST_STEP4: Get vm memory statistics by virsh dommemstat")
+        initial_rss = get_memory_statistics()
+
+        test.log.info("TEST_STEP5: Consume the guest memory")
+        consume_mem = free_mem - 102400
+        session = vm.wait_for_login()
+        libvirt_memory.consume_vm_freememory(session, consume_value=consume_mem)
+        session.close()
+
+        test.log.info("TEST_STEP6: Verify the memory usage is increased")
+        if fg_config == "fg_on":
+            time.sleep(5)
+        second_rss = get_memory_statistics()
+
+        if initial_rss > second_rss:
+            test.fail("After consuming mem, '%s' mem should be bigger "
+                      "than '%s'" % (second_rss, initial_rss))
+
+        test.log.info("TEST_STEP7: Wait for 5 seconds, check memory usage again")
+        # if fg_config == "fg_on":
+        #     time.sleep(10)
+        # third_rss = get_memory_statistics(fg_config)
+
+        # The diff_value is from feature owner experience, there might be some
+        # exception at some special case.
+        if fg_config in ["fg_undefined", "fg_off"]:
+            if abs(get_memory_statistics() - second_rss) > diff_value:
+                test.fail("Absolute value of the difference between two"
+                          " values %s" % diff_value)
+        elif fg_config == "fg_on":
+            if not utils_misc.wait_for(
+                    lambda: second_rss - get_memory_statistics() > diff_value, 200):
+                test.log.debug("Second rss is '%s', Third rss is '%s', difference is '%s'", second_rss, get_memory_statistics(), second_rss-get_memory_statistics())
+                test.fail("The difference of two rss value should "
+                          "bigger than '%s' " % diff_value)
+
+        test.log.info("TEST_STEP8: Change the current memory allocation")
+        virsh.setmem(vm_name, set_used_mem, debug=True, ignore_status=False)
+
+        test.log.info("TEST_STEP9: Check the memory allocation config")
+        if not utils_misc.wait_for(lambda: libvirt.check_result(virsh.dominfo(vm_name, debug=True), expected_match=dominfo_check) is None, 30, first=5):
+            test.fail("Expected get '%s' in virsh dominfo from the "
+                      "above result" % dominfo_check)
+
+    def teardown_test():
+        """
+        Clean data.
+        """
+        test.log.info("TEST_TEARDOWN: Clean up env.")
+        bkxml.sync()
+
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+
+    mem_attrs = eval(params.get("mem_attrs", "{}"))
+    device_dict = eval(params.get("device_dict", "{}"))
+    set_used_mem = params.get("set_used_mem")
+    dominfo_check = params.get("dominfo_check")
+    fg_config = params.get("fg_config")
+    diff_value = int(params.get("diff_value"))
+
+    try:
+        run_test()
+
+    finally:
+        teardown_test()

--- a/spell.ignore
+++ b/spell.ignore
@@ -848,6 +848,7 @@ rom
 rootfs
 rrunner
 rsyslog
+rss
 RTC
 rtype
 runnable


### PR DESCRIPTION
xxxx- 299024: Memory balloon freepagereporting config
```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 memory.balloon.freepagereporting

 (1/9) type_specific.io-github-autotest-libvirt.memory.balloon.freepagereporting.memory_allocation.fg_undefined.virtio_model: PASS (47.86 s)
 (2/9) type_specific.io-github-autotest-libvirt.memory.balloon.freepagereporting.memory_allocation.fg_undefined.virtio_trans_model: PASS (51.28 s)
 (3/9) type_specific.io-github-autotest-libvirt.memory.balloon.freepagereporting.memory_allocation.fg_undefined.virtio_non_trans_model: PASS (51.26 s)
 (4/9) type_specific.io-github-autotest-libvirt.memory.balloon.freepagereporting.memory_allocation.fg_off.virtio_model: PASS (51.33 s)
 (5/9) type_specific.io-github-autotest-libvirt.memory.balloon.freepagereporting.memory_allocation.fg_off.virtio_trans_model: PASS (51.34 s)
 (6/9) type_specific.io-github-autotest-libvirt.memory.balloon.freepagereporting.memory_allocation.fg_off.virtio_non_trans_model: PASS (51.32 s)
 (7/9) type_specific.io-github-autotest-libvirt.memory.balloon.freepagereporting.memory_allocation.fg_on.virtio_model: FAIL: The difference of two rss value should bigger than '819200'  (253.01 s)
 (8/9) type_specific.io-github-autotest-libvirt.memory.balloon.freepagereporting.memory_allocation.fg_on.virtio_trans_model: FAIL: After consuming mem, '767332' mem should be bigger than '804196' (52.90 s)
 (9/9) type_specific.io-github-autotest-libvirt.memory.balloon.freepagereporting.memory_allocation.fg_on.virtio_non_trans_model: FAIL: The difference of two rss value should bigger than '819200'  (252.99 s)
```