### PR TITLE
domtime: update for s390x

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domtime.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domtime.cfg
@@ -3,6 +3,13 @@
     start_vm = no
     take_regular_screendumps = "no"
     vm_stop_duration = 10
+    s390-virtio:
+        positive:
+            only get_time,with_pretty,suspend_vm,managedsave_vm
+        negative:
+            only shutdown_vm,get_time_readonly,no_agent_channel,no_agent
+        restore_time = no
+        get_local_hw = no
     variants:
         - positive:
             variants:

--- a/spell.ignore
+++ b/spell.ignore
@@ -401,6 +401,7 @@ hugepage
 Hugepage
 hugepages
 hugetlbfs
+hwclock
 hwinfo
 hwtype
 hyperv


### PR DESCRIPTION
hwclock is not available on s390x and guest agent operators that modify the time either.

1. Don't try to restore time (with --now flag) during teardown.
2. Disable test cases that try to modify time.
3. Skip step that uses hwclock.