### PR TITLE
Fix error of failed to get iface in vm from cfg file

### DIFF
--- a/libvirt/tests/src/virtual_network/connectivity/connectivity_check_bridge_interface.py
+++ b/libvirt/tests/src/virtual_network/connectivity/connectivity_check_bridge_interface.py
@@ -49,7 +49,8 @@ def run(test, params, env):
     iface_attrs['source']['bridge'] = bridge_name
     vm_attrs = eval(params.get('vm_attrs', '{}'))
     nwfilter_attrs = parse_attrs('nwfilter_attrs', params)
-    iface_in_vm = params.get('iface_in_vm', 'eno')
+    iface_in_vm = params.get('iface_in_vm')
+    iface_in_vm = iface_in_vm if iface_in_vm else 'eno'
 
     host_iface = params.get('host_iface')
     host_iface = host_iface if host_iface else utils_net.get_net_if(


### PR DESCRIPTION
Before:
TestFail: Expect mtu size: 4000, actual output: Device &quot;5&quot; does not exist.

After:
PASS 1-type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.bridge_interface.linux_br.multiqueue.nwfilter
