### PR TITLE
migration: Add two cases about migrate_tls_x509_verify

### DIFF
--- a/libvirt/tests/cfg/migration/migration_uri/tls_migrate_tls_x509_verify_on_src.cfg
+++ b/libvirt/tests/cfg/migration/migration_uri/tls_migrate_tls_x509_verify_on_src.cfg
@@ -1,0 +1,44 @@
+- migration.migration_uri.network_data_transport.tls.migrate_tls_x509_verify_on_src:
+    type = tls_migrate_tls_x509_verify
+    migration_setup = 'yes'
+    storage_type = 'nfs'
+    setup_local_nfs = 'yes'
+    disk_type = "file"
+    disk_source_protocol = "netfs"
+    mnt_path_name = ${nfs_mount_dir}
+    # Console output can only be monitored via virsh console output
+    only_pty = True
+    take_regular_screendumps = no
+    # Extra options to pass after <domain> <desturi>
+    virsh_migrate_extra = ''
+    # SSH connection time out
+    ssh_timeout = 60
+    # Local URI
+    virsh_migrate_connect_uri = 'qemu:///system'
+    virsh_migrate_dest_state = "running"
+    virsh_migrate_src_state = "shut off"
+    image_convert = 'no'
+    server_ip = "${migrate_dest_host}"
+    server_user = "root"
+    server_pwd = "${migrate_dest_pwd}"
+    status_error = "no"
+    check_network_accessibility_after_mig = "yes"
+    migrate_desturi_port = "16509"
+    migrate_desturi_type = "tcp"
+    virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
+    custom_pki_path = "/etc/pki/qemu"
+    qemu_tls = "yes"
+    server_cn = "wrong-hostname"
+    client_cn = "ENTER.YOUR.EXAMPLE.CLIENT_CN"
+    qemu_conf_path = '/etc/libvirt/qemu.conf'
+    transport_type = "tls"
+    test_case = "migrate_tls_x509_verify_on_src"
+    err_msg = "Certificate does not match the hostname"
+    status_error = "yes"
+    qemu_conf_src = '{"default_tls_x509_verify": "0", "migrate_tls_x509_verify": "0"}'
+    virsh_migrate_extra = "--tls"
+    variants:
+        - p2p:
+            virsh_migrate_options = '--live --p2p --verbose'
+        - non_p2p:
+            virsh_migrate_options = '--live --verbose'

--- a/libvirt/tests/cfg/migration/migration_uri/tls_migrate_tls_x509_verify_on_target.cfg
+++ b/libvirt/tests/cfg/migration/migration_uri/tls_migrate_tls_x509_verify_on_target.cfg
@@ -1,0 +1,75 @@
+- migration.migration_uri.network_data_transport.tls.migrate_tls_x509_verify_on_target:
+    type = tls_migrate_tls_x509_verify
+    migration_setup = 'yes'
+    storage_type = 'nfs'
+    setup_local_nfs = 'yes'
+    disk_type = "file"
+    disk_source_protocol = "netfs"
+    mnt_path_name = ${nfs_mount_dir}
+    # Console output can only be monitored via virsh console output
+    only_pty = True
+    take_regular_screendumps = no
+    # Extra options to pass after <domain> <desturi>
+    virsh_migrate_extra = ''
+    # SSH connection time out
+    ssh_timeout = 60
+    # Local URI
+    virsh_migrate_connect_uri = 'qemu:///system'
+    virsh_migrate_dest_state = "running"
+    virsh_migrate_src_state = "shut off"
+    image_convert = 'no'
+    server_ip = "${migrate_dest_host}"
+    server_user = "root"
+    server_pwd = "${migrate_dest_pwd}"
+    status_error = "no"
+    check_network_accessibility_after_mig = "yes"
+    migrate_desturi_port = "16509"
+    migrate_desturi_type = "tcp"
+    virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
+    custom_pki_path = "/etc/pki/qemu"
+    qemu_tls = "yes"
+    server_cn = "ENTER.YOUR.EXAMPLE.SERVER_CN"
+    client_cn = "ENTER.YOUR.EXAMPLE.CLIENT_CN"
+    qemu_conf_path = '/etc/libvirt/qemu.conf'
+    cert_path = "${custom_pki_path}/client-cert.pem"
+    tmp_cert_path = "/tmp/client-cert.pem"
+    transport_type = "tls"
+    test_case = "migrate_tls_x509_verify_on_target"
+    virsh_migrate_extra = "--tls"
+    variants:
+        - p2p:
+            virsh_migrate_options = '--live --p2p --verbose'
+        - non_p2p:
+            virsh_migrate_options = '--live --verbose'
+    variants:
+        - both_to_default:
+            # Use default value for default_tls_x509_verify and migrate_tls_x509_verify
+            default_qemu_conf = ["default_tls_x509_verify", "migrate_tls_x509_verify"]
+            err_msg = "Cannot read from TLS channel: Software caused connection abort"
+            migrate_again = "yes"
+            status_error = "yes"
+            migrate_again_status_error = "no"
+        - set_migrate_to_0:
+            default_qemu_conf = ["default_tls_x509_verify"]
+            qemu_conf_dest = '{r".*migrate_tls_x509_verify\s*=.*": "migrate_tls_x509_verify=0"}'
+            status_error = "no"
+        - set_default_to_0:
+            default_qemu_conf = ["migrate_tls_x509_verify"]
+            qemu_conf_dest = '{r".*default_tls_x509_verify\s*=.*": "default_tls_x509_verify=0"}'
+            status_error = "no"
+        - set_default_to_0_and_migrate_to_1:
+            qemu_conf_dest = '{r".*default_tls_x509_verify\s*=.*": "default_tls_x509_verify=0", r".*migrate_tls_x509_verify\s*=.*": "migrate_tls_x509_verify=1"}'
+            err_msg = "Cannot read from TLS channel: Software caused connection abort"
+            migrate_again = "yes"
+            status_error = "yes"
+            migrate_again_status_error = "no"
+        - set_default_to_1_and_migrate_to_0:
+            qemu_conf_dest = '{r".*default_tls_x509_verify\s*=.*": "default_tls_x509_verify=1", r".*migrate_tls_x509_verify\s*=.*": "migrate_tls_x509_verify=0"}'
+            status_error = "no"
+        - set_default_to_1:
+            default_qemu_conf = ["migrate_tls_x509_verify"]
+            qemu_conf_dest = '{r".*default_tls_x509_verify\s*=.*": "default_tls_x509_verify=1"}'
+            err_msg = "Cannot read from TLS channel: Software caused connection abort"
+            migrate_again = "yes"
+            status_error = "yes"
+            migrate_again_status_error = "no"

--- a/libvirt/tests/src/migration/migration_uri/tls_migrate_tls_x509_verify.py
+++ b/libvirt/tests/src/migration/migration_uri/tls_migrate_tls_x509_verify.py
@@ -1,0 +1,149 @@
+import os
+import shutil
+
+from virttest import libvirt_remote
+
+from virttest.utils_test import libvirt
+from virttest.utils_libvirt import libvirt_config
+
+from provider.migration import base_steps
+
+
+def update_qemu_conf_on_src(params, test, local_obj):
+    """
+    Update qemu configure file on source
+
+    :param params: Dictionary with the test parameter
+    :param test: Test object
+    :param local_obj: Local qemu conf object
+    """
+    qemu_conf_src = eval(params.get("qemu_conf_src", "{}"))
+
+    local_obj.append(libvirt.customize_libvirt_config(qemu_conf_src,
+                                                      "qemu",
+                                                      remote_host=False,
+                                                      extra_params=params))
+
+
+def update_qemu_conf_on_target(params, test, remote_obj):
+    """
+    Update qemu configure file on target
+
+    :param params: Dictionary with the test parameter
+    :param test: Test object
+    :param remote_obj: Remote qemu conf object
+    """
+    default_qemu_conf = params.get("default_qemu_conf")
+    qemu_conf_path = params.get("qemu_conf_path")
+    qemu_conf_dest = params.get("qemu_conf_dest", "{}")
+
+    if default_qemu_conf:
+        params['file_path'] = qemu_conf_path
+        remote_obj.append(libvirt_config.remove_key_in_conf(eval(default_qemu_conf),
+                                                            "qemu",
+                                                            remote_params=params,
+                                                            restart_libvirt=True))
+    if qemu_conf_dest:
+        remote_obj.append(libvirt_remote.update_remote_file(params,
+                                                            qemu_conf_dest,
+                                                            qemu_conf_path))
+
+
+def run(test, params, env):
+    """
+    Test default_tls_x509_verify/migrate_tls_x509_verify on source/target host.
+
+    :param test: test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    def setup_migrate_tls_x509_verify_on_target():
+        """
+        Setup steps for migrate_tls_x509_verify_on_target
+
+        """
+        test.log.info("Setup steps for migrate_tls_x509_verify_on_target.")
+        cert_path = params.get("cert_path")
+        tmp_cert_path = params.get("tmp_cert_path")
+
+        update_qemu_conf_on_target(params, test, remote_obj)
+        migration_obj.setup_connection()
+        if os.path.exists(tmp_cert_path):
+            os.remove(tmp_cert_path)
+        shutil.move(cert_path, tmp_cert_path)
+
+    def setup_migrate_tls_x509_verify_on_src():
+        """
+        Setup steps for migrate_tls_x509_verify_on_src
+
+        """
+        test.log.info("Setup steps for migrate_tls_x509_verify_on_src.")
+
+        update_qemu_conf_on_src(params, test, local_obj)
+        migration_obj.setup_connection()
+
+    def run_migration_again_migrate_tls_x509_verify_on_target():
+        """
+        Run migration again for migrate_tls_x509_verify_on_target
+
+        """
+        test.log.info("Run migration again for migrate_tls_x509_verify_on_target.")
+        cert_path = params.get("cert_path")
+        tmp_cert_path = params.get("tmp_cert_path")
+
+        if os.path.exists(cert_path):
+            os.remove(cert_path)
+        shutil.move(tmp_cert_path, cert_path)
+        migration_obj.run_migration_again()
+
+    def cleanup_migrate_tls_x509_verify_on_target():
+        """
+        Cleanup steps for migrate_tls_x509_verify_on_target
+
+        """
+        test.log.info("Cleanup steps migrate_tls_x509_verify_on_target.")
+        migration_obj.cleanup_connection()
+        if remote_obj:
+            for obj in remote_obj:
+                del obj
+
+    def cleanup_migrate_tls_x509_verify_on_src():
+        """
+        Cleanup steps for migrate_tls_x509_verify_on_src
+
+        """
+        test.log.info("Cleanup steps migrate_tls_x509_verify_on_src.")
+        migration_obj.cleanup_connection()
+        if local_obj:
+            for obj in local_obj:
+                libvirt.customize_libvirt_config(None,
+                                                 config_type="qemu",
+                                                 remote_host=False,
+                                                 is_recover=True,
+                                                 extra_params=params,
+                                                 config_object=obj)
+
+    migrate_again = "yes" == params.get("migrate_again", "no")
+    vm_name = params.get("migrate_main_vm")
+    test_case = params.get('test_case', '')
+
+    vm = env.get_vm(vm_name)
+    migration_obj = base_steps.MigrationBase(test, vm, params)
+    setup_test = eval("setup_%s" % test_case) if "setup_%s" % test_case in \
+        locals() else migration_obj.setup_connection
+    run_migration_again_test = eval("run_migration_again_%s" % test_case) if "run_migration_again_%s" % test_case in \
+        locals() else migration_obj.run_migration_again
+    cleanup_test = eval("cleanup_%s" % test_case) if "cleanup_%s" % test_case in \
+        locals() else migration_obj.cleanup_connection
+
+    remote_obj = []
+    local_obj = []
+
+    try:
+        setup_test()
+        migration_obj.run_migration()
+        if migrate_again:
+            run_migration_again_test()
+        migration_obj.verify_default()
+    finally:
+        cleanup_test()


### PR DESCRIPTION
XXX-298257 - [VM migration] network data transport - TLS
- default/migrate_tls_x509_verify on src host

XXX-293815 - [VM migration] network data transport - TLS
- default/migrate_tls_x509_verify on target host(enable/disable verify client)