### PR TITLE
sriov: Add a scalability test

### DIFF
--- a/libvirt/tests/cfg/sriov/scalability/sriov_scalability_max_vf.cfg
+++ b/libvirt/tests/cfg/sriov/scalability/sriov_scalability_max_vf.cfg
@@ -3,3 +3,9 @@
     start_vm = "no"
     vf_no = 63
     net_forward = {"mode": "hostdev", "managed": "yes"}
+    variants:
+        - maximum:
+            iface_num = 64
+        - exceed_maximum:
+            iface_num = 65
+            start_error = yes


### PR DESCRIPTION
This PR updates scalability test scenarios.


**Test results:**
```
 (1/2) type_specific.io-github-autotest-libvirt.sriov.scalability.max_vfs.maximum: PASS (485.47 s)
 (2/2) type_specific.io-github-autotest-libvirt.sriov.scalability.max_vfs.exceed_maximum: PASS (261.45 s)
```
