### PR TITLE
Decrease memory balloon period to make memory info collection more frequent

### DIFF
--- a/libvirt/tests/cfg/memory/memory_misc.cfg
+++ b/libvirt/tests/cfg/memory/memory_misc.cfg
@@ -109,7 +109,7 @@
             variants case:
                 - disk_caches:
                     membal_model = 'virtio'
-                    membal_stats_period = 2
+                    membal_stats_period = 1
                     membal_alias_name = 'balloon0'
                     allow_error = 15
         - xml_check:


### PR DESCRIPTION
The disk cache result would be more close to the result from real-time counting value.
result:
(1/1) type_specific.io-github-autotest-libvirt.memory_misc.dommemstat.disk_caches: PASS (31.32 s)