### PR TITLE
Fix the malformed default gatway

### DIFF
--- a/libvirt/tests/src/virtual_network/passt/passt_transfer_file.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_transfer_file.py
@@ -79,9 +79,9 @@ def transfer_vm_to_host(session, prot, ip_ver, vm_iface, firewalld,
     rec_file = params.get('rec_file')
     cmd_create_file = params.get('cmd_create_file')
     force_dhcp = True if ip_ver == 'ipv4' else False
-    vm_default_gw = utils_net.get_default_gateway(session=session,
-                                                  ip_ver=ip_ver,
-                                                  force_dhcp=force_dhcp)
+    vm_default_gw = utils_net.get_default_gateway_json(session=session,
+                                                       ip_ver=ip_ver,
+                                                       force_dhcp=force_dhcp)
     addr = vm_default_gw if ip_ver == 'ipv4' \
         else f'[{vm_default_gw}%{vm_iface}]'
     firewalld.stop()


### PR DESCRIPTION
On RHEL 10, the utils_net.get_default_gateway() will get outputs with color, which will be malformed showed in text. Replace it with get_default_gateway_json() can fix the issue.