### PR TITLE
Change grep pattern to avoid occasional memory size and address conflict

### DIFF
--- a/provider/numa/numa_base.py
+++ b/provider/numa/numa_base.py
@@ -192,7 +192,7 @@ def get_host_numa_memory_alloc_info(mem_size):
     :param mem_size: int, the vm memory size
     :return: str, the matched output in numa_maps
     """
-    cmd = 'grep -B1 %s /proc/`pidof qemu-kvm`/smaps' % mem_size
+    cmd = 'grep -B1 "%s " /proc/`pidof qemu-kvm`/smaps' % mem_size
     out = process.run(cmd, shell=True, verbose=True).stdout_text.strip()
     matches = re.findall('(\w+)-', out)
     if not matches:


### PR DESCRIPTION
results:
 (01/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_strict.single_node: PASS (36.39 s)
 (02/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_strict.multiple_nodes: PASS (37.56 s)
 (03/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_interleave.single_node: PASS (44.92 s)
 (04/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_interleave.multiple_nodes: PASS (44.26 s)
 (05/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_preferred.single_node: PASS (45.68 s)
 (06/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_preferred.multiple_nodes: PASS (44.38 s)
 (07/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_restrictive.single_node: PASS (9.00 s)
 (08/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_restrictive.multiple_nodes: PASS (8.95 s)
 (09/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.no_mem_mode.single_node: PASS (42.66 s)
 (10/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.no_mem_mode.multiple_nodes: PASS (45.53 s)
 (11/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.no_mem_mode.no_node: PASS (44.18 s)
 (12/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_interleave.mem_mode_strict.single_node: PASS (43.89 s)
 (13/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_interleave.mem_mode_strict.multiple_nodes: PASS (43.47 s)
 (14/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_interleave.mem_mode_interleave.single_node: PASS (77.15 s)
 (15/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_interleave.mem_mode_interleave.multiple_nodes: PASS (38.35 s)
 (16/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_interleave.mem_mode_preferred.single_node: PASS (43.93 s)
 (17/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_interleave.mem_mode_preferred.multiple_nodes: PASS (45.03 s)
 (18/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_interleave.mem_mode_restrictive.single_node: PASS (9.03 s)
 (19/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_interleave.mem_mode_restrictive.multiple_nodes: PASS (8.86 s)
 (20/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_interleave.no_mem_mode.single_node: PASS (42.28 s)
 (21/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_interleave.no_mem_mode.multiple_nodes: PASS (45.60 s)
 (22/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_interleave.no_mem_mode.no_node: PASS (43.10 s)
 (23/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_preferred.mem_mode_strict.single_node: PASS (44.44 s)
 (24/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_preferred.mem_mode_strict.multiple_nodes: PASS (44.05 s)
 (25/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_preferred.mem_mode_interleave.single_node: PASS (42.09 s)
 (26/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_preferred.mem_mode_interleave.multiple_nodes: PASS (44.63 s)
 (27/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_preferred.mem_mode_preferred.single_node: PASS (45.38 s)
 (28/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_preferred.mem_mode_preferred.multiple_nodes: PASS (43.12 s)
 (29/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_preferred.mem_mode_restrictive.single_node: PASS (8.79 s)
 (30/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_preferred.mem_mode_restrictive.multiple_nodes: PASS (8.77 s)
 (31/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_preferred.no_mem_mode.single_node: PASS (42.58 s)
 (32/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_preferred.no_mem_mode.multiple_nodes: PASS (44.37 s)
 (33/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_preferred.no_mem_mode.no_node: PASS (44.78 s)
 (34/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_restrictive.mem_mode_strict.single_node: PASS (8.94 s)
 (35/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_restrictive.mem_mode_strict.multiple_nodes: PASS (9.02 s)
 (36/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_restrictive.mem_mode_interleave.single_node: PASS (14.94 s)
 (37/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_restrictive.mem_mode_interleave.multiple_nodes: PASS (8.89 s)
 (38/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_restrictive.mem_mode_preferred.single_node: PASS (8.86 s)
 (39/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_restrictive.mem_mode_preferred.multiple_nodes: PASS (8.75 s)
 (40/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_restrictive.mem_mode_restrictive.single_node: PASS (44.94 s)
 (41/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_restrictive.mem_mode_restrictive.multiple_nodes: PASS (44.77 s)
 (42/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_restrictive.no_mem_mode.single_node: PASS (8.93 s)
 (43/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_restrictive.no_mem_mode.multiple_nodes: PASS (9.01 s)
 (44/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_restrictive.no_mem_mode.no_node: PASS (8.91 s)