### PR TITLE
Change audit log cmd to get rid of the time impact

### DIFF
--- a/libvirt/tests/cfg/memory/memory_devices/dimm_memory_hot_unplug.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/dimm_memory_hot_unplug.cfg
@@ -14,7 +14,7 @@
     max_mem = 4194304
     max_mem_slots = 16
     slot = '0'
-    audit_cmd = "ausearch --start today -m VIRT_RESOURCE | grep 'mem'"
+    audit_cmd = "ausearch -m VIRT_RESOURCE | grep 'mem' | tail -n 30"
     ausearch_check = 'old-mem=%d new-mem=%d'
     expected_log = "ACPI_DEVICE_OST|device_del"
     kernel_hp_file = '/sys/devices/system/node/node0/hugepages/hugepages-%skB/nr_hugepages'


### PR DESCRIPTION
test result:
(1/1) type_specific.io-github-autotest-libvirt.memory.devices.dimm.hot_unplug.online_movable_mem.source_and_mib: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.memory.devices.dimm.hot_unplug.online_movable_mem.source_and_mib: PASS (258.07 s)