### PR TITLE
migration: Fix xml error

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_mem.cfg
+++ b/libvirt/tests/cfg/migration/migrate_mem.cfg
@@ -56,7 +56,7 @@
         - mem_nvdimm:
             nvdimm_file_path = '${nfs_mount_dir}/nvdimm'
             nvdimm_file_size = '512M'
-            vm_attrs = {'max_mem_rt': 4096, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'M', 'vcpu': 4, 'cpu': {'mode': 'host-model', 'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '1024', 'unit': 'M'}, {'id': '1', 'cpus': '2-3', 'memory': '1024', 'unit': 'M'}]}}
+            vm_attrs = {'max_mem_rt': 4096, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'M', 'vcpu': 4, 'cpu': {'mode': 'host-passthrough', 'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '1024', 'unit': 'M'}, {'id': '1', 'cpus': '2-3', 'memory': '1024', 'unit': 'M'}]}}
             mem_device_attrs = {'mem_model': 'nvdimm', 'mem_access': 'shared', 'source': {'path': '${nvdimm_file_path}'}, 'target': {'size': 512, 'size_unit': 'M', 'node': 1, 'label': {'size': 256, 'size_unit': 'KiB'}}}
             qemu_checks = "nvdimm=on.*mem-path=${nvdimm_file_path.*share=yes.*size=536870912.*device.*nvdimm,node=1,label-size=262144}"
             migrate_vm_back = "yes"


### PR DESCRIPTION
Fix following error:
  LibvirtXMLError: ... Failed to define domain from ... error: unsupported
  configuration: Attribute migratable is only allowed for
  'host-passthrough' / 'maximum' CPU mode