### PR TITLE
migration_iommu_device: using migrate_vm_back option

### DIFF
--- a/libvirt/tests/src/sriov/vIOMMU/migration_iommu_device.py
+++ b/libvirt/tests/src/sriov/vIOMMU/migration_iommu_device.py
@@ -80,8 +80,10 @@ def run(test, params, env):
         migration_obj.verify_default()
         check_iommu_xml(vm, params)
 
-        test.log.info("TEST_STEP: Migrate back the VM to the source host.")
-        migration_obj.run_migration_back()
-        migration_obj.migration_test.ping_vm(vm, params)
+        migrate_vm_back = "yes" == params.get("migrate_vm_back", "yes")
+        if migrate_vm_back:
+            test.log.info("TEST_STEP: Migrate back the VM to the source host.")
+            migration_obj.run_migration_back()
+            migration_obj.migration_test.ping_vm(vm, params)
     finally:
         test_obj.teardown_iommu_test()


### PR DESCRIPTION
Use migrate_vm_back option in avocado-vt/share/cfg/base.cfg to determine whether to migrate the vm back to the source host.