### PR TITLE
v2v: only support 32 disks for v2v to rhev

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -251,6 +251,7 @@
             expect_msg = no
         - vddk_errors_41_disks:
             only negative_test
+            only rhev
             only esx_70
             #add required version due to bug2051564
             version_requried = "[virt-v2v-2.0.7-1,)"


### PR DESCRIPTION
Please refer bz#2051564.