### PR TITLE
virsh_event: Fix leaked cluster error on kill_qemu

### DIFF
--- a/libvirt/tests/cfg/event/virsh_event.cfg
+++ b/libvirt/tests/cfg/event/virsh_event.cfg
@@ -57,6 +57,7 @@
                             only test_events
                             events_list = "kill_qemu"
                             signal = 'SIGKILL'
+                            skip_cluster_leak_warn = "yes"
                 - reboot_event:
                     event_name = "reboot"
                     events_list = "reset"


### PR DESCRIPTION
### The Issue
The kill_qemu test case sends a SIGKILL signal to qemu, then checks to make sure the signal is properly detected

Killing qemu sometimes results in corruption of the qcow2 image in the form of leaked clusters. This is a natural side effect of the test. So, this should not result in a test failure

### The Fix
Suppress the error by setting the skip_cluster_leak_warn option to "yes"

### Evidence
Evidence the kill_qemu case still passes
```
(.libvirt-ci-venv-ci-runtest-NogP17) [root@ampere-mtsnow-altra-02 tp-libvirt]# avocado run --vt-type libvirt --vt-machine-type arm64-mmio --test-runner=runner virsh.event.positive_test.virsh_event.test_events.lifecycle_events.kill_qemu
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : 1a3173e680670e151d89dfbee3af1eb780a7c296
JOB LOG    : /var/log/avocado/job-results/job-2024-07-05T09.20-1a3173e/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.event.positive_test.virsh_event.test_events.lifecycle_events.kill_qemu.no_timeout.loop: PASS (44.00 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2024-07-05T09.20-1a3173e/results.html
JOB TIME   : 44.54 s
```