### PR TITLE
Update the file path to "/"

### DIFF
--- a/libvirt/tests/cfg/virtual_network/passt/passt_transfer_file.cfg
+++ b/libvirt/tests/cfg/virtual_network/passt/passt_transfer_file.cfg
@@ -35,7 +35,7 @@
             bs = 1M
         - 1G:
             bs = 100M
-    test_file = /tmp/${file_size}_file
+    test_file = /${file_size}_file
     rec_file = out_${file_size}
     cmd_create_file = dd if=/dev/urandom bs=${bs} count=10 > ${test_file}
     cmd_listen = f'socat -u {prot}-LISTEN:{port},reuseaddr OPEN:${rec_file},create'


### PR DESCRIPTION
In this case, we need to create a temporary file to test the file transfer function. The original /tmp directroy is not enough some times since we need to creat 1G file. So update the file path to be under "/".