### PR TITLE
add case for revert memory only snap

### DIFF
--- a/libvirt/tests/cfg/snapshot/revert_memory_only_snap.cfg
+++ b/libvirt/tests/cfg/snapshot/revert_memory_only_snap.cfg
@@ -1,0 +1,8 @@
+- snapshot_revert.memory_only_snap:
+    type = revert_memory_only_snap
+    start_vm = no
+    snap_names = ['s1', 's2', 's3']
+    target_disk = 'vda'
+    disk_type = 'file'
+    snap_options = "%s --memspec snapshot=external,file=/tmp/mem.%s --diskspec ${target_disk},snapshot=no"
+    func_supported_since_libvirt_ver = (9, 10, 0)

--- a/libvirt/tests/src/snapshot/revert_memory_only_snap.py
+++ b/libvirt/tests/src/snapshot/revert_memory_only_snap.py
@@ -1,0 +1,89 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright Redhat
+#
+#   SPDX-License-Identifier: GPL-2.0
+
+#   Author: Nannan Li <nanli@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+from virttest import libvirt_version
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+
+from provider.snapshot import snapshot_base
+from provider.virtual_disk import disk_base
+
+
+def run(test, params, env):
+    """
+    Revert guest to memory only snapshot.
+    """
+    def setup_test():
+        """
+        Check libvirt version
+        """
+        libvirt_version.is_libvirt_feature_supported(params)
+
+    def run_test():
+        """
+        Revert guest to memory only snapshot.
+        """
+        test.log.info("TEST_STEP1:Create memory only snaps for running guest.")
+        virsh.start(vm_name)
+        vm.wait_for_login().close()
+        for sname in snap_names:
+            virsh.snapshot_create_as(vm.name, snap_options % (sname, sname),
+                                     **virsh_dargs)
+            snap_lists = virsh.snapshot_list(vm_name, **virsh_dargs)
+            if sname not in snap_lists:
+                test.fail("Expect to get '%s' in snap list" % sname)
+
+        test.log.info("TEST_STEP2:Revert the second snap and check source path")
+        virsh.snapshot_revert(vm_name, snap_names[1], **virsh_dargs)
+
+        def _check_source_num():
+            vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+            source_list = disk_obj.get_source_list(vmxml, disk_type, target_disk)
+            if len(source_list) != 2:
+                test.fail('Expected disk source num should be 2 instead of %s '
+                          'in xml %s' % (len(source_list), vmxml))
+        _check_source_num()
+
+        test.log.info("TEST_STEP3:Revert the first snap and check source path")
+        virsh.snapshot_revert(vm_name, snap_names[0], **virsh_dargs)
+        _check_source_num()
+
+        test.log.info("TEST_STEP4:Revert the last snap and check source path")
+        virsh.snapshot_revert(vm_name, snap_names[2], **virsh_dargs)
+        _check_source_num()
+
+    def teardown_test():
+        """
+        Clean data.
+        """
+        test.log.info("TEST_TEARDOWN: Clean up env.")
+        snap_names.reverse()
+        test_obj.delete_snapshot(snap_names)
+        bkxml.sync()
+
+    vm_name = params.get("main_vm")
+    original_xml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = original_xml.copy()
+    vm = env.get_vm(vm_name)
+
+    virsh_dargs = {"debug": True, "ignore_status": True}
+    snap_names = eval(params.get("snap_names", '[]'))
+    snap_options = params.get("snap_options")
+    disk_type = params.get("disk_type")
+    target_disk = params.get("target_disk")
+    test_obj = snapshot_base.SnapshotTest(vm, test, params)
+    disk_obj = disk_base.DiskBase(test, vm, params)
+
+    try:
+        setup_test()
+        run_test()
+
+    finally:
+        teardown_test()


### PR DESCRIPTION
   xxxx-300470:Revert guest to memory only snapshot.
Signed-off-by: nanli <nanli@redhat.com>

```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 snapshot_revert.memory_only_snap

 (1/1) type_specific.io-github-autotest-libvirt.snapshot_revert.memory_only_snap: PASS (63.51 s)

```