### PR TITLE
memory: disable memory device tests on s390x

### DIFF
--- a/libvirt/tests/cfg/memory/memory_devices/dimm_memory_hot_unplug.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/dimm_memory_hot_unplug.cfg
@@ -1,4 +1,5 @@
 - memory.devices.dimm.hot_unplug:
+    no s390-virtio
     type = dimm_memory_hot_unplug
     start_vm = yes
     mem_model = 'dimm'

--- a/libvirt/tests/cfg/memory/memory_devices/dimm_memory_with_access_and_discard.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/dimm_memory_with_access_and_discard.cfg
@@ -9,6 +9,7 @@
     target_size = 131072
     requested_size = 131072
     block_size = 2048
+    no s390-virtio
     aarch64:
         target_size = 1048576
         requested_size = 524288

--- a/libvirt/tests/cfg/memory/memory_devices/dimm_memory_with_auto_placement_numatune.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/dimm_memory_with_auto_placement_numatune.cfg
@@ -6,6 +6,7 @@
     set_size = 131072
     dimm_dict = {'mem_model': '${mem_model}', 'target': {'size': ${set_size}, 'node': 0, 'size_unit': 'KiB'}}
     attach_dimm = {'mem_model': '${mem_model}', 'target': {'size': ${set_size}, 'node': 1, 'size_unit': 'KiB'}}
+    no s390-virtio
     aarch64:
         set_size = 1048576
     variants:
@@ -26,7 +27,6 @@
     tuning_attrs = "'numa_memory': {${mode_attrs} 'placement': '${placement}'}"
     variants:
         - with_numa:
-            no s390-virtio
             numa_mem = 1048576
             mem_value = 2490368
             current_mem = 2490368

--- a/libvirt/tests/cfg/memory/memory_devices/virtio_mem_access_and_discard.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/virtio_mem_access_and_discard.cfg
@@ -9,6 +9,7 @@
     target_size = 131072
     requested_size = 131072
     block_size = 2048
+    no s390-virtio
     aarch64:
         target_size = 1048576
         requested_size = 524288
@@ -58,7 +59,6 @@
     expected_discard = ['${discard_0}', 'True', 'True', 'False', 'False', 'True']
     variants:
         - with_numa:
-            no s390-virtio
             mem_value = 3145728
             current_mem = 3145728
             max_mem = 10485760


### PR DESCRIPTION
On s390x memory devices are not available. Disable test cases.