### PR TITLE
virsh_dump: add new case when no space left

### DIFF
--- a/libvirt/tests/cfg/guest_kernel_debugging/virsh_dump.cfg
+++ b/libvirt/tests/cfg/guest_kernel_debugging/virsh_dump.cfg
@@ -95,3 +95,6 @@
                     setup_libvirt_polkit = "yes"
                     unprivileged_user = "EXAMPLE"
                     virsh_uri = "qemu:///system"
+                - no_space_left:
+                    dump_options = "--memory-only"
+                    dump_dir = "/var/tmp/too_small"


### PR DESCRIPTION
VMs should keep running if dumping them fails because there's no space.