### PR TITLE
blkdeviotune: improve test log

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_blkdeviotune.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_blkdeviotune.py
@@ -25,7 +25,7 @@ def check_blkdeviotune(params):
     vm = params.get("vm")
     options = params.get("blkdevio_options")
     device = params.get("device_name", "")
-    result = virsh.blkdeviotune(vm_name, device)
+    result = virsh.blkdeviotune(vm_name, device, ignore_status=False)
     dicts = {}
     # Parsing command output and putting them into python dictionary.
     cmd_output = result.stdout.strip().splitlines()


### PR DESCRIPTION
The test case needs the output from 'blkdeviotune' on the disk in order to compare it with the XML values.

It was trying to compare with an empty dictionary because the result was empty with an error that was ignored.

Don't continue the test if the block I/O throttle parameters cannot be retrieved. This will show a test error indicating this.