### PR TITLE
Fix setmem failure on s390x

### DIFF
--- a/libvirt/tests/cfg/memory/virsh_setmem.cfg
+++ b/libvirt/tests/cfg/memory/virsh_setmem.cfg
@@ -17,6 +17,9 @@
     # expected to fail on older libvirt.
     setmem_old_libvirt_fail = "no"
     take_regular_screendumps = no
+    reset_vm_memory = "yes"
+    s390-virtio:
+        reset_vm_memory = "no"
     vm_attrs = {'memory': 4, 'memory_unit': 'GiB', 'current_mem': 4, 'current_mem_unit': 'GiB'}
     variants:
         - valid_options:


### PR DESCRIPTION
Fix setmem failure on s390x
Previously fixing by increasing memory doesn't apply on s390x ,which leads to some error:test conditions not met: Inside memory deviated