### PR TITLE
Clean boot config and add hard disk boot device

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_save_image_define.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_save_image_define.cfg
@@ -1,5 +1,6 @@
 - virsh.save_image_define:
     type = virsh_save_image_define
+    start_vm = "no"
     vm_save = "vm.save"
     kill_vm_on_error = "no"
     variants:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_save_image_edit.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_save_image_edit.cfg
@@ -1,5 +1,6 @@
 - virsh.save_image_edit:
     type = virsh_save_image_edit
+    start_vm = "no"
     vm_save = "vm.save"
     kill_vm_on_error = "no"
     take_regular_screendumps = "no"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_save_image_define.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_save_image_define.py
@@ -7,6 +7,7 @@ from avocado.core import exceptions
 
 from virttest import data_dir
 from virttest import virsh
+from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
 
 
@@ -74,6 +75,16 @@ def run(test, params, env):
     restore_state = params.get("restore_state", "running")
     vm_save = params.get("vm_save", "vm.save")
 
+    vm_backup = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    vmxml.remove_all_boots()
+    dict_os_attrs = {"boots": ["hd"]}
+    vmxml.set_os_attrs(**dict_os_attrs)
+    vmxml.sync()
+    vm = env.get_vm(vm_name)
+    vm.start()
+    vm.wait_for_login()
+
     try:
         # Get a tmp_dir.
         tmp_dir = data_dir.get_tmp_dir()
@@ -121,3 +132,5 @@ def run(test, params, env):
 
         if os.path.exists(xmlfile):
             os.remove(xmlfile)
+
+        vm_backup.sync()

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_save_image_edit.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_save_image_edit.py
@@ -75,13 +75,18 @@ def run(test, params, env):
     # MAIN TEST CODE ###
     # Process cartesian parameters
     vm_name = params.get("main_vm")
-    vm = env.get_vm(vm_name)
-    vm.wait_for_login()
-
     restore_state = params.get("restore_state", "")
     vm_save = params.get("vm_save", "vm.save")
 
     vm_backup = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    vmxml = vm_backup.copy()
+    vmxml.remove_all_boots()
+    dict_os_attrs = {"boots": ["hd"]}
+    vmxml.set_os_attrs(**dict_os_attrs)
+    vmxml.sync()
+    vm = env.get_vm(vm_name)
+    vm.start()
+    vm.wait_for_login()
 
     try:
         # Get a tmp_dir.


### PR DESCRIPTION
Some initial config xml don't config boot device in os tag, but boot order config at disk part. So delete all boot config then init hard disk boot device in os tag.

Test results:
 (1/3) type_specific.io-github-autotest-libvirt.virsh.save_image_edit.no_option: STARTED
 (1/3) type_specific.io-github-autotest-libvirt.virsh.save_image_edit.no_option: PASS (16.86 s)
 (2/3) type_specific.io-github-autotest-libvirt.virsh.save_image_edit.running: STARTED
 (2/3) type_specific.io-github-autotest-libvirt.virsh.save_image_edit.running: PASS (16.75 s)
 (3/3) type_specific.io-github-autotest-libvirt.virsh.save_image_edit.paused: STARTED
 (3/3) type_specific.io-github-autotest-libvirt.virsh.save_image_edit.paused: PASS (16.47 s)

(1/2) type_specific.io-github-autotest-libvirt.virsh.save_image_define.running: STARTED
 (1/2) type_specific.io-github-autotest-libvirt.virsh.save_image_define.running: PASS (16.26 s)
 (2/2) type_specific.io-github-autotest-libvirt.virsh.save_image_define.paused: STARTED
 (2/2) type_specific.io-github-autotest-libvirt.virsh.save_image_define.paused: PASS (16.97 s)