### PR TITLE
virtual_disk: fix error message for ccw negative case

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_ccw_addr.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_ccw_addr.cfg
@@ -10,7 +10,7 @@
         - negative_test:
            status_error = "yes"
            define_error = "yes"
-           error_msg = "cannot use CCW address type for device"
+           error_msg = "cannot use CCW address type for device | CCW addresses are not supported by machine type"
         - positive_test:
            status_error = "no"
            only attach_same_pci_slot


### PR DESCRIPTION
The error message for ccw negative case is changed now. So update the cfg file with the new error message.