### PR TITLE
Update the passt test as behavior changes

### DIFF
--- a/libvirt/tests/cfg/virtual_network/passt/passt_negative_setting.cfg
+++ b/libvirt/tests/cfg/virtual_network/passt/passt_negative_setting.cfg
@@ -33,6 +33,7 @@
             error_msg = Invalid interface name .*: No such device
         - inactive_host_iface:
             error_msg = External interface not usable
+            passt_version = 0^20250121.g4f2c8e7
         - non_exist_bind_ip:
             portForwards = {'portForwards': [{'ranges': [{'start': '9000'}], 'attrs': {'proto': 'tcp', 'address': 'IP_EXAMPLE'}}]}
             error_msg = Failed to bind port

--- a/libvirt/tests/src/virtual_network/passt/passt_negative_setting.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_negative_setting.py
@@ -130,7 +130,14 @@ def run(test, params, env):
             virsh.start(vm_name, uri=virsh_uri, **VIRSH_ARGS)
             result = virsh.attach_device(vm_name, iface_device.xml,
                                          uri=virsh_uri, debug=True)
-
+        if scenario == 'inactive_host_iface':
+            passt_ver_cmp = params.get("passt_version")
+            passt_ver = process.run("rpm -q passt", shell=True,
+                                    ignore_status=True).stdout_text.strip().split('-')[1]
+            # With newer passt version, vm can start successfully
+            # with inactive interface
+            if passt_ver >= passt_ver_cmp:
+                status_error, error_msg = False, ''
         libvirt.check_exit_status(result, status_error)
         if error_msg:
             libvirt.check_result(result, error_msg)


### PR DESCRIPTION
With passt rebase, the behavior changes when passt interface with source dev as an inactive host interface. The vm can start successfully now.