### PR TITLE
libvirt_rng: update rng to use external snapshot

### DIFF
--- a/libvirt/tests/cfg/security/rng/libvirt_rng.cfg
+++ b/libvirt/tests/cfg/security/rng/libvirt_rng.cfg
@@ -110,16 +110,16 @@
             snapshot_name = "rng.s"
             variants:
                 - snapshot_running:
+                    snap_options = "%s --memspec "
+                    mem_files = ["/var/lib/libvirt/images/avocado-memory.s1", "/var/lib/libvirt/images/avocado-memory.s2"]
                     snapshot_vm_running = "yes"
                     test_snapshot = "yes"
-                    snapshot_with_rng = "yes"
                 - snapshot_shutoff:
+                    snap_options = "%s --disk-only"
                     test_snapshot = "yes"
-                    snapshot_with_rng = "no"
             variants:
                 - back_rdm:
                     backend_dev = "/dev/random"
-                    snap_options = "%s --disk-only"
                 - back_tcp_connect:
                     backend_model = "egd"
                     backend_type = "tcp"


### PR DESCRIPTION
    Only external snapshot is officially supported, and it supports
    revert now. Update rng cases to use this. Since every step is
    external snapshot now, no need to do the 3rd snapshot test which
    was called snapshot_with_rng.
