### PR TITLE
numa: fix no enough memory

### DIFF
--- a/libvirt/tests/cfg/numa/guest_numa_topology/various_numa_topology_settings.cfg
+++ b/libvirt/tests/cfg/numa/guest_numa_topology/various_numa_topology_settings.cfg
@@ -8,10 +8,8 @@
     qemu_monitor_option = '--hmp'
     qemu_monitor_cmd = 'info memdev'    
     cpu_mode = 'host-model'
-    target_hugepages = 1024
     aarch64:
         cpu_mode = 'host-passthrough'
-    hugepage_size = 2048
     numa_cell_0 = {'id': '0', 'memory': '1048576', 'cpus': '0-1'}
     numa_cell_1 = {'id': '1', 'memory': '1048576', 'cpus': '2-3'}
     numa_cells = [${numa_cell_0}, ${numa_cell_1}]

--- a/libvirt/tests/cfg/numa/guest_numa_topology/various_numa_topology_settings.cfg
+++ b/libvirt/tests/cfg/numa/guest_numa_topology/various_numa_topology_settings.cfg
@@ -11,7 +11,6 @@
     target_hugepages = 1024
     aarch64:
         cpu_mode = 'host-passthrough'
-        target_hugepages = 32
     hugepage_size = 2048
     numa_cell_0 = {'id': '0', 'memory': '1048576', 'cpus': '0-1'}
     numa_cell_1 = {'id': '1', 'memory': '1048576', 'cpus': '2-3'}

--- a/libvirt/tests/src/numa/guest_numa_topology/various_numa_topology_settings.py
+++ b/libvirt/tests/src/numa/guest_numa_topology/various_numa_topology_settings.py
@@ -27,6 +27,16 @@ def setup_default(test_obj):
     """
     test_obj.setup()
     hpc = test_setup.HugePageConfig(test_obj.params)
+
+    numa_cells = eval(test_obj.params.get('numa_cells', '[]'))
+    if numa_cells:
+        #set target_hugepages according to the setting of 'numa_cells'.
+        total_mem = 0
+        for i in range(len(numa_cells)):
+            total_mem += int(numa_cells[i]['memory'])
+        test_obj.params["target_hugepages"] = int(total_mem/hpc.get_hugepage_size())
+        hpc = test_setup.HugePageConfig(test_obj.params)
+
     hpc.setup()
     test_obj.params['hp_config_obj'] = hpc
     test_obj.test.log.debug("Step: setup is done")


### PR DESCRIPTION
On aarch64 with pagesize=4K, the hugepages count is too small to start VM.

Signed-off-by: Qian Jianhua <qianjh@fujitsu.com>

Before:
```
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_topology.various_numa_topology_settings.discard_none.memaccess_none: ERROR: VM 'avocado-vt-vm1' failed to start: error: Failed to start domain 'avocado-vt-vm1'\nerror: internal error: process exited while connecting to monitor: 2024-05-30T09:26:58.786400Z qemu-kvm: unable to map backing store for guest RAM: Cannot allocate memory(... (62.76 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_topology.various_numa_topology_settings.discard_none.memaccess_shared: ERROR: VM 'avocado-vt-vm1' failed to start: error: Failed to start domain 'avocado-vt-vm1'\nerror: internal error: process exited while connecting to monitor: 2024-05-30T09:28:24.806387Z qemu-kvm: unable to map backing store for guest RAM: Cannot allocate memory(... (62.84 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_topology.various_numa_topology_settings.discard_none.memaccess_private: ERROR: VM 'avocado-vt-vm1' failed to start: error: Failed to start domain 'avocado-vt-vm1'\nerror: internal error: QEMU unexpectedly closed the monitor (vm='avocado-vt-vm1'): 2024-05-30T09:29:49.046362Z qemu-kvm: unable to map backing store for guest RAM: Cannot ... (51.02 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_topology.various_numa_topology_settings.discard_yes.memaccess_none: ERROR: VM 'avocado-vt-vm1' failed to start: error: Failed to start domain 'avocado-vt-vm1'\nerror: internal error: process exited while connecting to monitor: 2024-05-30T09:31:03.926423Z qemu-kvm: unable to map backing store for guest RAM: Cannot allocate memory(... (61.34 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_topology.various_numa_topology_settings.discard_yes.memaccess_shared: ERROR: VM 'avocado-vt-vm1' failed to start: error: Failed to start domain 'avocado-vt-vm1'\nerror: internal error: process exited while connecting to monitor: 2024-05-30T09:32:29.646450Z qemu-kvm: unable to map backing store for guest RAM: Cannot allocate memory(... (50.47 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_topology.various_numa_topology_settings.discard_yes.memaccess_private: ERROR: VM 'avocado-vt-vm1' failed to start: error: Failed to start domain 'avocado-vt-vm1'\nerror: internal error: QEMU unexpectedly closed the monitor (vm='avocado-vt-vm1'): 2024-05-30T09:33:45.816339Z qemu-kvm: unable to map backing store for guest RAM: Cannot ... (63.82 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_topology.various_numa_topology_settings.discard_no.memaccess_none: ERROR: VM 'avocado-vt-vm1' failed to start: error: Failed to start domain 'avocado-vt-vm1'\nerror: internal error: process exited while connecting to monitor: 2024-05-30T09:35:10.526390Z qemu-kvm: unable to map backing store for guest RAM: Cannot allocate memory(... (50.89 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_topology.various_numa_topology_settings.discard_no.memaccess_shared: ERROR: VM 'avocado-vt-vm1' failed to start: error: Failed to start domain 'avocado-vt-vm1'\nerror: internal error: process exited while connecting to monitor: 2024-05-30T09:36:25.946417Z qemu-kvm: unable to map backing store for guest RAM: Cannot allocate memory(... (63.97 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_topology.various_numa_topology_settings.discard_no.memaccess_private: ERROR: VM 'avocado-vt-vm1' failed to start: error: Failed to start domain 'avocado-vt-vm1'\nerror: internal error: process exited while connecting to monitor: 2024-05-30T09:37:50.776341Z qemu-kvm: unable to map backing store for guest RAM: Cannot allocate memory(... (63.65 s)
```

After
```
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_topology.various_numa_topology_settings.discard_none.memaccess_none: PASS (122.12 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_topology.various_numa_topology_settings.discard_none.memaccess_shared: PASS (135.64 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_topology.various_numa_topology_settings.discard_none.memaccess_private: PASS (123.28 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_topology.various_numa_topology_settings.discard_yes.memaccess_none: PASS (136.77 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_topology.various_numa_topology_settings.discard_yes.memaccess_shared: PASS (125.00 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_topology.various_numa_topology_settings.discard_yes.memaccess_private: PASS (137.44 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_topology.various_numa_topology_settings.discard_no.memaccess_none: PASS (125.16 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_topology.various_numa_topology_settings.discard_no.memaccess_shared: PASS (124.42 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_topology.various_numa_topology_settings.discard_no.memaccess_private: PASS (136.42 s)
```