### PR TITLE
memory_backing: fix source and allocation on s390x

### DIFF
--- a/libvirt/tests/cfg/memory/memory_backing/memory_source_and_allocation.cfg
+++ b/libvirt/tests/cfg/memory/memory_backing/memory_source_and_allocation.cfg
@@ -8,6 +8,10 @@
     monitor_cmd = "info memdev"
     memory_name_pattern = 'memory backend: (\S+)'
     check_thread = '{"execute":"qom-get", "arguments":{"path": "/objects/%s", "property":"%s"}}'
+    s390-virtio:
+        set_pagesize = 1024
+        kvm_module_parameters =
+        check_allocated_cmd = "grep -A20 '^Size:.*1048576' /proc/`pidof qemu-kvm`/smaps"
     aarch64:
         set_pagesize = 524288
         set_pagenum = 4
@@ -59,6 +63,7 @@
             alloc_mode_path = {'element_attrs': ["./memoryBacking/allocation[@mode=${mode}]", "./memoryBacking/allocation[@threads=${threads}]"]}
     variants numa_discard:
         - with_numa:
+            no s390-virtio
             numa_mem = 2097152
             numa_attrs = {'vcpu': 4,'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-3', 'memory': '${numa_mem}', 'unit': 'KiB'}]}}
         - without_numa:
@@ -69,3 +74,7 @@
             current_mem = "2097152"
             mem_value = "2097152"
             mem_attrs = {'memory_unit':'${mem_unit}','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}'}
+            s390-virtio:
+                current_mem = "1048576"
+                mem_value = "1048576"
+                mem_attrs = {'memory_unit':'${mem_unit}','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}'}

--- a/libvirt/tests/src/memory/memory_backing/memory_source_and_allocation.py
+++ b/libvirt/tests/src/memory/memory_backing/memory_source_and_allocation.py
@@ -7,8 +7,8 @@
 #   Author: Nannan Li <nanli@redhat.com>
 #
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-import re
 import json
+import re
 
 from avocado.utils import process
 


### PR DESCRIPTION
1. Fix hpage size
2. Add kvm_module_parameters to enable hpage on CI
3. Disable unsupported scenarios