### PR TITLE
Refactor iommu migration case

### DIFF
--- a/libvirt/tests/src/sriov/vIOMMU/migration_iommu_device.py
+++ b/libvirt/tests/src/sriov/vIOMMU/migration_iommu_device.py
@@ -1,11 +1,10 @@
-from virttest import libvirt_version
 from virttest import virsh
 
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_libvirt import libvirt_vmxml
 
-from provider.sriov import sriov_base
 from provider.migration import base_steps
+from provider.viommu import viommu_base
 
 
 def run(test, params, env):
@@ -65,14 +64,13 @@ def run(test, params, env):
                     "interface", iface_dict)
         migration_obj.setup_default()
 
-    libvirt_version.is_libvirt_feature_supported(params)
     cleanup_ifaces = "yes" == params.get("cleanup_ifaces", "yes")
     iommu_dict = eval(params.get('iommu_dict', '{}'))
     iface_dict = eval(params.get('iface_dict', '{}'))
 
     vm_name = params.get("main_vm", "avocado-vt-vm1")
     vm = env.get_vm(vm_name)
-    test_obj = sriov_base.SRIOVTest(vm, test, params)
+    test_obj = viommu_base.VIOMMUTest(vm, test, params)
     migration_obj = base_steps.MigrationBase(test, vm, params)
 
     try:


### PR DESCRIPTION
**depends on:**
- https://github.com/autotest/tp-libvirt/pull/5711

**Test results:**
```
 (1/6) type_specific.io-github-autotest-libvirt.vIOMMU.migration.iommu_device.virtio_muti_devices.vhost_on.virtio: PASS (215.73 s)
 (2/6) type_specific.io-github-autotest-libvirt.vIOMMU.migration.iommu_device.virtio_muti_devices.vhost_on.intel: PASS (366.61 s)
 (3/6) type_specific.io-github-autotest-libvirt.vIOMMU.migration.iommu_device.virtio_muti_devices.vhost_off.virtio: PASS (212.62 s)
 (4/6) type_specific.io-github-autotest-libvirt.vIOMMU.migration.iommu_device.virtio_muti_devices.vhost_off.intel: PASS (365.11 s)
 (5/6) type_specific.io-github-autotest-libvirt.vIOMMU.migration.iommu_device.scsi_controller.virtio: PASS (213.75 s)
 (6/6) type_specific.io-github-autotest-libvirt.vIOMMU.migration.iommu_device.scsi_controller.intel: PASS (387.80 s)

```