### PR TITLE
libvirt_rng: fix unstable dd count

### DIFF
--- a/libvirt/tests/cfg/libvirt_rng.cfg
+++ b/libvirt/tests/cfg/libvirt_rng.cfg
@@ -90,6 +90,7 @@
         - rng_rate:
             test_qemu_cmd = "yes"
             test_guest = "yes"
+            dd_throughput = "bs=512 count=100"
             variants:
                 - back_rdm:
                     rng_rate = "{'bytes':'5000','period':'2000'}"


### PR DESCRIPTION
When count is too small, the rng rate can not control accuratly. 
So we tune it bigger to make the case stable.

Signed-off-by: Dan Zheng <dzheng@redhat.com>