### PR TITLE
libvirtd: Fix condition

### DIFF
--- a/libvirt/tests/src/daemon/check_daemon_after_remove_pkgs.py
+++ b/libvirt/tests/src/daemon/check_daemon_after_remove_pkgs.py
@@ -46,9 +46,9 @@ def run(test, params, env):
             test.error("Failed to remove libvirt packages on guest")
 
         for daemon in daemons:
-            err, out = session.cmd_status_output("systemctl -a| grep %s" % daemon)
+            _, out = session.cmd_status_output("systemctl -a| grep %s" % daemon)
             LOGGER.debug(out)
-            if err or daemon in out and "not-found" not in out:
+            if daemon in out and "not-found" not in out:
                 test.fail("%s still exists after removing libvirt pkgs" % daemon)
 
     finally:


### PR DESCRIPTION
Based d9d6fb8, there are three results for `systemctl -a| grep virtlogd`:
1. status is 1, output is none --> pass
2. status is 0, output contains the daemon and 'not-found' --> pass
3. status is 0, output contains the daemon but no 'not-found' --> fail

The previous condition will determine that the first case fails. 

Just judging the output should be enough here.

Test Result:
Before:
```
(1/1) type_specific.io-github-autotest-libvirt.daemon.check_daemon_after_remove_pkgs.legacy_daemon: FAIL: virtlogd still exists after removing libvirt pkgs (230.58 s)
```
After:
```
(1/1) type_specific.io-github-autotest-libvirt.daemon.check_daemon_after_remove_pkgs.legacy_daemon: PASS (217.12 s)
```