### PR TITLE
memory_balloon: diable new virtio-model tests on s390x

### DIFF
--- a/libvirt/tests/cfg/memory/memory_balloon/mem_balloon_autodeflate.cfg
+++ b/libvirt/tests/cfg/memory/memory_balloon/mem_balloon_autodeflate.cfg
@@ -11,8 +11,10 @@
         - virtio_model:
             memballoon_model = "virtio"
         - virtio_trans_model:
+            no s390-virtio
             memballoon_model = "virtio-transitional"
         - virtio_non_trans_model:
+            no s390-virtio
             memballoon_model = "virtio-non-transitional"
     variants:
         - autodeflate_undefined:


### PR DESCRIPTION
The virtio models transitional and non-transitional are not available on s390x. Disable tests.