### PR TITLE
iothread: add case with two iothread inactive

### DIFF
--- a/libvirt/tests/cfg/cpu/iothread.cfg
+++ b/libvirt/tests/cfg/cpu/iothread.cfg
@@ -5,7 +5,7 @@
         - positive_test:
             variants:
                 - iothread_config:
-                    start_vm = "yes"
+                    need_start_vm = "yes"
                     variants:
                         - only_iothread_id:
                             iothread_ids = "6"
@@ -15,7 +15,7 @@
                             iothread_ids = "2 4 6 8"
                             iothread_num = "5"
                 - defaultiothread_config:
-                    start_vm = "yes"
+                    need_start_vm = "yes"
                     func_supported_since_libvirt_ver = (8, 5, 0)
                     vm_attrs = {'defaultiothread': {'thread_pool_min': '8', 'thread_pool_max': '16'}}
                 - thread_pool:
@@ -30,7 +30,7 @@
                         - shutoff_vm:
                             cmd_options = '--config'
                         - live_vm:
-                            start_vm = "yes"
+                            need_start_vm = "yes"
                             pre_vm_stats = "running"
                             cmd_options = ''
                 - iothreadpin:
@@ -51,6 +51,19 @@
                     iothreadset_id = "1"
                     iothreadset_val = "--poll-max-ns 2147483647 --poll-grow 2147483647 --poll-shrink 2147483647"
                     test_operations = "iothreadset"
+                - iothread_cold_set:
+                    func_supported_since_libvirt_ver = (9, 4, 0)
+                    need_start_vm = "yes"
+                    thread_pool_min = 2147483647
+                    thread-pool-max = 2147483647
+                    iothread_num = "2"
+                    iothread_ids = "1 2"
+                    iothreadset_id = "1"
+                    iothreadset_val = "--thread-pool-min 2147483647 --thread-pool-max 2147483647 --poll-max-ns 2147483647 --poll-grow 2147483647 --poll-shrink 2147483647"
+                    cmd_options = '--config'
+                    iothread_config = {'iothread': [{'id': '2', 'thread_pool_min': '1', 'thread_pool_max': '1', 'poll': {'max': '1', 'grow': '1', 'shrink': '1'}}]}
+                    test_operations = "iothreadset"
+                    check_iotheadids_inactive = "yes"
                 - disk_attach:
                     pre_vm_stats = "running"
                     create_disk = "yes"
@@ -69,7 +82,7 @@
                             iothreadpins = "2:100"
                             pseries, aarch64:
                                 iothreadpins = "2:300"
-                            start_vm = "yes"
+                            need_start_vm = "yes"
                             err_msg = "Numerical result out of range|Invalid argument"
                         - no_matchs_iothread:
                             define_error = "yes"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_iothreadadd.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_iothreadadd.cfg
@@ -10,6 +10,7 @@
     iothreadpins = "2:1 1:0-1"
     iothreads = "2"
     iothread_id = "6"
+    start_vm = 'no'
     variants:
         - normal_test:
             status_error = "no"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_iothreaddel.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_iothreaddel.cfg
@@ -10,6 +10,7 @@
     iothreads = "2"
     iothreadpins = "2:1 1:0-1"
     iothread_id = "2"
+    start_vm = 'no'
     variants:
         - normal_test:
             status_error = "no"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_iothreadinfo.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_iothreadinfo.cfg
@@ -9,6 +9,7 @@
     # The format of iothreadpins is IOTHEADID:CPUSET
     iothreads = "2"
     iothreadpins = "2:1 1:0-1"
+    start_vm = 'no'
     variants:
         - normal_test:
             status_error = "no"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_iothreadpin.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_iothreadpin.cfg
@@ -9,6 +9,7 @@
     iothreads = "2"
     iothreadpins = "2:1 1:0-1"
     iothread_id = "2"
+    start_vm = 'no'
     variants:
         - normal_test:
             cpuset = "1"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_iothreadadd.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_iothreadadd.py
@@ -26,6 +26,23 @@ def get_xmlinfo(vm_name, options):
     return xml_info.iothreadids.iothread
 
 
+def check_iothread_id(iothread_list, search_iothread_id, test):
+    """
+    Check if the specified iothread id exists
+
+    :param iothread_list: list, iothread id information
+    :param search_iothread_id: str, the iothread id to be searched
+    :param test: test object
+    """
+    found = False
+    for a_iothread in iothread_list:
+        if search_iothread_id == a_iothread['id']:
+            found = True
+    if not found:
+        test.fail("Can not find iothread '%s' in "
+                  "domain xml" % search_iothread_id)
+
+
 def run(test, params, env):
     """
     Test command: virsh iothread.
@@ -115,9 +132,7 @@ def run(test, params, env):
             # Check domainxml
             iothread_info = get_xmlinfo(vm_name, options)
             logging.debug("iothreadinfo: %s", iothread_info)
-            if {'id': iothread_id} not in iothread_info:
-                test.fail("Failed to add iothread '%s' in "
-                          "domain xml" % iothread_id)
+            check_iothread_id(iothread_info, iothread_id, test)
 
             # Check iothreadinfo by virsh command
             iothread_info = libvirt.get_iothreadsinfo(dom_option, options)

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_iothreaddel.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_iothreaddel.py
@@ -26,6 +26,23 @@ def get_xmlinfo(vm_name, options):
     return xml_info.iothreadids.iothread
 
 
+def check_iothread_id(iothread_list, search_iothread_id, test):
+    """
+    Check if the specified iothread id exists
+
+    :param iothread_list: list, iothread id information
+    :param search_iothread_id: str, the iothread id to be searched
+    :param test: test object
+    """
+    found = False
+    for a_iothread in iothread_list:
+        if search_iothread_id == a_iothread['id']:
+            found = True
+    if found:
+        test.fail("Can find iothread '%s' in "
+                  "domain xml" % search_iothread_id)
+
+
 def run(test, params, env):
     """
     Test command: virsh iothreaddel.
@@ -115,15 +132,13 @@ def run(test, params, env):
             # Check domainxml
             iothread_info = get_xmlinfo(vm_name, options)
             logging.debug("iothreadinfo: %s", iothread_info)
-            if iothread_id in iothread_info:
-                raise exceptions.TestFail("Failed to add iothread %s in domain xml",
-                                          iothread_id)
+            check_iothread_id(iothread_info, iothread_id, test)
 
             # Check iothreadinfo by virsh command
             iothread_info = libvirt.get_iothreadsinfo(dom_option, options)
             logging.debug("iothreadinfo: %s", iothread_info)
             if iothread_id in iothread_info:
-                raise exceptions.TestFail("Failed to add iothread %s", iothread_id)
+                raise exceptions.TestFail("Failed to delete iothread %s", iothread_id)
 
     finally:
         # Cleanup


### PR DESCRIPTION
This is to test the iothread parameters could be set before vm starts
Case ID: XXX-299032

Depends on 
- https://github.com/avocado-framework/avocado-vt/pull/3791

Signed-off-by: Dan Zheng <dzheng@redhat.com>