### PR TITLE
boot_from_usb_device.cfg: Update regex

### DIFF
--- a/libvirt/tests/cfg/guest_os_booting/boot_order/boot_from_usb_device.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/boot_order/boot_from_usb_device.cfg
@@ -3,7 +3,7 @@
     start_vm = no
     bus_type = "usb"
     bootmenu_dict = {'bootmenu_enable': 'yes', 'bootmenu_timeout': '3000', 'bios_useserial': 'yes'}
-    check_prompt = "UEFI .* USB|1. USB MSC Drive .*|UsbBootDetectMedia: UsbBootIsUnitReady .*"
+    check_prompt = "UEFI .* USB|1. USB MSC Drive .*|UsbBootDetectMedia: UsbBootIsUnitReady .*|.*UsbBootExecCmd: Success to Exec 0x0 Cmd \(Result = 1\).*"
     only q35, aarch64
     aarch64:
 	bootmenu_dict = {'bootmenu_enable': 'yes', 'bootmenu_timeout': '3000'}


### PR DESCRIPTION
### The Problem
The test guest_os_booting.boot_order.usb_device.block_device looks for a regex to see if the usb boot device is being booted first.

If the usb device is blank, edk2 will reorder the boot order, to deprioritize the usb device. And it won't print it first in the boot order.

### The Solution

We can see that it attempts to boot from the usb if we see edk2 printing the "USB_BOOT_TEST_UNIT_READY" command output.

```
UsbBootExecCmd: Success to Exec 0x0 Cmd (Result = 1)
```

Cmd 0x0: Test Unit Ready Opcode (See [usb protocol documentation](https://usb.org/sites/default/files/usb_msc_boot_1.0.pdf))
Result = 1: The unit was ready for further commands

This is printed when edk2 is asking the USB device if it is ready to recieve further commands. We can simply test for this output to see if edk2 considered the usb device for booting.

### Evidence
The test passing with the change
```
[root@ampere-mtjade-altra-04 tp-libvirt]# avocado run --vt-type libvirt --vt-machine-type arm64-mmio --test-runner=runner guest_os_booting.boot_order.usb_device.block_device
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : 16130450a7e9c9e7f37b0cc248c78651f7f6f6fc
JOB LOG    : /var/log/avocado/job-results/job-2024-09-04T10.34-1613045/job.log
 (1/1) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.usb_device.block_device: PASS (38.56 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2024-09-04T10.34-1613045/results.html
JOB TIME   : 39.18 s
```