### PR TITLE
sriov: fix ipxe rom file issue

### DIFF
--- a/provider/sriov/sriov_base.py
+++ b/provider/sriov/sriov_base.py
@@ -258,12 +258,11 @@ class SRIOVTest(object):
         rom_vendor_device = lspci_stdout[1:-1].replace(':', '') + '.rom'
         rom_file = os.path.join('/usr/share/ipxe', rom_vendor_device)
         if not os.path.exists(rom_file):
-            build_cmd = "git clone https://github.com/ipxe/ipxe.git;\
-                         pushd ipxe/src; make bin/{0}; cp bin/{0} {1}; popd; \
-                         rm -rf ipxe".format(rom_vendor_device, rom_file)
-            process.run(build_cmd, shell=True, verbose=True)
-            if not os.path.exists(rom_file):
-                self.test.error("This test needs rom file: %s." % rom_file)
+            virtio_rom_file = "/usr/share/ipxe/1af41000.rom"
+            if not os.path.exists(virtio_rom_file):
+                self.test.error(f"This test needs a rom file, but neither {rom_file}"
+                                "nor {virtio_rom_file} exist!")
+            return virtio_rom_file
         return rom_file
 
     def create_iface_dev(self, dev_type, iface_dict):


### PR DESCRIPTION
Relying on ipxe build in tests when cannot obtain VF pxe rom file is an unstable testing method. Because this case is mainly to test the xml but not the pxe function. So we decided to use the fixed virtio rom file to test.
The error message:
This test needs rom file: /usr/share/ipxe/8086154c.rom.