### PR TITLE
vIOMMU: Add a hotplug case

### DIFF
--- a/libvirt/tests/cfg/sriov/vIOMMU/hotplug_device_with_iommu_enabled.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/hotplug_device_with_iommu_enabled.cfg
@@ -1,0 +1,59 @@
+- vIOMMU.hotplug_device_with_iommu_enabled:
+    type = hotplug_device_with_iommu_enabled
+    start_vm = "no"
+    ping_dest = '8.8.8.8'
+    disk_driver = {'name': 'qemu', 'type': 'qcow2', 'iommu': 'on'}
+    variants:
+        - virtio:
+            only q35, aarch64
+            no ats_on
+            func_supported_since_libvirt_ver = (8, 3, 0)
+            iommu_dict = {'model': 'virtio'}
+        - intel:
+            only q35
+            start_vm = "yes"
+            enable_guest_iommu = "yes"
+            iommu_dict = {'model': 'intel', 'driver': {'intremap': 'on', 'caching_mode': 'on', 'eim': 'on', 'iotlb': 'on', 'aw_bits': '48'}}
+        - smmuv3:
+            only aarch64
+            no ats_on
+            func_supported_since_libvirt_ver = (5, 5, 0)
+            iommu_dict = {'model': 'smmuv3'}
+    variants:
+        - e1000e:
+            only q35
+            iface_model = 'e1000e'
+            iface_dict = {'type_name': 'network', 'model': '${iface_model}', 'source': {'network': 'default'}}
+            test_devices = ["Eth"]
+        - rtl8139:
+            only q35
+            iface_model = 'rtl8139'
+            iface_dict = {'type_name': 'network', 'model': '${iface_model}', 'source': {'network': 'default'}}
+            controller_dicts = [{'type': 'pci', 'model': 'pcie-to-pci-bridge'}]
+        - virtio_muti_devices:
+            disk_dict = {'target': {'dev': 'vdb', 'bus': 'virtio'}, 'device': 'disk', 'driver': ${disk_driver}}
+            test_devices = ["Eth", "block"]
+            variants:
+                - vhost_on:
+                    interface_driver_name = "vhost"
+                - vhost_off:
+                    interface_driver_name = "qemu"
+            interface_driver = {'driver_attr': {'name': '${interface_driver_name}', 'iommu': 'on'}}
+            iface_dict = {'type_name': 'network', 'model': 'virtio', 'driver': ${interface_driver}, 'source': {'network': 'default'}}
+        - hostdev_iface:
+            only virtio
+            need_sriov = yes
+            ping_dest = ''
+            test_devices = ["Eth"]
+            iface_dict = {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}}
+        - scsi_controller:
+            test_devices = ["scsi"]
+            controller_dicts = [{'type': 'scsi', 'model': 'virtio-scsi','driver': {'iommu': 'on'}}]
+            disk_dict = {'target': {'dev': 'sda', 'bus': 'scsi'}}
+            cleanup_ifaces = no
+        - ats_on:
+            test_devices = ["Eth", "block"]
+            disk_driver = {'name': 'qemu', 'type': 'qcow2', 'iommu': 'on', 'ats': 'on'}
+            disk_dict = {'target': {'dev': 'vdb', 'bus': 'virtio'}, 'device': 'disk', 'driver': ${disk_driver}}
+            interface_driver = {'driver_attr': {'name': 'vhost', 'iommu': 'on', 'ats': 'on'}}
+            iface_dict = {'type_name': 'network', 'model': 'virtio', 'driver': ${interface_driver}, 'source': {'network': 'default'}}

--- a/libvirt/tests/src/sriov/vIOMMU/hotplug_device_with_iommu_enabled.py
+++ b/libvirt/tests/src/sriov/vIOMMU/hotplug_device_with_iommu_enabled.py
@@ -1,0 +1,116 @@
+import os
+import time
+
+from virttest import data_dir
+from virttest import utils_disk
+from virttest import utils_net
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_disk
+from virttest.utils_libvirt import libvirt_vmxml
+
+from provider.sriov import sriov_base
+from provider.viommu import viommu_base
+from provider.sriov import check_points as sriov_check_points
+
+
+def run(test, params, env):
+    """
+    Hotplug devices with iommu enabled to a vm with an iommu device
+    """
+    def detach_dev(device_type, dev_iommu_info, vm_session):
+        """
+        Detach device and check iommu group if needed
+
+        :param device_type: Device type
+        :param dev_iommu_info: Device's iommu group info
+        :param vm_session: VM session
+        """
+        dev_obj = vm_xml.VMXML.new_from_dumpxml(vm_name).get_devices(device_type)[-1]
+        virsh.detach_device(vm_name, dev_obj.xml, wait_for_event=True,
+                            debug=True, ignore_status=False)
+        if dev_iommu_info:
+            res = vm_session.cmd_status_output('ifconfig')
+            test.log.debug(res)
+            s, o = vm_session.cmd_status_output("ls %s" % dev_iommu_info)
+            test.log.debug(f"{device_type} iommu check: {o}")
+            if not s:
+                test.fail("The %s should be removed from the iommu group" % device_type)
+
+    cleanup_ifaces = params.get("cleanup_ifaces", "yes")
+    disk_dict = eval(params.get('disk_dict', '{}'))
+
+    ping_dest = params.get('ping_dest')
+    iommu_dict = eval(params.get('iommu_dict', '{}'))
+    test_devices = eval(params.get("test_devices", "[]"))
+    need_sriov = "yes" == params.get("need_sriov", "no")
+
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    vm = env.get_vm(vm_name)
+    sroiv_test_obj = None
+    new_disk_path = None
+
+    test_obj = viommu_base.VIOMMUTest(vm, test, params)
+    if need_sriov:
+        sroiv_test_obj = sriov_base.SRIOVTest(vm, test, params)
+
+    try:
+        test_obj.setup_iommu_test(iommu_dict=iommu_dict, cleanup_ifaces=cleanup_ifaces)
+        test_obj.prepare_controller()
+        test.log.info("TEST_STEP: Start the VM.")
+        if not vm.is_alive():
+            vm.start()
+        vm.cleanup_serial_console()
+        vm.create_serial_console()
+        vm_session = vm.wait_for_serial_login(
+            timeout=int(params.get('login_timeout')))
+
+        if disk_dict:
+            test.log.info("TEST_STEP: Attach a disk device to VM.")
+            disk_dict = test_obj.update_disk_addr(disk_dict)
+            disk_size = params.get("size", "200M")
+            new_disk_path = os.path.join(data_dir.get_data_dir(), "images", "test.qcow2")
+            libvirt_disk.create_disk("file", new_disk_path, disk_size, disk_format="qcow2")
+            disk_dict.update({'source': {'attrs': {'file': new_disk_path}}})
+            disk_obj = libvirt_vmxml.create_vm_device_by_type('disk', disk_dict)
+            virsh.attach_device(vm.name, disk_obj.xml, debug=True, ignore_status=False)
+
+        if need_sriov:
+            test_obj.params["iface_dict"] = str(sroiv_test_obj.parse_iface_dict())
+        iface_dict = test_obj.parse_iface_dict()
+
+        if cleanup_ifaces == "yes":
+            iface_obj = libvirt_vmxml.create_vm_device_by_type("interface", iface_dict)
+            virsh.attach_device(vm.name, iface_obj.xml, debug=True, ignore_status=False)
+            # Sleep 20s to stabilize the attached interface
+            time.sleep(20)
+
+        test.log.info("TEST_STEP: Check dmesg message about iommu inside the vm.")
+        vm_session.cmd("dmesg | grep -i 'Adding to iommu group'", timeout=300)
+        dev_iommu_groups = viommu_base.check_vm_iommu_group(vm_session, test_devices)
+        test.log.debug(f"Device iommu groups info: {dev_iommu_groups}")
+
+        if "block" in test_devices:
+            test.log.info("TEST_STEP: Check VM disk io.")
+            new_disk = libvirt_disk.get_non_root_disk_name(vm_session)[0]
+            utils_disk.dd_data_to_vm_disk(vm_session, new_disk)
+            test.log.info("TEST_STEP: Detach the disk.")
+            detach_dev("disk", dev_iommu_groups["block"], vm_session)
+
+        test.log.info("TEST_STEP: Check VM network.")
+        if need_sriov:
+            sriov_check_points.check_vm_network_accessed(vm_session, ping_dest=ping_dest)
+        else:
+
+            s, o = utils_net.ping(ping_dest, count=5, timeout=240, session=vm_session)
+            if s:
+                test.fail("Failed to ping %s! status: %s, output: %s." % (ping_dest, s, o))
+
+        test.log.info("TEST_STEP: Detach the interface.")
+        detach_dev("interface", dev_iommu_groups.get("Eth"), vm_session)
+
+    finally:
+        test_obj.teardown_iommu_test()
+        if new_disk_path and os.path.exists(new_disk_path):
+            os.remove(new_disk_path)


### PR DESCRIPTION
This PR adds:
    VIRT-296710: [vIOMMU] hotplug/unplug devices with iommu enabled


**Test results:** The failed case is due to a known issue.
```
 (01/12) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.e1000e.virtio: PASS (69.83 s)
 (02/12) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.e1000e.intel: PASS (203.39 s)
 (03/12) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.rtl8139.virtio: PASS (70.67 s)
 (04/12) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.rtl8139.intel: PASS (209.17 s)
 (05/12) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.virtio_muti_devices.vhost_on.virtio: PASS (75.64 s)
 (06/12) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.virtio_muti_devices.vhost_on.intel: PASS (210.10 s)
 (07/12) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.virtio_muti_devices.vhost_off.virtio:PASS (80.29 s)
 (08/12) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.virtio_muti_devices.vhost_off.intel: PASS (208.30 s)
 (09/12) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.hostdev_iface.virtio: PASS (97.88 s)
 (10/12) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.scsi_controller.virtio: PASS (51.70 s)
 (11/12) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.scsi_controller.intel: PASS (193.07 s)
 (12/12) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.ats_on.intel: PASS (201.35 s)
(1/7) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.virtio_muti_devices.vhost_on.virtio: PASS (85.57 s)
 (2/7) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.virtio_muti_devices.vhost_on.smmuv3: PASS (88.49 s)
 (3/7) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.virtio_muti_devices.vhost_off.virtio: PASS (88.56 s)
 (4/7) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.virtio_muti_devices.vhost_off.smmuv3: PASS (88.51 s)
 (5/7) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.hostdev_iface.virtio: ERROR: Shell process terminated while waiting for command to complete: "dmesg | grep -i 'Adding to iommu group'"    (status: 0,    output: '') (81.35 s)
 (6/7) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.scsi_controller.virtio: PASS (57.67 s)
 (7/7) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.scsi_controller.smmuv3: PASS (58.57 s)
RESULTS    : PASS 6 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2024-07-23T05.58-f55c1d0/results.html
JOB TIME   : 549.35 s

```