### PR TITLE
attach_user_type_iface:Workaround timeout error when running virsh cmd

### DIFF
--- a/libvirt/tests/src/virtual_network/attach_detach_device/attach_user_type_iface.py
+++ b/libvirt/tests/src/virtual_network/attach_detach_device/attach_user_type_iface.py
@@ -112,5 +112,8 @@ def run(test, params, env):
         if len(iface_list):
             test.fail('Found interface xml on vm which should be detached:'
                       f'{iface_list}')
+        # Workaround timeout when running virsh dumpxml
+        vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(
+            vm_name, virsh_instance=virsh_ins)
     finally:
         bkxml.sync(virsh_instance=virsh_ins)


### PR DESCRIPTION
Test result:
 (1/1) type_specific.local.virtual_network.attach_device.user_type_iface.non_root_user: STARTED
 (1/1) type_specific.local.virtual_network.attach_device.user_type_iface.non_root_user: PASS (54.31 s)