### PR TITLE
passt/connection_between_2vms: fix config for s390x

### DIFF
--- a/libvirt/tests/cfg/virtual_network/passt/passt_connectivity_between_2vms.cfg
+++ b/libvirt/tests/cfg/virtual_network/passt/passt_connectivity_between_2vms.cfg
@@ -41,3 +41,11 @@
             conn_check_args_1 = ('TCP6', server_default_gw_v6, vm_c_iface, 41335, 41335)
             conn_check_args_2 = ('UDP4', server_default_gw, None, 21335, 21335)
             conn_check_args_3 = ('UDP6', server_default_gw_v6, vm_c_iface, 21335, 21335)
+            s390-virtio:
+                iface_attrs = {'model': 'virtio', **${ips}, 'backend': ${backend}, 'source': {'dev': '${host_iface}'}, 'type_name': 'user', **${portForwards}}
+                iface_c_attrs = {'model': 'virtio', **${ips}, 'backend': ${backend}, 'source': {'dev': '${host_iface}'}, 'type_name': 'user'}
+                vm_c_iface = enc1
+                conn_check_args_0 = ('TCP4', server_default_gw, None, 41335, 41335)
+                conn_check_args_1 = ('TCP6', server_default_gw_v6, vm_c_iface, 41335, 41335)
+                conn_check_args_2 = ('UDP4', server_default_gw, None, 21335, 21335)
+                conn_check_args_3 = ('UDP6', server_default_gw_v6, vm_c_iface, 21335, 21335)


### PR DESCRIPTION
No acpi on s390x and interfaces are named differently (qeth and virtio enc+devno).