### PR TITLE
Added better logging of VM start error

### DIFF
--- a/libvirt/tests/src/libvirt_hooks.py
+++ b/libvirt/tests/src/libvirt_hooks.py
@@ -492,11 +492,11 @@ def run(test, params, env):
                 lxc_hook()
 
         except virt_vm.VMStartError as e:
-            logging.info(str(e))
             if start_error:
+                logging.info(str(e))
                 pass
             else:
-                test.fail('VM Failed to start for some reason!')
+                test.fail(f"VM Failed to start: {str(e)}")
         else:
             if start_error:
                 test.fail('VM started unexpected')


### PR DESCRIPTION
There is know error behind this behavior, where the VM will not start for first time in RHEL-10.0. 
In *hook tests we get the test result "VM Failed to start for some reason!"

Just added more info get proper details and have it linked with correct tasks with same failure.

Failed test:
- rhel.libvirt_hooks.vm.start_stop (from avocado-vt)