### PR TITLE
migrate_vm: Fixup umount failure

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_vm.cfg
+++ b/libvirt/tests/cfg/migration/migrate_vm.cfg
@@ -11,10 +11,10 @@
     client_user = "root"
     client_pwd = "${migrate_source_pwd}"
     start_vm = "no"
+    storage_type =
     transport = "ssh"
     port = "22"
     client = "ssh"
-    start_vm = "no"
     ssh_port = "${port}"
     # setup NFS test environment
     nfs_client_ip = "${server_ip}"


### PR DESCRIPTION
To avoid clearing the nfs environment twice, clear storage_type in the test to skip setup/cleanup nfs parts.

**Before the fix:**
` (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_vm.positive_testing.live_migration.cpuset.without_postcopy: ERROR: Failures occurred while postprocess:\nFailed to run: ssh root@10.6.8.64 -o StrictHostKeyChecking=no 'umount -l /var/lib/libvirt/migrate' (172.35 s)
`


**After the fix:**
```
 (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_vm.positive_testing.live_migration.cpuset.without_postcopy: PASS (135.99 s)
(1/5) type_specific.io-github-autotest-libvirt.virsh.migrate_vm.positive_testing.live_migration.with_hugepages.without_postcopy: STARTED
 (1/5) type_specific.io-github-autotest-libvirt.virsh.migrate_vm.positive_testing.live_migration.with_hugepages.without_postcopy: PASS (149.31 s)
 (2/5) type_specific.io-github-autotest-libvirt.virsh.migrate_vm.positive_testing.migration_with_devices.eject_cdrom_in_guest.without_postcopy: STARTED
 (2/5) type_specific.io-github-autotest-libvirt.virsh.migrate_vm.positive_testing.migration_with_devices.eject_cdrom_in_guest.without_postcopy: PASS (119.86 s)
 (3/5) type_specific.io-github-autotest-libvirt.virsh.migrate_vm.positive_testing.migration_with_devices.startup_policy.attach_cdrom.mandatory_policy.without_postcopy: STARTED
 (3/5) type_specific.io-github-autotest-libvirt.virsh.migrate_vm.positive_testing.migration_with_devices.startup_policy.attach_cdrom.mandatory_policy.without_postcopy: PASS (119.94 s)
 (4/5) type_specific.io-github-autotest-libvirt.virsh.migrate_vm.positive_testing.migration_with_devices.attach_virtual_disk.without_postcopy: STARTED
 (4/5) type_specific.io-github-autotest-libvirt.virsh.migrate_vm.positive_testing.migration_with_devices.attach_virtual_disk.without_postcopy: PASS (130.28 s)
 (5/5) type_specific.io-github-autotest-libvirt.virsh.migrate_vm.positive_testing.migration_with_devices.attach_virtual_nic.without_postcopy: STARTED
 (5/5) type_specific.io-github-autotest-libvirt.virsh.migrate_vm.positive_testing.migration_with_devices.attach_virtual_nic.without_postcopy: PASS (124.73 s)


```