### PR TITLE
Virtual_disk: fix no scsi_generic file issue

### DIFF
--- a/libvirt/tests/src/scsi/scsi_device.py
+++ b/libvirt/tests/src/scsi/scsi_device.py
@@ -612,6 +612,8 @@ def run(test, params, env):
     params.pop('boot_order')
 
     try:
+        # Load sg module
+        process.run("modprobe sg", shell=True, ignore_status=True, verbose=True)
         run_test_case(test, params, env)
         if coldplug:
             vm.start()


### PR DESCRIPTION
The error of "error: cannot open directory '/sys/bus/scsi/devices/11:0:0:0/scsi_generic': No such file or directory" is caused by the missing sg module. So add it in script.