### PR TITLE
fix virsh domstats block.allocation not changing issue during blockco…

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockcommit/check_allocation_watermark_during_blockcommit.cfg
+++ b/libvirt/tests/cfg/backingchain/blockcommit/check_allocation_watermark_during_blockcommit.cfg
@@ -2,24 +2,40 @@
     type = check_allocation_watermark_during_blockcommit
     target_disk = "vdb"
     domstats_option = " --block --backing | grep allocation "
+    changing_index = "4"
+    changing_alloc = "block.${changing_index}.allocation"
     disappear_index = "4"
     disappear_alloc = "block.${disappear_index}.allocation"
     lvm_num = 3
     snap_nums = 3
-    virsh_opt = " -k0"
+    write_file_bs = "1M"
+    write_file_count = "400"
+    lv_size = "200M"
     variants case:
         - inactive_layer:
-            commit_option = "--top ${target_disk}[3] --base ${target_disk}[1] --wait --verbose --bandwidth 10"
+            commit_option = "--top ${target_disk}[3] --base ${target_disk}[1] --wait --verbose --bandwidth 1"
             commit_success_msg = "Commit complete"
         - active_layer:
-            commit_option = " --wait --verbose --pivot --bandwidth 10"
+            commit_option = " --wait --verbose --pivot --bandwidth 1"
             commit_success_msg = "Successfully pivoted"
     variants:
         - file_disk:
+            storage_type = nfs
+            set_sebool_local = 'yes'
+            local_boolean_varible = 'virt_use_nfs'
+            setup_local_nfs = "yes"
+            nfs_mount_src = "/var/lib/avocado/data/avocado-vt/nfs-export"
+            nfs_mount_dir = "/var/lib/avocado/data/avocado-vt/nfs-mount"
+            nfs_mount_options = "rw"
+            export_ip = "*"
+            export_dir = "/var/lib/avocado/data/avocado-vt/nfs-export"
+            export_options= "rw,root_squash"
+            local_boolean_value = "on"
             disk_type = "nfs"
             disk_dict = {"type_name":"file", "target":{"dev": "${target_disk}", "bus": "virtio"}, "driver": {"name": "qemu", "type":"qcow2"}}
             extra_option = ",snapshot=external --diskspec vda,snapshot=no "
         - block_disk:
             disk_type = "block"
-            disk_dict = {"type_name":"${disk_type}", "target":{"dev": "${target_disk}", "bus": "virtio"}, "driver": {"name": "qemu", "type":"raw"}}
-            extra_option = ",snapshot=external,stype=block --diskspec vda,snapshot=no --reuse-external "
+            convert_format = "qcow2"
+            disk_dict = {"type_name":"${disk_type}", "target":{"dev": "${target_disk}", "bus": "virtio"}, "driver": {"name": "qemu", "type":"qcow2"}}
+            extra_option = ",snapshot=external,stype=block --diskspec vda,snapshot=no --reuse-external"

--- a/provider/virtual_disk/disk_base.py
+++ b/provider/virtual_disk/disk_base.py
@@ -48,6 +48,7 @@ class DiskBase(object):
         self.new_image_path = ''
         self.path_list = ''
         self.disk_backend = ''
+        self.disk_size = "50M"
 
     @staticmethod
     def get_source_list(vmxml, disk_type, target_dev):
@@ -129,6 +130,10 @@ class DiskBase(object):
             if not new_image_path:
                 new_image_path = self.create_lvm_disk_path(
                     vg_name=self.vg_name, lv_name=self.lv_name, **kwargs)
+                if self.params.get('convert_format'):
+                    process.run("qemu-img create -f %s /dev/%s/%s %s" % (
+                            self.params.get('convert_format'), self.vg_name,
+                            self.lv_name, self.disk_size), shell=True)
             disk_dict.update({'source': {'attrs': {'dev': new_image_path}}})
 
         elif disk_type == 'volume':
@@ -146,7 +151,7 @@ class DiskBase(object):
                 new_image_path = nfs_res['mount_dir'] + '/test.img'
 
                 libvirt.create_local_disk("file", path=new_image_path,
-                                          size='50M',
+                                          size=self.disk_size,
                                           disk_format="qcow2", **kwargs)
             disk_dict.update({'source': {'attrs': {'file': new_image_path}}})
 
@@ -288,7 +293,7 @@ class DiskBase(object):
         if kwargs.get("size"):
             kwargs.pop("size")
         path = libvirt.create_local_disk("lvm", size=size, vgname=vg_name,
-                                         lvname=lv_name, **kwargs)
+                                         lvname=lv_name)
 
         return path
 


### PR DESCRIPTION
…mmit

   add utils_misc.wait for function

```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockcommit.allocation_watermark
 (1/4) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.allocation_watermark.file_disk.inactive_layer: PASS (82.96 s)
 (2/4) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.allocation_watermark.file_disk.active_layer: PASS (82.68 s)
 (3/4) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.allocation_watermark.block_disk.inactive_layer: PASS (79.07 s)
 (4/4) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.allocation_watermark.block_disk.active_layer: PASS (81.31 s)


```