### PR TITLE
Decrease memory size to make unplug memory device more reliable

### DIFF
--- a/libvirt/tests/cfg/event/virsh_event.cfg
+++ b/libvirt/tests/cfg/event/virsh_event.cfg
@@ -116,8 +116,8 @@
                     max_mem = 25600000
                     maxmem_slots = "16"
                     mem_unit = "KiB"
-                    memory = 4048896
-                    current_mem = 4048896
+                    memory = 1572864
+                    current_mem = 1572864
                     dimm_unit = "m"
                     dimm_size = 128
                     cpu_mode = 'host-model'
@@ -198,3 +198,4 @@
                     # Test virsh qemu_monitor_event
                     no invalid_event
                     qemu_monitor_test = "yes"
+


### PR DESCRIPTION
Test results:
x86_64:
(1/2) type_specific.io-github-autotest-libvirt.virsh.event.positive_test.virsh_event.test_events.device-removal-failed_event.no_timeout.loop: PASS (96.89 s)
 (2/2) type_specific.io-github-autotest-libvirt.virsh.event.positive_test.qemu_monitor_event.pretty_option.device-removal-failed_event.no_timeout.loop: PASS (97.23 s)

aarch64 4k:
(1/2) type_specific.io-github-autotest-libvirt.virsh.event.positive_test.virsh_event.test_events.device-removal-failed_event.no_timeout.loop: PASS (126.71 s)
 (2/2) type_specific.io-github-autotest-libvirt.virsh.event.positive_test.qemu_monitor_event.pretty_option.device-removal-failed_event.no_timeout.loop: PASS (118.64 s)

aarch64 64k:
(1/2) type_specific.io-github-autotest-libvirt.virsh.event.positive_test.virsh_event.test_events.device-removal-failed_event.no_timeout.loop: PASS (97.89 s)
 (2/2) type_specific.io-github-autotest-libvirt.virsh.event.positive_test.qemu_monitor_event.pretty_option.device-removal-failed_event.no_timeout.loop: PASS (96.59 s)