### PR TITLE
vm_start_destroy_repeatedly: Add Hugepage Variant

### DIFF
--- a/libvirt/tests/cfg/vm_start_destroy_repeatedly.cfg
+++ b/libvirt/tests/cfg/vm_start_destroy_repeatedly.cfg
@@ -3,3 +3,11 @@
     num_cycles = 3000
     start_vm = no
     test_timeout = 288000
+    check_hugepage_status = False
+    variants:
+       - hugepage:
+           num_cycles = 100
+           check_hugepage_status = True
+           mb_params = {'hugepages': {}, 'source_type': 'memfd', 'access_mode': 'shared'}
+           vm_attrs = {'memory': 8388608, 'memory_unit': 'KiB'}
+       - @default:

--- a/libvirt/tests/src/vm_start_destroy_repeatedly.py
+++ b/libvirt/tests/src/vm_start_destroy_repeatedly.py
@@ -1,6 +1,9 @@
 import logging
+from virttest import test_setup
 from virttest import virsh
 from virttest import utils_misc
+from virttest.staging import utils_memory
+from virttest.libvirt_xml import vm_xml
 
 
 def power_cycle_vm(test, vm, vm_name, login_timeout, startup_wait, resume_wait):
@@ -37,6 +40,61 @@ def power_cycle_vm(test, vm, vm_name, login_timeout, startup_wait, resume_wait):
         test.fail("Failed to shutdown VM")
 
 
+def setup_hugepage(vm, params):
+    vm_attrs = eval(params.get("vm_attrs", "{}"))
+    memory_amount = int(vm_attrs["memory"])
+
+    #Reserve memory for hugepages
+    hugepage_size = utils_memory.get_huge_page_size()
+    hugepage_nr = int(memory_amount) / hugepage_size
+
+    config_params = params.copy()
+    config_params["mem"] = memory_amount
+    config_params["target_hugepages"] = hugepage_nr
+    hpc = test_setup.HugePageConfig(config_params)
+    hpc.setup()
+
+    #Prepare VM XML
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm.name)
+    backup_xml = vmxml.copy()
+
+    #Remove old memory tags
+    vmxml.xmltreefile.remove_by_xpath("/memory")
+    vmxml.xmltreefile.remove_by_xpath("/currentMemory")
+
+    #Include memory backing
+    mb_xml = vm_xml.VMMemBackingXML()
+    mb_params = eval(params.get("mb_params", "{}"))
+    mb_xml.setup_attrs(**mb_params)
+    vmxml.setup_attrs(**vm_attrs)
+    vmxml.mb = mb_xml
+
+    #The relevant bug only appears if disk cache='none'
+    xmltreefile = vmxml.__dict_get__('xml')
+    disk_nodes = xmltreefile.find("devices").findall("disk")
+    qcow_disk = [disk for disk in disk_nodes if disk.find("driver").get("type") == "qcow2"][0]
+    if qcow_disk.find("driver").get("cache") != "none":
+        qcow_disk.find("driver").set("cache", "none")
+
+    vmxml.xmltreefile.write()
+    vmxml.sync()
+    logging.info("New XML for Hugepage testing: {}".format(vmxml))
+
+    return hugepage_nr, backup_xml, hpc
+
+
+def check_hugepage_status(test, hugepage_nr):
+    if hugepage_nr != utils_memory.get_num_huge_pages():
+        test.fail("Total number of hugepages does not match. Expected: {}. Actual: {}"
+                  .format(hugepage_nr, utils_memory.get_num_huge_pages()))
+    if hugepage_nr != utils_memory.get_num_huge_pages_free():
+        test.fail("Number of free huge pages does not match. Expected: {}. Actual: {}"
+                  .format(hugepage_nr, utils_memory.get_num_huge_pages_free()))
+    if utils_memory.get_num_huge_pages_rsvd() != 0:
+        test.fail("Huge pages still reserved. Expected: 0. Actual: {}"
+                  .format(utils_memory.get_num_huge_pages_rsvd()))
+
+
 def run(test, params, env):
     """
     Test qemu-kvm startup reliability
@@ -52,10 +110,25 @@ def run(test, params, env):
     login_timeout = float(params.get("login_timeout", 240))     # Controls vm.wait_for_login() timeout
     startup_wait = float(params.get("startup_wait", 240))       # Controls wait time for virsh.start()
     resume_wait = float(params.get("resume_wait", 240))          # Controls wait for virsh.resume()
+    hugepage_check = bool(params.get("check_hugepage_status", False))
+    vm_memory = int(params.get("vm_memory", 8388608))
 
-    for i in range(num_cycles):
-        logging.info("Starting vm '%s' -- attempt #%d", vm_name, i+1)
+    backup_xml = None
+    hugepage_nr = None
+    hpc = None
+    if hugepage_check:
+        hugepage_nr, backup_xml, hpc = setup_hugepage(vm, params)
+        logging.info("hugepage_nr: {}".format(hugepage_nr))
 
-        power_cycle_vm(test, vm, vm_name, login_timeout, startup_wait, resume_wait)
+    try:
+        for i in range(num_cycles):
+            logging.info("Starting vm '%s' -- attempt #%d", vm_name, i+1)
 
-        logging.info("Completed vm '%s' power cycle #%d", vm_name, i+1)
+            power_cycle_vm(test, vm, vm_name, login_timeout, startup_wait, resume_wait)
+
+            logging.info("Completed vm '%s' power cycle #%d", vm_name, i+1)
+    finally:
+        if hugepage_check:
+            check_hugepage_status(test, hugepage_nr)
+            backup_xml.sync()
+            hpc.cleanup()


### PR DESCRIPTION
### Description

Add variant to vm_start_destroy_repeatedly.py for handling a vm with hugepages. Bugs have been filed related to this

### New Steps
1) Set number of huge pages = vm_memory / hugepage size
2) Add necessary XML to define a vm with hugepages
3) Run start/stop loop as before
4) Check number of huge pages, to ensure the number is the same

### Evidence
Test passing with num_cycles = '1'
```
[root@ampere-mtjade-altra-04 tp-libvirt]# avocado run --vt-type libvirt --vt-machine-type arm64-mmio --test-runner=runner vm_start_destroy_repeatedly.hugepage
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : c951d499a5134c08af4d8ad016fd3c78ac717619
JOB LOG    : /var/log/avocado/job-results/job-2024-09-03T12.23-c951d49/job.log
 (1/1) type_specific.io-github-autotest-libvirt.vm_start_destroy_repeatedly.hugepage: PASS (35.59 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2024-09-03T12.23-c951d49/results.html
JOB TIME   : 36.24 s
```