### PR TITLE
revert_snap_with_flags: skip secure boot check

### DIFF
--- a/libvirt/tests/cfg/snapshot/revert_snap_with_flags.cfg
+++ b/libvirt/tests/cfg/snapshot/revert_snap_with_flags.cfg
@@ -7,6 +7,7 @@
     vars_path = "/var/lib/libvirt/qemu/nvram/${main_vm}_VARS.fd"
     snap1_options = "%s --diskspec vda,snapshot=external,file=/tmp/vda.%s"
     snap2_options = "%s --memspec snapshot=external,file=/tmp/mem.%s --diskspec vda,snapshot=external,file=/tmp/vda.%s"
-    flags = [" --current --paused"," --running --reset-nvram", " --force"]
     func_supported_since_libvirt_ver = (9, 10, 0)
-
+    s390-virtio:
+        vars_path =
+        flags = [" --current --paused"," --running", " --force"]

--- a/libvirt/tests/src/snapshot/revert_snap_with_flags.py
+++ b/libvirt/tests/src/snapshot/revert_snap_with_flags.py
@@ -59,13 +59,15 @@ def run(test, params, env):
         check_vm_state_in_dom_list(test, vm_name, vm_state="paused")
 
         test.log.info("TEST_STEP4: Revert snapshot to the first snap")
-        vars_hash1 = process.run("sha256sum %s" % vars_path, ignore_status=False)
+        if vars_path:
+            vars_hash1 = process.run("sha256sum %s" % vars_path, ignore_status=False)
         virsh.snapshot_revert(vm_name, snap_names[0],
                               options=revert_flags[1], **virsh_dargs)
-        vars_hash2 = process.run("sha256sum %s" % vars_path, ignore_status=False)
-        if vars_hash1 == vars_hash2:
-            test.fail("Expect to get different hash values for '%s', "
-                      "but got both '%s' " % (vars_path, vars_hash1))
+        if vars_path:
+            vars_hash2 = process.run("sha256sum %s" % vars_path, ignore_status=False)
+            if vars_hash1 == vars_hash2:
+                test.fail("Expect to get different hash values for '%s', "
+                          "but got both '%s' " % (vars_path, vars_hash1))
 
         test.log.info("TEST_STEP5: Revert snapshot to the second snap force")
         virsh.snapshot_revert(vm_name, snap_names[1],


### PR DESCRIPTION
On s390x, we don't have the vars file for secure boot. Don't check it.
Also, no nvram, so don't run that flag.