### PR TITLE
viommu: Fix up incorrect devices' address issue

### DIFF
--- a/libvirt/tests/cfg/sriov/vIOMMU/iommu_device_settings.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/iommu_device_settings.cfg
@@ -64,5 +64,6 @@
         - pcie_root_port_from_expander_bus:
             test_devices = ["Eth", "block"]
             root_port = {'type': 'pci', 'model': 'pcie-root-port', 'pre_controller': 'pcie-expander-bus'}
-            controller_dicts = [{'type': 'pci', 'model': 'pcie-expander-bus', 'pre_controller': 'pcie-root'}, ${root_port}, ${root_port}]
+            controller_dicts = [{'type': 'pci', 'model': 'pcie-expander-bus', 'target': {'busNr': '252'}, 'pre_controller': 'pcie-root'}, ${root_port}, ${root_port}]
+            iface_dict = {'source': {'network': 'default'}}
             disk_dict = {'target': {'dev': 'vda', 'bus': 'virtio'}, 'device': 'disk', 'driver': ${disk_driver}}


### PR DESCRIPTION
Update to use the correct controller, disk and interface addresses.

**Depends on:**
- https://github.com/avocado-framework/avocado-vt/pull/4055

**Test results:**
```
 (01/11) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.virtio_muti_devices.vhost_on.virtio: STARTED
 (01/11) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.virtio_muti_devices.vhost_on.virtio: PASS (36.27 s)
 (02/11) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.virtio_muti_devices.vhost_on.smmuv3: STARTED
 (02/11) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.virtio_muti_devices.vhost_on.smmuv3: PASS (57.59 s)
 (03/11) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.virtio_muti_devices.vhost_off.virtio: STARTED
 (03/11) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.virtio_muti_devices.vhost_off.virtio: PASS (36.76 s)
 (04/11) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.virtio_muti_devices.vhost_off.smmuv3: STARTED
 (04/11) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.virtio_muti_devices.vhost_off.smmuv3: PASS (35.86 s)
 (05/11) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.hostdev_iface.virtio: STARTED
 (05/11) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.hostdev_iface.virtio: PASS (67.13 s)
 (06/11) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.scsi_controller.virtio: STARTED
 (06/11) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.scsi_controller.virtio: PASS (35.73 s)
 (07/11) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.scsi_controller.smmuv3: STARTED
 (07/11) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.scsi_controller.smmuv3: PASS (56.20 s)
 (08/11) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_to_pci_bridge_controller.virtio_non_transitional.virtio: STARTED
 (08/11) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_to_pci_bridge_controller.virtio_non_transitional.virtio: PASS (57.08 s)
 (09/11) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_to_pci_bridge_controller.hostdev_iface.virtio: STARTED
 (09/11) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_to_pci_bridge_controller.hostdev_iface.virtio: PASS (66.80 s)
 (10/11) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_root_port_from_expander_bus.virtio: STARTED
 (10/11) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_root_port_from_expander_bus.virtio: PASS (59.41 s)
 (11/11) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_root_port_from_expander_bus.smmuv3: STARTED
 (11/11) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_root_port_from_expander_bus.smmuv3: PASS (37.83 s)
RESULTS    : PASS 11 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0

```