### PR TITLE
virtual_disk: fix snapshot issue for ovmf guest

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
@@ -518,8 +518,10 @@ def run(test, params, env):
         snapshot1 = "s1"
         snapshot2 = "s2"
         snapshot2_file = os.path.join(data_dir.get_data_dir(), "s2")
-        ret = virsh.snapshot_create(vm_name, "", **virsh_dargs)
-        libvirt.check_exit_status(ret)
+        # Skip internal snapshot for ovmf guest
+        if "os_firmware" not in vmxml.os.fetch_attrs():
+            ret = virsh.snapshot_create(vm_name, "", **virsh_dargs)
+            libvirt.check_exit_status(ret)
 
         ret = virsh.snapshot_create_as(vm_name, "%s --disk-only" % snapshot1,
                                        **virsh_dargs)
@@ -1364,6 +1366,8 @@ def run(test, params, env):
                 osxml.type = vmxml.os.type
                 osxml.arch = vmxml.os.arch
                 osxml.machine = vmxml.os.machine
+                if vmxml.os.fetch_attrs().get("os_firmware") == "efi":
+                    osxml.os_firmware = vmxml.os.os_firmware
                 if test_boot_console:
                     osxml.loader = "/usr/share/seabios/bios.bin"
                     osxml.bios_useserial = "yes"


### PR DESCRIPTION
There are two problems in virtual_disks_multidisks.py script: 
1) The os xml will change to seabios guest when we testing ovmf guest because of incorrectos xml configuration
2) Internal snapshot is not supportted in ovmf guest.

Fix the above problems by adding os_firmware attribute and skip internal snapshot test for ovmf guest.