### PR TITLE
storage: add case for logical pool lifecycle from empty vg

### DIFF
--- a/libvirt/tests/cfg/storage/virsh_pool_autostart.cfg
+++ b/libvirt/tests/cfg/storage/virsh_pool_autostart.cfg
@@ -54,6 +54,9 @@
                             source_format = "lvm2"
                         - source_format_auto:
                             source_format = "auto"
+                        - with_empty_vg:
+                            func_supported_since_libvirt_ver = (9, 9, 0)
+                            with_empty_vg = "yes"
                 - pool_type_netfs:
                     pool_type = "netfs"
                     pool_target = "/nfs-mount"

--- a/libvirt/tests/src/storage/virsh_pool.py
+++ b/libvirt/tests/src/storage/virsh_pool.py
@@ -422,7 +422,7 @@ def run(test, params, env):
             # pool as active. This is independent of autostart.
             # So a directory based storage pool is thus pretty much always active,
             # and so as the SCSI pool.
-            if pool_type not in ['dir', 'scsi']:
+            if pool_type not in ['dir', 'scsi', 'logical']:
                 if pool_type == 'disk' and libvirt_version.version_compare(8, 1, 0):
                     utlv.check_exit_status(result)
                 else:


### PR DESCRIPTION
VIRT-300253: Logical pool lifecycle from empty vg and restart service. Also because the status of logical pool will keep active after restarting the service. So update another case together.