### PR TITLE
add rbd with luks scenario in blockcopy with dest xml case

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockcopy/blockcopy_with_different_dest_xml.cfg
+++ b/libvirt/tests/cfg/backingchain/blockcopy/blockcopy_with_different_dest_xml.cfg
@@ -30,6 +30,23 @@
             rbd_image_size = "${image_size}"
             sec_dict = {"secret_ephemeral": "no", "secret_private": "yes", "description": "sec_desc", "usage": "ceph", "usage_name": "cephlibvirt"}
             dest_disk_dict = {"type_name":"network", "target":{"dev": "${target_disk}", "bus": "scsi"}, "driver": {"name": "qemu", "type":"raw"}}
+        - rbd_with_luks_and_auth:
+            source_disk_dict = {"type_name":"${source_disk_type}", "target":{"dev": "${target_disk}", "bus": "scsi"}, "driver": {"name": "qemu", "type":"qcow2"}}
+            dest_disk_type = "rbd_with_luks_and_auth"
+            mon_host = "EXAMPLE_MON_HOST"
+            auth_key = "EXAMPLE_AUTH_KEY"
+            auth_user = "EXAMPLE_AUTH_USER"
+            image_path = "EXAMPLE_IMAGE_PATH"
+            client_name = "EXAMPLE_CLIENT_NAME"
+            rbd_image_size = "${image_size}"
+            ceph_usage_name="cephlibvirt"
+            sec_dict = {"secret_ephemeral": "no", "secret_private": "yes", "description": "sec_desc_auth", "usage": "ceph", "usage_name": "${ceph_usage_name}"}
+            dest_disk_dict = {"type_name":"network", "target":{"dev": "${target_disk}", "bus": "scsi"}, "driver": {"name": "qemu", "type":"raw"}}
+            private_key_password = "EXAMPLE_PWD"
+            secret_pwd = "`printf %s ${private_key_password} | base64`"
+            rbd_image_format = "luks"
+            rbd_image_parameter = "--object secret,id=luks1.img_luks0,data=${secret_pwd},format=base64 -o key-secret=luks1.img_luks0 rbd:{}:id={}:key={}:auth_supported=cephx:mon_host={}"
+            luks_sec_dict = {"secret_ephemeral": "no", "secret_private": "yes", "description": "sec_desc_luks", "usage": "volume", "volume":"%s", "uuid":"198784e8-f977-40ac-8d0d-4d0fcca70588"}
         - nbd_disk:
             dest_disk_type = "nbd"
             nbd_server_port = "10808"


### PR DESCRIPTION
  xxxx-294410: Do blockcopy with different dest XML - rbd with luks and auth
Signed-off-by: nanli <nanli@redhat.com>

```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockcopy.dest_xml.rbd_with_luks_and_auth
 (1/1) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.dest_xml.rbd_with_luks_and_auth.pivot_reuse_external: PASS (56.15 s)
 (1/1) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.dest_xml.rbd_with_luks_and_auth.finish_reuse_external: PASS (61.22 s)

```

Got error on rhel10 ,it's a bug 
```
2024-07-07 21:47:09,652 virsh            L0822 DEBUG| Running virsh command: blockcopy avocado-vt-vm1 vdb  --pivot  --xml /tmp/xml_utils_temp_jjulza25.xml --transient-job --reuse-external --verbose --wait
2024-07-07 21:47:09,652 process          L0658 INFO | Running '/bin/virsh blockcopy avocado-vt-vm1 vdb  --pivot  --xml /tmp/xml_utils_temp_jjulza25.xml --transient-job --reuse-external --verbose --wait '
2024-07-07 21:47:09,839 process          L0470 DEBUG| [stderr] error: internal error: unable to execute QEMU command 'blockdev-add': encryption load fail: Invalid argument
```