### PR TITLE
fix blockcopy too fast to test

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockjob/blockjob_pivot_after_irregular_operations.cfg
+++ b/libvirt/tests/cfg/backingchain/blockjob/blockjob_pivot_after_irregular_operations.cfg
@@ -6,7 +6,7 @@
     abort_option = " --abort"
     variants test_scenario:
         - before_finish:
-            blockcopy_options = "blockcopy %s %s %s --transient-job --bandwidth 2"
+            blockcopy_options = "blockcopy %s %s %s --transient-job --bytes 200"
             err_msg = "not ready for pivot yet"
         - delete_copy_file:
             blockcopy_options = " --transient-job --wait --verbose "


### PR DESCRIPTION
Test result:

Before fixed:
`Expect should fail with one of ['not ready for pivot yet'], but failed with:error: invalid argument: disk vda does not have an active block job&#10;`

After fixed
```
 avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockjob.pivot.before_finish --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.backingchain.blockjob.pivot.before_finish: PASS (47.98 s)

```