### PR TITLE
Increase numa memory to avoid guest start failure for lack of memory

### DIFF
--- a/libvirt/tests/cfg/memory/memory_attach_device.cfg
+++ b/libvirt/tests/cfg/memory/memory_attach_device.cfg
@@ -16,5 +16,5 @@
             vm_attrs = {'max_mem_rt': 10485760, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB', 'vcpu': 4, 'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '1048576', 'unit': 'KiB'}]}}
             mem_device_attrs = {'mem_model': 'virtio-mem', 'target': {'requested_unit': 'KiB', 'size': 262144, 'node': 0, 'size_unit': 'KiB', 'requested_size': 131072, 'block_unit': 'KiB', 'block_size': 2048}}
             aarch64:
-                vm_attrs = {'max_mem_rt': 10485760, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB', 'vcpu': 4, 'cpu': {'mode': 'host-passthrough', 'numa_cell': [{'id': '0', 'cpus': '0-3', 'memory': '524288', 'unit': 'KiB'}]}}
+                vm_attrs = {'max_mem_rt': 20971520, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB', 'vcpu': 4, 'cpu': {'mode': 'host-passthrough', 'numa_cell': [{'id': '0', 'cpus': '0-3', 'memory': '8388608', 'unit': 'KiB'}]}}
                 mem_device_attrs = {'mem_model': 'virtio-mem', 'target': {'requested_unit': 'KiB', 'size': 1048576, 'node': 0, 'size_unit': 'KiB', 'requested_size': 524288, 'block_unit': 'KiB', 'block_size': 524288}}

--- a/libvirt/tests/cfg/memory/memory_update_device.cfg
+++ b/libvirt/tests/cfg/memory/memory_update_device.cfg
@@ -13,7 +13,7 @@
             mem_device_attrs = {'mem_model': 'virtio-mem', 'target': {'requested_unit': 'KiB', 'size': 262144, 'node': 0, 'size_unit': 'KiB', 'requested_size': 131072, 'block_unit': 'KiB', 'block_size': 2048}}
             requested_size = 160MiB
             aarch64:
-                vm_attrs = {'max_mem_rt': 10485760, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB', 'vcpu': 4, 'cpu': {'mode': 'host-passthrough', 'numa_cell': [{'id': '0', 'cpus': '0-3', 'memory': '524288', 'unit': 'KiB'}]}}
+                vm_attrs = {'max_mem_rt': 20971520, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB', 'vcpu': 4, 'cpu': {'mode': 'host-passthrough', 'numa_cell': [{'id': '0', 'cpus': '0-3', 'memory': '8388608', 'unit': 'KiB'}]}}
                 mem_device_attrs = {'mem_model': 'virtio-mem', 'target': {'requested_unit': 'KiB', 'size': 1048576, 'node': 0, 'size_unit': 'KiB', 'requested_size': 524288, 'block_unit': 'KiB', 'block_size': 524288}}
                 requested_size = 1048576KiB
             check_log_str = "MEMORY_DEVICE_SIZE_CHANGE.*virtiomem"


### PR DESCRIPTION
result on aarch64 64k:
 (1/1) type_specific.io-github-autotest-libvirt.memory_update_device.virtio_mem: PASS (60.10 s)
 (1/2) type_specific.io-github-autotest-libvirt.memory_attach_device.virtio_mem.cold_plug: PASS (67.71 s)
 (2/2) type_specific.io-github-autotest-libvirt.memory_attach_device.virtio_mem.hot_plug: PASS (66.78 s)