### PR TITLE
virtual_network/element_model: don't check pci model on s390x

### DIFF
--- a/libvirt/tests/cfg/virtual_network/elements_and_attributes/element_model.cfg
+++ b/libvirt/tests/cfg/virtual_network/elements_and_attributes/element_model.cfg
@@ -18,6 +18,8 @@
         - virtio:
             iface_driver = virtio_net
             pci_model = pcie-root-port
+            s390-virtio:
+                check_pci_model = no
         - e1000e:
             iface_driver = e1000e
             pci_model = pcie-root-port
@@ -30,4 +32,6 @@
         - test:
             status_error = yes
             err_msg = is not a valid device model name
+            s390-virtio:
+                check_pci_model = no
     iface_attrs = {'source': {'network': 'default'}, 'model': '${model_type}', 'type_name': 'network'}


### PR DESCRIPTION
On s390x, interfaces are not PCI devices per default. Don't check the pci model.