### PR TITLE
cpu_xml: fix negative case with missing feature

### DIFF
--- a/libvirt/tests/deps/negative_domcapabilities_s390x.xml
+++ b/libvirt/tests/deps/negative_domcapabilities_s390x.xml
@@ -35,6 +35,7 @@
     </mode>
     <mode name='host-model' supported='yes'>
       <model fallback='forbid'>gen15a-base</model>
+      <feature policy='require' name='cmma'/>
       <feature policy='require' name='ctop'/>
       <feature policy='require' name='aen'/>
       <feature policy='require' name='cmmnt'/>


### PR DESCRIPTION
'ctop' has become part of host feature list with QEMU 8.2. Therefore the negative test with hypervisor-cpu-compare failed. Add another feature that's not part of host cpu feature list as returned by domcapabilities.

To find this kind of condition: list all recognized features with qemu-kvm -cpu ?. Then get domcapabilities and check for features that are not listed there.