### PR TITLE
virtio_page_per_vq: enhance input event file

### DIFF
--- a/libvirt/tests/cfg/virtio/virtio_page_per_vq.cfg
+++ b/libvirt/tests/cfg/virtio/virtio_page_per_vq.cfg
@@ -41,7 +41,7 @@
                 - mouse:
                 - tablet:
                 - passthrough:
-                    device_dict = {**${device_dict}, 'source_evdev': '/dev/input/event0'}
+                    device_dict = {**${device_dict}, 'source_evdev': '%s'}
         - video:
             only default_start
             device_dict = {'model_type': 'virtio', **${driver_dict}, 'model_heads': '1'}


### PR DESCRIPTION
Regarding /dev/input/event* files, there might be some different situation.
For example,
- No event file exsit at all
- Only /dev/input/event0 exists
- Only /dev/input/event1 exists
- Both /dev/input/event0 and /dev/input/event1 exists
- and more ...

So this patch is intending to support above situations instead of hardcoding with event1.