### PR TITLE
Add adaption to support different huge page size for multi arch

### DIFF
--- a/libvirt/tests/cfg/memory/memory_backing/hugepage_nodeset.cfg
+++ b/libvirt/tests/cfg/memory/memory_backing/hugepage_nodeset.cfg
@@ -2,21 +2,30 @@
     type = hugepage_nodeset
     no s390-virtio
     start_vm = no
-    page_size = "2048"
     page_unit = "KiB"
-    current_mem = 2072576
-    mem_value = 2072576
     mem_unit = "KiB"
     current_mem_unit = "KiB"
-    set_pagesize = "2048"
-    set_pagenum = "1024"
     expect_str = "huge"
-    aarch64:
-        page_size = "524288"
-        current_mem = 1572864
-        mem_value = 1572864
-        set_pagesize = "524288"
-        set_pagenum = "4"
+    variants kernel_pagesize:
+        - 4k:
+            default_page_size = 4
+            variants huge_pagesize:
+                - 2048:
+                    page_size = "2048"
+                    current_mem = 2072576
+                    mem_value = 2072576
+                    set_pagesize = "2048"
+                    set_pagenum = "1024"
+        - 64k:
+            default_page_size = 64
+            only aarch64
+            variants huge_pagesize:
+                - 524288:
+                    page_size = "524288"
+                    current_mem = 1572864
+                    mem_value = 1572864
+                    set_pagesize = "524288"
+                    set_pagenum = "4"
     variants:
         - nodeset_0:
             nodeset = "0"
@@ -30,7 +39,7 @@
         - with_numa:
             numa_size_1 = 1048576
             numa_size_2 = 1024000
-            aarch64:
+            524288:
                 numa_size_2 = 524288
             numa_cpu = {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '${numa_size_1}', 'unit': 'KiB'}, {'id': '1', 'cpus': '2-3', 'memory': '${numa_size_2}', 'unit': 'KiB'}]}
             vm_attrs = {${memory_backing_dict},"cpu":${numa_cpu},'vcpu': 4,'max_mem_rt_slots': 16,'memory_unit':"${mem_unit}",'memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}','max_mem_rt': 3145728, 'max_mem_rt_unit': "KiB"}
@@ -40,5 +49,6 @@
             vm_attrs = {${memory_backing_dict}, 'memory_unit':'${mem_unit}','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}'}
             expect_xpath = [{'element_attrs':[".//page[@size='${page_size}']", ".//page[@unit='${page_unit}']"]}]
             allocated_mem = "2072576"
-            aarch64:
+            524288:
                 allocated_mem = "1572864"
+

--- a/libvirt/tests/src/memory/memory_backing/hugepage_nodeset.py
+++ b/libvirt/tests/src/memory/memory_backing/hugepage_nodeset.py
@@ -19,6 +19,8 @@ from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 from virttest.utils_libvirt import libvirt_vmxml
 
+from provider.memory import memory_base
+
 
 def check_numa_maps(test, params, result):
     """
@@ -69,6 +71,8 @@ def run(test, params, env):
         Allocate hugepage memory
         """
         test.log.info("TEST_SETUP: Allocate hugepage memory")
+        memory_base.check_mem_page_sizes(
+            test, pg_size=int(default_page_size), hp_size=int(set_pagesize))
         hp_cfg = test_setup.HugePageConfig(params)
         hp_cfg.set_kernel_hugepages(set_pagesize, set_pagenum)
 
@@ -127,6 +131,7 @@ def run(test, params, env):
     vm_attrs = eval(params.get('vm_attrs', '{}'))
 
     allocated_mem = params.get('allocated_mem')
+    default_page_size = params.get("default_page_size")
     set_pagesize = params.get("set_pagesize")
     set_pagenum = params.get("set_pagenum")
     expect_xpath = eval(params.get("expect_xpath"))

--- a/provider/memory/memory_base.py
+++ b/provider/memory/memory_base.py
@@ -5,11 +5,17 @@ from avocado.core import exceptions
 from avocado.utils import cpu
 from avocado.utils import memory as avocado_mem
 
+from virttest import virsh
 from virttest import libvirt_version
 from virttest import utils_misc
-
 from virttest.libvirt_xml.devices import memory
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_test import libvirt
 from virttest.utils_version import VersionInterval
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_libvirt import libvirt_misc
+
+virsh_dargs = {"ignore_status": False, "debug": True}
 
 
 def convert_data_size(current_size, dest_unit="KiB"):
@@ -149,3 +155,96 @@ def adjust_memory_size(params):
         params.update({'block_size': default_pagesize_KiB})
         params.update({'request_size': default_pagesize_KiB})
         params.update({'target_size': default_pagesize_KiB*2})
+
+
+def define_guest_with_memory_device(params, mem_attr_list, vm_attrs=None):
+    """
+    Define guest with specified memory device.
+
+    :param params: a dict for parameters.
+    :param mem_attr_list: memory device attributes list.
+    :param vm_attrs: basic vm attributes to define.
+    """
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(params.get("main_vm"))
+    if vm_attrs:
+        vmxml.setup_attrs(**vm_attrs)
+
+    if not isinstance(mem_attr_list, list):
+        mem_attr_list = [mem_attr_list]
+    for mem in mem_attr_list:
+        memory_object = libvirt_vmxml.create_vm_device_by_type('memory', mem)
+        vmxml.devices = vmxml.devices.append(memory_object)
+    vmxml.sync()
+
+
+def plug_memory_and_check_result(test, params, mem_dict, operation='attach',
+                                 expected_error='', expected_event='', **kwargs):
+    """
+    Hot plug or hot unplug memory and check event.
+
+    :param test: test object.
+    :param params: dictionary with the test parameters.
+    :param mem_dict: the memory dict to plug.
+    :param operation: the operation of plug or unplug.
+    :param expected_error: expected error after plug or unplug.
+    :param expected_event: expected event for plug or unplug.
+    """
+    vm_name = params.get('main_vm')
+    plug_dimm = libvirt_vmxml.create_vm_device_by_type('memory', mem_dict)
+
+    wait_event = True if expected_event else False
+    if operation == "attach":
+        res = virsh.attach_device(vm_name, plug_dimm.xml, wait_for_event=wait_event,
+                                  event_type=expected_event, debug=True, **kwargs)
+    elif operation == "detach":
+        res = virsh.detach_device(vm_name, plug_dimm.xml, wait_for_event=wait_event,
+                                  event_type=expected_event, debug=True, **kwargs)
+
+    if expected_error:
+        libvirt.check_result(res, expected_fails=expected_error)
+    else:
+        libvirt.check_exit_status(res)
+
+
+def check_dominfo(vm, test, expected_max, expected_used):
+    """
+    Check Max memory value and Used memory in virsh dominfo result.
+
+    :param vm: vm object.
+    :param test: test object.
+    :param params: dictionary with the test parameters.
+    :param expected_max: expected Max memory in virsh dominfo.
+    :param expected_used: expected Used memory in virsh dominfo.
+    """
+    result = virsh.dominfo(vm.name, **virsh_dargs).stdout_text.strip()
+
+    dominfo_dict = libvirt_misc.convert_to_dict(
+        result, pattern=r'(\S+ \S+):\s+(\S+)')
+    if dominfo_dict["Max memory"] != expected_max:
+        test.fail("Memory value should be %s " % expected_max)
+    if dominfo_dict["Used memory"] != expected_used:
+        test.fail("Current memory should be %s " % expected_used)
+    test.log.debug("Check virsh dominfo successfully.")
+
+
+def check_mem_page_sizes(test, pg_size=None, hp_size=None, hp_list=None):
+    """
+    Check host is suitable for various memory page sizes
+
+    :param test: test object
+    :param pg_size: int, default memory page size in KiB unit
+    :param hp_size: int, default memory huge page size in KiB unit
+    :param hp_list: list, huge page size int list in KiB unit
+    """
+    default_page_size = avocado_mem.get_page_size() / 1024
+    if pg_size and pg_size != default_page_size:
+        test.cancel("Expected host default page size is %s KiB, but get %s KiB" %
+                    (pg_size, default_page_size))
+    default_huge_page_size = avocado_mem.get_huge_page_size()
+    if hp_size and hp_size != default_huge_page_size:
+        test.cancel("Expected host default huge page size is %s KiB, but get %s KiB" %
+                    (hp_size, default_huge_page_size))
+    supported_hp_size_list = avocado_mem.get_supported_huge_pages_size()
+    if hp_list and not set(hp_list).issubset(set(supported_hp_size_list)):
+        test.cancel("Expected huge page size list is %s, but get %s" %
+                    (hp_list, supported_hp_size_list))


### PR DESCRIPTION
Test results on multi arch:
x86_64:
(1/4) type_specific.io-github-autotest-libvirt.memory.backing.nodeset.with_numa.nodeset_0.2M: PASS (33.56 s)
 (2/4) type_specific.io-github-autotest-libvirt.memory.backing.nodeset.with_numa.nodeset_not_exist.2M: PASS (7.83 s)
 (3/4) type_specific.io-github-autotest-libvirt.memory.backing.nodeset.without_numa.nodeset_0.2M: PASS (47.99 s)
 (4/4) type_specific.io-github-autotest-libvirt.memory.backing.nodeset.without_numa.nodeset_not_exist.2M: PASS (7.88 s)

aarch64 4k:
(1/8) type_specific.io-github-autotest-libvirt.memory.backing.nodeset.with_numa.nodeset_0.2M: PASS (41.69 s)
 (2/8) type_specific.io-github-autotest-libvirt.memory.backing.nodeset.with_numa.nodeset_0.512M: CANCEL: Expected host default huge page size is 524288 KiB, but get 2048 (7.02 s)
 (3/8) type_specific.io-github-autotest-libvirt.memory.backing.nodeset.with_numa.nodeset_not_exist.2M: PASS (7.40 s)
 (4/8) type_specific.io-github-autotest-libvirt.memory.backing.nodeset.with_numa.nodeset_not_exist.512M: CANCEL: Expected host default huge page size is 524288 KiB, but get 2048 (7.08 s)
 (5/8) type_specific.io-github-autotest-libvirt.memory.backing.nodeset.without_numa.nodeset_0.2M: PASS (39.22 s)
 (6/8) type_specific.io-github-autotest-libvirt.memory.backing.nodeset.without_numa.nodeset_0.512M: CANCEL: Expected host default huge page size is 524288 KiB, but get 2048 (7.08 s)
 (7/8) type_specific.io-github-autotest-libvirt.memory.backing.nodeset.without_numa.nodeset_not_exist.2M: PASS (7.68 s)
 (8/8) type_specific.io-github-autotest-libvirt.memory.backing.nodeset.without_numa.nodeset_not_exist.512M: CANCEL: Expected host default huge page size is 524288 KiB, but get 2048 (7.06 s)

aarch64 64k:
 (1/8) type_specific.io-github-autotest-libvirt.memory.backing.nodeset.with_numa.nodeset_0.2M: CANCEL: Expected host default huge page size is 2048 KiB, but get 524288 (4.98 s)
 (2/8) type_specific.io-github-autotest-libvirt.memory.backing.nodeset.with_numa.nodeset_0.512M: PASS (29.92 s)
 (3/8) type_specific.io-github-autotest-libvirt.memory.backing.nodeset.with_numa.nodeset_not_exist.2M: CANCEL: Expected host default huge page size is 2048 KiB, but get 524288 (5.46 s)
 (4/8) type_specific.io-github-autotest-libvirt.memory.backing.nodeset.with_numa.nodeset_not_exist.512M: PASS (5.70 s)
 (5/8) type_specific.io-github-autotest-libvirt.memory.backing.nodeset.without_numa.nodeset_0.2M: CANCEL: Expected host default huge page size is 2048 KiB, but get 524288 (5.54 s)
 (6/8) type_specific.io-github-autotest-libvirt.memory.backing.nodeset.without_numa.nodeset_0.512M: PASS (30.16 s)
 (7/8) type_specific.io-github-autotest-libvirt.memory.backing.nodeset.without_numa.nodeset_not_exist.2M: CANCEL: Expected host default huge page size is 2048 KiB, but get 524288 (5.52 s)
 (8/8) type_specific.io-github-autotest-libvirt.memory.backing.nodeset.without_numa.nodeset_not_exist.512M: PASS (5.56 s)