### PR TITLE
viommu: Fix pcie_to_pci_bridge_controller for aarch64

### DIFF
--- a/libvirt/tests/cfg/sriov/vIOMMU/iommu_device_settings.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/iommu_device_settings.cfg
@@ -50,11 +50,11 @@
             disk_dict = {'target': {'dev': 'sda', 'bus': 'scsi'}, 'driver': ${disk_driver}}
             cleanup_ifaces = no
         - pcie_to_pci_bridge_controller:
-            test_devices = ["Eth", "block"]
             controller_dicts = [{'type': 'pci', 'model': 'pcie-to-pci-bridge', 'pre_controller': 'pcie-root-port'}]
             disk_dict = {'target': {'dev': 'vda', 'bus': 'virtio'}, 'device': 'disk', 'driver': ${disk_driver}, 'model': 'virtio-non-transitional'}
             variants:
                 - virtio_non_transitional:
+                    no smmuv3
                     iface_dict = {'source': {'network': 'default'}, 'driver': {'driver_attr': {'iommu': 'on'}},'type_name': 'network', 'model': 'virtio-non-transitional'}
                 - hostdev_iface:
                     only virtio


### PR DESCRIPTION
1. Remove a case due to a WONTFIX issue(BZ2181309)
2. Remove incorrect checks
**Test results**
```
 (1/2) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_to_pci_bridge_controller.virtio_non_transitional.virtio: STARTED
 (1/2) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_to_pci_bridge_controller.virtio_non_transitional.virtio: PASS (42.27 s)
 (2/2) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_to_pci_bridge_controller.hostdev_iface.virtio: STARTED
 (2/2) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_to_pci_bridge_controller.hostdev_iface.virtio: PASS (55.49 s)
```
