### PR TITLE
vIOMMU: Add tests of intel iommu without ioapic feature

### DIFF
--- a/libvirt/tests/cfg/sriov/vIOMMU/intel_iommu_without_ioapic.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/intel_iommu_without_ioapic.cfg
@@ -3,6 +3,12 @@
     start_vm = "yes"
     enable_guest_iommu = "yes"
     feature_name = "ioapic"
-    err_msg = "IOMMU interrupt remapping requires split I/O APIC"
     iommu_dict = {'model': 'intel', 'driver': {'intremap': 'on'}}
     only q35
+    variants:
+        - default:
+            iommu_dict = {'model': 'intel'}
+        - intremap_on:
+            func_supported_since_libvirt_ver = (10, 10, 0)
+            iommu_dict = {'model': 'intel', 'driver': {'intremap': 'on'}}
+            auto_add_ioapic = "yes"

--- a/spell.ignore
+++ b/spell.ignore
@@ -435,6 +435,8 @@ inodes
 inpect
 installable
 installroot
+intel
+intremap
 invtsc
 inx
 io


### PR DESCRIPTION
Update to cover intremap on and off.

**Test results:**
 ```
(1/2) type_specific.io-github-autotest-libvirt.vIOMMU.intel_iommu.without_ioapic.default: STARTED
 (1/2) type_specific.io-github-autotest-libvirt.vIOMMU.intel_iommu.without_ioapic.default: PASS (124.25 s)
 (2/2) type_specific.io-github-autotest-libvirt.vIOMMU.intel_iommu.without_ioapic.intremap_on: STARTED
 (2/2) type_specific.io-github-autotest-libvirt.vIOMMU.intel_iommu.without_ioapic.intremap_on: PASS (132.04 s)
```