### PR TITLE
memory_nvdimm: Fix cpu mode to enable test for aarch64

### DIFF
--- a/libvirt/tests/cfg/memory/nvdimm.cfg
+++ b/libvirt/tests/cfg/memory/nvdimm.cfg
@@ -2,10 +2,12 @@
     type = nvdimm
     start_vm = no
     nvdimm_file_size = '512M'
+    cpuxml_mode = host-model
+    aarch64:
+        cpuxml_mode = host-passthrough
     variants:
         - back_file:
             nvdimm_file = /tmp/nvdimm
-            cpuxml_mode = host-model
             cpuxml_check = partial
             cpuxml_fallback = allow
             nvdimmxml_mem_model = nvdimm
@@ -37,6 +39,8 @@
                         - default:
                         - check_life_cycle:
                             check_life_cycle = "yes"
+                            error_msg_1 = "unsupported configuration: revert to external snapshot not supported yet"
+                            error_msg_2 = "internal error: Invalid target domain state 'disk-snapshot'. Refusing snapshot reversion"
                         - discard:
                             check = discard
                             nvdimmxml_discard = yes
@@ -46,7 +50,7 @@
                             check = pmem_alignsize
                             nvdimm_file_path = '/tmp/nvdimm'
                             alignsize = 2048
-                            vm_attrs = {'max_mem_rt': 8192, 'max_mem_rt_slots': 8, 'max_mem_rt_unit': 'M', 'vcpu': 4, 'cpu': {'mode': 'host-model', 'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '2097152', 'unit': 'K'}, {'id': '1', 'cpus': '2-3', 'memory': '2097152', 'unit': 'K'}]}}
+                            vm_attrs = {'max_mem_rt': 8192, 'max_mem_rt_slots': 8, 'max_mem_rt_unit': 'M', 'vcpu': 4, 'cpu': {'mode': '${cpuxml_mode}', 'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '2097152', 'unit': 'K'}, {'id': '1', 'cpus': '2-3', 'memory': '2097152', 'unit': 'K'}]}}
                             mem_device_attrs = {'mem_model': 'nvdimm', 'source': {'path': '${nvdimm_file_path}', 'alignsize': ${alignsize}, 'alignsize_unit': 'K', 'pmem': True}, 'target': {'size': 512, 'size_unit': 'M', 'node': 1, 'readonly': True, 'label': {'size': 128, 'size_unit': 'KiB'}}}
                             qemu_checks = "align.*pmem"
                             error_msg = "['pwrite.* failed: Operation not permitted', 'wrong fs type, bad option, bad superblock on /dev/pmem0']"
@@ -113,7 +117,6 @@
             nvdimmxml2_label_size = 128
             nvdimmxml2_label_size_unit = KiB
             nvdimmxml2_address_slot = 1
-            cpuxml_mode = host-model
             cpuxml_check = partial
             cpuxml_fallback = allow
             cpuxml_topology = {'sockets': '2', 'cores': '2', 'threads': '1'}


### PR DESCRIPTION
The cpu mode is host-passthrough for arm.

Internal snapshots of a VM with pflash based firmware are not supported on arm, so skip this check on arm

The following is the test result on arm, the failed two cases are because arm does not support and they have been skipped in libvirt-ci:
```
 (1/6) type_specific.io-github-autotest-libvirt.nvdimm.back_file.label.default: PASS (89.60 s)
 (2/6) type_specific.io-github-autotest-libvirt.nvdimm.back_file.label.check_life_cycle: PASS (107.47 s)
 (3/6) type_specific.io-github-autotest-libvirt.nvdimm.back_file.label.discard: PASS (10.98 s)
 (4/6) type_specific.io-github-autotest-libvirt.nvdimm.back_file.label.pmem_alignsize: ERROR: Command '/usr/bin/virsh start avocado-vt-vm1 ' failed.\nstdout: b'\n'\nstderr: b"error: Failed to start domain 'avocado-vt-vm1'\nerror: unsupported configuration: nvdimm pmem property is not available with this QEMU binary\n"\nadditional_info: None (11.85 s)
 (5/6) type_specific.io-github-autotest-libvirt.nvdimm.back_file.no_label: PASS (191.47 s)
 (6/6) type_specific.io-github-autotest-libvirt.nvdimm.hot_plug: FAIL: error: Failed to detach device from /tmp/xml_utils_temp__yvn_jk8.xml\nerror: internal error: unable to execute QEMU command 'device_del': nvdimm device hot unplug is not supported yet.\n (59.04 s)
RESULTS    : PASS 4 | ERROR 1 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```