### PR TITLE
Add new case of qos: test bandwidth boundry

### DIFF
--- a/libvirt/tests/cfg/virtual_network/qos/test_bandwidth_boundry.cfg
+++ b/libvirt/tests/cfg/virtual_network/qos/test_bandwidth_boundry.cfg
@@ -1,0 +1,21 @@
+- virtual_network.qos.test_bandwidth_boundry:
+    type = test_bandwidth_boundry
+    start_vm = yes
+    variants bw_type:
+        - inbound:
+        - outbound:
+    variants scenario:
+        - boundry:
+            bw_args = 4294967295,4294967295,4194303
+        - over_boundry_average:
+            bw_args = 1000000000000000000,4096,4096
+            status_error = yes
+            err_msg = ${bw_type} rate larger than maximum 4294967295
+        - over_boundry_peak:
+            bw_args = 4096,1000000000000000000,4096
+            status_error = yes
+            err_msg = ${bw_type} rate larger than maximum 4294967295
+        - over_boundry_burst:
+            bw_args = 1024000,4096,4194304
+            status_error = yes
+            err_msg = numerical overflow: value '4194304' is too big for 'burst' parameter, maximum is '4194303'

--- a/libvirt/tests/src/virtual_network/qos/test_bandwidth_boundry.py
+++ b/libvirt/tests/src/virtual_network/qos/test_bandwidth_boundry.py
@@ -1,0 +1,60 @@
+import logging
+
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_misc
+from virttest.utils_test import libvirt
+
+from provider.virtual_network import network_base
+
+VIRSH_ARGS = {'ignore_status': False, 'debug': True}
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+
+def run(test, params, env):
+    """
+    Test bandwidth boundary of an interface via domiftune
+
+    """
+    vm_name = params.get('main_vm')
+    vm = env.get_vm(vm_name)
+    bw_type = params.get('bw_type', '')
+    bw_args = params.get('bw_args', '')
+    status_error = 'yes' == params.get("status_error", 'no')
+    err_msg = params.get('err_msg')
+
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+
+    try:
+        iface = network_base.get_iface_xml_inst(vm_name, 'on vm')
+        mac = iface.mac_address
+        domiftune_args = {bw_type: bw_args}
+        virsh_result = virsh.domiftune(
+            vm_name, mac, **domiftune_args, debug=True)
+        libvirt.check_exit_status(virsh_result, status_error)
+        if status_error:
+            libvirt.check_result(virsh_result, err_msg)
+            return
+
+        out = virsh.domiftune(vm_name, mac, **VIRSH_ARGS).stdout_text
+
+        bw_out = libvirt_misc.convert_to_dict(
+            out, '(\S+)\s*:\s*(\d+)')
+        bw_values = bw_out[f'{bw_type}.average'], \
+            bw_out[f'{bw_type}.peak'], bw_out[f'{bw_type}.burst']
+        if ','.join(bw_values) != bw_args:
+            test.fail(f'Bandwidth from domiftune is {",".join(bw_values)}, '
+                      f'but it should be {bw_args}')
+
+        iface = network_base.get_iface_xml_inst(vm_name, 'after domiftune')
+        iface_attrs = iface.fetch_attrs()
+        bw_attrs = iface_attrs['bandwidth'][bw_type]
+        bw_xml_values = ','.join([bw_attrs['average'], bw_attrs['peak'],
+                                  bw_attrs['burst']])
+        if bw_xml_values != bw_args:
+            test.fail(f'Bandwidth from interface xml is {bw_xml_values}, '
+                      f'but it should be {bw_args}')
+    finally:
+        bkxml.sync()


### PR DESCRIPTION
- VIRT-303876 - [Qos][domiftune] Test bandwidth boundary of an interface via domiftune

Test result:
```
 (1/8) type_specific.local.virtual_network.qos.test_bandwidth_boundry.boundry.inbound: STARTED
 (1/8) type_specific.local.virtual_network.qos.test_bandwidth_boundry.boundry.inbound: PASS (8.28 s)
 (2/8) type_specific.local.virtual_network.qos.test_bandwidth_boundry.boundry.outbound: STARTED
 (2/8) type_specific.local.virtual_network.qos.test_bandwidth_boundry.boundry.outbound: PASS (10.95 s)
 (3/8) type_specific.local.virtual_network.qos.test_bandwidth_boundry.over_boundry_average.inbound: STARTED
 (3/8) type_specific.local.virtual_network.qos.test_bandwidth_boundry.over_boundry_average.inbound: PASS (18.91 s)
 (4/8) type_specific.local.virtual_network.qos.test_bandwidth_boundry.over_boundry_average.outbound: STARTED
 (4/8) type_specific.local.virtual_network.qos.test_bandwidth_boundry.over_boundry_average.outbound: PASS (16.87 s)
 (5/8) type_specific.local.virtual_network.qos.test_bandwidth_boundry.over_boundry_peak.inbound: STARTED
 (5/8) type_specific.local.virtual_network.qos.test_bandwidth_boundry.over_boundry_peak.inbound: PASS (18.35 s)
 (6/8) type_specific.local.virtual_network.qos.test_bandwidth_boundry.over_boundry_peak.outbound: STARTED
 (6/8) type_specific.local.virtual_network.qos.test_bandwidth_boundry.over_boundry_peak.outbound: PASS (17.22 s)
 (7/8) type_specific.local.virtual_network.qos.test_bandwidth_boundry.over_boundry_burst.inbound: STARTED
 (7/8) type_specific.local.virtual_network.qos.test_bandwidth_boundry.over_boundry_burst.inbound: PASS (18.73 s)
 (8/8) type_specific.local.virtual_network.qos.test_bandwidth_boundry.over_boundry_burst.outbound: STARTED
 (8/8) type_specific.local.virtual_network.qos.test_bandwidth_boundry.over_boundry_burst.outbound: PASS (16.38 s)
RESULTS    : PASS 8 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```