### PR TITLE
Increase current memory to avoid guest boot failure for short of memory

### DIFF
--- a/libvirt/tests/cfg/libvirt_mem.cfg
+++ b/libvirt/tests/cfg/libvirt_mem.cfg
@@ -185,6 +185,7 @@
                             max_mem_rt =
                             max_mem =
                             numa_cells =
+                            current_mem = 2048000
                             attach_option = "--config"
                         - attach_invalid_type:
                             memory_addr = "{'type':'diee','slot':'16','base':'0x11fffffffff'}"

--- a/libvirt/tests/cfg/memory/memory_misc.cfg
+++ b/libvirt/tests/cfg/memory/memory_misc.cfg
@@ -152,7 +152,7 @@
                     vmxml_max_mem_unit = 'KiB'
                     vmxml_max_mem = 1024000
                     vmxml_current_mem_unit = 'KiB'
-                    vmxml_current_mem = 1024000
+                    vmxml_current_mem = 2048000
                     vmxml_vcpu = 4
                     cpu_attrs = {'mode': 'host-model', 'numa_cell': [{'id': '0', 'cpus': '0,2', 'memory': '${numa_node_size}', 'unit': 'KiB'}, {'id': '1', 'cpus': '1,3', 'memory': '${numa_node_size}', 'unit': 'KiB'}]}
                     aarch64:


### PR DESCRIPTION
Test results:
(1/1) type_specific.io-github-autotest-libvirt.libvirt_mem.negative_test.attach_error.attach_nonexist_node: PASS (42.67 s)
(1/1) type_specific.io-github-autotest-libvirt.memory_misc.audit_size.at_dt_mem: PASS (39.59 s)