### PR TITLE
virtual_network: remove acpi settings in connectivity_check_ethernet_interface

### DIFF
--- a/libvirt/tests/cfg/virtual_network/connectivity/connectivity_check_ethernet_interface.cfg
+++ b/libvirt/tests/cfg/virtual_network/connectivity/connectivity_check_ethernet_interface.cfg
@@ -31,8 +31,7 @@
                 - macvtap:
                     vm_ping_outside = pass
                     vm_ping_host_public = fail
-            iface_attrs = {'target': {'dev': tap_name, 'managed': 'no'}, 'model': 'virtio', 'type_name': 'ethernet', **${mtu_attrs}, 'acpi': {'index': '1'}}
-            vm_iface = eno1
+            iface_attrs = {'target': {'dev': tap_name, 'managed': 'no'}, 'model': 'virtio', 'type_name': 'ethernet', **${mtu_attrs}}
         - negative_test:
             status_error = yes
             variants:

--- a/libvirt/tests/src/virtual_network/connectivity/connectivity_check_ethernet_interface.py
+++ b/libvirt/tests/src/virtual_network/connectivity/connectivity_check_ethernet_interface.py
@@ -11,6 +11,7 @@ from virttest.utils_libvirt import libvirt_unprivileged
 from virttest.utils_libvirt import libvirt_vmxml
 from virttest.utils_test import libvirt
 
+from provider.interface import interface_base
 from provider.virtual_network import network_base
 
 LOG = logging.getLogger('avocado.' + __name__)
@@ -50,10 +51,8 @@ def run(test, params, env):
     tap_name = tap_type + '_' + rand_id
     tap_mtu = params.get('tap_mtu')
     iface_mtu = params.get('iface_mtu')
-    vm_iface = params.get('vm_iface')
     host_ip = utils_net.get_host_ip_address(ip_ver='ipv4')
     iface_attrs = eval(params.get('iface_attrs'))
-    vm_iface = params.get('vm_iface', 'eno1')
     outside_ip = params.get('outside_ip')
     host_iface = params.get('host_iface')
     host_iface = host_iface if host_iface else utils_net.get_net_if(
@@ -113,6 +112,7 @@ def run(test, params, env):
                 LOG.info('MTU check of vmxml PASS')
 
             # Check mtu inside vm
+            vm_iface = interface_base.get_vm_iface(session)
             vm_iface_info = utils_net.get_linux_iface_info(iface=vm_iface,
                                                            session=session)
             vm_mtu = vm_iface_info['mtu']


### PR DESCRIPTION
arm does not support acpi index.
remove acpi settings here as the scenario is not for acpi test.

Test results are as follows, the failed 3 cases are caused by other issues.
```
 (1/9) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.ethernet_interface.managed_no.positive_test.tap.no_mtu.non_root_user: PASS (93.33 s)                                                                                                                                                      
 (2/9) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.ethernet_interface.managed_no.positive_test.tap.larger_mtu.non_root_user: PASS (91.79 s)                                                                                                                                                  
 (3/9) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.ethernet_interface.managed_no.positive_test.tap.smaller_mtu.non_root_user: PASS (88.63 s)                                                                                                                                                 
 (4/9) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.ethernet_interface.managed_no.positive_test.macvtap.no_mtu.non_root_user: PASS (69.62 s)                                                                                                                                                  
 (5/9) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.ethernet_interface.managed_no.positive_test.macvtap.larger_mtu.non_root_user: ERROR: Command 'ip link set dev macvtap_ZJK mtu 2000' failed.\nstdout: b''\nstderr: b'RTNETLINK answers: Invalid argument\n'\nadditional_info: None (13.35 s)
 (6/9) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.ethernet_interface.managed_no.positive_test.macvtap.smaller_mtu.non_root_user: ERROR: Command 'ip link set dev macvtap_4Um mtu 2000' failed.\nstdout: b''\nstderr: b'RTNETLINK answers: Invalid argument\n'\nadditional_info: None (13.17 s)
 (7/9) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.ethernet_interface.managed_no.negative_test.no_target_dev.non_root_user: PASS (15.77 s)                                                                                                                                                   
 (8/9) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.ethernet_interface.managed_no.negative_test.target_dev_not_exist.non_root_user: PASS (15.95 s)                                                                                                                                            
 (9/9) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.ethernet_interface.managed_no.negative_test.managed_yes.non_root_user: FAIL: Expect should fail with one of ['The .* interface already exists'], but failed with:\n\n\nerror: Failed to start domain 'unpr-vm'\nerror: Cannot set interface MAC to fe:54:00:02:b6:66 on 'tap_e2c': Operation not permitted\n (43.12 s)
```