### PR TITLE
migrate_network: enable configuration of host interface

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_network.cfg
+++ b/libvirt/tests/cfg/migration/migrate_network.cfg
@@ -16,6 +16,8 @@
     virsh_migrate_dest_state = running
     virsh_migrate_src_state = running
     virsh_migrate_options = "--live --p2p --verbose"
+    host_iface_src =
+    host_iface_dst =
     # Local URI
     virsh_migrate_connect_uri = "qemu:///system"
     migrate_vm_back = "yes"


### PR DESCRIPTION
direct-macvtap uses host interfaces on source and target. Make them configurable by their name.