### PR TITLE
virsh_domstate: Update panic device's xml

### DIFF
--- a/libvirt/tests/src/virsh_cmd/monitor/virsh_domstate.py
+++ b/libvirt/tests/src/virsh_cmd/monitor/virsh_domstate.py
@@ -2,7 +2,6 @@ import re
 import os
 import shutil
 import logging as log
-import platform
 import time
 import signal
 
@@ -166,12 +165,6 @@ def run(test, params, env):
             if not vmxml.xmltreefile.find('devices').findall('panic'):
                 # Add <panic> device to domain
                 panic_dev = Panic()
-                if "ppc" not in platform.machine():
-                    panic_dev.addr_type = "isa"
-                    panic_dev.addr_iobase = "0x505"
-                if platform.machine() == 'aarch64':
-                    panic_dev.model = "pvpanic"
-                    panic_dev.addr_type = "pci"
                 vmxml.add_device(panic_dev)
             vmxml.sync()
             # Config auto_dump_path in qemu.conf


### PR DESCRIPTION
Update to use <panic/> to ask libvirt to configure the model attribute automatically.

**Test results:** The 2 failed cases are caused by unsupported actions, need to remove it in another pr.
```
# avocado run --vt-type libvirt --test-runner=runner --vt-machine-type arm64-mmio virsh.domstate..crash_vm --vt-connect-uri qemu:///system
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : 2ba50875a7a31cd3c7af28cfc1c967a38bef02f8
JOB LOG    : /var/log/avocado/job-results/job-2024-09-09T04.06-2ba5087/job.log
 (1/8) type_specific.io-github-autotest-libvirt.virsh.domstate.normal_test.reason.crash_vm.oncrash_destroy: PASS (28.66 s)
 (2/8) type_specific.io-github-autotest-libvirt.virsh.domstate.normal_test.reason.crash_vm.oncrash_restart: PASS (52.31 s)
 (3/8) type_specific.io-github-autotest-libvirt.virsh.domstate.normal_test.reason.crash_vm.oncrash_preserve.normal: PASS (26.60 s)
 (4/8) type_specific.io-github-autotest-libvirt.virsh.domstate.normal_test.reason.crash_vm.oncrash_preserve.reset: PASS (49.31 s)
 (5/8) type_specific.io-github-autotest-libvirt.virsh.domstate.normal_test.reason.crash_vm.oncrash_coredump_destroy: PASS (82.68 s)
 (6/8) type_specific.io-github-autotest-libvirt.virsh.domstate.normal_test.reason.crash_vm.oncrash_coredump_restart: PASS (52.65 s)
 (7/8) type_specific.io-github-autotest-libvirt.virsh.domstate.normal_test.reason.crash_vm.oncrash_rename_restart.normal: ERROR: Failed to define avocado-vt-vm1 for reason:\nerror: Failed to define domain from /tmp/xml_utils_temp_hfe03vg6.xml\nerror: unsupported configuration: qemu driver doesn't support the 'rename-restart' action for 'on_reboot'/'on_poweroff'/'on_crash'\n (6.96 s)
 (8/8) type_specific.io-github-autotest-libvirt.virsh.domstate.normal_test.reason.crash_vm.oncrash_rename_restart.restart_libvirtd: ERROR: Failed to define avocado-vt-vm1 for reason:\nerror: Failed to define domain from /tmp/xml_utils_temp_muugs6eg.xml\nerror: unsupported configuration: qemu driver doesn't support the 'rename-restart' action for 'on_reboot'/'on_poweroff'/'on_crash'\n (6.80 s)

```