### PR TITLE
Remove vm destroy right after vm start to avoid destroy cmd failure

### DIFF
--- a/libvirt/tests/cfg/memory/memory_backing/lifecycle_for_hugepage.cfg
+++ b/libvirt/tests/cfg/memory/memory_backing/lifecycle_for_hugepage.cfg
@@ -1,5 +1,6 @@
 - memory.backing.lifecycle:
     type = lifecycle_for_hugepage
+    start_vm = no
     total_hugepage_mem = 2097152
     vm_nr_hugepages = 1024
     mount_size = "1048576"

--- a/libvirt/tests/src/memory/memory_backing/lifecycle_for_hugepage.py
+++ b/libvirt/tests/src/memory/memory_backing/lifecycle_for_hugepage.py
@@ -121,7 +121,6 @@ def setup_test(vm_name, params, test):
     hp_cfg.hugepage_size = mount_size
     hp_cfg.mount_hugepage_fs()
     utils_libvirtd.Libvirtd().restart()
-    virsh.destroy(vm_name)
 
 
 def run_test(vm, params, test):


### PR DESCRIPTION
vm destroy right after vm start may fail destroy cmd (when vm initial time need longer time, for instance using hugepage), then the failed destroy cmd may impact following guest save cmd.

Resuts: run 20 times all pass:
(1/1) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.default_hugepage_size: PASS (143.65 s)