### PR TITLE
Fix libvirt_ap_passthrough_autostart failure due to incorrectly string

### DIFF
--- a/libvirt/tests/src/passthrough/ap/libvirt_ap_passthrough_autostart.py
+++ b/libvirt/tests/src/passthrough/ap/libvirt_ap_passthrough_autostart.py
@@ -38,7 +38,7 @@ def confirm_device_is_running(uuid, session=None):
         """Parameterless helper function to use with wait_for"""
         cmd = "mdevctl list -u %s" % uuid
         err, out = cmd_status_output(cmd, shell=True, session=session)
-        LOG.debug(err, out)
+        LOG.debug("mediated device status - {}, output - {}.".format(err, out))
         return uuid in out
     if not wait_for(_is_listed, timeout=5):
         raise TestFail("Mediated device UUID(%s) not listed" % uuid)


### PR DESCRIPTION
Fix libvirt_ap_passthrough_autostart failure due to incorrectly string format in LOG.debug

Typically, it will throw TypeError: not all arguments converted during string formatting