### PR TITLE
iface_stat: fix test on s390x

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_stat.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_stat.cfg
@@ -22,3 +22,5 @@
                                 - macvtap:
                                     func_supported_since_libvirt_ver = (9, 2, 0)
                     iface_attrs = {'acpi': {'index': '5'}, 'target': {'dev': tap_name, 'managed': 'no'}, 'model': 'virtio', 'type_name': 'ethernet'}
+                    s390-virtio:
+                        iface_attrs = {'target': {'dev': tap_name, 'managed': 'no'}, 'model': 'virtio', 'type_name': 'ethernet'}

--- a/libvirt/tests/src/virtual_network/iface_stat.py
+++ b/libvirt/tests/src/virtual_network/iface_stat.py
@@ -187,6 +187,7 @@ def run(test, params, env):
                 unpr_vmxml.del_device('interface', by_tag=True)
                 libvirt_vmxml.modify_vm_device(unpr_vmxml, 'interface',
                                                iface_attrs)
+                unpr_vmxml.del_seclabel(by_attr=[('model', 'dac')])
                 network_base.define_vm_for_unprivileged_user(unpr_user,
                                                              unpr_vmxml)
                 unpr_vm_name = unpr_vmxml.vm_name


### PR DESCRIPTION
1. No ACPI, remove from definition
2. Our domain uses security driver 'dac' which is not available for unprivileged users. Remove it.