### PR TITLE
Adaption for rhel8 aarch64

### DIFF
--- a/libvirt/tests/cfg/event/virsh_event.cfg
+++ b/libvirt/tests/cfg/event/virsh_event.cfg
@@ -123,7 +123,7 @@
                     cpu_mode = 'host-model'
                     aarch64:
                         cpu_mode = 'host-passthrough'
-                        dimm_size = 512
+                        dimm_size = 1024
                     expected_fails = "unplug of device was rejected by the guest"
                 - watchdog_event:
                     event_all_option = "yes"


### PR DESCRIPTION
Since on rhel8 section size must be at least 1024MB for 64K base, so plugged memory must equal or bigger than 1024M.

Test result on rhel8 aarch64 64k:
(1/1) type_specific.io-github-autotest-libvirt.virsh.event.positive_test.virsh_event.test_events.device-removal-failed_event.no_timeout.loop: PASS (57.34 s)