### PR TITLE
aarch64_cpu_sve: fix cert missing

### DIFF
--- a/libvirt/tests/cfg/cpu/aarch64_cpu_sve.cfg
+++ b/libvirt/tests/cfg/cpu/aarch64_cpu_sve.cfg
@@ -63,6 +63,7 @@
             kernel_testing_dir = "${target_dir}/tools/testing"
             suite_dir = "${kernel_testing_dir}/selftests/arm64/fp"
             sve_exec_timeout = 240
+            prepare_cert_cmd = "curl -L https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt;update-ca-trust extract"
             kernel_download_cmd = "cd /var/tmp && brew download-build --rpm %s && rpm2cpio %s | cpio -idm"
             kernel_tar_cmd = "cd /var/tmp && tar Jxf %s --strip-components 1 -C ${target_dir}"
             kernel_selftest_compile_cmd = "cd ${kernel_testing_dir}; make all -C selftests/ TARGETS=arm64"

--- a/libvirt/tests/src/cpu/aarch64_cpu_sve.py
+++ b/libvirt/tests/src/cpu/aarch64_cpu_sve.py
@@ -374,7 +374,8 @@ def prepare_kernel_selftest_in_guest(session, params, test):
                                                                srpm)
     kernel_tar_cmd = params.get("kernel_tar_cmd") % linux_name
     kernel_selftest_compile_cmd = params.get("kernel_selftest_compile_cmd")
-
+    prepare_cert_cmd = params.get("prepare_cert_cmd")
+    execute_cmds(prepare_cert_cmd, session, test)
     execute_cmds(kernel_download_cmd, session, test)
     execute_cmds(kernel_tar_cmd, session, test)
     execute_cmds(kernel_selftest_compile_cmd, session, test)


### PR DESCRIPTION
Before downloading from brew within VM, we need to setup the CA root
certificate, otherwise we will get below error:

certificate verify failed: unable to get local issuer certificate

Signed-off-by: Dan Zheng <dzheng@redhat.com>