### PR TITLE
guest numa add aarch64 hugep page adaption

### DIFF
--- a/libvirt/tests/cfg/numa/guest_numa.cfg
+++ b/libvirt/tests/cfg/numa/guest_numa.cfg
@@ -40,7 +40,6 @@
                      variants:
                          - m_strict:
                              memnode_mode_0 = "strict"
-                             kernel_hp_file = "/sys/devices/system/node/node1/hugepages/hugepages-2048kB/nr_hugepages"
                          - m_preferred:
                              memnode_mode_0 = "preferred"
                          - m_interleave:
@@ -61,7 +60,6 @@
                          - mem_backend:
                              no no_numatune_memnode..numatune_mem
                  - hugepage:
-                     vmpage_size_0 = "2048"
                      vmpage_unit_0 = "KiB"
                      vmpage_nodeset_0 = "0"
                      qemu_cmdline_numa_cell_0 = "node,nodeid=0,cpus=0-1,memdev=ram-node0"
@@ -72,6 +70,7 @@
                              cell_memory_1 = "1048576"
                              variants:
                                  - 2M:
+                                     vmpage_size_0 = "2048"
                                      hugepage_size_0 = "2048"
                                      page_num_0 = "512"
                                      page_nodenum_0 = "1"
@@ -94,7 +93,8 @@
                                      pseries:
                                         page_nodenum_0 = "0"
                          - host_total:
-                             nr_pagesize_total = "1024"
+                             vmpage_size_0 = "2048"
+                             hugepage_mem_total = "2097152"
         - negative_test:
              status_error = "yes"
              cell_id_0 = "0"


### PR DESCRIPTION
test results:
on x86:
(01/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.2M.topology.no_numatune_memnode.numatune_mem: PASS (49.22 s)
 (02/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.2M.topology.no_numatune_memnode.no_numatune_mem: PASS (49.89 s)
 (03/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.2M.topology.numatune_memnode.m_strict.numatune_mem: PASS (47.79 s)
 (04/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.2M.topology.numatune_memnode.m_strict.no_numatune_mem: PASS (49.40 s)
 (05/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.2M.topology.numatune_memnode.m_preferred.numatune_mem: PASS (49.80 s)
 (06/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.2M.topology.numatune_memnode.m_preferred.no_numatune_mem: PASS (49.53 s)
 (07/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.2M.topology.numatune_memnode.m_interleave.numatune_mem: PASS (47.51 s)
 (08/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.2M.topology.numatune_memnode.m_interleave.no_numatune_mem: PASS (47.43 s)
 (09/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.2M.no_topo.no_numatune_memnode.numatune_mem: PASS (47.64 s)
 (10/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.2M.no_topo.no_numatune_memnode.no_numatune_mem: PASS (49.64 s)
 (11/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.2M.no_topo.numatune_memnode.m_strict.numatune_mem: PASS (47.86 s)
 (12/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.2M.no_topo.numatune_memnode.m_strict.no_numatune_mem: PASS (47.59 s)
 (13/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.2M.no_topo.numatune_memnode.m_preferred.numatune_mem: PASS (49.75 s)
 (14/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.2M.no_topo.numatune_memnode.m_preferred.no_numatune_mem: PASS (49.78 s)
 (15/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.2M.no_topo.numatune_memnode.m_interleave.numatune_mem: PASS (47.96 s)
 (16/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.2M.no_topo.numatune_memnode.m_interleave.no_numatune_mem: PASS (49.80 s)
 (17/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.1G.topology.no_numatune_memnode.numatune_mem: PASS (49.97 s)
 (18/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.1G.topology.no_numatune_memnode.no_numatune_mem: PASS (49.71 s)
 (19/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.1G.topology.numatune_memnode.m_strict.numatune_mem: PASS (47.50 s)
 (20/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.1G.topology.numatune_memnode.m_strict.no_numatune_mem: PASS (49.75 s)
 (21/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.1G.topology.numatune_memnode.m_preferred.numatune_mem: PASS (49.91 s)
 (22/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.1G.topology.numatune_memnode.m_preferred.no_numatune_mem: PASS (49.60 s)
 (23/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.1G.topology.numatune_memnode.m_interleave.numatune_mem: PASS (49.75 s)
 (24/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.1G.topology.numatune_memnode.m_interleave.no_numatune_mem: PASS (49.75 s)
 (25/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.1G.no_topo.no_numatune_memnode.numatune_mem: PASS (49.74 s)
 (26/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.1G.no_topo.no_numatune_memnode.no_numatune_mem: PASS (49.80 s)
 (27/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.1G.no_topo.numatune_memnode.m_strict.numatune_mem: PASS (47.72 s)
 (28/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.1G.no_topo.numatune_memnode.m_strict.no_numatune_mem: PASS (49.80 s)
 (29/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.1G.no_topo.numatune_memnode.m_preferred.numatune_mem: PASS (49.75 s)
 (30/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.1G.no_topo.numatune_memnode.m_preferred.no_numatune_mem: PASS (50.08 s)
 (31/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.1G.no_topo.numatune_memnode.m_interleave.numatune_mem: PASS (50.15 s)
 (32/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.1G.no_topo.numatune_memnode.m_interleave.no_numatune_mem: PASS (49.65 s)
 (33/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.16M.topology.no_numatune_memnode.numatune_mem: CANCEL: Hugepage size [16384] isn't supported, please verify kernel cmdline configuration. (8.28 s)
 (34/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.16M.topology.no_numatune_memnode.no_numatune_mem: CANCEL: Hugepage size [16384] isn't supported, please verify kernel cmdline configuration. (8.23 s)
 (35/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.16M.topology.numatune_memnode.m_strict.numatune_mem: CANCEL: Hugepage size [16384] isn't supported, please verify kernel cmdline configuration. (8.19 s)
 (36/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.16M.topology.numatune_memnode.m_strict.no_numatune_mem: CANCEL: Hugepage size [16384] isn't supported, please verify kernel cmdline configuration. (8.23 s)
 (37/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.16M.topology.numatune_memnode.m_preferred.numatune_mem: CANCEL: Hugepage size [16384] isn't supported, please verify kernel cmdline configuration. (8.11 s)
 (38/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.16M.topology.numatune_memnode.m_preferred.no_numatune_mem: CANCEL: Hugepage size [16384] isn't supported, please verify kernel cmdline configuration. (8.19 s)
 (39/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.16M.topology.numatune_memnode.m_interleave.numatune_mem: CANCEL: Hugepage size [16384] isn't supported, please verify kernel cmdline configuration. (8.20 s)
 (40/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.16M.topology.numatune_memnode.m_interleave.no_numatune_mem: CANCEL: Hugepage size [16384] isn't supported, please verify kernel cmdline configuration. (8.26 s)
 (41/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.16M.no_topo.no_numatune_memnode.numatune_mem: CANCEL: Hugepage size [16384] isn't supported, please verify kernel cmdline configuration. (8.20 s)
 (42/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.16M.no_topo.no_numatune_memnode.no_numatune_mem: CANCEL: Hugepage size [16384] isn't supported, please verify kernel cmdline configuration. (8.14 s)
 (43/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.16M.no_topo.numatune_memnode.m_strict.numatune_mem: CANCEL: Hugepage size [16384] isn't supported, please verify kernel cmdline configuration. (8.18 s)
 (44/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.16M.no_topo.numatune_memnode.m_strict.no_numatune_mem: CANCEL: Hugepage size [16384] isn't supported, please verify kernel cmdline configuration. (8.30 s)
 (45/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.16M.no_topo.numatune_memnode.m_preferred.numatune_mem: CANCEL: Hugepage size [16384] isn't supported, please verify kernel cmdline configuration. (8.19 s)
 (46/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.16M.no_topo.numatune_memnode.m_preferred.no_numatune_mem: CANCEL: Hugepage size [16384] isn't supported, please verify kernel cmdline configuration. (8.17 s)
 (47/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.16M.no_topo.numatune_memnode.m_interleave.numatune_mem: CANCEL: Hugepage size [16384] isn't supported, please verify kernel cmdline configuration. (8.28 s)
 (48/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.16M.no_topo.numatune_memnode.m_interleave.no_numatune_mem: CANCEL: Hugepage size [16384] isn't supported, please verify kernel cmdline configuration. (8.17 s)
 (49/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.topology.no_numatune_memnode.numatune_mem: PASS (47.49 s)
 (50/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.topology.no_numatune_memnode.no_numatune_mem: PASS (47.30 s)
 (51/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.topology.numatune_memnode.m_strict.numatune_mem: PASS (47.41 s)
 (52/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.topology.numatune_memnode.m_strict.no_numatune_mem: PASS (47.58 s)
 (53/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.topology.numatune_memnode.m_preferred.numatune_mem: PASS (49.53 s)
 (54/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.topology.numatune_memnode.m_preferred.no_numatune_mem: PASS (49.75 s)
 (55/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.topology.numatune_memnode.m_interleave.numatune_mem: PASS (47.53 s)
 (56/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.topology.numatune_memnode.m_interleave.no_numatune_mem: PASS (49.53 s)
 (57/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.no_topo.no_numatune_memnode.numatune_mem: PASS (47.84 s)
 (58/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.no_topo.no_numatune_memnode.no_numatune_mem: PASS (47.46 s)
 (59/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.no_topo.numatune_memnode.m_strict.numatune_mem: PASS (49.55 s)
 (60/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.no_topo.numatune_memnode.m_strict.no_numatune_mem: PASS (47.69 s)
 (61/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.no_topo.numatune_memnode.m_preferred.numatune_mem: PASS (47.44 s)
 (62/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.no_topo.numatune_memnode.m_preferred.no_numatune_mem: PASS (49.58 s)
 (63/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.no_topo.numatune_memnode.m_interleave.numatune_mem: PASS (47.50 s)
 (64/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.no_topo.numatune_memnode.m_interleave.no_numatune_mem: PASS (47.63 s)




on aarch64 64k:
(01/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.2M.topology.no_numatune_memnode.numatune_mem: PASS (64.84 s)
 (02/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.2M.topology.no_numatune_memnode.no_numatune_mem: PASS (73.48 s)
 (03/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.2M.topology.numatune_memnode.m_strict.numatune_mem: PASS (73.69 s)
 (04/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.2M.topology.numatune_memnode.m_strict.no_numatune_mem: PASS (72.98 s)
 (05/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.2M.topology.numatune_memnode.m_preferred.numatune_mem: PASS (71.63 s)
 (06/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.2M.topology.numatune_memnode.m_preferred.no_numatune_mem: PASS (72.65 s)
 (07/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.2M.topology.numatune_memnode.m_interleave.numatune_mem: PASS (71.31 s)
 (08/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.2M.topology.numatune_memnode.m_interleave.no_numatune_mem: PASS (80.28 s)
 (09/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.2M.no_topo.no_numatune_memnode.numatune_mem: PASS (74.55 s)
 (10/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.2M.no_topo.no_numatune_memnode.no_numatune_mem: PASS (65.46 s)
 (11/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.2M.no_topo.numatune_memnode.m_strict.numatune_mem: PASS (81.92 s)
 (12/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.2M.no_topo.numatune_memnode.m_strict.no_numatune_mem: PASS (67.54 s)
 (13/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.2M.no_topo.numatune_memnode.m_preferred.numatune_mem: PASS (78.30 s)
 (14/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.2M.no_topo.numatune_memnode.m_preferred.no_numatune_mem: PASS (72.32 s)
 (15/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.2M.no_topo.numatune_memnode.m_interleave.numatune_mem: PASS (65.03 s)
 (16/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.2M.no_topo.numatune_memnode.m_interleave.no_numatune_mem: PASS (72.48 s)
 (17/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.1G.topology.no_numatune_memnode.numatune_mem: CANCEL: Hugepage size [1048576] isn't supported, please verify kernel cmdline configuration. (32.97 s)
 (18/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.1G.topology.no_numatune_memnode.no_numatune_mem: CANCEL: Hugepage size [1048576] isn't supported, please verify kernel cmdline configuration. (32.98 s)
 (19/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.1G.topology.numatune_memnode.m_strict.numatune_mem: CANCEL: Hugepage size [1048576] isn't supported, please verify kernel cmdline configuration. (33.01 s)
 (20/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.1G.topology.numatune_memnode.m_strict.no_numatune_mem: CANCEL: Hugepage size [1048576] isn't supported, please verify kernel cmdline configuration. (32.91 s)
 (21/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.1G.topology.numatune_memnode.m_preferred.numatune_mem: CANCEL: Hugepage size [1048576] isn't supported, please verify kernel cmdline configuration. (33.10 s)
 (22/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.1G.topology.numatune_memnode.m_preferred.no_numatune_mem: CANCEL: Hugepage size [1048576] isn't supported, please verify kernel cmdline configuration. (32.79 s)
 (23/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.1G.topology.numatune_memnode.m_interleave.numatune_mem: CANCEL: Hugepage size [1048576] isn't supported, please verify kernel cmdline configuration. (33.08 s)
 (24/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.1G.topology.numatune_memnode.m_interleave.no_numatune_mem: CANCEL: Hugepage size [1048576] isn't supported, please verify kernel cmdline configuration. (32.94 s)
 (25/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.1G.no_topo.no_numatune_memnode.numatune_mem: CANCEL: Hugepage size [1048576] isn't supported, please verify kernel cmdline configuration. (33.08 s)
 (26/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.1G.no_topo.no_numatune_memnode.no_numatune_mem: CANCEL: Hugepage size [1048576] isn't supported, please verify kernel cmdline configuration. (32.35 s)
 (27/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.1G.no_topo.numatune_memnode.m_strict.numatune_mem: CANCEL: Hugepage size [1048576] isn't supported, please verify kernel cmdline configuration. (32.62 s)
 (28/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.1G.no_topo.numatune_memnode.m_strict.no_numatune_mem: CANCEL: Hugepage size [1048576] isn't supported, please verify kernel cmdline configuration. (33.01 s)
 (29/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.1G.no_topo.numatune_memnode.m_preferred.numatune_mem: CANCEL: Hugepage size [1048576] isn't supported, please verify kernel cmdline configuration. (33.11 s)
 (30/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.1G.no_topo.numatune_memnode.m_preferred.no_numatune_mem: CANCEL: Hugepage size [1048576] isn't supported, please verify kernel cmdline configuration. (33.09 s)
 (31/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.1G.no_topo.numatune_memnode.m_interleave.numatune_mem: CANCEL: Hugepage size [1048576] isn't supported, please verify kernel cmdline configuration. (32.94 s)
 (32/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.1G.no_topo.numatune_memnode.m_interleave.no_numatune_mem: CANCEL: Hugepage size [1048576] isn't supported, please verify kernel cmdline configuration. (32.73 s)
 (33/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.16M.topology.no_numatune_memnode.numatune_mem: CANCEL: Hugepage size [16384] isn't supported, please verify kernel cmdline configuration. (32.72 s)
 (34/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.16M.topology.no_numatune_memnode.no_numatune_mem: CANCEL: Hugepage size [16384] isn't supported, please verify kernel cmdline configuration. (33.18 s)
 (35/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.16M.topology.numatune_memnode.m_strict.numatune_mem: CANCEL: Hugepage size [16384] isn't supported, please verify kernel cmdline configuration. (33.12 s)
 (36/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.16M.topology.numatune_memnode.m_strict.no_numatune_mem: CANCEL: Hugepage size [16384] isn't supported, please verify kernel cmdline configuration. (32.79 s)
 (37/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.16M.topology.numatune_memnode.m_preferred.numatune_mem: CANCEL: Hugepage size [16384] isn't supported, please verify kernel cmdline configuration. (33.07 s)
 (38/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.16M.topology.numatune_memnode.m_preferred.no_numatune_mem: CANCEL: Hugepage size [16384] isn't supported, please verify kernel cmdline configuration. (33.01 s)
 (39/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.16M.topology.numatune_memnode.m_interleave.numatune_mem: CANCEL: Hugepage size [16384] isn't supported, please verify kernel cmdline configuration. (33.08 s)
 (40/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.16M.topology.numatune_memnode.m_interleave.no_numatune_mem: CANCEL: Hugepage size [16384] isn't supported, please verify kernel cmdline configuration. (34.07 s)
 (41/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.16M.no_topo.no_numatune_memnode.numatune_mem: CANCEL: Hugepage size [16384] isn't supported, please verify kernel cmdline configuration. (32.92 s)
 (42/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.16M.no_topo.no_numatune_memnode.no_numatune_mem: CANCEL: Hugepage size [16384] isn't supported, please verify kernel cmdline configuration. (32.85 s)
 (43/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.16M.no_topo.numatune_memnode.m_strict.numatune_mem: CANCEL: Hugepage size [16384] isn't supported, please verify kernel cmdline configuration. (32.85 s)
 (44/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.16M.no_topo.numatune_memnode.m_strict.no_numatune_mem: CANCEL: Hugepage size [16384] isn't supported, please verify kernel cmdline configuration. (32.74 s)
 (45/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.16M.no_topo.numatune_memnode.m_preferred.numatune_mem: CANCEL: Hugepage size [16384] isn't supported, please verify kernel cmdline configuration. (41.08 s)
 (46/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.16M.no_topo.numatune_memnode.m_preferred.no_numatune_mem: CANCEL: Hugepage size [16384] isn't supported, please verify kernel cmdline configuration. (24.35 s)
 (47/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.16M.no_topo.numatune_memnode.m_interleave.numatune_mem: CANCEL: Hugepage size [16384] isn't supported, please verify kernel cmdline configuration. (33.64 s)
 (48/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.per_node.16M.no_topo.numatune_memnode.m_interleave.no_numatune_mem: CANCEL: Hugepage size [16384] isn't supported, please verify kernel cmdline configuration. (32.81 s)
 (49/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.topology.no_numatune_memnode.numatune_mem: PASS (72.62 s)
 (50/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.topology.no_numatune_memnode.no_numatune_mem: PASS (74.13 s)
 (51/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.topology.numatune_memnode.m_strict.numatune_mem: PASS (75.88 s)
 (52/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.topology.numatune_memnode.m_strict.no_numatune_mem: PASS (75.73 s)
 (53/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.topology.numatune_memnode.m_preferred.numatune_mem: PASS (76.14 s)
 (54/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.topology.numatune_memnode.m_preferred.no_numatune_mem: PASS (75.99 s)
 (55/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.topology.numatune_memnode.m_interleave.numatune_mem: PASS (74.06 s)
 (56/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.topology.numatune_memnode.m_interleave.no_numatune_mem: PASS (73.27 s)
 (57/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.hPASS (80.38 s)opo.no_numatune
 (58/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.no_topo.no_numatune_memnode.no_numatune_mem: PASS (65.57 s)
 (59/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.no_topo.numatune_memnode.m_strict.numatune_mem: PASS (72.86 s)
 (60/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.no_topo.numatune_memnode.m_strict.no_numatune_mem: PASS (76.45 s)
 (61/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.no_topo.numatune_memnode.m_preferred.numatune_mem: PASS (75.80 s)
 (62/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.no_topo.numatune_memnode.m_preferred.no_numatune_mem: PASS (83.85 s)
 (63/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.no_topo.numatune_memnode.m_interleave.numatune_mem: PASS (74.10 s)
 (64/64) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.no_topo.numatune_memnode.m_interleave.no_numatune_mem: PASS (75.50 s)
