### PR TITLE
viommu: Fixup incorrect disk xml issues

### DIFF
--- a/libvirt/tests/cfg/sriov/vIOMMU/iommu_device_settings.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/iommu_device_settings.cfg
@@ -46,7 +46,8 @@
         - scsi_controller:
             test_devices = ["scsi"]
             controller_dicts = [{'type': 'scsi', 'model': 'virtio-scsi','driver': {'iommu': 'on'}}]
-            disk_dict = {'target': {'dev': 'sda', 'bus': 'scsi'}}
+            disk_driver = {'name': 'qemu', 'type': 'qcow2'}
+            disk_dict = {'target': {'dev': 'sda', 'bus': 'scsi'}, 'driver': ${disk_driver}}
             cleanup_ifaces = no
         - pcie_to_pci_bridge_controller:
             test_devices = ["Eth", "block"]

--- a/libvirt/tests/src/sriov/vIOMMU/iommu_device_settings.py
+++ b/libvirt/tests/src/sriov/vIOMMU/iommu_device_settings.py
@@ -35,8 +35,11 @@ def run(test, params, env):
 
         for dev in ["disk", "video"]:
             dev_dict = eval(params.get('%s_dict' % dev, '{}'))
-            if dev == "disk":
+            if dev == "disk" and dev_dict:
                 dev_dict = test_obj.update_disk_addr(dev_dict)
+                if dev_dict["target"].get("bus") != "virtio":
+                    libvirt_vmxml.modify_vm_device(
+                            vm_xml.VMXML.new_from_dumpxml(vm.name), dev, {'driver': None})
 
             libvirt_vmxml.modify_vm_device(
                 vm_xml.VMXML.new_from_dumpxml(vm.name), dev, dev_dict)

--- a/provider/viommu/viommu_base.py
+++ b/provider/viommu/viommu_base.py
@@ -59,16 +59,16 @@ class VIOMMUTest(object):
         :return: The updated iface_dict
         """
         mac_addr = utils_net.generate_mac_address_simple()
-        iface_dict = eval(self.params.get('iface_dict', '{}'))
+        iface_dict = eval(self.params.get("iface_dict", "{}"))
         self.test.log.debug("iface_dict2: %s.", iface_dict)
 
         if self.controller_dicts and iface_dict:
-            iface_bus = "%0#4x" % int(self.controller_dicts[-1].get('index'))
-            iface_attrs = {'bus': iface_bus}
+            iface_bus = "%0#4x" % int(self.controller_dicts[-1].get("index"))
+            iface_attrs = {"bus": iface_bus}
             if isinstance(self.dev_slot, int):
                 self.dev_slot += 1
-                iface_attrs.update({'slot': self.dev_slot})
-            iface_dict.update({"address": {'attrs': iface_attrs}})
+                iface_attrs.update({"slot": self.dev_slot})
+            iface_dict.update({"address": {"attrs": iface_attrs}})
         self.test.log.debug("iface_dict: %s.", iface_dict)
         return iface_dict
 
@@ -85,25 +85,25 @@ class VIOMMUTest(object):
             pre_controller = contr_dict.get("pre_controller")
             if pre_controller:
                 pre_contrs = list(
-                    filter(None, [c.get('index') for c in self.controller_dicts
-                                  if c['type'] == contr_dict['type'] and
-                                  c['model'] == pre_controller]))
+                    filter(None, [c.get("index") for c in self.controller_dicts
+                                  if c["type"] == contr_dict["type"] and
+                                  c["model"] == pre_controller]))
                 if pre_contrs:
                     pre_idx = pre_contrs[0]
                 else:
                     pre_idx = libvirt_pcicontr.get_max_contr_indexes(
                         vm_xml.VMXML.new_from_dumpxml(self.vm.name),
-                        contr_dict['type'], pre_controller)
+                        contr_dict["type"], pre_controller)
                 if not pre_idx:
                     self.test.error(
                         f"Unable to get index of {pre_controller} controller!")
                 contr_dict.pop("pre_controller")
             libvirt_vmxml.modify_vm_device(
-                vm_xml.VMXML.new_from_dumpxml(self.vm.name), 'controller',
+                vm_xml.VMXML.new_from_dumpxml(self.vm.name), "controller",
                 contr_dict, 100)
-            contr_dict['index'] = libvirt_pcicontr.get_max_contr_indexes(
+            contr_dict["index"] = libvirt_pcicontr.get_max_contr_indexes(
                 vm_xml.VMXML.new_from_dumpxml(self.vm.name),
-                contr_dict['type'], contr_dict['model'])[-1]
+                contr_dict["type"], contr_dict["model"])[-1]
         return self.controller_dicts
 
     def update_disk_addr(self, disk_dict):
@@ -114,19 +114,20 @@ class VIOMMUTest(object):
         :return: The updated disk attrs
         """
         if self.controller_dicts:
-            dev_bus = self.controller_dicts[-1].get('index')
-            dev_attrs = {'bus': dev_bus}
-            if disk_dict['target']['bus'] != "scsi":
-                dev_attrs.update({'type': self.controller_dicts[-1].get('type')})
-                if self.controller_dicts[-1].get('model') == 'pcie-to-pci-bridge':
+            dev_bus = self.controller_dicts[-1].get("index")
+            dev_attrs = {"bus": "0"}
+            if disk_dict["target"]["bus"] != "scsi":
+                dev_attrs = {"bus": dev_bus}
+                dev_attrs.update({"type": self.controller_dicts[-1].get("type")})
+                if self.controller_dicts[-1].get("model") == "pcie-to-pci-bridge":
                     self.dev_slot = 1
-                    dev_attrs.update({'slot': self.dev_slot})
+                    dev_attrs.update({"slot": self.dev_slot})
 
-            disk_dict.update({"address": {'attrs': dev_attrs}})
-            if disk_dict['target']['bus'] == "scsi":
-                disk_dict['address']['attrs'].update({'type': 'drive'})
+            disk_dict.update({"address": {"attrs": dev_attrs}})
+            if disk_dict["target"]["bus"] == "scsi":
+                disk_dict["address"]["attrs"].update({"type": "drive", "controller": dev_bus})
 
-            if self.controller_dicts[-1]['model'] == 'pcie-root-port':
+            if self.controller_dicts[-1]["model"] == "pcie-root-port":
                 self.controller_dicts.pop()
         return disk_dict
 
@@ -136,13 +137,13 @@ class VIOMMUTest(object):
 
         :param dargs: Other test keywords
         """
-        iommu_dict = dargs.get('iommu_dict', {})
+        iommu_dict = dargs.get("iommu_dict", {})
         dev_type = dargs.get("dev_type", "interface")
         cleanup_ifaces = "yes" == dargs.get("cleanup_ifaces", "yes")
 
         if cleanup_ifaces:
-            libvirt_vmxml.remove_vm_devices_by_type(self.vm, 'interface')
-            libvirt_vmxml.remove_vm_devices_by_type(self.vm, 'hostdev')
+            libvirt_vmxml.remove_vm_devices_by_type(self.vm, "interface")
+            libvirt_vmxml.remove_vm_devices_by_type(self.vm, "hostdev")
         if iommu_dict:
             self.test.log.info("TEST_SETUP: Add iommu device.")
             libvirt_virtio.add_iommu_dev(self.vm, iommu_dict)


### PR DESCRIPTION
The disk and scsi controller may enable iommu by default, so update to use the proper disk and controller settings.

Depends on:
- https://github.com/avocado-framework/avocado-vt/pull/3999
**Test results:** The failed case is caused by a known issue.
```
 (1/7) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.virtio_muti_devices.vhost_on.virtio: PASS (78.88 s)
 (2/7) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.virtio_muti_devices.vhost_on.smmuv3: PASS (81.11 s)
 (3/7) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.virtio_muti_devices.vhost_off.virtio: PASS (80.84 s)
 (4/7) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.virtio_muti_devices.vhost_off.smmuv3: PASS (80.47 s)
 (5/7) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.hostdev_iface.virtio: PASS (86.11 s)
 (6/7) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.scsi_controller.virtio: PASS (81.51 s)
 (7/7) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.scsi_controller.smmuv3: PASS (80.42 s)
 (01/12) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.virtio_muti_devices.vhost_on.virtio: PASS (73.07 s)
 (02/12) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.virtio_muti_devices.vhost_on.smmuv3: PASS (44.81 s)
 (03/12) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.virtio_muti_devices.vhost_off.virtio: PASS (44.29 s)
 (04/12) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.virtio_muti_devices.vhost_off.smmuv3: PASS (44.73 s)
 (05/12) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.hostdev_iface.virtio: PASS (58.90 s)
 (06/12) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.scsi_controller.virtio: PASS (43.68 s)
 (07/12) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.scsi_controller.smmuv3: PASS (51.34 s)
 (08/12) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_to_pci_bridge_controller.virtio_non_transitional.virtio: PASS (45.05 s)
 (09/12) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_to_pci_bridge_controller.virtio_non_transitional.smmuv3: ERROR: Login timeout expired    (output: 'exceeded 360 s timeout') (385.64 s)
 (10/12) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_to_pci_bridge_controller.hostdev_iface.virtio: PASS (60.61 s)
 (11/12) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_root_port_from_expander_bus.virtio: PASS (77.67 s)
 (12/12) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_root_port_from_expander_bus.smmuv3: PASS (56.51 s)
RESULTS    : PASS 11 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2024-09-19T06.03-ea671be/results.html
JOB TIME   : 987.20 s

```