### PR TITLE
virt_admin: pause after daemon restart

### DIFF
--- a/libvirt/tests/src/virt_admin/management/virt_admin_server_threadpool_set.py
+++ b/libvirt/tests/src/virt_admin/management/virt_admin_server_threadpool_set.py
@@ -1,6 +1,7 @@
 import logging as log
 from virttest import virt_admin
 from virttest import utils_libvirtd
+import time
 
 
 # Using as lower capital is not the best way to do, but this is just a
@@ -32,6 +33,7 @@ def run(test, params, env):
         server_name = virt_admin.check_server_name()
 
     daemon = utils_libvirtd.Libvirtd()
+    time.sleep(10)
     vp = virt_admin.VirtadminPersistent()
 
     def threadpool_info(server):

--- a/libvirt/tests/src/virt_admin/monitor/virt_admin_srv_threadpool_info.py
+++ b/libvirt/tests/src/virt_admin/monitor/virt_admin_srv_threadpool_info.py
@@ -1,3 +1,4 @@
+import time
 from virttest import virt_admin
 from virttest import utils_libvirtd
 
@@ -34,6 +35,7 @@ def run(test, params, env):
             config.prio_workers = prio_workers
 
         daemon.restart()
+        time.sleep(10)
         result = virt_admin.srv_threadpool_info(server_name, ignore_status=True,
                                                 debug=True)
 


### PR DESCRIPTION
We've seen virtqemud trying to access some unconfined service in these tests, making them fail only in our CI.

We have not been able to identify which PID it is trying to read.

Given that both tests do a restart before the access violation and in a previous test round executing some bash command right after didn't reproduce the violation, let's try to wait 10sec to see if it makes a difference.