### PR TITLE
ism_pci_passthrough: add hotplug case

### DIFF
--- a/libvirt/tests/cfg/passthrough/pci/ism_pci_passthrough.cfg
+++ b/libvirt/tests/cfg/passthrough/pci/ism_pci_passthrough.cfg
@@ -1,7 +1,7 @@
 - libvirt_pci_passthrough.ism:
     only s390-virtio
     type = ism_pci_passthrough
-    start_vm = no
+    start_vm = yes
     pci_dev = LIBVIRT_PCI_NAME
     guest_iface = enc1
     variants:
@@ -13,3 +13,5 @@
             check = start_after_reboot
         - connect:
             check = smc_functional
+        - hotplug:
+            check = available_hotplug

--- a/provider/vfio/__init__.py
+++ b/provider/vfio/__init__.py
@@ -1,19 +1,26 @@
 from virttest.libvirt_xml.devices.hostdev import Hostdev
 
 
-def get_hostdev_xml(uuid, model):
+def get_hostdev_xml(address, model=""):
     """
     Creates a hostdev instance for a mediated device
     with given uuid.
 
-    :param uuid: UUID of the mediated device
+    :param address: For mediated devices, the UUID of the mediated device
+                    For PCI devices, the full address element
     :param model: mediated device type model, e.g. 'vfio-ccw'
+                  If omitted, treat as PCI device
     """
 
     hostdev_xml = Hostdev()
     hostdev_xml.mode = "subsystem"
-    hostdev_xml.model = model
-    hostdev_xml.type = "mdev"
-    hostdev_xml.source = hostdev_xml.new_source(**{"uuid": uuid})
+    if "vfio" in model:
+        hostdev_xml.model = model
+        hostdev_xml.type = "mdev"
+        hostdev_xml.source = hostdev_xml.new_source(**{"uuid": address})
+    else:
+        hostdev_xml.type = "pci"
+        hostdev_xml.managed = "yes"
+        hostdev_xml.source = hostdev_xml.new_source(**address)
     hostdev_xml.xmltreefile.write()
     return hostdev_xml


### PR DESCRIPTION
1. Extract check the device is ISM to reuse between hotplug and coldplug functions.
2. Create new test config and test step.
3. Add hotplug function.
4. Change provider function to create pci host device XML, too.