### PR TITLE
numa: Enable test for ARM 16G hugepage memory

### DIFF
--- a/libvirt/tests/cfg/numa/host_numa/host_numa_info.cfg
+++ b/libvirt/tests/cfg/numa/host_numa/host_numa_info.cfg
@@ -8,3 +8,8 @@
             allocate_dict = {2048: 200, 1048576: 2}
             aarch64:
                 allocate_dict = {2048: 200, 524288: 4}
+        - 16G:
+            only aarch64
+            required_kernel = [5.14.0,)
+            expect_nodes_num = 1
+            allocate_dict = {16777216: 1}


### PR DESCRIPTION
There are relatively few arm machines with 2 numa nodes that can allocate 16G large pages, so the test for 16G hugepage memory was adjusted to the machine with one numa node.

Test results on one numa node ARM machine:
```
 (1/2) type_specific.io-github-autotest-libvirt.host_numa.numa_info.default: CANCEL: Expect 2 numa nodes at least, but found 1 (9.33 s)
 (2/2) type_specific.io-github-autotest-libvirt.host_numa.numa_info.16G: PASS (39.34 s)
```

Test results on two numa nodes ARM machine:
```
 (1/2) type_specific.io-github-autotest-libvirt.host_numa.numa_info.default: PASS (28.98 s)
 (2/2) type_specific.io-github-autotest-libvirt.host_numa.numa_info.16G: CANCEL: Can not set at least one page with pagesize '16777216' on node '0' (42.56 s)
```