### PR TITLE
Replace virsh.VirshPersistent to avoid timeout error

### DIFF
--- a/libvirt/tests/src/guest_agent/unix_source_path/agent_auto_generated_unix_source_path_session_mode.py
+++ b/libvirt/tests/src/guest_agent/unix_source_path/agent_auto_generated_unix_source_path_session_mode.py
@@ -60,7 +60,7 @@ def run(test, params, env):
     vm = libvirt_unprivileged.get_unprivileged_vm(vm_name, test_user,
                                                   test_passwd,
                                                   **unpr_vm_args)
-    virsh_ins = virsh.VirshPersistent(uri=vm.connect_uri)
+    virsh_ins = virsh.Virsh(uri=vm.connect_uri)
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(
         vm_name, virsh_instance=virsh_ins)
     backup_xml = vmxml.copy()
@@ -108,4 +108,3 @@ def run(test, params, env):
         vm_new.destroy()
         virsh_ins.domrename(vm_new.name, vm.name, debug=True)
         backup_xml.sync(virsh_instance=virsh_ins)
-        virsh_ins.close_session()

--- a/libvirt/tests/src/virtual_device/filesystem_device_unprivileged.py
+++ b/libvirt/tests/src/virtual_device/filesystem_device_unprivileged.py
@@ -83,7 +83,7 @@ def _initialize_unpr_virsh():
 
     global unpr_virsh
     unpr_uri = f"qemu+ssh://{test_user}@localhost/session"
-    unpr_virsh = virsh.VirshPersistent(uri=unpr_uri, safe=True)
+    unpr_virsh = virsh.Virsh(uri=unpr_uri, safe=True)
 
     host_session = ShellSession("su")
     remote.VMManager.set_ssh_auth(host_session, "localhost", test_user, test_passwd)
@@ -393,8 +393,6 @@ def run(test, params, env):
     finally:
         for xml in backupxmls:
             xml.sync(virsh_instance=unpr_virsh)
-        if unpr_virsh:
-            del unpr_virsh
         for fs_dict in fs_dicts:
             source_dir = fs_dict["source"]["dir"]
             if os.path.exists(source_dir):

--- a/libvirt/tests/src/virtual_network/link_state/link_state_model_type.py
+++ b/libvirt/tests/src/virtual_network/link_state/link_state_model_type.py
@@ -50,7 +50,7 @@ def run(test, params, env):
         vm_name = params.get("unpr_vm_name")
         vm = libvirt_unprivileged.get_unprivileged_vm(
             vm_name, test_user, test_passwd, **unpr_vm_args)
-        virsh_ins = virsh.VirshPersistent(uri=vm.connect_uri)
+        virsh_ins = virsh.Virsh(uri=vm.connect_uri)
 
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(
         vm_name, virsh_instance=virsh_ins)


### PR DESCRIPTION
Same as e65a0b9

Test result
```
 (1/3) type_specific.local.virtual_network.link_state.model.user.passt.unprivileged_user.virtio.initial_up: STARTED
 (1/3) type_specific.local.virtual_network.link_state.model.user.passt.unprivileged_user.virtio.initial_up: PASS (56.48 s)
 (2/3) type_specific.local.agent.auto_generated.unix_source_path.session_mode: STARTED
 (2/3) type_specific.local.agent.auto_generated.unix_source_path.session_mode: PASS (57.27 s)
 (3/3) type_specific.local.virtual_devices.filesystem_device_unprivileged.one_fs.with_hugepages.one_guest.hotplug: STARTED
 (3/3) type_specific.local.virtual_devices.filesystem_device_unprivileged.one_fs.with_hugepages.one_guest.hotplug: PASS (64.84 s)
```