### PR TITLE
virsh/nodedev: fix chain test

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_dumpxml_chain.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_dumpxml_chain.cfg
@@ -1,8 +1,9 @@
-- virsh.nodedev_dumpxml_chain:
+- virsh.nodedev_dumpxml.chain:
     type = virsh_nodedev_dumpxml_chain
     vms = ""
     main_vm = ""
     start_vm = "no"
+    device_ids = 0.0.1234,0.0.4567
     variants:
         - device_type_dasd:
             only s390-virtio

--- a/provider/vfio/ccw.py
+++ b/provider/vfio/ccw.py
@@ -310,6 +310,24 @@ def assure_preconditions():
     utils_package.package_install(["mdevctl", "driverctl"])
 
 
+def select_first_available_device(device_ids):
+    """
+    Loops through the given device identifiers and selects
+    the first device that exists on the system.
+
+    :param device_ids: list of potential device identifiers.
+    :return device: device info as defined by SubchannelPaths
+    :raise TestError: if no available devices is found.
+    """
+    paths = SubchannelPaths()
+    paths.get_info()
+    for device in paths.devices:
+        for device_id in device_ids:
+            if device[paths.HEADER["Device"]] == device_id:
+                return device
+    raise TestError(f"None of the devices is available, {device_ids}")
+
+
 def get_device_info(devid=None):
     """
     Gets the device info for passthrough.


### PR DESCRIPTION
1. Fix test name, subtest should be nodedev_dumpxml.chain for better discoverability and set definition.
2. Update test to run against a specific device.
3. Allow for a list of devices to be physically present. The test will configure the first one to establish the test precondition.