### PR TITLE
nmi_test: disable second inject for s390x

### DIFF
--- a/libvirt/tests/cfg/guest_kernel_debugging/nmi_test.cfg
+++ b/libvirt/tests/cfg/guest_kernel_debugging/nmi_test.cfg
@@ -18,3 +18,7 @@
                     # using inject-nmi and qemu-monitor-command to send nmi,
                     # so the expected times are 2 for Non-maskable interrupts
                     expected_nmi_times = 2
+                    check_qemu_monitor = yes
+                    s390-virtio:
+                        expected_nmi_times = 0
+                        check_qemu_monitor = no

--- a/libvirt/tests/src/guest_kernel_debugging/nmi_test.py
+++ b/libvirt/tests/src/guest_kernel_debugging/nmi_test.py
@@ -77,6 +77,7 @@ def run(test, params, env):
     expected_nmi_times = params.get("expected_nmi_times", '0')
     kernel_params = params.get("kernel_params", "")
     unprivileged_user = params.get('unprivileged_user')
+    check_qemu_monitor = "yes" == params.get("check_qemu_monitor", "yes")
     if unprivileged_user:
         if unprivileged_user.count('EXAMPLE'):
             unprivileged_user = 'testacl'
@@ -115,8 +116,9 @@ def run(test, params, env):
             logging.info("Inject NMI to the guest via virsh inject_nmi")
             virsh.inject_nmi(vm_name, debug=True, ignore_status=False)
 
-            logging.info("Inject NMI to the guest via virsh qemu_monitor_command")
-            virsh.qemu_monitor_command(vm_name, '{"execute":"inject-nmi"}')
+            if check_qemu_monitor:
+                logging.info("Inject NMI to the guest via virsh qemu_monitor_command")
+                virsh.qemu_monitor_command(vm_name, '{"execute":"inject-nmi"}')
 
             # injects a Non-Maskable Interrupt into the default CPU (x86/s390)
             # or all CPUs (ppc64), as usual, the default CPU index is 0


### PR DESCRIPTION
On s390x the inject NMI behavior is different to other archs: It panics and if kdump is configured the kernel will be dumped and the guest reboots.

Both will result in the NMI inject count 0.

A second quick injection will result in a panic because kdump is not up yet.

Skip the qemu-monitor command, only check the libvirt command.