### PR TITLE
case update: blockcopy dest xml for block disk with iscsi preparation

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockcopy/blockcopy_with_different_dest_xml.cfg
+++ b/libvirt/tests/cfg/backingchain/blockcopy/blockcopy_with_different_dest_xml.cfg
@@ -20,6 +20,7 @@
         - block_disk:
             dest_disk_type = "block"
             dest_disk_dict = {"type_name":"${dest_disk_type}", "target":{"dev": "${target_disk}", "bus": "virtio"}, "driver": {"name": "qemu", "type":"raw"}}
+            simulated_iscsi = "modprobe scsi_debug dev_size_mb=800"
         - rbd_with_auth_disk:
             dest_disk_type = "rbd_with_auth"
             mon_host = "EXAMPLE_MON_HOST"


### PR DESCRIPTION
    xxxx-294410:Do blockcopy with different dest XML
Signed-off-by: nanli <nanli@redhat.com>

```
 avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 backingchain.blockcopy.dest_xml.block_disk.finish_reuse_external --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.dest_xml.block_disk.finish_reuse_external: PASS (60.01 s)

```
Others related
```
avocado run --vt-type libvirt --test-runner=runner --vt-machine-type q35 guest_os_booting.boot_order.hotplug backingchain.blockcopy.zero_length_disk snapshot_revert.xml_updated virtual_disks.discard_no_unref
 (01/19) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.hotplug.disk_device: PASS (24.58 s)
 (02/19) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.hotplug.usb_device: PASS (30.72 s)
 (03/19) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.hotplug.filesystem_device: PASS (31.42 s)
 (04/19) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.zero_length_disk.with_transient_job: PASS (9.19 s)
 (05/19) type_specific.io-github-autotest-libvirt.snapshot_revert.xml_updated.hotplug_disk: PASS (55.68 s)
 (06/19) type_specific.io-github-autotest-libvirt.snapshot_revert.xml_updated.hotplug_vcpus: PASS (58.03 s)
 (07/19) type_specific.io-github-autotest-libvirt.snapshot_revert.xml_updated.blkiotune: PASS (55.12 s)
 (08/19) type_specific.io-github-autotest-libvirt.virtual_disks.discard_no_unref.start_vm.enable.with_discard_unmap.file_disk: PASS (37.75 s)
 (09/19) type_specific.io-github-autotest-libvirt.virtual_disks.discard_no_unref.start_vm.enable.with_discard_unmap.block_disk: PASS (47.20 s)
 (10/19) type_specific.io-github-autotest-libvirt.virtual_disks.discard_no_unref.start_vm.enable.with_discard_ignore.file_disk: PASS (34.97 s)
 (11/19) type_specific.io-github-autotest-libvirt.virtual_disks.discard_no_unref.start_vm.enable.with_discard_ignore.block_disk: PASS (47.02 s)
 (12/19) type_specific.io-github-autotest-libvirt.virtual_disks.discard_no_unref.start_vm.disable.with_discard_unmap.file_disk: PASS (34.85 s)
 (13/19) type_specific.io-github-autotest-libvirt.virtual_disks.discard_no_unref.start_vm.disable.with_discard_unmap.block_disk: PASS (46.89 s)
 (14/19) type_specific.io-github-autotest-libvirt.virtual_disks.discard_no_unref.start_vm.disable.with_discard_ignore.file_disk: PASS (34.50 s)
 (15/19) type_specific.io-github-autotest-libvirt.virtual_disks.discard_no_unref.start_vm.disable.with_discard_ignore.block_disk: PASS (46.88 s)
 (16/19) type_specific.io-github-autotest-libvirt.virtual_disks.discard_no_unref.hotplug_disk.enable.with_discard_unmap.file_disk: PASS (35.87 s)
 (17/19) type_specific.io-github-autotest-libvirt.virtual_disks.discard_no_unref.define_invalid.raw_format.enable.with_discard_unmap.file_disk: PASS (5.91 s)
 (18/19) type_specific.io-github-autotest-libvirt.virtual_disks.discard_no_unref.define_invalid.readonly_mode.enable.with_discard_unmap.file_disk: PASS (5.82 s)
 (19/19) type_specific.io-github-autotest-libvirt.virtual_disks.discard_no_unref.update_negative.enable.with_discard_unmap.file_disk: PASS (32.63 s)

```