### PR TITLE
lifecycle_time: relax test condition

### DIFF
--- a/libvirt/tests/src/cpu/lifecycle_time.py
+++ b/libvirt/tests/src/cpu/lifecycle_time.py
@@ -39,7 +39,7 @@ def run(test, params, env):
         session.close()
 
         lines = out.split('\n')
-        if len(lines) < 2 or 'real\t0m1.00' not in lines[1]:
+        if len(lines) < 2 or 'real\t0m1.0' not in lines[1]:
             test.fail("VM seems to have slept longer than expected: %s" % out)
     except Exception as e:
         test.error("Test error: %s" % e)


### PR DESCRIPTION
When running this test several times it sometimes
takes up to 1.029 seconds to sleep for 1 second.
This is still a good test result for the original
issue where we had deviations for 100-10000%.

Use a less strict check to account for this variability.