### PR TITLE
Fix setpool virt_qemu_ga_read_nonsecurity_files timeout issue

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domfstrim.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domfstrim.py
@@ -27,7 +27,7 @@ def try_set_selinux_label(session):
 
     :param session: VM console session
     """
-    session.cmd_output("setsebool -P virt_qemu_ga_read_nonsecurity_files on")
+    session.cmd_output("setsebool -P virt_qemu_ga_read_nonsecurity_files on", timeout=120)
 
 
 def run(test, params, env):


### PR DESCRIPTION
virt_qemu_ga_read_nonsecurity_files need reboot guest, it takes more time to finish this in some extreme case