### PR TITLE
Modify the watchdog expire time

### DIFF
--- a/libvirt/tests/src/event/virsh_event.py
+++ b/libvirt/tests/src/event/virsh_event.py
@@ -543,7 +543,7 @@ def run(test, params, env):
                         test.fail("Failed to trigger watchdog: %s" % details)
                     session.close()
                     # watchdog acts slowly, waiting for it.
-                    time.sleep(30)
+                    time.sleep(60)
                     expected_events_list.append("'watchdog' for %s: " + "%s" % action)
                     if action == 'pause':
                         expected_events_list.append("'lifecycle' for %s: Suspended Watchdog")


### PR DESCRIPTION
From libvirt-9.1, iTCO watchdog are the default watchdog device for q35 guests. The default expirt time of iTCO watchdog are about 60s. As for the event case, we just need to verify that there would be corresponding watchdog events after we trigger the watchdog. It has nothing to do with how much time watchdog devices need to expire. So I extend the watchdog expirt time here.