### PR TITLE
fix memory case failed due to empty clean file in teardown

### DIFF
--- a/libvirt/tests/src/memory/memory_devices/virtio_memory_with_numa_node_tuning.py
+++ b/libvirt/tests/src/memory/memory_devices/virtio_memory_with_numa_node_tuning.py
@@ -430,8 +430,8 @@ def run(test, params, env):
         """
         test.log.info("TEST_TEARDOWN: Clean up env.")
         bkxml.sync()
-        for file in params.get("cleanup_file"):
-            process.run("echo 0 > %s" % file)
+        for file in params.get("cleanup_file", []):
+            process.run("echo 0 > %s" % file, ignore_status=True)
         hg_path = params.get("hg_path")
         if hg_path:
             process.run("umount %s; rm %s" % (hg_path, hg_path), ignore_status=True)


### PR DESCRIPTION
  give default value for clean file
Signed-off-by: nanli <nanli@redhat.com>

```
 avocado run --vt-type libvirt --vt-omit-data-loss --vt-machine-type arm64-mmio memory.devices.virtio.with_numa_tuning --vt-connect-uri qemu:///system

 (01/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.with_source_virtio_mem.strict: STARTED
 (01/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.with_source_virtio_mem.strict: CANCEL: Expect 2 numa nodes at least, but found 1 (29.23 s)
 (02/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.with_source_virtio_mem.interleave: STARTED
 (02/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.with_source_virtio_mem.interleave: CANCEL: Expect 2 numa nodes at least, but found 1 (27.29 s)
 (03/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.with_source_virtio_mem.preferred: STARTED
 (03/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.with_source_virtio_mem.preferred: CANCEL: Expect 2 numa nodes at least, but found 1 (26.90 s)
 (04/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.with_source_virtio_mem.undefined: STARTED
 (04/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.with_source_virtio_mem.undefined: CANCEL: Expect 2 numa nodes at least, but found 1 (27.02 s)
 (05/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.no_source_virtio_mem.strict: STARTED
 (05/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.no_source_virtio_mem.strict: CANCEL: Expect 2 numa nodes at least, but found 1 (127.45 s)
 (06/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.no_source_virtio_mem.interleave: STARTED
 (06/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.no_source_virtio_mem.interleave: CANCEL: Expect 2 numa nodes at least, but found 1 (127.25 s)
 (07/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.no_source_virtio_mem.preferred: STARTED

..All skipped 
```