### PR TITLE
vm_create_destroy_concurrently: Reliability Test

### DIFF
--- a/libvirt/tests/cfg/vm_create_destroy_concurrently.cfg
+++ b/libvirt/tests/cfg/vm_create_destroy_concurrently.cfg
@@ -1,0 +1,5 @@
+- vm_create_destroy_concurrently:
+    type = vm_create_destroy_concurrently
+    start_vm = no
+    num_threads = 3
+    run_time = 1800

--- a/libvirt/tests/src/vm_create_destroy_concurrently.py
+++ b/libvirt/tests/src/vm_create_destroy_concurrently.py
@@ -1,0 +1,141 @@
+from virttest.libvirt_xml import vm_xml
+from virttest import data_dir, utils_libvirtd, utils_sys
+
+import logging
+import subprocess
+
+
+def create_scripts(vmxml, num_scripts, timeout):
+    """
+    Create scripts for creating and destroying
+    VMs. We create separate scripts so we can
+    execute them concurrently, and overcome
+    python's GIL
+
+    :param vmxml: Base xml for the VMs
+    that will be created
+
+    :param num_scripts: number of scripts to
+    create
+
+    :param timeout: amount of time to spend creating
+    and destroying VMs
+    """
+    tmp_dir = data_dir.get_tmp_dir(public=False)
+    vm_name = vmxml.vm_name
+    script_names = []
+
+    for i in range(num_scripts):
+        xml_path = tmp_dir + "/xml_" + str(i) + ".xml"
+        sh_path = tmp_dir + "/script_" + str(i) + ".sh"
+
+        # SELinux does not allow multiple VM operations the same qcow2 files
+        vmxml.remove_all_disk()
+
+        for item in ["loader", "nvram"]:
+            if item in str(vmxml):
+                vmxml.xmltreefile.remove_by_xpath("/os/%s" % item, remove_all=True)
+
+        with open(xml_path, "w") as outfile:
+            outfile.write(str(vmxml))
+
+        logging.debug("Written vm xml file to {}".format(xml_path))
+        logging.info("VM XML Contents: \n{}".format(str(vmxml)))
+
+        with open(sh_path, "w") as outfile:
+            script = """
+                end=$((SECONDS+{}));
+                while [ $SECONDS -lt $end ] ; do
+                    virsh create {} || continue ;
+                    virsh destroy {} ;
+                done ;
+                """.format(timeout, xml_path, vm_name)
+            outfile.write(script)
+            logging.debug("Script file contents {}".format(script))
+
+        logging.debug("Written script file to {}".format(sh_path))
+
+        script_names.append(sh_path)
+
+    return script_names
+
+
+def get_pids_for(names):
+    """
+    Given a list of names, retrieve the
+    PIDs for matching processes
+
+    Sort of equivalent to: 'ps aux | grep name'
+
+    :param names: List of process names to look for
+    """
+
+    pids = utils_sys.get_pids_for(names)
+    logging.info("Processes and Pids matching {}: {}".format(names, pids))
+
+    return pids
+
+
+def get_libvirt_pids(test, daemon):
+    """
+    Given a Libvirtd daemon object, retrieve the
+    pids relevant to the libvirt services
+
+    :param test: Avocado test object
+    :param daemon: Avocado-vt libvirtd daemon
+    object. Provides list of libvirt services
+    """
+    if not daemon.is_running():
+        test.fail("No libvirt daemon running")
+
+    return get_pids_for(daemon.service_list)
+
+
+def run(test, params, env):
+    """
+    This test ensures that VMs can be created concurrently.
+    Test Process:
+        1) Create bash scripts to create and destroy transient VMs
+        2) Execute the scripts simultaneously for a given number of seconds
+        3) Check that libvirt daemon(s) have not changed PID
+        4) Check to ensure there are no orphan VMs
+    """
+
+    daemon = utils_libvirtd.Libvirtd()
+    pids_before_test = get_libvirt_pids(test, daemon)
+
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+
+    num_threads = int(params.get("num_threads", 3))
+    wait_time = int(params.get("run_time", 60))
+
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    scripts = create_scripts(vmxml, num_threads, wait_time)
+
+    processes = []
+    for i in range(num_threads):
+        process = subprocess.Popen(["/bin/bash", scripts[i]], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        processes.append(process)
+
+    exit_codes = [p.wait() for p in processes]
+
+    for i in range(len(exit_codes)):
+        if exit_codes[i] != 0:
+            fail = processes[i]
+            logging.debug("Script did not exit cleanly")
+            logging.debug("\tstderr: {}".format(fail.stderr.read()))
+            logging.debug("\tstdout: {}".format(fail.stdout.read()))
+
+    if [x for x in exit_codes if x != 0] != []:
+        test.fail("Test Failed with script errors")
+
+    pids_after_test = get_libvirt_pids(test, daemon)
+    if pids_before_test != pids_after_test:
+        logging.debug("Pids Before Test: {}".format(pids_before_test))
+        logging.debug("Pids After Test: {}".format(pids_after_test))
+        test.fail("Libvirt pids changed")
+
+    vm_pids = get_pids_for([vm_name])
+    if vm_pids != []:
+        test.fail("Orphan VM(s): PID(s) {} belonging to {}".format(vm_pids, vm_name))


### PR DESCRIPTION
### The Issue
Libvirt provides unique UUIDs to every VM, in order to uniquely identify the VMs.

When transient VMs are created, libvirt allows it to have a non-unique name/UUID. So long as any other VM with the same name/UUID is a persistant VM, that is not running

If two transient VMs are created at the same time, with the same name/UUID, a race condition exists. We expect libvirt to create one VM, and prevent the creation of another. However, sometimes this is not what happens

If such a race condition occurs, Libvirt may crash, and orphan VMs may be created. This test checks for this.

### The Test: vm_create_destroy_concurrently
1. Create several loops that continuosly start and destroy a transient VM. Python's GIL prevents the same bytecodes from executing at the same time. To ensure that a race condition can happen, and the GIL cannot prevent it, the vms are created from an external bash script
2. Wait for a given number of seconds (run_time in cfg file), stop the loops
3. Make sure that libvirtd has not crashed. This is done by check to make sure the libvirt daemon(s) have the same pid at the start and end of the test
4. Ensure there are no orphan VMs

### Evidence the test works
This test did not pass when it was first written. A bug was filed: [RHEL-49607](https://issues.redhat.com/browse/RHEL-49607). Once the patches where supplied, the test passes.

The test passing when run for 30 minutes:
```
[root@ampere-mtjade-altramax-01 tp-libvirt]# avocado run --vt-type libvirt --vt-machine-type arm64-mmio --test-runner=runner vm_create_destroy_concurrently
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : cd6b89e304a7909eb6f44943734f184933ad1ed9
JOB LOG    : /var/log/avocado/job-results/job-2024-07-22T11.55-cd6b89e/job.log
 (1/1) type_specific.io-github-autotest-libvirt.vm_create_destroy_concurrently: PASS (1807.94 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2024-07-22T11.55-cd6b89e/results.html
JOB TIME   : 1810.09 s
```
