### PR TITLE
migration: Using migrate_vm_back option

### DIFF
--- a/libvirt/tests/src/guest_os_booting/migration/migration_boot.py
+++ b/libvirt/tests/src/guest_os_booting/migration/migration_boot.py
@@ -49,6 +49,17 @@ def run(test, params, env):
         update_vm_xml(vm, params)
         migration_obj.setup_default()
 
+    def verify_test_again():
+        """
+        Test verify
+        """
+        migrate_vm_back = "yes" == params.get("migrate_vm_back", "yes")
+        if not migrate_vm_back:
+            return
+        test.log.info("Verify test again.")
+        dargs = {"check_disk_on_dest": "no"}
+        migration_obj.migration_test.post_migration_check([vm], dargs)
+
     vm_name = guest_os_booting_base.get_vm(params)
     vm = env.get_vm(vm_name)
 
@@ -62,8 +73,7 @@ def run(test, params, env):
 
         test.log.info("TEST_STEP: Migrate back the VM to the source host.")
         migration_obj.run_migration_back()
-        dargs = {"check_disk_on_dest": "no"}
-        migration_obj.migration_test.post_migration_check([vm], dargs)
+        verify_test_again()
 
     finally:
         migration_obj.cleanup_default()

--- a/libvirt/tests/src/migration/migration_with_vtpm/migration_with_external_tpm.py
+++ b/libvirt/tests/src/migration/migration_with_vtpm/migration_with_external_tpm.py
@@ -197,6 +197,9 @@ def run(test, params, env):
 
         """
         tpm_security_contexts = params.get("tpm_security_contexts")
+        migrate_vm_back = "yes" == params.get("migrate_vm_back", "yes")
+        if not migrate_vm_back:
+            return
 
         check_vtpm_func(params, vm, test)
         vm.shutdown()

--- a/libvirt/tests/src/migration/migration_with_vtpm/migration_with_shared_tpm.py
+++ b/libvirt/tests/src/migration/migration_with_vtpm/migration_with_shared_tpm.py
@@ -250,6 +250,10 @@ def run(test, params, env):
         Verify steps for migration back
 
         """
+        migrate_vm_back = "yes" == params.get("migrate_vm_back", "yes")
+        if not migrate_vm_back:
+            return
+
         tpm_security_contexts_restore = params.get("tpm_security_contexts_restore")
         check_vtpm_func(params, vm, test)
         vm.shutdown()

--- a/provider/migration/base_steps.py
+++ b/provider/migration/base_steps.py
@@ -228,6 +228,9 @@ class MigrationBase(object):
         """
         Execute migration from target host to source host
         """
+        migrate_vm_back = "yes" == self.params.get("migrate_vm_back", "yes")
+        if not migrate_vm_back:
+            return
         virsh_options = self.params.get("virsh_options", "")
         extra = self.params.get("virsh_migrate_extra")
         options = self.params.get("virsh_migrate_options", "--live --verbose")


### PR DESCRIPTION
Use migrate_vm_back option in avocado-vt/share/cfg/base.cfg to determine whether to migrate vm back to source host.