### PR TITLE
virtual_network: Add a case about memlock limit for vdpa interfaces

### DIFF
--- a/libvirt/tests/cfg/virtual_network/locked_memory_vdpa/hotplug_mem_to_vm_with_vdpa.cfg
+++ b/libvirt/tests/cfg/virtual_network/locked_memory_vdpa/hotplug_mem_to_vm_with_vdpa.cfg
@@ -1,0 +1,30 @@
+- virtual_network.locked_memory.vdpa_interface.hotplug_mem:
+    type = hotplug_mem_to_vm_with_vdpa
+    start_vm = no
+
+    current_mem = 2
+    current_mem_unit = 'GiB'
+    cpu_setting = {'numa_cell': [{'id': '0', 'cpus': '0-3', 'memory': '1', 'unit': 'GiB'}, {'id': '1', 'cpus': '4-7', 'memory': '1', 'unit': 'GiB'}]}
+    max_mem_rt = 6291456
+    max_mem_rt_unit = 'K'
+    max_mem_rt_slots = 32
+    vcpu = 8
+    func_supported_since_libvirt_ver = (7, 3, 0)
+    func_supported_since_qemu_kvm_ver = (6, 0, 0)
+    iface_dict = {"source": {'dev':'/dev/vhost-vdpa-0'}}
+    only x86_64
+
+    variants test_target:
+        - simulator:
+        - mellanox:
+    variants test_scenario:
+        - at_memory_to_vm_with_iface:
+            vm_attrs = {'max_mem_rt': ${max_mem_rt}, 'max_mem_rt_slots': ${max_mem_rt_slots}, 'max_mem_rt_unit': '${max_mem_rt_unit}', 'current_mem': ${current_mem}, 'current_mem_unit': '${current_mem_unit}','vcpu': ${vcpu}, 'cpu': ${cpu_setting}}
+            mem_dict = {'mem_model': 'dimm', 'target': {'size': 1, 'size_unit': 'G', 'node': 0}}
+        - at_memory_to_vm_with_iface_and_locked_mem:
+            vm_attrs = {'max_mem_rt': ${max_mem_rt}, 'max_mem_rt_slots': ${max_mem_rt_slots}, 'max_mem_rt_unit': '${max_mem_rt_unit}', 'current_mem': ${current_mem}, 'current_mem_unit': '${current_mem_unit}','vcpu': ${vcpu},'memtune':{'hard_limit': 10485760, 'hard_limit_unit': 'KiB'}, 'mb': {'locked': True}, 'cpu': ${cpu_setting}}
+            mem_dict = {'mem_model': 'dimm', 'target': {'size': 1, 'size_unit': 'G', 'node': 0}}
+        - at_iface_and_memory:
+            vm_attrs = {'max_mem_rt': ${max_mem_rt}, 'max_mem_rt_slots': ${max_mem_rt_slots}, 'max_mem_rt_unit': '${max_mem_rt_unit}', 'current_mem': ${current_mem}, 'current_mem_unit': '${current_mem_unit}','vcpu': ${vcpu}, 'cpu': ${cpu_setting}}
+            mem_dict1 = {'mem_model': 'dimm', 'target': {'size': 256, 'size_unit': 'M', 'node': 0}}
+            mem_dict2 = {'mem_model': 'dimm', 'target': {'size': 256, 'size_unit': 'M', 'node': 1}}

--- a/libvirt/tests/src/virtual_network/locked_memory_vdpa/hotplug_mem_to_vm_with_vdpa.py
+++ b/libvirt/tests/src/virtual_network/locked_memory_vdpa/hotplug_mem_to_vm_with_vdpa.py
@@ -1,0 +1,207 @@
+from virttest import libvirt_version
+from virttest import utils_misc
+from virttest import utils_vdpa
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.libvirt_xml.devices.memory import Memory
+from virttest.utils_libvirt import libvirt_memory
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+from provider.interface import interface_base
+
+VIRSH_ARGS = {'debug': True, 'ignore_status': False}
+
+
+def run(test, params, env):
+    """
+    Hotplug memory to vm with vDPA type interface and check the locked memory
+    """
+
+    def check_environment(params):
+        """
+        Check the test environment
+
+        :param params: Dictionary with the test parameters
+        """
+        libvirt_version.is_libvirt_feature_supported(params)
+        utils_misc.is_qemu_function_supported(params)
+
+    def setup_test():
+        """
+        Set up test
+
+        1) Remove interface devices
+        2) Setup test environment for a specific interface if needed
+        3) Set VM attrs
+
+        :return: An object of special test environment
+        """
+        test.log.debug("Remove VM's interface devices.")
+        libvirt_vmxml.remove_vm_devices_by_type(vm, 'interface')
+        test_env_obj = None
+        if test_target == "simulator":
+            test_env_obj = utils_vdpa.VDPASimulatorTest()
+        else:
+            pf_pci = utils_vdpa.get_vdpa_pci()
+            test_env_obj = utils_vdpa.VDPAOvsTest(pf_pci)
+        test_env_obj.setup()
+
+        test.log.debug("Update VM's settings.")
+        vm_attrs = eval(params.get('vm_attrs', '{}'))
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        vmxml.setup_attrs(**vm_attrs)
+        vmxml.sync()
+        test.log.debug("Updated VM xml: %s.",
+                       vm_xml.VMXML.new_from_dumpxml(vm_name))
+        return test_env_obj
+
+    def teardown_test():
+        """
+        Cleanup vDPA environment
+        """
+        if test_obj:
+            test_obj.cleanup()
+
+    def setup_at_memory_to_vm_with_iface():
+        """
+        Prepare a vm with max memory, numa, and an interface
+        """
+        test_env_obj = setup_test()
+        # Add interface device
+        iface_dict = eval(params.get('iface_dict', '{}'))
+        iface_dev = interface_base.create_iface(dev_type, iface_dict)
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        libvirt.add_vm_device(vmxml, iface_dev)
+        test.log.debug("VM xml after updating ifaces: %s.",
+                       vm_xml.VMXML.new_from_dumpxml(vm_name))
+        return test_env_obj
+
+    def test_at_memory_to_vm_with_iface():
+        """
+        hotplug memory device to vm with an interface
+
+        1) Start vm and check the locked memory
+        2) Hotplug memory device and check the locked memory
+        """
+        vm.start()
+        vm.wait_for_serial_login(timeout=240).close()
+        new_vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+
+        # MEMLOCK value is guest memory + 1G(for the passthrough device)
+        expr_memlock = libvirt_memory.normalize_mem_size(
+            new_vmxml.get_current_mem(),
+            new_vmxml.get_current_mem_unit()) + 1073741824
+        if not libvirt_memory.comp_memlock(expr_memlock):
+            test.fail("Unable to get correct MEMLOCK after VM startup!")
+
+        test.log.info("Hotplug memory device.")
+        mem_dict = eval(params.get('mem_dict', '{}'))
+        memxml = Memory()
+        memxml.setup_attrs(**mem_dict)
+        virsh.attach_device(vm_name, memxml.xml, **VIRSH_ARGS)
+        expr_memlock += libvirt_memory.normalize_mem_size(
+            mem_dict['target']['size'], mem_dict['target']['size_unit'])
+        if not libvirt_memory.comp_memlock(expr_memlock):
+            test.fail("Unable to get correct MEMLOCK after attaching a memory "
+                      "device!")
+
+    def test_at_iface_and_memory():
+        """
+        hotplug an interface and memory devices
+
+        1) Start vm and check the default locked memory
+        2) Hotplug an interface and check the locked memory
+        3) Hotplug 2 memory devices and check the locked memory
+        4) Hot-unplug a memory device and check the locked memory
+        """
+        vm.start()
+        vm.wait_for_serial_login(timeout=240).close()
+        expr_memlock = 67108864
+        if not libvirt_memory.comp_memlock(expr_memlock):
+            test.fail("Unable to get correct default!")
+
+        interface_base.attach_iface_device(vm_name, dev_type, params)
+
+        new_vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        # MEMLOCK value is guest memory + 1G(for the passthrough device)
+        expr_memlock = libvirt_memory.normalize_mem_size(
+            new_vmxml.get_current_mem(),
+            new_vmxml.get_current_mem_unit()) + 1073741824
+        if not libvirt_memory.comp_memlock(expr_memlock):
+            test.fail("Unable to get correct MEMLOCK after VM startup!")
+
+        test.log.info("Hotplug memory devices.")
+        for mem_attrs in ['mem_dict1', 'mem_dict2']:
+            mem_dict = eval(params.get(mem_attrs, '{}'))
+            memxml = Memory()
+            memxml.setup_attrs(**mem_dict)
+            virsh.attach_device(vm_name, memxml.xml, **VIRSH_ARGS)
+            expr_memlock += libvirt_memory.normalize_mem_size(
+                mem_dict['target']['size'], mem_dict['target']['size_unit'])
+            if not libvirt_memory.comp_memlock(expr_memlock):
+                test.fail("Unable to get correct MEMLOCK after attaching a "
+                          "memory device!")
+
+        test.log.info("Detach a memory device and check memlock.")
+        memxml = vm_xml.VMXML.new_from_dumpxml(
+            vm_name).get_devices('memory')[-1]
+        cmd_result = virsh.detach_device(vm_name, memxml.xml,
+                                         wait_for_event=True,
+                                         debug=True)
+        if cmd_result.exit_status:
+            libvirt.check_result(cmd_result, 'unplug of device was rejected')
+            if not libvirt_memory.comp_memlock(expr_memlock):
+                test.fail("Detaching mem failed, MEMLOCK should not change!")
+        else:
+            if not libvirt_memory.comp_memlock(expr_memlock):
+                test.fail("Unable to get correct MEMLOCK after detaching a "
+                          "memory device!")
+
+    def setup_at_memory_to_vm_with_iface_and_locked_mem():
+        """
+        Prepare a vm with max memory, locked mem, numa, and an interface
+        """
+        return setup_at_memory_to_vm_with_iface()
+
+    def test_at_memory_to_vm_with_iface_and_locked_mem():
+        """
+        hotplug memory device
+
+        1) Start a guest with max memory + locked + interface
+        2) Hotplug a memory device and check the locked memory
+        """
+        vm.start()
+        vm.wait_for_serial_login(timeout=240).close()
+        new_vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+
+        expr_memlock = libvirt_memory.normalize_mem_size(
+            new_vmxml.memtune.hard_limit, new_vmxml.memtune.hard_limit_unit)
+        if not libvirt_memory.comp_memlock(expr_memlock):
+            test.fail("Unable to get correct MEMLOCK after VM startup!")
+
+    check_environment(params)
+    # Variable assignment
+    test_scenario = params.get('test_scenario', '')
+    test_target = params.get('test_target', '')
+    dev_type = params.get('dev_type', 'vdpa')
+    run_test = eval("test_%s" % test_scenario)
+    setup_func = eval("setup_%s" % test_scenario) if "setup_%s" % \
+        test_scenario in locals() else setup_test
+
+    vm_name = params.get('main_vm')
+    vm = env.get_vm(vm_name)
+
+    vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+    backup_vmxml = vmxml.copy()
+
+    test_obj = None
+    try:
+        # Execute test
+        test_obj = setup_func()
+        run_test()
+
+    finally:
+        backup_vmxml.sync()
+        teardown_test()


### PR DESCRIPTION
This PR adds:
    RHEL-283024 - [vdpa] hotplug memory to vm with vdpa type
        interface and check the memlock limit


**Test results:**
```
 (1/6) type_specific.io-github-autotest-libvirt.virtual_network.locked_memory.vdpa_interface.hotplug_mem.at_memory_to_vm_with_iface.simulator: PASS (49.73 s)
 (2/6) type_specific.io-github-autotest-libvirt.virtual_network.locked_memory.vdpa_interface.hotplug_mem.at_memory_to_vm_with_iface.mellanox: PASS (72.22 s)
 (3/6) type_specific.io-github-autotest-libvirt.virtual_network.locked_memory.vdpa_interface.hotplug_mem.at_memory_to_vm_with_iface_and_locked_mem.simulator: PASS (50.74 s)
 (4/6) type_specific.io-github-autotest-libvirt.virtual_network.locked_memory.vdpa_interface.hotplug_mem.at_memory_to_vm_with_iface_and_locked_mem.mellanox: PASS (75.29 s)
 (5/6) type_specific.io-github-autotest-libvirt.virtual_network.locked_memory.vdpa_interface.hotplug_mem.at_iface_and_memory.simulator: PASS (98.82 s)
 (6/6) type_specific.io-github-autotest-libvirt.virtual_network.locked_memory.vdpa_interface.hotplug_mem.at_iface_and_memory.mellanox: PASS (82.79 s)

```