### PR TITLE
fix not running error when save domain

### DIFF
--- a/libvirt/tests/src/memory/memory_backing/lifecycle_for_hugepage.py
+++ b/libvirt/tests/src/memory/memory_backing/lifecycle_for_hugepage.py
@@ -157,6 +157,7 @@ def run_test(vm, params, test):
     libvirt.check_result(ret, expected_fails=start_error)
     if start_error:
         return
+    vm.wait_for_login().close()
     vmxml = vm_xml.VMXML.new_from_dumpxml(vm.name)
     test.log.debug("After start vm, get vmxml is :%s", vmxml)
 


### PR DESCRIPTION
  give login when first start domain
Signed-off-by: nanli <nanli@redhat.com>

Before fix
`CmdError: Command '/usr/bin/virsh save avocado-vt-vm1 /tmp/guest.save ' failed.stdout: b'\n'stderr: b&quot;error: Failed to save domain 'avocado-vt-vm1' to /tmp/guest.save\nerror: operation failed: domain is not running\n&quot;additional_info: None&#10;`


After fix

```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 memory.backing.lifecycle.memory_hugepage.default_hugepage_size --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.default_hugepage_size: PASS (115.52 s)
```