### PR TITLE
virsh_console.py: Fix prompt regex

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_console.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_console.py
@@ -81,7 +81,7 @@ def vm_console_config(vm, test, device='ttyS0',
 
 
 def check_duplicated_console(command, force_command, status_error, login_user,
-                             login_passwd, test):
+                             login_passwd, test, prompt_regex):
     """
     Test opening a second console with another console active using --force
     option or not.
@@ -93,7 +93,7 @@ def check_duplicated_console(command, force_command, status_error, login_user,
     :param login_passwd: Password for logging into the VM.
     :param test: Test Object
     """
-    session = aexpect.ShellSession(command)
+    session = aexpect.ShellSession(command, prompt=prompt_regex)
     if not status_error:
         # Test duplicated console session
         res = process.run(command, timeout=CMD_TIMEOUT,
@@ -104,7 +104,7 @@ def check_duplicated_console(command, force_command, status_error, login_user,
                       "but succeeded with:\n%s" % res)
 
         # Test duplicated console session with force option
-        force_session = aexpect.ShellSession(force_command)
+        force_session = aexpect.ShellSession(force_command, prompt=prompt_regex)
         force_status = utils_test.libvirt.verify_virsh_console(
             force_session, login_user, login_passwd,
             timeout=CMD_TIMEOUT, debug=True)
@@ -116,7 +116,7 @@ def check_duplicated_console(command, force_command, status_error, login_user,
 
 
 def check_disconnect_on_shutdown(vm, command, status_error, login_user,
-                                 login_passwd, test):
+                                 login_passwd, test, prompt_regex):
     """
     Test whether an active console will disconnect after shutting down the VM.
 
@@ -127,7 +127,7 @@ def check_disconnect_on_shutdown(vm, command, status_error, login_user,
     :param login_passwd: Password for logging into the VM.
     :param test: Test Object
     """
-    session = aexpect.ShellSession(command)
+    session = aexpect.ShellSession(command, prompt=prompt_regex)
     if not status_error:
         log = ""
         console_cmd = "shutdown -h now"
@@ -200,6 +200,7 @@ def run(test, params, env):
     domid = ""
     uri = params.get("virsh_uri")
     unprivileged_user = params.get('unprivileged_user')
+    prompt_regex = params.get("prompt_regex", r"(.*)(\[.+@.+\]#)\s(.*)$")
 
     # PAPR guests don't usually have a true serial device (ttyS0),
     # they only have the hypervisor console (/dev/hvc0)
@@ -260,7 +261,7 @@ def run(test, params, env):
         else:
             command = "virsh console %s" % vm_ref
             force_command = "virsh console %s --force" % vm_ref
-        console_session = aexpect.ShellSession(command)
+        console_session = aexpect.ShellSession(command, prompt=prompt_regex)
 
         status = utils_test.libvirt.verify_virsh_console(
             console_session, login_user, login_passwd,
@@ -268,9 +269,9 @@ def run(test, params, env):
         console_session.close()
 
         check_duplicated_console(command, force_command, status_error,
-                                 login_user, login_passwd, test)
+                                 login_user, login_passwd, test, prompt_regex)
         check_disconnect_on_shutdown(vm, command, status_error, login_user,
-                                     login_passwd, test)
+                                     login_passwd, test, prompt_regex)
     finally:
         # Recover state of vm.
         if vm_state == "paused":


### PR DESCRIPTION
### The Issue 
When looking for a console prompt, the script uses a regex. However this regex will not match the prompt if there is garbage in the console.

This garbage often appears as kernel debug messages. EG:
```
[root@localhost ~]# [   24.552883] block dm-0: the capability attribute has been deprecated
```
### The Solution
Update the regex to allow for garbage in the console

### Evidence
Here is the relevant tests passing
```
[root@ampere-mtsnow-altramax-52 tp-libvirt]# avocado run --vt-type libvirt --vt-machine-type arm64-mmio --test-runner=runner virsh.console.normal_test.acl_test.valid_domuuid
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : 8a813b75eff1eee64999efb224e81e1fd99b0e4c
JOB LOG    : /var/log/avocado/job-results/job-2024-08-14T09.34-8a813b7/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.console.normal_test.acl_test.valid_domuuid: PASS (70.86 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2024-08-14T09.34-8a813b7/results.html
JOB TIME   : 71.26 s
```

```
[root@ampere-mtsnow-altramax-52 tp-libvirt]# avocado run --vt-type libvirt --vt-machine-type arm64-mmio --test-runner=runner virsh.console.normal_test.acl_test.valid_domid
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : b9bed3233fc021211df3dda54787cd9be37249c1
JOB LOG    : /var/log/avocado/job-results/job-2024-08-14T09.07-b9bed32/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.console.normal_test.acl_test.valid_domid: PASS (76.05 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2024-08-14T09.07-b9bed32/results.html
JOB TIME   : 76.45 s
[root@ampere-mtsnow-altr
```