### PR TITLE
migration: Update error message

### DIFF
--- a/libvirt/tests/cfg/migration_with_copy_storage/network_data_transport/tls_wrong_cert_configurations.cfg
+++ b/libvirt/tests/cfg/migration_with_copy_storage/network_data_transport/tls_wrong_cert_configurations.cfg
@@ -46,7 +46,7 @@
     variants cert_configuration:
         - no_client_cert_on_src:
             cert_path = "${custom_pki_path}/client-cert.pem"
-            err_msg = "Cannot read from TLS channel: Software caused connection abort"
+            err_msg = "Cannot read from TLS channel:"
         - no_server_cert_on_target:
             cert_path = "${custom_pki_path}/server-cert.pem"
             err_msg = "unable to execute QEMU command 'object-add': Unable to access credentials ${cert_path}: No such file or directory"


### PR DESCRIPTION
Test result:

Before:
 (1/1) type_specific.io-github-autotest-libvirt.migration_with_copy_storage.network_data_transport.tls.wrong_cert_configurations.no_client_cert_on_src.copy_storage_all.p2p: FAIL: Can not find the expected patterns 'Cannot read from TLS channel: Software caused connection abort' in output 'error: internal error: unable to execute QEMU command 'blockdev-add': Failed to read option reply: Cannot read from TLS channel: The TLS connect... (192.16 s)

After:
 (1/4) type_specific.io-github-autotest-libvirt.migration_with_copy_storage.network_data_transport.tls.wrong_cert_configurations.no_client_cert_on_src.copy_storage_all.p2p: STARTED
 (1/4) type_specific.io-github-autotest-libvirt.migration_with_copy_storage.network_data_transport.tls.wrong_cert_configurations.no_client_cert_on_src.copy_storage_all.p2p: PASS (191.15 s)
 (2/4) type_specific.io-github-autotest-libvirt.migration_with_copy_storage.network_data_transport.tls.wrong_cert_configurations.no_client_cert_on_src.copy_storage_all.non_p2p: STARTED
 (2/4) type_specific.io-github-autotest-libvirt.migration_with_copy_storage.network_data_transport.tls.wrong_cert_configurations.no_client_cert_on_src.copy_storage_all.non_p2p: PASS (195.60 s)
 (3/4) type_specific.io-github-autotest-libvirt.migration_with_copy_storage.network_data_transport.tls.wrong_cert_configurations.no_client_cert_on_src.copy_storage_inc.p2p: STARTED
 (3/4) type_specific.io-github-autotest-libvirt.migration_with_copy_storage.network_data_transport.tls.wrong_cert_configurations.no_client_cert_on_src.copy_storage_inc.p2p: PASS (193.66 s)
 (4/4) type_specific.io-github-autotest-libvirt.migration_with_copy_storage.network_data_transport.tls.wrong_cert_configurations.no_client_cert_on_src.copy_storage_inc.non_p2p: STARTED
 (4/4) type_specific.io-github-autotest-libvirt.migration_with_copy_storage.network_data_transport.tls.wrong_cert_configurations.no_client_cert_on_src.copy_storage_inc.non_p2p: PASS (191.10 s)