### PR TITLE
migration: Fix authentication failed issue for ipv6 test

### DIFF
--- a/libvirt/tests/cfg/migration/migration_uri/migration_desturi.cfg
+++ b/libvirt/tests/cfg/migration/migration_uri/migration_desturi.cfg
@@ -64,6 +64,7 @@
             ipv6_config = "yes"
             ipv6_addr_des = "ENTER.YOUR.IPv6.DESTINATION"
             dest_host = "[${ipv6_addr_des}]"
+            server_info_ip = "${ipv6_addr_des}"
         - hostname:
             dest_host = "ENTER.YOUR.EXAMPLE.SERVER_CN"
         - wrong_hostname:


### PR DESCRIPTION
Set 'server_info_ip' parameter to fix authentication failed issue.