### PR TITLE
migrate_vm: fix cpu list on s390x

### DIFF
--- a/libvirt/tests/src/migration/migrate_vm.py
+++ b/libvirt/tests/src/migration/migrate_vm.py
@@ -507,6 +507,8 @@ def get_same_processor(test, server_ip, server_user, server_pwd, verbose):
     if status:
         test.fail("Failed to run '%s' on the remote: %s" % (cmd, output))
     remote_processors = re.findall(r'processor\s+: (\d+)', output)
+    if not remote_processors:
+        remote_processors = re.findall(r'processor\s+(\d+):', output)
     if verbose:
         logging.debug("Local processors: %s", local_processors)
         logging.debug("Remote processors: %s", remote_processors)


### PR DESCRIPTION
On s390x the /proc/cpuinfo output looks different from the one on x86_64.
This could apply to other archs, too. So, if the first regex doesn't match, try the other one.

Output on x86_64 F40 6.11 kernel:
```
grep processor /proc/cpuinfo
processor	: 0
processor	: 1
processor	: 2
processor	: 3
processor	: 4
...
```

Output on s390x RHEL 9 kernel 5.14:
```
processor 0: version = FF,  identification = 2EB428,  machine = 8561
processor 1: version = FF,  identification = 2EB428,  machine = 8561
processor 2: version = FF,  identification = 2EB428,  machine = 8561
processor 3: version = FF,  identification = 2EB428,  machine = 8561
```