### PR TITLE
vm_start_destroy_repeatedly: VM Reliability Test

### DIFF
--- a/libvirt/tests/cfg/vm_start_destroy_repeatedly.cfg
+++ b/libvirt/tests/cfg/vm_start_destroy_repeatedly.cfg
@@ -1,0 +1,4 @@
+- vm_start_destroy_repeatedly:
+    type = vm_start_destroy_repeatedly
+    num_cycles = 2000
+    start_vm = no

--- a/libvirt/tests/src/vm_start_destroy_repeatedly.py
+++ b/libvirt/tests/src/vm_start_destroy_repeatedly.py
@@ -1,0 +1,60 @@
+import logging
+import time
+from virttest import virsh
+from virttest import utils_misc
+
+
+def power_cycle_vm(test, vm, vm_name, login_timeout, startup_wait, resume_wait):
+    """
+    Cycle vm through start-login-shutdown loop
+
+    :param vm: vm object
+    :param vm_name: vm name
+    :param login_timeout: timeout given to vm.wait_for_login
+    :param startup_wait: how long to wait after the vm has been started
+    :param resume_wait: how long to wait after the paused vm is resumed
+
+    This tests the vm startup and destroy sequences by:
+        1) Starting the vm
+        2) Verifying the vm is alive
+        3) Logging into vm
+        4) Logging out of the vm
+        5) Destroying the vm
+    """
+
+    virsh.start(vm_name, options="--paused", ignore_status=False)
+    time.sleep(startup_wait)
+
+    virsh.resume(vm_name, ignore_status=False)
+    time.sleep(resume_wait)
+
+    session = vm.wait_for_login(timeout=login_timeout)
+    session.close()
+
+    virsh.shutdown(vm_name, ignore_status=False)
+
+    utils_misc.wait_for(lambda: vm.state() == "shut off", 360)
+    if vm.state() != "shut off":
+        test.fail("Failed to shutdown VM")
+
+
+def run(test, params, env):
+    """
+    Test qemu-kvm startup reliability
+
+    :param test: test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    num_cycles = int(params.get("num_cycles"))                  # Parameter to control the number of times to start/restart the vm
+    login_timeout = float(params.get("login_timeout", 240))     # Controls vm.wait_for_login() timeout
+    startup_wait = float(params.get("startup_wait", 2))         # Controls wait time for virsh.start()
+    resume_wait = float(params.get("resume_wait", 40))          # Controls wait for virsh.resume()
+
+    for i in range(num_cycles):
+        logging.info("Starting vm '%s' -- attempt #%d", vm_name, i+1)
+        power_cycle_vm(test, vm, vm_name, login_timeout, startup_wait, resume_wait)
+        logging.info("\t-> Completed vm '%s' power cycle #%d", vm_name, i+1)


### PR DESCRIPTION
## Overview
Add test for vm start and destroy reliability

## Details
Add test vm_startup_reliability. The test follows this procedure

1. Start the vm
2. Verify the vm is alive
3. Log into the vm
4. Log out of the vm
5. Destroy the vm
6. Repeat steps 1-5 128 times

## Evidence that it works
```
avocado run --vt-type libvirt --test-runner=runner vm_startup_reliability
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : bdc8c6351bfc354a25af338c85c0cf603ec9645d
JOB LOG    : /var/log/avocado/job-results/job-2024-06-21T13.56-bdc8c63/job.log
 (1/7) type_specific.io-github-autotest-libvirt.vm_startup_reliability: PASS (95.33 s)
 (2/7) type_specific.io-github-autotest-libvirt.vm_startup_reliability: PASS (92.28 s)
 (3/7) type_specific.io-github-autotest-libvirt.vm_startup_reliability: PASS (89.01 s)
 (4/7) type_specific.io-github-autotest-libvirt.vm_startup_reliability: PASS (92.62 s)
 (5/7) type_specific.io-github-autotest-libvirt.vm_startup_reliability: PASS (92.80 s)
 (6/7) type_specific.io-github-autotest-libvirt.vm_startup_reliability: PASS (91.33 s)
 (7/7) type_specific.io-github-autotest-libvirt.vm_startup_reliability: PASS (91.24 s)
RESULTS    : PASS 7 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2024-06-21T13.56-bdc8c63/results.html
JOB TIME   : 645.26 s
```
