### PR TITLE
connectivity_check_user_interace: use multiline match for checks

### DIFF
--- a/libvirt/tests/src/virtual_network/connectivity/connectivity_check_user_interface.py
+++ b/libvirt/tests/src/virtual_network/connectivity/connectivity_check_user_interface.py
@@ -28,13 +28,9 @@ def check_val(expect, actual, info, test):
     """
     if expect is None:
         return
-    match = False
-    if '+' in expect:
-        match = re.search(expect, actual)
-    elif 'nameserver' in info:
-        match = expect in actual
-    else:
-        match = expect == actual
+    pattern = re.compile(expect, re.MULTILINE)
+    LOG.debug(pattern)
+    match = pattern.search(actual)
     if match:
         LOG.debug(f'{info} match. Expect {expect}, got {actual}')
     else:


### PR DESCRIPTION
On systems where there is more than one NIC the default gw function will return several values. Use a multiline regex pattern instead in all cases: it covers both scenarios.