### PR TITLE
CPU: Add new test case for SVE support.

### DIFF
--- a/libvirt/tests/cfg/cpu/aarch64_cpu_sve.cfg
+++ b/libvirt/tests/cfg/cpu/aarch64_cpu_sve.cfg
@@ -41,9 +41,13 @@
                     vector_lenth_list = '[{"sve":"disable"}, {"sve128":"require"}]'
                     define_error = "yes"
                     expect_msg = "SVE disabled, but SVE vector lengths provided"
+        - no_host_sve_support:
+            only negative_test
+            host_without_sve = "yes"
+            status_error = "yes"
     variants:
         - positive_test:
             status_error = "no"
         - negative_test:
-            only invalid_length, conflict_length
+            only invalid_length, conflict_length, no_host_sve_support
             status_error = "yes"


### PR DESCRIPTION
This commit adds a new test case to check
the SVE support on the host. The new
test case checks for the absence of SVE
on the host.

Tested with libvirt version 8.0.0

Test results:
**avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio aarch64_cpu_sve --vt-connect-uri qemu:///system**
(1/9) type_specific.io-github-autotest-libvirt.aarch64_cpu_sve.positive_test.boot_test.enable_sve: CANCEL: Host doesn't support SVE (27.25 s)
 (2/9) type_specific.io-github-autotest-libvirt.aarch64_cpu_sve.positive_test.boot_test.disable_sve: CANCEL: Host doesn't support SVE (27.34 s)
 (3/9) type_specific.io-github-autotest-libvirt.aarch64_cpu_sve.positive_test.vector_length_test.valid_length.single_vector.sve128: CANCEL: Host doesn't support SVE (29.39 s)
 (4/9) type_specific.io-github-autotest-libvirt.aarch64_cpu_sve.positive_test.vector_length_test.valid_length.single_vector.sve256: CANCEL: Host doesn't support SVE (27.25 s)
 (5/9) type_specific.io-github-autotest-libvirt.aarch64_cpu_sve.positive_test.vector_length_test.valid_length.single_vector.sve512: CANCEL: Host doesn't support SVE (27.37 s)
 (6/9) type_specific.io-github-autotest-libvirt.aarch64_cpu_sve.positive_test.vector_length_test.valid_length.mutiple_vector: CANCEL: Host doesn't support SVE (29.32 s)
 (7/9) type_specific.io-github-autotest-libvirt.aarch64_cpu_sve.negative_test.vector_length_test.invalid_length: CANCEL: Host doesn't support SVE (27.31 s)
 (8/9) type_specific.io-github-autotest-libvirt.aarch64_cpu_sve.negative_test.vector_length_test.conflict_length: CANCEL: Host doesn't support SVE (27.37 s)
 (9/9) type_specific.io-github-autotest-libvirt.aarch64_cpu_sve.negative_test.host_sve_check: PASS (30.05 s)

