### PR TITLE
Fixup:Shell command timeout error when running curl

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_stat.py
+++ b/libvirt/tests/src/virtual_network/iface_stat.py
@@ -140,7 +140,7 @@ def run(test, params, env):
                 for _ in range(3):
                     session.cmd('curl -O https://avocado-project.org/data/'
                                 'assets/jeos/27/jeos-27-64.qcow2.xz -L',
-                                timeout=240)
+                                timeout=240, ignore_all_errors=True)
                 host_iface_stat = get_host_iface_stat(vm_name,
                                                       iface_target_dev,
                                                       **virsh_args)


### PR DESCRIPTION
Ignore errors when trying to download a large file. The purpose was not to actually get the file, but to create a lot of network trafic, therefore whether the command succeeds or not doesn't matter.

Test result:
```
 (1/2) type_specific.io-github-autotest-libvirt.virtual_network.iface_stat.compare.ethernet_type.managed_no.tap: PASS (274.72 s)
 (2/2) type_specific.io-github-autotest-libvirt.virtual_network.iface_stat.compare.ethernet_type.managed_no.macvtap: PASS (424.07 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```

Before:
```
ShellTimeoutError: Timeout expired while waiting for shell command to complete: 'curl -O https://avocado-project.org/data/assets/jeos/27/jeos-27-64.qcow2.xz -L'    (output: '  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0  
...
```
