### PR TITLE
boot_from_usb_device: Fix bios serial console unsupported on arm

### DIFF
--- a/libvirt/tests/cfg/guest_os_booting/boot_order/boot_from_usb_device.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/boot_order/boot_from_usb_device.cfg
@@ -3,8 +3,10 @@
     start_vm = no
     bus_type = "usb"
     bootmenu_dict = {'bootmenu_enable': 'yes', 'bootmenu_timeout': '3000', 'bios_useserial': 'yes'}
-    check_prompt = "UEFI .* USB|1. USB MSC Drive .*"
+    check_prompt = "UEFI .* USB|1. USB MSC Drive .*|UsbBootDetectMedia: UsbBootIsUnitReady .*"
     only q35, aarch64
+    aarch64:
+	bootmenu_dict = {'bootmenu_enable': 'yes', 'bootmenu_timeout': '3000'}
     variants usb_device:
         - block_device:
             disk_type = "block"
@@ -13,5 +15,6 @@
         - redirdev_device:
             port_num = "4000"
             device_attrs = {'source': {'host': 'localhost', 'service': '4000', 'mode': 'connect'}, 'protocol': {'type': 'raw'}, 'type_name': 'tcp', 'bus': '${bus_type}', 'type': 'tcp', 'boot': {'order': '1'}}
+            only q35
         - hostdev_device:
             device_attrs = {'type_name': 'usb', 'mode': 'subsystem', 'source': {'vendor_id': '%s', 'product_id': '%s'}, 'type': 'usb', 'managed': 'no', 'boot_order': '1'}

--- a/libvirt/tests/src/guest_os_booting/boot_order/boot_from_usb_device.py
+++ b/libvirt/tests/src/guest_os_booting/boot_order/boot_from_usb_device.py
@@ -35,7 +35,7 @@ def run(test, params, env):
         test.log.info("The lsusb command result: {}".format(lsusb_list))
         found_device = False
         for line in lsusb_list:
-            if re.search('hub|Controller', line, re.IGNORECASE):
+            if re.search('hub|Controller|Keyboard|Mouse|Cdrom|Floppy', line, re.IGNORECASE):
                 continue
             if len(line.split()[5].split(':')) == 2:
                 vendor_id, product_id = line.split()[5].split(':')
@@ -59,7 +59,7 @@ def run(test, params, env):
             for _ in range(3):
                 vm.serial_console.sendcontrol('[')
         vm.serial_console.read_until_any_line_matches(
-             [check_prompt], timeout=30, internal_timeout=0.5)
+            [check_prompt], timeout=100, internal_timeout=5.0)
 
     vm_name = params.get("main_vm")
     disk_type = params.get("disk_type")


### PR DESCRIPTION
### The Issue
A test related to boot_from_usb_device.py would not pass:
guest_os_booting.boot_order.usb_device.hostdev_device

The test would fail with the following error message
```
LibvirtXMLError: Failed to define avocado-vt-vm1 for reason:error: Failed to define domain from /tmp/xml_utils_temp_l7acogze.xmlerror: unsupported configuration: BIOS serial console only supported on x86 architectures&#10;
```

This test would not pass for two reasons
1) the 'bios_useserial' flag is not compatible with aarch64/edk2
2) The UEFI prints a different string on aarch64 than it does on other platforms. The test looks at this output, so this is bad.

### The Fix
Redefine check_prompt and bootmenu_dict in the *.cfg file.

### Evidence
Console output from hostdev_device passing:
 ```
(.libvirt-ci-venv-ci-runtest-V9zHvu) [root@hpe-apollo-cn99xx-01 avocado-vt]# avocado run --vt-type libvirt --test-runner=runner guest_os_booting.boot_order.usb_device.hostdev_device
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : c6e208e9ce9dbdae2c02267c568f4df847000772
JOB LOG    : /var/log/avocado/job-results/job-2024-06-20T13.54-c6e208e/job.log
 (1/3) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.usb_device.hostdev_device: PASS (28.44 s)
 (2/3) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.usb_device.hostdev_device: PASS (33.55 s)
 (3/3) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.usb_device.hostdev_device: PASS (35.85 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2024-06-20T13.54-c6e208e/results.html
JOB TIME   : 98.87 s
```

Console output from block_device passing:
```
(.libvirt-ci-venv-ci-runtest-gSROHM) [root@hpe-apollo-cn99xx-16 tp-libvirt]# avocado run --vt-type libvirt --test-runner=runner guest_os_booting.boot_order.usb_device.block_device
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : 455aec60818e94c2c8edf15d4ac5d605b0c37b49
JOB LOG    : /var/log/avocado/job-results/job-2024-06-24T12.15-455aec6/job.log
 (1/3) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.usb_device.block_device: PASS (48.03 s)
 (2/3) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.usb_device.block_device: PASS (48.06 s)
 (3/3) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.usb_device.block_device: PASS (46.54 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2024-06-24T12.15-455aec6/results.html
JOB TIME   : 143.69 s
```