### PR TITLE
virsh_guestinfo: Remove color of "ip" output

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_guestinfo.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_guestinfo.py
@@ -304,7 +304,7 @@ def run(test, params, env):
         if_info = {}
         session = vm.wait_for_login()
         try:
-            ip_cmd = 'ip a'
+            ip_cmd = 'ip -c=never a'
             ip_lines = session.cmd_output(ip_cmd).strip().splitlines()
             if_info = parse_interface_info(ip_lines)
         finally:


### PR DESCRIPTION
The output of ip command in the VM needs to be updated to avoid format issues.

**Before the fix:**
` (1/1) type_specific.io-github-autotest-libvirt.virsh.guestinfo.positive.interface_info: FAIL: The interface info get from guestinfo cmd is not correct. (70.07 s)`

**After the fix:**
 (1/1) type_specific.io-github-autotest-libvirt.virsh.guestinfo.positive.interface_info: PASS (62.25 s)
