### PR TITLE
Change content comparison to subset

### DIFF
--- a/libvirt/tests/src/numa/numa_capabilities.py
+++ b/libvirt/tests/src/numa/numa_capabilities.py
@@ -52,8 +52,9 @@ def run(test, params, env):
                 cpu_topo_list.append(cpu_dict)
             logging.debug("cpu topology list from capabilities xml is %s",
                           cpu_list_from_xml)
-            if cpu_list_from_xml != cpu_topo_list:
-                test.fail("cpu list %s from capabilities xml not "
-                          "expected.")
+            for i, cpu_dict in enumerate(cpu_list_from_xml):
+                if not set(cpu_dict.items()).issubset(set(cpu_topo_list[i].items())):
+                    test.fail("cpu list %s from capabilities xml is not subset from "
+                              "system %s" % (cpu_list_from_xml, cpu_topo_list))
     finally:
         libvirtd.restart()


### PR DESCRIPTION
Since in latest rhel9.4, cluster_id is introduced into cpu numa node capabilities. So to compromise rhel8, change content comparison to subset. 
Test result on rhel9.4 x86_64:
 (1/1) type_specific.io-github-autotest-libvirt.numa_capabilities.default: PASS (12.85 s)