### PR TITLE
Add new cases of libvirtd

### DIFF
--- a/libvirt/tests/cfg/daemon/check_socket_files_with_services.cfg
+++ b/libvirt/tests/cfg/daemon/check_socket_files_with_services.cfg
@@ -1,0 +1,5 @@
+- daemon.check_socket_files_with_services:
+    type = check_socket_files_with_services
+    start_vm = no
+    service_list = ['qemu', 'interface', 'network', 'nodedev', 'nwfilter', 'secret', 'storage', 'proxy']
+    other_socket_files = ['virtlockd-sock', 'virtlogd-sock']

--- a/libvirt/tests/cfg/daemon/check_virsh_connection_switch_between_monolithic_and_modular.cfg
+++ b/libvirt/tests/cfg/daemon/check_virsh_connection_switch_between_monolithic_and_modular.cfg
@@ -1,0 +1,3 @@
+- daemon.check_virsh_connection_switch_between_monolithic_and_modular:
+    type = check_virsh_connection_switch_between_monolithic_and_modular
+    start_vm = no

--- a/libvirt/tests/cfg/daemon/enable_disable_daemon_socket_services.cfg
+++ b/libvirt/tests/cfg/daemon/enable_disable_daemon_socket_services.cfg
@@ -1,0 +1,17 @@
+- daemon.enable_disable_daemon_socket_services:
+    type = enable_disable_daemon_socket_services
+    start_vm = no
+    service_list = ['qemu', 'interface', 'network', 'nodedev', 'nwfilter', 'secret', 'storage', 'proxy']
+    variants:
+        - main_socket:
+            service_list = ['qemu', 'interface', 'network', 'nodedev', 'nwfilter', 'secret', 'storage']
+            sock_type = 
+        - ro_socket:
+            service_list = ['qemu', 'interface', 'network', 'nodedev', 'nwfilter', 'secret', 'storage']
+            sock_type = -ro
+        - admin_socket:
+            service_list = ['qemu', 'interface', 'network', 'nodedev', 'nwfilter', 'secret', 'storage']
+            sock_type = -admin
+        - only_virtproxyd:
+            service_list = ['proxy']
+            sock_type = 

--- a/libvirt/tests/src/daemon/check_socket_files_with_services.py
+++ b/libvirt/tests/src/daemon/check_socket_files_with_services.py
@@ -1,0 +1,58 @@
+import logging
+import os
+
+from virttest.staging import service
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+
+def run(test, params, env):
+    """
+    Check the socket files are cleaned or created after stop/start
+    daemons' service.
+    """
+    daemon_list = eval(params.get('service_list'))
+    other_socket_files = eval(params.get('other_socket_files'))
+
+    try:
+        daemon_srv_list = []
+        daemon_list = [f'virt{sub_daemon}d' for sub_daemon in daemon_list]
+        for daemon in daemon_list:
+            daemon_srv = service.Factory.create_service(daemon)
+            daemon_srv_list.append(daemon_srv)
+            daemon_srv.start()
+
+        all_sock_files = os.listdir('/var/run/libvirt')
+
+        daemons = daemon_list.copy()
+        daemons.remove('virtqemud')
+        daemons.remove('virtproxyd')
+        daemons.append('libvirt')
+        expect_s_files = [[f'{x}-admin-sock',
+                           f'{x}-sock',
+                           f'{x}-sock-ro'] for x in daemons]
+        expect_s_files = [x for y in expect_s_files for x in y]
+        expect_s_files.extend(other_socket_files)
+        LOG.debug(f'Expect socket files:\n{expect_s_files}')
+        diff = set(expect_s_files).difference(set(all_sock_files))
+        if diff:
+            test.fail(f'Not found expected socket files: {diff}')
+
+        for daemon in daemon_list:
+            daemon_sock_srv = service.Factory.create_service(
+                daemon + '.socket')
+            daemon_sock_srv.stop()
+
+        all_sock_files = os.listdir('/var/run/libvirt')
+        LOG.debug(f'All files in /var/run/libvirt\n{all_sock_files}')
+        left_s_files = set(expect_s_files).intersection(set(all_sock_files))
+        LOG.debug(f'Socket files left: {left_s_files}')
+        unexpect = left_s_files.difference(set(other_socket_files))
+        if unexpect:
+            test.fail(f'Found unexpected socket files left: {unexpect}')
+
+    finally:
+        for daemon in daemon_list:
+            daemon_sock_srv = service.Factory.create_service(
+                daemon + '.socket')
+            daemon_sock_srv.start()

--- a/libvirt/tests/src/daemon/check_virsh_connection_switch_between_monolithic_and_modular.py
+++ b/libvirt/tests/src/daemon/check_virsh_connection_switch_between_monolithic_and_modular.py
@@ -1,0 +1,33 @@
+import logging
+
+from virttest.staging import service
+
+from provider.libvirtd import libvirtd_base
+
+VIRSH_ARGS = {'ignore_status': False, 'debug': True}
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+
+def run(test, params, env):
+    """
+    Verify virsh connection can work well after switching between the legacy
+    monolithic daemon and the modular daemon
+    """
+    try:
+        libvirtd_srv = service.Factory.create_service('libvirtd')
+        virtqemud_srv = service.Factory.create_service('virtqemud')
+        libvirtd_base.check_virsh_connection('before test')
+        libvirtd_base.check_service_status('virtqemud', True)
+        libvirtd_srv.start()
+        libvirtd_base.check_service_status('libvirtd', True)
+        libvirtd_base.check_service_status('virtqemud', False)
+        libvirtd_base.check_virsh_connection(
+            'after switch to legacy monolithic daemon mode')
+        virtqemud_srv.start()
+        libvirtd_base.check_service_status('libvirtd', False)
+        libvirtd_base.check_service_status('virtqemud', True)
+        libvirtd_base.check_virsh_connection(
+            'after switch back to modular daemon mode')
+    finally:
+        virtqemud_srv.start()

--- a/libvirt/tests/src/daemon/enable_disable_daemon_socket_services.py
+++ b/libvirt/tests/src/daemon/enable_disable_daemon_socket_services.py
@@ -1,0 +1,52 @@
+import logging
+
+from virttest.staging import service
+
+from provider.libvirtd import libvirtd_base
+
+VIRSH_ARGS = {'ignore_status': False, 'debug': True}
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+
+def run(test, params, env):
+    """
+    Verify socket services will be in expected status after enable/disable
+    """
+    service_list = eval(params.get('service_list'))
+    sock_type = params.get('sock_type') + '.socket'
+    daemon_list = [f'virt{ser}d' for ser in service_list]
+
+    # Disable main socket before test
+    for daemon in daemon_list:
+        socket_srv = service.Factory.create_service(daemon + '.socket')
+        socket_srv.disable()
+
+    try:
+        LOG.info('Test enable socket services')
+        for daemon in daemon_list:
+            socket_srv = service.Factory.create_service(daemon + sock_type)
+            LOG.debug(f'Enable service [{socket_srv}]')
+            socket_srv.enable()
+            libvirtd_base.check_service_status(daemon + '.socket',
+                                               expect_enabled=True)
+            libvirtd_base.check_service_status(daemon + '-ro.socket',
+                                               expect_enabled=True)
+            libvirtd_base.check_service_status(daemon + '-admin.socket',
+                                               expect_enabled=True)
+
+        LOG.info('Test disable socket services')
+        for daemon in daemon_list:
+            socket_srv = service.Factory.create_service(daemon + sock_type)
+            LOG.debug(f'Disable service [{socket_srv}]')
+            socket_srv.disable()
+            libvirtd_base.check_service_status(daemon + '.socket',
+                                               expect_enabled=False)
+            libvirtd_base.check_service_status(daemon + '-ro.socket',
+                                               expect_enabled=False)
+            libvirtd_base.check_service_status(daemon + '-admin.socket',
+                                               expect_enabled=False)
+    finally:
+        for daemon in daemon_list:
+            socket_srv = service.Factory.create_service(daemon + '.socket')
+            socket_srv.enable()

--- a/provider/libvirtd/libvirtd_base.py
+++ b/provider/libvirtd/libvirtd_base.py
@@ -1,0 +1,54 @@
+
+import logging
+
+from avocado.core import exceptions
+from virttest import virsh
+from virttest.staging import service
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+
+def check_service_status(service_name, expect_active=None,
+                         expect_enabled=None):
+    """
+    Check status of service
+
+    :param service_name: name of service to be checked
+    :param expect_active: expect service status, True if active,
+                          False if inactive, defaults to None
+    :param expect_enabled: expect service enablement, True if enabled
+                           False if disenabled, defaults to None
+    """
+    LOG.info(f'Check service status of {service_name}')
+    srvc = service.Factory.create_service(service_name)
+    LOG.debug(f'Service [{service_name}] status is '
+              f'{"active" if srvc.status() else "inactive"}.\n'
+              f'Service [{service_name}] is '
+              f'{"enabled" if srvc.is_enabled() else "disabled"}')
+    if expect_active is not None:
+        if srvc.status() == expect_active:
+            LOG.info(f'Service status check PASSED')
+        else:
+            raise exceptions.TestFail(f'Expect service [{service_name}] to be '
+                                      f'{"active" if expect_active else "inactive"}')
+    if expect_enabled is not None:
+        if srvc.is_enabled() is expect_enabled:
+            LOG.info(f'Service enable check PASSED')
+        else:
+            raise exceptions.TestFail(f'Expect service [{service_name}] to be '
+                                      f'{"enabled" if expect_enabled else "disabled"}')
+
+
+def check_virsh_connection(msg):
+    """
+    Check virsh connection by running virsh list
+
+    :param msg: message to display
+    """
+    LOG.info(f'Check virsh connection {msg}')
+    conn_result = virsh.dom_list(debug=True)
+    if conn_result.exit_status == 0:
+        LOG.info(f'Virsh connection check {msg} PASSED')
+    else:
+        raise exceptions.TestFail(f'Virsh connection {msg} FAILED:\n'
+                                  f'{conn_result.stderr_text}')


### PR DESCRIPTION
- VIRT-300392 - Enable/disable daemons socket services
- VIRT-300393 - Check the socket files after start/stop daemons' socket service
- VIRT-300394 - Check virsh connection after switching between the legacy monolithic daemon and the modular daemon

Test result:
```
 (1/6) type_specific.io-github-autotest-libvirt.daemon.check_virsh_connection_switch_between_monolithic_and_modular: PASS (6.54 s)
 (2/6) type_specific.io-github-autotest-libvirt.daemon.enable_disable_daemon_socket_services.main_socket: PASS (14.20 s)
 (3/6) type_specific.io-github-autotest-libvirt.daemon.enable_disable_daemon_socket_services.ro_socket: PASS (14.13 s)
 (4/6) type_specific.io-github-autotest-libvirt.daemon.enable_disable_daemon_socket_services.admin_socket: PASS (14.20 s)
 (5/6) type_specific.io-github-autotest-libvirt.daemon.enable_disable_daemon_socket_services.only_virtproxyd: PASS (6.61 s)
 (6/6) type_specific.io-github-autotest-libvirt.daemon.check_socket_files_with_services: PASS (6.30 s)
RESULTS    : PASS 6 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```