### PR TITLE
Clean the env before vm clone

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_managedsave.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_managedsave.py
@@ -538,5 +538,5 @@ def run(test, params, env):
         if multi_guests:
             for i in range(int(multi_guests)):
                 virsh.remove_domain("%s_%s" % (vm_name, i),
-                                    "--remove-all-storage",
+                                    "--remove-all-storage --nvram",
                                     debug=True)


### PR DESCRIPTION
There could be scenario that existing VMs with the same name which block the following operations. Remove these VMs to clean the env.