### PR TITLE
iface_stat:Fix error of command timeout

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_stat.py
+++ b/libvirt/tests/src/virtual_network/iface_stat.py
@@ -140,7 +140,8 @@ def run(test, params, env):
                 for _ in range(3):
                     session.cmd('curl -O https://avocado-project.org/data/'
                                 'assets/jeos/27/jeos-27-64.qcow2.xz -L',
-                                timeout=240, ignore_all_errors=True)
+                                timeout=60, ignore_all_errors=True)
+                    session.sendcontrol("c")
                 host_iface_stat = get_host_iface_stat(vm_name,
                                                       iface_target_dev,
                                                       **virsh_args)


### PR DESCRIPTION
Send control+c to cancel previous command to make sure the next command could be executed correctly.

Test result:
```
 (1/1) type_specific.local.virtual_network.iface_stat.compare.ethernet_type.managed_no.macvtap: STARTED
 (1/1) type_specific.local.virtual_network.iface_stat.compare.ethernet_type.managed_no.macvtap: PASS (222.66 s)

 (1/1) type_specific.local.virtual_network.iface_stat.compare.direct_type: STARTED
 (1/1) type_specific.local.virtual_network.iface_stat.compare.direct_type: PASS (209.92 s)

 (1/2) type_specific.io-github-autotest-libvirt.virtual_network.iface_stat.compare.direct_type: STARTED
 (1/2) type_specific.io-github-autotest-libvirt.virtual_network.iface_stat.compare.direct_type: PASS (222.56 s)
 (2/2) type_specific.io-github-autotest-libvirt.virtual_network.iface_stat.compare.ethernet_type.managed_no.macvtap: STARTED
 (2/2) type_specific.io-github-autotest-libvirt.virtual_network.iface_stat.compare.ethernet_type.managed_no.macvtap: PASS (239.31 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```