### PR TITLE
guest_os_booting: Fix up login timeout issue

### DIFF
--- a/libvirt/tests/cfg/guest_os_booting/boot_order/boot_from_cdrom_device.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/boot_order/boot_from_cdrom_device.cfg
@@ -6,11 +6,13 @@
     variants:
         - without_cdrom:
             only os_dev
+            aarch64:
+                bootable_patterns = ["Shell>"]
         - with_cdrom_with_no_src:
             cdrom1_attrs = {'target': {'dev': 'sda', 'bus': 'sata'}, **${cdrom_attrs}}
             aarch64:
                 cdrom1_attrs = {'target': {'dev': 'sda', 'bus': 'scsi'}, **${cdrom_attrs}}
-                bootable_patterns = ["Shell>"] 
+                bootable_patterns = ["Shell>"]
         - with_cdrom:
             check_bootable_iso = "yes"
             cdrom1_attrs = {'source': {'attrs': {'file': boot_img_path}}, 'target': {'dev': 'sda', 'bus': 'scsi'}, **${cdrom_attrs}}
@@ -24,7 +26,7 @@
                 check_bootable_iso = "yes"
                 bootable_patterns = ["begin the installation process|Install Red Hat Enterprise"]
             os_dev:
-               status_error = "yes"  
+               status_error = "yes"
     variants:
         - os_dev:
             os_attrs_boots = ['cdrom']

--- a/libvirt/tests/src/guest_os_booting/boot_order/boot_from_cdrom_device.py
+++ b/libvirt/tests/src/guest_os_booting/boot_order/boot_from_cdrom_device.py
@@ -102,7 +102,7 @@ def run(test, params, env):
         vm.start()
         if bootable_patterns:
             vm.serial_console.read_until_output_matches(
-                bootable_patterns, timeout=60, internal_timeout=0.5)
+                bootable_patterns, timeout=360, internal_timeout=0.5)
         else:
             try:
                 vm.wait_for_serial_login().close()


### PR DESCRIPTION
On aarch64, the vm will enter uefi if there's no cdrom device. This is as expected so updating the expected result.


**Before the fix:**
`c (1/1) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.ovmf.os_dev.without_cdrom: FAIL: Login timeout expired    (output: 'exceeded 360 s timeout') (389.46 s)
`
**After the fix:**
 (1/1) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.ovmf.os_dev.without_cdrom: PASS (328.10 s)
