### PR TITLE
guest_os_booting: Fix the nonexist_template case error

### DIFF
--- a/libvirt/tests/cfg/guest_os_booting/ovmf_firmware/ovmf_nvram.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/ovmf_firmware/ovmf_nvram.cfg
@@ -28,4 +28,4 @@
             variants:
                 - nonexist_template:
                     template_path = "nonexist"
-                    error_msg = "error: Failed to open file.+: No such file or directory"
+                    error_msg = "error: Failed to open file.+: No such file or directory|conversion of the nvram template to another target format"

--- a/libvirt/tests/src/guest_os_booting/ovmf_firmware/ovmf_nvram.py
+++ b/libvirt/tests/src/guest_os_booting/ovmf_firmware/ovmf_nvram.py
@@ -22,16 +22,18 @@ def run(test, params, env):
     smm_state = params.get("smm_state")
     error_msg = params.get("error_msg", "")
     template_path = params.get("template_path", "")
-    if template_path:
-        nvram_dict = eval(params.get("nvram_dict", "{}") % template_path)
-    else:
-        nvram_dict = eval(params.get("nvram_dict"))
 
     vm = env.get_vm(vm_name)
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     bkxml = vmxml.copy()
 
     try:
+        if template_path:
+            nvram_dict = eval(params.get("nvram_dict", "{}") % template_path)
+            if template_path == "nonexist":
+                vmxml.sync("--nvram")
+        else:
+            nvram_dict = eval(params.get("nvram_dict"))
         if smm_state:
             guest_os.prepare_smm_xml(vm_name, smm_state, smm_size=None)
         guest_os.prepare_os_xml(vm_name, nvram_dict, firmware_type)


### PR DESCRIPTION
1. nvram file should be cleared before the testing
2. error message changed

Before the fix:
```
 (1/1) type_specific.io-github-autotest-libvirt.guest_os_booting.ovmf_nvram.negative_test.nonexist_template: FAIL: Expect should fail with one of ['error: Failed to open file.+: No such file or directory'], but failed with:\n\n\nerror: Failed to start domain 'avocado-vt-vm1'\nerror: Operation not supported: conversion of the nvram template to another target format is not ... (10.01 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2024-12-27T04.16-865d082/results.html
JOB TIME   : 11.99 s

Test summary:
1-type_specific.io-github-autotest-libvirt.guest_os_booting.ovmf_nvram.negative_test.nonexist_template: FAIL
(.libvirt-ci-venv-ci-runtest-d2E5ZF) [root@dell-per750-61 ~]
```

After the fix:
```
 (1/1) type_specific.io-github-autotest-libvirt.guest_os_booting.ovmf_nvram.negative_test.nonexist_template: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.guest_os_booting.ovmf_nvram.negative_test.nonexist_template: PASS (9.66 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2024-12-27T04.17-2f1317b/results.html
JOB TIME   : 11.75 s
(.libvirt-ci-venv-ci-runtest-d2E5ZF) [root@dell-per750-61 ~]# 
```

aarch64:
```
 (1/1) type_specific.io-github-autotest-libvirt.guest_os_booting.ovmf_nvram.negative_test.nonexist_template: PASS (5.33 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2024-12-27T04.15-bf87ed2/results.html
JOB TIME   : 9.50 s
(.libvirt-ci-venv-ci-runtest-N3wQe0) [root@ampere-mtsnow-altramax
```