### PR TITLE
guest_os_booting: Fix a hardcode arch type issue

### DIFF
--- a/libvirt/tests/cfg/guest_os_booting/os_configuration/without_default_os_attributes.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/os_configuration/without_default_os_attributes.cfg
@@ -2,11 +2,11 @@
     type = without_default_os_attributes
     start_vm = no
     firmware_type = "ovmf"
-    only q35
+    only q35, aarch64
     variants:
         - without_arch:
             os_dict = {'type': 'hvm', 'boots': ['hd'], 'machine': 'q35', 'os_firmware': 'efi'}
-            os_xpath = [{'element_attrs': ["./os/type[@arch='x86_64']"]}]
+            os_xpath = [{"element_attrs": [f"./os/type[@arch='{host_arch}']"]}]
         - without_boot_dev:
             os_dict = {'type': 'hvm', 'arch': 'x86_64', 'machine': 'q35', 'os_firmware': 'efi'}
             os_xpath = [{'element_attrs': ["./os/boot[@dev='hd']"]}]

--- a/libvirt/tests/src/guest_os_booting/os_configuration/without_default_os_attributes.py
+++ b/libvirt/tests/src/guest_os_booting/os_configuration/without_default_os_attributes.py
@@ -2,6 +2,8 @@
 #   SPDX-License-Identifier: GPL-2.0
 #   Author: Meina Li <meili@redhat.com>
 
+import platform
+
 from virttest import virsh
 
 from virttest.libvirt_xml import vm_xml
@@ -20,6 +22,7 @@ def run(test, params, env):
     vm_name = guest_os.get_vm(params)
     firmware_type = params.get("firmware_type")
     os_dict = eval(params.get("os_dict"))
+    host_arch = platform.machine()
     os_xpath = eval(params.get("os_xpath"))
 
     vm = env.get_vm(vm_name)


### PR DESCRIPTION
The arch type should be obtained from the host.


` (1/1) type_specific.io-github-autotest-libvirt.guest_os_booting.os_configuration.without_arch: PASS (42.79 s)
`