### PR TITLE
Update case of save_with_options

### DIFF
--- a/libvirt/tests/cfg/save_and_restore/save_with_options.cfg
+++ b/libvirt/tests/cfg/save_and_restore/save_with_options.cfg
@@ -3,6 +3,10 @@
     variants scenario:
         - no_opt:
             options = 
+            check_reason = yes
+            check_reason_cmd = "while true; do virsh domjobinfo avocado-vt-vm1; done"
+            pattern_running = "Job type:\s*Unbounded\s*Operation:\s*Save"
+            pattern_completed = "Job type:\s*Completed\s*Operation:\s*Save"
         - verbose_opt:
             options = --verbose
             expect_msg = 'Save:\s\[100.*%\]'
@@ -21,9 +25,11 @@
     variants:
         - running_vm:
             pre_state = running
+            domst_reason = restored
         - paused_vm:
             no verbose_opt, xml_opt, bypass_cache_opt
             pre_state = paused
+            domst_reason = migrating
     variants mode:
         - readonly:
             only running_vm.no_opt


### PR DESCRIPTION
Add steps to monitor with domjobinfo and check domstate reason

Test result:
```
 (1/3) type_specific.local.save_and_restore.save_with_options.readonly.running_vm.no_opt: STARTED
 (1/3) type_specific.local.save_and_restore.save_with_options.readonly.running_vm.no_opt: PASS (24.44 s)
 (2/3) type_specific.local.save_and_restore.save_with_options.normal.running_vm.no_opt: STARTED
 (2/3) type_specific.local.save_and_restore.save_with_options.normal.running_vm.no_opt: PASS (39.92 s)
 (3/3) type_specific.local.save_and_restore.save_with_options.normal.paused_vm.no_opt: STARTED
 (3/3) type_specific.local.save_and_restore.save_with_options.normal.paused_vm.no_opt: PASS (48.85 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```