### PR TITLE
Fix multiattributes.file_disk.start_guest failure on s390x

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_multiattributes.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_multiattributes.cfg
@@ -4,6 +4,7 @@
     disk_target_dev = "vda"
     dom_iothreads = "1"
     driver_attributes = {'name': 'qemu', 'type': 'raw', 'cache': 'none', 'error_policy': 'stop',}
+    no s390-virtio 
     variants:
         - start_guest:
     variants:


### PR DESCRIPTION
multiattributes on disk is not supported on s390x