### PR TITLE
numa: remove 'kernelpagesize_kB' parameter

### DIFF
--- a/libvirt/tests/cfg/numa/guest_numa_node_tuning/change_numa_tuning.cfg
+++ b/libvirt/tests/cfg/numa/guest_numa_node_tuning/change_numa_tuning.cfg
@@ -17,7 +17,4 @@
             mem_mode = 'preferred'
         - mem_mode_restrictive:
             mem_mode = 'restrictive'
-            kernelpagesize_kB = '4'
-            aarch64:
-                kernelpagesize_kB = '64'
     numa_memory = {'mode': '${mem_mode}', 'nodeset': '%s'}

--- a/libvirt/tests/src/numa/guest_numa_node_tuning/change_numa_tuning.py
+++ b/libvirt/tests/src/numa/guest_numa_node_tuning/change_numa_tuning.py
@@ -21,6 +21,7 @@ from virttest.utils_libvirt import libvirt_memory
 from virttest.utils_libvirt import libvirt_misc
 from virttest.utils_libvirt import libvirt_vmxml
 from virttest.utils_test import libvirt
+from virttest.staging import utils_memory
 
 
 from provider.numa import numa_base
@@ -77,7 +78,7 @@ def verify_host_numa_memory_allocation(test_obj, check_N0=False):
     :param test_obj: NumaTest object
     """
     mem_size = get_memory_in_vmxml(test_obj)
-    kernelpagesize_kB = test_obj.params.get('kernelpagesize_kB')
+    kernelpagesize_kB = utils_memory.getpagesize()
     out_numa_maps = numa_base.get_host_numa_memory_alloc_info(mem_size)
     all_nodes = test_obj.online_nodes_withmem
     N0_value = re.findall('N%s=(\d+)' % all_nodes[0], out_numa_maps)


### PR DESCRIPTION
remove 'kernelpagesize_KB' parameter, and get pagesize with getpagesize().

Signed-off-by: Qian Jianhua <qianjh@fujitsu.com>

Before:
```
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.change_numa_tuning.mem_mode_restrictive: FAIL: The numa_maps should include 'kernelpagesize_kB=64'， but not found (123.15 s)
```

After:
```
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.change_numa_tuning.mem_mode_restrictive: PASS (126.90 s)
```