### PR TITLE
vcpu_metrics.py: Multiqueue Not Supported for type='user'

### DIFF
--- a/libvirt/tests/src/cpu/vcpu_metrics.py
+++ b/libvirt/tests/src/cpu/vcpu_metrics.py
@@ -130,6 +130,7 @@ def setup_with_unprivileged_user(vm, params, test):
     test.log.debug("Remove 'dac' security driver for unprivileged user")
     vmxml.del_seclabel(by_attr=[('model', 'dac')])
     libvirt_vmxml.modify_vm_device(vmxml, 'interface', interface_attrs)
+    vmxml.xmltreefile.remove_by_xpath("/devices/interface/driver", True)
     boot_disk = vmxml.devices.by_device_tag('disk')[0]
     first_disk_source = boot_disk.fetch_attrs()['source']['attrs']['file']
     unprivileged_boot_disk_path = os.path.join(unprivileged_boot_disk_path, os.path.basename(first_disk_source))


### PR DESCRIPTION
### The Problem

libvirt does not support more than one interface queue for hosts using \<interface type='user\'>

If the xml that is being used for this test sets the number of queues higher, then the test will fail.

### Solution

We remove the part of the XML that specifies the number of queues. This way Libvirt can default to a correct number

### Evidence
Below is evidence this change works
```
(.libvirt-ci-venv-ci-runtest-KSgk7Y) [root@ampere-mtsnow-altramax-03 tp-libvirt]# avocado run --vt-type libvirt --vt-machine-type arm64-mmio --test-runner=runner virsh.vcpu_metrics.normal_test.with_unprivileged_user
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : 2d55e8f2cf872500aa52d38b7b3f85986b8609d8
JOB LOG    : /var/log/avocado/job-results/job-2024-08-13T14.30-2d55e8f/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.vcpu_metrics.normal_test.with_unprivileged_user: PASS (13.54 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2024-08-13T14.30-2d55e8f/results.html
JOB TIME   : 13.93 s
```