### PR TITLE
fix memory numa case name

### DIFF
--- a/libvirt/tests/cfg/memory/memory_devices/virtio_mem_auto_placement.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/virtio_mem_auto_placement.cfg
@@ -33,7 +33,7 @@
             mode_attrs = ""
     tuning_attrs = "'numa_memory': {${mode_attrs} 'placement': '${placement}'}"
     variants:
-        - with_2_numa_nodes:
+        - with_numa:
             numa_mem = 1048576
             mem_value = 2097152
             current_mem = 2097152


### PR DESCRIPTION
```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 memory.devices.virtio_mem.auto_placement
 (1/5) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.auto_placement.with_numa.strict: PASS (100.39 s)
 (2/5) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.auto_placement.with_numa.interleave: PASS (96.63 s)
 (3/5) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.auto_placement.with_numa.preferred: PASS (103.85 s)
 (4/5) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.auto_placement.with_numa.restrictive: PASS (94.96 s)
 (5/5) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.auto_placement.with_numa.undefined: PASS (100.83 s)
```
