### PR TITLE
Add the cases of virtiofs openfiles

### DIFF
--- a/libvirt/tests/cfg/virtual_device/filesystem_device.cfg
+++ b/libvirt/tests/cfg/virtual_device/filesystem_device.cfg
@@ -40,6 +40,7 @@
             variants:
                 - thread_pool_16:
                   thread_pool_size = 16
+                  openfiles = "yes"
                   only positive_test..nop..xattr_on.cache_mode_auto, positive_test..detach_device..xattr_on.cache_mode_auto
                 - thread_pool_noset:
             variants:


### PR DESCRIPTION
Issue: VIRTUCT-387
avocado-vt: https://github.com/avocado-framework/avocado-vt/pull/4044
This is a trivial element, I did not add a specific pattern for this element. I just combine the test of the element to thread_pool test, otherwise the case pattern would be even longer