### PR TITLE
guest_os_booting: Fix a case error

### DIFF
--- a/libvirt/tests/cfg/guest_os_booting/boot_order/boot_from_cdrom_device.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/boot_order/boot_from_cdrom_device.cfg
@@ -7,12 +7,12 @@
         - without_cdrom:
             only os_dev
             aarch64:
-                bootable_patterns = ["Shell>"]
+                bootable_patterns = ["Shell>", "Booting .* on physical CPU"]
         - with_cdrom_with_no_src:
             cdrom1_attrs = {'target': {'dev': 'sda', 'bus': 'sata'}, **${cdrom_attrs}}
             aarch64:
                 cdrom1_attrs = {'target': {'dev': 'sda', 'bus': 'scsi'}, **${cdrom_attrs}}
-                bootable_patterns = ["Shell>"]
+                bootable_patterns = ["Shell>", "Booting .* on physical CPU"]
         - with_cdrom:
             check_bootable_iso = "yes"
             cdrom1_attrs = {'source': {'attrs': {'file': boot_img_path}}, 'target': {'dev': 'sda', 'bus': 'scsi'}, **${cdrom_attrs}}


### PR DESCRIPTION
There is no particular order in which devices with no bootindex property set will be considered for booting. So it is possible to enter the disk system even without cdrom.


**Test results:**
```
 (1/1) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.ovmf.os_dev.without_cdrom: PASS (41.63 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.cdrom_device.ovmf.os_dev.with_cdrom_with_no_src: PASS (41.74 s)
```
