### PR TITLE
Inc_backup: fix two random timeout failures

### DIFF
--- a/libvirt/tests/src/incremental_backup/incremental_backup_push_mode.py
+++ b/libvirt/tests/src/incremental_backup/incremental_backup_push_mode.py
@@ -1,6 +1,7 @@
 import logging as log
 import os
 import signal
+import platform
 
 from avocado.utils import process
 
@@ -265,7 +266,8 @@ def run(test, params, env):
             backup_options = backup_xml.xml + " " + checkpoint_xml.xml
 
             # Create some data in vdb
-            dd_count = params.get("dd_count", "1")
+            host_arch = platform.machine()
+            dd_count = params.get("dd_count") if host_arch != "x86_64" else "1"
             dd_seek = str(backup_index * 10 + 10)
             dd_bs = "1M"
             session = vm.wait_for_login()


### PR DESCRIPTION
From https://github.com/autotest/tp-libvirt/pull/4670 we know that the
current dd_count is suitable for arm. But for x86 it may still have
timeout issue or backup job not canceled issue. So this PR uses platform
function to distinguish time.