### PR TITLE
virtual_network: Update the regex of sndbuf

### DIFF
--- a/libvirt/tests/src/virtual_network/elements_and_attributes/element_sndbuf.py
+++ b/libvirt/tests/src/virtual_network/elements_and_attributes/element_sndbuf.py
@@ -33,7 +33,7 @@ def run(test, params, env):
         vm.start()
         session = vm.wait_for_serial_login()
 
-        libvirt.check_qemu_cmd_line(f'"sndbuf":{sndbuf}')
+        libvirt.check_qemu_cmd_line(f'"sndbuf":{sndbuf}|sndbuf={sndbuf}')
 
         ips = {'outside_ip': outside_ip}
         network_base.ping_check(params, ips, session, force_ipv4=True)


### PR DESCRIPTION
The format of sndbuf in qemu cmd line is different on 8 and 9.

Before:
```
 (1/3) type_specific.io-github-autotest-libvirt.virtual_network.elements_and_attributes.sndbuf.0: FAIL: Expecting '"sndbuf":0' does exist in qemu command line, but  notfound (49.72 s)
 (2/3) type_specific.io-github-autotest-libvirt.virtual_network.elements_and_attributes.sndbuf.1600: FAIL: Expecting '"sndbuf":1600' does exist in qemu command line, but  notfound (55.65 s)
 (3/3) type_specific.io-github-autotest-libvirt.virtual_network.elements_and_attributes.sndbuf.1800: FAIL: Expecting '"sndbuf":1800' does exist in qemu command line, but  notfound (55.19 s)
```

After:
```
 (1/3) type_specific.io-github-autotest-libvirt.virtual_network.elements_and_attributes.sndbuf.0: PASS (51.73 s)
 (2/3) type_specific.io-github-autotest-libvirt.virtual_network.elements_and_attributes.sndbuf.1600: PASS (85.91 s)
 (3/3) type_specific.io-github-autotest-libvirt.virtual_network.elements_and_attributes.sndbuf.1800: PASS (59.38 s)
```