### PR TITLE
Add vms = avocado-vt-vm1 vm1 back to scsi_device.cfg

### DIFF
--- a/libvirt/tests/cfg/scsi/scsi_device.cfg
+++ b/libvirt/tests/cfg/scsi/scsi_device.cfg
@@ -2,6 +2,7 @@
     type = scsi_device
     status_error = "no"
     start_vm = "no"
+    vms = avocado-vt-vm1 vm1
     variants scsi_type:
         - scsi_hostdev:
             variants:


### PR DESCRIPTION
Add vms = avocado-vt-vm1 vm1 back to scsi_device.cfg

This is an adjustment for PR: https://github.com/autotest/tp-libvirt/pull/5085