### PR TITLE
migrate_vm: disable negative test

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_vm.cfg
+++ b/libvirt/tests/cfg/migration/migrate_vm.cfg
@@ -751,6 +751,7 @@
                                     virsh_options = "--live --verbose --copy-storage-inc"
                                     err_msg = "error: Operation not supported: pre-creation of storage targets for incremental storage migration is not supported|error: Operation not supported: pre-creation of storage target.*for incremental storage migration of .* is not supported"
                         - backing_file_with_copy_storage_inc:
+                            no s390-virtio
                             create_target_image = "no"
                             setup_nfs = "yes"
                             enable_virt_use_nfs = "yes"


### PR DESCRIPTION
The test creates an unbootable disk. On s390x, the VM will immediately stop running. So, the rest of the test steps can't execute.