### PR TITLE
vdpa: Fixup 'save' related failures

### DIFF
--- a/libvirt/tests/cfg/virtual_network/lifecycle/lifecycle_vdpa_interface.cfg
+++ b/libvirt/tests/cfg/virtual_network/lifecycle/lifecycle_vdpa_interface.cfg
@@ -6,7 +6,6 @@
     func_supported_since_libvirt_ver = (7, 3, 0)
     func_supported_since_qemu_kvm_ver = (6, 0, 0)
     iface_dict = {"source": {'dev':'/dev/vhost-vdpa-0'}}
-    save_error = "yes"
     variants test_target:
         - simulator:
         - mellanox:

--- a/libvirt/tests/src/virtual_network/lifecycle/lifecycle_vdpa_interface.py
+++ b/libvirt/tests/src/virtual_network/lifecycle/lifecycle_vdpa_interface.py
@@ -56,15 +56,12 @@ def run(test, params, env):
             vm, test_obj=test_obj, config_vdpa=True, **params)
 
         test.log.info("Save the VM.")
-        save_error = "yes" == params.get("save_error", "no")
         save_path = os.path.join(data_dir.get_tmp_dir(), vm.name + '.save')
-        res = virsh.save(vm.name, save_path, debug=True)
-        libvirt.check_exit_status(res, expect_error=save_error)
-        if not save_error:
-            test.log.info("Restore vm.")
-            virsh.restore(save_path, **VIRSH_ARGS)
-            check_points.check_network_accessibility(
-                vm, test_obj=test_obj, config_vdpa=False, **params)
+        virsh.save(vm.name, save_path, **VIRSH_ARGS)
+        test.log.info("Restore vm.")
+        virsh.restore(save_path, **VIRSH_ARGS)
+        check_points.check_network_accessibility(
+            vm, test_obj=test_obj, config_vdpa=False, **params)
 
         test.log.info("Suspend and resume the vm.")
         virsh.suspend(vm.name, **VIRSH_ARGS)


### PR DESCRIPTION
The vDPA interface starts to support save/restore, so updating the cases.

**Test results:**
**Before the fix:**
` (1/1) type_specific.io-github-autotest-libvirt.virtual_network.lifecycle.vdpa_interface.default.mellanox: FAIL: Run '/usr/bin/virsh save avocado-vt-vm1 /tmp/avocado_2rd5ls9z/avocado-vt-vm1.save ' expect fail, but run successfully. (127.67 s)
`
**after the fix:**
` (1/1) type_specific.io-github-autotest-libvirt.virtual_network.lifecycle.vdpa_interface.default.mellanox: PASS (199.00 s)
`