### PR TITLE
v2v: fix failed case for vmx+ssh connection of esx7.0

### DIFF
--- a/v2v/tests/cfg/v2v_options.cfg
+++ b/v2v/tests/cfg/v2v_options.cfg
@@ -239,13 +239,13 @@
                 - vmx_ssh:
                     only input_mode.none
                     only output_mode.libvirt
-                    esx_ip = ESX_70_HOSTNAME_V2V_EXAMPLE
+                    esx_ip = ESX_80_HOSTNAME_V2V_EXAMPLE
                     esx_host_user = "root"
                     esx_host_passwd = RHV_NODE_PASSWORD
                     checkpoint = vmx_ssh
                     main_vm = VM_NAME_VMX_SSH_V2V_EXAMPLE
                     output_format = qcow2
-                    vmx = ssh://root@${esx_ip}/vmfs/volumes/esx6.5-function/${main_vm}/${main_vm}.vmx
+                    vmx = ssh://root@${esx_ip}/vmfs/volumes/esx8.0-matrix/${main_vm}/${main_vm}.vmx
                 - qemu_session:
                     only input_mode.libvirt.kvm.default
                     only output_mode.libvirt


### PR DESCRIPTION
For esx7.0 issue on vmx+ssh, change the value of parameters to esx8.0.