### PR TITLE
add case for virtio memory dynamic slots

### DIFF
--- a/libvirt/tests/cfg/memory/memory_devices/virtio_mem_dynamic_slots.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/virtio_mem_dynamic_slots.cfg
@@ -1,0 +1,46 @@
+- memory.devices.virtio_mem.dynamic_slots:
+    type = virtio_mem_dynamic_slots
+    no s390-virtio
+    start_vm = "no"
+    mem_model = "virtio-mem"
+    allocate_size = "3145728"
+    allocate_memory = "${allocate_size}KiB"
+    mem_value = 2097152
+    current_mem = 2097152
+    max_mem = 4194304
+    numa_mem = 1048576
+    base_attrs = "'vcpu': 4, 'memory_unit':'KiB','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'KiB'"
+    numa_attrs = "'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '${numa_mem}', 'unit': 'KiB'},{'id':'1','cpus': '2-3','memory':'${numa_mem}','unit':'KiB'}]}"
+    max_attrs = "'max_mem_rt': ${max_mem}, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB'"
+    vm_attrs = {${base_attrs}, ${numa_attrs}, ${max_attrs}}
+    required_kernel = [5.14.0,)
+    guest_required_kernel = [5.8.0,)
+    func_supported_since_libvirt_ver = (10, 0, 0)
+    func_supported_since_qemu_kvm_ver = (8, 2, 0)
+    machine_version = "9.4.0"
+    monitor_cmd = " info mtree"
+    monitor_option = " --hmp"
+    variants:
+        - basic_virtio:
+            target_size = 524288
+            request_size = 524288
+            virtio_mem_dict = {'mem_model':'${mem_model}','target': {'size':${target_size}, 'requested_size': ${request_size},'block_size': %s, 'node':0}}
+    variants dynamic_memory_slots:
+        - undefined_dynamic_memory_slots:
+            slots_pattern = ["alias memslot-0 @memvirtiomem0", "alias memslot-0 @memvirtiomem1"]
+        - enable_dynamic_memory_slots:
+            dynamic_slot_attr =  {"dynamicMemslots":"yes"}
+            slots_pattern = ["alias memslot-0 @memvirtiomem0", "alias memslot-0 @memvirtiomem1"]
+        - disable_dynamic_memory_slots:
+            dynamic_slot_attr =  {"dynamicMemslots":"no"}
+            slots_pattern = ["memvirtiomem0", "memvirtiomem1"]
+    variants memory_backing:
+        - default_mb:
+        - file_mb:
+            source_type = 'file'
+            source_attr = "'source_type':'${source_type}'"
+        - hugepages_mb:
+            hugepages_attr = "'hugepages': {}"
+        - memfd_mb:
+            source_type = 'memfd'
+            source_attr = "'source_type':'${source_type}'"

--- a/libvirt/tests/src/memory/memory_devices/virtio_mem_dynamic_slots.py
+++ b/libvirt/tests/src/memory/memory_devices/virtio_mem_dynamic_slots.py
@@ -1,0 +1,125 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright Redhat
+#
+#   SPDX-License-Identifier: GPL-2.0
+
+#   Author: Nannan Li <nanli@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import re
+
+from avocado.utils import memory
+
+from virttest import virsh
+from virttest import test_setup
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+
+from provider.memory import memory_base
+
+
+def update_vm_attrs(test, params):
+    """
+    Update vm attrs.
+
+    :param test: Virt test object.
+    :param params: Dict with test params.
+    :return vm_attrs: expected vm attrs dict.
+    """
+    source_attr = params.get('source_attr')
+    hugepages_attr = params.get('hugepages_attr')
+    vm_attrs = eval(params.get("vm_attrs"))
+
+    mb_value = ""
+    for item in [source_attr, hugepages_attr]:
+        if item is not None:
+            mb_value = mb_value + item + ","
+    mb = eval("{'mb':{%s}}" % mb_value[:-1])
+    vm_attrs.update(mb)
+    test.log.debug("Get current vm attrs is :%s", vm_attrs)
+
+    return vm_attrs
+
+
+def run(test, params, env):
+    """
+    Verify dynamic memory slots attribute works with virtio-mem memory device
+    """
+    def setup_test():
+        """
+        Allocate huge page memory
+        """
+        if memory_backing == "hugepages_mb":
+            test.log.info("TEST_SETUP: Allocate huge page memory")
+            params["target_hugepages"] = allocate_size/default_hugepage_size
+            hp_cfg = test_setup.HugePageConfig(params)
+            params["hpc_cfg"] = hp_cfg
+            hp_cfg.setup()
+
+    def run_test():
+        """
+        Verify dynamic memory slots attribute works with virtio-mem memory device
+        """
+        test.log.info("TEST_STEP1: Define guest with virtio memory")
+        vm_attrs = update_vm_attrs(test, params)
+        memory_base.define_guest_with_memory_device(
+            params, virtio_mem_dict, vm_attrs)
+
+        test.log.info("TEST_STEP2: Start vm")
+        vm.start()
+        vm.wait_for_login().close()
+        test.log.debug("Get xml after starting vm:%s",
+                       vm_xml.VMXML.new_from_inactive_dumpxml(vm_name))
+
+        test.log.info("TEST_SETUP3: Hotplug a virtio-mem device")
+        mem_obj = libvirt_vmxml.create_vm_device_by_type("memory", virtio_mem_dict)
+        virsh.attach_device(
+            vm.name, mem_obj.xml, wait_for_event=True, **virsh_dargs)
+
+        test.log.info("TEST_SETUP4: Check qemu-monitor-command")
+        output = virsh.qemu_monitor_command(
+            vm_name, monitor_cmd, monitor_option, **virsh_dargs
+        )
+        for pattern in slots_pattern:
+            if not re.search(pattern, output.stdout_text.strip()):
+                test.fail("Expect '%s' in qemu-monitor-command" % pattern)
+
+    def teardown_test():
+        """
+        Clean data.
+        """
+        test.log.info("TEST_TEARDOWN: Clean up env.")
+        bkxml.sync()
+        if memory_backing == "hugepages_mb":
+            params["hpc_cfg"].cleanup()
+
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    memory_base.check_supported_version(params, test, vm)
+
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+    virsh_dargs = {"debug": True, "ignore_status": False}
+
+    default_hugepage_size = memory.get_huge_page_size()
+    allocate_size = int(params.get("allocate_size"))
+    memory_backing = params.get("memory_backing")
+    machine_version = params.get("machine_version")
+    monitor_cmd = params.get("monitor_cmd")
+    monitor_option = params.get("monitor_option")
+    slots_pattern = eval(params.get("slots_pattern"))
+    dynamic_slot_attr = eval(params.get("dynamic_slot_attr", "{}"))
+    virtio_mem_dict = eval(params.get('virtio_mem_dict') % default_hugepage_size)
+    if dynamic_slot_attr:
+        virtio_mem_dict['target']['attrs'] = dynamic_slot_attr
+
+    if not libvirt_vmxml.check_guest_machine_type(vmxml, machine_version):
+        test.fail("Guest config machine should be >= rhel{}".format(
+            machine_version))
+    try:
+        setup_test()
+        run_test()
+
+    finally:
+        teardown_test()


### PR DESCRIPTION
   xxxx-300535:Dynamic memory slots for virtio-mem device
Signed-off-by: nanli <nanli@redhat.com>

Depend on https://github.com/avocado-framework/avocado-vt/pull/3934
```

 avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 memory.devices.virtio_mem.dynamic_slots
 (01/12) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.dynamic_slots.default_mb.undefined_dynamic_memory_slots.basic_virtio: PASS (72.83 s)
 (02/12) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.dynamic_slots.default_mb.enable_dynamic_memory_slots.basic_virtio: PASS (98.43 s)
 (03/12) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.dynamic_slots.default_mb.disable_dynamic_memory_slots.basic_virtio: PASS (73.02 s)
 (04/12) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.dynamic_slots.file_mb.undefined_dynamic_memory_slots.basic_virtio: PASS (73.44 s)
 (05/12) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.dynamic_slots.file_mb.enable_dynamic_memory_slots.basic_virtio: PASS (73.26 s)
 (06/12) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.dynamic_slots.file_mb.disable_dynamic_memory_slots.basic_virtio: PASS (73.21 s)
 (07/12) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.dynamic_slots.hugepages_mb.undefined_dynamic_memory_slots.basic_virtio: PASS (73.40 s)
 (08/12) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.dynamic_slots.hugepages_mb.enable_dynamic_memory_slots.basic_virtio: PASS (73.47 s)
 (09/12) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.dynamic_slots.hugepages_mb.disable_dynamic_memory_slots.basic_virtio: PASS (73.53 s)
 (10/12) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.dynamic_slots.memfd_mb.undefined_dynamic_memory_slots.basic_virtio: PASS (74.24 s)
 (11/12) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.dynamic_slots.memfd_mb.enable_dynamic_memory_slots.basic_virtio: PASS (73.13 s)
 (12/12) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.dynamic_slots.memfd_mb.disable_dynamic_memory_slots.basic_virtio: PASS (73.02 s)

```