### PR TITLE
svirt/selinux/per_device: return if expected error is found

### DIFF
--- a/libvirt/tests/src/svirt/selinux/selinux_seclabel_per_device.py
+++ b/libvirt/tests/src/svirt/selinux/selinux_seclabel_per_device.py
@@ -88,6 +88,8 @@ def run(test, params, env):
             except xcepts.LibvirtXMLError as details:
                 if not status_error:
                     test.fail(details)
+                else:
+                    return
             test.log.debug("VM XML: %s.", VMXML.new_from_inactive_dumpxml(vm_name))
             if not ('res' in locals() and res.exit_status != 0):
                 res = virsh.start(vm.name)


### PR DESCRIPTION
`status_error` expected to be `yes` on invalid configuration, that is, either during xml setup

a) through `vmxml.sync` which undefines and tries to define the VM, or b) through attach through `virsh.attach_device`.

Both will raise LibvirtXMLError on failure. So, if as expected this error is raised for coldplug, we can stop the test execution by returning and considering the test PASS.