### PR TITLE
virsh_domif_setlink_getlink:Remove driver settings from iface when model is not virtio

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domif_setlink_getlink.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domif_setlink_getlink.py
@@ -10,6 +10,7 @@ from virttest import utils_net
 from virttest import utils_misc
 from virttest import utils_libvirtd
 from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
 from virttest.utils_test import libvirt
 
 
@@ -160,6 +161,9 @@ def run(test, params, env):
     # generate a new one suitable for the model
     if vm.is_alive():
         vm.destroy()
+    if model_type != 'virtio':
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm.name)
+        libvirt_vmxml.modify_vm_device(vmxml, 'interface', {'driver': None})
     iface_dict = {'model': model_type, 'del_addr': 'yes'}
     libvirt.modify_vm_iface(vm_name[0], "update_iface", iface_dict)
     # Vm status


### PR DESCRIPTION
'driver' is only supported by virtio

Depends on:
- https://github.com/avocado-framework/avocado-vt/pull/3999

Test result:
```
(01/12) type_specific.io-github-autotest-libvirt.virsh.domif_setlink_getlink.positive_test.e1000e.interface_net.no_config.domain_name.running_guest.domif_setlink.setlink_down: PASS (82.74 s)
 (02/12) type_specific.io-github-autotest-libvirt.virsh.domif_setlink_getlink.positive_test.e1000e.interface_net.no_config.domain_name.running_guest.domif_setlink.stable_test.setlink_down.restart_libvirtd: PASS (193.15 s)
 (03/12) type_specific.io-github-autotest-libvirt.virsh.domif_setlink_getlink.positive_test.e1000e.interface_mac.no_config.domain_name.running_guest.domif_setlink.setlink_down: PASS (72.76 s)
 (04/12) type_specific.io-github-autotest-libvirt.virsh.domif_setlink_getlink.positive_test.e1000e.interface_mac.no_config.domain_name.running_guest.domif_setlink.stable_test.setlink_up.save_restore: PASS (82.62 s)
 (05/12) type_specific.io-github-autotest-libvirt.virsh.domif_setlink_getlink.positive_test.e1000e.interface_mac.no_config.domain_name.running_guest.domif_setlink.stable_test.setlink_down.save_restore:PAASS (184.97 s)
 (06/12) type_specific.io-github-autotest-libvirt.virsh.domif_setlink_getlink.positive_test.rtl8139.interface_net.no_config.domain_name.running_guest.domif_setlink.setlink_down: PASS (80.13 s)
 (07/12) type_specific.io-github-autotest-libvirt.virsh.domif_setlink_getlink.positive_test.rtl8139.interface_net.no_config.domain_name.running_guest.domif_setlink.stable_test.setlink_down.restart_libvirtd: PASS (190.98 s)
 (08/12) type_specific.io-github-autotest-libvirt.virsh.domif_setlink_getlink.positive_test.rtl8139.interface_mac.no_config.domain_name.running_guest.domif_setlink.setlink_down: PASS (78.10 s)
 (09/12) type_specific.io-github-autotest-libvirt.virsh.domif_setlink_getlink.positive_test.rtl8139.interface_mac.no_config.domain_name.running_guest.domif_setlink.stable_test.setlink_up.save_restore: PASS (84.44 s)
 (10/12) type_specific.io-github-autotest-libvirt.virsh.domif_setlink_getlink.positive_test.rtl8139.interface_mac.no_config.domain_name.running_guest.domif_setlink.stable_test.setlink_down.save_restore:PASS (185.93 s)
 (11/12) type_specific.io-github-autotest-libvirt.virsh.domif_setlink_getlink.multi_functional_test.e1000e.check_update_device: PASS (90.11 s)
 (12/12) type_specific.io-github-autotest-libvirt.virsh.domif_setlink_getlink.multi_functional_test.rtl8139.check_update_device: PASS (87.60 s)
RESULTS    : PASS 12 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```