### PR TITLE
fix serial pty log case not found vm login prompt

### DIFF
--- a/libvirt/tests/cfg/serial/serial_pty_log.cfg
+++ b/libvirt/tests/cfg/serial/serial_pty_log.cfg
@@ -2,6 +2,7 @@
     type = serial_pty_log
     start_vm = no
     remove_devices = "['serial','console']"
+    boot_prompt = 'localhost login,Login Prompts'
     variants:
         - file:
             serial_dev_type = pty
@@ -11,11 +12,9 @@
             aarch64:
                 target_type = system-serial
                 target_model = pl011
-                boot_prompt = 'localhost login'
             s390x:
                 target_type = sclp-serial
                 target_model = sclpconsole
-                boot_prompt = 'localhost login'
             stdio_handler = 'file'
         - logd:
             serial_dev_type = pty
@@ -25,9 +24,7 @@
             aarch64:
                 target_type = system-serial
                 target_model = pl011
-                boot_prompt = 'localhost login'
             s390x:
                 target_type = sclp-serial
                 target_model = sclpconsole
-                boot_prompt = 'localhost login'
             stdio_handler = 'logd'

--- a/libvirt/tests/src/serial/serial_pty_log.py
+++ b/libvirt/tests/src/serial/serial_pty_log.py
@@ -27,10 +27,10 @@ def check_pty_log_file(file_path, boot_prompt):
     with open(file_path, errors='ignore') as fp:
         contents = fp.read()
     logging.debug("The contents of log file are : %s" % contents)
-    ret = contents.find(boot_prompt)
-    if ret == -1:
-        return False
-    return True
+    ret = []
+    for prompt in boot_prompt.split(','):
+        ret.append(contents.find(prompt) != -1)
+    return any(ret)
 
 
 def run(test, params, env):


### PR DESCRIPTION
  login prompt is changing
Signed-off-by: nanli <nanli@redhat.com>

```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 serial.pty.log

 (1/2) type_specific.io-github-autotest-libvirt.serial.pty.log.file: PASS (52.60 s)
 (2/2) type_specific.io-github-autotest-libvirt.serial.pty.log.logd: PASS (56.60 s)

```