### PR TITLE
iface_update: change huge average value

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_update.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_update.cfg
@@ -178,9 +178,9 @@
                                     new_iface_outbound = "{'average':'128','peak':'256','burst':'256'}"
                                     expect_err_msg = "could not convert bandwidth average value|Expected non-negative integer value"
                                 - huge_val:
-                                    new_iface_inbound = "{'average':'10000000000000000','peak':'5000','burst':'1024'}"
+                                    new_iface_inbound = "{'average':'100000000000000000','peak':'5000','burst':'1024'}"
                                     new_iface_outbound = "{'average':'128','peak':'256','burst':'256'}"
-                                    expect_err_msg = 'Illegal "quantum"'
+                                    expect_err_msg = "too big for 'average' parameter, maximum is '18014398509481984'"
                                 - missing:
                                     new_iface_inbound = "{'peak':'5000','burst':'1024'}"
                                     new_iface_outbound = "{'peak':'256','burst':'256'}"


### PR DESCRIPTION
Bug RHEL-45200(libvirt-10.8.0) start to reject huge average values larger than '18014398509481984', so change the test value and error msg.