### PR TITLE
memory_misc: Enable test for aarch64

### DIFF
--- a/libvirt/tests/cfg/memory/memory_misc.cfg
+++ b/libvirt/tests/cfg/memory/memory_misc.cfg
@@ -40,6 +40,8 @@
                     numa_node_size = 512000
                     cpu_attrs = {'numa_cell': [{'id': '0', 'cpus': '0-7', 'memory': '${numa_node_size}', 'unit': 'KiB'}, {'id': '1', 'cpus': '8-15', 'memory': '${numa_node_size}', 'unit': 'KiB'}]}
                     mem_device_attrs = {'source': {'pagesize_unit': 'KiB', 'pagesize': 2048, 'nodemask': '0'}, 'mem_model': 'dimm', 'target': {'size': 131072, 'node': 1, 'size_unit': 'KiB'}}
+                    aarch64:
+                        mem_device_attrs = {'source': {'pagesize_unit': 'KiB', 'pagesize': 524288, 'nodemask': '0'}, 'mem_model': 'dimm', 'target': {'size': 524288, 'node': 1, 'size_unit': 'KiB'}}
                 - nodeset_specified:
                     no s390-virtio
                     pagesize = 1048576
@@ -58,19 +60,29 @@
                     no s390-virtio
                     pagesize = 2048
                     pagenum = 5120
+                    aarch64:
+                        pagesize = 524288
+                        pagenum = 20
                     vm_attrs = {'max_mem_rt': 83886080, 'max_mem_rt_slots': 8, 'max_mem_rt_unit': 'KiB', 'memory': 20971520, 'memory_unit': 'KiB', 'current_mem': 20971520, 'current_mem_unit': 'KiB'}
                     mem_backing_attrs = {'hugepages': {}}
                     cpu_attrs = {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '19922944', 'unit': 'KiB', 'discard': 'yes'}]}
-                    mem_device_attrs = {'source': {'pagesize_unit': 'KiB', 'pagesize': 2048, 'nodemask': '0'}, 'mem_model': 'dimm', 'target': {'size': 1048576, 'node': 0, 'size_unit': 'KiB'}}
+                    mem_device_attrs = {'source': {'pagesize_unit': 'KiB', 'pagesize': ${pagesize}, 'nodemask': '0'}, 'mem_model': 'dimm', 'target': {'size': 1048576, 'node': 0, 'size_unit': 'KiB'}}
                 - mount_hp_running_vm:
                     no s390-virtio
                     pagesize = 2048
-                    hp_path = '/dev/hugepages1G'
+                    mount_pagesize = 1048576
+                    mount_path = '/dev/hugepages1G'
+                    mount_option = 'pagesize=1G'
+                    aarch64:
+                        pagesize = 524288
+                        mount_pagesize = 2048
+                        mount_path= '/dev/hugepages2M'
+                        mount_option = 'pagesize=2M'
                     vm_attrs = {'vcpu': 4, 'max_mem_rt': 15242880, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB'}
                     numa_node_size = 1048576
                     cpu_attrs = {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '${numa_node_size}', 'unit': 'KiB'}, {'id': '1', 'cpus': '2-3', 'memory': '${numa_node_size}', 'unit': 'KiB'}]}
                     mem_backing_attrs = {'hugepages': {'pages': [{'unit': 'KiB', 'size': '${pagesize}'}]}}
-                    mem_device_attrs = {'source': {'pagesize': 1048576, 'pagesize_unit': 'KiB'}, 'mem_model': 'dimm', 'target': {'size': 1048576, 'node': 0, 'size_unit': 'KiB'}}
+                    mem_device_attrs = {'source': {'pagesize': ${mount_pagesize}, 'pagesize_unit': 'KiB'}, 'mem_model': 'dimm', 'target': {'size': 1048576, 'node': 0, 'size_unit': 'KiB'}}
         - edit_mem:
             variants case:
                 - forbid_0:
@@ -143,6 +155,8 @@
                     vmxml_current_mem = 1024000
                     vmxml_vcpu = 4
                     cpu_attrs = {'mode': 'host-model', 'numa_cell': [{'id': '0', 'cpus': '0,2', 'memory': '${numa_node_size}', 'unit': 'KiB'}, {'id': '1', 'cpus': '1,3', 'memory': '${numa_node_size}', 'unit': 'KiB'}]}
+                    aarch64:
+                        cpu_attrs = {'mode': 'host-passthrough', 'numa_cell': [{'id': '0', 'cpus': '0,2', 'memory': '${numa_node_size}', 'unit': 'KiB'}, {'id': '1', 'cpus': '1,3', 'memory': '${numa_node_size}', 'unit': 'KiB'}]}
                     dimm_device_1_attrs = {'mem_model': 'dimm', 'target': {'size': ${at_size}, 'size_unit': 'KiB', 'node': 1}}
                     dimm_device_0_attrs = {'mem_model': 'dimm', 'target': {'size': 0, 'size_unit': 'KiB', 'node': 0}}
                     audit_cmd = ausearch -ts recent -m VIRT_RESOURCE| grep 'mem'


### PR DESCRIPTION
Update the hugepagesize to enable test for aarch64

The test results are as follows, the one failure case is another scripts issue.
```
 (01/21) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.no_numa: CANCEL: This case is not supported by current libvirt. (6.56 s)
 (02/21) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.mem_lock.no_limit: PASS (8.95 s)
 (03/21) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.mem_lock.hard_limit: PASS (8.23 s)
 (04/21) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.prealloc_thread.file_backed: CANCEL: This libvirt version doesn't support this function. (6.14 s)                                                                                                                                                
 (05/21) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.prealloc_thread.memfd_backed: CANCEL: This libvirt version doesn't support this function. (6.15 s)                                                                                                                                               
 (06/21) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.prealloc_thread.ram_backed: CANCEL: This libvirt version doesn't support this function. (6.01 s)                                                                                                                                                 
 (07/21) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.no_mem_backing: PASS (8.54 s)
 (08/21) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.nodeset_specified.nodeset_0: PASS (7.25 s)
 (09/21) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.nodeset_specified.nodeset_01: PASS (7.52 s)
 (10/21) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.hp_from_2_numa_nodes: PASS (12.39 s)
 (11/21) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.mount_hp_running_vm: PASS (51.21 s)
 (12/21) type_specific.io-github-autotest-libvirt.memory_misc.edit_mem.forbid_0.set_mem: PASS (6.91 s)
 (13/21) type_specific.io-github-autotest-libvirt.memory_misc.edit_mem.forbid_0.set_cur_mem: PASS (7.04 s)
 (14/21) type_specific.io-github-autotest-libvirt.memory_misc.edit_mem.forbid_0.set_with_numa: PASS (7.02 s)
 (15/21) type_specific.io-github-autotest-libvirt.memory_misc.edit_mem.mem_unit.1000M: PASS (31.50 s)
 (16/21) type_specific.io-github-autotest-libvirt.memory_misc.edit_mem.mem_unit.1024M: PASS (31.08 s)
 (17/21) type_specific.io-github-autotest-libvirt.memory_misc.edit_mem.mem_unit.1G: PASS (31.66 s)
 (18/21) type_specific.io-github-autotest-libvirt.memory_misc.dommemstat.disk_caches: PASS (32.82 s)
 (19/21) type_specific.io-github-autotest-libvirt.memory_misc.dimm.multiop: PASS (11.32 s)
 (20/21) type_specific.io-github-autotest-libvirt.memory_misc.audit_size.at_dt_mem: ERROR: Command '/usr/bin/virsh detach-device avocado-vt-vm1 /tmp/xml_utils_temp_dyun4ga3.xml' failed.\nstdout: b'\n'\nstderr: b'error: Failed to detach device from /tmp/xml_utils_temp_dyun4ga3.xml\nerror: operation failed: unplug of device was rejected by the gues... (39.32 s)
 (21/21) type_specific.io-github-autotest-libvirt.memory_misc.managedsave.size_check: PASS (35.45 s)
```