### PR TITLE
Fix irregular usage of test log

### DIFF
--- a/libvirt/tests/src/memory/memory_allocation/define_value_unit.py
+++ b/libvirt/tests/src/memory/memory_allocation/define_value_unit.py
@@ -133,7 +133,7 @@ def run(test, params, env):
                     test.fail('%s should be %s instead of %s ' %
                               (attr, result[attr], new_value))
                 else:
-                    test.log.debug("Get correct %s=%s in xml", (attr, result[attr]))
+                    test.log.debug("Get correct %s=%s in xml", attr, result[attr])
 
     def set_negative_memory(case):
         """


### PR DESCRIPTION
test results:
 (1/7) type_specific.io-github-autotest-libvirt.memory.allocation.define_value_unit.without_numa.positive_test.bytes: STARTED
 (1/7) type_specific.io-github-autotest-libvirt.memory.allocation.define_value_unit.without_numa.positive_test.bytes: PASS (17.34 s)
 (2/7) type_specific.io-github-autotest-libvirt.memory.allocation.define_value_unit.without_numa.positive_test.KB: STARTED
 (2/7) type_specific.io-github-autotest-libvirt.memory.allocation.define_value_unit.without_numa.positive_test.KB: PASS (14.56 s)
 (3/7) type_specific.io-github-autotest-libvirt.memory.allocation.define_value_unit.without_numa.positive_test.KiB: STARTED
 (3/7) type_specific.io-github-autotest-libvirt.memory.allocation.define_value_unit.without_numa.positive_test.KiB: PASS (14.50 s)
 (4/7) type_specific.io-github-autotest-libvirt.memory.allocation.define_value_unit.without_numa.positive_test.MB: STARTED
 (4/7) type_specific.io-github-autotest-libvirt.memory.allocation.define_value_unit.without_numa.positive_test.MB: PASS (14.69 s)
 (5/7) type_specific.io-github-autotest-libvirt.memory.allocation.define_value_unit.without_numa.positive_test.MiB: STARTED
 (5/7) type_specific.io-github-autotest-libvirt.memory.allocation.define_value_unit.without_numa.positive_test.MiB: PASS (14.62 s)
 (6/7) type_specific.io-github-autotest-libvirt.memory.allocation.define_value_unit.without_numa.positive_test.GB: STARTED
 (6/7) type_specific.io-github-autotest-libvirt.memory.allocation.define_value_unit.without_numa.positive_test.GB: PASS (14.18 s)
 (7/7) type_specific.io-github-autotest-libvirt.memory.allocation.define_value_unit.without_numa.positive_test.GiB: STARTED
 (7/7) type_specific.io-github-autotest-libvirt.memory.allocation.define_value_unit.without_numa.positive_test.GiB: PASS (14.38 s)