### PR TITLE
passt/reconnect: fix on multi-arch

### DIFF
--- a/libvirt/tests/cfg/virtual_network/passt/passt_reconnect.cfg
+++ b/libvirt/tests/cfg/virtual_network/passt/passt_reconnect.cfg
@@ -40,3 +40,6 @@
             conn_check_args_1 = ('TCP6', 'localhost', 31339, 41339, True, None)
             conn_check_args_2 = ('UDP4', 'localhost', 2025, 2025, True, None)
             conn_check_args_3 = ('UDP6', 'localhost', 2025, 2025, True, None)
+            s390-virtio:
+                iface_attrs = {'model': 'virtio', **${ips}, 'backend': ${backend}, 'source': {'dev': '${host_iface}'}, **${alias}, 'type_name': 'user', **${portForwards}}
+                vm_iface = enc1

--- a/libvirt/tests/src/virtual_network/passt/passt_reconnect.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_reconnect.py
@@ -109,7 +109,7 @@ def run(test, params, env):
             test.fail(f'Logfile of passt "{log_file}" not created')
 
         session = vm.wait_for_serial_login(timeout=60)
-        passt.check_vm_ip(iface_attrs, session, host_iface)
+        passt.check_vm_ip(iface_attrs, session, host_iface, vm_iface)
         passt.check_vm_mtu(session, vm_iface, mtu)
         passt.check_default_gw(session)
         passt.check_nameserver(session)
@@ -124,7 +124,8 @@ def run(test, params, env):
         LOG.debug(f'Service status of firewalld: {firewalld.status()}')
 
         passt.check_connection(vm, vm_iface,
-                               ['TCP4', 'TCP6', 'UDP4', 'UDP6'])
+                               ['TCP4', 'TCP6', 'UDP4', 'UDP6'],
+                               host_iface)
 
         if 'portForwards' in iface_attrs:
             passt.check_portforward(vm, host_ip, params)


### PR DESCRIPTION
Depèends on https://github.com/autotest/tp-libvirt/pull/5361
Depends on https://github.com/avocado-framework/avocado-vt/pull/3818

No ACPI on s390x and interfaces are named differently. Pass VM interface name to avoid auto-naming.
Pass Host interface name to restrict gateway selection.