### PR TITLE
Update network case of defining net without ip

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_network.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_network.cfg
@@ -196,6 +196,7 @@
                             no_mac = "yes"
                         - negative_without_ip:
                             define_error = "yes"
+                            only_test_define = "yes"
                             no_ip = "yes"
                         - negative_with_dev:
                             define_error = "yes"

--- a/libvirt/tests/src/virtual_network/iface_network.py
+++ b/libvirt/tests/src/virtual_network/iface_network.py
@@ -673,6 +673,7 @@ TIMEOUT 3"""
     ipt6_rules = []
     define_macvtap = "yes" == params.get("define_macvtap", "no")
     net_dns_forwarders = params.get("net_dns_forwarders", "").split()
+    only_test_define = "yes" == params.get("only_test_define", "no")
 
     # Cancel if not yet supported in libvirt version under test
     if "floor" in ast.literal_eval(iface_bandwidth_inbound):
@@ -795,10 +796,14 @@ TIMEOUT 3"""
                 netxml.sync()
             except xcepts.LibvirtXMLError as details:
                 logging.info(str(details))
+                if only_test_define and libvirt_version.version_compare(10, 8, 0):
+                    define_error = False
                 if define_error:
                     return
                 else:
                     test.fail("Failed to define network")
+            if only_test_define:
+                return
 
         # Check open mode network xml
         if "mode" in forward and forward["mode"] == "open":


### PR DESCRIPTION
- VIRT-63196 - [virtual network] define a network with forward mode 'open'

Test result:
```
 (1/1) type_specific.local.virtual_network.iface_network.net_forward.net_open.negative_without_ip: STARTED
 (1/1) type_specific.local.virtual_network.iface_network.net_forward.net_open.negative_without_ip: PASS (8.76 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```