### PR TITLE
Adapt to default huge page size automatically

### DIFF
--- a/libvirt/tests/cfg/memory/memory_misc.cfg
+++ b/libvirt/tests/cfg/memory/memory_misc.cfg
@@ -27,9 +27,8 @@
                                 kvm_module_parameters = "hpage=1"
                         - memfd_backed:
                             mem_backing_attrs = {'hugepages': {}, 'source_type': 'memfd' ,'allocation': {'threads': '${threads_num}'}}
-                            qemu_check = '"qom-type":"memory-backend-memfd".*"hugetlbsize":2097152.*"prealloc-threads":${threads_num}'
+                            qemu_check = '"qom-type":"memory-backend-memfd".*"hugetlbsize":%s.*"prealloc-threads":${threads_num}'
                             s390-virtio:
-                                qemu_check = '"qom-type":"memory-backend-memfd".*"hugetlbsize":1048576.*"prealloc-threads":${threads_num}'
                                 kvm_module_parameters = "hpage=1"
                         - ram_backed:
                             mem_backing_attrs = {'allocation': {'mode': 'immediate', 'threads': '${threads_num}'}}

--- a/libvirt/tests/src/memory/memory_misc.py
+++ b/libvirt/tests/src/memory/memory_misc.py
@@ -311,6 +311,9 @@ def run(test, params, env):
         if case == 'prealloc_thread':
             virsh.start(vm_name, ignore_status=False)
             vm.wait_for_login().close()
+            nonlocal qemu_check
+            if scenario == 'memfd_backed':
+                qemu_check = qemu_check % (utils_memory.get_huge_page_size() * 1024)
             libvirt.check_qemu_cmd_line(qemu_check)
 
         if case == 'no_mem_backing':


### PR DESCRIPTION
test results:
 (1/3) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.prealloc_thread.file_backed: PASS (37.96 s)
 (2/3) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.prealloc_thread.memfd_backed: PASS (38.32 s)
 (3/3) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.prealloc_thread.ram_backed: PASS (38.13 s)