### PR TITLE
Change request size to fit for 512mb block size on aarch64 64k kernel

### DIFF
--- a/libvirt/tests/cfg/memory/memory_devices/virtio_mem_with_memory_allocation_and_numa.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/virtio_mem_with_memory_allocation_and_numa.cfg
@@ -61,7 +61,7 @@
         - virtio_mem_with_exceed_size:
             only without_numa.with_maxmemory
             target_size = "10485760"
-            request_size = "256"
+            request_size = "512"
             target_size_unit = "KiB"
             virtio_mem_dict = {'mem_model': '${mem_model}', 'target': {'requested_unit': '${request_size_unit}', 'size': ${target_size}, 'size_unit': '${target_size_unit}', 'requested_size': ${request_size}, 'block_unit': 'KiB', 'block_size': %s}}
             coldplug_start_error = "${err_msg2}"


### PR DESCRIPTION
test result:
 (1/3) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.define_guest.virtio_mem_with_exceed_size.without_numa.with_maxmemory: STARTED
 (1/3) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.define_guest.virtio_mem_with_exceed_size.without_numa.with_maxmemory: PASS (30.36 s)
 (2/3) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.cold_plug.virtio_mem_with_exceed_size.without_numa.with_maxmemory: STARTED
 (2/3) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.cold_plug.virtio_mem_with_exceed_size.without_numa.with_maxmemory: PASS (30.34 s)
 (3/3) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.hot_plug.virtio_mem_with_exceed_size.without_numa.with_maxmemory: STARTED
 (3/3) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.hot_plug.virtio_mem_with_exceed_size.without_numa.with_maxmemory: PASS (57.77 s)