### PR TITLE
requirements-travis: fix dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,19 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Update pip
+        run: pip install --upgrade pip
       - name: Install dependencies
         run: |
          pip install sphinx${SPHINX_VERSION:+==$SPHINX_VERSION}
          pip install -r requirements-travis.txt
       - name: Run inspekt
-        run: inspekt checkall --disable-style E501,E265,W601,W605,E402,E722,E741 --no-license-check
+        run: inspekt checkall --disable-style E501,E265,W601,W605,E402,E722,E741 --disable-lint W,R,C,E1002,E1101,E1103,E1120,F0401,I0011,E0601,E0602,E0606 --no-license-check
       - run: echo "This job's status is ${{ job.status }}."
       - name: Run spellchecker
-        run: pylint --errors-only --disable=all --enable=spelling --spelling-dict=en_US --spelling-private-dict-file=spell.ignore *
+        run: |
+         set +e
+         pylint --errors-only --disable=all --enable=spelling --spelling-dict=en_US --spelling-private-dict-file=spell.ignore *
+         exitcode=$?
+         set -e
+         test $exitcode == 32 -o $exitcode == 0

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,10 +1,14 @@
 coverage==5.1
 nose==1.3.0
 nosexcover==1.0.8
-tox==1.5.0
-virtualenv==1.9.1
+tox==1.5.0; python_version < '3.8'
+tox==4.16.0; python_version > '3.7'
+virtualenv==1.9.1; python_version < '3.8'
+virtualenv==20.26.3; python_version > '3.7'
 simplejson==3.8.1
-inspektor==0.5.2
-pylint==2.11.1
+inspektor==0.5.2; python_version < '3.8'
+inspektor==0.5.3; python_version > '3.7'
+pylint==2.11.1; python_version < '3.8'
+pylint==3.2.6; python_version > '3.7'
 pyenchant
 importlib-metadata==4.13.0; python_version == '3.7'


### PR DESCRIPTION
The systems can't be set up anymore for python versions
since 3.8. Update depdendencies.

There will be a later pylint version producing new errors.
Ignore these as we didn't check them before.

Update pip to latest to avoid other dependency issues.

Allow for pylint to exit with code 32 if there are no files to
check. Otherwise the build will fail.
For that, the exit-on-error must be temporarily switched off (set +e)
in the run commands.

Signed-off-by: Sebastian Mitterle <smitterl@redhat.com>