### PR TITLE
ethernet_interface: remove unsupported rom for s390x

### DIFF
--- a/libvirt/tests/cfg/virtual_network/connectivity/connectivity_check_ethernet_interface.cfg
+++ b/libvirt/tests/cfg/virtual_network/connectivity/connectivity_check_ethernet_interface.cfg
@@ -40,10 +40,15 @@
                             only smaller_mtu_multi_ifaces
                             extra_attrs = {'rom': {'enabled': 'no'}}
                             iface_attrs_2 = {'type_name': 'ethernet', 'target': {'dev': tap_name_2, 'managed': 'no'}, 'model': 'virtio', 'mtu': {'size': '${iface_mtu_2}'}, 'driver': {'driver_attr': {'name': 'vhost'}}, 'rom': {'enabled': 'no'}} 
+                            s390-virtio, aarch64:
+                                extra_attrs =
+                                iface_attrs_2 = {'type_name': 'ethernet', 'target': {'dev': tap_name_2, 'managed': 'no'}, 'model': 'virtio', 'mtu': {'size': '${iface_mtu_2}'}, 'driver': {'driver_attr': {'name': 'vhost'}}}
                 - macvtap:
                     vm_ping_outside = pass
                     vm_ping_host_public = fail
             iface_attrs = {'target': {'dev': tap_name, 'managed': 'no'}, 'model': 'virtio', 'type_name': 'ethernet', **${mtu_attrs}, **${extra_attrs}}
+            s390-virtio, aarch64:
+                iface_attrs = {'target': {'dev': tap_name, 'managed': 'no'}, 'model': 'virtio', 'type_name': 'ethernet', **${mtu_attrs}}
         - negative_test:
             status_error = yes
             variants:


### PR DESCRIPTION
On s390x ROM tuning is not supported.