### PR TITLE
add case for destroying storage pool with running vm and then restart…

### DIFF
--- a/libvirt/tests/cfg/storage/virsh_pool_autostart.cfg
+++ b/libvirt/tests/cfg/storage/virsh_pool_autostart.cfg
@@ -1,7 +1,5 @@
 - virsh.pool_autostart:
     type = virsh_pool_autostart
-    vms = ''
-    main_vm = ''
     pool_name = "virsh_pool_test"
     pool_type = "dir"
     start_vm = "no"
@@ -74,6 +72,11 @@
                             ip_protocal = "ipv4"
                         - ipv6_target:
                             ip_protocal = "ipv6"
+                        - destroy_pool_used_by_guest:
+                            destroy_pool_used_by_guest = "yes"
+                            new_dev = 'sdc'
+                            source_attr = "'source':{'attrs': {'pool': '%s', 'volume':'%s'}}"
+                            disk_dict = {"type_name":"volume",'device':'disk',${source_attr},"target":{"dev": "${new_dev}", "bus": "virtio"}, "driver": {"name": "qemu", "type":"raw"}}
                 - pool_type_scsi:
                     pool_type = "scsi"
                     pool_target = "/dev/disk/by-path"


### PR DESCRIPTION
   xxxx-196149: Destroy storage pool with running vm and then restart libvirtd - autostarted network based storage
Signed-off-by: nanli <nanli@redhat.com>

```
 avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 virsh.pool_autostart..destroy_pool_used_by_guest 
 (1/2) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_iscsi.destroy_pool_used_by_guest: PASS (68.80 s)
 (2/2) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.uuid_option.pool_type_iscsi.destroy_pool_used_by_guest: PASS (70.49 s)

```
Other cases
```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 virsh.pool_autostart.positive_test
 (01/44) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_dir: PASS (7.82 s)
 (02/44) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_disk.source_format_dos: PASS (33.03 s)
 (03/44) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_disk.source_format_dvh: PASS (27.70 s)
 (04/44) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_disk.source_format_gpt: PASS (27.36 s)
 (05/44) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_disk.source_format_mac: PASS (27.71 s)
 (06/44) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_disk.source_format_bsd: PASS (27.75 s)
 (07/44) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_disk.source_format_pc98: PASS (27.61 s)
 (08/44) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_disk.source_format_sun: PASS (27.57 s)
 (09/44) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_fs.source_format_ext2: PASS (27.76 s)
 (10/44) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_fs.source_format_ext3: PASS (28.03 s)
 (11/44) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_fs.source_format_ext4: PASS (27.82 s)
 (16/44) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_netfs.source_format_nfs: PASS (9.24 s)
 (17/44) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_netfs.source_format_glusterfs: SKIP: Missing command 'gluster'
 (18/44) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_iscsi.ipv4_target:PASS (30.25 s)
 (19/44) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_iscsi.ipv6_target:PASS (27.92 s)
 (20/44) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_iscsi.destroy_pool_in_guest: PASS (68.60 s)
 (21/44) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_scsi: PASS (33.73 s)
 (22/44) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_gluster: SKIP: Missing command 'gluster'
 (23/44) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.uuid_option.pool_type_dir: PASS (8.31 s)
 (24/44) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.uuid_option.pool_type_disk.source_format_dos: PASS (27.63 s)
 (25/44) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.uuid_option.pool_type_disk.source_format_dvh: PASS (27.58 s)
 (26/44) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.uuid_option.pool_type_disk.source_format_gpt: PASS (34.70 s)
 (27/44) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.uuid_option.pool_type_disk.source_format_mac: PASS (27.78 s)
 (28/44) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.uuid_option.pool_type_disk.source_format_bsd: PASS (27.46 s)
 (29/44) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.uuid_option.pool_type_disk.source_format_pc98: PASS (27.79 s)
 (30/44) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.uuid_option.pool_type_disk.source_format_sun: PASS (27.80 s)
 (31/44) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.uuid_option.pool_type_fs.source_format_ext2: PASS (27.59 s)
 (32/44) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.uuid_option.pool_type_fs.source_format_ext3: PASS (34.85 s)
 (33/44) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.uuid_option.pool_type_fs.source_format_ext4: PASS (27.62 s)

```