### PR TITLE
network: Add netperf testing

### DIFF
--- a/libvirt/tests/cfg/viommu_netperf.cfg
+++ b/libvirt/tests/cfg/viommu_netperf.cfg
@@ -1,0 +1,49 @@
+- vIOMMU.netperf:
+    type = viommu_netperf
+    vms = avocado-vt-vm1
+    net_name = network_conn
+    ip_attrs = {"netmask": "255.255.255.0", "address": "192.168.144.1", "dhcp_ranges": {"attrs": {"end": "192.168.144.254", "start": "192.168.144.2"}}}
+    iface_attrs = {"source": {"network": "${net_name}"}, "type_name": "network", "model": "virtio"}
+    network_attrs = {"name": "${net_name}", "forward": {"mode": "nat"}, "ips": [${ip_attrs}]}
+    start_vm = "no"
+    variants:
+        - virtio:
+            only q35, aarch64
+            func_supported_since_libvirt_ver = (8, 3, 0)
+            iommu_dict = {'model': 'virtio'}
+        - intel:
+            only q35
+            start_vm = "yes"
+            enable_guest_iommu = "yes"
+            iommu_dict = {'model': 'intel', 'driver': {'intremap': 'on', 'caching_mode': 'on', 'eim': 'on', 'iotlb': 'on', 'aw_bits': '48'}}
+        - smmuv3:
+            only aarch64
+            func_supported_since_libvirt_ver = (5, 5, 0)
+            iommu_dict = {'model': 'smmuv3'}
+    variants:
+        - e1000e:
+            only q35
+            iface_model = 'e1000e'
+            iface_dict = {'type_name': 'network', 'model': '${iface_model}', 'source': {'network': 'default'}}
+        - virtio_interface:
+            interface_driver_name = "vhost"
+            interface_driver = {'driver_attr': {'name': '${interface_driver_name}', 'iommu': 'on'}}
+            iface_dict = {'type_name': 'network', 'model': 'virtio', 'driver': ${interface_driver}, 'source': {'network': 'default'}}
+    variants:
+        - guest2guest:
+            vms = avocado-vt-vm1 vm2
+            netperf_client = avocado-vt-vm1
+            netperf_server = vm2
+        - host2guest:
+            netperf_client = ${local_ip}
+            netperf_server = ${main_vm}
+        - guest2host:
+            netperf_client = ${main_vm}
+            netperf_server = ${local_ip}
+            UDP_STREAM:
+                extra_cmd_opts = "-- -R 1"
+    variants:
+        - TCP_STREAM:
+            test_protocol = TCP_STREAM
+        - UDP_STREAM:
+            test_protocol = UDP_STREAM

--- a/libvirt/tests/cfg/virtual_network/connectivity/netperf_nat_interface.cfg
+++ b/libvirt/tests/cfg/virtual_network/connectivity/netperf_nat_interface.cfg
@@ -1,0 +1,27 @@
+- virtual_network.netperf.nat_interface:
+    type = netperf_nat_interface
+    vms = avocado-vt-vm1
+    start_vm = no
+    net_name = network_conn
+    ip_attrs = {"netmask": "255.255.255.0", "address": "192.168.144.1", "dhcp_ranges": {"attrs": {"end": "192.168.144.254", "start": "192.168.144.2"}}}
+    iface_attrs = {"source": {"network": "${net_name}"}, "type_name": "network", "model": "virtio"}
+    network_attrs = {"name": "${net_name}", "forward": {"mode": "nat"}, "ips": [${ip_attrs}]}
+
+    variants:
+        - guest2guest:
+            vms = avocado-vt-vm1 vm2
+            netperf_client = avocado-vt-vm1
+            netperf_server = vm2
+        - host2guest:
+            netperf_client = ${local_ip}
+            netperf_server = ${main_vm}
+        - guest2host:
+            netperf_client = ${main_vm}
+            netperf_server = ${local_ip}
+            UDP_STREAM:
+                extra_cmd_opts = "-- -R 1"
+    variants:
+        - TCP_STREAM:
+            test_protocol = TCP_STREAM
+        - UDP_STREAM:
+            test_protocol = UDP_STREAM

--- a/libvirt/tests/src/sriov/vIOMMU/viommu_netperf.py
+++ b/libvirt/tests/src/sriov/vIOMMU/viommu_netperf.py
@@ -1,0 +1,39 @@
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+
+from provider.viommu import viommu_base
+from provider.virtual_network import network_base
+
+
+def run(test, params, env):
+    """
+    Run netperf testing between host and vm with iommu device
+    """
+    cleanup_ifaces = "yes" == params.get("cleanup_ifaces", "yes")
+    iommu_dict = eval(params.get('iommu_dict', '{}'))
+
+    vms = params.get('vms').split()
+    vm_objs = [env.get_vm(vm_i) for vm_i in vms]
+
+    test_objs = [viommu_base.VIOMMUTest(vm, test, params) for vm in vm_objs]
+
+    try:
+        test.log.info("TEST_SETUP: Update VM XML.")
+        for test_obj in test_objs:
+            test_obj.setup_iommu_test(iommu_dict=iommu_dict,
+                                      cleanup_ifaces=cleanup_ifaces)
+
+        iface_dict = test_objs[0].parse_iface_dict()
+        if cleanup_ifaces:
+            vmxml_lists = list(map(vm_xml.VMXML.new_from_inactive_dumpxml, vms))
+            [libvirt_vmxml.modify_vm_device(vmxml_i, 'interface', iface_dict) for vmxml_i in vmxml_lists]
+
+        test.log.info('TEST_STEP: Start the VM(s)')
+        [vm_inst.start() for vm_inst in vm_objs]
+        [vm_inst.wait_for_login() for vm_inst in vm_objs]
+
+        test.log.info("TEST_STEP: Run netperf testing between host(vm) and vm.")
+        network_base.exec_netperf_test(params, env)
+    finally:
+        for test_obj in test_objs:
+            test_obj.teardown_iommu_test()

--- a/libvirt/tests/src/virtual_network/connectivity/netperf_nat_interface.py
+++ b/libvirt/tests/src/virtual_network/connectivity/netperf_nat_interface.py
@@ -1,0 +1,36 @@
+from provider.virtual_network import network_base
+
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_network
+from virttest.utils_libvirt import libvirt_vmxml
+
+
+def run(test, params, env):
+    """
+    Verify the guest can work well under the netperf stress test
+    """
+    vms = params.get('vms').split()
+    vm_objs = [env.get_vm(vm_i) for vm_i in vms]
+    network_attrs = eval(params.get('network_attrs'))
+    iface_attrs = eval(params.get('iface_attrs'))
+
+    bkxmls = list(map(vm_xml.VMXML.new_from_inactive_dumpxml, vms))
+
+    try:
+        libvirt_network.create_or_del_network(network_attrs)
+        test.log.debug(f'Network xml:\n'
+                       f'{virsh.net_dumpxml(network_attrs["name"]).stdout_text}')
+        vmxml_lists = list(map(vm_xml.VMXML.new_from_inactive_dumpxml, vms))
+        [libvirt_vmxml.modify_vm_device(vmxml_i, 'interface', iface_attrs)
+         for vmxml_i in vmxml_lists]
+
+        test.log.info('TEST_STEP: Start the VM(s)')
+        [vm_inst.start() for vm_inst in vm_objs]
+        [vm_inst.wait_for_login() for vm_inst in vm_objs]
+        network_base.exec_netperf_test(params, env)
+
+    finally:
+        [backup_xml.sync() for backup_xml in bkxmls]
+        libvirt_network.create_or_del_network(network_attrs, is_del=True)


### PR DESCRIPTION
This PR adds:
VIRT-302078 - Do netperf stress test for iommu enabled interface 
VIRT-301971 - Do netperf stress test for nat network interface


**Test results:**
```
_aarch64:_
 (01/18) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.TCP_STREAM.guest2guest.virtio_interface.virtio: PASS (106.22 s)
 (02/18) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.TCP_STREAM.guest2guest.virtio_interface.smmuv3: PASS (103.64 s)
 (03/18) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.TCP_STREAM.host2guest.virtio_interface.virtio: PASS (96.00 s)
 (04/18) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.TCP_STREAM.host2guest.virtio_interface.smmuv3: PASS (96.35 s)
 (05/18) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.TCP_STREAM.guest2host.virtio_interface.virtio: PASS (97.00 s)
 (06/18) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.TCP_STREAM.guest2host.virtio_interface.smmuv3: PASS (96.33 s)
 (07/18) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.UDP_STREAM.guest2guest.virtio_interface.virtio: PASS (105.31 s)
 (08/18) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.UDP_STREAM.guest2guest.virtio_interface.smmuv3: PASS (103.48 s)
 (09/18) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.UDP_STREAM.host2guest.virtio_interface.virtio: PASS (96.39 s)
 (10/18) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.UDP_STREAM.host2guest.virtio_interface.smmuv3: PASS (96.48 s)
 (11/18) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.UDP_STREAM.guest2host.virtio_interface.virtio: PASS (96.41 s)
 (12/18) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.UDP_STREAM.guest2host.virtio_interface.smmuv3: PASS (96.47 s)
 (13/18) type_specific.io-github-autotest-libvirt.virtual_network.netperf.nat_interface.TCP_STREAM.guest2guest: PASS (153.46 s)
 (14/18) type_specific.io-github-autotest-libvirt.virtual_network.netperf.nat_interface.TCP_STREAM.host2guest: PASS (104.20 s)
 (15/18) type_specific.io-github-autotest-libvirt.virtual_network.netperf.nat_interface.TCP_STREAM.guest2host: PASS (105.24 s)
 (16/18) type_specific.io-github-autotest-libvirt.virtual_network.netperf.nat_interface.UDP_STREAM.guest2guest: PASS (113.20 s)
 (17/18) type_specific.io-github-autotest-libvirt.virtual_network.netperf.nat_interface.UDP_STREAM.host2guest: PASS (103.37 s)
 (18/18) type_specific.io-github-autotest-libvirt.virtual_network.netperf.nat_interface.UDP_STREAM.guest2host: PASS (105.27 s)
RESULTS    : PASS 18 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0


_x86_64:_
 (01/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.TCP_STREAM.guest2guest.e1000e.virtio: STARTED
 (01/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.TCP_STREAM.guest2guest.e1000e.virtio: PASS (112.65 s)
 (02/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.TCP_STREAM.guest2guest.e1000e.intel: STARTED
 (02/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.TCP_STREAM.guest2guest.e1000e.intel: PASS (365.84 s)
 (03/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.TCP_STREAM.guest2guest.virtio_interface.virtio: STARTED
 (03/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.TCP_STREAM.guest2guest.virtio_interface.virtio: PASS (112.90 s)
 (04/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.TCP_STREAM.guest2guest.virtio_interface.intel: STARTED
 (04/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.TCP_STREAM.guest2guest.virtio_interface.intel: PASS (361.03 s)
 (05/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.TCP_STREAM.host2guest.e1000e.virtio: STARTED
 (05/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.TCP_STREAM.host2guest.e1000e.virtio: PASS (104.11 s)
 (06/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.TCP_STREAM.host2guest.e1000e.intel: STARTED
 (06/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.TCP_STREAM.host2guest.e1000e.intel: PASS (228.21 s)
 (07/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.TCP_STREAM.host2guest.virtio_interface.virtio: STARTED
 (07/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.TCP_STREAM.host2guest.virtio_interface.virtio: PASS (103.23 s)
 (08/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.TCP_STREAM.host2guest.virtio_interface.intel: STARTED
 (08/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.TCP_STREAM.host2guest.virtio_interface.intel: PASS (284.87 s)
 (09/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.TCP_STREAM.guest2host.e1000e.virtio: STARTED
 (09/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.TCP_STREAM.guest2host.e1000e.virtio: PASS (103.77 s)
 (10/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.TCP_STREAM.guest2host.e1000e.intel: STARTED
 (10/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.TCP_STREAM.guest2host.e1000e.intel: PASS (236.11 s)
 (11/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.TCP_STREAM.guest2host.virtio_interface.virtio: STARTED
 (11/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.TCP_STREAM.guest2host.virtio_interface.virtio: PASS (103.13 s)
 (12/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.TCP_STREAM.guest2host.virtio_interface.intel: STARTED
 (12/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.TCP_STREAM.guest2host.virtio_interface.intel: PASS (231.44 s)
 (13/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.UDP_STREAM.guest2guest.e1000e.virtio: STARTED
 (13/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.UDP_STREAM.guest2guest.e1000e.virtio: PASS (115.14 s)
 (14/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.UDP_STREAM.guest2guest.e1000e.intel: STARTED
 (14/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.UDP_STREAM.guest2guest.e1000e.intel: PASS (359.06 s)
 (15/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.UDP_STREAM.guest2guest.virtio_interface.virtio: STARTED
 (15/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.UDP_STREAM.guest2guest.virtio_interface.virtio: PASS (111.95 s)
 (16/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.UDP_STREAM.guest2guest.virtio_interface.intel: STARTED
 (16/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.UDP_STREAM.guest2guest.virtio_interface.intel: PASS (359.15 s)
 (17/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.UDP_STREAM.host2guest.e1000e.virtio: STARTED
 (17/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.UDP_STREAM.host2guest.e1000e.virtio: PASS (160.91 s)
 (18/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.UDP_STREAM.host2guest.e1000e.intel: STARTED
 (18/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.UDP_STREAM.host2guest.e1000e.intel: PASS (234.61 s)
 (19/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.UDP_STREAM.host2guest.virtio_interface.virtio: STARTED
 (19/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.UDP_STREAM.host2guest.virtio_interface.virtio: PASS (108.75 s)
 (20/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.UDP_STREAM.host2guest.virtio_interface.intel: STARTED
 (20/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.UDP_STREAM.host2guest.virtio_interface.intel: PASS (230.23 s)
 (21/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.UDP_STREAM.guest2host.e1000e.virtio: STARTED
 (21/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.UDP_STREAM.guest2host.e1000e.virtio: PASS (101.03 s)
 (22/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.UDP_STREAM.guest2host.e1000e.intel: STARTED
 (22/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.UDP_STREAM.guest2host.e1000e.intel: PASS (231.65 s)
 (23/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.UDP_STREAM.guest2host.virtio_interface.virtio: STARTED
 (23/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.UDP_STREAM.guest2host.virtio_interface.virtio: PASS (102.89 s)
 (24/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.UDP_STREAM.guest2host.virtio_interface.intel: STARTED
 (24/24) type_specific.io-github-autotest-libvirt.vIOMMU.netperf.UDP_STREAM.guest2host.virtio_interface.intel: PASS (236.53 s)
RESULTS    : PASS 24 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0


```
**Also reproduced a known bug:**
`virtual_network.netperf.nat_interface.UDP_STREAM.guest2host: ERROR: Timeout expired while waiting for shell command to complete: 'netperf -H <serverip> -l 60 -C -c -t UDP_STREAM -- -R 1'    (output: 'MIGRATED UDP STREAM TEST from 0.0.0.0 (0.0.0.0) port 0 AF_INET to <serverip> () port 0 AF_INET : histogram : interval : dir... (157.32 s)`

