### PR TITLE
fix not found vmx

### DIFF
--- a/libvirt/tests/src/cpu/vcpu_nested.py
+++ b/libvirt/tests/src/cpu/vcpu_nested.py
@@ -109,6 +109,7 @@ def run(test, params, env):
         Check whether the feature nested virt is enabled
         """
         vm.wait_for_login()
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
         cpu_feature = vmxml.cpu.get_dict_type_feature()
         if cpu_feature['vmx'] != 'require':
             test.fail("The feature policy of 'vmx' should not be %s, but require." % cpu_feature['vmx'])


### PR DESCRIPTION
   need to get vmxml again to get vmx
Signed-off-by: nanli <nanli@redhat.com>

Before fixed

```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 vcpu_nested.positive_test.check_nested_capability --vt-connect-uri qemu:///system
 (1/1) vcpu_nested.positive_test.check_nested_capability: ERROR: 'vmx' (154.23 s)

```
After fixed
```
 avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 vcpu_nested.positive_test.check_nested_capability --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.vcpu_nested.positive_test.check_nested_capability: PASS (140.65 s)

```