### PR TITLE
pxe_installation: add flag to void certificate error

### DIFF
--- a/virttools/tests/src/virt_install/pxe_installation.py
+++ b/virttools/tests/src/virt_install/pxe_installation.py
@@ -35,7 +35,7 @@ default linux
 label linux
 kernel kernel.img
 initrd initrd.img
-append ip=dhcp inst.repo=%s inst.ks=%s
+append ip=dhcp inst.repo=%s inst.ks=%s inst.noverifyssl
 """ % (install_tree_url, kickstart_url)
 
     with open(os.path.join(tftp_dir, boot_file), "w") as f:


### PR DESCRIPTION
Installation media might not have a valid certificate for our testing. This is not critical for the test case.
Append kernel parameter to skip verification.