### PR TITLE
Check the default backend for user type interface

### DIFF
--- a/libvirt/tests/cfg/host_hypervisor/domcapabilities_output.cfg
+++ b/libvirt/tests/cfg/host_hypervisor/domcapabilities_output.cfg
@@ -3,3 +3,5 @@
     start_vm = no
     variants test_case:
         - rm_ovmf_path:
+        - check_iface_backend:
+            func_supported_since_libvirt_ver = (10, 8, 0)

--- a/libvirt/tests/cfg/virtual_network/connectivity/connectivity_check_user_interface.cfg
+++ b/libvirt/tests/cfg/virtual_network/connectivity/connectivity_check_user_interface.cfg
@@ -41,6 +41,10 @@
                             ipv4_addr = 100.100.100.15
                             ipv4_default_gw = 100.100.100.2
                             nameserver = 100.100.100.3
+                        - with_backend:
+                            iface_attrs = {'model': 'virtio', 'type_name': 'user'}
+                            backend = {'type': 'default'}
+                            func_supported_since_libvirt_ver = (10, 8, 0)
         - negative_test:
             expect_error = yes
             variants:

--- a/libvirt/tests/src/host_hypervisor/domcapabilities_output.py
+++ b/libvirt/tests/src/host_hypervisor/domcapabilities_output.py
@@ -1,6 +1,7 @@
 import os
 
 from virttest.libvirt_xml import domcapability_xml
+from virttest import libvirt_version
 
 
 def get_ovmf_path():
@@ -59,6 +60,17 @@ def test_rm_ovmf_path(test):
                        "is recovered", dir_ovmf_path)
 
 
+def test_check_iface_backend(test):
+    domcapa_xml = domcapability_xml.DomCapabilityXML()
+    get_iface = domcapa_xml.xmltreefile.findall('/devices/interface/enum/value')
+    get_backend_list = set([i.text for i in get_iface])
+    test.log.debug("interface backend supported includes: %s", get_backend_list)
+    support_list = {'passt', 'default'}
+    if get_backend_list != support_list:
+        test.fail("current support interface backend should be %s, "
+                  "but it's %s", support_list, get_backend_list)
+
+
 def run(test, params, env):
     """
     This file includes to test scenarios for checking outputs of
@@ -69,5 +81,6 @@ def run(test, params, env):
 
     """
     test_case = params.get("test_case", "")
+    libvirt_version.is_libvirt_feature_supported(params)
     run_test = eval("test_%s" % test_case)
     run_test(test)


### PR DESCRIPTION
Since libvirt 10.8.0, to unify the xml for user type interface, for user type interface with backend as slirp, add the <backend type/> element, and the default backend is slirp.