### PR TITLE
fix maxvcpu increase makes the case checking maxvcpu failed

### DIFF
--- a/libvirt/tests/cfg/cpu/max_vcpus.cfg
+++ b/libvirt/tests/cfg/cpu/max_vcpus.cfg
@@ -50,8 +50,8 @@
                 - no_iommu:
                     only q35
                     check = "no_iommu"
+                    status_error = "no"
                     guest_vcpu = "256"
-                    err_msg = "unsupported configuration: more than 255 vCPUs require extended interrupt mode enabled on the iommu device"
                 - with_iommu:
                     only q35
                     check = "with_iommu"
@@ -60,5 +60,5 @@
                 - ioapic_iommu:
                     only q35
                     check = "ioapic_iommu_ne"
-                    guest_vcpu = "711"
+                    guest_vcpu = "4097"
                     err_msg = "unsupported configuration: Maximum CPUs greater than specified machine type limit|exceeds the maximum cpus supported|CPU topology doesn't match maximum vcpu count"


### PR DESCRIPTION
Update two cases
-  ioapic_iommu case: maxvxpu num changes from 710 to 2096
-  no_iommu case: automatically configure iommu (if it is missing) in the right way if a user
requests >255 CPUs. Source defect xxxx -65844 - this would be positive scenario , because the ioapic would be added automatically

Signed-off-by: nanli <nanli@redhat.com>

Before fixed
```
 avocado run --vt-type libvirt --vt-omit-data-loss --vt-machine-type q35 max_vcpus.negative_test.ioapic_iommu --vt-connect-uri qemu:///system

 (1/1) type_specific.io-github-autotest-libvirt.max_vcpus.negative_test.ioapic_iommu: FAIL: Expect should fail with one of unsupported configuration: Maximum CPUs greater than specified machine type limit|exceeds the maximum cpus supported, but succeeded: Domain 'avocado-vt-vm1' defined from /var/tmp/xml_utils_temp_7kyym6dk.xml\n\n\n (6.16 s)

avocado run --vt-type libvirt --vt-omit-data-loss --vt-machine-type q35 max_vcpus.negative_test.no_iommu --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.max_vcpus.negative_test.no_iommu: FAIL: Expect should fail with one of unsupported configuration: more than 255 vCPUs require extended interrupt mode enabled on the iommu device, but succeeded: Domain 'avocado-vt-vm1' defined from /var/tmp/xml_utils_temp_v5iyoaqy.xml\n\n\n (8.07 s)


```

After fixed

```
 avocado run --vt-type libvirt --vt-omit-data-loss --vt-machine-type q35 max_vcpus.negative_test.ioapic_iommu --vt-connect-uri qemu:///system

 (1/1) type_specific.io-github-autotest-libvirt.max_vcpus.negative_test.ioapic_iommu: PASS (5.92 s)

avocado run --vt-type libvirt --vt-omit-data-loss --vt-machine-type q35 max_vcpus.negative_test.no_iommu --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.max_vcpus.negative_test.no_iommu: FAIL: Expect should succeed, but got: \n\nerror: Failed to define domain from /var/tmp/xml_utils_temp_almayp_e.xml\nerror: unsupported configuration: IOMMU interrupt remapping requires split I/O APIC (ioapic driver='qemu')\n (14.29 s)
this Would be PASS after bug xxxx-65844 fixed 

```