### PR TITLE
v2v:fix the failed case in 9.4 functional testing

### DIFF
--- a/v2v/tests/cfg/convert_from_file.cfg
+++ b/v2v/tests/cfg/convert_from_file.cfg
@@ -115,7 +115,7 @@
                                     checkpoint = 'cpu_topology'
                                     v2v_debug = force_on
                                     ova_file_name = OVA_DIR_RHEL_LINUX_V2V_EXAMPLE.ova
-                                    ova_dir = OVA_DIR_ROOT_V2V_EXAMPLE/${ova_file_name}
+                                    ova_dir = ${ova_file_name}
                                     ova_copy_dir = 'OVA_DIR_COPY_V2V_EXAMPLE'
                                     input_file = ${ova_copy_dir}/${ova_file_name}
                                     msg_content_yes = ''


### PR DESCRIPTION
Refer the error: FileNotFoundError: [Errno 2] No such file or directory: '/var/lib/libvirt/images/v2v/ova-images//var/lib/libvirt/images/v2v/ova-images/esx6_7-rhel8.3-x86_64.ova'&#10;