### PR TITLE
virsh_detach_device_alias: remove test.skip

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
@@ -270,7 +270,7 @@ def run(test, params, env):
         if input_type == "passthrough":
             event = process.run("ls /dev/input/event*", shell=True, ignore_status=True).stdout
             if len(event) == 0:
-                test.skip("Not found any input devices")
+                test.cancel("Not found any input devices")
             input_dict.update({"source_evdev": event.decode('utf-8').split()[0]})
 
         input_obj = Input(type_name=input_type)

--- a/libvirt/tests/src/virtual_disks/virtual_disks_gluster.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_gluster.py
@@ -231,7 +231,7 @@ def run(test, params, env):
             virsh.undefine(vm_name, '--nvram', ignore_status=False)
             if virsh.create(vmxml_for_test.xml, **virsh_dargs).exit_status:
                 vmxml_backup.define()
-                test.skip("can't create the domain")
+                test.cancel("can't create the domain")
 
         # Run the tests.
         if pm_enabled:

--- a/libvirt/tests/src/virtual_network/iface_coalesce.py
+++ b/libvirt/tests/src/virtual_network/iface_coalesce.py
@@ -191,7 +191,7 @@ def run(test, params, env):
     """
 
     if not libvirt_version.version_compare(3, 3, 0):
-        test.skip("Coalesce setting is only supported by libvirt3.3.0 and above")
+        test.cancel("Coalesce setting is only supported by libvirt3.3.0 and above")
 
     vm_name = params.get("main_vm")
     vm = env.get_vm(vm_name)

--- a/libvirt/tests/src/vm_boot_with_kernel_param.py
+++ b/libvirt/tests/src/vm_boot_with_kernel_param.py
@@ -53,7 +53,7 @@ def run(test, params, env):
         cpu_model = cpu.get_cpu_info()['Model name'].upper()
         if cpu_check not in cpu_model:
             logging.info("This test will work for %s", cpu_check)
-            test.skip("Test is not applicable for %s" % cpu_model)
+            test.cancel("Test is not applicable for %s" % cpu_model)
     # back up vmxml
     for vm_name in vms:
         vm_dict[vm_name] = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
@@ -78,7 +78,7 @@ def run(test, params, env):
                         test.error("couldn't get cpu information from guest "
                                    "%s" % vm.name)
                     if cpu_check not in output.upper() and "radix" in boot_log:
-                        test.skip("radix MMU not supported in %s" % output)
+                        test.cancel("radix MMU not supported in %s" % output)
                 status, output = session.cmd_status_output("dmesg")
                 if status:
                     logging.error(output)


### PR DESCRIPTION
test.skip is not used any more.
