### PR TITLE
add case for virtio memory with various memory allocation and guest numa

### DIFF
--- a/libvirt/tests/cfg/memory/memory_devices/virtio_mem_with_memory_allocation_and_numa.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/virtio_mem_with_memory_allocation_and_numa.cfg
@@ -1,0 +1,81 @@
+- memory.devices.virtio_mem.memory_allocation_and_numa:
+    type = virtio_mem_with_memory_allocation_and_numa
+    no s390-virtio
+    start_vm = no
+    mem_model = "virtio-mem"
+    mem_value = 8388608
+    current_mem = 8388608
+    request_size = "512"
+    target_size = "512"
+    target_size_unit = "MiB"
+    request_size_unit = "MiB"
+    take_regular_screendumps = no
+    base_attrs = "'memory_unit':'KiB','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'KiB',"
+    err_msg1 = "cannot use/hotplug a memory device when domain 'maxMemory' is not defined"
+    err_msg2 = "target NUMA node needs to be specified for memory device"
+    err_msg3 = "can't add memory backend as guest has no NUMA nodes configured"
+    required_kernel = [5.14.0,)
+    guest_required_kernel = [5.8.0,)
+    func_supported_since_libvirt_ver = (8, 0, 0)
+    func_supported_since_qemu_kvm_ver = (6, 2, 0)
+    variants memory_allocation:
+        - no_maxmemory:
+            max_attrs = ""
+            define_error = "${err_msg1}"
+        - with_maxmemory:
+            max_mem = 20971520
+            max_attrs = '"max_mem_rt": ${max_mem}, "max_mem_rt_unit": "KiB",'
+    variants numa_topology:
+        - without_numa:
+            numa_attrs = ""
+        - with_numa:
+            numa_mem = 8388608
+            numa_attrs = "'vcpu': 4, 'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-3', 'memory': '${numa_mem}', 'unit': 'KiB'}]},"
+    vm_attrs = {${base_attrs} ${max_attrs} ${numa_attrs}}
+    variants:
+        - virtio_mem_with_node:
+            node = 0
+            virtio_mem_dict = {'mem_model': '${mem_model}', 'target': {'requested_unit': '${request_size_unit}', 'size': ${target_size}, 'node': ${node}, 'size_unit': '${target_size_unit}', 'requested_size': ${request_size}, 'block_unit': 'KiB', 'block_size': %s}}
+            no_maxmemory:
+                with_numa:
+                    cold_plug_error = "${err_msg1}"
+                    hot_plug_error = "${err_msg1}"
+                without_numa:
+                    cold_plug_error = "${err_msg3}"
+                    hot_plug_error = "${err_msg3}"
+        - virtio_mem_without_node:
+            virtio_mem_dict = {'mem_model': '${mem_model}', 'target': {'requested_unit': '${request_size_unit}', 'size': ${target_size}, 'size_unit': '${target_size_unit}', 'requested_size': ${request_size}, 'block_unit': 'KiB', 'block_size': %s}}
+            coldplug_start_error = "${err_msg1}"
+            with_numa:
+                cold_plug_error = "${err_msg1}"
+                with_maxmemory:
+                    define_error = "${err_msg2}"
+                    hot_plug_error = "${err_msg1}"
+            with_maxmemory:
+                hot_plug_error = "${err_msg2}"
+                cold_plug_error = "${err_msg2}"
+            no_maxmemory:
+                cold_plug_error = "${err_msg1}"
+                without_numa,with_numa:
+                    hot_plug_error = "${err_msg1}"
+        - virtio_mem_with_exceed_size:
+            only without_numa.with_maxmemory
+            target_size = "10485760"
+            request_size = "256"
+            target_size_unit = "KiB"
+            virtio_mem_dict = {'mem_model': '${mem_model}', 'target': {'requested_unit': '${request_size_unit}', 'size': ${target_size}, 'size_unit': '${target_size_unit}', 'requested_size': ${request_size}, 'block_unit': 'KiB', 'block_size': %s}}
+            coldplug_start_error = "${err_msg2}"
+            with_maxmemory:
+                hot_plug_error = "${err_msg2}"
+                cold_plug_error = "${err_msg2}"
+            without_numa:
+                with_maxmemory:
+                    define_error = "Total size of memory devices exceeds the total memory size"
+    variants plug_type:
+        - define_guest:
+        - cold_plug:
+            operation = "attach"
+            plug_option = " --config"
+        - hot_plug:
+            operation = "attach"
+            plug_option = " "

--- a/libvirt/tests/src/memory/memory_devices/virtio_mem_with_memory_allocation_and_numa.py
+++ b/libvirt/tests/src/memory/memory_devices/virtio_mem_with_memory_allocation_and_numa.py
@@ -1,0 +1,194 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright Redhat
+#
+#   SPDX-License-Identifier: GPL-2.0
+
+#   Author: Nannan Li <nanli@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import re
+
+from avocado.utils import memory as avocado_mem
+
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_test import libvirt
+
+from provider.memory import memory_base
+
+
+def adjust_virtio_mem_size_unit(params, test):
+    """
+    Adjust the virtio memory target size and request size to KiB unit.
+
+    :param params: dict, test parameters
+    :param test: test object.
+    """
+    target_size = int(memory_base.convert_data_size(
+        params.get("target_size") + params.get("target_size_unit")))
+    request_size = int(memory_base.convert_data_size(
+        params.get("request_size") + params.get("request_size_unit")))
+
+    params.update({"target_size": target_size})
+    params.update({"request_size": request_size})
+
+    test.log.debug("Convert params: target_size to be %s, request_size to be",
+                   target_size, request_size)
+
+
+def check_guest_xml(vm, params, test):
+    """
+    Check guest xml.
+
+    :param vm: vm object.
+    :param params: test parameters object
+    :param test: test object.
+    """
+    expect_mem = int(params.get("mem_value"))
+    expect_curr = int(params.get("current_mem"))
+    memory_allocation = params.get("memory_allocation")
+    numa_topology = params.get("numa_topology")
+    no_numa_and_max_mem = \
+        memory_allocation == "with_maxmemory" and numa_topology == "without_numa"
+
+    vmxml = vm_xml.VMXML.new_from_dumpxml(vm.name)
+    test.log.debug("Current guest xml is %s\n", vmxml)
+    memory = vmxml.get_memory()
+    current_mem = vmxml.get_current_mem()
+    virtio_mem = vmxml.get_devices("memory")[0]
+    target = virtio_mem.target
+    target_size = int(target.get_size())
+    target_node = target.get_node()
+    target_block = target.get_block_size()
+    target_request = target.get_requested_size()
+    target_current = int(target.get_current_size())
+
+    adjust_virtio_mem_size_unit(params, test)
+
+    test.log.debug("Check guest memory and current memory value")
+    if not no_numa_and_max_mem:
+        expect_mem = int(params.get("mem_value")) + target_size
+        expect_curr = int(params.get("current_mem")) + target_current
+    memory_base.compare_values(test, expect_mem, memory, "memory")
+    memory_base.compare_values(test, expect_curr, current_mem, "current memory")
+
+    test.log.debug("Check virtio memory size")
+    memory_base.compare_values(test, params.get("target_size"),
+                               target_size, "virtio mem target size")
+    memory_base.compare_values(test, params.get('default_hp'),
+                               target_block, "virtio mem block size")
+    memory_base.compare_values(test, params.get("request_size"),
+                               target_request, "virtio mem request size")
+    memory_base.compare_values(test, params.get("request_size"),
+                               target_current, "virtio mem current size")
+    if params.get("node"):
+        memory_base.compare_values(
+            test, int(params.get("node")), target_node, "numa node")
+    if params.get("numa_mem"):
+        memory_base.compare_values(test, params.get("numa_mem"),
+                                   vmxml.cpu.numa_cell[0].memory, "numa memory")
+
+
+def run(test, params, env):
+    """
+    Verify virtio-mem memory device works with various
+    memory allocation and numa setting.
+    """
+    def run_test_define_guest():
+        """
+        Define guest with memory allocation and numa, virtio memory.
+        """
+        test.log.info("TEST_STEP1: Define guest with one virtio-mem device")
+        try:
+            memory_base.define_guest_with_memory_device(
+                params, virtio_mem_dict, vm_attrs)
+
+        except Exception as e:
+            if define_error:
+                if not re.search(define_error, str(e)):
+                    test.fail("Except %s error msg, but got %s" % (define_error, e))
+                else:
+                    test.log.debug("Define guest with expected error:\n%s", e)
+                    return
+            else:
+                test.fail("Define guest failed")
+
+        test.log.info("TEST_STEP2: Start guest")
+        virsh.start(vm_name)
+        vm.wait_for_login().close()
+
+        test.log.info("TEST_STEP3: Check guest memory xml")
+        check_guest_xml(vm, params, test)
+
+    def run_test_cold_plug():
+        """
+         Check guest with various memory allocation and numa setting,
+        and cold plug virtio-mem memory device successfully.
+        """
+        test.log.info("TEST_STEP1: Define guest without virtio-mem devices")
+        vmxml.setup_attrs(**vm_attrs)
+        vmxml.sync()
+
+        test.log.info("TEST_STEP2: Cold-plug one virtio-mem device")
+        memory_base.plug_memory_and_check_result(
+            test, params, mem_dict=virtio_mem_dict, operation=operation,
+            expected_error=cold_plug_error, flagstr=plug_option)
+        if cold_plug_error:
+            return
+
+        test.log.info("TEST_STEP3: Start guest and check result")
+        res = virsh.start(vm_name)
+        libvirt.check_result(res, expected_fails=coldplug_start_error)
+
+    def run_test_hot_plug():
+        """
+        Check guest with various memory allocation and numa setting,
+        and hot plug virtio-mem memory device successfully.
+        """
+        test.log.info("TEST_STEP1: Define guest without virtio-mem devices")
+        vmxml.setup_attrs(**vm_attrs)
+        vmxml.sync()
+
+        test.log.info("TEST_STEP2: Start guest")
+        vm.start()
+        vm.wait_for_login().close()
+
+        test.log.info("TEST_STEP3: Hot-plug one virtio-mem device")
+        memory_base.plug_memory_and_check_result(
+            test, params, mem_dict=virtio_mem_dict, operation=operation,
+            expected_error=hot_plug_error, flagstr=plug_option)
+
+    def teardown_test():
+        """
+        Clean data.
+        """
+        test.log.info("TEST_TEARDOWN: Clean up env.")
+        bkxml.sync()
+
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    memory_base.check_supported_version(params, test, vm)
+
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+
+    default_hugepage_size = avocado_mem.get_huge_page_size()
+    vm_attrs = eval(params.get('vm_attrs', '{}'))
+    params.update({"default_hp": default_hugepage_size})
+    virtio_mem_dict = eval(params.get("virtio_mem_dict") % default_hugepage_size)
+    operation = params.get("operation")
+    plug_option = params.get("plug_option")
+    plug_type = params.get("plug_type")
+    define_error = params.get("define_error")
+    coldplug_start_error = params.get("coldplug_start_error")
+    hot_plug_error = params.get("hot_plug_error")
+    cold_plug_error = params.get("cold_plug_error")
+
+    run_test = eval("run_test_%s" % plug_type)
+
+    try:
+        run_test()
+
+    finally:
+        teardown_test()

--- a/provider/memory/memory_base.py
+++ b/provider/memory/memory_base.py
@@ -248,3 +248,19 @@ def check_mem_page_sizes(test, pg_size=None, hp_size=None, hp_list=None):
     if hp_list and not set(hp_list).issubset(set(supported_hp_size_list)):
         test.cancel("Expected huge page size list is %s, but get %s" %
                     (hp_list, supported_hp_size_list))
+
+
+def compare_values(test, expected, actual, check_item=''):
+    """
+    Compare two values are the same.
+
+    :params test, test object.
+    :params expected, expected value.
+    :params actual, actual value.
+    :params check_item, the item to be checked.
+    """
+    if expected != actual:
+        test.fail("Expect %s to get '%s' instead of '%s' " % (
+            check_item, expected, actual))
+    else:
+        test.log.debug("Check %s %s PASS", check_item, actual)


### PR DESCRIPTION
 xxxx-299031 Virtio-mem device with various memory allocation and guest numa settings.


```

 avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 memory.devices.virtio_mem.memory_allocation_and_numa
 (01/27) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.define_guest.virtio_mem_with_node.without_numa.no_maxmemory: PASS (40.78 s)
 (02/27) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.define_guest.virtio_mem_with_node.without_numa.with_maxmemory: PASS (75.51 s)
 (03/27) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.define_guest.virtio_mem_with_node.with_numa.no_maxmemory: PASS (42.39 s)
 (04/27) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.define_guest.virtio_mem_with_node.with_numa.with_maxmemory: PASS (75.50 s)
 (05/27) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.define_guest.virtio_mem_without_node.without_numa.no_maxmemory: PASS (40.85 s)
 (06/27) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.define_guest.virtio_mem_without_node.without_numa.with_maxmemory: PASS (76.11 s)
 (07/27) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.define_guest.virtio_mem_without_node.with_numa.no_maxmemory: PASS (42.37 s)
 (08/27) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.define_guest.virtio_mem_without_node.with_numa.with_maxmemory: PASS (40.88 s)
 (09/27) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.define_guest.virtio_mem_with_exceed_size.without_numa.with_maxmemory: PASS (40.75 s)
 (10/27) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.cold_plug.virtio_mem_with_node.without_numa.no_maxmemory: PASS (42.51 s)
 (11/27) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.cold_plug.virtio_mem_with_node.without_numa.with_maxmemory: PASS (43.75 s)
 (12/27) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.cold_plug.virtio_mem_with_node.with_numa.no_maxmemory: PASS (42.01 s)
 (13/27) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.cold_plug.virtio_mem_with_node.with_numa.with_maxmemory: PASS (43.59 s)
 (14/27) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.cold_plug.virtio_mem_without_node.without_numa.no_maxmemory: PASS (41.96 s)
 (15/27) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.cold_plug.virtio_mem_without_node.without_numa.with_maxmemory: PASS (42.07 s)
 (16/27) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.cold_plug.virtio_mem_without_node.with_numa.no_maxmemory: PASS (40.25 s)
 (17/27) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.cold_plug.virtio_mem_without_node.with_numa.with_maxmemory: PASS (40.28 s)
 (18/27) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.cold_plug.virtio_mem_with_exceed_size.without_numa.with_maxmemory: PASS (42.23 s)
 (19/27) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.hot_plug.virtio_mem_with_node.without_numa.no_maxmemory: PASS (77.94 s)
 (20/27) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.hot_plug.virtio_mem_with_node.without_numa.with_maxmemory: PASS (77.19 s)
 (21/27) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.hot_plug.virtio_mem_with_node.with_numa.no_maxmemory: PASS (77.04 s)
 (22/27) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.hot_plug.virtio_mem_with_node.with_numa.with_maxmemory: PASS (77.42 s)
 (23/27) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.hot_plug.virtio_mem_without_node.without_numa.no_maxmemory: PASS (75.06 s)
 (24/27) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.hot_plug.virtio_mem_without_node.without_numa.with_maxmemory: PASS (76.89 s)
 (25/27) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.hot_plug.virtio_mem_without_node.with_numa.no_maxmemory: PASS (75.52 s)
 (26/27) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.hot_plug.virtio_mem_without_node.with_numa.with_maxmemory: PASS (73.62 s)
 (27/27) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.hot_plug.virtio_mem_with_exceed_size.without_numa.with_maxmemory: PASS (77.26 s)

```