### PR TITLE
fix virsh create use incorrect log operation

### DIFF
--- a/libvirt/tests/src/backingchain/blockcopy/blockcopy_with_zero_length_disk.py
+++ b/libvirt/tests/src/backingchain/blockcopy/blockcopy_with_zero_length_disk.py
@@ -53,7 +53,7 @@ def run(test, params, env):
         test.log.debug("Define guest by xml:\n%s", vmxml)
         virsh.undefine(vm_name, options='--nvram', debug=True,
                        ignore_status=False)
-        virsh.create(vmxml.xml, shell=True)
+        virsh.create(vmxml.xml, debug=True, ignore_status=False)
 
     def run_test():
         """


### PR DESCRIPTION
 virsh cmd should use debug=True , not shell=True
Signed-off-by: nanli <nanli@redhat.com>