### PR TITLE
Unify the name of the vdpa cases

### DIFF
--- a/libvirt/tests/cfg/virtual_network/locked_memory_vdpa/mem_lock_limit_multiple_vdpa_interfaces.cfg
+++ b/libvirt/tests/cfg/virtual_network/locked_memory_vdpa/mem_lock_limit_multiple_vdpa_interfaces.cfg
@@ -1,4 +1,4 @@
-- virtual_network.locked_memory.vdpa_interfaceiface.multiple_interfaces:
+- virtual_network.locked_memory.vdpa_interface.multiple_interfaces:
     type = mem_lock_limit_multiple_vdpa_interfaces
     start_vm = no
     only x86_64


### PR DESCRIPTION
The jobs.yaml run vdpa related case in a separate job with a pattern "vdpa_interface". And these cases are excluded from the network job by the pattern "vdpa_interface" since it needs specific hardware.