### PR TITLE
vIOMMU: Add a case of intel iommu

### DIFF
--- a/libvirt/tests/cfg/sriov/vIOMMU/intel_iommu_virtio_device_with_ats.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/intel_iommu_virtio_device_with_ats.cfg
@@ -1,0 +1,31 @@
+- vIOMMU.intel_iommu.virtio_device_with_ats:
+    type = iommu_device_settings
+    start_vm = "yes"
+    enable_guest_iommu = "yes"
+    iommu_dict = {'model': 'intel', 'driver': {'intremap': 'on', 'iotlb': 'on'}}
+    ping_dest = '8.8.8.8'
+    disk_driver = {'name': 'qemu', 'type': 'qcow2', 'iommu': 'on', 'ats': 'on'}
+    only q35
+
+    variants:
+        - virtio_muti_devices:
+            disk_dict = {'target': {'dev': 'vda', 'bus': 'virtio'}, 'device': 'disk', 'driver': ${disk_driver}}
+            video_dict = {'primary': 'yes', 'model_heads': '1', 'model_type': 'virtio', 'driver': {'iommu': 'on'}}
+            test_devices = ["Eth", "block", "gpu"]
+            variants:
+                - vhost_on:
+                    interface_driver_name = "vhost"
+                - vhost_off:
+                    interface_driver_name = "qemu"
+            interface_driver = {'driver_attr': {'name': '${interface_driver_name}', 'iommu': 'on', 'ats': 'on'}}
+            iface_dict = {'type_name': 'network', 'model': 'virtio', 'driver': ${interface_driver}, 'source': {'network': 'default'}}
+        - scsi_controller:
+            test_devices = ["scsi"]
+            controller_dicts = [{'type': 'scsi', 'model': 'virtio-scsi','driver': {'iommu': 'on', 'ats': 'on'}}]
+            disk_dict = {'target': {'dev': 'sda', 'bus': 'scsi'}}
+            cleanup_ifaces = no
+        - pcie_root_port_from_expander_bus:
+            test_devices = ["Eth", "block"]
+            root_port = {'type': 'pci', 'model': 'pcie-root-port', 'pre_controller': 'pcie-expander-bus'}
+            controller_dicts = [{'type': 'pci', 'model': 'pcie-expander-bus', 'pre_controller': 'pcie-root'}, ${root_port}, ${root_port}]
+            disk_dict = {'target': {'dev': 'vda', 'bus': 'virtio'}, 'device': 'disk', 'driver': ${disk_driver}}


### PR DESCRIPTION
This PR adds:
    VIRT-294804 - Start vm with intel iommu and virtio devices
    with ats enabled


**Test results:**
```
 (1/4) type_specific.io-github-autotest-libvirt.vIOMMU.intel_iommu.virtio_device_with_ats.virtio_muti_devices.vhost_on: PASS (207.85 s)
 (2/4) type_specific.io-github-autotest-libvirt.vIOMMU.intel_iommu.virtio_device_with_ats.virtio_muti_devices.vhost_off: PASS (239.21 s)
 (3/4) type_specific.io-github-autotest-libvirt.vIOMMU.intel_iommu.virtio_device_with_ats.scsi_controller: PASS (213.35 s)
 (4/4) type_specific.io-github-autotest-libvirt.vIOMMU.intel_iommu.virtio_device_with_ats.pcie_root_port_from_expander_bus: PASS (212.59 s)

```