### PR TITLE
Fix ccw test cases failures in s390x

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_ccw_addr.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_ccw_addr.cfg
@@ -11,9 +11,10 @@
            status_error = "yes"
            define_error = "yes"
            error_msg = "cannot use CCW address type for device"
+           only attach_no_exist_disk
         - positive_test:
            status_error = "no"
-           only attach_same_pci_slot
+           no attach_no_exist_disk
     variants:
         - attach_no_exist_disk:
             only coldplug
@@ -37,7 +38,7 @@
             addr_attrs = "{'type': 'ccw', 'cssid': '0x0', 'ssid': '0x0', 'devno': '0x0000'}"
         - attach_rng:
             backend_device = "rng"
-            backend_dev = "/dev/hwrng"
+            backend_dev = "/dev/random"
             rng_model = "virtio"
             addr_attrs = "{'type': 'ccw', 'cssid': '0x0', 'ssid': '0x0', 'devno': '0x0000'}"
         - attach_same_pci_slot:


### PR DESCRIPTION
attach_disk,attach_controller,attach_rng is supported on s390x, so it is positive cases