### PR TITLE
vIOMMU: Add a case about intel iommu

### DIFF
--- a/libvirt/tests/cfg/sriov/vIOMMU/intel_iommu_without_enabling_caching_mode.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/intel_iommu_without_enabling_caching_mode.cfg
@@ -1,0 +1,16 @@
+- vIOMMU.intel_iommu.without_enabling_caching_mode:
+    type = intel_iommu_without_enabling_caching_mode
+    err_msg = "caching-mode=on for [i|I]ntel"
+    start_vm = "yes"
+    iommu_dict = {'model': 'intel', 'driver': {'intremap': 'on'}}
+    only q35
+
+    variants dev_type:
+        - hostdev_interface:
+            iface_dict = {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}}
+        - hostdev_device:
+            hostdev_dict = {'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': vf_pci_addr}, 'managed': 'yes'}
+    variants:
+        - cold_plug:
+            attach_option = "--config"
+        - hot_plug:

--- a/libvirt/tests/src/sriov/vIOMMU/intel_iommu_without_enabling_caching_mode.py
+++ b/libvirt/tests/src/sriov/vIOMMU/intel_iommu_without_enabling_caching_mode.py
@@ -1,0 +1,45 @@
+from virttest import virsh
+
+from virttest.utils_test import libvirt
+
+from provider.sriov import sriov_base
+
+
+def run(test, params, env):
+    """
+    This case is to test hostdev interface with IOMMU device but no
+    cache_mode=on.
+    """
+    attach_option = params.get("attach_option", "")
+    err_msg = params.get("err_msg")
+    dev_type = params.get("dev_type", "")
+    iommu_dict = eval(params.get('iommu_dict', '{}'))
+
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    vm = env.get_vm(vm_name)
+
+    test_obj = sriov_base.SRIOVTest(vm, test, params)
+    iface_dict = test_obj.parse_iface_dict()
+
+    try:
+        test_obj.setup_iommu_test(iommu_dict=iommu_dict, cleanup_ifaces=False)
+
+        if attach_option and vm.is_alive():
+            vm.destroy()
+        elif not attach_option and not vm.is_alive():
+            vm.start()
+            vm.wait_for_login().close()
+
+        iface_dev = test_obj.create_iface_dev(dev_type, iface_dict)
+        test.log.info("TEST_STEP: Attach hostdev interface.")
+        res = virsh.attach_device(vm.name, iface_dev.xml, debug=True,
+                                  flagstr=attach_option)
+        if attach_option:
+            libvirt.check_exit_status(res)
+            test.log.info("TEST_STEP: Start vm with hostdev.")
+            res = virsh.start(vm.name, debug=True)
+
+        libvirt.check_result(res, err_msg)
+
+    finally:
+        test_obj.teardown_iommu_test()


### PR DESCRIPTION
This PR adds:
    VIRT-294734 - Check libvirt will prompt error when intel
        iommu device with hostdev interface/device but no
        caching_mode=on

**Test results:**
```
 (5/8) type_specific.io-github-autotest-libvirt.vIOMMU.intel_iommu.without_enabling_caching_mode.cold_plug.hostdev_interface: PASS (29.05 s)
 (6/8) type_specific.io-github-autotest-libvirt.vIOMMU.intel_iommu.without_enabling_caching_mode.cold_plug.hostdev_device:PASS (27.94 s)
 (7/8) type_specific.io-github-autotest-libvirt.vIOMMU.intel_iommu.without_enabling_caching_mode.hot_plug.hostdev_interface: PASS (64.35 s)
 (8/8) type_specific.io-github-autotest-libvirt.vIOMMU.intel_iommu.without_enabling_caching_mode.hot_plug.hostdev_device: PASS (62.54 s)
```
