### PR TITLE
guest_os_booting: Extend timeout of vm start up

### DIFF
--- a/libvirt/tests/src/guest_os_booting/boot_order/boot_with_multiple_boot_dev.py
+++ b/libvirt/tests/src/guest_os_booting/boot_order/boot_with_multiple_boot_dev.py
@@ -92,7 +92,7 @@ def run(test, params, env):
             vm.wait_for_login(timeout=360).close()
             test.log.debug("Succeed to boot %s", vm_name)
         else:
-            vm.serial_console.read_until_output_matches(check_prompt, timeout=300,
+            vm.serial_console.read_until_output_matches(check_prompt, timeout=600,
                                                         internal_timeout=0.5)
     finally:
         bkxml.sync()


### PR DESCRIPTION
Update the timeout to make the case stable.

` (1/1) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.boot_with_multiple_boot_dev.network.cdrom.cdrom_bootable: PASS (268.03 s)
`