### PR TITLE
libvirtd: Fix expected result

### DIFF
--- a/libvirt/tests/cfg/daemon/conf_file/libvirtd_conf/virt_admin_logging.cfg
+++ b/libvirt/tests/cfg/daemon/conf_file/libvirtd_conf/virt_admin_logging.cfg
@@ -18,7 +18,7 @@
                     str_to_grep = "journal"
                 - libvirtd_virt_admin_log_output:
                     enable_libvirtd_debug_log = "no"
-                    log_outputs = "3:journald"
+                    log_outputs = "3:stderr"
                     enable_journal_socket = "no"
                     virt_disk_device_source = "/var/lib/libvirt/images/no_existed_libvirtd.qcow2"
                     log_file_path = "/var/log/messages"


### PR DESCRIPTION
Fix expected log_outputs of `virt-admin daemon-log-outputs`.

Before:
```
FAIL 1-type_specific.io-github-autotest-libvirt.conf_file.libvirtd_conf.virt_admin_logging.positive_test.libvirtd_virt_admin_log_output -> TestFail: Can not find expected log output: 3:journald from virt admin command output: Logging outputs: 3:stderr
```

After:
```
PASS 1-type_specific.io-github-autotest-libvirt.conf_file.libvirtd_conf.virt_admin_logging.positive_test.libvirtd_virt_admin_log_output
```