### PR TITLE
migration: Update error message

### DIFF
--- a/libvirt/tests/cfg/migration_with_copy_storage/migrate_vm_disk_on_shared_storage.cfg
+++ b/libvirt/tests/cfg/migration_with_copy_storage/migrate_vm_disk_on_shared_storage.cfg
@@ -30,7 +30,7 @@
             virsh_migrate_options = "--live --verbose"
     variants:
         - shared_storage:
-            err_msg = "unable to execute QEMU command 'block-export-add': Block node is read-only"
+            err_msg = "unable to execute QEMU command 'block-export-add'"
     variants:
         - copy_storage_all:
             copy_storage_option = "--copy-storage-all"


### PR DESCRIPTION
Before:
Can not find the expected patterns 'unable to execute QEMU command 'block-export-add': Block node is read-only' in output 'error: internal error: unable to execute QEMU command 'block-export-add': Failed to get "write" lock'

After:
 (1/1) type_specific.io-github-autotest-libvirt.migration_with_copy_storage.migrate_vm_disk_on_shared_storage.copy_storage_all.shared_storage.p2p: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.migration_with_copy_storage.migrate_vm_disk_on_shared_storage.copy_storage_all.shared_storage.p2p: PASS (155.80 s)