### PR TITLE
Add new features support and enable more utils

### DIFF
--- a/virttools/tests/cfg/bootc_image_builder/bootc_disk_image_build.cfg
+++ b/virttools/tests/cfg/bootc_image_builder/bootc_disk_image_build.cfg
@@ -25,6 +25,7 @@
             os_password = "bob"
             qcow..upstream_bib:
                 filesystem_size_set = "yes"
+                file_dir_set = "yes"
             anaconda-iso..upstream_bib..fedora_40:
                 kickstart = "yes"
                 use_toml_config = "yes"
@@ -44,7 +45,7 @@
 				    local_container = "yes"
 			- centos10:
 			    container_url = "quay.io/centos-bootc/centos-bootc:stream10"
-			    only upstream_bib..use_config_json..tls_verify_enable, rhel_9.5_nightly_bib..use_config_json..tls_verify_enable, rhel_9.6_nightly_bib..use_config_json..tls_verify_enable, rhel_9.4_nightly_bib..use_config_json..tls_verify_enable
+			    only upstream_bib..use_config_json..tls_verify_enable, rhel_10.0_bib..use_config_json..tls_verify_enable, rhel_9.6_nightly_bib..use_config_json..tls_verify_enable, rhel_9.4_nightly_bib..use_config_json..tls_verify_enable
 			    roofs = "xfs"
 			    rhel_9.4_nightly_bib..use_config_json..tls_verify_enable:
 			        roofs = ""
@@ -91,6 +92,8 @@
         - rhel_9.5_nightly:
             container_url = "registry.stage.redhat.io/rhel9/rhel-bootc:9.5"
             only rhel_9.5_nightly_bib
+            qcow..rhel_9.6_nightly_bib:
+                enable_lvm_disk_partitions = "yes"
             redhat_version_id = "9.5"
             no anaconda-iso
         - rhel_9.6_nightly:
@@ -220,10 +223,10 @@
             output_sub_folder = "vpc"
             output_name = "disk.vhd"
             no s390-virtio
-            only upstream_bib, rhel_9.5_nightly_bib
+            only upstream_bib, rhel_9.6_nightly_bib, rhel_10.0_bib
         - gce:
             disk_image_type = "gce"
             output_sub_folder = "gce"
             output_name = "image.tar.gz"
             no s390-virtio
-            only upstream_bib, rhel_9.5_nightly_bib
+            only upstream_bib, rhel_9.6_nightly_bib, rhel_10.0_bib

--- a/virttools/tests/cfg/bootc_image_builder/bootc_disk_image_install.cfg
+++ b/virttools/tests/cfg/bootc_image_builder/bootc_disk_image_install.cfg
@@ -40,10 +40,12 @@
 			- centos10:
 			    container_url = "quay.io/centos-bootc/centos-bootc:stream10"
 			    only efi
-			    only upstream_bib, rhel_9.5_nightly_bib, rhel_9.6_nightly_bib, rhel_9.4_nightly_bib
+			    only upstream_bib, rhel_10.0_bib, rhel_9.6_nightly_bib, rhel_9.4_nightly_bib
 			    roofs = "ext4"
 			    rhel_9.4_nightly_bib:
 			        roofs = ""
+			    anaconda-iso..upstream_bib:
+			        check_squashfs = "yes"
         - fedora:
             variants fedora_bootc_image:
 			- fedora_40:
@@ -228,10 +230,10 @@
             output_sub_folder = "vpc"
             output_name = "disk.vhd"
             no s390-virtio
-            only upstream_bib, rhel_9.5_nightly_bib
+            only upstream_bib, rhel_9.6_nightly_bib, rhel_10.0_bib
         - gce:
             disk_image_type = "gce"
             output_sub_folder = "gce"
             output_name = "image.tar.gz"
             no s390-virtio
-            only upstream_bib, rhel_9.5_nightly_bib
+            only upstream_bib, rhel_9.6_nightly_bib, rhel_10.0_bib

--- a/virttools/tests/src/bootc_image_builder/bootc_disk_image_build.py
+++ b/virttools/tests/src/bootc_image_builder/bootc_disk_image_build.py
@@ -110,6 +110,10 @@ def prepare_env_and_execute_bib(params, test):
         options += f" -v {root_dir}/policy.json:/etc/containers/policy.json -v {root_dir}/bib_lookaside.yaml:/etc/containers/registries.d/bib_lookaside.yaml "
         options += f" -v /var/lib/containers/sigstore:/var/lib/containers/sigstore -v {root_dir}/key.gpg:{root_dir}key.gpg "
 
+    # Pull images first
+    if "local" not in container_url:
+        bib_utils.podman_pull(container_url)
+
     result = bib_utils.podman_command_build(bib_image_url, disk_image_type, container_url, config_json_file,
                                             local_container, enable_tls_verify, ownership,
                                             key_store_mounted, target_arch, roofs, options, **aws_config_dict)

--- a/virttools/tests/src/bootc_image_builder/bootc_disk_image_install.py
+++ b/virttools/tests/src/bootc_image_builder/bootc_disk_image_install.py
@@ -111,6 +111,10 @@ def prepare_env_and_execute_bib(params, test):
         bib_utils.podman_push(params.get("podman_quay_username"), params.get("podman_quay_password"),
                               params.get("registry"), container_url)
 
+    # Pull images first
+    if "local" not in container_url:
+        bib_utils.podman_pull(container_url)
+
     result = bib_utils.podman_command_build(bib_image_url, disk_image_type, container_url, config_json_file,
                                             local_container, enable_tls_verify, ownership,
                                             key_store_mounted, None, roofs, options, **aws_config_dict)


### PR DESCRIPTION
Add new features support and enable more utils
1. Remove virt-manager package install since it is never necessary
2. Enable local storage as default since it is default behaviour after
   bootc image builder feature updates
3. Enable -use-librepo when building out anaconda-iso since this is
   default feature for anaconda-iso
4. Add util: podman_pull to support podman download image before run
   bootc image builder
5. Add files and directories customization when creating json files
   since it is new feature for bootc image builder
6. Enable vhd on rhel_9.6 and rhel_10.0 since this feature are
   newly supported on those two releases
7. Add check_squashfs when anaconda-iso since it is new feature
   requirement when building out anaconda-iso