### PR TITLE
Update the lock options and virtiofsd options format

### DIFF
--- a/libvirt/tests/cfg/virtual_device/filesystem_device.cfg
+++ b/libvirt/tests/cfg/virtual_device/filesystem_device.cfg
@@ -3,9 +3,7 @@
     take_regular_screendumps = "no"
     vms = "avocado-vt-vm1"
     start_vm = no
-    cache_mode = "none"
-    lock_posix = "off"
-    flock = "off"
+    cache_mode = "auto"
     virtiofsd_path = "/usr/libexec/virtiofsd"
     queue_size = "512"
     driver_type = "virtiofs"
@@ -32,17 +30,17 @@
                 - two_guests:
                     vms = "avocado-vt-vm1 avocado-vt-vm2"
                     guest_num = 2
-                    only nop.fs_test.xattr_on.flock_off.lock_posix_off.cache_mode_none..one_fs, hotplug_unplug..fs_test.xattr_on.flock_off.lock_posix_off.cache_mode_none..one_fs
+                    only nop.fs_test.xattr_on.cache_mode_auto..one_fs, hotplug_unplug..fs_test.xattr_on.cache_mode_auto..one_fs
             variants:
                 - one_fs:
                     fs_num = 1
                 - multiple_fs:
                     fs_num = 2
-                    only xattr_on.flock_off.lock_posix_off.cache_mode_none
+                    only xattr_on.cache_mode_auto
             variants:
                 - thread_pool_16:
                   thread_pool_size = 16
-                  only positive_test..nop..xattr_on.flock_off.lock_posix_off.cache_mode_none, positive_test..detach_device..xattr_on.flock_off.lock_posix_off.cache_mode_none
+                  only positive_test..nop..xattr_on.cache_mode_auto, positive_test..detach_device..xattr_on.cache_mode_auto
                 - thread_pool_noset:
             variants:
                 - cache_mode_none:
@@ -51,16 +49,6 @@
                     cache_mode = "always"
                 - cache_mode_auto:
                     cache_mode = "auto"
-            variants:
-                - lock_posix_off:
-                    lock_posix = "off" 
-                - lock_posix_on:
-                    lock_posix = "on"
-            variants:
-                - flock_on:
-                    flock = "on"
-                - flock_off:
-                    flock = "off"
             variants:
                 - xattr_on:
                     xattr = "on"
@@ -72,9 +60,9 @@
         - nop:
         - socket_file_checking:
             socket_file_checking = "yes"
-            only xattr_on.flock_off.lock_posix_off.cache_mode_none, externally_launched_fs_test
+            only xattr_on.cache_mode_auto, externally_launched_fs_test
         - lifecycle:
-            only xattr_on.flock_off.lock_posix_off.cache_mode_none..one_fs
+            only xattr_on.cache_mode_auto..one_fs
             variants:
                 - suspend_resume:
                     suspend_resume = "yes"
@@ -93,16 +81,16 @@
                     source_dir = "/var/tmp/mount_tag0"
                     dev_type = "filesystem"
                     vm_attrs = {'mb': {"source_type":"file", 'access_mode': 'shared'}}
-                    fs_dict = {'accessmode':'passthrough', 'driver': {'type': 'virtiofs', 'queue':'512'}, 'source':{'dir': '${source_dir}'}, "target": {'dir': 'mount_tag0'}, 'binary': {'path': '/usr/libexec/virtiofsd', 'xattr': 'on','cache_mode':'none','lock_posix':'off','flock':'off'}}
+                    fs_dict = {'accessmode':'passthrough', 'driver': {'type': 'virtiofs', 'queue':'512'}, 'source':{'dir': '${source_dir}'}, "target": {'dir': 'mount_tag0'}, 'binary': {'path': '/usr/libexec/virtiofsd', 'xattr': 'on','cache_mode':'always'}}
         - coldplug_coldunplug:
-            only xattr_on.flock_off.lock_posix_off.cache_mode_none..one_fs
+            only xattr_on.cache_mode_auto..one_fs
             coldplug = "yes"
         - hotplug_unplug:
             hotplug_unplug = "yes"
             variants:
                 - detach_device_alias:
                     detach_device_alias = "yes"
-                    only xattr_on.flock_off.lock_posix_off.cache_mode_none
+                    only xattr_on.cache_mode_auto
                     variants:
                         - stdio_handler:
                             variants:
@@ -127,7 +115,7 @@
                       with_hugepages = no
                       with_memfd = yes
         - negative_test:
-            only fs_test.xattr_on.flock_off.lock_posix_off.cache_mode_none..one_fs.one_guest
+            only fs_test.xattr_on.cache_mode_auto..one_fs.one_guest
             status_error = "yes"
             variants:
                 - invalid_queue_size:


### PR DESCRIPTION
1. For bug RHEL-7108, virtiofsd options format has been updated, we need to update the script.
2. In the commit for fix bug RHEL-7108, lock options are not allowed to config any more, so we need to remove them thoroughly.
3. Cache mode "none" can not be used from virtiofsd-1.11.1, it should be replaced as "never" from now on. RFE bug about mode "never" will be filed later.