### PR TITLE
Libvirt_rng: update codes for hotplug rng_current check

### DIFF
--- a/libvirt/tests/cfg/security/rng/libvirt_rng.cfg
+++ b/libvirt/tests/cfg/security/rng/libvirt_rng.cfg
@@ -17,6 +17,8 @@
             variants:
                 - positive:
                     rng_random_source = "yes"
+                    test_guest_rng_file = "yes"
+                    guest_required_kernel = [5.14.0,)
                     variants:
                         - no_options:
                         - persistent:


### PR DESCRIPTION
Updated Case IDs:  VIRT-17260 RHEL-112509 VIRT-98364 VIRT-96327 VIRT-98408 VIRT-98365 RHEL-188620 VIRT-98425 

**Case Updates**
1.  From  kernel-5.14.0-298.el9, the default rng_current may not be virtio_rng if vm has other rng devices such as tpm, need manually switch to it
2. Ensure `[root@localhost ~]# cat /sys/devices/virtual/misc/hw_random/rng_available` does not include virtio rng device after it was detached

**This case update is due to the following issue:**

**Issue:**
Failed to check rng file on guest. The virtio device is not the current rng device.

**More specifically:**

L0333 DEBUG| rng avail:tpm-rng-0 virtio_rng.0, current:tpm-rng-0

**Tests passing:**



