### PR TITLE
Get the vm_iface name from the guest OS

### DIFF
--- a/libvirt/tests/src/virtual_network/passt/passt_attach_detach.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_attach_detach.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import shutil
+import platform
 
 import aexpect
 from virttest import libvirt_version
@@ -124,7 +125,9 @@ def run(test, params, env):
                 test.fail(f'Logfile of passt "{log_file}" not created')
 
             session = vm.wait_for_serial_login(timeout=60)
-            passt.check_vm_ip(iface_attrs, session, host_iface)
+            if platform.machine() != 'x86_64':
+                vm_iface = utils_net.get_linux_ifname(session, mac)
+            passt.check_vm_ip(iface_attrs, session, host_iface, vm_iface)
             passt.check_vm_mtu(session, vm_iface, mtu)
             passt.check_default_gw(session)
             passt.check_nameserver(session)

--- a/libvirt/tests/src/virtual_network/passt/passt_function.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_function.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import shutil
+import platform
 
 import aexpect
 from virttest import libvirt_version
@@ -97,7 +98,9 @@ def run(test, params, env):
             test.fail(f'Logfile of passt "{log_file}" not created')
 
         session = vm.wait_for_serial_login(timeout=60)
-        passt.check_vm_ip(iface_attrs, session, host_iface)
+        if platform.machine() != "x86_64":
+            vm_iface = utils_net.get_linux_ifname(session, mac)
+        passt.check_vm_ip(iface_attrs, session, host_iface, vm_iface)
         passt.check_vm_mtu(session, vm_iface, mtu)
         passt.check_default_gw(session)
         passt.check_nameserver(session)

--- a/libvirt/tests/src/virtual_network/passt/passt_reconnect.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_reconnect.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import shutil
+import platform
 
 import aexpect
 from avocado.utils import process
@@ -109,7 +110,9 @@ def run(test, params, env):
             test.fail(f'Logfile of passt "{log_file}" not created')
 
         session = vm.wait_for_serial_login(timeout=60)
-        passt.check_vm_ip(iface_attrs, session, host_iface)
+        if platform.machine() != 'x86_64':
+            vm_iface = utils_net.get_linux_ifname(session, mac)
+        passt.check_vm_ip(iface_attrs, session, host_iface, vm_iface)
         passt.check_vm_mtu(session, vm_iface, mtu)
         passt.check_default_gw(session)
         passt.check_nameserver(session)

--- a/provider/virtual_network/passt.py
+++ b/provider/virtual_network/passt.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 import random
 from socket import socket
 
@@ -169,15 +170,17 @@ def check_proc_info(params, log_file, mac):
         raise exceptions.TestFail(';'.join(failed_check))
 
 
-def check_vm_ip(iface_attrs, session, host_iface):
+def check_vm_ip(iface_attrs, session, host_iface, vm_iface=None):
     """
     Check if vm ip and prefix meet expectation
 
     :param iface_attrs: attributes of interface
     :param session: shell session instance of vm
     :param host_iface: host interface
+    :param vm_iface: VM interface, can be omitted on x86_64
     """
-    vm_iface = 'eno' + iface_attrs.get('acpi', {'index': '1'})['index']
+    if not vm_iface:
+        vm_iface = 'eno' + iface_attrs.get('acpi', {'index': '1'})['index']
     vm_ip, prefix = get_iface_ip_and_prefix(vm_iface, session=session)
     LOG.debug(f'VM ip and prefix: {vm_ip}, {prefix}')
     if 'ips' in iface_attrs:
@@ -232,21 +235,24 @@ def check_vm_mtu(session, iface, mtu):
 
 def check_default_gw(session):
     """
-    Check whether default host gateways of host and guest are consistent
+    Check whether default host gateways of host and guest are consistent,
+    i.e. the guest's gateways are available on the host.
 
     :param session: vm shell session instance
     """
-    host_gw = utils_net.get_default_gateway(force_dhcp=True)
-    vm_gw = utils_net.get_default_gateway(session=session, force_dhcp=True)
+    host_gw = utils_net.get_default_gateway(force_dhcp=True).split()
+    vm_gw = utils_net.get_default_gateway(session=session,
+                                          force_dhcp=True).split()
     LOG.debug(f'Host and vm default ipv4 gateway: {host_gw}, {vm_gw}')
-    host_gw_v6 = utils_net.get_default_gateway(ip_ver='ipv6')
-    vm_gw_v6 = utils_net.get_default_gateway(session=session, ip_ver='ipv6')
+    host_gw_v6 = utils_net.get_default_gateway(ip_ver='ipv6').split()
+    vm_gw_v6 = utils_net.get_default_gateway(session=session,
+                                             ip_ver='ipv6').split()
     LOG.debug(f'Host and vm default ipv6 gateway: {host_gw_v6}, {vm_gw_v6}')
 
-    if host_gw != vm_gw:
+    if [x for x in vm_gw if x not in host_gw]:
         raise exceptions.TestFail(
             'Host default ipv4 gateway not consistent with vm.')
-    if host_gw_v6 != vm_gw_v6:
+    if [x for x in vm_gw_v6 if x not in host_gw_v6]:
         raise exceptions.TestFail(
             'Host default ipv6 gateway not consistent with vm.')
 
@@ -258,8 +264,11 @@ def check_nameserver(session):
     :param session: vm shell session instance
     """
     get_cmd = 'cat /etc/resolv.conf|grep -vE "#|;"'
-    on_host = process.run(get_cmd, shell=True).stdout_text.strip()
-    on_vm = session.cmd_output(get_cmd).strip()
+    on_host = process.run(get_cmd, shell=True).stdout_text.strip().split()
+    on_vm = session.cmd_output(get_cmd).strip().split()
+    # remove zone index
+    on_host = [re.sub(r'%.*', '', x) for x in on_host]
+    on_vm = [re.sub(r'%.*', '', x) for x in on_vm]
     if on_host == on_vm:
         LOG.debug(f'Nameserver on vm is consistent with host:\n{on_host}')
     else:
@@ -320,16 +329,20 @@ def check_protocol_connection(src_sess, tar_sess, protocol, addr,
                                   f'actually is {conneted}')
 
 
-def check_connection(vm, vm_iface, protocols):
+def check_connection(vm, vm_iface, protocols, host_iface=None):
     """
     Check connection of vm and host
 
     :param vm: vm instance
     :param vm_iface: interface of vm
     :param protocols: protocols to check
+    :param host_iface: host interface to get default gw for
+                       if ommitted all default routes are returned
     """
-    default_gw = utils_net.get_default_gateway(force_dhcp=True)
-    default_gw_v6 = utils_net.get_default_gateway(ip_ver='ipv6')
+    default_gw = utils_net.get_default_gateway(force_dhcp=True,
+                                               target_iface=host_iface)
+    default_gw_v6 = utils_net.get_default_gateway(ip_ver='ipv6',
+                                                  target_iface=host_iface)
     for protocol in protocols:
         host_sess = aexpect.ShellSession('su')
         vm_sess = vm.wait_for_serial_login(timeout=60)
@@ -379,7 +392,7 @@ def check_port_listen(ports, protocol, host_ip=None):
     """
     if protocol.lower() not in ('tcp', 'udp'):
         raise exceptions.TestError(f'Unsupported protocol: {protocol}')
-    cmd_listen = process.run(f"ss -{protocol[0].lower()}lpn|egrep 'passt.avx2'",
+    cmd_listen = process.run(f"ss -{protocol[0].lower()}lpn|egrep 'passt'",
                              shell=True).stdout_text
     for item in ports:
         if item in cmd_listen:


### PR DESCRIPTION
With acpi feature, we can assume that the vm_iface is "eno1" with the <acpi index="1"/> setting. But it only works on x86 now. Update it to get the vm_iface name from the guest OS instead.