### PR TITLE
passt/function: fix for multi-arch

### DIFF
--- a/libvirt/tests/cfg/virtual_network/passt/passt_function.cfg
+++ b/libvirt/tests/cfg/virtual_network/passt/passt_function.cfg
@@ -22,6 +22,9 @@
             iface_attrs = {'model': 'virtio', 'acpi': {'index': '1'}, 'type_name': 'user', 'backend': {'type': 'passt'}, 'source': {'dev': host_iface}}
             vm_iface = eno1
             vm_ping_outside = pass
+            s390-virtio:
+                iface_attrs = {'model': 'virtio', 'type_name': 'user', 'backend': {'type': 'passt'}, 'source': {'dev': host_iface}}
+                vm_iface = enc1
         - ip_portfw:
             ipv6_prefix = 128
             alias = {'name': 'ua-c87b89ff-b769-4abc-921f-30d42d7aec5b'}
@@ -30,6 +33,8 @@
             vm_iface = eno1
             vm_ping_outside = pass
             vm_ping_host_public = pass
+            s390-virtio:
+                vm_iface = enc1
             variants:
                 - ip_addr:
                     portForward_0 = {'attrs': {'proto': 'tcp'}, 'ranges': [{'start': '31339', 'to': '41339'}]}
@@ -54,8 +59,8 @@
                     portForward_0 = {'attrs': {'proto': 'tcp', 'dev': host_iface}, 'ranges': [{'start': '31339', 'to': '41339'}]}
                     portForward_1 = {'attrs': {'proto': 'udp', 'dev': host_iface}, 'ranges': [{'start': '2025'}]}
                     portForwards = [${portForward_0}, ${portForward_1}]
-                    tcp_port_list = [f'*%{vm_iface}:31339']
-                    udp_port_list = [f'0.0.0.0%{vm_iface}:2025', f'[::]%{vm_iface}:2025']
+                    tcp_port_list = [f'*%{host_iface}:31339']
+                    udp_port_list = [f'0.0.0.0%{host_iface}:2025', f'[::]%{host_iface}:2025']
                     conn_check_args_1 = ('TCP4', host_ip, 31339, 41339, True, None)
                     conn_check_args_2 = ('TCP6', host_ip_v6, 31339, 41339, True, None)
                     conn_check_args_3 = ('UDP4', host_ip, 2025, 2025, True, None)
@@ -65,9 +70,11 @@
                     portForward_1 = {'attrs': {'proto': 'udp', 'address': host_ip, 'dev': host_iface}, 'ranges': [{'start': '2025'}]}
                     portForward_2 = {'attrs': {'proto': 'tcp', 'address': host_ip_v6, 'dev': host_iface}, 'ranges': [{'start': '51339'}]}
                     portForwards = [${portForward_0}, ${portForward_1}, ${portForward_2}]
-                    tcp_port_list = [f'{host_ip}%{vm_iface}:31339', f'[{host_ip_v6}]%{vm_iface}:51339']
-                    udp_port_list = [f'{host_ip}%{vm_iface}:2025']
+                    tcp_port_list = [f'{host_ip}%{host_iface}:31339', f'[{host_ip_v6}]%{host_iface}:51339']
+                    udp_port_list = [f'{host_ip}%{host_iface}:2025']
                     conn_check_args_1 = ('TCP4', host_ip, 31339, 41339, True, None)
                     conn_check_args_2 = ('UDP4', host_ip, 2025, 2025, True, None)
                     conn_check_args_3 = ('TCP6', host_ip_v6, 51339, 51339, True, None)
             iface_attrs = {'model': 'virtio', 'acpi': {'index': '1'}, 'ips': ${ips}, 'backend': ${backend}, 'source': {'dev': host_iface}, 'alias': ${alias}, 'type_name': 'user', 'portForwards': ${portForwards}}
+            s390-virtio:
+                iface_attrs = {'model': 'virtio', 'ips': ${ips}, 'backend': ${backend}, 'source': {'dev': host_iface}, 'alias': ${alias}, 'type_name': 'user', 'portForwards': ${portForwards}}


### PR DESCRIPTION
Depends on https://github.com/autotest/tp-libvirt/pull/5361

1. Configure values for s390x
2. Get IP addresses by host interface to avoid issues when there's more than one functional NIC.
3. Use the host_iface in several functions to make sure the right interface is tested.
4. The test needs to check the ports on the host not in the guest. Therefore, configure the host_iface.