### PR TITLE
memory_hugepage_mount: Enable test for aarch64

### DIFF
--- a/libvirt/tests/cfg/memory/memory_backing/hugepage_mount_path.cfg
+++ b/libvirt/tests/cfg/memory/memory_backing/hugepage_mount_path.cfg
@@ -5,12 +5,19 @@
     set_pagenum_1 = "2"
     set_pagesize_2 = "2048"
     set_pagenum_2 = "3072"
+    aarch64:
+        set_pagesize_1 = "2048"
+        set_pagenum_1 = "1024"
+        set_pagesize_2 = "524288"
+        set_pagenum_2 = "6"
     security_context = "drwxr-xr-x. 3 root root system_u:object_r:hugetlbfs_t:s0"
     log_path = "/var/log/libvirt/qemu/%s.log"
     guest_log_error1 = "hugepage is not mounted"
     guest_log_error2 = "unable to create backing store for hugepages: Permission denied"
     page_unit = "KiB"
     page_size = "2048"
+    aarch64:
+        page_size = "524288"
     numa_size = 1048576
     mem_unit = "KiB"
     mem_value = 2097152
@@ -26,10 +33,15 @@
             path = "/dev/hugepages"
             vm_hugepage_mountpoint = "/dev/hugepages1G"
             mount_pagesize = "1G"
+            aarch64:
+                vm_hugepage_mountpoint = "/dev/hugepages2M"
+                mount_pagesize = "2M"
             expect_active = "True"
             expect_state = "active"
             check_qemu = ['"mem-path":"${path}/libvirt/qemu/','"prealloc":true']
             attach_dict = {'mem_model': 'dimm', 'source': {"pagesize":1048576, "pagesize_unit":"KiB"},'target': {'size': 1048576, 'size_unit': 'KiB','node':0}}
+            aarch64:
+                attach_dict = {'mem_model': 'dimm', 'source': {"pagesize":2048, "pagesize_unit":"KiB"},'target': {'size': 1048576, 'size_unit': 'KiB','node':0}}
             check_security_cmd = "ls -l -Z ${path}/libvirt/qemu/ -d"
         - disabled:
             hugetlbfs_mount  = '""'


### PR DESCRIPTION
The default hugepage size is 512M for aarch64.

Update the test case according to the changes in polarion case for aarch64.

Test Result:
```
 (1/3) type_specific.io-github-autotest-libvirt.memory.backing.mount_path.default: PASS (73.04 s)
 (2/3) type_specific.io-github-autotest-libvirt.memory.backing.mount_path.disabled: PASS (33.81 s)
 (3/3) type_specific.io-github-autotest-libvirt.memory.backing.mount_path.customized: PASS (40.59 s)
```