### PR TITLE
Change guest memory statistics checking timeline

### DIFF
--- a/libvirt/tests/cfg/memory/memory_balloon/period_config_of_memory_balloon.cfg
+++ b/libvirt/tests/cfg/memory/memory_balloon/period_config_of_memory_balloon.cfg
@@ -5,7 +5,7 @@
     current_mem_unit = "KiB"
     current_mem = "2097152"
     mem_value = "2097152"
-    mem_operation = "swapoff -a; dd if=/dev/zero of=/tmp/temp bs=1024K count=10; memhog -r5 500M"
+    mem_operation = "swapoff -a && dd if=/dev/zero of=/tmp/temp bs=1024K count=10 && timeout 5s memhog -r5000 500M"
     variants:
         - virtio_model:
             memballoon_model = "virtio"


### PR DESCRIPTION
test results:
 (1/6) type_specific.io-github-autotest-libvirt.memory.balloon.period.memory_allocation.undefined_period.virtio_model: PASS (38.63 s)
 (2/6) type_specific.io-github-autotest-libvirt.memory.balloon.period.memory_allocation.undefined_period.virtio_trans_model: /PASS (39.18 s)
 (3/6) type_specific.io-github-autotest-libvirt.memory.balloon.period.memory_allocation.undefined_period.virtio_non_trans_model: PASS (46.12 s)
 (4/6) type_specific.io-github-autotest-libvirt.memory.balloon.period.memory_allocation.int_period.virtio_model: PASS (45.47 s)
 (5/6) type_specific.io-github-autotest-libvirt.memory.balloon.period.memory_allocation.int_period.virtio_trans_model: PASS (45.95 s)
 (6/6) type_specific.io-github-autotest-libvirt.memory.balloon.period.memory_allocation.int_period.virtio_non_trans_model: PASS (42.17 s)