### PR TITLE
virtual_network: remove acpi settings in connectivity_check_user_interface

### DIFF
--- a/libvirt/tests/cfg/virtual_network/connectivity/connectivity_check_user_interface.cfg
+++ b/libvirt/tests/cfg/virtual_network/connectivity/connectivity_check_user_interface.cfg
@@ -19,10 +19,9 @@
     variants:
         - positive_test:
             expect_error = no
-            vm_iface = eno1
             variants:
                 - default:
-                    iface_attrs = {'model': 'virtio', 'type_name': 'user', 'acpi': {'index': '1'}, }
+                    iface_attrs = {'model': 'virtio', 'type_name': 'user'}
                     ipv4_addr = 10.0.2.15
                     ipv4_prefix = 24
                     ipv4_default_gw = 10.0.2.2
@@ -30,7 +29,7 @@
                 - customized_ip:
                     variants:
                         - no_prefix:
-                            iface_attrs = {'model': 'virtio', 'type_name': 'user', 'acpi': {'index': '1'}, 'ips': [{'address': '100.100.100.20', 'family': 'ipv4'}, {'address': '2001:db8:ac10:fd01::', 'family': 'ipv6'}]}
+                            iface_attrs = {'model': 'virtio', 'type_name': 'user', 'ips': [{'address': '100.100.100.20', 'family': 'ipv4'}, {'address': '2001:db8:ac10:fd01::', 'family': 'ipv6'}]}
                             ipv4_addr = \d+.0.2.15
                             ipv4_prefix = 8
                             ipv6_addr = 2001:db8:ac10:fd01:.+
@@ -38,7 +37,7 @@
                             ipv4_default_gw = \d+.0.2.2
                             nameserver = \d+.0.2.3
                         - with_prefix:
-                            iface_attrs = {'model': 'virtio', 'type_name': 'user', 'acpi': {'index': '1'}, 'ips': [{'address': '100.100.100.20', 'family': 'ipv4', 'prefix': '24'}, {'address': '2001:db8:ac10:fd01::', 'family': 'ipv6', 'prefix': '64'}]}
+                            iface_attrs = {'model': 'virtio', 'type_name': 'user', 'ips': [{'address': '100.100.100.20', 'family': 'ipv4', 'prefix': '24'}, {'address': '2001:db8:ac10:fd01::', 'family': 'ipv6', 'prefix': '64'}]}
                             ipv4_addr = 100.100.100.15
                             ipv4_default_gw = 100.100.100.2
                             nameserver = 100.100.100.3

--- a/libvirt/tests/src/virtual_network/connectivity/connectivity_check_user_interface.py
+++ b/libvirt/tests/src/virtual_network/connectivity/connectivity_check_user_interface.py
@@ -10,6 +10,7 @@ from virttest.utils_libvirt import libvirt_unprivileged
 from virttest.utils_libvirt import libvirt_vmxml
 from virttest.utils_test import libvirt
 
+from provider.interface import interface_base
 from provider.virtual_network import network_base
 from provider.virtual_network import passt
 
@@ -73,7 +74,6 @@ def run(test, params, env):
     params['host_ip_v6'] = host_ip_v6 = utils_net.get_host_ip_address(
         ip_ver='ipv6')
     iface_attrs = eval(params.get('iface_attrs'))
-    vm_iface = params.get('vm_iface', 'eno1')
     outside_ip = params.get('outside_ip')
     host_iface = params.get('host_iface')
     host_iface = host_iface if host_iface else utils_net.get_net_if(
@@ -108,6 +108,7 @@ def run(test, params, env):
 
         session = vm.wait_for_serial_login(timeout=60)
         LOG.debug(session.cmd_output('ip addr'))
+        vm_iface = interface_base.get_vm_iface(session)
         vm_ipv4, vm_ipv4_pfx = passt.get_iface_ip_and_prefix(vm_iface, session)
         LOG.debug(f'vm ipv4 address and prefix: {vm_ipv4} {vm_ipv4_pfx}')
         check_val(ipv4_addr, vm_ipv4, 'vm ipv4', test)


### PR DESCRIPTION
arm does not support acpi index.
remove acpi settings here as the scenario is not for acpi test.

Test Results are as follows, the failed two cases are cause by another issue.
```
 (01/14) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.user_interface.positive_test.default.root_user: FAIL: default ipv4 gateway not match. Expect 10.0.2.2, but got ip route|grep dhcp | awk '/default/ { print $3 }}'\n10.0.2.2 (51.56 s)                                                   
 (02/14) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.user_interface.positive_test.default.non_root_user: FAIL: default ipv4 gateway not match. Expect 10.0.2.2, but got ip route|grep dhcp | awk '/default/ { print $3 }}'\n10.0.2.2 (57.93 s)                                               
 (03/14) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.user_interface.positive_test.customized_ip.no_prefix.root_user: PASS (89.59 s)
 (04/14) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.user_interface.positive_test.customized_ip.no_prefix.non_root_user: PASS (68.45 s)
 (05/14) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.user_interface.positive_test.customized_ip.with_prefix.root_user: PASS (114.00 s)                                                                                                                                                        
 (06/14) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.user_interface.positive_test.customized_ip.with_prefix.non_root_user: PASS (67.82 s)   
 (07/14) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.user_interface.negative_test.multi_addr_ipv4.root_user: PASS (8.77 s)
 (08/14) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.user_interface.negative_test.multi_addr_ipv4.non_root_user: PASS (14.79 s)                                                                                                                                                              
 (09/14) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.user_interface.negative_test.multi_addr_ipv6.root_user: PASS (8.78 s)                                                                                                                                                                   
 (10/14) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.user_interface.negative_test.multi_addr_ipv6.non_root_user: PASS (14.69 s)                                                                                                                                                              
 (11/14) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.user_interface.negative_test.invalid_prefix_2.root_user: PASS (8.78 s)                                                                                                                                                                  
 (12/14) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.user_interface.negative_test.invalid_prefix_2.non_root_user: PASS (14.77 s)                                                                                                                                                             
 (13/14) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.user_interface.negative_test.invalid_prefix_28.root_user: PASS (8.62 s)                                                                                                                                                                 
 (14/14) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.user_interface.negative_test.invalid_prefix_28.non_root_user: PASS (14.61 s)
```