### PR TITLE
migration: Update error message

### DIFF
--- a/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_tls_wrong_cert_configuration.cfg
+++ b/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_tls_wrong_cert_configuration.cfg
@@ -42,7 +42,7 @@
     variants cert_configuration:
         - no_client_cert_on_src:
             cert_path = "${custom_pki_path}/client-cert.pem"
-            err_msg = "Cannot write to TLS channel: Input/output error|unable to execute QEMU command 'object-add': Unable to access credentials ${cert_path}|job 'migration out' failed: Cannot read from TLS channel: Software caused connection abort"
+            err_msg = "Cannot write to TLS channel: Input/output error|unable to execute QEMU command 'object-add': Unable to access credentials ${cert_path}|Cannot read from TLS channel"
         - no_server_cert_on_target:
             cert_path = "${custom_pki_path}/server-cert.pem"
             err_msg = "unable to execute QEMU command 'object-add': Unable to access credentials ${cert_path}"


### PR DESCRIPTION
Before:
Can not find the expected patterns 'Cannot write to TLS channel: Input/output error|unable to execute QEMU command 'object-add': Unable to access credentials /etc/pki/qemu/client-cert.pem|job 'migration out' failed: Cannot read from TLS channel: Software caused connection abort' in output 'error: operation failed: job 'migration out' failed: Cannot read from TLS channel: The TLS connection was non-properly terminated.'


After:
 (1/2) type_specific.io-github-autotest-libvirt.migration.migration_uri.network_data_transport.tls.wrong_cert_configuration.no_client_cert_on_src.p2p: STARTED
 (1/2) type_specific.io-github-autotest-libvirt.migration.migration_uri.network_data_transport.tls.wrong_cert_configuration.no_client_cert_on_src.p2p: PASS (256.80 s)
 (2/2) type_specific.io-github-autotest-libvirt.migration.migration_uri.network_data_transport.tls.wrong_cert_configuration.no_client_cert_on_src.non_p2p: STARTED
 (2/2) type_specific.io-github-autotest-libvirt.migration.migration_uri.network_data_transport.tls.wrong_cert_configuration.no_client_cert_on_src.non_p2p: PASS (255.14 s)