### PR TITLE
Fix serial.pty.log.file failure on s390x

### DIFF
--- a/libvirt/tests/src/serial/serial_pty_log.py
+++ b/libvirt/tests/src/serial/serial_pty_log.py
@@ -97,7 +97,7 @@ def run(test, params, env):
 
         # Need to wait for a while to get login prompt
         if not utils_misc.wait_for(
-                lambda: check_pty_log_file(log_file, boot_prompt), 6):
+                lambda: check_pty_log_file(log_file, boot_prompt), 15):
             test.fail("Failed to find the vm login prompt from %s" % log_file)
 
     except Exception as e:


### PR DESCRIPTION
Fix serial.pty.log.file failure on s390x
Extend timeout to grab log since it may run under VM