### PR TITLE
libvirtd: Fix LibvirtXMLError exception issue

### DIFF
--- a/libvirt/tests/src/daemon/crash_regression.py
+++ b/libvirt/tests/src/daemon/crash_regression.py
@@ -10,7 +10,7 @@ from virttest import virsh
 from virttest import data_dir
 from virttest.utils_libvirtd import LibvirtdSession
 from virttest.utils_libvirtd import Libvirtd
-from virttest.libvirt_xml.xcepts import LibvirtXMLError
+from virttest.libvirt_xml import xcepts
 from virttest.libvirt_xml.vm_xml import VMXML, VMCPUXML, VMPMXML
 from virttest.libvirt_xml.network_xml import NetworkXML, IPXML
 from virttest.libvirt_xml.devices import interface
@@ -98,7 +98,7 @@ def run_mix_boot_order_os_boot(params, libvirtd, vm):
 
         try:
             vm_xml.sync()
-        except LibvirtXMLError:
+        except xcepts.LibvirtXMLError:
             pass
     finally:
         vm_xml_backup.sync()
@@ -158,7 +158,7 @@ def run_invalid_interface(params, libvirtd, vm):
 
         try:
             vm_xml.sync()
-        except LibvirtXMLError:
+        except xcepts.LibvirtXMLError:
             pass
     finally:
         vm_xml_backup.sync()


### PR DESCRIPTION
Fix the problem that LibvirtXMLError exception cannot be thrown successfully

Before:
```
ERROR 1-type_specific.io-github-autotest-libvirt.daemon.crash_regression.mix_boot_order_os_boot -> LibvirtXMLError: Failed to define avocado-vt-vm1 for reason:error: Failed to define domain from /tmp/xml_utils_temp_8zdo8v4r.xmlerror: XML error: Invalid value for attribute 'order' in element 'boot': Zero is not permitted
ERROR 1-type_specific.io-github-autotest-libvirt.daemon.crash_regression.invalid_interface -> LibvirtXMLError: Failed to define avocado-vt-vm1 for reason:error: Failed to define domain from /tmp/xml_utils_temp_1av1jk2v.xmlerror: internal error: No <source> 'bridge' attribute specified with <interface type='bridge'/>
```

After:
```
PASS 1-type_specific.io-github-autotest-libvirt.daemon.crash_regression.mix_boot_order_os_boot
PASS 1-type_specific.io-github-autotest-libvirt.daemon.crash_regression.invalid_interface
```