### PR TITLE
Fail test case when huge page is not enough, and add huge page cleanup.

### DIFF
--- a/libvirt/tests/src/memory/memory_misc.py
+++ b/libvirt/tests/src/memory/memory_misc.py
@@ -266,8 +266,8 @@ def run(test, params, env):
                 test, pg_size=default_page_size, hp_size=pagesize, hp_list=[mount_pagesize])
             vm_mem_size = vmxml.memory
             hp_cfg = test_setup.HugePageConfig(params)
-            hp_cfg.set_kernel_hugepages(pagesize, vm_mem_size // pagesize)
-            hp_cfg.set_kernel_hugepages(mount_pagesize, mem_device_size // mount_pagesize)
+            hp_cfg.set_kernel_hugepages(pagesize, vm_mem_size // pagesize, False)
+            hp_cfg.set_kernel_hugepages(mount_pagesize, mem_device_size // mount_pagesize, False)
             set_vmxml(vmxml, params)
             _setup_mbxml()
             vmxml.sync()
@@ -454,6 +454,9 @@ def run(test, params, env):
             utils_disk.umount('hugetlbfs', mount_path, 'hugetlbfs')
             if os.path.exists(mount_path):
                 os.rmdir(mount_path)
+            hp_cfg = test_setup.HugePageConfig(params)
+            hp_cfg.set_kernel_hugepages(int(params.get('mount_pagesize')), 0)
+            hp_cfg.cleanup()
 
     def run_test_edit_mem(case):
         """


### PR DESCRIPTION
test result:
(1/1) type_specific.io-github-autotest-libvirt.memory_misc.memorybacking.mount_hp_running_vm.64k.524288.16777216: PASS (50.82 s)