### PR TITLE
virtual_network: Add a case of link state

### DIFF
--- a/libvirt/tests/cfg/virtual_network/link_state/link_state_model_type.cfg
+++ b/libvirt/tests/cfg/virtual_network/link_state/link_state_model_type.cfg
@@ -1,0 +1,49 @@
+- virtual_network.link_state.model:
+    type = link_state_model_type
+    start_vm = no
+    timeout = 240
+    outside_ip = "www.redhat.com"
+    vm_ping_outside = pass
+    variants:
+        - initial_up:
+            initial_link_state = "up"
+        - initial_down:
+            initial_link_state = "down"
+        - without_state:
+    variants model_type:
+        - virtio:
+        - e1000e:
+            only x86_64
+        - igb:
+            only x86_64
+            func_supported_since_libvirt_ver = (9, 3, 0)
+        - rtl8139:
+            only x86_64
+    variants interface_type:
+        - network:
+            iface_base_attrs = {"type_name": "network", "source": {"network": "default"}}
+        - direct:
+            only virtio
+            host_iface =
+            iface_base_attrs = {"type_name": "direct", "source": {"dev": host_iface, "mode": "bridge"}}
+        - user:
+            only virtio
+            variants:
+                - root:
+                    iface_base_attrs = {"type_name": "user"}
+                - passt:
+                    host_iface =
+                    iface_base_attrs = {"backend": {"type": "passt"}, "source": {"dev": host_iface}, "type_name": "user"}
+                    variants:
+                        - root:
+                            test_user = "root"
+                        - unprivileged_user:
+                            test_user = USER.EXAMPLE
+                            test_passwd = PASSWORD.EXAMPLE
+                            unpr_vm_name = UNPRIVILEGED_VM.EXAMPLE
+        - ethernet:
+            only virtio
+            create_tap = "yes"
+            iface_base_attrs = {"type_name": "ethernet", "target": {"dev": tap_name, "managed": "no"}}
+
+    iface_attrs = {"model": "${model_type}", **${iface_base_attrs}}

--- a/libvirt/tests/src/virtual_network/link_state/link_state_model_type.py
+++ b/libvirt/tests/src/virtual_network/link_state/link_state_model_type.py
@@ -1,0 +1,110 @@
+from virttest import libvirt_version
+from virttest import virsh
+from virttest import utils_misc
+from virttest import utils_net
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_unprivileged
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+from provider.interface import interface_base
+from provider.virtual_network import network_base
+
+VIRSH_ARGS = {"ignore_status": False, "debug": True}
+
+
+def run(test, params, env):
+    """
+    Start vm with different interface type with various model type and link
+    state setting
+    """
+    libvirt_version.is_libvirt_feature_supported(params)
+
+    outside_ip = params.get("outside_ip")
+    host_iface = params.get("host_iface")
+    host_iface = host_iface if host_iface else utils_net.get_net_if(
+        state="UP")[0]
+    rand_id = utils_misc.generate_random_string(3)
+    bridge_name = "br_" + rand_id
+    tap_name = "tap_" + rand_id
+    interface_type = params.get("interface_type")
+    iface_attrs = eval(params.get("iface_attrs", "{}"))
+    initial_link_state = params.get("initial_link_state", "")
+    if initial_link_state:
+        iface_attrs.update({"link_state": initial_link_state})
+    test_states = [("yes", "up"), ("no", "down")]
+    if initial_link_state == "down":
+        test_states.reverse()
+
+    virsh_ins = virsh
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    test_passwd = params.get("test_passwd", "")
+    test_user = params.get("test_user", "root")
+    if test_user != "root":
+        unpr_vm_args = {"username": params.get("username"),
+                        "password": params.get("password")}
+        vm_name = params.get("unpr_vm_name")
+        vm = libvirt_unprivileged.get_unprivileged_vm(
+            vm_name, test_user, test_passwd, **unpr_vm_args)
+        virsh_ins = virsh.VirshPersistent(uri=vm.connect_uri)
+
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(
+        vm_name, virsh_instance=virsh_ins)
+    bkxml = vmxml.copy()
+
+    try:
+        if interface_type == "ethernet":
+            utils_net.create_linux_bridge_tmux(bridge_name, host_iface)
+            network_base.create_tap(tap_name, bridge_name, "root")
+
+        vmxml.del_device('interface', by_tag=True)
+        libvirt_vmxml.modify_vm_device(vmxml, 'interface', iface_attrs, virsh_instance=virsh_ins)
+        test.log.debug(f'VMXML of {vm_name}:\n{virsh_ins.dumpxml(vm_name).stdout_text}')
+        vm.start()
+        session = vm.wait_for_serial_login()
+        vm_iface = interface_base.get_vm_iface(session)
+
+        test.log.info("TEST_STEP: Check the link state in vm.")
+        iflist = libvirt.get_interface_details(vm_name, virsh_instance=virsh_ins)
+        test.log.debug(f'iflist of vm: {iflist}')
+        iface_info = iflist[0]
+        iface_mac = iface_info['mac']
+        for exp_link_state, exp_domiflik_state in test_states:
+            if exp_link_state == test_states[-1][0]:
+                virsh_ins.domif_setlink(
+                    vm_name, iface_mac, exp_domiflik_state, **VIRSH_ARGS)
+            link_info = virsh_ins.domif_getlink(
+                vm_name, iface_mac, **VIRSH_ARGS).stdout_text
+            if exp_domiflik_state not in link_info:
+                test.fail("Failed to get expected interface link state '%s'!"
+                          % exp_domiflik_state)
+
+            output = session.cmd_output("ethtool %s" % vm_iface)
+            test.log.debug(output)
+            if "Link detected: %s" % exp_link_state not in output:
+                test.fail("Failed to get expected link state '%s' in ethtool "
+                          "cmd!" % exp_link_state)
+
+            if exp_link_state == "yes":
+                if exp_link_state == test_states[-1][0]:
+                    utils_net.restart_guest_network(session)
+                ips = {'outside_ip': outside_ip}
+                network_base.ping_check(params, ips, session, force_ipv4=True)
+        vm_iface = vm_xml.VMXML.new_from_dumpxml(vm.name,
+                                                 virsh_instance=virsh_ins)\
+            .devices.by_device_tag("interface")[0]
+
+        test.log.info("TEST_STEP: Check the live xml for the current link state.")
+        iface_attrs = vm_iface.fetch_attrs()
+        test.log.debug(f"iface attrs: {iface_attrs}")
+        if iface_attrs.get("link_state") != exp_domiflik_state:
+            test.fail("Failed to get expected link state '%s'." % exp_domiflik_state)
+        session.close()
+
+    finally:
+        bkxml.sync()
+        if interface_type == "ethernet":
+            network_base.delete_tap(tap_name)
+            utils_net.delete_linux_bridge_tmux(bridge_name, host_iface)


### PR DESCRIPTION
This PR adds:
    VIRT-298009 - Start vm with different interface type with
        various model type and link state setting


Depends on:
- https://github.com/avocado-framework/avocado-vt/pull/3887

**Test results:** The failed cases are due to a known issue.
```
 (01/27) type_specific.io-github-autotest-libvirt.virtual_network.link_state.model.network.virtio.initial_up: PASS (57.17 s)
 (02/27) type_specific.io-github-autotest-libvirt.virtual_network.link_state.model.network.virtio.initial_down: PASS (62.61 s)
 (03/27) type_specific.io-github-autotest-libvirt.virtual_network.link_state.model.network.virtio.without_state: PASS (99.20 s)
 (04/27) type_specific.io-github-autotest-libvirt.virtual_network.link_state.model.network.e1000e.initial_up: PASS (57.55 s)
 (05/27) type_specific.io-github-autotest-libvirt.virtual_network.link_state.model.network.e1000e.initial_down: FAIL: Failed to get expected link state 'no' in ethtool cmd! (95.03 s)
 (06/27) type_specific.io-github-autotest-libvirt.virtual_network.link_state.model.network.e1000e.without_state: PASS (58.76 s)
 (07/27) type_specific.io-github-autotest-libvirt.virtual_network.link_state.model.network.igb.initial_up:PASS (50.78 s)
 (08/27) type_specific.io-github-autotest-libvirt.virtual_network.link_state.model.network.igb.initial_down: FAIL: Failed to get expected link state 'no' in ethtool cmd! (45.18 s)
 (09/27) type_specific.io-github-autotest-libvirt.virtual_network.link_state.model.network.igb.without_state: PASS (49.67 s)
 (10/27) type_specific.io-github-autotest-libvirt.virtual_network.link_state.model.network.rtl8139.initial_up: PASS (58.43 s)
 (11/27) type_specific.io-github-autotest-libvirt.virtual_network.link_state.model.network.rtl8139.initial_down: PASS (63.40 s)
 (12/27) type_specific.io-github-autotest-libvirt.virtual_network.link_state.model.network.rtl8139.without_state: PASS (58.03 s)
 (13/27) type_specific.io-github-autotest-libvirt.virtual_network.link_state.model.direct.virtio.initial_up: PASS (57.17 s)
 (14/27) type_specific.io-github-autotest-libvirt.virtual_network.link_state.model.direct.virtio.initial_down: PASS (83.23 s)
 (15/27) type_specific.io-github-autotest-libvirt.virtual_network.link_state.model.direct.virtio.without_state: PASS (57.32 s)
 (16/27) type_specific.io-github-autotest-libvirt.virtual_network.link_state.model.user.root.virtio.initial_up: PASS (57.65 s)
 (17/27) type_specific.io-github-autotest-libvirt.virtual_network.link_state.model.user.root.virtio.initial_down: PASS (59.56 s)
 (18/27) type_specific.io-github-autotest-libvirt.virtual_network.link_state.model.user.root.virtio.without_state: PASS (59.31 s)
 (19/27) type_specific.io-github-autotest-libvirt.virtual_network.link_state.model.user.passt.root.virtio.initial_up: PASS (57.56 s)
 (20/27) type_specific.io-github-autotest-libvirt.virtual_network.link_state.model.user.passt.root.virtio.initial_down: PASS (61.49 s)
 (21/27) type_specific.io-github-autotest-libvirt.virtual_network.link_state.model.user.passt.root.virtio.without_state: PASS (57.67 s)
 (22/27) type_specific.io-github-autotest-libvirt.virtual_network.link_state.model.user.passt.unprivileged_user.virtio.initial_up: PASS (62.49 s)
 (23/27) type_specific.io-github-autotest-libvirt.virtual_network.link_state.model.user.passt.unprivileged_user.virtio.initial_down: PASS (67.38 s)
 (24/27) type_specific.io-github-autotest-libvirt.virtual_network.link_state.model.user.passt.unprivileged_user.virtio.without_state: PASS (63.48 s)
 (25/27) type_specific.io-github-autotest-libvirt.virtual_network.link_state.model.ethernet.virtio.initial_up: PASS (78.07 s)
 (26/27) type_specific.io-github-autotest-libvirt.virtual_network.link_state.model.ethernet.virtio.initial_down: PASS (103.90 s)
 (27/27) type_specific.io-github-autotest-libvirt.virtual_network.link_state.model.ethernet.virtio.without_state: PASS (77.49 s)
RESULTS    : PASS 25 | ERROR 0 | FAIL 2 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2024-04-08T06.00-352a747/results.html
JOB TIME   : 1762.44 s

```