### PR TITLE
virtual_networks: remove spaces before comparing rx_frames

### DIFF
--- a/provider/virtual_network/network_base.py
+++ b/provider/virtual_network/network_base.py
@@ -291,7 +291,7 @@ def get_ethtool_coalesce(iface):
     eth_out = re.sub("[\t ]+", "", eth_out)
     eth_out = re.sub("n/a", "0", eth_out)
     items = [x.split(':') for x in eth_out.splitlines() if x]
-    coalesce = {item[0]: item[1] for item in items[1:] if len(item) == 2}
+    coalesce = {item[0]: item[1].strip() for item in items[1:] if len(item) == 2}
 
     return coalesce
 


### PR DESCRIPTION
Fixed a bug related to rx_frames comparison.
The issue was that the collected rx_frames contained spaces, while the expected rx_frames did not.

Before:
```
 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.update_device.coalesce.nat_net.update_iface_coalesce: FAIL: rx-frames of vnet0 should be 64, not  64 (31.53 s)
```

After:
```
 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.update_device.coalesce.nat_net.update_iface_coalesce: PASS (36.08 s)
```