### PR TITLE
virtual_disk: fix positional arguments mismatch in function definition and call

### DIFF
--- a/libvirt/tests/src/scsi/scsi_device.py
+++ b/libvirt/tests/src/scsi/scsi_device.py
@@ -477,12 +477,13 @@ def check_hostdev_shareable_attr(test, params):
             test.fail("VM: % failed to find shareable attribute in output: %s" % (vm_name, str(hostdev_xml)))
 
 
-def test_coldplug_scsi_hostdev_qemu_pr_helper(test, params):
+def test_coldplug_scsi_hostdev_qemu_pr_helper(test, params, env):
     """
     Test coldplug scsi hostdev and check qemu-pr-helper status
 
     :param test: one test object instance
     :param params: dict wrapped with params
+    :param env: environment instance
     """
     vm_name = params.get("main_vm")
     block_device = setup_scsi_debug_block_device()


### PR DESCRIPTION
Fix positional arguments mismatch for test_coldplug_scsi_hostdev_qemu_pr_helper.

Before:
```
ERROR 1-type_specific.io-github-autotest-libvirt.scsi_device_manipulate.coldplug.scsi_hostdev.positive.qemu_pr_helper -> TypeError: test_coldplug_scsi_hostdev_qemu_pr_helper() takes 2 positional arguments but 3 were given
```

After:
```
PASS 1-type_specific.io-github-autotest-libvirt.scsi_device_manipulate.coldplug.scsi_hostdev.positive.qemu_pr_helper
```