### PR TITLE
virtual_network/link_state: configure host_iface for all tests

### DIFF
--- a/libvirt/tests/cfg/virtual_network/link_state/link_state_model_type.cfg
+++ b/libvirt/tests/cfg/virtual_network/link_state/link_state_model_type.cfg
@@ -4,6 +4,7 @@
     timeout = 240
     outside_ip = "www.redhat.com"
     vm_ping_outside = pass
+    host_iface =
     variants:
         - initial_up:
             initial_link_state = "up"
@@ -24,7 +25,6 @@
             iface_base_attrs = {"type_name": "network", "source": {"network": "default"}}
         - direct:
             only virtio
-            host_iface =
             iface_base_attrs = {"type_name": "direct", "source": {"dev": host_iface, "mode": "bridge"}}
         - user:
             only virtio
@@ -32,7 +32,6 @@
                 - root:
                     iface_base_attrs = {"type_name": "user"}
                 - passt:
-                    host_iface =
                     iface_base_attrs = {"backend": {"type": "passt"}, "source": {"dev": host_iface}, "type_name": "user"}
                     variants:
                         - root:


### PR DESCRIPTION
ethernet was missing host-iface and failed
move the parameter to the top to apply it to all tests