### PR TITLE
passt: fix check_default_gw

### DIFF
--- a/libvirt/tests/src/virtual_network/passt/passt_attach_detach.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_attach_detach.py
@@ -126,7 +126,7 @@ def run(test, params, env):
             session = vm.wait_for_serial_login(timeout=60)
             passt.check_vm_ip(iface_attrs, session, host_iface, vm_iface)
             passt.check_vm_mtu(session, vm_iface, mtu)
-            passt.check_default_gw(session)
+            passt.check_default_gw(session, host_iface)
             passt.check_nameserver(session)
 
             ips = {

--- a/libvirt/tests/src/virtual_network/passt/passt_function.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_function.py
@@ -99,7 +99,7 @@ def run(test, params, env):
         session = vm.wait_for_serial_login(timeout=60)
         passt.check_vm_ip(iface_attrs, session, host_iface, vm_iface)
         passt.check_vm_mtu(session, vm_iface, mtu)
-        passt.check_default_gw(session)
+        passt.check_default_gw(session, host_iface)
         passt.check_nameserver(session)
 
         ips = {

--- a/libvirt/tests/src/virtual_network/passt/passt_reconnect.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_reconnect.py
@@ -111,7 +111,7 @@ def run(test, params, env):
         session = vm.wait_for_serial_login(timeout=60)
         passt.check_vm_ip(iface_attrs, session, host_iface, vm_iface)
         passt.check_vm_mtu(session, vm_iface, mtu)
-        passt.check_default_gw(session)
+        passt.check_default_gw(session, host_iface)
         passt.check_nameserver(session)
 
         ips = {

--- a/libvirt/tests/src/virtual_network/passt/passt_transfer_file.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_transfer_file.py
@@ -172,7 +172,7 @@ def run(test, params, env):
         LOG.debug(virsh_ins.dumpxml(vm_name).stdout_text)
 
         session = vm.wait_for_serial_login(timeout=60)
-        passt.check_default_gw(session)
+        passt.check_default_gw(session, host_iface)
 
         prot = 'TCP' if ip_ver == 'ipv4' else 'TCP6'
         if direction == 'host_to_vm':


### PR DESCRIPTION
The default gateway function in utils_net now will return None when it detects ipv6 multipath.

Update the provider code to fail the test if this is the case. If not, the test case will fail with "NoneType" object has no attribute 'split'".

Also, pass the host interface to be tested to have more control.