### PR TITLE
Fix virsh dump memory-only format kdump-* failure

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_dump.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_dump.py
@@ -183,7 +183,7 @@ def run(test, params, env):
                 return False
             logging.debug("Run file %s output: %s", dump_file, output)
             actual_format = output.split(" ")[1]
-            if actual_format.lower() != dump_image_format.lower():
+            if actual_format.lower() not in (dump_image_format.lower(), "flattened"):
                 logging.error("Compress dumped file to %s fail: %s" %
                               (dump_image_format, actual_format))
                 return False


### PR DESCRIPTION
### Fix virsh dump memory-only format kdump-* failure

Since linux command 'file <file_name>' version 5.44, the memory-only dump formats: 
kdump-zlib, kdump-lzo and kdump-snappy are taken as 'flattened kdump compressed 
dump'
Source: [file-command-flattened-kdump-compress](https://github.com/file/file/commit/65be19044894d012f66e20765a14fea1ee5af973)
In older 'file' version < 5.44 the same dump formats are taken as 'data'
This is leading to the failure of tests 11 and 28 in ras bucket

Signed-off-by: Misbah Anjum N [misanjum@linux.vnet.ibm.com](mailto:misanjum@linux.vnet.ibm.com)