### PR TITLE
memory_binding_with_emulator_thread: fix cpu model for arm

### DIFF
--- a/libvirt/tests/cfg/numa/guest_numa_node_tuning/memory_binding_with_emulator_thread.cfg
+++ b/libvirt/tests/cfg/numa/guest_numa_node_tuning/memory_binding_with_emulator_thread.cfg
@@ -2,15 +2,19 @@
     func_supported_since_libvirt_ver = (9, 3, 0)
     type = memory_binding_with_emulator_thread
     take_regular_screendumps = no
-    start_vm = "no"    
+    start_vm = "no"
     numa_cell = "'numa_cell': [{'id': '0', 'cpus': '0-3', 'memory': '2097152', 'unit': 'KiB'}]"
     max_mem_value = "'max_mem_rt': 15360000, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB'"
     mem_value = "'memory': 2097152, 'memory_unit': 'KiB'"
     current_mem_value = ${mem_value}
-    vm_attrs = {${max_mem_value}, ${mem_value}, ${current_mem_value}, 'vcpu': 4, 'cpu': {'mode': 'host-model', ${numa_cell}}}
+    cpu_mode = 'host-model'
+    no s390-virtio
+    aarch64:
+        cpu_mode = 'host-passthrough'
+    vm_attrs = {${max_mem_value}, ${mem_value}, ${current_mem_value}, 'vcpu': 4, 'cpu': {'mode': '${cpu_mode}', ${numa_cell}}}
     mem_device_attrs = {'mem_model': 'dimm', 'target': {'size': 524288, 'node': 0, 'size_unit': 'KiB'}}
     qemu_line_hugepage_without_context = '-object {"qom-type":"memory-backend-file","id":"ram-node0".*"host-nodes":\[%s\].*-object {"qom-type":"memory-backend-file","id":"memdimm0".*"host-nodes":\[%s\]'
-    qemu_line_hugepage_with_context = '-object {"qom-type":"thread-context","id":"tc-ram-node0","node-affinity":\[%s\].*-object {"qom-type":"memory-backend-file","id":"ram-node0".*"host-nodes":\[%s\].*-object {"qom-type":"thread-context","id":"tc-memdimm0","node-affinity":\[%s\].*-object {"qom-type":"memory-backend-file","id":"memdimm0".*"host-nodes":\[%s\]'    
+    qemu_line_hugepage_with_context = '-object {"qom-type":"thread-context","id":"tc-ram-node0","node-affinity":\[%s\].*-object {"qom-type":"memory-backend-file","id":"ram-node0".*"host-nodes":\[%s\].*-object {"qom-type":"thread-context","id":"tc-memdimm0","node-affinity":\[%s\].*-object {"qom-type":"memory-backend-file","id":"memdimm0".*"host-nodes":\[%s\]'
     qemu_line_default_mem_without_context = '-object {"qom-type":"memory-backend-ram","id":"ram-node0",.*"host-nodes":\[%s\].*-object {"qom-type":"memory-backend-ram","id":"memdimm0".*"host-nodes":\[%s\]'
     variants emulator_pin_cpu:
         - emulatorpin_single_node:
@@ -24,7 +28,7 @@
             overlap_emulatorpin_nodeset = yes
     variants memory_binding_mode:
         - mem_mode_strict:
-            mem_mode = 'strict'            
+            mem_mode = 'strict'
         - mem_mode_interleave:
             mem_mode = 'interleave'
         - mem_mode_preferred:
@@ -34,9 +38,9 @@
     variants pagesize:
         - default_pagesize:
         - hugepage:
-            memory_backing = {'hugepages': {'pages': [{'size': '2', 'unit': 'M'}]}}            
+            memory_backing = {'hugepages': {'pages': [{'size': '2', 'unit': 'M'}]}}
             hugepage_size = 2048
             kernel_hp_file = '/sys/devices/system/node/node%s/hugepages/hugepages-${hugepage_size}kB/nr_hugepages'
-            target_hugepages = 1536            
+            target_hugepages = 1536
     numa_memory = {'mode': '${mem_mode}', 'nodeset': '%s'}
     numa_memnode = [{'cellid': '0', 'mode': '${mem_mode}', 'nodeset': '%s'}]


### PR DESCRIPTION
The cpu model supported on arm is host-passthrough instead of host-model.

Signed-off-by: Dan Zheng <dzheng@redhat.com>