### PR TITLE
virtual_network: Extend event_timeout for arm

### DIFF
--- a/libvirt/tests/src/virtual_network/hotplug/attach_detach_interface/attach_interface_with_model.py
+++ b/libvirt/tests/src/virtual_network/hotplug/attach_detach_interface/attach_interface_with_model.py
@@ -107,7 +107,9 @@ def run(test, params, env):
             check_model_controller(vm_name, pci_model, test)
 
         virsh.detach_device_alias(vm_name, alias_name,
-                                  wait_for_event=True, **VIRSH_ARGS)
+                                  wait_for_event=True,
+                                  event_timeout=20,
+                                  **VIRSH_ARGS)
         iflist = libvirt.get_interface_details(vm_name)
         test.log.debug(f"iflist of vm: {iflist}")
         if iflist:


### PR DESCRIPTION
Waiting for device-removed event takes more time than x86.

**Test results:**
` (1/1) type_specific.io-github-autotest-libvirt.virtual_network.hotplug.attach_interface.model.virtio: PASS (68.29 s)
`
