### PR TITLE
aarch64_cpu_sve: update

### DIFF
--- a/libvirt/tests/cfg/cpu/aarch64_cpu_sve.cfg
+++ b/libvirt/tests/cfg/cpu/aarch64_cpu_sve.cfg
@@ -4,50 +4,69 @@
     check_cmd_lscpu = "which lscpu"
     check_sve = "lscpu  | grep sve"
     check_sve_config = "grep CONFIG_ARM64_SVE=y /boot/config-%s"
-    get_maxium_sve_length = "dmesg | grep 'SVE: maximum available vector length'"
+    get_maximum_sve_length = "dmesg | grep 'SVE: maximum available vector length'"
     cpu_xml_policy = "require"
     cpu_xml_mode = "host-passthrough"
     only aarch64
     variants:
         - boot_test:
+            status_error = "no"
             variants:
                 - enable_sve:
-                    expect_sve = "yes"
                 - disable_sve:
                     cpu_xml_policy = "disable"
                     expect_sve = "no"
-        - vector_length_test:
+        - with_vector_length:
             variants:
                 - valid_length:
-                    expect_sve = "yes"
+                    status_error = "no"
                     variants:
-                        - single_vector:
-                            variants:
-                                - sve128:
-                                    vector_length = "sve128"
-                                - sve256:
-                                    vector_length = "sve256"
-                                - sve512:
-                                    vector_length = "sve512"
-                        - mutiple_vector:
-                            vector_lenth_list = '[{"sve128":"require"}, {"sve256":"require"}, {"sve384":"disable"}, {"sve512":"require"}]'
+                        - 128:
+                            vector_length = "sve128"
+                        - 256:
+                            vector_length = "sve256"
+                        - 512:
+                            vector_length = "sve512"
+                        - all_supported_lengths:
+                            all_supports = "yes"
                 - invalid_length:
-                    only negative_test
-                    expect_sve = "no"
+                    status_error = "yes"
                     vector_length = "sve1234"
                     expect_msg = "unsupported configuration: unknown CPU feature: sve1234"
                 - conflict_length:
-                    only negative_test
-                    vector_lenth_list = '[{"sve":"disable"}, {"sve128":"require"}]'
+                    status_error = "yes"
+                    vector_length_list = '[{"sve":"disable"}, {"sve128":"require"}]'
                     define_error = "yes"
                     expect_msg = "SVE disabled, but SVE vector lengths provided"
-        - no_host_sve_support:
-            only negative_test
-            host_without_sve = "yes"
-            status_error = "yes"
-    variants:
-        - positive_test:
+                - unsupported_length:
+                    unsupported_len = yes
+                    status_error = "yes"
+                    expect_msg = "does not support the vector length"
+                - discontinous_length:
+                    status_error = "yes"
+                    discontinous_len = "yes"
+                    expect_msg = "KVM host requires all supported vector lengths smaller than .* bits .* enabled"
+        - optimized-routines:
             status_error = "no"
-        - negative_test:
-            only invalid_length, conflict_length, no_host_sve_support
+            all_supports = "yes"
+            install_pkgs = ["git", "gcc", "make", "glibc-static", "mpfr-devel", "libmpc-devel"]
+            target_dir = "/home/optimized_routines"
+            optimized_repo_cmd = "git clone --depth=1 https://github.com/ARM-software/optimized-routines ${target_dir}"
+            optimized_echo_cmd = "echo 'CFLAGS += -march=armv8.2-a+sve' >> config.mk"
+            optimized_compile_cmd = "cd ${target_dir}; cp config.mk.dist config.mk; ${optimized_echo_cmd}; make"
+            optimized_execute_cmd = "cd ${target_dir}; make check 2>/dev/null"
+        - sve_stress:
+            status_error = "no"
+            all_supports = "yes"
+            install_pkgs = ["git", "gcc", "make", "kernel-devel", "kernel-headers", "rsync", "brewkoji", "tar"]            
+            target_dir = "/home/sve_stress"
+            suite_dir = "${target_dir}/tools/testing/selftests/arm64/fp"
+            sve_exec_timeout = 360
+            sve_stress_download_cmd = "cd /var/tmp && brew download-build --rpm %s && rpm2cpio %s | cpio -idm"
+            sve_stress_tar_cmd = "cd /var/tmp && tar Jxf %s --strip-components 1 -C ${target_dir}"
+            sve_stress_compile_cmd = "cd ${suite_dir}; make"
+            sve_stress_get_lenths = "${suite_dir}/sve-probe-vls"
+            sve_stress_exec_cmd = "cd ${suite_dir}; timeout ${sve_exec_timeout} ./vlset --inherit %s ./sve-stress 2>/dev/null"
+        - no_host_sve_support:
+            host_without_sve = "yes"
             status_error = "yes"

--- a/libvirt/tests/cfg/virtual_network/update_device/update_iface_trustGuestRxFilters.cfg
+++ b/libvirt/tests/cfg/virtual_network/update_device/update_iface_trustGuestRxFilters.cfg
@@ -4,6 +4,7 @@
     timeout = 240
     host_iface =
     outside_ip = 'www.redhat.com'
+    func_supported_since_libvirt_ver = (10, 0, 0)
     variants:
         - yes_to_no:
             trustGRF = 'yes'

--- a/libvirt/tests/src/cpu/aarch64_cpu_sve.py
+++ b/libvirt/tests/src/cpu/aarch64_cpu_sve.py
@@ -1,8 +1,9 @@
+import json
 import re
 import logging as log
 
-from avocado.utils import process
 from avocado.core import exceptions
+from avocado.utils import process
 
 from virttest import virsh
 from virttest import utils_package
@@ -16,6 +17,344 @@ from virttest.utils_test import libvirt
 logging = log.getLogger('avocado.' + __name__)
 
 
+def get_vector_lengths(vm_name):
+    """
+    Get the supported and unsupported vector lengths on the host
+
+    :param vm_name: str, the vm name
+    :return: (dict, dict), the supported and unsupported vector list
+    """
+    cmd = '{"execute":"query-cpu-model-expansion", "arguments": {"type": "full", "model": {"name":"host"}}}'
+    virsh_opt = {"debug": True, "ignore_status": False}
+    unsupported_list = []
+    supported_list = []
+    ret = virsh.qemu_monitor_command(vm_name, cmd, **virsh_opt)
+    length_obj = json.loads(ret.stdout_text.strip())
+    props_dict = length_obj.get("return").get("model").get("props")
+    for v_length, status in props_dict.items():
+        match = re.findall("sve(\d+)", v_length)
+        if not match:
+            continue
+        if not status:
+            unsupported_list.append(int(match[0]))
+        elif status:
+            supported_list.append(int(match[0]))
+    supported_list.sort(reverse=True)
+    unsupported_list.sort(reverse=True)
+    logging.debug("The unsupported vector length in the vm:%s", unsupported_list)
+    logging.debug("The supported vector length in the vm:%s", supported_list)
+    return (supported_list, unsupported_list)
+
+
+def prepare_env(vm, params, test):
+    """
+    Prepare test env
+
+    :param vm: The virtual machine
+    :param params: dict, test parameters
+    :param test: test object
+    """
+    check_sve = params.get("check_sve", "")
+    host_without_sve = "yes" == params.get("host_without_sve", "no")
+    check_sve_config = params.get("check_sve_config", "")
+    session = None
+    try:
+        # Cancel test if the Host doesn't support or supports SVE based on configuration
+        if process.run(check_sve, ignore_status=True, shell=True).exit_status:
+            if not host_without_sve:
+                test.cancel("Host doesn't support SVE")
+            else:
+                return
+        else:
+            if host_without_sve:
+                test.cancel("Host supports SVE")
+
+        if not vm.is_alive():
+            vm.start()
+        session = vm.wait_for_login(timeout=120)
+        current_boot = session.cmd("uname -r").strip()
+        # To enable SVE: Hardware support && enable kconfig
+        # CONFIG_ARM64_SVE
+        if session.cmd_status(check_sve_config % current_boot):
+            test.cancel("Guest kernel doesn't enable CONFIG_ARM64_SVE")
+
+        # Install lscpu tool that check whether CPU has SVE
+        if (not utils_package.package_install("util-linux")
+                or not utils_package.package_install("util-linux", session)):
+            test.error("Failed to install util-linux")
+
+    except (exceptions.TestCancel, exceptions.TestError):
+        raise
+    except Exception as e:
+        test.error("Failed to prepare test env: %s" % e)
+    finally:
+        if session:
+            session.close()
+
+
+def get_max_sve_len_in_guest(vm_session, params, test):
+    """
+    Get the maximum supported sve length of guest
+
+    :param vm_session: The virtual machine session
+    :param params: dict, test parameters
+    :param test: test object
+    :return: str, maximum vector length. Format: e.g sve512
+    """
+    get_maximum_sve_len = params.get("get_maximum_sve_length", "")
+    sve_length_bit = ""
+    try:
+        ret = vm_session.cmd(get_maximum_sve_len).strip()
+        # dmesg record maximum sve length in bytes
+        sve_length_byte = re.search(r"length (\d+) bytes", ret).groups()[0]
+        # Change max_length into sve + length(bit) E.g. sve512
+        sve_length_bit = "sve" + str(int(sve_length_byte) * 8)
+        logging.debug("The guest maximum SVE vector length is %s", sve_length_bit)
+    except Exception as e:
+        test.fail("Failed to get maximum guest SVE vector length: %s" % e)
+
+    return sve_length_bit
+
+
+def guest_has_sve(vm_session, params, test):
+    """
+    Check whether guest has SVE
+
+    :param vm_session: The virtual machine session
+    :param params: dict, test parameters
+    :param test: test object
+
+    :return True if guest has sve
+    """
+    check_sve = params.get("check_sve", "")
+    ret = False
+    try:
+        if not vm_session.cmd_status(check_sve):
+            ret = True
+    except Exception as e:
+        test.error("Failed to check guest SVE: %s" % e)
+    return ret
+
+
+def check_vector_length_supported(vector_length, supported_list):
+    """
+    Check if a given vector length is supported on the host
+
+    :param vector_length: str, sve length
+    :param supported_list: list, sve lengths supported
+    :return: bool, True if supported, otherwise False
+    """
+    match = re.findall("sve(\d+)", vector_length)
+    if match and int(match[0]) in supported_list:
+        return True
+    else:
+        logging.warning("The vector length %s (in bits) is "
+                        "unsupported on the host" % vector_length)
+        return False
+
+
+def gen_disable_features(enable_length, supported_list):
+    """
+    Generate the cpu features to be disabled
+
+    :param enable_length: str, sve length to be enabled
+    :param supported_list: dict, sve lengths supported
+    :return: list, disabled cpu features
+    """
+    result = []
+    enable_length = re.findall("sve(\d+)", enable_length)[0]
+    for a_length in supported_list:
+        if a_length > int(enable_length):
+            result.append({"sve%d" % a_length: "disable"})
+    return result
+
+
+def gen_cpu_features(supported_list, unsupported_list, params, test):
+    """
+    Generate cpu features
+
+    :param supported_list: dict, sve lengths supported
+    :param unsupported_list: dict, sve lengths unsupported
+    :param params: dict, test parameters
+    :param test: test object
+    :return: list, cpu features
+    """
+    all_supports = params.get("all_supports", "no") == "yes"
+    status_error = "yes" == params.get("status_error", "no")
+    vector_length = params.get("vector_length")
+    cpu_xml_policy = params.get("cpu_xml_policy", "require")
+    unsupported_len = params.get("unsupported_len")
+    discontinous_len = params.get("discontinous_len")
+    result = []
+
+    if not status_error:
+        if all_supports:
+            result.append({"sve": cpu_xml_policy})
+            for a_length in supported_list:
+                result.append({"sve%d" % a_length: cpu_xml_policy})
+            return result
+        if vector_length:
+            if not check_vector_length_supported(vector_length, supported_list):
+                test.cancel("The vector length is not supported on the host")
+            result.append({vector_length: cpu_xml_policy})
+            result.extend(gen_disable_features(vector_length, supported_list))
+        else:
+            result.append({"sve": cpu_xml_policy})
+    else:
+        vector_length_list = params.get("vector_length_list")
+        if unsupported_len:
+            if len(unsupported_list) > 1:
+                result.append({"sve%d" % unsupported_list[0]: cpu_xml_policy})
+            else:
+                test.cancel("No unsupported vector length by the host is available")
+        elif discontinous_len:
+            if len(supported_list) == 1:
+                test.cancel("Require at least two supported "
+                            "sve lengths for the test, but only one is found")
+            result.append({"sve%d" % supported_list[0]: "require"})
+            result.append({"sve%d" % supported_list[len(supported_list) - 1]: "disable"})
+        elif vector_length_list:
+            vector_length_list = eval(vector_length_list)
+            for one_len in vector_length_list:
+                result.append(one_len)
+        else:
+            if vector_length:
+                result.append({vector_length: cpu_xml_policy})
+    return result
+
+
+def update_cpu_xml(cpu_xml, params, test, supported_list, unsupported_list):
+    """
+    Update vm cpu xml object
+
+    :param cpu_xml: VMCPUXML instance
+    :param params: dict, test parameters
+    :param test: test object
+    :param supported_list: list, sve lengths supported
+    :param unsupported_list: list, sve lengths unsupported
+    """
+    # For sve, each SVE vector_length is a feature name
+    # E.g. sve128 sve256 sve512
+    # Test unsupported vector length
+    vector_list = gen_cpu_features(supported_list, unsupported_list, params, test)
+    for vector in vector_list:
+        for length, policy in vector.items():
+            cpu_xml.add_feature(length, policy)
+    logging.debug("cpu_xml is %s" % cpu_xml)
+
+
+def execute_cmds(cmd, session, test, timeout=360, ignore_status=False):
+    """
+    Execute a command with vm session
+
+    :param cmd: str, the command to be executed
+    :param session: vm session
+    :param test: test object
+    :param timeout: int, defaults to 360
+    :param ignore_status: bool, defaults to False
+    :return: str, the output of the command
+    """
+    status, output = session.cmd_status_output(cmd, timeout=timeout)
+    if status:
+        msg = "Fail to execute %s with error %s,\
+               message: %s" % (cmd, status, output)
+        if not ignore_status:
+            test.fail(msg)
+        else:
+            test.log.error(msg)
+    return output
+
+
+def run_optimized_routines_in_guest(session, params, test):
+    """
+    Run optimized routines test suite within the guest
+
+    :param session: vm session
+    :param params: dict, test parameters
+    :param test: test object
+    """
+    execute_cmds(params.get("optimized_repo_cmd"), session, test)
+    execute_cmds(params.get("optimized_compile_cmd"), session, test)
+    output = execute_cmds(params.get("optimized_execute_cmd"), session, test)
+    results = re.findall(r"^(\w+) \w+sve$", output, re.M)
+    if not all([result == "PASS" for result in results]):
+        test.fail("The optimized-routines sve tests have failures in log\n%s" % results)
+    else:
+        test.log.debug("Verify optimized-routines sve tests in guest - PASS")
+
+
+def execute_sve_stress_by_suite(length_list, session, params, test):
+    """
+    Execute sve_stress test suite within the guest
+
+    :param length_list: list, sve lengths
+    :param session: vm session
+    :param params: dict, test parameters
+    :param test: test object
+    """
+    sve_stress_exec_cmd = params.get("sve_stress_exec_cmd")
+    sve_exec_timeout = int(params.get("sve_exec_timeout"))
+
+    for a_length in length_list:
+        exec_cmd = sve_stress_exec_cmd % a_length
+        output = session.cmd_output(exec_cmd,
+                                    timeout=sve_exec_timeout + 10)
+        results_lines = [result for result in output.splitlines() if
+                         result.startswith("Terminated by")]
+        if len(re.findall(r"no error", output, re.M)) != len(results_lines):
+            test.log.debug("Test results: %s", results_lines)
+            test.fail("SVE stress test failed")
+        test.log.debug("Verify sve stress test for length %s (in bytes) - PASS" % a_length)
+
+
+def verify_sve_length_by_suite(supported_list, session, params, test):
+    """
+    Verify the supported sve lengths are same with test suite output
+
+    :param supported_list: list, supported sve length (in bits), like [128, 256]
+    :param session: vm session
+    :param params: dict, test parameters
+    :param test: test object
+    :return: list, sve length (in bytes) list from test suite command
+                   like ['16', '32']
+    """
+    sve_stress_get_lenths = params.get("sve_stress_get_lenths")
+    output = execute_cmds(sve_stress_get_lenths, session, test)
+    results = re.findall(r"# (\d+)$", output, re.M)
+    new_results = [int(result) * 8 for result in results]
+    if set(new_results) != set(supported_list):
+        test.fail("The sve-probe-vls output %s does "
+                  "not match the supported sve lenths %s" % (results,
+                                                             supported_list))
+    else:
+        test.log.debug("Verify sve-probe-vls output in guest - PASS")
+    return results
+
+
+def run_sve_stress_test_in_guest(supported_list, session, params, test):
+    """
+    Run sve stress test suite within the guest
+
+    :param supported_list: list, supported sve lengths
+    :param session: vm session
+    :param params: dict, test parameters
+    :param test: test object
+    """
+    kernel_version = session.cmd_output("uname -r").rsplit('.', 1)[0]
+    srpm = "kernel-%s.src.rpm" % kernel_version
+    linux_name = "linux-%s.tar.xz" % kernel_version
+    sve_stress_download_cmd = params.get("sve_stress_download_cmd") % (srpm,
+                                                                       srpm)
+    sve_stress_tar_cmd = params.get("sve_stress_tar_cmd") % linux_name
+    sve_stress_compile_cmd = params.get("sve_stress_compile_cmd")
+
+    execute_cmds(sve_stress_download_cmd, session, test)
+    execute_cmds(sve_stress_tar_cmd, session, test)
+    execute_cmds(sve_stress_compile_cmd, session, test)
+    sve_lengths = verify_sve_length_by_suite(supported_list, session, params, test)
+    execute_sve_stress_by_suite(sve_lengths, session, params, test)
+
+
 def run(test, params, env):
     """
     Test aarch64 SVE feature
@@ -26,136 +365,28 @@ def run(test, params, env):
     """
     vm_name = params.get("main_vm", "avocado-vt-vm1")
     vm = env.get_vm(vm_name)
-    start_vm = params.get("start_vm", "no")
-    check_sve = params.get("check_sve", "")
-    check_sve_config = params.get("check_sve_config", "")
-    get_maxium_sve_length = params.get("get_maxium_sve_length", "")
-
     cpu_xml_mode = params.get("cpu_xml_mode", "host-passthrough")
-    cpu_xml_policy = params.get("cpu_xml_policy", "require")
-
     status_error = "yes" == params.get("status_error", "no")
     define_error = "yes" == params.get("define_error", "no")
-    host_without_sve = "yes" == params.get("host_without_sve", "no")
     expect_sve = "yes" == params.get("expect_sve", "yes")
     expect_msg = params.get("expect_msg", "")
     vector_length = params.get("vector_length", "sve")
-    vector_lenth_list = params.get("vector_lenth_list", "")
+    sve_stress_exec_cmd = params.get("sve_stress_exec_cmd")
+    optimized_execute_cmd = params.get("optimized_execute_cmd")
+    target_dir = params.get("target_dir")
 
-    def _prepare_env(vm):
-        """
-        Prepare test env
+    prepare_env(vm, params, test)
+    supported_list, unsupported_list = get_vector_lengths(vm_name)
 
-        :param vm: The virtual machine
-        """
-        try:
-            if not vm.is_alive():
-                vm.start()
-            session = vm.wait_for_login(timeout=120)
-            current_boot = session.cmd('uname -r').strip()
-
-            # Install lscpu tool that check whether CPU has SVE
-            if (not utils_package.package_install("util-linux")
-                    or not utils_package.package_install("util-linux", session)):
-                test.error("Failed to install util-linux")
-
-            # Cancel test if the Host doesn't support or supports SVE based on configuration
-            if process.run(check_sve, ignore_status=True, shell=True).exit_status:
-                if not host_without_sve:
-                    test.cancel("Host doesn't support SVE")
-                else:
-                    return
-            else:
-                if host_without_sve:
-                    test.cancel("Host supports SVE")
-
-            # To enable SVE: Hardware support && enable kconfig
-            # CONFIG_ARM64_SVE
-            if session.cmd_status(check_sve_config % current_boot):
-                test.cancel("Guest kernel doesn't enable CONFIG_ARM64_SVE")
-        except (exceptions.TestCancel, exceptions.TestError):
-            raise
-        except Exception as e:
-            test.error("Failed to prepare test env: %s" % e)
-        finally:
-            if session:
-                session.close()
-
-    def _get_maxium_sve_length(vm):
-        """
-        Get the maximum supported sve length of guest
-
-        : return maximum vector length. Format: e.g sve512
-        """
-        try:
-            session = None
-            if not vm.is_alive():
-                vm.start()
-            session = vm.wait_for_login(timeout=120)
-            ret = session.cmd(get_maxium_sve_length).strip()
-            # dmesg record maximum sve length in bytes
-            sve_length_byte = re.search(r"length (\d+) bytes", ret).groups()[0]
-            # Change max_length into sve + length(bit) E.g. sve512
-            sve_length_bit = "sve" + str(int(sve_length_byte) * 8)
-            logging.debug("The guest maximum SVE vector length is %s", sve_length_bit)
-        except Exception as e:
-            test.fail("Failed to get maximum guest SVE vector length: %s" % e)
-        finally:
-            if session:
-                session.close()
-        return sve_length_bit
-
-    def _guest_has_sve(vm):
-        """
-        Check whether guest has SVE
-
-        :param vm: The virtual machine
-
-        :return True if guest has sve
-        """
-        try:
-            ret = False
-            session = None
-            if not vm.is_alive():
-                vm.start()
-            session = vm.wait_for_login(timeout=120)
-            if not session.cmd_status(check_sve):
-                ret = True
-        except Exception as e:
-            test.error("Failed to check guest SVE: %s" % e)
-        finally:
-            if session:
-                session.close()
-        return ret
-
-    # Close guest and edit guest xml
-    if vm.is_alive() and start_vm == "no":
+    if vm.is_alive():
         vm.destroy(gracefully=False)
 
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     original_vm_xml = vmxml.copy()
-
     try:
-        # Install lscpu && Check host sve support &&
-        # Check guest guest kernel support
-        _prepare_env(vm)
-
-        # Create cpu xml and modify SVE
         cpu_xml = vm_xml.VMCPUXML()
         cpu_xml.mode = cpu_xml_mode
-        # For sve, each SVE vector_length is a feature name
-        # E.g. sve128 sve256 sve512
-        if vector_lenth_list:
-            vector_list = eval(vector_lenth_list)
-            for vector in vector_list:
-                for length, policy in vector.items():
-                    cpu_xml.add_feature(length, policy)
-        else:
-            cpu_xml.add_feature(vector_length, cpu_xml_policy)
-
-        logging.debug("cpu_xml is %s" % cpu_xml)
-
-        # Updae vm's cpu
+        update_cpu_xml(cpu_xml, params, test, supported_list, unsupported_list)
         vmxml.cpu = cpu_xml
         try:
             vmxml.sync()
@@ -165,45 +396,55 @@ def run(test, params, env):
                 if not re.search(expect_msg, str(e)):
                     test.fail("Expect definition failure: %s but got %s" %
                               (expect_msg, str(e)))
-                return True
+                else:
+                    test.log.debug("Verify the expected vm definition error - PASS")
+                    return
             else:
                 test.error("Failed to define guest: %s" % str(e))
 
-        result = virsh.start(vm_name)
-        special_error_msg = "CPU does not support the vector length"
-        if re.search(special_error_msg, result.stderr_text):
-            test.cancel(result.stderr_text)
-        libvirt.check_exit_status(result, status_error)
-
-        if status_error:
-            # Test boot failed
-            if result.exit_status:
-                if not re.search(expect_msg, result.stderr.strip()):
-                    logging.debug(result.stderr.strip())
-                    test.fail("Failed to get expect err msg: %s" % expect_msg)
-                else:
-                    logging.info("Get expected err msg %s" % expect_msg)
-        else:
-            # Test boot successfully
+        result = virsh.start(vm_name, debug=True, ignore_status=True)
+        libvirt.check_result(result, expected_fails=expect_msg)
+        # Test boot successfully
+        if not status_error:
+            session = vm.wait_for_login(timeout=120)
             if expect_sve:
-                # Enable SVE in domain xml
-                if not _guest_has_sve(vm):
+                # Expect SVE is enabled in domain xml
+                if not guest_has_sve(session, params, test):
                     test.fail("Expect guest cpu enable SVE")
-
-                # SVE available with only the selected vector
+                else:
+                    test.log.debug("Verify sve is enabled in guest - PASS")
+                # Expect SVE is available with only the selected vector
                 expect_vector_length = vector_length
-                available_maxium_sve_length = _get_maxium_sve_length(vm)
+                available_maximum_sve_length = get_max_sve_len_in_guest(session, params, test)
                 if vector_length == "sve":
-                    expect_vector_length = available_maxium_sve_length
-                if expect_vector_length != available_maxium_sve_length:
+                    expect_vector_length = "sve%d" % supported_list[0]
+                if expect_vector_length != available_maximum_sve_length:
                     test.fail("Expect guest support %s" % vector_length)
+                else:
+                    test.log.debug("Verify the supported maximum "
+                                   "vector length is %s in guest "
+                                   "- PASS" % expect_vector_length)
+
+                install_pkgs = eval(params.get("install_pkgs", "[]"))
+                if install_pkgs and not utils_package.package_install(install_pkgs, session, 360):
+                    test.error("Failed to install %s on guest." % install_pkgs)
+
+                if target_dir:
+                    execute_cmds("mkdir -p %s" % target_dir, session, test)
+                    if sve_stress_exec_cmd:
+                        run_sve_stress_test_in_guest(supported_list, session, params, test)
+                    if optimized_execute_cmd:
+                        run_optimized_routines_in_guest(session, params, test)
+                    execute_cmds("rm -rf %s" % target_dir, session, test)
             else:
                 # Disable SVE in domain xml
-                if _guest_has_sve(vm):
+                if guest_has_sve(session, params, test):
                     test.fail("Expect guest cpu disable SVE")
-
+                else:
+                    test.log.debug("Verify sve is disabled in guest - PASS")
+            if session:
+                session.close()
     finally:
-        # Restore guest
         if vm.is_alive():
             vm.destroy(gracefully=False)
         original_vm_xml.sync()

--- a/libvirt/tests/src/virtual_network/update_device/update_iface_trustGuestRxFilters.py
+++ b/libvirt/tests/src/virtual_network/update_device/update_iface_trustGuestRxFilters.py
@@ -1,6 +1,7 @@
 import logging
 
 from avocado.utils import process
+from virttest import libvirt_version
 from virttest import utils_net
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
@@ -18,6 +19,7 @@ def run(test, params, env):
     """
     Test live update trustGuestRxFilters for direct type interface
     """
+    libvirt_version.is_libvirt_feature_supported(params)
     vm_name = params.get('main_vm')
     vm = env.get_vm(vm_name)
     host_iface = params.get('host_iface')
@@ -48,6 +50,10 @@ def run(test, params, env):
         iface_update = network_base.get_iface_xml_inst(vm_name, 'after update')
         LOG.debug(f'iface trustGuestRxFilters after update: '
                   f'{iface_update.trustGuestRxFilters}')
+        if iface_update.trustGuestRxFilters != update_attrs[
+                'trustGuestRxFilters']:
+            test.fail(f'Interface trustGuestRxFilters not successfully updated '
+                      f'to {update_attrs["trustGuestRxFilters"]}')
 
         mac_host = utils_net.get_linux_iface_info(iface=target_dev)['address']
 


### PR DESCRIPTION
aarch64_cpu_sve: add more tests

- Refine the codes structure
- Dynamically test with all supported sve lengths instead of hardcodes
- Add sve stress test suite in vm
- Add optimized routines test suite in vm
- Add discontinuous enabled sve length test

Signed-off-by: Dan Zheng <dzheng@redhat.com>