### PR TITLE
guest_ob_booting: Fixup an error of UnboundLocalError: disk_image

### DIFF
--- a/libvirt/tests/src/guest_os_booting/boot_order/boot_with_multiple_boot_dev.py
+++ b/libvirt/tests/src/guest_os_booting/boot_order/boot_with_multiple_boot_dev.py
@@ -70,6 +70,8 @@ def run(test, params, env):
     vm_name = guest_os.get_vm(params)
     check_prompt = eval(params.get("check_prompt", "[]"))
     bootable_device = params.get("bootable_device")
+    disk_image = ""
+    cdrom_path = ""
 
     vm = env.get_vm(vm_name)
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm.name)


### PR DESCRIPTION


This pr is to fix below error:
**rhel.guest_os_booting.boot_order.boot_with_multiple_boot_dev.network.cdrom.network_bootable**
`UnboundLocalError: local variable 'disk_image' referenced before assignment`