### PR TITLE
daemon/remove_pkgs: improve logging

### DIFF
--- a/libvirt/tests/src/daemon/check_daemon_after_remove_pkgs.py
+++ b/libvirt/tests/src/daemon/check_daemon_after_remove_pkgs.py
@@ -46,8 +46,9 @@ def run(test, params, env):
             test.error("Failed to remove libvirt packages on guest")
 
         for daemon in daemons:
-            cmd = "systemctl -a | grep %s | grep -v not-found" % daemon
-            if not session.cmd_status(cmd):
+            err, out = session.cmd_status_output("systemctl -a| grep %s" % daemon)
+            LOGGER.debug(out)
+            if err or daemon in out and "not-found" not in out:
                 test.fail("%s still exists after removing libvirt pkgs" % daemon)
 
     finally:


### PR DESCRIPTION
https://github.com/autotest/tp-libvirt/commit/d9d6fb8d9e5cfea7c585fea18d9022856be9a99b introduced another condition.

However, the command was executed in Bash and either true or false. Now log the output for easier debugging.

Debugging output now:
```
2023-11-28 03:22:56,962 check_daemon_aft L0051 DEBUG|   virtlogd.service                                                                                               loaded    inactive dead      libvirt logging daemon
  virtlogd-admin.socket                                                                                          loaded    inactive dead      libvirt logging daemon admin socket
  virtlogd.socket                                                                                                loaded    inactive dead      libvirt logging daemon socket
```