### PR TITLE
iface_update:Fix error when trying to get net interface

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_update.py
+++ b/libvirt/tests/src/virtual_network/iface_update.py
@@ -314,7 +314,9 @@ def run(test, params, env):
                     state_map = "%s.*\n.*%s" % (iface_link_value.upper(), mac_addr)
                     session = vm.wait_for_serial_login()
                     logging.info("ip link output:%s", session.cmd_output("ip link"))
-                    if_name = utils_net.get_net_if(runner=session.cmd_output, state=state_map)[0]
+                    if_name = utils_net.get_net_if(
+                        runner=session.cmd_output, state=state_map,
+                        ip_options='--color=never')[0]
                     if not check_iface_link(session, mac_addr, new_iface_link):
                         test.fail('iface link check inside vm failed.')
                     session.close()


### PR DESCRIPTION
Depends on 
- https://github.com/avocado-framework/avocado-vt/pull/4063

Test result:
```
 (1/4) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.positive_test.update_link: STARTED
 (1/4) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.positive_test.update_link: PASS (35.43 s)
 (2/4) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.positive_test.update_link_with_rom: STARTED
 (2/4) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.positive_test.update_link_with_rom: PASS (36.99 s)
 (3/4) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.positive_test.update_link_without_addr: STARTED
 (3/4) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.positive_test.update_link_without_addr: PASS (44.20 s)
 (4/4) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.positive_test.update_link_diff_type: STARTED
 (4/4) type_specific.io-github-autotest-libvirt.virtual_network.iface_update.positive_test.update_link_diff_type: PASS (48.27 s)
RESULTS    : PASS 4 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```


