### PR TITLE
fix virsh hypervisor-cpu-compare case due to feature update

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_hypervisor_cpu_compare.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_hypervisor_cpu_compare.cfg
@@ -70,8 +70,7 @@
         - capa_xml:
             no s390-virtio, aarch64
             compare_file_type = "capa_xml"
-            status_error = "yes"
-            msg_pattern = "incompatible"
+            status_error = "no"
         - cpu_xml:
             extract_mode = "yes"
             variants:
@@ -81,8 +80,7 @@
                 - f_capa_xml:
                     no s390-virtio, aarch64
                     compare_file_type = "capa_xml"
-                    status_error = "yes"
-                    msg_pattern = "incompatible"
+                    status_error = "no"
                 - f_domcapa_xml:
                     compare_file_type = "domcapa_xml"
                     msg_pattern = "identical"


### PR DESCRIPTION
Before fixed

`Expect should fail but got:&#10;The CPU provided by hypervisor on the host is a superset of CPU described in /var/tmp/avocado_7em7bl6d/cpu.xml&#10;&#10;
`


After fixed
```
avocado run --vt-type libvirt --vt-omit-data-loss --vt-machine-type q35 virsh.hypervisor_cpu_compare.capa_xml --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.virsh.hypervisor_cpu_compare.capa_xml: PASS (6.96 s)
avocado run --vt-type libvirt --vt-omit-data-loss --vt-machine-type q35 virsh.hypervisor_cpu_compare.capa_xml --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.virsh.hypervisor_cpu_compare.capa_xml: PASS (6.96 s)

```