### PR TITLE
libvirt_hooks.py: Fix string matching

### DIFF
--- a/libvirt/tests/cfg/libvirt_hooks.cfg
+++ b/libvirt/tests/cfg/libvirt_hooks.cfg
@@ -24,6 +24,7 @@
             variants:
                 - start_stop:
                     test_start_stop = "yes"
+                    release_reason = "shutdown"
                 - libvirtd_t:
                     test_libvirtd = "yes"
                 - save_restore:

--- a/libvirt/tests/src/libvirt_hooks.py
+++ b/libvirt/tests/src/libvirt_hooks.py
@@ -85,6 +85,7 @@ def run(test, params, env):
         """
         Do start/stop operation and check the results.
         """
+        release_reason = params.get("release_reason", "-")
         logging.info("Try to test start/stop hooks...")
         hook_para = "%s %s" % (hook_file, vm_name)
         prepare_hook_file(hook_script %
@@ -102,7 +103,7 @@ def run(test, params, env):
             vm.destroy()
             hook_str = hook_para + " stopped end -"
             assert check_hooks(hook_str)
-            hook_str = hook_para + " release end -"
+            hook_str = hook_para + " release end " + release_reason
             assert check_hooks(hook_str)
         except AssertionError:
             utils_misc.log_last_traceback()


### PR DESCRIPTION
### The Issue
Since a recent libvirt commit, the hook log for the hook "release end" provides a reason for the release.
```
/etc/libvirt/hooks/qemu guest_name release end <shutoff-reason>
```
The test currently looks for a logline that does not provide a reason for release. This appears like this:
```
/etc/libvirt/hooks/qemu guest_name release end -
```
This results in the test failing if a reason is provided. E.G. the test will fail if this log line is given:
```
/etc/libvirt/hooks/qemu guest_name release end shutdown
```
### The Fix
Alter test such that it only looks for "release end shutdown"

### Evidence
Console output showing this test passing
```
(.libvirt-ci-venv-ci-runtest-IDDz4J) [root@ampere-mtsnow-altramax-48 tp-libvirt]# avocado run --vt-type libvirt --vt-machine-type arm64-mmio --test-runner=runner libvirt_hooks.vm.start_stop
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : f844c41492c07d9c4bab462b3f0d60d5b2486945
JOB LOG    : /var/log/avocado/job-results/job-2024-07-22T09.52-f844c41/job.log
 (1/1) type_specific.io-github-autotest-libvirt.libvirt_hooks.vm.start_stop: PASS (62.05 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2024-07-22T09.52-f844c41/results.html
JOB TIME   : 62.44 s
```