### PR TITLE
Change memory size according to case update

### DIFF
--- a/libvirt/tests/cfg/memory/memory_backing/lifecycle_for_hugepage.cfg
+++ b/libvirt/tests/cfg/memory/memory_backing/lifecycle_for_hugepage.cfg
@@ -1,17 +1,20 @@
 - memory.backing.lifecycle:
     type = lifecycle_for_hugepage
     start_vm = no
-    total_hugepage_mem = 2097152
-    vm_nr_hugepages = 1024
+    total_hugepage_mem = 8388608
+    vm_nr_hugepages = 4096
     mount_size = "1048576"
-    current_mem = 2097152
-    mem_value = 2097152
+    current_mem = 8388608
+    mem_value = 8388608
     mem_unit = "KiB"
     current_mem_unit = "KiB"
-    target_hugepages = 2
+    target_hugepages = 8
     set_pagesize ="1048576"
-    set_pagenum = "2"
+    set_pagenum = "8"
     s390-virtio:
+        total_hugepage_mem = 2097152
+        current_mem = 2097152
+        mem_value = 2097152
         set_pagesize = "1024"
         mount_size = "1024"
         set_pagenum = "2048"
@@ -53,7 +56,7 @@
                     page_size = "2"
                     page_unit = "M"
                     set_pagesize ="2048"
-                    set_pagenum = "1024"
+                    set_pagenum = "4096"
                     mount_size = ${set_pagesize}
                     memory_backing_dict = "'mb': {'hugepages': {'pages': [{'unit': '${page_unit}', 'size': '${page_size}'}]}}"
                     vm_attrs = {${memory_backing_dict}, 'memory_unit':'${mem_unit}','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}'}
@@ -77,7 +80,7 @@
                     page_size = "64"
                     page_unit = "KiB"
                     set_pagesize ="64"
-                    set_pagenum = "32768"
+                    set_pagenum = "131072"
                     mount_size = ${set_pagesize}
                     memory_backing_dict = "'mb': {'hugepages': {'pages': [{'unit': '${page_unit}', 'size': '${page_size}'}]}}"
                     vm_attrs = {${memory_backing_dict}, 'memory_unit':'${mem_unit}','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}'}
@@ -88,7 +91,7 @@
                     page_size = "32"
                     page_unit = "M"
                     set_pagesize ="32768"
-                    set_pagenum = "64"
+                    set_pagenum = "256"
                     mount_size = ${set_pagesize}
                     memory_backing_dict = "'mb': {'hugepages': {'pages': [{'unit': '${page_unit}', 'size': '${page_size}'}]}}"
                     vm_attrs = {${memory_backing_dict}, 'memory_unit':'${mem_unit}','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}'}
@@ -101,8 +104,9 @@
                     vm_attrs = {${memory_backing_dict}, 'memory_unit':'${mem_unit}','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}'}
                     define_error = "hugepage size can't be zero"
                 - scarce_mem:
-                    current_mem = 3145728
-                    mem_value = 3145728
+                    current_mem = 9437184
+                    mem_value = 9437184
                     memory_backing_dict = "'mb': {'hugepages': {}}"
                     vm_attrs = {${memory_backing_dict}, 'memory_unit':'${mem_unit}','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}'}
                     start_error = "unable to map backing store for guest RAM: Cannot allocate memory"
+


### PR DESCRIPTION
test results for other archs:
x86
(1/5) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.default_page_size: PASS (116.40 s)
 (2/5) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.default_hugepage_size: PASS (109.78 s)
 (3/5) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.1G: PASS (114.96 s)
 (4/5) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.0: PASS (24.76 s)
 (5/5) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.scarce_mem: PASS (38.21 s)
 
 
 
 aarch 64 4k:
  (1/9) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.default_page_size: PASS (103.16 s)
 (2/9) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.default_hugepage_size: PASS (96.01 s)
 (3/9) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.1G: PASS (107.18 s)
 (4/9) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.2M: CANCEL: 2M is the default huge page size and tested in another test scenario (9.33 s)
 (5/9) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.16G: SKIP: The hugepage size '16777216' is not supported on current arch (support: [2048, 32768, 64, 1048576])
 (6/9) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.64K: PASS (99.05 s)
 (7/9) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.32M: PASS (104.32 s)
 (8/9) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.0: PASS (18.69 s)
 (9/9) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.scarce_mem: PASS (20.26 s)
 
64k:
  (1/9) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.default_page_size: PASS (89.62 s)
 (2/9) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.default_hugepage_size: PASS (97.46 s)
 (3/9) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.1G: SKIP: The hugepage size '1048576' is not supported on current arch (support: [16777216, 2048, 524288])
 (4/9) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.2M: PASS (88.72 s)
 (5/9) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.16G: PASS (118.23 s)
 (6/9) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.64K: SKIP: The hugepage size '64' is not supported on current arch (support: [16777216, 2048, 524288])
 (7/9) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.32M: SKIP: The hugepage size '32768' is not supported on current arch (support: [16777216, 2048, 524288])
 (8/9) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.0: PASS (16.52 s)
 (9/9) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.scarce_mem: PASS (18.69 s)
 
 
 s390:
  (1/3) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.1M: PASS (43.80 s)
 (2/3) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.0: PASS (5.56 s)
 (3/3) type_specific.io-github-autotest-libvirt.memory.backing.lifecycle.memory_hugepage.scarce_mem: PASS (6.36 s)