### PR TITLE
transitional_vsock: disable on s390x

### DIFF
--- a/libvirt/tests/cfg/virtio_transitional/virtio_transitional_vsock.cfg
+++ b/libvirt/tests/cfg/virtio_transitional/virtio_transitional_vsock.cfg
@@ -4,14 +4,13 @@
     start_vm = no
     addr_pattern = '\d\d:\d\d\.\d'
     device_pattern = 'Communication controller: Red Hat.* Device | Communication controller: Red Hat.* socket'
+    no s390-virtio
     variants:
         - virtio:
             virtio_model = "virtio"
         - virtio_transitional:
-            no s390-virtio
             virtio_model = "virtio-transitional"
         - virtio_non_transitional:
-            no s390-virtio
             virtio_model = "virtio-non-transitional"
     variants:
         - boot_test:


### PR DESCRIPTION
The test assumes that vsock is a PCI device with additional device information to be checked. Only one test variant applies to s390x (virtio).

We already have test vsock.* that covers this setup and more as it also covers functionality (establish communication).

Therefore, skip this test suite for s390x.