### PR TITLE
Changing a negative scenario to positive

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_create_as.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_create_as.cfg
@@ -35,9 +35,6 @@
                             domain_state = "paused"
                         - running_domain:
                             domain_state = "running"
-                - autodestroy_domain:
-                    create_autodestroy = "yes"
-                    snap_createas_opts = "--disk-only"
                 - quiesce_without_unix_channel:
                     unix_channel = "no"
                     snap_createas_opts = "--quiesce --disk-only"
@@ -162,6 +159,10 @@
                     snap_createas_opts = "--print-xml --name tt --description hello --disk-only"
                     diskspec_opts1 = "vda,snapshot=internal,driver=raw,file=test1.img"
                     diskspec_opts2 = "vdb,snapshot=no"
+                - autodestroy_domain:
+                    status_error = "yes"
+                    create_autodestroy = "yes"
+                    snap_createas_opts = "--disk-only"
             variants:
                 - file_disk:
                     variants:


### PR DESCRIPTION
Description:
In my recent PR #6114, I had added required changes for autodestroy.
As per the comments received, modifying the test to be a positive scenario rather than a negative one.

Signed-off-by: Kowshik Jois B S <kowsjois@linux.ibm.com>
