### PR TITLE
vcpu_misc.cfg, fix for cpu model on maxphysaddr case

### DIFF
--- a/libvirt/tests/cfg/cpu/vcpu_misc.cfg
+++ b/libvirt/tests/cfg/cpu/vcpu_misc.cfg
@@ -35,6 +35,7 @@
                     expected_str_after_startup = 'mode="host-passthrough"'
                     customize_cpu_features = "yes"
                 - with_maxphysaddr:
+                    cpu_mode = "host-model"  
                     no s390-virtio,aarch64
                     func_supported_since_libvirt_ver = (9, 3, 0)
                     maxphysaddr = {'mode': 'passthrough', 'limit':'%d'}


### PR DESCRIPTION
## Issue
Test case "vcpu_misc.positive_test.with_maxphysaddr" fails with error:
VMIPAddressMissingError: No ipv4 DHCP lease for MAC 52:54:00:5c:26:e6&#10;

## Steps to reproduce the issue
1) Create a vm xml that does not define the cpu. For example:
```
<domain type='kvm'>
  <name>{{domain}}</name>
  <memory unit='KiB'>1048576</memory>
  <currentMemory unit='KiB'>1048576</currentMemory>
  <vcpu placement='static'>1</vcpu>
  <os>
    <type arch='x86_64' machine='pc'>hvm</type>
    <boot dev='hd'/>
  </os>
  <devices>
    <emulator>/usr/libexec/qemu-kvm</emulator>
    <disk type='file' device='disk'>
      <driver name='qemu' type='qcow2' cache='none'/>
      <source file='{{image_path}}'/>
      <target dev='vda' bus='virtio'/>
    </disk>
    <interface type='bridge'>
      <mac address='52:54:00:cb:dd:86'/>
      <source bridge='virbr0'/>
      <model type='virtio'/>
    </interface>
    <serial type='pty'/>
  </devices>
</domain>
```
2) Create the vm using "virsh define <my_file>.xml"
3) Start the vm using "virsh start \<domain\>"
4) Run the test "vcpu_misc.positive_test.with_maxphysaddr" on the new domain

This will result in the test failing.

## Cause
virsh/libvirtd fills in the cpu definition xml automatically if no cpu is defined. The default xml is:
```
  <cpu mode='custom' match='exact' check='none'>
    <model fallback='forbid'>qemu64</model>
    <maxphysaddr mode='passthrough' limit='38'/>
  </cpu>
```

This is not good. Many guests, including JEOS and RHEL cannot run with the "qemu64" cpu. They kernel panic because "qemu64" lacks the appropriate instructions.

This results in the guest becoming unresponsive, and unable to pass the test if the cpu was not defined in the test vm's xml.

## Fix
Set the cpu_mode to "host-model" for this test case. This way the test vm has a CPU that is supported by guests.