### PR TITLE
Change cpu mode to host-passthrough for aarch64

### DIFF
--- a/libvirt/tests/cfg/memory/hmat.cfg
+++ b/libvirt/tests/cfg/memory/hmat.cfg
@@ -2,6 +2,8 @@
     type = hmat
     start_vm = no
     cpuxml_cpu_mode = "host-model"
+    aarch64:
+        cpuxml_cpu_mode = "host-passthrough"
     cpuxml_mode = "qemu64"
     cpuxml_fallback = "allow"
     cpuxml_numa_cell = [{'id': '0', 'cpus': '0-5', 'memory': '512', 'unit': 'M'}, {'id': '1', 'memory': '512', 'unit': 'M'}]


### PR DESCRIPTION
test results on aarch64:
 (1/2) type_specific.io-github-autotest-libvirt.hmat.hmat: PASS (31.32 s)
 (2/2) type_specific.io-github-autotest-libvirt.hmat.cell_distances: PASS (31.33 s)