### PR TITLE
Fix scsi_hostdev.positive.qemu_pr_helper case failure

### DIFF
--- a/libvirt/tests/src/scsi/scsi_device.py
+++ b/libvirt/tests/src/scsi/scsi_device.py
@@ -477,14 +477,16 @@ def check_hostdev_shareable_attr(test, params):
             test.fail("VM: % failed to find shareable attribute in output: %s" % (vm_name, str(hostdev_xml)))
 
 
-def test_coldplug_scsi_hostdev_qemu_pr_helper(test, params):
+def test_coldplug_scsi_hostdev_qemu_pr_helper(test, params, env):
     """
     Test coldplug scsi hostdev and check qemu-pr-helper status
 
     :param test: one test object instance
     :param params: dict wrapped with params
+    :param env: environment instance
     """
     vm_name = params.get("main_vm")
+    _ = env.get_vm(vm_name)
     block_device = setup_scsi_debug_block_device()
 
     disk_src_dict = {"attrs": {"dev": block_device}}


### PR DESCRIPTION
Fix scsi_hostdev.positive.qemu_pr_helper case failure
Since it use uniform pattern: run_test_case(test, params, env) to trigger test method, so all test method has 3 parameters