### PR TITLE
Check the cpu topology from virsh capabilities is the subset of result from system

### DIFF
--- a/libvirt/tests/src/numa/host_numa/host_numa_info.py
+++ b/libvirt/tests/src/numa/host_numa/host_numa_info.py
@@ -318,9 +318,9 @@ def verify_node_cpus_under_cell(test_obj, cpu_list, node_id):
     one_numa_node = NumaNode(int(node_id) + 1)
     for one_cpu_dict in cpu_list:
         cpu_info_in_sys = one_numa_node.get_cpu_topology(one_cpu_dict['id'])
-        if one_cpu_dict != cpu_info_in_sys:
+        if not set(one_cpu_dict.items()).issubset(cpu_info_in_sys.items()):
             test_obj.test.fail("Expect cpu '%s' in node '%s' "
-                               "to be '%s', but found "
+                               "to be included in '%s', but found "
                                "'%s'" % (one_cpu_dict['id'],
                                          node_id,
                                          cpu_info_in_sys,


### PR DESCRIPTION
Since in rhel8 the cpu cluster_id is not available from virsh capabilities, so change the comparison logic to checking the cpu topology from virsh capabilities is the subset of result from system

result on rhel9:
 (1/1) type_specific.io-github-autotest-libvirt.host_numa.numa_info.default: PASS (8.75 s)

result on rhel8:
 (1/1) type_specific.io-github-autotest-libvirt.host_numa.numa_info.default: PASS (10.94 s)

