### PR TITLE
virsh_nodecpustats: test_disable_enable_cpu() check if cpu online

### DIFF
--- a/libvirt/tests/src/virsh_cmd/host/virsh_nodecpustats.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_nodecpustats.py
@@ -242,7 +242,7 @@ def test_disable_enable_cpu(test, host_cpus_list, params):
     libvirt.check_result(output, expected_fails=[err_msg])
 
     logging.debug("Online host cpu %s" % host_cpus_list[-1])
-    if cpuutil.online(host_cpus_list[-1]):
+    if not cpuutil.online(host_cpus_list[-1]):
         test.error("Failed to online host cpu %s" % host_cpus_list[-1])
     subtest_cpu_percentage_option(test, host_cpus_list[-1], with_cpu_option=False)
 


### PR DESCRIPTION
**Issue:**
Failed to online host cpu 79

_Note: cpu num variable varies depending on the test_

**Fix:**
The cpu.py function online() returns True if the cpu is online and False if the cpu is offline (in other words, true/false is not tied to if the action performed successfully). This is also the case for def offline(cpu). Therefore, in the case when checking if the cpu is successfully turned online, the test should fail if online() returns False.

**Test Passing:**
```
(.libvirt-ci-venv-ci-runtest-1BjoYw) [root@ampere-one-01 ~]# avocado run --vt-type libvirt --vt-omit-data-loss --vt-machine-type arm64-mmio virsh.nodecpustats.disable_enable_cpu --vt-connect-uri qemu:///system
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : 045ddabb4514f318bf6449d27c7a4d78d20cb357
JOB LOG    : /var/log/avocado/job-results/job-2024-10-29T17.41-045ddab/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.nodecpustats.disable_enable_cpu: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.virsh.nodecpustats.disable_enable_cpu: PASS (6.98 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2024-10-29T17.41-045ddab/results.html
JOB TIME   : 8.38 s
```
