### PR TITLE
Add version check for interface with all zeros mac

### DIFF
--- a/libvirt/tests/cfg/virtual_network/elements_and_attributes/element_mac_specific_addr.cfg
+++ b/libvirt/tests/cfg/virtual_network/elements_and_attributes/element_mac_specific_addr.cfg
@@ -18,6 +18,7 @@
             expect_xml_mac = ${set_mac}
             expect_tap_mac = fa:
         - all_zeros:
+            func_supported_since_libvirt_ver = (9, 9, 0)
             mac = {'mac_address': '00:00:00:00:00:00'}
             expect_xml_mac = 52:54:00.*
             expect_tap_mac = fe:

--- a/libvirt/tests/src/virtual_network/elements_and_attributes/element_mac_specific_addr.py
+++ b/libvirt/tests/src/virtual_network/elements_and_attributes/element_mac_specific_addr.py
@@ -3,6 +3,7 @@ import re
 
 from virttest import utils_net
 from virttest import virsh
+from virttest import libvirt_version
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_libvirt import libvirt_vmxml
 from virttest.utils_test import libvirt
@@ -18,6 +19,7 @@ def run(test, params, env):
     """
     Test start vm or hotplug interface with specific mac address
     """
+    libvirt_version.is_libvirt_feature_supported(params)
     vm_name = params.get('main_vm')
     vm = env.get_vm(vm_name)
     scenario = params.get('scenario')


### PR DESCRIPTION
Since the issue is fixed on libvirt-9.9.0, add the version check for interface with all zeros mac.