### PR TITLE
tpm_device: add swtpm debug logging test

### DIFF
--- a/libvirt/tests/cfg/virtual_device/tpm_device.cfg
+++ b/libvirt/tests/cfg/virtual_device/tpm_device.cfg
@@ -39,6 +39,15 @@
                         - version_default:
                             only plain
                             backend_version = 'none'
+                        - debug:
+                            func_supported_since_libvirt_ver = (10, 6, 0)
+                            only encrypted 
+                            only pcrbank_default
+                            variants:
+                                - lvl_5:
+                                    backend_debug = '5'
+                                - lvl_20:
+                                    backend_debug = '20'
                         - persistent_state:
                             persistent_state = 'yes'
                             func_supported_since_libvirt_ver = (7, 0, 0)
@@ -209,6 +218,11 @@
                                 - version_textdefault:
                                     backend_version = 'default'
                                     xml_errmsg = "Invalid value for attribute 'version' in element 'backend': 'default'"
+                        - invalid_debug:
+                            func_supported_since_libvirt_ver = (10, 6, 0)
+                            backend_debug = '-1'
+                            backend_version = '2.0'
+                            xml_errmsg = "Invalid.*'debug' in element 'backend'.*Expected non-negative integer value"
                         - encrypt_secret:
                             backend_version = '2.0'
                             variants:


### PR DESCRIPTION
Add two classical values '5','20' test, and a negative '-1' test. Swtpm/libtpms debugging is very much non-stable/non-contract thing according to developer, our QE can first check sth different from non-setting, not sure the obvious difference between each level.