### PR TITLE
memory: Enable test for aarch64

### DIFF
--- a/libvirt/tests/cfg/memory/memory_backing/page_locking_and_shared_pages.cfg
+++ b/libvirt/tests/cfg/memory/memory_backing/page_locking_and_shared_pages.cfg
@@ -3,6 +3,9 @@
     start_vm = no
     pagesize = 2048
     pagenum = 1024
+    aarch64:
+        pagesize = 524288
+        pagenum = 4
     expect_exist = True
     variants lock_config:
         - lock_default:
@@ -26,6 +29,9 @@
             ksm_qemu_line = "mem-merge=off"
     variants page_config:
         - page_default:
+            kernel_pagesize = 4
+            aarch64:
+                kernel_pagesize = 64
         - hugepage:
             hugepages_dict = "'hugepages': {}"
     variants:

--- a/libvirt/tests/src/memory/memory_backing/page_locking_and_shared_pages.py
+++ b/libvirt/tests/src/memory/memory_backing/page_locking_and_shared_pages.py
@@ -97,9 +97,9 @@ def run(test, params, env):
             return
         else:
             if page_config == "page_default":
-                if (nr_unevictable_2 - nr_unevictable)*4 < mem_value:
+                if (nr_unevictable_2 - nr_unevictable)*kernel_pagesize < mem_value:
                     test.fail("Unevictable memory pages should less than %d" % mem_value)
-                if (lock_pages_2 - lock_pages)*4 < mem_value:
+                if (lock_pages_2 - lock_pages)*kernel_pagesize < mem_value:
                     test.fail("Locked memory pages should less than %d" % mem_value)
             elif page_config == "hugepage":
                 if (nr_unevictable_2 - nr_unevictable) < 0:
@@ -139,6 +139,7 @@ def run(test, params, env):
     qemu_line = eval(params.get("qemu_line"))
     hard_limit = int(params.get("hard_limit", 0))
     mem_value = int(params.get("mem_value", ''))
+    kernel_pagesize = int(params.get("kernel_pagesize", 0))
 
     lock_dict = params.get("lock_dict", "")
     tune_dict = eval(params.get("tune_dict", "{}"))


### PR DESCRIPTION
Update hugepagesize and kernel pagesize for aarch64

Test Result:
```
 (01/10) type_specific.io-github-autotest-libvirt.memory.backing.page_locking_and_shared_pages.memory_allocation.page_default.ksm_default.lock_without_hard_limit: PASS (27.26 s)
 (02/10) type_specific.io-github-autotest-libvirt.memory.backing.page_locking_and_shared_pages.memory_allocation.page_default.ksm_default.lock_hard_limit: PASS (29.01 s)
 (03/10) type_specific.io-github-autotest-libvirt.memory.backing.page_locking_and_shared_pages.memory_allocation.page_default.ksm_disabled.lock_default: PASS (28.96 s)
 (04/10) type_specific.io-github-autotest-libvirt.memory.backing.page_locking_and_shared_pages.memory_allocation.page_default.ksm_disabled.lock_without_hard_limit: PASS (28.89 s)
 (05/10) type_specific.io-github-autotest-libvirt.memory.backing.page_locking_and_shared_pages.memory_allocation.page_default.ksm_disabled.lock_hard_limit: PASS (29.04 s)
 (06/10) type_specific.io-github-autotest-libvirt.memory.backing.page_locking_and_shared_pages.memory_allocation.hugepage.ksm_default.lock_without_hard_limit: PASS (31.13 s)
 (07/10) type_specific.io-github-autotest-libvirt.memory.backing.page_locking_and_shared_pages.memory_allocation.hugepage.ksm_default.lock_hard_limit: PASS (31.01 s)
 (08/10) type_specific.io-github-autotest-libvirt.memory.backing.page_locking_and_shared_pages.memory_allocation.hugepage.ksm_disabled.lock_default: PASS (30.73 s)
 (09/10) type_specific.io-github-autotest-libvirt.memory.backing.page_locking_and_shared_pages.memory_allocation.hugepage.ksm_disabled.lock_without_hard_limit: PASS (30.93 s)
 (10/10) type_specific.io-github-autotest-libvirt.memory.backing.page_locking_and_shared_pages.memory_allocation.hugepage.ksm_disabled.lock_hard_limit: PASS (32.11 s)
```