### PR TITLE
iface_options:Fix error of get wrong ip addr

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_bridge.py
+++ b/libvirt/tests/src/virtual_network/iface_bridge.py
@@ -17,6 +17,8 @@ from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices import interface
 from virttest.libvirt_xml import network_xml
 
+from provider.virtual_network import network_base
+
 NETWORK_SCRIPT = "/etc/sysconfig/network-scripts/ifcfg-"
 
 
@@ -249,7 +251,7 @@ def run(test, params, env):
         remote_url = params.get("remote_ip", "www.google.com")
 
         try:
-            vm1_ip = utils_net.get_guest_ip_addr(session1, mac)
+            vm1_ip = network_base.get_vm_ip(session1, mac)
         except Exception as errs:
             test.fail("vm1 can't get IP with the new create bridge: %s" % errs)
         if test_qos:

--- a/libvirt/tests/src/virtual_network/iface_network.py
+++ b/libvirt/tests/src/virtual_network/iface_network.py
@@ -26,6 +26,8 @@ from virttest.libvirt_xml.network_xml import NetworkXML
 from virttest.libvirt_xml.devices.interface import Interface
 from virttest import libvirt_version
 
+from provider.virtual_network import network_base
+
 
 # Using as lower capital is not the best way to do, but this is just a
 # workaround to avoid changing the entire file.
@@ -482,8 +484,8 @@ TIMEOUT 3"""
 
         # It may take some time to get the ip address
         def get_ip_func():
-            return utils_net.get_guest_ip_addr(session, iface_mac,
-                                               ip_version=ip_ver)
+            return network_base.get_vm_ip(session, iface_mac,
+                                          ip_ver=ip_ver)
 
         utils_misc.wait_for(get_ip_func, 5)
         if not get_ip_func():
@@ -1086,7 +1088,7 @@ TIMEOUT 3"""
                 if test_dhcp_range:
                     dhcp_range = int(params.get("dhcp_range", "252"))
                     utils_net.restart_guest_network(session, iface_mac)
-                    vm_ip = utils_net.get_guest_ip_addr(session, iface_mac)
+                    vm_ip = network_base.get_vm_ip(session, iface_mac)
                     logging.debug("Guest has ip: %s", vm_ip)
                     if not vm_ip and dhcp_range:
                         test.fail("Guest has invalid ip address")
@@ -1100,8 +1102,7 @@ TIMEOUT 3"""
                         vms_mac = vms.get_virsh_mac_address()
                         # restart guest network to get ip addr
                         utils_net.restart_guest_network(sess, vms_mac)
-                        vms_ip = utils_net.get_guest_ip_addr(sess,
-                                                             vms_mac)
+                        vms_ip = network_base.get_vm_ip(sess, vms_mac)
                         if not vms_ip and dhcp_range:
                             test.fail("Guest has invalid ip address")
                         elif vms_ip and not dhcp_range:

--- a/libvirt/tests/src/virtual_network/iface_options.py
+++ b/libvirt/tests/src/virtual_network/iface_options.py
@@ -29,6 +29,7 @@ from virttest.libvirt_xml import xcepts
 from virttest.staging import utils_memory
 
 from virttest import libvirt_version
+from provider.virtual_network import network_base
 
 
 # Using as lower capital is not the best way to do, but this is just a
@@ -382,8 +383,8 @@ def run(test, params, env):
         utils_net.restart_guest_network(session, mac)
         # Wait for IP address is ready
         utils_misc.wait_for(
-            lambda: utils_net.get_guest_ip_addr(session, mac), 10)
-        return utils_net.get_guest_ip_addr(session, mac)
+            lambda: network_base.get_vm_ip(session, mac), 10)
+        return network_base.get_vm_ip(session, mac)
 
     def check_user_network(session):
         """

--- a/libvirt/tests/src/virtual_network/virtual_network_multivms.py
+++ b/libvirt/tests/src/virtual_network/virtual_network_multivms.py
@@ -15,6 +15,8 @@ from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices import interface
 
+from provider.virtual_network import network_base
+
 
 # Using as lower capital is not the best way to do, but this is just a
 # workaround to avoid changing the entire file.
@@ -368,7 +370,7 @@ def run(test, params, env):
             for vm_i in vm_list:
                 mac = vm_xml.VMXML.get_first_mac_by_name(vm_i.name)
                 sess = vm_i.wait_for_serial_login()
-                vm_ip = utils_net.get_guest_ip_addr(sess, mac, timeout=5)
+                vm_ip = network_base.get_vm_ip(sess, mac, timeout=5)
                 session_n_ip[sess] = vm_ip
                 logging.debug('Vm %s ip: %s', vm_i.name, vm_ip)
                 if not vm_ip:


### PR DESCRIPTION
Test result:
```
 (1/3) type_specific.io-github-autotest-libvirt.virtual_network.iface_options.iface_type.type_user.default: STARTED
 (1/3) type_specific.io-github-autotest-libvirt.virtual_network.iface_options.iface_type.type_user.default: PASS (65.91 s)
 (2/3) type_specific.io-github-autotest-libvirt.virtual_network.iface_options.iface_type.type_user.type_user_set_ip.ignore_prefix: STARTED
 (2/3) type_specific.io-github-autotest-libvirt.virtual_network.iface_options.iface_type.type_user.type_user_set_ip.ignore_prefix: PASS (123.55 s)
 (3/3) type_specific.io-github-autotest-libvirt.virtual_network.iface_options.iface_type.type_user.type_user_set_ip.set_prefix: STARTED
 (3/3) type_specific.io-github-autotest-libvirt.virtual_network.iface_options.iface_type.type_user.type_user_set_ip.set_prefix: PASS (123.03 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0

 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.iface_bridge.default.shared_physical_network: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.iface_bridge.default.shared_physical_network: PASS (141.91 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0

 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.iface_options.iface_type.type_mcast: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.iface_options.iface_type.type_mcast: PASS (132.82 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0

 (1/7) type_specific.io-github-autotest-libvirt.virtual_network.multivms.port_isolated.iface.set_iface.with_net.set_one: STARTED
 (1/7) type_specific.io-github-autotest-libvirt.virtual_network.multivms.port_isolated.iface.set_iface.with_net.set_one: PASS (179.73 s)
 (2/7) type_specific.io-github-autotest-libvirt.virtual_network.multivms.port_isolated.iface.update_iface.yes_to_none: STARTED
 (2/7) type_specific.io-github-autotest-libvirt.virtual_network.multivms.port_isolated.iface.update_iface.yes_to_none: PASS (165.13 s)
 (3/7) type_specific.io-github-autotest-libvirt.virtual_network.multivms.port_isolated.iface.update_iface.yes_to_no: STARTED
 (3/7) type_specific.io-github-autotest-libvirt.virtual_network.multivms.port_isolated.iface.update_iface.yes_to_no: PASS (184.98 s)
 (4/7) type_specific.io-github-autotest-libvirt.virtual_network.multivms.port_isolated.network.set_no: STARTED
 (4/7) type_specific.io-github-autotest-libvirt.virtual_network.multivms.port_isolated.network.set_no: PASS (186.91 s)
 (5/7) type_specific.io-github-autotest-libvirt.virtual_network.multivms.macTableManager.nat.set_libvirt: STARTED
 (5/7) type_specific.io-github-autotest-libvirt.virtual_network.multivms.macTableManager.nat.set_libvirt: PASS (166.08 s)
 (6/7) type_specific.io-github-autotest-libvirt.virtual_network.multivms.macTableManager.nat.resume_vm: STARTED
 (6/7) type_specific.io-github-autotest-libvirt.virtual_network.multivms.macTableManager.nat.resume_vm: PASS (191.60 s)
 (7/7) type_specific.io-github-autotest-libvirt.virtual_network.multivms.macTableManager.linux_br.set_libvirt: STARTED
 (7/7) type_specific.io-github-autotest-libvirt.virtual_network.multivms.macTableManager.linux_br.set_libvirt: PASS (188.04 s)
RESULTS    : PASS 7 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0

 (1/2) type_specific.io-github-autotest-libvirt.virtual_network.iface_bridge.hotplug_iface.shared_physical_network: STARTED
 (1/2) type_specific.io-github-autotest-libvirt.virtual_network.iface_bridge.hotplug_iface.shared_physical_network: PASS (96.51 s)
 (2/2) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.net_macvtap.net_bridge.multi_guests: STARTED
 (2/2) type_specific.io-github-autotest-libvirt.virtual_network.iface_network.net_macvtap.net_bridge.multi_guests: PASS (125.57 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```