### PR TITLE
fix snapshot case to use appropirate get snap state function

### DIFF
--- a/libvirt/tests/cfg/snapshot/revert_snap_based_on_state.cfg
+++ b/libvirt/tests/cfg/snapshot/revert_snap_based_on_state.cfg
@@ -1,19 +1,19 @@
-- snapshot_revert.snap_and_domain_status:
-    type = revert_snap_based_on_status
+- snapshot_revert.snap_and_domain_state:
+    type = revert_snap_based_on_state
     start_vm = no
     snap_name = 's1'
     func_supported_since_libvirt_ver = (9, 10, 0)
-    variants :
+    variants:
         - snap_running:
-            snap_status = "running"
-            expected_status = "${snap_status}"
+            snap_state = "running"
+            expected_state = "${snap_state}"
             snap_options = " %s --memspec snapshot=external,file=/tmp/mem.s1 --diskspec vda,snapshot=external,file=/tmp/vda.s1"
         - snap_shutoff:
-            snap_status = "shutoff"
-            expected_status = "shut off"
+            snap_state = "shutoff"
+            expected_state = "shut off"
             snap_options = " %s --diskspec vda,snapshot=external,file=/tmp/vda.s1"
     variants:
         - vm_running:
-            vm_status = "running"
+            vm_state = "running"
         - vm_shutoff:
-            vm_status = "shut off"
+            vm_state = "shut off"

--- a/libvirt/tests/src/snapshot/revert_snap_based_on_state.py
+++ b/libvirt/tests/src/snapshot/revert_snap_based_on_state.py
@@ -11,47 +11,64 @@ from virttest import libvirt_version
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
+from virttest.utils_libvirt import libvirt_misc
 
 from provider.snapshot import snapshot_base
 
 
 def run(test, params, env):
     """
-    Revert snapshots based on different domain status.
+    Revert snapshots based on different domain state.
     """
+
+    def get_snap_state(vm_name):
+        """
+        Get list of snapshots state of domain.
+
+        :param vm_name: name of domain
+        :return: dict of snapshot names and snapshot state,
+         e.g.: get {'s1': 'running', 's2': 'running'}
+        """
+        result = virsh.command("snapshot-list %s" % vm_name,
+                               **virsh_dargs).stdout_text.strip()
+        state_dict = libvirt_misc.convert_to_dict(
+            result, r"(\S*) *\d+.* \d*:\d*:\d* .\d* *(\S*)")
+        test.log.debug("Get snap name and state dict is :%s", state_dict)
+        return state_dict
+
     def run_test():
         """
-        Revert snapshots based on different domain status.
+        Revert snapshots based on different domain state.
         """
         test.log.info("TEST_STEP1: Prepare a snap.")
-        if snap_status == "running":
+        if snap_state == "running":
             virsh.start(vm_name, **virsh_dargs)
             vm.wait_for_login().close()
         virsh.snapshot_create_as(vm_name, snap_options % snap_name,
                                  **virsh_dargs)
-        status_result = virsh.snapshot_status(vm_name, **virsh_dargs)
-        if status_result[snap_name] != snap_status:
-            test.fail("%s status should be '%s' instead of '%s'" % (
-                snap_name, snap_status, status_result[snap_name]))
+        state_result = get_snap_state(vm_name)
+        if state_result[snap_name] != snap_state:
+            test.fail("%s state should be '%s' instead of '%s'" % (
+                snap_name, snap_state, state_result[snap_name]))
         else:
-            test.log.debug("Check snap status '%s' is correct" % snap_status)
+            test.log.debug("Check snap state '%s' is correct" % snap_state)
 
-        test.log.info("TEST_STEP2: Set domain status.")
-        if vm_status.replace(' ', '') != snap_status:
-            if vm_status == "shut off":
+        test.log.info("TEST_STEP2: Set domain state.")
+        if vm_state.replace(' ', '') != snap_state:
+            if vm_state == "shut off":
                 virsh.destroy(vm_name, **virsh_dargs)
-            elif vm_status == "running":
+            elif vm_state == "running":
                 virsh.start(vm_name, **virsh_dargs)
                 vm.wait_for_login().close()
 
         test.log.info("TEST_STEP3: Revert the snapshot")
         virsh.snapshot_revert(vm_name, snap_name, **virsh_dargs)
 
-        test.log.info("TEST_STEP5: Check expected domain status")
-        if not libvirt.check_vm_state(vm_name, expected_status):
-            test.fail("VM status should be '%s' after reverting." % expected_status)
+        test.log.info("TEST_STEP5: Check expected domain state")
+        if not libvirt.check_vm_state(vm_name, expected_state):
+            test.fail("VM state should be '%s' after reverting." % expected_state)
         else:
-            test.log.debug("Check vm status '%s' is correct", expected_status)
+            test.log.debug("Check vm state '%s' is correct", expected_state)
 
     def teardown_test():
         """
@@ -68,9 +85,9 @@ def run(test, params, env):
     virsh_dargs = {"debug": True, "ignore_status": True}
     snap_name = params.get("snap_name")
     snap_options = params.get("snap_options")
-    snap_status = params.get("snap_status")
-    vm_status = params.get("vm_status")
-    expected_status = params.get("expected_status")
+    snap_state = params.get("snap_state")
+    vm_state = params.get("vm_state")
+    expected_state = params.get("expected_state")
     test_obj = snapshot_base.SnapshotTest(vm, test, params)
 
     try:


### PR DESCRIPTION
-   no need to use the new created function: virsh.snapshot_status
- replace snap_status with snap_state 

  
Signed-off-by: nanli <nanli@redhat.com>
```
 avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 snapshot_revert.snap_and_domain_status

 (1/4) type_specific.io-github-autotest-libvirt.snapshot_revert.snap_and_domain_status.vm_running.snap_running: PASS (38.76 s)
 (2/4) type_specific.io-github-autotest-libvirt.snapshot_revert.snap_and_domain_status.vm_running.snap_shutoff: PASS (44.38 s)
 (3/4) type_specific.io-github-autotest-libvirt.snapshot_revert.snap_and_domain_status.vm_shutoff.snap_running: PASS (53.22 s)
 (4/4) type_specific.io-github-autotest-libvirt.snapshot_revert.snap_and_domain_status.vm_shutoff.snap_shutoff: PASS (8.48 s)

```