### PR TITLE
add case for virtio-mem auto placement

### DIFF
--- a/libvirt/tests/cfg/memory/memory_devices/virtio_mem_auto_placement.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/virtio_mem_auto_placement.cfg
@@ -1,0 +1,45 @@
+- memory.devices.virtio_mem.auto_placement:
+    type = virtio_mem_auto_placement
+    no s390-virtio
+    start_vm = "no"
+    placement = "auto"
+    mem_model = "virtio-mem"
+    block_size = 2048
+    set_size = 131072
+    requested_size = 131072
+    aarch64:
+        block_size = 524288
+        set_size = 1048576
+        requested_size = 524288
+    virtio_mem_dict = {'mem_model': '${mem_model}', 'target': {'requested_unit': 'KiB', 'size': ${requested_size}, 'node': 0, 'size_unit': 'KiB', 'requested_size': ${requested_size}, 'block_unit': 'KiB', 'block_size': ${block_size}}}
+    required_kernel = [5.14.0,)
+    guest_required_kernel = [5.8.0,)
+    func_supported_since_libvirt_ver = (8, 0, 0)
+    func_supported_since_qemu_kvm_ver = (6, 2, 0)
+    variants:
+        - strict:
+            tuning_mode = "strict"
+            mode_attrs = "'mode': '${tuning_mode}',"
+        - interleave:
+            tuning_mode = "interleave"
+            mode_attrs = "'mode': '${tuning_mode}',"
+        - preferred:
+            tuning_mode = "preferred"
+            mode_attrs = "'mode': '${tuning_mode}',"
+        - restrictive:
+            tuning_mode = "restrictive"
+            mode_attrs = "'mode': '${tuning_mode}',"
+        - undefined:
+            mode_attrs = ""
+    tuning_attrs = "'numa_memory': {${mode_attrs} 'placement': '${placement}'}"
+    variants:
+        - with_2_numa_nodes:
+            numa_mem = 1048576
+            mem_value = 2097152
+            current_mem = 2097152
+            max_mem = 15242880
+            max_mem_slots = 16
+            base_attrs = "'vcpu': 4, 'placement': '${placement}', 'memory_unit':'KiB','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'KiB'"
+            numa_attrs = "'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '${numa_mem}', 'unit': 'KiB'},{'id':'1','cpus': '2-3','memory':'${numa_mem}','unit':'KiB'}]}"
+            max_attrs = "'max_mem_rt': ${max_mem}, 'max_mem_rt_slots': ${max_mem_slots}, 'max_mem_rt_unit': 'KiB'"
+            vm_attrs = {${base_attrs}, ${numa_attrs}, ${max_attrs}, ${tuning_attrs}}

--- a/libvirt/tests/src/memory/memory_devices/virtio_mem_auto_placement.py
+++ b/libvirt/tests/src/memory/memory_devices/virtio_mem_auto_placement.py
@@ -1,0 +1,94 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright Redhat
+#
+#   SPDX-License-Identifier: GPL-2.0
+
+#   Author: Nannan Li <nanli@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import time
+
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.libvirt_xml.devices import memory
+from virttest.utils_libvirt import libvirt_vmxml
+
+from provider.memory import memory_base
+from provider.numa import numa_base
+
+
+def run(test, params, env):
+    """
+    1.Define guest with dimm devices.
+    2.Attach dimm and check mem value
+    """
+
+    def setup_test():
+        """
+        Check available numa nodes num.
+        """
+        memory_base.check_supported_version(params, test, vm)
+        test.log.info("TEST_SETUP: Check available numa nodes num")
+        numa_obj = numa_base.NumaTest(vm, params, test)
+        numa_obj.check_numa_nodes_availability()
+
+    def run_test():
+        """
+        Define guest, check xml, check memory
+        """
+        test.log.info("TEST_SETUP1: Define guest")
+        vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+        vmxml.setup_attrs(**vm_attrs)
+        virsh.define(vmxml.xml, debug=True, ignore_status=False)
+
+        libvirt_vmxml.modify_vm_device(
+            vm_xml.VMXML.new_from_inactive_dumpxml(vm_name), 'memory',
+            virtio_mem_dict)
+
+        test.log.info("TEST_STEP2: Start vm")
+        vm.start()
+        vm.wait_for_login().close()
+
+        test.log.info("TEST_SETUP3: Hotplug a virtio-mem device")
+        mem_obj = memory.Memory()
+        mem_obj.setup_attrs(**virtio_mem_dict)
+        virsh.attach_device(vm.name, mem_obj.xml, debug=True,
+                            wait_for_event=True, ignore_status=False)
+
+        test.log.info("TEST_SETUP4: Check the virtio-mem device memory")
+        time.sleep(3)
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        test.log.debug("The new xml is:\n%s", vmxml)
+
+        mem_list = vmxml.devices.by_device_tag('memory')
+        for mem in mem_list:
+            actual_size = mem.fetch_attrs()['target']['current_size']
+            if str(actual_size) != requested_size:
+                test.fail("Expected to get requested size '%s', "
+                          "but got '%s'" % (requested_size, actual_size))
+            else:
+                test.log.debug('Check requested size "%s" correctly' % requested_size)
+
+    def teardown_test():
+        """
+        Clean data.
+        """
+        test.log.info("TEST_TEARDOWN: Clean up env.")
+        bkxml.sync()
+
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+    vm_attrs = eval(params.get('vm_attrs', '{}'))
+    virtio_mem_dict = eval(params.get('virtio_mem_dict', '{}'))
+    requested_size = params.get("requested_size")
+
+    try:
+        setup_test()
+        run_test()
+
+    finally:
+        teardown_test()


### PR DESCRIPTION
    VIRT-299160: Virtio-mem memory device with auto placement numatune
Signed-off-by: nanli <nanli@redhat.com>


RHEL9+ x86

```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35  memory.devices.virtio_mem.auto_placement.with_numa
 (1/5) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.auto_placement.with_numa.strict: PASS (57.20 s)
 (2/5) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.auto_placement.with_numa.interleave: PASS (59.28 s)
 (3/5) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.auto_placement.with_numa.preferred: PASS (58.19 s)
 (4/5) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.auto_placement.with_numa.restrictive: PASS (58.18 s)
 (5/5) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.auto_placement.with_numa.undefined: PASS (57.43 s)

```

RHEL9+aarch64


```
 avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio  memory.devices.virtio_mem.auto_placement.with_numa

 (1/5) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.auto_placement.with_numa.strict: PASS (80.28 s)
 (2/5) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.auto_placement.with_numa.interleave: PASS (76.84 s)
 (3/5) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.auto_placement.with_numa.preferred: PASS (76.30 s)
 (4/5) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.auto_placement.with_numa.restrictive: PASS (81.88 s)
 (5/5) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.auto_placement.with_numa.undefined: PASS (78.27 s)



```