### PR TITLE
libvirt_rng: improve regex for virtio device

### DIFF
--- a/libvirt/tests/src/libvirt_rng.py
+++ b/libvirt/tests/src/libvirt_rng.py
@@ -364,7 +364,7 @@ def run(test, params, env):
             test.fail("Failed to check rng file on guest."
                       " The virtio device is not available.")
         if set_virtio_current:
-            virtio_dev = [x for x in rng_avail.split('\n') if 'virtio' in x][0]
+            virtio_dev = re.findall('virtio_rng.\d+', rng_avail)[0]
             _ = session.cmd_output(("echo -n %s > %s" %
                                     (virtio_dev, rng_files[1])),
                                    timeout=timeout)


### PR DESCRIPTION
The line intends to select the first virtio rng device that's available. Use a pattern to select it.