### PR TITLE
v2v:fix func TC "unset virtio-win"

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -173,7 +173,7 @@
                     variants:
                         - unset:
                             checkpoint += 'unset'
-                            missing = 'Red Hat VirtIO SCSI,Red Hat VirtIO Ethernet Adapte'
+                            missing = 'Red Hat VirtIO SCSI,Red Hat VirtIO Ethernet Adapte,VirtIO RNG,VirtIO Serial,VirtIO Balloon'
                             only dest_libvirt
                         - custom:
                             checkpoint += 'custom'


### PR DESCRIPTION
Enabling virtio
       "Virtio" is the name for a set of drivers which make disk (block device), network and other guest operations work much faster on KVM.
