### PR TITLE
Fix Error: bad escape \\s at position 0

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_from_native.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domxml_from_native.py
@@ -34,7 +34,7 @@ def run(test, params, env):
         pid = vm.get_pid()
         cmdline = process.run("cat -v /proc/%d/cmdline" % pid).stdout_text
         cmdline = re.sub(r'\^@', ' ', cmdline)
-        cmdline_tmp = re.sub(r'\s-drive\s[^\s]+', '\s', cmdline)
+        cmdline_tmp = re.sub(r'\s-drive\s[^\s]+', ' ', cmdline)
 
         # Libvirt requires the binary path for domxml-from-native to succeed
         # /proc/pid/cmdline would give qemu cmdline with binary without


### PR DESCRIPTION
### Fix Error: bad escape \\s at position 0

From python3.7, using '\s' leads to **re ERROR**
In python3.6 and below, the same was treated as DeprecationWarning
Hence replacing '\s' in the code simply with ' ' will work

Source: [github-python/cpython-issues#27030](https://github.com/python/cpython/commit/9bd85b83f66d31e39282244e455275bd9cd91bb1#diff-a0fc71db3d118bcf5fa27a2eb5d4e9c5)
Source: [stack-overflow-bad-escape](https://stackoverflow.com/questions/58328587/python-3-7-4-re-error-bad-escape-s-at-position-0)

Signed-off-by: Misbah Anjum N [misanjum@linux.vnet.ibm.com](mailto:misanjum@linux.vnet.ibm.com)