### PR TITLE
Update case of rejecting big inbound average values

### DIFF
--- a/libvirt/tests/cfg/virtual_network/update_device/update_iface_qos_invalid.cfg
+++ b/libvirt/tests/cfg/virtual_network/update_device/update_iface_qos_invalid.cfg
@@ -9,8 +9,13 @@
             update_attrs = {'bandwidth': {'inbound': {'average': '-1', 'peak': '5000', 'burst': '1024'}}}
             err_msg = could not convert bandwidth average value|Expected non-negative integer value
         - big_value:
-            update_attrs = {'bandwidth': {'inbound': {'average': '10000000000000000', 'peak': '5000', 'burst': '1024'}}}
-            err_msg = could not convert bandwidth average value|Expected non-negative integer value
+            func_supported_since_libvirt_ver = (10,8,0)
+            update_attrs = {'bandwidth': {'inbound': {'average': '100000000000000000', 'peak': '5000', 'burst': '1024'}}}
+            err_msg = numerical overflow: value .* is too big for 'average' parameter, maximum is
+        - max_value:
+            func_supported_since_libvirt_ver = (10,8,0)
+            update_attrs = {'bandwidth': {'inbound': {'average': '18014398509481984', 'peak': '5000', 'burst': '1024'}}}
+            status_error = no
         - no_mandatory_average:
             update_attrs = {'bandwidth': {'outbound': {'peak': '5000', 'burst': '1024'}}}
             err_msg = Missing mandatory average or floor attributes

--- a/libvirt/tests/src/virtual_network/update_device/update_iface_qos_invalid.py
+++ b/libvirt/tests/src/virtual_network/update_device/update_iface_qos_invalid.py
@@ -1,5 +1,6 @@
 import logging
 
+from virttest import libvirt_version
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_libvirt import libvirt_vmxml
@@ -16,6 +17,7 @@ def run(test, params, env):
     """
     Test live update interface bandwidth setting by update-device or domiftune
     """
+    libvirt_version.is_libvirt_feature_supported(params)
     vm_name = params.get('main_vm')
     vm = env.get_vm(vm_name)
     status_error = 'yes' == params.get('status_error', 'no')


### PR DESCRIPTION
- VIRT-294768 - update-device qos Live update the QoS setting by update-device with invalid values

Test result:
```
 (1/5) type_specific.local.virtual_network.update_device.iface_qos.invalid.neg_value: STARTED
 (1/5) type_specific.local.virtual_network.update_device.iface_qos.invalid.neg_value: PASS (29.51 s)
 (2/5) type_specific.local.virtual_network.update_device.iface_qos.invalid.big_value: STARTED
 (2/5) type_specific.local.virtual_network.update_device.iface_qos.invalid.big_value: PASS (31.35 s)
 (3/5) type_specific.local.virtual_network.update_device.iface_qos.invalid.max_value: STARTED
 (3/5) type_specific.local.virtual_network.update_device.iface_qos.invalid.max_value: PASS (37.01 s)
 (4/5) type_specific.local.virtual_network.update_device.iface_qos.invalid.no_mandatory_average: STARTED
 (4/5) type_specific.local.virtual_network.update_device.iface_qos.invalid.no_mandatory_average: PASS (38.44 s)
 (5/5) type_specific.local.virtual_network.update_device.iface_qos.invalid.floor_without_bandwidth: STARTED
 (5/5) type_specific.local.virtual_network.update_device.iface_qos.invalid.floor_without_bandwidth: PASS (36.75 s)
RESULTS    : PASS 5 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```