### PR TITLE
migration: Add -color=never option

### DIFF
--- a/libvirt/tests/src/migration/migrate_network.py
+++ b/libvirt/tests/src/migration/migrate_network.py
@@ -15,6 +15,7 @@ from virttest.utils_test import libvirt
 from virttest.utils_libvirt import libvirt_network
 from virttest.libvirt_xml.devices import interface
 
+from provider.virtual_network import network_base
 
 # Using as lower capital is not the best way to do, but this is just a
 # workaround to avoid changing the entire file.
@@ -104,7 +105,7 @@ def run(test, params, env):
         if net_dict.get("name", "") == "direct-macvtap":
             logging.info("Updating network iface name")
             if not iface_name:
-                iface_name = utils_net.get_net_if(runner=runner, state="UP")[0]
+                iface_name = utils_net.get_net_if(runner=runner, state="UP", ip_options='-color=never')[0]
             net_dict.update({'forward_interface': [{'dev': iface_name}]})
         else:
             # TODO: support other types
@@ -251,12 +252,12 @@ def run(test, params, env):
             logging.debug("target xml is %s" % target_org_xml)
 
         if ovs_bridge_name:
-            status, stdout = utils_net.create_ovs_bridge(ovs_bridge_name)
+            status, stdout = utils_net.create_ovs_bridge(ovs_bridge_name, ip_options='-color=never')
             if status:
                 test.fail("Failed to create ovs bridge on local. Status: %s"
                           "Stdout: %s" % (status, stdout))
             status, stdout = utils_net.create_ovs_bridge(
-                ovs_bridge_name, session=remote_session)
+                ovs_bridge_name, session=remote_session, ip_options='-color=never')
             if status:
                 test.fail("Failed to create ovs bridge on remote. Status: %s"
                           "Stdout: %s" % (status, stdout))
@@ -319,7 +320,7 @@ def run(test, params, env):
         if not utils_package.package_install('dhcp-client', session=vm_session):
             test.error("Failed to install dhcp-client on guest.")
         utils_net.restart_guest_network(vm_session)
-        vm_ip = utils_net.get_guest_ip_addr(vm_session, mac)
+        vm_ip = network_base.get_vm_ip(vm_session, mac)
         logging.debug("VM IP Addr: %s", vm_ip)
 
         if direct_mode:
@@ -426,8 +427,8 @@ def run(test, params, env):
                 network_dict, is_del=True, remote_args=remote_virsh_dargs)
             libvirt_network.create_or_del_network(network_dict, is_del=True)
         if ovs_bridge_name:
-            utils_net.delete_ovs_bridge(ovs_bridge_name)
-            utils_net.delete_ovs_bridge(ovs_bridge_name, session=remote_session)
+            utils_net.delete_ovs_bridge(ovs_bridge_name, ip_options='-color=never')
+            utils_net.delete_ovs_bridge(ovs_bridge_name, session=remote_session, ip_options='-color=never')
 
         remote_session.close()
         if target_vm_session:


### PR DESCRIPTION
Before:
 (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_network.direct.fake_macvtap_exists_dest.with_postcopy: ERROR: list index out of range (80.04 s)

After:
 (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_network.direct.fake_macvtap_exists_dest.with_postcopy: PASS (286.50 s)

 (1/4) type_specific.io-github-autotest-libvirt.virsh.migrate_network.direct.fake_macvtap_exists_dest.without_postcopy: STARTED
 (1/4) type_specific.io-github-autotest-libvirt.virsh.migrate_network.direct.fake_macvtap_exists_dest.without_postcopy: PASS (231.38 s)
 (2/4) type_specific.io-github-autotest-libvirt.virsh.migrate_network.direct.macvtap_exists_dest.with_postcopy: STARTED
 (2/4) type_specific.io-github-autotest-libvirt.virsh.migrate_network.direct.macvtap_exists_dest.with_postcopy: PASS (364.32 s)
 (3/4) type_specific.io-github-autotest-libvirt.virsh.migrate_network.direct.macvtap_exists_dest.without_postcopy: STARTED
 (3/4) type_specific.io-github-autotest-libvirt.virsh.migrate_network.direct.macvtap_exists_dest.without_postcopy: PASS (365.55 s)
 (4/4) type_specific.io-github-autotest-libvirt.virsh.migrate_network.ovs_br.without_postcopy: STARTED
 (4/4) type_specific.io-github-autotest-libvirt.virsh.migrate_network.ovs_br.without_postcopy: PASS (347.67 s)