### PR TITLE
numa: Fix nodeset sequence

### DIFF
--- a/libvirt/tests/src/numa/guest_numa_node_tuning/host_guest_mixed_memory_binding.py
+++ b/libvirt/tests/src/numa/guest_numa_node_tuning/host_guest_mixed_memory_binding.py
@@ -285,7 +285,7 @@ def check_cgroup(numatest_obj):
        memnode_mode != 'restrictive'):
         mem_nodeset = numatest_obj.params['nodeset']
         memnode_nodeset = eval(numatest_obj.params['numa_memnode'])[0].get('nodeset')
-        nodeset = ','.join(list(set(mem_nodeset).union(set(memnode_nodeset))))
+        nodeset = ','.join(sorted(set(mem_nodeset).union(set(memnode_nodeset))))
         nodeset = numa_base.convert_to_string_with_dash(nodeset)
         for item in [emulator_cpuset_mems, vcpu0_cpuset_mems, vcpu1_cpuset_mems]:
             if item != nodeset:


### PR DESCRIPTION
set() is unordered, list() cannot sort data, so there is no guarantee that nodes will be spliced in order. Use sort() instead.

For numa_base.convert_to_string_with_dash(), 
"0, 1" will be converted to "0-1" which is an expected result.
"1, 0" will just keep "1, 0".

Before:
```
FAIL 1-type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_strict.single_node -> TestFail: Expect cpuset.mems to be 1,0, but found 0-1
```

After:
```
PASS 1-type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_strict.single_node
```