### PR TITLE
Prepare certain state before managedsave

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_managedsave.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_managedsave.py
@@ -427,6 +427,9 @@ def run(test, params, env):
             vm_ref = params.get(vm_ref)
         elif vm_ref == "name":
             vm_ref = vm_name
+        # Prepare the certain state before managedsave
+        if params.get('paused_after_start_vm'):
+            virsh.suspend(vm_ref)
 
         # Ignore exception with "ignore_status=True"
         if progress:


### PR DESCRIPTION
For the case "managedsave.status_error_no.name_option.paused_status" we need to prepare the VM to be in paused state before managedsave.