### PR TITLE
virtual_disks: Add 2 cases of vhostvdpa_block

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/vhostvdpa_block_backend_type/define_start_vm_with_vhostvdpa_backend_disk.cfg
+++ b/libvirt/tests/cfg/virtual_disks/vhostvdpa_block_backend_type/define_start_vm_with_vhostvdpa_backend_disk.cfg
@@ -1,0 +1,26 @@
+- virtual_disk.vhostvdpa.define_start:
+    type = define_start_vm_with_vhostvdpa_backend_disk
+    start_vm = no
+    simulator = "yes"
+    driver_type = "raw"
+    disk_vdpa_attrs = {"source": {"attrs": {"dev": "/dev/vhost-vdpa-0"}}, "type_name": "vhostvdpa"}
+    func_supported_since_libvirt_ver = (9, 10, 0)
+    only x86_64
+    variants cache_mode:
+        - none:
+        - directsync:
+        - no_specified_value:
+            define_error = "yes"
+    variants:
+        - default:
+        - without_shared_memory:
+            only none
+            without_shared_memory = "yes"
+            define_error = "yes"
+        - qcow2_dirver:
+            only none
+            driver_type = "qcow2"
+            start_error = "yes"
+
+    disk_driver = {"driver": {"name": "qemu", "type": "${driver_type}", "cache": "${cache_mode}", "io": "threads", "copy_on_read": "on", "discard": "unmap", "detect_zeroes": "on"}}
+    disk_attrs = {"device": "disk", "target": {"dev": "vdb", "bus": "virtio"}, **${disk_vdpa_attrs}, **${disk_driver}}

--- a/libvirt/tests/src/virtual_disks/vhostvdpa_block_backend_type/define_start_vm_with_vhostvdpa_backend_disk.py
+++ b/libvirt/tests/src/virtual_disks/vhostvdpa_block_backend_type/define_start_vm_with_vhostvdpa_backend_disk.py
@@ -1,0 +1,75 @@
+from virttest import libvirt_version
+from virttest import utils_vdpa
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_disk
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+VIRSH_ARGS = {'debug': True, 'ignore_status': False}
+
+
+def run(test, params, env):
+    """
+    Verify that vm can be defined and started with vhost-vdpa backend disk,
+    and disk I/O in guest can work
+    """
+    libvirt_version.is_libvirt_feature_supported(params)
+    disk_attrs = eval(params.get("disk_attrs", "{}"))
+    without_shared_memory = "yes" == params.get("without_shared_memory", "no")
+    define_error = "yes" == params.get("define_error", "no")
+    start_error = "yes" == params.get("start_error", "no")
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+
+    try:
+        test.log.info("TEST_STEP: Define a VM with vhostvdpa disk.")
+        test_env_obj = utils_vdpa.VDPASimulatorTest(sim_dev_module="vdpa_sim_blk", mgmtdev="vdpasim_blk")
+        test_env_obj.setup()
+        if not without_shared_memory:
+            vm_xml.VMXML.set_memoryBacking_tag(vm_name, access_mode="shared", hpgs=False)
+        disk_dev = libvirt_vmxml.create_vm_device_by_type("disk", disk_attrs)
+        vmxml_new = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        vmxml_new.add_device(disk_dev)
+
+        test.log.debug(f'VMXML of {vm_name}:\n{vmxml_new}')
+        cmd_result = virsh.define(vmxml_new.xml, debug=True)
+        libvirt.check_exit_status(cmd_result, define_error)
+        if define_error:
+            return
+
+        test.log.info("TEST_STEP: Start the VM.")
+        cmd_result = virsh.start(vm_name)
+        libvirt.check_exit_status(cmd_result, start_error)
+        if start_error:
+            return
+        vm_session = vm.wait_for_login()
+
+        test.log.info("TEST_STEP: Check VM's xml.")
+        vdpa_device = vm_xml.VMXML.new_from_dumpxml(vm.name)\
+            .devices.by_device_tag("disk")[-1]
+        vdpa_dev_attrs = vdpa_device.fetch_attrs()
+        test.log.debug(vdpa_dev_attrs)
+        for k, v in disk_attrs.items():
+            if k == "source":
+                act_dev = vdpa_dev_attrs[k]["attrs"].get("dev")
+                exp_dev = v["attrs"]["dev"]
+                test.log.debug(f"Actual dev: {act_dev}")
+                test.log.debug(f"Expected dev: {exp_dev}")
+                if act_dev != exp_dev:
+                    test.fail("Incorrect disk dev!")
+            elif vdpa_dev_attrs[k] != v:
+                test.fail("Failed to get expected disk attributes(%s) in live xml!"
+                          "It should be %s." % (vdpa_dev_attrs[k], v))
+
+        test.log.info("TEST_STEP: Check r/w operations on vhostvdpa disk.")
+        new_disk = libvirt_disk.get_non_root_disk_name(vm_session)[0]
+        if not libvirt_disk.check_virtual_disk_io(vm, new_disk):
+            test.fail("Failed to check disk io for %s!" % new_disk)
+
+    finally:
+        bkxml.sync()
+        test_env_obj.cleanup()

--- a/spell.ignore
+++ b/spell.ignore
@@ -1118,6 +1118,7 @@ vdb
 vdb's
 vdc
 vddk
+vdpa
 vdsm
 vdx
 vepa


### PR DESCRIPTION
This pr adds:
    VIRT-300428 - Define&Start vm with disk of vhostvdpa backend
    VIRT-300445 - Define/start vm with disk of vhostvdpa backend
        - invalid configuration

Depends on:
- https://github.com/avocado-framework/avocado-vt/pull/3893

**Test results:** The failed case is caused by an issue.
 ```
(1/5) type_specific.io-github-autotest-libvirt.virtual_disk.vhostvdpa.define_start.default.none: PASS (46.15 s)
 (2/5) type_specific.io-github-autotest-libvirt.virtual_disk.vhostvdpa.define_start.default.directsync: FAIL: Failed to check disk io for vdb! (51.62 s)

 (3/5) type_specific.io-github-autotest-libvirt.virtual_disk.vhostvdpa.define_start.default.no_specified_value: PASS (10.23 s)
 (4/5) type_specific.io-github-autotest-libvirt.virtual_disk.vhostvdpa.define_start.without_shared_memory.none: PASS (9.54 s)
 (5/5) type_specific.io-github-autotest-libvirt.virtual_disk.vhostvdpa.define_start.qcow2_dirver.none: PASS (10.79 s)
```
