### PR TITLE
vIOMMU: Fixup a timeout issue

### DIFF
--- a/libvirt/tests/src/sriov/vIOMMU/iommu_device_lifecycle.py
+++ b/libvirt/tests/src/sriov/vIOMMU/iommu_device_lifecycle.py
@@ -65,8 +65,8 @@ def run(test, params, env):
                 session = vm.wait_for_serial_login(
                     timeout=int(params.get('login_timeout')))
                 session.sendline(params.get("reboot_command"))
-                _match, _text = session.read_until_last_line_matches(
-                    [r"[Ll]ogin:\s*$"], timeout=240, internal_timeout=0.5)
+                _match, _text = session.read_until_output_matches(
+                    [r"[Ll]ogin:\s*"], timeout=240, internal_timeout=0.5)
                 session.close()
 
             session = vm.wait_for_serial_login(


### PR DESCRIPTION
There might be some other outputs after showing 'login:', so update the pattern for checking vm reboot.

**Before the fix:**
` (1/1) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.reboot_many_times.hostdev_iface.virtio: ERROR: Timeout expired while looking for pattern '[Ll]ogin:\\s*$'    (output: 'shutdown -r now\n[root@localhost ~]# [   34.816260] vda2: Can\'t mount, would change RO state\n[\x1b[0;32m  OK  \x1b[0m] Started \x1b[0;1;39mShow Plymouth Reboot Screen\x1b[0m.\n[\x1b... (403.37 s)`

**After the fix:**
` (1/1) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.reboot_many_times.hostdev_iface.virtio: PASS (317.94 s)`
