### PR TITLE
Add skip logic for cpu frequency checking on aarch64

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_nodeinfo.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_nodeinfo.cfg
@@ -4,6 +4,9 @@
     start_vm = no
     virsh_node_options = ""
     status_error = "no"
+    check_frequency = yes
+    aarch64:
+        check_frequency = no
     variants test_case:
         - no_option:
             libvirtd = "on"

--- a/libvirt/tests/src/virsh_cmd/host/virsh_nodeinfo.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_nodeinfo.py
@@ -106,11 +106,12 @@ def run(test, params, env):
         # that it's within 20 percent of each value to give us enough of
         # a "fudge" factor to declare "close enough". Don't return a failure
         # just print a debug message and move on.
-        diffval = abs(int(cpu_frequency_nodeinfo) - int(cpu_frequency_os))
-        if (float(diffval) / float(cpu_frequency_nodeinfo) > 0.20 or
-                float(diffval) / float(cpu_frequency_os) > 0.20):
-            logging.debug("Virsh nodeinfo output didn't match CPU "
-                          "frequency within 20 percent")
+        if 'yes' == params.get('check_frequency', 'no'):
+            diffval = abs(int(cpu_frequency_nodeinfo) - int(cpu_frequency_os))
+            if (float(diffval) / float(cpu_frequency_nodeinfo) > 0.20 or
+                    float(diffval) / float(cpu_frequency_os) > 0.20):
+                logging.debug("Virsh nodeinfo output didn't match CPU "
+                              "frequency within 20 percent")
 
         # Get CPU topology from virsh capabilities xml
         cpu_topology = capability_xml.CapabilityXML()['cpu_topology']


### PR DESCRIPTION
on aarch64 virsh nodeinfo could not get cpu frequency currently, so add skip logic.

test result:
 (1/1) type_specific.io-github-autotest-libvirt.virsh.nodeinfo.no_option: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.virsh.nodeinfo.no_option: PASS (6.28 s)