### PR TITLE
Fix useradd: user 'testuser1' already exists issue

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_set_user_password.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_set_user_password.py
@@ -116,17 +116,16 @@ def run(test, params, env):
             if start_ga:
                 # Stop guest agent in vm
                 vm.prepare_guest_agent(prepare_xml=False, channel=False, start=False)
-
-            # Del user
-            if add_user:
-                session = vm.wait_for_login(timeout=30, username="root", password=ori_passwd)
-                cmd = "userdel -f -r %s" % set_user_name
-                status, output = session.cmd_status_output(cmd)
-                if status:
-                    test.error("Deleting user '%s' got failed: '%s'" %
-                               (set_user_name, output))
-                session.close()
     finally:
+        # Del user
+        if add_user:
+            session = vm.wait_for_login(timeout=30, username="root", password=ori_passwd)
+            cmd = "userdel -f -r %s" % set_user_name
+            status, output = session.cmd_status_output(cmd)
+            if status:
+                test.error("Deleting user '%s' got failed: '%s'" %
+                           (set_user_name, output))
+            session.close()
         vmxml_bak.sync()
         # Recover VM
         if vm.is_alive():


### PR DESCRIPTION
Fix useradd: user 'testuser1' already exists issue
Move delete user action into finally block to ensure del user action can be executed.