### PR TITLE
libvirt-mem: Enable check for test_qemu_cmd

### DIFF
--- a/libvirt/tests/src/libvirt_mem.py
+++ b/libvirt/tests/src/libvirt_mem.py
@@ -515,7 +515,8 @@ def run(test, params, env):
         elif discard:
             vm.start()
             session = vm.wait_for_login()
-            check_qemu_cmd(max_mem_rt, tg_size)
+            if test_qemu_cmd:
+                check_qemu_cmd(max_mem_rt, tg_size)
         dev_xml = None
 
         # To attach the memory device.
@@ -605,7 +606,8 @@ def run(test, params, env):
 
         if mem_align:
             dom_mem = check_mem_align()
-            check_qemu_cmd(dom_mem['maxMemory'], dom_mem['attached_mem'])
+            if test_qemu_cmd:
+                check_qemu_cmd(dom_mem['maxMemory'], dom_mem['attached_mem'])
             if hot_plug and params['delta'] != dom_mem['attached_mem']:
                 test.fail('Memory after attach not equal to original mem + attached mem')
 


### PR DESCRIPTION
### libvirt-mem: Enable check for test_qemu_cmd

The following testcases are failing because because of the check for test_qemu_cmd is not added in the script
1. type_specific.io-github-autotest-libvirt.libvirt_mem. positive_test.align_256m.cold_plug:
FAIL: Qemu command check fail. (205.37 s)
2. type_specific.io-github-autotest-libvirt.libvirt_mem. positive_test.align_256m.hot_plug:
FAIL: Qemu command check fail. (209.51 s)

In the libvirt_mem.cfg, the following parameter is set to no - "test_qemu_cmd = no"
Hence, the check must be added in all places

Signed-off-by: Misbah Anjum N [misanjum@linux.vnet.ibm.com](mailto:misanjum@linux.vnet.ibm.com)