### PR TITLE
libvirt_ccw_passthrough: use wait_for instead of sleep

### DIFF
--- a/libvirt/tests/src/passthrough/ccw/libvirt_ccw_passthrough.py
+++ b/libvirt/tests/src/passthrough/ccw/libvirt_ccw_passthrough.py
@@ -1,10 +1,29 @@
-from time import sleep
 from uuid import uuid4
 
+from virttest.utils_misc import wait_for, cmd_status_output
 from virttest.utils_zchannels import ChannelPaths
 from virttest.libvirt_xml.vm_xml import VMXML
 
 from provider.vfio import ccw
+
+
+def mdev_listed(uuid):
+    """
+    Returns a function that will check if the mediated device
+    with given uuid is listed
+
+    :param uuid: uuid of the mediated device
+    """
+
+    def _mdev_listed():
+        """
+        True if uuid is listed, False else
+        """
+        cmd = "lsmdev"
+        _, o = cmd_status_output(cmd)
+        return uuid in o
+
+    return _mdev_listed
 
 
 def run(test, params, env):
@@ -56,8 +75,7 @@ def run(test, params, env):
 
             ccw.set_override(schid)
             ccw.start_device(uuid, schid)
-
-            sleep(2)
+            wait_for(lambda: mdev_listed(uuid), timeout=10)
             vm.start()
             session = vm.wait_for_login()
 


### PR DESCRIPTION
The device_remove test case sometimes still fails. Instead now allow for up to 10 seconds for device to appear and instead use wait_for.