### PR TITLE
fix memory lifecycle memory allocation issue

### DIFF
--- a/libvirt/tests/cfg/memory/memory_allocation/lifecycle_with_memory_allocation.cfg
+++ b/libvirt/tests/cfg/memory/memory_allocation/lifecycle_with_memory_allocation.cfg
@@ -5,7 +5,7 @@
     current_mem = 1843200
     current_mem_unit = 'KiB'
     max_mem_slots = 16
-    max_mem = 15242880
+    max_mem = 15360000
     max_mem_unit = 'KiB'
     numa_mem = 1048576
     variants case:
@@ -27,3 +27,4 @@
                     max_mem_attr = "'max_mem_rt': ${max_mem}, 'max_mem_rt_slots': ${max_mem_slots}, 'max_mem_rt_unit': '${max_mem_unit}'"
                     vm_attrs = {${max_mem_attr},'memory_unit':'${mem_unit}','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}'}
                     error_msg = "At least one numa node has to be configured when enabling memory hotplug"
+                    expect_xpath = [{'element_attrs':[".//currentMemory[@unit='${current_mem_unit}']"],'text':'${current_mem}'}, {'element_attrs':[".//memory[@unit='${mem_unit}']"],'text':'${mem_value}'}, {'element_attrs':[".//cell[@memory='${mem_value}']"]}]


### PR DESCRIPTION
   update version for negative cases
Signed-off-by: nanli <nanli@redhat.com>

Before fixed 
```
 avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 memory.allocation.lifecycle.negative_test.with_maxmemory --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.memory.allocation.lifecycle.negative_test.with_maxmemory: FAIL: Expect should fail with one of At least one numa node has to be configured when enabling memory hotplug, but succeeded: Domain 'avocado-vt-vm1' defined from /tmp/xml_utils_temp_vpdb2syi.xml\n\n\n (10.87 s)
```

After fixed : rhel9+rhel8
```
 avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 memory.allocation.lifecycle
 (1/3) type_specific.io-github-autotest-libvirt.memory.allocation.lifecycle.positive_test.without_maxmemory: PASS (118.35 s)
 (2/3) type_specific.io-github-autotest-libvirt.memory.allocation.lifecycle.positive_test.with_numa: PASS (121.71 s)
 (3/3) type_specific.io-github-autotest-libvirt.memory.allocation.lifecycle.negative_test.with_maxmemory: PASS (118.45 s)

```