### PR TITLE
migration: Update check vm state method

### DIFF
--- a/libvirt/tests/cfg/migration/destructive_operations_around_live_migration/kill_qemu_during_finishphase.cfg
+++ b/libvirt/tests/cfg/migration/destructive_operations_around_live_migration/kill_qemu_during_finishphase.cfg
@@ -29,6 +29,9 @@
     migrate_again = "yes"
     service_name = "qemu-kvm"
     migrate_again_status_error = "no"
+    virsh_migrate_extra = "--postcopy-bandwidth 10 --bandwidth 10"
+    virsh_migrate_extra_mig_again = " "
+    action_during_mig = '[{"func": "virsh.migrate_postcopy", "func_param": "'%s' % params.get('migrate_main_vm')", "need_sleep_time": "10"}, {"func": "check_vm_status_during_mig", "func_param": {"vm_name": "${main_vm}", "src_state":"paused", "src_reason": "post-copy"}, "need_sleep_time": "5"}, {"func": "libvirt_service.kill_service", "func_param": "params"}]'
     variants:
         - p2p:
             virsh_migrate_options = '--live --p2p --verbose'
@@ -36,18 +39,16 @@
             virsh_migrate_options = '--live --verbose'
     variants:
         - with_postcopy:
-            postcopy_options = "--timeout 2 --timeout-postcopy --postcopy --postcopy-bandwidth 10 --bandwidth 10"
+            postcopy_options = "--postcopy"
     variants test_case:
         - kill_dest_qemu:
             service_on_dst = "yes"
             expected_event_src = ["Suspended Post-copy", "Suspended Post-copy Error"]
             expected_event_target = ["Stopped Failed"]
-            action_during_mig = '[{"func": "libvirt.check_vm_state", "func_param": {"vm_name": "${main_vm}", "state": "paused", "reason":"post-copy"}, "need_sleep_time": "5"}, {"func": "libvirt_service.kill_service", "func_param": "params"}]'
             expected_dest_state = "nonexist"
             expected_src_state = "paused"
         - kill_src_qemu:
             expected_dest_state = "running"
             expected_src_state = "shut off"
-            expected_event_src = ["Suspended Post-copy Error", "Stopped Failed"]
+            expected_event_src = ["Suspended Post-copy", "Stopped Failed"]
             expected_event_target = ["Resumed Post-copy Error"]
-            action_during_mig = '[{"func": "libvirt.check_vm_state", "func_param": {"vm_name": "${main_vm}", "state": "paused", "reason":"post-copy"}, "need_sleep_time": "8"}, {"func": "libvirt_service.kill_service", "func_param": "params"}]'

--- a/libvirt/tests/cfg/migration/migration_performance_tuning/migration_timeout_action.cfg
+++ b/libvirt/tests/cfg/migration/migration_performance_tuning/migration_timeout_action.cfg
@@ -29,8 +29,7 @@
     test_case = "timeout_action"
     migrate_speed = "5"
     timeout_value = "8"
-    action_during_mig = '[{"func": "check_vm_status_during_mig", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "set_migrate_speed_to_high", "func_param": "params"}]'
-    vm_status_during_mig = "paused"
+    action_during_mig = '[{"func": "check_vm_status_during_mig", "after_event": "iteration: '1'", "func_param": {"vm_name": "${main_vm}", "dest_state": "paused", "src_state":"paused", "dest_uri": "${virsh_migrate_desturi}"}, "need_sleep_time": "${timeout_value}"}, {"func": "set_migrate_speed_to_high", "func_param": "params"}]'
     stress_package = "stress"
     stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20s"
     variants:

--- a/provider/migration/migration_base.py
+++ b/provider/migration/migration_base.py
@@ -453,23 +453,23 @@ def set_bandwidth(params):
         virsh.migrate_getspeed(vm_name, debug=True)
 
 
-def check_vm_status_during_mig(params):
+def check_vm_status_during_mig(vm_name, dest_state=None, src_state=None, dest_uri=None, src_reason=None):
     """
     Check vm status during migration
 
-    :param params: dict, get expected status of vm, vm name, destination uri, source uri and timeout value
+    :param vm_name: vm name
+    :param dest_state: expected status of vm on target host
+    :param src_state: expected status of vm on source host
+    :param dest_uri: destination uri
+    :param src_reason: expected reason of vm state on source host
     :raise: test fail when check vm status failed
     """
-    vm_status_during_mig = params.get("vm_status_during_mig")
-    vm_name = params.get("migrate_main_vm")
-    dest_uri = params.get("virsh_migrate_desturi")
-    src_uri = params.get("virsh_migrate_connect_uri")
-    timeout_value = params.get("timeout_value")
-    if timeout_value:
-        time.sleep(int(timeout_value))
-    for uri in [dest_uri, src_uri]:
-        if not libvirt.check_vm_state(vm_name, vm_status_during_mig, uri=uri):
-            raise exceptions.TestFail("VM status is not '%s' during migration on %s." % (vm_status_during_mig, uri))
+    if dest_state:
+        if not libvirt.check_vm_state(vm_name, dest_state, uri=dest_uri):
+            raise exceptions.TestFail("VM status is not '%s' during migration on target." % dest_state)
+    if src_state:
+        if not libvirt.check_vm_state(vm_name, src_state, src_reason):
+            raise exceptions.TestFail("VM status is not '%s' during migration on source." % src_state)
 
 
 def check_vm_state(params):


### PR DESCRIPTION
When vm state is wrong, libvirt.check_vm_state don't report the error.
So update check_vm_status_during_mig() and use it to check vm state.