### PR TITLE
Add new case of update interface: update-device with options

### DIFF
--- a/libvirt/tests/cfg/virtual_network/update_device/update_iface_with_options_active.cfg
+++ b/libvirt/tests/cfg/virtual_network/update_device/update_iface_with_options_active.cfg
@@ -1,0 +1,32 @@
+- virtual_network.update_device.with_options.active_vm:
+    type = update_iface_with_options
+    start_vm = no
+    timeout = 240
+    vm_active = True
+    iface_attrs = {'link_state': 'up'}
+    update_attrs = {'link_state': 'down'}
+    variants options:
+        - live:
+            update_expect = {'active': True, 'inactive': False}
+        - live_persistent:
+            update_expect = {'active': True, 'inactive': True}
+        - live_config:
+            update_expect = {'active': True, 'inactive': True}
+        - live_current:
+            status_error = yes
+            err_msg = Options .* and .* are mutually exclusive
+            update_expect = {'active': False, 'inactive': False}
+        - current:
+            update_expect = {'active': True, 'inactive': False}
+        - persistent:
+            update_expect = {'active': True, 'inactive': True}
+        - persistent_current:
+            status_error = yes
+            err_msg = Options .* and .* are mutually exclusive
+            update_expect = {'active': False, 'inactive': False}
+        - config:
+            update_expect = {'active': False, 'inactive': True}
+        - config_persistent:
+            update_expect = {'active': True, 'inactive': True}
+        - none:
+            update_expect = {'active': True, 'inactive': False}

--- a/libvirt/tests/cfg/virtual_network/update_device/update_iface_with_options_inactive.cfg
+++ b/libvirt/tests/cfg/virtual_network/update_device/update_iface_with_options_inactive.cfg
@@ -1,0 +1,38 @@
+- virtual_network.update_device.with_options.inactive_vm:
+    type = update_iface_with_options
+    start_vm = no
+    timeout = 240
+    vm_active = False
+    iface_attrs = {'link_state': 'up'}
+    update_attrs = {'link_state': 'down'}
+    variants options:
+        - live:
+            status_error = yes
+            err_msg = Requested operation is not valid: domain is not running
+            update_expect = {'inactive': False}
+        - live_persistent:
+            status_error = yes
+            err_msg = Requested operation is not valid: domain is not running
+            update_expect = {'inactive': False}
+        - live_config:
+            status_error = yes
+            err_msg = Requested operation is not valid: domain is not running
+            update_expect = {'inactive': False}
+        - live_current:
+            status_error = yes
+            err_msg = Options --current and --live are mutually exclusive
+            update_expect = {'inactive': False}
+        - current:
+            update_expect = {'inactive': True}
+        - persistent:
+            update_expect = {'inactive': True}
+        - persistent_current:
+            status_error = yes
+            err_msg = Options --persistent and --current are mutually exclusive
+            update_expect = {'inactive': False}
+        - config:
+            update_expect = {'inactive': True}
+        - config_persistent:
+            update_expect = {'inactive': True}
+        - none:
+            update_expect = {'inactive': True}

--- a/libvirt/tests/src/virtual_network/update_device/update_iface_with_options.py
+++ b/libvirt/tests/src/virtual_network/update_device/update_iface_with_options.py
@@ -1,0 +1,90 @@
+import logging
+
+from virttest import utils_net
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+from provider.virtual_network import network_base
+
+VIRSH_ARGS = {'ignore_status': False, 'debug': True}
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+
+def run(test, params, env):
+    """
+    Test Update an interface by update-device
+    with --live/--config/--current/--persistent on active/inactive domain
+    """
+    vm_name = params.get('main_vm')
+    vm = env.get_vm(vm_name)
+    status_error = 'yes' == params.get('status_error', 'no')
+    err_msg = params.get('err_msg')
+    iface_attrs = eval(params.get('iface_attrs', '{}'))
+    update_attrs = eval(params.get('update_attrs', '{}'))
+    update_expect = eval(params.get('update_expect', '{}'))
+    options = params.get('options')
+    vm_active = eval(params.get('vm_active'))
+
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+
+    try:
+        libvirt_vmxml.modify_vm_device(vmxml, 'interface', iface_attrs)
+        LOG.debug(f'VMXML of {vm_name}:\n{virsh.dumpxml(vm_name).stdout_text}')
+
+        if vm_active:
+            vm.start()
+            vm.wait_for_serial_login().close()
+
+        iface = network_base.get_iface_xml_inst(vm_name, 'on vm')
+        mac = iface.mac_address
+        LOG.debug(f'Mac address of iface: {mac}')
+        LOG.debug(f'Update iface with attrs: {update_attrs}')
+        iface.setup_attrs(**update_attrs)
+
+        # Generate options for update-device command
+        options = options.split('_') if 'none' not in options else []
+        options = ' '.join([f'--{opt}' for opt in options])
+        LOG.debug(f'Update iface with xml:\n{iface}')
+        up_result = virsh.update_device(vm_name, iface.xml, flagstr=options,
+                                        debug=True)
+        libvirt.check_exit_status(up_result, status_error)
+        if err_msg:
+            libvirt.check_result(up_result, err_msg)
+
+        if vm_active:
+            iface_active = network_base.get_iface_xml_inst(
+                vm_name, 'on active vm after update')
+            LOG.debug(f'link state on active xml should be '
+                      f'{"down" if update_expect["active"] else "up"}')
+            if (iface_active.link_state == 'down') is not update_expect['active']:
+                test.fail('update result of iface xml on active vm '
+                          'not met expectation.')
+
+        iface_inactive = network_base.get_iface_xml_inst(
+            vm_name, 'on inactive vm after update', options='--inactive')
+        LOG.debug(f'link state on inactive xml should be '
+                  f'{"down" if update_expect["inactive"] else "up"}')
+        if (iface_inactive.link_state == 'down') is not update_expect['inactive']:
+            test.fail('update result of iface xml on inactive vm '
+                      'not met expectation.')
+
+        # Check update result on vm with ethtool
+        if vm_active:
+            session = vm.wait_for_serial_login()
+            vm_iface_info = utils_net.get_linux_iface_info(
+                mac=mac, session=session)
+            LOG.debug(f'iface info on vm: {vm_iface_info}')
+            ethtool_output = session.cmd_output(
+                f'ethtool {vm_iface_info["ifname"]}')
+            LOG.debug(f'ethtool output:\n{ethtool_output}')
+            LOG.debug(f'"Link detected" should be '
+                      f'{"no" if update_expect["active"] else "yes"}')
+            if ('Link detected: no' in ethtool_output) is not \
+                    update_expect['active']:
+                test.fail('ethtool check inside vm failed.')
+    finally:
+        bkxml.sync()

--- a/provider/virtual_network/network_base.py
+++ b/provider/virtual_network/network_base.py
@@ -265,7 +265,7 @@ def set_static_ip(iface, ip, netmask, session):
     session.cmd(f'ifconfig {iface} {ip}/{netmask}')
 
 
-def get_iface_xml_inst(vm_name, comment, index=0):
+def get_iface_xml_inst(vm_name, comment, index=0, options=''):
     """
     Get iface xml instance with given vm and index
 
@@ -274,7 +274,7 @@ def get_iface_xml_inst(vm_name, comment, index=0):
     :param index: index of interface on vm, defaults to 0
     :return: xml instance of interface
     """
-    vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+    vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name, options=options)
     iface = vmxml.get_devices('interface')[index]
     LOG.debug(f'Interface xml ({comment}):\n{iface}')
     return iface


### PR DESCRIPTION
- VIRT-298326 - [update-device] Update an interface by update-device with --live/--config/--current/--persistent on active domain
- VIRT-298319 - [update-device] Update an interface by update-device with --live/--config/--current/--persistent on inactive domain

Test result:
```
 (01/20) type_specific.io-github-autotest-libvirt.virtual_network.update_device.with_options.active_vm.live: PASS (64.53 s)
 (02/20) type_specific.io-github-autotest-libvirt.virtual_network.update_device.with_options.active_vm.live_persistent: PASS (65.27 s)
 (03/20) type_specific.io-github-autotest-libvirt.virtual_network.update_device.with_options.active_vm.live_config: PASS (65.47 s)
 (04/20) type_specific.io-github-autotest-libvirt.virtual_network.update_device.with_options.active_vm.live_current: PASS (65.33 s)
 (05/20) type_specific.io-github-autotest-libvirt.virtual_network.update_device.with_options.active_vm.current: PASS (65.04 s)
 (06/20) type_specific.io-github-autotest-libvirt.virtual_network.update_device.with_options.active_vm.persistent: PASS (64.86 s)
 (07/20) type_specific.io-github-autotest-libvirt.virtual_network.update_device.with_options.active_vm.persistent_current:PASS (65.32 s)
 (08/20) type_specific.io-github-autotest-libvirt.virtual_network.update_device.with_options.active_vm.config: PASS (64.87 s)
 (09/20) type_specific.io-github-autotest-libvirt.virtual_network.update_device.with_options.active_vm.config_persistent: PASS (65.46 s)
 (10/20) type_specific.io-github-autotest-libvirt.virtual_network.update_device.with_options.active_vm.none: PASS (64.89 s)
 (11/20) type_specific.io-github-autotest-libvirt.virtual_network.update_device.with_options.inactive_vm.live: PASS (6.20 s)
 (12/20) type_specific.io-github-autotest-libvirt.virtual_network.update_device.with_options.inactive_vm.live_persistent: PASS (6.19 s)
 (13/20) type_specific.io-github-autotest-libvirt.virtual_network.update_device.with_options.inactive_vm.live_config: PASS (6.13 s)
 (14/20) type_specific.io-github-autotest-libvirt.virtual_network.update_device.with_options.inactive_vm.live_current: PASS (6.22 s)
 (15/20) type_specific.io-github-autotest-libvirt.virtual_network.update_device.with_options.inactive_vm.current: PASS (6.21 s)
 (16/20) type_specific.io-github-autotest-libvirt.virtual_network.update_device.with_options.inactive_vm.persistent: PASS (6.22 s)
 (17/20) type_specific.io-github-autotest-libvirt.virtual_network.update_device.with_options.inactive_vm.persistent_current:
 PASS (6.25 s)
 (18/20) type_specific.io-github-autotest-libvirt.virtual_network.update_device.with_options.inactive_vm.config: PASS (6.25 s)
 (19/20) type_specific.io-github-autotest-libvirt.virtual_network.update_device.with_options.inactive_vm.config_persistent:
PASS (6.23 s)
 (20/20) type_specific.io-github-autotest-libvirt.virtual_network.update_device.with_options.inactive_vm.none: PASS (6.21 s)
RESULTS    : PASS 20 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```