### PR TITLE
fix incorrect memory negative case error msg

### DIFF
--- a/libvirt/tests/cfg/memory/memory_devices/invalid_dimm_memory_device_config.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/invalid_dimm_memory_device_config.cfg
@@ -38,8 +38,6 @@
             addr_type = 'fakedimm'
             define_error = "Invalid value for attribute 'type' in element 'address': '${addr_type}'"
             define_error_8 = "unknown address type '${addr_type}'"
-            aarch64:
-                define_error = "unknown address type '${addr_type}'"
     addr_dict = "'address':{'attrs': {'type': '${addr_type}', 'base': '${addr_base}', 'slot': '${slot}'}}"
     source_dict = "'source': {'nodemask': '${node_mask}','pagesize': %d, 'pagesize_unit':'${pagesize_unit}'}"
     dimm_dict = {'mem_model':'dimm', ${source_dict}, ${addr_dict}, 'target': {'size':${target_size}, 'size_unit':'KiB','node':${guest_node}}}


### PR DESCRIPTION
Before fixed:
```

avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio memory.devices.invalid_dimm.with_numa.invalid_addr_type --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.memory.devices.invalid_dimm.with_numa.invalid_addr_type: FAIL: Expect to get 'unknown address type 'fakedimm'' error, but got 'Failed to define avocado-vt-vm1 for reason:\nerror: Failed to define domain from /tmp/xml_utils_temp_vcdw24g9.xml\nerror: XML error: Invalid value for attribute 'type' in element 'address': 'fa... (8.29 s)

```


After fixed: rhel9+arm ,rhel8+arm ---TBD
```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio memory.devices.invalid_dimm.with_numa.invalid_addr_type --vt-connect-uri qemu:///system

 (1/1) type_specific.io-github-autotest-libvirt.memory.devices.invalid_dimm.with_numa.invalid_addr_type: PASS (9.96 s)

```