### PR TITLE
virtio_transitional_mem_balloon: fix test on s390x

### DIFF
--- a/libvirt/tests/cfg/virtio_transitional/virtio_transitional_mem_balloon.cfg
+++ b/libvirt/tests/cfg/virtio_transitional/virtio_transitional_mem_balloon.cfg
@@ -2,6 +2,9 @@
     type = virtio_transitional_mem_balloon
     start_vm = no
     vm_memory = 8388608
+    detect_cmd = 'lspci |grep balloon'
+    s390-virtio:
+        detect_cmd = 'lscss |grep "3832/05"'
     variants:
         - virtio:
             virtio_model = "virtio"

--- a/libvirt/tests/src/virtio_transitional/virtio_transitional_mem_balloon.py
+++ b/libvirt/tests/src/virtio_transitional/virtio_transitional_mem_balloon.py
@@ -95,7 +95,7 @@ def run(test, params, env):
         if is_windows_guest:
             return
         # Check if memory balloon device exists on guest
-        status = session.cmd_status_output('lspci |grep balloon')[0]
+        status = session.cmd_status_output(params.get("detect_cmd"))[0]
         if status != 0:
             test.fail("Didn't detect memory balloon device on guest.")
         # Save and restore guest


### PR DESCRIPTION
On s390x, memballoon is a ccw device per libvirt default, not pci.

Make the command to detect the device configurable and set s390x-specific value.