### PR TITLE
libvirt_rng: revert commit to avoid timeouts

### DIFF
--- a/libvirt/tests/cfg/libvirt_rng.cfg
+++ b/libvirt/tests/cfg/libvirt_rng.cfg
@@ -8,6 +8,7 @@
     # Devices that might be present though not configured via <rng>.
     # For example, devices that are provided by the CPU.
     ignored_devices = s390-trng,trng,tpm-rng-0
+    dd_throughput = "bs=512 count=10"
     variants:
         - hotplug_unplug:
             only backend_rdm.default, backend_tcp, backend_udp, backend_builtin

--- a/libvirt/tests/src/libvirt_rng.py
+++ b/libvirt/tests/src/libvirt_rng.py
@@ -377,8 +377,8 @@ def run(test, params, env):
         rng_rate = params.get("rng_rate")
         # For rng rate test this command and return in a short time
         # but for other test it will hang
-        cmd = ("dd if=/dev/hwrng of=rng.test bs=1M count=10"
-               " && rm -f rng.test")
+        cmd = ("dd if=/dev/hwrng of=rng.test %s"
+               " && rm -f rng.test" % dd_throughput)
         try:
             ret, output = session.cmd_status_output(cmd, timeout=timeout)
             if ret and expect_fail:
@@ -488,6 +488,7 @@ def run(test, params, env):
     with_packed = "yes" == params.get("with_packed", "no")
     driver_packed = params.get("driver_packed", "on")
     urandom = "yes" == params.get("urandom", "no")
+    dd_throughput = params.get("dd_throughput")
 
     if params.get("backend_model") == "builtin" and not libvirt_version.version_compare(6, 2, 0):
         test.cancel("Builtin backend is not supported on this libvirt version")


### PR DESCRIPTION
Before commit 40b1324887851acc3abc1c88bc250faea279b032 dd read and wrote 512 bytes at a time (bs default), 100 times. This led to a total size of 51200 bytes = 0.512 KB = 0.000512 MB.

The commit set instead 1M = 1MB to be written and read at a time, 10 times. This would result in a total size of 10 MB which seems to be a typo because 10 MB are 10 000 000 bytes and the set rate limit is 2500 bytes per second in the rng_rate test cases; the test would most definitely timeout because 'dd' will need at least 4000 seconds, that is, more than 1 hr, to finish.

Because of this commit we now experience timeouts on VM that performed well, so revert it.

If there are timeouts with the original command, it is likely because the backends don't create enough entropy. Making sure that rngd is running on the test host should solve this for two major backend scenarios that use /dev/random, that is:

a) model='random', /dev/random
b) model='egd' type='tcp': the test feeds it from /dev/random, s. code

model='builtin' uses a QEMU-internal generator. The rate check tests the upper limit, so if a generator doesn't provide at a higher rate any rate is still valid, so in those cases we should test a lower rate limit.


However, on request, to avoid timeouts on low performance systems
set count to 10. This will create only 5KB and for the rate_limit
cases this would mean with a limit of 2500 B/s ~ 2.4 KB/s
2-3 seconds will be sufficient. On the other hand, as the limiting
can result in higher throughput initially, this amount might not
be enough on some systems to average out the initial deviation.
Therefore, make the throughput configurable in case the rate_limit
check fails on specific systems.