### PR TITLE
memory: Increase guest memory to 4G

### DIFF
--- a/libvirt/tests/cfg/memory/virsh_setmem.cfg
+++ b/libvirt/tests/cfg/memory/virsh_setmem.cfg
@@ -17,6 +17,7 @@
     # expected to fail on older libvirt.
     setmem_old_libvirt_fail = "no"
     take_regular_screendumps = no
+    vm_attrs = {'memory': 4, 'memory_unit': 'GiB', 'current_mem': 4, 'current_mem_unit': 'GiB'}
     variants:
         - valid_options:
             # These should not fail

--- a/libvirt/tests/src/memory/virsh_setmem.py
+++ b/libvirt/tests/src/memory/virsh_setmem.py
@@ -10,6 +10,9 @@ from virttest import utils_misc
 from virttest import libvirt_version
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
+from virttest.staging import utils_memory
+
+from provider.memory import memory_base
 
 
 # Using as lower capital is not the best way to do, but this is just a
@@ -250,6 +253,21 @@ def run(test, params, env):
     # Back up domain XML
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     backup_xml = vmxml.copy()
+
+    vm_attrs = eval(params.get('vm_attrs'))
+    memory_size = vm_attrs['memory']
+    memory_unit = vm_attrs['memory_unit']
+    guest_memory = memory_base.convert_data_size(
+        str(memory_size) + memory_unit, dest_unit='KiB')
+    host_free_mem = utils_memory.freememtotal()
+    logging.debug("The allocation memory for guest is %sKiB,"
+                  " the total free memory of host is %sKiB.",
+                  guest_memory, host_free_mem)
+    if host_free_mem < guest_memory:
+        test.cancel("There is not enough memory for guest.")
+
+    vmxml.setup_attrs(**vm_attrs)
+    vmxml.sync()
 
     if with_packed and not libvirt_version.version_compare(6, 3, 0):
         test.cancel("The virtio packed attribute is not supported in"


### PR DESCRIPTION
The previous guest memory setting was 2G, but the half memory test would fail because 1G was not enough to maintain the normal operation of the guest.

Before:
```
(1/1) type_specific.io-github-autotest-libvirt.virsh.setmem.valid_options.running.half_mem.domid.dom_opt_size_opt.no_cmd_flag: ERROR: Login timeout expired    (output: "exceeded 240 s timeout, last failure: Login timeout expired    (output: '')") (419.32 s)
```

After:
```
(1/1) type_specific.io-github-autotest-libvirt.virsh.setmem.valid_options.running.half_mem.domid.dom_opt_size_opt.no_cmd_flag: PASS (72.23 s)
```