### PR TITLE
fix detach memory device event not found issue

### DIFF
--- a/libvirt/tests/cfg/memory/memory_devices/dimm_memory_hot_unplug.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/dimm_memory_hot_unplug.cfg
@@ -8,9 +8,9 @@
     target_size = "524288"
     size_unit = 'KiB'
     node = 0
-    mem_value = 2097152
-    current_mem = 2097152
-    numa_mem = 1048576
+    mem_value = 3145728
+    current_mem = 3145728
+    numa_mem = 1572864
     max_mem = 4194304
     max_mem_slots = 16
     slot = '0'


### PR DESCRIPTION
  increase the memory size
Signed-off-by: nanli <nanli@redhat.com>

Before fixed

 `(1/1) type_specific.io-github-autotest-libvirt.memory.devices.dimm.hot_unplug.online_movable_mem.source_and_mib: ERROR: Not found event device-removed after 20 seconds (185.88 s)
`


After fixed

```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 memory.devices.dimm.hot_unplug.online_movable_mem.source_and_mib --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.memory.devices.dimm.hot_unplug.online_movable_mem.source_and_mib: PASS (169.05 s)



```