### PR TITLE
vDPA: Add libvirt version check for save/restore

### DIFF
--- a/libvirt/tests/cfg/virtual_network/lifecycle/lifecycle_vdpa_interface.cfg
+++ b/libvirt/tests/cfg/virtual_network/lifecycle/lifecycle_vdpa_interface.cfg
@@ -5,6 +5,7 @@
     only x86_64
     func_supported_since_libvirt_ver = (7, 3, 0)
     func_supported_since_qemu_kvm_ver = (6, 0, 0)
+    save_supported_ver = (8, 5, 0)
     iface_dict = {"source": {'dev':'/dev/vhost-vdpa-0'}}
     variants test_target:
         - simulator:

--- a/libvirt/tests/src/virtual_network/lifecycle/lifecycle_vdpa_interface.py
+++ b/libvirt/tests/src/virtual_network/lifecycle/lifecycle_vdpa_interface.py
@@ -55,13 +55,17 @@ def run(test, params, env):
         check_points.check_network_accessibility(
             vm, test_obj=test_obj, config_vdpa=True, **params)
 
-        test.log.info("Save the VM.")
-        save_path = os.path.join(data_dir.get_tmp_dir(), vm.name + '.save')
-        virsh.save(vm.name, save_path, **VIRSH_ARGS)
-        test.log.info("Restore vm.")
-        virsh.restore(save_path, **VIRSH_ARGS)
-        check_points.check_network_accessibility(
-            vm, test_obj=test_obj, config_vdpa=False, **params)
+        save_supported_ver = {
+            'func_supported_since_libvirt_ver': params.get('save_supported_ver',
+                                                           '(8,5,0)')}
+        if libvirt_version.is_libvirt_feature_supported(save_supported_ver, True):
+            test.log.info("Save the VM.")
+            save_path = os.path.join(data_dir.get_tmp_dir(), vm.name + '.save')
+            virsh.save(vm.name, save_path, **VIRSH_ARGS)
+            test.log.info("Restore vm.")
+            virsh.restore(save_path, **VIRSH_ARGS)
+            check_points.check_network_accessibility(
+                vm, test_obj=test_obj, config_vdpa=False, **params)
 
         test.log.info("Suspend and resume the vm.")
         virsh.suspend(vm.name, **VIRSH_ARGS)


### PR DESCRIPTION
Update code to check libvirt version for saving/restore the VM with vDPA


**Test results:**
```
 (1/2) type_specific.io-github-autotest-libvirt.virtual_network.lifecycle.vdpa_interface.default.simulator: PASS (121.44 s)
 (2/2) type_specific.io-github-autotest-libvirt.virtual_network.lifecycle.vdpa_interface.default.mellanox: PASS (132.18 s)
```
