### PR TITLE
virtio_transitional_nic: don't attach incompatible controller

### DIFF
--- a/libvirt/tests/cfg/virtio_transitional/virtio_transitional_nic.cfg
+++ b/libvirt/tests/cfg/virtio_transitional/virtio_transitional_nic.cfg
@@ -18,6 +18,9 @@
     variants:
         - virtio:
             virtio_model = "virtio"
+            s390-virtio:
+                check_pci_bridge = no
+                bridge_controller_needed = no
         - virtio_transitional:
             no s390-virtio
             virtio_model = "virtio-transitional"


### PR DESCRIPTION
On s390x, pci bridge is not available. Don't attach this.