### PR TITLE
migration: Update error message

### DIFF
--- a/libvirt/tests/cfg/migration/async_ops/destroy_vm_during_performphase.cfg
+++ b/libvirt/tests/cfg/migration/async_ops/destroy_vm_during_performphase.cfg
@@ -62,4 +62,4 @@
             expected_dest_state = "nonexist"
             expected_src_state = "shut off"
             action_during_mig = [{"func": "virsh.destroy", "after_event": "iteration: '1'", "func_param": {"name": "${main_vm}"}}]
-            err_msg = "domain is not running"
+            err_msg = "domain is not running|internal error: QEMU unexpectedly closed the monitor"

--- a/libvirt/tests/cfg/migration/guest_lifecycle_operations_during_migration/migration_poweroff_vm.cfg
+++ b/libvirt/tests/cfg/migration/guest_lifecycle_operations_during_migration/migration_poweroff_vm.cfg
@@ -55,3 +55,5 @@
             with_postcopy:
                 poweroff_vm_dest = "yes"
                 virsh_migrate_src_state = "paused"
+            with_precopy:
+                err_msg = "domain is not running|internal error: QEMU unexpectedly closed the monitor"

--- a/libvirt/tests/cfg/migration/migration_uri/tls_migrate_tls_x509_verify_on_src.cfg
+++ b/libvirt/tests/cfg/migration/migration_uri/tls_migrate_tls_x509_verify_on_src.cfg
@@ -33,7 +33,7 @@
     qemu_conf_path = '/etc/libvirt/qemu.conf'
     transport_type = "tls"
     test_case = "migrate_tls_x509_verify_on_src"
-    err_msg = "Certificate does not match the hostname"
+    err_msg = "Certificate does not match the hostname|internal error: QEMU unexpectedly closed the monitor"
     status_error = "yes"
     qemu_conf_src = '{"default_tls_x509_verify": "0", "migrate_tls_x509_verify": "0"}'
     virsh_migrate_extra = "--tls"


### PR DESCRIPTION
Before:
Can not find the expected patterns 'domain is not running' in output 'Migration: [ 0.58 %] Migration: [ 0.83 %] Migration: [ 1.25 %] Migration: [ 1.51 %] Migration: [ 1.82 %] Migration: [ 2.07 %]error: internal error: QEMU unexpectedly closed the monitor (vm='avocado-vt-vm1'): 2025-01-09T18:20:49.709830Z qemu-kvm: check_section_footer: Read section footer failed: -5&#10;2025-01-09T18:20:49.710893Z qemu-kvm: load of migration failed: Invalid argument'


After:
 (1/1) type_specific.io-github-autotest-libvirt.migration.guest_lifecycle_operations_during_migration.migration_poweroff_vm.non_nbd.with_precopy.non_p2p: PASS (254.27 s)

 (1/1) type_specific.io-github-autotest-libvirt.migration.migration_uri.network_data_transport.tls.migrate_tls_x509_verify_on_src.p2p: PASS (257.00 s)

 (1/1) type_specific.io-github-autotest-libvirt.migration.async_ops.destroy_vm_during_performphase.destroy_src_vm.with_precopy.non_p2p: PASS (329.14 s)