### PR TITLE
update internal snapshot with external snapshot

### DIFF
--- a/libvirt/tests/cfg/security/rng/libvirt_rng.cfg
+++ b/libvirt/tests/cfg/security/rng/libvirt_rng.cfg
@@ -9,6 +9,7 @@
     # For example, devices that are provided by the CPU.
     ignored_devices = s390-trng,trng,tpm-rng-0
     dd_throughput = "bs=512 count=10"
+    snap_options = " %s"
     variants:
         - hotplug_unplug:
             only backend_rdm.default, backend_tcp, backend_udp, backend_builtin
@@ -118,6 +119,7 @@
             variants:
                 - back_rdm:
                     backend_dev = "/dev/random"
+                    snap_options = "%s --disk-only"
                 - back_tcp_connect:
                     backend_model = "egd"
                     backend_type = "tcp"

--- a/libvirt/tests/src/security/rng/libvirt_rng.py
+++ b/libvirt/tests/src/security/rng/libvirt_rng.py
@@ -38,6 +38,7 @@ def run(test, params, env):
     """
     vm_name = params.get("main_vm")
     vm = env.get_vm(vm_name)
+    snap_options = params.get("snap_options")
 
     def check_rng_xml(xml_set, exists=True):
         """
@@ -272,7 +273,8 @@ def run(test, params, env):
         snapshot_name2 = "snap.s2"
         if not snapshot_vm_running:
             vm.destroy(gracefully=False)
-        ret = virsh.snapshot_create_as(vm_name, snapshot_name1, debug=True)
+        ret = virsh.snapshot_create_as(
+            vm_name, options=snap_options % snapshot_name1, debug=True)
         libvirt.check_exit_status(ret)
         snap_lists = virsh.snapshot_list(vm_name, debug=True)
         if snapshot_name not in snap_lists:
@@ -548,7 +550,8 @@ def run(test, params, env):
             if snapshot_vm_running:
                 vm.start()
                 vm.wait_for_login().close()
-            ret = virsh.snapshot_create_as(vm_name, snapshot_name, debug=True)
+            ret = virsh.snapshot_create_as(
+                vm_name, options=snap_options % snapshot_name, debug=True)
             libvirt.check_exit_status(ret)
 
         # Destroy VM first


### PR DESCRIPTION
   xxxx-17255 Snapshot of shutoff guest with random backend virtio-rng device. -- Use external snapshots in all steps instead of internal snapshot.


Signed-off-by: nanli <nanli@redhat.com>

```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 libvirt_rng.rng_snapshot.back_rdm.snapshot_shutoff.device_assign
 (1/1) type_specific.io-github-autotest-libvirt.libvirt_rng.rng_snapshot.back_rdm.snapshot_shutoff.device_assign: PASS (73.95 s)
```
Other related

```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 libvirt_rng

 [root@dell-per740-08 tp-libvirt]# avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 libvirt_rng
 (01/38) type_specific.io-github-autotest-libvirt.libvirt_rng.backend_builtin.hotplug_unplug.positive.no_options: PASS (49.31 s)
 (02/38) type_specific.io-github-autotest-libvirt.libvirt_rng.backend_builtin.hotplug_unplug.positive.persistent: PASS (47.94 s)
 (03/38) type_specific.io-github-autotest-libvirt.libvirt_rng.backend_builtin.device_assign: PASS (54.86 s)
 (04/38) type_specific.io-github-autotest-libvirt.libvirt_rng.backend_rdm.default.hotplug_unplug.positive.no_options: PASS (55.37 s)
 (05/38) type_specific.io-github-autotest-libvirt.libvirt_rng.backend_rdm.default.hotplug_unplug.positive.persistent: PASS (49.10 s)
 (06/38) type_specific.io-github-autotest-libvirt.libvirt_rng.backend_rdm.default.device_assign: PASS (54.84 s)
 (07/38) type_specific.io-github-autotest-libvirt.libvirt_rng.backend_rdm.urandom.device_assign: PASS (55.51 s)
 (08/38) type_specific.io-github-autotest-libvirt.libvirt_rng.backend_rdm.detach_device_alias.current.device_assign: PASS (51.09 s)
 (09/38) type_specific.io-github-autotest-libvirt.libvirt_rng.backend_rdm.detach_device_alias.live.device_assign: PASS (54.59 s)
 (10/38) type_specific.io-github-autotest-libvirt.libvirt_rng.backend_rdm.detach_device_alias.config.device_assign: PASS (61.81 s)
 (11/38) type_specific.io-github-autotest-libvirt.libvirt_rng.backend_rdm.with_packed_on.device_assign: PASS (47.29 s)
 (12/38) type_specific.io-github-autotest-libvirt.libvirt_rng.backend_rdm.invalid_address.device_assign: PASS (12.70 s)
 (13/38) type_specific.io-github-autotest-libvirt.libvirt_rng.backend_rdm.invalid_model.device_assign: PASS (18.40 s)
 (14/38) type_specific.io-github-autotest-libvirt.libvirt_rng.backend_udp.bind_connect_mode.hotplug_unplug.positive.no_options: PASS (57.43 s)
 (15/38) type_specific.io-github-autotest-libvirt.libvirt_rng.backend_udp.bind_connect_mode.hotplug_unplug.positive.persistent: PASS (46.06 s)
 (16/38) type_specific.io-github-autotest-libvirt.libvirt_rng.backend_udp.bind_connect_mode.device_assign: PASS (45.65 s)
 (17/38) type_specific.io-github-autotest-libvirt.libvirt_rng.backend_udp.connect_mode.hotplug_unplug.positive.no_options: PASS (46.93 s)
 (18/38) type_specific.io-github-autotest-libvirt.libvirt_rng.backend_udp.connect_mode.hotplug_unplug.positive.persistent: PASS (47.24 s)
 (19/38) type_specific.io-github-autotest-libvirt.libvirt_rng.backend_udp.connect_mode.device_assign: PASS (46.68 s)
 (20/38) type_specific.io-github-autotest-libvirt.libvirt_rng.backend_tcp.connect_mode.hotplug_unplug.positive.no_options: PASS (57.76 s)
 (21/38) type_specific.io-github-autotest-libvirt.libvirt_rng.backend_tcp.connect_mode.hotplug_unplug.positive.persistent: PASS (52.72 s)


```