### PR TITLE
Update case:connectivity check of ethernet type interface

### DIFF
--- a/libvirt/tests/cfg/virtual_network/connectivity/connectivity_check_ethernet_interface.cfg
+++ b/libvirt/tests/cfg/virtual_network/connectivity/connectivity_check_ethernet_interface.cfg
@@ -52,11 +52,17 @@
                     err_msg = target dev must be supplied when managed='no'
                 - target_dev_not_exist:
                     iface_attrs = {'model': 'virtio', 'type_name': 'ethernet', 'target': {'dev': 'test', 'managed': 'no'}}
-                    err_msg = target managed='no' but specified dev doesn't exist
+                    err_msg = "target managed='no' but specified dev doesn't exist"
                 - managed_yes:
                     func_supported_since_libvirt_ver = (9,0,0) 
                     tap_type = tap
                     iface_attrs = {'model': 'virtio', 'type_name': 'ethernet', 'target': {'dev': tap_name, 'managed': 'yes'}}
                     err_msg = The .* interface already exists
+                - no_multi_queue_flag:
+                    func_supported_since_libvirt_ver = (10,8,0)
+                    tap_type = tap
+                    tap_flag = 
+                    iface_attrs = {'model': 'virtio', 'type_name': 'ethernet', 'target': {'dev': tap_name, 'managed': 'no'}, 'driver': {'driver_attr': {'queues': '2'}}}
+                    err_msg = Unable to create multiple fds for tap device .*\(maybe existing device was created without multi_queue flag\)
     variants:
         - managed_no:

--- a/libvirt/tests/src/virtual_network/connectivity/connectivity_check_ethernet_interface.py
+++ b/libvirt/tests/src/virtual_network/connectivity/connectivity_check_ethernet_interface.py
@@ -70,13 +70,22 @@ def run(test, params, env):
 
     try:
         mac_addr = vm_xml.VMXML.get_first_mac_by_name(vm_name, virsh_ins)
+        tap_flag = ''
+        for attr in (iface_attrs, iface_attrs_2):
+            if attr.get('driver', {}).get('driver_attr', {}).get('queues'):
+                tap_flag = 'multi_queue'
+                break
+        if params.get('tap_flag') is not None:
+            tap_flag = params.get('tap_flag')
 
         if tap_type:
             if tap_type == 'tap':
                 utils_net.create_linux_bridge_tmux(bridge_name, host_iface)
-                network_base.create_tap(tap_name, bridge_name, test_user)
+                network_base.create_tap(
+                    tap_name, bridge_name, test_user, flag=tap_flag)
                 if iface_amount == 'two_ifaces':
-                    network_base.create_tap(tap_name_2, 'virbr0', test_user)
+                    network_base.create_tap(
+                        tap_name_2, 'virbr0', test_user, flag=tap_flag)
             elif tap_type == 'macvtap':
                 mac_addr = network_base.create_macvtap(tap_name, host_iface,
                                                        test_user)

--- a/provider/virtual_network/network_base.py
+++ b/provider/virtual_network/network_base.py
@@ -139,7 +139,7 @@ def ping_check(params, ips, session=None, force_ipv4=True, **args):
             raise exceptions.TestFail(msg)
 
 
-def create_tap(tap_name, bridge_name, user):
+def create_tap(tap_name, bridge_name, user, flag=''):
     """
     Create tap device
 
@@ -149,7 +149,7 @@ def create_tap(tap_name, bridge_name, user):
     """
     # Create tap device with ip command
     tap_cmd = f'ip tuntap add mode tap user {user} group {user} name ' \
-              f'{tap_name};ip link set {tap_name} up;' \
+              f'{tap_name} {flag};ip link set {tap_name} up;' \
               f'ip link set {tap_name} master {bridge_name}'
     # Execute command as root
     process.run(tap_cmd, shell=True, verbose=True)


### PR DESCRIPTION
- VIRT-296218 - [ethernet] Check connectivity for ethernet type interface with managed='no'

Test result:
```
 (01/11) type_specific.local.virtual_network.connectivity_check.ethernet_interface.managed_no.positive_test.tap.one_iface.no_mtu.non_root_user: STARTED
 (01/11) type_specific.local.virtual_network.connectivity_check.ethernet_interface.managed_no.positive_test.tap.one_iface.no_mtu.non_root_user: PASS (69.17 s)
 (02/11) type_specific.local.virtual_network.connectivity_check.ethernet_interface.managed_no.positive_test.tap.one_iface.larger_mtu.non_root_user: STARTED
 (02/11) type_specific.local.virtual_network.connectivity_check.ethernet_interface.managed_no.positive_test.tap.one_iface.larger_mtu.non_root_user: PASS (72.34 s)
 (03/11) type_specific.local.virtual_network.connectivity_check.ethernet_interface.managed_no.positive_test.tap.one_iface.smaller_mtu.non_root_user: STARTED
 (03/11) type_specific.local.virtual_network.connectivity_check.ethernet_interface.managed_no.positive_test.tap.one_iface.smaller_mtu.non_root_user: PASS (66.16 s)
 (04/11) type_specific.local.virtual_network.connectivity_check.ethernet_interface.managed_no.positive_test.tap.two_ifaces.smaller_mtu_multi_ifaces.non_root_user: STARTED
 (04/11) type_specific.local.virtual_network.connectivity_check.ethernet_interface.managed_no.positive_test.tap.two_ifaces.smaller_mtu_multi_ifaces.non_root_user: PASS (86.04 s)
 (05/11) type_specific.local.virtual_network.connectivity_check.ethernet_interface.managed_no.positive_test.macvtap.no_mtu.non_root_user: STARTED
 (05/11) type_specific.local.virtual_network.connectivity_check.ethernet_interface.managed_no.positive_test.macvtap.no_mtu.non_root_user: PASS (58.46 s)
 (06/11) type_specific.local.virtual_network.connectivity_check.ethernet_interface.managed_no.positive_test.macvtap.larger_mtu.non_root_user: STARTED
 (06/11) type_specific.local.virtual_network.connectivity_check.ethernet_interface.managed_no.positive_test.macvtap.larger_mtu.non_root_user: PASS (71.67 s)
 (07/11) type_specific.local.virtual_network.connectivity_check.ethernet_interface.managed_no.positive_test.macvtap.smaller_mtu.non_root_user: STARTED
 (07/11) type_specific.local.virtual_network.connectivity_check.ethernet_interface.managed_no.positive_test.macvtap.smaller_mtu.non_root_user: PASS (59.79 s)
 (08/11) type_specific.local.virtual_network.connectivity_check.ethernet_interface.managed_no.negative_test.no_target_dev.non_root_user: STARTED
 (08/11) type_specific.local.virtual_network.connectivity_check.ethernet_interface.managed_no.negative_test.no_target_dev.non_root_user: PASS (15.00 s)
 (09/11) type_specific.local.virtual_network.connectivity_check.ethernet_interface.managed_no.negative_test.target_dev_not_exist.non_root_user: STARTED
 (09/11) type_specific.local.virtual_network.connectivity_check.ethernet_interface.managed_no.negative_test.target_dev_not_exist.non_root_user: PASS (14.58 s)
 (10/11) type_specific.local.virtual_network.connectivity_check.ethernet_interface.managed_no.negative_test.managed_yes.non_root_user: STARTED
 (10/11) type_specific.local.virtual_network.connectivity_check.ethernet_interface.managed_no.negative_test.managed_yes.non_root_user: PASS (38.13 s)
 (11/11) type_specific.local.virtual_network.connectivity_check.ethernet_interface.managed_no.negative_test.no_multi_queue_flag.non_root_user: STARTED
 (11/11) type_specific.local.virtual_network.connectivity_check.ethernet_interface.managed_no.negative_test.no_multi_queue_flag.non_root_user: PASS (38.68 s)
RESULTS    : PASS 11 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```