### PR TITLE
replace bidirectional pipe with 2 unidirectional pipes (in/out) 

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
@@ -463,10 +463,10 @@ class SerialPipe(SerialFile):
 
     identifier = None
     type_name = "pipe"
-    
+
     @staticmethod
     def make_source(filepath):
-        pipe_suffixes= [".in",".out"]
+        pipe_suffixes = [".in", ".out"]
         for suffix in pipe_suffixes:
             pipe_path = filepath + suffix
             try:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
@@ -463,14 +463,17 @@ class SerialPipe(SerialFile):
 
     identifier = None
     type_name = "pipe"
+    pipe_suffixes=[".in",".out"]
 
     @staticmethod
     def make_source(filepath):
-        try:
-            os.unlink(filepath)
-        except OSError:
-            pass
-        os.mkfifo(filepath)
+        for suffix in pipe_suffixes:
+            pipe_path=filepath+suffix
+            try:
+                os.unlink(pipe_path)
+            except OSError:
+                pass
+            os.mkfifo(pipe_path)
 
     def init_device(self, index):
         return super(SerialPipe, self).init_device(index)  # stub for now

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_attach_device.py
@@ -463,12 +463,12 @@ class SerialPipe(SerialFile):
 
     identifier = None
     type_name = "pipe"
-    pipe_suffixes=[".in",".out"]
-
+    
     @staticmethod
     def make_source(filepath):
+        pipe_suffixes= [".in",".out"]
         for suffix in pipe_suffixes:
-            pipe_path=filepath+suffix
+            pipe_path = filepath + suffix
             try:
                 os.unlink(pipe_path)
             except OSError:


### PR DESCRIPTION
fix the issue that guest boot failure with bidirectional pipe device. 
refers to https://bugzilla.redhat.com/show_bug.cgi?id=2106975  