### PR TITLE
rx_tx_queue_size:Skip getting tx size from interface xml

### DIFF
--- a/libvirt/tests/cfg/virtual_network/driver/rx_tx_queue_size.cfg
+++ b/libvirt/tests/cfg/virtual_network/driver/rx_tx_queue_size.cfg
@@ -13,6 +13,7 @@
                     rx_tx_attrs = {'rx_queue_size': '512', 'tx_queue_size': '256'}
                 - rx_1024_tx_unset:
                     rx_tx_attrs = {'rx_queue_size': '1024'}
+                    actual_tx = 256
         - negative:
             status_error = yes
             variants:

--- a/libvirt/tests/src/virtual_network/driver/rx_tx_queue_size.py
+++ b/libvirt/tests/src/virtual_network/driver/rx_tx_queue_size.py
@@ -53,7 +53,7 @@ def run(test, params, env):
 
         iface = network_base.get_iface_xml_inst(vm_name, 'after vm start')
         actual_rx = int(iface.driver.driver_attr.get('rx_queue_size'))
-        actual_tx = int(iface.driver.driver_attr.get('tx_queue_size'))
+        actual_tx = int(params.get('actual_tx') or iface.driver.driver_attr.get('tx_queue_size'))
         LOG.debug(
             f'Actual rx_queue_size={actual_rx} tx_queue_size={actual_tx}')
         if str(actual_rx) != iface_attrs['driver']['driver_attr']['rx_queue_size']:


### PR DESCRIPTION
Cannot get tx size from interface xml when it's not set

Test result:
```
 (1/9) type_specific.local.virtual_network.driver.rx_tx_queue_size.positive.rx_256_tx_256: STARTED
 (1/9) type_specific.local.virtual_network.driver.rx_tx_queue_size.positive.rx_256_tx_256: PASS (34.39 s)
 (2/9) type_specific.local.virtual_network.driver.rx_tx_queue_size.positive.rx_512_tx_256: STARTED
 (2/9) type_specific.local.virtual_network.driver.rx_tx_queue_size.positive.rx_512_tx_256: PASS (36.93 s)
 (3/9) type_specific.local.virtual_network.driver.rx_tx_queue_size.positive.rx_1024_tx_unset: STARTED
 (3/9) type_specific.local.virtual_network.driver.rx_tx_queue_size.positive.rx_1024_tx_unset: PASS (44.16 s)
 (4/9) type_specific.local.virtual_network.driver.rx_tx_queue_size.negative.rx_128_tx_unset: STARTED
 (4/9) type_specific.local.virtual_network.driver.rx_tx_queue_size.negative.rx_128_tx_unset: PASS (17.45 s)
 (5/9) type_specific.local.virtual_network.driver.rx_tx_queue_size.negative.rx_2048_tx_unset: STARTED
 (5/9) type_specific.local.virtual_network.driver.rx_tx_queue_size.negative.rx_2048_tx_unset: PASS (17.26 s)
 (6/9) type_specific.local.virtual_network.driver.rx_tx_queue_size.negative.rx_511_tx_unset: STARTED
 (6/9) type_specific.local.virtual_network.driver.rx_tx_queue_size.negative.rx_511_tx_unset: PASS (7.25 s)
 (7/9) type_specific.local.virtual_network.driver.rx_tx_queue_size.negative.rx_unset_tx_128: STARTED
 (7/9) type_specific.local.virtual_network.driver.rx_tx_queue_size.negative.rx_unset_tx_128: PASS (16.96 s)
 (8/9) type_specific.local.virtual_network.driver.rx_tx_queue_size.negative.rx_unset_tx_2048: STARTED
 (8/9) type_specific.local.virtual_network.driver.rx_tx_queue_size.negative.rx_unset_tx_2048: PASS (17.26 s)
 (9/9) type_specific.local.virtual_network.driver.rx_tx_queue_size.negative.rx_unset_tx_512: STARTED
 (9/9) type_specific.local.virtual_network.driver.rx_tx_queue_size.negative.rx_unset_tx_512: PASS (17.17 s)
RESULTS    : PASS 9 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```
