### PR TITLE
guest_os_booting: Extend timeout

### DIFF
--- a/libvirt/tests/src/guest_os_booting/boot_order/boot_with_multiple_boot_order.py
+++ b/libvirt/tests/src/guest_os_booting/boot_order/boot_with_multiple_boot_order.py
@@ -92,7 +92,7 @@ def run(test, params, env):
             vm.wait_for_login(timeout=360).close()
             test.log.debug("Succeed to boot %s", vm_name)
         else:
-            vm.serial_console.read_until_output_matches(check_prompt, timeout=300,
+            vm.serial_console.read_until_output_matches(check_prompt, timeout=600,
                                                         internal_timeout=0.5)
     finally:
         bkxml.sync()


### PR DESCRIPTION
Extend timeout of checking vm boot up to make the script more stable


` (1/1) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_order.network.cdrom.cdrom_bootable: PASS (332.98 s)
`