### PR TITLE
vIOMMU: Fix incorrect disk driver setting issue

### DIFF
--- a/libvirt/tests/cfg/sriov/vIOMMU/intel_iommu_virtio_device_with_ats.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/intel_iommu_virtio_device_with_ats.cfg
@@ -22,7 +22,8 @@
         - scsi_controller:
             test_devices = ["scsi"]
             controller_dicts = [{'type': 'scsi', 'model': 'virtio-scsi','driver': {'iommu': 'on', 'ats': 'on'}}]
-            disk_dict = {'target': {'dev': 'sda', 'bus': 'scsi'}}
+            disk_driver = {'name': 'qemu', 'type': 'qcow2'}
+            disk_dict = {'target': {'dev': 'sda', 'bus': 'scsi'}, 'driver': ${disk_driver}}
             cleanup_ifaces = no
         - pcie_root_port_from_expander_bus:
             test_devices = ["Eth", "block"]


### PR DESCRIPTION
The value of disk driver will be removed before setting disk xml, so add driver settings in cfg.

**Test results:**
` (1/1) type_specific.io-github-autotest-libvirt.vIOMMU.intel_iommu.virtio_device_with_ats.scsi_controller: PASS (169.67 s)
`