### PR TITLE
update_iface_link_state: make host_iface configurable

### DIFF
--- a/libvirt/tests/cfg/virtual_network/update_device/update_iface_link_state.cfg
+++ b/libvirt/tests/cfg/virtual_network/update_device/update_iface_link_state.cfg
@@ -31,6 +31,7 @@
             iface_base_attrs = {"type_name": "direct", "source": {"dev": host_iface, "mode": "bridge"}}
         - ethernet:
             only virtio
+            host_iface =
             create_tap = "yes"
             iface_base_attrs = {"type_name": "ethernet", "target": {"dev": tap_name, "managed": "no"}}
 


### PR DESCRIPTION
Need to run this test against the second interface on our host.