### PR TITLE
guest_os_booting: Correct the supported arch types

### DIFF
--- a/libvirt/tests/cfg/guest_os_booting/boot_menu/bootmenu.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/boot_menu/bootmenu.cfg
@@ -3,6 +3,8 @@
     start_vm = no
     bootmenu_enable = "yes"
     bootmenu_dict = {'bootmenu_enable': '%s', 'bootmenu_timeout': '%s', 'bios_useserial': 'yes'}
+    aarch64:
+        bootmenu_dict = {'bootmenu_enable': '%s', 'bootmenu_timeout': '%s'}
     variants:
         - positive_test:
             status_error = "no"
@@ -31,9 +33,10 @@
                     error_msg = "invalid value for boot menu timeout, must be in range [0,65535]"
     variants:
         - by_ovmf:
-            only q35
+            only q35, aarch64
             firmware_type = "ovmf"
             check_prompt = "BdsDxe: loading Boot0000 "UiApp" from Fv"
         - by_seabios:
+            only x86_64
             firmware_type = "seabios"
             check_prompt = "Select boot device"

--- a/libvirt/tests/cfg/guest_os_booting/boot_order/boot_from_cdrom_device.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/boot_order/boot_from_cdrom_device.cfg
@@ -9,12 +9,16 @@
             only os_dev
         - with_cdrom_with_no_src:
             cdrom1_attrs = {'target': {'dev': 'sda', 'bus': 'sata'}, **${cdrom_attrs}}
+            aarch64:
+                cdrom1_attrs = {'target': {'dev': 'sda', 'bus': 'scsi'}, **${cdrom_attrs}}
         - with_cdrom:
             check_bootable_iso = "yes"
             cdrom1_attrs = {'source': {'attrs': {'file': boot_img_path}}, 'target': {'dev': 'sda', 'bus': 'scsi'}, **${cdrom_attrs}}
         - multi_cdroms:
             cdrom1_attrs = {'target': {'dev': 'sda', 'bus': 'scsi'}, **${cdrom_attrs}}
             cdrom2_attrs = {'source': {'attrs': {'file': boot_img_path}}, 'target': {'dev': 'sdb', 'bus': 'sata'}, **${cdrom_attrs}}
+            aarch64:
+                cdrom2_attrs = {'source': {'attrs': {'file': boot_img_path}}, 'target': {'dev': 'sdb', 'bus': 'scsi'}, **${cdrom_attrs}}
             cdrom_boot_order:
                 check_bootable_iso = "yes"
             os_dev:
@@ -29,4 +33,4 @@
             with_cdrom_with_no_src:
                 status_error = "yes"
         - ovmf:
-            only q35
+            only q35, aarch64

--- a/libvirt/tests/cfg/guest_os_booting/boot_order/boot_from_disk_device.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/boot_order/boot_from_disk_device.cfg
@@ -12,6 +12,8 @@
                     disk1_img = "non-bootable.qcow2"
                     disk2_attrs = {'target': {'dev': 'sda', 'bus': 'sata'}}
                     status_error = "yes"
+                    aarch64:
+                        disk2_attrs = {'target': {'dev': 'sda', 'bus': 'scsi'}}
         - disk_boot_order:
             variants:
                 - single_disk:
@@ -26,4 +28,4 @@
         - seabios:
             only x86_64
         - ovmf:
-            only q35
+            only q35, aarch64

--- a/libvirt/tests/cfg/guest_os_booting/boot_order/boot_from_usb_device.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/boot_order/boot_from_usb_device.cfg
@@ -4,7 +4,7 @@
     bus_type = "usb"
     bootmenu_dict = {'bootmenu_enable': 'yes', 'bootmenu_timeout': '3000', 'bios_useserial': 'yes'}
     check_prompt = "UEFI .* USB|1. USB MSC Drive .*"
-    only q35
+    only q35, aarch64
     variants usb_device:
         - block_device:
             disk_type = "block"

--- a/libvirt/tests/cfg/guest_os_booting/boot_order/boot_with_multiple_boot_dev.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/boot_order/boot_with_multiple_boot_dev.cfg
@@ -2,7 +2,11 @@
     type = boot_with_multiple_boot_dev
     start_vm = no
     os_dict = {'boots': ['%s', '%s'], 'bootmenu_enable': 'yes', 'bios_useserial': 'yes'}
-    cdrom_dict = {'source': {'attrs': {'file': '%s'}}, 'type_name': 'file', 'device': 'cdrom', 'driver': {'name': 'qemu', 'type': 'raw'}, 'target': {'dev': 'sda', 'bus': 'sata'}}
+    target_bus = 'sata'
+    aarch64:
+      target_bus = 'scsi'
+      os_dict = {'boots': ['%s', '%s'], 'bootmenu_enable': 'yes'}
+    cdrom_dict = {'source': {'attrs': {'file': '%s'}}, 'type_name': 'file', 'device': 'cdrom', 'driver': {'name': 'qemu', 'type': 'raw'}, 'target': {'dev': 'sda', 'bus': '${target_bus}'}}
     check_prompt = ["begin the installation process|Install Red Hat Enterprise"]
     variants first_dev:
         - hd:

--- a/libvirt/tests/cfg/guest_os_booting/boot_order/boot_with_multiple_boot_order.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/boot_order/boot_with_multiple_boot_order.cfg
@@ -2,7 +2,11 @@
     type = boot_with_multiple_boot_order
     start_vm = no
     os_dict = {'bootmenu_enable': 'yes', 'bios_useserial': 'yes'}
-    cdrom_dict = {'source': {'attrs': {'file': '%s'}}, 'type_name': 'file', 'device': 'cdrom', 'driver': {'name': 'qemu', 'type': 'raw'}, 'target': {'dev': 'sda', 'bus': 'sata'}}
+    target_bus = 'sata'
+    aarch64:
+      os_dict = {'bootmenu_enable': 'yes'}
+      target_bus = 'scsi'
+    cdrom_dict = {'source': {'attrs': {'file': '%s'}}, 'type_name': 'file', 'device': 'cdrom', 'driver': {'name': 'qemu', 'type': 'raw'}, 'target': {'dev': 'sda', 'bus': '${target_bus}'}}
     check_prompt = ["begin the installation process|Install Red Hat Enterprise"]
     variants first_dev:
         - hd:

--- a/libvirt/tests/cfg/guest_os_booting/ovmf_firmware/ovmf_backed_nvram.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/ovmf_firmware/ovmf_backed_nvram.cfg
@@ -3,12 +3,18 @@
     start_vm = no
     loader_path = "/usr/share/edk2/ovmf/OVMF_CODE.secboot.fd"
     template_path = "/usr/share/edk2/ovmf/OVMF_VARS.secboot.fd"
-    os_dict = {'secure': 'yes', 'loader_readonly': 'yes', 'loader_type': 'pflash', 'loader': '${loader_path}'}
+    os_secure = "yes"
     firmware_type = "ovmf"
     nvram_attrs = {'nvram_attrs': {'template': '${template_path}', 'type': '%s'}}
     func_supported_since_libvirt_ver = (8, 5, 0)
-    only q35
-    only x86_64
+    only q35, aarch64
+    aarch64:
+        loader_path = "/usr/share/edk2/aarch64/QEMU_EFI-silent-pflash.qcow2"
+        template_path = "/usr/share/edk2/aarch64/vars-template-pflash.qcow2"
+        os_secure = "no"
+        nvram_attrs = {'nvram_attrs': {'template': '${template_path}', 'type': '%s', 'format': 'qcow2'}}
+    os_dict = {'secure': '${os_secure}', 'loader_readonly': 'yes', 'loader_type': 'pflash', 'loader': '${loader_path}'}
+
     variants source_type:
         - file:
             nvram_source = {'nvram_source': {'attrs': {'file': '%s'}}}

--- a/libvirt/tests/cfg/guest_os_booting/ovmf_firmware/ovmf_firmware_feature.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/ovmf_firmware/ovmf_firmware_feature.cfg
@@ -4,15 +4,17 @@
     loader_path = "/usr/share/edk2/ovmf/OVMF_CODE.secboot.fd"
     nvram_template = "/usr/share/edk2/ovmf/OVMF_VARS.secboot.fd"
     firmware_type = "ovmf"
-    only q35
+    only q35, aarch64
     variants:
         - positive_test:
             status_error = "no"
             variants:
                 - enable_secure_boot:
+                    no aarch64
                     firmware_dict = {'os_firmware': 'efi', 'firmware': {'feature': [{'enabled': 'yes', 'name': 'enrolled-keys'}, {'enabled': 'yes', 'name': 'secure-boot'}]}}
                     firmware_xpath = [{'element_attrs': ["./os/nvram[@template='${nvram_template}']"]}, {'element_attrs': ["./os/loader[@type='pflash']"], 'text': '${loader_path}'}]
                 - disable_secure_boot:
+                    no aarch64
                     nvram_template = "/usr/share/edk2/ovmf/OVMF_VARS.fd"
                     firmware_dict = {'os_firmware': 'efi', 'firmware': {'feature': [{'enabled': 'no', 'name': 'enrolled-keys'}, {'enabled': 'yes', 'name': 'secure-boot'}]}}
                     firmware_xpath = [{'element_attrs': ["./os/nvram[@template='${nvram_template}']"]}, {'element_attrs': ["./os/loader[@type='pflash']"], 'text': '${loader_path}'}]
@@ -20,6 +22,9 @@
                     func_supported_since_libvirt_ver = (9, 0, 0)
                     loader_path = "/usr/share/edk2/ovmf/OVMF_CODE.fd"
                     nvram_template = "/usr/share/edk2/ovmf/OVMF_VARS.fd"
+                    aarch64:
+                        loader_path = "/usr/share/edk2/aarch64/QEMU_EFI-silent-pflash.qcow2"
+                        nvram_template = "/usr/share/edk2/aarch64/vars-template-pflash.qcow2"
                     firmware_dict = {'os_firmware': 'efi', 'firmware': {'feature': [{'enabled': 'no', 'name': 'enrolled-keys'}, {'enabled': 'no', 'name': 'secure-boot'}]}}
                     firmware_xpath = [{'element_attrs': ["./os/nvram[@template='${nvram_template}']"]}, {'element_attrs': ["./os/loader[@readonly='yes']"], 'text': '${loader_path}'}]
         - negative_test:

--- a/libvirt/tests/cfg/guest_os_booting/ovmf_firmware/ovmf_loader.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/ovmf_firmware/ovmf_loader.cfg
@@ -4,17 +4,24 @@
     loader_path = "/usr/share/edk2/ovmf/OVMF_CODE.secboot.fd"
     smm_state = "on"
     firmware_type = "ovmf"
-    only q35
+    os_secure = "yes"
+    aarch64:
+        os_secure = "no"
+        smm_state =
+        loader_path = "/usr/share/edk2/aarch64/QEMU_EFI-silent-pflash.qcow2"
+    only q35, aarch64
     variants:
         - positive_test:
             variants:
                 - default_value:
-                    loader_dict = {'secure': 'yes', 'loader_readonly': 'yes', 'loader_type': 'pflash', 'loader': '${loader_path}'}
+                    loader_dict = {'secure': '${os_secure}', 'loader_readonly': 'yes', 'loader_type': 'pflash', 'loader': '${loader_path}'}
                 - secure_no:
+                    no aarch64
                     nvram_path = "/var/lib/libvirt/qemu/nvram/nvram_VARS.fd"
                     nvram_template = "/usr/share/edk2/ovmf/OVMF_VARS.fd"
                     loader_dict = {'loader': '${loader_path}', 'nvram': '${nvram_path}', 'nvram_attrs': {'template': '${nvram_template}'}, 'secure': 'no', 'loader_readonly': 'yes', 'loader_type': 'pflash'}
                 - stateless_yes:
+                    no aarch64
                     stateless  = "yes"
                     func_supported_since_libvirt_ver = (8, 6, 0)
                     loader_path = "/usr/share/edk2/ovmf/OVMF.amdsev.fd"
@@ -24,13 +31,13 @@
             variants:
                 - readonly_no:
                     func_supported_since_libvirt_ver = (9, 5, 0)
-                    loader_dict = {'secure': 'yes', 'loader_readonly': 'no', 'loader_type': 'pflash', 'loader': '${loader_path}'}
+                    loader_dict = {'secure': '${os_secure}', 'loader_readonly': 'no', 'loader_type': 'pflash', 'loader': '${loader_path}'}
                     error_msg = "Could not open .+: Permission denied"
                 - type_rom:
-                    loader_dict = {'secure': 'yes', 'loader_readonly': 'yes', 'loader_type': 'rom', 'loader': '${loader_path}'}
+                    loader_dict = {'secure': '${os_secure}', 'loader_readonly': 'yes', 'loader_type': 'rom', 'loader': '${loader_path}'}
                     error_msg = "could not load PC BIOS"
                 - incorrect_loader_path:
                     use_file = "yes"
                     incorrect_loader_path = "/tmp/test"
-                    loader_dict = {'secure': 'yes', 'loader_readonly': 'yes', 'loader_type': 'pflash', 'loader': '${incorrect_loader_path}'}
+                    loader_dict = {'secure': '${os_secure}', 'loader_readonly': 'yes', 'loader_type': 'pflash', 'loader': '${incorrect_loader_path}'}
                     error_msg = "Could not open .+: Permission denied" || "unable to find any master var store for loader"

--- a/libvirt/tests/cfg/guest_os_booting/ovmf_firmware/ovmf_nvram.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/ovmf_firmware/ovmf_nvram.cfg
@@ -3,19 +3,27 @@
     start_vm = no
     smm_state = "on"
     loader_path = "/usr/share/edk2/ovmf/OVMF_CODE.secboot.fd"
-    nvram_dict = {'secure': 'yes', 'loader_readonly': 'yes', 'loader_type': 'pflash', 'loader': '${loader_path}', 'nvram_attrs': {'template': '%s'}}
+    os_secure = "yes"
+    aarch64:
+        smm_state =
+        os_secure = "no"
+        loader_path = "/usr/share/edk2/aarch64/QEMU_EFI-silent-pflash.qcow2"
+    nvram_dict = {'secure': '${os_secure}', 'loader_readonly': 'yes', 'loader_type': 'pflash', 'loader': '${loader_path}', 'nvram_attrs': {'template': '%s'}}
     firmware_type = "ovmf"
-    only q35
+    only q35, aarch64
     variants:
         - positive_test:
             variants:
                 - template_enable_secure:
+                    no aarch64
                     template_path = "/usr/share/edk2/ovmf/OVMF_VARS.secboot.fd"
                 - template_disable_secure:
                     template_path = "/usr/share/edk2/ovmf/OVMF_VARS.fd"
+                    aarch64:
+                        template_path = "/usr/share/edk2/aarch64/vars-template-pflash.qcow2"
                 - manual_nvram_file:
                     nvram_file = "/tmp/nvram"
-                    nvram_dict = {'secure': 'yes', 'loader_readonly': 'yes', 'loader_type': 'pflash', 'loader': '${loader_path}', 'nvram': '${nvram_file}'}
+                    nvram_dict = {'secure': '${os_secure}', 'loader_readonly': 'yes', 'loader_type': 'pflash', 'loader': '${loader_path}', 'nvram': '${nvram_file}'}
         - negative_test:
             variants:
                 - nonexist_template:

--- a/libvirt/tests/cfg/guest_os_booting/ovmf_firmware/ovmf_seclabel_in_nvram.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/ovmf_firmware/ovmf_seclabel_in_nvram.cfg
@@ -3,13 +3,18 @@
     start_vm = no
     loader_path = "/usr/share/edk2/ovmf/OVMF_CODE.secboot.fd"
     template_path = "/usr/share/edk2/ovmf/OVMF_VARS.secboot.fd"
-    os_dict = {'secure': 'yes', 'loader_readonly': 'yes', 'loader_type': 'pflash', 'loader': '${loader_path}'}
+    os_secure = "yes"
     nvram_attrs = {'nvram_attrs': {'template': '${template_path}', 'type': 'file'}}
+    aarch64:
+        loader_path = "/usr/share/edk2/aarch64/QEMU_EFI-silent-pflash.qcow2"
+        template_path = "/usr/share/edk2/aarch64/vars-template-pflash.qcow2"
+        os_secure = "no"
+        nvram_attrs = {'nvram_attrs': {'template': '${template_path}', 'type': 'file', 'format': 'qcow2'}}
     nvram_source = {'nvram_source': {'seclabels': [{'label': '%s', 'model': '%s', 'relabel': 'yes'}], 'attrs': {'file': '%s'}}}
+    os_dict = {'secure': '${os_secure}', 'loader_readonly': 'yes', 'loader_type': 'pflash', 'loader': '${loader_path}'}
     firmware_type = "ovmf"
     func_supported_since_libvirt_ver = (8, 5, 0)
-    only q35
-    only x86_64
+    only q35, aarch64
     variants:
         - positive_test:
             variants:

--- a/libvirt/tests/cfg/guest_os_booting/seabios_firmware/seabios_loader.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/seabios_firmware/seabios_loader.cfg
@@ -5,6 +5,7 @@
     loader_type = "rom"
     loader_dict = {'loader_type': '%s', 'loader': '%s'}
     firmware_type = "seabios"
+    only x86_64
     variants:
         - positive_test:
             variants:

--- a/libvirt/tests/cfg/guest_os_booting/useserial/useserial.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/useserial/useserial.cfg
@@ -13,5 +13,6 @@
             only q35
             firmware_type = "ovmf"
         - by_seabios:
+            only x86_64
             firmware_type = "seabios"
             check_prompt = "Press ESC for boot menu"


### PR DESCRIPTION
To enable tests on arm, correct the cfg files in this PR.

Test results: Most of cases are passed, I will fix the reset failures in another pr.
![image](https://github.com/autotest/tp-libvirt/assets/49855663/de650760-11f2-4f83-83ab-f49718695681)
