### PR TITLE
attach_interface_with_model: don't attach incompatible controller

### DIFF
--- a/libvirt/tests/cfg/virtual_network/hotplug/attach_detach_interface/attach_interface_with_model.cfg
+++ b/libvirt/tests/cfg/virtual_network/hotplug/attach_detach_interface/attach_interface_with_model.cfg
@@ -11,6 +11,7 @@
             pci_model = pcie-root-port
             s390-virtio:
                 check_pci_model = no
+                bridge_controller_needed = no
         - e1000e:
             only x86_64
             iface_driver = e1000e

--- a/libvirt/tests/src/virtual_network/hotplug/attach_detach_interface/attach_interface_with_model.py
+++ b/libvirt/tests/src/virtual_network/hotplug/attach_detach_interface/attach_interface_with_model.py
@@ -52,18 +52,21 @@ def run(test, params, env):
     iface_driver = params.get("iface_driver")
     model_type = params.get("model_type")
     check_pci_model = params.get("check_pci_model", "yes") == "yes"
+    bridge_controller_needed = params.get("bridge_controller_needed", "yes") == "yes"
 
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     bkxml = vmxml.copy()
 
     try:
-        pci_controllers = vmxml.get_controllers("pci")
-        for controller in pci_controllers:
-            if controller.get("model") == "pcie-to-pci-bridge":
-                break
-        else:
-            controller_dict = {"model": "pcie-to-pci-bridge"}
-            libvirt_vmxml.modify_vm_device(vmxml, "controller", controller_dict, 50)
+        if bridge_controller_needed:
+            pci_controllers = vmxml.get_controllers("pci")
+            for controller in pci_controllers:
+                if controller.get("model") == "pcie-to-pci-bridge":
+                    break
+            else:
+                controller_dict = {"model": "pcie-to-pci-bridge"}
+                libvirt_vmxml.modify_vm_device(vmxml, "controller", controller_dict, 50)
+
         libvirt_vmxml.remove_vm_devices_by_type(vm, "interface")
         test.log.debug(f"VMXML of {vm_name}:\n{virsh.dumpxml(vm_name).stdout_text}")
 


### PR DESCRIPTION
On s390x, pcie-to-pci-bridge is not available. Don't attach this.