### PR TITLE
Add new case of update-device of iface qos:invalid value

### DIFF
--- a/libvirt/tests/cfg/virtual_network/update_device/update_iface_qos_invalid.cfg
+++ b/libvirt/tests/cfg/virtual_network/update_device/update_iface_qos_invalid.cfg
@@ -1,0 +1,19 @@
+- virtual_network.update_device.iface_qos.invalid:
+    type = update_iface_qos_invalid
+    start_vm = no
+    timeout = 240
+    status_error = yes
+    iface_attrs = {'source': {'network': 'default'}, 'type_name': 'network', 'model': 'virtio'}
+    variants:
+        - neg_value:
+            update_attrs = {'bandwidth': {'inbound': {'average': '-1', 'peak': '5000', 'burst': '1024'}}}
+            err_msg = could not convert bandwidth average value|Expected non-negative integer value
+        - big_value:
+            update_attrs = {'bandwidth': {'inbound': {'average': '10000000000000000', 'peak': '5000', 'burst': '1024'}}}
+            err_msg = could not convert bandwidth average value|Expected non-negative integer value
+        - no_mandatory_average:
+            update_attrs = {'bandwidth': {'outbound': {'peak': '5000', 'burst': '1024'}}}
+            err_msg = Missing mandatory average or floor attributes
+        - floor_without_bandwidth:
+            update_attrs = {'bandwidth': {'outbound': {'average': '128', 'peak': '256', 'burst': '256'},'inbound': {'average': '1000', 'peak': '5000', 'floor': '200', 'burst': '1024'}}}
+            err_msg = Invalid use of 'floor' on interface with MAC address .* - network .* has no inbound QoS set

--- a/libvirt/tests/src/virtual_network/update_device/update_iface_qos_invalid.py
+++ b/libvirt/tests/src/virtual_network/update_device/update_iface_qos_invalid.py
@@ -1,0 +1,47 @@
+import logging
+
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+from provider.virtual_network import network_base
+
+VIRSH_ARGS = {'ignore_status': False, 'debug': True}
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+
+def run(test, params, env):
+    """
+    Test live update interface bandwidth setting by update-device or domiftune
+    """
+    vm_name = params.get('main_vm')
+    vm = env.get_vm(vm_name)
+    status_error = 'yes' == params.get('status_error', 'no')
+    err_msg = params.get('err_msg')
+    iface_attrs = eval(params.get('iface_attrs', '{}'))
+    update_attrs = eval(params.get('update_attrs', '{}'))
+
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+
+    try:
+        vmxml.del_device('interface', by_tag=True)
+        libvirt_vmxml.modify_vm_device(vmxml, 'interface', iface_attrs)
+        LOG.debug(f'VMXML of {vm_name}:\n{virsh.dumpxml(vm_name).stdout_text}')
+
+        vm.start()
+        vm.wait_for_serial_login().close()
+
+        iface = network_base.get_iface_xml_inst(vm_name, 'on vm')
+        LOG.debug(f'Update iface with attrs: {update_attrs}')
+        iface.setup_attrs(**update_attrs)
+
+        LOG.debug(f'Update iface with xml:\n{iface}')
+        up_result = virsh.update_device(vm_name, iface.xml, debug=True)
+        libvirt.check_exit_status(up_result, status_error)
+        if err_msg:
+            libvirt.check_result(up_result, err_msg)
+    finally:
+        bkxml.sync()


### PR DESCRIPTION
- VIRT-294768 - [update-device][qos] Live update the QoS setting by update-device with invalid values

Test result:
```
 (1/4) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.invalid.neg_value: PASS (77.66 s)
 (2/4) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.invalid.big_value: FAIL: Expect should fail with one of ['could not convert bandwidth average value|Expected non-negative integer value'], but failed with:\n\n\nerror:  (44.55 s)
 (3/4) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.invalid.no_mandatory_average: PASS (43.56 s)
 (4/4) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_qos.invalid.floor_without_bandwidth: PASS (77.40 s)
```