### PR TITLE
virt_xml_validate: remove vm snapshot after use

### DIFF
--- a/libvirt/tests/src/virt_cmd/virt_xml_validate.py
+++ b/libvirt/tests/src/virt_cmd/virt_xml_validate.py
@@ -34,6 +34,8 @@ def domainsnapshot_validate(test, vm_name, file=None, **virsh_dargs):
 
     cmd_result = virsh.snapshot_dumpxml(vm_name, snapshot_name, to_file=file)
     libvirt.check_exit_status(cmd_result)
+    cmd_result = virsh.snapshot_delete(vm_name, snapshot_name, to_file=file)
+    libvirt.check_exit_status(cmd_result)
 
 
 def network_validate(test, net_name, file=None, **virsh_dargs):


### PR DESCRIPTION
**Issue**
For virsh.event tests run under the function-misc job, the following error occured in a few of the test runs:
```
avocado.virttest.virsh virsh L1685 ERROR| Undefine VM avocado-vt-vm1 failed:Command '/usr/bin/virsh undefine avocado-vt-vm1 --keep-nvram' failed.
stdout: b'\n'stderr: b"error: Failed to undefine domain 'avocado-vt-vm1'\nerror: Requested operation is not valid: cannot delete inactive domain with 1 snapshots\n"additional_info: None
```
However, when simply running any of the virsh.event tests in isolation, they would consistently pass.

**Relation to virt_xml_validate**
Analysis showed that this error was due to `virt_xml_validate.domainsnapshot`. More specifically, when the function-misc job ran`virt_xml_validate.domainsnapshot` before the virsh.event tests, the virsh.event tests would fail; if it was run after the virsh.event tests, all would pass. This happened because `virt_xml_validate.domainsnapshot` created a snapshot of the vm and since avocado-vt-vm1 is reused between tests, this snapshot persisted. However, because of this snapshot, the virsh.event tests couldn't undefine the vm.

**Example Failure**
```
# The virsh.event test passes initially #
(.libvirt-ci-venv-ci-runtest-ZpY1gU) [root@ampere-mtsnow-altra-10 /]# avocado run --vt-type libvirt --vt-omit-data-loss --vt-machine-type arm64-mmio virsh.event.negative_test.qemu_monitor_event.invalid_timeout --vt-connect-uri qemu://system
JOB ID     : 1a68c713d25448c6d37691a46869d8d10ef2754e
JOB LOG    : /var/log/avocado/job-results/job-2025-01-10T16.43-1a68c71/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.event.negative_test.qemu_monitor_event.invalid_timeout: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.virsh.event.negative_test.qemu_monitor_event.invalid_timeout: PASS (48.32 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2025-01-10T16.43-1a68c71/results.html
JOB TIME   : 50.16 s

# No snapshots #
(.libvirt-ci-venv-ci-runtest-ZpY1gU) [root@ampere-mtsnow-altra-10 /]# virsh snapshot-list avocado-vt-vm1
 Name   Creation Time   State
-------------------------------

# Now running virt_xml_validate.domainsnapshot test #
(.libvirt-ci-venv-ci-runtest-ZpY1gU) [root@ampere-mtsnow-altra-10 /]# avocado run --vt-type libvirt --vt-omit-data-loss --vt-machine-type arm64-mmio virt_xml_validate.domainsnapshot --vt-connect-uri qemu:///system
JOB ID     : f58edf575bcd942959ced032d64f31709c05c58d
JOB LOG    : /var/log/avocado/job-results/job-2025-01-10T16.45-f58edf5/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virt_xml_validate.domainsnapshot: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.virt_xml_validate.domainsnapshot: PASS (47.94 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2025-01-10T16.45-f58edf5/results.html
JOB TIME   : 49.56 s

# Snapshot now exists after the test was run # 
(.libvirt-ci-venv-ci-runtest-ZpY1gU) [root@ampere-mtsnow-altra-10 /]# virsh snapshot-list avocado-vt-vm1
 Name                                     Creation Time               State
-------------------------------------------------------------------------------
 snap-avocado-vt-vm1-1736545576.2404351   2025-01-10 16:46:16 -0500   shutoff

# Now the virsh.event test fails #
(.libvirt-ci-venv-ci-runtest-ZpY1gU) [root@ampere-mtsnow-altra-10 /]# avocado run --vt-type libvirt --vt-omit-data-loss --vt-machine-type arm64-mmio virsh.event.negative_test.qemu_monitor_event.invalid_timeout --vt-connect-uri qemu://system
JOB ID     : 82008819120b42b1d47d339bf0ad7198e7715b10
JOB LOG    : /var/log/avocado/job-results/job-2025-01-10T16.46-8200881/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.event.negative_test.qemu_monitor_event.invalid_timeout: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.virsh.event.negative_test.qemu_monitor_event.invalid_timeout: ERROR: Failed to undefine avocado-vt-vm1. (48.19 s)
RESULTS    : PASS 0 | ERROR 1 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2025-01-10T16.46-8200881/results.html
JOB TIME   : 49.90 s
```

**Fix**
The fix is to simply have `virt_xml_validate.domainsnapshot` remove the snapshot after the test is finished using it.

**Tests Passing**
_Note: since there are many virsh.event tests, chose to only run a random selection_
```
(.libvirt-ci-venv-ci-runtest-ZpY1gU) [root@ampere-mtsnow-altra-10 /]# avocado run --vt-type libvirt --vt-omit-data-loss --vt-machine-type arm64-mmio virt_xml_validate.domainsnapshot --vt-connect-uri qemu:///system
JOB ID     : fd9b71253b68fb8f39040f45a699ceea863bde3b
JOB LOG    : /var/log/avocado/job-results/job-2025-01-10T16.51-fd9b712/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virt_xml_validate.domainsnapshot: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.virt_xml_validate.domainsnapshot: PASS (48.09 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2025-01-10T16.51-fd9b712/results.html
JOB TIME   : 49.82 s

(.libvirt-ci-venv-ci-runtest-ZpY1gU) [root@ampere-mtsnow-altra-10 /]# virsh snapshot-list avocado-vt-vm1
 Name   Creation Time   State
-------------------------------

(.libvirt-ci-venv-ci-runtest-ZpY1gU) [root@ampere-mtsnow-altra-10 /]# avocado run --vt-type libvirt --vt-omit-data-loss --vt-machine-type arm64-mmio virsh.event.negative_test --vt-connect-uri qemu:///system
JOB ID     : 5b956c47122168c05eeee907fa805852a181e1f7
JOB LOG    : /var/log/avocado/job-results/job-2025-01-10T16.53-5b956c4/job.log
 (1/3) type_specific.io-github-autotest-libvirt.virsh.event.negative_test.virsh_event.invalid_event: STARTED
 (1/3) type_specific.io-github-autotest-libvirt.virsh.event.negative_test.virsh_event.invalid_event: PASS (48.51 s)
 (2/3) type_specific.io-github-autotest-libvirt.virsh.event.negative_test.virsh_event.invalid_timeout: STARTED
 (2/3) type_specific.io-github-autotest-libvirt.virsh.event.negative_test.virsh_event.invalid_timeout: PASS (48.39 s)
 (3/3) type_specific.io-github-autotest-libvirt.virsh.event.negative_test.qemu_monitor_event.invalid_timeout: STARTED
 (3/3) type_specific.io-github-autotest-libvirt.virsh.event.negative_test.qemu_monitor_event.invalid_timeout: PASS (48.12 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2025-01-10T16.53-5b956c4/results.html
JOB TIME   : 148.82 s
```

