### PR TITLE
Change comparison logic, including xml element without child element

### DIFF
--- a/libvirt/tests/src/numa/guest_numa_topology/numa_topology_with_cpu_topology.py
+++ b/libvirt/tests/src/numa/guest_numa_topology/numa_topology_with_cpu_topology.py
@@ -37,9 +37,9 @@ def prepare_vm_xml(test_obj):
     cpu_topology = eval(test_obj.params.get('cpu_topology', '{}'))
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(test_obj.vm.name)
     if numa_cells:
-        if vmxml.xmltreefile.find('cpu'):
+        if vmxml.xmltreefile.find('cpu') is not None:
             cpuxml = vmxml.cpu
-            if cpuxml.xmltreefile.find('topology'):
+            if cpuxml.xmltreefile.find('topology') is not None:
                 del cpuxml.topology
         else:
             cpuxml = vm_xml.VMCPUXML()


### PR DESCRIPTION
the original logic will ignore cpu xml like` <cpu mode="host-model" check="partial" /> `after change, only no cpu element will go to else part.

Test results:
 (1/2) type_specific.io-github-autotest-libvirt.guest_numa_topology.numa_topology_with_cpu_topology.vcpu_with_order: PASS (79.41 s)
 (2/2) type_specific.io-github-autotest-libvirt.guest_numa_topology.numa_topology_with_cpu_topology.vcpu_without_order: PASS (48.76 s)