### PR TITLE
migration: Fix parameters issue

### DIFF
--- a/libvirt/tests/src/migration/live_migration.py
+++ b/libvirt/tests/src/migration/live_migration.py
@@ -325,7 +325,7 @@ def run(test, params, env):
         do_mig_param = {"vm": vm, "mig_test": migration_test, "src_uri": None, "dest_uri": dest_uri,
                         "options": options, "virsh_options": virsh_options, "extra": extra,
                         "action_during_mig": action_during_mig, "extra_args": extra_args}
-        migration_base.do_migration(do_mig_param)
+        migration_base.do_migration(**do_mig_param)
 
         func_returns = dict(migration_test.func_ret)
         migration_test.func_ret.clear()
@@ -370,7 +370,7 @@ def run(test, params, env):
             do_mig_param = {"vm": vm, "mig_test": migration_test, "src_uri": None, "dest_uri": dest_uri,
                             "options": options, "virsh_options": virsh_options, "extra": extra,
                             "action_during_mig": action_during_mig, "extra_args": extra_args}
-            migration_base.do_migration(do_mig_param)
+            migration_base.do_migration(**do_mig_param)
             if return_port:
                 func_returns = dict(migration_test.func_ret)
                 logging.debug("Migration returns function "

--- a/libvirt/tests/src/migration/migrate_event.py
+++ b/libvirt/tests/src/migration/migrate_event.py
@@ -81,7 +81,7 @@ def run(test, params, env):
         do_mig_param = {"vm": vm, "mig_test": migration_test, "src_uri": None, "dest_uri": dest_uri,
                         "options": options, "virsh_options": virsh_options, "extra": extra,
                         "action_during_mig": action_during_mig, "extra_args": extra_args}
-        migration_base.do_migration(do_mig_param)
+        migration_base.do_migration(**do_mig_param)
 
         func_returns = dict(migration_test.func_ret)
         migration_test.func_ret.clear()

--- a/libvirt/tests/src/migration/migrate_service_control.py
+++ b/libvirt/tests/src/migration/migrate_service_control.py
@@ -137,7 +137,7 @@ def run(test, params, env):
         do_mig_param = {"vm": vm, "mig_test": migration_test, "src_uri": None, "dest_uri": dest_uri,
                         "options": options, "virsh_options": virsh_options, "extra": extra,
                         "action_during_mig": action_during_mig, "extra_args": extra_args}
-        migration_base.do_migration(do_mig_param)
+        migration_base.do_migration(**do_mig_param)
 
         func_returns = dict(migration_test.func_ret)
         migration_test.func_ret.clear()
@@ -157,7 +157,7 @@ def run(test, params, env):
             do_mig_param = {"vm": vm, "mig_test": migration_test, "src_uri": None, "dest_uri": dest_uri,
                             "options": options, "virsh_options": virsh_options, "extra": extra,
                             "action_during_mig": action_during_mig, "extra_args": extra_args}
-            migration_base.do_migration(do_mig_param)
+            migration_base.do_migration(**do_mig_param)
         if int(migration_test.ret.exit_status) == 0:
             migration_test.post_migration_check([vm], params, dest_uri=dest_uri)
     finally:

--- a/libvirt/tests/src/migration/migrate_with_various_hostname.py
+++ b/libvirt/tests/src/migration/migrate_with_various_hostname.py
@@ -197,7 +197,7 @@ def run(test, params, env):
         do_mig_param = {"vm": vm, "mig_test": migration_test, "src_uri": None, "dest_uri": dest_uri,
                         "options": options, "virsh_options": virsh_options, "extra": extra,
                         "action_during_mig": None, "extra_args": extra_args}
-        migration_base.do_migration(do_mig_param)
+        migration_base.do_migration(**do_mig_param)
 
         func_returns = dict(migration_test.func_ret)
         migration_test.func_ret.clear()
@@ -215,7 +215,7 @@ def run(test, params, env):
             do_mig_param = {"vm": vm, "mig_test": migration_test, "src_uri": None, "dest_uri": dest_uri,
                             "options": options, "virsh_options": virsh_options, "extra": extra,
                             "action_during_mig": None, "extra_args": extra_args}
-            migration_base.do_migration(do_mig_param)
+            migration_base.do_migration(**do_mig_param)
         if int(migration_test.ret.exit_status) == 0:
             migration_test.post_migration_check([vm], params, dest_uri=dest_uri, src_uri=bk_uri)
     finally:

--- a/provider/migration/base_steps.py
+++ b/provider/migration/base_steps.py
@@ -171,7 +171,7 @@ class MigrationBase(object):
         do_mig_param = {"vm": self.vm, "mig_test": self.migration_test, "src_uri": None,
                         "dest_uri": dest_uri, "options": options, "virsh_options": virsh_options,
                         "extra": extra, "action_during_mig": action_during_mig, "extra_args": extra_args}
-        migration_base.do_migration(do_mig_param)
+        migration_base.do_migration(**do_mig_param)
 
     def run_migration_again(self):
         """
@@ -222,7 +222,7 @@ class MigrationBase(object):
         do_mig_param = {"vm": self.vm, "mig_test": self.migration_test, "src_uri": None,
                         "dest_uri": dest_uri, "options": options, "virsh_options": virsh_options,
                         "extra": extra, "action_during_mig": action_during_mig, "extra_args": extra_args}
-        migration_base.do_migration(do_mig_param)
+        migration_base.do_migration(**do_mig_param)
 
     def run_migration_back(self):
         """

--- a/provider/migration/migration_base.py
+++ b/provider/migration/migration_base.py
@@ -81,24 +81,24 @@ def parse_funcs(action_during_mig, test, params):
                    "function name and list are supported")
 
 
-def do_migration(do_mig_param):
+def do_migration(**kwargs):
     """
     The wrapper function to call migration
 
-    :param do_mig_param: do migration parameters, dict, contains vm object,
-                         MigrationTest object, source uri, target uri, migration
-                         options, virsh options, extra options for migration, list
-                         or single function to run during migration, arguments for test
+    :param kwargs: do migration parameters, dict, contains vm object,
+                   MigrationTest object, source uri, target uri, migration
+                   options, virsh options, extra options for migration, list
+                   or single function to run during migration, arguments for test
     """
-    vm = do_mig_param['vm']
-    mig_test = do_mig_param['mig_test']
-    src_uri = do_mig_param['src_uri']
-    dest_uri = do_mig_param['dest_uri']
-    options = do_mig_param['options']
-    virsh_options = do_mig_param['virsh_options']
-    extra = do_mig_param['extra']
-    action_during_mig = do_mig_param['action_during_mig']
-    extra_args = do_mig_param['extra_args']
+    vm = kwargs.get('vm')
+    mig_test = kwargs.get('mig_test')
+    src_uri = kwargs.get('src_uri')
+    dest_uri = kwargs.get('dest_uri')
+    options = kwargs.get('options')
+    virsh_options = kwargs.get('virsh_options')
+    extra = kwargs.get('extra')
+    action_during_mig = kwargs.get('action_during_mig')
+    extra_args = kwargs.get('extra_args')
     vm_name = None
 
     if extra and "--dname" in extra:
@@ -571,7 +571,7 @@ def resume_migration_again(params):
     do_mig_param = {"vm": migration_obj.vm, "mig_test": migration_obj.migration_test, "src_uri": None,
                     "dest_uri": dest_uri, "options": options, "virsh_options": virsh_options,
                     "extra": extra_twice_during_mig, "action_during_mig": None, "extra_args": extra_args_twice_during_mig}
-    do_migration(do_mig_param)
+    do_migration(**do_mig_param)
 
 
 def check_event_before_unattended(params):


### PR DESCRIPTION
Fix following issue:
  TypeError: do_migration() got an unexpected keyword argument 'vm'