### PR TITLE
virsh_emulatorpin: Fix ValueError: invalid mode: 'rU'

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_emulatorpin.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_emulatorpin.py
@@ -38,7 +38,7 @@ def get_emulatorpin_from_cgroup(params, test):
         cpuset_file = os.path.join(cpuset_path, "cpuset.cpus")
 
     try:
-        with open(cpuset_file, "rU") as f_emulatorpin_params:
+        with open(cpuset_file, "r") as f_emulatorpin_params:
             emulatorpin_params_from_cgroup = f_emulatorpin_params.readline()
         return emulatorpin_params_from_cgroup
     except IOError:


### PR DESCRIPTION
**Before the fix:**
```
JOB LOG    : /var/log/avocado/job-results/job-2024-06-06T07.20-402657b/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.emulatorpin.positive_testing.set_emulatorpin_parameter.running_guest.cpulist.emulatorpin_options.current.ranges.default: ERROR: invalid mode: 'rU' (7.97 s)
```

**After the fix:**
` (1/1) type_specific.io-github-autotest-libvirt.virsh.emulatorpin.positive_testing.set_emulatorpin_parameter.running_guest.cpulist.emulatorpin_options.current.ranges.default: PASS (7.99 s)`
