### PR TITLE
vIOMMU: Add a case of attach iommu device

### DIFF
--- a/libvirt/tests/cfg/sriov/vIOMMU/attach_iommu_device.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/attach_iommu_device.cfg
@@ -1,0 +1,20 @@
+- vIOMMU.attach_iommu_device:
+    type = attach_iommu_device
+    start_vm = "no"
+    err_msg = "attach of device 'iommu' is not supported"
+    variants:
+        - virtio:
+            only q35, aarch64
+            func_supported_since_libvirt_ver = (8, 3, 0)
+            iommu_dict = {'model': 'virtio'}
+        - intel:
+            only q35
+            iommu_dict = {'model': 'intel', 'driver': {'intremap': 'on', 'caching_mode': 'on'}}
+        - smmuv3:
+            only aarch64
+            func_supported_since_libvirt_ver = (5, 5, 0)
+            iommu_dict = {'model': 'smmuv3'}
+    variants:
+        - cold_plug:
+            attach_option = "--config"
+        - hot_plug:

--- a/libvirt/tests/src/sriov/vIOMMU/attach_iommu_device.py
+++ b/libvirt/tests/src/sriov/vIOMMU/attach_iommu_device.py
@@ -1,0 +1,35 @@
+from virttest import libvirt_version
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+
+def run(test, params, env):
+    """
+    Hotplug or coldplug iommu device to guest
+    """
+    libvirt_version.is_libvirt_feature_supported(params)
+    iommu_dict = eval(params.get('iommu_dict', '{}'))
+    attach_option = params.get("attach_option", "")
+    err_msg = params.get("err_msg")
+
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    vm = env.get_vm(vm_name)
+    vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+    backup_vmxml = vmxml.copy()
+    try:
+        if attach_option and vm.is_alive():
+            vm.destroy()
+        elif not attach_option and not vm.is_alive():
+            vm.start()
+            vm.wait_for_login().close()
+
+        iommu_dev = libvirt_vmxml.create_vm_device_by_type('iommu', iommu_dict)
+        test.log.debug(f"iommu device: {iommu_dev}")
+        res = virsh.attach_device(vm.name, iommu_dev.xml, debug=True,
+                                  flagstr=attach_option)
+        libvirt.check_result(res, err_msg)
+    finally:
+        backup_vmxml.sync()


### PR DESCRIPTION
This PR adds:
    VIRT-294818 - Hotplug or coldplug iommu device to guest

**Test results:**
```
 (1/8) type_specific.io-github-autotest-libvirt.vIOMMU.attach_iommu_device.cold_plug.virtio: PASS (8.70 s)
 (2/8) type_specific.io-github-autotest-libvirt.vIOMMU.attach_iommu_device.cold_plug.intel: PASS (8.61 s)
 (3/8) type_specific.io-github-autotest-libvirt.vIOMMU.attach_iommu_device.hot_plug.virtio: PASS (47.83 s)
 (4/8) type_specific.io-github-autotest-libvirt.vIOMMU.attach_iommu_device.hot_plug.intel: PASS (44.33 s)

```