### PR TITLE
iface_network.py: Fix for pid path checking issue

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_network.py
+++ b/libvirt/tests/src/virtual_network/iface_network.py
@@ -168,7 +168,7 @@ TIMEOUT 3"""
         else:
             return iface_model
 
-    def run_dnsmasq_default_test(key, value=None, exists=True, name="default"):
+    def run_dnsmasq_default_test(key, value=None, exists=True, name="default", ignore_error=False):
         """
         Test dnsmasq configuration.
 
@@ -176,6 +176,7 @@ TIMEOUT 3"""
         :param value: value in conf file to check
         :param exists: check the key:value exist or not
         :param name: The name of conf file
+        :param ignore_error: whether to ignore the checking failure
         """
         conf_file = "/var/lib/libvirt/dnsmasq/%s.conf" % name
         if not os.path.exists(conf_file):
@@ -189,12 +190,23 @@ TIMEOUT 3"""
             config = "%s=%s" % (key, value)
         else:
             config = key
+
+        def _checkpid(msg):
+            if ignore_error:
+                logging.error(msg)
+                return False
+            else:
+                test.fail(msg)
         if not configs.count(config):
             if exists:
-                test.fail("Can't find %s=%s in configuration file" % (key, value))
+                msg = "Can't find %s=%s in configuration file" % (key, value)
+                _checkpid(msg)
         else:
             if not exists:
-                test.fail("Found %s=%s in configuration file" % (key, value))
+                msg = "Found %s=%s in configuration file" % (key, value)
+                _checkpid(msg)
+        if ignore_error:
+            return True
 
     def run_dnsmasq_addnhosts_test(hostip, hostnames):
         """
@@ -952,10 +964,10 @@ TIMEOUT 3"""
                 run_dnsmasq_default_test("dhcp-range", "192.168.122.2,192.168.122.254,255.255.252.0")
             # check the left part in dnsmasq conf
             run_dnsmasq_default_test("strict-order", name=net_name)
-            if libvirt_version.version_compare(6, 0, 0):
-                run_dnsmasq_default_test("pid-file", "/run/libvirt/network/%s.pid" % net_name, name=net_name)
-            else:
-                run_dnsmasq_default_test("pid-file", "/var/run/libvirt/network/%s.pid" % net_name, name=net_name)
+            pid_check = run_dnsmasq_default_test("pid-file", "/var/run/libvirt/network/%s.pid" % net_name, name=net_name, ignore_error=True)
+            pid_check_ = run_dnsmasq_default_test("pid-file", "/run/libvirt/network/%s.pid" % net_name, name=net_name, ignore_error=True)
+            if not (pid_check or pid_check_):
+                test.fail("pid-file of the dnsmasq process checking fail!")
             run_dnsmasq_default_test("except-interface", "lo", name=net_name)
             run_dnsmasq_default_test("bind-dynamic", name=net_name)
             if not disable_dhcp:


### PR DESCRIPTION
Signed-off-by: Kowshik Jois B S <kowsjois@linux.ibm.com>

Tests passed with the updated changes.

 (2/9) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.dnsmasq_test.net_dns_forward: PASS (24.47 s)
 (3/9) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.dnsmasq_test.net_domain: PASS (25.41 s)
 (4/9) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.dnsmasq_test.net_netmask: PASS (25.32 s)
 (5/9) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.dnsmasq_test.net_forwarder_full: PASS (24.42 s)
 (6/9) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.dnsmasq_test.net_forwarder_domain: PASS (24.94 s)
 (7/9) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.dnsmasq_test.net_forwarder_mix: PASS (24.32 s)
 (8/9) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.dnsmasq_test.disable_dns: PASS (24.17 s)