### PR TITLE
revert_snap_with_flags: fix incorrect nvram file on arm

### DIFF
--- a/libvirt/tests/cfg/snapshot/revert_snap_with_flags.cfg
+++ b/libvirt/tests/cfg/snapshot/revert_snap_with_flags.cfg
@@ -5,6 +5,8 @@
     target_disk = 'vda'
     disk_type = 'file'
     vars_path = "/var/lib/libvirt/qemu/nvram/${main_vm}_VARS.fd"
+    aarch64:
+        vars_path = "/var/lib/libvirt/qemu/nvram/${main_vm}_VARS.qcow2"
     snap1_options = "%s --diskspec vda,snapshot=external,file=/tmp/vda.%s"
     snap2_options = "%s --memspec snapshot=external,file=/tmp/mem.%s --diskspec vda,snapshot=external,file=/tmp/vda.%s"
     flags = [" --current --paused"," --running --reset-nvram", " --force"]


### PR DESCRIPTION
On aarm64, the default nvram file name is different from the one on x86_64.

Signed-off-by: Dan Zheng <dzheng@redhat.com>