### PR TITLE
Add network case of passt lifecycle

### DIFF
--- a/libvirt/tests/cfg/virtual_network/passt/passt_lifecycle.cfg
+++ b/libvirt/tests/cfg/virtual_network/passt/passt_lifecycle.cfg
@@ -1,0 +1,57 @@
+- virtual_network.passt.lifecycle:
+    type = passt_lifecycle
+    func_supported_since_libvirt_ver = (9, 0, 0)
+    host_iface =
+    outside_ip = 'www.redhat.com'
+    start_vm = no
+    mtu = 65520
+    variants operation:
+        - save_restore:
+            operation_a = save
+            operation_b = restore
+            options_a = {'name': vm_name, 'path': save_path}
+            options_b = {'path': save_path}
+            passt_running = no
+        - managedsave_start:
+            operation_a = managedsave
+            operation_b = start
+            passt_running = no
+        - suspend_resume:
+            operation_a = suspend
+            operation_b = resume
+            passt_running = yes
+    variants user_type:
+        - non_root_user:
+            test_user = USER.EXAMPLE
+            test_passwd = PASSWORD.EXAMPLE
+            user_id = 
+            unpr_vm_name = UNPRIVILEGED_VM.EXAMPLE
+            socket_dir = f'/run/user/{user_id}/libvirt/qemu/run/passt/'
+    variants scenario:
+        - ip_portfw:
+            ipv6_prefix = 128
+            alias = {'name': 'ua-c87b89ff-b769-4abc-921f-30d42d7aec5b'}
+            backend = {'type': 'passt'}
+            ips = [{'address': '172.17.2.4', 'family': 'ipv4', 'prefix': '24'}, {'address': '2001:db8:ac10:fd01::20', 'family': 'ipv6'}]
+            vm_iface = eno1
+            vm_ping_outside = pass
+            vm_ping_host_public = pass
+            portForward_0 = {'attrs': {'proto': 'tcp'}, 'ranges': [{'start': '31339', 'to': '41339'}]}
+            portForward_1 = {'attrs': {'proto': 'udp'}, 'ranges': [{'start': '2025'}]}
+            portForward_2 = {'attrs': {'proto': 'tcp', 'address': host_ip}, 'ranges': [{'start': '4025', 'end': '4035', 'to': '5025'},{'start': '9000'}, {'start': '4030', 'end': '4034', 'exclude': 'yes'}]}
+            portForwards = [${portForward_0}, ${portForward_1}, ${portForward_2}]
+            proc_checks = ['--tcp-ports 31339:41339', '--udp-ports 2025', f'--tcp-ports {host_ip}/4025-4035:5025-5035,9000,~4030-4034']
+            tcp_port_list = [4025, 4026, 4027, 4028, 4029, 4035, 9000, '*:31339']
+            udp_port_list = ['0.0.0.0:2025', '[::]:2025']
+            conn_check_args_0 = ('TCP4', host_ip, 31339, 41339, True, None)
+            conn_check_args_1 = ('TCP4', host_ip, 4025, 5025, True, None)
+            conn_check_args_2 = ('TCP4', 'localhost', 4025, 5025, False, 'Connection refused')
+            conn_check_args_3 = ('TCP4', 'localhost', 31339, 41339, True, None)
+            conn_check_args_4 = ('TCP4', host_ip, 4030, 4030, False, 'Connection refused')
+            conn_check_args_5 = ('TCP6', 'localhost', 31339, 41339, True, None)
+            conn_check_args_6 = ('TCP6', '::1', 31339, 41339, True, None)
+            conn_check_args_7 = ('UDP4', 'localhost', 2025, 2025, True, None)
+            iface_attrs = {'model': 'virtio', 'acpi': {'index': '1'}, 'ips': ${ips}, 'backend': ${backend}, 'source': {'dev': host_iface}, 'alias': ${alias}, 'type_name': 'user', 'portForwards': ${portForwards}}
+            s390-virtio:
+                vm_iface = enc1
+                iface_attrs = {'model': 'virtio', 'ips': ${ips}, 'backend': ${backend}, 'source': {'dev': host_iface}, 'alias': ${alias}, 'type_name': 'user', 'portForwards': ${portForwards}}

--- a/libvirt/tests/src/virtual_network/passt/passt_lifecycle.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_lifecycle.py
@@ -1,0 +1,163 @@
+import logging
+import os
+import shutil
+
+import aexpect
+from virttest import libvirt_version
+from virttest import remote
+from virttest import utils_misc
+from virttest import utils_net
+from virttest import utils_selinux
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.staging import service
+from virttest.utils_libvirt import libvirt_unprivileged
+from virttest.utils_libvirt import libvirt_vmxml
+
+from provider.virtual_network import network_base
+from provider.virtual_network import passt
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+IPV6_LENGTH = 128
+VIRSH_ARGS = {'ignore_status': False, 'debug': True}
+
+
+def run(test, params, env):
+    """
+    Test passt lifecycle
+    """
+    libvirt_version.is_libvirt_feature_supported(params)
+    root = 'root_user' == params.get('user_type', '')
+    if root:
+        vm_name = params.get('main_vm')
+        vm = env.get_vm(vm_name)
+        virsh_ins = virsh
+        log_dir = params.get('log_dir')
+        user_id = params.get('user_id')
+    else:
+        vm_name = params.get('unpr_vm_name')
+        test_user = params.get('test_user', '')
+        test_passwd = params.get('test_passwd', '')
+        user_id = passt.get_user_id(test_user)
+        unpr_vm_args = {
+            'username': params.get('username'),
+            'password': params.get('password'),
+        }
+        vm = libvirt_unprivileged.get_unprivileged_vm(vm_name, test_user,
+                                                      test_passwd,
+                                                      **unpr_vm_args)
+        uri = f'qemu+ssh://{test_user}@localhost/session'
+        virsh_ins = virsh.VirshPersistent(uri=uri)
+        host_session = aexpect.ShellSession('su')
+        remote.VMManager.set_ssh_auth(host_session, 'localhost', test_user,
+                                      test_passwd)
+        host_session.close()
+
+    host_iface = params.get('host_iface')
+    host_iface = host_iface if host_iface else utils_net.get_net_if(
+        state="UP")[0]
+    host_ip = utils_net.get_ip_address_by_interface(host_iface, ip_ver='ipv4')
+    host_ip_v6 = utils_net.get_ip_address_by_interface(
+        host_iface, ip_ver='ipv6')
+    params['host_ip_v6'] = host_ip_v6
+    params['socket_dir'] = socket_dir = eval(params.get('socket_dir'))
+    params['proc_checks'] = proc_checks = eval(params.get('proc_checks', '{}'))
+    mtu = params.get('mtu')
+    outside_ip = params.get('outside_ip')
+    log_file = f'/run/user/{user_id}/passt.log'
+    iface_attrs = eval(params.get('iface_attrs'))
+    iface_attrs['backend']['logFile'] = log_file
+    operation_a = params.get('operation_a')
+    operation_b = params.get('operation_b')
+    save_path = f'/home/{test_user}/save_{utils_misc.generate_random_string(3)}'
+    options_a = eval(params.get('options_a', '{}'))
+    options_b = eval(params.get('options_b', '{}'))
+    passt_running = 'yes' == params.get('passt_running', 'no')
+
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name,
+                                                   virsh_instance=virsh_ins)
+    bkxml = vmxml.copy()
+
+    selinux_status = passt.ensure_selinux_enforcing()
+    passt.check_socat_installed()
+
+    firewalld = service.Factory.create_service("firewalld")
+    try:
+        operation_a = eval(f'virsh_ins.{operation_a}')
+        operation_b = eval(f'virsh_ins.{operation_b}')
+
+        if root:
+            passt.make_log_dir(user_id, log_dir)
+
+        default_gw = utils_net.get_default_gateway()
+        default_gw_v6 = utils_net.get_default_gateway(ip_ver='ipv6')
+
+        vmxml.del_device('interface', by_tag=True)
+        vmxml.sync(virsh_instance=virsh_ins)
+        libvirt_vmxml.modify_vm_device(vmxml, 'interface', iface_attrs,
+                                       virsh_instance=virsh_ins)
+        LOG.debug(virsh_ins.dumpxml(vm_name).stdout_text)
+        mac = vm.get_virsh_mac_address()
+
+        vm.start()
+        passt.check_proc_info(params, log_file, mac)
+
+        options_a = {'name': vm_name} if not options_a else options_a
+        options_b = {'name': vm_name} if not options_b else options_b
+        operation_a(**options_a, **VIRSH_ARGS)
+        if passt_running:
+            passt.check_proc_info(params, log_file, mac)
+        else:
+            passt.check_passt_pid_not_exist()
+        operation_b(**options_b, **VIRSH_ARGS)
+
+        # Check the passt log
+        if not os.path.exists(log_file):
+            test.fail(f'Logfile of passt "{log_file}" not created')
+
+        # Re-create console since vm has been restored/resumed
+        vm.cleanup_serial_console()
+        vm.create_serial_console()
+        session = vm.wait_for_serial_login(timeout=60)
+
+        vm_iface = utils_net.get_linux_ifname(session, mac)
+        passt.check_vm_ip(iface_attrs, session, host_iface, vm_iface)
+        passt.check_vm_mtu(session, vm_iface, mtu)
+        passt.check_default_gw(session, host_iface)
+        passt.check_nameserver(session)
+
+        ips = {
+            'outside_ip': outside_ip,
+            'host_public_ip': host_ip,
+        }
+        network_base.ping_check(params, ips, session, force_ipv4=True)
+        session.close()
+
+        firewalld.stop()
+        LOG.debug(f'Status of firewalld: {firewalld.status()}')
+        passt.check_connection(vm, vm_iface,
+                               ['TCP4', 'TCP6', 'UDP4', 'UDP6'],
+                               host_iface)
+
+        if 'portForwards' in iface_attrs:
+            passt.check_portforward(vm, host_ip, params, host_iface)
+
+        vm_sess = vm.wait_for_serial_login(timeout=60)
+        vm_sess.cmd('systemctl start firewalld')
+        vm.destroy()
+
+        passt.check_passt_pid_not_exist()
+        if os.listdir(socket_dir):
+            test.fail(f'Socket dir is not empty: {os.listdir(socket_dir)}')
+
+    finally:
+        firewalld.start()
+        bkxml.sync(virsh_instance=virsh_ins)
+        if root:
+            shutil.rmtree(log_dir)
+        else:
+            del virsh_ins
+        utils_selinux.set_status(selinux_status)
+        if os.path.exists(save_path):
+            os.remove(save_path)


### PR DESCRIPTION
- VIRT-297078 - [user][passt] Test the lifecycle of the vm with passt backend interface

```
 (1/3) type_specific.io-github-autotest-libvirt.virtual_network.passt.lifecycle.ip_portfw.non_root_user.save_restore: PASS (243.39 s)
 (2/3) type_specific.io-github-autotest-libvirt.virtual_network.passt.lifecycle.ip_portfw.non_root_user.managedsave_start: PASS (243.84 s)
 (3/3) type_specific.io-github-autotest-libvirt.virtual_network.passt.lifecycle.ip_portfw.non_root_user.suspend_resume: PASS (241.78 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```