### PR TITLE
migration: Fix cpu mode and feature for aarch64

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_mem.cfg
+++ b/libvirt/tests/cfg/migration/migrate_mem.cfg
@@ -29,10 +29,10 @@
     variants case:
         - mem_device:
             cpuxml_cpu_mode = "host-model"
+            aarch64:
+                cpuxml_cpu_mode = "host-passthrough"
             cpuxml_fallback = "allow"
             cpuxml_model = "qemu64"
-            cpu_feature = "svm"
-            cpu_feature_policy = "disable"
             cpuxml_numa_cell = [{'id': '0', 'cpus': '0-1', 'memory': '1024', 'unit': 'MiB', 'discard': 'yes'}, {'id': '1', 'cpus': '2-3', 'memory': '1024', 'unit': 'MiB'}]
             setvm_max_mem_rt_slots = "16"
             setvm_max_mem_rt = 8192


### PR DESCRIPTION
1. cpu mode should be host-passthrough on aarch64
2. sve disabled feature is not needed on both aarch64 and x86_64

Test results:
```
2024-10-30 01:29:14,803 avocado.app human            L0129 DEBUG|  (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_mem.mem_device:
2024-10-30 01:29:14,803 avocado.app human            L0136 DEBUG| ^[[1D^[[92mPASS^[[0m (149.47 s)
```
