### PR TITLE
Fix build domain xml error

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_managedsave.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_managedsave.cfg
@@ -43,6 +43,8 @@
                 - cpu_mode:
                     managedsave_cpumode = "yes"
                     cpu_mode = "host-model"
+                    aarch64:
+                        cpu_mode = "host-passthrough"
                     cpu_match = "exact"
                     cpu_fallback = "forbid"
                     cpu_topology_sockets = "2"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_managedsave.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_managedsave.py
@@ -314,7 +314,7 @@ def run(test, params, env):
             vm.start()
         except Exception as e:
             logging.error(str(e))
-            test.cancel("Build domain xml failed")
+            test.error("Build domain xml failed")
 
     status_error = ("yes" == params.get("status_error", "no"))
     vm_ref = params.get("managedsave_vm_ref", "name")


### PR DESCRIPTION
1) aarch64 doesn't support 'host-model', change it to host-passthrough. 2) Let the script return error instead of cancel when build xml fails.