### PR TITLE
Memory backing related cases change huge page mult arch config

### DIFF
--- a/libvirt/tests/cfg/memory/memory_backing/discard_memory_content_setting.cfg
+++ b/libvirt/tests/cfg/memory/memory_backing/discard_memory_content_setting.cfg
@@ -1,14 +1,28 @@
 - memory.backing.discard:
     type = discard_memory_content_setting
     start_vm = "no"
-    set_pagesize = 2048
-    set_pagenum = 1024
     numa_mem = 2097152
     qemu_line = '"discard-data":%s'
-    s390-virtio:
-        set_pagesize = 1024
-        set_pagenum = 2048
-        kvm_module_parameters =
+    variants kernel_pagesize:
+        - 4k:
+            default_page_size = 4
+            variants huge_pagesize:
+                - 2048:
+                    no s390-virtio
+                    set_pagesize = 2048
+                    set_pagenum = 1024
+                - 1024:
+                    only s390-virtio
+                    set_pagesize = 1024
+                    set_pagenum = 2048
+                    kvm_module_parameters =
+        - 64k:
+            only aarch64
+            default_page_size = 64
+            variants huge_pagesize:
+                - 524288:
+                    set_pagesize = 524288
+                    set_pagenum = 4
     variants source:
         - file:
             source_type = 'file'
@@ -23,9 +37,6 @@
             source_attr = "'source_type':'${source_type}'"
             source_path = {'element_attrs': ['./memoryBacking/source/[@type="${source_type}"]']}
         - hugepaged_file:
-            aarch64:
-                set_pagesize = 524288
-                set_pagenum = 4
             source_type = 'hugepage'
             hugepages_attr = "'hugepages': {}"
             hugepages_path = {'element_attrs': ['./memoryBacking/hugepages']}
@@ -57,3 +68,4 @@
             current_mem = "2097152"
             mem_value = "2097152"
             mem_attrs = {'memory_unit':'${mem_unit}','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}'}
+

--- a/libvirt/tests/cfg/memory/memory_backing/hugepage_mount_path.cfg
+++ b/libvirt/tests/cfg/memory/memory_backing/hugepage_mount_path.cfg
@@ -2,47 +2,55 @@
     type = hugepage_mount_path
     no s390-virtio
     mem_value = 2097152
-    set_pagesize_1 = "1048576"
-    set_pagenum_1 = "2"
-    set_pagesize_2 = "2048"
-    set_pagenum_2 = "3072"
-    aarch64:
-        set_pagesize_1 = "2048"
-        set_pagenum_1 = "1024"
-        set_pagesize_2 = "524288"
-        set_pagenum_2 = "6"
     security_context = "drwxr-xr-x. 3 root root system_u:object_r:hugetlbfs_t:s0"
     log_path = "/var/log/libvirt/qemu/%s.log"
     guest_log_error1 = "hugepage is not mounted"
     guest_log_error2 = "unable to create backing store for hugepages: Permission denied"
     page_unit = "KiB"
-    page_size = "2048"
-    aarch64:
-        page_size = "524288"
     numa_size = 1048576
     mem_unit = "KiB"
     mem_value = 2097152
     current_mem = 2097152
     max_mem = 15242880
-    memory_backing_dict = "'mb': {'hugepages': {'pages': [{'unit': '${page_unit}', 'size': '${page_size}'}]}}"
-    numa_cpu = {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '${numa_size}', 'unit': 'KiB'}, {'id': '1', 'cpus': '2-3', 'memory': '${numa_size}', 'unit': 'KiB'}]}
-    vm_attrs = {${memory_backing_dict},"cpu":${numa_cpu},'vcpu': 4,'max_mem_rt_slots': 16,'memory_unit':"${mem_unit}",'memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'KiB','max_mem_rt': ${max_mem}, 'max_mem_rt_unit': "KiB"}
     start_vm = "no"
     consume_value = 204800
+    variants kernel_pagesize:
+        - 4k:
+            default_page_size = 4
+            variants huge_pagesize:
+                - 2M:
+                    page_size = "2048"
+                    set_pagesize_2 = "2048"
+                    set_pagenum_2 = "3072"
+                    variants ext_huge_pagesize:
+                        - 1G:
+                            other_huge_pagesize = 1048576
+                            vm_hugepage_mountpoint = "/dev/hugepages1G"
+                            mount_pagesize = "1G"
+                            set_pagesize_1 = "1048576"
+                            set_pagenum_1 = "2"
+        - 64k:
+            only aarch64
+            default_page_size = 64
+            variants huge_pagesize:
+                - 512M:
+                    page_size = "524288"
+                    set_pagesize_2 = "524288"
+                    set_pagenum_2 = "6"
+                    variants ext_huge_pagesize:
+                        - 2M:
+                            other_huge_pagesize = 2048
+                            vm_hugepage_mountpoint = "/dev/hugepages2M"
+                            mount_pagesize = "2M"
+                            set_pagesize_1 = "2048"
+                            set_pagenum_1 = "1024"
     variants case:
         - default:
             path = "/dev/hugepages"
-            vm_hugepage_mountpoint = "/dev/hugepages1G"
-            mount_pagesize = "1G"
-            aarch64:
-                vm_hugepage_mountpoint = "/dev/hugepages2M"
-                mount_pagesize = "2M"
             expect_active = "True"
             expect_state = "active"
             check_qemu = ['"mem-path":"${path}/libvirt/qemu/','"prealloc":true']
-            attach_dict = {'mem_model': 'dimm', 'source': {"pagesize":1048576, "pagesize_unit":"KiB"},'target': {'size': 1048576, 'size_unit': 'KiB','node':0}}
-            aarch64:
-                attach_dict = {'mem_model': 'dimm', 'source': {"pagesize":2048, "pagesize_unit":"KiB"},'target': {'size': 1048576, 'size_unit': 'KiB','node':0}}
+            attach_dict = {'mem_model': 'dimm', 'source': {"pagesize":${other_huge_pagesize}, "pagesize_unit":"KiB"},'target': {'size': 1048576, 'size_unit': 'KiB','node':0}}
             check_security_cmd = "ls -l -Z ${path}/libvirt/qemu/ -d"
         - disabled:
             hugetlbfs_mount  = '""'
@@ -57,3 +65,7 @@
             expect_state = "active"
             check_security_cmd = "ls -l -Z ${path}/libvirt/qemu -d"
             check_qemu = ['"mem-path":"${path}/libvirt/qemu/','"prealloc":true']
+    memory_backing_dict = "'mb': {'hugepages': {'pages': [{'unit': '${page_unit}', 'size': '${page_size}'}]}}"
+    numa_cpu = {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '${numa_size}', 'unit': 'KiB'}, {'id': '1', 'cpus': '2-3', 'memory': '${numa_size}', 'unit': 'KiB'}]}
+    vm_attrs = {${memory_backing_dict},"cpu":${numa_cpu},'vcpu': 4,'max_mem_rt_slots': 16,'memory_unit':"${mem_unit}",'memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'KiB','max_mem_rt': ${max_mem}, 'max_mem_rt_unit': "KiB"}
+

--- a/libvirt/tests/cfg/memory/memory_backing/memory_access_mode.cfg
+++ b/libvirt/tests/cfg/memory/memory_backing/memory_access_mode.cfg
@@ -1,20 +1,31 @@
 - memory.backing.access_mode:
     type = memory_access_mode
-    set_pagesize = 2048
-    set_pagenum = 1024
     numa_mem = 2097152
-    aarch64:
-        set_pagesize = 524288
-        set_pagenum = 4
     start_vm = no
     qemu_monitor_option = '--hmp'
     qemu_monitor_cmd = 'info memdev'
     pattern_share = "share:\s*{}"
     mem_backend = "memory backend: ram-node0"
-    s390-virtio:
-        set_pagesize = 1024
-        set_pagenum = 2048
-        kvm_module_parameters =
+    variants kernel_pagesize:
+        - 4k:
+            default_page_size = 4
+            variants huge_pagesize:
+                - 2048:
+                    no s390-virtio
+                    set_pagesize = 2048
+                    set_pagenum = 1024
+                - 1024:
+                    only s390-virtio
+                    set_pagesize = 1024
+                    set_pagenum = 2048
+                    kvm_module_parameters =
+        - 64k:
+            only aarch64
+            default_page_size = 64
+            variants huge_pagesize:
+                - 524288:
+                    set_pagesize = 524288
+                    set_pagenum = 4
     variants source:
         - file:
             source_type = 'file'
@@ -72,3 +83,4 @@
             current_mem = "2097152"
             mem_value = "2097152"
             mem_attrs = {'memory_unit':'${mem_unit}','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}'}
+

--- a/libvirt/tests/cfg/memory/memory_backing/memory_source_and_allocation.cfg
+++ b/libvirt/tests/cfg/memory/memory_backing/memory_source_and_allocation.cfg
@@ -2,19 +2,31 @@
     type = memory_source_and_allocation
     start_vm = no
     check_allocated_cmd = "grep -A20 '^Size:.*2097152' /proc/`pidof qemu-kvm`/smaps"
-    set_pagesize = 2048
-    set_pagenum = 1024
     monitor_option = "--hmp"
     monitor_cmd = "info memdev"
     memory_name_pattern = 'memory backend: (\S+)'
     check_thread = '{"execute":"qom-get", "arguments":{"path": "/objects/%s", "property":"%s"}}'
-    s390-virtio:
-        set_pagesize = 1024
-        kvm_module_parameters =
-        check_allocated_cmd = "grep -A20 '^Size:.*1048576' /proc/`pidof qemu-kvm`/smaps"
-    aarch64:
-        set_pagesize = 524288
-        set_pagenum = 4
+    variants kernel_pagesize:
+        -4k:
+            default_page_size = 4
+            variants huge_pagesize:
+                - 2048:
+                    no s390-virtio
+                    set_pagesize = 2048
+                    set_pagenum = 1024
+                - 1024:
+                    only s390-virtio
+                    set_pagesize = 1024
+                    set_pagenum = 1024
+                    kvm_module_parameters =
+                    check_allocated_cmd = "grep -A20 '^Size:.*1048576' /proc/`pidof qemu-kvm`/smaps"
+        -64k:
+            only aarch64
+            default_page_size = 64
+            variants huge_pagesize:
+                - 524288:
+                    set_pagesize = 524288
+                    set_pagenum = 4
     variants source:
         - file:
             source_type = 'file'
@@ -78,3 +90,4 @@
                 current_mem = "1048576"
                 mem_value = "1048576"
                 mem_attrs = {'memory_unit':'${mem_unit}','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}'}
+

--- a/libvirt/tests/cfg/memory/memory_backing/page_locking_and_shared_pages.cfg
+++ b/libvirt/tests/cfg/memory/memory_backing/page_locking_and_shared_pages.cfg
@@ -1,15 +1,27 @@
 - memory.backing.page_locking_and_shared_pages:
     type = page_locking_and_shared_pages
     start_vm = no
-    pagesize = 2048
-    pagenum = 1024
-    aarch64:
-        pagesize = 524288
-        pagenum = 4
-    s390-virtio:
-        pagesize = 1024
-        pagenum = 2048
     expect_exist = True
+    variants default_pagesize:
+        - 4k:
+            kernel_pagesize = 4
+            variants huge_pagesize:
+                - 1024:
+                    only s390-virtio
+                    pagesize = 1024
+                    pagenum = 2048
+                - 2048:
+                    no s390-virtio
+                    pagesize = 2048
+                    pagenum = 1024
+        - 64k:
+            only aarch64
+            kernel_pagesize = 64
+            variants huge_pagesize:
+                - 524288:
+                    only aarch64
+                    pagesize = 524288
+                    pagenum = 4
     variants lock_config:
         - lock_default:
             only ksm_disabled
@@ -32,9 +44,6 @@
             ksm_qemu_line = "mem-merge=off"
     variants page_config:
         - page_default:
-            kernel_pagesize = 4
-            aarch64:
-                kernel_pagesize = 64
         - hugepage:
             hugepages_dict = "'hugepages': {}"
             s390-virtio:
@@ -47,3 +56,4 @@
             mem_value = "2097152"
             mem_attrs = {'memory_unit':'${mem_unit}','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}'}
     qemu_line = ["${lock_qemu_line}", "${ksm_qemu_line}"]
+

--- a/libvirt/tests/src/memory/memory_backing/discard_memory_content_setting.py
+++ b/libvirt/tests/src/memory/memory_backing/discard_memory_content_setting.py
@@ -15,6 +15,8 @@ from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 from virttest.utils_libvirt import libvirt_vmxml
 
+from provider.memory import memory_base
+
 
 def run(test, params, env):
     """
@@ -97,6 +99,8 @@ def run(test, params, env):
         Prepare memory device
         """
         test.log.info("TEST_SETUP: Set hugepage.")
+        memory_base.check_mem_page_sizes(
+            test, int(default_page_size), int(set_pagesize))
         hp_cfg.set_kernel_hugepages(set_pagesize, set_pagenum)
 
     def run_test():
@@ -140,6 +144,7 @@ def run(test, params, env):
     qemu_line = params.get("qemu_line")
     numa_discard = params.get("numa_discard")
     mem_discard = params.get("mem_discard")
+    default_page_size = params.get("default_page_size")
     set_pagesize = params.get("set_pagesize")
     set_pagenum = params.get("set_pagenum")
 

--- a/libvirt/tests/src/memory/memory_backing/hugepage_mount_path.py
+++ b/libvirt/tests/src/memory/memory_backing/hugepage_mount_path.py
@@ -22,6 +22,8 @@ from virttest.utils_test import libvirt
 from virttest.utils_libvirt import libvirt_memory
 from virttest.staging import service
 
+from provider.memory import memory_base
+
 
 def run(test, params, env):
     """
@@ -33,7 +35,8 @@ def run(test, params, env):
         Set hugepage on host and prepare guest
         """
         test.log.info("TEST_SETUP: Set hugepage on host and prepare guest")
-
+        memory_base.check_mem_page_sizes(
+            test, default_page_size, int(set_pagesize_2), [int(set_pagesize_1)])
         hp_cfg = test_setup.HugePageConfig(params)
         if case == "customized":
             process.run("umount %s" % default_path, ignore_status=True)
@@ -162,6 +165,7 @@ def run(test, params, env):
     default_path = params.get("default_path")
     consume_value = int(params.get("consume_value"))
 
+    default_page_size = int(params.get('default_page_size'))
     mount_pagesize = params.get("mount_pagesize", '{}')
     set_pagesize_1 = params.get("set_pagesize_1")
     set_pagenum_1 = params.get("set_pagenum_1")

--- a/libvirt/tests/src/memory/memory_backing/memory_access_mode.py
+++ b/libvirt/tests/src/memory/memory_backing/memory_access_mode.py
@@ -17,6 +17,8 @@ from virttest.utils_test import libvirt
 from virttest.utils_libvirt import libvirt_vmxml
 from virttest.utils_libvirt import libvirt_memory
 
+from provider.memory import memory_base
+
 
 def get_vm_attrs(test, params):
     """
@@ -152,6 +154,8 @@ def run(test, params, env):
         """
         Setup pagesize
         """
+        memory_base.check_mem_page_sizes(
+            test, pg_size=int(default_page_size), hp_size=int(set_pagesize))
         hp_cfg.set_kernel_hugepages(set_pagesize, set_pagenum)
 
     def run_test():
@@ -220,6 +224,7 @@ def run(test, params, env):
     mem_backend = params.get("mem_backend")
     qemu_monitor_cmd = params.get('qemu_monitor_cmd')
     qemu_monitor_option = params.get('qemu_monitor_option')
+    default_page_size = params.get("default_page_size")
     set_pagesize = params.get("set_pagesize")
     set_pagenum = params.get("set_pagenum")
 

--- a/libvirt/tests/src/memory/memory_backing/memory_source_and_allocation.py
+++ b/libvirt/tests/src/memory/memory_backing/memory_source_and_allocation.py
@@ -21,6 +21,8 @@ from virttest.utils_test import libvirt
 from virttest.utils_libvirt import libvirt_vmxml
 from virttest.utils_libvirt import libvirt_memory
 
+from provider.memory import memory_base
+
 
 def run(test, params, env):
     """
@@ -154,6 +156,8 @@ def run(test, params, env):
         """
         Setup pagesize
         """
+        memory_base.check_mem_page_sizes(
+            test, pg_size=int(default_page_size), hp_size=int(set_pagesize))
         hp_cfg.set_kernel_hugepages(set_pagesize, set_pagenum)
 
     def run_test():
@@ -242,6 +246,7 @@ def run(test, params, env):
     memory_name_pattern = params.get("memory_name_pattern")
     check_allocated_cmd = params.get("check_allocated_cmd")
     numa_attrs = eval(params.get("numa_attrs", '{}'))
+    default_page_size = params.get("default_page_size")
     set_pagesize = params.get("set_pagesize")
     set_pagenum = params.get("set_pagenum")
     source_attr = params.get("source_attr", "")

--- a/libvirt/tests/src/memory/memory_backing/page_locking_and_shared_pages.py
+++ b/libvirt/tests/src/memory/memory_backing/page_locking_and_shared_pages.py
@@ -17,6 +17,8 @@ from virttest.utils_test import libvirt
 from virttest.utils_libvirt import libvirt_memory
 from virttest.staging import utils_memory
 
+from provider.memory import memory_base
+
 
 def run(test, params, env):
     """
@@ -47,6 +49,9 @@ def run(test, params, env):
         Prepare init xml
         """
         test.log.info("TEST_SETUP: Set hugepage")
+
+        memory_base.check_mem_page_sizes(
+            test, kernel_pagesize, int(pagesize))
         hp_cfg = test_setup.HugePageConfig(params)
         hp_cfg.set_kernel_hugepages(pagesize, pagenum)
 


### PR DESCRIPTION
Test results:
x86_64:
 (01/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_private.mem_access_private.file.4k.2048: PASS (49.63 s)
 (02/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_private.mem_access_private.anonymous.4k.2048: PASS (49.95 s)
 (03/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_private.mem_access_private.memfd.4k.2048: PASS (49.74 s)
 (04/84) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_private.mem_access_private.no_source.4k.2048: PASS (49.98 s)

aarch64 64k:
 (001/168) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_private.mem_access_private.file.4k.2048: CANCEL: Expected host default page size is 4 KiB, but get 64.0 KiB (4.70 s)
 (002/168) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_private.mem_access_private.file.64k.524288: PASS (33.70 s)
 (003/168) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_private.mem_access_private.anonymous.4k.2048: CANCEL: Expected host default page size is 4 KiB, but get 64.0 KiB (5.47 s)
 (004/168) type_specific.io-github-autotest-libvirt.memory.backing.access_mode.memory_allocation.without_hugepage.numa_access_private.mem_access_private.anonymous.64k.524288: PASS (30.68 s)


x86_64:
(01/32) type_specific.io-github-autotest-libvirt.memory.backing.source_and_allocation.memory_allocation.with_numa.ondemand.page_default.file.4k.2048: PASS (48.59 s)
 (02/32) type_specific.io-github-autotest-libvirt.memory.backing.source_and_allocation.memory_allocation.with_numa.ondemand.page_default.anonymous.4k.2048: PASS (46.71 s)
 (03/32) type_specific.io-github-autotest-libvirt.memory.backing.source_and_allocation.memory_allocation.with_numa.ondemand.page_default.memfd.4k.2048: PASS (49.65 s)
 (04/32) type_specific.io-github-autotest-libvirt.memory.backing.source_and_allocation.memory_allocation.with_numa.ondemand.page_default.source_default.4k.2048: PASS (48.88 s)


aarch64 64k:
 (01/64) type_specific.io-github-autotest-libvirt.memory.backing.source_and_allocation.memory_allocation.with_numa.ondemand.page_default.file.4k.2048: CANCEL: Expected host default page size is 4 KiB, but get 64.0 KiB (4.92 s)
 (02/64) type_specific.io-github-autotest-libvirt.memory.backing.source_and_allocation.memory_allocation.with_numa.ondemand.page_default.file.64k.524288: PASS (34.20 s)
 (03/64) type_specific.io-github-autotest-libvirt.memory.backing.source_and_allocation.memory_allocation.with_numa.ondemand.page_default.anonymous.4k.2048: CANCEL: Expected host default page size is 4 KiB, but get 64.0 KiB (5.41 s)
 (04/64) type_specific.io-github-autotest-libvirt.memory.backing.source_and_allocation.memory_allocation.with_numa.ondemand.page_default.anonymous.64k.524288: PASS (30.77 s)
 (05/64) type_specific.io-github-autotest-libvirt.memory.backing.source_and_allocation.memory_allocation.with_numa.ondemand.page_default.memfd.4k.2048: CANCEL: Expected host default page size is 4 KiB, but get 64.0 KiB (5.48 s)


x86:
 (1/3) type_specific.io-github-autotest-libvirt.memory.backing.mount_path.default.4k.2M.1G: PASS (56.01 s)
 (2/3) type_specific.io-github-autotest-libvirt.memory.backing.mount_path.disabled.4k.2M.1G: PASS (8.57 s)
 (3/3) type_specific.io-github-autotest-libvirt.memory.backing.mount_path.customized.4k.2M.1G: PASS (10.68 s)

aarch64 4k:
(1/6) type_specific.io-github-autotest-libvirt.memory.backing.mount_path.default.4k.2M.1G: PASS (81.68 s)
 (2/6) type_specific.io-github-autotest-libvirt.memory.backing.mount_path.default.64k.512M.2M: CANCEL: Expected host default page size is 64 KiB, but get 4.0 KiB (24.29 s)
 (3/6) type_specific.io-github-autotest-libvirt.memory.backing.mount_path.disabled.4k.2M.1G: PASS (36.42 s)
 (4/6) type_specific.io-github-autotest-libvirt.memory.backing.mount_path.disabled.64k.512M.2M: CANCEL: Expected host default page size is 64 KiB, but get 4.0 KiB (33.83 s)
 (5/6) type_specific.io-github-autotest-libvirt.memory.backing.mount_path.customized.4k.2M.1G: PASS (49.94 s)
 (6/6) type_specific.io-github-autotest-libvirt.memory.backing.mount_path.customized.64k.512M.2M: CANCEL: Expected host default page size is 64 KiB, but get 4.0 KiB (24.34 s)

aarch64 64k:
 (1/6) type_specific.io-github-autotest-libvirt.memory.backing.mount_path.default.4k.2M.1G: CANCEL: Expected host default page size is 4 KiB, but get 64.0 KiB (21.47 s)
 (2/6) type_specific.io-github-autotest-libvirt.memory.backing.mount_path.default.64k.512M.2M: PASS (90.93 s)
 (3/6) type_specific.io-github-autotest-libvirt.memory.backing.mount_path.disabled.4k.2M.1G: CANCEL: Expected host default page size is 4 KiB, but get 64.0 KiB (22.40 s)
 (4/6) type_specific.io-github-autotest-libvirt.memory.backing.mount_path.disabled.64k.512M.2M: PASS (33.65 s)
 (5/6) type_specific.io-github-autotest-libvirt.memory.backing.mount_path.customized.4k.2M.1G: CANCEL: Expected host default page size is 4 KiB, but get 64.0 KiB (31.49 s)
 (6/6) type_specific.io-github-autotest-libvirt.memory.backing.mount_path.customized.64k.512M.2M: PASS (48.44 s)



x86_64:
(01/32) type_specific.io-github-autotest-libvirt.memory.backing.discard.memory_allocation.numa_discard_yes.mem_discard_yes.file.4k.2048: PASS (46.49 s)
 (02/32) type_specific.io-github-autotest-libvirt.memory.backing.discard.memory_allocation.numa_discard_yes.mem_discard_yes.anonymous.4k.2048: PASS (48.89 s)
 (03/32) type_specific.io-github-autotest-libvirt.memory.backing.discard.memory_allocation.numa_discard_yes.mem_discard_yes.memfd.4k.2048: PASS (47.80 s)
 (04/32) type_specific.io-github-autotest-libvirt.memory.backing.discard.memory_allocation.numa_discard_yes.mem_discard_yes.hugepaged_file.4k.2048: PASS (48.57 s)
 (05/32) type_specific.io-github-autotest-libvirt.memory.backing.discard.memory_allocation.numa_discard_yes.mem_discard_not_defined.file.4k.2048: PASS (47.82 s)

aarch64 4k:
 (01/64) type_specific.io-github-autotest-libvirt.memory.backing.discard.memory_allocation.numa_discard_yes.mem_discard_yes.file.4k.2048: PASS (77.40 s)
 (02/64) type_specific.io-github-autotest-libvirt.memory.backing.discard.memory_allocation.numa_discard_yes.mem_discard_yes.file.64k.524288: CANCEL: Expected host default page size is 64 KiB, but get 4.0 KiB (24.84 s)
 (03/64) type_specific.io-github-autotest-libvirt.memory.backing.discard.memory_allocation.numa_discard_yes.mem_discard_yes.anonymous.4k.2048: PASS (82.86 s)
 (04/64) type_specific.io-github-autotest-libvirt.memory.backing.discard.memory_allocation.numa_discard_yes.mem_discard_yes.anonymous.64k.524288: CANCEL: Expected host default page size is 64 KiB, but get 4.0 KiB (23.62 s)

aarch 64k:
 (01/64) type_specific.io-github-autotest-libvirt.memory.backing.discard.memory_allocation.numa_discard_yes.mem_discard_yes.file.4k.2048: CANCEL: Expected host default page size is 4 KiB, but get 64.0 KiB (9.99 s)
 (02/64) type_specific.io-github-autotest-libvirt.memory.backing.discard.memory_allocation.numa_discard_yes.mem_discard_yes.file.64k.524288: PASS (50.82 s)
 (03/64) type_specific.io-github-autotest-libvirt.memory.backing.discard.memory_allocation.numa_discard_yes.mem_discard_yes.anonymous.4k.2048: CANCEL: Expected host default page size is 4 KiB, but get 64.0 KiB (12.65 s)
 (04/64) type_specific.io-github-autotest-libvirt.memory.backing.discard.memory_allocation.numa_discard_yes.mem_discard_yes.anonymous.64k.524288: PASS (47.24 s)



x86_64:
 (01/10) type_specific.io-github-autotest-libvirt.memory.backing.page_locking_and_shared_pages.memory_allocation.page_default.ksm_default.lock_without_hard_limit.4k.2048: PASS (46.50 s)
 (02/10) type_specific.io-github-autotest-libvirt.memory.backing.page_locking_and_shared_pages.memory_allocation.page_default.ksm_default.lock_hard_limit.4k.2048: PASS (47.19 s)
 (03/10) type_specific.io-github-autotest-libvirt.memory.backing.page_locking_and_shared_pages.memory_allocation.page_default.ksm_disabled.lock_default.4k.2048: PASS (48.26 s)
 (04/10) type_specific.io-github-autotest-libvirt.memory.backing.page_locking_and_shared_pages.memory_allocation.page_default.ksm_disabled.lock_without_hard_limit.4k.2048: PASS (47.17 s)


aarch64 64k:
(01/20) type_specific.io-github-autotest-libvirt.memory.backing.page_locking_and_shared_pages.memory_allocation.page_default.ksm_default.lock_without_hard_limit.4k.2048: CANCEL: Expected host default page size is 4 KiB, but get 64.0 KiB (10.32 s)
 (02/20) type_specific.io-github-autotest-libvirt.memory.backing.page_locking_and_shared_pages.memory_allocation.page_default.ksm_default.lock_without_hard_limit.64k.524288: PASS (48.25 s)
 (03/20) type_specific.io-github-autotest-libvirt.memory.backing.page_locking_and_shared_pages.memory_allocation.page_default.ksm_default.lock_hard_limit.4k.2048: CANCEL: Expected host default page size is 4 KiB, but get 64.0 KiB (12.57 s)
 (04/20) type_specific.io-github-autotest-libvirt.memory.backing.page_locking_and_shared_pages.memory_allocation.page_default.ksm_default.lock_hard_limit.64k.524288: PASS (48.98 s)

aarch64 4k:
 (01/20) type_specific.io-github-autotest-libvirt.memory.backing.page_locking_and_shared_pages.memory_allocation.page_default.ksm_default.lock_without_hard_limit.4k.2048: PASS (79.91 s)
 (02/20) type_specific.io-github-autotest-libvirt.memory.backing.page_locking_and_shared_pages.memory_allocation.page_default.ksm_default.lock_without_hard_limit.64k.524288: CANCEL: Expected host default page size is 64 KiB, but get 4.0 KiB (24.31 s)
 (03/20) type_specific.io-github-autotest-libvirt.memory.backing.page_locking_and_shared_pages.memory_allocation.page_default.ksm_default.lock_hard_limit.4k.2048: PASS (89.50 s)
 (04/20) type_specific.io-github-autotest-libvirt.memory.backing.page_locking_and_shared_pages.memory_allocation.page_default.ksm_default.lock_hard_limit.64k.524288: CANCEL: Expected host default page size is 64 KiB, but get 4.0 KiB (24.26 s)