### PR TITLE
Virtio_packed: add new test scenarios of driver packed attribute

### DIFF
--- a/libvirt/tests/cfg/virtio/virtio_page_per_vq.cfg
+++ b/libvirt/tests/cfg/virtio/virtio_page_per_vq.cfg
@@ -1,7 +1,7 @@
 - virtio_attributes.virtio_page_per_vq:
     type = virtio_page_per_vq
     start_vm = no
-    driver_dict = {'driver': {'page_per_vq': 'on'}}
+    driver_dict = {'driver': {'page_per_vq': 'on', 'packed': 'on'}}
     ping_outside = 'www.google.com'
     func_supported_since_libvirt_ver = (8, 5, 0)
     no s390-virtio
@@ -15,7 +15,7 @@
             disk_image = '/var/lib/avocado/data/avocado-vt/images/jeos-27-x86_64.qcow2'
             aarch64:
                 disk_image = '/var/lib/avocado/data/avocado-vt/images/jeos-27-aarch64.qcow2'
-            driver_dict = {'driver': {'name': 'qemu', 'type': 'qcow2', 'page_per_vq': 'on'}}
+            driver_dict = {'driver': {'name': 'qemu', 'type': 'qcow2', 'page_per_vq': 'on', 'packed': 'on'}}
             device_dict = {'device': 'disk', 'type_name': 'file', **${driver_dict}, 'source': {'attrs': {'file': '${disk_image}'}}, 'target': {'dev': 'vdb', 'bus': 'virtio'}}
         - controller:
             variants:
@@ -27,7 +27,7 @@
                     controller_type = "virtio-serial"
                     device_dict = {**${driver_dict}, 'type': 'virtio-serial', 'index': '0', 'type_name': 'virtio-serial'}
         - interface:
-            driver_dict = {'driver': {'driver_attr': {'page_per_vq': 'on'}}}
+            driver_dict = {'driver': {'driver_attr': {'page_per_vq': 'on', 'packed': 'on'}}}
             device_dict = {'type_name': 'network', 'model': 'virtio', 'source': {'network': 'default'}, **${driver_dict}, 'mac_address': '52:54:00:26:08:7b'}
         - rng:
             device_dict = {'backend': {'backend_dev': '/dev/urandom', 'backend_model': 'random'}, **${driver_dict}, 'rng_model': 'virtio'}
@@ -41,10 +41,10 @@
                 - mouse:
                 - tablet:
                 - passthrough:
-                    device_dict = {**${device_dict}, 'source_evdev': '/dev/input/event1'}
+                    device_dict = {**${device_dict}, 'source_evdev': '/dev/input/event0'}
         - video:
             only default_start
             device_dict = {'model_type': 'virtio', **${driver_dict}, 'model_heads': '1'}
         - filesystem:
-            driver_dict = {'driver': {'type': 'virtiofs', 'page_per_vq': 'on'}}
+            driver_dict = {'driver': {'type': 'virtiofs', 'page_per_vq': 'on', 'packed': 'on'}}
             device_dict = {'source': {'dir': '/tmp'}, **${driver_dict}, 'type_name': 'mount', 'accessmode': 'passthrough', 'target': {'dir': 'mount_tag'}, 'binary': {'xattr': 'on', 'path': '/usr/libexec/virtiofsd', 'cache_mode': 'always'}}


### PR DESCRIPTION
Automate VIRT-293723 - [packed] Start vm with virtio packed attribute and check the bit. After discussion, we don't need to add the checkpoint of bit. Also because this attribute have already been covered in some devices but not filesystem, video and others. So I covered all them directly in the previous test script.