### PR TITLE
vdpa: Fix an issue due to cmd output change

### DIFF
--- a/provider/interface/vdpa_base.py
+++ b/provider/interface/vdpa_base.py
@@ -143,7 +143,7 @@ def get_multiplier(vm_session, pci_id):
     :return: The multiplier of VM's interface
     """
     cmd = "lspci -vvv -s %s | awk -F '=' '/multiplier=/ {print $NF}'" % pci_id
-    act_mul = vm_session.cmd_output(cmd).strip()
+    act_mul = vm_session.cmd_output(cmd).splitlines()[-1]
     LOG.debug("Actual multiplier: %s", act_mul)
     return act_mul
 


### PR DESCRIPTION
**Before the fix:**
` (1/1) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.vdpa_interface.driver_queues.page_per_vq.mellanox:FAIL: The multiplier should be 00001000, but got <-s 01:00.0 | awk -F '=' '/multiplier=/ {print $NF}'\n00001000. (69.87 s)`


**After the fix:**
` (1/1) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.vdpa_interface.driver_queues.page_per_vq.mellanox: PASS (91.64 s)
`