### PR TITLE
vIOMMU: Add a case about iommu address width

### DIFF
--- a/libvirt/tests/cfg/sriov/vIOMMU/intel_iommu_aw_bits.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/intel_iommu_aw_bits.cfg
@@ -1,0 +1,16 @@
+- vIOMMU.intel_iommu.aw_bits:
+    type = intel_iommu_aw_bits
+    start_vm = "yes"
+    enable_guest_iommu = "yes"
+    only q35
+
+    variants aw_bits_value:
+        - 48:
+        - 39:
+        - 36:
+            status_error = yes
+            err_msg = "Supported values for aw-bits are"
+        - 3423:
+            status_error = yes
+            err_msg = "Parameter 'aw-bits' expects uint8_t"
+    iommu_dict = {'model': 'intel', 'driver': {'intremap': 'on', 'caching_mode': 'on', 'iotlb': 'on', 'aw_bits': ${aw_bits_value}}}

--- a/libvirt/tests/src/sriov/vIOMMU/intel_iommu_aw_bits.py
+++ b/libvirt/tests/src/sriov/vIOMMU/intel_iommu_aw_bits.py
@@ -1,0 +1,40 @@
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_test import libvirt
+
+from provider.sriov import sriov_base
+
+
+def run(test, params, env):
+    """
+    Start vm with different iommu address width values.
+    """
+    iommu_dict = eval(params.get('iommu_dict', '{}'))
+    aw_bits_value = params.get("aw_bits_value")
+    err_msg = params.get("err_msg")
+    status_error = "yes" == params.get("status_error", "no")
+
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    vm = env.get_vm(vm_name)
+    test_obj = sriov_base.SRIOVTest(vm, test, params)
+    try:
+        test_obj.setup_iommu_test(iommu_dict=iommu_dict)
+
+        test.log.info("TEST_STEP: Start the VM.")
+        result = virsh.start(vm.name, debug=True)
+        libvirt.check_exit_status(result, status_error)
+        if status_error:
+            if err_msg:
+                libvirt.check_result(result, err_msg)
+            return
+        vm.cleanup_serial_console()
+        vm.create_serial_console()
+        vm_session = vm.wait_for_serial_login(
+            timeout=int(params.get('login_timeout')))
+        test.log.debug(vm_xml.VMXML.new_from_dumpxml(vm.name))
+
+        test.log.info("TEST_STEP: Check dmesg message.")
+        vm_session.cmd("dmesg | grep -i 'Host address width %s'" % aw_bits_value)
+    finally:
+        test_obj.teardown_iommu_test()


### PR DESCRIPTION
This PR adds:
    Start vm with different iommu address width values


**Test results:**

```
 (1/4) type_specific.io-github-autotest-libvirt.vIOMMU.intel_iommu.aw_bits.48: PASS (204.65 s)
 (2/4) type_specific.io-github-autotest-libvirt.vIOMMU.intel_iommu.aw_bits.39: PASS (200.77 s)
 (3/4) type_specific.io-github-autotest-libvirt.vIOMMU.intel_iommu.aw_bits.36: PASS (168.02 s)
 (4/4) type_specific.io-github-autotest-libvirt.vIOMMU.intel_iommu.aw_bits.3423: PASS (167.79 s)
```
