### PR TITLE
iface-hoplug: Change login method for network interface verification

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_hotplug.py
+++ b/libvirt/tests/src/virtual_network/iface_hotplug.py
@@ -235,8 +235,7 @@ def run(test, params, env):
 
             def check_iface_exist():
                 try:
-                    session = vm.wait_for_serial_login(username=username,
-                                                       password=password)
+                    session = vm.wait_for_login(serial=True)
                     if utils_net.get_linux_ifname(session, iface['mac']):
                         return True
                     else:
@@ -291,8 +290,7 @@ def run(test, params, env):
             # Start the domain if needed
             if vm.is_dead():
                 vm.start()
-            session = vm.wait_for_serial_login(username=username,
-                                               password=password)
+            session = vm.wait_for_login(serial=True)
 
             # check if interface is attached
             for iface in iface_list:


### PR DESCRIPTION
###  Change login method for network interface verification

1. Use wait_for_login(serial=True) method to login into the guest through ssh first and then try serial login if failed.
2. Using vm.wait_for_serial_login(username, password) as the primary method is leading to Login Timeout Issues.
3. In order to check if network iface exists, using the wait_for_login method is faster and successful. If failed, serial=True will result in fallback to serial login.

Signed-off-by: Misbah Anjum N [misanjum@linux.vnet.ibm.com](mailto:misanjum@linux.vnet.ibm.com)