### PR TITLE
Qemu: snapshot: Don't forbid snapshot if autodestroy is registered!

### DIFF
--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_create_as.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_create_as.py
@@ -594,7 +594,14 @@ def run(test, params, env):
             # check status_error
             if status_error == "yes":
                 if status == 0:
-                    test.fail("Run successfully with wrong command!")
+                    # snapshots can be created for the guests created
+                    # with 'autodestroy' option on libvirt v5.8.0 and above!
+                    if libvirt_version.version_compare(5, 8, 0) and \
+                            create_autodestroy:
+                        logging.info("Run passed as expected in "
+                                     "libvirt version >= 5.8.0")
+                    else:
+                        test.fail("Run successfully with wrong command!")
                 else:
                     # Check memspec file should be removed if failed
                     if (options.find("memspec") >= 0 and


### PR DESCRIPTION
Signed-off-by: Kowshik Jois B S <kowsjois@linux.ibm.com>

Description: On v5.8.0 and later versions of libvirt, it is allowed to take the snapshot of guests created with 'autodestroy' option since semantically VIR_DOMAIN_START_AUTODESTROY doesn't really clash with snapshot operations as the VM stays on the same host and thus bound to the same connection.

Referrece commit: https://gitlab.com/libvirt/libvirt/-/commit/045a8e197c1e14faa1c32bd637033838269094a2