### PR TITLE
Change huge page assignment automatically to adapt for aarch64.

### DIFF
--- a/libvirt/tests/cfg/memory/memory_devices/lifecycle_of_mixed_memory_devices.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/lifecycle_of_mixed_memory_devices.cfg
@@ -8,26 +8,26 @@
     nvdimm_path_1 = "/tmp/nvdimm1"
     nvdimm_path_2 = "/tmp/nvdimm2"
     save_file = "/tmp/guest.save"
-    nr_hugepages = 256
+    total_hugepage_size = 1048576
     kernel_hp_file = "/proc/sys/vm/nr_hugepages"
     truncate_cmd = "truncate -s 512M ${nvdimm_path_1} && truncate -s 512M ${nvdimm_path_2}"
     kernel_params_remove = "memhp_default_state"
     kernel_params_add = "memhp_default_state=online_movable"
     page_size = 2048
-    dimm_1 = [262144, 262144, 1, "", 1, "dimm_dict_1"]
+    dimm_1 = [524288, 524288, 1, "", 1, "dimm_dict_1"]
     nvdimm_1 = [524288, 0, 2, "", "", "nvdimm_dict_1"]
     virtio_mem_1 = [2097152, 1048576, 3, "", "", "virtio_mem_dict_1"]
-    dimm_2 = [262144, 262144,"", 1, "", "dimm_dict_2"]
+    dimm_2 = [524288, 524288,"", 1, "", "dimm_dict_2"]
     nvdimm_2 = [524288, 0, "", 2, "", "nvdimm_dict_2"]
-    virtio_mem_2 = [262144, 262144, "", 3, "","virtio_mem_dict_2"]
+    virtio_mem_2 = [524288, 524288, "", 3, "","virtio_mem_dict_2"]
     set_items = ["memory_affected", "current_mem_affected","init_seq","hotplug_seq","hotunplug_seq", "dev_dict"]
     set_value = [${dimm_1}, ${nvdimm_1}, ${virtio_mem_1}, ${dimm_2}, ${nvdimm_2}, ${virtio_mem_2}]
-    dimm_target_dize = 262144
-    nvdimm_target_dize = 524288
+    dimm_target_size = 524288
+    nvdimm_target_size = 524288
     virtio_mem_target_size = 2097152
-    dimm_dict_1 = {'mem_model': 'dimm', 'mem_access':'private','mem_discard':'no','source': {"pagesize":${page_size}, "pagesize_unit":"KiB"},'target': {'size': ${dimm_target_dize}, 'size_unit': 'KiB','node':0}}
-    nvdimm_dict_1 = {'mem_model': 'nvdimm', 'source': {"path":"${nvdimm_path_1}"}, 'target': {'size': ${nvdimm_target_dize}, 'size_unit': 'KiB','node':1 }}
-    virtio_mem_dict_1 = {'mem_model': 'virtio-mem', 'target': {'size': ${virtio_mem_target_size}, 'size_unit': 'KiB','node':0, 'block_unit':'KiB','block_size':2048,'requested_size':1048576, 'requested_unit':'KiB'}}
+    dimm_dict_1 = {'mem_model': 'dimm', 'mem_access':'private','mem_discard':'no','source': {"pagesize":${page_size}, "pagesize_unit":"KiB"},'target': {'size': ${dimm_target_size}, 'size_unit': 'KiB','node':0}}
+    nvdimm_dict_1 = {'mem_model': 'nvdimm', 'source': {"path":"${nvdimm_path_1}"}, 'target': {'size': ${nvdimm_target_size}, 'size_unit': 'KiB','node':1 }}
+    virtio_mem_dict_1 = {'mem_model': 'virtio-mem', 'target': {'size': ${virtio_mem_target_size}, 'size_unit': 'KiB','node':0, 'block_unit':'KiB','block_size':${page_size},'requested_size':1048576, 'requested_unit':'KiB'}}
     variants:
         - mutiple_mem:
             no s390-virtio
@@ -35,12 +35,13 @@
             guest_required_kernel = [5.8.0,)
             func_supported_since_libvirt_ver = (8, 0, 0)
             func_supported_since_qemu_kvm_ver = (6, 2, 0)
-            dimm_dict_2 = {'mem_model': 'dimm', 'mem_access':'shared','mem_discard':'yes','target': {'size': ${dimm_target_dize}, 'size_unit': 'KiB','node':1}}
-            nvdimm_dict_2 = {'mem_model': 'nvdimm', 'source': {"path":"${nvdimm_path_2}"}, 'target': {'size': ${nvdimm_target_dize}, 'size_unit': 'KiB','node':1, 'label':{'size':128, 'size_unit':'KiB'} }}
-            virtio_mem_dict_2 = {'mem_model': 'virtio-mem','source': {"pagesize":${page_size}, "pagesize_unit":"KiB"}, 'target': {'size': 262144, 'size_unit': 'KiB','node':0, 'block_unit':'KiB','block_size':2048,'requested_size':262144, 'requested_unit':'KiB'}}
-            xpath_basic = {'element_attrs': [".//memory[@unit='${default_unit}']"],'text': '%s'},{'element_attrs': [".//currentMemory[@unit='${default_unit}']"],'text': '%s'},{'element_attrs': [".//alias[@name='dimm0']"]},{'element_attrs': [".//address[@slot='0']",".//address[@type='dimm']"]},{'element_attrs': [".//alias[@name='nvdimm1']"]},{'element_attrs': [".//address[@slot='1']",".//address[@type='dimm']"]},{'element_attrs': [".//alias[@name='virtiomem0']"]}
+            dimm_dict_2 = {'mem_model': 'dimm', 'mem_access':'shared','mem_discard':'yes','target': {'size': ${dimm_target_size}, 'size_unit': 'KiB','node':1}}
+            nvdimm_dict_2 = {'mem_model': 'nvdimm', 'source': {"path":"${nvdimm_path_2}"}, 'target': {'size': ${nvdimm_target_size}, 'size_unit': 'KiB','node':1, 'label':{'size':128, 'size_unit':'KiB'} }}
+            virtio_mem_dict_2 = {'mem_model': 'virtio-mem','source': {"pagesize":${page_size}, "pagesize_unit":"KiB"}, 'target': {'size': 524288, 'size_unit': 'KiB','node':0, 'block_unit':'KiB','block_size':${page_size},'requested_size':524288, 'requested_unit':'KiB'}}
+            xpath_basic = {'element_attrs': [".//memory[@unit='${default_unit}']"],'text':'%s'},{'element_attrs': [".//currentMemory[@unit='${default_unit}']"],'text': '%s'},{'element_attrs': [".//alias[@name='dimm0']"]},{'element_attrs': [".//address[@slot='0']",".//address[@type='dimm']"]},{'element_attrs': [".//alias[@name='nvdimm1']"]},{'element_attrs': [".//address[@slot='1']",".//address[@type='dimm']"]},{'element_attrs': [".//alias[@name='virtiomem0']"]}
             xpath_after_start = [${xpath_basic}]
             xpath_after_attached = [${xpath_basic},{'element_attrs': [".//alias[@name='dimm2']"]},{'element_attrs': [".//address[@slot='2']",".//address[@type='dimm']"]},{'element_attrs': [".//alias[@name='nvdimm3']"]}, {'element_attrs': [".//address[@slot='3']",".//address[@type='dimm']"]},{'element_attrs': [".//alias[@name='virtiomem1']"]}]
             xpath_after_detached = [${xpath_basic}, {'element_attrs': [".//alias[@name='dimm2']"]},{'element_attrs': [".//address[@slot='2']",".//address[@type='dimm']"]},{'element_attrs': [".//alias[@name='nvdimm3']"]},{'element_attrs': [".//address[@slot='3']",".//address[@type='dimm']"]},{'element_attrs': [".//alias[@name='virtiomem1']"]}]
             del_head = 2
             del_tail = 4
+


### PR DESCRIPTION
Test result on aarch64 64k:
 (1/1) type_specific.io-github-autotest-libvirt.memory.devices.lifecycle.mutiple_mem: PASS (147.81 s)

Test result on x86_64:
(1/1) type_specific.io-github-autotest-libvirt.memory.devices.lifecycle.mutiple_mem: PASS (155.30 s)