### PR TITLE
Add current memory config to replace default

### DIFF
--- a/libvirt/tests/cfg/memory/memory_attach_device.cfg
+++ b/libvirt/tests/cfg/memory/memory_attach_device.cfg
@@ -13,8 +13,8 @@
             guest_required_kernel = [5.8.0,)
             func_supported_since_libvirt_ver = (8, 0, 0)
             func_supported_since_qemu_kvm_ver = (6, 2, 0)
-            vm_attrs = {'max_mem_rt': 10485760, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB', 'vcpu': 4, 'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '1048576', 'unit': 'KiB'}]}}
+            vm_attrs = {'max_mem_rt': 10485760, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB', 'current_mem': 2097152, 'current_mem_unit':'KiB', 'vcpu': 4, 'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '2097152', 'unit': 'KiB'}]}}
             mem_device_attrs = {'mem_model': 'virtio-mem', 'target': {'requested_unit': 'KiB', 'size': 262144, 'node': 0, 'size_unit': 'KiB', 'requested_size': 131072, 'block_unit': 'KiB', 'block_size': 2048}}
             aarch64:
-                vm_attrs = {'max_mem_rt': 20971520, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB', 'vcpu': 4, 'cpu': {'mode': 'host-passthrough', 'numa_cell': [{'id': '0', 'cpus': '0-3', 'memory': '8388608', 'unit': 'KiB'}]}}
+                vm_attrs = {'max_mem_rt': 20971520, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB', 'current_mem': 8388608, 'current_mem_unit':'KiB', 'vcpu': 4, 'cpu': {'mode': 'host-passthrough', 'numa_cell': [{'id': '0', 'cpus': '0-3', 'memory': '8388608', 'unit': 'KiB'}]}}
                 mem_device_attrs = {'mem_model': 'virtio-mem', 'target': {'requested_unit': 'KiB', 'size': 1048576, 'node': 0, 'size_unit': 'KiB', 'requested_size': 524288, 'block_unit': 'KiB', 'block_size': 524288}}


### PR DESCRIPTION
Test results:
x86_64:
 (1/2) type_specific.io-github-autotest-libvirt.memory_attach_device.virtio_mem.cold_plug: PASS (69.72 s)
 (2/2) type_specific.io-github-autotest-libvirt.memory_attach_device.virtio_mem.hot_plug: PASS (66.97 s)

aarch64 4k:
 (1/2) type_specific.io-github-autotest-libvirt.memory_attach_device.virtio_mem.cold_plug: PASS (72.25 s)
 (2/2) type_specific.io-github-autotest-libvirt.memory_attach_device.virtio_mem.hot_plug: PASS (70.91 s)