### PR TITLE
fix virtio memory unplug case error msg compability issue

### DIFF
--- a/libvirt/tests/cfg/memory/memory_devices/virtio_mem_hot_unplug.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/virtio_mem_hot_unplug.cfg
@@ -39,6 +39,9 @@
     func_supported_since_libvirt_ver = (10, 0, 0)
     func_supported_since_qemu_kvm_ver = (8, 2, 0)
     machine_version = "9.4.0"
+    zero_size_error_msg = "virtio-mem device cannot get unplugged while 'size' != '0'"
+    zero_request_error_msg = "virtio-mem device cannot get unplugged while 'requested-size' != '0'"
+    basic_error_msg = "virtio-mem device cannot get unplugged while some of its memory is still plugged"
     variants case:
         - target_and_address:
             unplug_request_size = '0'
@@ -74,13 +77,13 @@
             nonexistent_mem:
                 unplug_error = "model 'virtio-mem' memory device not present in the domain configuration"
             none_zero_current:
-                unplug_error = "virtio-mem device cannot get unplugged while 'size' != '0'"
+                unplug_error = "${zero_size_error_msg}|${basic_error_msg}"
             none_zero_request:
-                unplug_error = "virtio-mem device cannot get unplugged while 'requested-size' != '0'"
+                unplug_error = "${zero_request_error_msg}|${basic_error_msg}"
         - detach_alias:
             no nonexistent_mem
             detach_method = "detach_alias"
             none_zero_current:
-                unplug_error = "virtio-mem device cannot get unplugged while 'size' != '0'"
+                unplug_error = "${zero_size_error_msg}|${basic_error_msg}"
             none_zero_request:
-                unplug_error = "virtio-mem device cannot get unplugged while 'requested-size' != '0'"
+                unplug_error = "${zero_request_error_msg}|${basic_error_msg}"


### PR DESCRIPTION
 unplug error msg needs to get compability
Signed-off-by: nanli <nanli@redhat.com>
```

 avocado run --vt-type libvirt --vt-machine-type arm64-mmio memory.devices.virtio_mem.hot_unplug.detach.none_zero_current --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.hot_unplug.detach.none_zero_current: PASS (152.72 s)

avocado run --vt-type libvirt  --vt-machine-type arm64-mmio memory.devices.virtio_mem.hot_unplug.detach.none_zero_request --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.hot_unplug.detach.none_zero_request: PASS (153.04 s)

```