### PR TITLE
virtual_disks: Add a vhostvdpa-blk test

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/vhostvdpa_block_backend_type/define_start_vms_with_same_vhostvdpa_backend_disk.cfg
+++ b/libvirt/tests/cfg/virtual_disks/vhostvdpa_block_backend_type/define_start_vms_with_same_vhostvdpa_backend_disk.cfg
@@ -1,0 +1,12 @@
+- virtual_disks.vhostvdpa.define_start_multi_vms_with_same_disk:
+    type = define_start_vms_with_same_vhostvdpa_backend_disk
+    start_vm = no
+    simulator = "yes"
+    func_supported_since_libvirt_ver = (9, 10, 0)
+    only x86_64
+
+    vms = avocado-vt-vm1 vm2
+    disk_vdpa_attrs = {"source": {"attrs": {"dev": "/dev/vhost-vdpa-0"}}, "type_name": "vhostvdpa"}
+    disk_driver = {"driver": {"name": "qemu", "type": "raw", "cache": "none", "io": "threads", "copy_on_read": "on", "discard": "unmap", "detect_zeroes": "on"}}
+    disk_attrs = {"device": "disk", "target": {"dev": "vdb", "bus": "virtio"}, **${disk_vdpa_attrs}, **${disk_driver}}
+    err_msg = "vdpa device.*Device or resource busy"

--- a/libvirt/tests/src/virtual_disks/vhostvdpa_block_backend_type/define_start_vms_with_same_vhostvdpa_backend_disk.py
+++ b/libvirt/tests/src/virtual_disks/vhostvdpa_block_backend_type/define_start_vms_with_same_vhostvdpa_backend_disk.py
@@ -1,0 +1,48 @@
+from virttest import libvirt_version
+from virttest import utils_vdpa
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+VIRSH_ARGS = {'debug': True, 'ignore_status': False}
+
+
+def run(test, params, env):
+    """
+    Verify that if two vms use the same vhost-vdpa backend, the second one will
+    fail to start
+    """
+    libvirt_version.is_libvirt_feature_supported(params)
+
+    disk_attrs = eval(params.get("disk_attrs", "{}"))
+    err_msg = params.get("err_msg")
+    vms = params.get('vms').split()
+    vm_list = [env.get_vm(v_name) for v_name in vms]
+    vm, vm2 = vm_list[:2]
+
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm.name)
+    vm2_xml_backup = vm_xml.VMXML.new_from_inactive_dumpxml(vm2.name)
+
+    bkxml = vmxml.copy()
+
+    try:
+        test.log.info("TEST_STEP: Define two VMs with the same vhostvdpa disk.")
+        test_env_obj = utils_vdpa.VDPASimulatorTest(
+            sim_dev_module="vdpa_sim_blk", mgmtdev="vdpasim_blk")
+        test_env_obj.setup()
+        for _vm in [vm, vm2]:
+            vm_xml.VMXML.set_memoryBacking_tag(
+                _vm.name, access_mode="shared", hpgs=False)
+            libvirt_vmxml.modify_vm_device(
+                vm_xml.VMXML.new_from_dumpxml(_vm.name), "disk", disk_attrs, 1)
+            test.log.debug(f'VMXML of {_vm.name}:\n{virsh.dumpxml(_vm.name).stdout_text}')
+
+        test.log.info("TEST_STEP: Start the VMs.")
+        vm.start()
+        cmd_result = virsh.start(vm2.name)
+        libvirt.check_result(cmd_result, err_msg)
+    finally:
+        bkxml.sync()
+        vm2_xml_backup.sync()
+        test_env_obj.cleanup()


### PR DESCRIPTION
This pr adds:
VIRT-300442 - Define&Start two vms with disk of a same vhostvdpa backend


**Test results:**
` (1/1) type_specific.io-github-autotest-libvirt.virtual_disks.vhostvdpa.define_start_multi_vms_with_same_disk: PASS (16.25 s)`
