### PR TITLE
connectivity_check_user_interface:Fix error when setting mac_address

### DIFF
--- a/libvirt/tests/src/virtual_network/connectivity/connectivity_check_user_interface.py
+++ b/libvirt/tests/src/virtual_network/connectivity/connectivity_check_user_interface.py
@@ -95,7 +95,7 @@ def run(test, params, env):
         vmxml.del_device('interface', by_tag=True)
         vmxml.sync(virsh_instance=virsh_ins)
         iface = libvirt_vmxml.create_vm_device_by_type(
-            'interface', {**iface_attrs, **{'mac_address': mac}})
+            'interface', {**iface_attrs, **({'mac_address': mac} if mac else {})})
         vmxml.add_device(iface)
         define_result = virsh.define(vmxml.xml, debug=True, uri=virsh_uri)
         libvirt.check_exit_status(define_result, expect_error)


### PR DESCRIPTION
The value of mac getting from vmxml could be None when there's no interface on vm which could lead to Error when trying to set the value to new interface.

Test result:
```
before:
 (1/1) type_specific.local.virtual_network.connectivity_check.user_interface.positive_test.default.non_root_user: STARTED
 (1/1) type_specific.local.virtual_network.connectivity_check.user_interface.positive_test.default.non_root_user: ERROR: Error in Delter for property "mac_address", element tag "mac" not found on parent at xpath "/" in XML\n<interface type="user"><model type="virtio" /></interface>\n (13.52 s)

after:
 (1/1) type_specific.local.virtual_network.connectivity_check.user_interface.positive_test.default.non_root_user: STARTED
 (1/1) type_specific.local.virtual_network.connectivity_check.user_interface.positive_test.default.non_root_user: PASS (47.78 s)
```