### PR TITLE
Fix test log related irregular usage

### DIFF
--- a/libvirt/tests/src/numa/numa_memAccess.py
+++ b/libvirt/tests/src/numa/numa_memAccess.py
@@ -26,7 +26,7 @@ def define_and_check_xml(vmxml, params):
         if "cell_id" in key:
             numa_cells.append(eval(params[key]))
     pages = [eval(params["page_id_0"])]
-    logging.debug(numa_cells, pages)
+    logging.debug("numa cell is: %s, pages are: %s", numa_cells, pages)
 
     del vmxml.numa_memory
     vmcpuxml = libvirt_xml.vm_xml.VMCPUXML()

--- a/libvirt/tests/src/numa/numa_node_tuning/auto_mem_placement_with_incompatible_host_nodeset.py
+++ b/libvirt/tests/src/numa/numa_node_tuning/auto_mem_placement_with_incompatible_host_nodeset.py
@@ -52,7 +52,7 @@ def run(test, params, env):
         session.send('ZZ')
         _, text = session.read_until_any_line_matches(
             [r"%s" % error_msg], timeout=10, internal_timeout=1)
-        test.log.debug("Checked '%s' exists in '%s'", (error_msg, text))
+        test.log.debug("Checked '%s' exists in '%s'", error_msg, text)
         test.log.debug("Input 'i' to turn off validation")
         session.sendline('i')
 
@@ -60,8 +60,7 @@ def run(test, params, env):
         _, text = session.read_until_any_line_matches(
             [r"%s" % (success_msg % vm_name)], timeout=10, internal_timeout=1)
         session.close()
-        test.log.debug("Checked '%s' exists in '%s'", (success_msg % vm_name,
-                                                       text))
+        test.log.debug("Checked '%s' exists in '%s'", success_msg % vm_name, text)
 
         vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
         libvirt_vmxml.check_guest_xml_by_xpaths(


### PR DESCRIPTION
Test result:
 (1/1) type_specific.io-github-autotest-libvirt.numa_memAccess.invalid: PASS (19.08 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.incompatible_host_nodeset.strict: PASS (20.61 s)