### PR TITLE
passt:Fix error of getting wrong gateway

### DIFF
--- a/libvirt/tests/src/virtual_network/passt/passt_connectivity_between_2vms.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_connectivity_between_2vms.py
@@ -106,9 +106,9 @@ def run(test, params, env):
          for session in (server_session, client_session)]
 
         server_default_gw = utils_net.get_default_gateway(
-            session=server_session, force_dhcp=True)
+            session=server_session, force_dhcp=True, json=True)
         server_default_gw_v6 = utils_net.get_default_gateway(
-            session=server_session, ip_ver='ipv6')
+            session=server_session, ip_ver='ipv6', json=True)
 
         firewalld.stop()
         server_session.cmd('systemctl stop firewalld')

--- a/provider/virtual_network/passt.py
+++ b/provider/virtual_network/passt.py
@@ -243,10 +243,10 @@ def check_default_gw(session, host_iface=None):
     :param host_iface: if given, only check gateway information on this
                        host interface
     """
-    host_gw = utils_net.get_default_gateway(force_dhcp=True,
-                                            target_iface=host_iface).split()
-    vm_gw = utils_net.get_default_gateway(session=session,
-                                          force_dhcp=True).split()
+    host_gw = utils_net.get_default_gateway(
+        force_dhcp=True, target_iface=host_iface, json=True).split()
+    vm_gw = utils_net.get_default_gateway(
+        session=session, force_dhcp=True, json=True).split()
     LOG.debug(f'Host and vm default ipv4 gateway: {host_gw}, {vm_gw}')
     if [x for x in vm_gw if x not in host_gw]:
         raise exceptions.TestFail(


### PR DESCRIPTION
Depends on
- https://github.com/avocado-framework/avocado-vt/pull/4029

Test result:
```
 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.passt.reconnect.ip_portfw.root_user: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.passt.reconnect.ip_portfw.root_user: PASS (243.66 s)

 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.passt.interface_function.minimal.non_root_user: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.passt.interface_function.minimal.non_root_user: PASS (120.16 s)

 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.passt.connectivity_between_2vms.ip_portfw.root_user: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.passt.connectivity_between_2vms.ip_portfw.root_user: PASS (201.49 s)
```