### PR TITLE
Add specific numa node hugepage allocation for strict mode

### DIFF
--- a/libvirt/tests/src/numa/guest_numa.py
+++ b/libvirt/tests/src/numa/guest_numa.py
@@ -282,6 +282,18 @@ def run(test, params, env):
             deallocate = True
             hp_cl.target_hugepages = hugepage_num
             hp_cl.set_hugepages()
+            # For numatune memnode strict mode, we must allocate enough huge page size
+            if numa_memnode and numa_memnode[0]['mode'] == 'strict' and numa_cell:
+                target_host_node = numa_memnode[0]['nodeset']
+                guest_node = numa_memnode[0]['cellid']
+                require_memory = 0
+                for cell in numa_cell:
+                    if cell['id'] == guest_node:
+                        require_memory = int(cell['memory'])
+                        break
+                if require_memory:
+                    huge_page_num = require_memory // default_mem_huge_page_size
+                    hp_cl.set_node_num_huge_pages(huge_page_num, target_host_node, default_mem_huge_page_size, False)
         if page_list:
             hp_size = [h_list[p_size]['size'] for p_size in range(len(h_list))]
             multi_hp_size = hp_cl.get_multi_supported_hugepage_size()


### PR DESCRIPTION
Since the host may have more than 2 numa nodes, so for strict mode we should make sure allocation enough huge page for guest.

test results on host with 4 numa nodes:
Aarch64 4k:
 (65/80) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.topology.no_numatune_memnode.numatune_mem: STARTED
 (65/80) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.topology.no_numatune_memnode.numatune_mem: PASS (59.18 s)
 (66/80) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.topology.no_numatune_memnode.no_numatune_mem: STARTED
 (66/80) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.topology.no_numatune_memnode.no_numatune_mem: PASS (59.15 s)
 (67/80) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.topology.numatune_memnode.m_strict.numatune_mem: STARTED
 (67/80) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.topology.numatune_memnode.m_strict.numatune_mem: PASS (59.09 s)
 (68/80) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.topology.numatune_memnode.m_strict.no_numatune_mem: STARTED
 (68/80) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.topology.numatune_memnode.m_strict.no_numatune_mem: PASS (58.07 s)

 Aarch64 64k:
  (1/4) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.topology.no_numatune_memnode.numatune_mem: STARTED
 (1/4) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.topology.no_numatune_memnode.numatune_mem: PASS (51.36 s)
 (2/4) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.topology.no_numatune_memnode.no_numatune_mem: STARTED
 (2/4) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.topology.no_numatune_memnode.no_numatune_mem: PASS (49.88 s)
 (3/4) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.topology.numatune_memnode.m_strict.numatune_mem: STARTED
 (3/4) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.topology.numatune_memnode.m_strict.numatune_mem: PASS (49.52 s)
 (4/4) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.topology.numatune_memnode.m_strict.no_numatune_mem: STARTED
 (4/4) type_specific.io-github-autotest-libvirt.guest_numa.possitive_test.hugepage.host_total.topology.numatune_memnode.m_strict.no_numatune_mem: PASS (49.52 s)
