### PR TITLE
libvirt_ccw_passthrough: add sleep

### DIFF
--- a/libvirt/tests/src/passthrough/ccw/libvirt_ccw_passthrough.py
+++ b/libvirt/tests/src/passthrough/ccw/libvirt_ccw_passthrough.py
@@ -1,3 +1,4 @@
+from time import sleep
 from uuid import uuid4
 
 from virttest.utils_zchannels import ChannelPaths
@@ -56,6 +57,7 @@ def run(test, params, env):
             ccw.set_override(schid)
             ccw.start_device(uuid, schid)
 
+            sleep(2)
             vm.start()
             session = vm.wait_for_login()
 


### PR DESCRIPTION
The test fails sometimes in CI when trying to start the VM. The mediated device doesn't seem to be present yet. I can't reproduce this but adding sleep of 2 secs to confirm in future runs that it's really about timing.