### PR TITLE
Update wrong configuration for migration test for network data transport tls

### DIFF
--- a/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_tls.cfg
+++ b/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_tls.cfg
@@ -52,7 +52,7 @@
             libvirtd_debug_level = "1"
             libvirtd_debug_filters = "1:*"
             check_str_local_log = '['"dir":"/etc/pki/qemu","endpoint":"client","verify-peer":true']'
-            check_str_remote_log = '"dir":"/etc/pki/qemu","endpoint":"server","verify-peer":true'
+            check_str_remote_log = '['"dir":"/etc/pki/qemu","endpoint":"server","verify-peer":true']'
             action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: \'1\'", "func_param": "params"}, {"func": "set_migrate_speed_to_high", "func_param": "params"}]'
         - tls_destination:
             no with_postcopy

--- a/provider/migration/base_steps.py
+++ b/provider/migration/base_steps.py
@@ -368,10 +368,13 @@ class MigrationBase(object):
         :param remote_str_in_log: True if the remote file should include the given string,
                                   otherwise, False
         """
-        check_str_local_log = eval(self.params.get("check_str_local_log", "[]"))
-        check_no_str_local_log = eval(self.params.get("check_no_str_local_log", "[]"))
-        check_str_remote_log = eval(self.params.get("check_str_remote_log", "[]"))
-        check_no_str_remote_log = eval(self.params.get("check_no_str_remote_log", "[]"))
+        try:
+            check_str_local_log = eval(self.params.get("check_str_local_log", "[]"))
+            check_no_str_local_log = eval(self.params.get("check_no_str_local_log", "[]"))
+            check_str_remote_log = eval(self.params.get("check_str_remote_log", "[]"))
+            check_no_str_remote_log = eval(self.params.get("check_no_str_remote_log", "[]"))
+        except Exception as e:
+            self.test.error(f"Wrong test configuration. Unable to eval one or more parameter(s): {str(e)}")
         log_file = self.params.get("libvirtd_debug_file")
         runner_on_target = None
 


### PR DESCRIPTION
There was wrong configuration for remote_log file, failing when trying to setup and check the remote log. (script was unable to eval provided value.

I've updated configuration and slightly improved the parameter evaluation, so the test will fail with more meaningful message.

There is no change in test logic.

manual run PASSED on testing environment for RHEL-9.6. ARM

