### PR TITLE
update memory case name with 2 numa nodes

### DIFF
--- a/libvirt/tests/cfg/memory/memory_devices/invalid_dimm_memory_device_config.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/invalid_dimm_memory_device_config.cfg
@@ -44,7 +44,7 @@
     source_dict = "'source': {'nodemask': '${node_mask}','pagesize': %d, 'pagesize_unit':'${pagesize_unit}'}"
     dimm_dict = {'mem_model':'dimm', ${source_dict}, ${addr_dict}, 'target': {'size':${target_size}, 'size_unit':'KiB','node':${guest_node}}}
     variants basic_memory:
-        - with_numa:
+        - with_2_numa_nodes:
             no s390-virtio
             numa_attrs = "'vcpu': 4,'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '${numa_mem}', 'unit': 'KiB'},{'id':'1','cpus': '2-3','memory':'${numa_mem}','unit':'KiB'}]}"
             vm_attrs = {${numa_attrs}, ${max_dict}, 'memory_unit':'KiB','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':"KiB"}

--- a/libvirt/tests/cfg/memory/memory_devices/invalid_virtio_mem_config.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/invalid_virtio_mem_config.cfg
@@ -44,7 +44,7 @@
     source_dict = "'source': {'nodemask': '${node_mask}','pagesize': %d, 'pagesize_unit':'${pagesize_unit}'}"
     mem_dict = {'mem_model':'${mem_model}', ${source_dict}, 'target': {'size':${target_size}, 'size_unit':'KiB', ${addr_dict}, 'node':${guest_node},'requested_size': ${request_size}, 'block_size': ${block_size}}}
     variants basic_memory:
-        - with_numa:
+        - with_2_numa_nodes:
             no s390-virtio
                 mem_value = 2097152
                 mem_unit = 'KiB'


### PR DESCRIPTION
  Give more specific name for case name
Signed-off-by: nanli <nanli@redhat.com>

```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 memory.devices.invalid_dimm

 (1/6) type_specific.io-github-autotest-libvirt.memory.devices.invalid_dimm.with_numa.exceed_slot: PASS (15.26 s)
 (2/6) type_specific.io-github-autotest-libvirt.memory.devices.invalid_dimm.with_numa.max_addr: PASS (14.97 s)
 (3/6) type_specific.io-github-autotest-libvirt.memory.devices.invalid_dimm.with_numa.unexisted_node: PASS (26.26 s)
 (4/6) type_specific.io-github-autotest-libvirt.memory.devices.invalid_dimm.with_numa.unexisted_nodemask: PASS (14.41 s)
 (5/6) type_specific.io-github-autotest-libvirt.memory.devices.invalid_dimm.with_numa.invalid_pagesize: PASS (14.43 s)
 (6/6) type_specific.io-github-autotest-libvirt.memory.devices.invalid_dimm.with_numa.invalid_addr_type: PASS (16.12 s)


avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 memory.devices.invalid_virtio_mem.with_numa
 (1/7) type_specific.io-github-autotest-libvirt.memory.devices.invalid_virtio_mem.with_numa.over_request_mem: PASS (41.49 s)
 (2/7) type_specific.io-github-autotest-libvirt.memory.devices.invalid_virtio_mem.with_numa.max_addr: PASS (40.19 s)
 (3/7) type_specific.io-github-autotest-libvirt.memory.devices.invalid_virtio_mem.with_numa.unexisted_node: PASS (43.17 s)
 (4/7) type_specific.io-github-autotest-libvirt.memory.devices.invalid_virtio_mem.with_numa.unexisted_nodemask: PASS (40.60 s)
 (5/7) type_specific.io-github-autotest-libvirt.memory.devices.invalid_virtio_mem.with_numa.invalid_pagesize: PASS (40.71 s)
 (6/7) type_specific.io-github-autotest-libvirt.memory.devices.invalid_virtio_mem.with_numa.small_block: PASS (40.27 s)
 (7/7) type_specific.io-github-autotest-libvirt.memory.devices.invalid_virtio_mem.with_numa.invalid_block: PASS (41.26 s)
```
