### PR TITLE
libvirt-mem: Update testcases for ppc64le arch

### DIFF
--- a/libvirt/tests/cfg/libvirt_mem.cfg
+++ b/libvirt/tests/cfg/libvirt_mem.cfg
@@ -132,7 +132,7 @@
                             memory_addr = "{'type':'dimm','slot':'0','base':'0x100000000'}"
                             node_mask = 0
                 - without_numa_save_restore:
-                    no x86_64,aarch64
+                    no x86_64,aarch64,ppc64le
                     max_mem_rt = 20971520
                     numa_cells = ""
                     tg_node = ""
@@ -180,7 +180,7 @@
                             page_size = 4
                             page_unit = "KiB"
                         - without_numa:
-                            only x86_64,aarch64
+                            only x86_64,aarch64,ppc64le
                             define_error = "yes"
                             max_mem_rt = 20971520
                             numa_cells = ""


### PR DESCRIPTION
### libvirt-mem: Update testcases for ppc64le arch

1. On ppc64le arch, xml does not support numa with memory device same as x86_64 or aarch64. Hence, removing the testcase for ppc64le
2. Similarly, negative test scenario is added for checking the same on ppc64le

Signed-off-by: Misbah Anjum N [misanjum@linux.vnet.ibm.com](mailto:misanjum@linux.vnet.ibm.com)