### PR TITLE
fix storage ceph case cannot get correcct replaced param

### DIFF
--- a/libvirt/tests/cfg/storage/virsh_pool.cfg
+++ b/libvirt/tests/cfg/storage/virsh_pool.cfg
@@ -17,11 +17,11 @@
                     pool_type = 'rbd'
                     required_commands = "['parallel', 'rbd']"
                     auth_key = "EXAMPLE_AUTH_KEY"
-                    auth_user = 'EXAMPLE_AUTH_USER'
-                    client_name = 'EXAMPLE_CLIENT_NAME'
-                    ceph_host_ip = 'EXAMPLE_MON_HOST_AUTHX'
+                    auth_user = "EXAMPLE_AUTH_USER"
+                    client_name = "EXAMPLE_CLIENT_NAME"
+                    ceph_host_ip = "EXAMPLE_MON_HOST_AUTHX"
                     mon_host = "${ceph_host_ip}"
-                    pool_source_name = 'EXAMPLE_POOL_NAME'
+                    pool_source_name = "EXAMPLE_POOL_NAME"
                     pool_name = 'libvirt-rbd-pool'
                     image_path = "${pool_source_name}/%s_rbd.img"
                     rbd_image_size = '5M'


### PR DESCRIPTION
  we need to use double quotation marks instead of single quotation
Signed-off-by: nanli <nanli@redhat.com>

Error:
`/usr/bin/virsh pool-undefine libvirt-rbd-pool ' failed.stdout: b'\n'stderr: b&quot;error: failed to get pool 'libvirt-rbd-pool'\nerror: Storage pool not found: no storage pool with matching name 'libvirt-rbd-pool'\n&quot;additional_info: None&#10;`
`'rbd -m EXAMPLE_MON_HOST_AUTHX  create EXAMPLE_POOL_NAME/9.4_rbd.img -s 5
`
Fixed
`Get the correct parameter`