### PR TITLE
Fixup:passt_negative:sync vmxml after deleting vm ifaces

### DIFF
--- a/libvirt/tests/src/virtual_network/passt/passt_negative_setting.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_negative_setting.py
@@ -17,6 +17,7 @@ from virttest.utils_test import libvirt
 
 from provider.virtual_network import passt
 
+VIRSH_ARGS = {'ignore_status': False, 'debug': True}
 LOG = logging.getLogger('avocado.' + __name__)
 DOWN_IFACE_NAME = "br1234"
 
@@ -119,9 +120,14 @@ def run(test, params, env):
         if operation == 'start_vm':
             vmxml.add_device(iface_device)
             vmxml.sync(virsh_instance=virsh_ins)
+            LOG.debug(
+                f'VMXML: {virsh.dumpxml(vm_name, uri=virsh_uri).stdout_text}')
             result = virsh.start(vm_name, uri=virsh_uri, debug=True)
         if operation == 'hotplug':
-            virsh.start(vm_name, uri=virsh_uri)
+            vmxml.sync(virsh_instance=virsh_ins)
+            LOG.debug(
+                f'VMXML: {virsh.dumpxml(vm_name, uri=virsh_uri).stdout_text}')
+            virsh.start(vm_name, uri=virsh_uri, **VIRSH_ARGS)
             result = virsh.attach_device(vm_name, iface_device.xml,
                                          uri=virsh_uri, debug=True)
 


### PR DESCRIPTION
Test result:

```
 (01/36) type_specific.io-github-autotest-libvirt.virtual_network.passt.negative_setting.log_no_permission.start_vm.root_user: PASS (5.49 s)
 (02/36) type_specific.io-github-autotest-libvirt.virtual_network.passt.negative_setting.log_no_permission.start_vm.non_root_user: PASS (8.74 s)
 (03/36) type_specific.io-github-autotest-libvirt.virtual_network.passt.negative_setting.log_no_permission.hotplug.root_user: PASS (5.48 s)
 (04/36) type_specific.io-github-autotest-libvirt.virtual_network.passt.negative_setting.log_no_permission.hotplug.non_root_user: PASS (8.72 s)
 (05/36) type_specific.io-github-autotest-libvirt.virtual_network.passt.negative_setting.rm_passt_pgk.start_vm.root_user: PASS (64.66 s)
 (06/36) type_specific.io-github-autotest-libvirt.virtual_network.passt.negative_setting.rm_passt_pgk.start_vm.non_root_user: PASS (68.79 s)
 (07/36) type_specific.io-github-autotest-libvirt.virtual_network.passt.negative_setting.rm_passt_pgk.hotplug.root_user: PASS (65.97 s)
 (08/36) type_specific.io-github-autotest-libvirt.virtual_network.passt.negative_setting.rm_passt_pgk.hotplug.non_root_user: PASS (70.77 s)
 (09/36) type_specific.io-github-autotest-libvirt.virtual_network.passt.negative_setting.non_exist_host_iface.start_vm.root_user: PASS (5.95 s)
 (10/36) type_specific.io-github-autotest-libvirt.virtual_network.passt.negative_setting.non_exist_host_iface.start_vm.non_root_user: PASS (9.21 s)
 (11/36) type_specific.io-github-autotest-libvirt.virtual_network.passt.negative_setting.non_exist_host_iface.hotplug.root_user: PASS (5.98 s)
 (12/36) type_specific.io-github-autotest-libvirt.virtual_network.passt.negative_setting.non_exist_host_iface.hotplug.non_root_user: PASS (9.17 s)
 (13/36) type_specific.io-github-autotest-libvirt.virtual_network.passt.negative_setting.inactive_host_iface.start_vm.root_user: PASS (6.98 s)
 (14/36) type_specific.io-github-autotest-libvirt.virtual_network.passt.negative_setting.inactive_host_iface.start_vm.non_root_user: PASS (11.60 s)
 (15/36) type_specific.io-github-autotest-libvirt.virtual_network.passt.negative_setting.inactive_host_iface.hotplug.root_user: PASS (8.76 s)
 (16/36) type_specific.io-github-autotest-libvirt.virtual_network.passt.negative_setting.inactive_host_iface.hotplug.non_root_user: PASS (12.16 s)
 (17/36) type_specific.io-github-autotest-libvirt.virtual_network.passt.negative_setting.non_exist_bind_ip.start_vm.root_user: PASS (7.12 s)
 (18/36) type_specific.io-github-autotest-libvirt.virtual_network.passt.negative_setting.non_exist_bind_ip.start_vm.non_root_user: PASS (11.61 s)
 (19/36) type_specific.io-github-autotest-libvirt.virtual_network.passt.negative_setting.non_exist_bind_ip.hotplug.root_user: PASS (8.58 s)
 (20/36) type_specific.io-github-autotest-libvirt.virtual_network.passt.negative_setting.non_exist_bind_ip.hotplug.non_root_user: PASS (12.25 s)
 (21/36) type_specific.io-github-autotest-libvirt.virtual_network.passt.negative_setting.port_occupied.start_vm.root_user:PASS (7.31 s)
 (22/36) type_specific.io-github-autotest-libvirt.virtual_network.passt.negative_setting.port_occupied.start_vm.non_root_user: PASS (11.84 s)
 (23/36) type_specific.io-github-autotest-libvirt.virtual_network.passt.negative_setting.port_occupied.hotplug.root_user: PASS (8.81 s)
 (24/36) type_specific.io-github-autotest-libvirt.virtual_network.passt.negative_setting.port_occupied.hotplug.non_root_user: PASS (12.45 s)
 (25/36) type_specific.io-github-autotest-libvirt.virtual_network.passt.negative_setting.port_under_1024.start_vm.root_user: PASS (7.10 s)
 (26/36) type_specific.io-github-autotest-libvirt.virtual_network.passt.negative_setting.port_under_1024.start_vm.non_root_user: PASS (11.67 s)
 (27/36) type_specific.io-github-autotest-libvirt.virtual_network.passt.negative_setting.port_under_1024.hotplug.root_user: PASS (8.50 s)
 (28/36) type_specific.io-github-autotest-libvirt.virtual_network.passt.negative_setting.port_under_1024.hotplug.non_root_user: PASS (12.20 s)
 (29/36) type_specific.io-github-autotest-libvirt.virtual_network.passt.negative_setting.port_outofrange.start_vm.root_user: PASS (6.00 s)
 (30/36) type_specific.io-github-autotest-libvirt.virtual_network.passt.negative_setting.port_outofrange.start_vm.non_root_user: PASS (9.23 s)
 (31/36) type_specific.io-github-autotest-libvirt.virtual_network.passt.negative_setting.port_outofrange.hotplug.root_user: PASS (5.99 s)
 (32/36) type_specific.io-github-autotest-libvirt.virtual_network.passt.negative_setting.port_outofrange.hotplug.non_root_user: PASS (9.27 s)
 (33/36) type_specific.io-github-autotest-libvirt.virtual_network.passt.negative_setting.port_overlap.start_vm.root_user: PASS (6.04 s)
 (34/36) type_specific.io-github-autotest-libvirt.virtual_network.passt.negative_setting.port_overlap.start_vm.non_root_user: PASS (9.18 s)
 (35/36) type_specific.io-github-autotest-libvirt.virtual_network.passt.negative_setting.port_overlap.hotplug.root_user: PASS (5.89 s)
 (36/36) type_specific.io-github-autotest-libvirt.virtual_network.passt.negative_setting.port_overlap.hotplug.non_root_user: PASS (9.19 s)
RESULTS    : PASS 36 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```