### PR TITLE
memory: Fix property to correctly check hugepage size

### DIFF
--- a/libvirt/tests/src/memory/memory_backing/memory_source_and_allocation.py
+++ b/libvirt/tests/src/memory/memory_backing/memory_source_and_allocation.py
@@ -139,12 +139,12 @@ def run(test, params, env):
             hugepage = str(json.loads(result)['return'])
 
             result = virsh.qemu_monitor_command(
-                vm_name, check_thread % (mem_name, 'hugetlbsize'), debug=True).stdout_text
+                vm_name, check_thread % (mem_name, 'size'), debug=True).stdout_text
             hugepage_size = str(json.loads(result)['return'])
 
             if hugepage != 'True':
                 test.fail("Expect to get hugepage 'True', but got '%s'" % hugepage)
-            if hugepage_size != memory_value:
+            if int(hugepage_size) != int(memory_value) * 1024:
                 test.fail("Expect to get hugepage size '%s', but got '%s'" % (
                     hugepage_size, memory_value))
             test.log.debug("Get correct hugepage '%s' and hugepage_size '%s'",


### PR DESCRIPTION
The **size** property should be used to check the size of hugepage intead of **hugetlbsize**.

The feature owner has updated the  step 7 of case xxx-297914.

Before:
```
 (1/2) type_specific.io-github-autotest-libvirt.memory.backing.source_and_allocation.memory_allocation.with_numa.immediate.hugepage.memfd: FAIL: Expect to get hugepage size '536870912', but got '2097152' (9.33 s)                                                                                                         
 (2/2) type_specific.io-github-autotest-libvirt.memory.backing.source_and_allocation.memory_allocation.without_numa.immediate.hugepage.memfd: FAIL: Expect to get hugepage size '536870912', but got '2097152' (10.25 s)
```

After:
```
 (1/2) type_specific.io-github-autotest-libvirt.memory.backing.source_and_allocation.memory_allocation.with_numa.immediate.hugepage.memfd: PASS (35.21 s)
 (2/2) type_specific.io-github-autotest-libvirt.memory.backing.source_and_allocation.memory_allocation.without_numa.immediate.hugepage.memfd: PASS (38.93 s)
```