### PR TITLE
vcpu_misc: fix default value issue for mem file

### DIFF
--- a/libvirt/tests/src/cpu/vcpu_misc.py
+++ b/libvirt/tests/src/cpu/vcpu_misc.py
@@ -243,7 +243,7 @@ def run(test, params, env):
     bkxml = vmxml.copy()
     managed_save_file = "/var/lib/libvirt/qemu/save/%s.save" % vm_name
     maxphysaddr = params.get('maxphysaddr')
-    mem_file = params.get('mem_file')
+    mem_file = params.get('mem_file', "")
 
     try:
         if check_vendor_id:


### PR DESCRIPTION
  mem_file param needs a default value to not influence other cases
Signed-off-by: nanli <nanli@redhat.com>

Before fixed
`ERROR: stat: path should be string, bytes, os.PathLike or integer, not NoneType
`
After fixed

```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 vcpu_misc.positive_test.with_topology.vcpus_max_equal_topology vcpu_misc.positive_test.vendor_id vcpu_misc.positive_test.mode_max vcpu_misc.positive_test.managedsave_restore vcpu_misc.positive_test.with_maxphysaddr vcpu_misc.negative_test.with_topology.vcpus_max_exceed_topology vcpu_misc.negative_test.with_topology.vcpus_max_less_than_topology

 (1/7) type_specific.io-github-autotest-libvirt.vcpu_misc.positive_test.with_topology.vcpus_max_equal_topology: PASS (9.43 s)
 (2/7) type_specific.io-github-autotest-libvirt.vcpu_misc.positive_test.vendor_id: PASS (46.67 s)
 (3/7) type_specific.io-github-autotest-libvirt.vcpu_misc.positive_test.mode_max: PASS (56.47 s)
 (4/7) type_specific.io-github-autotest-libvirt.vcpu_misc.positive_test.managedsave_restore: PASS (39.46 s)
 (5/7) type_specific.io-github-autotest-libvirt.vcpu_misc.positive_test.with_maxphysaddr: PASS (52.39 s)
 (6/7) type_specific.io-github-autotest-libvirt.vcpu_misc.negative_test.with_topology.vcpus_max_exceed_topology: PASS (34.23 s)
 (7/7) type_specific.io-github-autotest-libvirt.vcpu_misc.negative_test.with_topology.vcpus_max_less_than_topology: PASS (28.30 s)
```