### PR TITLE
guest_agent: Add a case about socket path

### DIFF
--- a/libvirt/tests/cfg/guest_agent/guest_agent.cfg
+++ b/libvirt/tests/cfg/guest_agent/guest_agent.cfg
@@ -10,8 +10,12 @@
             only ga_started
             hotunplug_ga = "yes"
         - customize_source_path:
-            src_path = '/test/agent'
             con_label = "system_u:object_r:qemu_var_run_t:s0"
+            variants:
+                - auto_gen_path:
+                    src_path = "/40-a/org.qemu.guest_agent.0"
+                - random:
+                    src_path = "/test/agent"
         - hotplug_ga_without_tgt_type:
             only ga_started
             hotplug_ga_without_tgt_type = "yes"

--- a/libvirt/tests/src/guest_agent/guest_agent.py
+++ b/libvirt/tests/src/guest_agent/guest_agent.py
@@ -91,10 +91,12 @@ def run(test, params, env):
     label = params.get("con_label")
     vm = env.get_vm(vm_name)
 
+    socket_file_dir_created = False
     if src_path:
         socket_file_dir = os.path.dirname(src_path)
         if not os.path.exists(socket_file_dir):
             os.mkdir(socket_file_dir)
+            socket_file_dir_created = True
         shutil.chown(socket_file_dir, "qemu", "qemu")
         utils_selinux.set_context_of_file(filename=socket_file_dir,
                                           context=label)
@@ -142,3 +144,5 @@ def run(test, params, env):
     finally:
         vm.destroy()
         backup_xml.sync()
+        if socket_file_dir_created and os.path.exists(socket_file_dir):
+            os.rmdir(socket_file_dir)


### PR DESCRIPTION
This PR adds a test about a socket path belonging to part of auto-generated path.

```
 (1/6) type_specific.io-github-autotest-libvirt.guest_agent.positive.ga_started.ga_state_test: PASS (57.75 s)
 (2/6) type_specific.io-github-autotest-libvirt.guest_agent.positive.ga_started.restart_libvirtd: PASS (57.35 s)
 (3/6) type_specific.io-github-autotest-libvirt.guest_agent.positive.ga_started.suspend_resume_guest: PASS (57.07 s)
 (4/6) type_specific.io-github-autotest-libvirt.guest_agent.positive.ga_started.hotunplug_ga: PASS (55.82 s)
 (5/6) type_specific.io-github-autotest-libvirt.guest_agent.positive.ga_started.customize_source_path.auto_gen_path: PASS (57.38 s)
 (6/6) type_specific.io-github-autotest-libvirt.guest_agent.positive.ga_started.customize_source_path.random: PASS (57.15 s)
 (1/6) type_specific.io-github-autotest-libvirt.guest_agent.negative.ga_started.hotplug_ga_without_tgt_type: PASS (57.72 s)
 (2/6) type_specific.io-github-autotest-libvirt.guest_agent.negative.ga_stopped.ga_state_test: PASS (57.15 s)
 (3/6) type_specific.io-github-autotest-libvirt.guest_agent.negative.ga_stopped.restart_libvirtd: PASS (58.64 s)
 (4/6) type_specific.io-github-autotest-libvirt.guest_agent.negative.ga_stopped.suspend_resume_guest: PASS (58.62 s)
 (5/6) type_specific.io-github-autotest-libvirt.guest_agent.negative.ga_stopped.customize_source_path.auto_gen_path: PASS (57.50 s)
 (6/6) type_specific.io-github-autotest-libvirt.guest_agent.negative.ga_stopped.customize_source_path.random: PASS (57.61 s)

```