### PR TITLE
Add adaption for aarch64 4k kernel

### DIFF
--- a/libvirt/tests/cfg/memory/memory_devices/change_virtio_mem_request_size.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/change_virtio_mem_request_size.cfg
@@ -2,12 +2,9 @@
     type = change_virtio_mem_request_size
     no s390-virtio
     start_vm = yes
-    kernel_extra_params_add = "memhp_default_state=online_movable"
-    kernel_extra_params_remove = "memhp_default_state"
     mem_model = "virtio-mem"
     allocate_huge_pages = "4194304KiB"
     target_size = 1048576
-    block_size = 2048
     request_size = 524288
     requested_unit = "KiB"
     basic_request = "${request_size}${requested_unit}"
@@ -35,6 +32,8 @@
             no file hugepages memfd
             mem_basic = {'mem_model': '${mem_model}', 'target': {'requested_unit': '${requested_unit}', 'size': %s, 'node': ${basic_node}, 'size_unit': 'KiB', 'requested_size': %s, 'block_unit': 'KiB', 'block_size': %s}}
         - running_guest:
+            kernel_extra_params_add = "memhp_default_state=online_movable"
+            kernel_extra_params_remove = "memhp_default_state"
             attach_node = 1
             attached_device =  "--node ${attach_node}"
             basic_device_alias = "--alias virtiomem0"

--- a/libvirt/tests/src/memory/memory_devices/change_virtio_mem_request_size.py
+++ b/libvirt/tests/src/memory/memory_devices/change_virtio_mem_request_size.py
@@ -293,7 +293,7 @@ def run(test, params, env):
         test.log.info("TEST_STEP3: Check the virtio-mem memory device config")
         converted_req = int(memory_base.convert_data_size(update_request_size, requested_unit))
         check_list = [(target_size, 'size'), (converted_req, 'requested_size'),
-                      (basic_node, 'node'), (block_size, 'block_size')]
+                      (basic_node, 'node'), (params.get('default_pagesize'), 'block_size')]
         for items in check_list:
             check_various_size(test, vm_name, items[0], check_item=items[1])
 
@@ -349,13 +349,11 @@ def run(test, params, env):
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     bkxml = vmxml.copy()
     vm = env.get_vm(vm_name)
-    memory_base.adjust_memory_size(params)
 
     allocate_huge_pages = re.findall(r'\d+', params.get("allocate_huge_pages"))[0]
     guest_state = params.get("guest_state")
     basic_node = params.get("basic_node")
     target_size = int(params.get("target_size"))
-    block_size = params.get("block_size")
     mem_basic = params.get("mem_basic", "{}")
     mem_attach = params.get("mem_attach", "{}")
     attached_device = params.get("attached_device")


### PR DESCRIPTION
1. add adaption for aarch64 4k kernel
2. remove kernel parameter change for shut off guest
3. results:
3.1 x86_64
(01/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.file.normal_requested.running_guest: PASS (215.76 s)
 (02/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.file.zero_requested.running_guest: PASS (205.89 s)
 (03/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.file.bigger_requested.running_guest: PASS (204.23 s)
 (04/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.file.not_mutiple_of_block_requested.running_guest: PASS (205.36 s)
 (05/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.hugepages.normal_requested.running_guest: PASS (202.38 s)
 (06/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.hugepages.zero_requested.running_guest: PASS (204.51 s)
 (07/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.hugepages.bigger_requested.running_guest: PASS (206.90 s)
 (08/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.hugepages.not_mutiple_of_block_requested.running_guest: PASS (202.62 s)
 (09/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.memfd.normal_requested.running_guest: PASS (204.33 s)
 (10/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.memfd.zero_requested.running_guest: PASS (202.23 s)
 (11/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.memfd.bigger_requested.running_guest: PASS (203.65 s)
 (12/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.memfd.not_mutiple_of_block_requested.running_guest: PASS (208.57 s)
 (13/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.undefined.normal_requested.shutoff_guest: PASS (41.00 s)
 (14/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.undefined.normal_requested.running_guest: PASS (218.58 s)
 (15/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.undefined.zero_requested.shutoff_guest: PASS (40.77 s)
 (16/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.undefined.zero_requested.running_guest: PASS (218.80 s)
 (17/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.undefined.bigger_requested.shutoff_guest: PASS (42.08 s)
 (18/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.undefined.bigger_requested.running_guest: PASS (220.89 s)
 (19/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.undefined.not_mutiple_of_block_requested.shutoff_guest: PASS (39.25 s)
 (20/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.undefined.not_mutiple_of_block_requested.running_guest: PASS (216.77 s)

3.2 aarch64 64k:
(01/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.file.normal_reques
ted.running_guest: PASS (184.32 s)                                                                          
 (02/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.file.zero_requeste
d.running_guest: PASS (185.84 s)                                                                            
 (03/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.file.bigger_reques
ted.running_guest: PASS (186.04 s)                                                                          
 (04/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.file.not_mutiple_o
f_block_requested.running_guest: PASS (186.53 s)                                                            
 (05/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.hugepages.normal_r
equested.running_guest: PASS (186.52 s)                                                                     
 (06/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.hugepages.zero_req
uested.running_guest: PASS (185.33 s)              
 (07/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.hugepages.bigger_r
equested.running_guest: PASS (185.27 s)                                                                     
 (08/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.hugepages.not_muti
ple_of_block_requested.running_guest: PASS (185.25 s)
 (09/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.memfd.normal_reque
sted.running_guest: PASS (185.31 s)
(10/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.memfd.zero_request
ed.running_guest: PASS (186.37 s)                     
 (11/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.memfd.bigger_reque
sted.running_guest: PASS (186.57 s)                                                                         
 (12/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.memfd.not_mutiple_
of_block_requested.running_guest: PASS (185.55 s)                                                           
 (13/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.undefined.normal_r
equested.shutoff_guest: PASS (144.05 s)                                                                     
 (14/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.undefined.normal_r
equested.running_guest: PASS (186.44 s)              
 (15/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.undefined.zero_req
uested.shutoff_guest: PASS (142.65 s)                                                                       
 (16/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.undefined.zero_req
uested.running_guest: PASS (186.42 s)                                                                       
 (17/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.undefined.bigger_r
equested.shutoff_guest: PASS (141.95 s)                                                                     
 (18/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.undefined.bigger_r
equested.running_guest: PASS (185.23 s)                                                                     
 (19/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.undefined.not_muti
ple_of_block_requested.shutoff_guest: PASS (142.71 s)                                                       
 (20/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.undefined.not_muti
ple_of_block_requested.running_guest: PASS (186.08 s) 

3.3 aarch64 4k:
(01/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.file.normal_requested.running_guest: PASS (185.37 s)
 (02/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.file.zero_requested.running_guest: PASS (190.30 s)
 (03/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.file.bigger_requested.running_guest: PASS (188.06 s)
 (04/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.file.not_mutiple_of_block_requested.running_guest: PASS (186.23 s)
 (05/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.hugepages.normal_requested.running_guest: PASS (185.91 s)
 (06/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.hugepages.zero_requested.running_guest: PASS (186.22 s)
 (07/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.hugepages.bigger_requested.running_guest: PASS (186.78 s)
 (08/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.hugepages.not_mutiple_of_block_requested.running_guest: PASS (187.61 s)
 (09/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.memfd.normal_requested.running_guest: PASS (186.85 s)
 (10/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.memfd.zero_requested.running_guest: PASS (186.09 s)
 (11/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.memfd.bigger_requested.running_guest: PASS (189.71 s)
 (12/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.memfd.not_mutiple_of_block_requested.running_guest: PASS (189.95 s)
 (13/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.undefined.normal_requested.shutoff_guest: PASS (144.67 s)
 (14/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.undefined.normal_requested.running_guest: PASS (186.16 s)
 (15/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.undefined.zero_requested.shutoff_guest: PASS (144.33 s)
 (16/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.undefined.zero_requested.running_guest: PASS (187.07 s)
 (17/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.undefined.bigger_requested.shutoff_guest: PASS (142.89 s)
 (18/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.undefined.bigger_requested.running_guest: PASS (185.95 s)
 (19/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.undefined.not_mutiple_of_block_requested.shutoff_guest: PASS (143.34 s)
 (20/20) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.change_memory.undefined.not_mutiple_of_block_requested.running_guest: PASS (187.78 s)