### PR TITLE
virsh-dump: Add Crash Utility Tests for vmcore

### DIFF
--- a/libvirt/tests/cfg/guest_kernel_debugging/virsh_dump.cfg
+++ b/libvirt/tests/cfg/guest_kernel_debugging/virsh_dump.cfg
@@ -98,3 +98,21 @@
                 - no_space_left:
                     dump_options = "--memory-only"
                     dump_dir = "/var/tmp/too_small"
+        - crash_utility_tests:
+            crash_utility = "yes"
+            variants:
+                - memory_dump:
+                    dump_options = "--memory-only"
+                    variants:
+                        - elf_format:
+                            memory_dump_format = 'elf'
+                        - kdump-zlib_format:
+                            memory_dump_format = 'kdump-zlib'
+                        - kdump-lzo_format:
+                            memory_dump_format = 'kdump-lzo'
+                        - kdump-snappy_format:
+                            memory_dump_format = 'kdump-snappy'
+                - memory_crash_dump:
+                    dump_options = "--crash --memory-only"
+                - memory_bypass_cache_dump:
+                    dump_options = "--memory-only --bypass-cache --verbose"


### PR DESCRIPTION
### virsh-dump: Add Crash Utility Tests for vmcore

This Patch adds support for testing Crash Utility
for vmcore generated by "virsh dump" command.

Crash Utility is a tool that allows us to interactively analyze a running Linux system as well as a core dump created.

This crash_utility function works as following:
Check the working of crash utility tool to analyse the guest dump In order for the function to work, both the guest and the host must have the same kernel
- If crash tool or kernel debug libraries are not installed, the test returns error
- If crash tool cannot read into the vmcore, the test returns fail
- If crash tool can read the vmcore, the test returns pass

The Function returns:
            0: Success
            1: Crash command failed
            2: Dependency installation failed or vmlinux not found
            3: Kernel mismatch between host and guest
            4: Guest kernel retrieval failed
            5: Unsupported distribution
            6: virsh dump unsuccessful

Signed-off-by: Misbah Anjum N [misanjum@linux.vnet.ibm.com](mailto:misanjum@linux.vnet.ibm.com)