### PR TITLE
guest_os_booting: Skip templateFormat when comparing os xml

### DIFF
--- a/libvirt/tests/src/guest_os_booting/ovmf_firmware/ovmf_backed_nvram.py
+++ b/libvirt/tests/src/guest_os_booting/ovmf_firmware/ovmf_backed_nvram.py
@@ -30,6 +30,8 @@ def run(test, params, env):
         current_os_attrs = os_xml.fetch_attrs()
         for key in os_attrs:
             if key in current_os_attrs:
+                if key == "nvram_attrs":
+                    current_os_attrs[key].pop("templateFormat")
                 if os_attrs[key] != current_os_attrs[key]:
                     test.fail("Configured os xml value {} doesn't match the"
                               " entry {} in guest xml".format(os_attrs[key], current_os_attrs[key]))


### PR DESCRIPTION
The 'templateFormat' is automatically added in os xml and causes the xml comparison to fail.


**Before the fix:**
` (1/1) type_specific.io-github-autotest-libvirt.guest_os_booting.ovmf_backed_nvram.file: FAIL: Configured os xml value {'template': '/usr/share/edk2/aarch64/vars-template-pflash.qcow2', 'type': 'file', 'format': 'qcow2'} doesn't match the entry {'template': '/usr/share/edk2/aarch64/vars-template-pflash.qcow2', 'templateFormat': 'qcow2', 'type': 'fi... (36.60 s)`


**After the fix:**
` (1/1) type_specific.io-github-autotest-libvirt.guest_os_booting.ovmf_backed_nvram.file: PASS (36.69 s)
`