### PR TITLE
migration: Fix no storage pool issue

### DIFF
--- a/libvirt/tests/src/migration_with_copy_storage/precreate_none_target_disk.py
+++ b/libvirt/tests/src/migration_with_copy_storage/precreate_none_target_disk.py
@@ -89,6 +89,7 @@ def run(test, params, env):
         cmd = "qemu-img info %s -U" % disk_source_name
         src_image_info = process.run(cmd, ignore_status=True, shell=True).stdout_text.strip()
 
+        remote.run_remote_cmd("mkdir -p %s" % pool_target, params)
         virsh.pool_create_as(pool_name, pool_type, pool_target, uri=dest_uri,
                              ignore_status=True, debug=True)
 


### PR DESCRIPTION
Before:
TestFail: error: Storage pool not found: no storage pool with matching target path '/var/lib/libvirt/migrate'

After:
 (1/1) type_specific.io-github-autotest-libvirt.migration_with_copy_storage.precreate_none_target_disk.copy_storage_all.raw_format.p2p: PASS (144.27 s)