### PR TITLE
corrected a misspelled remote_ip

### DIFF
--- a/libvirt/tests/src/virsh_cmd/host/virsh_hostname.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_hostname.py
@@ -30,7 +30,7 @@ def run(test, params, env):
     remote_uri = params.get("remote_uri", None)
 
     if remote_uri and remote_ip.count("EXAMPLE"):
-        test.cancel("Pls configure rempte_ip first")
+        test.cancel("Pls configure remote_ip first")
 
     session = None
     if remote_uri:


### PR DESCRIPTION
Description: remote_ip was wrongly typed as rempte_ip. Have fixed it with this PR!

Signed-off By: Kowshik Jois B S<kowsjois@linux.ibm.com>