### PR TITLE
virtual_disks_multidisks: fix disk discovery

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_multidisks.cfg
@@ -249,6 +249,7 @@
                             driver_option = "name=qemu,type=raw,iothread=4"
                             variants:
                                 - ide_bus:
+                                    no s390-virtio
                                     virt_disk_device_target = "hdb"
                                     virt_disk_device_bus = "ide"
                                 - dom_iothreads:
@@ -379,6 +380,7 @@
                             virt_disk_device_target = "hda"
                             virt_disk_device_bus = "ide"
                         - disk_bus_fdc:
+                            no s390-virtio
                             virt_disk_device = "floppy"
                             virt_disk_device_target = "fda"
                             virt_disk_device_bus = "fdc"
@@ -581,6 +583,7 @@
                             virt_disk_at_dt_disk = "yes"
                             disks_attach_option = "--mode readonly --sourcetype file;"
                 - disk_readonly_nfs_floppy:
+                    no s390-virtio
                     only coldplug
                     virt_disk_device_test_readonly = "yes"
                     virt_disk_device = "floppy"
@@ -700,6 +703,7 @@
                         virt_disk_device_bus = "scsi"
                         virt_disk_device_target = "sda"
                 - disk_floppy_update_boot_order:
+                    no s390-virtio
                     only coldplug
                     floppy_path = '/var/lib/libvirt/images/fd2.img'
                     disk_floppy_update_boot_order = "yes"
@@ -716,6 +720,7 @@
                     only coldplug
                     no q35
                     no aarch64
+                    no s390-virtio
                     virt_disk_with_source = "yes"
                     virt_disk_device = "disk"
                     virt_disk_device_source = "ide1"
@@ -1010,6 +1015,7 @@
                     only coldplug
                     no q35
                     no aarch64
+                    no s390-virtio
                     status_error = "yes"
                     disk_virtio_multi_ide_controller = "yes"
                     virt_disk_device = "disk"


### PR DESCRIPTION
Depends on https://github.com/avocado-framework/avocado-vt/pull/3815

The tests used the disk target as identifier for the disk inside of the VM. However, the target is not guaranteed to show up in the guest as-is, especially given that the /dev/XdY paths are not persistent and can change between boots.

Use instead a function that identifies a new disk inside of a VM as the one disk that has no root mount on itself, its partitions or volumes.

Finally, the delete_scsi_disk doesn't return any value so it was always looping for the full timeout. Wrap it into a function that confirms if both the module and device have been removed.