### PR TITLE
Add nvdimm pmem support check

### DIFF
--- a/libvirt/tests/cfg/memory/nvdimm.cfg
+++ b/libvirt/tests/cfg/memory/nvdimm.cfg
@@ -48,6 +48,7 @@
                             error_msg = 'discard is not supported for nvdimms'
                         - pmem_alignsize:
                             check = pmem_alignsize
+                            pmem_support_check_cmd = "yum deplist qemu-kvm-core | grep libpmem"
                             nvdimm_file_path = '/tmp/nvdimm'
                             alignsize = 2048
                             vm_attrs = {'max_mem_rt': 8192, 'max_mem_rt_slots': 8, 'max_mem_rt_unit': 'M', 'vcpu': 4, 'cpu': {'mode': '${cpuxml_mode}', 'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '2097152', 'unit': 'K'}, {'id': '1', 'cpus': '2-3', 'memory': '2097152', 'unit': 'K'}]}}

--- a/libvirt/tests/src/memory/nvdimm.py
+++ b/libvirt/tests/src/memory/nvdimm.py
@@ -133,6 +133,18 @@ def check_nvdimm_file(test_str, file_name, vm_session, test):
         test.fail('"%s" should be in output' % test_str)
 
 
+def is_pmem_supported(params):
+    """
+    check if pmem is supported by qemu-kvm
+
+    :param params: dict, test parameters
+    :return: whether pmem is supported
+    """
+    pmem_support_check_cmd = params.get('pmem_support_check_cmd')
+    cmd_result = process.run(pmem_support_check_cmd, ignore_status=True, shell=True)
+    return not cmd_result.exit_status
+
+
 def setup_test_pmem_alignsize(guest_xml, params):
     """
     Setup steps for pmem and alignsize test
@@ -143,6 +155,10 @@ def setup_test_pmem_alignsize(guest_xml, params):
     """
     vm_attrs = eval(params.get('vm_attrs', '{}'))
     mem_device_attrs = eval(params.get('mem_device_attrs', '{}'))
+    if not is_pmem_supported(params):
+        mem_device_attrs['source']['pmem'] = False
+        params.update({'qemu_checks': params.get('qemu_checks').replace('pmem', '')})
+
     if vm_attrs:
         guest_xml.setup_attrs(**vm_attrs)
     if mem_device_attrs:


### PR DESCRIPTION
pmem not support results:
(1/1) type_specific.io-github-autotest-libvirt.nvdimm.back_file.label.pmem_alignsize: PASS (47.91 s)
 pmem support results:
(1/1) type_specific.io-github-autotest-libvirt.nvdimm.back_file.label.pmem_alignsize: PASS (49.21 s)