### PR TITLE
Add case for migration with numa topology

### DIFF
--- a/libvirt/tests/cfg/numa/guest_numa_topology/migration_with_numa_topology.cfg
+++ b/libvirt/tests/cfg/numa/guest_numa_topology/migration_with_numa_topology.cfg
@@ -1,0 +1,44 @@
+- guest_numa_topology.migration_with_numa_topology:
+    type = migration_with_numa_topology
+    only aarch64
+    start_vm = 'no'
+    dest_persist_xml = "yes"
+    dest_xml = "yes"
+    migration_bandwidth = "1000"
+    base_migration_options = "--live --p2p --persistent --undefinesource --bandwidth ${migration_bandwidth}"
+    node_0_cpu = 0-1
+    node_1_cpu = 2-3
+    node_num = 4
+    vcpu_memory_dict = "'vcpu': 8, 'memory_unit':'KiB','memory':8388608,'current_mem':8388608,'current_mem_unit':'KiB'"
+    variants:
+        - one_cluster_on_numa:
+            topology_dict = {'sockets': '2', 'clusters':'2', 'cores': '2', 'threads': '1'}
+            node_2_cpu = 4-5
+            node_3_cpu = 6-7
+            numa_list = "[{'id': '0', 'cpus': '${node_0_cpu}', 'memory': '2097152', 'unit': 'KiB'}, {'id': '1', 'cpus': '${node_1_cpu}', 'memory': '2097152', 'unit': 'KiB'}, {'id': '2', 'cpus': '${node_2_cpu}', 'memory': '2097152', 'unit': 'KiB'}, {'id': '3', 'cpus': '${node_3_cpu}', 'memory': '2097152', 'unit': 'KiB'}]"
+        - multi_cluster_on_numa:
+            topology_dict = {'sockets': '1', 'clusters':'4', 'cores': '2', 'threads': '1'}
+            node_2_cpu = 4-7
+            numa_list = "[{'id': '0', 'cpus': '${node_0_cpu}', 'memory': '2097152', 'unit': 'KiB'}, {'id': '1', 'cpus': '${node_1_cpu}', 'memory': '2097152', 'unit': 'KiB'}, {'id': '2', 'cpus': '${node_2_cpu}', 'memory': '2097152', 'unit': 'KiB'}, {'id': '3', 'memory': '2097152', 'unit': 'KiB'}]"
+    variants:
+        - base_options:
+            add_options = ""
+        - addtional_options:
+            no aarch64
+            migration_connections = 3
+            add_options = "--auto-converge  --parallel --parallel-connections ${migration_connections} --tls"
+    variants:
+        - without_postcopy:
+            copy_type = ""
+        - postcopy:
+            no aarch64
+            only base_options
+            copy_type = "--postcopy"
+    variants:
+        - with_back_migration:
+            migrate_vm_back = "yes"
+        - no_back_migration:
+            migrate_vm_back = "no"
+    vm_attrs = {${vcpu_memory_dict}, 'cpu': {'numa_cell': ${numa_list}}}
+    virsh_migrate_options = "${base_migration_options} ${add_options} ${copy_type}"
+

--- a/libvirt/tests/src/numa/guest_numa_topology/migration_with_numa_topology.py
+++ b/libvirt/tests/src/numa/guest_numa_topology/migration_with_numa_topology.py
@@ -1,0 +1,94 @@
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright Red Hat
+#
+#   SPDX-License-Identifier: GPL-2.0
+#
+#   Author: Liang Cong <lcong@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+from virttest import utils_misc
+from virttest import migration_template as mt
+from virttest.libvirt_xml import vm_xml
+
+
+class MigrationWithNumaTopology(mt.MigrationTemplate):
+
+    def __init__(self, test, env, params, *args, **dargs):
+        super().__init__(test, env, params, *args, **dargs)
+
+    @staticmethod
+    @mt.vm_session_handler
+    def check_guest_numa_cpu(vm, test, params):
+        """
+        Check cpu id on each guest numa node
+
+        :param vm: guest vm object
+        :param test: test object
+        :param params: test parameters
+        """
+        node_num = int(params.get("node_num"))
+        exp_nodes_cpu_list = [utils_misc.cpu_str_to_list(params.get(
+            "node_%s_cpu" % i)) if params.get("node_%s_cpu" % i) else [] for i in range(node_num)]
+        guest_numa_info = utils_misc.NumaInfo(session=vm.session)
+        act_nodes_cpu_list = []
+        for node_index in range(len(guest_numa_info.nodes)):
+            cpu_list = list(map(int, guest_numa_info.nodes[node_index].cpus))
+            act_nodes_cpu_list.append(cpu_list)
+            test.log.debug("guest node %s has cpus: %s" %
+                           (node_index, cpu_list))
+        if exp_nodes_cpu_list != act_nodes_cpu_list:
+            test.fail("Expect numa nodes cpu list is %s, but get %s" %
+                      (exp_nodes_cpu_list, act_nodes_cpu_list))
+
+    def _pre_start_vm(self):
+        """
+        Operation before start guest on source host:
+        Define the guest
+        """
+        vm_attrs = eval(self.params.get("vm_attrs", "{}"))
+        vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(self.main_vm.name)
+        vmxml.setup_attrs(**vm_attrs)
+        vmxml.cpu.topology = eval(self.params.get("topology_dict", "{}"))
+        vmxml.sync()
+
+    def _post_start_vm(self):
+        """
+        Operation after start guest on source host:
+        Check guest numa cpu after guest starts
+        """
+        self.check_guest_numa_cpu(self.main_vm, self.test, self.params)
+
+    def _post_migrate(self):
+        """
+        Operation after migration:
+        Check guest numa cpu after migration
+        """
+        self.check_guest_numa_cpu(self.main_vm, self.test, self.params)
+
+    def _post_migrate_back(self):
+        """
+        Operation after back migration:
+        Check guest numa cpu after back migration
+        """
+        self.check_guest_numa_cpu(self.main_vm, self.test, self.params)
+
+
+def run(test, params, env):
+    """
+    1. Assign cpu topology with numa node
+    2. Start guest
+    3. Verify the guest cpu assignment for numa nodes on src host
+    4. Do migration
+    5. Verify the guest cpu assignment for numa nodes on dest host
+    6. Do back migration
+    7. Verify the guest cpu assignment for numa nodes on src host
+    """
+
+    migrationobj = MigrationWithNumaTopology(test, env, params)
+    try:
+        migrationobj.runtest()
+    finally:
+        migrationobj.cleanup()


### PR DESCRIPTION
Case ID: VIRT-301811
depends on pr https://github.com/avocado-framework/avocado-vt/pull/4016
Test results:
Notes: For there is warning or error msg logged in guest dmesg during the migration, to test the whole process, so the test result ignore these dmesg msg.

 (1/4) type_specific.io-github-autotest-libvirt.guest_numa_topology.migration_with_numa_topology.with_back_migration.without_postcopy.base_options.one_cluster_on_numa: STARTED
 (1/4) type_specific.io-github-autotest-libvirt.guest_numa_topology.migration_with_numa_topology.with_back_migration.without_postcopy.base_options.one_cluster_on_numa: PASS (448.59 s)
 (2/4) type_specific.io-github-autotest-libvirt.guest_numa_topology.migration_with_numa_topology.with_back_migration.without_postcopy.base_options.multi_cluster_on_numa: STARTED
 (2/4) type_specific.io-github-autotest-libvirt.guest_numa_topology.migration_with_numa_topology.with_back_migration.without_postcopy.base_options.multi_cluster_on_numa: PASS (449.70 s)
 (3/4) type_specific.io-github-autotest-libvirt.guest_numa_topology.migration_with_numa_topology.no_back_migration.without_postcopy.base_options.one_cluster_on_numa: STARTED
 (3/4) type_specific.io-github-autotest-libvirt.guest_numa_topology.migration_with_numa_topology.no_back_migration.without_postcopy.base_options.one_cluster_on_numa: PASS (516.16 s)
 (4/4) type_specific.io-github-autotest-libvirt.guest_numa_topology.migration_with_numa_topology.no_back_migration.without_postcopy.base_options.multi_cluster_on_numa: STARTED
 (4/4) type_specific.io-github-autotest-libvirt.guest_numa_topology.migration_with_numa_topology.no_back_migration.without_postcopy.base_options.multi_cluster_on_numa: PASS (531.67 s)