### PR TITLE
v2v:fix v2v-options failed case -adding version control

### DIFF
--- a/v2v/tests/cfg/v2v_options.cfg
+++ b/v2v/tests/cfg/v2v_options.cfg
@@ -333,6 +333,7 @@
                             expect_msg = yes
                             msg_content = "Remove  1 Package"
                         - required_patch:
+                            version_required = "(,virt-v2v-2.4.0-1)"
                             check_command = "rpm -q --changelog %s"
                             checkpoint = check_patch
                 - print_estimate:


### PR DESCRIPTION
Confirm with developer, the patch is included upstream in virt-v2v >= 2.4.  Any version
above this doesn't need the separate patch.