### PR TITLE
fix package upated for usb case

### DIFF
--- a/libvirt/tests/cfg/guest_os_booting/boot_order/boot_from_usb_device.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/boot_order/boot_from_usb_device.cfg
@@ -16,6 +16,6 @@
             port_num = "4000"
             device_attrs = {'source': {'host': 'localhost', 'service': '4000', 'mode': 'connect'}, 'protocol': {'type': 'raw'}, 'type_name': 'tcp', 'bus': '${bus_type}', 'type': 'tcp', 'boot': {'order': '1'}}
             only q35
-            required_cmds = ['usbredirserver', 'lsusb']
+            required_cmds = ['lsusb']
         - hostdev_device:
             device_attrs = {'type_name': 'usb', 'mode': 'subsystem', 'source': {'vendor_id': '%s', 'product_id': '%s'}, 'type': 'usb', 'managed': 'no', 'boot_order': '1'}

--- a/libvirt/tests/cfg/usb/usb_device.cfg
+++ b/libvirt/tests/cfg/usb/usb_device.cfg
@@ -68,7 +68,9 @@
         - redirdev:
             only companion
             only pcie-to-pci-bridge,pci-root
-            pkgs_host = "usbutils,usbredir-server"
+            pkgs_host = "usbutils"
+#             pkgs_host_rhel9 = ",usbredir-server"
+#             pkgs_host_rhel10 = ",usbredir-tools"
             device_name = "redirdev"
             variants:
                 - spicevmc:

--- a/provider/usb/usb_base.py
+++ b/provider/usb/usb_base.py
@@ -1,0 +1,49 @@
+from avocado.utils import distro
+from avocado.utils import process
+
+
+def get_host_pkg_and_cmd():
+    """
+    Get package and related command on the host.
+
+    :return: pkg_and_cmd, extra usb package name and command.
+    """
+    if int(distro.detect().version) <= 9:
+        pkg_and_cmd = ("usbredir-server", "usbredirserver")
+    else:
+        pkg_and_cmd = ("usbredir-tools", "usbredirect")
+    return pkg_and_cmd
+
+
+def start_redirect_server(params, usb_cmd, vendor_id, product_id):
+    """
+    Start redirect server
+
+    :param params: Dict with test params.
+    :param usb_cmd, the usb command to confirm how to start server.
+    :param vendor_id, vendor id.
+    :param product_id, produce id.
+    :return server_id, redirect server id
+    """
+    port_num = params.get("port_num")
+    if usb_cmd == "usbredirserver":
+        ps = process.SubProcess("usbredirserver -p {} {}:{}".format
+                                (port_num, vendor_id, product_id),
+                                shell=True)
+    elif usb_cmd == "usbredirect":
+        ps = process.SubProcess(
+            "usbredirect --device {}:{} --as {}:{}".format
+            (vendor_id, product_id, "127.0.0.1", port_num),
+            shell=True)
+    server_id = ps.start()
+    return server_id
+
+
+def kill_redirect_server(usb_cmd):
+    """
+    Kill redirect server
+
+    :param usb_cmd, the usb command to kill server.
+    """
+    if 'server_id' in globals():
+        process.run("killall {}".format(usb_cmd), ignore_status=True)


### PR DESCRIPTION
  usbredirserver is updated to usbredirect
Signed-off-by: nanli <nanli@redhat.com>

```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 guest_os_booting.boot_order.usb_device

 (1/3) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.usb_device.block_device: PASS (41.59 s)
 (2/3) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.usb_device.redirdev_device: PASS (15.60 s)
 (3/3) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.usb_device.hostdev_device: PASS (15.70 s)


avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 guest_os_booting.boot_order.usb_device.redirdev_device
 (1/1) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.usb_device.redirdev_device: PASS (15.28 s)

```