### PR TITLE
unsupported_live_update:Remove interface backend settings before setting new value

### DIFF
--- a/libvirt/tests/cfg/virtual_network/update_device/unsupported_live_update_alter.cfg
+++ b/libvirt/tests/cfg/virtual_network/update_device/unsupported_live_update_alter.cfg
@@ -36,6 +36,7 @@
             err_msg = cannot modify network device model from .* to .*
         - backend:
             extra_attrs = {'backend': {'tap': '/dev/net/tun', 'vhost': '/dev/vhost-net'}}
+            tmp_attrs = {'backend': None}
             update_attrs = {'backend': {'tap': '/dev/net/tun'}}
             err_msg = cannot modify network device backend settings
         - driver:

--- a/libvirt/tests/cfg/virtual_network/update_device/unsupported_live_update_delete.cfg
+++ b/libvirt/tests/cfg/virtual_network/update_device/unsupported_live_update_delete.cfg
@@ -27,10 +27,6 @@
             extra_attrs = {'rom': {'enabled': 'no'}}
             del_attr = rom
             err_msg = cannot modify network device rom enabled setting
-        - target_dev:
-            extra_attrs = {'target': {'dev': 'test'}}
-            del_attr = target
-            err_msg = cannot modify network device tap name
         - model_type:
             del_attr = model
             err_msg = cannot modify network device model from .* to .*
@@ -41,10 +37,6 @@
         - driver:
             del_attr = driver
             err_msg = cannot modify virtio network device driver attributes
-        - alias_name:
-            extra_attrs = {'alias': {'name': 'ua-47034d36-5483-411c-86f8-7989d08d762b'}}
-            del_attr = alias
-            err_msg = device not found: no device found at address .* matching MAC address .* and alias .*
         - mac:
             del_attr = mac_address
             err_msg = "cannot change network interface mac address|device not found"

--- a/libvirt/tests/src/virtual_network/update_device/unsupported_live_update.py
+++ b/libvirt/tests/src/virtual_network/update_device/unsupported_live_update.py
@@ -29,6 +29,7 @@ def run(test, params, env):
     iface_attrs = {**base_iface_attrs, **extra_attrs}
 
     update_attrs = eval(params.get('update_attrs', '{}'))
+    tmp_attrs = eval(params.get('tmp_attrs', '{}'))
     del_attr = params.get('del_attr')
 
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
@@ -41,7 +42,6 @@ def run(test, params, env):
             vmxml.os = osxml
             libvirt_vmxml.modify_vm_device(vmxml, 'disk', {'boot': '1'})
 
-        vmxml.del_device('interface', by_tag=True)
         libvirt_vmxml.modify_vm_device(vmxml, 'interface', iface_attrs)
         LOG.debug(f'VMXML of {vm_name}:\n{virsh.dumpxml(vm_name).stdout_text}')
 
@@ -56,6 +56,8 @@ def run(test, params, env):
             else:
                 eval(f'iface.del_{del_attr}')()
         else:
+            if tmp_attrs:
+                iface.setup_attrs(**tmp_attrs)
             iface.setup_attrs(**update_attrs)
         LOG.debug(f'Interface xml to update with:\n{iface}')
 


### PR DESCRIPTION
    unsupported_live_update:Remove interface backend settings before setting
    new value

    Since the original dict value won't be deleted automatically, but we
    want to remove one attribute.
    And don't remove interfaces on vmxml before test setting.
    And remove 2 test cases that are no need to test (bug won't do)

Test result:

```
 (01/29) type_specific.local.virtual_network.update_device.unsupported_live_update.delete.acpi_index: STARTED
 (01/29) type_specific.local.virtual_network.update_device.unsupported_live_update.delete.acpi_index: PASS (29.74 s)
 (02/29) type_specific.local.virtual_network.update_device.unsupported_live_update.delete.sndbuf: STARTED
 (02/29) type_specific.local.virtual_network.update_device.unsupported_live_update.delete.sndbuf: PASS (31.57 s)
 (03/29) type_specific.local.virtual_network.update_device.unsupported_live_update.delete.mtu: STARTED
 (03/29) type_specific.local.virtual_network.update_device.unsupported_live_update.delete.mtu: PASS (38.67 s)
 (04/29) type_specific.local.virtual_network.update_device.unsupported_live_update.delete.boot_order: STARTED
 (04/29) type_specific.local.virtual_network.update_device.unsupported_live_update.delete.boot_order: PASS (37.98 s)
 (05/29) type_specific.local.virtual_network.update_device.unsupported_live_update.delete.rom: STARTED
 (05/29) type_specific.local.virtual_network.update_device.unsupported_live_update.delete.rom: PASS (37.79 s)
 (06/29) type_specific.local.virtual_network.update_device.unsupported_live_update.delete.target_dev: STARTED
 (06/29) type_specific.local.virtual_network.update_device.unsupported_live_update.delete.target_dev: FAIL: Run '/bin/virsh update-device avocado-vt-vm1 /var/tmp/xml_utils_temp_qdshdasy.xml ' expect fail, but run successfully. (38.28 s)
 (07/29) type_specific.local.virtual_network.update_device.unsupported_live_update.delete.model_type: STARTED
 (07/29) type_specific.local.virtual_network.update_device.unsupported_live_update.delete.model_type: PASS (38.36 s)
 (08/29) type_specific.local.virtual_network.update_device.unsupported_live_update.delete.backend: STARTED
 (08/29) type_specific.local.virtual_network.update_device.unsupported_live_update.delete.backend: PASS (40.15 s)
 (09/29) type_specific.local.virtual_network.update_device.unsupported_live_update.delete.driver: STARTED
 (09/29) type_specific.local.virtual_network.update_device.unsupported_live_update.delete.driver: PASS (38.13 s)
 (10/29) type_specific.local.virtual_network.update_device.unsupported_live_update.delete.alias_name: STARTED
 (10/29) type_specific.local.virtual_network.update_device.unsupported_live_update.delete.alias_name: FAIL: Run '/bin/virsh update-device avocado-vt-vm1 /var/tmp/xml_utils_temp_gdsp9vp9.xml ' expect fail, but run successfully. (35.78 s)
 (11/29) type_specific.local.virtual_network.update_device.unsupported_live_update.delete.mac: STARTED
 (11/29) type_specific.local.virtual_network.update_device.unsupported_live_update.delete.mac: PASS (35.41 s)
 (12/29) type_specific.local.virtual_network.update_device.unsupported_live_update.alter.acpi_index: STARTED
 (12/29) type_specific.local.virtual_network.update_device.unsupported_live_update.alter.acpi_index: PASS (36.44 s)
 (13/29) type_specific.local.virtual_network.update_device.unsupported_live_update.alter.sndbuf: STARTED
 (13/29) type_specific.local.virtual_network.update_device.unsupported_live_update.alter.sndbuf: PASS (37.91 s)
 (14/29) type_specific.local.virtual_network.update_device.unsupported_live_update.alter.mtu: STARTED
 (14/29) type_specific.local.virtual_network.update_device.unsupported_live_update.alter.mtu: PASS (38.29 s)
 (15/29) type_specific.local.virtual_network.update_device.unsupported_live_update.alter.boot_order: STARTED
 (15/29) type_specific.local.virtual_network.update_device.unsupported_live_update.alter.boot_order: PASS (37.51 s)
 (16/29) type_specific.local.virtual_network.update_device.unsupported_live_update.alter.rom: STARTED
 (16/29) type_specific.local.virtual_network.update_device.unsupported_live_update.alter.rom: PASS (38.69 s)
 (17/29) type_specific.local.virtual_network.update_device.unsupported_live_update.alter.target_dev: STARTED
 (17/29) type_specific.local.virtual_network.update_device.unsupported_live_update.alter.target_dev: PASS (37.28 s)
 (18/29) type_specific.local.virtual_network.update_device.unsupported_live_update.alter.model_type: STARTED
 (18/29) type_specific.local.virtual_network.update_device.unsupported_live_update.alter.model_type: PASS (31.15 s)
 (19/29) type_specific.local.virtual_network.update_device.unsupported_live_update.alter.backend: STARTED
 (19/29) type_specific.local.virtual_network.update_device.unsupported_live_update.alter.backend: PASS (34.98 s)
 (20/29) type_specific.local.virtual_network.update_device.unsupported_live_update.alter.driver: STARTED
 (20/29) type_specific.local.virtual_network.update_device.unsupported_live_update.alter.driver: PASS (34.91 s)
 (21/29) type_specific.local.virtual_network.update_device.unsupported_live_update.alter.alias_name: STARTED
 (21/29) type_specific.local.virtual_network.update_device.unsupported_live_update.alter.alias_name: PASS (36.10 s)
 (22/29) type_specific.local.virtual_network.update_device.unsupported_live_update.alter.mac: STARTED
 (22/29) type_specific.local.virtual_network.update_device.unsupported_live_update.alter.mac: PASS (38.05 s)
 (23/29) type_specific.local.virtual_network.update_device.unsupported_live_update.add.acpi_index: STARTED
 (23/29) type_specific.local.virtual_network.update_device.unsupported_live_update.add.acpi_index: PASS (37.53 s)
 (24/29) type_specific.local.virtual_network.update_device.unsupported_live_update.add.sndbuf: STARTED
 (24/29) type_specific.local.virtual_network.update_device.unsupported_live_update.add.sndbuf: PASS (37.95 s)
 (25/29) type_specific.local.virtual_network.update_device.unsupported_live_update.add.mtu: STARTED
 (25/29) type_specific.local.virtual_network.update_device.unsupported_live_update.add.mtu: PASS (64.65 s)
 (26/29) type_specific.local.virtual_network.update_device.unsupported_live_update.add.boot_order: STARTED
 (26/29) type_specific.local.virtual_network.update_device.unsupported_live_update.add.boot_order: PASS (34.60 s)
 (27/29) type_specific.local.virtual_network.update_device.unsupported_live_update.add.rom: STARTED
 (27/29) type_specific.local.virtual_network.update_device.unsupported_live_update.add.rom: PASS (38.14 s)
 (28/29) type_specific.local.virtual_network.update_device.unsupported_live_update.add.backend: STARTED
 (28/29) type_specific.local.virtual_network.update_device.unsupported_live_update.add.backend: PASS (37.94 s)
 (29/29) type_specific.local.virtual_network.update_device.unsupported_live_update.add.driver: STARTED
 (29/29) type_specific.local.virtual_network.update_device.unsupported_live_update.add.driver: PASS (37.54 s)
RESULTS    : PASS 27 | ERROR 0 | FAIL 2 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```
The 2 failed cases are now removed from cfg