### PR TITLE
memory_tuning: add new case for memory tuning

### DIFF
--- a/libvirt/tests/cfg/memory/memory_tuning/memory_tuning_settings.cfg
+++ b/libvirt/tests/cfg/memory/memory_tuning/memory_tuning_settings.cfg
@@ -1,0 +1,22 @@
+- memory.tuning:
+    type = memory_tuning_settings
+    start_vm = no
+    memtune_cmd_parameter_seq = ['hard_limit', 'soft_limit', 'swap_hard_limit']
+    max_limit_dict = {'hard_limit':-1, 'soft_limit':-1, 'swap_hard_limit':-1}
+    vm_attrs = {'memory_unit':"KiB", 'memory':2097152, 'current_mem':2097152, 'current_mem_unit':'KiB'}
+    cgroupv1_error_for_zero_hard_limit = "Unable to write to '.*memory.limit_in_bytes': Device or resource busy"
+    variants test_target:
+        - normal:
+            target_limit_dict = {'hard_limit':3072005, 'soft_limit':2048003, 'swap_hard_limit':4096010}
+        - zero:
+            target_limit_dict = {'soft_limit':0, 'hard_limit':0}
+            shutdown_timeout = 2
+        - minus:
+            init_hard_limit = 3072005
+            init_soft_limit = 2048003
+            init_swap_hard_limit = 4096010
+            init_limit_dict = {'hard_limit':${init_hard_limit}, 'soft_limit':${init_soft_limit}, 'swap_hard_limit':${init_swap_hard_limit}}
+            init_memory_tuning_dict = "'memtune': {'hard_limit':${init_hard_limit}, 'hard_limit_unit':'KiB', 'soft_limit':${init_soft_limit}, 'soft_limit_unit':'KiB', 'swap_hard_limit':${init_swap_hard_limit}, 'swap_limit_unit':'KiB'}"
+            target_limit_dict = {'soft_limit':-1, 'swap_hard_limit':-1, 'hard_limit':-1}
+            vm_attrs = {'memory_unit':"KiB", 'memory':2097152, 'current_mem':2097152, 'current_mem_unit':'KiB', ${init_memory_tuning_dict}}
+

--- a/libvirt/tests/src/memory/memory_tuning/memory_tuning_settings.py
+++ b/libvirt/tests/src/memory/memory_tuning/memory_tuning_settings.py
@@ -1,0 +1,221 @@
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright Red Hat
+#
+#   SPDX-License-Identifier: GPL-2.0
+#
+#   Author: Liang Cong <lcong@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+import re
+
+from virttest import libvirt_cgroup
+from virttest import utils_libvirtd
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.libvirt_xml import xcepts
+from virttest.utils_test import libvirt
+from virttest.staging import utils_memory
+
+
+def run(test, params, env):
+    """
+    Verify memory tuning parameters take effect
+    """
+
+    def adjust_limit_for_memory_page(limit_dict):
+        """
+        Limit value would be aligned to the default memory page size
+        """
+        default_page_size = utils_memory.getpagesize()
+        return {key: (value // default_page_size * default_page_size)
+                if value != -1 else value for key, value in limit_dict.items()}
+
+    def check_limit_by_virsh_memtune(limit_dict):
+        """
+        Check the memtune limit is expected by virsh memtune
+        """
+        expected_limit_dict = adjust_limit_for_memory_page(limit_dict)
+        for key, value in expected_limit_dict.items():
+            actual_value = virsh.memtune_get(vm_name, key)
+            if actual_value != value:
+                test.fail("memtune limit %s expected %s, but get %s instead"
+                          % (key, value, actual_value))
+
+    def set_limit_by_virsh_memtune_in_turn(limit_dict):
+        """
+        Set memory limit by virsh memtune one by one
+        """
+        vm_pid = vm.get_pid()
+        cg = libvirt_cgroup.CgroupTest(vm_pid)
+        for key, value in limit_dict.items():
+            options = " --%s %s" % (re.sub('_', '-', key), value)
+            result = virsh.memtune_set(vm_name, options, debug=True)
+            if not cg.is_cgroup_v2_enabled() and 'hard_limit' == key and 0 == value:
+                libvirt.check_result(
+                    result, expected_fails=cgroupv1_error_for_zero_hard_limit)
+            else:
+                libvirt.check_exit_status(result)
+
+    def set_limit_by_virsh_memtune_once(limit_dict):
+        """
+        Set memory limit by virsh memtune all together
+        """
+        limit_value_list = [str(limit_dict[limit_name])
+                            for limit_name in memtune_cmd_parameter_seq]
+        options = " %s" % " ".join(limit_value_list)
+        virsh.memtune_set(vm_name, options, debug=True, ignore_status=False)
+
+    def check_limit_by_cgroup(limit_dict):
+        """
+        Check the memtune limit is expected by cgroup
+        """
+        adjusted_limit_dict = adjust_limit_for_memory_page(limit_dict)
+        expected_limit_dict = {key: (value*1024) if value != -1 else 'max'
+                               for key, value in adjusted_limit_dict.items()}
+        vm_pid = vm.get_pid()
+        cg = libvirt_cgroup.CgroupTest(vm_pid)
+        limit_cgroup_dict = cg.get_standardized_cgroup_info("memtune")
+        for key in expected_limit_dict:
+            if str(expected_limit_dict[key]) != limit_cgroup_dict[key]:
+                test.fail("cgroup memory limit %s expected %s, but get %s instead"
+                          % (key, expected_limit_dict[key], limit_cgroup_dict[key]))
+
+    def check_limit_by_virsh_dump(limit_dict):
+        """
+        check the memtune limit is expected by virsh dump
+        """
+        guest_xml = vm_xml.VMXML.new_from_dumpxml(vm.name)
+        if len(set(limit_dict.values())) == 1 and list(limit_dict.values())[0] == -1:
+            try:
+                if hasattr(guest_xml, "memtune"):
+                    test.fail("memtune should not appear in config xml, "
+                              "but found memtune XML:\n%s" % guest_xml.memtune)
+            except xcepts.LibvirtXMLNotFoundError:
+                pass
+        else:
+            memtune_element = guest_xml.memtune
+            for key, value in limit_dict.items():
+                if int(getattr(memtune_element, key)) != value:
+                    test.fail("memtune limit %s should be %s "
+                              "in config xml, but found value:%s"
+                              % (key, value, getattr(memtune_element, key)))
+
+    def run_test():
+        """
+        Test steps
+        """
+
+        test.log.info("TEST_SETUP1: Define the guest")
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        vmxml.setup_attrs(**vm_attrs)
+        virsh.define(vmxml.xml, ignore_status=False, debug=True)
+
+        test.log.info("TEST_STEP2: Start the guest")
+        if not vm.is_alive():
+            vm.start()
+        vm_pid = vm.get_pid()
+        cg = libvirt_cgroup.CgroupTest(vm_pid)
+
+        test.log.info("TEST_STEP3: Check the memtune setting")
+        if "minus" == test_target:
+            expected_limit_dict = init_limit_dict
+        else:
+            expected_limit_dict = max_limit_dict
+        check_limit_by_virsh_memtune(expected_limit_dict)
+
+        test.log.info("TEST_STEP4: Change the memtune settings one by one")
+        set_limit_by_virsh_memtune_in_turn(target_limit_dict)
+
+        test.log.info("TEST_STEP5: Check the guest status")
+        if 'zero' == test_target:
+            vm.wait_for_shutdown(shutdown_timeout)
+        actual_state = virsh.domstate(
+            vm_name, "--reason", debug=True).stdout.strip()
+        if 'zero' == test_target:
+            expected_state = "shut off (crashed)" if cg.is_cgroup_v2_enabled(
+            ) else "running (booted)"
+            if expected_state != actual_state:
+                test.fail("Guest state should be '%s', "
+                          "but get %s instead" % (expected_state, actual_state))
+            return
+        else:
+            if "running (booted)" != actual_state:
+                test.fail("Guest state should be 'running (booted)', "
+                          "but get %s instead" % actual_state)
+
+        test.log.info("TEST_STEP6: For scenarios with running guest, "
+                      "check the memtune values")
+        check_limit_by_virsh_memtune(target_limit_dict)
+
+        test.log.info("TEST_STEP7: For scenarios with running guest, "
+                      "check the cgroup settings")
+        check_limit_by_cgroup(target_limit_dict)
+
+        test.log.info("TEST_STEP8: For scenarios with running guest, "
+                      "destroy and start the guest")
+        vm.destroy()
+        vm.start()
+
+        test.log.info("TEST_STEP9: For scenarios with running guest, "
+                      "change the memtune setting all together")
+        set_limit_by_virsh_memtune_once(target_limit_dict)
+
+        test.log.info("TEST_STEP10: For scenarios with running guest, "
+                      "check the memtune values")
+        check_limit_by_virsh_memtune(target_limit_dict)
+
+        test.log.info("TEST_STEP11: For scenarios with running guest, "
+                      "check the cgroup settings")
+        check_limit_by_cgroup(target_limit_dict)
+
+        test.log.info("TEST_STEP12: For scenarios with running guest, "
+                      "check the memtune config xml")
+        check_limit_by_virsh_dump(target_limit_dict)
+
+        test.log.info("TEST_STEP13: For scenarios with running guest, "
+                      "restart the libvirt daemon")
+        utils_libvirtd.libvirtd_restart()
+
+        test.log.info("TEST_STEP14-1: For scenarios with running guest, "
+                      "check the memtune values")
+        check_limit_by_virsh_memtune(target_limit_dict)
+
+        test.log.info("TEST_STEP14-2: For scenarios with running guest, "
+                      "check the cgroup settings")
+        check_limit_by_cgroup(target_limit_dict)
+
+        test.log.info("TEST_STEP14-3: For scenarios with running guest, "
+                      "check the memtune config xml")
+        check_limit_by_virsh_dump(target_limit_dict)
+
+    def teardown_test():
+        """
+        Restore guest config xml.
+        """
+        test.log.info("TEST_TEARDOWN: Restore guest config xml.")
+        bkxml.sync()
+
+    vm_name = params.get('main_vm')
+    vm = env.get_vm(vm_name)
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+    vm_attrs = eval(params.get('vm_attrs', '{}'))
+    test_target = params.get('test_target')
+    max_limit_dict = eval(params.get('max_limit_dict', '{}'))
+    init_limit_dict = eval(params.get('init_limit_dict', '{}'))
+    target_limit_dict = eval(params.get('target_limit_dict', '{}'))
+    memtune_cmd_parameter_seq = eval(
+        params.get('memtune_cmd_parameter_seq', '[]'))
+    cgroupv1_error_for_zero_hard_limit = params.get(
+        'cgroupv1_error_for_zero_hard_limit', '')
+    shutdown_timeout = int(params.get('shutdown_timeout', 0))
+
+    try:
+        run_test()
+
+    finally:
+        teardown_test()

--- a/libvirt/tests/src/memory/memory_tuning/memory_tuning_settings.py
+++ b/libvirt/tests/src/memory/memory_tuning/memory_tuning_settings.py
@@ -29,6 +29,9 @@ def run(test, params, env):
     def adjust_limit_for_memory_page(limit_dict):
         """
         Limit value would be aligned to the default memory page size
+
+        :param params: dict of memory limitation
+        :return: dict, adjucted memory limitation dict from host page size
         """
         default_page_size = utils_memory.getpagesize()
         return {key: (value // default_page_size * default_page_size)
@@ -37,6 +40,8 @@ def run(test, params, env):
     def check_limit_by_virsh_memtune(limit_dict):
         """
         Check the memtune limit is expected by virsh memtune
+
+        :param params: dict of memory limitation
         """
         expected_limit_dict = adjust_limit_for_memory_page(limit_dict)
         for key, value in expected_limit_dict.items():
@@ -48,6 +53,8 @@ def run(test, params, env):
     def set_limit_by_virsh_memtune_in_turn(limit_dict):
         """
         Set memory limit by virsh memtune one by one
+
+        :param params: dict of memory limitation
         """
         vm_pid = vm.get_pid()
         cg = libvirt_cgroup.CgroupTest(vm_pid)
@@ -63,6 +70,8 @@ def run(test, params, env):
     def set_limit_by_virsh_memtune_once(limit_dict):
         """
         Set memory limit by virsh memtune all together
+
+        :param params: dict of memory limitation
         """
         limit_value_list = [str(limit_dict[limit_name])
                             for limit_name in memtune_cmd_parameter_seq]
@@ -72,6 +81,8 @@ def run(test, params, env):
     def check_limit_by_cgroup(limit_dict):
         """
         Check the memtune limit is expected by cgroup
+
+        :param params: dict of memory limitation
         """
         adjusted_limit_dict = adjust_limit_for_memory_page(limit_dict)
         expected_limit_dict = {key: (value*1024) if value != -1 else 'max'
@@ -87,6 +98,8 @@ def run(test, params, env):
     def check_limit_by_virsh_dump(limit_dict):
         """
         check the memtune limit is expected by virsh dump
+
+        :param params: dict of memory limitation
         """
         guest_xml = vm_xml.VMXML.new_from_dumpxml(vm.name)
         if len(set(limit_dict.values())) == 1 and list(limit_dict.values())[0] == -1:
@@ -108,6 +121,8 @@ def run(test, params, env):
     def check_guest_memtune_related_values(limit_dict):
         """
         check memtune by cmd virsh memtune, cgroup value and guest config xml
+
+        :param params: dict of memory limitation
         """
         test.log.info("Check the memtune value by virsh memtune")
         check_limit_by_virsh_memtune(limit_dict)

--- a/libvirt/tests/src/memory/memory_tuning/memory_tuning_settings.py
+++ b/libvirt/tests/src/memory/memory_tuning/memory_tuning_settings.py
@@ -96,7 +96,7 @@ def run(test, params, env):
                               "but found memtune XML:\n%s" % guest_xml.memtune)
             except xcepts.LibvirtXMLNotFoundError as detail:
                 test.log.debug(
-                    "Did not find the memtune xml, error is:%s" % detail)
+                    "Did not find the memtune xml, error is:%s", detail)
         else:
             memtune_element = guest_xml.memtune
             for key, value in limit_dict.items():

--- a/libvirt/tests/src/memory/memory_tuning/memory_tuning_settings.py
+++ b/libvirt/tests/src/memory/memory_tuning/memory_tuning_settings.py
@@ -109,7 +109,7 @@ def run(test, params, env):
         Test steps
         """
 
-        test.log.info("TEST_SETUP1: Define the guest")
+        test.log.info("TEST_STEP1: Define the guest")
         vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
         vmxml.setup_attrs(**vm_attrs)
         virsh.define(vmxml.xml, ignore_status=False, debug=True)

--- a/libvirt/tests/src/memory/memory_tuning/memory_tuning_settings.py
+++ b/libvirt/tests/src/memory/memory_tuning/memory_tuning_settings.py
@@ -31,7 +31,7 @@ def run(test, params, env):
         Limit value would be aligned to the default memory page size
 
         :param params: dict of memory limitation
-        :return: dict, adjucted memory limitation dict from host page size
+        :return: dict, adjusted memory limitation dict from host page size
         """
         default_page_size = utils_memory.getpagesize()
         return {key: (value // default_page_size * default_page_size)

--- a/spell.ignore
+++ b/spell.ignore
@@ -150,6 +150,7 @@ conf
 config
 Config
 configs
+Cong
 coredump
 corescount
 cpu
@@ -492,6 +493,8 @@ kwargs
 lan
 lcheng
 lchown
+lcong
+Liang
 libexec
 libguestfs
 libnbd


### PR DESCRIPTION
test result on rhel9.3:
 (1/3) type_specific.io-github-autotest-libvirt.memory.tuning.normal: PASS (38.49 s)
 (2/3) type_specific.io-github-autotest-libvirt.memory.tuning.zero: PASS (10.53 s)
 (3/3) type_specific.io-github-autotest-libvirt.memory.tuning.minus: PASS (38.86 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/Code/avocado/avocado/mytest/job-results/job-2023-11-06T03.23-826d3c7/results.html
JOB TIME   : 89.55 s
test result on rhel8.9:
JOB LOG    : /root/Code/testbase/job-results/job-2023-11-06T03.15-59114db/job.log
 (1/3) type_specific.io-github-autotest-libvirt.memory.tuning.normal: PASS (29.37 s)
 (2/3) type_specific.io-github-autotest-libvirt.memory.tuning.zero: PASS (9.77 s)
 (3/3) type_specific.io-github-autotest-libvirt.memory.tuning.minus: PASS (30.68 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /root/Code/testbase/job-results/job-2023-11-06T03.15-59114db/results.html
JOB TIME   : 71.56 s