### PR TITLE
Fixup:trustGuestRxFilters:Add version check and xml check

### DIFF
--- a/libvirt/tests/cfg/virtual_network/update_device/update_iface_trustGuestRxFilters.cfg
+++ b/libvirt/tests/cfg/virtual_network/update_device/update_iface_trustGuestRxFilters.cfg
@@ -4,6 +4,7 @@
     timeout = 240
     host_iface =
     outside_ip = 'www.redhat.com'
+    func_supported_since_libvirt_ver = (10, 0, 0)
     variants:
         - yes_to_no:
             trustGRF = 'yes'

--- a/libvirt/tests/src/virtual_network/update_device/update_iface_trustGuestRxFilters.py
+++ b/libvirt/tests/src/virtual_network/update_device/update_iface_trustGuestRxFilters.py
@@ -1,6 +1,7 @@
 import logging
 
 from avocado.utils import process
+from virttest import libvirt_version
 from virttest import utils_net
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
@@ -18,6 +19,7 @@ def run(test, params, env):
     """
     Test live update trustGuestRxFilters for direct type interface
     """
+    libvirt_version.is_libvirt_feature_supported(params)
     vm_name = params.get('main_vm')
     vm = env.get_vm(vm_name)
     host_iface = params.get('host_iface')
@@ -48,6 +50,10 @@ def run(test, params, env):
         iface_update = network_base.get_iface_xml_inst(vm_name, 'after update')
         LOG.debug(f'iface trustGuestRxFilters after update: '
                   f'{iface_update.trustGuestRxFilters}')
+        if iface_update.trustGuestRxFilters != update_attrs[
+                'trustGuestRxFilters']:
+            test.fail(f'Interface trustGuestRxFilters not successfully updated '
+                      f'to {update_attrs["trustGuestRxFilters"]}')
 
         mac_host = utils_net.get_linux_iface_info(iface=target_dev)['address']
 


### PR DESCRIPTION
- Add version check
- Add xml check after update-device

Test result:
```
 (1/2) type_specific.io-github-autotest-libvirt.virtual_network.update_device.update_iface_trustGuestRxFilters.yes_to_no: PASS (60.01 s)
 (2/2) type_specific.io-github-autotest-libvirt.virtual_network.update_device.update_iface_trustGuestRxFilters.no_to_yes:PAASS (59.83 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```