### PR TITLE
gmap: remove lock options

### DIFF
--- a/libvirt/tests/cfg/memory/gmap.cfg
+++ b/libvirt/tests/cfg/memory/gmap.cfg
@@ -7,4 +7,4 @@
         - l3_shadow_table_counters:
             l2_mem = 3906250
             target_tag = "mount_tag0"
-            fs_dict = {'accessmode': 'passthrough',  'source': {'dir': 'replace_in_code'}, "target": {'dir': '${target_tag}'}, 'binary': {'lock_posix':'off','flock':'off'}, 'driver': {'type': 'virtiofs'}}
+            fs_dict = {'accessmode': 'passthrough',  'source': {'dir': 'replace_in_code'}, "target": {'dir': '${target_tag}'}, 'driver': {'type': 'virtiofs'}}


### PR DESCRIPTION
Recent Libvirt versions don't allow for these attributes. As they are not needed in this test, remove them.