### PR TITLE
migration: Update error message

### DIFF
--- a/libvirt/tests/cfg/migration/migration_uri/tls_migrate_tls_x509_verify_on_target.cfg
+++ b/libvirt/tests/cfg/migration/migration_uri/tls_migrate_tls_x509_verify_on_target.cfg
@@ -45,7 +45,7 @@
         - both_to_default:
             # Use default value for default_tls_x509_verify and migrate_tls_x509_verify
             default_qemu_conf = ["default_tls_x509_verify", "migrate_tls_x509_verify"]
-            err_msg = "Cannot read from TLS channel: Software caused connection abort"
+            err_msg = "Cannot read from TLS channel"
             migrate_again = "yes"
             status_error = "yes"
             migrate_again_status_error = "no"
@@ -59,7 +59,7 @@
             status_error = "no"
         - set_default_to_0_and_migrate_to_1:
             qemu_conf_dest = '{r".*default_tls_x509_verify\s*=.*": "default_tls_x509_verify=0", r".*migrate_tls_x509_verify\s*=.*": "migrate_tls_x509_verify=1"}'
-            err_msg = "Cannot read from TLS channel: Software caused connection abort"
+            err_msg = "Cannot read from TLS channel"
             migrate_again = "yes"
             status_error = "yes"
             migrate_again_status_error = "no"
@@ -69,7 +69,7 @@
         - set_default_to_1:
             default_qemu_conf = ["migrate_tls_x509_verify"]
             qemu_conf_dest = '{r".*default_tls_x509_verify\s*=.*": "default_tls_x509_verify=1"}'
-            err_msg = "Cannot read from TLS channel: Software caused connection abort"
+            err_msg = "Cannot read from TLS channel"
             migrate_again = "yes"
             status_error = "yes"
             migrate_again_status_error = "no"


### PR DESCRIPTION
Before:
Can not find the expected patterns 'Cannot read from TLS channel: Software caused connection abort' in output 'error: operation failed: job 'migration out' failed: Cannot read from TLS channel: The TLS connection was non-properly terminated.'

After:
 (1/1) type_specific.io-github-autotest-libvirt.migration.migration_uri.network_data_transport.tls.migrate_tls_x509_verify_on_target.both_to_default.non_p2p: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.migration.migration_uri.network_data_transport.tls.migrate_tls_x509_verify_on_target.both_to_default.non_p2p: PASS (350.26 s)