### PR TITLE
Add new case of attach interface with boot order

### DIFF
--- a/libvirt/tests/cfg/virtual_network/attach_detach_device/attach_iface_with_boot_order.cfg
+++ b/libvirt/tests/cfg/virtual_network/attach_detach_device/attach_iface_with_boot_order.cfg
@@ -1,0 +1,21 @@
+- virtual_network.attach_detach_device.boot_order:
+    type = attach_iface_with_boot_order
+    start_vm = no
+    timeout = 240
+    status_error = yes
+    variants scenario:
+        - vm_with_os_boot:
+            os_attrs = {'boots': ['hd']}
+            boot_order = 2
+            err_msg = per-device boot elements cannot be used together with os/boot elements
+        - dup_boot_order:
+            boot_order = 1
+            disk_attrs = {'boot': '${boot_order}'}
+            err_msg = unsupported configuration: boot order ${boot_order} is already used by another device
+        - neg_value:
+            boot_order = -1
+            err_msg = Expected non-negative integer value
+        - str_value:
+            boot_order = ss
+            err_msg = Expected non-negative integer value
+    iface_attrs = {'source': {'network': 'default'}, 'model': 'virtio', 'type_name': 'network', 'boot': '${boot_order}'}

--- a/libvirt/tests/src/virtual_network/attach_detach_device/attach_iface_with_boot_order.py
+++ b/libvirt/tests/src/virtual_network/attach_detach_device/attach_iface_with_boot_order.py
@@ -1,0 +1,61 @@
+import logging
+
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+VIRSH_ARGS = {'ignore_status': False, 'debug': True}
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+
+def run(test, params, env):
+    """
+    Test attach interface with boot order
+    """
+    vm_name = params.get('main_vm')
+    vm = env.get_vm(vm_name)
+    status_error = 'yes' == params.get('status_error', 'no')
+    err_msg = params.get('err_msg')
+    iface_attrs = eval(params.get('iface_attrs', '{}'))
+    os_attrs = eval(params.get('os_attrs', '{}'))
+    disk_attrs = eval(params.get('disk_attrs', '{}'))
+
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+
+    try:
+        vmxml.del_device('interface', by_tag=True)
+        vmxml.sync()
+
+        if os_attrs:
+            vmxml.setup_attrs(os=os_attrs)
+        if disk_attrs:
+            osxml = vmxml.os
+            osxml.del_boots()
+            vmxml.os = osxml
+            vmxml.sync()
+            libvirt_vmxml.modify_vm_device(vmxml, 'disk', disk_attrs)
+
+        LOG.debug(f'VMXML of {vm_name}:\n{virsh.dumpxml(vm_name).stdout_text}')
+
+        vm.start()
+        vm.wait_for_serial_login().close()
+
+        iface = libvirt_vmxml.create_vm_device_by_type(
+            'interface', iface_attrs)
+        LOG.debug(f'Interface to attach:\n{iface}')
+
+        def check_attach(option=''):
+            at_result = virsh.attach_device(vm_name, iface.xml, flagstr=option,
+                                            debug=True)
+            libvirt.check_exit_status(at_result, status_error)
+            if err_msg:
+                libvirt.check_result(at_result, err_msg)
+
+        check_attach()
+        check_attach('--config')
+
+    finally:
+        bkxml.sync()


### PR DESCRIPTION
- VIRT-299227 - [attach-device][boot order] hotplug an interface with boot order

Test result:
```
 (1/4) type_specific.io-github-autotest-libvirt.virtual_network.attach_detach_device.boot_order.vm_with_os_boot: PASS (35.51 s)
 (2/4) type_specific.io-github-autotest-libvirt.virtual_network.attach_detach_device.boot_order.dup_boot_order: PASS (37.40 s)
 (3/4) type_specific.io-github-autotest-libvirt.virtual_network.attach_detach_device.boot_order.neg_value: PASS (35.68 s)
 (4/4) type_specific.io-github-autotest-libvirt.virtual_network.attach_detach_device.boot_order.str_value: PASS (35.87 s)
RESULTS    : PASS 4 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```