### PR TITLE
boot_order: ensure only 1 repo is used to get boot.iso

### DIFF
--- a/libvirt/tests/src/guest_os_booting/boot_order/boot_from_cdrom_device.py
+++ b/libvirt/tests/src/guest_os_booting/boot_order/boot_from_cdrom_device.py
@@ -30,7 +30,7 @@ def parse_cdroms_attrs(params):
         cdrom_attrs_list.append(cdrom2_attrs)
 
     if cdrom1_attrs.get('source') or cdrom2_attrs.get('source'):
-        cmd = "dnf repolist -v enabled |awk '/Repo-baseurl.*composes.*BaseOS.*os/ {print $NF}'"
+        cmd = "dnf repolist -v enabled |awk '/Repo-baseurl.*composes.*BaseOS.*os/ {res=$NF} END{print res}'"
         repo_url = process.run(cmd, shell=True).stdout_text.strip()
         boot_img_url = os.path.join(repo_url, 'images', 'boot.iso')
         if os.path.exists(boot_img_path):

--- a/libvirt/tests/src/guest_os_booting/boot_order/boot_with_multiple_boot_dev.py
+++ b/libvirt/tests/src/guest_os_booting/boot_order/boot_with_multiple_boot_dev.py
@@ -47,7 +47,7 @@ def prepare_device(params, vm_name, bootable_device):
         libvirt_vmxml.modify_vm_device(vmxml, 'disk', disk_dict)
     if bootable_device == "cdrom_bootable":
         cdrom_path = os.path.join(data_dir.get_data_dir(), 'images', 'boot.iso')
-        cmd = "dnf repolist -v enabled |awk '/Repo-baseurl.*composes.*BaseOS.*os/ {print $NF}'"
+        cmd = "dnf repolist -v enabled |awk '/Repo-baseurl.*composes.*BaseOS.*os/ {res=$NF} END{print res}'"
         repo_url = process.run(cmd, shell=True).stdout_text.strip()
         boot_img_url = os.path.join(repo_url, 'images', 'boot.iso')
         download.get_file(boot_img_url, cdrom_path)

--- a/libvirt/tests/src/guest_os_booting/boot_order/boot_with_multiple_boot_order.py
+++ b/libvirt/tests/src/guest_os_booting/boot_order/boot_with_multiple_boot_order.py
@@ -42,7 +42,7 @@ def prepare_device_attrs(params, vm_name, bootable_device):
         file_list.append(disk_image)
     if bootable_device == "cdrom_bootable":
         cdrom_path = os.path.join(data_dir.get_data_dir(), 'images', 'boot.iso')
-        cmd = "dnf repolist -v enabled |awk '/Repo-baseurl.*composes.*BaseOS.*os/ {print $NF}'"
+        cmd = "dnf repolist -v enabled |awk '/Repo-baseurl.*composes.*BaseOS.*os/ {res=$NF} END{print res}'"
         repo_url = process.run(cmd, shell=True).stdout_text.strip()
         boot_img_url = os.path.join(repo_url, 'images', 'boot.iso')
         download.get_file(boot_img_url, cdrom_path)


### PR DESCRIPTION
**Issue:**
VMStartError: VM 'avocado-vt-vm1' failed to start: error: Failed to start domain 'avocado-vt-vm1'error: Cannot access storage file '/var/lib/avocado/data/avocado-vt/boot.iso': No such file or directory(exit status: 1)

**Fix:**
This issue is caused by multiple repos being fetched and then their urls being concatenated together. The fix is to ensure that only 1 repo is fetched (the last result), which can in turn get the boot.iso file.

**Passing test results:**
```
[root@beaver-9 cfg]# /usr/local/bin/avocado run --vt-type libvirt --vt-machine-type q35 guest_os_booting.boot_order.boot_with_multiple_boot_order guest_os_booting.boot_order.boot_with_multiple_boot_dev guest_os_booting.boot_order.cdrom_device --vt-connect-uri qemu:///system
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : aa01df59903d22cb23773751a3445c660bb215e4
JOB LOG    : /var/log/avocado/job-results/job-2024-09-09T11.47-aa01df5/job.log
 (01/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.hd.cdrom.hd_bootable: STARTED
 (01/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.hd.cdrom.hd_bootable: PASS (43.60 s)
 (02/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.hd.cdrom.cdrom_bootable: STARTED
 (02/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.hd.cdrom.cdrom_bootable: PASS (34.07 s)
 (03/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.hd.network.hd_bootable: STARTED
 (03/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.hd.network.hd_bootable: PASS (57.45 s)
 (04/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.hd.network.network_bootable: STARTED
 (04/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.hd.network.network_bootable: PASS (21.81 s)
 (05/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.cdrom.hd.hd_bootable: STARTED
 (05/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.cdrom.hd.hd_bootable: PASS (57.15 s)
 (06/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.cdrom.hd.cdrom_bootable: STARTED
 (06/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.cdrom.hd.cdrom_bootable: PASS (32.83 s)
 (07/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.cdrom.network.cdrom_bootable: STARTED
 (07/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.cdrom.network.cdrom_bootable: PASS (32.29 s)
 (08/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.cdrom.network.network_bootable: STARTED
 (08/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.cdrom.network.network_bootable: PASS (20.46 s)
 (09/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.network.hd.hd_bootable: STARTED
 (09/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.network.hd.hd_bootable: ERROR: Login timeout expired    (output: 'exceeded 360 s timeout, last failure: Could not verify DHCP lease: 52:54:00:f4:f8:41 --> 192.168.122.103') (557.86 s)
 (10/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.network.hd.network_bootable: STARTED
 (10/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.network.hd.network_bootable: PASS (21.45 s)
 (11/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.network.cdrom.cdrom_bootable: STARTED
 (11/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.network.cdrom.cdrom_bootable: PASS (281.26 s)
 (12/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.network.cdrom.network_bootable: STARTED
 (12/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.network.cdrom.network_bootable: PASS (20.09 s)
 (13/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.hd.cdrom.hd_bootable: STARTED
 (13/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.hd.cdrom.hd_bootable: PASS (56.82 s)
 (14/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.hd.cdrom.cdrom_bootable: STARTED
 (14/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.hd.cdrom.cdrom_bootable: PASS (32.46 s)
 (15/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.hd.network.hd_bootable: STARTED
 (15/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.hd.network.hd_bootable: PASS (55.24 s)
 (16/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.hd.network.network_bootable: STARTED
 (16/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.hd.network.network_bootable: PASS (20.80 s)
 (17/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.cdrom.hd.hd_bootable: STARTED
 (17/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.cdrom.hd.hd_bootable: PASS (55.68 s)
 (18/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.cdrom.hd.cdrom_bootable: STARTED
 (18/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.cdrom.hd.cdrom_bootable: PASS (123.07 s)
 (19/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.cdrom.network.cdrom_bootable: STARTED
 (19/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.cdrom.network.cdrom_bootable: PASS (31.62 s)
 (20/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.cdrom.network.network_bootable: STARTED
 (20/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.cdrom.network.network_bootable: PASS (19.24 s)
 (21/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.network.hd.hd_bootable: STARTED
 (21/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.network.hd.hd_bootable: ERROR: Login timeout expired    (output: 'exceeded 360 s timeout, last failure: Could not verify DHCP lease: 52:54:00:f4:f8:41 --> 192.168.122.103') (556.50 s)
 (22/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.network.hd.network_bootable: STARTED
 (22/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.network.hd.network_bootable: PASS (20.36 s)
 (23/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.network.cdrom.cdrom_bootable: STARTED
 (23/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.network.cdrom.cdrom_bootable: PASS (280.73 s)
 (24/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.network.cdrom.network_bootable: STARTED
 (24/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.network.cdrom.network_bootable: PASS (19.30 s)
 (25/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.seabios.os_dev.without_cdrom: STARTED
 (25/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.seabios.os_dev.without_cdrom: PASS (55.24 s)
 (26/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.seabios.os_dev.with_cdrom_with_no_src: STARTED
 (26/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.seabios.os_dev.with_cdrom_with_no_src: PASS (259.08 s)
 (27/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.seabios.os_dev.with_cdrom: STARTED
 (27/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.seabios.os_dev.with_cdrom: PASS (24.60 s)
 (28/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.seabios.os_dev.multi_cdroms: STARTED
 (28/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.seabios.os_dev.multi_cdroms: PASS (272.80 s)
 (29/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.seabios.cdrom_boot_order.with_cdrom_with_no_src: STARTED
 (29/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.seabios.cdrom_boot_order.with_cdrom_with_no_src: PASS (259.47 s)
 (30/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.seabios.cdrom_boot_order.with_cdrom: STARTED
 (30/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.seabios.cdrom_boot_order.with_cdrom: PASS (25.13 s)
 (31/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.seabios.cdrom_boot_order.multi_cdroms: STARTED
 (31/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.seabios.cdrom_boot_order.multi_cdroms: PASS (25.45 s)
 (32/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.ovmf.os_dev.without_cdrom: STARTED
 (32/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.ovmf.os_dev.without_cdrom: FAIL: Login timeout expired    (output: 'exceeded 240 s timeout') (268.73 s)
 (33/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.ovmf.os_dev.with_cdrom_with_no_src: STARTED
 (33/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.ovmf.os_dev.with_cdrom_with_no_src: PASS (44.49 s)
 (34/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.ovmf.os_dev.with_cdrom: STARTED
 (34/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.ovmf.os_dev.with_cdrom: PASS (30.53 s)
 (35/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.ovmf.os_dev.multi_cdroms: STARTED
 (35/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.ovmf.os_dev.multi_cdroms: PASS (262.92 s)
 (36/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.ovmf.cdrom_boot_order.with_cdrom_with_no_src: STARTED
 (36/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.ovmf.cdrom_boot_order.with_cdrom_with_no_src: PASS (55.18 s)
 (37/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.ovmf.cdrom_boot_order.with_cdrom: STARTED
 (37/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.ovmf.cdrom_boot_order.with_cdrom: PASS (31.32 s)
 (38/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.ovmf.cdrom_boot_order.multi_cdroms: STARTED
 (38/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.ovmf.cdrom_boot_order.multi_cdroms: PASS (31.50 s)
RESULTS    : PASS 35 | ERROR 2 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2024-09-09T11.47-aa01df5/results.html
JOB TIME   : 4138.21 s
```

Note: the 3 failing test cases are not related to the issue being addressed in this PR. All relevant test cases pass.