### PR TITLE
fix iommu was added  automatically when cpus are bigger than 255

### DIFF
--- a/libvirt/tests/src/cpu/max_vcpus.py
+++ b/libvirt/tests/src/cpu/max_vcpus.py
@@ -166,7 +166,8 @@ def run(test, params, env):
             vmxml.vcpu = int(guest_vcpu)
             set_iommu(vmxml)
             result_need_check = virsh.define(vmxml.xml, debug=True)
-
+            if libvirt_version.version_compare(10, 10, 0):
+                err_msg = ""
         # Add ioapic and iommu device in xml for q35 VM
         if check.startswith('ioapic_iommu'):
             logging.info('Modify features')


### PR DESCRIPTION
   LIBVIRT-1414 says case update
Signed-off-by: nanli <nanli@redhat.com>

Before fixed:
```
avocado run --vt-type libvirt --vt-omit-data-loss --vt-machine-type q35 max_vcpus.negative_test.with_iommu --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.max_vcpus.negative_test.with_iommu: FAIL: Expect should fail with one of IOMMU interrupt remapping requires split I/O APIC \(ioapic driver='qemu'\), but succeeded: Domain 'avocado-vt-vm1' defined from /var/tmp/xml_utils_temp_91mfmfls.xml\n\n\n (6.13 s)

```
After fixed:
` (1/1) type_specific.io-github-autotest-libvirt.max_vcpus.negative_test.with_iommu: PASS (5.87 s)
`