### PR TITLE
misc_virtual_devices: fix "No more available PCI slots" error

### DIFF
--- a/libvirt/tests/src/virtual_device/input_devices_plug_unplug.py
+++ b/libvirt/tests/src/virtual_device/input_devices_plug_unplug.py
@@ -10,6 +10,7 @@
 from virttest.libvirt_xml.devices.input import Input
 from virttest.libvirt_xml.vm_xml import VMXML
 from virttest import virsh
+from virttest.utils_libvirt import libvirt_pcicontr
 
 
 def prepare_vm_xml(vm_xml, device_type, test):
@@ -67,6 +68,7 @@ def run(test, params, env):
     3. check the result
     """
     vm_name = params.get("main_vm", "avocado-vt-vm1")
+    libvirt_pcicontr.reset_pci_num(vm_name)
     vm = env.get_vm(vm_name)
     vm_xml = VMXML.new_from_dumpxml(vm_name)
     vm_xml_backup = vm_xml.copy()


### PR DESCRIPTION
Signed-off-by: Qian Jianhua <qianjh@fujitsu.com>

Before:
```
 (1/1) type_specific.io-github-autotest-libvirt.virtual_devices.input_devices_plug_unplug.hot.bus_virtio.tablet_mouse_keyboard: ERROR: Command '/bin/virsh attach-device avocado-vt-vm1 /tmp/xml_utils_temp_cqyyjueb.xml' failed.\nstdout: b'\n'\nstderr: b'error: Failed to attach device from /tmp/xml_utils_temp_cqyyjueb.xml\nerror: internal error: No more available PCI slots\n'\nadditional_info:... (27.21 s)
```

After:
```
 (1/1) type_specific.io-github-autotest-libvirt.virtual_devices.input_devices_plug_unplug.hot.bus_virtio.tablet_mouse_keyboard: PASS (50.72 s)
```