### PR TITLE
libvirt_rng: fix snapshot with egd

### DIFF
--- a/libvirt/tests/cfg/security/rng/libvirt_rng.cfg
+++ b/libvirt/tests/cfg/security/rng/libvirt_rng.cfg
@@ -109,16 +109,14 @@
                     rng_rate = "{'bytes':'5000','period':'2000'}"
                     backend_model = "builtin"
         - rng_snapshot:
-            snapshot_name = "rng.s"
+            test_snapshot = "yes"
             variants:
                 - snapshot_running:
                     snap_options = "%s --memspec "
                     mem_files = ["/var/lib/libvirt/images/avocado-memory.s1", "/var/lib/libvirt/images/avocado-memory.s2"]
                     snapshot_vm_running = "yes"
-                    test_snapshot = "yes"
                 - snapshot_shutoff:
                     snap_options = "%s --disk-only"
-                    test_snapshot = "yes"
             variants:
                 - back_rdm:
                     backend_dev = "/dev/random"
@@ -135,13 +133,13 @@
                 - back_udp:
                     backend_model = "egd"
                     backend_type = "udp"
-                    backend_source = "{'mode':'bind','service':'1234'} {'mode':'connect','host':'1.2.3.4','service':'1234'}"
+                    backend_source = "{'mode':'bind','service':'1024'} {'mode':'connect','host':'127.0.0.1','service':'1234'}"
         - multiple_rng:
                 device_num = 3
                 backend_dev_0 = "/dev/random"
                 backend_dev_1 = "/dev/random"
                 backend_model_2 = "egd"
                 backend_type_2 = "udp"
-                backend_source_2 = "{'mode':'connect','host':'1.2.3.4','service':'1234'}"
+                backend_source_2 = "{'mode':'connect','host':'127.0.0.1','service':'1234'}"
                 test_qemu_cmd = "yes"
                 test_guest = "yes"

--- a/spell.ignore
+++ b/spell.ignore
@@ -267,6 +267,7 @@ dzheng
 ebtables
 efi
 eg
+egd
 els
 embeddedqemu
 emulatorbin
@@ -384,7 +385,9 @@ hostfile
 hostname
 hostnuma
 hotplug
+hotplugs
 Hotplug
+Hotplugs
 hotpluggable
 hotplugged
 Hotplugged
@@ -1101,6 +1104,7 @@ upadte
 Updae
 uperf
 uptime
+urandom
 uri
 URI
 uris


### PR DESCRIPTION
Refactor:
1. variant rng_snapshot always has 'test_snapshot', move to top
2. snapshot_name was used as indicator for snapshot test variants, hence synonymous with 'test_snapshot', remove it from config
3. 'modify_rng_xml' had a very complicated logic, split into two functions to make it simpler to understand; when there are snapshots then the VM can't by 'sync'd, ie. re-defined; in those cases, 'edit' is used instead - both are coldplug
4. check_snapshot didn't use bgjob, remove it from parameters
5. check_snapshot must revert to the first snapshot 's1' where there was no rng device
6. move logic into functions so that the test steps are clearer
   - clear rng devices
   - take snapshot if testing snapshots
   - update xml in case of coldplug
   - create fake egd if necessary (connect mode)
   - start vm
   - update xml in case of hotplug
   - run test checks

Furthermore,
a. explicitly start fake egd also for snapshot test
b. wait a bit after launching fake edg for connect mode to make sure VM
   doesn't start before it's up
c. wait a bit more after booting VM for it to listen in bind mode before
   starting fake egd in bind mode

Finally, apply `black` for standard formatting.