### PR TITLE
s390x/migrate: disable some unsupported tests

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_mem.cfg
+++ b/libvirt/tests/cfg/migration/migrate_mem.cfg
@@ -28,6 +28,7 @@
     start_vm = "no"
     variants case:
         - mem_device:
+            no s390-virtio
             cpuxml_cpu_mode = "host-model"
             aarch64:
                 cpuxml_cpu_mode = "host-passthrough"
@@ -54,6 +55,7 @@
         - mem_balloon:
             ballooned_mem = "716800"
         - mem_nvdimm:
+            no s390-virtio
             nvdimm_file_path = '${nfs_mount_dir}/nvdimm'
             nvdimm_file_size = '512M'
             vm_attrs = {'max_mem_rt': 4096, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'M', 'vcpu': 4, 'cpu': {'mode': 'host-passthrough', 'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '1024', 'unit': 'M'}, {'id': '1', 'cpus': '2-3', 'memory': '1024', 'unit': 'M'}]}}

--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -493,6 +493,7 @@
                             dst_secret_value = ${src_secret_value}
                             cmd_in_vm_after_migration = "tpm2_getrandom 10"                                                   
                 - timer:
+                    no s390-virtio
                     timer_migration = "yes"
                     asynch_migrate = "yes"
                     actions_during_migration = "setmaxdowntime"


### PR DESCRIPTION
1. No timer support on s390x
2. No mem device support (nv)dimm on s390x