### PR TITLE
emulatorpin: enable test case always

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_emulatorpin.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_emulatorpin.py
@@ -254,9 +254,6 @@ def run(test, params, env):
     check_cpus_allowed_list = "yes" == params.get("check_cpus_allowed_list", "")
 
     host_cpus_num = cpu.online_count()
-    if all_cpuset and int(host_cpus_num) % 8 != 0:
-        test.cancel("Host cpu number is expected to be multiple of 8, "
-                    "but found %s" % host_cpus_num)
     # Backup original vm
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     vmxml_backup = vmxml.copy()


### PR DESCRIPTION
The test case is valuable even if the number of host cpus is not a multiple of 8 which is a special subcase of issue reported in https://bugzilla.redhat.com/show_bug.cgi?id=1227180

Instead of skipping if this is not a case run it still.

We'll have an internal test doc to document the behavior in case of multiple of 8.