### PR TITLE
Add debug info and libvirt daemon restart check

### DIFF
--- a/libvirt/tests/src/memory/memory_devices/virtio_mem_device_lifecycle.py
+++ b/libvirt/tests/src/memory/memory_devices/virtio_mem_device_lifecycle.py
@@ -11,7 +11,7 @@
 
 import os
 
-from virttest import utils_libvirtd
+from virttest.utils_libvirtd import Libvirtd
 from virttest import virsh
 
 from virttest.libvirt_xml import vm_xml
@@ -49,6 +49,7 @@ def run(test, params, env):
                                   like {"alias_name":[xpath1, xpath2]},...}
         """
         vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        test.log.debug("Current guest config xml is:\n%s", vmxml)
         memory_devices = vmxml.devices.by_device_tag('memory')
         target_memory_num = 0
         for alias_name, xpath_list in xpath_dict.items():
@@ -173,7 +174,9 @@ def run(test, params, env):
         vm.wait_for_login().close()
         check_virtio_mem_device_xml({init_alias_name: init_xpath_list, plug_alias_name: plug_xpath_list})
 
-        utils_libvirtd.libvirtd_restart()
+        libvirt_daemon = Libvirtd()
+        if not libvirt_daemon.restart(reset_failed=False):
+            test.fail('libvirt deamon restarts failed or is not working properly')
         check_virtio_mem_device_xml({init_alias_name: init_xpath_list, plug_alias_name: plug_xpath_list})
 
     def teardown_test():


### PR DESCRIPTION
result:
 (1/8) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.lifecycle.all_requested_and_address.no_source.4k: PASS (132.09 s)
 (2/8) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.lifecycle.all_requested_and_address.nodemask.4k: PASS (132.80 s)
 (3/8) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.lifecycle.all_requested_and_address.pagesize.4k: PASS (132.09 s)
 (4/8) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.lifecycle.all_requested_and_address.nodemask_pagesize.4k: PASS (179.90 s)
 (5/8) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.lifecycle.part_requested_and_no_address.no_source.4k: PASS (135.37 s)
 (6/8) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.lifecycle.part_requested_and_no_address.nodemask.4k: PASS (133.55 s)
 (7/8) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.lifecycle.part_requested_and_no_address.pagesize.4k: PASS (132.08 s)
 (8/8) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.lifecycle.part_requested_and_no_address.nodemask_pagesize.4k: PASS (131.97 s)