### PR TITLE
guest_numa: fix out of date qemu cmd line update

### DIFF
--- a/libvirt/tests/cfg/numa/guest_numa.cfg
+++ b/libvirt/tests/cfg/numa/guest_numa.cfg
@@ -28,8 +28,8 @@
                  - no_numatune_mem:
              variants:
                  - no_numatune_memnode:
-                     qemu_cmdline_numa_cell_0 = "node,nodeid=0,cpus=0-1,mem=1024"
-                     qemu_cmdline_numa_cell_1 = "node,nodeid=1,cpus=2-3,mem=1024"
+                     qemu_cmdline_numa_cell_0 = "node,nodeid=0,cpus=0-1,memdev=ram-node0"
+                     qemu_cmdline_numa_cell_1 = "node,nodeid=1,cpus=2-3,memdev=ram-node1"
                  - numatune_memnode:
                      memnode_nodeset_0 = 1
                      pseries:


### PR DESCRIPTION
The excluded libvirt version and machine types are out of date. Those old versions should not in our test scope and should be given up. Instead, we should use new qemu command line not only on q35, but also other arches, like aarch64.