### PR TITLE
Fix iothread failures in s390x

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_iothreads_queue.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_iothreads_queue.cfg
@@ -11,11 +11,11 @@
             queue_num = "3"
             driver = {'name': 'qemu', 'queues': '${queue_num}'}
             driver_iothreads = {'iothread': [{'queue': [{'id': '0'}, {'id': '1'}], 'id': '1'}, {'queue': [{'id': '2'}], 'id': '2'}]}
-            check_qemu_pattern = '"driver":"virtio-blk-pci","num-queues":3,"iothread-vq-mapping":\[{"iothread":"iothread1","vqs":\[0,1\]},{"iothread":"iothread2","vqs":\[2\]}\]'
+            check_qemu_pattern = '"driver":"virtio-blk-.*","num-queues":3,"iothread-vq-mapping":\[{"iothread":"iothread1","vqs":\[0,1\]},{"iothread":"iothread2","vqs":\[2\]}\]'
         - round_robin:
             driver = {'name': 'qemu', 'type': 'qcow2'}
             driver_iothreads = {'iothread': [{'id': '1'}, {'id': '2'}, {'id': '3'}]}
-            check_qemu_pattern = '"driver":"virtio-blk-pci","iothread-vq-mapping":\[{"iothread":"iothread1"},{"iothread":"iothread2"},{"iothread":"iothread3"}\]'
+            check_qemu_pattern = '"driver":"virtio-blk-.*","iothread-vq-mapping":\[{"iothread":"iothread1"},{"iothread":"iothread2"},{"iothread":"iothread3"}\]'
     variants scenario:
         - define_start:
         - define_invalid:
@@ -87,7 +87,7 @@
             new_target = {'dev': '${new_target_dev}', 'bus': 'virtio'}
             new_source = {'attrs': {'file': '%s'}}
             new_disk_dict = {'target': ${new_target}, 'device': 'disk', 'driver': {'name': 'qemu', 'type': 'qcow2'}, 'driver_iothreads': ${new_driver_iothreads}, 'source': ${new_source}}
-            check_libvirtd_log = '"driver":"virtio-blk-pci","iothread-vq-mapping":\[{"iothread":"iothread1"},{"iothread":"iothread2"},{"iothread":"iothread3"}\]'
+            check_libvirtd_log = '"driver":"virtio-blk-.*","iothread-vq-mapping":\[{"iothread":"iothread1"},{"iothread":"iothread2"},{"iothread":"iothread3"}\]'
             log_level = "1"
     variants disk_bus:
         - virtio:


### PR DESCRIPTION
Use wild matching characters to match expected result, instead of hard-coded string for specific arches