### PR TITLE
Ingnore scm devices on S390

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_list.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_list.cfg
@@ -17,6 +17,7 @@
                     comparison_mode = exact
                     s390-virtio:
                         comparison_mode = similar
+                        remove_scm_device = "yes"
                 - multi_cap_option:
                     cap_option = multi
                 - long_cap_option:

--- a/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_list.py
+++ b/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_list.py
@@ -30,6 +30,26 @@ def get_avail_caps(all_caps):
     return avail_caps
 
 
+def get_scm_devices():
+    """
+    Get all Storage Class Memory Increments devices, only for s390.
+
+    :return:  A list contains all available scm devices in string.
+    """
+    scm_devices = []
+    try:
+        utils_path.find_command('lsscm')
+        scm_output = process.run('lsscm', ignore_status=True, shell=True).stdout_text
+        scm_list = scm_output.split('\n')[2:-1]
+        for scm in scm_list:
+            scm_info_list = [info for info in scm.split(' ') if info != '']
+            scm_devices.append('block_' + scm_info_list[2])
+    except utils_path.CmdNotFoundError:
+        logging.warning('Cmd lsscm not found!')
+        logging.warning('You can try to install it by `yum install s390utils*`')
+    return scm_devices
+
+
 def get_storage_devices():
     """
     Retrieve storage devices list from sysfs.
@@ -248,6 +268,7 @@ def run(test, params, env):
         return True
 
     mode = params.get("comparison_mode", "exact")
+    remove_scm_device = 'yes' == params.get("remove_scm_device", "no")
     all_caps = ['system', 'pci', 'usb_device', 'usb', 'net', 'scsi_host',
                 'scsi_target', 'scsi', 'storage', 'fc_host', 'vports',
                 'scsi_generic', 'ccw', 'css']
@@ -293,6 +314,11 @@ def run(test, params, env):
                 break
             elif result.exit_status == 0 and expect_succeed == 'no':
                 break
+            if cap == 'storage' and remove_scm_device:
+                scm_devices = get_scm_devices()
+                if scm_devices:
+                    devices[cap] = [device for device in devices[cap]
+                                    if device not in scm_devices]
             if not _check_result(cap, devices[cap], result.stdout.strip(), mode):
                 check_failed = True
                 break

--- a/spell.ignore
+++ b/spell.ignore
@@ -869,6 +869,7 @@ sata
 scenaries
 schedinfo
 schid
+scm
 scp
 scsi
 schid


### PR DESCRIPTION
Scm devices are only used in combination with z/OS.
Test result:
JOB ID     : eb5c2c18968651ed63b78547cc593b730cfa5251
JOB LOG    : /var/lib/avocado/job-results/job-2024-01-07T22.27-eb5c2c1/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.nodedev_list.valid_option.non_acl.one_cap_option: PASS (5.18 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2024-01-07T22.27-eb5c2c1/results.html
JOB TIME   : 5.51 s