### PR TITLE
Add hugepage allocation checking

### DIFF
--- a/libvirt/tests/src/memory/memory_backing/lifecycle_for_hugepage.py
+++ b/libvirt/tests/src/memory/memory_backing/lifecycle_for_hugepage.py
@@ -117,7 +117,7 @@ def setup_test(vm_name, params, test):
 
     utils_memory.set_num_huge_pages(int(vm_nr_hugepages))
     hp_cfg = test_setup.HugePageConfig(params)
-    hp_cfg.set_kernel_hugepages(set_pagesize, set_pagenum)
+    hp_cfg.set_kernel_hugepages(set_pagesize, set_pagenum, False)
     hp_cfg.hugepage_size = mount_size
     hp_cfg.mount_hugepage_fs()
     utils_libvirtd.Libvirtd().restart()


### PR DESCRIPTION
test results:
(1/3) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.default_page_size: PASS (141.77 s)
 (2/3) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.2M: PASS (152.55 s)
 (3/3) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.16G: CANCEL: Only can set 0 pages for 16777216 hugepage, but need 1 (34.41 s)