### PR TITLE
v2v: fix the failed case with deprecated i440fx type img

### DIFF
--- a/v2v/tests/cfg/specific_kvm.cfg
+++ b/v2v/tests/cfg/specific_kvm.cfg
@@ -252,9 +252,6 @@
             only rhev
             checkpoint = 'host_no_space_setcache'
             main_vm = 'VM_ESX_DEFAULT_NAME_V2V_EXAMPLE'
-        - mem_alloc:
-            only source_kvm
-            main_vm = VM_MEM_ACCLOC_V2V_EXAMPLE
         - no_libguestfs_backend:
             only esx.esx_70
             main_vm = 'VM_ESX_DEFAULT_NAME_V2V_EXAMPLE'
@@ -352,7 +349,7 @@
                         - network:
                             only network.e1000,non_exist_network
                 - to_libvirt:
-                    only display.mix,display.listen,mem_alloc,80_chars
+                    only display.mix,display.listen,80_chars
                     only output_mode.libvirt
                 - to_local:
                     only win_rootonlinux

--- a/v2v/tests/cfg/v2v_options.cfg
+++ b/v2v/tests/cfg/v2v_options.cfg
@@ -358,6 +358,11 @@
                     only output_mode.none
                     input_disk_image = '/DISK_IMAGE_PATH_V2V_EXAMPLE/IMAGE_WITH_IMMUTABLE_BITS_V2V_EXAMPLE'
                     v2v_options = '-i disk ${input_disk_image} -o null'
+                - mem_alloc:                    
+                    only input_mode.none
+                    only output_mode.none
+                    input_disk_image = '/DISK_IMAGE_PATH_V2V_EXAMPLE/IMAGE_WITH_MEM_ALLOC_V2V_EXAMPLE'
+                    v2v_options = '-i disk ${input_disk_image} -o null'
         - negative_test:
             status_error = "yes"
             variants:


### PR DESCRIPTION
 fix specific-kvm failed case with deprecated i440fx type img