### PR TITLE
Update case of connectivity check of ethernet interface

### DIFF
--- a/libvirt/tests/cfg/virtual_network/connectivity/connectivity_check_ethernet_interface.cfg
+++ b/libvirt/tests/cfg/virtual_network/connectivity/connectivity_check_ethernet_interface.cfg
@@ -4,11 +4,11 @@
     timeout = 240
     outside_ip = 'www.redhat.com'
     host_iface =
+    extra_attrs = {}
     variants user_type:
         - non_root_user:
             test_user = USER.EXAMPLE
             test_passwd = PASSWORD.EXAMPLE
-            user_id = 
             unpr_vm_name = UNPRIVILEGED_VM.EXAMPLE
     variants:
         - positive_test:
@@ -24,14 +24,26 @@
                     tap_mtu = 1400
                     iface_mtu = 1200
                     mtu_attrs = {'mtu': {'size': ${iface_mtu}}}
+                - smaller_mtu_multi_ifaces:
+                    only two_ifaces
+                    tap_mtu = 1400
+                    iface_mtu = 1200
+                    iface_mtu_2 = 1150
+                    mtu_attrs = {'mtu': {'size': ${iface_mtu}}}
             variants tap_type:
                 - tap:
                     vm_ping_outside = pass
                     vm_ping_host_public = pass
+                    variants iface_amount:
+                        - one_iface:
+                        - two_ifaces:
+                            only smaller_mtu_multi_ifaces
+                            extra_attrs = {'rom': {'enabled': 'no'}}
+                            iface_attrs_2 = {'type_name': 'ethernet', 'target': {'dev': tap_name_2, 'managed': 'no'}, 'model': 'virtio', 'mtu': {'size': '${iface_mtu_2}'}, 'driver': {'driver_attr': {'name': 'vhost'}}, 'rom': {'enabled': 'no'}} 
                 - macvtap:
                     vm_ping_outside = pass
                     vm_ping_host_public = fail
-            iface_attrs = {'target': {'dev': tap_name, 'managed': 'no'}, 'model': 'virtio', 'type_name': 'ethernet', **${mtu_attrs}}
+            iface_attrs = {'target': {'dev': tap_name, 'managed': 'no'}, 'model': 'virtio', 'type_name': 'ethernet', **${mtu_attrs}, **${extra_attrs}}
         - negative_test:
             status_error = yes
             variants:


### PR DESCRIPTION
- VIRT-296218 - [ethernet] Check connectivity for ethernet type interface with managed='no'

Test result:
```
 (1/1) type_specific.local.virtual_network.connectivity_check.ethernet_interface.managed_no.positive_test.tap.two_ifaces.smaller_mtu_multi_ifaces.non_root_user: PASS (82.05 s)
```