### PR TITLE
Ignore the numa node without cpu

### DIFF
--- a/libvirt/tests/src/numa/guest_numa_node_tuning/auto_memory_nodeset_placement.py
+++ b/libvirt/tests/src/numa/guest_numa_node_tuning/auto_memory_nodeset_placement.py
@@ -391,8 +391,6 @@ def get_cpus_by_numad_advisory(test_obj):
         if cpus_from_numactl:
             cpus_from_numactl = cpus_from_numactl[0].strip().split(' ')
             cpus_from_numactl = [int(item) for item in cpus_from_numactl]
-        else:
-            test_obj.test.error("Can not find node %s's cpus" % nodeset_numad)
         cpus += cpus_from_numactl
     test_obj.test.log.debug("The cpus on the node advised by numad: %s", cpus)
     return sorted(cpus)


### PR DESCRIPTION
test result:

1. all numa node have cpu:
 (01/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_defined.mem_mode_strict.vcpu_auto: PASS (33.24 s)
 (02/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_defined.mem_mode_strict.vcpu_static: PASS (32.48 s)
 (03/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_defined.mem_mode_interleave.vcpu_auto: PASS (42.53 s)
 (04/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_defined.mem_mode_interleave.vcpu_static: PASS (36.52 s)
 (05/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_defined.mem_mode_preferred.vcpu_auto: PASS (41.15 s)
 (06/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_defined.mem_mode_preferred.vcpu_static: PASS (36.88 s)
......

3. some numa nodes have no cpu:
 (01/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_defined.mem_mode_strict.vcpu_auto: PASS (34.91 s)
 (02/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_defined.mem_mode_strict.vcpu_static: PASS (32.47 s)
 (03/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_defined.mem_mode_interleave.vcpu_auto: PASS (33.57 s)
 (04/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_defined.mem_mode_interleave.vcpu_static: PASS (30.67 s)
 (05/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_defined.mem_mode_preferred.vcpu_auto: PASS (41.21 s)
 (06/36) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.auto_memory_nodeset_placement.without_iothread.nodeset_defined.mem_mode_preferred.vcpu_static: PASS (31.96 s)
...