### PR TITLE
memory: Fixup 'No case to run' issue

### DIFF
--- a/libvirt/tests/cfg/memory/memory_backing/hugepage_nodeset.cfg
+++ b/libvirt/tests/cfg/memory/memory_backing/hugepage_nodeset.cfg
@@ -35,7 +35,7 @@
             memory_backing_dict = "'mb': {'hugepages': {'pages': [{'unit': '${page_unit}', 'size': '${page_size}','nodeset':'${nodeset}'}]}}"
             with_numa_error = "error: hugepages: node 2 not found"
             without_numa_error = "error: hugepages: node 0 not found"
-    variants config:
+    variants numa_config:
         - with_numa:
             numa_size_1 = 1048576
             numa_size_2 = 1024000

--- a/libvirt/tests/src/memory/memory_backing/hugepage_nodeset.py
+++ b/libvirt/tests/src/memory/memory_backing/hugepage_nodeset.py
@@ -135,8 +135,8 @@ def run(test, params, env):
     set_pagesize = params.get("set_pagesize")
     set_pagenum = params.get("set_pagenum")
     expect_xpath = eval(params.get("expect_xpath"))
-    config = params.get("config")
-    globals()["config_error"] = params.get("%s_error" % config, None)
+    numa_config = params.get("numa_config")
+    globals()["config_error"] = params.get("%s_error" % numa_config, None)
 
     try:
         setup_test()


### PR DESCRIPTION
The variant 'config' in hugepage_nodeset.cfg makes avocado impossible to obtain normal cases.


**Before the fix:**
```
# avocado list --vt-type libvirt  --vt-machine-type arm64-mmio memory.backing.nodeset
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
```
**After the fix:**
` (8/8) type_specific.io-github-autotest-libvirt.memory.backing.nodeset.without_numa.nodeset_not_exist.64k.524288: PASS (5.93 s)
`

