### PR TITLE
remot_with_unix: fix socket reload

### DIFF
--- a/libvirt/tests/cfg/remote_access/remote_with_unix.cfg
+++ b/libvirt/tests/cfg/remote_access/remote_with_unix.cfg
@@ -51,7 +51,6 @@
                     sasl_user_pwd = "('test', '123456'), ('libvirt', '123456')"
                     sasl_allowed_username_list = ['test', 'libvirt']
                 - socket_access_controls:
-                    traditional_mode = "yes"
                     auth_unix_ro = "none"
                     auth_unix_rw = "none"
                     unix_sock_group = "wheel"

--- a/libvirt/tests/src/remote_access/remote_access.py
+++ b/libvirt/tests/src/remote_access/remote_access.py
@@ -12,6 +12,7 @@ from virttest import virsh
 from virttest import remote
 from virttest import utils_config
 from virttest import utils_iptables
+from virttest import utils_split_daemons
 
 from virttest import libvirt_version
 from virttest.utils_sasl import SASL
@@ -232,6 +233,7 @@ def run(test, params, env):
     """
 
     test_dict = dict(params)
+    test_dict['traditional_mode'] = "no" if utils_split_daemons.is_modular_daemon() else "yes"
     socket_access_controls_cfg_file = test_dict.get("socket_access_controls_cfg_file", "no")
     if socket_access_controls_cfg_file == "yes":
         if libvirt_version.version_compare(6, 0, 0):


### PR DESCRIPTION
Reload libvirtd sockets when using unix sockets for connection was always done, also for modular daemons.

Use libvirtd only if system is not configured with modular daemons.