### PR TITLE
v2v:fix cpu-topology TC

### DIFF
--- a/v2v/tests/cfg/convert_from_file.cfg
+++ b/v2v/tests/cfg/convert_from_file.cfg
@@ -114,10 +114,10 @@
                                 - cpu_topology:
                                     checkpoint = 'cpu_topology'
                                     v2v_debug = force_on
-                                    ova_file_name = OVA_DIR_RHEL_LINUX_V2V_EXAMPLE.ova
-                                    ova_dir = ${ova_file_name}
+                                    ova_file_name = OVA_FILE_CPU_TOPOLOGY_V2V_EXAMPLE
+                                    ova_dir = OVA_DIR_ROOT_V2V_EXAMPLE
                                     ova_copy_dir = 'OVA_DIR_COPY_V2V_EXAMPLE'
-                                    input_file = ${ova_copy_dir}/${ova_file_name}
+                                    input_file = ${ova_dir}/${ova_file_name}
                                     msg_content_yes = ''
                         - special:
                             ova_dir = 'OVA_DIR_SPECIAL_V2V_EXAMPLE'


### PR DESCRIPTION
Fix the failed TC:
FileNotFoundError: [Errno 2] No such file or directory: '/var/lib/libvirt/images/v2v/ova-images/esx6_7-rhel8.3-x86_64.ova'&#10;