### PR TITLE
passt:Update to reuse original mac address of vm

### DIFF
--- a/libvirt/tests/src/virtual_network/passt/passt_connectivity_between_2vms.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_connectivity_between_2vms.py
@@ -1,6 +1,5 @@
 import logging
 import shutil
-import time
 
 import aexpect
 from virttest import libvirt_version
@@ -96,8 +95,6 @@ def run(test, params, env):
         [LOG.debug(virsh.dumpxml(vm_name, uri=virsh_uri).stdout_text)
          for vm_name in (vm_name, vm_c.name)]
 
-        # wait for the vm boot before first time to try serial login
-        time.sleep(5)
         server_session = vm.wait_for_serial_login(60)
         client_session = vm_c.wait_for_serial_login(60)
 

--- a/libvirt/tests/src/virtual_network/passt/passt_function.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_function.py
@@ -11,7 +11,6 @@ from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.staging import service
 from virttest.utils_libvirt import libvirt_unprivileged
-from virttest.utils_libvirt import libvirt_vmxml
 
 from provider.virtual_network import network_base
 from provider.virtual_network import passt
@@ -81,10 +80,7 @@ def run(test, params, env):
         default_gw = utils_net.get_default_gateway()
         default_gw_v6 = utils_net.get_default_gateway(ip_ver='ipv6')
 
-        vmxml.del_device('interface', by_tag=True)
-        vmxml.sync(virsh_instance=virsh_ins)
-        libvirt_vmxml.modify_vm_device(vmxml, 'interface', iface_attrs,
-                                       virsh_instance=virsh_ins)
+        passt.vm_add_iface(vmxml, iface_attrs, virsh_ins)
         LOG.debug(virsh_ins.dumpxml(vm_name).stdout_text)
         mac = vm.get_virsh_mac_address()
 

--- a/libvirt/tests/src/virtual_network/passt/passt_negative_setting.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_negative_setting.py
@@ -15,6 +15,7 @@ from virttest.staging import service
 from virttest.utils_libvirt import libvirt_vmxml
 from virttest.utils_test import libvirt
 
+from provider.virtual_network import network_base
 from provider.virtual_network import passt
 
 LOG = logging.getLogger('avocado.' + __name__)
@@ -111,6 +112,9 @@ def run(test, params, env):
         else:
             return
 
+        vm_iface = network_base.get_iface_xml_inst(
+            vmxml.vm_name, '', virsh_ins=virsh_ins)
+        iface_attrs.update({'mac_address': vm_iface.mac_address})
         vmxml.del_device('interface', by_tag=True)
         iface_device = libvirt_vmxml.create_vm_device_by_type('interface',
                                                               iface_attrs)

--- a/libvirt/tests/src/virtual_network/passt/passt_reconnect.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_reconnect.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import shutil
-import time
 
 import aexpect
 from avocado.utils import process
@@ -108,8 +107,6 @@ def run(test, params, env):
         if not os.path.exists(log_file):
             test.fail(f'Logfile of passt "{log_file}" not created')
 
-        # wait for the vm boot before first time to try serial login
-        time.sleep(5)
         session = vm.wait_for_serial_login(timeout=60)
         vm_iface = utils_net.get_linux_ifname(session, mac)
         passt.check_vm_ip(iface_attrs, session, host_iface, vm_iface)

--- a/provider/virtual_network/passt.py
+++ b/provider/virtual_network/passt.py
@@ -1,7 +1,7 @@
 import logging
 import os
-import re
 import random
+import re
 import time
 from socket import socket
 
@@ -12,6 +12,8 @@ from virttest import utils_misc
 from virttest import utils_net
 from virttest import utils_selinux
 from virttest.utils_libvirt import libvirt_vmxml
+
+from provider.virtual_network.network_base import get_iface_xml_inst
 
 VIRSH_ARGS = {'ignore_status': False, 'debug': True}
 IPV6_LENGTH = 128
@@ -71,6 +73,8 @@ def vm_add_iface(vmxml, iface_attrs, virsh_ins):
     :param iface_attrs: attributes of iface
     :param virsh_ins: virsh instance
     """
+    vm_iface = get_iface_xml_inst(vmxml.vm_name, '', virsh_ins=virsh_ins)
+    iface_attrs.update({'mac_address': vm_iface.mac_address})
     vmxml.del_device('interface', by_tag=True)
     iface_device = libvirt_vmxml.create_vm_device_by_type('interface',
                                                           iface_attrs)


### PR DESCRIPTION
And remove waiting time before serial_login

Test result:
```
 (1/7) type_specific.io-github-autotest-libvirt.virtual_network.passt.negative_setting.log_no_permission.start_vm.root_user: PASS (7.65 s)
 (2/7) type_specific.io-github-autotest-libvirt.virtual_network.passt.transfer_file.ipv4.host_to_vm.10M.ip_portfw.root_user: PASS (117.20 s)
 (3/7) type_specific.io-github-autotest-libvirt.virtual_network.passt.transfer_file.ipv4.vm_to_host.1G.ip_portfw.root_user: PASS (187.54 s)
 (4/7) type_specific.io-github-autotest-libvirt.virtual_network.passt.attach_detach.ip_portfw.attach.non_root_user: PASS (177.38 s)
 (5/7) type_specific.io-github-autotest-libvirt.virtual_network.passt.attach_detach.ip_portfw.attach_detach.non_root_user:PASS (191.11 s)
 (6/7) type_specific.io-github-autotest-libvirt.virtual_network.passt.connectivity_between_2vms.ip_portfw.non_root_user: PASS (69.10 s)
 (7/7) type_specific.io-github-autotest-libvirt.virtual_network.passt.interface_function.ip_portfw.ip_addr.root_user: PASS (394.90 s)
RESULTS    : PASS 7 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
