### PR TITLE
Snapshot_revert: fix "list index out of range" issue

### DIFF
--- a/libvirt/tests/cfg/snapshot/revert_snap_with_flags.cfg
+++ b/libvirt/tests/cfg/snapshot/revert_snap_with_flags.cfg
@@ -7,6 +7,7 @@
     vars_path = "/var/lib/libvirt/qemu/nvram/${main_vm}_VARS.fd"
     snap1_options = "%s --diskspec vda,snapshot=external,file=/tmp/vda.%s"
     snap2_options = "%s --memspec snapshot=external,file=/tmp/mem.%s --diskspec vda,snapshot=external,file=/tmp/vda.%s"
+    flags = [" --current --paused"," --running --reset-nvram", " --force"]
     func_supported_since_libvirt_ver = (9, 10, 0)
     s390-virtio:
         vars_path =


### PR DESCRIPTION
Now the revert_snap_with_flags test can not be tested in x86 because no flags list in cfg file. Now add it to fix.