### PR TITLE
Filter out pcibridge.positive_test.hotplug.pci_br.no_device on s390x

### DIFF
--- a/libvirt/tests/cfg/controller/pcibridge.cfg
+++ b/libvirt/tests/cfg/controller/pcibridge.cfg
@@ -27,6 +27,7 @@
                             pci_model_name = 'pcie-pci-bridge'
                         - pci_br:
                             no q35
+                            no s390-virtio
                             pci_model ='pci-bridge'
                             pci_model_name = 'pci-bridge'
                 - max_slots:


### PR DESCRIPTION
Filter out pcibridge.positive_test.hotplug.pci_br.no_device on s390x

It also filter out on q35 on x86_64