### PR TITLE
Resolve test issue with aarch64 and 4k default hp size

### DIFF
--- a/libvirt/tests/cfg/svirt/umask_value/svirt_umask_files_accessed_by_qemu.cfg
+++ b/libvirt/tests/cfg/svirt/umask_value/svirt_umask_files_accessed_by_qemu.cfg
@@ -3,8 +3,10 @@
     start_vm = "no"
     umask_value = '027'
     mem_backing_attrs = {'hugepages': {}}
+    default_hp_size = 2048
     target_hugepages = 1024
     aarch64:
+        default_hp_size = 524288
         target_hugepages = 4
     s390-virtio:
         kvm_module_parameters = "hpage=1"

--- a/libvirt/tests/cfg/svirt/umask_value/svirt_umask_files_accessed_by_qemu.cfg
+++ b/libvirt/tests/cfg/svirt/umask_value/svirt_umask_files_accessed_by_qemu.cfg
@@ -3,10 +3,5 @@
     start_vm = "no"
     umask_value = '027'
     mem_backing_attrs = {'hugepages': {}}
-    default_hp_size = 2048
-    target_hugepages = 1024
-    aarch64:
-        default_hp_size = 524288
-        target_hugepages = 4
     s390-virtio:
         kvm_module_parameters = "hpage=1"

--- a/libvirt/tests/src/svirt/umask_value/svirt_umask_files_accessed_by_qemu.py
+++ b/libvirt/tests/src/svirt/umask_value/svirt_umask_files_accessed_by_qemu.py
@@ -7,6 +7,7 @@ from virttest import test_setup
 from virttest import utils_libvirtd
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.vm_xml import VMXML
+from avocado.utils import memory as avocado_mem
 
 
 def run(test, params, env):
@@ -30,6 +31,19 @@ def run(test, params, env):
         if os.path.exists(hp_path):
             shutil.rmtree(hp_path)
             utils_libvirtd.Libvirtd().restart()
+
+        # verify test runs on machine with expected hugepagesize
+        # and recalculate the target_hugepage if necessary
+        default_hp_size = int(params.get("default_hp_size", 2048))
+        target_hugepages = int(params.get("target_hugepages", 1024))
+        actual_hp_size = avocado_mem.get_huge_page_size()
+        if actual_hp_size != default_hp_size:
+            # actual hp size is different that is expected for defined number of hupages
+            # as the size is not the main focus of the test, we have to recalculate and replace
+            new_target_hugepages = int((default_hp_size * target_hugepages) / actual_hp_size)
+            test.log.warn(f"Default HP size is different than expected. Parameter 'target_hugepagees' was updated: {new_target_hugepages}")
+            params["target_hugepages"] = new_target_hugepages
+
         hp_cfg = test_setup.HugePageConfig(params)
         hp_cfg.set_hugepages()
 

--- a/libvirt/tests/src/svirt/umask_value/svirt_umask_files_accessed_by_qemu.py
+++ b/libvirt/tests/src/svirt/umask_value/svirt_umask_files_accessed_by_qemu.py
@@ -32,13 +32,13 @@ def run(test, params, env):
             shutil.rmtree(hp_path)
             utils_libvirtd.Libvirtd().restart()
 
-        # verify test runs on machine with expected hugepagesize
+        # verify test runs on machine with expected size of hugepages
         # and recalculate the target_hugepage if necessary
         default_hp_size = int(params.get("default_hp_size", 2048))
         target_hugepages = int(params.get("target_hugepages", 1024))
         actual_hp_size = avocado_mem.get_huge_page_size()
         if actual_hp_size != default_hp_size:
-            # actual hp size is different that is expected for defined number of hupages
+            # actual hp size is different that is expected for defined number of hugepages
             # as the size is not the main focus of the test, we have to recalculate and replace
             new_target_hugepages = int((default_hp_size * target_hugepages) / actual_hp_size)
             test.log.warn(f"Default HP size is different than expected. Parameter 'target_hugepagees' was updated: {new_target_hugepages}")


### PR DESCRIPTION
Configuration of test for aarch64 expects 64k default hp size,, therefore test is not able to start the machine for 4k. 
- added expected default_hp_size into configuration
- added check in the test that VM default_hp_size is same as expected, and update parameters otherwise.