### PR TITLE
vIOMMU: Update iommu cold plug cases

### DIFF
--- a/libvirt/tests/src/sriov/vIOMMU/attach_iommu_device.py
+++ b/libvirt/tests/src/sriov/vIOMMU/attach_iommu_device.py
@@ -25,6 +25,14 @@ def run(test, params, env):
         elif not attach_option and not vm.is_alive():
             vm.start()
             vm.wait_for_login().close()
+        if libvirt_version.version_compare(10, 5, 0) and attach_option:
+            vmxml = vm_xml.VMXML.new_from_dumpxml(vm.name)
+            features = vmxml.features
+            if not features.has_feature('ioapic') and iommu_dict.get('model') == "intel":
+                features.add_feature('ioapic', 'driver', 'qemu')
+                vmxml.features = features
+                vmxml.sync()
+            err_msg = ''
 
         iommu_dev = libvirt_vmxml.create_vm_device_by_type('iommu', iommu_dict)
         test.log.debug(f"iommu device: {iommu_dev}")


### PR DESCRIPTION
Feature changed to support iommu device cold plug, so update the code.


**Test results:**
```
libvirt-10.5.0-1
 (1/4) type_specific.io-github-autotest-libvirt.vIOMMU.attach_iommu_device.cold_plug.virtio:PASS (7.86 s)
 (2/4) type_specific.io-github-autotest-libvirt.vIOMMU.attach_iommu_device.cold_plug.intel: PASS (8.09 s)
 (3/4) type_specific.io-github-autotest-libvirt.vIOMMU.attach_iommu_device.hot_plug.virtio: PASS (36.46 s)
 (4/4) type_specific.io-github-autotest-libvirt.vIOMMU.attach_iommu_device.hot_plug.intel: PASS (40.25 s)
 (1/4) type_specific.io-github-autotest-libvirt.vIOMMU.attach_iommu_device.cold_plug.virtio: PASS (5.01 s)
 (2/4) type_specific.io-github-autotest-libvirt.vIOMMU.attach_iommu_device.cold_plug.smmuv3: PASS (5.06 s)
 (3/4) type_specific.io-github-autotest-libvirt.vIOMMU.attach_iommu_device.hot_plug.virtio: PASS (38.46 s)
 (4/4) type_specific.io-github-autotest-libvirt.vIOMMU.attach_iommu_device.hot_plug.smmuv3: PASS (36.46 s)
RESULTS    : PASS 4 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0


10.4.0-1
 (1/2) type_specific.io-github-autotest-libvirt.vIOMMU.attach_iommu_device.cold_plug.virtio:PASS (7.78 s)
 (2/2) type_specific.io-github-autotest-libvirt.vIOMMU.attach_iommu_device.cold_plug.intel: PASS (11.29 s)

```