### PR TITLE
libvirt_mem add adaption for aarch64

### DIFF
--- a/libvirt/tests/cfg/libvirt_mem.cfg
+++ b/libvirt/tests/cfg/libvirt_mem.cfg
@@ -83,6 +83,7 @@
                 - no_attach:
                     test_qemu_cmd = "no"
                 - with_source:
+                    max_mem_rt = 2621440
                     test_qemu_cmd = "no"
                     tg_size = 524288
                     tg_node = 0
@@ -95,9 +96,6 @@
                     test_qemu_cmd = "no"
                     test_mem_binding = "no"
                     setup_hugepages = "yes"
-                    huge_page_num = 2000
-                    pseries:
-                        huge_page_num = 200
                     max_mem_rt = 25600000
                     max_mem = "2609152"
                     current_mem = "2609152"
@@ -105,7 +103,7 @@
                     model_fallback = "forbid"
                     tg_size = 524288
                     tg_node = 0
-                    page_size = 2048
+                    total_huge_page_size = 4194304
                     page_unit = "KiB"
                     node_mask = 0
                     huge_pages = "{'size':'2048','unit':'KiB','nodeset':'0'}"
@@ -134,6 +132,7 @@
                             memory_addr = "{'type':'dimm','slot':'0','base':'0x100000000'}"
                             node_mask = 0
                 - without_numa_save_restore:
+                    no x86_64,aarch64
                     max_mem_rt = 20971520
                     numa_cells = ""
                     tg_node = ""
@@ -173,12 +172,19 @@
                         - invalid_address:
                             memory_addr = "{'type':'dimm','slot':'1','base':'0x11fffffffff'}"
                         - invalid_vm_node:
+                            define_error = "yes"
                             tg_node = 7
                         - invalid_host_node:
                             node_mask = 1-3
                             tg_nddode = 1
                             page_size = 4
                             page_unit = "KiB"
+                        - without_numa:
+                            only x86_64,aarch64
+                            define_error = "yes"
+                            max_mem_rt = 20971520
+                            numa_cells = ""
+                            tg_node = ""
                 - attach_error:
                     attach_device = "yes"
                     attach_error = "yes"
@@ -187,7 +193,6 @@
                             max_mem_rt =
                             max_mem =
                             numa_cells =
-                            current_mem = 2048000
                             attach_option = "--config"
                         - attach_invalid_type:
                             memory_addr = "{'type':'diee','slot':'16','base':'0x11fffffffff'}"
@@ -238,3 +243,4 @@
                         - with_numa:
                             set_max_mem = "2560001"
                             max_mem_option = "--config"
+

--- a/libvirt/tests/src/libvirt_mem.py
+++ b/libvirt/tests/src/libvirt_mem.py
@@ -57,7 +57,10 @@ def run(test, params, env):
 
     def get_hugepage_num(total_huge_page_size):
         """
-        Calculate huge page number according to total huge page size
+        Calculate huge page number according to total huge page size.
+
+        :param total_huge_page_size: required total huge page size in KiB
+        :return: huge page number required
         """
         default_mem_huge_page_size = utils_memory.get_huge_page_size()
         return int(total_huge_page_size) // default_mem_huge_page_size


### PR DESCRIPTION
aarch64 64k result：
(01/27) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.with_source: PASS (67.53 s)
 (02/27) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.hugepages.no_numatune.hot_plug: PASS (107.45 s)
 (03/27) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.hugepages.no_numatune.hot_unplug: PASS (107.14 s)
 (04/27) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.hugepages.no_numatune.cold_plug: PASS (76.40 s)
 (05/27) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.hugepages.no_numatune.cold_plug_discard: PASS (76.40 s)
 (06/27) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.hugepages.no_numatune.discard: PASS (110.34 s)
 (07/27) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.hugepages.with_numatune.hot_plug: PASS (104.88 s)
 (08/27) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.hugepages.with_numatune.hot_unplug: PASS (109.83 s)
 (09/27) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.hugepages.with_numatune.cold_plug: PASS (76.30 s)
 (10/27) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.hugepages.with_numatune.cold_plug_discard: PASS (76.50 s)
 (11/27) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.hugepages.with_numatune.discard: PASS (108.93 s)
 (12/27) type_specific.io-github-autotest-libvirt.libvirt_mem.negative_test.start_error.invalid_slot: PASS (13.00 s)
 (13/27) type_specific.io-github-autotest-libvirt.libvirt_mem.negative_test.start_error.invalid_address: PASS (16.15 s)
 (14/27) type_specific.io-github-autotest-libvirt.libvirt_mem.negative_test.start_error.invalid_vm_node: PASS (14.99 s)
 (15/27) type_specific.io-github-autotest-libvirt.libvirt_mem.negative_test.start_error.invalid_host_node: PASS (15.70 s)
 (16/27) type_specific.io-github-autotest-libvirt.libvirt_mem.negative_test.attach_error.attach_nonexist_node: PASS (77.62 s)
 (17/27) type_specific.io-github-autotest-libvirt.libvirt_mem.negative_test.attach_error.attach_invalid_type: PASS (47.73 s)
 (18/27) type_specific.io-github-autotest-libvirt.libvirt_mem.negative_test.attach_error.attach_duplicate_node: PASS (49.34 s)
 (19/27) type_specific.io-github-autotest-libvirt.libvirt_mem.negative_test.attach_error.attach_many_times: PASS (48.55 s)
 (20/27) type_specific.io-github-autotest-libvirt.libvirt_mem.negative_test.attach_error.attach_invalid_size: PASS (50.62 s)
 (21/27) type_specific.io-github-autotest-libvirt.libvirt_mem.negative_test.attach_error.attach_gt_max: PASS (84.45 s)
 (22/27) type_specific.io-github-autotest-libvirt.libvirt_mem.negative_test.detach_error.detach_invalid_type: PASS (49.19 s)
 (23/27) type_specific.io-github-autotest-libvirt.libvirt_mem.negative_test.detach_error.detach_duplicate_node: PASS (49.01 s)
 (24/27) type_specific.io-github-autotest-libvirt.libvirt_mem.negative_test.detach_error.detach_many_times: PASS (48.57 s)
 (25/27) type_specific.io-github-autotest-libvirt.libvirt_mem.negative_test.detach_error.detach_invalid_size: PASS (49.87 s)
 (26/27) type_specific.io-github-autotest-libvirt.libvirt_mem.negative_test.setmem_error.without_numa: PASS (45.32 s)
 (27/27) type_specific.io-github-autotest-libvirt.libvirt_mem.negative_test.setmem_error.with_numa: PASS (44.92 s)
 (1/1) type_specific.io-github-autotest-libvirt.libvirt_mem.negative_test.start_error.without_numa: PASS (12.04 s)

x86_64 result:
 (01/27) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.with_source: PASS (68.73 s)
 (02/27) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.hugepages.no_numatune.hot_plug: PASS (103.53 s)
 (03/27) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.hugepages.no_numatune.hot_unplug: PASS (109.88 s)
 (04/27) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.hugepages.no_numatune.cold_plug: PASS (78.26 s)
 (05/27) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.hugepages.no_numatune.cold_plug_discard: PASS (81.70 s)
 (06/27) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.hugepages.no_numatune.discard: PASS (117.86 s)
 (07/27) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.hugepages.with_numatune.hot_plug: PASS (102.43 s)
 (08/27) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.hugepages.with_numatune.hot_unplug: PASS (108.56 s)
 (09/27) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.hugepages.with_numatune.cold_plug: PASS (79.79 s)
 (10/27) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.hugepages.with_numatune.cold_plug_discard: PASS (76.18 s)
 (11/27) type_specific.io-github-autotest-libvirt.libvirt_mem.positive_test.hugepages.with_numatune.discard: PASS (111.79 s)
 (12/27) type_specific.io-github-autotest-libvirt.libvirt_mem.negative_test.start_error.invalid_slot: PASS (10.16 s)
 (13/27) type_specific.io-github-autotest-libvirt.libvirt_mem.negative_test.start_error.invalid_address: PASS (10.30 s)
 (14/27) type_specific.io-github-autotest-libvirt.libvirt_mem.negative_test.start_error.invalid_vm_node: PASS (9.38 s)
 (15/27) type_specific.io-github-autotest-libvirt.libvirt_mem.negative_test.start_error.invalid_host_node: PASS (10.10 s)
 (16/27) type_specific.io-github-autotest-libvirt.libvirt_mem.negative_test.attach_error.attach_nonexist_node: PASS (50.78 s)
 (17/27) type_specific.io-github-autotest-libvirt.libvirt_mem.negative_test.attach_error.attach_invalid_type: PASS (48.37 s)
 (18/27) type_specific.io-github-autotest-libvirt.libvirt_mem.negative_test.attach_error.attach_duplicate_node: PASS (48.54 s)
 (19/27) type_specific.io-github-autotest-libvirt.libvirt_mem.negative_test.attach_error.attach_many_times: PASS (50.55 s)
 (20/27) type_specific.io-github-autotest-libvirt.libvirt_mem.negative_test.attach_error.attach_invalid_size: PASS (50.67 s)
 (21/27) type_specific.io-github-autotest-libvirt.libvirt_mem.negative_test.attach_error.attach_gt_max: PASS (95.35 s)
 (22/27) type_specific.io-github-autotest-libvirt.libvirt_mem.negative_test.detach_error.detach_invalid_type: PASS (50.38 s)
 (23/27) type_specific.io-github-autotest-libvirt.libvirt_mem.negative_test.detach_error.detach_duplicate_node: PASS (50.53 s)
 (24/27) type_specific.io-github-autotest-libvirt.libvirt_mem.negative_test.detach_error.detach_many_times: PASS (48.49 s)
 (25/27) type_specific.io-github-autotest-libvirt.libvirt_mem.negative_test.detach_error.detach_invalid_size: PASS (50.38 s)
 (26/27) type_specific.io-github-autotest-libvirt.libvirt_mem.negative_test.setmem_error.without_numa: PASS (48.89 s)
 (27/27) type_specific.io-github-autotest-libvirt.libvirt_mem.negative_test.setmem_error.with_numa: PASS (48.73 s)
 (1/1) type_specific.io-github-autotest-libvirt.libvirt_mem.negative_test.start_error.without_numa: PASS (9.59 s)