### PR TITLE
libvirt_rng: Add alternative expected error

### DIFF
--- a/libvirt/tests/cfg/libvirt_rng.cfg
+++ b/libvirt/tests/cfg/libvirt_rng.cfg
@@ -59,10 +59,10 @@
                     driver_packed = "on"
                 - invalid_address:
                     address = "{ 'domain': '0x9999', 'bus': '0x00', 'slot': '0x00', 'function': '0x0'}"
-                    expected_create_error = "Invalid PCI address"
+                    expected_create_error = ".*Invalid PCI address.*"
                 - invalid_model:
                     rng_model = virtio-abc
-                    expected_create_error = "RNG model"
+                    expected_create_error = ".*(RNG model|model.*rng.*virtio-abc).*"
         - backend_udp:
             backend_model = "egd"
             backend_type = "udp"

--- a/libvirt/tests/src/libvirt_rng.py
+++ b/libvirt/tests/src/libvirt_rng.py
@@ -694,8 +694,9 @@ def run(test, params, env):
                           '\n%s' % details)
         except xcepts.LibvirtXMLError as details:
             logging.info(str(details))
-            if expected_create_error not in str(details):
-                test.fail("Didn't find expected error:"
+            details = str(details).replace("\n", "")
+            if not re.match(expected_create_error, details):
+                test.fail("Didn't match expected error:"
                           " %s" % expected_create_error)
     finally:
         # Delete snapshots.


### PR DESCRIPTION
The error message has change but is still
valid as it mentions the device model.