### PR TITLE
Fix attach-detach disk failure

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device_matrix.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device_matrix.py
@@ -7,6 +7,7 @@ from virttest import virsh
 from virttest import data_dir
 from virttest import utils_misc
 from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_disk
 from virttest.utils_test import libvirt
 
 
@@ -225,11 +226,11 @@ def run(test, params, env):
         libvirt.create_local_disk("file", device_source, "1")
 
         # Get disk xml file.
-        disk_params = {'type_name': "file", 'device_type': device,
-                       'target_dev': device_target, 'target_bus': "virtio",
-                       'source_file': device_source, 'driver_name': "qemu",
-                       'driver_type': "raw"}
-        disk_xml = libvirt.create_disk_xml(disk_params)
+        disk_xml_obj = libvirt_disk.create_primitive_disk_xml(
+            "file", device,
+            device_target, "virtio",
+            "raw", {"attrs": {"file": device_source}}, None)
+        disk_xml = disk_xml_obj.xml
 
         # Copy disk xml for virsh.detach in the following code
         new_xml_path = os.path.join(data_dir.get_tmp_dir(), "disk_copy.xml")


### PR DESCRIPTION
Fix attach-detach disk failure

libvirt.create_disk_xml() return embedded object xml, and the parent object: disk_xml may be gc quickly because there is no reference to it

libvirt_disk.create_primitive_disk_xml() return disk_xml itself, since it is assigned to one variable and the reference count is not zero, so it is not gced soon.