### PR TITLE
get_vm_ip:Return None if needed

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_network.py
+++ b/libvirt/tests/src/virtual_network/iface_network.py
@@ -1107,7 +1107,7 @@ TIMEOUT 3"""
                         vms_mac = vms.get_virsh_mac_address()
                         # restart guest network to get ip addr
                         utils_net.restart_guest_network(sess, vms_mac)
-                        vms_ip = network_base.get_vm_ip(sess, vms_mac)
+                        vms_ip = network_base.get_vm_ip(sess, vms_mac, ignore_error=True)
                         if not vms_ip and dhcp_range:
                             test.fail("Guest has invalid ip address")
                         elif vms_ip and not dhcp_range:

--- a/provider/virtual_network/network_base.py
+++ b/provider/virtual_network/network_base.py
@@ -19,13 +19,15 @@ VIRSH_ARGS = {'ignore_status': False, 'debug': True}
 LOG = logging.getLogger('avocado.' + __name__)
 
 
-def get_vm_ip(session, mac, ip_ver="ipv4", timeout=5):
+def get_vm_ip(session, mac, ip_ver="ipv4", timeout=5, ignore_error=False):
     """
     Get vm ip address
 
     :param session: vm session
     :param mac: mac address of vm
     :param ip_ver: ip version, defaults to "ipv4"
+    :param ignore_error: True to return None, False to raise exception,
+           defaults to False
     :return: ip address of given mac
     """
     def _get_vm_ip():
@@ -39,16 +41,16 @@ def get_vm_ip(session, mac, ip_ver="ipv4", timeout=5):
                            and addr.get('mngtmpaddr') is not True]
 
         if len(target_addr) == 0:
-            LOG.warn(f'No ip addr of given mac: {mac}')
+            LOG.warning(f'No ip addr of given mac: {mac}')
             return
         elif len(target_addr) > 1:
-            LOG.warn(f'Multiple ip addr: {target_addr}')
+            LOG.warning(f'Multiple ip addr: {target_addr}')
 
         return target_addr[0]['local']
 
     vm_ip = utils_misc.wait_for(_get_vm_ip, timeout, ignore_errors=True)
 
-    if not vm_ip:
+    if not vm_ip and not ignore_error:
         raise exceptions.TestError(
             f'Cannot find {ip_ver} addr with given mac: {mac}')
 


### PR DESCRIPTION
We use get_vm_ip to replace utils_net.get_guest_ip_addr in some test code to avoid potential risks, but it changes the original behavior which is to return None when cannot get valid ip address. Add an argument to choose between returning None or raising error to fix this problem.

Test result:
```
 (1/1) type_specific.local.virtual_network.iface_network.net_macvtap.net_bridge.multi_guests: STARTED
 (1/1) type_specific.local.virtual_network.iface_network.net_macvtap.net_bridge.multi_guests: PASS (98.11 s)
```