### PR TITLE
Transitional_memballoon: update memory size to test in aarch64

### DIFF
--- a/libvirt/tests/cfg/virtio_transitional/virtio_transitional_blk.cfg
+++ b/libvirt/tests/cfg/virtio_transitional/virtio_transitional_blk.cfg
@@ -45,7 +45,6 @@
             at_disk_bus = scsi
     variants:
         - @default:
-            only q35
             only boot_test
             no virtio_transitional
         - rhel6_guest:

--- a/libvirt/tests/cfg/virtio_transitional/virtio_transitional_mem_balloon.cfg
+++ b/libvirt/tests/cfg/virtio_transitional/virtio_transitional_mem_balloon.cfg
@@ -1,7 +1,7 @@
 - virtio_transitional_mem_balloon:
     type = virtio_transitional_mem_balloon
-    only q35
     start_vm = no
+    vm_memory = 8388608
     variants:
         - virtio:
             virtio_model = "virtio"
@@ -13,7 +13,9 @@
             virtio_model = "virtio-non-transitional"
     variants:
         - @default:
+            no virtio_transitional
         - rhel6_guest:
+            only q35
             os_variant = rhel6
             image_path = images/rhel6-x86_64-latest.qcow2
             guest_src_url = "http://download.libvirt.redhat.com/libvirt-CI-resources/RHEL-6.10-x86_64-latest.qcow2"

--- a/libvirt/tests/cfg/virtio_transitional/virtio_transitional_nic.cfg
+++ b/libvirt/tests/cfg/virtio_transitional/virtio_transitional_nic.cfg
@@ -26,10 +26,10 @@
             virtio_model = "virtio-non-transitional"
     variants:
         - @default:
-            only q35
             only boot_test
             no virtio_transitional
         - rhel6_guest:
+            only q35
             os_variant = rhel6
             only virtio_transitional
             no Windows

--- a/libvirt/tests/cfg/virtio_transitional/virtio_transitional_rng.cfg
+++ b/libvirt/tests/cfg/virtio_transitional/virtio_transitional_rng.cfg
@@ -18,7 +18,6 @@
             hotplug = yes
     variants:
         - @default:
-            only q35
             only boot_test
             no virtio_transitional
             disk_model = ${virtio_model}

--- a/libvirt/tests/cfg/virtio_transitional/virtio_transitional_vsock.cfg
+++ b/libvirt/tests/cfg/virtio_transitional/virtio_transitional_vsock.cfg
@@ -20,7 +20,6 @@
             hotplug = yes
     variants:
         - @default:
-            only q35
             only boot_test
             no virtio_transitional
         - rhel6_guest:

--- a/libvirt/tests/src/virtio_transitional/virtio_transitional_mem_balloon.py
+++ b/libvirt/tests/src/virtio_transitional/virtio_transitional_mem_balloon.py
@@ -45,6 +45,7 @@ def run(test, params, env):
     os_variant = params.get("os_variant", "")
     params["disk_model"] = virtio_model
     set_crypto_policy = params.get("set_crypto_policy")
+    vm_memory = int(params.get("vm_memory"))
 
     if not libvirt_version.version_compare(5, 0, 0):
         test.cancel("This libvirt version doesn't support "
@@ -68,6 +69,8 @@ def run(test, params, env):
             libvirt.modify_vm_iface(vm_name, "update_iface", iface_params)
             # Remove nvram setting for rhel6 guest
             virtio_transitional_base.remove_rhel6_nvram(vm_name)
+        vmxml.memory = vm_memory
+        vmxml.sync()
         libvirt.set_vm_disk(vm, params)
         # The local variable "vmxml" will not be updated since set_vm_disk
         # sync with another dumped xml inside the function


### PR DESCRIPTION
With the default memory size, the guest can't boot in aarch64. So update it to be also covered in aarch64.