### PR TITLE
virtual_networks: Extend the timeout for obtaining guest IP

### DIFF
--- a/libvirt/tests/src/virtual_network/virtual_network_multivms.py
+++ b/libvirt/tests/src/virtual_network/virtual_network_multivms.py
@@ -368,7 +368,7 @@ def run(test, params, env):
             for vm_i in vm_list:
                 mac = vm_xml.VMXML.get_first_mac_by_name(vm_i.name)
                 sess = vm_i.wait_for_serial_login()
-                vm_ip = utils_net.get_guest_ip_addr(sess, mac)
+                vm_ip = utils_net.get_guest_ip_addr(sess, mac, timeout=5)
                 session_n_ip[sess] = vm_ip
                 logging.debug('Vm %s ip: %s', vm_i.name, vm_ip)
                 if not vm_ip:


### PR DESCRIPTION
The guest ip addr may not be obtained within 1 second, extend the timeout to 5.

Before:
```
(1/1) type_specific.io-github-autotest-libvirt.virtual_network.multivms.port_isolated.iface.set_iface.with_net.set_one:  ERROR: Got vm avocado-vt-vm1 ip as None! (129.72 s)
```

After:
```
(1/1) type_specific.io-github-autotest-libvirt.virtual_network.multivms.port_isolated.iface.set_iface.with_net.set_one:  PASS (178.31 s)
```