### PR TITLE
memory: Enable test for aarch64

### DIFF
--- a/libvirt/tests/cfg/memory/memory_backing/memory_access_mode.cfg
+++ b/libvirt/tests/cfg/memory/memory_backing/memory_access_mode.cfg
@@ -3,6 +3,9 @@
     set_pagesize = 2048
     set_pagenum = 1024
     numa_mem = 2097152
+    aarch64:
+        set_pagesize = 524288
+        set_pagenum = 4
     start_vm = no
     qemu_monitor_option = '--hmp'
     qemu_monitor_cmd = 'info memdev'
@@ -45,6 +48,8 @@
             numa_attrs = {'vcpu': 4,'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-3', 'memory': '${numa_mem}', 'unit': 'KiB'}]}}
         - no_numa:
             mem_backend = "memory backend: pc.ram"
+            aarch64:
+                mem_backend = "memory backend: mach-virt.ram"
     variants mem_pagesize:
         - without_hugepage:
         - with_hugepage:


### PR DESCRIPTION
Update the hugepagesize and memory backend for arm

Test Result:
```
 (01/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_private.mem_access_private.file: PASS (27.98 s)                                                                                                                                                  
 (02/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_private.mem_access_private.anonymous: PASS (29.01 s)                                                                                                                                             
 (03/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_private.mem_access_private.memfd: PASS (28.97 s)                                                                                                                                                 
 (04/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_private.mem_access_private.no_source: PASS (28.71 s)                                                                                                                                             
 (05/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_private.mem_access_shared.file: PASS (28.69 s)                                                                                                                                                   
 (06/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_private.mem_access_shared.anonymous: PASS (28.68 s)                                                                                                                                              
 (07/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_private.mem_access_shared.memfd: PASS (28.76 s)                                                                                                                                                  
 (08/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_private.mem_access_shared.no_source: PASS (27.83 s)                                                                                                                                              
 (09/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_private.mem_access_default.file: PASS (28.94 s)                                                                                                                                                  
 (10/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_private.mem_access_default.anonymous: PASS (28.89 s)                                                                                                                                             
 (11/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_private.mem_access_default.memfd: PASS (28.62 s)                                                                                                                                                 
 (12/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_private.mem_access_default.no_source: PASS (28.71 s)                                                                                                                                             
 (13/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_shared.mem_access_private.file: PASS (28.77 s)                                                                                                                                                   
 (14/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_shared.mem_access_private.anonymous: PASS (29.02 s)                                                                                                                                              
 (15/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_shared.mem_access_private.memfd: PASS (28.60 s)                                                                                                                                                  
 (16/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_shared.mem_access_private.no_source: PASS (28.88 s)                                                                                                                                              
 (17/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_shared.mem_access_shared.file: PASS (28.63 s)                                                                                                                                                    
 (18/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_shared.mem_access_shared.anonymous: PASS (28.83 s)                                                                                                                                               
 (19/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_shared.mem_access_shared.memfd: PASS (29.01 s)                                                                                                                                                   
 (20/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_shared.mem_access_shared.no_source: PASS (29.26 s)                                                                                                                                               
 (21/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_shared.mem_access_default.file: PASS (29.03 s)                                                                                                                                                   
 (22/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_shared.mem_access_default.anonymous: PASS (28.58 s)                                                                                                                                              
 (23/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_shared.mem_access_default.memfd: PASS (30.00 s)                                                                                                                                                  
 (24/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_shared.mem_access_default.no_source: PASS (29.01 s)                                                                                                                                              
 (25/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_default.mem_access_private.file: PASS (28.92 s)                                                                                                                                                  
 (26/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_default.mem_access_private.anonymous: PASS (28.62 s)                                                                                                                                             
 (27/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_default.mem_access_private.memfd: PASS (28.66 s)                                                                                                                                                 
 (28/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_default.mem_access_private.no_source: PASS (28.68 s)                                                                                                                                             
 (29/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_default.mem_access_shared.file: PASS (28.60 s)                                                                                                                                                   
 (30/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_default.mem_access_shared.anonymous: PASS (28.99 s)                                                                                                                                              
 (31/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_default.mem_access_shared.memfd: PASS (28.63 s)                                                                                                                                                  
 (32/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_default.mem_access_shared.no_source: PASS (28.67 s)                                                                                                                                              
 (33/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_default.mem_access_default.file: PASS (28.97 s)                                                                                                                                                  
 (34/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_default.mem_access_default.anonymous: PASS (28.48 s)                                                                                                                                             
 (35/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_default.mem_access_default.memfd: PASS (28.69 s)                                                                                                                                                 
 (36/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_default.mem_access_default.no_source: PASS (28.23 s)                                                                                                                                             
 (37/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.no_numa.mem_access_private.file: PASS (28.52 s)
 (38/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.no_numa.mem_access_private.anonymous: PASS (28.47 s)
 (39/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.no_numa.mem_access_private.memfd: PASS (28.60 s)                                                                                                                                                             
 (40/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.no_numa.mem_access_private.no_source: PASS (28.64 s)                                                                                                                                                         
 (41/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.no_numa.mem_access_shared.file: PASS (28.39 s)
 (42/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.no_numa.mem_access_shared.anonymous: PASS (28.74 s)                                                                                                                                                          
 (43/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.no_numa.mem_access_shared.memfd: PASS (29.06 s)
 (44/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.no_numa.mem_access_shared.no_source: PASS (27.74 s)                                                                                                                                                          
 (45/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.no_numa.mem_access_default.file: PASS (28.45 s)
 (46/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.no_numa.mem_access_default.anonymous: PASS (28.39 s)                                                                                                                                                         
 (47/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.no_numa.mem_access_default.memfd: PASS (28.37 s)                                                                                                                                                             
 (48/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.no_numa.mem_access_default.no_source: PASS (28.46 s)                                                                                                                                                         
 (49/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_private.mem_access_private.file: PASS (31.53 s)                                                                                                                                                     
 (50/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_private.mem_access_private.memfd: PASS (31.99 s)                                                                                                                                                    
 (51/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_private.mem_access_private.no_source: PASS (31.14 s)                                                                                                                                                
 (52/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_private.mem_access_shared.file: PASS (30.69 s)                                                                                                                                                      
 (53/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_private.mem_access_shared.memfd: PASS (31.34 s)                                                                                                                                                     
 (54/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_private.mem_access_shared.no_source: PASS (31.14 s)                                                                                                                                                 
 (55/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_private.mem_access_default.file: PASS (32.12 s)                                                                                                                                                     
 (56/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_private.mem_access_default.memfd: PASS (31.22 s)                                                                                                                                                    
 (57/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_private.mem_access_default.no_source: PASS (31.30 s)                                                                                                                                                
 (58/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_shared.mem_access_private.file: PASS (30.95 s)                                                                                                                                                      
 (59/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_shared.mem_access_private.memfd: PASS (31.11 s)                                                                                                                                                     
 (60/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_shared.mem_access_private.no_source: PASS (32.43 s)                                                                                                                                                 
 (61/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_shared.mem_access_shared.file: PASS (30.74 s)                                                                                                                                                       
 (62/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_shared.mem_access_shared.memfd: PASS (31.09 s)                                                                                                                                                      
 (63/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_shared.mem_access_shared.no_source: PASS (30.53 s)                                                                                                                                                  
 (64/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_shared.mem_access_default.file: PASS (30.20 s)                                                                                                                                                      
 (65/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_shared.mem_access_default.memfd: PASS (30.49 s)                                                                                                                                                     
 (66/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_shared.mem_access_default.no_source: PASS (30.54 s)                                                                                                                                                 
 (67/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_default.mem_access_private.file: PASS (31.49 s)                                                                                                                                                     
 (68/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_default.mem_access_private.memfd: PASS (31.17 s)                                                                                                                                                    
 (69/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_default.mem_access_private.no_source: PASS (30.61 s)                                                                                                                                                
 (70/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_default.mem_access_shared.file: PASS (31.54 s)                                                                                                                                                      
 (71/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_default.mem_access_shared.memfd: PASS (31.82 s)                                                                                                                                                     
 (72/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_default.mem_access_shared.no_source: PASS (32.13 s)                                                                                                                                                 
 (73/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_default.mem_access_default.file: PASS (31.16 s)                                                                                                                                                     
 (74/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_default.mem_access_default.memfd: PASS (30.55 s)                                                                                                                                                    
 (75/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.numa_access_default.mem_access_default.no_source: PASS (30.68 s)                                                                                                                                                
 (76/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.no_numa.mem_access_private.file: PASS (30.51 s)                                                                                                                                                                 
 (77/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.no_numa.mem_access_private.memfd: PASS (30.61 s)                                                                                                                                                                
 (78/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.no_numa.mem_access_private.no_source: PASS (30.57 s)                                                                                                                                                            
 (79/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.no_numa.mem_access_shared.file: PASS (30.49 s)                                                                                                                                                                  
 (80/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.no_numa.mem_access_shared.memfd: PASS (30.57 s)                                                                                                                                                                 
 (81/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.no_numa.mem_access_shared.no_source: PASS (30.40 s)                                                                                                                                                             
 (82/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.no_numa.mem_access_default.file: PASS (30.70 s)                                                                                                                                                                 
 (83/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.no_numa.mem_access_default.memfd: PASS (30.57 s)                                                                                                                                                                
 (84/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.with_hugepage.no_numa.mem_access_default.no_source: PASS (31.02 s)                                                                                                                                                            
RESULTS    : PASS 84 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```