### PR TITLE
snapshot_with_genid: not supported on s390x

### DIFF
--- a/libvirt/tests/cfg/snapshot/revert_snap_for_guest_with_genid.cfg
+++ b/libvirt/tests/cfg/snapshot/revert_snap_for_guest_with_genid.cfg
@@ -1,4 +1,5 @@
 - snapshot_revert.with_genid:
+    no s390-virtio
     type = revert_snap_for_guest_with_genid
     start_vm = no
     func_supported_since_libvirt_ver = (9, 10, 0)


### PR DESCRIPTION
&lt;genid&gt; is not supported on s390x. (s390x has no ACPI and is Big-Endian, no BIOS, no UEFI.) Disable the test.