### PR TITLE
migration: add case about migrate vm with cpu mode

### DIFF
--- a/libvirt/tests/cfg/migration/migration_misc/migration_with_cpu_mode.cfg
+++ b/libvirt/tests/cfg/migration/migration_misc/migration_with_cpu_mode.cfg
@@ -1,0 +1,42 @@
+- migration.migration_misc.migration_with_cpu_mode:
+    type = migration_with_cpu_mode
+    migration_setup = 'yes'
+    storage_type = 'nfs'
+    setup_local_nfs = 'yes'
+    disk_type = "file"
+    disk_source_protocol = "netfs"
+    mnt_path_name = ${nfs_mount_dir}
+    # Console output can only be monitored via virsh console output
+    only_pty = True
+    take_regular_screendumps = no
+    # Extra options to pass after <domain> <desturi>
+    virsh_migrate_extra = ''
+    # SSH connection time out
+    ssh_timeout = 60
+    # Local URI
+    virsh_migrate_connect_uri = 'qemu:///system'
+    image_convert = 'no'
+    server_ip = "${migrate_dest_host}"
+    server_user = "root"
+    server_pwd = "${migrate_dest_pwd}"
+    status_error = "no"
+    migrate_desturi_port = "16509"
+    migrate_desturi_type = "tcp"
+    virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
+    start_vm = "no"
+    variants:
+        - p2p:
+            virsh_migrate_options = '--live --p2p --verbose'
+        - non_p2p:
+            virsh_migrate_options = '--live --verbose'
+    variants migration_option:
+        - with_xml:
+        - without_xml:
+    variants cpu_mode:
+        - host_model:
+            no s390x
+            numa_cell = "'numa_cell': [{'cpus': '0-1', 'memory': '2097152', 'unit': 'KiB'}]"
+            vm_attrs = {'cpu': {'mode': 'host-model', 'check': 'partial', ${numa_cell}}}
+        - custom:
+            no aarch64
+            cpu_mode = "custom"

--- a/libvirt/tests/src/migration/migration_misc/migration_with_cpu_mode.py
+++ b/libvirt/tests/src/migration/migration_misc/migration_with_cpu_mode.py
@@ -1,0 +1,55 @@
+import os
+
+from virttest import data_dir
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+
+from provider.migration import base_steps
+
+
+def run(test, params, env):
+    """
+    Verify that migration can succeed when cpu mode is configured.
+
+    :param test: test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    def setup_test():
+        """
+        Setup steps
+
+        """
+        cpu_mode = params.get("cpu_mode")
+        migration_option = params.get("migration_option")
+
+        test.log.info("Setup steps.")
+        migration_obj.setup_connection()
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        if cpu_mode == "host_model":
+            vm_attrs = eval(params.get('vm_attrs', '{}'))
+            vmxml.setup_attrs(**vm_attrs)
+            vmxml.sync()
+        else:
+            base_steps.sync_cpu_for_mig(params)
+
+        if not vm.is_alive():
+            vm.start()
+            vm.wait_for_login().close()
+
+        if migration_option == "with_xml":
+            xmlfile = os.path.join(data_dir.get_tmp_dir(), '%s.xml' % vm_name)
+            virsh.dumpxml(vm_name, extra="--migratable", to_file=xmlfile, ignore_status=False)
+            params.update({"virsh_migrate_extra": f"--xml {xmlfile}"})
+
+    vm_name = params.get("migrate_main_vm")
+
+    vm = env.get_vm(vm_name)
+    migration_obj = base_steps.MigrationBase(test, vm, params)
+
+    try:
+        setup_test()
+        migration_obj.run_migration()
+        migration_obj.verify_default()
+    finally:
+        migration_obj.cleanup_connection()


### PR DESCRIPTION
XXX-303279 - [VM migration] migrate vm with cpu mode


Test result:
 (1/8) type_specific.io-github-autotest-libvirt.migration.migration_misc.migration_with_cpu_features.host_model.with_xml.p2p: STARTED
 (1/8) type_specific.io-github-autotest-libvirt.migration.migration_misc.migration_with_cpu_features.host_model.with_xml.p2p: PASS (184.62 s)
 (2/8) type_specific.io-github-autotest-libvirt.migration.migration_misc.migration_with_cpu_features.host_model.with_xml.non_p2p: STARTED
 (2/8) type_specific.io-github-autotest-libvirt.migration.migration_misc.migration_with_cpu_features.host_model.with_xml.non_p2p: PASS (184.97 s)
 (3/8) type_specific.io-github-autotest-libvirt.migration.migration_misc.migration_with_cpu_features.host_model.without_xml.p2p: STARTED
 (3/8) type_specific.io-github-autotest-libvirt.migration.migration_misc.migration_with_cpu_features.host_model.without_xml.p2p: PASS (184.75 s)
 (4/8) type_specific.io-github-autotest-libvirt.migration.migration_misc.migration_with_cpu_features.host_model.without_xml.non_p2p: STARTED
 (4/8) type_specific.io-github-autotest-libvirt.migration.migration_misc.migration_with_cpu_features.host_model.without_xml.non_p2p: PASS (184.71 s)
 (5/8) type_specific.io-github-autotest-libvirt.migration.migration_misc.migration_with_cpu_features.custom.with_xml.p2p: STARTED
 (5/8) type_specific.io-github-autotest-libvirt.migration.migration_misc.migration_with_cpu_features.custom.with_xml.p2p: PASS (184.72 s)
 (6/8) type_specific.io-github-autotest-libvirt.migration.migration_misc.migration_with_cpu_features.custom.with_xml.non_p2p: STARTED
 (6/8) type_specific.io-github-autotest-libvirt.migration.migration_misc.migration_with_cpu_features.custom.with_xml.non_p2p: PASS (184.30 s)
 (7/8) type_specific.io-github-autotest-libvirt.migration.migration_misc.migration_with_cpu_features.custom.without_xml.p2p: STARTED
 (7/8) type_specific.io-github-autotest-libvirt.migration.migration_misc.migration_with_cpu_features.custom.without_xml.p2p: PASS (184.40 s)
 (8/8) type_specific.io-github-autotest-libvirt.migration.migration_misc.migration_with_cpu_features.custom.without_xml.non_p2p: STARTED
 (8/8) type_specific.io-github-autotest-libvirt.migration.migration_misc.migration_with_cpu_features.custom.without_xml.non_p2p: PASS (185.50 s)