### PR TITLE
virtual_networks: Update error message to match more distros

### DIFF
--- a/libvirt/tests/cfg/virtual_network/attach_detach_device/attach_iface_with_boot_order.cfg
+++ b/libvirt/tests/cfg/virtual_network/attach_detach_device/attach_iface_with_boot_order.cfg
@@ -14,8 +14,8 @@
             err_msg = unsupported configuration: boot order ${boot_order} is already used by another device
         - neg_value:
             boot_order = -1
-            err_msg = Expected non-negative integer value
+            err_msg = Expected non-negative integer value|Expected integer value
         - str_value:
             boot_order = ss
-            err_msg = Expected non-negative integer value
+            err_msg = Expected non-negative integer value|Expected integer value
     iface_attrs = {'source': {'network': 'default'}, 'model': 'virtio', 'type_name': 'network', 'boot': '${boot_order}'}


### PR DESCRIPTION
The error messages for the negative tests are different on xxxx-8 and xxxx-9:
On xxxx-8: XML error: Invalid value for attribute 'order' in element 'boot': '-1'. Expected integer value
On xxxx-9: XML error: Invalid value for attribute 'order' in element 'boot': '-1'. Expected non-negative integer value

Test result on xxxx-8:
```
(1/1) type_specific.io-github-autotest-libvirt.virtual_network.attach_detach_device.boot_order.neg_value: PASS (24.13 s)
```

Test result on xxxx-9:
```
(1/1) type_specific.io-github-autotest-libvirt.virtual_network.attach_detach_device.boot_order.neg_value: PASS (32.42 s)
```