### PR TITLE
Replace virsh.VirshPersistent with virsh.Virsh to avoid error

### DIFF
--- a/libvirt/tests/src/virtual_network/attach_detach_device/attach_user_type_iface.py
+++ b/libvirt/tests/src/virtual_network/attach_detach_device/attach_user_type_iface.py
@@ -36,7 +36,7 @@ def run(test, params, env):
                                                       test_passwd,
                                                       **unpr_vm_args)
         uri = f'qemu+ssh://{test_user}@localhost/session'
-        virsh_ins = virsh.VirshPersistent(uri=uri)
+        virsh_ins = virsh.Virsh(uri=uri)
         host_session = aexpect.ShellSession('su')
         remote.VMManager.set_ssh_auth(host_session, 'localhost', test_user,
                                       test_passwd)

--- a/libvirt/tests/src/virtual_network/connectivity/connectivity_check_ethernet_interface.py
+++ b/libvirt/tests/src/virtual_network/connectivity/connectivity_check_ethernet_interface.py
@@ -41,7 +41,7 @@ def run(test, params, env):
                                                       test_passwd,
                                                       **unpr_vm_args)
         uri = f'qemu+ssh://{test_user}@localhost/session'
-        virsh_ins = virsh.VirshPersistent(uri=uri)
+        virsh_ins = virsh.Virsh(uri=uri)
         host_session = aexpect.ShellSession('su')
         remote.VMManager.set_ssh_auth(host_session, 'localhost', test_user,
                                       test_passwd)
@@ -200,5 +200,3 @@ def run(test, params, env):
             if tap_type == 'tap':
                 utils_net.delete_linux_bridge_tmux(bridge_name, host_iface)
         bkxml.sync(virsh_instance=virsh_ins)
-        if not root:
-            virsh_ins.close_session()

--- a/libvirt/tests/src/virtual_network/connectivity/connectivity_check_user_interface.py
+++ b/libvirt/tests/src/virtual_network/connectivity/connectivity_check_user_interface.py
@@ -65,7 +65,7 @@ def run(test, params, env):
         vm = libvirt_unprivileged.get_unprivileged_vm(vm_name, test_user,
                                                       test_passwd,
                                                       **unpr_vm_args)
-        virsh_ins = virsh.VirshPersistent(uri=virsh_uri)
+        virsh_ins = virsh.Virsh(uri=virsh_uri)
         host_session = aexpect.ShellSession('su')
         remote.VMManager.set_ssh_auth(host_session, 'localhost', test_user,
                                       test_passwd)
@@ -144,5 +144,3 @@ def run(test, params, env):
         vm.destroy()
     finally:
         bkxml.sync(virsh_instance=virsh_ins)
-        if not root:
-            del virsh_ins

--- a/libvirt/tests/src/virtual_network/passt/passt_attach_detach.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_attach_detach.py
@@ -57,7 +57,7 @@ def run(test, params, env):
                                                       test_passwd,
                                                       **unpr_vm_args)
         uri = f'qemu+ssh://{test_user}@localhost/session'
-        virsh_ins = virsh.VirshPersistent(uri=uri)
+        virsh_ins = virsh.Virsh(uri=uri)
         host_session = aexpect.ShellSession('su')
         remote.VMManager.set_ssh_auth(host_session, 'localhost', test_user,
                                       test_passwd)
@@ -182,6 +182,4 @@ def run(test, params, env):
         bkxml.sync(virsh_instance=virsh_ins)
         if root:
             shutil.rmtree(log_dir)
-        else:
-            del virsh_ins
         utils_selinux.set_status(selinux_status)

--- a/libvirt/tests/src/virtual_network/passt/passt_connectivity_between_2vms.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_connectivity_between_2vms.py
@@ -52,7 +52,7 @@ def run(test, params, env):
                                                         test_passwd,
                                                         **unpr_vm_args)
         uri = f'qemu+ssh://{test_user}@localhost/session'
-        virsh_ins = virsh.VirshPersistent(uri=uri)
+        virsh_ins = virsh.Virsh(uri=uri)
         host_session = aexpect.ShellSession('su')
         remote.VMManager.set_ssh_auth(host_session, 'localhost', test_user,
                                       test_passwd)
@@ -132,6 +132,4 @@ def run(test, params, env):
         bkxml_c.sync(virsh_instance=virsh_ins)
         if root:
             shutil.rmtree(log_dir)
-        else:
-            del virsh_ins
         utils_selinux.set_status(selinux_status)

--- a/libvirt/tests/src/virtual_network/passt/passt_function.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_function.py
@@ -46,7 +46,7 @@ def run(test, params, env):
                                                       test_passwd,
                                                       **unpr_vm_args)
         uri = f'qemu+ssh://{test_user}@localhost/session'
-        virsh_ins = virsh.VirshPersistent(uri=uri)
+        virsh_ins = virsh.Virsh(uri=uri)
         host_session = aexpect.ShellSession('su')
         remote.VMManager.set_ssh_auth(host_session, 'localhost', test_user,
                                       test_passwd)
@@ -131,6 +131,4 @@ def run(test, params, env):
         bkxml.sync(virsh_instance=virsh_ins)
         if root:
             shutil.rmtree(log_dir)
-        else:
-            del virsh_ins
         utils_selinux.set_status(selinux_status)

--- a/libvirt/tests/src/virtual_network/passt/passt_lifecycle.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_lifecycle.py
@@ -48,7 +48,7 @@ def run(test, params, env):
                                                       test_passwd,
                                                       **unpr_vm_args)
         uri = f'qemu+ssh://{test_user}@localhost/session'
-        virsh_ins = virsh.VirshPersistent(uri=uri)
+        virsh_ins = virsh.Virsh(uri=uri)
         host_session = aexpect.ShellSession('su')
         remote.VMManager.set_ssh_auth(host_session, 'localhost', test_user,
                                       test_passwd)
@@ -156,8 +156,6 @@ def run(test, params, env):
         bkxml.sync(virsh_instance=virsh_ins)
         if root:
             shutil.rmtree(log_dir)
-        else:
-            del virsh_ins
         utils_selinux.set_status(selinux_status)
         if os.path.exists(save_path):
             os.remove(save_path)

--- a/libvirt/tests/src/virtual_network/passt/passt_negative_setting.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_negative_setting.py
@@ -43,7 +43,7 @@ def run(test, params, env):
         remote.VMManager.set_ssh_auth(host_session, 'localhost', test_user,
                                       test_passwd)
         host_session.close()
-        virsh_ins = virsh.VirshPersistent(uri=virsh_uri)
+        virsh_ins = virsh.Virsh(uri=virsh_uri)
 
     scenario = params.get('scenario')
     operation = params.get('operation')
@@ -143,8 +143,6 @@ def run(test, params, env):
         bkxml.sync(virsh_instance=virsh_ins)
         if root:
             shutil.rmtree(log_dir)
-        else:
-            del virsh_ins
         utils_selinux.set_status(selinux_status)
         process.run(f'ip link del {DOWN_IFACE_NAME}',
                     shell=True, ignore_status=True)

--- a/libvirt/tests/src/virtual_network/passt/passt_reconnect.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_reconnect.py
@@ -50,7 +50,7 @@ def run(test, params, env):
                                                       test_passwd,
                                                       **unpr_vm_args)
         uri = f'qemu+ssh://{test_user}@localhost/session'
-        virsh_ins = virsh.VirshPersistent(uri=uri)
+        virsh_ins = virsh.Virsh(uri=uri)
         host_session = aexpect.ShellSession('su')
         remote.VMManager.set_ssh_auth(host_session, 'localhost', test_user,
                                       test_passwd)
@@ -141,6 +141,4 @@ def run(test, params, env):
         bkxml.sync(virsh_instance=virsh_ins)
         if root:
             shutil.rmtree(log_dir)
-        else:
-            del virsh_ins
         utils_selinux.set_status(selinux_status)

--- a/libvirt/tests/src/virtual_network/passt/passt_transfer_file.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_transfer_file.py
@@ -143,7 +143,7 @@ def run(test, params, env):
                                                       test_passwd,
                                                       **unpr_vm_args)
         uri = f'qemu+ssh://{test_user}@localhost/session'
-        virsh_ins = virsh.VirshPersistent(uri=uri)
+        virsh_ins = virsh.Virsh(uri=uri)
         host_session = aexpect.ShellSession('su')
         remote.VMManager.set_ssh_auth(host_session, 'localhost', test_user,
                                       test_passwd)
@@ -193,6 +193,4 @@ def run(test, params, env):
         bkxml.sync(virsh_instance=virsh_ins)
         if root:
             shutil.rmtree(log_dir)
-        else:
-            del virsh_ins
         utils_selinux.set_status(selinux_status)


### PR DESCRIPTION
The old cold uses virsh.VirshPersistent which requires active aexpect session which is unnecessary for these tests and might cause timeout error of unknown reason occasionally. Replace them with virsh.Virsh could avoid the errors.

```
 (1/3) type_specific.local.virtual_network.connectivity_check.ethernet_interface.managed_no.positive_test.tap.one_iface.larger_mtu.non_root_user: STARTED
 (1/3) type_specific.local.virtual_network.connectivity_check.ethernet_interface.managed_no.positive_test.tap.one_iface.larger_mtu.non_root_user: PASS (68.49 s)
 (2/3) type_specific.local.virtual_network.connectivity_check.user_interface.positive_test.default.non_root_user: STARTED
 (2/3) type_specific.local.virtual_network.connectivity_check.user_interface.positive_test.default.non_root_user: PASS (52.70 s)
 (3/3) type_specific.local.virtual_network.attach_device.user_type_iface.non_root_user: STARTED
 (3/3) type_specific.local.virtual_network.attach_device.user_type_iface.non_root_user: PASS (53.41 s)
```