### PR TITLE
Migration: option to enable/disable backward migration testing

### DIFF
--- a/libvirt/tests/cfg/guest_os_booting/migration/migration_boot.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/migration/migration_boot.cfg
@@ -23,6 +23,7 @@
     virsh_migrate_options = "--p2p --live --verbose  --persistent"
     virsh_migrate_desturi = "qemu+ssh://${migrate_dest_host}/system"
     virsh_migrate_connect_uri = "qemu:///system"
+    enable_backward_migration = 'yes'
     variants:
         - os_dev:
             os_attrs_boots = ['hd', 'cdrom', 'network']

--- a/libvirt/tests/cfg/migration/migration_with_vtpm/migration_with_external_tpm.cfg
+++ b/libvirt/tests/cfg/migration/migration_with_vtpm/migration_with_external_tpm.cfg
@@ -27,6 +27,7 @@
     status_error = "no"
     transport_type = "ssh"
     virsh_migrate_desturi = "qemu+ssh://${migrate_dest_host}/system"
+    enable_backward_migration = 'yes'
     # vtpm setting
     func_supported_since_libvirt_ver = (9, 0, 0)
     no pseries, s390-virtio

--- a/libvirt/tests/cfg/migration/migration_with_vtpm/migration_with_shared_tpm.cfg
+++ b/libvirt/tests/cfg/migration/migration_with_vtpm/migration_with_shared_tpm.cfg
@@ -31,6 +31,7 @@
     libvirtd_debug_file = '/var/log/libvirt/virtqemud.log'
     func_supported_since_libvirt_ver = (9, 0, 0)
     tpm_model = "tpm-crb"
+    enable_backward_migration = 'yes'
     aarch64:
         tpm_model = "tpm-tis"
 

--- a/libvirt/tests/src/guest_os_booting/migration/migration_boot.py
+++ b/libvirt/tests/src/guest_os_booting/migration/migration_boot.py
@@ -51,6 +51,7 @@ def run(test, params, env):
 
     vm_name = guest_os_booting_base.get_vm(params)
     vm = env.get_vm(vm_name)
+    enable_backward_migration = "yes" == params.get("enable_backward_migration", "yes")
 
     migration_obj = base_steps.MigrationBase(test, vm, params)
 
@@ -60,10 +61,11 @@ def run(test, params, env):
         migration_obj.run_migration()
         migration_obj.verify_default()
 
-        test.log.info("TEST_STEP: Migrate back the VM to the source host.")
-        migration_obj.run_migration_back()
-        dargs = {"check_disk_on_dest": "no"}
-        migration_obj.migration_test.post_migration_check([vm], dargs)
+        if enable_backward_migration:
+            test.log.info("TEST_STEP: Migrate back the VM to the source host.")
+            migration_obj.run_migration_back()
+            dargs = {"check_disk_on_dest": "no"}
+            migration_obj.migration_test.post_migration_check([vm], dargs)
 
     finally:
         migration_obj.cleanup_default()

--- a/libvirt/tests/src/migration/migration_with_vtpm/migration_with_external_tpm.py
+++ b/libvirt/tests/src/migration/migration_with_vtpm/migration_with_external_tpm.py
@@ -224,6 +224,7 @@ def run(test, params, env):
         migration_obj.cleanup_connection()
 
     vm_name = params.get("migrate_main_vm")
+    enable_backward_migration = "yes" == params.get("enable_backward_migration", "yes")
 
     libvirt_version.is_libvirt_feature_supported(params)
     vm = env.get_vm(vm_name)
@@ -234,7 +235,8 @@ def run(test, params, env):
         migration_obj.run_migration()
         verify_test()
         launch_external_swtpm(params, test, skip_setup=True)
-        migration_obj.run_migration_back()
-        verify_test_again()
+        if enable_backward_migration:
+            migration_obj.run_migration_back()
+            verify_test_again()
     finally:
         cleanup_test()

--- a/libvirt/tests/src/migration/migration_with_vtpm/migration_with_shared_tpm.py
+++ b/libvirt/tests/src/migration/migration_with_vtpm/migration_with_shared_tpm.py
@@ -268,6 +268,7 @@ def run(test, params, env):
 
     vm_name = params.get("migrate_main_vm")
     shared_storage_type = params.get('shared_storage_type', '')
+    enable_backward_migration = "yes" == params.get("enable_backward_migration", "yes")
 
     libvirt_version.is_libvirt_feature_supported(params)
     vm = env.get_vm(vm_name)
@@ -282,7 +283,8 @@ def run(test, params, env):
         setup_test()
         migration_obj.run_migration()
         verify_test()
-        migration_obj.run_migration_back()
-        verify_test_again()
+        if enable_backward_migration:
+            migration_obj.run_migration_back()
+            verify_test_again()
     finally:
         cleanup_test()


### PR DESCRIPTION
Added an option, `enable_backward_migration`, to enable ("yes") or disable ("no") backward migration testing in select test cases. This is because, for rhel10.0 aarch64, the focus is on forward, not backward, migration for now.

This result shows that setting the parameter to "no" successfully skips backwards migration and allows the tests to pass.

```
avocado run --vt-type libvirt --vt-omit-data-loss --vt-machine-type arm64-pci migration_with_vtpm.migration_with_external_tpm.persistent_and_p2p migration_with_vtpm.migration_with_shared_tpm.nfs.persistent_and_p2p guest_os_booting.migration.boot.boot_order guest_os_booting.migration.boot.os_dev --vt-connect-uri qemu:///system --vt-extra-params "enable_backward_migration = 'no'"
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : 2a618f16fd961c490b5dd0f4c030f31f8e1b5211
JOB LOG    : /var/log/avocado/job-results/job-2024-11-20T17.26-2a618f1/job.log
 (1/4) type_specific.io-github-autotest-libvirt.migration_with_vtpm.migration_with_external_tpm.persistent_and_p2p: STARTED
 (1/4) type_specific.io-github-autotest-libvirt.migration_with_vtpm.migration_with_external_tpm.persistent_and_p2p: PASS (150.59 s)
 (2/4) type_specific.io-github-autotest-libvirt.migration_with_vtpm.migration_with_shared_tpm.nfs.persistent_and_p2p: STARTED
 (2/4) type_specific.io-github-autotest-libvirt.migration_with_vtpm.migration_with_shared_tpm.nfs.persistent_and_p2p: PASS (154.55 s)
 (3/4) type_specific.io-github-autotest-libvirt.guest_os_booting.migration.boot.boot_order: STARTED
 (3/4) type_specific.io-github-autotest-libvirt.guest_os_booting.migration.boot.boot_order: PASS (138.03 s)
 (4/4) type_specific.io-github-autotest-libvirt.guest_os_booting.migration.boot.os_dev: STARTED
 (4/4) type_specific.io-github-autotest-libvirt.guest_os_booting.migration.boot.os_dev: PASS (137.82 s)
RESULTS    : PASS 4 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2024-11-20T17.26-2a618f1/results.html
JOB TIME   : 585.19 s
```