### PR TITLE
Add new image type:vhd/gce support in bootc image builder

### DIFF
--- a/virttools/tests/cfg/bootc_image_builder/bootc_disk_image_build.cfg
+++ b/virttools/tests/cfg/bootc_image_builder/bootc_disk_image_build.cfg
@@ -1,6 +1,6 @@
 - bootc_image_builder.bib.disk_image_generation:
     type = bootc_disk_image_build
-    only x86_64, aarch64
+    only x86_64, aarch64, s390x, ppc64le
     start_vm = False
     take_regular_screendumps = "no"
     start_vm = "no"
@@ -23,10 +23,14 @@
         - use_config_json:
             os_username = "alice"
             os_password = "bob"
+            qcow..upstream_bib:
+                filesystem_size_set = "yes"
             anaconda-iso..upstream_bib..fedora_40:
                 kickstart = "yes"
-            anaconda-iso..rhel_9.5_nightly_bib..local_image:
+                use_toml_config = "yes"
+            anaconda-iso..rhel_9.5_nightly_bib..local_image, anaconda-iso..rhel_9.6_nightly_bib..local_image:
                 kickstart = "yes"
+                filesystem_size_set = "yes"
         - unuse_config_json:
     variants image_ref:
         - centos:
@@ -34,15 +38,20 @@
 			- centos9:
 			    container_url = "quay.io/centos-bootc/centos-bootc:stream9"
 			    only use_config_json..tls_verify_disable
+			    x86_64, aarch64:
+			        anaconda-iso.upstream_bib:
+				    signed_container = "yes"
+				    local_container = "yes"
 			- centos10:
 			    container_url = "quay.io/centos-bootc/centos-bootc:stream10"
-			    only upstream_bib..use_config_json..tls_verify_enable, rhel_9.5_nightly_bib..use_config_json..tls_verify_enable, rhel_9.4_nightly_bib..use_config_json..tls_verify_enable
+			    only upstream_bib..use_config_json..tls_verify_enable, rhel_9.5_nightly_bib..use_config_json..tls_verify_enable, rhel_9.6_nightly_bib..use_config_json..tls_verify_enable, rhel_9.4_nightly_bib..use_config_json..tls_verify_enable
 			    roofs = "xfs"
 			    rhel_9.4_nightly_bib..use_config_json..tls_verify_enable:
 			        roofs = ""
         - fedora:
             variants fedora_bootc_image:
 			- fedora_40:
+			    no s390-virtio
 			    only upstream_bib..tls_verify_enable
 			    ownership ="107:107"
 			    container_url = "quay.io/fedora/fedora-bootc:40"
@@ -55,36 +64,61 @@
 			    roofs = "xfs"
 			    raw..upstream_bib:
 				roofs = "ext4"
+				enable_lvm_disk_partitions = "yes"
+			    anaconda-iso..upstream_bib:
+				enable_plain_disk_partitions = "yes"
+			    s390-virtio:
+				container_url = "quay.io/fedora/fedora-bootc:41"
         - local_image:
             container_base_folder = "/var/lib/libvirt/images"
             container_url = "localhost/bootc:eln"
             local_container = "yes"
             build_container = "registry.stage.redhat.io/rhel9/rhel-bootc:rhel-9.4"
             rhel_9.5_nightly_bib:
-                build_container = "registry.stage.redhat.io/rhel9/rhel-bootc:rhel-9.5"
+                build_container = "registry.stage.redhat.io/rhel9/rhel-bootc:9.5"
+            rhel_9.6_nightly_bib, upstream_bib:
+                build_container = "registry.stage.redhat.io/rhel9/rhel-bootc:9.6"
             rhel_10.0_bib:
-                build_container = "registry.stage.redhat.io/rhel10-beta/rhel-bootc:rhel-10.0-beta"
+                build_container = "registry.stage.redhat.io/rhel10/rhel-bootc:10.0"
         - rhel_9.4:
-            build_container = "registry.redhat.io/rhel9/rhel-bootc:9.4"
+            build_container = "registry.redhat.io/rhel9-eus/rhel-9.4-bootc:9.4"
             container_url = "quay.io/wenbaoxin/rhel9test"
             only rhel_9.4_bib
+        - rhel_9.5:
+            build_container = "registry.redhat.io/rhel9/rhel-bootc:9.5"
+            container_url = "quay.io/wenbaoxin/rhel9-rhel_bootc"
+            only rhel_9.5_bib
         - rhel_9.5_nightly:
-            container_url = "registry.stage.redhat.io/rhel9/rhel-bootc:rhel-9.5"
+            container_url = "registry.stage.redhat.io/rhel9/rhel-bootc:9.5"
             only rhel_9.5_nightly_bib
+            redhat_version_id = "9.5"
+            no anaconda-iso
+        - rhel_9.6_nightly:
+            container_url = "registry.stage.redhat.io/rhel9/rhel-bootc:9.6"
+            only rhel_9.6_nightly_bib
+            redhat_version_id = "9.6"
             no anaconda-iso
         - rhel_10.0_nightly:
-            container_url = "registry.stage.redhat.io/rhel10-beta/rhel-bootc:rhel-10.0-beta"
+            container_url = "registry.stage.redhat.io/rhel10/rhel-bootc:10.0"
             enable_tls_verify = "false"
+            redhat_version_id = "10.0"
             only rhel_10.0_bib
             no anaconda-iso
         - cross_build:
-            container_url = "quay.io/centos-bootc/centos-bootc:stream9"
+            local_container = "yes"
+            manifest = "manifest-test"
+            container_base_folder = "/var/lib/libvirt/images"
+            build_container = "quay.io/centos-bootc/centos-bootc-dev:stream9"
+            container_url = "localhost/manifest-test"
             target_arch = "aarch64"
+            roofs = "btrfs"
+            enable_btrf_disk_partitions = "yes"
+            filesystem_size_set = "no"
             only qcow..upstream_bib..use_config_json..tls_verify_enable
     variants bib_ref:
         - upstream_bib:
-            registry_key = "example_stage_key"
-            redhat_registry = "registry.stage.redhat.io"
+            registry_stage_key = "example_stage_key"
+            redhat_stage_registry = "registry.stage.redhat.io"
             bib_image_url = "quay.io/centos-bootc/bootc-image-builder:latest"
             podman_stage_username = "11009103|stage"
             podman_stage_password = "example_stage_password"
@@ -100,9 +134,9 @@
             anaconda-iso..rhel_9.4:
                 custom_repo = "rhel-9.4.repo"
         - rhel_9.4_nightly_bib:
-            registry_key = "example_stage_key"
-            redhat_registry = "registry.stage.redhat.io"
-            bib_image_url = "registry.stage.redhat.io/rhel9/bootc-image-builder:rhel-9.4"
+            registry_stage_key = "example_stage_key"
+            redhat_stage_registry = "registry.stage.redhat.io"
+            bib_image_url = "registry.stage.redhat.io/rhel9/bootc-image-builder:9.4"
             key_store_mounted = "/etc/pki:/etc/pki"
             podman_stage_username = "11009103|stage"
             podman_stage_password = "example_stage_password"
@@ -110,20 +144,41 @@
                 custom_repo = "rhel-9.4.repo"
                 compose_url = "example_compose_url"
             no cross_build
+        - rhel_9.5_bib:
+            podman_redhat_username = "podman_redhat_username"
+            podman_redhat_password = "podman_redhat_password"
+            redhat_registry = "registry.redhat.io"
+            container_base_folder = "/var/lib/libvirt/images"
+            bib_image_url = "registry.redhat.io/rhel9/bootc-image-builder:9.5"
+            podman_quay_username = "podman_quay_username"
+            podman_quay_password = "podman_quay_password"
+            only rhel_9.5..use_config_json..tls_verify_enable
+            anaconda-iso..rhel_9.5:
+                custom_repo = "rhel-9.5.repo"
         - rhel_9.5_nightly_bib:
-            registry_key = "example_stage_key"
-            redhat_registry = "registry.stage.redhat.io"
-            bib_image_url = "registry.stage.redhat.io/rhel9/bootc-image-builder:rhel-9.5"
+            registry_stage_key = "example_stage_key"
+            redhat_stage_registry = "registry.stage.redhat.io"
+            bib_image_url = "registry.stage.redhat.io/rhel9/bootc-image-builder:9.5"
             key_store_mounted = "/etc/pki:/etc/pki"
             podman_stage_username = "11009103|stage"
             podman_stage_password = "example_stage_password"
             anaconda-iso..local_image:
                 custom_repo = "rhel-9.5.repo"
                 compose_url = "example_compose_url"
+        - rhel_9.6_nightly_bib:
+            registry_stage_key = "example_stage_key"
+            redhat_stage_registry = "registry.stage.redhat.io"
+            bib_image_url = "registry.stage.redhat.io/rhel9/bootc-image-builder:9.6"
+            key_store_mounted = "/etc/pki:/etc/pki"
+            podman_stage_username = "11009103|stage"
+            podman_stage_password = "example_stage_password"
+            anaconda-iso..local_image:
+                custom_repo = "rhel-9.6.repo"
+                compose_url = "example_compose_url"
         - rhel_10.0_bib:
-            registry_key = "example_stage_key"
-            redhat_registry = "registry.stage.redhat.io"
-            bib_image_url = "registry.stage.redhat.io/rhel10-beta/bootc-image-builder:rhel-10.0-beta"
+            registry_stage_key = "example_stage_key"
+            redhat_stage_registry = "registry.stage.redhat.io"
+            bib_image_url = "registry.stage.redhat.io/rhel10/bootc-image-builder:10.0"
             key_store_mounted = "/etc/pki:/etc/pki"
             podman_stage_username = "11009103|stage"
             podman_stage_password = "example_stage_password"
@@ -133,6 +188,7 @@
     variants:
         - ami:
             disk_image_type = "ami"
+            no s390-virtio
             output_sub_folder = "image"
             output_name = "disk.raw"
             aws_secret_folder = "/var/lib/libvirt/images"
@@ -140,7 +196,7 @@
             aws_access_key = "example_aws_access_key"
             aws_region = "us-east-1"
             aws_ami_name = "build_${bib_ref}-${image_ref}-component-bootc-${disk_image_type}"
-            use_config_json..tls_verify_enable:
+            rhel_9.5_nightly_bib..use_config_json..tls_verify_enable, rhel_9.5_nightly_bib..use_config_json..tls_verify_enable, upstream_bib.centos.centos10.use_config_json.tls_verify_enable:
                 aws_config_dict = "{'aws.secrets':'${aws_secret_folder}/aws.secrets','aws_ami_name':'${aws_ami_name}','aws_bucket':'bib-component-test','aws_region':'${aws_region}'}"
         - qcow:
             disk_image_type = "qcow2"
@@ -150,6 +206,7 @@
             disk_image_type = "vmdk"
             output_sub_folder = "vmdk"
             output_name = "disk.vmdk"
+            no s390-virtio
         - anaconda-iso:
             disk_image_type = "anaconda-iso"
             output_sub_folder = "bootiso"
@@ -158,3 +215,15 @@
             disk_image_type = "raw"
             output_sub_folder = "image"
             output_name = "disk.raw"
+        - vhd:
+            disk_image_type = "vhd"
+            output_sub_folder = "vpc"
+            output_name = "disk.vhd"
+            no s390-virtio
+            only upstream_bib, rhel_9.5_nightly_bib
+        - gce:
+            disk_image_type = "gce"
+            output_sub_folder = "gce"
+            output_name = "image.tar.gz"
+            no s390-virtio
+            only upstream_bib, rhel_9.5_nightly_bib

--- a/virttools/tests/cfg/bootc_image_builder/bootc_disk_image_install.cfg
+++ b/virttools/tests/cfg/bootc_image_builder/bootc_disk_image_install.cfg
@@ -1,6 +1,6 @@
 - bootc_image_builder.bib.disk_image_install:
     type = bootc_disk_image_install
-    only x86_64, aarch64
+    only x86_64, aarch64, s390x, ppc64le
     start_vm = False
     take_regular_screendumps = "no"
     start_vm = "no"
@@ -36,9 +36,11 @@
             variants centos_bootc_image:
 			- centos9:
 			    container_url = "quay.io/centos-bootc/centos-bootc:stream9"
+			    only bios
 			- centos10:
 			    container_url = "quay.io/centos-bootc/centos-bootc:stream10"
-			    only upstream_bib, rhel_9.5_nightly_bib, rhel_9.4_nightly_bib
+			    only efi
+			    only upstream_bib, rhel_9.5_nightly_bib, rhel_9.6_nightly_bib, rhel_9.4_nightly_bib
 			    roofs = "ext4"
 			    rhel_9.4_nightly_bib:
 			        roofs = ""
@@ -46,20 +48,27 @@
             variants fedora_bootc_image:
 			- fedora_40:
 			    only upstream_bib
+			    only bios
 			    container_url = "quay.io/fedora/fedora-bootc:40"
 			    roofs = "ext4"
 			    qcow..upstream_bib:
 				roofs = "xfs"
 			    anaconda-iso..upstream_bib:
 				kickstart = "yes"
+			    raw..upstream_bib:
+				filesystem_size_set = "yes"
+                            no s390-virtio
 			- fedora_latest:
 			    only upstream_bib
+			    only efi
 			    container_url = "quay.io/fedora/fedora-bootc:latest"
 			    roofs = "xfs"
 			    raw..upstream_bib:
 				roofs = "ext4"
+			    s390-virtio:
+				container_url = "quay.io/fedora/fedora-bootc:41"
         - rhel_9.4:
-            build_container = "registry.redhat.io/rhel9/rhel-bootc:9.4"
+            build_container = "registry.redhat.io/rhel9-eus/rhel-9.4-bootc:9.4"
             container_url = "quay.io/wenbaoxin/rhel9test"
             only rhel_9.4_bib
         - local_image:
@@ -68,24 +77,43 @@
             local_container = "yes"
             build_container = "registry.stage.redhat.io/rhel9/rhel-bootc:rhel-9.4"
             rhel_9.5_nightly_bib:
-                build_container = "registry.stage.redhat.io/rhel9/rhel-bootc:rhel-9.5"
+                build_container = "registry.stage.redhat.io/rhel9/rhel-bootc:9.5"
                 fips_enable = "yes"
+                enable_fips_enable_repo = "yes"
+            rhel_9.6_nightly_bib, upstream_bib:
+                build_container = "registry.stage.redhat.io/rhel9/rhel-bootc:9.6"
+                fips_enable = "yes"
+                enable_fips_enable_repo = "yes"
+            anaconda-iso..upstream_bib, anaconda-iso..rhel_9.5_nightly_bib:
+                fips_enable = "yes"
+                use_toml_config = "yes"
+                kickstart = "yes"
+                enable_fips_enable_repo = "no"
             rhel_10.0_bib:
-                build_container = "registry.stage.redhat.io/rhel10-beta/rhel-bootc:rhel-10.0-beta"
+                build_container = "registry.stage.redhat.io/rhel10/rhel-bootc:10.0"
+        - rhel_9.5:
+            build_container = "registry.redhat.io/rhel9/rhel-bootc:9.5"
+            container_url = "quay.io/wenbaoxin/rhel9-rhel_bootc"
+            only rhel_9.5_bib
         - rhel_9.5_nightly:
-            container_url = "registry.stage.redhat.io/rhel9/rhel-bootc:rhel-9.5"
+            container_url = "registry.stage.redhat.io/rhel9/rhel-bootc:9.5"
             enable_tls_verify = "false"
             only rhel_9.5_nightly_bib
             no anaconda-iso
+        - rhel_9.6_nightly:
+            container_url = "registry.stage.redhat.io/rhel9/rhel-bootc:9.6"
+            enable_tls_verify = "false"
+            only rhel_9.6_nightly_bib
+            no anaconda-iso
         - rhel_10.0_nightly:
-            container_url = "registry.stage.redhat.io/rhel10-beta/rhel-bootc:rhel-10.0-beta"
+            container_url = "registry.stage.redhat.io/rhel10/rhel-bootc:10.0"
             enable_tls_verify = "false"
             only rhel_10.0_bib
             no anaconda-iso
     variants bib_ref:
         - upstream_bib:
-            registry_key = "example_stage_key"
-            redhat_registry = "registry.stage.redhat.io"
+            registry_stage_key = "example_stage_key"
+            redhat_stage_registry = "registry.stage.redhat.io"
             bib_image_url = "quay.io/centos-bootc/bootc-image-builder:latest"
             podman_stage_username = "11009103|stage"
             podman_stage_password = "example_stage_password"
@@ -101,29 +129,50 @@
                 custom_repo = "rhel-9.4.repo"
             only rhel_9.4
         - rhel_9.4_nightly_bib:
-            registry_key = "example_stage_key"
-            redhat_registry = "registry.stage.redhat.io"
-            bib_image_url = "registry.stage.redhat.io/rhel9/bootc-image-builder:rhel-9.4"
+            registry_stage_key = "example_stage_key"
+            redhat_stage_registry = "registry.stage.redhat.io"
+            bib_image_url = "registry.stage.redhat.io/rhel9/bootc-image-builder:9.4"
             key_store_mounted = "/etc/pki:/etc/pki"
             podman_stage_username = "11009103|stage"
             podman_stage_password = "example_stage_password"
             anaconda-iso..local_image:
                 custom_repo = "rhel-9.4.repo"
                 compose_url = "example_compose_url"
+        - rhel_9.5_bib:
+            podman_redhat_username = "11080659|chwen"
+            podman_redhat_password = "podman_redhat_password"
+            redhat_registry = "registry.redhat.io"
+            container_base_folder = "/var/lib/libvirt/images"
+            bib_image_url = "registry.redhat.io/rhel9/bootc-image-builder:9.5"
+            podman_quay_username = "wenbaoxin"
+            podman_quay_password = "doudou303"
+            anaconda-iso..rhel_9.5:
+                custom_repo = "rhel-9.5.repo"
+            only rhel_9.5
         - rhel_9.5_nightly_bib:
-            registry_key = "example_stage_key"
-            redhat_registry = "registry.stage.redhat.io"
-            bib_image_url = "registry.stage.redhat.io/rhel9/bootc-image-builder:rhel-9.5"
+            registry_stage_key = "example_stage_key"
+            redhat_stage_registry = "registry.stage.redhat.io"
+            bib_image_url = "registry.stage.redhat.io/rhel9/bootc-image-builder:9.5"
             key_store_mounted = "/etc/pki:/etc/pki"
             podman_stage_username = "11009103|stage"
             podman_stage_password = "example_stage_password"
             anaconda-iso..local_image:
                 custom_repo = "rhel-9.5.repo"
                 compose_url = "example_compose_url"
+        - rhel_9.6_nightly_bib:
+            registry_stage_key = "example_stage_key"
+            redhat_stage_registry = "registry.stage.redhat.io"
+            bib_image_url = "registry.stage.redhat.io/rhel9/bootc-image-builder:9.6"
+            key_store_mounted = "/etc/pki:/etc/pki"
+            podman_stage_username = "11009103|stage"
+            podman_stage_password = "example_stage_password"
+            anaconda-iso..local_image:
+                custom_repo = "rhel-9.6.repo"
+                compose_url = "example_compose_url"
         - rhel_10.0_bib:
-            registry_key = "example_stage_key"
-            redhat_registry = "registry.stage.redhat.io"
-            bib_image_url = "registry.stage.redhat.io/rhel10-beta/bootc-image-builder:rhel-10.0-beta"
+            registry_stage_key = "example_stage_key"
+            redhat_stage_registry = "registry.stage.redhat.io"
+            bib_image_url = "registry.stage.redhat.io/rhel10/bootc-image-builder:10.0"
             key_store_mounted = "/etc/pki:/etc/pki"
             podman_stage_username = "11009103|stage"
             podman_stage_password = "example_stage_password"
@@ -133,6 +182,7 @@
     variants:
         - ami:
             disk_image_type = "ami"
+            no s390-virtio
             output_sub_folder = "image"
             output_name = "disk.raw"
             aws_secret_folder = "/var/lib/libvirt/images"
@@ -145,7 +195,11 @@
             aws_vpc_id = "example_vpc"
             aws_subnet_id = "example_subnet"
             aws_config_dict = "{'aws.secrets':'${aws_secret_folder}/aws.secrets','aws_ami_name':'${aws_ami_name}','aws_bucket':'bib-component-test','aws_region':'${aws_region}'}"
-            rhel_9.5_nightly_bib..centos.centos9, rhel_9.5_nightly_bib..fedora_eln, rhel_9.5_nightly_bib..local_image:
+            rhel_9.5_nightly_bib..centos.centos9, rhel_9.5_nightly_bib..local_image:
+                aws_config_dict = {}
+            rhel_9.6_nightly_bib..centos.centos9, rhel_9.6_nightly_bib..local_image:
+                aws_config_dict = {}
+            upstream_bib..centos, upstream_bib..local_image, upstream_bib..fedora.fedora_40:
                 aws_config_dict = {}
         - qcow:
             disk_image_type = "qcow2"
@@ -155,6 +209,7 @@
             disk_image_type = "vmdk"
             output_sub_folder = "vmdk"
             output_name = "disk.vmdk"
+            no s390-virtio
             local_image:
                 add_vmware_tool = "yes"
             rhel_9.4:
@@ -168,3 +223,15 @@
             disk_image_type = "raw"
             output_sub_folder = "image"
             output_name = "disk.raw"
+        - vhd:
+            disk_image_type = "vhd"
+            output_sub_folder = "vpc"
+            output_name = "disk.vhd"
+            no s390-virtio
+            only upstream_bib, rhel_9.5_nightly_bib
+        - gce:
+            disk_image_type = "gce"
+            output_sub_folder = "gce"
+            output_name = "image.tar.gz"
+            no s390-virtio
+            only upstream_bib, rhel_9.5_nightly_bib


### PR DESCRIPTION
Add new image type:vdh/gce support in bootc image builder
vhd/gce are newly introduced support disk image type, and is only supported on upstream