### PR TITLE
Change memory size, memory address and guest node

### DIFF
--- a/libvirt/tests/cfg/memory/memory_devices/dimm_memory_hot_unplug.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/dimm_memory_hot_unplug.cfg
@@ -8,8 +8,8 @@
     target_size = "524288"
     size_unit = 'KiB'
     node = 0
-    mem_value = 3145728
-    current_mem = 3145728
+    mem_value = 3670016
+    current_mem = 3670016
     numa_mem = 1572864
     max_mem = 4194304
     max_mem_slots = 16
@@ -23,14 +23,14 @@
     vm_attrs = {${numa_dict},${max_dict},'memory_unit':'KiB','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'KiB'}
     variants plug_dimm_type:
         - target_and_address:
-            base = "0x100000000"
+            base = "0x140000000"
             addr_dict = "'address':{'attrs': {'type':'dimm','slot':'${slot}','base':'${base}'}}"
             dimm_dict = {'mem_model':'${mem_model}',${addr_dict},'target': {'size':${target_size}, 'size_unit':'${size_unit}', 'node':${node}}}
             unplug_dimm_dict = ${dimm_dict}
         - source_and_mib:
-            target_size = "1024"
+            target_size = "512"
             size_unit = 'MiB'
-            node = 1
+            node = 0
             source_dict = "'source':{'nodemask': '0','pagesize': %d, 'pagesize_unit':'KiB'}"
             dimm_dict = {'mem_model':'${mem_model}',${source_dict},'target': {'size':${target_size}, 'size_unit':'${size_unit}', 'node':${node}}}
             unplug_dimm_dict = ${dimm_dict}

--- a/libvirt/tests/src/memory/memory_devices/dimm_memory_hot_unplug.py
+++ b/libvirt/tests/src/memory/memory_devices/dimm_memory_hot_unplug.py
@@ -54,10 +54,10 @@ def check_guest_virsh_dominfo(vm, test, params, unplugged=False):
 
     target_size = adjust_size_unit(params)
     if unplugged:
-        expected_mem = str(mem_value)
+        expected_mem = str(mem_value - target_size)
         expected_curr = str(current_mem - target_size)
     else:
-        expected_mem = str(mem_value + target_size)
+        expected_mem = str(mem_value)
         expected_curr = str(current_mem)
 
     memory_base.check_dominfo(vm, test, expected_mem, expected_curr)
@@ -86,7 +86,7 @@ def check_after_detach(vm, test, params):
 
     target_size = adjust_size_unit(params)
     libvirtd_log_file = os.path.join(test.debugdir, "libvirtd.log")
-    ausearch_check = params.get("ausearch_check") % (mem_value+target_size, mem_value)
+    ausearch_check = params.get("ausearch_check") % (mem_value, mem_value - target_size)
 
     # Check the audit log by ausearch.
     ausearch_result = process.run(audit_cmd, shell=True)
@@ -102,7 +102,7 @@ def check_after_detach(vm, test, params):
     # Check the memory allocation and memory device config.
     vmxml = vm_xml.VMXML.new_from_dumpxml(vm.name)
     libvirt_vmxml.check_guest_xml_by_xpaths(
-        vmxml, eval(base_xpath % (mem_value, current_mem-target_size)))
+        vmxml, eval(base_xpath % (mem_value - target_size, current_mem - target_size)))
     if vmxml.devices.by_device_tag("memory"):
         test.fail("Dimm memory still exist after unplugging")
 
@@ -153,7 +153,7 @@ def run(test, params, env):
         target_size = adjust_size_unit(params)
         vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
         libvirt_vmxml.check_guest_xml_by_xpaths(
-            vmxml, eval(base_xpath % (mem_value + target_size, current_mem)))
+            vmxml, eval(base_xpath % (mem_value, current_mem)))
         libvirt_vmxml.check_guest_xml_by_xpaths(
             vmxml.devices.by_device_tag("memory")[0], eval(dimm_xpath % (target_size, slot)))
 


### PR DESCRIPTION
Change memory size to make logic same as current memory. 
Change memory address to avoid conflict.
Change guest node to make memory device hot-unplug reject by guest.

Test results:
(1/5) type_specific.io-github-autotest-libvirt.memory.devices.dimm.hot_unplug.default_mem.target_and_address: PASS (32.86 s)
 (2/5) type_specific.io-github-autotest-libvirt.memory.devices.dimm.hot_unplug.default_mem.source_and_mib: PASS (34.27 s)
 (3/5) type_specific.io-github-autotest-libvirt.memory.devices.dimm.hot_unplug.default_mem.unexisted_device: PASS (39.88 s)
 (4/5) type_specific.io-github-autotest-libvirt.memory.devices.dimm.hot_unplug.online_movable_mem.target_and_address: PASS (168.38 s)
 (5/5) type_specific.io-github-autotest-libvirt.memory.devices.dimm.hot_unplug.online_movable_mem.source_and_mib: PASS (163.48 s)