### PR TITLE
sriov: Add a case about network connections

### DIFF
--- a/libvirt/tests/cfg/sriov/network/sriov_check_network_connections.cfg
+++ b/libvirt/tests/cfg/sriov/network/sriov_check_network_connections.cfg
@@ -1,0 +1,8 @@
+- sriov.network.check_connections:
+    type = sriov_check_network_connections
+    only x86_64, aarch64
+
+    start_vm = "no"
+    network_dict = {'forward': {'mode': 'hostdev', 'managed': 'yes'}, 'name': 'hostdev_net', 'pf': {'dev': pf_name}}
+    iface_dict = {'type_name': 'network', 'source': {'network': 'hostdev_net'}}
+    iface_nums = 2

--- a/libvirt/tests/src/sriov/network/sriov_check_network_connections.py
+++ b/libvirt/tests/src/sriov/network/sriov_check_network_connections.py
@@ -1,0 +1,46 @@
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_network
+from virttest.utils_libvirt import libvirt_vmxml
+
+from provider.sriov import sriov_base
+
+
+def run(test, params, env):
+    """
+    Check the number of connections on hostdev network
+    """
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    vm = env.get_vm(vm_name)
+    sriov_test_obj = sriov_base.SRIOVTest(vm, test, params)
+    network_dict = sriov_test_obj.parse_network_dict()
+    net_name = network_dict.get("name")
+    iface_dict = eval(params.get("iface_dict", "{}"))
+    iface_nums = int(params.get("iface_nums", "2"))
+
+    try:
+        sriov_test_obj.setup_default(network_dict=network_dict)
+        for idx in range(iface_nums):
+            libvirt_vmxml.modify_vm_device(
+                vm_xml.VMXML.new_from_inactive_dumpxml(vm_name),
+                'interface', iface_dict, idx)
+        test.log.debug(f"vm xml: {vm_xml.VMXML.new_from_dumpxml(vm_name)}")
+
+        test.log.info("TEST_STEP: Start a VM with hostdev interfaces.")
+        vm.start()
+        vm.wait_for_serial_login().close()
+
+        test.log.info(f"TEST_STEP: Check if there are {iface_nums} network connections.")
+        libvirt_network.check_network_connection(net_name, iface_nums)
+
+        test.log.info(f"TEST_STEP: Destroy and start network and vm.")
+        virsh.net_destroy(net_name, debug=True, ignore_status=False)
+        virsh.net_start(net_name, debug=True, ignore_status=False)
+        vm.destroy()
+        vm.start()
+
+        test.log.info(f"TEST_STEP: Check if there are {iface_nums} network connections.")
+        libvirt_network.check_network_connection(net_name, iface_nums)
+    finally:
+        sriov_test_obj.teardown_default(network_dict=network_dict)


### PR DESCRIPTION
This PR adds:
VIRT-301829 - Check the number of connections on hostdev network during vm destroy/start


` (1/1) type_specific.io-github-autotest-libvirt.sriov.network.check_connections: PASS (151.23 s)
`