### PR TITLE
Start virtqemud for the modular daemon mode

### DIFF
--- a/libvirt/tests/src/daemon/conf_file/qemu_conf/set_virtlogd.py
+++ b/libvirt/tests/src/daemon/conf_file/qemu_conf/set_virtlogd.py
@@ -11,6 +11,7 @@ from avocado.utils import process
 from virttest import utils_config
 from virttest import utils_libvirtd
 from virttest import utils_package
+from virttest import utils_split_daemons
 from virttest import virt_vm
 from virttest.staging import service
 from virttest.libvirt_xml.vm_xml import VMXML
@@ -251,7 +252,8 @@ def run(test, params, env):
         if restart_libvirtd or stop_libvirtd:
             virtlogd_pid = check_service_status("virtlogd", service_start=True)
             logging.info("virtlogd pid: %s", virtlogd_pid)
-            check_service_status("libvirtd", service_start=True)
+            service_name = "virtqemud" if utils_split_daemons.is_modular_daemon else "libvirtd"
+            check_service_status(service_name, service_start=True)
 
         # Restart libvirtd to make change valid.
         if not libvirtd.restart():


### PR DESCRIPTION
Test result:
$avocado run conf_file.qemu_conf.set_virtlogd.positive_test.restart --vt-type libvirt
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : 73e8c2f7dd614f76a30a0338c1d142fb58ae716d
JOB LOG    : /var/lib/avocado/job-results/job-2023-12-13T03.04-73e8c2f/job.log
 (1/1) type_specific.io-github-autotest-libvirt.conf_file.qemu_conf.set_virtlogd.positive_test.restart: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.conf_file.qemu_conf.set_virtlogd.positive_test.restart: PASS (77.78 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2023-12-13T03.04-73e8c2f/results.html
JOB TIME   : 78.81 s
