### PR TITLE
Change parameter check_str_remote_log to support eval to python list

### DIFF
--- a/libvirt/tests/cfg/migration/migration_with_vtpm/migration_with_shared_tpm.cfg
+++ b/libvirt/tests/cfg/migration/migration_with_vtpm/migration_with_shared_tpm.cfg
@@ -23,7 +23,7 @@
     tpm_cmd = "tpm2_getrandom --hex 16"
     auth_sec_dict = {"sec_ephemeral": "no", "sec_private": "yes", "sec_desc": "sample vTPM secret", "sec_usage": "vtpm", "sec_name": "VTPM_example"}
     secret_value = "sec value test"
-    check_str_remote_log = "migration release-lock-outgoing,incoming"
+    check_str_remote_log = ["migration release-lock-outgoing,incoming"]
     set_remote_libvirtd_log = "yes"
     libvirtd_file_type = "virtqemud"
     remote_file_type = "virtqemud"


### PR DESCRIPTION
check_str_remote_log should be a string which could be parsed to a list by eval()

After fix test result:
 (1/1) type_specific.io-github-autotest-libvirt.migration_with_vtpm.migration_with_shared_tpm.nfs.persistent_and_p2p: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.migration_with_vtpm.migration_with_shared_tpm.nfs.persistent_and_p2p: PASS (204.22 s)