### PR TITLE
Update case of virtual network - qos

### DIFF
--- a/libvirt/tests/cfg/virtual_network/qos/check_actual_network_throughput.cfg
+++ b/libvirt/tests/cfg/virtual_network/qos/check_actual_network_throughput.cfg
@@ -32,4 +32,7 @@
                     iface_attrs = {'type_name': 'bridge', 'source': {'bridge': br_name}, 'model': 'virtio', **${iface_bw_attrs}}
                 - ovs_br:
                     iface_attrs = {'type_name': 'bridge', 'source': {'bridge': br_name}, 'model': 'virtio', **${iface_bw_attrs}, 'virtualport': {'type': 'openvswitch'}}
-
+                    libvirtd_debug_file = /var/log/libvirt/libvird.log
+                    libvirtd_debug_level = 1
+                    expect_msg = warning.*Setting different .peak. value than .average. for QoS for OVS interface.*might have unexpected results
+                    throuput_bw = 1024

--- a/libvirt/tests/src/virtual_network/qos/check_actual_network_throughput.py
+++ b/libvirt/tests/src/virtual_network/qos/check_actual_network_throughput.py
@@ -38,6 +38,8 @@ def run(test, params, env):
     net_attrs = eval(params.get('net_attrs', '{}'))
     inbound = eval(params.get('inbound'))
     outbound = eval(params.get('outbound'))
+    throuput_bw = params.get('throuput_bw')
+    expect_msg = params.get('expect_msg')
 
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     bkxml = vmxml.copy()
@@ -65,6 +67,9 @@ def run(test, params, env):
 
         vm.start()
         vm_sess = vm.wait_for_serial_login()
+        if expect_msg:
+            libvirt.check_logfile(expect_msg,
+                                  params.get("libvirtd_debug_file"))
 
         iface = network_base.get_iface_xml_inst(vm_name, 'on vm')
         mac = iface.mac_address
@@ -105,7 +110,7 @@ def run(test, params, env):
 
         network_base.check_throughput(
             vm_sess.cmd, lambda x: process.run(x).stdout_text,
-            vm_ip, inbound["average"], 'inbound'
+            vm_ip, throuput_bw if throuput_bw else inbound["average"], 'inbound'
         )
 
         network_base.check_throughput(


### PR DESCRIPTION
- VIRT-296327 - [Qos] Check the actual network throughput per bandwidth settings in network/interface

```
(1/2) type_specific.local.virtual_network.qos.check_actual_network_throughput.network.br.ovs_br: STARTED
(1/2) type_specific.local.virtual_network.qos.check_actual_network_throughput.network.br.ovs_br: PASS (123.85 s)
(2/2) type_specific.local.virtual_network.qos.check_actual_network_throughput.br.ovs_br: STARTED
(2/2) type_specific.local.virtual_network.qos.check_actual_network_throughput.br.ovs_br: PASS (102.41 s)
```