### PR TITLE
Virsh event add adaption for aarch64

### DIFF
--- a/libvirt/tests/cfg/event/virsh_event.cfg
+++ b/libvirt/tests/cfg/event/virsh_event.cfg
@@ -120,6 +120,10 @@
                     current_mem = 4048896
                     dimm_unit = "m"
                     dimm_size = 128
+                    cpu_mode = 'host-model'
+                    aarch64:
+                        cpu_mode = 'host-passthrough'
+                        dimm_size = 512
                     expected_fails = "unplug of device was rejected by the guest"
                 - watchdog_event:
                     event_all_option = "yes"

--- a/libvirt/tests/src/event/virsh_event.py
+++ b/libvirt/tests/src/event/virsh_event.py
@@ -153,6 +153,7 @@ def run(test, params, env):
         vmxml.max_mem_rt_slots = int(params.get("maxmem_slots"))
         mem_unit = params.get("mem_unit")
         vmxml.max_mem_rt_unit = mem_unit
+        cpu_mode = params.get("cpu_mode")
         current_mem = int(params.get("current_mem"))
         vmxml.current_mem = current_mem
         vmxml.current_mem_unit = mem_unit
@@ -177,10 +178,10 @@ def run(test, params, env):
         if vmxml.xmltreefile.find('cpu'):
             vmxml_cpu = vmxml.cpu
             logging.debug("Existing cpu configuration in guest xml:\n%s", vmxml_cpu)
-            vmxml_cpu.mode = 'host-model'
+            vmxml_cpu.mode = cpu_mode
         else:
             vmxml_cpu = vm_xml.VMCPUXML()
-            vmxml_cpu.xml = "<cpu mode='host-model'><numa/></cpu>"
+            vmxml_cpu.xml = "<cpu mode='%s'><numa/></cpu>" % cpu_mode
         vmxml.vcpu = numa_nodes * 2
         vmxml_cpu.numa_cell = vmxml_cpu.dicts_to_cells(numa_dict_list)
         logging.debug(vmxml_cpu.numa_cell)


### PR DESCRIPTION
Test result on aarch64 64k:
 (1/2) type_specific.io-github-autotest-libvirt.virsh.event.positive_test.virsh_event.test_events.device-removal-failed_event.no_timeout.loop: PASS (150.40 s)
 (2/2) type_specific.io-github-autotest-libvirt.virsh.event.positive_test.qemu_monitor_event.pretty_option.device-removal-failed_event.no_timeout.loop: PASS (149.08 s)