### PR TITLE
v2v:fix the failed case: specific_kvm..no_space.esx..

### DIFF
--- a/v2v/tests/cfg/specific_kvm.cfg
+++ b/v2v/tests/cfg/specific_kvm.cfg
@@ -249,6 +249,7 @@
                     checkpoint = 'sync_ntp'
         - no_space:
             only esx.esx_70
+            only rhev
             checkpoint = 'host_no_space_setcache'
             main_vm = 'VM_ESX_DEFAULT_NAME_V2V_EXAMPLE'
         - mem_alloc:
@@ -286,6 +287,7 @@
             main_vm = 'VM_NAME_80_CHARS_V2V_EXAMPLE'
         - non_exist_network:
             only source_esx.esx_80
+            only rhev
             boottype = 2
             main_vm = 'VM_NON_EXIST_NETWORK_V2V_EXAMPLE'
             skip_vm_check = yes


### PR DESCRIPTION
to libvirt will cause the error:
nbdkit: file.15: error: pwrite: No space left on device.

only to rhev can succeed.