### PR TITLE
fix controller case use elem.address while no  addr ele

### DIFF
--- a/libvirt/tests/src/controller/controller_functional.py
+++ b/libvirt/tests/src/controller/controller_functional.py
@@ -281,23 +281,24 @@ def run(test, params, env):
                     (cntlr_type is None or elem.type == cntlr_type) and
                     (model is None or elem.model == model) and
                     (index is None or elem.index == index)):
-                addr_elem = elem.address
-                if addr_elem is None:
-                    test.error("Can not find 'Address' "
-                               "element for the controller")
-                p4 = None
-                if 'ccw' == cntlr_bus:
-                    p1 = int(addr_elem.attrs.get('cssid'), 0)
-                    p2 = int(addr_elem.attrs.get('ssid'), 0)
-                    p3 = int(addr_elem.attrs.get('devno'), 0)
-                else:
-                    p1 = int(addr_elem.attrs.get('bus'), 0)
-                    p2 = int(addr_elem.attrs.get('slot'), 0)
-                    p3 = int(addr_elem.attrs.get('function'), 0)
-                    p4 = addr_elem.attrs.get('multifunction')
-                addr_str = '%02d:%02x.%1d' % (p1, p2, p3)
-                logging.debug("Controller address is %s", addr_str)
-                return (addr_str, p1, p2, p3, p4)
+                if elem._get_list("address"):
+                    addr_elem = elem.address
+                    if addr_elem is None:
+                        test.error("Can not find 'Address' "
+                                   "element for the controller")
+                    p4 = None
+                    if 'ccw' == cntlr_bus:
+                        p1 = int(addr_elem.attrs.get('cssid'), 0)
+                        p2 = int(addr_elem.attrs.get('ssid'), 0)
+                        p3 = int(addr_elem.attrs.get('devno'), 0)
+                    else:
+                        p1 = int(addr_elem.attrs.get('bus'), 0)
+                        p2 = int(addr_elem.attrs.get('slot'), 0)
+                        p3 = int(addr_elem.attrs.get('function'), 0)
+                        p4 = addr_elem.attrs.get('multifunction')
+                    addr_str = '%02d:%02x.%1d' % (p1, p2, p3)
+                    logging.debug("Controller address is %s", addr_str)
+                    return (addr_str, p1, p2, p3, p4)
 
         return (None, None, None, None, None)
 


### PR DESCRIPTION
before fixing
```
LibvirtXMLNotFoundError: Error in Getter for property &quot;address&quot;, element tag &quot;address&quot; not found on parent at xpath &quot;/&quot; in XML&lt;controller type=&quot;pci&quot; index=&quot;0&quot; model=&quot;pcie-root&quot; /&gt;&#10;

```

after fixing
```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 controller.functional.positive_tests.pcie_root_children --vt-connect-uri qemu:///system

 (1/1) type_specific.io-github-autotest-libvirt.controller.functional.positive_tests.pcie_root_children: PASS (27.67 s)

```

All Other influenced case
```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 controller.functional
(01/31) type_specific.io-github-autotest-libvirt.controller.functional.positive_tests.pcie_root: PASS (27.45 s)
 (02/31) type_specific.io-github-autotest-libvirt.controller.functional.positive_tests.controller_alias: PASS (28.04 s)
 (03/31) type_specific.io-github-autotest-libvirt.controller.functional.positive_tests.pcie_root_port_model: PASS (29.47 s)
 (04/31) type_specific.io-github-autotest-libvirt.controller.functional.positive_tests.pcie_pci_bridge_autoadd: PASS (5.96 s)
 (05/31) type_specific.io-github-autotest-libvirt.controller.functional.positive_tests.pcie_root_children: PASS (27.72 s)
 (06/31) type_specific.io-github-autotest-libvirt.controller.functional.positive_tests.pcie_expander_bus_child: PASS (29.17 s)
 (07/31) type_specific.io-github-autotest-libvirt.controller.functional.positive_tests.pcie_expander_bus_busNr.default_busNr: PASS (5.01 s)
 (08/31) type_specific.io-github-autotest-libvirt.controller.functional.positive_tests.pcie_expander_bus_busNr.special_busNr: PASS (5.15 s)
 (09/31) type_specific.io-github-autotest-libvirt.controller.functional.positive_tests.e1000e_default_assign: PASS (5.08 s)
 (10/31) type_specific.io-github-autotest-libvirt.controller.functional.positive_tests.pcie_expander_bus_numa: PASS (28.21 s)
 (11/31) type_specific.io-github-autotest-libvirt.controller.functional.positive_tests.scsi_multifunc: PASS (27.80 s)
 (12/31) type_specific.io-github-autotest-libvirt.controller.functional.positive_tests.usb_controller.auto_addr.ehci_model: PASS (29.41 s)
 (13/31) type_specific.io-github-autotest-libvirt.controller.functional.positive_tests.usb_controller.auto_addr.ich9_ehci1_model: PASS (27.92 s)
 (14/31) type_specific.io-github-autotest-libvirt.controller.functional.positive_tests.usb_controller.auto_addr.nec_xhci_model: PASS (29.30 s)
 (15/31) type_specific.io-github-autotest-libvirt.controller.functional.positive_tests.usb_controller.auto_addr.qemu_xhci_model.non_pseries_machine: PASS (29.28 s)
 (16/31) type_specific.io-github-autotest-libvirt.controller.functional.positive_tests.usb_controller.manual_addr.ehci_model: PASS (29.24 s)
 (17/31) type_specific.io-github-autotest-libvirt.controller.functional.positive_tests.usb_controller.manual_addr.nec_xhci_model: PASS (29.34 s)
 (18/31) type_specific.io-github-autotest-libvirt.controller.functional.positive_tests.usb_controller.manual_addr.qemu_xhci_model.non_pseries_machine: PASS (29.30 s)
 (19/31) type_specific.io-github-autotest-libvirt.controller.functional.negative_tests.invalid_index.invalid_root_index.pcie_root: PASS (4.86 s)
 (20/31) type_specific.io-github-autotest-libvirt.controller.functional.negative_tests.invalid_index.negative.pci_bridge: PASS (4.81 s)
 (21/31) type_specific.io-github-autotest-libvirt.controller.functional.negative_tests.invalid_index.negative.pcie_root: PASS (4.82 s)
 (22/31) type_specific.io-github-autotest-libvirt.controller.functional.negative_tests.invalid_index.zero.q35_machine.pci_bridge: PASS (4.84 s)
 (23/31) type_specific.io-github-autotest-libvirt.controller.functional.negative_tests.invalid_index.exceed_max.q35_machine.pci_bridge: PASS (4.79 s)
 (24/31) type_specific.io-github-autotest-libvirt.controller.functional.negative_tests.invalid_index.string_inx.pci_bridge: PASS (4.79 s)
 (25/31) type_specific.io-github-autotest-libvirt.controller.functional.negative_tests.invalid_index.index_equal_bus.pci_bridge: PASS (4.76 s)
 (26/31) type_specific.io-github-autotest-libvirt.controller.functional.negative_tests.invalid_model.other_model: PASS (4.82 s)
 (27/31) type_specific.io-github-autotest-libvirt.controller.functional.negative_tests.invalid_root_model.pci_root_model: PASS (4.76 s)
 (28/31) type_specific.io-github-autotest-libvirt.controller.functional.negative_tests.invalid_root_model.other_model: PASS (4.82 s)
 (29/31) type_specific.io-github-autotest-libvirt.controller.functional.negative_tests.invalid_chassisNr.zero: PASS (5.06 s)
 (30/31) type_specific.io-github-autotest-libvirt.controller.functional.negative_tests.invalid_chassisNr.large: PASS (5.02 s)
 (31/31) type_specific.io-github-autotest-libvirt.controller.functional.negative_tests.invalid_chassisNr.string: PASS (4.99 s)


```