### PR TITLE
Add new case of update-device of interface qos

### DIFF
--- a/libvirt/tests/cfg/virtual_network/update_device/update_iface_qos.cfg
+++ b/libvirt/tests/cfg/virtual_network/update_device/update_iface_qos.cfg
@@ -1,0 +1,38 @@
+- virtual_network.update_device.iface_qos:
+    type = update_iface_qos
+    start_vm = no
+    timeout = 240
+    host_iface =
+    extra_attrs = {}
+    variants:
+        - inbound_outbound:
+            scope = ['inbound', 'outbound']
+        - inbound_only:
+            scope = ['outbound']
+        - outbound_only:
+            scope = ['outbound']
+    variants operation:
+        - add:
+            update_attrs = {'bandwidth': {'outbound': {'average': '200', 'peak': '400', 'burst': '600'},'inbound': {'average': '100', 'peak': '300', 'burst': '500'}}}
+        - update:
+            extra_attrs = {'bandwidth': {'outbound': {'average': '200', 'peak': '400', 'burst': '600'},'inbound': {'average': '100', 'peak': '300', 'burst': '500'}}}
+            update_attrs = {'bandwidth': {'outbound': {'average': '300', 'peak': '400', 'burst': '500'},'inbound': {'average': '500', 'peak': '700', 'burst': '900'}}}
+        - delete:
+            extra_attrs = {'bandwidth': {'outbound': {'average': '200', 'peak': '400', 'burst': '600'},'inbound': {'average': '100', 'peak': '300', 'burst': '500'}}}
+            update_attrs = {'bandwidth': {'outbound': {'average': '0', 'peak': '0', 'burst': '0'},'inbound': {'average': '0', 'peak': '0', 'burst': '0'}}}
+    variants method:
+        - update-device:
+            delete:
+                only inbound_outbound
+        - domiftune:
+    variants iface_setting:
+        - net_iface_default_net:
+            iface_attrs = {'source': {'network': 'default'}, 'type_name': 'network'}
+        - br_iface_linux_br:
+            br_type = linux_br
+            iface_attrs = {'type_name': 'bridge', 'source': {'bridge': br_name}}
+        - br_iface_ovs_br:
+            br_type = ovs_br
+            iface_attrs = {'type_name': 'bridge', 'source': {'bridge': br_name}, 'virtualport': {'type': 'openvswitch'}}
+        - direct_bridge_iface:
+            iface_attrs = {'type_name': 'direct', 'source': {'dev': host_iface, 'mode': 'bridge'}}

--- a/libvirt/tests/src/virtual_network/update_device/update_iface_qos.py
+++ b/libvirt/tests/src/virtual_network/update_device/update_iface_qos.py
@@ -1,0 +1,173 @@
+import logging
+
+from avocado.utils import process
+from virttest import utils_misc
+from virttest import utils_net
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_misc
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+from provider.virtual_network import network_base
+
+VIRSH_ARGS = {'ignore_status': False, 'debug': True}
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+
+def domiftune_to_dict(output):
+    """
+    Convert domiftune output to dict
+
+    :param output: domiftune output
+    :return: converted dict
+    """
+    tmp_dict = libvirt_misc.convert_to_dict(output, '(\S+)\s*:\s*(\d+)')
+    final = {}
+    final['inbound'] = {k.split('.')[-1]: v for k, v in tmp_dict.items()
+                        if k.startswith('inbound')}
+    final['outbound'] = {k.split('.')[-1]: v for k, v in tmp_dict.items()
+                         if k.startswith('outbound')}
+    return final
+
+
+def run(test, params, env):
+    """
+    Test live update interface bandwidth setting by update-device or domiftune
+    """
+    vm_name = params.get('main_vm')
+    vm = env.get_vm(vm_name)
+    br_type = params.get('br_type', '')
+    rand_id = utils_misc.generate_random_string(3)
+    br_name = br_type + '_' + rand_id
+    host_iface = params.get('host_iface')
+    host_iface = host_iface if host_iface else utils_net.get_net_if(
+        state='UP')[0]
+    iface_attrs = eval(params.get('iface_attrs', '{}'))
+    extra_attrs = eval(params.get('extra_attrs', '{}'))
+    net_attrs = eval(params.get('net_attrs', '{}'))
+
+    scope = eval(params.get('scope', '[]'))
+    method = params.get('method', '')
+    operation = params.get('operation', '')
+
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+
+    try:
+        if br_type == 'linux_br':
+            utils_net.create_linux_bridge_tmux(br_name, host_iface)
+            process.run(f'ip l show type bridge {br_name}', shell=True)
+        elif br_type == 'ovs_br':
+            utils_net.create_ovs_bridge(br_name)
+
+        vmxml.del_device('interface', by_tag=True)
+
+        # Update iface_attrs with certain bandwidth settings
+        extra_attrs = {'bandwidth': {k: extra_attrs['bandwidth'][k]
+                                     for k in scope}
+                       } if extra_attrs else extra_attrs
+        iface_attrs.update(extra_attrs)
+        libvirt_vmxml.modify_vm_device(vmxml, 'interface', iface_attrs)
+        LOG.debug(f'VMXML of {vm_name}:\n{virsh.dumpxml(vm_name).stdout_text}')
+
+        # For direct interface type, "tc class show dev" will show the outbound
+        # instead of the inbound setting, and "tc filter show dev" will show
+        # the inbound instead of the outbound setting
+        iface_type = iface_attrs['type_name']
+        class_key = 'outbound' if iface_type == 'direct' else 'inbound'
+        filter_key = 'inbound' if iface_type == 'direct' else 'outbound'
+
+        vm.start()
+        session = vm.wait_for_serial_login()
+
+        iface = network_base.get_iface_xml_inst(vm_name, 'on vm')
+        mac = iface.mac_address
+        tap_device = libvirt.get_ifname_host(vm_name, mac)
+        LOG.debug(f'tap device on host with mac {mac} is: {tap_device}.')
+
+        if 'bandwidth' in iface_attrs:
+            if class_key in scope and not utils_net.check_class_rules(
+                    tap_device, '1:1', iface_attrs['bandwidth'][class_key]):
+                test.fail(
+                    'Class rule check before update failed. Please check log.')
+            if filter_key in scope and not utils_net.check_filter_rules(
+                    tap_device, iface_attrs['bandwidth'][filter_key]):
+                test.fail(
+                    'Filter rule check before update failed. Please check log.')
+
+        # Remove out-of-scope settings
+        update_attrs = eval(params.get('update_attrs', '{}'))
+        update_attrs['bandwidth'] = {k: update_attrs['bandwidth'][k]
+                                     for k in scope}
+        LOG.debug(f'Update iface with attrs: {update_attrs}')
+        if method == 'update-device':
+            if operation == 'delete':
+                iface.del_bandwidth()
+            else:
+                iface.setup_attrs(**update_attrs)
+            LOG.debug(f'Update iface with xml:\n{iface}')
+            virsh.update_device(vm_name, iface.xml, **VIRSH_ARGS)
+
+        elif method == 'domiftune':
+            domiftune_args = {}
+            if 'inbound' in scope:
+                bw_in = update_attrs['bandwidth']['inbound']
+                inbound = f'{bw_in["average"]},{bw_in["peak"]},{bw_in["burst"]}'
+                domiftune_args.update({'inbound': inbound})
+            if 'outbound' in scope:
+                bw_out = update_attrs['bandwidth']['outbound']
+                outbound = f'{bw_out["average"]},{bw_out["peak"]},{bw_out["burst"]}'
+                domiftune_args.update({'outbound': outbound})
+            virsh.domiftune(vm_name, tap_device, **
+                            domiftune_args, **VIRSH_ARGS)
+        else:
+            test.error(f'Unsupported method: {method}.')
+
+        iface_update = network_base.get_iface_xml_inst(vm_name, 'after update')
+        if operation == 'delete':
+            if 'bandwidth' in iface_update.fetch_attrs():
+                test.fail('Bandwidth of interface xml not deleted')
+        else:
+            LOG.debug(iface_update.bandwidth)
+            for key in scope:
+                if iface_update.fetch_attrs()['bandwidth'][key] != update_attrs['bandwidth'][key]:
+                    test.fail(
+                        'Bandwidth of interface xml not correctly updated')
+
+        if operation == 'delete':
+            out_c = process.run(f'tc class show dev {tap_device}'
+                                ).stdout_text.strip()
+            out_f = process.run(f'tc filter show dev {tap_device} parent ffff'
+                                ).stdout_text.strip()
+            if any([out_c, out_f]):
+                test.fail('There should not be output of tc class/filter '
+                          'command when bandwidth settings is deleted.')
+        else:
+            if class_key in scope and not utils_net.check_class_rules(
+                    tap_device, '1:1', update_attrs['bandwidth'][class_key]):
+                test.fail(
+                    'Class rule check after update failed. Please check log.')
+            if filter_key in scope and not utils_net.check_filter_rules(
+                    tap_device, update_attrs['bandwidth'][filter_key]):
+                test.fail(
+                    'Filter rule check after update failed. Please check log.')
+
+        domiftune_output = virsh.domiftune(vm_name, tap_device,
+                                           **VIRSH_ARGS).stdout_text
+        domiftune_dict = domiftune_to_dict(domiftune_output)
+        LOG.debug(f'domiftune to dict: {domiftune_dict}')
+        for key in scope:
+            if not update_attrs['bandwidth'][key].items() <= \
+                    domiftune_dict[key].items():
+                test.fail(f'domiftune {key} check fail.')
+
+    finally:
+        if 'session' in locals():
+            session.close()
+        bkxml.sync()
+        if br_type == 'linux_br':
+            utils_net.delete_linux_bridge_tmux(br_name, host_iface)
+        if br_type == 'ovs_br':
+            utils_net.delete_ovs_bridge(br_name)


### PR DESCRIPTION
- VIRT-294746 - [update-device][qos] Live update interface bandwidth setting by update-device or domiftune

Test result:
```
 (01/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.net_iface_default_net.update-device.add.inbound_outbound: PASS (46.34 s)
 (02/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.net_iface_default_net.update-device.add.inbound_only: PASS (79.46 s)
 (03/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.net_iface_default_net.update-device.add.outbound_only: PASS (79.48 s)
 (04/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.net_iface_default_net.update-device.update.inbound_outbound: PASS (79.49 s)
 (05/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.net_iface_default_net.update-device.update.inbound_only: PASS (79.68 s)
 (06/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.net_iface_default_net.update-device.update.outbound_only: PASS (79.48 s)
 (07/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.net_iface_default_net.update-device.delete.inbound_outbound: PASS (79.57 s)
 (08/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.net_iface_default_net.domiftune.add.inbound_outbound: PASS (79.36 s)
 (09/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.net_iface_default_net.domiftune.add.inbound_only: PASS (79.58 s)
 (10/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.net_iface_default_net.domiftune.add.outbound_only: PASS (79.38 s)
 (11/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.net_iface_default_net.domiftune.update.inbound_outbound: PASS (79.55 s)
 (12/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.net_iface_default_net.domiftune.update.inbound_only: PASS (45.87 s)
 (13/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.net_iface_default_net.domiftune.update.outbound_only: PASS (79.41 s)
 (14/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.net_iface_default_net.domiftune.delete.inbound_outbound: PASS (79.36 s)
 (15/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.net_iface_default_net.domiftune.delete.inbound_only: PASS (79.45 s)
 (16/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.net_iface_default_net.domiftune.delete.outbound_only: PASS (79.39 s)
 (17/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.br_iface_linux_br.update-device.add.inbound_outbound: PASS (70.47 s)
 (18/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.br_iface_linux_br.update-device.add.inbound_only: PASS (71.18 s)
 (19/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.br_iface_linux_br.update-device.add.outbound_only: PASS (68.24 s)
 (20/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.br_iface_linux_br.update-device.update.inbound_outbound: PASS (66.42 s)
 (21/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.br_iface_linux_br.update-device.update.inbound_only: PASS (66.77 s)
 (22/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.br_iface_linux_br.update-device.update.outbound_only: PASS (68.27 s)
 (23/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.br_iface_linux_br.update-device.delete.inbound_outbound: PASS (67.90 s)
 (24/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.br_iface_linux_br.domiftune.add.inbound_outbound: PASS (67.73 s)
 (25/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.br_iface_linux_br.domiftune.add.inbound_only: PASS (67.29 s)
 (26/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.br_iface_linux_br.domiftune.add.outbound_only: PASS (70.94 s)
 (27/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.br_iface_linux_br.domiftune.update.inbound_outbound: PASS (70.26 s)
 (28/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.br_iface_linux_br.domiftune.update.inbound_only: PASS (70.37 s)
 (29/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.br_iface_linux_br.domiftune.update.outbound_only: PASS (68.11 s)
 (30/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.br_iface_linux_br.domiftune.delete.inbound_outbound: PASS (65.52 s)
 (31/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.br_iface_linux_br.domiftune.delete.inbound_only: PASS (69.64 s)
 (32/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.br_iface_linux_br.domiftune.delete.outbound_only: PASS (68.15 s)
 (33/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.br_iface_ovs_br.update-device.add.inbound_outbound: FAIL: Class rule check after update failed. Please check log. (72.47 s)
 (34/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.br_iface_ovs_br.update-device.add.inbound_only: FAIL: Filter rule check after update failed. Please check log. (73.88 s)
 (35/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.br_iface_ovs_br.update-device.add.outbound_only: FAIL: Filter rule check after update failed. Please check log. (76.17 s)
 (36/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.br_iface_ovs_br.update-device.update.inbound_outbound: FAIL: Filter rule check before update failed. Please check log. (73.09 s)
 (37/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.br_iface_ovs_br.update-device.update.inbound_only: FAIL: Filter rule check before update failed. Please check log. (74.45 s)
 (38/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.br_iface_ovs_br.update-device.update.outbound_only: FAIL: Filter rule check before update failed. Please check log. (75.16 s)
 (39/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.br_iface_ovs_br.update-device.delete.inbound_outbound: FAIL: Filter rule check before update failed. Please check log. (70.88 s)
 (40/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.br_iface_ovs_br.domiftune.add.inbound_outbound: FAIL: Class rule check after update failed. Please check log. (76.02 s)
 (41/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.br_iface_ovs_br.domiftune.add.inbound_only: FAIL: Filter rule check after update failed. Please check log. (76.40 s)
 (42/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.br_iface_ovs_br.domiftune.add.outbound_only: FAIL: Filter rule check after update failed. Please check log. (71.48 s)
 (43/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.br_iface_ovs_br.domiftune.update.inbound_outbound: FAIL: Filter rule check before update failed. Please check log. (70.90 s)
 (44/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.br_iface_ovs_br.domiftune.update.inbound_only: FAIL: Filter rule check before update failed. Please check log. (75.12 s)
 (45/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.br_iface_ovs_br.domiftune.update.outbound_only: FAIL: Filter rule check before update failed. Please check log. (71.50 s)
 (46/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.br_iface_ovs_br.domiftune.delete.inbound_outbound: FAIL: Filter rule check before update failed. Please check log. (75.16 s)
 (47/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.br_iface_ovs_br.domiftune.delete.inbound_only: FAIL: Filter rule check before update failed. Please check log. (71.74 s)
 (48/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.br_iface_ovs_br.domiftune.delete.outbound_only: FAIL: Filter rule check before update failed. Please check log. (73.74 s)
 (49/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.direct_bridge_iface.update-device.add.inbound_outbound: PASS (45.15 s)
 (50/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.direct_bridge_iface.update-device.add.inbound_only: PASS (45.12 s)
 (51/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.direct_bridge_iface.update-device.add.outbound_only: PASS (45.33 s)
 (52/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.direct_bridge_iface.update-device.update.inbound_outbound: PASS (45.54 s)
 (53/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.direct_bridge_iface.update-device.update.inbound_only: PASS (45.39 s)
 (54/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.direct_bridge_iface.update-device.update.outbound_only: PASS (45.19 s)
 (55/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.direct_bridge_iface.update-device.delete.inbound_outbound: PASS (45.10 s)
 (56/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.direct_bridge_iface.domiftune.add.inbound_outbound: PASS (45.40 s)
 (57/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.direct_bridge_iface.domiftune.add.inbound_only: PASS (45.30 s)
 (58/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.direct_bridge_iface.domiftune.add.outbound_only: PASS (45.49 s)
 (59/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.direct_bridge_iface.domiftune.update.inbound_outbound: PASS (46.15 s)
 (60/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.direct_bridge_iface.domiftune.update.inbound_only: PASS (45.58 s)
 (61/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.direct_bridge_iface.domiftune.update.outbound_only: PASS (46.20 s)
 (62/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.direct_bridge_iface.domiftune.delete.inbound_outbound: PASS (45.57 s)
 (63/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.direct_bridge_iface.domiftune.delete.inbound_only: PASS (45.12 s)
 (64/64) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.direct_bridge_iface.domiftune.delete.outbound_only: PASS (45.74 s)
RESULTS    : PASS 48 | ERROR 0 | FAIL 16 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```
The failed cases were caused by an known issue.