### PR TITLE
Graphical: fix an intermittent network issue caused by network configuration

### DIFF
--- a/libvirt/tests/src/graphics/graphics_functional.py
+++ b/libvirt/tests/src/graphics/graphics_functional.py
@@ -1656,6 +1656,13 @@ def run(test, params, env):
     config = utils_config.LibvirtQemuConfig()
     libvirtd = utils_libvirtd.Libvirtd()
 
+    # Update the value of IPv6 router advertisement to 2 to avoid failure when
+    # the IPv6 can configure route automatically
+    default_route = process.run("ip route | grep default", shell=True, verbose=True).stdout_text
+    default_interface = default_route.split(' ')[4]
+    process.run("echo 2 > /proc/sys/net/ipv6/conf/%s/accept_ra" % default_interface, shell=True)
+    process.run("cat /proc/sys/net/ipv6/conf/%s/accept_ra" % default_interface).stdout_text
+
     secret_uuid = ""
     if vnc_secret_uuid == "valid":
         secret_uuid = create_secret(config.vnc_tls_x509_secret_uuid, secret_password)


### PR DESCRIPTION
Fix the intermittent error: LibvirtXMLError: Failed to start network virt-test-nat.Detail: error: Failed to start network virt-test-naterror: internal error: Check the host setup: interface eth0 has kernel autoconfigured IPv6 routes and enabling forwarding without accept_ra set to 2 will cause the kernel to flush them, breaking networking.