### PR TITLE
guest_os_booting: Fix nvram_attrs xml comparison failure

### DIFF
--- a/libvirt/tests/src/guest_os_booting/ovmf_firmware/ovmf_backed_nvram.py
+++ b/libvirt/tests/src/guest_os_booting/ovmf_firmware/ovmf_backed_nvram.py
@@ -32,6 +32,8 @@ def run(test, params, env):
             if key in current_os_attrs:
                 if key == "nvram_attrs":
                     current_os_attrs[key].pop("templateFormat")
+                    if "format" not in os_attrs[key]:
+                        os_attrs[key]["format"] = "raw"
                 if os_attrs[key] != current_os_attrs[key]:
                     test.fail("Configured os xml value {} doesn't match the"
                               " entry {} in guest xml".format(os_attrs[key], current_os_attrs[key]))

--- a/libvirt/tests/src/guest_os_booting/ovmf_firmware/ovmf_seclabel_in_nvram.py
+++ b/libvirt/tests/src/guest_os_booting/ovmf_firmware/ovmf_seclabel_in_nvram.py
@@ -31,6 +31,11 @@ def run(test, params, env):
         current_os_attrs = os_xml.fetch_attrs()
         for key in os_attrs:
             if key in current_os_attrs:
+                if key == "nvram_attrs":
+                    current_os_attrs[key].pop("templateFormat")
+                    if "format" not in os_attrs[key]:
+                        os_attrs[key]["format"] = "raw"
+
                 if os_attrs[key] != current_os_attrs[key]:
                     test.fail("Configured os xml value {} doesn't match the"
                               " entry {} in guest xml".format(os_attrs[key], current_os_attrs[key]))


### PR DESCRIPTION

Test results: on x86_64:
```
#  avocado run --vt-type libvirt --vt-omit-data-loss --vt-machine-type q35 guest_os_booting.ovmf_backed_nvram.file guest_os_booting.ovmf_seclabel_in_nvram.positive_test.with_dac_seclabel guest_os_booting.ovmf_seclabel_in_nvram.positive_test.with_selinux_seclabel
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. Screendump and Windows guest BSOD detection are disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
No python imaging library installed. PPM image conversion to JPEG disabled. In order to enable it, please install python-imaging or the equivalent for your distro.
JOB ID     : 919e67f1feb396b5ef4187047fb98302585391e7
JOB LOG    : /var/log/avocado/job-results/job-2025-01-06T01.26-919e67f/job.log
 (1/3) type_specific.io-github-autotest-libvirt.guest_os_booting.ovmf_backed_nvram.file: STARTED
 (1/3) type_specific.io-github-autotest-libvirt.guest_os_booting.ovmf_backed_nvram.file: PASS (33.02 s)
 (2/3) type_specific.io-github-autotest-libvirt.guest_os_booting.ovmf_seclabel_in_nvram.positive_test.with_dac_seclabel: STARTED
 (2/3) type_specific.io-github-autotest-libvirt.guest_os_booting.ovmf_seclabel_in_nvram.positive_test.with_dac_seclabel: PASS (33.87 s)
 (3/3) type_specific.io-github-autotest-libvirt.guest_os_booting.ovmf_seclabel_in_nvram.positive_test.with_selinux_seclabel: STARTED
 (3/3) type_specific.io-github-autotest-libvirt.guest_os_booting.ovmf_seclabel_in_nvram.positive_test.with_selinux_seclabel: PASS (34.34 s)

```

on aarch64:
```
 (1/1) type_specific.io-github-autotest-libvirt.guest_os_booting.ovmf_seclabel_in_nvram.positive_test.with_selinux_seclabel: PASS (37.49 s)
 (1/1) type_specific.io-github-autotest-libvirt.guest_os_booting.ovmf_seclabel_in_nvram.positive_test.with_dac_seclabel: PASS (36.81 s)
```
