### PR TITLE
virtual_network:Use get_default_gateway to get host iface name

### DIFF
--- a/libvirt/tests/src/virtual_network/attach_detach_device/attach_mtu_malformed.py
+++ b/libvirt/tests/src/virtual_network/attach_detach_device/attach_mtu_malformed.py
@@ -25,8 +25,8 @@ def run(test, params, env):
     net_name = 'net_' + rand_id
     source_net = params.get('source_net', net_name)
     host_iface = params.get('host_iface')
-    host_iface = host_iface if host_iface else utils_net.get_net_if(
-        state='UP')[0]
+    host_iface = host_iface if host_iface else utils_net.get_default_gateway(
+        iface_name=True, force_dhcp=True).split()[0]
     iface_attrs = eval(params.get('iface_attrs', '{}'))
     net_attrs = eval(params.get('net_attrs', '{}'))
 

--- a/libvirt/tests/src/virtual_network/connectivity/connectivity_check_bridge_interface.py
+++ b/libvirt/tests/src/virtual_network/connectivity/connectivity_check_bridge_interface.py
@@ -53,8 +53,8 @@ def run(test, params, env):
     iface_in_vm = iface_in_vm if iface_in_vm else 'eno'
 
     host_iface = params.get('host_iface')
-    host_iface = host_iface if host_iface else utils_net.get_net_if(
-        state="UP")[0]
+    host_iface = host_iface if host_iface else utils_net.get_default_gateway(
+        iface_name=True, force_dhcp=True).split()[0]
 
     bkxmls = list(map(vm_xml.VMXML.new_from_inactive_dumpxml, vms))
 

--- a/libvirt/tests/src/virtual_network/connectivity/connectivity_check_bridge_interface_unprivileged.py
+++ b/libvirt/tests/src/virtual_network/connectivity/connectivity_check_bridge_interface_unprivileged.py
@@ -29,8 +29,8 @@ def run(test, params, env):
     linux_bridge = 'br_' + rand_id
     br_conf_file = '/etc/qemu-kvm/bridge.conf'
     host_iface = params.get('host_iface')
-    host_iface = host_iface if host_iface else utils_net.get_net_if(
-        state="UP")[0]
+    host_iface = host_iface if host_iface else utils_net.get_default_gateway(
+        iface_name=True, force_dhcp=True).split()[0]
 
     unpr_user = params.get('unpr_user', 'test_unpr') + rand_id
 

--- a/libvirt/tests/src/virtual_network/connectivity/connectivity_check_direct_interface.py
+++ b/libvirt/tests/src/virtual_network/connectivity/connectivity_check_direct_interface.py
@@ -22,8 +22,8 @@ def run(test, params, env):
     vm, ep_vm = (env.get_vm(vm_i) for vm_i in vms)
     outside_ip = params.get('outside_ip')
     host_iface = params.get('host_iface')
-    host_iface = host_iface if host_iface else utils_net.get_net_if(
-        state="UP")[0]
+    host_iface = host_iface if host_iface else utils_net.get_default_gateway(
+        iface_name=True, force_dhcp=True).split()[0]
     iface_attrs = eval(params.get('iface_attrs', '{}'))
 
     bkxmls = list(map(vm_xml.VMXML.new_from_inactive_dumpxml, vms))

--- a/libvirt/tests/src/virtual_network/connectivity/connectivity_check_ethernet_interface.py
+++ b/libvirt/tests/src/virtual_network/connectivity/connectivity_check_ethernet_interface.py
@@ -54,8 +54,8 @@ def run(test, params, env):
     iface_attrs = eval(params.get('iface_attrs'))
     outside_ip = params.get('outside_ip')
     host_iface = params.get('host_iface')
-    host_iface = host_iface if host_iface else utils_net.get_net_if(
-        state="UP")[0]
+    host_iface = host_iface if host_iface else utils_net.get_default_gateway(
+        iface_name=True, force_dhcp=True).split()[0]
     host_ip = utils_net.get_ip_address_by_interface(host_iface, ip_ver='ipv4')
     status_error = 'yes' == params.get('status_error', 'no')
     err_msg = params.get('err_msg')

--- a/libvirt/tests/src/virtual_network/connectivity/connectivity_check_user_interface.py
+++ b/libvirt/tests/src/virtual_network/connectivity/connectivity_check_user_interface.py
@@ -76,8 +76,8 @@ def run(test, params, env):
     iface_attrs = eval(params.get('iface_attrs'))
     outside_ip = params.get('outside_ip')
     host_iface = params.get('host_iface')
-    host_iface = host_iface if host_iface else utils_net.get_net_if(
-        state='UP')[0]
+    host_iface = host_iface if host_iface else utils_net.get_default_gateway(
+        iface_name=True, force_dhcp=True).split()[0]
 
     ipv4_addr = params.get('ipv4_addr')
     ipv4_prefix = params.get('ipv4_prefix')

--- a/libvirt/tests/src/virtual_network/elements_and_attributes/attribute_port_isolated.py
+++ b/libvirt/tests/src/virtual_network/elements_and_attributes/attribute_port_isolated.py
@@ -35,8 +35,8 @@ def run(test, params, env):
     net_attrs = eval(params.get('net_attrs', '{}'))
     port_attrs = eval(params.get('port_attrs', '{}'))
     host_iface = params.get('host_iface')
-    host_iface = host_iface if host_iface else utils_net.get_net_if(
-        state='UP')[0]
+    host_iface = host_iface if host_iface else utils_net.get_default_gateway(
+        iface_name=True, force_dhcp=True).split()[0]
 
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     bkxmls = list(map(vm_xml.VMXML.new_from_inactive_dumpxml, vms))

--- a/libvirt/tests/src/virtual_network/elements_and_attributes/element_coalesce.py
+++ b/libvirt/tests/src/virtual_network/elements_and_attributes/element_coalesce.py
@@ -31,8 +31,8 @@ def run(test, params, env):
     br_name = br_type + '_' + rand_id
 
     host_iface = params.get('host_iface')
-    host_iface = host_iface if host_iface else utils_net.get_net_if(
-        state="UP")[0]
+    host_iface = host_iface if host_iface else utils_net.get_default_gateway(
+        iface_name=True, force_dhcp=True).split()[0]
     iface_attrs = eval(params.get('iface_attrs', '{}'))
 
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)

--- a/libvirt/tests/src/virtual_network/iface_stat.py
+++ b/libvirt/tests/src/virtual_network/iface_stat.py
@@ -151,7 +151,8 @@ def run(test, params, env):
 
             host_iface = params.get("host_iface")
             if not host_iface:
-                host_iface = utils_net.get_net_if(state="UP")[0]
+                host_iface = utils_net.get_default_gateway(
+                    iface_name=True, force_dhcp=True).split()[0]
             if iface_type == 'direct':
                 iface_dict = {k.replace('new_iface_', ''): v
                               for k, v in params.items()

--- a/libvirt/tests/src/virtual_network/link_state/link_state_model_type.py
+++ b/libvirt/tests/src/virtual_network/link_state/link_state_model_type.py
@@ -25,8 +25,8 @@ def run(test, params, env):
 
     outside_ip = params.get("outside_ip")
     host_iface = params.get("host_iface")
-    host_iface = host_iface if host_iface else utils_net.get_net_if(
-        state="UP")[0]
+    host_iface = host_iface if host_iface else utils_net.get_default_gateway(
+        iface_name=True, force_dhcp=True).split()[0]
     rand_id = utils_misc.generate_random_string(3)
     bridge_name = "br_" + rand_id
     tap_name = "tap_" + rand_id

--- a/libvirt/tests/src/virtual_network/passt/passt_attach_detach.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_attach_detach.py
@@ -67,8 +67,8 @@ def run(test, params, env):
     virsh_uri = params.get('virsh_uri')
     add_iface = 'yes' == params.get('add_iface', 'no')
     host_iface = params.get('host_iface')
-    host_iface = host_iface if host_iface else utils_net.get_net_if(
-        state="UP")[0]
+    host_iface = host_iface if host_iface else utils_net.get_default_gateway(
+        iface_name=True, force_dhcp=True).split()[0]
     host_ip = utils_net.get_ip_address_by_interface(host_iface, ip_ver='ipv4')
     host_ip_v6 = utils_net.get_ip_address_by_interface(host_iface, ip_ver='ipv6')
     iface_attrs = eval(params.get('iface_attrs'))

--- a/libvirt/tests/src/virtual_network/passt/passt_connectivity_between_2vms.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_connectivity_between_2vms.py
@@ -67,8 +67,8 @@ def run(test, params, env):
     params['proc_checks'] = proc_checks = eval(params.get('proc_checks', '{}'))
     vm_c_iface = params.get('vm_c_iface', 'eno1')
     host_iface = params.get('host_iface')
-    host_iface = host_iface if host_iface else utils_net.get_net_if(
-        state="UP")[0]
+    host_iface = host_iface if host_iface else utils_net.get_default_gateway(
+        iface_name=True, force_dhcp=True).split()[0]
     iface_attrs['backend']['logFile'] = log_file
     iface_c_attrs['backend']['logFile'] = log_file_c
     iface_attrs['source']['dev'] = host_iface

--- a/libvirt/tests/src/virtual_network/passt/passt_function.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_function.py
@@ -53,8 +53,8 @@ def run(test, params, env):
         host_session.close()
 
     host_iface = params.get('host_iface')
-    host_iface = host_iface if host_iface else utils_net.get_net_if(
-        state="UP")[0]
+    host_iface = host_iface if host_iface else utils_net.get_default_gateway(
+        iface_name=True, force_dhcp=True).split()[0]
     host_ip = utils_net.get_ip_address_by_interface(host_iface, ip_ver='ipv4')
     host_ip_v6 = utils_net.get_ip_address_by_interface(host_iface, ip_ver='ipv6')
     params['host_ip_v6'] = host_ip_v6

--- a/libvirt/tests/src/virtual_network/passt/passt_negative_setting.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_negative_setting.py
@@ -50,8 +50,8 @@ def run(test, params, env):
     error_msg = params.get('error_msg')
     iface_attrs = eval(params.get('iface_attrs'))
     host_iface = params.get('host_iface')
-    host_iface = host_iface if host_iface else utils_net.get_net_if(
-        state="UP")[0]
+    host_iface = host_iface if host_iface else utils_net.get_default_gateway(
+        iface_name=True, force_dhcp=True).split()[0]
     log_file = f'/run/user/{user_id}/passt.log' \
         if not params.get('log_file') else params['log_file']
     iface_attrs['backend']['logFile'] = log_file

--- a/libvirt/tests/src/virtual_network/passt/passt_reconnect.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_reconnect.py
@@ -64,8 +64,8 @@ def run(test, params, env):
     qemu_cmd_check = params.get('qemu_cmd_check')
     outside_ip = params.get('outside_ip')
     host_iface = params.get('host_iface')
-    host_iface = host_iface if host_iface else utils_net.get_net_if(
-        state="UP")[0]
+    host_iface = host_iface if host_iface else utils_net.get_default_gateway(
+        iface_name=True, force_dhcp=True).split()[0]
     log_file = f'/run/user/{user_id}/passt.log'
     iface_attrs['backend']['logFile'] = log_file
     iface_attrs['source']['dev'] = host_iface

--- a/libvirt/tests/src/virtual_network/passt/passt_transfer_file.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_transfer_file.py
@@ -151,8 +151,8 @@ def run(test, params, env):
     params['socket_dir'] = socket_dir = eval(params.get('socket_dir'))
     params['proc_checks'] = proc_checks = eval(params.get('proc_checks', '{}'))
     host_iface = params.get('host_iface')
-    host_iface = host_iface if host_iface else utils_net.get_net_if(
-        state="UP")[0]
+    host_iface = host_iface if host_iface else utils_net.get_default_gateway(
+        iface_name=True, force_dhcp=True).split()[0]
     log_file = f'/run/user/{user_id}/passt.log'
     iface_attrs['backend']['logFile'] = log_file
     iface_attrs['source']['dev'] = host_iface

--- a/libvirt/tests/src/virtual_network/qos/check_bandwidth_by_domiftune.py
+++ b/libvirt/tests/src/virtual_network/qos/check_bandwidth_by_domiftune.py
@@ -28,8 +28,8 @@ def run(test, params, env):
     rand_id = utils_misc.generate_random_string(3)
     br_name = br_type + '_' + rand_id
     host_iface = params.get('host_iface')
-    host_iface = host_iface if host_iface else utils_net.get_net_if(
-        state='UP')[0]
+    host_iface = host_iface if host_iface else utils_net.get_default_gateway(
+        iface_name=True, force_dhcp=True).split()[0]
     iface_attrs = eval(params.get('iface_attrs', '{}'))
     net_attrs = eval(params.get('net_attrs', '{}'))
     update_bw = eval(params.get('update_bw', '{}'))

--- a/libvirt/tests/src/virtual_network/update_device/update_device_coalesce.py
+++ b/libvirt/tests/src/virtual_network/update_device/update_device_coalesce.py
@@ -47,8 +47,8 @@ def run(test, params, env):
     mac = utils_net.generate_mac_address_simple()
     iface_attrs = eval(params.get('iface_attrs', '{}'))
     host_iface = params.get('host_iface')
-    host_iface = host_iface if host_iface else utils_net.get_net_if(
-        state='UP')[0]
+    host_iface = host_iface if host_iface else utils_net.get_default_gateway(
+        iface_name=True, force_dhcp=True).split()[0]
     rx_frames = params.get('rx_frames', '0')
     updated_rx_frames = params.get('updated_rx_frames', '0')
     updated_coalesce = eval(params.get('updated_coalesce', '{}'))

--- a/libvirt/tests/src/virtual_network/update_device/update_iface_link_state.py
+++ b/libvirt/tests/src/virtual_network/update_device/update_iface_link_state.py
@@ -21,8 +21,8 @@ def run(test, params, env):
 
     outside_ip = params.get("outside_ip")
     host_iface = params.get("host_iface")
-    host_iface = host_iface if host_iface else utils_net.get_net_if(
-        state="UP")[0]
+    host_iface = host_iface if host_iface else utils_net.get_default_gateway(
+        iface_name=True, force_dhcp=True).split()[0]
     rand_id = utils_misc.generate_random_string(3)
     bridge_name = "br_" + rand_id
     tap_name = "tap_" + rand_id

--- a/libvirt/tests/src/virtual_network/update_device/update_iface_qos.py
+++ b/libvirt/tests/src/virtual_network/update_device/update_iface_qos.py
@@ -42,8 +42,8 @@ def run(test, params, env):
     rand_id = utils_misc.generate_random_string(3)
     br_name = br_type + '_' + rand_id
     host_iface = params.get('host_iface')
-    host_iface = host_iface if host_iface else utils_net.get_net_if(
-        state='UP')[0]
+    host_iface = host_iface if host_iface else utils_net.get_default_gateway(
+        iface_name=True, force_dhcp=True).split()[0]
     iface_attrs = eval(params.get('iface_attrs', '{}'))
     extra_attrs = eval(params.get('extra_attrs', '{}'))
     net_attrs = eval(params.get('net_attrs', '{}'))

--- a/libvirt/tests/src/virtual_network/update_device/update_iface_source.py
+++ b/libvirt/tests/src/virtual_network/update_device/update_iface_source.py
@@ -25,8 +25,8 @@ def run(test, params, env):
     rand_id = utils_misc.generate_random_string(3)
     net_name = 'net_' + rand_id
     host_iface = params.get('host_iface')
-    host_iface = host_iface if host_iface else utils_net.get_net_if(
-        state='UP')[0]
+    host_iface = host_iface if host_iface else utils_net.get_default_gateway(
+        iface_name=True, force_dhcp=True).split()[0]
     iface_attrs = eval(params.get('iface_attrs', '{}'))
     net_attrs = eval(params.get('net_attrs', '{}'))
     status_error = 'yes' == params.get('status_error', 'no')

--- a/libvirt/tests/src/virtual_network/update_device/update_iface_trustGuestRxFilters.py
+++ b/libvirt/tests/src/virtual_network/update_device/update_iface_trustGuestRxFilters.py
@@ -23,8 +23,8 @@ def run(test, params, env):
     vm_name = params.get('main_vm')
     vm = env.get_vm(vm_name)
     host_iface = params.get('host_iface')
-    host_iface = host_iface if host_iface else utils_net.get_net_if(
-        state='UP')[0]
+    host_iface = host_iface if host_iface else utils_net.get_default_gateway(
+        iface_name=True, force_dhcp=True).split()[0]
     iface_attrs = eval(params.get('iface_attrs', '{}'))
     ips = {'outside_ip': params.get('outside_ip')}
 

--- a/libvirt/tests/src/virtual_network/update_device/update_iface_type_live.py
+++ b/libvirt/tests/src/virtual_network/update_device/update_iface_type_live.py
@@ -27,8 +27,8 @@ def run(test, params, env):
     iface_attrs = eval(params.get('iface_attrs', '{}'))
     iface_type = params.get('iface_type')
     host_iface = params.get('host_iface')
-    host_iface = host_iface if host_iface else utils_net.get_net_if(
-        state='UP')[0]
+    host_iface = host_iface if host_iface else utils_net.get_default_gateway(
+        iface_name=True, force_dhcp=True).split()[0]
     net_attrs = eval(params.get('net_attrs', '{}'))
 
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)

--- a/libvirt/tests/src/virtual_network/update_device/update_port_isolated.py
+++ b/libvirt/tests/src/virtual_network/update_device/update_port_isolated.py
@@ -111,8 +111,8 @@ def run(test, params, env):
     net_attrs = eval(params.get('net_attrs', '{}'))
     update_port_attrs = eval(params.get('update_port_attrs', '{}'))
     host_iface = params.get('host_iface')
-    host_iface = host_iface if host_iface else utils_net.get_net_if(
-        state='UP')[0]
+    host_iface = host_iface if host_iface else utils_net.get_default_gateway(
+        iface_name=True, force_dhcp=True).split()[0]
 
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     bkxmls = list(map(vm_xml.VMXML.new_from_inactive_dumpxml, vms))

--- a/provider/virtual_network/passt.py
+++ b/provider/virtual_network/passt.py
@@ -1,7 +1,7 @@
 import logging
 import os
-import re
 import random
+import re
 import time
 from socket import socket
 
@@ -138,8 +138,8 @@ def check_proc_info(params, log_file, mac):
     socket_dir = params.get('socket_dir')
 
     host_iface = params.get('host_iface')
-    host_iface = host_iface if host_iface else utils_net.get_net_if(
-        state="UP")[0]
+    host_iface = host_iface if host_iface else utils_net.get_default_gateway(
+        iface_name=True, force_dhcp=True).split()[0]
 
     proc_info = get_proc_info('passt')
     LOG.debug(proc_info)


### PR DESCRIPTION
The original way is to get the 1st iface that is UP which is not reliable since an interface might be UP even if it doesn't have an ip address.