### PR TITLE
enable one snap multi children case

### DIFF
--- a/libvirt/tests/cfg/snapshot/delete_external_snap_with_references.cfg
+++ b/libvirt/tests/cfg/snapshot/delete_external_snap_with_references.cfg
@@ -16,6 +16,6 @@
             variants:
                 - tail_to_head:
                     del_index = [4, 3, 0]
-#                 - head_to_tail:
-#                     del_index = [0, 3, 4]
+                - head_to_tail:
+                    del_index = [0, 3, 4]
 


### PR DESCRIPTION
  it's related a bug, The bug is fixed now
Signed-off-by: nanli <nanli@redhat.com>

```
 avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 snapshot_delete..head_to_tail

 (1/1) type_specific.io-github-autotest-libvirt.snapshot_delete.multiple_children.del_non_current_branch.head_to_tail: PASS (105.73 s)

```