### PR TITLE
SRIOV: add new negative scenario when start vm with hostdev interface

### DIFF
--- a/libvirt/tests/cfg/sriov/vm_lifecycle/sriov_vm_lifecycle_start_negative.cfg
+++ b/libvirt/tests/cfg/sriov/vm_lifecycle/sriov_vm_lifecycle_start_negative.cfg
@@ -30,6 +30,10 @@
                     iommu_dict = {'driver': {'intremap': 'on'}, 'model': 'intel'}
                     iface_dict = {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}}
                     err_msg = "iommu to enable"
+                - invalid_driver_model:
+                    driver_model = "test"
+                    iface_dict = {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}, 'driver': {'driver_attr': {'name': 'vfio', 'model': '${driver_model}'}}}
+                    err_msg = "Failed to load PCI driver module ${driver_model}"
         - hostdev_device:
             variants test_scenario:
                 - iommu_without_caching:


### PR DESCRIPTION
    This PR mainly automates a new negative scenatio with invalid driver
    model for hostdev interface in VIRT-293914.