### PR TITLE
security/virt_what: add test for expected value

### DIFF
--- a/libvirt/tests/cfg/security/virt_what_cvm.cfg
+++ b/libvirt/tests/cfg/security/virt_what_cvm.cfg
@@ -1,0 +1,9 @@
+- virt_what.cvm:
+   type = virt_what_cvm
+   start_vm = yes
+   variants:
+       - expected_value:
+           # The EXPECTED_VALUE depends on the VM. A normal VM would have "".
+           # man virt-what-cvm lists the available values for VM where
+           # confidentiality is enabled
+           expected_cvm =

--- a/libvirt/tests/src/security/virt_what_cvm.py
+++ b/libvirt/tests/src/security/virt_what_cvm.py
@@ -1,0 +1,27 @@
+import logging as log
+
+from virttest import utils_misc, utils_package
+
+
+logging = log.getLogger("avocado." + __name__)
+
+
+def run(test, params, env):
+    """
+    Confirms that the output of virt-what-cvm is as expected.
+
+    :params test: The avocado test object
+    :params params: Parameters for the test
+    :params env: The avocado test environment object
+    """
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    expected_cvm = params.get("expected_cvm")
+    session = vm.wait_for_login()
+    utils_package.package_install("virt-what", session=session)
+    _, o = utils_misc.cmd_status_output("virt-what-cvm", session=session)
+    if o.strip() != expected_cvm.strip():
+        test.fail(
+            f"Unexpected value '{o.strip()}' instead of {expected_cvm.strip()}."
+            " Note that the command is supported since virt-what-1.25-10."
+        )

--- a/spell.ignore
+++ b/spell.ignore
@@ -170,6 +170,7 @@ ctrl
 currentvcpu
 curvcpu
 CVE
+cvm
 dac
 DAC
 darget


### PR DESCRIPTION
Since virt-what-1.25-9, there's an additional command 'virt-what-cvm' that gives information about if and which confidential VM mode is running.

The test per default assumes that the VM runs without confidentiality. It can be configured to cover other values depending on the guest. The supported outputs are listed on the man virt-what-cvm.