### PR TITLE
v2v: fix the failed tc: specific_kvm..sync_ntp

### DIFF
--- a/v2v/tests/src/specific_kvm.py
+++ b/v2v/tests/src/specific_kvm.py
@@ -842,6 +842,7 @@ def run(test, params, env):
             LOG.info('Sync time with %s', ntp_server)
             cmd = ['yum -y install chrony',
                    'systemctl start chronyd',
+                   'systemctl enable chronyd',
                    'chronyc add server %s' % ntp_server,
                    'chronyc waitsync']
             vm_cmd(cmd)


### PR DESCRIPTION
To make ntpd service enable after rebooting.