### PR TITLE
storage_ceph: use xargs instead of parallel as a tool of parallel testing

### DIFF
--- a/libvirt/tests/cfg/storage/virsh_pool.cfg
+++ b/libvirt/tests/cfg/storage/virsh_pool.cfg
@@ -15,7 +15,7 @@
                     func_supported_since_libvirt_ver = (9, 5, 0)
                     parallel_executable_path = '../../deps/cve_2023_3750.sh'
                     pool_type = 'rbd'
-                    required_commands = "['parallel', 'rbd']"
+                    required_commands = "['rbd']"
                     auth_key = "EXAMPLE_AUTH_KEY"
                     auth_user = "EXAMPLE_AUTH_USER"
                     client_name = "EXAMPLE_CLIENT_NAME"

--- a/libvirt/tests/deps/cve_2023_3750.sh
+++ b/libvirt/tests/deps/cve_2023_3750.sh
@@ -7,7 +7,7 @@ POOL=$1
 VOL=$2
 function test_run() {
  while true;do
-   parallel -N0 "virsh -r 'pool-list; vol-info --pool $1 $2'" ::: {1..100}
+   seq 1 100 | xargs -n 1 -P 10 -I {} sh -c 'virsh -r "pool-list; vol-info --pool $1 --vol $2"' -- $1 $2
  done
 }
 


### PR DESCRIPTION
Parallel package sometimes is not included in the new compose. So use xargs to have a stable test for this case.