### PR TITLE
Guestvcpus: enable/disable max vcpu by guest agent

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_guestvcpus.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_guestvcpus.cfg
@@ -8,6 +8,7 @@
     take_regular_screendumps="no"
     vcpus_num = "20"
     vcpus_placement = "static"
+    max_test_combine = ""
     option = ""
     combine = ""
     error_msg = []
@@ -26,6 +27,9 @@
                     option = "--enable"
                 - combine:
                     combine = "yes"
+        - max_test:
+            status_error = "no"
+            max_test_combine = "yes"
         - error_test:
             status_error = "yes"
             variants:

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_guestvcpus.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_guestvcpus.py
@@ -1,5 +1,6 @@
 import logging as log
 
+from avocado.utils import cpu
 
 from virttest import virsh
 from virttest import cpu as cpuutil
@@ -19,14 +20,81 @@ def run(test, params, env):
     The command query or modify state of vcpu in the vm
     1. Prepare test environment, start vm with guest agent
     2. Perform virsh guestvcpus query/enable/disable operation
-    3. Check the cpus in the vm
-    4. Recover test environment
+    3. Check the vcpu number by virsh command via guest agent
+    4. Check the vcpu number within the guest
+    5. In combine tests, repeat steps 2-4
+    6. Recover test environment
     """
     vm_name = params.get("main_vm")
     vm = env.get_vm(vm_name)
     vcpus_num = int(params.get("vcpus_num", "20"))
     vcpus_placement = params.get("vcpus_placement", "static")
+    max_test_combine = params.get("max_test_combine", "")
     option = params.get("option", "")
+    combine = params.get("combine", "")
+    status_error = params.get("status_error", "no")
+    vcpus_list = ""
+
+    # Back up domain XML
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    vmxml_bakup = vmxml.copy()
+
+    # Max test: set vcpus_num to the host online cpu number
+    if max_test_combine == "yes":
+        vcpus_num = cpu.online_count()
+        logging.debug("Host online CPU number: %s", str(vcpus_num))
+
+    try:
+        # Modify vm with static vcpus
+        if vm.is_alive():
+            vm.destroy()
+        vmxml.placement = vcpus_placement
+        vmxml.set_vm_vcpus(vm_name, vcpus_num, vcpus_num, topology_correction=True)
+        logging.debug("Define guest with '%s' vcpus", str(vcpus_num))
+
+        # Start guest agent in vm
+        vm.prepare_guest_agent()
+
+        # Normal test: disable/enable guest vcpus
+        if option and status_error == "no":
+            for vcpu in range(1, vcpus_num):
+                virsh.guestvcpus(vm_name, str(vcpu), option, debug=True)
+            check_cpu_count(test, params, env, vcpus_num, option)
+
+        # Combine: --disable 1-max then --enable
+        if (max_test_combine == "yes" or combine == "yes") and status_error == "no":
+            vcpus_list = '1' + '-' + str(vcpus_num - 1)
+            option = "--disable"
+            virsh.guestvcpus(vm_name, vcpus_list, option, debug=True)
+            check_cpu_count(test, params, env, vcpus_num, option)
+
+            # Max test: --enable 1-max (no change to vcpus_list)
+            # Normal test: --enable 1
+            if combine == "yes":
+                vcpus_list = '1'
+
+            option = "--enable"
+            virsh.guestvcpus(vm_name, vcpus_list, option, debug=True)
+            check_cpu_count(test, params, env, vcpus_num, option)
+
+    finally:
+        # Recover VM
+        if vm.is_alive():
+            vm.destroy(gracefully=False)
+        logging.info("Restoring vm...")
+        vmxml_bakup.sync()
+
+
+def check_cpu_count(test, params, env, vcpus_num, option=""):
+    """
+    Makes any changes necessary for the error test and then
+    runs the vcpu checks specified in steps 3 and 4 of run()
+
+    3. Check the vcpu number by virsh command via guest agent
+    4. Check the vcpu number within the guest
+    """
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
     combine = params.get("combine", "")
     invalid_domain = params.get("invalid_domain", "")
     domain_name = params.get("domain_name", "")
@@ -36,96 +104,61 @@ def run(test, params, env):
     vcpus_list = ""
     offline_vcpus = ""
 
-    # Back up domain XML
-    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
-    vmxml_bakup = vmxml.copy()
-
-    try:
-        # Modify vm with static vcpus
-        if vm.is_alive():
-            vm.destroy()
-        vmxml.placement = vcpus_placement
-        vmxml.set_vm_vcpus(vm_name, vcpus_num, vcpus_num, topology_correction=True)
-        logging.debug("Define guest with '%s' vcpus" % str(vcpus_num))
-
-        # Start guest agent in vm
-        vm.prepare_guest_agent()
-
-        # Normal test: disable/ enable guest vcpus
-        if option and status_error == "no":
-            for cpu in range(1, vcpus_num):
-                virsh.guestvcpus(vm_name, str(cpu), option, debug=True)
-
-        # Normal test: combine: --disable 1-max then --enable 1
-        if combine == "yes" and status_error == "no":
-            vcpus_list = '1' + '-' + str(vcpus_num - 1)
-            option = "--disable"
-            virsh.guestvcpus(vm_name, vcpus_list, option, debug=True)
-            vcpus_list = '1'
-            option = "--enable"
-            virsh.guestvcpus(vm_name, vcpus_list, option, debug=True)
-
-        # Error test: invalid_domain
-        if invalid_domain == "yes":
-            vm_name = domain_name
-        # Error test: invalid_cpulist
-        if invalid_cpulist == "yes":
-            if option == "--enable":
-                vcpus_list = str(vcpus_num)
-            else:
-                vcpus_list = '0' + '-' + str(vcpus_num - 1)
-            ret = virsh.guestvcpus(vm_name, vcpus_list, option)
+    # Error test: invalid_domain
+    if invalid_domain == "yes":
+        vm_name = domain_name
+    # Error test: invalid_cpulist
+    if invalid_cpulist == "yes":
+        if option == "--enable":
+            vcpus_list = str(vcpus_num)
         else:
-            # Query guest vcpus
-            ret = virsh.guestvcpus(vm_name)
-            output = ret.stdout.strip()
+            vcpus_list = '0' + '-' + str(vcpus_num - 1)
+        ret = virsh.guestvcpus(vm_name, vcpus_list, option)
+    else:
+        # Query guest vcpus
+        ret = virsh.guestvcpus(vm_name)
+        output = ret.stdout.strip()
 
-        # Check test results
-        if status_error == "yes":
-            libvirt.check_result(ret, error_msg)
+    # Check test results
+    if status_error == "yes":
+        libvirt.check_result(ret, error_msg)
+    else:
+        # Check the test result of query
+        ret_output = dict([item.strip() for item in line.split(":")]
+                          for line in output.split("\n"))
+        if combine == "yes" and option == "--enable":
+            online_vcpus = '0-1'
+        elif option == "--disable":
+            online_vcpus = '0'
         else:
-            # Check the test result of query
-            ret_output = dict([item.strip() for item in line.split(":")]
-                              for line in output.split("\n"))
-            if combine == "yes":
-                online_vcpus = '0-1'
-            elif option == "--disable":
-                online_vcpus = '0'
-            else:
-                online_vcpus = '0' + '-' + str(vcpus_num - 1)
+            # either normal --enable test or max test on the --enable step
+            online_vcpus = '0' + '-' + str(vcpus_num - 1)
 
-            if ret_output["online"] != online_vcpus:
-                test.fail("Query result is different from"
-                          " the '%s' command." % option)
+        if ret_output["online"] != online_vcpus:
+            test.fail("Expected online vcpus to be %s, "
+                      "but found %s." % (online_vcpus, ret_output["online"]))
 
-            # Check the cpu in guest
-            session = vm.wait_for_login()
-            vm_cpu_info = cpuutil.get_cpu_info(session)
-            session.close()
+        # Check the vcpu number within the guest
+        session = vm.wait_for_login()
+        vm_cpu_info = cpuutil.get_cpu_info(session)
+        session.close()
 
-            if combine == "yes":
-                online_vcpus = '0,1'
-            elif option == "--disable":
-                online_vcpus = '0'
-                offline_vcpus = '1' + '-' + str(vcpus_num - 1)
-            else:
-                online_vcpus = '0' + '-' + str(vcpus_num - 1)
+        if combine == "yes" and option == "--enable":
+            online_vcpus = '0,1'
+        elif option == "--disable":
+            online_vcpus = '0'
+            offline_vcpus = '1' + '-' + str(vcpus_num - 1)
+        else:
+            # either normal --enable test or max test on the --enable step
+            online_vcpus = '0' + '-' + str(vcpus_num - 1)
 
-            if offline_vcpus:
-                if (vm_cpu_info["Off-line CPU(s) list"] != offline_vcpus or
-                        vm_cpu_info["On-line CPU(s) list"] != online_vcpus):
-                    test.fail("CPUs in vm is different from"
-                              " the %s command." % option)
-            elif vm_cpu_info["On-line CPU(s) list"] != online_vcpus:
-                test.fail("On-line CPUs in vm is different"
-                          " from the %s command." % option)
-            else:
-                logging.debug("lscpu in vm '%s' is: \n '%s'" %
-                              (vm_name, vm_cpu_info))
-
-    finally:
-        # Recover VM
-        if vm.is_alive():
-            vm.destroy(gracefully=False)
-        logging.info("Restoring vm...")
-        vmxml_bakup.sync()
+        if offline_vcpus:
+            if (vm_cpu_info["Off-line CPU(s) list"] != offline_vcpus or
+                    vm_cpu_info["On-line CPU(s) list"] != online_vcpus):
+                test.fail("CPUs in vm is different from"
+                          " the `virsh guestvcpus %s` command." % option)
+        elif vm_cpu_info["On-line CPU(s) list"] != online_vcpus:
+            test.fail("On-line CPUs in vm is different"
+                      " from the `virsh guestvcpus %s` command." % option)
+        logging.debug("lscpu in vm '%s' is: \n '%s'",
+                      vm_name, vm_cpu_info)


### PR DESCRIPTION
Case ID: VIRT-301878
Automates the case that verifies that the maximum vcpu (numbers = #host_online_cpu - 1) in the guest can be disabled and then enabled. This is done by modifying the existing virsh_guestvcpus.py test file.

Evidence of tests passing:
```
[root@ampere-mtsnow-altra-07 /]# avocado run --vt-type libvirt virsh.guestvcpus.max_test
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : 1b1991ea18284ce10f02306864ac7f7bfbdbb903
JOB LOG    : /var/log/avocado/job-results/job-2024-09-23T12.50-1b1991e/job.log
 (1/7) type_specific.io-github-autotest-libvirt.virsh.guestvcpus.max_test: STARTED
 (1/7) type_specific.io-github-autotest-libvirt.virsh.guestvcpus.max_test: PASS (94.42 s)
 (2/7) type_specific.io-github-autotest-libvirt.virsh.guestvcpus.max_test: STARTED
 (2/7) type_specific.io-github-autotest-libvirt.virsh.guestvcpus.max_test: PASS (86.99 s)
 (3/7) type_specific.io-github-autotest-libvirt.virsh.guestvcpus.max_test: STARTED
 (3/7) type_specific.io-github-autotest-libvirt.virsh.guestvcpus.max_test: PASS (84.96 s)
 (4/7) type_specific.io-github-autotest-libvirt.virsh.guestvcpus.max_test: STARTED
 (4/7) type_specific.io-github-autotest-libvirt.virsh.guestvcpus.max_test: PASS (84.49 s)
 (5/7) type_specific.io-github-autotest-libvirt.virsh.guestvcpus.max_test: STARTED
 (5/7) type_specific.io-github-autotest-libvirt.virsh.guestvcpus.max_test: PASS (85.38 s)
 (6/7) type_specific.io-github-autotest-libvirt.virsh.guestvcpus.max_test: STARTED
 (6/7) type_specific.io-github-autotest-libvirt.virsh.guestvcpus.max_test: PASS (83.34 s)
 (7/7) type_specific.io-github-autotest-libvirt.virsh.guestvcpus.max_test: STARTED
 (7/7) type_specific.io-github-autotest-libvirt.virsh.guestvcpus.max_test: PASS (85.10 s)
RESULTS    : PASS 7 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2024-09-23T12.50-1b1991e/results.html
JOB TIME   : 608.71 s
```