### PR TITLE
Add scenario of passt function test

### DIFF
--- a/libvirt/tests/cfg/virtual_network/passt/passt_function.cfg
+++ b/libvirt/tests/cfg/virtual_network/passt/passt_function.cfg
@@ -19,33 +19,55 @@
             socket_dir = f'/run/user/{user_id}/libvirt/qemu/run/passt/'
     variants scenario:
         - minimal:
-            iface_attrs = {'model': 'virtio', 'acpi': {'index': '1'}, 'type_name': 'user', 'backend': {'type': 'passt'}, 'source': {'dev': '${host_iface}'}}
+            iface_attrs = {'model': 'virtio', 'acpi': {'index': '1'}, 'type_name': 'user', 'backend': {'type': 'passt'}, 'source': {'dev': host_iface}}
             vm_iface = eno1
             vm_ping_outside = pass
         - ip_portfw:
+            ipv6_prefix = 128
             alias = {'name': 'ua-c87b89ff-b769-4abc-921f-30d42d7aec5b'}
             backend = {'type': 'passt'}
             ips = [{'address': '172.17.2.4', 'family': 'ipv4', 'prefix': '24'}, {'address': '2001:db8:ac10:fd01::20', 'family': 'ipv6'}]
-            portForward_0 = {'attrs': {'proto': 'tcp'}, 'ranges': [{'start': '31339', 'to': '41339'}]}
-            portForward_1 = {'attrs': {'proto': 'udp'}, 'ranges': [{'start': '2025'}]}
-            portForward_2 = {'attrs': {'proto': 'tcp', 'address': host_ip}, 'ranges': [{'start': '4025', 'end': '4035', 'to': '5025'},{'start': '9000'}, {'start': '4030', 'end': '4034', 'exclude': 'yes'}]}
-            portForward_3 = {'attrs': {'proto': 'udp', 'address': host_ip_v6}, 'ranges': [{'start': '8002'}, {'start': '4431', 'to': '4432'}]}
-            portForwards = [${portForward_0}, ${portForward_1}, ${portForward_2}, ${portForward_3}]
-            iface_attrs = {'model': 'virtio', 'acpi': {'index': '1'}, 'ips': ${ips}, 'backend': ${backend}, 'source': {'dev': '${host_iface}'}, 'alias': ${alias}, 'type_name': 'user', 'portForwards': ${portForwards}}
-            proc_checks = ['--tcp-ports 31339:41339', '--udp-ports 2025', f'--tcp-ports {host_ip}/4025-4035:5025-5035,9000,~4030-4034', f'--udp-ports {host_ip_v6}/8002,4431:4432']
-            ipv6_prefix = 128
             vm_iface = eno1
             vm_ping_outside = pass
             vm_ping_host_public = pass
-            tcp_port_list = [4025, 4026, 4027, 4028, 4029, 4035, 9000, '*:31339']
-            udp_port_list = ['0.0.0.0:2025', '[::]:2025', f'[{host_ip_v6}]:4431', f'[{host_ip_v6}]:8002']
-            conn_check_args_0 = ('TCP4', 'localhost', 31339, 41339, True, None)
-            conn_check_args_1 = ('TCP4', host_ip, 31339, 41339, True, None)
-            conn_check_args_2 = ('TCP4', host_ip, 4025, 5025, True, None)
-            conn_check_args_3 = ('TCP4', 'localhost', 4025, 5025, False, 'Connection refused')
-            conn_check_args_4 = ('TCP4', host_ip, 4030, 4030, False, 'Connection refused')
-            conn_check_args_5 = ('TCP6', 'localhost', 31339, 41339, True, None)
-            conn_check_args_6 = ('TCP6', '::1', 31339, 41339, True, None)
-            conn_check_args_7 = ('UDP4', 'localhost', 2025, 2025, True, None)
-            conn_check_args_8 = ('UDP6', host_ip_v6, 4431, 4432, True, None)
-            conn_check_args_9 = ('UDP6', '::1', 4431, 4432, False, None)
+            variants:
+                - ip_addr:
+                    portForward_0 = {'attrs': {'proto': 'tcp'}, 'ranges': [{'start': '31339', 'to': '41339'}]}
+                    portForward_1 = {'attrs': {'proto': 'udp'}, 'ranges': [{'start': '2025'}]}
+                    portForward_2 = {'attrs': {'proto': 'tcp', 'address': host_ip}, 'ranges': [{'start': '4025', 'end': '4035', 'to': '5025'},{'start': '9000'}, {'start': '4030', 'end': '4034', 'exclude': 'yes'}]}
+                    portForward_3 = {'attrs': {'proto': 'udp', 'address': host_ip_v6}, 'ranges': [{'start': '8002'}, {'start': '4431', 'to': '4432'}]}
+                    portForwards = [${portForward_0}, ${portForward_1}, ${portForward_2}, ${portForward_3}]
+                    proc_checks = ['--tcp-ports 31339:41339', '--udp-ports 2025', f'--tcp-ports {host_ip}/4025-4035:5025-5035,9000,~4030-4034', f'--udp-ports {host_ip_v6}/8002,4431:4432']
+                    tcp_port_list = [4025, 4026, 4027, 4028, 4029, 4035, 9000, '*:31339']
+                    udp_port_list = ['0.0.0.0:2025', '[::]:2025', f'[{host_ip_v6}]:4431', f'[{host_ip_v6}]:8002']
+                    conn_check_args_0 = ('TCP4', host_ip, 31339, 41339, True, None)
+                    conn_check_args_1 = ('TCP4', host_ip, 4025, 5025, True, None)
+                    conn_check_args_2 = ('TCP4', 'localhost', 4025, 5025, False, 'Connection refused')
+                    conn_check_args_3 = ('TCP4', 'localhost', 31339, 41339, True, None)
+                    conn_check_args_4 = ('TCP4', host_ip, 4030, 4030, False, 'Connection refused')
+                    conn_check_args_5 = ('TCP6', 'localhost', 31339, 41339, True, None)
+                    conn_check_args_6 = ('TCP6', '::1', 31339, 41339, True, None)
+                    conn_check_args_7 = ('UDP4', 'localhost', 2025, 2025, True, None)
+                    conn_check_args_8 = ('UDP6', host_ip_v6, 4431, 4432, True, None)
+                    conn_check_args_9 = ('UDP6', '::1', 4431, 4432, False, None)
+                - dev_only:
+                    portForward_0 = {'attrs': {'proto': 'tcp', 'dev': host_iface}, 'ranges': [{'start': '31339', 'to': '41339'}]}
+                    portForward_1 = {'attrs': {'proto': 'udp', 'dev': host_iface}, 'ranges': [{'start': '2025'}]}
+                    portForwards = [${portForward_0}, ${portForward_1}]
+                    tcp_port_list = [f'*%{vm_iface}:31339']
+                    udp_port_list = [f'0.0.0.0%{vm_iface}:2025', f'[::]%{vm_iface}:2025']
+                    conn_check_args_1 = ('TCP4', host_ip, 31339, 41339, True, None)
+                    conn_check_args_2 = ('TCP6', host_ip_v6, 31339, 41339, True, None)
+                    conn_check_args_3 = ('UDP4', host_ip, 2025, 2025, True, None)
+                    conn_check_args_4 = ('UDP6', host_ip_v6, 2025, 2025, True, None)                    
+                - dev_and_ip:
+                    portForward_0 = {'attrs': {'proto': 'tcp', 'address': host_ip, 'dev': host_iface}, 'ranges': [{'start': '31339', 'to': '41339'}]}
+                    portForward_1 = {'attrs': {'proto': 'udp', 'address': host_ip, 'dev': host_iface}, 'ranges': [{'start': '2025'}]}
+                    portForward_2 = {'attrs': {'proto': 'tcp', 'address': host_ip_v6, 'dev': host_iface}, 'ranges': [{'start': '51339'}]}
+                    portForwards = [${portForward_0}, ${portForward_1}, ${portForward_2}]
+                    tcp_port_list = [f'{host_ip}%{vm_iface}:31339', f'[{host_ip_v6}]%{vm_iface}:51339']
+                    udp_port_list = [f'{host_ip}%{vm_iface}:2025']
+                    conn_check_args_1 = ('TCP4', host_ip, 31339, 41339, True, None)
+                    conn_check_args_2 = ('UDP4', host_ip, 2025, 2025, True, None)
+                    conn_check_args_3 = ('TCP6', host_ip_v6, 51339, 51339, True, None)
+            iface_attrs = {'model': 'virtio', 'acpi': {'index': '1'}, 'ips': ${ips}, 'backend': ${backend}, 'source': {'dev': host_iface}, 'alias': ${alias}, 'type_name': 'user', 'portForwards': ${portForwards}}

--- a/libvirt/tests/src/virtual_network/passt/passt_function.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_function.py
@@ -55,7 +55,6 @@ def run(test, params, env):
     host_ip = utils_net.get_host_ip_address(ip_ver='ipv4')
     params['host_ip_v6'] = host_ip_v6 = utils_net.get_host_ip_address(
         ip_ver='ipv6')
-    iface_attrs = eval(params.get('iface_attrs'))
     params['socket_dir'] = socket_dir = eval(params.get('socket_dir'))
     params['proc_checks'] = proc_checks = eval(params.get('proc_checks', '{}'))
     vm_iface = params.get('vm_iface', 'eno1')
@@ -65,8 +64,8 @@ def run(test, params, env):
     host_iface = host_iface if host_iface else utils_net.get_net_if(
         state="UP")[0]
     log_file = f'/run/user/{user_id}/passt.log'
+    iface_attrs = eval(params.get('iface_attrs'))
     iface_attrs['backend']['logFile'] = log_file
-    iface_attrs['source']['dev'] = host_iface
 
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name,
                                                    virsh_instance=virsh_ins)

--- a/provider/virtual_network/passt.py
+++ b/provider/virtual_network/passt.py
@@ -156,7 +156,6 @@ def check_proc_info(params, log_file, mac):
             failed_check.append(f'{target} should be in process CMD')
 
     check_list = [
-        f'--mac-addr {mac}',
         f'--interface {host_iface}',
         f'--log-file {log_file}',
         f'--socket {socket_dir}',
@@ -399,6 +398,7 @@ def check_portforward(vm, host_ip, params):
     :param params: test params
     """
     host_ip_v6 = params.get('host_ip_v6')
+    vm_iface = params.get('vm_iface')
     tcp_port_list = eval(params.get('tcp_port_list', '[]'))
     tcp_port_list = [f'{host_ip}:{port}' if str(port).isdigit()
                      else port for port in tcp_port_list]


### PR DESCRIPTION
- VIRT-297101 - [user][passt] Passt backend interface - check the portforwarding feature

Test result:
```
(1/8) type_specific.io-github-autotest-libvirt.virtual_network.passt.interface_function.minimal.root_user: PASS (243.62 s)
(2/8) type_specific.io-github-autotest-libvirt.virtual_network.passt.interface_function.minimal.non_root_user: PASS (168.62 s)
(3/8) type_specific.io-github-autotest-libvirt.virtual_network.passt.interface_function.ip_portfw.ip_addr.root_user: PASS (489.26 s)
(4/8) type_specific.io-github-autotest-libvirt.virtual_network.passt.interface_function.ip_portfw.ip_addr.non_root_user: PASS (413.99 s)
(5/8) type_specific.io-github-autotest-libvirt.virtual_network.passt.interface_function.ip_portfw.dev_only.root_user: PASS (417.03 s)
(6/8) type_specific.io-github-autotest-libvirt.virtual_network.passt.interface_function.ip_portfw.dev_only.non_root_user: PASS (283.01 s)
(7/8) type_specific.io-github-autotest-libvirt.virtual_network.passt.interface_function.ip_portfw.dev_and_ip.root_user: PASS (395.76 s)
(8/8) type_specific.io-github-autotest-libvirt.virtual_network.passt.interface_function.ip_portfw.dev_and_ip.non_root_user: PASS (260.73 s)
RESULTS    : PASS 8 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```