### PR TITLE
Fix folder exist issue on save_to_nfs

### DIFF
--- a/libvirt/tests/src/save_and_restore/save_to_nfs.py
+++ b/libvirt/tests/src/save_and_restore/save_to_nfs.py
@@ -68,7 +68,8 @@ def run(test, params, env):
         os.chmod(save_path, mod)
 
         LOG.debug('Make nfs mount dir and mount nfs storage')
-        os.mkdir(nfs_mount_dir)
+        if not os.path.exists(nfs_mount_dir):
+            os.mkdir(nfs_mount_dir)
         utils_disk.mount('127.0.0.1:' + nfs['export_dir'], nfs_mount_dir,
                          'nfs', options='rw')
 


### PR DESCRIPTION
In some extreme case, folder:nfs_mount_dir may already exist before mkdir()