### PR TITLE
New test case: qemu_cmdline

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/virsh_qemu_cmdline_core.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/virsh_qemu_cmdline_core.cfg
@@ -1,0 +1,6 @@
+- io-github-autotest-libvirt.virsh.qemu_cmdline_core:
+    virt_test_type = libvirt
+    provider = io-github-autotest-libvirt
+    type = virsh_qemu_cmdline_core
+    variants:
+        - qemu_cmdline_more_cpus:

--- a/libvirt/tests/cfg/virsh_cmd/virsh_qemu_cmdline_core.py
+++ b/libvirt/tests/cfg/virsh_cmd/virsh_qemu_cmdline_core.py
@@ -1,0 +1,30 @@
+import subprocess
+
+def run(test, params, env):
+
+    qemu_binary = params.get("qemu_binary")
+    errors = ["tcg_region_init", "assertion failed", "Aborted",
+              "core dumped", "Invalid CPU topology"]
+
+    def check_qemu_cmdline(cpus=9999):
+
+        print("checking with %d CPUs" % cpus)
+
+        command = "%s -accel tcg -smp 10,maxcpus=%d" % (qemu_binary, cpus)
+        global output
+        output = subprocess.getoutput(command)
+
+        for err in errors:
+            if err in output:
+                return True
+        return False
+
+    cpus = ["9000", "123", "97865", "56789", "123456789"]
+
+    for cpu in cpus:
+        failed = check_qemu_cmdline(int(cpu))
+        if failed:
+            break
+
+    if failed:
+        test.fail(output)

--- a/libvirt/tests/src/virsh_cmd/virsh_qemu_cmdline_core.cfg
+++ b/libvirt/tests/src/virsh_cmd/virsh_qemu_cmdline_core.cfg
@@ -1,0 +1,6 @@
+- io-github-autotest-libvirt.virsh.qemu_cmdline_core:
+    virt_test_type = libvirt
+    provider = io-github-autotest-libvirt
+    type = virsh_qemu_cmdline_core
+    variants:
+        - qemu_cmdline_more_cpus:

--- a/libvirt/tests/src/virsh_cmd/virsh_qemu_cmdline_core.py
+++ b/libvirt/tests/src/virsh_cmd/virsh_qemu_cmdline_core.py
@@ -3,7 +3,7 @@ import subprocess
 def run(test, params, env):
     
     qemu_binary = params.get("qemu_binary")
-    errors = ["tcg_region_init", "assertion failed", "Aborted", \
+    errors = ["tcg_region_init", "assertion failed", "Aborted",
               "core dumped", "Invalid CPU topology"]
 
     def check_qemu_cmdline(cpus=9999):

--- a/libvirt/tests/src/virsh_cmd/virsh_qemu_cmdline_core.py
+++ b/libvirt/tests/src/virsh_cmd/virsh_qemu_cmdline_core.py
@@ -1,0 +1,30 @@
+import subprocess
+
+def run(test, params, env):
+    
+    qemu_binary = params.get("qemu_binary")
+    errors = ["tcg_region_init", "assertion failed", "Aborted", \
+              "core dumped", "Invalid CPU topology"]
+
+    def check_qemu_cmdline(cpus=9999):
+
+        print("checking with %d CPUs" % cpus)
+
+        command = "%s -accel tcg -smp 10,maxcpus=%d" % (qemu_binary, cpus)
+        global output
+        output = subprocess.getoutput(command)
+
+        for err in errors:
+            if err in output:
+                return True
+        return False
+
+    cpus = ["9000", "123", "97865", "56789", "123456789"]
+
+    for cpu in cpus:
+        failed = check_qemu_cmdline(int(cpu))
+        if failed:
+            break
+
+    if failed:
+        test.fail(output)


### PR DESCRIPTION
There was a bug reported where qemu command line was giving core dump error as below.

_# qemu-system-ppc64 -accel tcg -smp 10,maxcpus=9000
**
ERROR:../tcg/region.c:782:tcg_region_init: assertion failed: (region_size >= 2 * page_size)
Bail out! ERROR:../tcg/region.c:782:tcg_region_init: assertion failed: (region_size >= 2 * page_size)
Aborted (core dumped)_

A fix has been posted upstream and is merged with distros(Fedora and Ubuntu). Adding this test case to catch such a scenario in future.

Reference bug: https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/2055003

Signed-off-by: Kowshik Jois B S <kowsjois@linux.ibm.com>