### PR TITLE
sriov: Update to remove vfio module

### DIFF
--- a/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_interface_special_situations.py
+++ b/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_interface_special_situations.py
@@ -27,10 +27,8 @@ def run(test, params, env):
                                    debug=True, ignore_status=False)
 
         elif test_scenario == "module_auto_reload":
-            modules = ["vfio_pci", "vfio_iommu_type1"]
-            test.log.info("TEST_SETUP: Remove modules: %s." % modules)
-            for module_name in modules:
-                KernelModuleHandler(module_name).unload_module()
+            test.log.info("TEST_SETUP: Remove vfio module.")
+            KernelModuleHandler("vfio").unload_module()
 
     def check_vm_iface_after_detaching(test_scenario):
         """


### PR DESCRIPTION
The module list needs to update on some drivers, so update to remove 'vfio' module directly.


**Test results:**
```
 (1/4) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_interface_special_situations.no_detach_for_no_managed: PASS (107.27 s)
 (2/4) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_interface_special_situations.with_model: PASS (123.06 s)
 (3/4) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_interface_special_situations.module_auto_reload: PASS (122.50 s)
 (4/4) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_interface_special_situations.to_vm_with_hostdev_ifaces: PASS (162.55 s)
```