### PR TITLE
crypto_nodedev: improve reliability

### DIFF
--- a/libvirt/tests/src/virsh_cmd/nodedev/crypto_nodedev_create_destroy.py
+++ b/libvirt/tests/src/virsh_cmd/nodedev/crypto_nodedev_create_destroy.py
@@ -4,7 +4,6 @@ import os
 
 from uuid import uuid1
 
-from avocado.utils import process
 from virttest import libvirt_version
 from virttest import virsh
 from virttest import utils_misc
@@ -119,7 +118,7 @@ def check_device_attributes_are_dumped(test, dev_name, adapter, domain):
     :param domain: domain number in base 16
     """
 
-    process.run("udevadm settle")
+    time.sleep(10)
     nodedevice_xml = nodedev_xml.NodedevXML.new_from_dumpxml(dev_name)
     mdev_cap_xml = nodedevice_xml.get_cap()
     logging.debug("MdevXML: %s", mdev_cap_xml)


### PR DESCRIPTION
Waiting for udevadm settle doesn't seem to make sure Libvirt has the latest device information.

Instead add a sleep. If this doesn't fix the brittleness we might want to restart virtqemud.