### PR TITLE
boot_order: waiting for the boot.iso file to download

### DIFF
--- a/libvirt/tests/src/guest_os_booting/boot_order/boot_with_multiple_boot_order.py
+++ b/libvirt/tests/src/guest_os_booting/boot_order/boot_with_multiple_boot_order.py
@@ -4,10 +4,10 @@
 
 import os
 
-from avocado.utils import download
 from avocado.utils import process
 
 from virttest import data_dir
+from virttest import utils_misc
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_libvirt import libvirt_vmxml
 from virttest.utils_test import libvirt
@@ -18,10 +18,11 @@ from provider.guest_os_booting import guest_os_booting_base as guest_os
 file_list = []
 
 
-def prepare_device_attrs(params, vm_name, bootable_device):
+def prepare_device_attrs(test, params, vm_name, bootable_device):
     """
     Prepare the device xml based on different test matrix.
 
+    :params test: test object
     :params params: wrapped dict with all parameters
     :params vm_name: the guest name
     :params bootable_device: the bootable device
@@ -45,7 +46,8 @@ def prepare_device_attrs(params, vm_name, bootable_device):
         cmd = "dnf repolist -v enabled |awk '/Repo-baseurl.*composes.*BaseOS.*os/ {res=$NF} END{print res}'"
         repo_url = process.run(cmd, shell=True).stdout_text.strip()
         boot_img_url = os.path.join(repo_url, 'images', 'boot.iso')
-        download.get_file(boot_img_url, cdrom_path)
+        if not utils_misc.wait_for(lambda: guest_os.test_file_download(boot_img_url, cdrom_path), 60):
+            test.fail('Unable to download boot image')
     else:
         cdrom_path = os.path.join(data_dir.get_data_dir(), 'images', 'test.iso')
         libvirt.create_local_disk("file", path=cdrom_path, size="500M", disk_format="raw")
@@ -79,7 +81,7 @@ def run(test, params, env):
 
     try:
         test.log.info("TEST_SETUP: prepare a guest with necessary attributes.")
-        prepare_device_attrs(params, vm_name, bootable_device)
+        prepare_device_attrs(test, params, vm_name, bootable_device)
         test.log.info("TEST_STEP1: start the guest.")
         if not vm.is_alive():
             vm.start()

--- a/provider/guest_os_booting/guest_os_booting_base.py
+++ b/provider/guest_os_booting/guest_os_booting_base.py
@@ -2,6 +2,8 @@ import logging
 
 from avocado.core import exceptions
 from avocado.utils import distro
+from avocado.utils import download
+from avocado.utils import process
 
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
@@ -102,3 +104,14 @@ def check_vm_startup(vm, vm_name, error_msg=None):
         vm.wait_for_login().close()
         LOG.debug("Succeed to boot %s", vm_name)
     return vmxml
+
+
+def test_file_download(url, path):
+    """
+    Returns true if the file could be successfully downloaded
+
+    :param url: source URL
+    :param path: destination path
+    """
+    download.get_file(url, path)
+    return process.run('ls -d ' + path, ignore_status="yes").exit_status == 0


### PR DESCRIPTION
**Issue:**
VMStartError: VM 'avocado-vt-vm1' failed to start: error: Failed to start domain 'avocado-vt-vm1'error: Cannot access storage file '/var/lib/avocado/data/avocado-vt/images/boot.iso': No such file or directory(exit status: 1)&#10;

**_More specifically:_**
```
L0087 INFO | Fetching http://download.eng.pek2.redhat.com/rhel-9/composes/RHEL-9/RHEL-9.5.0-20240924.2/compose/BaseOS/x86_64/os/images/boot.iso -> /var/lib/avocado/data/avocado-vt/images/boot.iso
L0059 DEBUG| Updated HWADDR (34:48:ed:f9:e2:20)<->(10.73.178.185) IP pair into address cache
L0050 ERROR| Timeout was reached: timed out
L0702 DEBUG| [stderr] Failed to get file. Probably timeout was reached when connecting to the server.
```

**Fix:** 

This issue is likely due to the download.get_file() failing to get the boot.iso file because of some connection issue. The fix waits 60 seconds for the download to succeed. If it does not succeed within that time limit, a test failure is raised.

**Tests passing:**
```
[root@beaver-6 /]# /usr/local/bin/avocado run --vt-type libvirt --vt-machine-type q35 guest_os_booting.boot_order.boot_with_multiple_boot_order guest_os_booting.boot_order.boot_with_multiple_boot_dev guest_os_booting.boot_order.cdrom_device --vt-connect-uri qemu:///system
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : cac2b54fa3278080183433a319403bef59484b04
JOB LOG    : /var/log/avocado/job-results/job-2024-10-02T10.51-cac2b54/job.log
 (01/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.hd.cdrom.hd_bootable: STARTED
 (01/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.hd.cdrom.hd_bootable: PASS (69.38 s)
 (02/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.hd.cdrom.cdrom_bootable: STARTED
 (02/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.hd.cdrom.cdrom_bootable: PASS (35.58 s)
 (03/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.hd.network.hd_bootable: STARTED
 (03/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.hd.network.hd_bootable: PASS (57.77 s)
 (04/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.hd.network.network_bootable: STARTED
 (04/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.hd.network.network_bootable: PASS (20.86 s)
 (05/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.cdrom.hd.hd_bootable: STARTED
 (05/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.cdrom.hd.hd_bootable: PASS (58.69 s)
 (06/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.cdrom.hd.cdrom_bootable: STARTED
 (06/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.cdrom.hd.cdrom_bootable: PASS (64.04 s)
 (07/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.cdrom.network.cdrom_bootable: STARTED
 (07/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.cdrom.network.cdrom_bootable: PASS (32.45 s)
 (08/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.cdrom.network.network_bootable: STARTED
 (08/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.cdrom.network.network_bootable: PASS (19.58 s)
 (09/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.network.hd.hd_bootable: STARTED
 (09/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.network.hd.hd_bootable: PASS (567.03 s)
 (10/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.network.hd.network_bootable: STARTED
 (10/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.network.hd.network_bootable: PASS (22.78 s)
 (11/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.network.cdrom.cdrom_bootable: STARTED
 (11/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.network.cdrom.cdrom_bootable: PASS (284.58 s)
 (12/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.network.cdrom.network_bootable: STARTED
 (12/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.network.cdrom.network_bootable: PASS (19.90 s)
 (13/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.hd.cdrom.hd_bootable: STARTED
 (13/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.hd.cdrom.hd_bootable: PASS (146.68 s)
 (14/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.hd.cdrom.cdrom_bootable: STARTED
 (14/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.hd.cdrom.cdrom_bootable: PASS (32.78 s)
 (15/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.hd.network.hd_bootable: STARTED
 (15/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.hd.network.hd_bootable: PASS (57.92 s)
 (16/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.hd.network.network_bootable: STARTED
 (16/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.hd.network.network_bootable: PASS (20.35 s)
 (17/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.cdrom.hd.hd_bootable: STARTED
 (17/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.cdrom.hd.hd_bootable: PASS (58.47 s)
 (18/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.cdrom.hd.cdrom_bootable: STARTED
 (18/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.cdrom.hd.cdrom_bootable: PASS (33.15 s)
 (19/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.cdrom.network.cdrom_bootable: STARTED
 (19/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.cdrom.network.cdrom_bootable: PASS (32.12 s)
 (20/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.cdrom.network.network_bootable: STARTED
 (20/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.cdrom.network.network_bootable: PASS (19.53 s)
 (21/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.network.hd.hd_bootable: STARTED
 (21/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.network.hd.hd_bootable: PASS (565.79 s)
 (22/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.network.hd.network_bootable: STARTED
 (22/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.network.hd.network_bootable: PASS (20.54 s)
 (23/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.network.cdrom.cdrom_bootable: STARTED
 (23/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.network.cdrom.cdrom_bootable: PASS (282.52 s)
 (24/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.network.cdrom.network_bootable: STARTED
 (24/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.network.cdrom.network_bootable: PASS (19.90 s)
 (25/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.seabios.os_dev.without_cdrom: STARTED
 (25/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.seabios.os_dev.without_cdrom: PASS (50.74 s)
 (26/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.seabios.os_dev.with_cdrom_with_no_src: STARTED
 (26/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.seabios.os_dev.with_cdrom_with_no_src: PASS (258.89 s)
 (27/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.seabios.os_dev.with_cdrom: STARTED
 (27/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.seabios.os_dev.with_cdrom: PASS (24.37 s)
 (28/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.seabios.os_dev.multi_cdroms: STARTED
 (28/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.seabios.os_dev.multi_cdroms: PASS (300.23 s)
 (29/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.seabios.cdrom_boot_order.with_cdrom_with_no_src: STARTED
 (29/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.seabios.cdrom_boot_order.with_cdrom_with_no_src: PASS (288.83 s)
 (30/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.seabios.cdrom_boot_order.with_cdrom: STARTED
 (30/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.seabios.cdrom_boot_order.with_cdrom: PASS (24.45 s)
 (31/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.seabios.cdrom_boot_order.multi_cdroms: STARTED
 (31/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.seabios.cdrom_boot_order.multi_cdroms: PASS (54.82 s)
 (32/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.ovmf.os_dev.without_cdrom: STARTED
 (32/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.ovmf.os_dev.without_cdrom: FAIL: Login timeout expired    (output: 'exceeded 240 s timeout') (269.16 s)
 (33/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.ovmf.os_dev.with_cdrom_with_no_src: STARTED
 (33/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.ovmf.os_dev.with_cdrom_with_no_src: PASS (45.19 s)
 (34/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.ovmf.os_dev.with_cdrom: STARTED
 (34/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.ovmf.os_dev.with_cdrom: PASS (30.53 s)
 (35/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.ovmf.os_dev.multi_cdroms: STARTED
 (35/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.ovmf.os_dev.multi_cdroms: PASS (262.32 s)
 (36/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.ovmf.cdrom_boot_order.with_cdrom_with_no_src: STARTED
 (36/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.ovmf.cdrom_boot_order.with_cdrom_with_no_src: PASS (52.45 s)
 (37/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.ovmf.cdrom_boot_order.with_cdrom: STARTED
 (37/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.ovmf.cdrom_boot_order.with_cdrom: PASS (30.55 s)
 (38/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.ovmf.cdrom_boot_order.multi_cdroms: STARTED
 (38/38) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.ovmf.cdrom_boot_order.multi_cdroms: PASS (31.15 s)
RESULTS    : PASS 37 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2024-10-02T10.51-cac2b54/results.html
JOB TIME   : 4299.39 s
```
Note: the failing test case is not related to the issue being addressed in this PR. All relevant test cases pass.

