### PR TITLE
migrate_with_virtual_devices: fix rng check method

### DIFF
--- a/libvirt/tests/src/migration/migrate_with_virtual_devices.py
+++ b/libvirt/tests/src/migration/migrate_with_virtual_devices.py
@@ -552,21 +552,21 @@ class MigrationWithRng(MigrationVirtualDevicesBase):
         """
 
         logging.debug("Check rng device in vm")
-        check_cmd = "dd if=/dev/hwrng of=/dev/null count=2 bs=2"
+        check_cmd = "cat /sys/devices/virtual/misc/hw_random/rng_available"
         timeout = 10
 
         try:
             status, output = vm.session.cmd_status_output(check_cmd, timeout)
-            logging.debug("cmd exit status: %s, cmd output: %s",
+            logging.debug("cmd exit status: %s, current rng available: %s",
                           status, output)
-
-            if status == 0:
+            status = True if output.count("virtio_rng") else False
+            if status is True:
                 if rng_present:
                     return
                 else:
                     raise DeviceNotRemovedError("rng")
             else:
-                if not rng_present and "No such device" in output:
+                if not rng_present:
                     return
                 elif rng_present:
                     raise DeviceNotFoundError("rng")


### PR DESCRIPTION
As there might be other built-in rng devices, we only need to check
if attached virtio rng is in rng_available.

Signed-off-by: Dan Zheng <dzheng@redhat.com>