### PR TITLE
Filter virtio_transitional_blk on s390x

### DIFF
--- a/libvirt/tests/cfg/virtio_transitional/virtio_transitional_blk.cfg
+++ b/libvirt/tests/cfg/virtio_transitional/virtio_transitional_blk.cfg
@@ -1,6 +1,7 @@
 - virtio_transitional_blk:
     type = virtio_transitional_blk
     start_vm = no
+    no s390-virtio
     Windows:
         get_device_cmd = "wmic diskdrive get index, size"
         get_device_pattern = "^\d+"
@@ -10,11 +11,9 @@
             virtio_model = "virtio"
             controller_model = "virtio-scsi"
         - virtio_transitional:
-            no s390-virtio
             virtio_model = "virtio-transitional"
             controller_model = ${virtio_model}
         - virtio_non_transitional:
-            no s390-virtio
             virtio_model = "virtio-non-transitional"
     variants:
         - boot_test:


### PR DESCRIPTION
s390x
In s390x avocado-vt-vm1 guest, there is already one virto-scsi controller, but the code to libvirt.set_vm_disk(vm, params) to update it, but it throw error: XML error: Multiple 'scsi' controllers with index '0'