### PR TITLE
virtual_disks: Add a vhostvdpa-blk test

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/vhostvdpa_block_backend_type/define_start_vm_with_multi_vhostvdpa_backend_disks.cfg
+++ b/libvirt/tests/cfg/virtual_disks/vhostvdpa_block_backend_type/define_start_vm_with_multi_vhostvdpa_backend_disks.cfg
@@ -1,0 +1,12 @@
+- virtual_disks.vhostvdpa.define_start_multi_disks:
+    type = define_start_vm_with_multi_vhostvdpa_backend_disks
+    start_vm = no
+    simulator = "yes"
+    func_supported_since_libvirt_ver = (9, 10, 0)
+    only x86_64
+
+    disk_vdpa_attrs = {"source": {"attrs": {"dev": "/dev/vhost-vdpa-0"}}, "type_name": "vhostvdpa"}
+    disk2_vdpa_attrs = {"source": {"attrs": {"dev": "/dev/vhost-vdpa-1"}}, "type_name": "vhostvdpa"}
+    disk_driver = {"driver": {"name": "qemu", "type": "raw", "cache": "none", "io": "threads", "copy_on_read": "on", "discard": "unmap", "detect_zeroes": "on"}}
+    disk_attrs = {"device": "disk", "target": {"dev": "vdb", "bus": "virtio"}, **${disk_vdpa_attrs}, **${disk_driver}}
+    disk2_attrs = {"device": "disk", "target": {"dev": "vdc", "bus": "virtio"}, **${disk2_vdpa_attrs}, **${disk_driver}}

--- a/libvirt/tests/src/virtual_disks/vhostvdpa_block_backend_type/define_start_vm_with_multi_vhostvdpa_backend_disks.py
+++ b/libvirt/tests/src/virtual_disks/vhostvdpa_block_backend_type/define_start_vm_with_multi_vhostvdpa_backend_disks.py
@@ -1,0 +1,45 @@
+from virttest import libvirt_version
+from virttest import utils_vdpa
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_disk
+from virttest.utils_libvirt import libvirt_vmxml
+
+VIRSH_ARGS = {'debug': True, 'ignore_status': False}
+
+
+def run(test, params, env):
+    """
+    Verify that a vm can have more than one vhost-vdpa backend disks,
+    and both the two disks can be successfully written to/read from.
+    """
+    libvirt_version.is_libvirt_feature_supported(params)
+    disk_attrs = eval(params.get("disk_attrs", "{}"))
+    disk2_attrs = eval(params.get("disk2_attrs", "{}"))
+
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+
+    try:
+        test.log.info("TEST_STEP: Define a VM with vhost-vdpa disk.")
+        test_env_obj = utils_vdpa.VDPASimulatorTest(sim_dev_module="vdpa_sim_blk", mgmtdev="vdpasim_blk")
+        test_env_obj.setup(dev_num=2)
+        vm_xml.VMXML.set_memoryBacking_tag(vm_name, access_mode="shared", hpgs=False)
+        libvirt_vmxml.modify_vm_device(vm_xml.VMXML.new_from_dumpxml(vm_name), "disk", disk_attrs, 1)
+        libvirt_vmxml.modify_vm_device(vm_xml.VMXML.new_from_dumpxml(vm_name), "disk", disk2_attrs, 2)
+
+        vm.start()
+        vm_session = vm.wait_for_login()
+
+        test.log.info("TEST_STEP: Check r/w operations on vhost-vdpa disk.")
+        new_disks = libvirt_disk.get_non_root_disk_names(vm_session)
+        vm_session.close()
+        for disk in new_disks:
+            if not libvirt_disk.check_virtual_disk_io(vm, disk[0]):
+                test.fail("Failed to check disk io for %s!" % disk[0])
+
+    finally:
+        bkxml.sync()
+        test_env_obj.cleanup()


### PR DESCRIPTION
This PR adds:
    VIRT-300441: Define&Start vm with two disks of vhostvdpa backend

Depends on:
- https://github.com/avocado-framework/avocado-vt/pull/3893
- https://github.com/autotest/tp-libvirt/pull/5570

**Test results:**
```
(1/1) type_specific.io-github-autotest-libvirt.virtual_disk.vhostvdpa.define_start_multi_disks: PASS (56.23 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/lib/avocado/job-results/job-2024-04-18T22.18-67c2b69/results.html
JOB TIME   : 58.10 s
```
