### PR TITLE
graphical_framebuffers: fix virtqemud service failed issue with vnc_tls_x509_verify

### DIFF
--- a/libvirt/tests/src/graphics/graphics_functional.py
+++ b/libvirt/tests/src/graphics/graphics_functional.py
@@ -209,7 +209,7 @@ class EnvState(object):
             self.qemu_config.vnc_tls_x509_verify = tls_x509_verify
 
         if vnc_tls_x509_secret_uuid == "not_set":
-            del self.qemu_config.vnc_tls_x509_verify
+            del self.qemu_config.vnc_tls_x509_secret_uuid
         else:
             self.qemu_config.vnc_tls = "1"
             if vnc_secret_uuid == "invalid":


### PR DESCRIPTION
The virtqemud service restarts failed when testing vnc_only.vnc_tls_x509_verify related issues. That's because the vnc_tls_x509_verify in qemu_config will be deleted in the next "if vnc_tls_x509_secret_uuid == "not_set" statement. Here update it to the correct one vnc_tls_x509_secret_uuid.