### PR TITLE
check_actual_network_throughput_direct:Reduce average value

### DIFF
--- a/libvirt/tests/cfg/virtual_network/qos/check_actual_network_throughput_direct.cfg
+++ b/libvirt/tests/cfg/virtual_network/qos/check_actual_network_throughput_direct.cfg
@@ -5,8 +5,8 @@
     vms = avocado-vt-vm1 vm2
     timeout = 240
     host_iface =
-    inbound = {'average': '128', 'peak': '1024', 'burst': '32'}
-    outbound = {'average': '128', 'peak': '1024', 'burst': '32'}
+    inbound = {'average': '64', 'peak': '1024', 'burst': '32'}
+    outbound = {'average': '64', 'peak': '1024', 'burst': '32'}
     iface_bw_attrs = {'bandwidth': {'inbound': ${inbound}, 'outbound': ${outbound}}}
     variants:
         - with_network:


### PR DESCRIPTION
Reduce average value to avoid test failure

Test result: 
```
 (1/2) type_specific.io-github-autotest-libvirt.virtual_network.qos.check_actual_network_throughput.direct.with_network: STARTED
 (1/2) type_specific.io-github-autotest-libvirt.virtual_network.qos.check_actual_network_throughput.direct.with_network: PASS (119.70 s)
 (2/2) type_specific.io-github-autotest-libvirt.virtual_network.qos.check_actual_network_throughput.direct.without_network: STARTED
 (2/2) type_specific.io-github-autotest-libvirt.virtual_network.qos.check_actual_network_throughput.direct.without_network: PASS (136.43 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```