### PR TITLE
storage_ceph: update the quotes of ceph variant from '' to "" to match the jobs.yaml

### DIFF
--- a/libvirt/tests/cfg/storage/virsh_pool.cfg
+++ b/libvirt/tests/cfg/storage/virsh_pool.cfg
@@ -17,12 +17,12 @@
                     pool_type = 'rbd'
                     required_commands = "['parallel', 'rbd']"
                     auth_key = "EXAMPLE_AUTH_KEY"
-                    auth_user = 'EXAMPLE_AUTH_USER'
-                    client_name = 'EXAMPLE_CLIENT_NAME'
-                    ceph_host_ip = 'EXAMPLE_MON_HOST_AUTHX'
+                    auth_user = "EXAMPLE_AUTH_USER"
+                    client_name = "EXAMPLE_CLIENT_NAME"
+                    ceph_host_ip = "EXAMPLE_MON_HOST_AUTHX"
                     mon_host = "${ceph_host_ip}"
-                    pool_source_name = 'EXAMPLE_POOL_NAME'
-                    pool_name = 'libvirt-rbd-pool'
+                    pool_source_name = "EXAMPLE_POOL_NAME"
+                    pool_name = "libvirt-rbd-pool"
                     image_path = "${pool_source_name}/%s_rbd.img"
                     rbd_image_size = '5M'
                     pool_source_attrs = "'source': {'host_name': '${ceph_host_ip}', 'auth_type': 'ceph', 'auth_username': 'admin', 'vg_name': '${pool_source_name}', 'secret_uuid': '%s'}"


### PR DESCRIPTION
Now the ceph variants in virsh_pool.cfg can't be translated to the values in jobs.yaml. That's because the quotes of ceph variant are different between cfg file and jobs.yaml.