### PR TITLE
controller_functional: add alias case

### DIFF
--- a/libvirt/tests/cfg/controller/controller_functional.cfg
+++ b/libvirt/tests/cfg/controller/controller_functional.cfg
@@ -12,7 +12,7 @@
             controller_type = pci
             variants:
                 - pci_bridge_auto_add:
-                    only i440fx 
+                    only i440fx
                     remove_address = "no"
                     variants:
                         - no_pci_controller:
@@ -36,7 +36,7 @@
                     controller_model = pci-root
                     controller_pcihole64 = 1024
                 - pcie_root:
-                    only q35
+                    only q35, aarch64
                     controller_type = pci
                     controller_model = pcie-root
                 - second_level_bridge:
@@ -50,19 +50,33 @@
                       controller_type = virtio-serial
                       controller_bus = ccw
                 - controller_alias:
-                    only i440fx
-                    add_contrl_list = "[{'model': 'pci-root', 'index': '0', 'alias': 'ua-PCI_ROOT'},{'model': 'pci-bridge', 'alias': 'ua-PCI_BRIDGE'}, {'model': 'pci-expander-bus', 'alias': 'ua-PCI_EXPANDER_BUS'}]"
-                    qemu_patterns = "[('-device', 'pci-bridge.*,.*,.*id.*ua-PCI_BRIDGE'), ('-device', 'pxb.*,.*,.*id.*ua-PCI_EXPANDER_BUS')]"
+                    no s390-virtio, pseries
+                    pcie_root_config = {'model': 'pcie-root', 'index': '0', 'alias': 'ua-ROOT'}
+                    pcie_root_port_config = {'model': 'pcie-root-port', 'alias': 'ua-ROOT_PORT'}
+                    pcie_root_port2_config = {'model': 'pcie-root-port', 'alias': 'ua-ROOT_PORT2'}
+                    pcie_to_pci_bridge_config = {'model': 'pcie-to-pci-bridge', 'alias': 'ua-ROOT_PCIE_PCI'}
+                    pci_bridge_config = {'model': 'pci-bridge', 'alias': 'ua-PCI_BRIDGE'}
+                    pcie_switch_upstream_port = {'model': 'pcie-switch-upstream-port', 'alias': 'ua-UPSTREAM_PORT'}
+                    pcie_switch_downstream_port = {'model': 'pcie-switch-downstream-port', 'alias': 'ua-DOWNSTREAM_PORT'}
+                    pci_expander_bus_config = {'model': 'pcie-expander-bus', 'alias': 'ua-PCIE_EXPANDER_BUS'}
+                    add_contrl_list = "[${pcie_root_config},${pcie_root_port_config}, ${pcie_root_port2_config}, ${pcie_to_pci_bridge_config}, ${pci_bridge_config}, ${pcie_switch_upstream_port}, ${pcie_switch_downstream_port}, ${pci_expander_bus_config}]"
+                    pattern1 = "('-device', 'pcie-root-port.*,.*,.*id.*ua-ROOT_PORT'), ('-device', 'pcie-root-port.*,.*,.*id.*ua-ROOT_PORT2')"
+                    pattern2 = "('-device', 'pcie-pci-bridge.*,.*id.*ua-ROOT_PCIE_PCI'), ('-device', 'pci-bridge.*,.*,.*id.*ua-PCI_BRIDGE')"
+                    pattern3 = "('-device', 'upstream.*,.*id.*ua-UPSTREAM_PORT'),('-device', 'downstream.*,.*id.*ua-DOWNSTREAM_PORT')"
+                    qemu_patterns = "[${pattern1},${pattern2},${pattern3},('-device', 'pxb-pcie.*,.*,.*id.*ua-PCIE_EXPANDER_BUS')]"
+                    i440fx:
+                        add_contrl_list = "[{'model': 'pci-root', 'index': '0', 'alias': 'ua-PCI_ROOT'},{'model': 'pci-bridge', 'alias': 'ua-PCI_BRIDGE'}, {'model': 'pci-expander-bus', 'alias': 'ua-PCI_EXPANDER_BUS'}]"
+                        qemu_patterns = "[('-device', 'pci-bridge.*,.*,.*id.*ua-PCI_BRIDGE'), ('-device', 'pxb.*,.*,.*id.*ua-PCI_EXPANDER_BUS')]"
                     check_contr_addr = "no"
                     check_within_guest = "no"
                 - pcie_root_port_model:
-                    only q35
+                    only q35, aarch64
                     run_vm = "yes"
                     check_contr_addr = "no"
                     remove_contr = "no"
                     new_model = pcie-root-port
                     old_model = ioh3420
-                    auto_index = "yes"
+                    auto_index= "yes"
                     attach_option = "--address pci:0000.%s.00.0"
                     qemu_patterns = "[('-device', 'pcie-root-port.*,.*id.*pci.%s.*,.*bus.*pcie.0.*,.*addr.*0x2')]"
                     guest_patterns = "['00:.* PCI bridge: Red Hat']"
@@ -168,7 +182,7 @@
                     controller_type = virtio-serial
                     controller_vectors = '1'
                 - virtio_serial_0_vectors:
-                    no q35
+                    no q35, aarch64
                     controller_type = virtio-serial
                     controller_vectors = '0'
                 - usb_controller:
@@ -177,10 +191,10 @@
                     variants:
                         # ehci and ich9-ehci1 are USB2.0 controller model
                         - ehci_model:
-                            no pseries
+                            no pseries, aarch64
                             controller_model = ehci
                         - ich9_ehci1_model:
-                            no pseries
+                            no pseries, aarch64
                             controller_model = ich9-ehci1
                             companion_controller_model = ich9-uhci
                             companion_controller_num = 3
@@ -188,7 +202,7 @@
                             controller_index = 0
                         # nec-xhci and qemu-xhci are USB3.0 controller model
                         - nec_xhci_model:
-                            no pseries
+                            no pseries, aarch64
                             controller_model = nec-xhci
                         - qemu_xhci_model:
                             variants:
@@ -217,7 +231,7 @@
                                     only i440fx
                                     controller_model = pci-root
                                 - pcie_root:
-                                    only q35
+                                    only q35, aarch64
                                     controller_model = pcie-root
                         - negative:
                             controller_index = -1
@@ -226,7 +240,7 @@
                                 - pci_bridge:
                                     controller_model = pci-bridge
                                 - pcie_root:
-                                    only q35
+                                    only q35, aarch64
                                     controller_model = pcie-root
                         - zero:
                             controller_index = 0
@@ -300,7 +314,7 @@
                             controller_model = 'pcie-root'
                             err_msg = "The PCI controller.*index='0' must be model='pci-root'"
                         - pci_root_model:
-                            only q35
+                            only q35, aarch64
                             controller_model = 'pci-root'
                             err_msg = "The PCI controller.*index='0' must be model='pcie-root'"
                         - other_model:


### PR DESCRIPTION
- Add alias for some pcie related controllers and check in qemu command line.
- Enable some cases on arm

Signed-off-by: Dan Zheng <dzheng@redhat.com>