### PR TITLE
interface_base:Add --color=never to ip command

### DIFF
--- a/provider/interface/interface_base.py
+++ b/provider/interface/interface_base.py
@@ -55,7 +55,8 @@ def get_vm_iface(vm_session, ignore_status=False):
     :param ignore_status: Whether to raise an exception if there is no interface
     :return: VM's first interface
     """
-    p_iface, _v_ifc = utils_net.get_remote_host_net_ifs(vm_session)
+    p_iface, _v_ifc = utils_net.get_remote_host_net_ifs(
+        vm_session, ip_options='-color=never')
     vm_iface = p_iface[:1:]
     if not vm_iface:
         if ignore_status:


### PR DESCRIPTION
Depends on
- https://github.com/avocado-framework/avocado-vt/pull/4032

Test result:
```
 (1/3) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_link_state.network.virtio.add: STARTED
 (1/3) type_specific.io-github-autotest-libvirt.virtual_network.update_device.iface_link_state.network.virtio.add: PASS (46.39 s)
 (2/3) type_specific.io-github-autotest-libvirt.virtual_network.elements_and_attributes.model.default: STARTED
 (2/3) type_specific.io-github-autotest-libvirt.virtual_network.elements_and_attributes.model.default: PASS (53.52 s)
 (3/3) type_specific.io-github-autotest-libvirt.virtual_network.link_state.model.network.e1000e.initial_up: STARTED
 (3/3) type_specific.io-github-autotest-libvirt.virtual_network.link_state.model.network.e1000e.initial_up: PASS (57.87 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```