### PR TITLE
viommu: Add a case for file transfers

### DIFF
--- a/libvirt/tests/cfg/sriov/vIOMMU/viommu_transfer_file.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/viommu_transfer_file.cfg
@@ -1,0 +1,27 @@
+- vIOMMU.transfer_file:
+    type = viommu_transfer_file
+    start_vm = "no"
+    disk_driver = {'name': 'qemu', 'type': 'qcow2', 'iommu': 'on'}
+    variants:
+        - virtio:
+            only q35, aarch64
+            func_supported_since_libvirt_ver = (8, 3, 0)
+            iommu_dict = {'model': 'virtio'}
+        - intel:
+            only q35
+            start_vm = "yes"
+            enable_guest_iommu = "yes"
+            iommu_dict = {'model': 'intel', 'driver': {'intremap': 'on', 'caching_mode': 'on', 'eim': 'on', 'iotlb': 'on', 'aw_bits': '48'}}
+        - smmuv3:
+            only aarch64
+            func_supported_since_libvirt_ver = (5, 5, 0)
+            iommu_dict = {'model': 'smmuv3'}
+    variants:
+        - e1000e:
+            only q35
+            iface_model = 'e1000e'
+            iface_dict = {'type_name': 'network', 'model': '${iface_model}', 'source': {'network': 'default'}}
+        - virtio_interface:
+            interface_driver_name = "vhost"
+            interface_driver = {'driver_attr': {'name': '${interface_driver_name}', 'iommu': 'on'}}
+            iface_dict = {'type_name': 'network', 'model': 'virtio', 'driver': ${interface_driver}, 'source': {'network': 'default'}}

--- a/libvirt/tests/src/sriov/vIOMMU/viommu_transfer_file.py
+++ b/libvirt/tests/src/sriov/vIOMMU/viommu_transfer_file.py
@@ -1,0 +1,39 @@
+from virttest import utils_test
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+
+from provider.viommu import viommu_base
+
+
+def run(test, params, env):
+    """
+    Transfer a file between host and vm with iommu device
+    """
+    cleanup_ifaces = "yes" == params.get("cleanup_ifaces", "yes")
+    iommu_dict = eval(params.get('iommu_dict', '{}'))
+
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    vm = env.get_vm(vm_name)
+
+    test_obj = viommu_base.VIOMMUTest(vm, test, params)
+
+    try:
+        test.log.info("TEST_SETUP: Update VM XML.")
+        test_obj.setup_iommu_test(iommu_dict=iommu_dict,
+                                  cleanup_ifaces=cleanup_ifaces)
+
+        iface_dict = test_obj.parse_iface_dict()
+        if cleanup_ifaces:
+            libvirt_vmxml.modify_vm_device(
+                    vm_xml.VMXML.new_from_dumpxml(vm.name),
+                    "interface", iface_dict)
+
+        test.log.info("TEST_STEP: Start the VM.")
+        vm.start()
+        test.log.debug(vm_xml.VMXML.new_from_dumpxml(vm.name))
+
+        test.log.info("TEST_STEP: Transfer a file between host and vm.")
+        utils_test.run_file_transfer(test, params, env)
+    finally:
+        test_obj.teardown_iommu_test()


### PR DESCRIPTION
This PR adds:
    VIRT-301880: Transfer a file between host and vm with iommu device

**Test results:**
```
 (1/2) type_specific.io-github-autotest-libvirt.vIOMMU.transfer_file.virtio_interface.virtio: PASS (79.73 s)
 (2/2) type_specific.io-github-autotest-libvirt.vIOMMU.transfer_file.virtio_interface.smmuv3: PASS (49.39 s)

 (1/4) type_specific.io-github-autotest-libvirt.vIOMMU.transfer_file.e1000e.virtio: PASS (184.21 s)
 (2/4) type_specific.io-github-autotest-libvirt.vIOMMU.transfer_file.e1000e.intel: PASS (339.61 s)
 (3/4) type_specific.io-github-autotest-libvirt.vIOMMU.transfer_file.virtio_interface.virtio: PASS (184.73 s)
 (4/4) type_specific.io-github-autotest-libvirt.vIOMMU.transfer_file.virtio_interface.intel: PASS (321.49 s)

```