### PR TITLE
incremental_backup: fix timeout issue of dd commands in guest

### DIFF
--- a/libvirt/tests/cfg/incremental_backup/incremental_backup_push_mode.cfg
+++ b/libvirt/tests/cfg/incremental_backup/incremental_backup_push_mode.cfg
@@ -34,12 +34,12 @@
                             only original_disk_local.coldplug_disk.backup_to_raw.backup_to_block
                             expect_backup_canceled = "yes"
                             original_disk_size = "5000M"
-                            dd_count = "4000"
+                            dd_count = "2000"
                         - kill_qemu:
                             only original_disk_local.hotplug_disk.backup_to_qcow2.backup_to_block
                             expect_backup_canceled = "yes"
                             original_disk_size = "5000M"
-                            dd_count = "4000"
+                            dd_count = "2000"
                 - positive_test:
     variants:
         - backup_to_qcow2:


### PR DESCRIPTION
Now the written size in guest is big that it may cause timeout sometimes: Timeout expired while waiting for shell command to complete: 'dd if=/dev/urandom of=/dev/vdb bs=1M seek=10 count=4000; sync'. This PR mainly reduce the size.