### PR TITLE
memory_backing: fix on s390x

### DIFF
--- a/libvirt/tests/cfg/memory/memory_backing/discard_memory_content_setting.cfg
+++ b/libvirt/tests/cfg/memory/memory_backing/discard_memory_content_setting.cfg
@@ -5,6 +5,10 @@
     set_pagenum = 1024
     numa_mem = 2097152
     qemu_line = '"discard-data":%s'
+    s390-virtio:
+        set_pagesize = 1024
+        set_pagenum = 2048
+        kvm_module_parameters =
     variants source:
         - file:
             source_type = 'file'

--- a/libvirt/tests/cfg/memory/memory_backing/hugepage_mount_path.cfg
+++ b/libvirt/tests/cfg/memory/memory_backing/hugepage_mount_path.cfg
@@ -1,5 +1,6 @@
 - memory.backing.mount_path:
     type = hugepage_mount_path
+    no s390-virtio
     mem_value = 2097152
     set_pagesize_1 = "1048576"
     set_pagenum_1 = "2"

--- a/libvirt/tests/cfg/memory/memory_backing/memory_access_mode.cfg
+++ b/libvirt/tests/cfg/memory/memory_backing/memory_access_mode.cfg
@@ -11,6 +11,10 @@
     qemu_monitor_cmd = 'info memdev'
     pattern_share = "share:\s*{}"
     mem_backend = "memory backend: ram-node0"
+    s390-virtio:
+        set_pagesize = 1024
+        set_pagenum = 2048
+        kvm_module_parameters =
     variants source:
         - file:
             source_type = 'file'
@@ -37,19 +41,24 @@
         - mem_access_default:
     variants numa_access:
         - numa_access_private:
+            no s390-virtio
             numa_access_mode = 'private'
             numa_attrs = {'vcpu': 4,'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-3', 'memory': '${numa_mem}', 'unit': 'KiB', 'memAccess':'${numa_access_mode}'}]}}
             numa_access_path = {'element_attrs': ['./cpu/numa/cell/[@memAccess="${numa_access_mode}"]', './cpu/numa/cell/[@memory="${numa_mem}"]']}
         - numa_access_shared:
+            no s390-virtio
             numa_access_mode = 'shared'
             numa_attrs = {'vcpu': 4,'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-3', 'memory': '${numa_mem}', 'unit': 'KiB', 'memAccess':'${numa_access_mode}'}]}}
             numa_access_path = {'element_attrs': ['./cpu/numa/cell/[@memAccess="${numa_access_mode}"]', './cpu/numa/cell/[@memory="${numa_mem}"]']}
         - numa_access_default:
+            no s390-virtio
             numa_attrs = {'vcpu': 4,'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-3', 'memory': '${numa_mem}', 'unit': 'KiB'}]}}
         - no_numa:
             mem_backend = "memory backend: pc.ram"
             aarch64:
                 mem_backend = "memory backend: mach-virt.ram"
+            s390-virtio:
+                mem_backend = "memory backend: s390.ram"
     variants mem_pagesize:
         - without_hugepage:
         - with_hugepage:

--- a/libvirt/tests/cfg/memory/memory_backing/page_locking_and_shared_pages.cfg
+++ b/libvirt/tests/cfg/memory/memory_backing/page_locking_and_shared_pages.cfg
@@ -6,6 +6,9 @@
     aarch64:
         pagesize = 524288
         pagenum = 4
+    s390-virtio:
+        pagesize = 1024
+        pagenum = 2048
     expect_exist = True
     variants lock_config:
         - lock_default:
@@ -34,6 +37,8 @@
                 kernel_pagesize = 64
         - hugepage:
             hugepages_dict = "'hugepages': {}"
+            s390-virtio:
+                kvm_module_parameters =
     variants:
         - memory_allocation:
             mem_unit = "KiB"


### PR DESCRIPTION
1. Enable activating hpage on s390x through kvm_module_parameters (will be set by CI).
2. Memory backing backend on s390x is s390.ram
3. Fix hpage size on s390x.
4. Exclude numa tests on s390x.
5. Exclude mount_path set because
       a. it is too tightly coupled with numa
       b. it assumes two different hpage sizes are available
       c. it assumes availability of mem devices