### PR TITLE
boot_integration: fix test for unexpected control codes

### DIFF
--- a/libvirt/tests/src/bios/boot_integration.py
+++ b/libvirt/tests/src/bios/boot_integration.py
@@ -78,7 +78,7 @@ def console_check(vm, pattern, debug_log=False):
     :return: function returning true if console output matches pattern
     """
     def _matches():
-        output = vm.serial_console.get_stripped_output()
+        output = vm.serial_console.get_output()
         matches = re.search(pattern, output, re.S)
         if debug_log:
             logging.debug("Checked for '%s' in '%s'", pattern, output)


### PR DESCRIPTION
aexpect will raise an error if the console contains certain control codes, s. https://github.com/avocado-framework/aexpect/issues/133

This happens in `get_stripped_output`. By using `get_output`, this can't happen and the test passes.