### PR TITLE
Workaround:Remove multi-queue setting

### DIFF
--- a/libvirt/tests/cfg/save_and_restore/restore_from_local_file.cfg
+++ b/libvirt/tests/cfg/save_and_restore/restore_from_local_file.cfg
@@ -1,6 +1,7 @@
 - save_and_restore.restore_from_local_file:
     type = restore_from_local_file
     save_opt =
+    start_vm = no
     variants scenario:
         - file_opt:
             pre_path_options = --file

--- a/libvirt/tests/cfg/save_and_restore/save_with_options.cfg
+++ b/libvirt/tests/cfg/save_and_restore/save_with_options.cfg
@@ -1,5 +1,6 @@
 - save_and_restore.save_with_options:
     type = save_with_options
+    start_vm = no
     variants scenario:
         - no_opt:
             options = 

--- a/libvirt/tests/src/save_and_restore/restore_from_local_file.py
+++ b/libvirt/tests/src/save_and_restore/restore_from_local_file.py
@@ -7,6 +7,7 @@ from avocado.utils import software_manager
 from virttest import utils_misc
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
 from virttest.utils_test import libvirt
 
 from provider.save import save_base
@@ -112,6 +113,10 @@ def run(test, params, env):
     bkxml = vmxml.copy()
 
     try:
+        # Workaround bug: Remove multi-queue setting
+        libvirt_vmxml.modify_vm_device(vmxml, 'interface', {'driver': None})
+        vm.start()
+
         pid_ping, upsince = save_base.pre_save_setup(vm)
 
         virsh.save(vm_name, save_path, options=save_opt, **VIRSH_ARGS)

--- a/libvirt/tests/src/save_and_restore/save_to_block.py
+++ b/libvirt/tests/src/save_and_restore/save_to_block.py
@@ -7,6 +7,7 @@ from virttest import utils_libvirtd
 from virttest import utils_selinux
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
 from virttest.utils_test import libvirt
 
 from provider.save import save_base
@@ -33,6 +34,9 @@ def run(test, params, env):
     libvirtd = utils_libvirtd.Libvirtd()
 
     try:
+        # Workaround bug: Remove multi-queue setting
+        libvirt_vmxml.modify_vm_device(vmxml, 'interface', {'driver': None})
+
         selinux_status = passt.ensure_selinux_enforcing()
         if namespaces:
             qemu_conf.namespaces = eval(namespaces)

--- a/libvirt/tests/src/save_and_restore/save_to_nfs.py
+++ b/libvirt/tests/src/save_and_restore/save_to_nfs.py
@@ -8,6 +8,7 @@ from virttest import utils_libvirtd
 from virttest import utils_misc
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
 from virttest.utils_test import libvirt
 
 from provider.save import save_base
@@ -39,6 +40,9 @@ def run(test, params, env):
     libvirtd = utils_libvirtd.Libvirtd()
 
     try:
+        # Workaround bug: Remove multi-queue setting
+        libvirt_vmxml.modify_vm_device(vmxml, 'interface', {'driver': None})
+
         qemu_conf.dynamic_ownership = 0
         if vmxml.devices.by_device_tag('tpm') is not None:
             qemu_conf.swtpm_user = 'qemu'

--- a/libvirt/tests/src/save_and_restore/save_with_formats.py
+++ b/libvirt/tests/src/save_and_restore/save_with_formats.py
@@ -6,6 +6,7 @@ from virttest import utils_libvirtd
 from virttest import utils_misc
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
 from virttest.utils_test import libvirt
 
 from provider.save import save_base
@@ -33,6 +34,9 @@ def run(test, params, env):
     bkxml = vmxml.copy()
 
     try:
+        # Workaround bug: Remove multi-queue setting
+        libvirt_vmxml.modify_vm_device(vmxml, 'interface', {'driver': None})
+
         qemu_conf = utils_config.LibvirtQemuConfig()
         libvirtd = utils_libvirtd.Libvirtd()
         qemu_conf.save_image_format = save_format

--- a/libvirt/tests/src/save_and_restore/save_with_options.py
+++ b/libvirt/tests/src/save_and_restore/save_with_options.py
@@ -8,6 +8,7 @@ from virttest import utils_misc
 from virttest import utils_package
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
 from virttest.utils_test import libvirt
 
 from provider.save import save_base
@@ -39,6 +40,10 @@ def run(test, params, env):
     bkxml = vmxml.copy()
 
     try:
+        # Workaround bug: Remove multi-queue setting
+        libvirt_vmxml.modify_vm_device(vmxml, 'interface', {'driver': None})
+        vm.start()
+
         pid_ping, upsince = save_base.pre_save_setup(vm)
         if pre_state == 'paused':
             virsh.suspend(vm_name, **VIRSH_ARGS)

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_managedsave.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_managedsave.py
@@ -1,22 +1,21 @@
+import logging as log
 import os
 import re
 import time
-import logging as log
 
 from avocado.utils import process
 from avocado.utils import software_manager
-
-from virttest import virsh
-from virttest import utils_libvirtd
-from virttest import utils_config
-from virttest import utils_misc
-from virttest import utils_libguestfs
 from virttest import libvirt_version
+from virttest import utils_config
+from virttest import utils_libguestfs
+from virttest import utils_libvirtd
+from virttest import utils_misc
+from virttest import virsh
 from virttest.libvirt_xml import vm_xml
-from virttest.utils_test import libvirt
 from virttest.staging.service import Factory
 from virttest.staging.utils_memory import drop_caches
-
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
 
 # Using as lower capital is not the best way to do, but this is just a
 # workaround to avoid changing the entire file.
@@ -363,6 +362,10 @@ def run(test, params, env):
         # Destroy vm first for setting configuration file
         if vm.state() == "running":
             vm.destroy(gracefully=False)
+
+        # Workaround bug: Remove multi-queue setting
+        vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+        libvirt_vmxml.modify_vm_device(vmxml, 'interface', {'driver': None})
         # Prepare test environment.
         if libvirtd_state == "off":
             libvirtd.stop()


### PR DESCRIPTION
Test result:
```
 (1/1) type_specific.local.save_and_restore.save_with_options.normal.running_vm.no_opt: STARTED
 (1/1) type_specific.local.save_and_restore.save_with_options.normal.running_vm.no_opt: PASS (39.63 s)

 (1/1) type_specific.local.save_and_restore.save_with_formats.positive_test.raw: STARTED
 (1/1) type_specific.local.save_and_restore.save_with_formats.positive_test.raw: PASS (33.16 s)

 (1/2) type_specific.local.save_and_restore.save_to_block.qemu_namespace.enabled: STARTED
 (1/2) type_specific.local.save_and_restore.save_to_block.qemu_namespace.enabled: PASS (44.88 s)
 (2/2) type_specific.local.save_and_restore.save_to_nfs.root_squash.dynamic_ownership_off: STARTED
 (2/2) type_specific.local.save_and_restore.save_to_nfs.root_squash.dynamic_ownership_off: PASS (46.37 s)

 (1/1) type_specific.local.save_and_restore.restore_from_local_file.normal.file_opt: STARTED
 (1/1) type_specific.local.save_and_restore.restore_from_local_file.normal.file_opt: PASS (33.21 s)

 (1/1) type_specific.local.virsh.managedsave.status_error_no.name_option.normal_status.no_opt.show_progress: STARTED
 (1/1) type_specific.local.virsh.managedsave.status_error_no.name_option.normal_status.no_opt.show_progress: PASS (61.13 s)

```