### PR TITLE
update_iface_with_identifier: disable test on s390x

### DIFF
--- a/libvirt/tests/cfg/virtual_network/update_device/update_iface_with_identifier.cfg
+++ b/libvirt/tests/cfg/virtual_network/update_device/update_iface_with_identifier.cfg
@@ -23,6 +23,7 @@
                 status_error = yes
                 err_msg = cannot change network interface mac address from .* to .*
         - right_mac_alias_wrong_pci:
+            no s390-virtio
             status_error = yes
             err_msg = ${err_msg_matching}
             update_attrs = {'link_state': 'down'}


### PR DESCRIPTION
On s390x, virtio addresses are ccw not pci. Disable test case.