### PR TITLE
Add new case of start vm with specific mac address

### DIFF
--- a/libvirt/tests/cfg/virtual_network/elements_and_attributes/element_mac_specific_addr.cfg
+++ b/libvirt/tests/cfg/virtual_network/elements_and_attributes/element_mac_specific_addr.cfg
@@ -1,0 +1,38 @@
+- virtual_network.elements_and_attributes.mac.specific_addr:
+    type = element_mac_specific_addr
+    start_vm = no
+    timeout = 240
+    outside_ip = 'www.redhat.com'
+    vm_ping_outside = pass
+    variants scenario:
+        - pre_set:
+        - hotplug:
+    variants:
+        - default:
+            mac = {}
+            expect_xml_mac = 52:54:00.*
+            expect_tap_mac = fe:
+        - starts_with_0xfe:
+            set_mac = 'fe:54:00:70:58:07'
+            mac = {'mac_address': '${set_mac}'}
+            expect_xml_mac = ${set_mac}
+            expect_tap_mac = fa:
+        - all_zeros:
+            mac = {'mac_address': '00:00:00:00:00:00'}
+            expect_xml_mac = 52:54:00.*
+            expect_tap_mac = fe:
+        - multicast_addr:
+            mac = {'mac_address': '01:54:00:bc:f3:ec'}
+            status_error = yes
+            err_msg = expected unicast mac address, found multicast
+        - null_addr:
+            mac = {'mac_address': 'null'}
+            status_error = yes
+            err_msg = unable to parse mac address
+        - null_addr:
+            mac = {'mac_address': 'zero'}
+            status_error = yes
+            err_msg = unable to parse mac address
+        
+    iface_attrs = {**${mac}, 'model': 'virtio', 'type_name': 'network', 'source': {'network': 'default'}}
+

--- a/libvirt/tests/src/virtual_network/elements_and_attributes/element_mac_specific_addr.py
+++ b/libvirt/tests/src/virtual_network/elements_and_attributes/element_mac_specific_addr.py
@@ -1,0 +1,102 @@
+import logging
+import re
+
+from virttest import utils_net
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+from provider.virtual_network import network_base
+
+VIRSH_ARGS = {'ignore_status': False, 'debug': True}
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+
+def run(test, params, env):
+    """
+    Test start vm or hotplug interface with specific mac address
+    """
+    vm_name = params.get('main_vm')
+    vm = env.get_vm(vm_name)
+    scenario = params.get('scenario')
+    outside_ip = params.get('outside_ip')
+    status_error = 'yes' == params.get('status_error', 'no')
+    err_msg = params.get('err_msg')
+    set_mac = eval(params.get('mac', {})).get('mac_address')
+    iface_attrs = eval(params.get('iface_attrs', '{}'))
+    expect_xml_mac = params.get('expect_xml_mac')
+    expect_tap_mac = params.get('expect_tap_mac')
+
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+
+    try:
+        vmxml.del_device('interface', by_tag=True)
+        if scenario == 'pre_set':
+            iface = libvirt_vmxml.create_vm_device_by_type('interface',
+                                                           iface_attrs)
+            vmxml.add_device(iface)
+            LOG.debug(f'Interface to add to vm:\n{iface}')
+
+            if status_error:
+                start_result = virsh.define(vmxml.xml, debug=True)
+                libvirt.check_exit_status(start_result, status_error)
+                if err_msg:
+                    libvirt.check_result(start_result, expected_fails=err_msg)
+                return
+            else:
+                vmxml.sync()
+            vm.start()
+
+        elif scenario == 'hotplug':
+            vmxml.sync()
+            vm.start()
+            if set_mac:
+                at_options = f'network default --mac {set_mac} --model virtio'
+            else:
+                at_options = f'network default --model virtio'
+
+            at_result = virsh.attach_interface(vm_name, at_options, debug=True)
+            libvirt.check_exit_status(at_result, status_error)
+            if status_error:
+                if err_msg:
+                    libvirt.check_result(at_result, expected_fails=err_msg)
+                return
+
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        LOG.debug(f'VMXML of {vm_name}:\n{virsh.dumpxml(vm_name).stdout_text}')
+        iface_xml = vmxml.get_devices('interface')[0]
+        LOG.debug(f'Interface in vmxml:\n{iface_xml}')
+        vmxml_mac = iface_xml.mac_address
+        if not re.match(expect_xml_mac, vmxml_mac):
+            test.fail(f'Expect mac address on vmxml: {expect_tap_mac}, '
+                      f'not {vmxml_mac}')
+
+        virsh.domiflist(vm_name, **VIRSH_ARGS)
+        iflist = libvirt.get_interface_details(vm_name)
+        LOG.debug(f'iflist of vm: {iflist}')
+        tap_on_host = iflist[0]['interface']
+        LOG.debug(f'Tap device on host: {tap_on_host}')
+
+        # Get the expected mac address of tap device from mac address on vmxml
+        expect_tap_mac = re.sub('^\w+:', expect_tap_mac, vmxml_mac)
+        LOG.debug(f'Expect mac address of tap device on host: {expect_tap_mac}')
+        tap_mac = utils_net.get_linux_iface_info(iface=tap_on_host)['address']
+        if not re.match(expect_tap_mac, tap_mac):
+            test.fail(f'Expect mac address of tap device: {expect_tap_mac} '
+                      f'not {tap_mac}')
+
+        session = vm.wait_for_serial_login()
+        ip_in_vm = session.cmd_output('ip addr')
+        LOG.debug(f'ip addr output on vm:\n{ip_in_vm}')
+        if vmxml_mac not in ip_in_vm:
+            test.fail(f'Not found mac address from vmxml {vmxml_mac} in vm.')
+
+        ips = {'outside_ip': outside_ip}
+        network_base.ping_check(params, ips, session, force_ipv4=True)
+        session.close()
+
+    finally:
+        bkxml.sync()


### PR DESCRIPTION
- VIRT-296221 - [mac] Start vm or hotplug interface with specific mac address

Test result:
```
 (01/12) type_specific.io-github-autotest-libvirt.virtual_network.elements_and_attributes.mac.specific_addr.default.pre_set:PASS (81.23 s)
 (02/12) type_specific.io-github-autotest-libvirt.virtual_network.elements_and_attributes.mac.specific_addr.default.hotplug:PASS (82.21 s)
 (03/12) type_specific.io-github-autotest-libvirt.virtual_network.elements_and_attributes.mac.specific_addr.starts_with_0xfe.pre_set: PASS (52.19 s)
 (04/12) type_specific.io-github-autotest-libvirt.virtual_network.elements_and_attributes.mac.specific_addr.starts_with_0xfe.hotplug: PASS (47.32 s)
 (05/12) type_specific.io-github-autotest-libvirt.virtual_network.elements_and_attributes.mac.specific_addr.all_zeros.pre_set: PASS (48.19 s)
 (06/12) type_specific.io-github-autotest-libvirt.virtual_network.elements_and_attributes.mac.specific_addr.all_zeros.hotplug: PASS (81.46 s)
 (07/12) type_specific.io-github-autotest-libvirt.virtual_network.elements_and_attributes.mac.specific_addr.multicast_addr.pre_set: PASS (5.97 s)
 (08/12) type_specific.io-github-autotest-libvirt.virtual_network.elements_and_attributes.mac.specific_addr.multicast_addr.hotplug: PASS (7.05 s)
 (09/12) type_specific.io-github-autotest-libvirt.virtual_network.elements_and_attributes.mac.specific_addr.null_addr.pre_set: PASS (5.84 s)
 (10/12) type_specific.io-github-autotest-libvirt.virtual_network.elements_and_attributes.mac.specific_addr.null_addr.hotplug: PASS (7.09 s)
 (11/12) type_specific.io-github-autotest-libvirt.virtual_network.elements_and_attributes.mac.specific_addr.null_addr.pre_set: PASS (5.84 s)
 (12/12) type_specific.io-github-autotest-libvirt.virtual_network.elements_and_attributes.mac.specific_addr.null_addr.hotplug: PASS (7.09 s)
RESULTS    : PASS 12 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```