### PR TITLE
Fixup:cannot find message in log

### DIFF
--- a/libvirt/tests/src/daemon/conf_file/qemu_conf/set_virtlogd.py
+++ b/libvirt/tests/src/daemon/conf_file/qemu_conf/set_virtlogd.py
@@ -775,7 +775,7 @@ def run(test, params, env):
                           "Error: %s" % str(detail))
             # Check the new VM start log is appended to the end of the VM log file.
             if not with_console_log:
-                check_info_in_vm_log_file(vm_name, guest_log_file, cmd="tail -n 5",
+                check_info_in_vm_log_file(vm_name, guest_log_file,
                                           matchedMsg="char device redirected to /dev/pts")
 
     finally:


### PR DESCRIPTION
Expand the search scope to find expected message.

Test result:
```
 (1/5) type_specific.io-github-autotest-libvirt.conf_file.qemu_conf.set_virtlogd.positive_test.default: PASS (83.68 s)
 (2/5) type_specific.io-github-autotest-libvirt.conf_file.qemu_conf.set_virtlogd.positive_test.enable_logd: PASS (83.88 s)
 (3/5) type_specific.io-github-autotest-libvirt.conf_file.qemu_conf.set_virtlogd.positive_test.file_handler: PASS (78.99 s)
 (4/5) type_specific.io-github-autotest-libvirt.conf_file.qemu_conf.set_virtlogd.positive_test.restart: PASS (85.52 s)
 (5/5) type_specific.io-github-autotest-libvirt.conf_file.qemu_conf.set_virtlogd.positive_test.stop_libvirtd: PASS (84.62 s)
RESULTS    : PASS 5 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```

Before:
```
TestFail: Failed to get VM started log from VM log file: /var/log/libvirt/qemu/avocado-vt-vm1.log.
```