### PR TITLE
viommu: Add a test scenario about 'virsh reset'

### DIFF
--- a/libvirt/tests/cfg/sriov/vIOMMU/iommu_device_lifecycle.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/iommu_device_lifecycle.cfg
@@ -40,3 +40,4 @@
         - suspend_resume:
         - reboot_many_times:
             loop_time = 5
+        - reset:


### PR DESCRIPTION
This pr adds 'virsh reset' into viommu lifecycle testing.

**Test results:**
```
 (01/11) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.save_restore.virtio_muti_devices.vhost_on.virtio: PASS (76.58 s)
 (02/11) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.save_restore.virtio_muti_devices.vhost_on.smmuv3: PASS (76.84 s)
 (03/11) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.suspend_resume.virtio_muti_devices.vhost_on.virtio: PASS (74.65 s)
 (04/11) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.suspend_resume.virtio_muti_devices.vhost_on.smmuv3: PASS (74.39 s)
 (05/11) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.suspend_resume.hostdev_iface.virtio: PASS (135.01 s)
 (06/11) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.reboot_many_times.reset.virtio_muti_devices.vhost_on.virtio: PASS (189.77 s)
 (07/11) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.reboot_many_times.reset.virtio_muti_devices.vhost_on.smmuv3: PASS (188.35 s)
 (08/11) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.reboot_many_times.reset.hostdev_iface.virtio: PASS (203.01 s)
 (09/11) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.reboot_many_times.reboot_command.virtio_muti_devices.vhost_on.virtio: PASS (279.37 s)
 (10/11) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.reboot_many_times.reboot_command.virtio_muti_devices.vhost_on.smmuv3: PASS (278.11 s)
 (11/11) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.reboot_many_times.reboot_command.hostdev_iface.virtio: PASS (291.59 s)
RESULTS    : PASS 11 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0

 (01/10) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.reboot_many_times.reset.e1000e.virtio: PASS (204.68 s)
 (02/10) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.reboot_many_times.reset.e1000e.intel: PASS (297.02 s)
 (03/10) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.reboot_many_times.reset.virtio_muti_devices.vhost_on.virtio: PASS (191.67 s)
 (04/10) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.reboot_many_times.reset.virtio_muti_devices.vhost_on.intel: PASS (403.76 s)
 (05/10) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.reboot_many_times.reset.hostdev_iface.virtio: PASS (236.89 s)
 (06/10) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.reboot_many_times.reboot_command.e1000e.virtio: PASS (278.98 s)
 (07/10) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.reboot_many_times.reboot_command.e1000e.intel: PASS (393.14 s)
 (08/10) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.reboot_many_times.reboot_command.virtio_muti_devices.vhost_on.virtio: PASS (277.93 s)
 (09/10) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.reboot_many_times.reboot_command.virtio_muti_devices.vhost_on.intel: PASS (429.49 s)
 (10/10) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.reboot_many_times.reboot_command.hostdev_iface.virtio: PASS (294.32 s)


```