### PR TITLE
fix incorrect source path after blockcopy

### DIFF
--- a/libvirt/tests/src/backingchain/blockcopy/blockcopy_with_async_option.py
+++ b/libvirt/tests/src/backingchain/blockcopy/blockcopy_with_async_option.py
@@ -74,11 +74,17 @@ def run(test, params, env):
                                                                  event_output))
 
         elif case == 'async':
+            def _check_path():
+                try:
+                    check_obj.check_backingchain_from_vmxml(
+                        disk_type, target_disk, [test_obj.copy_image])
+                    return True
+                except Exception as e:
+                    return False
+
             test.log.info("TEST_STEP2: Check expected chain")
-            expected_chain = test_obj.\
-                convert_expected_chain(expected_chain_index)
-            check_obj.check_backingchain_from_vmxml(disk_type, target_disk,
-                                                    expected_chain)
+            if not utils_misc.wait_for(_check_path, 60):
+                test.fail('Expect source file to be %s' % [test_obj.copy_image])
 
     def _get_session():
         """

--- a/provider/backingchain/check_functions.py
+++ b/provider/backingchain/check_functions.py
@@ -37,12 +37,12 @@ class Checkfunction(object):
         vmxml = vm_xml.VMXML.new_from_dumpxml(self.vm.name)
         LOG.debug("Current vmxml is:\n%s", vmxml)
         source_list = DiskBase.get_source_list(vmxml, disk_type, target_dev)
-
         if source_list != expected_chain:
             self.test.fail('Expect source file to be %s, '
                            'but got %s' % (expected_chain, source_list))
         else:
             LOG.debug('Get correct backingchin')
+            return True
 
     def check_block_operation_result(self, vmxml, blockcommand,
                                      target_dev, bc_chain):


### PR DESCRIPTION
   Need wait some time to check after blockcopy
Signed-off-by: nanli <nanli@redhat.com>

` (1/1) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.async_option.async: PASS (51.83 s)
`