### PR TITLE
direct_kernel_boot: increase wait time for booting

### DIFF
--- a/libvirt/tests/src/guest_os_booting/direct_kernel_boot/direct_kernel_boot.py
+++ b/libvirt/tests/src/guest_os_booting/direct_kernel_boot/direct_kernel_boot.py
@@ -48,7 +48,7 @@ def run(test, params, env):
         test.log.debug("The final guest xml is %s", vmxml)
         if not vm.is_alive():
             vm.start()
-        vm.serial_console.read_until_any_line_matches([check_prompt], timeout=360)
+        vm.serial_console.read_until_any_line_matches([check_prompt], timeout=600)
     finally:
         bkxml.sync()
         for file_path in [boot_initrd, boot_vmlinuz]:


### PR DESCRIPTION
Increase timeout waiting for vm to boot since dracut-initqueue can occasionally take a long time to finish. This change helps make the test more stable.

Consistently passing tests:
```
(.libvirt-ci-venv-ci-runtest-GQXyvP) [root@nvidia-jetson-agx-orin-01 ~]# avocado run --vt-type libvirt --vt-omit-data-loss --vt-machine-type arm64-mmio guest_os_booting.direct_kernel_boot.start_guest --vt-connect-uri qemu:///system
JOB ID     : ab8692d1b86af4b770848ffda3f54bcf722612ab
JOB LOG    : /var/log/avocado/job-results/job-2025-02-13T10.52-ab8692d/job.log
 (1/1) type_specific.io-github-autotest-libvirt.guest_os_booting.direct_kernel_boot.start_guest: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.guest_os_booting.direct_kernel_boot.start_guest: PASS (342.96 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2025-02-13T10.52-ab8692d/results.html
JOB TIME   : 344.90 s
```