### PR TITLE
memory: Fix up a virtio-mem device coldplug issue

### DIFF
--- a/libvirt/tests/cfg/memory/memory_update_device.cfg
+++ b/libvirt/tests/cfg/memory/memory_update_device.cfg
@@ -10,9 +10,11 @@
             func_supported_since_libvirt_ver = (8, 0, 0)
             func_supported_since_qemu_kvm_ver = (6, 2, 0)
             vm_attrs = {'max_mem_rt': 10485760, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB', 'vcpu': 4, 'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '1048576', 'unit': 'KiB'}]}}
+            mem_device_attrs = {'mem_model': 'virtio-mem', 'target': {'requested_unit': 'KiB', 'size': 262144, 'node': 0, 'size_unit': 'KiB', 'requested_size': 131072, 'block_unit': 'KiB', 'block_size': 2048}}
+            requested_size = 160MiB
             aarch64:
                 vm_attrs = {'max_mem_rt': 10485760, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB', 'vcpu': 4, 'cpu': {'mode': 'host-passthrough', 'numa_cell': [{'id': '0', 'cpus': '0-3', 'memory': '524288', 'unit': 'KiB'}]}}
                 mem_device_attrs = {'mem_model': 'virtio-mem', 'target': {'requested_unit': 'KiB', 'size': 1048576, 'node': 0, 'size_unit': 'KiB', 'requested_size': 524288, 'block_unit': 'KiB', 'block_size': 524288}}
-            requested_size = 1048576KiB
+                requested_size = 1048576KiB
             check_log_str = "MEMORY_DEVICE_SIZE_CHANGE.*virtiomem"
             virsh_opts = "--alias %s --requested-size ${requested_size}"


### PR DESCRIPTION
Introduced by 869c29ebc659c


**Test result:**
` (1/1) type_specific.io-github-autotest-libvirt.memory_update_device.virtio_mem: PASS (104.18 s)
`