### PR TITLE
Get the iface name from the guest os

### DIFF
--- a/libvirt/tests/cfg/virtual_network/passt/passt_connectivity_between_2vms.cfg
+++ b/libvirt/tests/cfg/virtual_network/passt/passt_connectivity_between_2vms.cfg
@@ -36,7 +36,6 @@
             ipv6_addr_c = '2001:db8:ac10:fd01::20'
             ips = {'ips': [{'address': '${ipv4_addr_c}', 'family': 'ipv4', 'prefix': '24'}, {'address': '${ipv6_addr_c}', 'family': 'ipv6'}]}
             iface_c_attrs = {'model': 'virtio', 'acpi': {'index': '1'}, **${ips}, 'backend': ${backend}, 'source': {'dev': '${host_iface}'}, 'type_name': 'user'}
-            vm_c_iface = eno1
             conn_check_args_0 = ('TCP4', server_default_gw, None, 41335, 41335)
             conn_check_args_1 = ('TCP6', server_default_gw_v6, vm_c_iface, 41335, 41335)
             conn_check_args_2 = ('UDP4', server_default_gw, None, 21335, 21335)
@@ -44,7 +43,6 @@
             s390-virtio:
                 iface_attrs = {'model': 'virtio', **${ips}, 'backend': ${backend}, 'source': {'dev': '${host_iface}'}, 'type_name': 'user', **${portForwards}}
                 iface_c_attrs = {'model': 'virtio', **${ips}, 'backend': ${backend}, 'source': {'dev': '${host_iface}'}, 'type_name': 'user'}
-                vm_c_iface = enc1
                 conn_check_args_0 = ('TCP4', server_default_gw, None, 41335, 41335)
                 conn_check_args_1 = ('TCP6', server_default_gw_v6, vm_c_iface, 41335, 41335)
                 conn_check_args_2 = ('UDP4', server_default_gw, None, 21335, 21335)

--- a/libvirt/tests/src/virtual_network/passt/passt_connectivity_between_2vms.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_connectivity_between_2vms.py
@@ -64,7 +64,6 @@ def run(test, params, env):
     iface_c_attrs = eval(params.get('iface_c_attrs'))
     params['socket_dir'] = socket_dir = eval(params.get('socket_dir'))
     params['proc_checks'] = proc_checks = eval(params.get('proc_checks', '{}'))
-    vm_c_iface = params.get('vm_c_iface', 'eno1')
     host_iface = params.get('host_iface')
     host_iface = host_iface if host_iface else utils_net.get_net_if(
         state="UP")[0]
@@ -97,6 +96,8 @@ def run(test, params, env):
 
         server_session = vm.wait_for_serial_login(60)
         client_session = vm_c.wait_for_serial_login(60)
+        mac = vm_c.get_virsh_mac_address()
+        vm_c_iface = utils_net.get_linux_ifname(client_session, mac)
 
         [LOG.debug(session.cmd_output('ip a'))
          for session in (server_session, client_session)]


### PR DESCRIPTION
Get the iface name from the guest os instead of assume it's interface name.