### PR TITLE
v2v: fix the failed cases of specific-kvm on rhel9.5

### DIFF
--- a/v2v/tests/cfg/specific_kvm.cfg
+++ b/v2v/tests/cfg/specific_kvm.cfg
@@ -92,6 +92,8 @@
                     os_version = 'OS_VERSION_MULTI_DISK_WIN_V2V_EXAMPLE'
                     main_vm = 'VM_MULTI_DISK_WIN_V2V_EXAMPLE'
                     only source_esx.esx_70
+                    skip_vm_check = yes
+                    skip_reason = "bz#RHEL-17685 on win2016 guest"
         - multi_kernel:
             only source_esx.esx_70
             # this case requires '-v -x'
@@ -286,6 +288,8 @@
             only source_esx.esx_80
             boottype = 2
             main_vm = 'VM_NON_EXIST_NETWORK_V2V_EXAMPLE'
+            skip_vm_check = yes
+            skip_reason = "bz#RHEL-1718 on win11 guest"
     variants:
         - positive_test:
             status_error = 'no'


### PR DESCRIPTION
Due to "Wont Do" resolution bugs, skip checking VM after conversion.