### PR TITLE
add case for virt-xml-validate for virsh domcap

### DIFF
--- a/libvirt/tests/cfg/virt_cmd/virt_xml_validate.cfg
+++ b/libvirt/tests/cfg/virt_cmd/virt_xml_validate.cfg
@@ -28,3 +28,6 @@
             secret_volume = "/var/lib/libvirt/images/virt_xml_validate.secret"
         - interface:
             schema = "interface"
+        - domcapabilities:
+            func_supported_since_libvirt_ver = (10, 10, 0)
+            schema = "domcapabilities"

--- a/libvirt/tests/src/virt_cmd/virt_xml_validate.py
+++ b/libvirt/tests/src/virt_cmd/virt_xml_validate.py
@@ -8,6 +8,7 @@ from avocado.core import exceptions
 
 from virttest import virsh
 from virttest import data_dir
+from virttest import libvirt_version
 from virttest.utils_libvirt import libvirt_secret
 from virttest.utils_test import libvirt
 
@@ -183,10 +184,21 @@ def interface_validate(test, file=None, **virsh_dargs):
         test.error(str(e))
 
 
+def domcap_validate(file=None, **virsh_dargs):
+    """
+    Prepare schema domcapabilities.
+    :param file: domcapabilities output file
+    :param virsh_dargs: virsh debug args.
+    """
+    cmd_result = virsh.domcapabilities(options="> %s" % file, **virsh_dargs)
+    libvirt.check_exit_status(cmd_result)
+
+
 def run(test, params, env):
     """
     Test for virt-xml-validate
     """
+    libvirt_version.is_libvirt_feature_supported(params)
     # Get the full path of virt-xml-validate command.
     try:
         VIRT_XML_VALIDATE = astring.to_text(process.system_output("which virt-xml-validate", shell=True))
@@ -203,7 +215,7 @@ def run(test, params, env):
 
     valid_schemas = ['domain', 'domainsnapshot', 'network', 'storagepool',
                      'storagevol', 'nodedev', 'capability',
-                     'nwfilter', 'secret', 'interface']
+                     'nwfilter', 'secret', 'interface', 'domcapabilities']
     if schema not in valid_schemas:
         test.fail("invalid %s specified" % schema)
 
@@ -230,6 +242,9 @@ def run(test, params, env):
         secret_validate(test, secret_volume, file=output_path, **virsh_dargs)
     elif schema == "interface":
         interface_validate(test, file=output_path, **virsh_dargs)
+    elif schema == "domcapabilities":
+        domcap_validate(file=output_path, **virsh_dargs)
+        schema = ""
     else:
         # domain
         virsh.dumpxml(vm_name, to_file=output_path)


### PR DESCRIPTION
    xxxx-17141:validate libvirt XML files against a virsh domcap schema
Signed-off-by: nanli <nanli@redhat.com>

```
avocado run --vt-type libvirt virt_xml_validate.domcapabilities
 (1/1) type_specific.io-github-autotest-libvirt.virt_xml_validate.domcapabilities: PASS (7.28 s)

```