### PR TITLE
virsh_detach_device_alias: Skip test when no input

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
@@ -270,7 +270,7 @@ def run(test, params, env):
         if input_type == "passthrough":
             event = process.run("ls /dev/input/event*", shell=True, ignore_status=True).stdout
             if len(event) == 0:
-                test.error("Not found any input devices")
+                test.skip("Not found any input devices")
             input_dict.update({"source_evdev": event.decode('utf-8').split()[0]})
 
         input_obj = Input(type_name=input_type)


### PR DESCRIPTION
### The Problem

Tests rhel.virsh.detach_device_alias.live.input.passthrough and rhel.virsh.detach_device_alias.config.input.passthrough do not pass if there is not input device, as they require a device to passthrough to the vm

### The Solution
Skip the test if no input device can be found

### Evidence the Test Still Passes
```
[root@ampere-mtjade-altra-04 tp-libvirt]# avocado run --vt-type libvirt --vt-machine-type arm64-mmio --test-runner=runner virsh.detach_device_alias.config.input.passthrough
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : 5fc4b9b0c390401f0794dbc6ae4e963193f62d8e
JOB LOG    : /var/log/avocado/job-results/job-2024-09-03T12.57-5fc4b9b/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.detach_device_alias.config.input.passthrough: PASS (58.64 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2024-09-03T12.57-5fc4b9b/results.html
JOB TIME   : 59.32 s
```