### PR TITLE
cpu: Disable host dmesg checks

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_cpu_compare.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_cpu_compare.cfg
@@ -7,6 +7,7 @@
     cpu_compare_feature_num = -1
     cpu_compare_file_name = "cpu.xml"
     cpu_compare_modify_invalid = "no"
+    verify_guest_dmesg = no
     variants:
         - default_feature:
         - delete_feature:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_cpu_stats.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_cpu_stats.cfg
@@ -4,6 +4,7 @@
     cpu_stats_vm_ref = "name"
     cpu_stats_options = ""
     start_vm = "yes"
+    verify_guest_dmesg = no
     variants:
         - positive_test:
             status_error = "no"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_cpu_xml.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_cpu_xml.cfg
@@ -1,5 +1,6 @@
 - virsh.cpu_xml:
     type = virsh_cpu_xml
+    verify_guest_dmesg = no
     variants:
         - positive:
             variants:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_vcpuinfo.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_vcpuinfo.cfg
@@ -8,6 +8,7 @@
     kill_vm = "yes"
     # Test is not Guest OS dependent
     kill_vm_gracefully = "no"
+    verify_guest_dmesg = no
     variants:
         - normal_test:
             status_error = "no"


### PR DESCRIPTION
To avoid an issue caused by the unexpected ip_set warning in dmesg.

**Before the fix:**
` (1/1) type_specific.io-github-autotest-libvirt.virsh.vcpuinfo.normal_test.name_option: ERROR: Failures occurred while postprocess:\n\n: Guest avocado-vt-vm1 dmesg verification failed: Found unexpected failures in guest dmesg log Please check guest dmesg log in debug log. (31.72 s)`

**After the fix:**

` (1/1) type_specific.io-github-autotest-libvirt.virsh.vcpuinfo.normal_test.name_option: PASS (9.74 s)
`