### PR TITLE
Memory misc add multi huge page size config

### DIFF
--- a/libvirt/tests/cfg/memory/memory_misc.cfg
+++ b/libvirt/tests/cfg/memory/memory_misc.cfg
@@ -38,15 +38,36 @@
                     vm_attrs = {'max_mem_rt': 2124800, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB', 'memory': 1155072, 'memory_unit': 'KiB', 'current_mem': 1048576, 'current_mem_unit': 'KiB', 'vcpu': 16}
                     numa_node_size = 512000
                     cpu_attrs = {'numa_cell': [{'id': '0', 'cpus': '0-7', 'memory': '${numa_node_size}', 'unit': 'KiB'}, {'id': '1', 'cpus': '8-15', 'memory': '${numa_node_size}', 'unit': 'KiB'}]}
-                    mem_device_attrs = {'source': {'pagesize_unit': 'KiB', 'pagesize': 2048, 'nodemask': '0'}, 'mem_model': 'dimm', 'target': {'size': 131072, 'node': 1, 'size_unit': 'KiB'}}
-                    aarch64:
-                        mem_device_attrs = {'source': {'pagesize_unit': 'KiB', 'pagesize': 524288, 'nodemask': '0'}, 'mem_model': 'dimm', 'target': {'size': 524288, 'node': 1, 'size_unit': 'KiB'}}
+                    variants kernel_pagesize:
+                        - 4k:
+                            default_page_size = 4
+                            variants huge_pagesize:
+                                - 2048:
+                                    default_hugepage_size = 2048
+                                    mem_device_attrs = {'source': {'pagesize_unit': 'KiB', 'pagesize': 2048, 'nodemask': '0'}, 'mem_model': 'dimm', 'target': {'size': 131072, 'node': 1, 'size_unit': 'KiB'}}
+                        - 64k:
+                            only aarch64
+                            default_page_size = 64
+                            variants huge_pagesize:
+                                - 524288:
+                                    default_hugepage_size = 524288
+                                    mem_device_attrs = {'source': {'pagesize_unit': 'KiB', 'pagesize': 524288, 'nodemask': '0'}, 'mem_model': 'dimm', 'target': {'size': 524288, 'node': 1, 'size_unit': 'KiB'}}
                 - nodeset_specified:
                     no s390-virtio
-                    pagesize = 1048576
-                    aarch64:
-                        pagesize = 524288
-                    pagenum = 10
+                    variants kernel_pagesize:
+                        - 4k:
+                            default_page_size = 4
+                            variants huge_pagesize:
+                                - 1048576:
+                                    pagesize = 1048576
+                                    pagenum = 10
+                        - 64k:
+                            only aarch64
+                            default_page_size = 64
+                            variants huge_pagesize:
+                                - 16777216:
+                                    pagesize = 16777216
+                                    pagenum = 1
                     variants scenario:
                         - nodeset_0:
                             mem_backing_attrs = {'hugepages': {'pages': [{'unit': 'KiB', 'nodeset': '0', 'size': '${pagesize}'}]}, 'locked': True}
@@ -57,31 +78,55 @@
                             expect_msg = 'hugepages: node 0 not found'
                 - hp_from_2_numa_nodes:
                     no s390-virtio
-                    pagesize = 2048
-                    pagenum = 5120
-                    aarch64:
-                        pagesize = 524288
-                        pagenum = 20
-                    vm_attrs = {'max_mem_rt': 83886080, 'max_mem_rt_slots': 8, 'max_mem_rt_unit': 'KiB', 'memory': 20971520, 'memory_unit': 'KiB', 'current_mem': 20971520, 'current_mem_unit': 'KiB'}
+                    variants kernel_pagesize:
+                        - 4k:
+                            default_page_size = 4
+                            variants huge_pagesize:
+                                - 2048:
+                                    pagesize = 2048
+                                    pagenum = 2560
+                        - 64k:
+                            only aarch64
+                            default_page_size = 64
+                            variants huge_pagesize:
+                                - 524288:
+                                    pagesize = 524288
+                                    pagenum = 10
+                    vm_attrs = {'max_mem_rt': 83886080, 'max_mem_rt_slots': 8, 'max_mem_rt_unit': 'KiB', 'memory': 10485760, 'memory_unit': 'KiB', 'current_mem': 10485760, 'current_mem_unit': 'KiB'}
                     mem_backing_attrs = {'hugepages': {}}
-                    cpu_attrs = {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '19922944', 'unit': 'KiB', 'discard': 'yes'}]}
+                    cpu_attrs = {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '9437184', 'unit': 'KiB', 'discard': 'yes'}]}
                     mem_device_attrs = {'source': {'pagesize_unit': 'KiB', 'pagesize': ${pagesize}, 'nodemask': '0'}, 'mem_model': 'dimm', 'target': {'size': 1048576, 'node': 0, 'size_unit': 'KiB'}}
                 - mount_hp_running_vm:
                     no s390-virtio
-                    pagesize = 2048
-                    mount_pagesize = 1048576
-                    mount_path = '/dev/hugepages1G'
-                    mount_option = 'pagesize=1G'
-                    aarch64:
-                        pagesize = 524288
-                        mount_pagesize = 2048
-                        mount_path= '/dev/hugepages2M'
-                        mount_option = 'pagesize=2M'
-                    vm_attrs = {'vcpu': 4, 'max_mem_rt': 15242880, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB'}
+                    variants kernel_pagesize:
+                        - 4k:
+                            default_page_size = 4
+                            variants huge_pagesize:
+                                - 2048:
+                                    pagesize = 2048
+                                    variants ext_huge_pagesize:
+                                        - 1048576:
+                                            mount_pagesize = 1048576
+                                            mount_path = '/dev/hugepages1G'
+                                            mount_option = 'pagesize=1G'
+                                            mem_device_size = 1048576
+                        - 64k:
+                            only aarch64
+                            default_page_size = 64
+                            variants huge_pagesize:
+                                - 524288:
+                                    pagesize = 524288
+                                    variants ext_huge_pagesize:
+                                        - 16777216:
+                                            mount_pagesize = 16777216
+                                            mount_path= '/dev/hugepages16G'
+                                            mount_option = 'pagesize=16G'
+                                            mem_device_size = 16777216
+                    vm_attrs = {'vcpu': 4, 'max_mem_rt': 20971520, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB'}
                     numa_node_size = 1048576
                     cpu_attrs = {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '${numa_node_size}', 'unit': 'KiB'}, {'id': '1', 'cpus': '2-3', 'memory': '${numa_node_size}', 'unit': 'KiB'}]}
                     mem_backing_attrs = {'hugepages': {'pages': [{'unit': 'KiB', 'size': '${pagesize}'}]}}
-                    mem_device_attrs = {'source': {'pagesize': ${mount_pagesize}, 'pagesize_unit': 'KiB'}, 'mem_model': 'dimm', 'target': {'size': 1048576, 'node': 0, 'size_unit': 'KiB'}}
+                    mem_device_attrs = {'source': {'pagesize': ${mount_pagesize}, 'pagesize_unit': 'KiB'}, 'mem_model': 'dimm', 'target': {'size': ${mem_device_size}, 'node': 0, 'size_unit': 'KiB'}}
         - edit_mem:
             variants case:
                 - forbid_0:
@@ -183,3 +228,4 @@
                         vmxml_memory = 3145760
                         vmxml_current_mem = 3045760
                         cpu_attrs = {'mode': 'host-passthrough', 'numa_cell': [{'id': '0', 'cpus': '0,2', 'memory': '${numa_node_size}', 'unit': 'KiB'}, {'id': '1', 'cpus': '1,3', 'memory': '${numa_node_size}', 'unit': 'KiB'}]}
+


### PR DESCRIPTION
Test results:
x86_64:
 (1/1) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.no_mem_backing.4k.2048: PASS (9.35 s)
 (1/2) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.nodeset_specified.nodeset_0.4k.1048576:PASS (8.17 s)
 (2/2) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.nodeset_specified.nodeset_01.4k.1048576: PASS (8.26 s)
 (1/1) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.mount_hp_running_vm.4k.2048.1048576: PASS (55.11 s)
 (1/1) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.hp_from_2_numa_nodes.4k.2048: PASS (11.37 s)


aarch64 64k:
 (1/2) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.no_mem_backing.4k.2048: CANCEL: Expected host default page size is 4 KiB, but get 64.0 KiB (4.65 s)
 (2/2) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.no_mem_backing.64k.524288: PASS (6.56 s)
 (1/4) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.nodeset_specified.nodeset_0.4k.1048576:CANCEL: Expected host default page size is 4 KiB, but get 64.0 KiB (4.86 s)
 (2/4) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.nodeset_specified.nodeset_0.64k.16777216: PASS (5.65 s)
 (3/4) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.nodeset_specified.nodeset_01.4k.1048576: CANCEL: Expected host default page size is 4 KiB, but get 64.0 KiB (4.68 s)
 (4/4) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.nodeset_specified.nodeset_01.64k.16777216: PASS (5.70 s)
 (1/2) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.mount_hp_running_vm.4k.2048.1048576: CANCEL: Expected host default page size is 4 KiB, but get 64.0 KiB (4.73 s)
 (2/2) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.mount_hp_running_vm.64k.524288.16777216: PASS (37.96 s)
(1/2) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.hp_from_2_numa_nodes.4k.2048: CANCEL: Expected host default page size is 4 KiB, but get 64.0 KiB (8.41 s)
 (2/2) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.hp_from_2_numa_nodes.64k.524288: PASS (17.64 s)