### PR TITLE
vIOMMU: Update to wait events after disk is attached

### DIFF
--- a/libvirt/tests/src/sriov/vIOMMU/hotplug_device_with_iommu_enabled.py
+++ b/libvirt/tests/src/sriov/vIOMMU/hotplug_device_with_iommu_enabled.py
@@ -74,7 +74,7 @@ def run(test, params, env):
             libvirt_disk.create_disk("file", new_disk_path, disk_size, disk_format="qcow2")
             disk_dict.update({'source': {'attrs': {'file': new_disk_path}}})
             disk_obj = libvirt_vmxml.create_vm_device_by_type('disk', disk_dict)
-            virsh.attach_device(vm.name, disk_obj.xml, debug=True, ignore_status=False)
+            virsh.attach_device(vm.name, disk_obj.xml, debug=True, ignore_status=False, wait_for_event=True)
 
         if need_sriov:
             test_obj.params["iface_dict"] = str(sroiv_test_obj.parse_iface_dict())


### PR DESCRIPTION
Update to check the events to make sure the disk is attached correctly.

Test results: executed 20 times, all passed:
`  (1/1) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.scsi_controller.virtio: PASS (47.42 s)
`
