### PR TITLE
Automate Check the disk-change events for cdrom and disk when

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_cdrom_device.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_cdrom_device.cfg
@@ -129,6 +129,29 @@
             target_dev = "sdd"
             backend_device = "empty_source_cdrom_backend"
             only hotplug..positive_test
+        - dropped_changed_events_startuppolicy:
+            type_name = "file"
+            target_format = "raw"
+            virt_disk_device_source_second = "/var/lib/libvirt/images/none.qcow2"
+            virt_disk_device_source = "/var/lib/libvirt/images/none"
+            target_dev = "sdc"
+            startupPolicy="optional"
+            backend_device = "dropped_changed_events_startuppolicy"
+            only coldplug..positive_test
+        - block_cdrom_tainted:
+            only coldplug..positive_test
+            target_format = "raw"
+            type_name = "block"
+            target_dev = "sdb"
+            virt_disk_device_source = "/dev/sdb"
+            backend_device = "block_cdrom_tainted"
+        - disconnect_audit_cdrom_backend:
+            type_name = "file"
+            target_format = "raw"
+            virt_disk_device_source = "/var/lib/libvirt/images/disconnect.iso"
+            target_dev = "sdb"
+            backend_device = "disconnect_audit_cdrom_backend"
+            only coldplug..positive_test
     variants:
         - hotplug:
             virt_device_hotplug = "yes"


### PR DESCRIPTION
startuppolicy is set to optional

xx-38693 - [disk-change]Check the disk-change events when startuppolicy is optional
xx-112414 - start a guest with block type cdrom --bz1471225
xx-32763 - [audit log] Audit log related to guest CDROM
