### PR TITLE
Add new case of zone of network

### DIFF
--- a/libvirt/tests/cfg/virtual_network/network_misc.cfg
+++ b/libvirt/tests/cfg/virtual_network/network_misc.cfg
@@ -4,7 +4,21 @@
     variants test_group:
         - zone:
             variants case:
+                - libvirt_managed:
+                    br_attrs = {'stp': 'on', 'delay': '0'}
+                    variants forward_mode:
+                        - nat:
+                            default_zone = libvirt
+                        - route:
+                            default_zone = libvirt-routed
+                        - isolated:
+                            default_zone = libvirt
+                        - open:
+                            default_zone = no zone
+                    net_attrs = {'forward': {'mode': '${forward_mode}'}, 'name': net_name, 'ips': [{'address': '192.168.152.1', 'netmask': '255.255.255.0', 'dhcp_ranges': {'attrs': {'start': '192.168.152.2', 'end': '192.168.152.254'}}}]}
+                    expect_str = ['${default_zone} (active)', 'target: ACCEPT', 'interfaces: .*%s' % br, 'services: dhcp dhcpv6 dns ssh tftp', 'protocols: icmp ipv6-icmp', 'rule priority="32767" reject']
                 - public:
+                    net_attrs = {'forward': {'mode': 'nat'}, 'name': net_name, 'bridge': {'zone': 'public'}, 'ips': [{'address': '192.168.152.1', 'netmask': '255.255.255.0', 'dhcp_ranges': {'attrs': {'start': '192.168.152.2', 'end': '192.168.152.254'}}}]}
                 - info:
                     expect_str = ['libvirt (active)', 'target: ACCEPT', 'interfaces: .*%s' % br, 'services: dhcp dhcpv6 dns ssh tftp', 'protocols: icmp ipv6-icmp', 'rule priority="32767" reject']
         - iface_acpi:


### PR DESCRIPTION
- VIRT-298946 - [Zone] Define network with libvirt managed bridge zone

Test result:
```
 (1/6) type_specific.local.virtual_network.network_misc.zone.libvirt_managed.nat: STARTED
 (1/6) type_specific.local.virtual_network.network_misc.zone.libvirt_managed.nat: PASS (10.73 s)
 (2/6) type_specific.local.virtual_network.network_misc.zone.libvirt_managed.route: STARTED
 (2/6) type_specific.local.virtual_network.network_misc.zone.libvirt_managed.route: PASS (10.63 s)
 (3/6) type_specific.local.virtual_network.network_misc.zone.libvirt_managed.isolated: STARTED
 (3/6) type_specific.local.virtual_network.network_misc.zone.libvirt_managed.isolated: PASS (10.81 s)
 (4/6) type_specific.local.virtual_network.network_misc.zone.libvirt_managed.open: STARTED
 (4/6) type_specific.local.virtual_network.network_misc.zone.libvirt_managed.open: PASS (9.07 s)
 (5/6) type_specific.local.virtual_network.network_misc.zone.public: STARTED
 (5/6) type_specific.local.virtual_network.network_misc.zone.public: PASS (10.62 s)
 (6/6) type_specific.local.virtual_network.network_misc.zone.info: STARTED
 (6/6) type_specific.local.virtual_network.network_misc.zone.info: PASS (8.98 s)
RESULTS    : PASS 6 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```