### PR TITLE
Change memory verification to adapt to different page size

### DIFF
--- a/libvirt/tests/cfg/memory/memory_allocation/define_value_unit.cfg
+++ b/libvirt/tests/cfg/memory/memory_allocation/define_value_unit.cfg
@@ -6,9 +6,6 @@
     default_unit = "KiB"
     status_error = "no"
     result_dict = {'memory_unit': 'KiB', 'current_mem_unit': 'KiB', 'max_mem_rt_slots': ${max_mem_slots}, "max_mem_rt_unit":"KiB","numa_unit":"KiB"}
-    default_pagesize = 4
-    aarch64:
-        default_pagesize = 64
     variants case:
         - positive_test:
             variants:
@@ -79,3 +76,4 @@
             vm_attrs = {'max_mem_rt': ${max_mem}, 'max_mem_rt_slots': ${max_mem_slots}, 'max_mem_rt_unit': "${max_mem_unit}",'memory_unit':"${mem_unit}",'memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}',"cpu":${numa_cpu}}
             xpaths = [[{'element_attrs':['.//memory[@unit="${default_unit}"]'],'text':'%s'}],[{'element_attrs':['.//currentMemory[@unit="${default_unit}"]'],'text':'%s'}],[{'element_attrs':['.//maxMemory[@unit="${default_unit}"]'],'text':'%s'}],[{'element_attrs':['.//cell[@unit="${default_unit}"]','.//cell[@memory="%s"]']}]]
             numa_dict = {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '${mem_value}'}]}
+


### PR DESCRIPTION
Test results:

x86_64:
(01/16) type_specific.io-github-autotest-libvirt.memory.allocation.define_value_unit.without_numa.positive_test.bytes: PASS (45.46 s)
 (02/16) type_specific.io-github-autotest-libvirt.memory.allocation.define_value_unit.without_numa.positive_test.KB: PASS (47.45 s)
 (03/16) type_specific.io-github-autotest-libvirt.memory.allocation.define_value_unit.without_numa.positive_test.KiB: PASS (45.58 s)
 (04/16) type_specific.io-github-autotest-libvirt.memory.allocation.define_value_unit.without_numa.positive_test.MB: PASS (45.54 s)

aarch64 64k:
(01/16) type_specific.io-github-autotest-libvirt.memory.allocation.define_value_unit.without_numa.positive_test.bytes: PASS (45.95 s)
 (02/16) type_specific.io-github-autotest-libvirt.memory.allocation.define_value_unit.without_numa.positive_test.KB: PASS (44.01 s)
 (03/16) type_specific.io-github-autotest-libvirt.memory.allocation.define_value_unit.without_numa.positive_test.KiB: PASS (43.90 s)
 (04/16) type_specific.io-github-autotest-libvirt.memory.allocation.define_value_unit.without_numa.positive_test.MB: PASS (42.02 s)

aarch64 4k:
(01/16) type_specific.io-github-autotest-libvirt.memory.allocation.define_value_unit.without_numa.positive_test.bytes: PASS (40.17 s)
 (02/16) type_specific.io-github-autotest-libvirt.memory.allocation.define_value_unit.without_numa.positive_test.KB: PASS (55.53 s)
 (03/16) type_specific.io-github-autotest-libvirt.memory.allocation.define_value_unit.without_numa.positive_test.KiB: PASS (53.99 s)
 (04/16) type_specific.io-github-autotest-libvirt.memory.allocation.define_value_unit.without_numa.positive_test.MB: PASS (57.90 s)
