### PR TITLE
Resolve No migration result issue on aarch64 caused by low speed

### DIFF
--- a/libvirt/tests/cfg/migration/abort_precopy_migration/abort_by_domjobabort_on_target.cfg
+++ b/libvirt/tests/cfg/migration/abort_precopy_migration/abort_by_domjobabort_on_target.cfg
@@ -27,6 +27,8 @@
     virsh_migrate_dest_state = "running"
     virsh_migrate_src_state = "shut off"
     migrate_speed = "10"
+    aarch64:
+        migrate_speed = "15"
     stress_package = "stress"
     stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20s"
     variants:

--- a/libvirt/tests/cfg/migration/migration_uri/migration_desturi.cfg
+++ b/libvirt/tests/cfg/migration/migration_uri/migration_desturi.cfg
@@ -24,6 +24,8 @@
     status_error = "no"
     check_network_accessibility_after_mig = "yes"
     migrate_speed = "5"
+    aarch64:
+        migrate_speed = "15"
     action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: \'1\'", "func_param": "params"}]'
     check_local_port = "yes"
     test_case = "desturi"


### PR DESCRIPTION
Several tests are failing with No migration result. 
The migration will continue till the test timoute (15min) is hit and the migration is interrupted.
As the test is not focused on the performance, the speed  can be enlarged. 

According my investigation, from the value migration-speed=12 is it working. 