### PR TITLE
Storage: fix different results after restarting service for logical pool

### DIFF
--- a/libvirt/tests/src/storage/virsh_pool.py
+++ b/libvirt/tests/src/storage/virsh_pool.py
@@ -422,8 +422,9 @@ def run(test, params, env):
             # pool as active. This is independent of autostart.
             # So a directory based storage pool is thus pretty much always active,
             # and so as the SCSI pool.
-            if pool_type not in ['dir', 'scsi', 'logical']:
-                if pool_type == 'disk' and libvirt_version.version_compare(8, 1, 0):
+            if pool_type not in ['dir', 'scsi']:
+                if (pool_type == 'disk' and libvirt_version.version_compare(8, 1, 0)) or \
+                   (pool_type == 'logical' and libvirt_version.version_compare(9, 9, 0)):
                     utlv.check_exit_status(result)
                 else:
                     result = virsh.pool_start(pool_name, ignore_status=True)


### PR DESCRIPTION
The logical pool will be active from libvirt-9.9.0 after restarting service. So it need have different results before and after this version. This PR mainly fix the left issue which is not considered before.