### PR TITLE
add case for dimm with memory allocation and numa

### DIFF
--- a/libvirt/tests/cfg/memory/memory_devices/dimm_memory_with_memory_alloccation_and_numa.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/dimm_memory_with_memory_alloccation_and_numa.cfg
@@ -1,0 +1,65 @@
+- memory.devices.dimm.memory_allocation_and_numa:
+    type = dimm_memory_with_memory_alloccation_and_numa
+    no s390-virtio
+    start_vm = no
+    mem_model = "dimm"
+    mem_value = 2097152
+    current_mem = 2097152
+    numa_mem = 2097152
+    mem_dict = "'memory_unit':'KiB','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'KiB'"
+    target_size = 524288
+    target_size_big = 3145728
+    format_size = "params.get('target_size')"
+    basic_xpath = [{'element_attrs':[".//memory[@unit='KiB']"],'text':'${mem_value}'},{'element_attrs':[".//currentMemory[@unit='KiB']"],'text':'${current_mem}'}]
+    dimm_numa_xpath = [{'element_attrs':[".//cell[@memory='%s']"]},{'element_attrs':[".//memory/target/size[@unit='KiB']"],'text':'%s'},{'element_attrs':[".//memory/target/node"],'text':'0'}]
+    dimm_dict = "{'mem_model':'${mem_model}','target': {'size': %s, 'size_unit': 'KiB'}}"
+    dimm_node_dict = "{'mem_model':'${mem_model}','target': {'size': %s, 'size_unit': 'KiB','node':0}}"
+    variants memory_allocation:
+        - no_maxmemory:
+            max_dict = ""
+            define_error = "cannot use/hotplug a memory device when domain 'maxMemory' is not defined"
+            hotplug_error = "${define_error}"
+            hotplug_error_2 = "can't add memory backend as guest has no NUMA nodes configured"
+        - no_slot:
+            max_mem = 10485760
+            max_dict = '"max_mem_rt": ${max_mem}, "max_mem_rt_unit": "KiB"'
+            define_error = "failed to find an empty memory slot"
+            redefine_error = "both maximum memory size and memory slot count must be specified"
+            coldplug_error = "no free memory device slot available"
+        - with_slot:
+            max_mem = 10485760
+            max_mem_slots = 16
+            max_dict = '"max_mem_rt": ${max_mem}, "max_mem_rt_slots": ${max_mem_slots}, "max_mem_rt_unit": "KiB"'
+    variants numa_setting:
+        - no_numa:
+            numa_dict = ""
+            with_slot:
+                define_error = "At least one numa node has to be configured when enabling memory hotplug"
+                big_size_msg = "Total size of memory devices exceeds the total memory size"
+            no_maxmemory:
+                coldplug_error = "can't add memory backend as guest has no NUMA nodes configured"
+        - with_numa:
+            numa_dict = "'vcpu': 6,'cpu':{'numa_cell': [{'id': '0', 'cpus': '0-3', 'memory': '${numa_mem}'}]}"
+            with_slot:
+                define_error = "target NUMA node needs to be specified for memory device"
+            no_maxmemory:
+                coldplug_error = "cannot use/hotplug a memory device when domain 'maxMemory' is not defined"
+    variants device_operation:
+        - init_define_with_dimm:
+        - init_define_with_big_dimm:
+            only with_slot..no_numa
+            format_size = ""
+            dimm_dict = "{'mem_model':'${mem_model}','target': {'size': ${target_size_big}, 'size_unit': 'KiB'}, %s}"
+        - hotplug_without_node:
+            no_slot:
+                hotplug_error = "target NUMA node needs to be specified for memory device"
+            with_slot:
+                hotplug_error = "target NUMA node needs to be specified for memory device"
+        - hotplug_with_node:
+            dimm_dict = ${dimm_node_dict}
+            no_slot:
+                hotplug_error = "count of memory devices requiring memory slots '1' exceeds slots count '0'"
+        - coldplug_without_node:
+            coldplug_error_2 = "cannot use/hotplug a memory device when domain 'maxMemory' is not defined"
+        - coldplug_with_node:
+            dimm_dict = ${dimm_node_dict}

--- a/libvirt/tests/src/memory/memory_devices/dimm_memory_with_memory_alloccation_and_numa.py
+++ b/libvirt/tests/src/memory/memory_devices/dimm_memory_with_memory_alloccation_and_numa.py
@@ -1,0 +1,195 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright Redhat
+#
+#   SPDX-License-Identifier: GPL-2.0
+
+#   Author: Nannan Li <nanli@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+from provider.memory import memory_base
+
+virsh_dargs = {'debug': True, 'ignore_status': False}
+
+
+def get_vm_attrs(test, params):
+    """
+    Get vm attrs.
+
+    :param test: test object
+    :param params: dictionary with the test parameters
+    :return vm_attrs: get updated vm attrs dict.
+    """
+    mem_dict = params.get("mem_dict")
+    max_dict = params.get("max_dict")
+    numa_dict = params.get("numa_dict")
+    all_attrs = ""
+    for item in [mem_dict, max_dict, numa_dict]:
+        if item != "":
+            all_attrs += item + ","
+
+    vm_attrs = eval("{"+all_attrs+"}")
+    test.log.debug("Get current vm attrs is :%s", vm_attrs)
+
+    return vm_attrs
+
+
+def define_guest(params, guest_xml):
+    """
+    Define guest and check result.
+
+    :param params: dictionary with the test parameters.
+    :param guest_xml: the xml you want to define.
+    """
+    define_error = params.get("define_error")
+    device_operation = params.get("device_operation")
+    big_size_msg = params.get("big_size_msg")
+
+    res = virsh.define(guest_xml.xml, debug=True)
+    if params.get('slot_no_numa'):
+        if device_operation == "init_define_with_big_dimm":
+            libvirt.check_result(res, big_size_msg)
+        else:
+            libvirt.check_exit_status(res)
+    else:
+        libvirt.check_result(res, define_error)
+
+
+def check_hotplug_result(params, result):
+    """
+    Check guest hot plug result
+
+    :param params: dict wrapped with params.
+    :param result: hot plug result.
+    """
+    mem_alloc = params.get("memory_allocation")
+    device_operation = params.get("device_operation")
+    numa_setting = params.get("numa_setting")
+    hotplug_error = params.get("hotplug_error")
+    hotplug_error_2 = params.get("hotplug_error_2")
+
+    if mem_alloc == "no_maxmemory":
+        if numa_setting == "no_numa" and device_operation == "hotplug_with_node":
+            libvirt.check_result(result, hotplug_error_2)
+    elif mem_alloc == "with_slot" and device_operation == "hotplug_with_node":
+        libvirt.check_exit_status(result)
+    else:
+        libvirt.check_result(result, hotplug_error)
+
+
+def check_coldplug_result(params, result):
+    """
+    Check guest cold plug result
+
+    :param params: dict wrapped with params.
+    :param result: cold plug result.
+    """
+    mem_alloc = params.get("memory_allocation")
+    device_operation = params.get("device_operation")
+    coldplug_error = params.get("coldplug_error")
+    coldplug_error_2 = params.get("coldplug_error_2")
+
+    if mem_alloc == "with_slot":
+        libvirt.check_exit_status(result)
+    elif mem_alloc == "no_slot":
+        libvirt.check_result(result, coldplug_error)
+    elif mem_alloc == "no_maxmemory":
+        if device_operation == "coldplug_without_node":
+            libvirt.check_result(result, coldplug_error_2)
+        else:
+            libvirt.check_result(result, coldplug_error)
+
+
+def run(test, params, env):
+    """
+    Verify dimm memory device works with various memory allocation
+    and guest numa settings.
+    """
+    def run_test_init_define():
+        """
+        Test when define guest with dimm memory.
+        """
+        test.log.info("TEST_STEP1: Define vm with dimm and memory allocation")
+        vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+        vmxml.setup_attrs(**vm_attrs)
+        vmxml.devices = vmxml.devices.append(mem_obj)
+        define_guest(params, vmxml)
+
+        if params.get('slot_no_numa') and device_operation == "init_define_with_dimm":
+            test.log.info("TEST_STEP2,3: Start vm and check guest xml")
+            vm.start()
+            vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+            test.log.debug("Get guest xml:%s\n" % vmxml)
+            libvirt_vmxml.check_guest_xml_by_xpaths(vmxml, basic_xpath)
+            libvirt_vmxml.check_guest_xml_by_xpaths(
+                vmxml, eval(dimm_numa_xpath % (str(mem_value-int(target_size)),
+                                               target_size)))
+
+    def run_test_coldplug():
+        """
+        Test guest cold plug with dimm memory.
+        """
+        test.log.info("TEST_STEP1: Define vm without dimm")
+        original_vmxml.setup_attrs(**vm_attrs)
+        virsh.define(original_vmxml.xml, **virsh_dargs)
+
+        test.log.info("TEST_STEP2: Cold plug vm with dimm")
+        ret = virsh.attach_device(vm_name, mem_obj.xml, debug=True,
+                                  flagstr="--config")
+        check_coldplug_result(params, ret)
+
+    def run_test_hotplug():
+        """
+        Test guest hot plug with dimm memory.
+        """
+        test.log.info("TEST_STEP1: Define vm without dimm")
+        original_vmxml.setup_attrs(**vm_attrs)
+        virsh.define(original_vmxml.xml, **virsh_dargs)
+        virsh.start(vm_name, **virsh_dargs)
+        vm.wait_for_login().close()
+
+        test.log.info("TEST_STEP2: Hot plug vm with dimm")
+        res = virsh.attach_device(vm_name, mem_obj.xml, debug=True)
+        check_hotplug_result(params, res)
+
+    def teardown_test():
+        """
+        Clean data.
+        """
+        test.log.info("TEST_TEARDOWN: Clean up env.")
+        bkxml.sync()
+
+    vm_name = params.get("main_vm")
+    original_vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = original_vmxml.copy()
+    vm = env.get_vm(vm_name)
+    memory_base.adjust_memory_size(params)
+
+    vm_attrs = get_vm_attrs(test, params)
+    device_operation = params.get("device_operation")
+    fs = eval(params.get("format_size")) if params.get("format_size") else ""
+    dimm_dict = eval(params.get("dimm_dict") % fs)
+    mem_obj = libvirt_vmxml.create_vm_device_by_type('memory', dimm_dict)
+
+    target_size = params.get("target_size")
+    mem_value = int(params.get("mem_value"))
+    basic_xpath = eval(params.get("basic_xpath"))
+    dimm_numa_xpath = params.get("dimm_numa_xpath")
+    run_test = eval('run_test_%s' % device_operation.split('_with')[0])
+
+    memory_allocation = params.get("memory_allocation")
+    numa_setting = params.get("numa_setting")
+    params.update(
+        {'slot_no_numa': memory_allocation == "with_slot" and numa_setting == "no_numa"})
+
+    try:
+        run_test()
+
+    finally:
+        teardown_test()


### PR DESCRIPTION
    xxxx-299047: Dimm memory with various memory allocation and guest numa settings
Signed-off-by: nanli <nanli@redhat.com>

Rhel9.4+x86 , rhel9+aarch
```
 avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 memory.devices.dimm.memory_allocation_and_numa
 (01/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.init_define_with_dimm.no_numa.no_maxmemory: PASS (8.13 s)
 (02/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.init_define_with_dimm.no_numa.no_slot: PASS (7.98 s)
 (03/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.init_define_with_dimm.no_numa.with_slot: PASS (9.72 s)
 (04/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.init_define_with_dimm.with_numa.no_maxmemory: PASS (9.18 s)
 (05/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.init_define_with_dimm.with_numa.no_slot: PASS (8.16 s)
 (06/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.init_define_with_dimm.with_numa.with_slot: PASS (8.45 s)
 (07/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.init_define_with_big_dimm.no_numa.with_slot: PASS (8.51 s)
 (08/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.hotplug_without_node.no_numa.no_maxmemory: PASS (45.32 s)
 (09/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.hotplug_without_node.no_numa.no_slot: PASS (43.98 s)
 (10/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.hotplug_without_node.no_numa.with_slot: PASS (50.42 s)
 (11/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.hotplug_without_node.with_numa.no_maxmemory: PASS (42.39 s)
 (12/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.hotplug_without_node.with_numa.no_slot: PASS (42.69 s)
 (13/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.hotplug_without_node.with_numa.with_slot: PASS (49.93 s)
 (14/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.hotplug_with_node.no_numa.no_maxmemory: PASS (42.55 s)
 (15/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.hotplug_with_node.no_numa.no_slot: PASS (43.78 s)
 (16/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.hotplug_with_node.no_numa.with_slot: PASS (49.50 s)
 (17/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.hotplug_with_node.with_numa.no_maxmemory: PASS (42.63 s)
 (18/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.hotplug_with_node.with_numa.no_slot: PASS (50.39 s)
 (19/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.hotplug_with_node.with_numa.with_slot: PASS (43.16 s)
 (20/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.coldplug_without_node.no_numa.no_maxmemory: PASS (13.21 s)
 (21/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.coldplug_without_node.no_numa.no_slot: PASS (7.34 s)
 (22/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.coldplug_without_node.no_numa.with_slot: PASS (7.31 s)
 (23/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.coldplug_without_node.with_numa.no_maxmemory: PASS (7.59 s)
 (24/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.coldplug_without_node.with_numa.no_slot: PASS (7.71 s)
 (25/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.coldplug_without_node.with_numa.with_slot: PASS (16.04 s)
 (26/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.coldplug_with_node.no_numa.no_maxmemory: PASS (7.43 s)
 (27/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.coldplug_with_node.no_numa.no_slot: PASS (7.67 s)
 (28/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.coldplug_with_node.no_numa.with_slot: PASS (7.79 s)
 (29/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.coldplug_with_node.with_numa.no_maxmemory: PASS (19.73 s)
 (30/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.coldplug_with_node.with_numa.no_slot: PASS (7.57 s)
 (31/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.coldplug_with_node.with_numa.with_slot: PASS (7.64 s)


```
arm+rhel8 (All the  errors are expected or by bug  , feature owner suggested we don't implement it , because there will be too many error msg checking and this is also the old version  )

```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio memory.devices.dimm.memory_allocation_and_numa
 (01/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.init_define_with_dimm.no_numa.no_maxmemory: PASS (4.36 s)
 (02/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.init_define_with_dimm.no_numa.no_slot: FAIL: Expect should fail with one of ['failed to find an empty memory slot'], but failed with:\n\n\nsetlocale: No such file or directory\nerror: Failed to define domain from /tmp/xml_utils_temp_fhqwixq0.xml\nerror: XML error: both maximum memory size and memory slot... (4.80 s)
 (03/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.init_define_with_dimm.no_numa.with_slot: FAIL: setlocale: No such file or directory\nerror: Failed to define domain from /tmp/xml_utils_temp_y1mn5jjm.xml\nerror: unsupported configuration: At least one numa node has to be configured when enabling memory hotplug\n (4.84 s)
 (04/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.init_define_with_dimm.with_numa.no_maxmemory: PASS (4.52 s)
 (05/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.init_define_with_dimm.with_numa.no_slot: FAIL: Expect should fail with one of ['failed to find an empty memory slot'], but failed with:\n\n\nsetlocale: No such file or directory\nerror: Failed to define domain from /tmp/xml_utils_temp_e5k5y3vm.xml\nerror: XML error: both maximum memory size and memory slot... (4.94 s)
 (06/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.init_define_with_dimm.with_numa.with_slot: PASS (4.52 s)
 (07/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.init_define_with_big_dimm.no_numa.with_slot: PASS (4.49 s)
 (08/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.hotplug_without_node.no_numa.no_maxmemory: PASS (27.42 s)
 (09/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.hotplug_without_node.no_numa.no_slot: ERROR: Command '/usr/bin/virsh define --file /tmp/xml_utils_temp_0psqx5dd.xml' failed.\nstdout: b'\n'\nstderr: b'setlocale: No such file or directory\nerror: Failed to define domain from /tmp/xml_utils_temp_0psqx5dd.xml\nerror: XML error: both maximum memory size ... (4.39 s)
 (10/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.hotplug_without_node.no_numa.with_slot: ERROR: Command '/usr/bin/virsh define --file /tmp/xml_utils_temp_1bgvyff9.xml' failed.\nstdout: b'\n'\nstderr: b'setlocale: No such file or directory\nerror: Failed to define domain from /tmp/xml_utils_temp_1bgvyff9.xml\nerror: unsupported configuration: At least ... (4.49 s)
 (11/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.hotplug_without_node.with_numa.no_maxmemory: PASS (24.68 s)
 (12/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.hotplug_without_node.with_numa.no_slot: ERROR: Command '/usr/bin/virsh define --file /tmp/xml_utils_temp_23qrhlan.xml' failed.\nstdout: b'\n'\nstderr: b'setlocale: No such file or directory\nerror: Failed to define domain from /tmp/xml_utils_temp_23qrhlan.xml\nerror: XML error: both maximum memory size ... (4.46 s)
 (13/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.hotplug_without_node.with_numa.with_slot: PASS (23.87 s)
 (14/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.hotplug_with_node.no_numa.no_maxmemory: FAIL: Expect should fail with one of ["can't add memory backend as guest has no NUMA nodes configured"], but failed with:\n\n\nsetlocale: No such file or directory\nerror: Failed to attach device from /tmp/xml_utils_temp_vptxjgl3.xml\nerror: unsupported configuratio... (25.32 s)
 (15/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.hotplug_with_node.no_numa.no_slot: ERROR: Command '/usr/bin/virsh define --file /tmp/xml_utils_temp_hz8gpejg.xml' failed.\nstdout: b'\n'\nstderr: b'setlocale: No such file or directory\nerror: Failed to define domain from /tmp/xml_utils_temp_hz8gpejg.xml\nerror: XML error: both maximum memory size ... (4.49 s)
 (16/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.hotplug_with_node.no_numa.with_slot: ERROR: Command '/usr/bin/virsh define --file /tmp/xml_utils_temp_nvydwtpp.xml' failed.\nstdout: b'\n'\nstderr: b'setlocale: No such file or directory\nerror: Failed to define domain from /tmp/xml_utils_temp_nvydwtpp.xml\nerror: unsupported configuration: At least ... (4.44 s)
 (17/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.hotplug_with_node.with_numa.no_maxmemory: PASS (25.13 s)
 (18/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.hotplug_with_node.with_numa.no_slot: ERROR: Command '/usr/bin/virsh define --file /tmp/xml_utils_temp_k5v8_zgx.xml' failed.\nstdout: b'\n'\nstderr: b'setlocale: No such file or directory\nerror: Failed to define domain from /tmp/xml_utils_temp_k5v8_zgx.xml\nerror: XML error: both maximum memory size ... (4.45 s)
 (19/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.hotplug_with_node.with_numa.with_slot: PASS (23.88 s)
 (20/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.coldplug_without_node.no_numa.no_maxmemory: PASS (4.45 s)
 (21/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.coldplug_without_node.no_numa.no_slot: ERROR: Command '/usr/bin/virsh define --file /tmp/xml_utils_temp_hn6jl8mq.xml' failed.\nstdout: b'\n'\nstderr: b'setlocale: No such file or directory\nerror: Failed to define domain from /tmp/xml_utils_temp_hn6jl8mq.xml\nerror: XML error: both maximum memory size ... (4.31 s)
 (22/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.coldplug_without_node.no_numa.with_slot: ERROR: Command '/usr/bin/virsh define --file /tmp/xml_utils_temp_nnvlpscn.xml' failed.\nstdout: b'\n'\nstderr: b'setlocale: No such file or directory\nerror: Failed to define domain from /tmp/xml_utils_temp_nnvlpscn.xml\nerror: unsupported configuration: At least ... (4.64 s)
 (23/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.coldplug_without_node.with_numa.no_maxmemory: PASS (4.69 s)
 (24/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.coldplug_without_node.with_numa.no_slot: ERROR: Command '/usr/bin/virsh define --file /tmp/xml_utils_temp_u2tygzoj.xml' failed.\nstdout: b'\n'\nstderr: b'setlocale: No such file or directory\nerror: Failed to define domain from /tmp/xml_utils_temp_u2tygzoj.xml\nerror: XML error: both maximum memory size ... (4.45 s)
 (25/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.coldplug_without_node.with_numa.with_slot: PASS (4.63 s)
 (26/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.coldplug_with_node.no_numa.no_maxmemory: FAIL: Expect should fail with one of ["can't add memory backend as guest has no NUMA nodes configured"], but failed with:\n\n\nsetlocale: No such file or directory\nerror: Failed to attach device from /tmp/xml_utils_temp_065z3xce.xml\nerror: unsupported configuratio... (4.85 s)
 (27/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.coldplug_with_node.no_numa.no_slot: ERROR: Command '/usr/bin/virsh define --file /tmp/xml_utils_temp_h6e8oiyx.xml' failed.\nstdout: b'\n'\nstderr: b'setlocale: No such file or directory\nerror: Failed to define domain from /tmp/xml_utils_temp_h6e8oiyx.xml\nerror: XML error: both maximum memory size ... (4.42 s)
 (28/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.coldplug_with_node.no_numa.with_slot: ERROR: Command '/usr/bin/virsh define --file /tmp/xml_utils_temp_ivt5myxp.xml' failed.\nstdout: b'\n'\nstderr: b'setlocale: No such file or directory\nerror: Failed to define domain from /tmp/xml_utils_temp_ivt5myxp.xml\nerror: unsupported configuration: At least ... (4.71 s)
 (29/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.coldplug_with_node.with_numa.no_maxmemory: PASS (4.48 s)
 (30/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.coldplug_with_node.with_numa.no_slot: ERROR: Command '/usr/bin/virsh define --file /tmp/xml_utils_temp_ih656f_p.xml' failed.\nstdout: b'\n'\nstderr: b'setlocale: No such file or directory\nerror: Failed to define domain from /tmp/xml_utils_temp_ih656f_p.xml\nerror: XML error: both maximum memory size ... (4.78 s)
 (31/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.coldplug_with_node.with_numa.with_slot: PASS (4.48 s)
RESULTS    : PASS 14 | ERROR 12 | FAIL 5 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0

```