### PR TITLE
libvirtd: Add case about negative value for parameters in libvirtd conf

### DIFF
--- a/libvirt/tests/cfg/daemon/conf_file/libvirtd_conf/check_negative_parameter.cfg
+++ b/libvirt/tests/cfg/daemon/conf_file/libvirtd_conf/check_negative_parameter.cfg
@@ -1,0 +1,47 @@
+- conf_file.libvirtd_conf.check_negative_parameter:
+    type = check_negative_parameter
+    start_vm = no
+    log_file = "/var/log/messages"
+    require_modular_daemon = "yes"
+    variants parameter_name:
+        - listen_tcp:
+            only virtproxyd
+            parameter_value = "-1"
+        - listen_tls:
+            only virtproxyd
+            parameter_value = "-40"
+        - tls_no_sanity_certificate:
+            only virtproxyd
+            parameter_value = "-1"
+        - max_clients:
+            parameter_value = "-1"
+        - max_queued_clients:
+            parameter_value = "-1"
+        - max_anonymous_clients:
+            parameter_value = "-1"
+        - max_workers:
+            parameter_value = "-1"
+        - min_workers:
+            parameter_value = "-1"
+        - prio_workers:
+            parameter_value = "-1"
+        - max_client_requests:
+            parameter_value = "-5"
+        - audit_level:
+            parameter_value = "-2"
+        - audit_logging:
+            parameter_value = "-1"
+        - log_level:
+            parameter_value = "-1"
+        - keepalive_count:
+            parameter_value = "-5"
+    variants daemon_name:
+        - virtqemud:
+        - virtnwfilterd:
+        - virtinterfaced:
+        - virtsecretd:
+        - virtproxyd:
+        - virtstoraged:
+        - virtnodedevd:
+        - virtnetworkd:
+    check_string_in_log = "load config file: internal error: /etc/libvirt/${daemon_name}.conf"

--- a/libvirt/tests/src/daemon/conf_file/libvirtd_conf/check_negative_parameter.py
+++ b/libvirt/tests/src/daemon/conf_file/libvirtd_conf/check_negative_parameter.py
@@ -1,0 +1,49 @@
+import logging
+import time
+
+from avocado.utils import process
+
+from virttest import utils_config
+from virttest import utils_libvirtd
+from virttest import utils_split_daemons
+
+from virttest.utils_test import libvirt
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+
+def run(test, params, env):
+    """
+    Test libvirt should disallow negative value for options needed positive
+    integer etc in libvirtd.conf.
+
+    """
+    check_string_in_log = params.get("check_string_in_log")
+    daemon_name = params.get("daemon_name")
+    parameter_name = params.get("parameter_name")
+    parameter_value = params.get("parameter_value")
+    log_file = params.get("log_file")
+    require_modular_daemon = params.get('require_modular_daemon', "no") == "yes"
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    vm = env.get_vm(vm_name)
+
+    utils_split_daemons.daemon_mode_check(require_modular_daemon)
+    daemon = utils_libvirtd.Libvirtd(daemon_name)
+    daemon_conf = utils_config.get_conf_obj(daemon_name)
+
+    try:
+        cmd = "echo ' ' > %s" % log_file
+        process.run(cmd, shell=True)
+
+        daemon_conf[parameter_name] = parameter_value
+        if not daemon.restart(wait_for_start=False):
+            LOG.info("%s restart failed as expected.", daemon_name)
+        else:
+            test.fail("Expect %s restart failed, but successfully." % daemon_name)
+
+        time.sleep(1)
+        libvirt.check_logfile(check_string_in_log, log_file, str_in_log=True)
+
+    finally:
+        daemon_conf.restore()
+        daemon.restart()


### PR DESCRIPTION
XXXX-34455 - [libvirtd][config]Start libvirtd with negative value for parameters which require positive integer value in libvirtd.conf