### PR TITLE
virtual_network/update_device: don't test rom and acpi

### DIFF
--- a/libvirt/tests/cfg/virtual_network/update_device/unsupported_live_update_add.cfg
+++ b/libvirt/tests/cfg/virtual_network/update_device/unsupported_live_update_add.cfg
@@ -6,6 +6,7 @@
     status_error = yes
     variants:
         - acpi_index:
+            no s390-virtio
             update_attrs = {'acpi': {'index': '6'}}
             err_msg = changing device 'acpi index' is not allowed
         - sndbuf:
@@ -19,6 +20,7 @@
             update_attrs = {'boot': '3'}
             err_msg = cannot modify network device boot index setting
         - rom:
+            no s390-virtio
             update_attrs = {'rom': {'enabled': 'yes'}}
             err_msg = cannot modify network device rom enabled setting
         - backend:

--- a/libvirt/tests/cfg/virtual_network/update_device/unsupported_live_update_alter.cfg
+++ b/libvirt/tests/cfg/virtual_network/update_device/unsupported_live_update_alter.cfg
@@ -5,6 +5,7 @@
     status_error = yes
     variants:
         - acpi_index:
+            no s390-virtio
             extra_attrs = {'acpi': {'index': '4'}}
             update_attrs = {'acpi': {'index': '6'}}
             err_msg = changing device 'acpi index' is not allowed
@@ -22,6 +23,7 @@
             update_attrs = {'boot': '3'}
             err_msg = cannot modify network device boot index setting
         - rom:
+            no s390-virtio
             extra_attrs = {'rom': {'enabled': 'no'}}
             update_attrs = {'rom': {'enabled': 'yes'}}
             err_msg = cannot modify network device rom enabled setting

--- a/libvirt/tests/cfg/virtual_network/update_device/unsupported_live_update_delete.cfg
+++ b/libvirt/tests/cfg/virtual_network/update_device/unsupported_live_update_delete.cfg
@@ -5,6 +5,7 @@
     status_error = yes
     variants:
         - acpi_index:
+            no s390-virtio
             extra_attrs = {'acpi': {'index': '4'}}
             del_attr = acpi
             err_msg = changing device 'acpi index' is not allowed
@@ -22,6 +23,7 @@
             del_attr = boot
             err_msg = cannot modify network device boot index setting
         - rom:
+            no s390-virtio
             extra_attrs = {'rom': {'enabled': 'no'}}
             del_attr = rom
             err_msg = cannot modify network device rom enabled setting


### PR DESCRIPTION
On s390x, ROM and ACPI are not available. Don't run these tests.