### PR TITLE
Update expected result for ovs bridge throughput

### DIFF
--- a/libvirt/tests/cfg/virtual_network/qos/check_actual_network_throughput.cfg
+++ b/libvirt/tests/cfg/virtual_network/qos/check_actual_network_throughput.cfg
@@ -32,4 +32,10 @@
                     iface_attrs = {'type_name': 'bridge', 'source': {'bridge': br_name}, 'model': 'virtio', **${iface_bw_attrs}}
                 - ovs_br:
                     iface_attrs = {'type_name': 'bridge', 'source': {'bridge': br_name}, 'model': 'virtio', **${iface_bw_attrs}, 'virtualport': {'type': 'openvswitch'}}
+                    inbound = {'average': '512', 'peak': '512', 'burst': '32'}
+                    outbound = {'average': '128', 'peak': '1024', 'burst': '32'}
+                    iface_bw_attrs = {'bandwidth': {'inbound': ${inbound}, 'outbound': ${outbound}}}
+                - ovs_br_log:
+                    check_qos = no
+                    check_libvirtd_log = "Setting different 'peak' value than 'average' for QoS for OVS"
 


### PR DESCRIPTION
 For ovs bridge, if we set differnet value for peak and average, the average will map to the min rate, and peak to the max rate, which is different with linux bridge. For linux bridge, the average will map to max rate. To make the behavior consistent, set peak and average to be the same. When we set different value for average and peak on ovs bridge, libvirt will report warning on the libvirtd log.