### PR TITLE
guest_kernel_debugging: aarch64 supports panic since libvirt-9.1.0

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/monitor/virsh_domstate.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/monitor/virsh_domstate.cfg
@@ -42,8 +42,12 @@
                             variants:
                                 - oncrash_destroy:
                                     domstate_vm_oncrash = "destroy"
+                                    aarch64:
+                                        func_supported_since_libvirt_ver = (9, 1, 0)
                                 - oncrash_restart:
                                     domstate_vm_oncrash = "restart"
+                                    aarch64:
+                                        func_supported_since_libvirt_ver = (9, 1, 0)
                                 - oncrash_preserve:
                                     domstate_vm_oncrash = "preserve"
                                     variants:
@@ -55,10 +59,14 @@
                                     memory_value = "2097152"
                                     memory_unit = "KiB"
                                     domstate_vm_oncrash = "coredump-destroy"
+                                    aarch64:
+                                        func_supported_since_libvirt_ver = (9, 1, 0)
                                 - oncrash_coredump_restart:
                                     memory_value = "2097152"
                                     memory_unit = "KiB"
                                     domstate_vm_oncrash = "coredump-restart"
+                                    aarch64:
+                                        func_supported_since_libvirt_ver = (9, 1, 0)
                                 - oncrash_rename_restart:
                                     domstate_vm_oncrash = "rename-restart"
                                     variants:

--- a/libvirt/tests/src/virsh_cmd/monitor/virsh_domstate.py
+++ b/libvirt/tests/src/virsh_cmd/monitor/virsh_domstate.py
@@ -159,6 +159,7 @@ def run(test, params, env):
             vmxml.sync()
 
         if vm_action == "crash":
+            libvirt_version.is_libvirt_feature_supported(params)
             if vm.is_alive():
                 vm.destroy(gracefully=False)
             vmxml.on_crash = vm_oncrash_action


### PR DESCRIPTION
Signed-off-by: Qian Jianhua <qianjh@fujitsu.com>

libvirt8.0.0 test result:
Before:
```
 (1/1) type_specific.io-github-autotest-libvirt.virsh.domstate.normal_test.reason.crash_vm.oncrash_destroy: ERROR: Failed to define avocado-vt-vm1 for reason:\nerror: Failed to define domain from /tmp/xml_utils_temp_6885f_ot.xml\nerror: unsupported configuration: unknown panic model 'pvpanic'\n (9.69 s)
 (1/1) type_specific.io-github-autotest-libvirt.virsh.domstate.normal_test.reason.crash_vm.oncrash_restart: ERROR: Failed to define avocado-vt-vm1 for reason:\nerror: Failed to define domain from /tmp/xml_utils_temp_uvw1xi7l.xml\nerror: unsupported configuration: unknown panic model 'pvpanic'\n (9.84 s)
 (1/1) type_specific.io-github-autotest-libvirt.virsh.domstate.normal_test.reason.crash_vm.oncrash_coredump_destroy: ERROR: Failed to define avocado-vt-vm1 for reason:\nerror: Failed to define domain from /tmp/xml_utils_temp_gmn6ni1m.xml\nerror: unsupported configuration: unknown panic model 'pvpanic'\n (9.99 s)
 (1/1) type_specific.io-github-autotest-libvirt.virsh.domstate.normal_test.reason.crash_vm.oncrash_coredump_restart: ERROR: Failed to define avocado-vt-vm1 for reason:\nerror: Failed to define domain from /tmp/xml_utils_temp_gil9qlut.xml\nerror: unsupported configuration: unknown panic model 'pvpanic'\n (10.13 s)
```

After:
```
 (1/1) type_specific.io-github-autotest-libvirt.virsh.domstate.normal_test.reason.crash_vm.oncrash_destroy: CANCEL: This libvirt version doesn't support this function. (9.29 s)
 (1/1) type_specific.io-github-autotest-libvirt.virsh.domstate.normal_test.reason.crash_vm.oncrash_restart: CANCEL: This libvirt version doesn't support this function. (10.78 s)
 (1/1) type_specific.io-github-autotest-libvirt.virsh.domstate.normal_test.reason.crash_vm.oncrash_coredump_destroy: CANCEL: This libvirt version doesn't support this function. (9.26 s)
 (1/1) type_specific.io-github-autotest-libvirt.virsh.domstate.normal_test.reason.crash_vm.oncrash_coredump_restart: CANCEL: This libvirt version doesn't support this function. (9.19 s)
```
