### PR TITLE
add case for dimm memory with auto placement numatune

### DIFF
--- a/libvirt/tests/cfg/memory/memory_devices/dimm_memory_with_auto_placement_numatune.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/dimm_memory_with_auto_placement_numatune.cfg
@@ -1,0 +1,36 @@
+- memory.devices.dimm.auto_placement:
+    type = dimm_memory_with_auto_placement_numatune
+    start_vm = "no"
+    placement = "auto"
+    mem_model = "dimm"
+    set_size = 131072
+    dimm_dict = {'mem_model': '${mem_model}', 'target': {'size': ${set_size}, 'node': 0, 'size_unit': 'KiB'}}
+    attach_dimm = {'mem_model': '${mem_model}', 'target': {'size': ${set_size}, 'node': 1, 'size_unit': 'KiB'}}
+    aarch64:
+        set_size = 1048576
+    variants:
+        - strict:
+            tuning_mode = "strict"
+            mode_attrs = "'mode': '${tuning_mode}',"
+        - interleave:
+            tuning_mode = "interleave"
+            mode_attrs = "'mode': '${tuning_mode}',"
+        - preferred:
+            tuning_mode = "preferred"
+            mode_attrs = "'mode': '${tuning_mode}',"
+        - restrictive:
+            tuning_mode = "restrictive"
+            mode_attrs = "'mode': '${tuning_mode}',"
+        - undefined:
+            mode_attrs = ""
+    tuning_attrs = "'numa_memory': {${mode_attrs} 'placement': '${placement}'}"
+    variants:
+        - with_numa:
+            no s390-virtio
+            numa_mem = 1048576
+            mem_value = 2490368
+            current_mem = 2490368
+            base_attrs = "'vcpu': 4, 'placement': '${placement}', 'memory_unit':'KiB','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'KiB'"
+            numa_attrs = "'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '${numa_mem}', 'unit': 'KiB'},{'id':'1','cpus': '2-3','memory':'${numa_mem}','unit':'KiB'}]}"
+            max_attrs = "'max_mem_rt': 15242880, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB'"
+            vm_attrs = {${base_attrs}, ${numa_attrs}, ${max_attrs}, ${tuning_attrs}}

--- a/libvirt/tests/src/memory/memory_devices/dimm_memory_with_auto_placement_numatune.py
+++ b/libvirt/tests/src/memory/memory_devices/dimm_memory_with_auto_placement_numatune.py
@@ -1,0 +1,74 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright Redhat
+#
+#   SPDX-License-Identifier: GPL-2.0
+
+#   Author: Nannan Li <nanli@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+
+from provider.numa import numa_base
+
+
+def run(test, params, env):
+    """
+    1.Define guest with dimm devices and start guest.
+    2.Attach dimm memory.
+    """
+
+    def setup_test():
+        """
+        Check available numa nodes num.
+        """
+        test.log.info("TEST_SETUP: Check available numa nodes num")
+        numa_obj = numa_base.NumaTest(vm, params, test)
+        numa_obj.check_numa_nodes_availability()
+
+    def run_test():
+        """
+        Verify dimm memory device works with auto placement numatune.
+        """
+        test.log.info("TEST_SETUP1: Define guest with dimm memory")
+        vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+        vmxml.setup_attrs(**vm_attrs)
+        new_dimm = libvirt_vmxml.create_vm_device_by_type('memory', dimm_dict)
+        vmxml.devices = vmxml.devices.append(new_dimm)
+        vmxml.sync()
+
+        test.log.info("TEST_STEP2: Start vm")
+        vm.start()
+        vm.wait_for_login().close()
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        test.log.debug("Get guest xml is '%s' ", vmxml)
+
+        test.log.info("TEST_SETUP3: Hotplug a dimm device")
+        attach_mem = libvirt_vmxml.create_vm_device_by_type('memory', attach_dimm)
+        virsh.attach_device(vm.name, attach_mem.xml, debug=True,
+                            wait_for_event=True, ignore_status=False)
+
+    def teardown_test():
+        """
+        Clean data.
+        """
+        test.log.info("TEST_TEARDOWN: Clean up env.")
+        bkxml.sync()
+
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+    vm_attrs = eval(params.get('vm_attrs', '{}'))
+    dimm_dict = eval(params.get('dimm_dict', '{}'))
+    attach_dimm = eval(params.get("attach_dimm", '{}'))
+
+    try:
+        setup_test()
+        run_test()
+
+    finally:
+        teardown_test()

--- a/libvirt/tests/src/memory/memory_devices/virtio_mem_auto_placement.py
+++ b/libvirt/tests/src/memory/memory_devices/virtio_mem_auto_placement.py
@@ -21,8 +21,8 @@ from provider.numa import numa_base
 
 def run(test, params, env):
     """
-    1.Define guest with dimm devices.
-    2.Attach dimm and check mem value
+    1.Define guest with virtio-mem devices.
+    2.Attach virtio-mem and check mem value
     """
 
     def setup_test():


### PR DESCRIPTION
  xxxx-299044:Dimm memory device with auto placement numatune

Signed-off-by: nanli <nanli@redhat.com>
x86+RHEL9
```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 memory.devices.dimm.auto_placement
 (1/5) type_specific.io-github-autotest-libvirt.memory.devices.dimm.auto_placement.with_numa.strict: PASS (46.71 s)
 (2/5) type_specific.io-github-autotest-libvirt.memory.devices.dimm.auto_placement.with_numa.interleave: PASS (53.31 s)
 (3/5) type_specific.io-github-autotest-libvirt.memory.devices.dimm.auto_placement.with_numa.preferred: PASS (54.30 s)
 (4/5) type_specific.io-github-autotest-libvirt.memory.devices.dimm.auto_placement.with_numa.restrictive: PASS (53.57 s)
 (5/5) type_specific.io-github-autotest-libvirt.memory.devices.dimm.auto_placement.with_numa.undefined: PASS (53.12 s)

```
arm+RHEL8

```
 avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio memory.devices.dimm.auto_placement.with_2_numa_nodes

 (1/5) type_specific.io-github-autotest-libvirt.memory.devices.dimm.auto_placement.with_numa.strict: PASS (56.14 s)
 (2/5) type_specific.io-github-autotest-libvirt.memory.devices.dimm.auto_placement.with_numa.interleave: PASS (52.50 s)
 (3/5) type_specific.io-github-autotest-libvirt.memory.devices.dimm.auto_placement.with_numa.preferred: PASS (52.78 s)
 (4/5) type_specific.io-github-autotest-libvirt.memory.devices.dimm.auto_placement.with_numa.restrictive: PASS (53.66 s)
 (5/5) type_specific.io-github-autotest-libvirt.memory.devices.dimm.auto_placement.with_numa.undefined: PASS (52.53 s)


```