### PR TITLE
add case for invalid virtio-mem config

### DIFF
--- a/libvirt/tests/cfg/memory/memory_devices/invalid_virtio_mem_config.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/invalid_virtio_mem_config.cfg
@@ -1,0 +1,60 @@
+- memory.devices.invalid_virtio_mem:
+    type = invalid_virtio_mem_config
+    start_vm = 'no'
+    mem_model = 'virtio-mem'
+    node_mask = '0'
+    target_size = 524288
+    request_size = 262144
+    block_size = 2048
+    aarch64:
+        request_size = 524288
+        block_size = 524288
+    guest_node = 0
+    addr_base = '0x100000000'
+    pagesize_cmd = "getconf PAGE_SIZE"
+    pagesize_unit = 'b'
+    required_kernel = [5.14.0,)
+    guest_required_kernel = [5.8.0,)
+    func_supported_since_libvirt_ver = (8, 0, 0)
+    func_supported_since_qemu_kvm_ver = (6, 2, 0)
+    variants invalid_setting:
+        - over_request_mem:
+            request_size = 1048576
+            define_error = "requested size must be smaller than or equal to @size"
+        - max_addr:
+            addr_base = '0xffffffffffffffff'
+            define_error = "memory device address must be aligned to blocksize"
+        - unexisted_node:
+            guest_node = '6'
+            define_error = "can't add memory backend for guest node '${guest_node}' as the guest has only '2' NUMA nodes configured"
+        - unexisted_nodemask:
+            node_mask = '7'
+            start_vm_error = "NUMA node ${node_mask} is unavailable"
+        - invalid_pagesize:
+            invalid_pagesize = '9216'
+            pagesize_unit = 'b'
+            start_vm_error = "Unable to find any usable hugetlbfs mount for 9 KiB"
+        - small_block:
+            block_size = '1024'
+            define_error = "block size too small, must be at least"
+        - invalid_block:
+            block_size = "3072"
+            define_error = "block size must be a power of two"
+    addr_dict = "'address':{'attrs': {'base': '${addr_base}','slot': '0'}}"
+    source_dict = "'source': {'nodemask': '${node_mask}','pagesize': %d, 'pagesize_unit':'${pagesize_unit}'}"
+    mem_dict = {'mem_model':'${mem_model}', ${source_dict}, 'target': {'size':${target_size}, 'size_unit':'KiB', ${addr_dict}, 'node':${guest_node},'requested_size': ${request_size}, 'block_size': ${block_size}}}
+    variants basic_memory:
+        - with_numa:
+            no s390-virtio
+                mem_value = 2097152
+                mem_unit = 'KiB'
+                current_mem = 2097152
+                current_mem_unit = 'KiB'
+                numa_mem = 1048576
+                max_mem_slots = 16
+                max_mem = 10485760
+                max_mem_unit = 'KiB'
+                max_dict = '"max_mem_rt": ${max_mem}, "max_mem_rt_slots": ${max_mem_slots}, "max_mem_rt_unit": "${max_mem_unit}"'
+                numa_attrs = "'vcpu': 4,'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '${numa_mem}', 'unit': 'KiB'},{'id':'1','cpus': '2-3','memory':'${numa_mem}','unit':'KiB'}]}"
+                vm_attrs = {${numa_attrs}, ${max_dict}, 'memory_unit':'KiB','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':"KiB"}
+

--- a/libvirt/tests/src/memory/memory_devices/invalid_virtio_mem_config.py
+++ b/libvirt/tests/src/memory/memory_devices/invalid_virtio_mem_config.py
@@ -1,0 +1,146 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   SPDX-License-Identifier: GPL-2.0
+
+#   Author: Nannan Li <nanli@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+from avocado.utils import process
+
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.libvirt_xml.devices import memory
+from virttest.utils_test import libvirt
+
+from provider.numa import numa_base
+from provider.memory import memory_base
+
+
+def get_page_size(params):
+    """
+    Get pagesize value
+
+    :param params: Dictionary with the test parameters
+    """
+    invalid_pagesize = params.get("invalid_pagesize")
+    pagesize_cmd = params.get("pagesize_cmd")
+
+    if invalid_pagesize:
+        page_size = invalid_pagesize
+    else:
+        page_size = process.run(pagesize_cmd, ignore_status=True,
+                                shell=True).stdout_text.strip()
+    return int(page_size)
+
+
+def get_mem_obj(mem_dict):
+    """
+    Get mem object.
+
+    :param mem_dict: memory dict value
+    :return: mem_obj, memory object.
+    """
+    mem_obj = memory.Memory()
+    mem_obj.setup_attrs(**eval(mem_dict))
+    return mem_obj
+
+
+def define_guest(test, params, page_size):
+    """
+    Define guest with specific
+
+    :param test: test object
+    :param params: Dictionary with the test parameters.
+    :params: page_size, the pagesize that used when define guest.
+    """
+    vm_name = params.get("main_vm")
+    vm_attrs = eval(params.get("vm_attrs"))
+    mem_dict = params.get("mem_dict")
+    define_error = params.get("define_error")
+
+    vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+    vmxml.setup_attrs(**vm_attrs)
+
+    virtio_mem = get_mem_obj(mem_dict % page_size)
+    vmxml.devices = vmxml.devices.append(virtio_mem)
+    test.log.debug("Define vm with %s." % vmxml)
+
+    # Define guest
+    try:
+        vmxml.sync()
+    except Exception as e:
+        if define_error:
+            if define_error not in str(e):
+                test.fail("Expect to get '%s' error, but got '%s'" % (define_error, e))
+        else:
+            test.fail("Expect define successfully, but failed with '%s'" % e)
+
+
+def run(test, params, env):
+    """
+    Verify error messages prompt with invalid virtio-mem device configs
+
+    1.invalid value:
+     over committed requested memory, max address base, nonexistent guest node
+     nonexistent node mask, invalid pagesize, small block size, invalid block size
+    2.memory setting: with numa
+    """
+
+    def setup_test():
+        """
+        Check host has at least 2 numa nodes.
+        """
+        test.log.info("TEST_SETUP: Check the numa nodes")
+        numa_obj = numa_base.NumaTest(vm, params, test)
+        numa_obj.check_numa_nodes_availability()
+
+    def run_test():
+        """
+        Define vm with virtio-mem and start vm.
+        Define vm without virtio-mem and hotplug virtio-mem.
+        """
+        test.log.info("TEST_STEP1: Define vm with virio-mem")
+        source_pagesize = get_page_size(params)
+        define_guest(test, params, source_pagesize)
+
+        test.log.info("TEST_STEP2: Start guest")
+        start_result = virsh.start(vm_name, ignore_status=True, debug=True)
+        libvirt.check_result(start_result, start_vm_error)
+
+        test.log.info("TEST_STEP3: Start guest without virtio-mem")
+        original_vmxml.setup_attrs(**vm_attrs)
+        test.log.debug("Define vm without virtio-mem by '%s' \n", original_vmxml)
+        original_vmxml.sync()
+        virsh.start(vm_name, debug=True)
+
+        test.log.info("TEST_STEP4: Hotplug virtio-mem memory device")
+        mem_obj = get_mem_obj(mem_dict % source_pagesize)
+        result = virsh.attach_device(vm_name, mem_obj.xml, debug=True).stderr_text
+        if attach_error not in result:
+            test.fail("Expected get error '%s', but got '%s'" % (attach_error, result))
+
+    def teardown_test():
+        """
+        Clean data.
+        """
+        test.log.info("TEST_TEARDOWN: Clean up env.")
+        bkxml.sync()
+
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    original_vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = original_vmxml.copy()
+    mem_dict = params.get("mem_dict")
+    vm_attrs = eval(params.get("vm_attrs"))
+    start_vm_error = params.get("start_vm_error")
+    attach_error = params.get("start_vm_error", params.get("define_error"))
+
+    try:
+        memory_base.check_supported_version(params, test, vm)
+        setup_test()
+        run_test()
+
+    finally:
+        teardown_test()


### PR DESCRIPTION
    xxxx-299162: Invalid virtio-mem memory device config values
Signed-off-by: nanli <nanli@redhat.com>

Depend on https://github.com/avocado-framework/avocado-vt/pull/3802 

Rhel9 & x86
```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 memory.devices.invalid_virtio_mem.with_numa
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable 
 (1/7) type_specific.io-github-autotest-libvirt.memory.devices.invalid_virtio_mem.with_numa.over_request_mem: PASS (41.49 s)
 (2/7) type_specific.io-github-autotest-libvirt.memory.devices.invalid_virtio_mem.with_numa.max_addr: PASS (40.19 s)
 (3/7) type_specific.io-github-autotest-libvirt.memory.devices.invalid_virtio_mem.with_numa.unexisted_node: PASS (43.17 s)
 (4/7) type_specific.io-github-autotest-libvirt.memory.devices.invalid_virtio_mem.with_numa.unexisted_nodemask: PASS (40.60 s)
 (5/7) type_specific.io-github-autotest-libvirt.memory.devices.invalid_virtio_mem.with_numa.invalid_pagesize: PASS (40.71 s)
 (6/7) type_specific.io-github-autotest-libvirt.memory.devices.invalid_virtio_mem.with_numa.small_block: PASS (40.27 s)
 (7/7) type_specific.io-github-autotest-libvirt.memory.devices.invalid_virtio_mem.with_numa.invalid_block: PASS (41.26 s)

```
Rhel9 & Aarch64

```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio    memory.devices.invalid_virtio_mem.with_numa
 (1/7) type_specific.io-github-autotest-libvirt.memory.devices.invalid_virtio_mem.with_numa.over_request_mem: PASS (39.96 s)
 (2/7) type_specific.io-github-autotest-libvirt.memory.devices.invalid_virtio_mem.with_numa.max_addr: PASS (40.81 s)
 (3/7) type_specific.io-github-autotest-libvirt.memory.devices.invalid_virtio_mem.with_numa.unexisted_node: PASS (40.55 s)
 (4/7) type_specific.io-github-autotest-libvirt.memory.devices.invalid_virtio_mem.with_numa.unexisted_nodemask: PASS (39.68 s)
 (5/7) type_specific.io-github-autotest-libvirt.memory.devices.invalid_virtio_mem.with_numa.invalid_pagesize: PASS (39.09 s)
 (6/7) type_specific.io-github-autotest-libvirt.memory.devices.invalid_virtio_mem.with_numa.small_block: PASS (42.56 s)
 (7/7) type_specific.io-github-autotest-libvirt.memory.devices.invalid_virtio_mem.with_numa.invalid_block: PASS (42.62 s)

```