### PR TITLE
Add new case of virtual network:element coalesce

### DIFF
--- a/libvirt/tests/cfg/virtual_network/elements_and_attributes/element_coalesce.cfg
+++ b/libvirt/tests/cfg/virtual_network/elements_and_attributes/element_coalesce.cfg
@@ -1,0 +1,48 @@
+- virtual_network.elements_and_attributes.coalesce:
+    type = element_coalesce
+    start_vm = no
+    timeout = 240
+    outside_ip = 'www.redhat.com'
+    host_iface =
+    vm_ping_outside = pass
+    extra_attrs = {}
+    variants:
+        - nat_network:
+            iface_type = network
+            iface_source = default
+            variants iface_model:
+                - virtio:
+                    variants:
+                        - 32:
+                            max_frames = 32
+                        - big_value:
+                            max_frames = 4294967295
+                        - big_value_neg:
+                            max_frames = 10000000000
+                            status_error = yes
+                            err_msg = is too big for coalesce parameter
+                        - neg_val:
+                            max_frames = -1
+                            status_error = yes
+                            err_msg = cannot parse value '${max_frames}' for coalesce parameter
+                        - driver_qemu:
+                            max_frames = 32
+                            extra_attrs = {'driver': {'driver_attr': {'name': 'qemu'}}}
+                - e1000e:
+                    only q35
+                    max_frames = 32
+            iface_attrs = {'coalesce': {'max': '${max_frames}'}, 'type_name': 'network', 'source': {'network': 'default'}, 'model': '${iface_model}', **${extra_attrs}}
+        - br:
+            iface_type = bridge
+            variants br_type:
+                - linux_br:
+                    max_frames = 64
+                - ovs_br:
+                    max_frames = 32
+                    extra_attrs = {'virtualport': {'type': 'openvswitch'}}
+            iface_attrs = {'coalesce': {'max': '${max_frames}'}, 'type_name': 'bridge', 'source': {'bridge': br_name}, 'model': 'virtio', **${extra_attrs}}
+        - direct:
+            status_error = yes
+            err_msg = coalesce settings on interface type direct are not supported
+            max_frames = 64
+            iface_attrs = {'coalesce': {'max': '${max_frames}'}, 'type_name': 'direct', 'source': {'dev': host_iface, 'mode': 'bridge'}, 'model': 'virtio'}

--- a/libvirt/tests/src/virtual_network/elements_and_attributes/element_coalesce.py
+++ b/libvirt/tests/src/virtual_network/elements_and_attributes/element_coalesce.py
@@ -1,0 +1,90 @@
+import logging
+import re
+
+from avocado.utils import process
+from virttest import utils_misc
+from virttest import utils_net
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+from provider.virtual_network import network_base
+
+VIRSH_ARGS = {'ignore_status': False, 'debug': True}
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+
+def run(test, params, env):
+    """
+    Test 'coalesce' element of interface
+    """
+    vm_name = params.get('main_vm')
+    vm = env.get_vm(vm_name)
+    outside_ip = params.get('outside_ip')
+    status_error = 'yes' == params.get('status_error', 'no')
+    err_msg = params.get('err_msg')
+    br_type = params.get('br_type', '')
+    max_frames = params.get('max_frames')
+    rand_id = utils_misc.generate_random_string(3)
+    br_name = br_type + '_' + rand_id
+
+    host_iface = params.get('host_iface')
+    host_iface = host_iface if host_iface else utils_net.get_net_if(
+        state="UP")[0]
+    iface_attrs = eval(params.get('iface_attrs', '{}'))
+
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+
+    try:
+        if br_type == 'linux_br':
+            utils_net.create_linux_bridge_tmux(br_name, host_iface)
+            process.run(f'ip l show type bridge {br_name}', shell=True)
+        elif br_type == 'ovs_br':
+            utils_net.create_ovs_bridge(br_name)
+
+        vmxml.del_device('interface', by_tag=True)
+        iface = libvirt_vmxml.create_vm_device_by_type('interface', iface_attrs)
+        vmxml.add_device(iface)
+        LOG.debug(f'Interface to add to vm:\n{iface}')
+
+        if status_error:
+            start_result = virsh.define(vmxml.xml, debug=True)
+            libvirt.check_exit_status(start_result, status_error)
+            if err_msg:
+                libvirt.check_result(start_result, expected_fails=err_msg)
+            return
+        else:
+            vmxml.sync()
+
+        LOG.debug(f'VMXML of {vm_name}:\n{virsh.dumpxml(vm_name).stdout_text}')
+
+        vm.start()
+        virsh.domiflist(vm_name, **VIRSH_ARGS)
+        iflist = libvirt.get_interface_details(vm_name)
+        LOG.debug(f'iflist of vm: {iflist}')
+        domif = iflist[0]['interface']
+        LOG.debug(f'Domain interface: {domif}')
+
+        eth_output = process.run(f'ethtool -c {domif}|grep rx-frames',
+                                 shell=True).stdout_text
+        max_frames = min(int(max_frames), 64)
+        if re.search(f'rx-frames:\s+{max_frames}', eth_output):
+            LOG.debug('ethtool check PASS')
+        else:
+            test.fail(
+                f'"rx-frames: {max_frames}" not found in ethtool output.')
+
+        session = vm.wait_for_serial_login()
+        ips = {'outside_ip': outside_ip}
+        network_base.ping_check(params, ips, session, force_ipv4=True)
+        session.close()
+
+    finally:
+        bkxml.sync()
+        if br_type == 'linux_br':
+            utils_net.delete_linux_bridge_tmux(br_name, host_iface)
+        if br_type == 'ovs_br':
+            utils_net.delete_ovs_bridge(br_name)


### PR DESCRIPTION
- VIRT-296233: [coalesce] Set coalesce for network and bridge type interface

Test result:
```
 (1/9) type_specific.io-github-autotest-libvirt.virtual_network.elements_and_attributes.coalesce.nat_network.virtio.32: PASS (82.72 s)
 (2/9) type_specific.io-github-autotest-libvirt.virtual_network.elements_and_attributes.coalesce.nat_network.virtio.big_value: PASS (50.43 s)
 (3/9) type_specific.io-github-autotest-libvirt.virtual_network.elements_and_attributes.coalesce.nat_network.virtio.big_value_neg: PASS (7.10 s)
 (4/9) type_specific.io-github-autotest-libvirt.virtual_network.elements_and_attributes.coalesce.nat_network.virtio.neg_val: PASS (7.11 s)
 (5/9) type_specific.io-github-autotest-libvirt.virtual_network.elements_and_attributes.coalesce.nat_network.virtio.driver_qemu: PASS (50.83 s)
 (6/9) type_specific.io-github-autotest-libvirt.virtual_network.elements_and_attributes.coalesce.nat_network.e1000e: PASS (50.06 s)
 (7/9) type_specific.io-github-autotest-libvirt.virtual_network.elements_and_attributes.coalesce.br.linux_br: PASS (70.63 s)
 (8/9) type_specific.io-github-autotest-libvirt.virtual_network.elements_and_attributes.coalesce.br.ovs_br: PASS (74.76 s)
 (9/9) type_specific.io-github-autotest-libvirt.virtual_network.elements_and_attributes.coalesce.direct: PASS (7.16 s)
RESULTS    : PASS 9 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```