### PR TITLE
guest_os_booting/boot_order: expect error on s390x

### DIFF
--- a/libvirt/tests/cfg/guest_os_booting/boot_order/boot_from_virtiofs_device.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/boot_order/boot_from_virtiofs_device.cfg
@@ -3,6 +3,7 @@
     start_vm = no
     access_cmd = "virsh console %s"
     vm_memory = 15728640
+    no s390-virtio
     variants:
         - start_guest:
             target_dir = "mount_tag"

--- a/libvirt/tests/cfg/guest_os_booting/boot_order/hotplug_device_with_boot_order.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/boot_order/hotplug_device_with_boot_order.cfg
@@ -18,3 +18,5 @@
             source_dir = "/tmp"
             order_xpath = [{'element_attrs': ["./devices/filesystem/boot[@order='2']"]}]
             device_dict = {'target': {'dir': '${target_dir}'}, 'type_name': 'mount', 'source': {'dir': '${source_dir}'}, 'binary': {'path': '/usr/libexec/virtiofsd'}, 'accessmode': 'passthrough', 'boot': '2', 'driver': {'type': 'virtiofs'}}
+            s390-virtio:
+                expected_error = unsupported configuration: setting virtiofs boot order is supported only with PCI bus


### PR DESCRIPTION
On s390x, booting from virtiofs is not supported. Expect an error message.

Disable one other test. It would prepare the bootable environment before trying to set/use the boot from virtiofs. The preparation would take about 2 minutes. For this negative error message test on s390x, it's not necessary. Disable instead.

Also, run some reformatting by black.