### PR TITLE
libvirtd_conf: improve test error

### DIFF
--- a/libvirt/tests/src/daemon/conf_file/libvirtd_conf/set_audit_logging.py
+++ b/libvirt/tests/src/daemon/conf_file/libvirtd_conf/set_audit_logging.py
@@ -103,12 +103,14 @@ def run(test, params, env):
 
         """
         log_for_util = params.get("log_for_util")
-        if not libvirt.check_logfile(log_for_util, log_config_path, str_in_log=True):
+        if not libvirt.check_logfile(log_for_util, log_config_path,
+                                     ignore_status=True, str_in_log=True):
             test.fail("Can not find expected message :%s in log file:%s" % (log_for_util, log_config_path))
         log_for_filter_list = eval(params.get("log_for_filter_list"))
         for filter in log_for_filter_list:
             str_to_grep = "%s" % filter
-            if not libvirt.check_logfile(str_to_grep, log_config_path, str_in_log=False):
+            if libvirt.check_logfile(str_to_grep, log_config_path,
+                                     ignore_status=True, str_in_log=True):
                 test.fail("Find unexpected message :%s in log file:%s" % (str_to_grep, log_config_path))
 
     vm_name = params.get("main_vm", "avocado-vt-vm1")
@@ -146,3 +148,5 @@ def run(test, params, env):
     finally:
         libvirtd_config.restore()
         utils_libvirtd.Libvirtd('virtqemud').restart()
+        if log_config_path and os.path.exists(log_config_path):
+            os.remove(log_config_path)


### PR DESCRIPTION
`libvirt.check_logfile` will raise test failure if expectation unmet. However, the test code delivers more information, so let's not have it raise.

Also, remove the libvirtd.log file at the end of the test so that the next test won't read those log messages. The 'data_dir.get_tmp_dir' seemingly creates a tmp dir per job, that is, tests might share the same tmp_dir.