### PR TITLE
migration: Fix stress package issue

### DIFF
--- a/libvirt/tests/src/migration/live_migration.py
+++ b/libvirt/tests/src/migration/live_migration.py
@@ -315,6 +315,9 @@ def run(test, params, env):
                                                            test, params)
 
         if stress_package:
+            if libvirt_version.version_compare(10, 4, 0):
+                params.update({"stress_install_from_repo": "no"})
+                params.update({"stress_dependency_packages_list": "['gcc', 'make']"})
             migration_test.run_stress_in_vm(vm, params)
         mode = 'both' if '--postcopy' in postcopy_options else 'precopy'
         if migrate_speed:

--- a/libvirt/tests/src/migration/migrate_bandwidth.py
+++ b/libvirt/tests/src/migration/migrate_bandwidth.py
@@ -216,6 +216,9 @@ def run(test, params, env):
             get_speed(exp_migrate_speed)
 
         if stress_package:
+            if libvirt_version.version_compare(10, 4, 0):
+                params.update({"stress_install_from_repo": "no"})
+                params.update({"stress_dependency_packages_list": "['gcc', 'make']"})
             migration_test.run_stress_in_vm(vm, params)
 
         # Execute migration process

--- a/libvirt/tests/src/migration/migrate_over_unix.py
+++ b/libvirt/tests/src/migration/migrate_over_unix.py
@@ -238,6 +238,9 @@ def run(test, params, env):
         vms = [vm]
 
         if stress_guest:
+            if libvirt_version.version_compare(10, 4, 0):
+                params.update({"stress_install_from_repo": "no"})
+                params.update({"stress_dependency_packages_list": "['gcc', 'make']"})
             migration_test.run_stress_in_vm(vm, params)
 
         migration_test.do_migration(vms, None, dest_uri, 'orderly',

--- a/provider/migration/base_steps.py
+++ b/provider/migration/base_steps.py
@@ -6,6 +6,7 @@ from six import itervalues
 from virttest import data_dir
 from virttest import migration
 from virttest import libvirt_remote
+from virttest import libvirt_version
 from virttest import libvirt_vm
 from virttest import remote
 from virttest import utils_config
@@ -165,6 +166,9 @@ class MigrationBase(object):
         if migrate_speed:
             self.migration_test.control_migrate_speed(vm_name, int(migrate_speed), mode)
         if stress_package:
+            if libvirt_version.version_compare(10, 4, 0):
+                self.params.update({"stress_install_from_repo": "no"})
+                self.params.update({"stress_dependency_packages_list": "['gcc', 'make']"})
             self.migration_test.run_stress_in_vm(self.vm, self.params)
 
         # Execute migration process


### PR DESCRIPTION
There is no stress package in the latest repo. So we need to compile the stress package as a workaround.