### PR TITLE
Fixup:Failed to return ip when there're more than one

### DIFF
--- a/provider/virtual_network/network_base.py
+++ b/provider/virtual_network/network_base.py
@@ -39,8 +39,8 @@ def get_vm_ip(session, mac, ip_ver="ipv4"):
             f'Cannot find ip addr with given mac: {mac}')
     elif len(target_addr) > 1:
         LOG.warn(f'Multiple ip addr: {target_addr}')
-    else:
-        return target_addr[0]['local']
+
+    return target_addr[0]['local']
 
 
 def get_test_ips(session, mac, ep_session, ep_mac, net_name=None,


### PR DESCRIPTION
Test result:
```
 (1/4) type_specific.io-github-autotest-libvirt.virsh.net_update.normal-test.add-first.ip_dhcp_range.ipv6_addr.net_active.options_no.ip_dhcp_opt.with_ip_dhcp.parent_index_set_ipv6.use-in-guest: PASS (55.62 s)
 (2/4) type_specific.io-github-autotest-libvirt.virsh.net_update.normal-test.add.default.ip_dhcp_range.ipv6_addr.net_active.options_no.ip_dhcp_opt.without_ip_dhcp.parent_index_set_ipv6.use-in-guest: PASS (57.35 s)
 (3/4) type_specific.io-github-autotest-libvirt.virsh.net_update.normal-test.add.default.ip_dhcp_range.ipv6_addr.net_active.options_live.ip_dhcp_opt.without_ip_dhcp.parent_index_set_ipv6.use-in-guest: PASS (55.95 s)
 (4/4) type_specific.io-github-autotest-libvirt.virsh.net_update.normal-test.add.default.ip_dhcp_range.ipv6_addr.net_active.options_live_config.ip_dhcp_opt.without_ip_dhcp.parent_index_set_ipv6.use-in-guest: PASS (57.23 s)
RESULTS    : PASS 4 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```
