### PR TITLE
Add default value 0 when specific cpu toplogy file is missing

### DIFF
--- a/libvirt/tests/cfg/numa/numa_capabilities.cfg
+++ b/libvirt/tests/cfg/numa/numa_capabilities.cfg
@@ -5,3 +5,6 @@
     status_error = "no"
     variants:
         - default:
+            aarch64:
+                missing_cpu_topology_key = 'die_id'
+

--- a/libvirt/tests/src/numa/numa_capabilities.py
+++ b/libvirt/tests/src/numa/numa_capabilities.py
@@ -14,6 +14,7 @@ def run(test, params, env):
     """
     Test capabilities with host numa node topology
     """
+    missing_cpu_topology_key = params.get("missing_cpu_topology_key")
     libvirtd = utils_libvirtd.Libvirtd()
     libvirtd.start()
     try:
@@ -49,6 +50,10 @@ def run(test, params, env):
             cpu_topo_list = []
             for cpu_id in cpu_list:
                 cpu_dict = node_.get_cpu_topology(cpu_id)
+                # if specific cpu topology file from sysfs doesn't exist, default 0
+                # would be used in virsh capabilities
+                if missing_cpu_topology_key and cpu_dict[missing_cpu_topology_key] is None:
+                    cpu_dict[missing_cpu_topology_key] = '0'
                 cpu_topo_list.append(cpu_dict)
             logging.debug("cpu topology list from capabilities xml is %s",
                           cpu_list_from_xml)


### PR DESCRIPTION
if specific cpu topology file from sysfs doesn't exist, defalut 0 would be used in virsh capabilities.
Depends on avocado-vt pr: https://github.com/avocado-framework/avocado-vt/pull/4047

Test result:
(1/1) type_specific.io-github-autotest-libvirt.numa_capabilities.default: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.numa_capabilities.default: PASS (9.83 s)