### PR TITLE
Virstual_disk: fix shutdown event of vhostvdpa disk

### DIFF
--- a/libvirt/tests/src/virtual_disks/vhostvdpa_block_backend_type/vm_lifecycle_vhostvdpa_backend_disk.py
+++ b/libvirt/tests/src/virtual_disks/vhostvdpa_block_backend_type/vm_lifecycle_vhostvdpa_backend_disk.py
@@ -34,7 +34,7 @@ def run(test, params, env):
 
     libvirt_version.is_libvirt_feature_supported(params)
     disk_attrs = eval(params.get("disk_attrs", "{}"))
-    cmd_in_vm = "d=`date +%s`; echo $d >> /mnt/test ;sync; grep $d /mnt/test"
+    cmd_in_vm = "d=`date +%s`; echo $d >> /mnt/test; sync; grep $d /mnt/test"
     vm_name = params.get("main_vm")
     vm = env.get_vm(vm_name)
 
@@ -74,7 +74,7 @@ def run(test, params, env):
 
         test.log.info("TEST_STEP: Shutdown and start VM, check vhostvdpa disk r/w.")
         virsh.shutdown(vm.name, wait_for_event=True,
-                       event_type="disconnected.*(\n.*)*Shutdown Finished.*(\n.*)*Stopped",
+                       event_type=".*Shutdown Finished.*(\n.*)*Stopped",
                        **VIRSH_ARGS)
         virsh.start(vm.name, **VIRSH_ARGS)
         vm_session = vm.wait_for_login()


### PR DESCRIPTION
Fix the error of "EventNotFoundError: Not found event disconnected.*(.*)*Shutdown Finished.*(.*)*Stopped after 10 seconds". We can only check the last two events because maybe the disconnected event is not in output.