### PR TITLE
migration: Update case about io error

### DIFF
--- a/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_and_io_error_and_recover.cfg
+++ b/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_and_io_error_and_recover.cfg
@@ -21,7 +21,7 @@
     server_ip = "${migrate_dest_host}"
     server_user = "root"
     server_pwd = "${migrate_dest_pwd}"
-    check_network_accessibility_after_mig = "yes"
+    check_network_accessibility_after_mig = "no"
     migrate_desturi_port = "16509"
     migrate_desturi_type = "tcp"
     virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
@@ -31,7 +31,7 @@
     stress_package = "stress"
     stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20s"
     postcopy_options = "--timeout 4 --timeout-postcopy --postcopy"
-    action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "get_vm_serial_session_on_dest", "func_param": "params", "need_sleep_time": "10"}, {"func": "virsh.domjobabort", "func_param": "'%s --postcopy' % params.get('migrate_main_vm')"}]'
+    action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "write_vm_disk_on_dest", "func_param": "params", "need_sleep_time": "60"}, {"func": "virsh.domjobabort", "func_param": "'%s --postcopy' % params.get('migrate_main_vm')", "need_sleep_time": "5"}]'
     migrate_again = 'yes'
     migrate_again_status_error = 'no'
     action_during_mig_again = '[{"func": "set_migrate_speed_to_high", "before_pause": "yes", "func_param": "params"}]'

--- a/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/pause_and_io_error_and_recover.py
+++ b/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/pause_and_io_error_and_recover.py
@@ -26,8 +26,6 @@ def run(test, params, env):
 
         test.log.debug("Do I/O Error.")
         shutil.chown(disk_source, "root", "root")
-        vm_session.cmd("echo 'do disk I/O error test' > /tmp/disk_io_error_test")
-        vm_session.close()
 
     def verify_test():
         """

--- a/provider/migration/migration_base.py
+++ b/provider/migration/migration_base.py
@@ -720,9 +720,9 @@ def do_domjobabort(params):
     libvirt.check_result(ret, expected_fails=domjobabort_err_msg, check_both_on_error=True)
 
 
-def get_vm_serial_session_on_dest(params):
+def write_vm_disk_on_dest(params):
     """
-    Get vm serial session on dest
+    Write vm's disk on dest
 
     :param params: dictionary with the test parameter, get dest uri and migration object
     """
@@ -733,7 +733,8 @@ def get_vm_serial_session_on_dest(params):
     migration_obj.vm.cleanup_serial_console()
     migration_obj.vm.create_serial_console()
     vm_session = migration_obj.vm.wait_for_serial_login(timeout=120)
-    params.update({"vm_session": vm_session})
+    vm_session.cmd("while true; do echo 'do disk I/O error test' >> /tmp/disk_io_error_test; sleep 1; done &")
+    vm_session.close()
     migration_obj.vm.connect_uri = backup_uri
 
 


### PR DESCRIPTION
Currently, we cannot write to disk in the VM of the target host after aborting migration. So update script.

Before:
Timeout expired while waiting for shell command to complete: "echo 'do disk I/O error test' > /tmp/disk_io_error_test"    (output: '')

After:
 (1/1) type_specific.io-github-autotest-libvirt.migration.pause_postcopy_migration_and_recover.pause_and_io_error_and_recover.p2p: PASS (309.62 s)
 (1/1) type_specific.io-github-autotest-libvirt.migration.pause_postcopy_migration_and_recover.pause_and_io_error_and_recover.non_p2p: PASS (311.06 s)