### PR TITLE
Add network case of update-device

### DIFF
--- a/libvirt/tests/cfg/virtual_network/update_device/update_iface_with_identifier.cfg
+++ b/libvirt/tests/cfg/virtual_network/update_device/update_iface_with_identifier.cfg
@@ -1,0 +1,40 @@
+- virtual_network.update_device.iface_with_identifier:
+    type = update_iface_with_identifier
+    start_vm = no
+    timeout = 240
+    iface_a_attrs = {'source': {'network': 'default'}, 'model': 'virtio', 'type_name': 'network', 'alias': {'name': alias_a}}
+    iface_b_attrs = {'source': {'network': 'default'}, 'model': 'virtio', 'type_name': 'network', 'alias': {'name': alias_b}}
+    update_attrs = {'link_state': 'down'}
+    err_msg_matching = device not found: no device found at address .* matching MAC address .* and alias .*
+    variants scenario:
+        - mac_only:
+            del_tags = ['alias', 'address']
+            status_error = no
+        - alias_only:
+            del_tags = ['address', 'mac']
+            status_error = no
+            update:
+                status_error = yes
+                err_msg = cannot change network interface mac address from .* to .*
+        - pci_address_only:
+            del_tags = ['alias', 'mac']
+            status_error = no
+            update:
+                status_error = yes
+                err_msg = cannot change network interface mac address from .* to .*
+        - right_mac_alias_wrong_pci:
+            status_error = yes
+            err_msg = ${err_msg_matching}
+            update_attrs = {'link_state': 'down'}
+            update_pci = yes
+        - right_mac_pci_wrong_alias:
+            status_error = yes
+            err_msg = ${err_msg_matching}
+            update_attrs = {'link_state': 'down', 'alias': {'name': rand_alias}}
+        - wrong_mac_right_alias_pci:
+            status_error = yes
+            err_msg = ${err_msg_matching}
+            update_attrs = {'link_state': 'down', 'mac_address': rand_mac}
+    variants operation:
+        - update:
+        - hotunplug:

--- a/libvirt/tests/src/virtual_network/update_device/update_iface_with_identifier.py
+++ b/libvirt/tests/src/virtual_network/update_device/update_iface_with_identifier.py
@@ -1,0 +1,114 @@
+import logging
+
+from virttest import utils_misc
+from virttest import utils_net
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+from provider.virtual_network import network_base
+
+VIRSH_ARGS = {'ignore_status': False, 'debug': True}
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+
+def check_cmd_result(cmd_result, status_error, err_msg=None):
+    """
+    Check command result including exit status and error message
+
+    :param cmd_result: command result instance
+    :param status_error: expect error of command
+    :param err_msg: error message of command, defaults to None
+    """
+    libvirt.check_exit_status(cmd_result, status_error)
+    if err_msg:
+        libvirt.check_result(cmd_result, err_msg)
+
+
+def run(test, params, env):
+    """
+    Verify updating interface can identify by each of the mac/alias/PCI address,
+    and also by them together.
+    """
+    vm_name = params.get('main_vm')
+    vm = env.get_vm(vm_name)
+    status_error = 'yes' == params.get('status_error', 'no')
+    err_msg = params.get('err_msg')
+    alias_a = 'ua-' + utils_misc.generate_random_string(6)
+    alias_b = 'ua-' + utils_misc.generate_random_string(6)
+    rand_mac = utils_net.generate_mac_address_simple()
+    rand_alias = 'randa-' + utils_misc.generate_random_string(6)
+    iface_a_attrs = eval(params.get('iface_a_attrs', '{}'))
+    iface_b_attrs = eval(params.get('iface_b_attrs', '{}'))
+    update_attrs = eval(params.get('update_attrs', '{}'))
+    update_pci = 'yes' == params.get('update_pci', 'no')
+    del_tags = eval(params.get('del_tags', '[]'))
+    operation = params.get('operation')
+
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+
+    try:
+        vmxml.del_device('interface', by_tag=True)
+        for attrs in (iface_a_attrs, iface_b_attrs):
+            iface_x = libvirt_vmxml.create_vm_device_by_type(
+                'interface', attrs)
+            libvirt.add_vm_device(vmxml, iface_x)
+        LOG.debug(f'VMXMLof {vm_name}:\n{virsh.dumpxml(vm_name).stdout_text}')
+
+        vm.start()
+
+        # Get target iface
+        iface = network_base.get_iface_xml_inst(vm_name, '1st on vm')
+        mac = iface.mac_address
+
+        LOG.debug(f'Update iface with attrs: {update_attrs}')
+        iface.setup_attrs(**update_attrs)
+
+        if update_pci:
+            LOG.debug('Update iface xml pci address')
+            pci_addr_attrs = iface.address['attrs']
+            pci_addr_attrs['slot'] = str(hex(int(pci_addr_attrs['slot'],
+                                                 16) + 3))
+            iface.setup_attrs(address={'attrs': pci_addr_attrs})
+            LOG.debug(f'Update iface pci address to: {iface.address}')
+
+        for tag in del_tags:
+            LOG.debug(f'Remove <{tag}> from iface xml.')
+            iface.xmltreefile.remove_by_xpath(tag)
+        iface.xmltreefile.write()
+        LOG.debug(f'Update iface with xml:\n{iface}')
+
+        if operation == 'update':
+            up_result = virsh.update_device(vm_name, iface.xml, debug=True)
+            check_cmd_result(up_result, status_error, err_msg)
+            if status_error:
+                return
+            iface_update = network_base.get_iface_xml_inst(vm_name,
+                                                           'after update')
+            if iface_update.link_state == update_attrs['link_state']:
+                LOG.info('link_state of interface after update check PASS')
+            else:
+                test.fail(f'Interface link_state after update should be '
+                          f'{update_attrs["link_state"]}')
+
+        elif operation == 'hotunplug':
+            dt_result = virsh.detach_device(vm_name, iface.xml,
+                                            wait_for_event=True,
+                                            event_timeout=20,
+                                            debug=True)
+            check_cmd_result(dt_result, status_error, err_msg)
+            if status_error:
+                return
+            iflist = virsh.domiflist(vm_name, debug=True).stdout_text
+            if mac not in iflist:
+                LOG.info('Interface successfully detached:checked by domiflist')
+            else:
+                test.fail(f'Interface with mac {mac} not detached')
+        else:
+            test.error(f'Unknown operation: {operation}')
+
+    finally:
+        bkxml.sync()


### PR DESCRIPTION
- VIRT-298320 - [update-device] update an interface by update-device match by mac address, and alias & pci address together

Test result:
```
 (01/12) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_with_identifier.update.mac_only: PASS (7.92 s)
 (02/12) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_with_identifier.update.alias_only: PASS (7.96 s)
 (03/12) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_with_identifier.update.pci_address_only: PASS (7.82 s)
 (04/12) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_with_identifier.update.right_mac_alias_wrong_pci: PASS (7.82 s)
 (05/12) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_with_identifier.update.right_mac_pci_wrong_alias: PASS (7.83 s)
 (06/12) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_with_identifier.update.wrong_mac_right_alias_pci: PASS (7.79 s)
 (07/12) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_with_identifier.hotunplug.mac_only: PASS (23.98 s)
 (08/12) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_with_identifier.hotunplug.alias_only: PASS (24.05 s)
 (09/12) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_with_identifier.hotunplug.pci_address_only: PASS (24.01 s)
 (10/12) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_with_identifier.hotunplug.right_mac_alias_wrong_pci: PASS (9.05 s)
 (11/12) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_with_identifier.hotunplug.right_mac_pci_wrong_alias: PASS (8.94 s)
 (12/12) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_with_identifier.hotunplug.wrong_mac_right_alias_pci: PASS (8.99 s)
RESULTS    : PASS 12 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```