### PR TITLE
update_iface_with_unchangable: remove rom for s390x

### DIFF
--- a/libvirt/tests/cfg/virtual_network/update_device/update_iface_with_unchangable.cfg
+++ b/libvirt/tests/cfg/virtual_network/update_device/update_iface_with_unchangable.cfg
@@ -17,3 +17,5 @@
     iface_attrs_tune = {'sndbuf': 1600}
     iface_attrs_alias = {'name': 'ua-823c76fa-ee1d-4278-a613-2ba8ba179b61'}
     update_attrs = {'link_state': 'down'}
+    s390-virtio:
+        iface_attrs_rom = {}


### PR DESCRIPTION
On s390x ROM not available. Remove from config.