### PR TITLE
Extend the time for blockcopy to finish

### DIFF
--- a/libvirt/tests/src/backingchain/blockjob/blockjob_with_raw_option.py
+++ b/libvirt/tests/src/backingchain/blockjob/blockjob_with_raw_option.py
@@ -87,12 +87,12 @@ def run(test, params, env):
         test.log.info("Check if the job can be aborted successfully")
         if utils_misc.wait_for(
                 lambda: libvirt.check_blockjob(vm_name,
-                                               dev, "progress", "100(.00)?"), 100):
+                                               dev, "progress", "100(.00)?"), 300):
             virsh.blockjob(vm_name, dev, options=' --pivot',
                            debug=True,
                            ignore_status=False)
         else:
-            test.fail("Blockjob timeout in 100 sec.")
+            test.fail("Blockjob timeout in 300 sec.")
 
         test.log.info("TEST_STEP3: Check the output of 'blockjob --raw' "
                       "after aborting the job")


### PR DESCRIPTION
Current blockcopy will timeout in 100s. Extend the time to be 300s which is enough for the operation to finish.