### PR TITLE
update_device/iface: disable test on s390x

### DIFF
--- a/libvirt/tests/cfg/virtual_network/update_device/unsupported_live_update_delete.cfg
+++ b/libvirt/tests/cfg/virtual_network/update_device/unsupported_live_update_delete.cfg
@@ -28,6 +28,7 @@
             del_attr = rom
             err_msg = cannot modify network device rom enabled setting
         - model_type:
+            no s390-virtio
             del_attr = model
             err_msg = cannot modify network device model from .* to .*
         - backend:


### PR DESCRIPTION
On s390x, there's only one model. Trying to unset the type will be ignored.