### PR TITLE
fix not found threshold value

### DIFF
--- a/libvirt/tests/src/backingchain/virsh_domblk/domblkthreshold_with_backingchain_element.py
+++ b/libvirt/tests/src/backingchain/virsh_domblk/domblkthreshold_with_backingchain_element.py
@@ -1,7 +1,9 @@
 import re
+import time
 
 from virttest import utils_disk
 from virttest import virsh
+from virttest import utils_misc
 from virttest.libvirt_xml import vm_xml
 
 from provider.backingchain import blockcommand_base
@@ -45,6 +47,7 @@ def run(test, params, env):
         Do domblkthreshold for the entire disk device target
         """
         test.log.info("TEST_STEP1:Set domblkthreshold for the entire disk")
+        time.sleep(5)
         virsh.domblkthreshold(vm_name, '%s' % target_disk,
                               domblk_threshold, debug=True,
                               ignore_status=False)
@@ -77,6 +80,12 @@ def run(test, params, env):
         :param threshold_value: domstats threshold value, if it is None,
         result should be no output
         """
+        if not utils_misc.wait_for(
+                lambda:
+                bool(threshold_value) == ('threshold' in virsh.domstats(
+                    vm_name, options, debug=True).stdout_text.strip()), 30, 2):
+            test.fail('Failed to get expected threshold value in 30s')
+
         result = virsh.domstats(vm_name, options, debug=True,
                                 ignore_status=False).stdout_text.strip()
         if not threshold_value:


### PR DESCRIPTION
Give hard wait after creating snaps
Catch inappropriate error


Before fixed
```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.virsh_domblk.entire_disk --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.backingchain.virsh_domblk.entire_disk: FAIL: Not get correct threshold: block.*.threshold=1 should be in Domain: 'avocado-vt-vm1'\n  state.state=1\n  state.reason=1\n  cpu.time=41739024000\n  cpu.user=35797449000\n  cpu.system=5941575000\n  cpu.cache.monitor.count=0\n  cpu.haltpoll.success.time=96832680\n  ... (56.38 s)
```

After fixed

```
 avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.virsh_domblk.entire_disk --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.backingchain.virsh_domblk.entire_disk: PASS (73.60 s)

```

Other related cases
```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.virsh_domblk
 (1/2) type_specific.io-github-autotest-libvirt.backingchain.virsh_domblk.backing_target: PASS (76.50 s)
 (2/2) type_specific.io-github-autotest-libvirt.backingchain.virsh_domblk.entire_disk: PASS (72.00 s)

```