### PR TITLE
Snapshot: fix console failure when using the console for the second time

### DIFF
--- a/libvirt/tests/src/snapshot/delete_external_snap_with_references.py
+++ b/libvirt/tests/src/snapshot/delete_external_snap_with_references.py
@@ -46,8 +46,9 @@ def run(test, params, env):
         Delete the parent snapshot with multiple children.
         """
         test.log.info("TEST_STEP:Delete the parent snapshot with multi-child.")
-        virsh.start(vm_name)
-        vm.wait_for_login().close()
+        if not vm.is_alive():
+            virsh.start(vm_name)
+            vm.wait_for_login().close()
         del_res = virsh.snapshot_delete(vm.name, snap_names[0], debug=True)
         libvirt.check_exit_status(del_res, error_msg)
 

--- a/libvirt/tests/src/snapshot/revert_disk_external_snap.py
+++ b/libvirt/tests/src/snapshot/revert_disk_external_snap.py
@@ -29,7 +29,9 @@ def revert_snap_and_check_files(params, vm, test, snap_name, expected_files):
     """
     virsh.snapshot_revert(vm.name, snap_name, **virsh_dargs)
 
-    session = vm.wait_for_login()
+    vm.cleanup_serial_console()
+    vm.create_serial_console()
+    session = vm.wait_for_serial_login()
     for file in expected_files:
         output = session.cmd('ls %s' % file)
         if file not in output:
@@ -49,8 +51,8 @@ def run(test, params, env):
         Prepare file and snapshot.
         """
         test.log.info("TEST_SETUP: Create files and snaps in running guest.")
-        virsh.start(vm_name)
-        session = vm.wait_for_login()
+        vm.start()
+        session = vm.wait_for_serial_login()
         mem_file = " "
         for index, sname in enumerate(snap_names):
             session.cmd("touch %s" % file_list[index])

--- a/libvirt/tests/src/snapshot/revert_snapshot_after_xml_updated.py
+++ b/libvirt/tests/src/snapshot/revert_snapshot_after_xml_updated.py
@@ -68,7 +68,9 @@ def check_file_exist(test, vm, params, revert_snap):
 
     if not vm.is_alive():
         virsh.start(vm_name)
-    session = vm.wait_for_login()
+    vm.cleanup_serial_console()
+    vm.create_serial_console()
+    session = vm.wait_for_serial_login()
 
     if revert_snap == "1":
         file_list = eval(params.get("file_list"))[0:1]
@@ -186,8 +188,8 @@ def run(test, params, env):
             hotplug disk/hotplug vcpus/blkiotune
         """
         test.log.info("TEST_STEP1:Prepare a running guest and create file.")
-        virsh.start(vm_name)
-        session = vm.wait_for_login()
+        vm.start()
+        session = vm.wait_for_serial_login()
         create_file(vm, file_list[0], session)
 
         test.log.info("TEST_STEP2: Create snapshot.")


### PR DESCRIPTION
Fix "No console available" issues in some snapshot scripts: 
1) delete_external_snap_with_references.py: this script starts the guest
   twice. So I added an if statement to check vm.is_alive in the second
   time.
2) Another two scripts, to make sure the second console is same and
   pure. I added vm.cleanup_serial_console and vm.create_serial_console
   before the second time.