### PR TITLE
migration: Update migrate_maxdowntime to a common value

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -242,14 +242,15 @@
                     stress_in_vm = "yes"
                     virsh_opt = ' -k0'
                     low_speed = "50"
-                    migrate_maxdowntime = '0.100000'
                     grep_str_local_log = '"execute":"migrate-set-capabilities".*"capability":"auto-converge","state":true'
                     variants:
                         - default:
                             virsh_migrate_extra = "--auto-converge"
+                            migrate_maxdowntime = "EXAMPLE_AUTOCONVERGE_MAXDOWNTIME"
                         - customized:
                             initial = 30
                             increment = 15
+                            migrate_maxdowntime = '0.100000'
                             virsh_migrate_extra = "--auto-converge --auto-converge-initial ${initial} --auto-converge-increment ${increment}"
                 - cache_mode:
                     variants:


### PR DESCRIPTION
Set a common value for migrate_maxdowntime, then do replacement in local CI envirionment.