### PR TITLE
numa: replace parse_numa_nodeset_to_str() to convert_all_nodes_to_string()

### DIFF
--- a/libvirt/tests/src/numa/guest_numa_node_tuning/auto_memory_nodeset_placement.py
+++ b/libvirt/tests/src/numa/guest_numa_node_tuning/auto_memory_nodeset_placement.py
@@ -114,7 +114,7 @@ def verify_cgroup_mem_binding(test_obj):
     """
     mem_mode = test_obj.params.get('mem_mode')
     nodeset = test_obj.params.get('nodeset')
-    online_nodes = libvirt_numa.parse_numa_nodeset_to_str('x-y', test_obj.online_nodes)
+    online_nodes = libvirt_numa.convert_all_nodes_to_string(test_obj.online_nodes)
     vcpu_placement = eval(test_obj.params.get('vm_attrs')).get('placement')
     vm_pid = test_obj.vm.get_pid()
     cg = libvirt_cgroup.CgroupTest(vm_pid)

--- a/libvirt/tests/src/numa/guest_numa_node_tuning/memory_binding_setting.py
+++ b/libvirt/tests/src/numa/guest_numa_node_tuning/memory_binding_setting.py
@@ -179,7 +179,7 @@ def verify_cgroup(test_obj):
     """
     mem_mode = test_obj.params.get('mem_mode')
     nodeset = numa_base.convert_to_string_with_dash(test_obj.params.get('nodeset'))
-    online_nodes = libvirt_numa.parse_numa_nodeset_to_str('x-y', test_obj.online_nodes)
+    online_nodes = libvirt_numa.convert_all_nodes_to_string(test_obj.online_nodes)
     vm_pid = test_obj.vm.get_pid()
     cg = libvirt_cgroup.CgroupTest(vm_pid)
     surfix = 'emulator/cpuset.mems' if cg.is_cgroup_v2_enabled() else 'cpuset.mems'

--- a/libvirt/tests/src/numa/numa_memory.py
+++ b/libvirt/tests/src/numa/numa_memory.py
@@ -200,9 +200,7 @@ def run(test, params, env):
 
         if numa_memory.get('nodeset'):
             numa_nodeset_format = numa_memory.get('nodeset')
-            numa_memory['nodeset'] = libvirt_numa.parse_numa_nodeset_to_str(numa_nodeset_format,
-                                                                            node_list,
-                                                                            ignore_error=True)
+            numa_memory['nodeset'] = libvirt_numa.convert_all_nodes_to_string(node_list)
             used_node = cpu.cpus_parser(numa_memory['nodeset'])
             logging.debug("set node list is %s", used_node)
             if not status_error:

--- a/libvirt/tests/src/numa/numa_memory_migrate.py
+++ b/libvirt/tests/src/numa/numa_memory_migrate.py
@@ -64,8 +64,7 @@ def run(test, params, env):
     try:
         if numa_memory.get('nodeset'):
             numa_nodeset_format = numa_memory.get('nodeset')
-            numa_memory['nodeset'] = libvirt_numa.parse_numa_nodeset_to_str(numa_nodeset_format,
-                                                                            node_list)
+            numa_memory['nodeset'] = libvirt_numa.convert_all_nodes_to_string(node_list)
             used_node = cpu.cpus_parser(numa_memory['nodeset'])
             logging.debug("set node list is %s", used_node)
 

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_numatune.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_numatune.py
@@ -197,8 +197,7 @@ def dynamic_node_replacement(params, numa_info, test_obj):
     numa_nodeset_format = params.get('numa_nodeset')
     dynamic_nodeset = params.get('dynamic_nodeset', 'no') == 'yes'
     if dynamic_nodeset and 'numa_nodeset' in params:
-        params['numa_nodeset'] = libvirt_numa.parse_numa_nodeset_to_str(numa_nodeset_format,
-                                                                        node_list)
+        params['numa_nodeset'] = libvirt_numa.convert_all_nodes_to_string(node_list)
 
         logging.debug('The parameter "numa_nodeset" from config file is going to be replaced by: {} '
                       'available on this system'.format(params['numa_nodeset']))


### PR DESCRIPTION
In PR https://github.com/avocado-framework/avocado-vt/pull/3804, a similar bug is fixed by replacing parse_numa_nodeset_to_str with the new convert_all_nodes_to_string function. However, parse_numa_nodeset_to_str is still called at several places. Therefore, in this PR, replace all parse_numa_nodeset_to_str to convert_all_nodes_to_string.

Signed-off-by: Qian Jianhua [qianjh@fujitsu.com](mailto:qianjh@fujitsu.com)

Before:
```
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_defined.mem_mode_interleave.vcpu_auto: FAIL: Expect cpuset.mems=0-1, but found 0-3 (53.25 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_defined.mem_mode_interleave.vcpu_static: FAIL: Expect cpuset.mems=0-1, but found 0-3 (52.61 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_defined.mem_mode_preferred.vcpu_auto: FAIL: Expect cpuset.mems=0-1, but found 0-3 (53.94 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_defined.mem_mode_preferred.vcpu_static: FAIL: Expect cpuset.mems=0-1, but found 0-3 (52.94 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_undefined.mem_mode_none.vcpu_static: \^[[FAIL: Expect cpuset.mems=0-1, but found 0-3 (52.91 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_undefined.mem_mode_interleave.vcpu_auto: FAIL: Expect cpuset.mems=0-1, but found 0-3 (53.39 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_undefined.mem_mode_preferred.vcpu_auto: FAIL: Expect cpuset.mems=0-1, but found 0-3 (53.47 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.with_iothread.nodeset_defined.mem_mode_interleave.vcpu_auto: FAIL: Expect cpuset.mems=0-1, but found 0-3 (53.66 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.with_iothread.nodeset_defined.mem_mode_interleave.vcpu_static: FAIL: Expect cpuset.mems=0-1, but found 0-3 (53.05 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.with_iothread.nodeset_defined.mem_mode_preferred.vcpu_auto: FAIL: Expect cpuset.mems=0-1, but found 0-3 (53.69 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.with_iothread.nodeset_defined.mem_mode_preferred.vcpu_static: FAIL: Expect cpuset.mems=0-1, but found 0-3 (52.10 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.with_iothread.nodeset_undefined.mem_mode_none.vcpu_static: FAIL: Expect cpuset.mems=0-1, but found 0-3 (52.50 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.with_iothread.nodeset_undefined.mem_mode_interleave.vcpu_auto: FAIL: Expect cpuset.mems=0-1, but found 0-3 (53.37 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.with_iothread.nodeset_undefined.mem_mode_preferred.vcpu_auto: FAIL: Expect cpuset.mems=0-1, but found 0-3 (53.60 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.memory_binding_setting.default_pagesize.mem_mode_interleave.single_host_node: FAIL: Expect cpuset.mems in path '/sys/fs/cgroup/cpuset/machine.slice/machine-qemu\x2d1\x2davocado\x2dvt\x2dvm1.scope/libvirt/emulator/cpuset.mems' to be 0-1, but found '0-3' (53.02 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.memory_binding_setting.default_pagesize.mem_mode_preferred.single_host_node: FAIL: Expect cpuset.mems in path '/sys/fs/cgroup/cpuset/machine.slice/machine-qemu\x2d1\x2davocado\x2dvt\x2dvm1.scope/libvirt/emulator/cpuset.mems' to be 0-1, but found '0-3' (51.54 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.memory_binding_setting.hugepage.mem_mode_interleave.single_host_node: FAIL: Expect cpuset.mems in path '/sys/fs/cgroup/cpuset/machine.slice/machine-qemu\x2d1\x2davocado\x2dvt\x2dvm1.scope/libvirt/emulator/cpuset.mems' to be 0-1, but found '0-3' (55.88 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.memory_binding_setting.hugepage.mem_mode_interleave.multiple_host_nodes: FAIL: Expect cpuset.mems in path '/sys/fs/cgroup/cpuset/machine.slice/machine-qemu\x2d1\x2davocado\x2dvt\x2dvm1.scope/libvirt/emulator/cpuset.mems' to be 0-1, but found '0-3' (51.44 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.memory_binding_setting.hugepage.mem_mode_preferred.single_host_node: FAIL: Expect cpuset.mems in path '/sys/fs/cgroup/cpuset/machine.slice/machine-qemu\x2d1\x2davocado\x2dvt\x2dvm1.scope/libvirt/emulator/cpuset.mems' to be 0-1, but found '0-3' (51.97 s)
```

After:
```
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_defined.mem_mode_interleave.vcpu_auto: PASS (48.93 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_defined.mem_mode_interleave.vcpu_static: PASS (46.90 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_defined.mem_mode_preferred.vcpu_auto: PASS (48.31 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_defined.mem_mode_preferred.vcpu_static: PASS (46.35 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_undefined.mem_mode_none.vcpu_static: PASS (46.61 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_undefined.mem_mode_interleave.vcpu_auto: PASS (48.48 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_undefined.mem_mode_preferred.vcpu_auto: PASS (48.23 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.with_iothread.nodeset_defined.mem_mode_interleave.vcpu_auto: PASS (49.11 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.with_iothread.nodeset_defined.mem_mode_interleave.vcpu_static: PASS (47.16 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.with_iothread.nodeset_defined.mem_mode_preferred.vcpu_auto: PASS (49.38 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.with_iothread.nodeset_defined.mem_mode_preferred.vcpu_static: PASS (47.41 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.with_iothread.nodeset_undefined.mem_mode_none.vcpu_static: PASS (47.42 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.with_iothread.nodeset_undefined.mem_mode_interleave.vcpu_auto: PASS (49.02 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.with_iothread.nodeset_undefined.mem_mode_preferred.vcpu_auto: PASS (48.93 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.memory_binding_setting.default_pagesize.mem_mode_interleave.single_host_node: PASS (51.73 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.memory_binding_setting.default_pagesize.mem_mode_preferred.single_host_node: PASS (51.72 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.memory_binding_setting.hugepage.mem_mode_interleave.single_host_node: PASS (50.14 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.memory_binding_setting.hugepage.mem_mode_interleave.multiple_host_nodes: PASS (50.11 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.memory_binding_setting.hugepage.mem_mode_preferred.single_host_node: PASS (49.95 s)
```