### PR TITLE
iface_bridge: make host interface configurable

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_bridge.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_bridge.cfg
@@ -4,6 +4,7 @@
     vms = avocado-vt-vm1 vm2
     bridge_name = "test_br0"
     netdst_nic1 = ${bridge_name}
+    host_iface =
     # Replace remote_ip by a actual IP address
     remote_ip = "www.google.com"
     ping_count = 3

--- a/libvirt/tests/src/virtual_network/iface_bridge.py
+++ b/libvirt/tests/src/virtual_network/iface_bridge.py
@@ -113,7 +113,9 @@ def run(test, params, env):
     filter_name = params.get("filter_name", "vdsm-no-mac-spoofing")
     ping_count = params.get("ping_count", "5")
     ping_timeout = float(params.get("ping_timeout", "10"))
-    iface_name = utils_net.get_net_if(state="UP")[0]
+    host_iface = params.get("host_iface")
+    iface_name = host_iface if host_iface else utils_net.get_default_gateway(
+        iface_name=True, force_dhcp=True).split()[0]
     bridge_script = NETWORK_SCRIPT + bridge_name
     iface_script = NETWORK_SCRIPT + iface_name
     iface_script_bk = os.path.join(data_dir.get_tmp_dir(), "iface-%s.bk" % iface_name)


### PR DESCRIPTION
On our test environment we must use not the first host interface. Make configurable but maintain default behavior if not configured.