### PR TITLE
fix multiple numa hugepage cases on arm

### DIFF
--- a/libvirt/tests/cfg/numa/guest_numa_node_tuning/memory_binding_setting.cfg
+++ b/libvirt/tests/cfg/numa/guest_numa_node_tuning/memory_binding_setting.cfg
@@ -1,14 +1,14 @@
 - guest_numa_node_tuning.memory_binding_setting:
     type = memory_binding_setting
     take_regular_screendumps = no
-    start_vm = "no"    
+    start_vm = "no"
     mem_value = "'memory': 2072576, 'memory_unit': 'KiB'"
-    target_hugepages = "512"
+    hugepage_mem = 1048576
     cpu_mode = 'host-model'
     aarch64:
         mem_value = "'memory': 2097152, 'memory_unit': 'KiB'"
-        target_hugepages = "3"
         cpu_mode = 'host-passthrough'
+        hugepage_mem = 1572864
     current_mem_value = ${mem_value}
     vm_attrs = {${mem_value}, ${current_mem_value}, 'cpu': {'mode': '${cpu_mode}'}}
     variants memory_binding_nodeset:
@@ -18,22 +18,16 @@
             single_host_node = no
     variants memory_binding_mode:
         - mem_mode_strict:
-            mem_mode = 'strict'            
+            mem_mode = 'strict'
         - mem_mode_interleave:
-            mem_mode = 'interleave'            
+            mem_mode = 'interleave'
         - mem_mode_preferred:
-            mem_mode = 'preferred'            
+            mem_mode = 'preferred'
         - mem_mode_restrictive:
-            mem_mode = 'restrictive'            
+            mem_mode = 'restrictive'
     variants pagesize:
         - default_pagesize:
             only single_host_node
-            default_pagesize = 4
-            aarch64:
-                default_pagesize = 64
         - hugepage:
             memory_backing = {'hugepages': {}}
-            expected_hugepage_size = 2048
-            aarch64:
-                expected_hugepage_size = 524288
     numa_memory = {'mode': '${mem_mode}', 'nodeset': '%s'}

--- a/libvirt/tests/cfg/numa/guest_numa_node_tuning/memory_binding_with_emulator_thread.cfg
+++ b/libvirt/tests/cfg/numa/guest_numa_node_tuning/memory_binding_with_emulator_thread.cfg
@@ -38,9 +38,8 @@
     variants pagesize:
         - default_pagesize:
         - hugepage:
-            memory_backing = {'hugepages': {'pages': [{'size': '2', 'unit': 'M'}]}}
-            hugepage_size = 2048
-            kernel_hp_file = '/sys/devices/system/node/node%s/hugepages/hugepages-${hugepage_size}kB/nr_hugepages'
-            target_hugepages = 1536
+            hugepage_mem = 3145728
+            memory_backing = {'hugepages': {'pages': [{'size': '%s', 'unit': 'KiB'}]}}
+            kernel_hp_file = '/sys/devices/system/node/node%s/hugepages/hugepages-%skB/nr_hugepages'
     numa_memory = {'mode': '${mem_mode}', 'nodeset': '%s'}
     numa_memnode = [{'cellid': '0', 'mode': '${mem_mode}', 'nodeset': '%s'}]

--- a/libvirt/tests/cfg/numa/guest_numa_node_tuning/specific_numa_memory_bind_hugepage.cfg
+++ b/libvirt/tests/cfg/numa/guest_numa_node_tuning/specific_numa_memory_bind_hugepage.cfg
@@ -1,14 +1,13 @@
 - guest_numa_node_tuning.specific_numa_memory_bind_hugepage:
     type = specific_numa_memory_bind_hugepage
     take_regular_screendumps = no
-    start_vm = "no"    
+    start_vm = "no"
     max_mem_value = "'max_mem_rt': 15360000, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB'"
     mem_value = "'memory': 2097152, 'memory_unit': 'KiB'"
-    current_mem_value = ${mem_value} 
-    hugepage_size = 2048
-    memory_backing = {'hugepages': {'pages': [{'size': '${hugepage_size}', 'unit': 'KiB', 'nodeset': '0'}]}}
-    kernel_hp_file = '/sys/devices/system/node/node%s/hugepages/hugepages-${hugepage_size}kB/nr_hugepages'
-    target_hugepages = 500
+    current_mem_value = ${mem_value}
+    hugepage_mem = 1048576
+    memory_backing = {'hugepages': {'pages': [{'size': '%s', 'unit': 'KiB', 'nodeset': '0'}]}}
+    kernel_hp_file = '/sys/devices/system/node/node%s/hugepages/hugepages-%skB/nr_hugepages'
     single_host_node = yes
     cpu_mode = 'host-model'
     no s390x
@@ -16,7 +15,7 @@
         cpu_mode = 'host-passthrough'
     variants memory_binding_mode:
         - mem_mode_strict:
-            mem_mode = 'strict'            
+            mem_mode = 'strict'
         - mem_mode_interleave:
             mem_mode = 'interleave'
         - mem_mode_preferred:
@@ -26,12 +25,12 @@
             numa_memory = {'mode': '${mem_mode}', 'nodeset': '%s'}
     variants:
         - enough_numa_mem:
-            vm_node0_mem = 1024000
+            vm_node0_mem = 1048576
             vm_node1_mem = 1073152
         - scarce_numa_mem:
-            vm_node0_mem = 1048576
+            vm_node0_mem = 1572864
             vm_node1_mem = 1048576
             err_msg = 'unable to map backing store for guest RAM: Cannot allocate memory'
-    numa_cell = "'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '${vm_node0_mem}', 'unit': 'KiB'}, {'id': '1', 'cpus': '2-3', 'memory': '${vm_node1_mem}', 'unit': 'KiB'}]"        
+    numa_cell = "'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '${vm_node0_mem}', 'unit': 'KiB'}, {'id': '1', 'cpus': '2-3', 'memory': '${vm_node1_mem}', 'unit': 'KiB'}]"
     numa_memnode = [{'cellid': '0', 'mode': '${mem_mode}', 'nodeset': '%s'}]
     vm_attrs = {${max_mem_value}, ${mem_value}, ${current_mem_value}, 'vcpu': 4, 'cpu': {'mode': '${cpu_mode}', ${numa_cell}}}

--- a/libvirt/tests/src/numa/guest_numa_node_tuning/memory_binding_with_emulator_thread.py
+++ b/libvirt/tests/src/numa/guest_numa_node_tuning/memory_binding_with_emulator_thread.py
@@ -26,12 +26,15 @@ def setup_default(test_obj):
 
     :param test_obj: NumaTest object
     """
-    test_obj.setup(node_index=1)
+    test_obj.setup()
     if test_obj.params.get('memory_backing'):
+        numa_base.adjust_parameters(test_obj.params,
+                                    node_index='1',
+                                    hugepage_mem=int(test_obj.params.get("hugepage_mem")))
         hpc = test_setup.HugePageConfig(test_obj.params)
         hpc.setup()
         utils_libvirtd.Libvirtd().restart()
-        test_obj.params['hp_config_2M'] = hpc
+        test_obj.params['hpc_list'] = [hpc]
     test_obj.test.log.debug("Step: setup is done")
 
 

--- a/libvirt/tests/src/numa/guest_numa_node_tuning/specific_numa_memory_bind_hugepage.py
+++ b/libvirt/tests/src/numa/guest_numa_node_tuning/specific_numa_memory_bind_hugepage.py
@@ -25,10 +25,12 @@ def setup_default(test_obj):
     :param test_obj: NumaTest object
     """
     test_obj.setup()
+    numa_base.adjust_parameters(test_obj.params,
+                                hugepage_mem=int(test_obj.params.get("hugepage_mem")))
     hpc = test_setup.HugePageConfig(test_obj.params)
     hpc.setup()
     utils_libvirtd.Libvirtd().restart()
-    test_obj.params['hp_config_2M'] = hpc
+    test_obj.params['hpc_list'] = [hpc]
     test_obj.test.log.debug("Step: setup is done")
 
 


### PR DESCRIPTION
This is to make the script adapted to different huge pages provided by different arches.

Enable support for kernel 4k and 64k with different default huge page size on ARM.

Signed-off-by: Dan Zheng <dzheng@redhat.com>