### PR TITLE
fix memory cases format output fail due regex issue

### DIFF
--- a/libvirt/tests/src/memory/memory_devices/virtio_mem_with_memory_allocation_and_numa.py
+++ b/libvirt/tests/src/memory/memory_devices/virtio_mem_with_memory_allocation_and_numa.py
@@ -33,7 +33,7 @@ def adjust_virtio_mem_size_unit(params, test):
     params.update({"target_size": target_size})
     params.update({"request_size": request_size})
 
-    test.log.debug("Convert params: target_size to be %s, request_size to be",
+    test.log.debug("Convert params: target_size to be %s, request_size to be %s",
                    target_size, request_size)
 
 


### PR DESCRIPTION
  missing one format label
Signed-off-by: nanli <nanli@redhat.com>

```
avocado run --vt-type libvirt --vt-omit-data-loss --vt-machine-type q35 memory.devices.virtio_mem.memory_allocation_and_numa.define_guest.virtio_mem_with_node.without_numa.with_maxmemory memory.devices.virtio_mem.memory_allocation_and_numa.define_guest.virtio_mem_with_node.with_numa.with_maxmemory memory.devices.virtio_mem.memory_allocation_and_numa.define_guest.virtio_mem_without_node.without_numa.with_maxmemory   --vt-connect-uri qemu:///system 
 (1/3) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.define_guest.virtio_mem_with_node.without_numa.with_maxmemory: PASS (92.64 s)
 (2/3) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.define_guest.virtio_mem_with_node.with_numa.with_maxmemory: PASS (81.02 s)
 (3/3) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.define_guest.virtio_mem_without_node.without_numa.with_maxmemory: PASS (75.51 s)

```
