### PR TITLE
managedsave_cpu_mode: fix for s390x

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_managedsave.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_managedsave.cfg
@@ -51,6 +51,9 @@
                     cpu_topology_cores = "4"
                     cpu_topology_threads = "2"
                     vcpu_nums = "16"
+                    s390-virtio:
+                        cpu_topology_threads = "1"
+                        vcpu_nums = "8"
                 - undefine:
                     managedsave_undefine = "yes"
                 - bypass_cache:


### PR DESCRIPTION
On s390x, there are no threads, the value must be 1.