### PR TITLE
Stop guest start before case execution

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_memtune.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_memtune.cfg
@@ -1,5 +1,6 @@
 - virsh.memtune: install setup image_copy unattended_install.cdrom
     type = virsh_memtune
+    start_vm = no
     # Values are in KiB
     variants:
         - positive_test:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_memtune.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_memtune.py
@@ -178,7 +178,8 @@ def run(test, params, env):
 
     # Get the vm name, pid of vm and check for alive
     vm = env.get_vm(params["main_vm"])
-    vm.verify_alive()
+    if not vm.is_alive():
+        vm.start()
     pid = vm.get_pid()
 
     # Resolve the memory cgroup path for a domain


### PR DESCRIPTION
Before fix, below error for case on rhel9.4 when do post-process for guest vm:
(1/1) type_specific.io-github-autotest-libvirt.virsh.memtune.positive_test.normal_6: ERROR: Failures occurred while postprocess:\n\n: Guest avocado-vt-vm1 dmesg verification failed: Login timeout expired    (output: 'exceeded 240 s timeout')


After fix, test result:
x86_64 rhel9:
 (1/8) type_specific.io-github-autotest-libvirt.virsh.memtune.positive_test.normal_1: PASS (34.60 s)
 (2/8) type_specific.io-github-autotest-libvirt.virsh.memtune.positive_test.normal_2: PASS (38.76 s)
 (3/8) type_specific.io-github-autotest-libvirt.virsh.memtune.positive_test.normal_3: PASS (33.62 s)
 (4/8) type_specific.io-github-autotest-libvirt.virsh.memtune.positive_test.normal_4: PASS (33.66 s)
 (5/8) type_specific.io-github-autotest-libvirt.virsh.memtune.positive_test.normal_5: PASS (34.81 s)
 (6/8) type_specific.io-github-autotest-libvirt.virsh.memtune.positive_test.normal_6: PASS (296.15 s)
 (7/8) type_specific.io-github-autotest-libvirt.virsh.memtune.positive_test.normal_7: PASS (38.75 s)
 (8/8) type_specific.io-github-autotest-libvirt.virsh.memtune.positive_test.step_increment: PASS (35.23 s)
 (1/3) type_specific.io-github-autotest-libvirt.virsh.memtune.negative_test.invalid_2: PASS (38.40 s)
 (2/3) type_specific.io-github-autotest-libvirt.virsh.memtune.negative_test.invalid_3: PASS (33.56 s)
 (3/3) type_specific.io-github-autotest-libvirt.virsh.memtune.negative_test.invalid_4: PASS (34.80 s)

x86_64 rhel8:
 (01/12) type_specific.io-github-autotest-libvirt.virsh.memtune.positive_test.normal_1: PASS (25.48 s)
 (02/12) type_specific.io-github-autotest-libvirt.virsh.memtune.positive_test.normal_2: PASS (27.49 s)
 (03/12) type_specific.io-github-autotest-libvirt.virsh.memtune.positive_test.normal_3: PASS (27.52 s)
 (04/12) type_specific.io-github-autotest-libvirt.virsh.memtune.positive_test.normal_4: PASS (27.71 s)
 (05/12) type_specific.io-github-autotest-libvirt.virsh.memtune.positive_test.normal_5: PASS (35.34 s)
 (06/12) type_specific.io-github-autotest-libvirt.virsh.memtune.positive_test.normal_6: PASS (29.65 s)
 (07/12) type_specific.io-github-autotest-libvirt.virsh.memtune.positive_test.normal_7: PASS (28.09 s)
 (08/12) type_specific.io-github-autotest-libvirt.virsh.memtune.positive_test.step_increment: PASS (35.51 s)
 (09/12) type_specific.io-github-autotest-libvirt.virsh.memtune.negative_test.invalid_1: PASS (45.73 s)
 (10/12) type_specific.io-github-autotest-libvirt.virsh.memtune.negative_test.invalid_2: PASS (27.38 s)
 (11/12) type_specific.io-github-autotest-libvirt.virsh.memtune.negative_test.invalid_3: PASS (28.57 s)
 (12/12) type_specific.io-github-autotest-libvirt.virsh.memtune.negative_test.invalid_4: PASS (35.60 s)


 aarch64 64k:
 (1/8) type_specific.io-github-autotest-libvirt.virsh.memtune.positive_test.normal_1: PASS (32.28 s)
 (2/8) type_specific.io-github-autotest-libvirt.virsh.memtune.positive_test.normal_2: PASS (25.84 s)
 (3/8) type_specific.io-github-autotest-libvirt.virsh.memtune.positive_test.normal_3: PASS (25.97 s)
 (4/8) type_specific.io-github-autotest-libvirt.virsh.memtune.positive_test.normal_4: PASS (26.09 s)
 (5/8) type_specific.io-github-autotest-libvirt.virsh.memtune.positive_test.normal_5: PASS (23.86 s)
 (6/8) type_specific.io-github-autotest-libvirt.virsh.memtune.positive_test.normal_6: PASS (335.32 s)
 (7/8) type_specific.io-github-autotest-libvirt.virsh.memtune.positive_test.normal_7: PASS (46.84 s)
 (8/8) type_specific.io-github-autotest-libvirt.virsh.memtune.positive_test.step_increment: PASS (21.29 s)
 (1/3) type_specific.io-github-autotest-libvirt.virsh.memtune.negative_test.invalid_2: PASS (31.98 s)
 (2/3) type_specific.io-github-autotest-libvirt.virsh.memtune.negative_test.invalid_3: PASS (26.21 s)
 (3/3) type_specific.io-github-autotest-libvirt.virsh.memtune.negative_test.invalid_4: PASS (26.21 s)