### PR TITLE
Add one case to cover hotplug qcow2 image with opened fdgroup 

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_filedescriptor.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_filedescriptor.cfg
@@ -52,6 +52,13 @@
             file_descriptor_id = "5"
             source_file_path = "/var/lib/libvirt/images/save_test_fd"
             save_file_path = "/tmp/rhel"
+        - attach_device:
+            test_scenario = "attach_device"
+            fdgroup_name = "diskfdgroup"
+            file_descriptor_id = "6"
+            source_file_path = "/var/lib/libvirt/images/device_test_fd"
+            only hotplug..associate_flag_seclabel_default
+            target_format = "qcow2"
     variants:
         - coldplug:
             virt_device_hotplug = "no"


### PR DESCRIPTION
Add one case to cover hotplug qcow2 image with opened fdgroup by virsh attach-device

Bug 2193315 - Fail to hot-plug a qcow2 image with fdgroup