### PR TITLE
make cpu topology error msg be more compatible

### DIFF
--- a/libvirt/tests/cfg/cpu/max_vcpus.cfg
+++ b/libvirt/tests/cfg/cpu/max_vcpus.cfg
@@ -60,4 +60,4 @@
                     only q35
                     check = "ioapic_iommu_ne"
                     guest_vcpu = "711"
-                    err_msg = "unsupported configuration: Maximum CPUs greater than specified machine type limit|exceeds the maximum cpus supported"
+                    err_msg = "unsupported configuration: Maximum CPUs greater than specified machine type limit|exceeds the maximum cpus supported|CPU topology doesn't match maximum vcpu count"


### PR DESCRIPTION
 give one more error msg
Signed-off-by: nanli <nanli@redhat.com>

Before fixed
```
 avocado run --vt-type libvirt --vt-omit-data-loss --vt-machine-type q35 max_vcpus.negative_test.ioapic_iommu --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.max_vcpus.negative_test.ioapic_iommu: FAIL: Expect should fail with one of ['unsupported configuration: Maximum CPUs greater than specified machine type limit|exceeds the maximum cpus supported'], but failed with:\n\n\nerror: Failed to define domain from /var/tmp/xml_utils_temp_1c36vqvo.xml\nerror: uns... (7.27 s)
```

After fixed 
```
 avocado run --vt-type libvirt --vt-omit-data-loss --vt-machine-type q35 max_vcpus.negative_test.ioapic_iommu --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.max_vcpus.negative_test.ioapic_iommu: PASS (6.96 s)

```