### PR TITLE
numa: Fix parsing of more than two consecutive numa nodes

### DIFF
--- a/libvirt/tests/src/numa/guest_numa_node_tuning/host_guest_mixed_memory_binding.py
+++ b/libvirt/tests/src/numa/guest_numa_node_tuning/host_guest_mixed_memory_binding.py
@@ -19,6 +19,7 @@ from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 from virttest.utils_libvirt import libvirt_memory
+from virttest.utils_libvirt import libvirt_numa
 
 from provider.numa import numa_base
 
@@ -287,8 +288,7 @@ def check_cgroup(numatest_obj):
                                         "vcpu0_cpuset_mems=%s, "
                                         "vcpu1_cpuset_mems=%s", emulator_cpuset_mems,
                                         vcpu0_cpuset_mems, vcpu1_cpuset_mems)
-            all_nodes_str = ['%s' % a_node for a_node in all_nodes]
-            nodeset = numa_base.convert_to_string_with_dash(','.join(all_nodes_str))
+            nodeset = libvirt_numa.convert_all_nodes_to_string(all_nodes)
             for item in [emulator_cpuset_mems, vcpu0_cpuset_mems, vcpu1_cpuset_mems]:
                 if item != nodeset:
                     numatest_obj.test.fail("Expect cpuset.mems to be %s, "


### PR DESCRIPTION
Fix parsing of more than two consecutive numa nodes.
Before fixing, [0, 1, 2, 3] --> "0-1"
After fixing, [0, 1, 2, 3] --> "0-3"

Depend on:
- https://github.com/avocado-framework/avocado-vt/pull/3804

Test Results:
Before:
```
 (01/11) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_strict.single_node: PASS (12.85 s)                                                                                                                                                     
 (02/11) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_strict.multiple_nodes: PASS (60.44 s)                                                                                             
 (03/11) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_interleave.single_node: FAIL: Expect cpuset.mems to be 0-1, but found 0-3 (59.60 s)
 (04/11) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_interleave.multiple_nodes: FAIL: Expect cpuset.mems to be 0-1, but found 0-3 (58.81 s)                                                                                                 
 (05/11) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_preferred.single_node: FAIL: Expect cpuset.mems to be 0-1, but found 0-3 (58.79 s)                                                                                                     
 (06/11) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_preferred.multiple_nodes: PASS (12.96 s)                                                                                                                                               
 (07/11) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_restrictive.single_node: CANCEL: This libvirt version doesn't support this function. (8.95 s)                                                                                          
 (08/11) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_restrictive.multiple_nodes: CANCEL: This libvirt version doesn't support this function. (8.98 s)                                                                                       
 (09/11) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.no_mem_mode.single_node: FAIL: Expect cpuset.mems to be 0-1, but found 0-3 (58.69 s)                                                                                                            
 (10/11) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.no_mem_mode.multiple_nodes: FAIL: Expect cpuset.mems to be 0-1, but found 0-3 (58.73 s)                                                                                                         
 (11/11) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.no_mem_mode.no_node: FAIL: Expect cpuset.mems to be 0-1, but found 0-3 (58.67 s) 
```

After:
```
 (01/11) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_strict.single_node: PASS (12.73 s)                                                                                                                                                     
 (02/11) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_strict.multiple_nodes: PASS (57.86 s)                                                                                                                                                  
 (03/11) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_interleave.single_node: PASS (57.44 s)                                                                                                                                                 
 (04/11) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_interleave.multiple_nodes: PASS (57.45 s)                                                                                                                                              
 (05/11) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_preferred.single_node: PASS (57.64 s)                                                                                                                                                  
 (06/11) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_preferred.multiple_nodes: PASS (12.78 s)                                                                                                                                               
 (07/11) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_restrictive.single_node: CANCEL: This libvirt version doesn't support this function. (8.99 s)                                                                                          
 (08/11) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_restrictive.multiple_nodes: CANCEL: This libvirt version doesn't support this function. (9.01 s)                                                                                       
 (09/11) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.no_mem_mode.single_node: PASS (59.49 s)                                                                                                                                                         
 (10/11) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.no_mem_mode.multiple_nodes: PASS (57.52 s)                                                                                                                                                      
 (11/11) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.no_mem_mode.no_node: PASS (57.46 s)
```