### PR TITLE
virsh_edit: add logs

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_edit.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_edit.py
@@ -117,8 +117,10 @@ def run(test, params, env):
                                                        dic_mode["recover"]])
         else:
             status = libvirt.exec_virsh_edit(vm_name, [dic_mode["recover"]])
+        logging.info(status)
         vmxml.sync()
         if status and new_vcpus != expected_vcpu:
+            logging.debug("new_vcpus, expected_vcpu: %s, %s", new_vcpus, expected_vcpu)
             return False
         return status
 


### PR DESCRIPTION
Sometimes the test failed with right command, no additional info. Add some additional logs to help debugging the next time it happens.