### PR TITLE
v2v: fix the failed TC: specific_kvm.positive_test.linux.serial_port.…

### DIFF
--- a/v2v/tests/cfg/specific_kvm.cfg
+++ b/v2v/tests/cfg/specific_kvm.cfg
@@ -300,6 +300,7 @@
             only esx_80
             variants:
                 - chars_telnet:
+                    only libvirt
                     boottype = 2
                     main_vm = VM_NAME_SERVIAL_PORT_CHARACTERS_TELNET_URL_V2V_EXAMPLE
                 - empty_info:
@@ -307,6 +308,7 @@
                     main_vm = VM_NAME_SERVIAL_PORT_EMPTY_V2V_EXAMPLE
         - vmx_char:
             only esx_80
+            only libvirt
             boottype = 2
             main_vm = VM_NAME_VMX_CONTAINS_CHAR_V2V_EXAMPLE
     variants:


### PR DESCRIPTION
fix the case to rhev.
 (1/1) type_specific.io-github-autotest-libvirt.specific_kvm.positive_test.linux.serial_port.chars_telnet.esx.esx_80.output_mode.rhev.rhv_upload.it_vddk: ERROR: not well-formed (invalid token): line 2, column 0