### PR TITLE
fix snapshot case the libvirt version issue

### DIFF
--- a/libvirt/tests/src/snapshot/revert_memory_only_snap.py
+++ b/libvirt/tests/src/snapshot/revert_memory_only_snap.py
@@ -71,9 +71,9 @@ def run(test, params, env):
     target_disk = params.get("target_disk")
     test_obj = snapshot_base.SnapshotTest(vm, test, params)
     disk_obj = disk_base.DiskBase(test, vm, params)
+    libvirt_version.is_libvirt_feature_supported(params)
 
     try:
-        libvirt_version.is_libvirt_feature_supported(params)
         run_test()
 
     finally:

--- a/libvirt/tests/src/snapshot/revert_snap_based_on_state.py
+++ b/libvirt/tests/src/snapshot/revert_snap_based_on_state.py
@@ -90,9 +90,8 @@ def run(test, params, env):
     expected_state = params.get("expected_state")
     test_obj = snapshot_base.SnapshotTest(vm, test, params)
 
+    libvirt_version.is_libvirt_feature_supported(params)
     try:
-        libvirt_version.is_libvirt_feature_supported(params)
         run_test()
-
     finally:
         teardown_test()

--- a/libvirt/tests/src/snapshot/revert_snap_for_guest_with_genid.py
+++ b/libvirt/tests/src/snapshot/revert_snap_for_guest_with_genid.py
@@ -86,8 +86,8 @@ def run(test, params, env):
     snap_options = params.get("snap_options")
     test_obj = snapshot_base.SnapshotTest(vm, test, params)
 
+    libvirt_version.is_libvirt_feature_supported(params)
     try:
-        libvirt_version.is_libvirt_feature_supported(params)
         run_test()
 
     finally:


### PR DESCRIPTION
   teardown step should not be executed after check vesrion function is executed
Signed-off-by: nanli <nanli@redhat.com>

```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 snapshot_revert
 (1/1) type_specific.io-github-autotest-libvirt.snapshot_revert.memory_only_snap: PASS (52.41 s)
 (1/1) type_specific.io-github-autotest-libvirt.snapshot_revert.snap_and_domain_state: PASS (49.21 s)
 (1/1) type_specific.io-github-autotest-libvirt.snapshot_revert.with_genid: PASS (56.35 s)
```