### PR TITLE
Add new case of attach interface:mtu

### DIFF
--- a/libvirt/tests/cfg/virtual_network/attach_detach_device/attach_mtu_malformed.cfg
+++ b/libvirt/tests/cfg/virtual_network/attach_detach_device/attach_mtu_malformed.cfg
@@ -1,0 +1,30 @@
+- virtual_network.attach_detach_device.mtu.malformed:
+    type = attach_mtu_malformed
+    start_vm = no
+    timeout = 240
+    host_iface =
+    status_error = yes
+    variants iface_type:
+        - network:
+            variants net_type:
+                - nat:
+                    source_net = default
+                    variants:
+                        - non_digit_value:
+                            mtu_size = sdfg
+                            err_msg = malformed mtu size
+                        - neg_value:
+                            mtu_size = -1
+                            err_msg = malformed mtu size
+                        - large_value:
+                            mtu_size = 99999999
+                            err_msg = Cannot set interface MTU on .*: Invalid argument
+                - direct:
+                    net_attrs = {'forward': {'dev': host_iface, 'mode': 'bridge'}, 'forward_interface': [{'dev': host_iface}], 'name': net_name}
+                    mtu_size = 9000
+                    err_msg = Cannot set interface MTU on .*: Invalid argument
+            iface_attrs = {'type_name': 'network', 'source': {'network': source_net}, 'mtu': {'size': '${mtu_size}'}, 'model': 'virtio'}
+        - direct:
+            err_msg = setting MTU on interface type direct is not supported yet
+            mtu_size = 9000
+            iface_attrs = {'type_name': 'direct', 'source': {'dev': host_iface, 'mode': 'bridge'}, 'mtu': {'size': '${mtu_size}'}, 'model': 'virtio'}

--- a/libvirt/tests/src/virtual_network/attach_detach_device/attach_mtu_malformed.py
+++ b/libvirt/tests/src/virtual_network/attach_detach_device/attach_mtu_malformed.py
@@ -1,0 +1,61 @@
+import logging
+
+from virttest import utils_misc
+from virttest import utils_net
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_network
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+VIRSH_ARGS = {'ignore_status': False, 'debug': True}
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+
+def run(test, params, env):
+    """
+    Test attach interface with mtu configuration
+    """
+    vm_name = params.get('main_vm')
+    vm = env.get_vm(vm_name)
+    status_error = 'yes' == params.get('status_error', 'no')
+    err_msg = params.get('err_msg')
+    rand_id = utils_misc.generate_random_string(3)
+    net_name = 'net_' + rand_id
+    source_net = params.get('source_net', net_name)
+    host_iface = params.get('host_iface')
+    host_iface = host_iface if host_iface else utils_net.get_net_if(
+        state='UP')[0]
+    iface_attrs = eval(params.get('iface_attrs', '{}'))
+    net_attrs = eval(params.get('net_attrs', '{}'))
+
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+
+    try:
+        vmxml.del_device('interface', by_tag=True)
+        vmxml.sync()
+        LOG.debug(f'VMXML of {vm_name}:\n{virsh.dumpxml(vm_name).stdout_text}')
+
+        if net_attrs:
+            libvirt_network.create_or_del_network(net_attrs)
+            LOG.debug(f'Network xml:\n'
+                      f'{virsh.net_dumpxml(net_attrs["name"]).stdout_text}')
+
+        vm.start()
+        vm.wait_for_serial_login().close()
+
+        iface = libvirt_vmxml.create_vm_device_by_type(
+            'interface', iface_attrs)
+        LOG.debug(f'Interface to attach:\n{iface}')
+
+        at_result = virsh.attach_device(vm_name, iface.xml)
+        libvirt.check_exit_status(at_result, status_error)
+        if err_msg:
+            libvirt.check_result(at_result, err_msg)
+
+    finally:
+        bkxml.sync()
+        if net_attrs:
+            libvirt_network.create_or_del_network(net_attrs, is_del=True)


### PR DESCRIPTION
- VIRT-299228 - [attach-device][mtu] hotplug with malformed mtu size or to interface type not supported

Test result:
```
 (1/5) type_specific.io-github-autotest-libvirt.virtual_network.attach_detach_device.mtu.malformed.network.nat.non_digit_value: PASS (37.71 s)
 (2/5) type_specific.io-github-autotest-libvirt.virtual_network.attach_detach_device.mtu.malformed.network.nat.neg_value: PASS (36.99 s)
 (3/5) type_specific.io-github-autotest-libvirt.virtual_network.attach_detach_device.mtu.malformed.network.nat.large_value: PASS (37.40 s)
 (4/5) type_specific.io-github-autotest-libvirt.virtual_network.attach_detach_device.mtu.malformed.network.direct: PASS (37.00 s)
 (5/5) type_specific.io-github-autotest-libvirt.virtual_network.attach_detach_device.mtu.malformed.direct: PASS (36.44 s)
RESULTS    : PASS 5 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```