### PR TITLE
numa: use dynamic expected value for different architectures

### DIFF
--- a/libvirt/tests/src/numa/guest_numa_node_tuning/memory_binding_setting.py
+++ b/libvirt/tests/src/numa/guest_numa_node_tuning/memory_binding_setting.py
@@ -164,10 +164,7 @@ def verify_host_numa_memory_allocation(test_obj):
             else:
                 _check_values(True, 506, 506)
         elif not single_host_node and mem_mode in ['strict', 'restrictive']:
-            if platform.machine() == 'aarch64':
-                _check_values(True, 0, 0, 4)
-            else:
-                _check_values(True, 0, 0, 1012)
+            _check_values(True, 0, 0, int(mem_size/psize))
     test_obj.test.log.debug("Step: verify host numa node memory allocation PASS")
 
 


### PR DESCRIPTION
Fix the failed case on aarch64 with kernel pagesize=4K.

Signed-off-by: Qian Jianhua <qianjh@fujitsu.com>

Before:
```
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.memory_binding_setting.hugepage.mem_mode_strict.multiple_host_nodes: FAIL: Expect N0 + N1 = 4 in numa_maps, but found '1024' (132.91 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.memory_binding_setting.hugepage.mem_mode_restrictive.multiple_host_nodes: FAIL: Expect N0 + N1 = 4 in numa_maps, but found '1024' (143.61 s)
```

After:
```
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.memory_binding_setting.hugepage.mem_mode_strict.multiple_host_nodes: PASS (132.45 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.memory_binding_setting.hugepage.mem_mode_restrictive.multiple_host_nodes: PASS (138.77 s)
```