### PR TITLE
lifecycle_for_hugepage: removed the 16G hugepage test scenario

### DIFF
--- a/libvirt/tests/cfg/memory/memory_backing/lifecycle_for_hugepage.cfg
+++ b/libvirt/tests/cfg/memory/memory_backing/lifecycle_for_hugepage.cfg
@@ -62,19 +62,6 @@
                     vm_attrs = {${memory_backing_dict}, 'memory_unit':'${mem_unit}','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}'}
                     HugePages_Free =
                     free_hugepages = "0"
-                - 16G:
-                    only aarch64
-                    page_size = "16"
-                    page_unit = "G"
-                    set_pagesize ="16777216"
-                    set_pagenum = "1"
-                    mount_size = ${set_pagesize}
-                    mem_value = 16777216
-                    current_mem = 16777216
-                    memory_backing_dict = "'mb': {'hugepages': {'pages': [{'unit': '${page_unit}', 'size': '${page_size}'}]}}"
-                    vm_attrs = {${memory_backing_dict}, 'memory_unit':'${mem_unit}','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'${current_mem_unit}'}
-                    HugePages_Free =
-                    free_hugepages = "0"
                 - 64K:
                     only aarch64
                     page_size = "64"

--- a/libvirt/tests/cfg/memory/memory_misc.cfg
+++ b/libvirt/tests/cfg/memory/memory_misc.cfg
@@ -64,10 +64,6 @@
                         - 64k:
                             only aarch64
                             default_page_size = 64
-                            variants huge_pagesize:
-                                - 16777216:
-                                    pagesize = 16777216
-                                    pagenum = 1
                     variants scenario:
                         - nodeset_0:
                             mem_backing_attrs = {'hugepages': {'pages': [{'unit': 'KiB', 'nodeset': '0', 'size': '${pagesize}'}]}, 'locked': True}
@@ -116,12 +112,6 @@
                             variants huge_pagesize:
                                 - 524288:
                                     pagesize = 524288
-                                    variants ext_huge_pagesize:
-                                        - 16777216:
-                                            mount_pagesize = 16777216
-                                            mount_path= '/dev/hugepages16G'
-                                            mount_option = 'pagesize=16G'
-                                            mem_device_size = 16777216
                     vm_attrs = {'vcpu': 4, 'max_mem_rt': 20971520, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB'}
                     numa_node_size = 1048576
                     cpu_attrs = {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '${numa_node_size}', 'unit': 'KiB'}, {'id': '1', 'cpus': '2-3', 'memory': '${numa_node_size}', 'unit': 'KiB'}]}


### PR DESCRIPTION
Currently, 16G huge pages need to be manually configured on a special machine to be successfully allocated. It is meaningless to add it to regular automated testing, as it will always fail.
So removed the 16G hugepage test scenario.

ID:19546
Signed-off-by: zhenyzha [zhenyzha@redhat.com](mailto:zhenyzha@redhat.com)