### PR TITLE
Remove existing interfaces when testing timer

### DIFF
--- a/spell.ignore
+++ b/spell.ignore
@@ -1227,3 +1227,4 @@ hwrng
 buitin
 Meina
 meili
+ntp


### PR DESCRIPTION
Since RHEL8, the NTP protocol is implemented only by the chronyd daemon, which is enabled by default. Remove guest interface to prevent network connection, then guest will not sync time automatically to ntp server after boot. Otherwise, guest time will be synced to current real time regardless of guest configurations.