### PR TITLE
add case for suspend or shutdown vm via libvirt-guest service

### DIFF
--- a/libvirt/tests/cfg/daemon/conf_file/sysconfig_libvirt_guests/libvirt_guests.cfg
+++ b/libvirt/tests/cfg/daemon/conf_file/sysconfig_libvirt_guests/libvirt_guests.cfg
@@ -6,10 +6,42 @@
             status_error = "no"
             shutdown_timeout = 300
             variants:
+                - without_transient_vm:
+                - with_transient_vm:
+                    only no_parallel_shutdown.suspend_on_shutdown.default_vol.none_on_boot, no_parallel_shutdown.shutdown_on_shutdown.none_on_boot
+                    func_supported_since_libvirt_ver = (10, 3, 0)
+                    start_vm = "no"
+                    transient_vm = "yes"
+                    additional_vms = 1
+                    on_boot = ""
+                    shutdown_timeout = ""
+                    parallel_shutdown = ""
+                    variants:
+                        - persistent_only_none:
+                            persistent_only = ""
+                            shutdown_on_shutdown:
+                                transient_vm_operation = "shutdown"
+                            suspend_on_shutdown:
+                                transient_vm_operation = "nothing"
+                        - persistent_only_true:
+                            persistent_only = "true"
+                            transient_vm_operation = "nothing"
+                        - persistent_only_false:
+                            persistent_only = "false"
+                            transient_vm_operation = ${on_shutdown}
+                        - persistent_only_default:
+                            persistent_only = "default"
+                            shutdown_on_shutdown:
+                                transient_vm_operation = "shutdown"
+                            suspend_on_shutdown:
+                                transient_vm_operation = "nothing"
+            variants:
                 - start_on_boot:
                     on_boot = "start"
                 - ignore_on_boot:
                     on_boot = "ignore"
+                - none_on_boot:
+                    on_boot = ""
             variants:
                 - suspend_on_shutdown:
                     on_shutdown = "suspend"


### PR DESCRIPTION
   xxxx-300726:suspend or shutdown VM with PERSISTENT_ONLY - via restarting libvirt-guests.service
Signed-off-by: nanli <nanli@redhat.com>


Existed two bugs xxxx-56142 xxxx-56145
```

avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 managedsave.libvirt_guests.positive_test..with_transient_vm
 (1/8) type_specific.io-github-autotest-libvirt.managedsave.libvirt_guests.positive_test.no_parallel_shutdown.suspend_on_shutdown.default_vol.none_on_boot.with_transient_vm.persistent_only_none: PASS (79.00 s)
 (2/8) type_specific.io-github-autotest-libvirt.managedsave.libvirt_guests.positive_test.no_parallel_shutdown.suspend_on_shutdown.default_vol.none_on_boot.with_transient_vm.persistent_only_true: PASS (98.31 s)
 (3/8) type_specific.io-github-autotest-libvirt.managedsave.libvirt_guests.positive_test.no_parallel_shutdown.suspend_on_shutdown.default_vol.none_on_boot.with_transient_vm.persistent_only_false: FAIL: guest:avocado-vt-vm2 should be suspend on shutdown (98.57 s)
 (4/8) type_specific.io-github-autotest-libvirt.managedsave.libvirt_guests.positive_test.no_parallel_shutdown.suspend_on_shutdown.default_vol.none_on_boot.with_transient_vm.persistent_only_default: PASS (97.73 s)
 (5/8) type_specific.io-github-autotest-libvirt.managedsave.libvirt_guests.positive_test.no_parallel_shutdown.shutdown_on_shutdown.none_on_boot.with_transient_vm.persistent_only_none: ERROR: libvirt-guests failed to restart. Please check logs. (104.38 s)
 (6/8) type_specific.io-github-autotest-libvirt.managedsave.libvirt_guests.positive_test.no_parallel_shutdown.shutdown_on_shutdown.none_on_boot.with_transient_vm.persistent_only_true: PASS (102.53 s)
 (7/8) type_specific.io-github-autotest-libvirt.managedsave.libvirt_guests.positive_test.no_parallel_shutdown.shutdown_on_shutdown.none_on_boot.with_transient_vm.persistent_only_false: ERROR: libvirt-guests failed to restart. Please check logs. (101.30 s)
 (8/8) type_specific.io-github-autotest-libvirt.managedsave.libvirt_guests.positive_test.no_parallel_shutdown.shutdown_on_shutdown.none_on_boot.with_transient_vm.persistent_only_default: ERROR: libvirt-guests failed to restart. Please check logs. (98.09 s)



```