### PR TITLE
virsh_restore: enable tests for VMs with boot order

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_restore.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_restore.cfg
@@ -22,6 +22,9 @@
                     restore_extra_param = "--running"
                 - xml_option:
                     restore_extra_param = "--xml"
+                    os_update_dict = '{"boots": ["cdrom"]}'
+                    s390-virtio:
+                        os_update_dict = '{"bootmenu_enable": "yes"}'
                 - xml_option_dac:
                     only non_acl
                     restore_extra_param = "--xml"


### PR DESCRIPTION
The `xml_option` variant expects the VM to boot from //os/boot with dev="hd" and will skip otherwise.

Instead, allow for the test to configure the desired xml update for //os.

For s390x, //os/boot is not fully available, so set bootmenu for our xml instead.