### PR TITLE
Domif_setlink_getlink: closing and establishing connection with serial console before login

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domif_setlink_getlink.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domif_setlink_getlink.py
@@ -254,6 +254,9 @@ def run(test, params, env):
 
         error_msg = None
         if status_error == "no" and not post_action:
+            # Close then establish a connection with the serial console
+            vm.cleanup_serial_console()
+            vm.create_serial_console()
             # Serial login the vm to check link status
             # Start vm check the link statue
             session = vm.wait_for_serial_login(username=username,


### PR DESCRIPTION
Issue:
LoginTimeoutError: Login timeout expired    (output: 'exceeded 240 s timeout')&#10;

More specifically:

L0941 ERROR|   File "/var/lib/avocado/data/avocado-vt/virttest/test-providers.d/downloads/io-github-autotest-libvirt/libvirt/tests/src/virsh_cmd/domain/virsh_domif_setlink_getlink.py", line 259, in run    session = vm.wait_for_serial_login(username=username,
L0941 ERROR|   File "/var/ci/libvirt-ci/runtest/avocado-vt/avocado-vt/virttest/virt_vm.py", line 1523, in wait_for_serial_login    raise remote.LoginTimeoutError("exceeded %s s timeout" % timeout)
L0941 ERROR| aexpect.remote.LoginTimeoutError: Login timeout expired    (output: 'exceeded 240 s timeout')

Fix:
Run `vm.cleanup_serial_console()` and `vm.create_serial_console()` to close (if necessary) and then establish a connection with the serial console before running `vm.wait_for_serial_login()`

Tests passing:
```
(.libvirt-ci-venv-ci-runtest-PemBcX) [root@ampere-mtsnow-altramax-29 ~]# avocado run --vt-type libvirt --vt-machine-type arm64-mmio virsh.domif_setlink_getlink.positive_test.virtio.interface_mac.no_config --vt-connect-uri qemu:///system
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : 26b53ab3b30d8509e87cb0667623304211aef7ee
JOB LOG    : /var/log/avocado/job-results/job-2024-10-22T21.00-26b53ab/job.log
 (1/7) type_specific.io-github-autotest-libvirt.virsh.domif_setlink_getlink.positive_test.virtio.interface_mac.no_config.domain_name.running_guest.domif_setlink.setlink_up: STARTED
 (1/7) type_specific.io-github-autotest-libvirt.virsh.domif_setlink_getlink.positive_test.virtio.interface_mac.no_config.domain_name.running_guest.domif_setlink.setlink_up: PASS (60.22 s)
 (2/7) type_specific.io-github-autotest-libvirt.virsh.domif_setlink_getlink.positive_test.virtio.interface_mac.no_config.domain_name.running_guest.domif_setlink.setlink_down: STARTED
 (2/7) type_specific.io-github-autotest-libvirt.virsh.domif_setlink_getlink.positive_test.virtio.interface_mac.no_config.domain_name.running_guest.domif_setlink.setlink_down: PASS (61.23 s)
 (3/7) type_specific.io-github-autotest-libvirt.virsh.domif_setlink_getlink.positive_test.virtio.interface_mac.no_config.domain_name.running_guest.domif_setlink.stable_test.setlink_up.save_restore: STARTED
 (3/7) type_specific.io-github-autotest-libvirt.virsh.domif_setlink_getlink.positive_test.virtio.interface_mac.no_config.domain_name.running_guest.domif_setlink.stable_test.setlink_up.save_restore: PASS (66.78 s)
 (4/7) type_specific.io-github-autotest-libvirt.virsh.domif_setlink_getlink.positive_test.virtio.interface_mac.no_config.domain_name.running_guest.domif_setlink.stable_test.setlink_down.save_restore: STARTED
 (4/7) type_specific.io-github-autotest-libvirt.virsh.domif_setlink_getlink.positive_test.virtio.interface_mac.no_config.domain_name.running_guest.domif_setlink.stable_test.setlink_down.save_restore: PASS (62.01 s)
 (5/7) type_specific.io-github-autotest-libvirt.virsh.domif_setlink_getlink.positive_test.virtio.interface_mac.no_config.domain_name.shutoff_guest.domif_setlink.setlink_up: STARTED
 (5/7) type_specific.io-github-autotest-libvirt.virsh.domif_setlink_getlink.positive_test.virtio.interface_mac.no_config.domain_name.shutoff_guest.domif_setlink.setlink_up: PASS (44.33 s)
 (6/7) type_specific.io-github-autotest-libvirt.virsh.domif_setlink_getlink.positive_test.virtio.interface_mac.no_config.domain_name.shutoff_guest.domif_setlink.setlink_down: STARTED
 (6/7) type_specific.io-github-autotest-libvirt.virsh.domif_setlink_getlink.positive_test.virtio.interface_mac.no_config.domain_name.shutoff_guest.domif_setlink.setlink_down: PASS (43.91 s)
 (7/7) type_specific.io-github-autotest-libvirt.virsh.domif_setlink_getlink.positive_test.virtio.interface_mac.no_config.domain_UUID.shutoff_guest.domif_setlink.setlink_up: STARTED
 (7/7) type_specific.io-github-autotest-libvirt.virsh.domif_setlink_getlink.positive_test.virtio.interface_mac.no_config.domain_UUID.shutoff_guest.domif_setlink.setlink_up: PASS (43.93 s)
RESULTS    : PASS 7 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2024-10-22T21.00-26b53ab/results.html
JOB TIME   : 388.84 s
```