### PR TITLE
Increase current memory size to avoid guest crash during bootup

### DIFF
--- a/libvirt/tests/cfg/libvirt_mem.cfg
+++ b/libvirt/tests/cfg/libvirt_mem.cfg
@@ -193,6 +193,7 @@
                             max_mem_rt =
                             max_mem =
                             numa_cells =
+                            current_mem = 2048000
                             attach_option = "--config"
                         - attach_invalid_type:
                             memory_addr = "{'type':'diee','slot':'16','base':'0x11fffffffff'}"


### PR DESCRIPTION
Test result:
 (1/1) type_specific.io-github-autotest-libvirt.libvirt_mem.negative_test.attach_error.attach_nonexist_node: PASS (36.82 s)