### PR TITLE
qemu_monitor_socket_creation_delay: Fix a parameter issue

### DIFF
--- a/libvirt/tests/cfg/daemon/qemu_monitor_socket_creation_delay.cfg
+++ b/libvirt/tests/cfg/daemon/qemu_monitor_socket_creation_delay.cfg
@@ -5,3 +5,4 @@
     take_regular_screendumps = no
     qemu_wrapper_path = "../../deps/qemu_wrapper.py"
     tmp_qemu_wrapper_path = "/tmp/qemu_wrapper.py"
+    emulator_dict = {"path": "${tmp_qemu_wrapper_path}"}

--- a/libvirt/tests/src/daemon/qemu_monitor_socket_creation_delay.py
+++ b/libvirt/tests/src/daemon/qemu_monitor_socket_creation_delay.py
@@ -29,7 +29,6 @@ def run(test, params, env):
         os.chmod(tmp_qemu_wrapper_path, 0o755)
         process.run("chcon system_u:object_r:qemu_exec_t:s0 %s" % tmp_qemu_wrapper_path, shell=True)
 
-        emulator_dict = {"path": "%s" % tmp_qemu_wrapper_path}
         libvirt_vmxml.modify_vm_device(vmxml, "emulator", emulator_dict)
         vm.start()
     except virt_vm.VMStartError as e:


### PR DESCRIPTION
Update cfg file to add a missing 'emulator_dict' parameter.