### PR TITLE
libvirt_hooks: Fix string matching

### DIFF
--- a/libvirt/tests/src/libvirt_hooks.py
+++ b/libvirt/tests/src/libvirt_hooks.py
@@ -103,7 +103,10 @@ def run(test, params, env):
             vm.destroy()
             hook_str = hook_para + " stopped end -"
             assert check_hooks(hook_str)
-            hook_str = hook_para + " release end " + release_reason
+            if libvirt_version.version_compare(10, 5, 0):
+                hook_str = hook_para + " release end " + release_reason
+            else:
+                hook_str = hook_para + " release end -"
             assert check_hooks(hook_str)
         except AssertionError:
             utils_misc.log_last_traceback()


### PR DESCRIPTION
Before libvirt 10.5.0, hook_str is '...release end -'. After libvirt 10.5.0, hook_str is '...release end shutdown'.

Reference: https://github.com/autotest/tp-libvirt/pull/5782