### PR TITLE
memory_misc:update code according to xml class change

### DIFF
--- a/libvirt/tests/cfg/memory/memory_misc.cfg
+++ b/libvirt/tests/cfg/memory/memory_misc.cfg
@@ -113,7 +113,7 @@
                     vmxml_current_mem_unit = 'KiB'
                     vmxml_current_mem = 1024000
                     vmxml_vcpu = 4
-                    sysinfo_attrs = {'type': 'smbios', 'bios': {'entry': 'LENOVO', 'entry_name': 'vendor'}}
+                    sysinfo_attrs = {'type': 'smbios', 'bios_entry': [{'entry': 'LENOVO', 'entry_name': 'vendor'}]}
                     os_attrs = {'boots': ['hd', 'cdrom'], 'bootmenu_enable': 'yes', 'bootmenu_timeout': '3000', 'bios_useserial': 'yes', 'bios_reboot_timeout': '0', 'smbios_mode': 'sysinfo'}
                     idmap_attrs = {'uid': {'start': '0', 'target': '1000', 'count': '10'}, 'gid': {'start': '0', 'target': '1000', 'count': '10'}}
                     cpu_attrs = {'numa_cell': [{'id': '0', 'cpus': '0,2', 'memory': '513024', 'unit': 'KiB'}, {'id': '1', 'cpus': '1,3', 'memory': '513024', 'unit': 'KiB'}]}


### PR DESCRIPTION
Depends on: 
- https://github.com/avocado-framework/avocado-vt/pull/3790

Test result:
 (1/1) type_specific.io-github-autotest-libvirt.memory_misc.xml_check.smbios: PASS (6.68 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
