### PR TITLE
selinux_seclabel_per_device:Fix UnboundLocalError

### DIFF
--- a/libvirt/tests/src/svirt/selinux/selinux_seclabel_per_device.py
+++ b/libvirt/tests/src/svirt/selinux/selinux_seclabel_per_device.py
@@ -89,7 +89,7 @@ def run(test, params, env):
                 if not status_error:
                     test.fail(details)
             test.log.debug("VM XML: %s.", VMXML.new_from_inactive_dumpxml(vm_name))
-            if res.exit_status == 0:
+            if not ('res' in locals() and res.exit_status != 0):
                 res = virsh.start(vm.name)
         else:
             test.log.info("TEST_STEP: Hot plug a device with dac setting.")


### PR DESCRIPTION
Test result:
```
 (1/6) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.per_device.relabel_no.serial.cold_plug: PASS (7.05 s)
 (2/6) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.per_device.relabel_yes.without_label.serial.cold_plug: FAIL: Run '/bin/virsh start avocado-vt-vm1 ' expect fail, but run successfully. (7.71 s)
 (3/6) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.per_device.relabel_yes.label_legit.serial.cold_plug:
PASS (7.39 s)
 (4/6) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.per_device.relabel_yes.label_MCS.serial.cold_plug:PAASS (7.25 s)
 (5/6) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.per_device.relabel_yes.label_default.serial.cold_plug: PASS (7.21 s)
 (6/6) type_specific.io-github-autotest-libvirt.svirt.selinux.seclabel.per_device.relabel_yes.label_invalid_fmt.serial.cold_plug: PASS (7.15 s)
RESULTS    : PASS 5 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```