### PR TITLE
Add adaption for aarch64 huge pages

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_freepages.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_freepages.cfg
@@ -6,6 +6,7 @@
     variants:
         - positive_test:
             status_error = "no"
+            hugepage_allocation_dict = {'64':256, '2048':64, '32768':8, '524288':4, '1048576':2, '16777216':1}
             variants:
                 - option_all:
                     freepages_option = "--all"
@@ -17,20 +18,60 @@
                     freepages_pagesize = "EACH"
                 - pagesize_2M:
                     freepages_pagesize = "2M"
+                    pagesize_kb = '2048'
                 - pagesize_2048:
                     freepages_pagesize = "2048"
+                    pagesize_kb = '2048'
                 - pagesize_2048K:
                     freepages_pagesize = "2048K"
+                    pagesize_kb = '2048'
                 - pagesize_2048kib:
                     freepages_pagesize = "2048kib"
+                    pagesize_kb = '2048'
                 - pagesize_1G:
                     freepages_pagesize = "1G"
+                    pagesize_kb = '1048576'
                 - pagesize_1048576:
                     freepages_pagesize = "1048576"
+                    pagesize_kb = '1048576'
                 - pagesize_1048576K:
                     freepages_pagesize = "1048576K"
+                    pagesize_kb = '1048576'
                 - pagesize_1048576KIB:
                     freepages_pagesize = "1048576KIB"
+                    pagesize_kb = '1048576'
+                - pagesize_524288:
+                    only aarch64
+                    freepages_pagesize = "524288"
+                    pagesize_kb = '524288'
+                - pagesize_512M:
+                    only aarch64
+                    freepages_pagesize = "512M"
+                    pagesize_kb = '524288'
+                - pagesize_64:
+                    only aarch64
+                    freepages_pagesize = "64"
+                    pagesize_kb = '64'
+                - pagesize_64K:
+                    only aarch64
+                    freepages_pagesize = "64K"
+                    pagesize_kb = '64'
+                - pagesize_32768:
+                    only aarch64
+                    freepages_pagesize = "32768"
+                    pagesize_kb = '32768'
+                - pagesize_32M:
+                    only aarch64
+                    freepages_pagesize = "32M"
+                    pagesize_kb = '32768'
+                - pagesize_16G:
+                    only aarch64
+                    freepages_pagesize = "16G"
+                    pagesize_kb = '16777216'
+                - pagesize_16777216:
+                    only aarch64
+                    freepages_pagesize = "16777216"
+                    pagesize_kb = '16777216'
         - negative_test:
             status_error = "yes"
             variants:
@@ -47,3 +88,4 @@
                 - invalid_page_size:
                     freepages_cellno = "0"
                     freepages_pagesize = "-1"
+


### PR DESCRIPTION
Previously, this case is checking cpu flag for 2M and 1G huge page only for x86_64, so it is not fit for aarch64. So the update code add aarch64 supported huge page sizes and remove the cpu flag checking.

test result after fix:
x84
  (01/25) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.no_pagesize.option_all: PASS (9.42 s)
 (02/25) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.no_pagesize.each_cells: PASS (8.91 s)
 (03/25) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.each_pagesize.option_all: PASS (9.10 s)
 (04/25) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.each_pagesize.each_cells: PASS (9.23 s)
 (05/25) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2M.option_all: PASS (8.80 s)
 (06/25) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2M.each_cells: PASS (8.78 s)
 (07/25) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2048.option_all: PASS (8.76 s)
 (08/25) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2048.each_cells: PASS (8.91 s)
 (09/25) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2048K.option_all: PASS (8.84 s)
 (10/25) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2048K.each_cells: PASS (8.75 s)
 (11/25) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2048kib.option_all: PASS (8.75 s)
 (12/25) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2048kib.each_cells: PASS (8.73 s)
 (13/25) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1G.option_all: PASS (8.67 s)
 (14/25) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1G.each_cells: PASS (8.89 s)
 (15/25) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1048576.option_all: PASS (8.71 s)
 (16/25) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1048576.each_cells: PASS (8.77 s)
 (17/25) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1048576K.option_all: PASS (8.70 s)
 (18/25) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1048576K.each_cells: PASS (8.77 s)
 (19/25) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1048576KIB.option_all: PASS (8.70 s)
 (20/25) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1048576KIB.each_cells: PASS (8.82 s)
 (21/25) type_specific.io-github-autotest-libvirt.virsh.freepages.negative_test.invalid_option: PASS (6.35 s)
 (22/25) type_specific.io-github-autotest-libvirt.virsh.freepages.negative_test.mutually_exclusive_option: PASS (6.40 s)
 (23/25) type_specific.io-github-autotest-libvirt.virsh.freepages.negative_test.out_of_range_cellno: PASS (6.41 s)
 (24/25) type_specific.io-github-autotest-libvirt.virsh.freepages.negative_test.invalid_cellno: PASS (6.50 s)
 (25/25) type_specific.io-github-autotest-libvirt.virsh.freepages.negative_test.invalid_page_size: PASS (6.41 s)



aarch64 kernel-64k:
64k
 (01/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.no_pagesize.option_all: STARTED
 (01/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.no_pagesize.option_all: PASS (7.18 s)
 (02/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.no_pagesize.each_cells: STARTED
 (02/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.no_pagesize.each_cells: PASS (7.65 s)
 (03/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.each_pagesize.option_all: STARTED
 (03/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.each_pagesize.option_all: PASS (11.23 s)
 (04/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.each_pagesize.each_cells: STARTED
 (04/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.each_pagesize.each_cells: PASS (11.36 s)
 (05/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2M.option_all: STARTED
 (05/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2M.option_all: PASS (8.87 s)
 (06/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2M.each_cells: STARTED
 (06/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2M.each_cells: PASS (8.67 s)
 (07/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2048.option_all: STARTED
 (07/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2048.option_all: PASS (9.01 s)
 (08/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2048.each_cells: STARTED
 (08/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2048.each_cells: PASS (8.80 s)
 (09/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2048K.option_all: STARTED
 (09/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2048K.option_all: PASS (19.97 s)
 (10/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2048K.each_cells: STARTED
 (10/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2048K.each_cells: PASS (19.34 s)
 (11/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2048kib.option_all: STARTED
 (11/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2048kib.option_all: PASS (19.61 s)
 (12/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2048kib.each_cells: STARTED
 (12/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2048kib.each_cells: PASS (19.87 s)
 (13/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1G.option_all: STARTED
 (13/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1G.option_all: CANCEL: Required hugepage size 1048576KiB is not supported on this host. (18.27 s)
 (14/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1G.each_cells: STARTED
 (14/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1G.each_cells: CANCEL: Required hugepage size 1048576KiB is not supported on this host. (18.41 s)
 (15/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1048576.option_all: STARTED
 (15/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1048576.option_all: CANCEL: Required hugepage size 1048576KiB is not supported on this host. (18.66 s)
 (16/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1048576.each_cells: STARTED
 (16/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1048576.each_cells: CANCEL: Required hugepage size 1048576KiB is not supported on this host. (18.62 s)
 (17/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1048576K.option_all: STARTED
 (17/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1048576K.option_all: CANCEL: Required hugepage size 1048576KiB is not supported on this host. (18.50 s)
 (18/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1048576K.each_cells: STARTED
 (18/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1048576K.each_cells: CANCEL: Required hugepage size 1048576KiB is not supported on this host. (18.56 s)
 (19/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1048576KIB.option_all: STARTED
 (19/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1048576KIB.option_all: CANCEL: Required hugepage size 1048576KiB is not supported on this host. (18.50 s)
 (20/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1048576KIB.each_cells: STARTED
 (20/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1048576KIB.each_cells: CANCEL: Required hugepage size 1048576KiB is not supported on this host. (18.37 s)
 (21/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_524288.option_all: STARTED
 (21/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_524288.option_all: PASS (19.64 s)
 (22/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_524288.each_cells: STARTED
 (22/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_524288.each_cells: PASS (20.00 s)
 (23/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_512M.option_all: STARTED
 (23/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_512M.option_all: PASS (19.49 s)
 (24/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_512M.each_cells: STARTED
 (24/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_512M.each_cells: PASS (9.59 s)
 (25/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_64.option_all: STARTED
 (25/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_64.option_all: PASS (18.89 s)
 (26/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_64.each_cells: STARTED
 (26/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_64.each_cells: PASS (19.17 s)
 (27/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_64K.option_all: STARTED
 (27/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_64K.option_all: PASS (18.64 s)
 (28/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_64K.each_cells: STARTED
 (28/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_64K.each_cells: PASS (18.82 s)
 (29/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_32768.option_all: STARTED
 (29/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_32768.option_all: CANCEL: Required hugepage size 32768KiB is not supported on this host. (18.82 s)
 (30/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_32768.each_cells: STARTED
 (30/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_32768.each_cells: CANCEL: Required hugepage size 32768KiB is not supported on this host. (18.40 s)
 (31/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_32M.option_all: STARTED
 (31/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_32M.option_all: CANCEL: Required hugepage size 32768KiB is not supported on this host. (18.22 s)
 (32/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_32M.each_cells: STARTED
 (32/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_32M.each_cells: CANCEL: Required hugepage size 32768KiB is not supported on this host. (18.54 s)
 (33/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_16G.option_all: STARTED
 (33/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_16G.option_all: PASS (19.77 s)
 (34/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_16G.each_cells: STARTED
 (34/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_16G.each_cells: PASS (19.60 s)
 (35/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_16777216.option_all: STARTED
 (35/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_16777216.option_all: PASS (19.76 s)
 (36/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_16777216.each_cells: STARTED
 (36/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_16777216.each_cells: PASS (19.96 s)
 (37/41) type_specific.io-github-autotest-libvirt.virsh.freepages.negative_test.invalid_option: STARTED
 (37/41) type_specific.io-github-autotest-libvirt.virsh.freepages.negative_test.invalid_option: PASS (18.36 s)
 (38/41) type_specific.io-github-autotest-libvirt.virsh.freepages.negative_test.mutually_exclusive_option: STARTED
 (38/41) type_specific.io-github-autotest-libvirt.virsh.freepages.negative_test.mutually_exclusive_option: PASS (18.78 s)
 (39/41) type_specific.io-github-autotest-libvirt.virsh.freepages.negative_test.out_of_range_cellno: STARTED
 (39/41) type_specific.io-github-autotest-libvirt.virsh.freepages.negative_test.out_of_range_cellno: PASS (8.30 s)
 (40/41) type_specific.io-github-autotest-libvirt.virsh.freepages.negative_test.invalid_cellno: STARTED
 (40/41) type_specific.io-github-autotest-libvirt.virsh.freepages.negative_test.invalid_cellno: PASS (18.72 s)
 (41/41) type_specific.io-github-autotest-libvirt.virsh.freepages.negative_test.invalid_page_size: STARTED
 (41/41) type_specific.io-github-autotest-libvirt.virsh.freepages.negative_test.invalid_page_size: PASS (18.28 s)



aarch64 kernel-4k:
  (01/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.no_pagesize.option_all: STARTED
 (01/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.no_pagesize.option_all: PASS (8.63 s)
 (02/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.no_pagesize.each_cells: STARTED
 (02/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.no_pagesize.each_cells: PASS (9.07 s)
 (03/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.each_pagesize.option_all: STARTED
 (03/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.each_pagesize.option_all: PASS (13.97 s)
 (04/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.each_pagesize.each_cells: STARTED
 (04/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.each_pagesize.each_cells: PASS (14.31 s)
 (05/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2M.option_all: STARTED
 (05/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2M.option_all: PASS (10.33 s)
 (06/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2M.each_cells: STARTED
 (06/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2M.each_cells: PASS (10.19 s)
 (07/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2048.option_all: STARTED
 (07/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2048.option_all: PASS (9.81 s)
 (08/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2048.each_cells: STARTED
 (08/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2048.each_cells: PASS (9.79 s)
 (09/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2048K.option_all: STARTED
 (09/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2048K.option_all: PASS (9.89 s)
 (10/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2048K.each_cells: STARTED
 (10/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2048K.each_cells: PASS (9.94 s)
 (11/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2048kib.option_all: STARTED
 (11/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2048kib.option_all: PASS (9.93 s)
 (12/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2048kib.each_cells: STARTED
 (12/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_2048kib.each_cells: PASS (10.65 s)
 (13/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1G.option_all: STARTED
 (13/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1G.option_all: PASS (10.01 s)
 (14/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1G.each_cells: STARTED
 (14/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1G.each_cells: PASS (10.41 s)
 (15/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1048576.option_all: STARTED
 (15/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1048576.option_all: PASS (10.36 s)
 (16/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1048576.each_cells: STARTED
 (16/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1048576.each_cells: PASS (9.90 s)
 (17/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1048576K.option_all: STARTED
 (17/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1048576K.option_all: PASS (10.19 s)
 (18/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1048576K.each_cells: STARTED
 (18/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1048576K.each_cells: PASS (10.04 s)
 (19/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1048576KIB.option_all: STARTED
 (19/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1048576KIB.option_all: PASS (10.15 s)
 (20/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1048576KIB.each_cells: STARTED
 (20/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_1048576KIB.each_cells: PASS (10.13 s)
 (21/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_524288.option_all: STARTED
 (21/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_524288.option_all: CANCEL: Required hugepage size 524288KiB is not supported on this host. (8.61 s)
 (22/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_524288.each_cells: STARTED
 (22/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_524288.each_cells: CANCEL: Required hugepage size 524288KiB is not supported on this host. (8.87 s)
 (23/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_512M.option_all: STARTED
 (23/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_512M.option_all: CANCEL: Required hugepage size 524288KiB is not supported on this host. (8.93 s)
 (24/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_512M.each_cells: STARTED
 (24/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_512M.each_cells: CANCEL: Required hugepage size 524288KiB is not supported on this host. (8.87 s)
 (25/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_64.option_all: STARTED
 (25/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_64.option_all: PASS (10.36 s)
 (26/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_64.each_cells: STARTED
 (26/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_64.each_cells: PASS (20.29 s)
 (27/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_64K.option_all: STARTED
 (27/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_64K.option_all: PASS (10.48 s)
 (28/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_64K.each_cells: STARTED
 (28/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_64K.each_cells: PASS (10.21 s)
 (29/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_32768.option_all: STARTED
 (29/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_32768.option_all: PASS (10.24 s)
 (30/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_32768.each_cells: STARTED
 (30/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_32768.each_cells: PASS (10.37 s)
 (31/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_32M.option_all: STARTED
 (31/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_32M.option_all: PASS (10.17 s)
 (32/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_32M.each_cells: STARTED
 (32/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_32M.each_cells: PASS (10.28 s)
 (33/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_16G.option_all: STARTED
 (33/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_16G.option_all: CANCEL: Required hugepage size 16777216KiB is not supported on this host. (8.83 s)
 (34/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_16G.each_cells: STARTED
 (34/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_16G.each_cells: CANCEL: Required hugepage size 16777216KiB is not supported on this host. (8.95 s)
 (35/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_16777216.option_all: STARTED
 (35/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_16777216.option_all: CANCEL: Required hugepage size 16777216KiB is not supported on this host. (8.94 s)
 (36/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_16777216.each_cells: STARTED
 (36/41) type_specific.io-github-autotest-libvirt.virsh.freepages.positive_test.pagesize_16777216.each_cells: CANCEL: Required hugepage size 16777216KiB is not supported on this host. (8.89 s)
 (37/41) type_specific.io-github-autotest-libvirt.virsh.freepages.negative_test.invalid_option: STARTED
 (37/41) type_specific.io-github-autotest-libvirt.virsh.freepages.negative_test.invalid_option: PASS (8.77 s)
 (38/41) type_specific.io-github-autotest-libvirt.virsh.freepages.negative_test.mutually_exclusive_option: STARTED
 (38/41) type_specific.io-github-autotest-libvirt.virsh.freepages.negative_test.mutually_exclusive_option: PASS (9.34 s)
 (39/41) type_specific.io-github-autotest-libvirt.virsh.freepages.negative_test.out_of_range_cellno: STARTED
 (39/41) type_specific.io-github-autotest-libvirt.virsh.freepages.negative_test.out_of_range_cellno: PASS (9.27 s)
 (40/41) type_specific.io-github-autotest-libvirt.virsh.freepages.negative_test.invalid_cellno: STARTED
 (40/41) type_specific.io-github-autotest-libvirt.virsh.freepages.negative_test.invalid_cellno: PASS (9.33 s)
 (41/41) type_specific.io-github-autotest-libvirt.virsh.freepages.negative_test.invalid_page_size: STARTED
 (41/41) type_specific.io-github-autotest-libvirt.virsh.freepages.negative_test.invalid_page_size: PASS (8.95 s)