### PR TITLE
v2v: fix cpu-topology case on rhel10

### DIFF
--- a/v2v/tests/cfg/convert_from_file.cfg
+++ b/v2v/tests/cfg/convert_from_file.cfg
@@ -112,6 +112,7 @@
                                     ova_dir = OVA_DIR_BUG_2069768_V2V_EXAMPLE
                                     input_file = '${ova_copy_dir}/OVA_FILE_BUG_2069768_V2V_EXAMPLE'
                                 - cpu_topology:
+                                    only output_mode.rhev
                                     checkpoint = 'cpu_topology'
                                     v2v_debug = force_on
                                     ova_file_name = OVA_FILE_CPU_TOPOLOGY_V2V_EXAMPLE
@@ -301,6 +302,7 @@
                                     main_vm = 'VM_NAME_RHEL6_V2V_EXAMPLE'
                                 - cpu_topology:
                                     only esx_70
+                                    only output_mode.rhev
                                     vmx_nfs_src = NFS_ESX70_FUNC_VMX_V2V_EXAMPLE
                                     main_vm = 'VM_NAME_CPU_TOPOLOGY_V2V_EXAMPLE'
                                     v2v_debug = force_on

--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -895,6 +895,7 @@
         - cpu_topology:
             only esx_70
             only it_vddk
+            only rhev
             main_vm = VM_NAME_CPU_TOPOLOGY_V2V_EXAMPLE
             checkpoint = 'cpu_topology'
             v2v_debug = force_on


### PR DESCRIPTION
Please refer bz#1541908. 

* Output to RHV would create the required metadata (<rasd:num_of_sockets> etc) for topology.  But the CPU vendor
and model cannot be passed to RHV.

*Use virt-v2v to convert guest to libvirt, and check cpu info in guest xml after conversion,v2v could parse guest's cpu topology in guest xml correctly