### PR TITLE
migration: Fix no element found issue

### DIFF
--- a/libvirt/tests/src/migration/migration_with_vtpm/migration_with_external_tpm.py
+++ b/libvirt/tests/src/migration/migration_with_vtpm/migration_with_external_tpm.py
@@ -234,7 +234,7 @@ def run(test, params, env):
     migration_obj = base_steps.MigrationBase(test, vm, params)
 
     try:
-        if not base_steps.check_cpu_for_mig(desturi):
+        if not base_steps.check_cpu_for_mig(params):
             base_steps.sync_cpu_for_mig(params)
         setup_test()
         migration_obj.run_migration()

--- a/libvirt/tests/src/migration/migration_with_vtpm/migration_with_shared_tpm.py
+++ b/libvirt/tests/src/migration/migration_with_vtpm/migration_with_shared_tpm.py
@@ -291,7 +291,7 @@ def run(test, params, env):
 
     try:
         set_secret(params)
-        if not base_steps.check_cpu_for_mig(desturi):
+        if not base_steps.check_cpu_for_mig(params):
             base_steps.sync_cpu_for_mig(params)
         setup_test()
         migration_obj.run_migration()

--- a/libvirt/tests/src/migration/migration_with_vtpm/migration_with_vtpm_dev.py
+++ b/libvirt/tests/src/migration/migration_with_vtpm/migration_with_vtpm_dev.py
@@ -217,7 +217,7 @@ def run(test, params, env):
     vm = env.get_vm(vm_name)
     migration_obj = base_steps.MigrationBase(test, vm, params)
 
-    if base_steps.check_cpu_for_mig(desturi):
+    if base_steps.check_cpu_for_mig(params):
         if test_case != "diff_secret_on_src_and_dst":
             test.cancel("Need to use machines with different cpu to test this case.")
     else:


### PR DESCRIPTION
For aarch64, only supports migration tests between hosts with the same CPU, so no need to check the CPU.

For x86_64, update to use virsh hypervisor-cpu-compare command to compare CPU.