### PR TITLE
v2v: fix ogac and without_default_net cases on functional testing

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -542,7 +542,7 @@
                   qa_url = QEMU_GUEST_AGENT_DEBIAN_DOWNLOAD_URL_V2V_EXAMPLE
                   main_vm = VM_NAME_UBUNTU_V2V_EXAMPLE
                 - debian:
-                  only esx_70
+                  only esx_80
                   version_required = "[virt-v2v-2.0.6-3,)"
                   qa_path = 'linux/debian'
                   qa_url = QEMU_GUEST_AGENT_DEBIAN_DOWNLOAD_URL_V2V_EXAMPLE
@@ -553,8 +553,7 @@
                   qa_url = QEMU_GUEST_AGENT_SUSE_DOWNLOAD_URL_V2V_EXAMPLE
                   main_vm = VM_NAME_SLES_V2V_EXAMPLE
                 - opensuse:
-                  only esx_70
-                  boottype = 3
+                  only esx_80
                   qa_path = 'linux/lp151'
                   qa_url = QEMU_GUEST_AGENT_SUSE_DOWNLOAD_URL_V2V_EXAMPLE
                   main_vm = VM_NAME_OPENSUSE_V2V_EXAMPLE
@@ -578,6 +577,7 @@
                     expect_msg = no
         - without_default_net:
             only esx_70
+            only rhev
             main_vm = VM_NAME_ESX70_RHEL7_V2V_EXAMPLE
             checkpoint = "without_default_net"
             v2v_debug = force_on


### PR DESCRIPTION
update the newer version for ogac and check bz#1580452 for without_default_net 