### PR TITLE
Serial: Add a case for testing system-serial on aarch64

### DIFF
--- a/libvirt/tests/cfg/serial/serial_functional.cfg
+++ b/libvirt/tests/cfg/serial/serial_functional.cfg
@@ -48,6 +48,10 @@
             no s390-virtio
             serial_dev_type = pty
             target_type = pci-serial
+        - type_pty_system_serial:
+            only aarch64
+            serial_dev_type = pty
+            target_type = system-serial
         - type_spicevmc:
             serial_dev_type = spicevmc
         - type_spiceport:


### PR DESCRIPTION
On arrch64, system-serial is supported.