### PR TITLE
Fix setvirtlog failure due to not completion start of VM

### DIFF
--- a/libvirt/tests/src/daemon/conf_file/libvirtd_conf/set_audit_logging.py
+++ b/libvirt/tests/src/daemon/conf_file/libvirtd_conf/set_audit_logging.py
@@ -142,6 +142,7 @@ def run(test, params, env):
             check_virt_type_from_audit_log()
             check_msg_in_libvirtd_log("virDomainAudit")
         elif test_scenario == "default_audit_log":
+            vm.wait_for_login().close()
             ausearch_audit_log()
         elif test_scenario == "concurrent_filters":
             check_concurrent_filters()


### PR DESCRIPTION
Fix setvirtlog failure due to not completion start of VM
Add vm.wait_for_login().close() before calling on check log