### PR TITLE
Filesystem_device: updated test.cancel to test.error

### DIFF
--- a/libvirt/tests/src/virtual_device/filesystem_device.py
+++ b/libvirt/tests/src/virtual_device/filesystem_device.py
@@ -263,10 +263,10 @@ def run(test, params, env):
     huge_pages_num = 0
 
     if hotplug_unplug and not utils_path.find_command("lsof", default=False):
-        test.cancel("Lsof command is required to run test, but not installed")
+        test.error("Lsof command is required to run test, but not installed")
 
     if len(vm_names) != guest_num:
-        test.cancel("This test needs exactly %d vms." % guest_num)
+        test.error("This test needs exactly %d vms." % guest_num)
 
     if not libvirt_version.version_compare(7, 0, 0) and not with_numa:
         test.cancel("Not supported without NUMA before 7.0.0")


### PR DESCRIPTION
Updated test.cancel to test.error in filesystem_device.py for the lsof command not being installed error and
the not the correct amount of vms error to ensure that the test fails (instead of skips) when expected.