### PR TITLE
add case for revert disk external snapshot

### DIFF
--- a/libvirt/tests/cfg/snapshot/revert_disk_external_snap.cfg
+++ b/libvirt/tests/cfg/snapshot/revert_disk_external_snap.cfg
@@ -1,0 +1,11 @@
+- snapshot_revert.disk_external_snap:
+    type = revert_disk_external_snap
+    start_vm = no
+    snap_names = ['s1', 's2', 's3']
+    file_list = ["/mnt/s1", "/mnt/s2", "/mnt/s3"]
+    func_supported_since_libvirt_ver = (9, 10, 0)
+    variants snap_type:
+        - disk_only:
+            snap_options = " %s --disk-only %s"
+        - disk_and_memory:
+            snap_options = "%s --memspec snapshot=external,file=/tmp/mem.%s"

--- a/libvirt/tests/src/snapshot/revert_disk_external_snap.py
+++ b/libvirt/tests/src/snapshot/revert_disk_external_snap.py
@@ -1,0 +1,108 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright Redhat
+#
+#   SPDX-License-Identifier: GPL-2.0
+
+#   Author: Nannan Li <nanli@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+from virttest import libvirt_version
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+
+from provider.snapshot import snapshot_base
+
+virsh_dargs = {"debug": True, "ignore_status": False}
+
+
+def revert_snap_and_check_files(params, vm, test, snap_name, expected_files):
+    """
+    Revert the snapshot name and check expected file.
+
+    :param params: dict wrapped with params.
+    :param vm: vm object.
+    :param test: test object.
+    :param snap_name: snapshot name.
+    :param expected_files: expected file list.
+    """
+    virsh.snapshot_revert(vm.name, snap_name, **virsh_dargs)
+
+    session = vm.wait_for_login()
+    for file in expected_files:
+        output = session.cmd('ls %s' % file)
+        if file not in output:
+            test.fail("File %s not exist in %s" % (file, output))
+    params.get("test_obj").check_current_snapshot(snap_name)
+
+    test.log.debug("File %s exist in guest" % expected_files)
+    session.close()
+
+
+def run(test, params, env):
+    """
+    Revert guest to a disk external snapshot.
+    """
+    def setup_test():
+        """
+        Prepare file and snapshot.
+        """
+        test.log.info("TEST_SETUP: Create files and snaps in running guest.")
+        virsh.start(vm_name)
+        session = vm.wait_for_login()
+        mem_file = " "
+        for index, sname in enumerate(snap_names):
+            session.cmd("touch %s" % file_list[index])
+            if snap_type == "disk_and_memory":
+                mem_file = sname
+            virsh.snapshot_create_as(vm.name, snap_options % (sname, mem_file),
+                                     **virsh_dargs)
+            test_obj.check_snap_list(sname)
+
+        session.close()
+
+    def run_test():
+        """
+        Revert guest and check file list.
+        """
+        test.log.info("TEST_STEP1:Revert the 2nd snapshot and check files.")
+        revert_snap_and_check_files(params, vm, test, snap_names[1],
+                                    file_list[:2])
+
+        test.log.info("TEST_STEP2:Revert the first snapshot and check files.")
+        revert_snap_and_check_files(params, vm, test, snap_names[0],
+                                    [file_list[0]])
+
+        test.log.info("TEST_STEP3:Revert the last snap and check source files")
+        revert_snap_and_check_files(params, vm, test, snap_names[-1],
+                                    file_list)
+
+    def teardown_test():
+        """
+        Clean data.
+        """
+        test.log.info("TEST_TEARDOWN: Clean up env.")
+        snap_names.reverse()
+        test_obj.teardown_test()
+
+    vm_name = params.get("main_vm")
+    original_xml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    params['backup_vmxml'] = original_xml.copy()
+    vm = env.get_vm(vm_name)
+
+    snap_names = eval(params.get("snap_names", '[]'))
+    snap_type = params.get("snap_type")
+    snap_options = params.get("snap_options")
+    file_list = eval(params.get("file_list"))
+    test_obj = snapshot_base.SnapshotTest(vm, test, params)
+    params.update({"test_obj": test_obj})
+
+    libvirt_version.is_libvirt_feature_supported(params)
+
+    try:
+        setup_test()
+        run_test()
+
+    finally:
+        teardown_test()

--- a/provider/snapshot/snapshot_base.py
+++ b/provider/snapshot/snapshot_base.py
@@ -62,6 +62,18 @@ class SnapshotTest(object):
         virsh.snapshot_create(self.vm.name, snap_options, **self.virsh_dargs)
         virsh.snapshot_dumpxml(self.vm.name, snap_dict['snap_name'], **self.virsh_dargs)
 
+    def check_current_snapshot(self, snap_name):
+        """
+        Check vm current snapshot name is expected
+
+        :param snap_name, expected snapshot name.
+        """
+        current_name = virsh.snapshot_current(
+            self.vm.name, **self.virsh_dargs).stdout.strip()
+        if current_name != snap_name:
+            self.test.fail("Current snapshot name is %s, should be %s" % (
+                current_name, snap_name))
+
     def delete_snapshot(self, snap_names, options=''):
         """
         Delete snapshots of the vm


### PR DESCRIPTION
   xxxx-16604: Revert guest to disk external snapshot
Signed-off-by: nanli <nanli@redhat.com>

One error is an existing bug.
```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 snapshot_revert.disk_external_snap
 (1/2) type_specific.io-github-autotest-libvirt.snapshot_revert.disk_external_snap.disk_only: ERROR: Command '/usr/bin/virsh snapshot-revert avocado-vt-vm1 s2 ' failed.\nstdout: b'\n'\nstderr: b"error: Failed to revert snapshot s2\nerror: internal error: Invalid target domain state 'disk-snapshot'. Refusing snapshot reversion\n"\nadditional_info: None (42.80 s)
 (2/2) type_specific.io-github-autotest-libvirt.snapshot_revert.disk_external_snap.disk_and_memory: PASS
```