### PR TITLE
tpm_device.py: clean audit before vm start

### DIFF
--- a/libvirt/tests/cfg/virtual_device/tpm_device.cfg
+++ b/libvirt/tests/cfg/virtual_device/tpm_device.cfg
@@ -141,7 +141,7 @@
                     swtpm_path = '/usr/bin/swtpm'
                     variants:
                         - start_vm:
-                            audit_cmd = ausearch -ts recent -m VIRT_RESOURCE| grep 'tpm-external'
+                            audit_cmd = "cat /var/log/audit/audit.log| grep 'tpm-external'"
                             ausearch_check = 'reason=start.*device="/var/tmp/guest-swtpm.sock".*res=success'
                         - suspend_resume:
                             vm_operate = 'resume'


### PR DESCRIPTION
    Cleaning audit logs should be before vm start, and need clean all
    audit.log*(.1, .2, etc) files. Also move it later to wait more time.
    And replace ausearch cmd since it can not capture well sometimes,
    audit.log can reflect actual info instead.