### PR TITLE
vIOMMU: Add a vm lifecycle test

### DIFF
--- a/libvirt/tests/cfg/sriov/vIOMMU/iommu_device_lifecycle.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/iommu_device_lifecycle.cfg
@@ -1,0 +1,41 @@
+- vIOMMU.iommu_device_lifecycle:
+    type = iommu_device_lifecycle
+    start_vm = "no"
+    disk_driver = {'name': 'qemu', 'type': 'qcow2', 'iommu': 'on'}
+    variants:
+        - virtio:
+            only q35, aarch64
+            func_supported_since_libvirt_ver = (8, 3, 0)
+            iommu_dict = {'model': 'virtio'}
+        - intel:
+            only q35
+            start_vm = "yes"
+            enable_guest_iommu = "yes"
+            iommu_dict = {'model': 'intel', 'driver': {'intremap': 'on', 'caching_mode': 'on', 'eim': 'on', 'iotlb': 'on', 'aw_bits': '48'}}
+        - smmuv3:
+            only aarch64
+            func_supported_since_libvirt_ver = (5, 5, 0)
+            iommu_dict = {'model': 'smmuv3'}
+    variants:
+        - e1000e:
+            only q35
+            iface_model = 'e1000e'
+            iface_dict = {'type_name': 'network', 'model': '${iface_model}', 'source': {'network': 'default'}}
+        - virtio_muti_devices:
+            disk_dict = {'target': {'dev': 'vda', 'bus': 'virtio'}, 'device': 'disk', 'driver': ${disk_driver}}
+            video_dict = {'primary': 'yes', 'model_heads': '1', 'model_type': 'virtio', 'driver': {'iommu': 'on'}}
+            test_devices = ["Eth", "block", "gpu"]
+            variants:
+                - vhost_on:
+                    interface_driver_name = "vhost"
+            interface_driver = {'driver_attr': {'name': '${interface_driver_name}', 'iommu': 'on'}}
+            iface_dict = {'type_name': 'network', 'model': 'virtio', 'driver': ${interface_driver}, 'source': {'network': 'default'}}
+        - hostdev_iface:
+            only virtio
+            no save_restore
+            iface_dict = {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}}
+    variants test_scenario:
+        - save_restore:
+        - suspend_resume:
+        - reboot_many_times:
+            loop_time = 5


### PR DESCRIPTION
This PR adds:
    VIRT-294807 - [vIOMMU] Lifecycle test for vm with iommu device

**Test results:** some cases are failed due to known issues.
```
 (01/14) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.save_restore.e1000e.virtio: ERROR: Command '/bin/virsh restore /var/tmp/avocado-vt-vm1_Qdi.save ' failed.\nstdout: b'\n'\nstderr: b'error: Failed to restore domain from /var/tmp/avocado-vt-vm1_Qdi.save\nerror: operation failed: domain is not running\n'\nadditional_info: None (61.83 s)
 (02/14) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.save_restore.e1000e.intel: PASS (252.06 s)
 (03/14) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.save_restore.virtio_muti_devices.vhost_on.virtio: ERROR: Command '/bin/virsh restore /var/tmp/avocado-vt-vm1_X9N.save ' failed.\nstdout: b'\n'\nstderr: b'error: Failed to restore domain from /var/tmp/avocado-vt-vm1_X9N.save\nerror: operation failed: domain is not running\n'\nadditional_info: None (64.40 s)
 (04/14) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.save_restore.virtio_muti_devices.vhost_on.intel: PASS (252.99 s)
 (05/14) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.suspend_resume.e1000e.virtio: PASS (88.16 s)
 (06/14) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.suspend_resume.e1000e.intel: PASS (239.45 s)
 (07/14) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.suspend_resume.virtio_muti_devices.vhost_on.virtio: PASS (88.17 s)
 (08/14) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.suspend_resume.virtio_muti_devices.vhost_on.intel: PASS (240.67 s)
 (09/14) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.suspend_resume.hostdev_iface.virtio: PASS (80.61 s)
 (10/14) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.reboot_many_times.e1000e.virtio: PASS (324.01 s)
 (11/14) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.reboot_many_times.e1000e.intel: PASS (474.32 s)
 (12/14) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.reboot_many_times.virtio_muti_devices.vhost_on.virtio: PASS (325.47 s)
 (13/14) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.reboot_many_times.virtio_muti_devices.vhost_on.intel: PASS (474.24 s)
 (14/14) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.reboot_many_times.hostdev_iface.virtio: PASS (341.28 s)
Not opening readers, lock_server_running not locked
RESULTS    : PASS 12 | ERROR 2 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2024-01-29T03.56-52fd67a/results.html
JOB TIME   : 3310.32 s
(.libvirt-ci-venv-ci-ru
```