### PR TITLE
Fixup:SoftwareManager not found

### DIFF
--- a/libvirt/tests/src/libvirt_package.py
+++ b/libvirt/tests/src/libvirt_package.py
@@ -37,7 +37,7 @@ def run(test, params, env):
         elif libvirtd_state == "off":
             utils_libvirtd.libvirtd_stop()
         # if package exist, remove it
-        sm = software_manager.SoftwareManager()
+        sm = software_manager.manager.SoftwareManager()
         pkg_exist = []
         for item in pkg_list:
             if sm.check_installed(item):

--- a/libvirt/tests/src/libvirtd_start.py
+++ b/libvirt/tests/src/libvirtd_start.py
@@ -82,7 +82,7 @@ def run(test, params, env):
     # In RHEL6 iptables-services and firewalld is not supported
     # So try to install all required packages but ignore failures
     logging.info('Preparing firewall related packages')
-    software_mgr = software_manager.SoftwareManager()
+    software_mgr = software_manager.manager.SoftwareManager()
     for pkg in ['iptables', 'iptables-services', 'firewalld']:
         if not software_mgr.check_installed(pkg):
             software_mgr.install(pkg)

--- a/libvirt/tests/src/save_and_restore/restore_from_local_file.py
+++ b/libvirt/tests/src/save_and_restore/restore_from_local_file.py
@@ -57,7 +57,7 @@ def setup_bypass_cache(check_cmd, test):
     :param test: test instance
     :return: subprocess instance to run check command
     """
-    sm = software_manager.SoftwareManager()
+    sm = software_manager.manager.SoftwareManager()
     if not sm.check_installed('lsof'):
         test.error("Need to install lsof on host")
     sp = process.SubProcess(check_cmd, shell=True)

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_managedsave.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_managedsave.py
@@ -432,7 +432,7 @@ def run(test, params, env):
 
         # For bypass_cache test. Run a shell command to check fd flags while
         # executing managedsave command
-        software_mgr = software_manager.SoftwareManager()
+        software_mgr = software_manager.manager.SoftwareManager()
         if not software_mgr.check_installed('lsof'):
             logging.info('Installing lsof package:')
             software_mgr.install('lsof')

--- a/libvirt/tests/src/virt_cmd/virt_top.py
+++ b/libvirt/tests/src/virt_cmd/virt_top.py
@@ -21,7 +21,7 @@ def run(test, params, env):
     machine.
     """
     # Install virt-top package if missing.
-    software_mgr = software_manager.SoftwareManager()
+    software_mgr = software_manager.manager.SoftwareManager()
     if not software_mgr.check_installed('virt-top'):
         logging.info('Installing virt-top package:')
         software_mgr.install('virt-top')

--- a/v2v/tests/src/install.py
+++ b/v2v/tests/src/install.py
@@ -23,7 +23,7 @@ def run(test, params, env):
     minor_failure = False
     minor_failure_reasons = []
 
-    sm = software_manager.SoftwareManager()
+    sm = software_manager.manager.SoftwareManager()
 
     for name in params.get("installers", "").split():
         installer_obj = installer.make_installer(name, params, test)


### PR DESCRIPTION
Fix ERROR: module 'avocado.utils.software_manager' has no attribute 'SoftwareManager'

Test result of one case:
 (1/1) type_specific.io-github-autotest-libvirt.virsh.managedsave.status_error_yes.name_option.transient_vm: PASS (9.60 s)