### PR TITLE
migratpm-tistion: Fix tpm model on aarch64

### DIFF
--- a/libvirt/tests/cfg/migration/migration_with_vtpm/migration_with_shared_tpm.cfg
+++ b/libvirt/tests/cfg/migration/migration_with_vtpm/migration_with_shared_tpm.cfg
@@ -30,17 +30,20 @@
     libvirtd_debug_filters = "1:*"
     libvirtd_debug_file = '/var/log/libvirt/virtqemud.log'
     func_supported_since_libvirt_ver = (9, 0, 0)
+    tpm_model = "tpm-crb"
+    aarch64:
+        tpm_model = "tpm-tis"
 
     variants:
         - persistent_and_p2p:
             virsh_migrate_options = "--live --p2p --verbose --undefinesource --persistent"
-            tpm_dict = {'tpm_model': 'tpm-crb', 'backend': {'backend_type': 'emulator', 'backend_version': '2.0', 'encryption_secret': '0051c505-1ad0-4d77-9b3e-360c8f5e3b86', 'active_pcr_banks': {'sha256': 'True'}}}
+            tpm_dict = {'tpm_model': '${tpm_model}', 'backend': {'backend_type': 'emulator', 'backend_version': '2.0', 'encryption_secret': '0051c505-1ad0-4d77-9b3e-360c8f5e3b86', 'active_pcr_banks': {'sha256': 'True'}}}
         - persistent_and_non_p2p:
             virsh_migrate_options = "--live --verbose"
-            tpm_dict = {'tpm_model': 'tpm-crb', 'backend': {'backend_type': 'emulator', 'backend_version': '2.0', 'encryption_secret': '0051c505-1ad0-4d77-9b3e-360c8f5e3b86', 'active_pcr_banks': {'sha256': 'True'}}}
+            tpm_dict = {'tpm_model': '${tpm_model}', 'backend': {'backend_type': 'emulator', 'backend_version': '2.0', 'encryption_secret': '0051c505-1ad0-4d77-9b3e-360c8f5e3b86', 'active_pcr_banks': {'sha256': 'True'}}}
         - transient_and_non_p2p:
             virsh_migrate_options = "--live --verbose"
-            tpm_dict = {'tpm_model': 'tpm-crb', 'backend': {'backend_type': 'emulator', 'backend_version': '2.0', 'persistent_state': 'yes', 'encryption_secret': '0051c505-1ad0-4d77-9b3e-360c8f5e3b86', 'active_pcr_banks': {'sha256': 'True'}}}
+            tpm_dict = {'tpm_model': '${tpm_model}', 'backend': {'backend_type': 'emulator', 'backend_version': '2.0', 'persistent_state': 'yes', 'encryption_secret': '0051c505-1ad0-4d77-9b3e-360c8f5e3b86', 'active_pcr_banks': {'sha256': 'True'}}}
             transient_vm = "yes"
     variants shared_storage_type:
         - nfs:


### PR DESCRIPTION
Update to use 'tpm-tis' to avoide unsupported tpm model issue.
**Test results:**
` (1/1) type_specific.io-github-autotest-libvirt.migration_with_vtpm.migration_with_shared_tpm.nfs.persistent_and_p2p: PASS (218.59 s)`
