### PR TITLE
libvirt_rng: fix variable 'output' referenced before assignment

### DIFF
--- a/libvirt/tests/src/libvirt_rng.py
+++ b/libvirt/tests/src/libvirt_rng.py
@@ -393,6 +393,8 @@ def run(test, params, env):
 
             if expect_fail:
                 test.fail("Still can find rng device in guest")
+            elif rng_rate:
+                test.fail("No way to calc rng rate due to dd timeout")
             else:
                 logging.info("dd cmd do not fail with error")
                 # Check if file have data


### PR DESCRIPTION
When aexpect.exceptions.ShellTimeoutError is raised and the case is rng_rate, the UnboundLocalError: local variable 'output' referenced before assignment will be reported.
Because when the timeout happens, the dd rate will not be reported in dd cmdline, it has no way to calc the rate. So it's reasonable to fail the test when timeout happens.