### PR TITLE
[virsh_pool_autostart] avoid running vol-list too quickly after pool …

### DIFF
--- a/libvirt/tests/src/storage/virsh_pool_autostart.py
+++ b/libvirt/tests/src/storage/virsh_pool_autostart.py
@@ -1,5 +1,6 @@
 import os
 import re
+import time
 import logging as log
 
 from avocado.utils import process
@@ -159,9 +160,10 @@ def run(test, params, env):
                 pool = pool_ins.get_pool_uuid(pool_name)
             if destroy_pool_used_by_guest:
                 virsh.pool_start(pool_name, debug=True, ignore_status=False)
+                # Avoid running vol_list too quickly
+                time.sleep(3)
                 res = virsh.vol_list(pool_name, debug=True,
                                      ignore_status=False).stdout_text
-
                 vol = re.findall(r"(\S+)\ +(\S+)", str(res.strip()))[1]
                 if not vol:
                     test.fail('Expect to get vol in %s pool' % pool_name)


### PR DESCRIPTION
…start

From the log, we can see the pool-start and vol-list command execute in 1us. It may fail for ISCSI storage. We could use utils_misc.wait, but the command will be too complicated. Just use sleep to wait a second.

2024-07-01 09:09:52,851 process          L0739 INFO | Command '/usr/bin/virsh pool-start
2024-07-01 09:09:52,852 virsh            L0873 DEBUG| status: 0
2024-07-01 09:09:52,852 virsh            L0874 DEBUG| stdout: Pool virsh_pool_test started
2024-07-01 09:09:52,852 virsh            L0875 DEBUG| stderr:
2024-07-01 09:09:52,852 virsh            L0822 DEBUG| Running virsh command: vol-list virsh_pool_test
2024-07-01 09:09:52,852 process          L0658 INFO | Running '/usr/bin/virsh vol-list virsh_pool_test '
2024-07-01 09:09:52,874 process          L0470 DEBUG| [stdout]  Name   Path
2024-07-01 09:09:52,874 process          L0470 DEBUG| [stdout] --------------
2024-07-01 09:09:52,874 process          L0470 DEBUG| [stdout]
2024-07-01 09:09:52,874 process          L0739 INFO | Command '/usr/bin/virsh vol-list virsh_pool_test
2024-07-01 09:09:52,875 virsh            L0873 DEBUG| status: 0
2024-07-01 09:09:52,875 virsh            L0874 DEBUG| stdout: Name   Path--------------