### PR TITLE
Remove lock options and update cache mode

### DIFF
--- a/libvirt/tests/cfg/virtio/virtio_page_per_vq.cfg
+++ b/libvirt/tests/cfg/virtio/virtio_page_per_vq.cfg
@@ -47,4 +47,4 @@
             device_dict = {'model_type': 'virtio', **${driver_dict}, 'model_heads': '1'}
         - filesystem:
             driver_dict = {'driver': {'type': 'virtiofs', 'page_per_vq': 'on'}}
-            device_dict = {'source': {'dir': '/tmp'}, **${driver_dict}, 'type_name': 'mount', 'accessmode': 'passthrough', 'target': {'dir': 'mount_tag'}, 'binary': {'xattr': 'on', 'path': '/usr/libexec/virtiofsd', 'cache_mode': 'none'}}
+            device_dict = {'source': {'dir': '/tmp'}, **${driver_dict}, 'type_name': 'mount', 'accessmode': 'passthrough', 'target': {'dir': 'mount_tag'}, 'binary': {'xattr': 'on', 'path': '/usr/libexec/virtiofsd', 'cache_mode': 'always'}}

--- a/libvirt/tests/cfg/virtual_device/filesystem_device_unprivileged.cfg
+++ b/libvirt/tests/cfg/virtual_device/filesystem_device_unprivileged.cfg
@@ -30,6 +30,6 @@
         - with_shm:
     variants:
         - one_fs:
-              fs_dicts = [{'accessmode': 'passthrough',  'source': {'dir': '/tmp/dir1'}, "target": {'dir': 'mount_tag1'}, 'binary': {'path':'/usr/libexec/virtiofsd', 'lock_posix':'off','flock':'off', 'sandbox_mode':'namespace', 'xattr':'on', 'cache_mode':'none'}, 'driver': {'type': 'virtiofs', 'queue':'1024'}}]
+              fs_dicts = [{'accessmode': 'passthrough',  'source': {'dir': '/tmp/dir1'}, "target": {'dir': 'mount_tag1'}, 'binary': {'path':'/usr/libexec/virtiofsd', 'sandbox_mode':'namespace', 'xattr':'on', 'cache_mode':'always'}, 'driver': {'type': 'virtiofs', 'queue':'1024'}}]
         - two_fs:
-              fs_dicts = [{'accessmode': 'passthrough',  'source': {'dir': '/tmp/dir1'}, "target": {'dir': 'mount_tag1'}, 'binary': {'lock_posix':'off','flock':'off', 'sandbox_mode':'namespace'}, 'driver': {'type': 'virtiofs'}}, {'accessmode': 'passthrough',  'source': {'dir': '/tmp/dir2'}, "target": {'dir': 'mount_tag2'}, 'binary': {'lock_posix':'off','flock':'off', 'sandbox_mode':'namespace', 'xattr':'on', 'cache_mode':'none'}, 'driver': {'type': 'virtiofs'}}]
+              fs_dicts = [{'accessmode': 'passthrough',  'source': {'dir': '/tmp/dir1'}, "target": {'dir': 'mount_tag1'}, 'binary': {'sandbox_mode':'namespace'}, 'driver': {'type': 'virtiofs'}}, {'accessmode': 'passthrough',  'source': {'dir': '/tmp/dir2'}, "target": {'dir': 'mount_tag2'}, 'binary': {'sandbox_mode':'namespace', 'xattr':'on', 'cache_mode':'always'}, 'driver': {'type': 'virtiofs'}}]

--- a/libvirt/tests/src/virtio/virtio_page_per_vq.py
+++ b/libvirt/tests/src/virtio/virtio_page_per_vq.py
@@ -134,7 +134,7 @@ def run(test, params, env):
                           "got '%s'" % (pre_dict, cur_dict))
             else:
                 test.log.debug("Driver XML compare successfully. The '%s' matches"
-                               " the '%s'", (pre_dict, cur_dict))
+                               " the '%s'", pre_dict, cur_dict)
 
     def start_guest():
         """


### PR DESCRIPTION
1. In the commit for fix bug RHEL-7108, lock options are not allowed to config any more, so we need to remove them thoroughly.
2. Cache mode "none" can not be used from virtiofsd-1.11.1, it should be replaced as "never" from now on.
3. syntax of test.log need to be updated, or it will report error like: "TypeError: not enough arguments for format string"