### PR TITLE
Fix set memory deviation issue

### DIFF
--- a/libvirt/tests/cfg/memory/virsh_setmem.cfg
+++ b/libvirt/tests/cfg/memory/virsh_setmem.cfg
@@ -10,7 +10,7 @@
     setmem_delta_per = 15
     # Seconds to allow VM kernel to settle
     # on new memory
-    setmem_quiesce_delay = 3
+    setmem_quiesce_delay = 30
     # Select between two main sub-variants
     # for status_error expectation.  The third
     # variant, contains items that are only


### PR DESCRIPTION
In some nested virtualization such as s390x, it needs
more time to settle guest memory