### PR TITLE
Fix err prompt for no numa node in memory device xml

### DIFF
--- a/libvirt/tests/cfg/memory/memory_devices/dimm_memory_with_memory_alloccation_and_numa.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/dimm_memory_with_memory_alloccation_and_numa.cfg
@@ -61,5 +61,7 @@
                 hotplug_error = "count of memory devices requiring memory slots '1' exceeds slots count '0'"
         - coldplug_without_node:
             coldplug_error_2 = "cannot use/hotplug a memory device when domain 'maxMemory' is not defined"
+            with_slot:
+                coldplug_error_2 = "target NUMA node needs to be specified for memory device"
         - coldplug_with_node:
             dimm_dict = ${dimm_node_dict}

--- a/libvirt/tests/src/memory/memory_devices/dimm_memory_with_memory_alloccation_and_numa.py
+++ b/libvirt/tests/src/memory/memory_devices/dimm_memory_with_memory_alloccation_and_numa.py
@@ -96,7 +96,10 @@ def check_coldplug_result(params, result):
     coldplug_error_2 = params.get("coldplug_error_2")
 
     if mem_alloc == "with_slot":
-        libvirt.check_exit_status(result)
+        if device_operation == "coldplug_without_node":
+            libvirt.check_result(result, coldplug_error_2)
+        else:
+            libvirt.check_exit_status(result)
     elif mem_alloc == "no_slot":
         libvirt.check_result(result, coldplug_error)
     elif mem_alloc == "no_maxmemory":


### PR DESCRIPTION
latest libvirt add error prompt for cold-plugging memory device without numa node config, so add code adaption
results:
(01/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.init_define_with_dimm.no_numa.no_maxmemory: PASS (6.51 s)
 (02/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.init_define_with_dimm.no_numa.no_slot: PASS (6.61 s)
 (03/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.init_define_with_dimm.no_numa.with_slot: PASS (8.23 s)
 (04/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.init_define_with_dimm.with_numa.no_maxmemory: PASS (6.66 s)
 (05/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.init_define_with_dimm.with_numa.no_slot: PASS (6.68 s)
 (06/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.init_define_with_dimm.with_numa.with_slot: PASS (6.64 s)
 (07/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.init_define_with_big_dimm.no_numa.with_slot: PASS (6.56 s)
 (08/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.hotplug_without_node.no_numa.no_maxmemory: PASS (39.57 s)
 (09/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.hotplug_without_node.no_numa.no_slot: PASS (38.13 s)
 (10/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.hotplug_without_node.no_numa.with_slot: PASS (39.37 s)
 (11/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.hotplug_without_node.with_numa.no_maxmemory: PASS (38.27 s)
 (12/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.hotplug_without_node.with_numa.no_slot: PASS (38.07 s)
 (13/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.hotplug_without_node.with_numa.with_slot: PASS (38.29 s)
 (14/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.hotplug_with_node.no_numa.no_maxmemory: PASS (39.27 s)
 (15/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.hotplug_with_node.no_numa.no_slot: PASS (39.17 s)
 (16/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.hotplug_with_node.no_numa.with_slot: PASS (37.23 s)
 (17/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.hotplug_with_node.with_numa.no_maxmemory: PASS (35.12 s)
 (18/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.hotplug_with_node.with_numa.no_slot: PASS (37.17 s)
 (19/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.hotplug_with_node.with_numa.with_slot: PASS (37.29 s)
 (20/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.coldplug_without_node.no_numa.no_maxmemory: PASS (6.47 s)
 (21/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.coldplug_without_node.no_numa.no_slot: PASS (6.48 s)
 (22/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.coldplug_without_node.no_numa.with_slot: PASS (6.47 s)
 (23/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.coldplug_without_node.with_numa.no_maxmemory: PASS (6.47 s)
 (24/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.coldplug_without_node.with_numa.no_slot: PASS (6.47 s)
 (25/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.coldplug_without_node.with_numa.with_slot: PASS (6.72 s)
 (26/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.coldplug_with_node.no_numa.no_maxmemory: PASS (6.48 s)
 (27/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.coldplug_with_node.no_numa.no_slot: PASS (6.44 s)
 (28/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.coldplug_with_node.no_numa.with_slot: PASS (6.44 s)
 (29/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.coldplug_with_node.with_numa.no_maxmemory: PASS (6.51 s)
 (30/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.coldplug_with_node.with_numa.no_slot: PASS (6.52 s)
 (31/31) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_allocation_and_numa.coldplug_with_node.with_numa.with_slot: PASS (6.52 s)