### PR TITLE
add case for delete snap in parent external snap with muti children

### DIFF
--- a/libvirt/tests/cfg/snapshot/delete_external_snap_with_references.cfg
+++ b/libvirt/tests/cfg/snapshot/delete_external_snap_with_references.cfg
@@ -1,0 +1,21 @@
+- snapshot_delete.multiple_children:
+    type = delete_external_snap_with_references
+    start_vm = no
+    snap_options = "%s --memspec snapshot=external,file=/tmp/mem.%s --diskspec vda,snapshot=external,file=/tmp/vda.%s"
+    func_supported_since_libvirt_ver = (9, 10, 0)
+    variants case:
+        - del_parent_snap:
+            del_snap = 's1'
+            error_msg = "unsupported configuration: deletion of external disk snapshot with multiple children snapshots not supported"
+        - del_current_branch:
+            del_index = [2, 1, 0]
+            error_msg = "unsupported configuration: deletion of active external snapshot that is not a leaf snapshot is not supported"
+        - del_non_current_branch:
+            func_supported_since_libvirt_ver = (10, 0, 0)
+            error_msg = "deletion of non-leaf external snapshot that is not in active chain is not supported"
+            variants:
+                - tail_to_head:
+                    del_index = [4, 3, 0]
+#                 - head_to_tail:
+#                     del_index = [0, 3, 4]
+

--- a/libvirt/tests/src/snapshot/delete_external_snap_with_references.py
+++ b/libvirt/tests/src/snapshot/delete_external_snap_with_references.py
@@ -1,0 +1,111 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright Redhat
+#
+#   SPDX-License-Identifier: GPL-2.0
+
+#   Author: Nannan Li <nanli@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+from virttest import libvirt_version
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_test import libvirt
+
+from provider.snapshot import snapshot_base
+
+
+def run(test, params, env):
+    """
+    :params test: test object
+    :params params: wrapped dict with all parameters
+    :params env: test object
+    """
+    def setup_test():
+        """
+        Delete snapshots in the parent external snapshots
+        with multiple children.
+        """
+        test.log.info("TEST_SETUP: Prepare the parent external snapshot"
+                      " with multiple children")
+        virsh.start(vm_name)
+        vm.wait_for_login().close()
+        for sname in snap_names:
+            virsh.snapshot_create_as(vm.name, snap_options % (sname, sname, sname),
+                                     **virsh_dargs)
+            if sname == 's3':
+                virsh.snapshot_revert(vm_name, snap_names[0], **virsh_dargs)
+        res = virsh.snapshot_current(vm_name, **virsh_dargs).stdout.strip()
+        if res != snap_names[-1]:
+            test.fail("Expect the current snap name is '%s' instead of"
+                      " '%s'" % (snap_names[-1], res))
+        virsh.snapshot_list(vm_name, **virsh_dargs, options='--tree')
+
+    def run_test_del_parent_snap():
+        """
+        Delete the parent snapshot with multiple children.
+        """
+        test.log.info("TEST_STEP:Delete the parent snapshot with multi-child.")
+        virsh.start(vm_name)
+        vm.wait_for_login().close()
+        del_res = virsh.snapshot_delete(vm.name, snap_names[0], debug=True)
+        libvirt.check_exit_status(del_res, error_msg)
+
+    def run_test_del_current_branch():
+        """
+        Delete the snapshots of current branch.
+        """
+        test.log.info("TEST_STEP: Delete the snapshots of current branch.")
+        for times in range(1, 4):
+            curr_sname = virsh.snapshot_current(vm_name, **virsh_dargs).stdout.strip()
+            del_res = virsh.snapshot_delete(vm_name, curr_sname, debug=True)
+            if times == 3:
+                libvirt.check_exit_status(del_res, error_msg)
+        for index in del_index:
+            res = virsh.snapshot_delete(vm_name, snap_names[index], **virsh_dargs)
+            libvirt.check_exit_status(res)
+
+    def run_test_del_non_current_branch():
+        """
+        Delete the snapshots of non-current branch
+        """
+        test.log.info("TEST_STEP: Delete the snapshots of non-current branch.")
+        res = virsh.snapshot_delete(vm_name, snap_names[1], debug=True)
+        libvirt.check_exit_status(res, error_msg)
+
+        for index in [2, 1] + del_index:
+            res = virsh.snapshot_delete(vm_name, snap_names[index], **virsh_dargs)
+            libvirt.check_exit_status(res)
+
+    def teardown_test():
+        """
+        Clean data.
+        """
+        test.log.info("TEST_TEARDOWN: Clean up env.")
+        snap_names.reverse()
+        test_obj.virsh_dargs = {'ignore_status': True, 'debug': True}
+        test_obj.delete_snapshot(snap_names)
+        bkxml.sync()
+
+    vm_name = params.get("main_vm")
+    original_xml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = original_xml.copy()
+    vm = env.get_vm(vm_name)
+
+    snap_options = params.get("snap_options")
+    case = params.get("case")
+    run_test = eval("run_test_%s" % case)
+    error_msg = params.get("error_msg")
+
+    test_obj = snapshot_base.SnapshotTest(vm, test, params)
+    virsh_dargs = {"debug": True, "ignore_status": False}
+    snap_names = ['s1', 's2', 's3', 's4', 's5']
+    del_index = eval(params.get('del_index', '[]'))
+    libvirt_version.is_libvirt_feature_supported(params)
+
+    try:
+        setup_test()
+        run_test()
+
+    finally:
+        teardown_test()


### PR DESCRIPTION
   xxxx-300472:Delete snapshots in the parent external snapshots with multiple children.

```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 snapshot_delete.multiple_children
 (1/3) type_specific.io-github-autotest-libvirt.snapshot_delete.multiple_children.del_parent_snap: PASS (50.88 s)
 (2/3) type_specific.io-github-autotest-libvirt.snapshot_delete.multiple_children.del_current_branch: PASS (67.41 s)
 (3/3) type_specific.io-github-autotest-libvirt.snapshot_delete.multiple_children.del_non_current_branch.tail_to_head: PASS (68.94 s)

```