### PR TITLE
backingchain/blockcopy_options: fix added disk discovery

### DIFF
--- a/libvirt/tests/src/backingchain/blockcopy_options.py
+++ b/libvirt/tests/src/backingchain/blockcopy_options.py
@@ -42,7 +42,6 @@ def run(test, params, env):
         test_obj.new_image_path = image_path
         # start get old parts
         session = vm.wait_for_login()
-        test_obj.old_parts = utils_disk.get_parts_list(session)
         session.close()
         # attach new disk
         if encryption_disk:
@@ -84,9 +83,8 @@ def run(test, params, env):
                                        expected_value='true')
         # Check domain write file
         session = vm.wait_for_login()
-        new_parts = utils_disk.get_parts_list(session)
-        added_parts = list(set(new_parts).difference(set(test_obj.old_parts)))
-        utils_disk.linux_disk_check(session, added_parts[0])
+        added_disk, _ = libvirt_disk.get_non_root_disk_name(session)
+        utils_disk.linux_disk_check(session, added_disk)
         session.close()
 
     def teardown_blockcopy_extended_l2():


### PR DESCRIPTION
The tests recorded the list of disks before and after attachment. However /dev/XdY names can change between boots leading to test errors.

Use instead a function that identifies a new disk inside of a VM as the one disk that has no root mount on itself, its partitions or volumes.