### PR TITLE
SRIOV: fix "Login timeout expired" because of 256 vcpus

### DIFF
--- a/libvirt/tests/cfg/sriov/vIOMMU/intel_iommu_with_dma_translation.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/intel_iommu_with_dma_translation.cfg
@@ -13,5 +13,4 @@
             with_more_vcpus = "yes"
             dma_translation = "off"
             eim_dict = {'eim': 'on'}
-            guest_vcpus = 256
     iommu_dict = {'model': 'intel', 'driver': {'intremap': 'on', 'caching_mode': 'on', 'iotlb': 'on', 'dma_translation': '${dma_translation}'}}

--- a/libvirt/tests/src/sriov/vIOMMU/intel_iommu_with_dma_translation.py
+++ b/libvirt/tests/src/sriov/vIOMMU/intel_iommu_with_dma_translation.py
@@ -1,3 +1,4 @@
+from avocado.utils import cpu
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 
@@ -23,6 +24,7 @@ def run(test, params, env):
         test_obj.setup_iommu_test(iommu_dict=iommu_dict)
         if with_more_vcpus:
             vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+            guest_vcpus = cpu.online_count()
             vmxml.vcpu = int(guest_vcpus)
             vmxml.sync()
         test.log.info("TEST STEP2: Start the guest.")


### PR DESCRIPTION
The numbers of guest vcpu is better little than the host vcpus' number. But we don't have this host to match 256 cpus. So after discussing we decided to use the same host cpus' number to test guest vcpus.