### PR TITLE
Virt_admin_logging: create local disk and clear messages log

### DIFF
--- a/libvirt/tests/src/daemon/conf_file/libvirtd_conf/virt_admin_logging.py
+++ b/libvirt/tests/src/daemon/conf_file/libvirtd_conf/virt_admin_logging.py
@@ -21,6 +21,7 @@ from virttest import virt_admin
 
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_libvirt import libvirt_disk
+from virttest.utils_test import libvirt
 from virttest.staging import service
 
 
@@ -82,6 +83,10 @@ def create_customized_disk(params):
     source_dict.update({"file": source_file})
     disk_src_dict = {"attrs": source_dict}
 
+    libvirt.create_local_disk("file", source_file, 1, disk_format="qcow2")
+
+    cleanup_files.append(source_file)
+
     customized_disk = libvirt_disk.create_primitive_disk_xml(
         type_name, disk_device,
         device_target, device_bus,
@@ -131,6 +136,11 @@ def run(test, params, env):
     """
     vm_name = params.get("main_vm")
     vm = env.get_vm(vm_name)
+
+    # Clear log file
+    log_config_path = params.get("log_file_path")
+    truncate_log = "truncate -s 0 %s" % log_config_path
+    process.run(truncate_log, ignore_status=True, shell=True, verbose=True)
 
     # Back up xml file
     if vm.is_alive():


### PR DESCRIPTION
**Issue:**
TestFail: Check message log:journal failed in log file:/var/log/messages&#10;

**More specifically:**
```
ERROR| VM fails to start with:command: "/usr/bin/virsh -c 'qemu:///system' start avocado-vt-vm1 "exit_status: 1duration: 0.02745846800007712interrupted: Falsepid: 155132encoding: 'UTF-8'stdout: '\n'stderr: "error: Failed to start domain 'avocado-vt-vm1'\nerror: Cannot access storage file '/var/lib/libvirt/images/no_existed_journal.qcow2' (as uid:107, gid:107): No such file or directory\n"
```

**Fix:**
Run create_local_disk() to ensure that no_existed_journal.qcow2 exists. 

Additionally, since in some cases, this test case checks the entirety of /var/log/messages (which contains logs from all test runs) for the key word "journal" to determine whether the test passes/fails, this failure causes subsequent tests to pass because "journal" is present in the error message. To fix this, /var/log/messages is cleared at the beginning of the test run to make sure that the only messages checks are ones that were logged during that specific test run.

**Tests passing:**
```
[root@hpe-apollo-cn99xx-21 /]# /usr/local/bin/avocado run --vt-type libvirt --test-runner=runner conf_file.libvirtd_conf.virt_admin_logging.positive_test.journal_virt_admin_log_output --vt
-connect-uri qemu:///system
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : 3863ed038b0c7a6fb76a053ad249d337ab259263
JOB LOG    : /var/log/avocado/job-results/job-2024-10-17T10.41-3863ed0/job.log
 (1/7) type_specific.io-github-autotest-libvirt.conf_file.libvirtd_conf.virt_admin_logging.positive_test.journal_virt_admin_log_output: PASS (10.80 s)
 (2/7) type_specific.io-github-autotest-libvirt.conf_file.libvirtd_conf.virt_admin_logging.positive_test.journal_virt_admin_log_output: PASS (21.49 s)
 (3/7) type_specific.io-github-autotest-libvirt.conf_file.libvirtd_conf.virt_admin_logging.positive_test.journal_virt_admin_log_output: PASS (21.14 s)
 (4/7) type_specific.io-github-autotest-libvirt.conf_file.libvirtd_conf.virt_admin_logging.positive_test.journal_virt_admin_log_output: PASS (9.06 s)
 (5/7) type_specific.io-github-autotest-libvirt.conf_file.libvirtd_conf.virt_admin_logging.positive_test.journal_virt_admin_log_output: PASS (8.97 s)
 (6/7) type_specific.io-github-autotest-libvirt.conf_file.libvirtd_conf.virt_admin_logging.positive_test.journal_virt_admin_log_output: PASS (9.02 s)
 (7/7) type_specific.io-github-autotest-libvirt.conf_file.libvirtd_conf.virt_admin_logging.positive_test.journal_virt_admin_log_output: PASS (8.84 s)
RESULTS    : PASS 7 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2024-10-17T10.41-3863ed0/results.html
JOB TIME   : 90.53 s
```