### PR TITLE
add refining steps for dimm with access and discrad scenario

### DIFF
--- a/libvirt/tests/cfg/memory/memory_devices/dimm_memory_with_access_and_discard.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/dimm_memory_with_access_and_discard.cfg
@@ -1,21 +1,23 @@
 - memory.devices.dimm.access_and_discard:
     type = dimm_memory_with_access_and_discard
+    no s390-virtio
     start_vm = yes
     mem_model = "dimm"
     dimm_mem_num = 6
     share_0 = 'false'
     discard_0 = 'False'
     check_path = "ls -l /var/lib/libvirt/qemu/ram/%s"
-    target_size = 131072
-    requested_size = 131072
-    block_size = 2048
-    no s390-virtio
-    aarch64:
-        target_size = 1048576
-        requested_size = 524288
-        block_size = 524288
-    dimm_basic = {'mem_model': '${mem_model}', 'target': {'requested_unit': 'KiB', 'size': ${target_size}, 'size_unit': 'KiB', 'requested_size': ${requested_size}, 'block_unit': 'KiB', 'block_size': ${block_size}}}
+    target_size = 524288
+    requested_size = 1048576
+    dimm_basic = {'mem_model': '${mem_model}', 'target': {'requested_unit': 'KiB', 'size': ${target_size}, 'size_unit': 'KiB', 'requested_size': ${requested_size}, 'block_unit': 'KiB', 'block_size': %s}}
     kernel_params_add = "memhp_default_state=online_movable"
+    max_mem = 10485760
+    aarch64:
+        max_mem = 20971520
+    base_attrs = "'vcpu': 6, 'placement': 'static', 'memory_unit':'KiB','memory':3145728,'current_mem':3145728,'current_mem_unit':'KiB'"
+    numa_attrs = "'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '1048576', 'unit': 'KiB'}, {'id': '1', 'cpus': '2-3', 'memory': '1048576', 'unit': 'KiB', 'memAccess':'shared','discard':'yes'},{'id':'2','cpus': '4-5','memory':'1048576','unit':'KiB', 'memAccess':'private','discard':'no'}]}"
+    max_attrs = "'max_mem_rt': ${max_mem}, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB'"
+    vm_attrs = {${base_attrs}, ${numa_attrs}, ${max_attrs}}
     variants memory_backing:
         - file:
             source_type = 'file'
@@ -52,20 +54,8 @@
     expected_share = ['${share_0}', 'true', 'true', 'false', 'false', 'true']
     check_discard = '{"execute":"qom-get", "arguments":{"path":"/objects/%s", "property":"discard-data"}}'
     expected_discard = ['${discard_0}', 'True', 'True', 'False', 'False', 'True']
-    variants:
-        - with_numa:
-            no s390-virtio
-            mem_value = 3145728
-            current_mem = 3145728
-            max_mem = 10485760
-            numa_mem = 1048576
-            aarch64:
-                max_mem = 20971520
-            mem_access_1 = "shared"
-            discard_1 = "yes"
-            mem_access_2 = "private"
-            discard_2 = "no"
-            base_attrs = "'vcpu': 6, 'placement': 'static', 'memory_unit':'KiB','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'KiB'"
-            numa_attrs = "'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '${numa_mem}', 'unit': 'KiB'}, {'id': '1', 'cpus': '2-3', 'memory': '${numa_mem}', 'unit': 'KiB', 'memAccess':'${mem_access_1}','discard':'${discard_1}'},{'id':'2','cpus': '4-5','memory':'${numa_mem}','unit':'KiB', 'memAccess':'${mem_access_2}','discard':'${discard_2}'}]}"
-            max_attrs = "'max_mem_rt': ${max_mem}, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB'"
-            vm_attrs = {${base_attrs}, ${numa_attrs}, ${max_attrs}}
+    variants operation:
+        - cold_plug:
+            attach_option = "--config"
+        - hot_plug:
+            attach_option = " "


### PR DESCRIPTION
   xxx-299048:Dimm memory device with access and discard settings
Signed-off-by: nanli <nanli@redhat.com>
```

 avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35  memory.devices.dimm.access_and_discard
 (01/18) type_specific.io-github-autotest-libvirt.memory.devices.dimm.access_and_discard.cold_plug.undefined.file: PASS (118.76 s)
 (02/18) type_specific.io-github-autotest-libvirt.memory.devices.dimm.access_and_discard.cold_plug.undefined.anonymous: PASS (121.92 s)
 (03/18) type_specific.io-github-autotest-libvirt.memory.devices.dimm.access_and_discard.cold_plug.undefined.memfd: PASS (116.99 s)
 (04/18) type_specific.io-github-autotest-libvirt.memory.devices.dimm.access_and_discard.cold_plug.shared_and_discard.file: PASS (122.33 s)
 (05/18) type_specific.io-github-autotest-libvirt.memory.devices.dimm.access_and_discard.cold_plug.shared_and_discard.anonymous: PASS (123.65 s)
 (06/18) type_specific.io-github-autotest-libvirt.memory.devices.dimm.access_and_discard.cold_plug.shared_and_discard.memfd: PASS (117.82 s)
 (07/18) type_specific.io-github-autotest-libvirt.memory.devices.dimm.access_and_discard.cold_plug.private_and_no_discard.file: PASS (119.95 s)
 (08/18) type_specific.io-github-autotest-libvirt.memory.devices.dimm.access_and_discard.cold_plug.private_and_no_discard.anonymous: PASS (120.04 s)
 (09/18) type_specific.io-github-autotest-libvirt.memory.devices.dimm.access_and_discard.cold_plug.private_and_no_discard.memfd: PASS (118.44 s)
 (10/18) type_specific.io-github-autotest-libvirt.memory.devices.dimm.access_and_discard.hot_plug.undefined.file: PASS (125.25 s)
 (11/18) type_specific.io-github-autotest-libvirt.memory.devices.dimm.access_and_discard.hot_plug.undefined.anonymous: PASS (121.44 s)
 (12/18) type_specific.io-github-autotest-libvirt.memory.devices.dimm.access_and_discard.hot_plug.undefined.memfd: PASS (119.06 s)
 (13/18) type_specific.io-github-autotest-libvirt.memory.devices.dimm.access_and_discard.hot_plug.shared_and_discard.file: PASS (123.19 s)
 (14/18) type_specific.io-github-autotest-libvirt.memory.devices.dimm.access_and_discard.hot_plug.shared_and_discard.anonymous: -^[[C ^[[C^[[B^[[C^[[\^[[C^[[C^[[C^[[C^[[C^[[C^[[C^[[C^[[C^[[C^[[C^[[C^[[C^[[C^[[C^[[C^[[C^[[C^[[C^[[BPASS (127.20 s)
 (15/18) type_specific.io-github-autotest-libvirt.memory.devices.dimm.access_and_discard.hot_plug.shared_and_discard.memfd: PASS (121.02 s)
 (16/18) type_specific.io-github-autotest-libvirt.memory.devices.dimm.access_and_discard.hot_plug.private_and_no_discard.file: PASS (122.34 s)
 (17/18) type_specific.io-github-autotest-libvirt.memory.devices.dimm.access_and_discard.hot_plug.private_and_no_discard.anonymous: PASS (121.29 s)
 (18/18) type_specific.io-github-autotest-libvirt.memory.devices.dimm.access_and_discard.hot_plug.private_and_no_discard.memfd: PASS (121.67 s)

```