### PR TITLE
add case for reverting snap based on domain and snap status

### DIFF
--- a/libvirt/tests/cfg/snapshot/revert_snap_based_on_status.cfg
+++ b/libvirt/tests/cfg/snapshot/revert_snap_based_on_status.cfg
@@ -1,0 +1,19 @@
+- snapshot_revert.snap_and_domain_status:
+    type = revert_snap_based_on_status
+    start_vm = no
+    snap_name = 's1'
+    func_supported_since_libvirt_ver = (9, 10, 0)
+    variants :
+        - snap_running:
+            snap_status = "running"
+            expected_status = "${snap_status}"
+            snap_options = " %s --memspec snapshot=external,file=/tmp/mem.s1 --diskspec vda,snapshot=external,file=/tmp/vda.s1"
+        - snap_shutoff:
+            snap_status = "shutoff"
+            expected_status = "shut off"
+            snap_options = " %s --diskspec vda,snapshot=external,file=/tmp/vda.s1"
+    variants:
+        - vm_running:
+            vm_status = "running"
+        - vm_shutoff:
+            vm_status = "shut off"

--- a/libvirt/tests/src/snapshot/revert_snap_based_on_status.py
+++ b/libvirt/tests/src/snapshot/revert_snap_based_on_status.py
@@ -1,0 +1,81 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright Redhat
+#
+#   SPDX-License-Identifier: GPL-2.0
+
+#   Author: Nannan Li <nanli@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+from virttest import libvirt_version
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_test import libvirt
+
+from provider.snapshot import snapshot_base
+
+
+def run(test, params, env):
+    """
+    Revert snapshots based on different domain status.
+    """
+    def run_test():
+        """
+        Revert snapshots based on different domain status.
+        """
+        test.log.info("TEST_STEP1: Prepare a snap.")
+        if snap_status == "running":
+            virsh.start(vm_name, **virsh_dargs)
+            vm.wait_for_login().close()
+        virsh.snapshot_create_as(vm_name, snap_options % snap_name,
+                                 **virsh_dargs)
+        status_result = virsh.snapshot_status(vm_name, **virsh_dargs)
+        if status_result[snap_name] != snap_status:
+            test.fail("%s status should be '%s' instead of '%s'" % (
+                snap_name, snap_status, status_result[snap_name]))
+        else:
+            test.log.debug("Check snap status '%s' is correct" % snap_status)
+
+        test.log.info("TEST_STEP2: Set domain status.")
+        if vm_status.replace(' ', '') != snap_status:
+            if vm_status == "shut off":
+                virsh.destroy(vm_name, **virsh_dargs)
+            elif vm_status == "running":
+                virsh.start(vm_name, **virsh_dargs)
+                vm.wait_for_login().close()
+
+        test.log.info("TEST_STEP3: Revert the snapshot")
+        virsh.snapshot_revert(vm_name, snap_name, **virsh_dargs)
+
+        test.log.info("TEST_STEP5: Check expected domain status")
+        if not libvirt.check_vm_state(vm_name, expected_status):
+            test.fail("VM status should be '%s' after reverting." % expected_status)
+        else:
+            test.log.debug("Check vm status '%s' is correct", expected_status)
+
+    def teardown_test():
+        """
+        Clean data.
+        """
+        test.log.info("TEST_TEARDOWN: Clean up env.")
+        test_obj.delete_snapshot(snap_name)
+        bkxml.sync()
+
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    original_xml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = original_xml.copy()
+    virsh_dargs = {"debug": True, "ignore_status": True}
+    snap_name = params.get("snap_name")
+    snap_options = params.get("snap_options")
+    snap_status = params.get("snap_status")
+    vm_status = params.get("vm_status")
+    expected_status = params.get("expected_status")
+    test_obj = snapshot_base.SnapshotTest(vm, test, params)
+
+    try:
+        libvirt_version.is_libvirt_feature_supported(params)
+        run_test()
+
+    finally:
+        teardown_test()


### PR DESCRIPTION
   xxxx-300468: Revert snapshots based on different domain and snapshot status
Signed-off-by: nanli <nanli@redhat.com>

```
 avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 snapshot_revert.snap_and_domain_status
 (1/4) type_specific.io-github-autotest-libvirt.snapshot_revert.snap_and_domain_status.vm_running.snap_running: PASS (48.78 s)
 (2/4) type_specific.io-github-autotest-libvirt.snapshot_revert.snap_and_domain_status.vm_running.snap_shutoff: PASS (16.37 s)
 (3/4) type_specific.io-github-autotest-libvirt.snapshot_revert.snap_and_domain_status.vm_shutoff.snap_running: PASS (56.99 s)
 (4/4) type_specific.io-github-autotest-libvirt.snapshot_revert.snap_and_domain_status.vm_shutoff.snap_shutoff: PASS (15.73 s)

```

Depend on https://github.com/avocado-framework/avocado-vt/pull/3884 