### PR TITLE
Fix virsh.set_user_password.normal_test.normal_user.encrypted

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_set_user_password.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_set_user_password.py
@@ -74,12 +74,7 @@ def run(test, params, env):
 
             # Set the user password in vm
             if encrypted:
-                openssl_version = process.run("openssl version",
-                                              ignore_status=False)
-                if "OpenSSL 3.0." in openssl_version.stdout_text:
-                    cmd = "openssl passwd %s" % new_passwd
-                else:
-                    cmd = "openssl passwd -crypt %s" % new_passwd
+                cmd = "openssl passwd %s" % new_passwd
                 ret = process.run(cmd, shell=True)
                 libvirt.check_exit_status(ret)
                 en_passwd = str(ret.stdout_text.strip())


### PR DESCRIPTION
This case fail due to the fact that "openssl passwd -crypt %s" % new_passwd is not supported now, and use openssl passwd %s" % new_passwd directly