### PR TITLE
vIOMMU: Add tests for downstream ports

### DIFF
--- a/libvirt/tests/cfg/sriov/vIOMMU/hotplug_device_with_iommu_enabled.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/hotplug_device_with_iommu_enabled.cfg
@@ -57,3 +57,18 @@
             disk_dict = {'target': {'dev': 'vdb', 'bus': 'virtio'}, 'device': 'disk', 'driver': ${disk_driver}}
             interface_driver = {'driver_attr': {'name': 'vhost', 'iommu': 'on', 'ats': 'on'}}
             iface_dict = {'type_name': 'network', 'model': 'virtio', 'driver': ${interface_driver}, 'source': {'network': 'default'}}
+        - pcie_downstream_port:
+            test_devices = ["Eth", "block"]
+            upstream_port = {'type': 'pci', 'model': 'pcie-switch-upstream-port', 'pre_controller': 'pcie-root-port'}
+            downstream_port1 = {'type': 'pci', 'model': 'pcie-switch-downstream-port', 'target': {'chassis': '20', 'port': 0x0}, 'pre_controller': 'pcie-switch-upstream-port'}
+            downstream_port2 = {'type': 'pci', 'model': 'pcie-switch-downstream-port', 'target': {'chassis': '21', 'port': 0x0}, 'pre_controller': 'pcie-switch-upstream-port'}
+            iface_dict = {'type_name': 'network', 'model': 'virtio', 'driver': {'driver_attr': {'name': 'vhost', 'iommu': 'on'}}, 'source': {'network': 'default'}}
+            disk_dict = {'target': {'dev': 'vdb', 'bus': 'virtio'}, 'device': 'disk', 'driver': ${disk_driver}}
+            variants:
+                - from_pcie_root_port:
+                    root_port = {'type': 'pci', 'model': 'pcie-root-port', 'pre_controller': 'pcie-root'}
+                    controller_dicts = [${root_port}, ${upstream_port}, ${upstream_port}, ${downstream_port1}, ${downstream_port2}]
+                - from_expander_bus:
+                    downstream_port = {'type': 'pci', 'model': 'pcie-switch-downstream-port', 'pre_controller': 'pcie-switch-upstream-port'}
+                    root_port = {'type': 'pci', 'model': 'pcie-root-port', 'pre_controller': 'pcie-expander-bus'}
+                    controller_dicts = [{'type': 'pci', 'model': 'pcie-expander-bus', 'target': {'busNr': '250'}, 'pre_controller': 'pcie-root'}, ${root_port}, ${upstream_port}, ${upstream_port}, ${downstream_port}, ${downstream_port}]

--- a/libvirt/tests/cfg/sriov/vIOMMU/iommu_device_settings.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/iommu_device_settings.cfg
@@ -67,3 +67,19 @@
             controller_dicts = [{'type': 'pci', 'model': 'pcie-expander-bus', 'target': {'busNr': '252'}, 'pre_controller': 'pcie-root'}, ${root_port}, ${root_port}]
             iface_dict = {'source': {'network': 'default'}}
             disk_dict = {'target': {'dev': 'vda', 'bus': 'virtio'}, 'device': 'disk', 'driver': ${disk_driver}}
+        - pcie_downstream_port:
+            test_devices = ["Eth", "block"]
+            dev_in_same_iommu_group = ["XIO3130", *${test_devices}]
+            upstream_port = {'type': 'pci', 'model': 'pcie-switch-upstream-port', 'pre_controller': 'pcie-root-port'}
+            downstream_port1 = {'type': 'pci', 'model': 'pcie-switch-downstream-port', 'target': {'chassis': '20', 'port': 0x0}, 'pre_controller': 'pcie-switch-upstream-port'}
+            downstream_port2 = {'type': 'pci', 'model': 'pcie-switch-downstream-port', 'target': {'chassis': '21', 'port': 0x0}, 'pre_controller': 'pcie-switch-upstream-port'}
+            iface_dict = {'type_name': 'network', 'model': 'virtio', 'driver': {'driver_attr': {'name': 'vhost', 'iommu': 'on'}}, 'source': {'network': 'default'}}
+            disk_dict = {'target': {'dev': 'vdb', 'bus': 'virtio'}, 'device': 'disk', 'driver': ${disk_driver}}
+            variants:
+                - from_pcie_root_port:
+                    root_port = {'type': 'pci', 'model': 'pcie-root-port', 'pre_controller': 'pcie-root'}
+                    controller_dicts = [${root_port}, ${upstream_port}, ${upstream_port}, ${downstream_port1}, ${downstream_port2}]
+                - from_expander_bus:
+                    downstream_port = {'type': 'pci', 'model': 'pcie-switch-downstream-port', 'pre_controller': 'pcie-switch-upstream-port'}
+                    root_port = {'type': 'pci', 'model': 'pcie-root-port', 'pre_controller': 'pcie-expander-bus'}
+                    controller_dicts = [{'type': 'pci', 'model': 'pcie-expander-bus', 'target': {'busNr': '250'}, 'pre_controller': 'pcie-root'}, ${root_port}, ${upstream_port}, ${upstream_port}, ${downstream_port}, ${downstream_port}]


### PR DESCRIPTION
This pr adds tests for pcie-downstream-port in below cases: 
VIRT-294579 - [vIOMMU] Start vm with iommu device
VIRT-296710 - [vIOMMU] hotplug/unplug devices with iommu enabled

**Test results:** 
aarch64:
```
 (01/15) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.virtio_muti_devices.vhost_on.virtio: STARTED
 (01/15) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.virtio_muti_devices.vhost_on.virtio: PASS (73.59 s)
 (02/15) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.virtio_muti_devices.vhost_on.smmuv3: STARTED
 (02/15) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.virtio_muti_devices.vhost_on.smmuv3: PASS (74.86 s)
 (03/15) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.virtio_muti_devices.vhost_off.virtio: STARTED
 (03/15) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.virtio_muti_devices.vhost_off.virtio: PASS (75.11 s)
 (04/15) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.virtio_muti_devices.vhost_off.smmuv3: STARTED
 (04/15) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.virtio_muti_devices.vhost_off.smmuv3: PASS (75.61 s)
 (05/15) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.hostdev_iface.virtio: STARTED
 (05/15) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.hostdev_iface.virtio: PASS (104.83 s)
 (06/15) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.scsi_controller.virtio: STARTED
 (06/15) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.scsi_controller.virtio: PASS (75.07 s)
 (07/15) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.scsi_controller.smmuv3: STARTED
 (07/15) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.scsi_controller.smmuv3: PASS (75.96 s)
 (08/15) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_to_pci_bridge_controller.virtio_non_transitional.virtio: STARTED
 (08/15) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_to_pci_bridge_controller.virtio_non_transitional.virtio: PASS (76.62 s)
 (09/15) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_to_pci_bridge_controller.hostdev_iface.virtio: STARTED
 (09/15) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_to_pci_bridge_controller.hostdev_iface.virtio: PASS (106.50 s)
 (10/15) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_root_port_from_expander_bus.virtio: STARTED
 (10/15) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_root_port_from_expander_bus.virtio: PASS (82.30 s)
 (11/15) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_root_port_from_expander_bus.smmuv3: STARTED
 (11/15) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_root_port_from_expander_bus.smmuv3: PASS (81.41 s)
 (12/15) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_downstream_port.from_pcie_root_port.virtio: STARTED
 (12/15) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_downstream_port.from_pcie_root_port.virtio: PASS (84.71 s)
 (13/15) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_downstream_port.from_pcie_root_port.smmuv3: STARTED
 (13/15) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_downstream_port.from_pcie_root_port.smmuv3: PASS (86.19 s)
 (14/15) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_downstream_port.from_expander_bus.virtio: STARTED
 (14/15) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_downstream_port.from_expander_bus.virtio: PASS (87.19 s)
 (15/15) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_downstream_port.from_expander_bus.smmuv3: STARTED
 (15/15) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_downstream_port.from_expander_bus.smmuv3: PASS (87.49 s)
 (01/11) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.virtio_muti_devices.vhost_on.virtio: STARTED
 (01/11) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.virtio_muti_devices.vhost_on.virtio: PASS (79.36 s)
 (02/11) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.virtio_muti_devices.vhost_on.smmuv3: STARTED
 (02/11) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.virtio_muti_devices.vhost_on.smmuv3: PASS (82.09 s)
 (03/11) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.virtio_muti_devices.vhost_off.virtio: STARTED
 (03/11) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.virtio_muti_devices.vhost_off.virtio: PASS (81.70 s)
 (04/11) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.virtio_muti_devices.vhost_off.smmuv3: STARTED
 (04/11) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.virtio_muti_devices.vhost_off.smmuv3: PASS (81.68 s)
 (05/11) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.hostdev_iface.virtio: STARTED
 (05/11) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.hostdev_iface.virtio: PASS (84.86 s)
 (06/11) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.scsi_controller.virtio: STARTED
 (06/11) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.scsi_controller.virtio: PASS (51.60 s)
 (07/11) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.scsi_controller.smmuv3: STARTED
 (07/11) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.scsi_controller.smmuv3: PASS (50.67 s)
 (08/11) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.pcie_downstream_port.from_pcie_root_port.virtio: STARTED
 (08/11) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.pcie_downstream_port.from_pcie_root_port.virtio: PASS (86.93 s)
 (09/11) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.pcie_downstream_port.from_pcie_root_port.smmuv3: STARTED
 (09/11) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.pcie_downstream_port.from_pcie_root_port.smmuv3: PASS (87.39 s)
 (10/11) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.pcie_downstream_port.from_expander_bus.virtio: STARTED
 (10/11) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.pcie_downstream_port.from_expander_bus.virtio: PASS (92.68 s)
 (11/11) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.pcie_downstream_port.from_expander_bus.smmuv3: STARTED
 (11/11) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.pcie_downstream_port.from_expander_bus.smmuv3: PASS (87.47 s)

```

x86_64:
```
 (01/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.e1000e.virtio: STARTED
 (01/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.e1000e.virtio: PASS (97.56 s)
 (02/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.e1000e.intel: STARTED
 (02/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.e1000e.intel: PASS (200.25 s)
 (03/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.rtl8139.virtio: STARTED
 (03/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.rtl8139.virtio: PASS (75.03 s)
 (04/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.rtl8139.intel: STARTED
 (04/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.rtl8139.intel: PASS (199.16 s)
 (05/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.virtio_muti_devices.vhost_on.virtio: STARTED
 (05/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.virtio_muti_devices.vhost_on.virtio: PASS (75.53 s)
 (06/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.virtio_muti_devices.vhost_on.intel: STARTED
 (06/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.virtio_muti_devices.vhost_on.intel: PASS (200.68 s)
 (07/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.virtio_muti_devices.vhost_off.virtio: STARTED
 (07/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.virtio_muti_devices.vhost_off.virtio: PASS (76.21 s)
 (08/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.virtio_muti_devices.vhost_off.intel: STARTED
 (08/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.virtio_muti_devices.vhost_off.intel: PASS (240.88 s)
 (09/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.hostdev_iface.virtio: STARTED
 (09/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.hostdev_iface.virtio: PASS (103.35 s)
 (10/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.scsi_controller.virtio: STARTED
 (10/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.scsi_controller.virtio: PASS (94.11 s)
 (11/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.scsi_controller.intel: STARTED
 (11/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.scsi_controller.intel: PASS (197.60 s)
 (12/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_to_pci_bridge_controller.virtio_non_transitional.virtio: STARTED
 (12/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_to_pci_bridge_controller.virtio_non_transitional.virtio: PASS (86.09 s)
 (13/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_to_pci_bridge_controller.virtio_non_transitional.intel: STARTED
 (13/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_to_pci_bridge_controller.virtio_non_transitional.intel: PASS (194.77 s)
 (14/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_to_pci_bridge_controller.hostdev_iface.virtio: STARTED
 (14/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_to_pci_bridge_controller.hostdev_iface.virtio: PASS (103.42 s)
 (15/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_root_port_from_expander_bus.virtio: STARTED
 (15/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_root_port_from_expander_bus.virtio: PASS (81.50 s)
 (16/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_root_port_from_expander_bus.intel: STARTED
 (16/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_root_port_from_expander_bus.intel: PASS (223.79 s)
 (17/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_downstream_port.from_pcie_root_port.virtio: STARTED
 (17/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_downstream_port.from_pcie_root_port.virtio: PASS (83.93 s)
 (18/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_downstream_port.from_pcie_root_port.intel: STARTED
 (18/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_downstream_port.from_pcie_root_port.intel: PASS (205.81 s)
 (19/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_downstream_port.from_expander_bus.virtio: STARTED
 (19/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_downstream_port.from_expander_bus.virtio: PASS (90.05 s)
 (20/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_downstream_port.from_expander_bus.intel: STARTED
 (20/20) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_settings.pcie_downstream_port.from_expander_bus.intel: PASS (214.17 s)
 (01/16) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.e1000e.virtio: STARTED
 (01/16) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.e1000e.virtio: PASS (62.00 s)
 (02/16) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.e1000e.intel: STARTED
 (02/16) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.e1000e.intel: PASS (189.18 s)
 (03/16) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.rtl8139.virtio: STARTED
 (03/16) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.rtl8139.virtio: PASS (63.42 s)
 (04/16) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.rtl8139.intel: STARTED
 (04/16) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.rtl8139.intel: PASS (193.87 s)
 (05/16) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.virtio_muti_devices.vhost_on.virtio: STARTED
 (05/16) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.virtio_muti_devices.vhost_on.virtio: PASS (67.93 s)
 (06/16) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.virtio_muti_devices.vhost_on.intel: STARTED
 (06/16) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.virtio_muti_devices.vhost_on.intel: PASS (196.23 s)
 (07/16) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.virtio_muti_devices.vhost_off.virtio: STARTED
 (07/16) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.virtio_muti_devices.vhost_off.virtio: PASS (69.33 s)
 (08/16) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.virtio_muti_devices.vhost_off.intel: STARTED
 (08/16) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.virtio_muti_devices.vhost_off.intel: PASS (199.18 s)
 (09/16) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.hostdev_iface.virtio: STARTED
 (09/16) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.hostdev_iface.virtio: PASS (123.73 s)
 (10/16) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.scsi_controller.virtio: STARTED
 (10/16) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.scsi_controller.virtio: PASS (49.73 s)
 (11/16) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.scsi_controller.intel: STARTED
 (11/16) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.scsi_controller.intel: PASS (172.90 s)
 (12/16) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.ats_on.intel: STARTED
 (12/16) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.ats_on.intel: PASS (196.38 s)
 (13/16) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.pcie_downstream_port.from_pcie_root_port.virtio: STARTED
 (13/16) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.pcie_downstream_port.from_pcie_root_port.virtio: PASS (74.72 s)
 (14/16) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.pcie_downstream_port.from_pcie_root_port.intel: STARTED
 (14/16) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.pcie_downstream_port.from_pcie_root_port.intel: PASS (204.42 s)
 (15/16) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.pcie_downstream_port.from_expander_bus.virtio: STARTED
 (15/16) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.pcie_downstream_port.from_expander_bus.virtio: PASS (89.37 s)
 (16/16) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.pcie_downstream_port.from_expander_bus.intel: STARTED
 (16/16) type_specific.io-github-autotest-libvirt.vIOMMU.hotplug_device_with_iommu_enabled.pcie_downstream_port.from_expander_bus.intel: PASS (221.15 s)
```