### PR TITLE
cpu: Skip host-model for aarch64

### DIFF
--- a/libvirt/tests/cfg/cpu/vcpu_cve.cfg
+++ b/libvirt/tests/cfg/cpu/vcpu_cve.cfg
@@ -4,6 +4,7 @@
     start_vm = no
     variants cpu_mode:
         - host_model:
+            no aarch64
             cpu_mode = 'host-model'
         - host_passthrough:
             cpu_mode = 'host-passthrough'


### PR DESCRIPTION
aarch64 supports cpu_model "host-passthrough".

Test Result:
```
(1/1) type_specific.io-github-autotest-libvirt.vcpu.cve.guest_cpu_cve_status.host_passthrough: PASS (53.25 s)
```