### PR TITLE
Refactor vIOMMU test code

### DIFF
--- a/libvirt/tests/cfg/sriov/vIOMMU/iommu_alias.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/iommu_alias.cfg
@@ -1,5 +1,5 @@
-- sriov.vIOMMU.iommu.alias:
-    type = sriov_iommu_alias
+- vIOMMU.iommu.alias:
+    type = iommu_alias
     enable_guest_iommu = "yes"
     func_supported_since_libvirt_ver = (8, 7, 0)
     start_vm = "no"

--- a/libvirt/tests/cfg/sriov/vIOMMU/iommu_device_lifecycle.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/iommu_device_lifecycle.cfg
@@ -33,6 +33,7 @@
         - hostdev_iface:
             only virtio
             no save_restore
+            need_sriov = "yes"
             iface_dict = {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}}
     variants test_scenario:
         - save_restore:

--- a/libvirt/tests/cfg/sriov/vIOMMU/iommu_device_settings.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/iommu_device_settings.cfg
@@ -39,6 +39,7 @@
             iface_dict = {'type_name': 'network', 'model': 'virtio', 'driver': ${interface_driver}, 'source': {'network': 'default'}}
         - hostdev_iface:
             only virtio
+            need_sriov = yes
             ping_dest = ''
             test_devices = ["Eth"]
             iface_dict = {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}}
@@ -56,6 +57,7 @@
                     iface_dict = {'source': {'network': 'default'}, 'driver': {'driver_attr': {'iommu': 'on'}},'type_name': 'network', 'model': 'virtio-non-transitional'}
                 - hostdev_iface:
                     only virtio
+                    need_sriov = yes
                     ping_dest = ''
                     iface_dict = {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}}
         - pcie_root_port_from_expander_bus:

--- a/libvirt/tests/cfg/sriov/vIOMMU/virtio_iommu_with_addtional_attributes.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/virtio_iommu_with_addtional_attributes.cfg
@@ -1,5 +1,5 @@
-- sriov.vIOMMU.virtio_iommu.addtional_attributes:
-    type = sriov_virtio_iommu_with_addtional_attributes
+- vIOMMU.virtio_iommu.addtional_attributes:
+    type = virtio_iommu_with_addtional_attributes
     start_vm = "no"
     enable_guest_iommu = "yes"
     err_msg = "iommu model 'virtio' doesn't support additional attributes"

--- a/libvirt/tests/src/sriov/vIOMMU/intel_iommu_aw_bits.py
+++ b/libvirt/tests/src/sriov/vIOMMU/intel_iommu_aw_bits.py
@@ -3,7 +3,7 @@ from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 
-from provider.sriov import sriov_base
+from provider.viommu import viommu_base
 
 
 def run(test, params, env):
@@ -17,7 +17,7 @@ def run(test, params, env):
 
     vm_name = params.get("main_vm", "avocado-vt-vm1")
     vm = env.get_vm(vm_name)
-    test_obj = sriov_base.SRIOVTest(vm, test, params)
+    test_obj = viommu_base.VIOMMUTest(vm, test, params)
     try:
         test_obj.setup_iommu_test(iommu_dict=iommu_dict)
 

--- a/libvirt/tests/src/sriov/vIOMMU/iommu_alias.py
+++ b/libvirt/tests/src/sriov/vIOMMU/iommu_alias.py
@@ -1,4 +1,4 @@
-from provider.sriov import sriov_base
+from provider.viommu import viommu_base
 
 from virttest.libvirt_xml import vm_xml
 
@@ -41,11 +41,11 @@ def run(test, params, env):
 
     vm_name = params.get("main_vm", "avocado-vt-vm1")
     vm = env.get_vm(vm_name)
-    sriov_test_obj = sriov_base.SRIOVTest(vm, test, params)
+    test_obj = viommu_base.VIOMMUTest(vm, test, params)
 
     try:
-        sriov_test_obj.setup_iommu_test(iommu_dict=iommu_dict)
+        test_obj.setup_iommu_test(iommu_dict=iommu_dict)
         vm.start()
         check_xml(vm, exp_alias, iommu_has_addr)
     finally:
-        sriov_test_obj.teardown_default()
+        test_obj.teardown_iommu_test()

--- a/libvirt/tests/src/sriov/vIOMMU/iommu_device_lifecycle.py
+++ b/libvirt/tests/src/sriov/vIOMMU/iommu_device_lifecycle.py
@@ -1,7 +1,7 @@
 import os
 
-from virttest import libvirt_version
 from virttest import utils_misc
+from virttest import utils_net
 from virttest import virsh
 
 from virttest.libvirt_xml import vm_xml
@@ -9,7 +9,8 @@ from virttest.utils_libvirt import libvirt_vmxml
 
 from provider.save import save_base
 from provider.sriov import sriov_base
-from provider.sriov import check_points
+from provider.viommu import viommu_base
+from provider.sriov import check_points as sriov_check_points
 
 VIRSH_ARGS = {'debug': True, 'ignore_status': False}
 
@@ -18,18 +19,20 @@ def run(test, params, env):
     """
     Test lifecycle for vm with vIOMMU enabled with different devices.
     """
-    libvirt_version.is_libvirt_feature_supported(params)
     cleanup_ifaces = "yes" == params.get("cleanup_ifaces", "yes")
     ping_dest = params.get('ping_dest', "127.0.0.1")
     iommu_dict = eval(params.get('iommu_dict', '{}'))
     test_scenario = params.get("test_scenario")
+    need_sriov = "yes" == params.get("need_sriov", "no")
 
     vm_name = params.get("main_vm", "avocado-vt-vm1")
     vm = env.get_vm(vm_name)
 
     rand_id = utils_misc.generate_random_string(3)
     save_path = f'/var/tmp/{vm_name}_{rand_id}.save'
-    test_obj = sriov_base.SRIOVTest(vm, test, params)
+    test_obj = viommu_base.VIOMMUTest(vm, test, params)
+    if need_sriov:
+        sroiv_test_obj = sriov_base.SRIOVTest(vm, test, params)
     try:
         test.log.info("TEST_SETUP: Update VM XML.")
         test_obj.setup_iommu_test(iommu_dict=iommu_dict,
@@ -41,6 +44,10 @@ def run(test, params, env):
                 dev_dict = test_obj.update_disk_addr(dev_dict)
             libvirt_vmxml.modify_vm_device(
                 vm_xml.VMXML.new_from_dumpxml(vm.name), dev, dev_dict)
+        if need_sriov:
+            iface_dicts = sroiv_test_obj.parse_iface_dict()
+            test.log.debug(iface_dicts)
+            test_obj.params["iface_dict"] = str(sroiv_test_obj.parse_iface_dict())
         iface_dict = test_obj.parse_iface_dict()
         if cleanup_ifaces:
             libvirt_vmxml.modify_vm_device(
@@ -64,7 +71,13 @@ def run(test, params, env):
 
             session = vm.wait_for_serial_login(
                 timeout=int(params.get('login_timeout')))
-            check_points.check_vm_network_accessed(session, ping_dest=ping_dest)
+
+            if need_sriov:
+                sriov_check_points.check_vm_network_accessed(session, ping_dest=ping_dest)
+            else:
+                s, o = utils_net.ping(ping_dest, count=5, timeout=10, session=session)
+                if s:
+                    test.fail("Failed to ping %s! status: %s, output: %s." % (ping_dest, s, o))
         else:
             pid_ping, upsince = save_base.pre_save_setup(vm, serial=True)
             if test_scenario == "save_restore":

--- a/libvirt/tests/src/sriov/vIOMMU/iommu_device_settings.py
+++ b/libvirt/tests/src/sriov/vIOMMU/iommu_device_settings.py
@@ -1,11 +1,13 @@
-from virttest import libvirt_version
 from virttest import utils_disk
+from virttest import utils_net
 
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_libvirt import libvirt_vmxml
 
 from provider.sriov import sriov_base
-from provider.sriov import check_points
+from provider.viommu import viommu_base
+
+from provider.sriov import check_points as sriov_check_points
 
 
 def run(test, params, env):
@@ -13,25 +15,37 @@ def run(test, params, env):
     Start vm with iommu device and kinds of virtio devices with iommu=on, and
     check network and disk function.
     """
-    libvirt_version.is_libvirt_feature_supported(params)
     cleanup_ifaces = "yes" == params.get("cleanup_ifaces", "yes")
     ping_dest = params.get('ping_dest')
     iommu_dict = eval(params.get('iommu_dict', '{}'))
     test_devices = eval(params.get("test_devices", "[]"))
+    need_sriov = "yes" == params.get("need_sriov", "no")
 
     vm_name = params.get("main_vm", "avocado-vt-vm1")
     vm = env.get_vm(vm_name)
-    test_obj = sriov_base.SRIOVTest(vm, test, params)
+    sroiv_test_obj = None
+
+    test_obj = viommu_base.VIOMMUTest(vm, test, params)
+    if need_sriov:
+        sroiv_test_obj = sriov_base.SRIOVTest(vm, test, params)
+
     try:
         test_obj.setup_iommu_test(iommu_dict=iommu_dict, cleanup_ifaces=cleanup_ifaces)
         test_obj.prepare_controller()
+
         for dev in ["disk", "video"]:
             dev_dict = eval(params.get('%s_dict' % dev, '{}'))
             if dev == "disk":
                 dev_dict = test_obj.update_disk_addr(dev_dict)
+
             libvirt_vmxml.modify_vm_device(
                 vm_xml.VMXML.new_from_dumpxml(vm.name), dev, dev_dict)
+        if need_sriov:
+            iface_dicts = sroiv_test_obj.parse_iface_dict()
+            test.log.debug(iface_dicts)
+            test_obj.params["iface_dict"] = str(sroiv_test_obj.parse_iface_dict())
         iface_dict = test_obj.parse_iface_dict()
+
         if cleanup_ifaces:
             libvirt_vmxml.modify_vm_device(
                     vm_xml.VMXML.new_from_dumpxml(vm.name),
@@ -47,10 +61,15 @@ def run(test, params, env):
 
         test.log.info("TEST_STEP: Check dmesg message about iommu inside the vm.")
         vm_session.cmd("dmesg | grep -i 'Adding to iommu group'")
-        check_points.check_vm_iommu_group(vm_session, test_devices)
+        viommu_base.check_vm_iommu_group(vm_session, test_devices)
 
         test.log.info("TEST_STEP: Check if the VM disk and network are woring well.")
         utils_disk.dd_data_to_vm_disk(vm_session, "/mnt/test")
-        check_points.check_vm_network_accessed(vm_session, ping_dest=ping_dest)
+        if need_sriov:
+            sriov_check_points.check_vm_network_accessed(vm_session, ping_dest=ping_dest)
+        else:
+            s, o = utils_net.ping(ping_dest, count=5, timeout=10, session=vm_session)
+            if s:
+                test.fail("Failed to ping %s! status: %s, output: %s." % (ping_dest, s, o))
     finally:
         test_obj.teardown_iommu_test()

--- a/libvirt/tests/src/sriov/vIOMMU/virtio_iommu_with_addtional_attributes.py
+++ b/libvirt/tests/src/sriov/vIOMMU/virtio_iommu_with_addtional_attributes.py
@@ -1,4 +1,4 @@
-from provider.sriov import sriov_base
+from provider.viommu import viommu_base
 
 from virttest.libvirt_xml import xcepts
 from virttest.utils_libvirt import libvirt_virtio
@@ -13,7 +13,7 @@ def run(test, params, env):
 
     vm_name = params.get("main_vm", "avocado-vt-vm1")
     vm = env.get_vm(vm_name)
-    sriov_test_obj = sriov_base.SRIOVTest(vm, test, params)
+    test_obj = viommu_base.VIOMMUTest(vm, test, params)
 
     try:
         libvirt_virtio.add_iommu_dev(vm, iommu_dict)
@@ -26,4 +26,4 @@ def run(test, params, env):
     else:
         test.fail("Defining the VM should fail, but run successfully!")
     finally:
-        sriov_test_obj.teardown_default()
+        test_obj.teardown_iommu_test()

--- a/provider/viommu/viommu_base.py
+++ b/provider/viommu/viommu_base.py
@@ -1,0 +1,152 @@
+from avocado.core import exceptions
+
+from virttest import libvirt_version
+from virttest import utils_net
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_libvirt import libvirt_virtio
+from virttest.utils_libvirt import libvirt_pcicontr
+
+
+def check_vm_iommu_group(vm_session, test_devices):
+    """
+    Check the devices with iommu enabled are located in a separate iommu group
+
+    :param vm_session: VM session
+    :param test_devices: test devices to check
+    """
+    for dev in test_devices:
+        s, o = vm_session.cmd_status_output(
+            "lspci | awk 'BEGIN{IGNORECASE=1} /%s/ {print $1}'" % dev)
+        if s:
+            exceptions.TestFail("Failed to get pci address!")
+
+        cmd = ("find /sys/kernel/iommu_groups/ -type l | xargs ls -l | awk -F "
+               "'/' '/%s / {print(\"\",$2,$3,$4,$5,$6)}' OFS='/' " % o.strip())
+        s, o = vm_session.cmd_status_output(cmd)
+        if s:
+            exceptions.TestFail("Failed to find iommu group!")
+        s, o = vm_session.cmd_status_output("ls %s" % o)
+        if s:
+            exceptions.TestFail("Failed to get the device in the iommu group!")
+
+
+class VIOMMUTest(object):
+    def __init__(self, vm, test, params, session=None):
+        self.vm = vm
+        self.test = test
+        self.params = params
+        self.session = session
+        self.remote_virsh_dargs = None
+        self.controller_dicts = eval(self.params.get("controller_dicts", "[]"))
+
+        libvirt_version.is_libvirt_feature_supported(self.params)
+        new_xml = vm_xml.VMXML.new_from_inactive_dumpxml(self.vm.name)
+        self.orig_config_xml = new_xml.copy()
+
+    def parse_iface_dict(self):
+        """
+        Parse iface_dict from params
+
+        :return: The updated iface_dict
+        """
+        mac_addr = utils_net.generate_mac_address_simple()
+        iface_dict = eval(self.params.get('iface_dict', '{}'))
+        self.test.log.debug("iface_dict2: %s.", iface_dict)
+
+        if self.controller_dicts and iface_dict:
+            iface_bus = "%0#4x" % int(self.controller_dicts[-1].get('index'))
+            iface_attrs = {'bus': iface_bus}
+            if isinstance(self.dev_slot, int):
+                self.dev_slot += 1
+                iface_attrs.update({'slot': self.dev_slot})
+            iface_dict.update({"address": {'attrs': iface_attrs}})
+        self.test.log.debug("iface_dict: %s.", iface_dict)
+        return iface_dict
+
+    def prepare_controller(self):
+        """
+        Prepare controller(s)
+
+        :return: Updated controller attrs
+        """
+        if not self.controller_dicts:
+            return
+
+        for contr_dict in self.controller_dicts:
+            pre_controller = contr_dict.get("pre_controller")
+            if pre_controller:
+                pre_contrs = list(
+                    filter(None, [c.get('index') for c in self.controller_dicts
+                                  if c['type'] == contr_dict['type'] and
+                                  c['model'] == pre_controller]))
+                if pre_contrs:
+                    pre_idx = pre_contrs[0]
+                else:
+                    pre_idx = libvirt_pcicontr.get_max_contr_indexes(
+                        vm_xml.VMXML.new_from_dumpxml(self.vm.name),
+                        contr_dict['type'], pre_controller)
+                if not pre_idx:
+                    self.test.error(
+                        f"Unable to get index of {pre_controller} controller!")
+                contr_dict.pop("pre_controller")
+            libvirt_vmxml.modify_vm_device(
+                vm_xml.VMXML.new_from_dumpxml(self.vm.name), 'controller',
+                contr_dict, 100)
+            contr_dict['index'] = libvirt_pcicontr.get_max_contr_indexes(
+                vm_xml.VMXML.new_from_dumpxml(self.vm.name),
+                contr_dict['type'], contr_dict['model'])[-1]
+        return self.controller_dicts
+
+    def update_disk_addr(self, disk_dict):
+        """
+        Update disk address
+
+        :param disk_dict: The original disk attrs
+        :return: The updated disk attrs
+        """
+        if self.controller_dicts:
+            dev_bus = self.controller_dicts[-1].get('index')
+            dev_attrs = {'bus': dev_bus}
+            if disk_dict['target']['bus'] != "scsi":
+                dev_attrs.update({'type': self.controller_dicts[-1].get('type')})
+                if self.controller_dicts[-1].get('model') == 'pcie-to-pci-bridge':
+                    self.dev_slot = 1
+                    dev_attrs.update({'slot': self.dev_slot})
+
+            disk_dict.update({"address": {'attrs': dev_attrs}})
+            if disk_dict['target']['bus'] == "scsi":
+                disk_dict['address']['attrs'].update({'type': 'drive'})
+
+            if self.controller_dicts[-1]['model'] == 'pcie-root-port':
+                self.controller_dicts.pop()
+        return disk_dict
+
+    def setup_iommu_test(self, **dargs):
+        """
+        iommu test environment setup
+
+        :param dargs: Other test keywords
+        """
+        iommu_dict = dargs.get('iommu_dict', {})
+        dev_type = dargs.get("dev_type", "interface")
+        cleanup_ifaces = "yes" == dargs.get("cleanup_ifaces", "yes")
+
+        if cleanup_ifaces:
+            libvirt_vmxml.remove_vm_devices_by_type(self.vm, 'interface')
+            libvirt_vmxml.remove_vm_devices_by_type(self.vm, 'hostdev')
+        if iommu_dict:
+            self.test.log.info("TEST_SETUP: Add iommu device.")
+            libvirt_virtio.add_iommu_dev(self.vm, iommu_dict)
+
+    def teardown_iommu_test(self, **dargs):
+        """
+        Cleanup iommu test environment
+
+        :param dargs: Other test keywords
+        """
+        self.test.log.info("TEST_TEARDOWN: Recover test environment.")
+        if self.vm.is_alive():
+            self.vm.destroy(gracefully=False)
+        self.orig_config_xml.sync()


### PR DESCRIPTION
Test results - aarch64- build 20: all passed in jenkins or on local machine
![image](https://github.com/autotest/tp-libvirt/assets/49855663/6935c054-ce72-4def-975a-032534a57058)
 (1/1) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.virtio_muti_devices.vhost_on.smmuv3: PASS (84.02 s)
 (1/1) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.reboot_many_times.hostdev_iface.virtio: PASS (340.88 s)

Test results - x86_64- build 17: all passed in jenkins or on local machine except the last one(ip cmd timeout in guest, it's not related to this pr)
![image](https://github.com/autotest/tp-libvirt/assets/49855663/748b8fd0-41dd-4c3c-9553-6cd984b628ad)
 (1/1) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_interface_special_situations.with_model: PASS (73.83 s)
 (1/1) type_specific.io-github-autotest-libvirt.sriov.vm_lifecycle.reboot.hostdev_interface.vf_address.failover.with_iommu: PASS (288.50 s)
 (1/2) type_specific.io-github-autotest-libvirt.sriov.failover.at_dt_hostdev.hostdev_interface: PASS (139.77 s)

