### PR TITLE
virsh_domiftune:Update max boundary test

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domiftune.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domiftune.cfg
@@ -42,7 +42,7 @@
                                         - inside_boundary:
                                             inbound = 1024,1024,1024
                                         - maximum_boundary:
-                                            inbound = 4294967,4294967,4294967
+                                            inbound = 4194303,4194303,4194303
                                         - with_floor:
                                             only none
                                             pre_vmstate = "shutoff"
@@ -66,7 +66,7 @@
                                         - inside_boundary:
                                             outbound = '65535,65535,65535'
                                         - maximum_boundary:
-                                            outbound = '4294967,4294967,4294967'
+                                            outbound = '4194303,4194303,4194303'
                                     variants:
                                         - options:
                                             variants:


### PR DESCRIPTION
RHEL-65372 has set clear boundary and error message

Test result:
```
 (1/6) type_specific.local.virsh.domiftune.positive_testing.set_domif_parameter.running_guest.change_inbound.options.live.maximum_boundary: STARTED
 (1/6) type_specific.local.virsh.domiftune.positive_testing.set_domif_parameter.running_guest.change_inbound.options.live.maximum_boundary: PASS (52.39 s)
 (2/6) type_specific.local.virsh.domiftune.positive_testing.set_domif_parameter.running_guest.change_inbound.options.current.maximum_boundary: STARTED
 (2/6) type_specific.local.virsh.domiftune.positive_testing.set_domif_parameter.running_guest.change_inbound.options.current.maximum_boundary: PASS (34.96 s)
 (3/6) type_specific.local.virsh.domiftune.positive_testing.set_domif_parameter.running_guest.change_inbound.options.none.maximum_boundary: STARTED
 (3/6) type_specific.local.virsh.domiftune.positive_testing.set_domif_parameter.running_guest.change_inbound.options.none.maximum_boundary: PASS (45.35 s)
 (4/6) type_specific.local.virsh.domiftune.positive_testing.set_domif_parameter.running_guest.change_outbound.options.live.maximum_boundary: STARTED
 (4/6) type_specific.local.virsh.domiftune.positive_testing.set_domif_parameter.running_guest.change_outbound.options.live.maximum_boundary: PASS (42.60 s)
 (5/6) type_specific.local.virsh.domiftune.positive_testing.set_domif_parameter.running_guest.change_outbound.options.current.maximum_boundary: STARTED
 (5/6) type_specific.local.virsh.domiftune.positive_testing.set_domif_parameter.running_guest.change_outbound.options.current.maximum_boundary: PASS (42.63 s)
 (6/6) type_specific.local.virsh.domiftune.positive_testing.set_domif_parameter.running_guest.change_outbound.options.none.maximum_boundary: STARTED
 (6/6) type_specific.local.virsh.domiftune.positive_testing.set_domif_parameter.running_guest.change_outbound.options.none.maximum_boundary: PASS (43.88 s)
RESULTS    : PASS 6 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```