### PR TITLE
guest_os_booting: Enable serial logs

### DIFF
--- a/libvirt/tests/cfg/guest_os_booting/boot_order/boot_from_virtiofs_device.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/boot_order/boot_from_virtiofs_device.cfg
@@ -1,7 +1,6 @@
 - guest_os_booting.boot_order.virtiofs_device:
     type = boot_from_virtiofs_device
     start_vm = no
-    access_cmd = "virsh console %s"
     vm_memory = 15728640
     no s390-virtio
     variants:


### PR DESCRIPTION
Update to log serial message during the test.

**After the fix:**
```
(.libvirt-ci-venv-ci-runtest-5Kbze5) [root@dell-per730-61 1-type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.virtiofs_device.start_guest]# ls
data  debug.log  ip-sniffer.log  stderr  tmp_dir9jipvgg1  vm_info_avocado-vt-vm1_387044  whiteboard
```


**Before the fix:** vm serial messages are logged in serial-serial0-avocado-vt-vm1-Dnvv.log
```
 (1/1) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.virtiofs_device.start_guest: PASS (274.59 s)
RESULTS    : PASS 1 | ERROR (.libvirt-ci-venv-ci-runtest-5Kbze5) [root@dell-per730-61 1-type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.virtiofs_device.start_guest]# ls
data                                    stderr
debug.log                               tmp_dirh2aqyxv7
ip-sniffer.log                          vm_info_avocado-vt-vm1_521908
serial-serial0-avocado-vt-vm1-Dnvv.log  whiteboard
0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2025-02-05T04.10-ba1b63d/results.html
JOB TIME   : 277.55 s
```
