### PR TITLE
virsh_crash: Test to check environment behavior after test

### DIFF
--- a/libvirt/tests/cfg/virsh_crash.cfg
+++ b/libvirt/tests/cfg/virsh_crash.cfg
@@ -1,0 +1,4 @@
+- virsh.crash:
+    type = virsh_crash
+    variants:
+        - in_ci:

--- a/libvirt/tests/src/virsh_crash.py
+++ b/libvirt/tests/src/virsh_crash.py
@@ -1,0 +1,20 @@
+from time import sleep
+import logging as log
+
+from virttest import utils_misc
+
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
+
+
+def run(test, params, env):
+    utils_misc.cmd_status_output("virsh event --all --loop > /dev/null 2>&1 &",
+                                 shell=True)
+    sleep(5)
+    s, o = utils_misc.cmd_status_output("ulimit -S -c", shell=True)
+    logging.debug(o)
+    _, pid = utils_misc.cmd_status_output("pidof virsh", shell=True)
+    utils_misc.cmd_status_output("kill -11 %s" % pid, shell=True)
+


### PR DESCRIPTION
The test crashes virsh. It can be used to check if the core file will be recorded and if the coredump will be reported.