### PR TITLE
virtual_network: disable test cases with mixed boot order elements

### DIFF
--- a/libvirt/tests/cfg/virtual_network/attach_detach_device/attach_iface_with_boot_order.cfg
+++ b/libvirt/tests/cfg/virtual_network/attach_detach_device/attach_iface_with_boot_order.cfg
@@ -5,6 +5,7 @@
     status_error = yes
     variants scenario:
         - vm_with_os_boot:
+            no s390-virtio
             os_attrs = {'boots': ['hd']}
             boot_order = 2
             err_msg = per-device boot elements cannot be used together with os/boot elements

--- a/libvirt/tests/cfg/virtual_network/iface_attach_detach.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_attach_detach.cfg
@@ -12,6 +12,7 @@
                     virsh_options = ' --config'
             variants scenario:
                 - with_os_boot:
+                    no s390-virtio
                     error_msg = 'per-device boot elements cannot be used together with os/boot elements'
                 - with_boot_disk:
                     error_msg = 'boot order 1 is already used by another device'

--- a/libvirt/tests/cfg/virtual_network/iface_update.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_update.cfg
@@ -200,6 +200,7 @@
                 - update_boot_order:
                     variants:
                         - with_os_boot:
+                            no s390-virtio
                             new_iface_boot = '1'
                             expect_err_msg = 'per-device boot elements cannot be used together with os/boot elements'
                         - boot_order_occupied:


### PR DESCRIPTION
On s390x, only per-device <boot/> is supported. Disable test expecting conflict with //os/boot