### PR TITLE
guest_os_booting: Fix up issues of entering uefi shell

### DIFF
--- a/libvirt/tests/cfg/guest_os_booting/boot_order/boot_from_cdrom_device.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/boot_order/boot_from_cdrom_device.cfg
@@ -3,7 +3,6 @@
     start_vm = no
     disk1_attrs_target = {'dev': 'vda', 'bus': 'virtio'}
     cdrom_attrs = "{'type_name': 'file', 'device': 'cdrom', 'driver': {'name': 'qemu', 'type': 'raw', 'cache': 'none'}, 'readonly': True}"
-    bootable_patterns = ["begin the installation process|Install Red Hat Enterprise"]
     variants:
         - without_cdrom:
             only os_dev
@@ -11,9 +10,11 @@
             cdrom1_attrs = {'target': {'dev': 'sda', 'bus': 'sata'}, **${cdrom_attrs}}
             aarch64:
                 cdrom1_attrs = {'target': {'dev': 'sda', 'bus': 'scsi'}, **${cdrom_attrs}}
+                bootable_patterns = ["Shell>"] 
         - with_cdrom:
             check_bootable_iso = "yes"
             cdrom1_attrs = {'source': {'attrs': {'file': boot_img_path}}, 'target': {'dev': 'sda', 'bus': 'scsi'}, **${cdrom_attrs}}
+            bootable_patterns = ["begin the installation process|Install Red Hat Enterprise"]
         - multi_cdroms:
             cdrom1_attrs = {'target': {'dev': 'sda', 'bus': 'scsi'}, **${cdrom_attrs}}
             cdrom2_attrs = {'source': {'attrs': {'file': boot_img_path}}, 'target': {'dev': 'sdb', 'bus': 'sata'}, **${cdrom_attrs}}
@@ -21,6 +22,7 @@
                 cdrom2_attrs = {'source': {'attrs': {'file': boot_img_path}}, 'target': {'dev': 'sdb', 'bus': 'scsi'}, **${cdrom_attrs}}
             cdrom_boot_order:
                 check_bootable_iso = "yes"
+                bootable_patterns = ["begin the installation process|Install Red Hat Enterprise"]
             os_dev:
                status_error = "yes"  
     variants:

--- a/libvirt/tests/src/guest_os_booting/boot_order/boot_from_cdrom_device.py
+++ b/libvirt/tests/src/guest_os_booting/boot_order/boot_from_cdrom_device.py
@@ -98,7 +98,7 @@ def run(test, params, env):
         test.log.debug(vm_xml.VMXML.new_from_dumpxml(vm.name))
 
         vm.start()
-        if check_bootable_iso:
+        if bootable_patterns:
             vm.serial_console.read_until_output_matches(
                 bootable_patterns, timeout=60, internal_timeout=0.5)
         else:


### PR DESCRIPTION
Update to check ouput during os startup, because some cases will enter to uefi shell instead of os system in aarch64.

**Test results:**
```
 (1/7) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.ovmf.os_dev.without_cdrom: PASS (41.01 s)
 (2/7) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.ovmf.os_dev.with_cdrom_with_no_src: PASS (19.52 s)
 (3/7) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.ovmf.os_dev.with_cdrom: PASS (23.18 s)
 (4/7) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.ovmf.os_dev.multi_cdroms: PASS (268.16 s)
 (5/7) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.ovmf.cdrom_boot_order.with_cdrom_with_no_src: PASS (19.24 s)
 (6/7) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.ovmf.cdrom_boot_order.with_cdrom: PASS (23.80 s)
 (7/7) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.ovmf.cdrom_boot_order.multi_cdroms: PASS (24.05 s)

```