### PR TITLE
v2v:fix functional failed TC "luks-partition"

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -667,7 +667,7 @@
             version_required = "[virt-v2v-2.0.7-2,)"
             main_vm = VM_NAME_CLEVIS_LUKS_V2V_EXAMPLE
             luks_partition = VM_LUKS_PARTITION_EXAMPLE
-            v2v_opts = "--key "${luks_partition}":clevis"
+            v2v_opts = "--key ${luks_partition}:clevis"
         - logs:
             only esx_70
             main_vm = VM_NAME_ESX_DEFAULT_V2V_EXAMPLE


### PR DESCRIPTION
Fix: Incorrect quotation marks cause the variable can't get the value.

v2v_opts = --key "VM_LUKS_PARTITION_EXAMPLE":clevis