### PR TITLE
vIOMMU: Remove the iommu device before attaching it

### DIFF
--- a/libvirt/tests/src/sriov/vIOMMU/attach_iommu_device.py
+++ b/libvirt/tests/src/sriov/vIOMMU/attach_iommu_device.py
@@ -34,6 +34,7 @@ def run(test, params, env):
                 vmxml.sync()
             err_msg = ''
 
+        libvirt_vmxml.remove_vm_devices_by_type(vm, 'iommu')
         iommu_dev = libvirt_vmxml.create_vm_device_by_type('iommu', iommu_dict)
         test.log.debug(f"iommu device: {iommu_dev}")
         res = virsh.attach_device(vm.name, iommu_dev.xml, debug=True,


### PR DESCRIPTION
Update to remove the iommu device before attaching it to avoid failures.

**Before the fix:**
` (1/1) type_specific.io-github-autotest-libvirt.vIOMMU.attach_iommu_device.cold_plug.virtio: FAIL: Expect should succeed, but got: \n\nerror: Failed to attach device from /tmp/xml_utils_temp_rqu_qcdu.xml\nerror: Requested operation is not valid: domain already has an iommu device\n (6.65 s)
`
**After the fix:**
` (1/1) type_specific.io-github-autotest-libvirt.vIOMMU.attach_iommu_device.cold_plug.virtio: PASS (6.48 s)
`