### PR TITLE
update version for memory only snap case

### DIFF
--- a/libvirt/tests/cfg/snapshot/memory_snapshot_delete.cfg
+++ b/libvirt/tests/cfg/snapshot/memory_snapshot_delete.cfg
@@ -4,7 +4,7 @@
     start_vm = no
     snapshot_disk_list = "[{'disk_name': 'vda', 'disk_snapshot': 'no'}, {'disk_name': 'vdb', 'disk_snapshot': 'no'}]"
     snapshot_dict = {'description': 'Snapshot test', 'snap_name': '%s', 'mem_snap_type': 'external', 'mem_file': '%s'}
-    func_supported_since_libvirt_ver = (9, 0, 0)
+    func_supported_since_libvirt_ver = (9, 10, 0)
     variants disk_format:
         - type_qcow2:
             disk_driver = {'driver': {'name': 'qemu', 'type': 'qcow2'}}


### PR DESCRIPTION
    xxxx-298190:delete memory only snapshot
Signed-off-by: nanli <nanli@redhat.com>

 (1/2) type_specific.io-github-autotest-libvirt.memory_snapshot.delete.paused.qcow2: PASS (98.62 s)
 (2/2) type_specific.io-github-autotest-libvirt.memory_snapshot.delete.running.qcow2: PASS (55.64 s)