### PR TITLE
v2v: fix failed case on checking v2v version for rhel10

### DIFF
--- a/v2v/tests/src/v2v_options.py
+++ b/v2v/tests/src/v2v_options.py
@@ -587,9 +587,11 @@ def run(test, params, env):
                         'Not found disk or xml created by virt-v2v-copy-to-local')
             if checkpoint == 'check_version':
                 get_v2v_version = process.run('rpm -q virt-v2v', shell=True, ignore_status=True)
-                if (''.join(filter(str.isdigit, str(output_stdout)))[1:4] +
-                    ''.join(filter(str.isdigit, str(output_stdout)))[5]) != \
-                        ''.join(filter(str.isdigit, str(get_v2v_version.stdout)))[1:5]:
+                get_rpm_version = re.search(r'(\d+\.\d+\.\d+-\d+\.el\d+)', str(get_v2v_version.stdout))
+                rpm_version = get_rpm_version.group(1)
+                get_virt_v2v_version = re.search(r'(\d+\.\d+\.\d+).*(\d+\.el\d+)', str(output_stdout))
+                virt_v2v_version = get_virt_v2v_version.group(1) + '-' + get_virt_v2v_version.group(2)
+                if (rpm_version != virt_v2v_version):
                     test.fail('v2v version is incorrect in v2v version option')
 
         log_check = utils_v2v.check_log(params, output)


### PR DESCRIPTION
The check-version function failed on rhel10 cause the way to check versions is on the digital.
Fix the function and it can work both on rhel10 and rhel9.