### PR TITLE
Add a libvirt version check

### DIFF
--- a/libvirt/tests/cfg/virtual_network/connectivity/connectivity_check_ethernet_interface.cfg
+++ b/libvirt/tests/cfg/virtual_network/connectivity/connectivity_check_ethernet_interface.cfg
@@ -17,12 +17,12 @@
                 - no_mtu:
                     mtu_attrs = {}
                 - larger_mtu:
-                    tap_mtu = 2000
+                    tap_mtu = 1400
                     iface_mtu = 3000
                     mtu_attrs = {'mtu': {'size': ${iface_mtu}}}
                 - smaller_mtu:
-                    tap_mtu = 2000
-                    iface_mtu = 1400
+                    tap_mtu = 1400
+                    iface_mtu = 1200
                     mtu_attrs = {'mtu': {'size': ${iface_mtu}}}
             variants tap_type:
                 - tap:
@@ -43,6 +43,7 @@
                     iface_attrs = {'model': 'virtio', 'type_name': 'ethernet', 'target': {'dev': 'test', 'managed': 'no'}}
                     err_msg = target managed='no' but specified dev doesn't exist
                 - managed_yes:
+                    func_supported_since_libvirt_ver = (9,0,0) 
                     tap_type = tap
                     iface_attrs = {'model': 'virtio', 'type_name': 'ethernet', 'target': {'dev': tap_name, 'managed': 'yes'}}
                     err_msg = The .* interface already exists


### PR DESCRIPTION
Add a version check since the bug only fixed(bug 2144738) on rhel 9, so we skip the test "managed_no.negative_test.managed_yes" on rhel 8. Since set the macvtap device mtu bigger than 1500 need to set the physical iface's mtu first, so we update the test parameters to set the mtu less than 1500.