### PR TITLE
Fix three issues for more than 2 available host numa node

### DIFF
--- a/libvirt/tests/src/memory/memory_devices/virtio_memory_with_numa_node_tuning.py
+++ b/libvirt/tests/src/memory/memory_devices/virtio_memory_with_numa_node_tuning.py
@@ -68,7 +68,7 @@ def _allocate_huge_memory(params, test, allocate_mem,
     kernel_hp_file = params.get("kernel_hp_tmpl_file")
     cleanup_file = params.get("cleanup_file", [])
 
-    target_nodes = params.get("numa_obj").online_nodes_withmem
+    target_nodes = params.get("numa_obj").online_nodes_withmem[:2]
     params.update({"all_nodes": target_nodes})
 
     test.log.debug("Allocate %sKiB on %s pagesize", allocate_mem, hugepage_size)
@@ -431,10 +431,10 @@ def run(test, params, env):
         test.log.info("TEST_TEARDOWN: Clean up env.")
         bkxml.sync()
         for file in params.get("cleanup_file", []):
-            process.run("echo 0 > %s" % file, ignore_status=True)
+            process.run("echo 0 > %s" % file, ignore_status=True, shell=True)
         hg_path = params.get("hg_path")
         if hg_path:
-            process.run("umount %s; rm %s" % (hg_path, hg_path), ignore_status=True)
+            process.run("umount %s; rm -r %s" % (hg_path, hg_path), ignore_status=True, shell=True)
 
     vm_name = params.get("main_vm")
     vm = env.get_vm(vm_name)


### PR DESCRIPTION
1. When the host has more than 2 host numa node with memory, the huge page could be allocated on all these nodes, this would impact the verification, so limit only 2 host numa node for huge page allocation.
2. Enable shell when executing cmd with '>'.
3. Add '-r' for remove cmd to delete directory correctly.

test results:
 (01/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.with_source_virtio_mem.strict: STARTED
 (01/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.with_source_virtio_mem.strict: PASS (94.73 s)
 (02/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.with_source_virtio_mem.interleave: STARTED
 (02/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.with_source_virtio_mem.interleave: PASS (94.65 s)
 (03/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.with_source_virtio_mem.preferred: STARTED
 (03/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.with_source_virtio_mem.preferred: PASS (96.24 s)
 (04/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.with_source_virtio_mem.undefined: STARTED
 (04/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.with_source_virtio_mem.undefined: PASS (97.48 s)
 (05/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.no_source_virtio_mem.strict: STARTED
 (05/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.no_source_virtio_mem.strict: PASS (234.77 s)
 (06/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.no_source_virtio_mem.interleave: STARTED
 (06/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.no_source_virtio_mem.interleave: PASS (242.71 s)
 (07/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.no_source_virtio_mem.preferred: STARTED
 (07/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.no_source_virtio_mem.preferred: PASS (235.10 s)
 (08/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.no_source_virtio_mem.undefined: STARTED
 (08/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.no_source_virtio_mem.undefined: PASS (244.18 s)
 (09/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.requested_bigger_than_host_numa.strict: STARTED
 (09/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.requested_bigger_than_host_numa.strict:PASS (96.77 s)
 (10/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.requested_bigger_than_host_numa.interleave: STARTED
 (10/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.requested_bigger_than_host_numa.interleave: PASS (96.50 s)
 (11/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.requested_bigger_than_host_numa.preferred: STARTED
 (11/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.requested_bigger_than_host_numa.preferred: PASS (97.77 s)
 (12/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.requested_bigger_than_host_numa.undefined: STARTED
 (12/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.cold_plug.requested_bigger_than_host_numa.undefined: PASS (95.52 s)
 (13/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.hot_plug.with_source_virtio_mem.strict: STARTED
 (13/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.hot_plug.with_source_virtio_mem.strict: PASS (98.10 s)
 (14/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.hot_plug.with_source_virtio_mem.interleave: STARTED
 (14/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.hot_plug.with_source_virtio_mem.interleave: PASS (99.00 s)
 (15/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.hot_plug.with_source_virtio_mem.preferred: STARTED
 (15/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.hot_plug.with_source_virtio_mem.preferred: PASS (98.52 s)
 (16/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.hot_plug.with_source_virtio_mem.undefined: STARTED
 (16/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.hot_plug.with_source_virtio_mem.undefined: PASS (98.91 s)
 (17/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.hot_plug.no_source_virtio_mem.strict: STARTED
 (17/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.hot_plug.no_source_virtio_mem.strict: PASS (237.76 s)
 (18/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.hot_plug.no_source_virtio_mem.interleave: STARTED
 (18/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.hot_plug.no_source_virtio_mem.interleave: PASS (233.93 s)
 (19/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.hot_plug.no_source_virtio_mem.preferred: STARTED
 (19/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.hot_plug.no_source_virtio_mem.preferred: PASS (235.51 s)
 (20/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.hot_plug.no_source_virtio_mem.undefined: STARTED
 (20/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.hot_plug.no_source_virtio_mem.undefined: PASS (244.61 s)
 (21/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.hot_plug.requested_bigger_than_host_numa.strict: STARTED
 (21/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.hot_plug.requested_bigger_than_host_numa.strict: PASS (97.83 s)
 (22/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.hot_plug.requested_bigger_than_host_numa.interleave: STARTED
 (22/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.hot_plug.requested_bigger_than_host_numa.interleave: PASS (99.65 s)
 (23/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.hot_plug.requested_bigger_than_host_numa.preferred: STARTED
 (23/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.hot_plug.requested_bigger_than_host_numa.preferred: PASS (99.01 s)
 (24/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.hot_plug.requested_bigger_than_host_numa.undefined: STARTED
 (24/24) type_specific.io-github-autotest-libvirt.memory.devices.virtio.with_numa_tuning.hot_plug.requested_bigger_than_host_numa.undefined: PASS (98.06 s)