### PR TITLE
guest_os_booting: Remove unnecessary dhcp-client package

### DIFF
--- a/libvirt/tests/src/guest_os_booting/boot_order/boot_from_virtiofs_device.py
+++ b/libvirt/tests/src/guest_os_booting/boot_order/boot_from_virtiofs_device.py
@@ -36,7 +36,7 @@ def run(test, params, env):
         cmd1 = f"mkdir {install_root}"
         cmd2 = f"dnf --installroot={install_root} --releasever=9 install "\
                "system-release vim-minimal systemd passwd dnf rootfiles sudo "\
-               "kernel kernel-modules net-tools yum dhcp-client -y >/dev/null"
+               "kernel kernel-modules net-tools yum -y >/dev/null"
         # Create the initramfs.
         cmd3 = f"dracut {initrams_file} --early-microcode "\
                "--add virtiofs --filesystem virtiofs"


### PR DESCRIPTION
rhel9:
```
 (1/1) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.virtiofs_device.start_guest: PASS (109.51 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2024-12-20T06.32-4e45fbf/results.html
JOB TIME   : 110.96 s
(.libvirt-ci-venv-ci-runtest-qfudOX) [root@ampere-mtsnow-altramax-46 ~]# 
```
rhel10:
```
 (1/1) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.virtiofs_device.start_guest: PASS (162.49 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2024-12-20T06.32-906cb89/results.html
JOB TIME   : 164.46 s
(.libvirt-ci-venv-ci-runtest-6DIx80) [root@nvidia-jetson-agx-orin-04 job-2024-12-20T04.50-b79edb6]#
```