### PR TITLE
Exclude unsupported 16M hugepage test for aarch64 and x86_64

### DIFF
--- a/libvirt/tests/cfg/numa/guest_numa.cfg
+++ b/libvirt/tests/cfg/numa/guest_numa.cfg
@@ -85,6 +85,7 @@
                                      pseries:
                                         page_nodenum_0 = "0"
                                  - 16M:
+                                     no aarch64, x86_64
                                      max_mem = "2097152"
                                      vmpage_size_0 = "16384"
                                      hugepage_size_0 = "16384"


### PR DESCRIPTION
Exclude unsupported 16M hugepage on aarch64 and x86_64