### PR TITLE
Xxx 20690 managed save get relevant audit logs

### DIFF
--- a/libvirt/tests/src/save_and_restore/save_to_block.py
+++ b/libvirt/tests/src/save_and_restore/save_to_block.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from datetime import datetime
 
 from avocado.utils import process
 from virttest import utils_config
@@ -12,6 +13,7 @@ from virttest.utils_test import libvirt
 
 from provider.save import save_base
 from provider.virtual_network import passt
+from provider.ausearch import ausearch_base
 
 LOG = logging.getLogger('avocado.test.' + __name__)
 VIRSH_ARGS = {'debug': True, 'ignore_status': False}
@@ -32,9 +34,13 @@ def run(test, params, env):
 
     qemu_conf = utils_config.LibvirtQemuConfig()
     libvirtd = utils_libvirtd.Libvirtd()
+    selinux_status = None
 
     try:
-        # Workaround bug: Remove multi-queue setting
+        #setup ausearch checkopoint to see only relevant log rows
+        ausearch_start = datetime.now().strftime("%X")
+        LOG.debug(f"ausearch starting point:{ausearch_start}")
+
         libvirt_vmxml.modify_vm_device(vmxml, 'interface', {'driver': None})
 
         selinux_status = passt.ensure_selinux_enforcing()
@@ -50,6 +56,7 @@ def run(test, params, env):
         pid_ping, upsince = save_base.pre_save_setup(vm)
 
         process.run(f'ls -lZ {save_path}')
+
         virsh.save(vm_name, save_path, **VIRSH_ARGS)
         label_output = process.run(f'ls -lZ {save_path}').stdout_text
         match = re.search(expect_label, label_output)
@@ -62,8 +69,8 @@ def run(test, params, env):
         if vm.state() != 'running':
             test.fail(f'VM should be running after restore, not {vm.state()}')
 
-        avc_denied = process.run("grep -E 'avc:.*denied' /var/log/audit/audit.log",
-                                 ignore_status=True).stdout_text.strip()
+        avc_denied = ausearch_base.summarize_ausearch_results(ausearch_start)
+
         if avc_denied:
             test.fail(f'Got avc denied:\n{avc_denied}')
 
@@ -74,4 +81,5 @@ def run(test, params, env):
         libvirtd.restart()
         bkxml.sync()
         libvirt.setup_or_cleanup_iscsi(is_setup=False)
-        utils_selinux.set_status(selinux_status)
+        if selinux_status:
+            utils_selinux.set_status(selinux_status)

--- a/provider/ausearch/ausearch_base.py
+++ b/provider/ausearch/ausearch_base.py
@@ -7,7 +7,9 @@ from avocado.utils import process
 LOG = logging.getLogger('avocado.test.' + __name__)
 
 
-def summarize_ausearch_results(ausearch_start, denial_types=None, log_ausearch_rows=True):
+def summarize_ausearch_results(ausearch_start, 
+                               denial_types=["AVC", "USER_AVC", "SELINUX_ERR", "USER_SELINUX_ERR"], 
+                               log_ausearch_rows=True):
     """
     Summarizes SELinux AVC denials from ausearch output.
 
@@ -26,10 +28,6 @@ def summarize_ausearch_results(ausearch_start, denial_types=None, log_ausearch_r
     Raises:
     - process.CmdError: If `ausearch` encounters an error other than "<no matches>".
     """
-
-    # Default denial types if none are provided
-    if denial_types is None:
-        denial_types = ["AVC", "USER_AVC", "SELINUX_ERR", "USER_SELINUX_ERR"]
 
     # Construct the ausearch command with dynamic denial types
     ausearch_cmd = f"ausearch --input-logs {' '.join(f'-m {t}' for t in denial_types)} --start {ausearch_start}"

--- a/provider/ausearch/ausearch_base.py
+++ b/provider/ausearch/ausearch_base.py
@@ -1,0 +1,69 @@
+import logging
+import re
+from collections import defaultdict
+
+from avocado.utils import process
+
+LOG = logging.getLogger('avocado.test.' + __name__)
+
+
+def summarize_ausearch_results(ausearch_start, denial_types=None, log_ausearch_rows=True):
+    """
+    Summarizes SELinux AVC denials from ausearch output.
+
+    This function extracts and summarize denials from the `ausearch` command
+    based on user-specified denial types
+
+    Parameters:
+    - ausearch_start (str): The starting datetime for `ausearch` to filter logs.
+    - denial_types (list, optional): A list of SELinux denial types to include in the search.
+      Defaults to `["AVC", "USER_AVC", "SELINUX_ERR", "USER_SELINUX_ERR"]` if not provided.
+    - log_ausearch_rows (bool): If True, logs the full ausearch output for debugging. Default is True.
+
+    Returns:
+    - str: A formatted summary of AVC denials in the format:
+        "Total denials: <count>, Processes: <process_name> (<actions>); ..."
+    Raises:
+    - process.CmdError: If `ausearch` encounters an error other than "<no matches>".
+    """
+
+    # Default denial types if none are provided
+    if denial_types is None:
+        denial_types = ["AVC", "USER_AVC", "SELINUX_ERR", "USER_SELINUX_ERR"]
+
+    # Construct the ausearch command with dynamic denial types
+    ausearch_cmd = f"ausearch --input-logs {' '.join(f'-m {t}' for t in denial_types)} --start {ausearch_start}"
+    avc_denied = process.run(ausearch_cmd, ignore_status=True, shell=True)
+
+    if avc_denied.exit_status != 0 and avc_denied.stderr_text.strip() != "<no matches>":
+        raise process.CmdError(ausearch_cmd, avc_denied.result)
+
+    avc_stdout = avc_denied.stdout_text.strip()
+    if not avc_stdout:
+        return ""
+
+    if log_ausearch_rows:
+        LOG.debug(f"ausearch denied rows after save and restore:\n--------------------------\n{avc_stdout}\n")
+
+    # Process returned stdout and generate summary
+    avc_pattern = re.compile(r'avc:\s+denied\s+\{\s*([^}]+)\s*\}\s+for\s+pid=\d+\s+comm="?([^"\s]+)"?', re.IGNORECASE)
+
+    # Dictionary to store process denial counts
+    denial_summary = defaultdict(lambda: defaultdict(int))
+    total_denials = 0
+
+    # Read and process the log file
+    for line in avc_stdout.splitlines():
+        match = avc_pattern.search(line)
+        if match:
+            total_denials += 1
+            action, avc_process = match.groups()
+            denial_summary[avc_process][action.strip()] += 1
+
+    summary = f"Total denials: {total_denials}, Processes: "
+
+    for avc_process, actions in denial_summary.items():
+        # potential output with denial counts:  summary += f" {avc_process}:" + ", ".join(f"{count} {action}" for action, count in denial_summary[avc_process].items())
+        summary += f"{avc_process} (" + ", ".join(actions.keys()) + '); '
+
+    return summary


### PR DESCRIPTION
Update avc denials returned by test so:
- only denials related to given test are counted (and not all from all tests)
- information about denials are summarized by process so the Error in jenkis is unified and same errors are marked as one not distinguished by pids, randomized file names etc.
- new provider, that is able to create such summary introduced, so it can be used also in other cases if necessary

Reason:
- actual test is reporting more than 70 denails even there are "only" 9 of them.
- Failures with same reason are reported in Jira as single tasks, and they can be logged under same.