### PR TITLE
Fix the login timeout issue

### DIFF
--- a/libvirt/tests/src/virtual_network/passt/passt_attach_detach.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_attach_detach.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import shutil
+import time
 
 import aexpect
 from virttest import libvirt_version
@@ -122,6 +123,8 @@ def run(test, params, env):
             if not os.path.exists(log_file):
                 test.fail(f'Logfile of passt "{log_file}" not created')
 
+            # wait for the vm boot before first time to try serial login
+            time.sleep(5)
             session = vm.wait_for_serial_login(timeout=60)
             vm_iface = utils_net.get_linux_ifname(session, mac)
             passt.check_vm_ip(iface_attrs, session, host_iface, vm_iface)

--- a/libvirt/tests/src/virtual_network/passt/passt_connectivity_between_2vms.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_connectivity_between_2vms.py
@@ -1,5 +1,6 @@
 import logging
 import shutil
+import time
 
 import aexpect
 from virttest import libvirt_version
@@ -95,6 +96,8 @@ def run(test, params, env):
         [LOG.debug(virsh.dumpxml(vm_name, uri=virsh_uri).stdout_text)
          for vm_name in (vm_name, vm_c.name)]
 
+        # wait for the vm boot before first time to try serial login
+        time.sleep(5)
         server_session = vm.wait_for_serial_login(60)
         client_session = vm_c.wait_for_serial_login(60)
 

--- a/libvirt/tests/src/virtual_network/passt/passt_reconnect.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_reconnect.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import shutil
+import time
 
 import aexpect
 from avocado.utils import process
@@ -107,6 +108,8 @@ def run(test, params, env):
         if not os.path.exists(log_file):
             test.fail(f'Logfile of passt "{log_file}" not created')
 
+        # wait for the vm boot before first time to try serial login
+        time.sleep(5)
         session = vm.wait_for_serial_login(timeout=60)
         vm_iface = utils_net.get_linux_ifname(session, mac)
         passt.check_vm_ip(iface_attrs, session, host_iface, vm_iface)


### PR DESCRIPTION
Some passt related cases failed since login timeout issue. It's beacuase the serial login sendkey which paused booting. Sleep 5s in these cases to skip the interruption.