### PR TITLE
 Multi_vms_with_stress: add a test about starting VMs with stress workload on host

### DIFF
--- a/libvirt/tests/cfg/cpu/multi_vms_with_stress.cfg
+++ b/libvirt/tests/cfg/cpu/multi_vms_with_stress.cfg
@@ -1,0 +1,5 @@
+- multi_vms_with_stress:
+    type = multi_vms_with_stress
+    memory = 4194304
+    vm_names = vm2 vm3
+    stress_args = '--cpu 4 --io 4 --vm 2 --vm-bytes 128M &'

--- a/libvirt/tests/src/cpu/multi_vms_with_stress.py
+++ b/libvirt/tests/src/cpu/multi_vms_with_stress.py
@@ -1,0 +1,82 @@
+import logging as log
+
+from avocado.utils import cpu
+
+from virttest import utils_test
+from virttest.libvirt_xml import vm_xml
+
+LOG = log.getLogger('avocado.' + __name__)
+
+
+def run(test, params, env):
+    """
+    Test that multiple vms can start when stress workload is running on the host.
+
+    Steps:
+    1. Prepare 3 vms that each have even vcpu number around 2/3 of # host_online_cpu
+    2. Start stress workload on the host
+    3. Start all vms and verify vms could be logged in normally
+    4. Verify all vms could be gracefully shutdown successfully
+    """
+    memory = params.get("memory", "4194304")
+    main_vm_name = params.get("main_vm")
+    main_vm = env.get_vm(main_vm_name)
+    vm_names = params.get("vm_names").split()
+    vms = [main_vm]
+    vmxml_backups = []
+
+    # Get vms
+    for i, vm_name in enumerate(vm_names):
+        vms.append(main_vm.clone(vm_name))
+
+    for vm in vms:
+        # Back up domain XMLs
+        vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm.name)
+        vmxml_backups.append(vmxml.copy())
+        # Increase memory
+        vmxml.memory = int(memory)
+        vmxml.current_mem = int(memory)
+        vmxml.sync()
+
+    try:
+        # Get host online cpu number
+        host_online_cpus = cpu.online_count()
+        LOG.debug("Host online CPU number: %s", str(host_online_cpus))
+
+        # Prepare 3 vms and each vm has even vcpus number which is about 2/3 of # host_online_cpu
+        for i, vm in enumerate(vms):
+            if vm.is_alive():
+                vm.destroy()
+            vcpus_num = host_online_cpus * 2 // int(len(vms))
+            if (vcpus_num % 2 != 0):
+                vcpus_num += 1
+            vm_xml.VMXML.new_from_inactive_dumpxml(vm.name).set_vm_vcpus(vm.name, vcpus_num, vcpus_num, topology_correction=True)
+            LOG.debug("Defined vm %s with '%s' vcpu(s)", vm.name, str(vcpus_num))
+
+        # Start stress workload on the host
+        # params must include stress_args
+        utils_test.load_stress("stress_on_host", params=params)
+
+        # Start all vms and verify vms could be logged in normally
+        for vm in vms:
+            vm.prepare_guest_agent()
+            vm.wait_for_login()
+            if (vm.state() != "running"):
+                test.fail("VM %s should be running, not %s" % (vm.name, vm.state()))
+
+        # Verify all vms could be gracefully shutdown successfully
+        for vm in vms:
+            vm.shutdown()
+            if (vm.state() != "shut off"):
+                test.fail("VM %s should be shut off, not %s" % (vm.name, vm.state()))
+
+    finally:
+        # Stop stress workload
+        utils_test.unload_stress("stress_on_host", params=params)
+
+        # Recover VMs
+        for i, vm in enumerate(vms):
+            if vm.is_alive():
+                vm.destroy(gracefully=False)
+            LOG.info("Restoring vm %s...", vm.name)
+            vmxml_backups[i].sync()


### PR DESCRIPTION
Case ID: VIRT-301893

Automates the case that tests that multiple vms can use #host_only_cpu to start when stress workload is running on the host.

**Test steps:**
    1. Prepare 3 vms that each have even vcpu number around 2/3 of # host_online_cpu
    2. Start stress workload on the host
    3. Start all vms and verify vms could be logged in normally
    4. Verify all vms could be gracefully shutdown successfully

**Evidence of tests passing:**
```
(.libvirt-ci-venv-ci-runtest-TSPbXe) [root@ampere-mtsnow-altramax-31 ~]# avocado run --vt-type libvirt multi_vms_with_stress
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : f8b4b60d59e7cf3d867104d46833fe6c8eb9e868
JOB LOG    : /var/log/avocado/job-results/job-2024-10-24T10.41-f8b4b60/job.log
 (1/7) type_specific.io-github-autotest-libvirt.multi_vms_with_stress: STARTED
 (1/7) type_specific.io-github-autotest-libvirt.multi_vms_with_stress: PASS (135.31 s)
 (2/7) type_specific.io-github-autotest-libvirt.multi_vms_with_stress: STARTED
 (2/7) type_specific.io-github-autotest-libvirt.multi_vms_with_stress: PASS (135.70 s)
 (3/7) type_specific.io-github-autotest-libvirt.multi_vms_with_stress: STARTED
 (3/7) type_specific.io-github-autotest-libvirt.multi_vms_with_stress: PASS (135.55 s)
 (4/7) type_specific.io-github-autotest-libvirt.multi_vms_with_stress: STARTED
 (4/7) type_specific.io-github-autotest-libvirt.multi_vms_with_stress: PASS (138.33 s)
 (5/7) type_specific.io-github-autotest-libvirt.multi_vms_with_stress: STARTED
 (5/7) type_specific.io-github-autotest-libvirt.multi_vms_with_stress: PASS (138.49 s)
 (6/7) type_specific.io-github-autotest-libvirt.multi_vms_with_stress: STARTED
 (6/7) type_specific.io-github-autotest-libvirt.multi_vms_with_stress: PASS (137.15 s)
 (7/7) type_specific.io-github-autotest-libvirt.multi_vms_with_stress: STARTED
 (7/7) type_specific.io-github-autotest-libvirt.multi_vms_with_stress: PASS (138.84 s)
RESULTS    : PASS 7 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2024-10-24T10.41-f8b4b60/results.html
JOB TIME   : 976.49 s
```

