### PR TITLE
boot_from_usb_device: fix incorrect package checking

### DIFF
--- a/libvirt/tests/cfg/guest_os_booting/boot_order/boot_from_usb_device.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/boot_order/boot_from_usb_device.cfg
@@ -16,5 +16,6 @@
             port_num = "4000"
             device_attrs = {'source': {'host': 'localhost', 'service': '4000', 'mode': 'connect'}, 'protocol': {'type': 'raw'}, 'type_name': 'tcp', 'bus': '${bus_type}', 'type': 'tcp', 'boot': {'order': '1'}}
             only q35
+            required_cmds = ['usbredirserver', 'lsusb']
         - hostdev_device:
             device_attrs = {'type_name': 'usb', 'mode': 'subsystem', 'source': {'vendor_id': '%s', 'product_id': '%s'}, 'type': 'usb', 'managed': 'no', 'boot_order': '1'}

--- a/libvirt/tests/src/guest_os_booting/boot_order/boot_from_usb_device.py
+++ b/libvirt/tests/src/guest_os_booting/boot_order/boot_from_usb_device.py
@@ -68,6 +68,7 @@ def run(test, params, env):
     device_attrs = eval(params.get("device_attrs", "{}"))
     port_num = params.get("port_num")
     check_prompt = params.get("check_prompt")
+    required_cmds = eval(params.get("required_cmds", "[]"))
 
     vm = env.get_vm(vm_name)
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
@@ -77,8 +78,9 @@ def run(test, params, env):
     disk_obj = disk_base.DiskBase(test, vm, params)
 
     try:
-        if not (shutil.which("lsusb") and shutil.which("usbredirserver")):
-            test.error("Package related with usb command is not installed. Please install it.")
+        for cmd in required_cmds:
+            if not (shutil.which(cmd)):
+                test.fail("Command '{}' is not available. Please install the relevant package(s)".format(cmd))
         vmxml = guest_os.prepare_os_xml(vm_name, bootmenu_dict)
         vmxml.remove_all_boots()
 


### PR DESCRIPTION
boot_from_usb_device: Package is not installed

### The Issue: 
Regardless of which subtest is run, boot_from_usb_device checks for the existence of usbredirdev and lsusb. 
This check is not required for the block_device test, but block_device still checks for it. This results in a fail on platforms that do not support usbredirdev, such as aarch64.

### The Fix 
Parameterize the test, so that each subtest can specify a list of required commands. 
This way block_device and usbredirdev tests can specify their required packages individually. And the lack of a required command for redirdev will not fail block_device

### Evidence
Evidence that block_device passes on aarch64
```
(.libvirt-ci-venv-ci-runtest-JFpiaA) [root@ampere-mtsnow-altramax-52 avocado-vt]# avocado run --vt-type libvirt --vt-machine-type arm64-mmio --test-runner=runner guest_os_booting.boot_order.usb_device.block_device
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : a001395d16d8743fa6ac48ae987bcdaffed2989a
JOB LOG    : /var/log/avocado/job-results/job-2024-07-02T10.51-a001395/job.log
 (1/1) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.usb_device.block_device: PASS (42.88 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2024-07-02T10.51-a001395/results.html
JOB TIME   : 43.24 s
```

Evidence the test errors out on a 'q35' system without usbredirserver
```
(.libvirt-ci-venv-ci-runtest-JFpiaA) [root@ampere-mtsnow-altramax-52 avocado-vt]# avocado run --vt-type libvirt --vt-machine-type q35 --test-runner=runner guest_os_booting.boot_order.usb_device.redirdev_device
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : 820b34dfcd01b022cd2967ca84e655f0daf31569
JOB LOG    : /var/log/avocado/job-results/job-2024-07-02T10.52-820b34d/job.log
 (1/1) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.usb_device.redirdev_device: FAIL: Required command 'usbredirserver' is not installed (4.94 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2024-07-02T10.52-820b34d/results.html
JOB TIME   : 5.29 s
```