### PR TITLE
migration: Add case about vtpm state on block device

### DIFF
--- a/libvirt/tests/cfg/migration/migration_with_vtpm/migration_with_vtpm_state_on_block_dev.cfg
+++ b/libvirt/tests/cfg/migration/migration_with_vtpm/migration_with_vtpm_state_on_block_dev.cfg
@@ -1,0 +1,69 @@
+- migration_with_vtpm.migration_with_vtpm_state_on_block_dev:
+    type = migration_with_vtpm_state_on_block_dev
+    migration_setup = 'yes'
+    storage_type = 'nfs'
+    setup_local_nfs = 'yes'
+    disk_type = "file"
+    disk_source_protocol = "netfs"
+    mnt_path_name = ${nfs_mount_dir}
+    # Console output can only be monitored via virsh console output
+    only_pty = True
+    take_regular_screendumps = no
+    # Extra options to pass after <domain> <desturi>
+    virsh_migrate_extra = ""
+    # SSH connection time out
+    ssh_timeout = 60
+    start_vm = "no"
+    # Local URI
+    virsh_migrate_connect_uri = "qemu:///system"
+    server_ip = "${migrate_dest_host}"
+    server_user = "root"
+    server_pwd = "${migrate_dest_pwd}"
+    client_ip = "${migrate_source_host}"
+    client_user = "root"
+    client_pwd = "${migrate_source_pwd}"
+    transport_type = "ssh"
+    migrate_desturi_type = "ssh"
+    virsh_migrate_desturi = "qemu+ssh://${migrate_dest_host}/system"
+    tpm_cmd = "tpm2_getrandom --hex 16"
+    auth_sec_dict = {"sec_ephemeral": "no", "sec_private": "yes", "sec_desc": "sample vTPM secret", "sec_usage": "vtpm", "sec_name": "VTPM_example"}
+    src_secret_value = "sec value test"
+    src_secret_value_path = "/var/tmp/src_secretinfile"
+    dst_secret_value = ${src_secret_value}
+    dst_secret_value_path = "/var/tmp/dst_secretinfile"
+    status_error = "no"
+    func_supported_since_libvirt_ver = (10, 10, 0)
+    block_path = "/iscsiswtpm"
+    libvirtd_debug_file = '/var/log/libvirt/virtqemud.log'
+    libvirtd_debug_filters = "1:*"
+    libvirtd_debug_level = "1"
+    libvirtd_file_type = "virtqemud"
+    unexpected_in_list_1 = "['support explicit locking']"
+    expected_in_list_1 = "['swtpm socket.*--tpmstate.*,lock']"
+    expected_in_list_2 = "['qemuTPMVirCommandSwtpmAddTPMState.*This swtpm version doesn\'t support explicit locking', '--tpmstate dir=/test/myDir,mode=0600']"
+    unexpected_in_list_3 = "['swtpm socket.*--tpmstate.*,lock']"
+    expected_in_list_3 = "['qemuTPMGetSwtpmSetupStateArg.*This swtpm version doesn\'t support explicit locking', '--tpmstate dir=/test/myDir,mode=0600']"
+    tpm_model = "tpm-crb"
+    aarch64:
+        tpm_model = "tpm-tis"
+    variants test_case:
+        - auto_create_dir:
+            block_dir = "${block_path}/mig_vtpm_auto_dir_test"
+            tpm_dict = {'tpm_model': '${tpm_model}', 'backend': {'backend_type': 'emulator', 'backend_version': '2.0', 'encryption_secret': '0051c505-1ad0-4d77-9b3e-360c8f5e3b86', 'source': {'type': 'dir', 'path': '${block_dir}'}}}
+            check_lables_1 = '[r"tss  tss  system_u:object_r:virt_var_lib_t:s0.*.lock", r"tss  tss  system_u:object_r:virt_var_lib_t:s0.*tpm2-00.permall"]'
+            check_lables_2 = '[r"tss  tss  system_u:object_r:svirt_image_t:s0:c.*.lock", r"tss  tss  system_u:object_r:svirt_image_t:s0:c.*tpm2-00.permall"]'
+            check_lables_3 = '[r"tss  tss  system_u:object_r:virt_var_lib_t:s0.*.lock", r"tss  tss  system_u:object_r:virt_var_lib_t:s0.*tpm2-00.permall"]'
+        - manual_create_dir:
+            block_dir = "${block_path}/mig_vtpm_manual_dir_test"
+            tpm_dict = {'tpm_model': '${tpm_model}', 'backend': {'backend_type': 'emulator', 'backend_version': '2.0', 'encryption_secret': '0051c505-1ad0-4d77-9b3e-360c8f5e3b86', 'source': {'type': 'dir', 'path': '${block_dir}'}}}
+            check_lables_1 = '[r"root root system_u:object_r:virt_var_lib_t:s0.*.", r"root root unconfined_u:object_r:virt_var_lib_t:s0.*.."]'
+            check_lables_2 = '[r"tss  tss  system_u:object_r:svirt_image_t:s0:c.*.lock", r"tss  tss  system_u:object_r:svirt_image_t:s0:c.*tpm2-00.permall"]'
+            check_lables_3 = '[r"tss  tss  system_u:object_r:virt_var_lib_t:s0.*.lock", r"tss  tss  system_u:object_r:virt_var_lib_t:s0.*tpm2-00.permall"]'
+        - auto_create_file:
+            dir_name = "mig_vtpm_auto_file_test"
+            file_name = "${dir_name}2-00.permall"
+            block_dir = "${block_path}/{dir_name}"
+            tpm_dict = {'tpm_model': '${tpm_model}', 'backend': {'backend_type': 'emulator', 'backend_version': '2.0', 'encryption_secret': '0051c505-1ad0-4d77-9b3e-360c8f5e3b86', 'source': {'type': 'file', 'path': '${block_dir}/${file_name}'}}}
+            check_lables_1 = '[r"tss  tss  system_u:object_r:virt_var_lib_t:s0.*.", r"root root unconfined_u:object_r:default_t:s0.*.."]'
+            check_lables_2 = '[r"tss  tss  system_u:object_r:svirt_image_t:s0:c.*${file_name}"]'
+            check_lables_3 = '[r"tss  tss  system_u:object_r:virt_var_lib_t:s0.*${file_name}"]'

--- a/libvirt/tests/src/migration/migration_with_vtpm/migration_with_vtpm_state_on_block_dev.py
+++ b/libvirt/tests/src/migration/migration_with_vtpm/migration_with_vtpm_state_on_block_dev.py
@@ -1,0 +1,345 @@
+import os
+import re
+
+from avocado.utils import process
+
+from virttest import libvirt_version
+from virttest import remote
+from virttest import utils_disk
+from virttest import utils_test
+from virttest import virsh
+
+from virttest.utils_test import libvirt
+
+from provider.migration import base_steps
+from provider.migration import migration_vtpm
+
+
+def check_labels(params, dir_name, expected_labels, test, remote_host=False):
+    """
+    Check tpm state files' labels
+
+    :param params: Dictionary with the test parameters
+    :param dir_name: dir name
+    :param expected_labels: Expected labels
+    :param test: test object
+    :param remote_host: if True, will check dir on target host
+    """
+    test.log.debug(f"expected labels: {expected_labels}")
+    cmd = "ls -alZ %s" % dir_name
+    if remote_host:
+        ret = remote.run_remote_cmd(cmd, params, ignore_status=False).stdout_text.strip()
+    else:
+        ret = process.run(cmd, shell=True, verbose=True).stdout_text.strip()
+    for item in expected_labels:
+        if not re.findall(item, ret):
+            test.fail(f"Unable to find {item} in {ret}")
+
+
+def check_dir(params, dir_name, test, remote_host=False):
+    """
+    Check dir
+
+    :param params: Dictionary with the test parameters
+    :param dir_name: dir name
+    :param test: test object
+    :param remote_host: if True, will check dir on target host
+    """
+    if remote_host:
+        cmd = f"ls -A {dir_name}"
+        ret = remote.run_remote_cmd(cmd, params, ignore_status=True).stdout_text.strip()
+    else:
+        ret = os.listdir(dir_name)
+    if len(ret) != 0:
+        test.fail(f"{dir_name} is not empty: {ret}")
+
+
+def check_items(expected_list, log_file, test, str_in_log=True):
+    """
+    Check log in file
+
+    :param expected_list: Expected list
+    :param log_file: log file name
+    :param test: test object
+    :param str_in_log: if true, check string in log
+    """
+    if str_in_log:
+        for item in expected_list:
+            if not re.findall(item, log_file):
+                test.fail(f"Not found '{item}' in log.")
+    else:
+        for item in expected_list:
+            if re.findall(item, log_file):
+                test.fail(f"Found '{item}' in log.")
+
+
+def check_capability(params, test):
+    """
+    Check capability
+
+    :param params: Dictionary with the test parameters
+    :param test: test object
+    """
+    with open(params.get("libvirtd_debug_file"), 'r') as f:
+        log_file = f.read()
+        if migration_vtpm.compare_swtpm_version(0, 10):
+            cmd = "swtpm socket --print-capabilities"
+            ret = process.run(cmd, shell=True, verbose=True).stdout_text.strip()
+            if "tpmstate-opt-lock" not in ret:
+                test.fail(f"Not found 'tpmstate-opt-lock' in {ret}")
+
+            check_items(eval(params.get("unexpected_list_1", "[]")), log_file, test, str_in_log=False)
+            check_items(eval(params.get("expected_list_1"), "[]"), log_file, test)
+        else:
+            if libvirt_version.version_compare(11, 0, 0):
+                check_items(eval(params.get("expected_list_2"), "[]"), log_file, test)
+            else:
+                check_items(eval(params.get("unexpected_list_3", "[]")), log_file, test, str_in_log=False)
+                check_items(eval(params.get("expected_list_3", "[]")), log_file, test)
+
+
+def prepare_iscsi_disk(params, test, block_dev):
+    """
+    Prepare iscsi disk for test
+
+    :param params: Dictionary with the test parameters
+    :param test: test object
+    :param block_dev: block device
+    """
+    client_ip = params.get("client_ip")
+    block_path = params.get("block_path")
+    dev_src = None
+    dev_target = None
+    target_luns = None
+
+    test.log.info("prepare iscsi disk")
+    dev_src = libvirt.setup_or_cleanup_iscsi(is_setup=True,
+                                             is_login=True,
+                                             image_size="1G",
+                                             emulated_image="emulated-iscsi-1",
+                                             portal_ip=client_ip)
+
+    target_luns, _ = libvirt.setup_or_cleanup_iscsi(is_setup=True,
+                                                    is_login=False,
+                                                    image_size="1G",
+                                                    emulated_image="emulated-iscsi-2",
+                                                    portal_ip=client_ip)
+    test.log.debug(f"target_luns: {target_luns}")
+    dev_target = block_dev.iscsi_login_setup(client_ip, target_luns)
+    test.log.debug(f"dev_src: {dev_src}")
+    test.log.debug(f"dev_target: {dev_target}")
+
+    cmd = f"mkfs.xfs -f {dev_src}"
+    process.run(cmd, shell=True, verbose=True)
+
+    cmd = f"mkdir -p {block_path}"
+    process.run(cmd, shell=True, verbose=True)
+
+    cmd = f'semanage fcontext -a -t virt_var_lib_t "{block_path}(/.*)?"'
+    process.run(cmd, shell=True, verbose=True)
+    remote.run_remote_cmd(cmd, params, ignore_status=False)
+
+    cmd = f"mkfs.xfs -f {dev_target}"
+    remote.run_remote_cmd(cmd, params, ignore_status=False)
+
+    cmd = f"mkdir -p {block_path}"
+    remote.run_remote_cmd(cmd, params, ignore_status=False)
+    return (dev_src, dev_target, target_luns)
+
+
+def run(test, params, env):
+    """
+    Test migration for vm with vtpm state on block dev.
+
+    :param test: test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    def setup_auto_create_dir():
+        """
+        Setup steps for auto_create_dir case
+
+        """
+        server_ip = params.get("server_ip")
+        server_user = params.get("server_user", "root")
+        server_pwd = params.get("server_pwd")
+
+        test.log.info("Setup steps for auto_create_dir.")
+        utils_disk.mount(dev_src, block_path)
+        process.run(f"restorecon -Rv {block_path}", shell=True, verbose=True)
+
+        server_session = remote.wait_for_login("ssh", server_ip, "22", server_user, server_pwd, r"[\#\$]\s*$")
+        utils_disk.mount(dev_target, block_path, session=server_session)
+        remote.run_remote_cmd(f"restorecon -Rv {block_path}", params, ignore_status=False)
+        server_session.close()
+
+    def setup_manual_create_dir():
+        """
+        Setup steps for manual_create_dir case
+
+        """
+        server_ip = params.get("server_ip")
+        server_user = params.get("server_user", "root")
+        server_pwd = params.get("server_pwd")
+
+        test.log.info("Setup steps for manual_create_dir.")
+        process.run(f"mkdir {block_dir}", shell=True, verbose=True)
+        utils_disk.mount(dev_src, block_dir)
+        process.run(f"restorecon -Rv {block_path}", shell=True, verbose=True)
+
+        server_session = remote.wait_for_login("ssh", server_ip, "22", server_user, server_pwd, r"[\#\$]\s*$")
+        remote.run_remote_cmd(f"mkdir {block_dir}", params, ignore_status=False)
+        utils_disk.mount(dev_target, block_dir, session=server_session)
+        remote.run_remote_cmd(f"restorecon -Rv {block_path}", params, ignore_status=False)
+        server_session.close()
+
+        check_labels(params, block_dir, eval(params.get("check_lables_1")), test)
+
+    def setup_auto_create_file():
+        """
+        Setup steps for auto_create_file
+
+        """
+        server_ip = params.get("server_ip")
+        server_user = params.get("server_user", "root")
+        server_pwd = params.get("server_pwd")
+
+        test.log.info("Setup steps for auto_create_file.")
+        process.run(f"mkdir {block_dir}", shell=True, verbose=True)
+        utils_disk.mount(dev_src, block_dir)
+        process.run(f"restorecon -Rv {block_dir}", shell=True, verbose=True)
+        process.run(f"chown tss:tss {block_dir}", shell=True, verbose=True)
+
+        server_session = remote.wait_for_login("ssh", server_ip, "22", server_user, server_pwd, r"[\#\$]\s*$")
+        remote.run_remote_cmd(f"mkdir {block_dir}", params, ignore_status=False)
+        utils_disk.mount(dev_target, block_dir, session=server_session)
+        remote.run_remote_cmd(f"restorecon -Rv {block_dir}", params, ignore_status=False)
+        remote.run_remote_cmd(f"chown tss:tss {block_dir}", params, ignore_status=False)
+        server_session.close()
+
+        check_labels(params, block_dir, eval(params.get("check_lables_1")), test)
+
+    def setup_test():
+        """
+        Setup steps
+
+        """
+        test.log.info("Setup steps.")
+        nonlocal dev_src, dev_target, target_luns
+        dev_src, dev_target, target_luns = prepare_iscsi_disk(params, test, block_dev)
+        migration_obj.setup_connection()
+
+        if test_case == "auto_create_dir":
+            setup_auto_create_dir()
+        elif test_case == "manual_create_dir":
+            setup_manual_create_dir()
+        elif test_case == "auto_create_file":
+            setup_auto_create_file()
+
+        migration_vtpm.setup_vtpm(params, test, vm)
+        check_labels(params, block_dir, eval(params.get("check_lables_2")), test)
+        migration_vtpm.check_vtpm_func(params, vm, test)
+        check_capability(params, test)
+
+    def verify_test():
+        """
+        Verify steps
+
+        """
+        test.log.info("Verify steps.")
+        check_labels(params, block_dir, eval(params.get("check_lables_2")), test, remote_host=True)
+        migration_vtpm.check_vtpm_func(params, vm, test, remote_host=True)
+
+    def verify_test_again():
+        """
+        Verify again
+
+        """
+        test.log.info("Verify again.")
+        if test_case == "auto_create_dir":
+            check_dir(params, block_path, test, remote_host=True)
+
+        migration_vtpm.check_vtpm_func(params, vm, test)
+        check_labels(params, block_dir, eval(params.get("check_lables_2")), test)
+
+        virsh.destroy(vm_name, debug=True)
+        if not vm.wait_for_shutdown():
+            test.error('VM failed to shutdown in 60s')
+        check_labels(params, block_dir, eval(params.get("check_lables_3")), test)
+        virsh.undefine(vm_name, options='--nvram', debug=True)
+        if test_case == "auto_create_dir":
+            check_dir(params, block_path, test)
+
+    def cleanup_test():
+        """
+        Cleanup steps
+
+        """
+        desturi = params.get("virsh_migrate_desturi")
+        dst_secret_value_path = params.get("dst_secret_value_path")
+        src_secret_value_path = params.get("src_secret_value_path")
+        server_ip = params.get("server_ip")
+        server_user = params.get("server_user", "root")
+        server_pwd = params.get("server_pwd")
+        client_ip = params.get("client_ip")
+
+        test.log.info("Cleanup steps.")
+
+        def _umount_dir(dir_path):
+            utils_disk.umount(dev_src, dir_path)
+            server_session = remote.wait_for_login("ssh", server_ip, "22", server_user, server_pwd, r"[\#\$]\s*$")
+            utils_disk.umount(dev_target, dir_path, session=server_session)
+            server_session.close()
+
+        if test_case == "auto_create_dir":
+            _umount_dir(block_path)
+        else:
+            _umount_dir(block_dir)
+
+        block_dev.iscsi_login_setup(client_ip, target_luns, is_login=False)
+        libvirt.setup_or_cleanup_iscsi(is_setup=False, emulated_image="emulated-iscsi-2", portal_ip=client_ip)
+        libvirt.setup_or_cleanup_iscsi(is_setup=False, emulated_image="emulated-iscsi-1", portal_ip=client_ip)
+
+        if src_sec_uuid:
+            virsh.secret_undefine(src_sec_uuid, debug=True, ignore_status=True)
+        if dst_sec_uuid:
+            virsh.secret_undefine(dst_sec_uuid, debug=True, ignore_status=True, uri=desturi)
+
+        migration_obj.cleanup_connection()
+        cmd = f"rm -rf {dst_secret_value_path}"
+        remote.run_remote_cmd(cmd, params)
+        process.run(cmd, shell=True, ignore_status=True)
+        cmd = f"rm -rf {src_secret_value_path}"
+        process.run(cmd, shell=True, ignore_status=True)
+        cmd = f"rm -rf {block_path}"
+        remote.run_remote_cmd(cmd, params)
+        process.run(cmd, shell=True, ignore_status=True)
+
+    vm_name = params.get("migrate_main_vm")
+    test_case = params.get("test_case")
+    block_dir = params.get("block_dir")
+    block_path = params.get("block_path")
+    new_ownership = params.get("new_ownership")
+    src_sec_uuid = None
+    dst_sec_uuid = None
+    dev_src = None
+    dev_target = None
+    target_luns = None
+
+    libvirt_version.is_libvirt_feature_supported(params)
+
+    vm = env.get_vm(vm_name)
+    migration_obj = base_steps.MigrationBase(test, vm, params)
+    block_dev = utils_test.RemoteDiskManager(params)
+
+    try:
+        src_sec_uuid, dst_sec_uuid = migration_vtpm.set_secret(params)
+        if not base_steps.check_cpu_for_mig(params):
+            base_steps.sync_cpu_for_mig(params)
+        setup_test()
+        migration_obj.run_migration()
+        verify_test()
+        migration_obj.run_migration_back()
+        verify_test_again()
+    finally:
+        cleanup_test()

--- a/provider/migration/migration_vtpm.py
+++ b/provider/migration/migration_vtpm.py
@@ -1,0 +1,153 @@
+import logging as log
+import os
+
+from avocado.utils import process
+
+from virttest import remote
+from virttest import utils_package
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_secret
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+from provider.migration import base_steps            # pylint: disable=W0611
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
+
+
+def check_vtpm_func(params, vm, test, remote_host=False):
+    """
+    Check vtpm function
+
+    :param params: dict, test parameters
+    :param vm: VM object
+    :param test: test object
+    :param remote_host: True to check context on remote
+    """
+    tpm_cmd = params.get("tpm_cmd")
+    dest_uri = params.get("virsh_migrate_desturi")
+    src_uri = params.get("virsh_migrate_connect_uri")
+    test.log.debug("Check vtpm func: %s (remote).", remote)
+    if remote_host:
+        if vm.serial_console is not None:
+            vm.cleanup_serial_console()
+        vm.connect_uri = dest_uri
+    if vm.serial_console is None:
+        vm.create_serial_console()
+    vm_session = vm.wait_for_serial_login(timeout=240)
+    if not utils_package.package_install("tpm2-tools", vm_session):
+        test.error("Failed to install tpm2-tools in vm")
+    cmd_result = vm_session.cmd_status(tpm_cmd)
+    vm_session.close()
+    if remote_host:
+        if vm.serial_console is not None:
+            vm.cleanup_serial_console()
+        vm.connect_uri = src_uri
+    if cmd_result:
+        test.fail("Fail to run '%s': %s." % (tpm_cmd, cmd_result))
+
+
+def setup_vtpm(params, test, vm):
+    """
+    Setup vTPM device in guest xml
+
+    :param params: dict, test parameters
+    :param vm: VM object
+    :param test: test object
+    """
+    vm_name = params.get("migrate_main_vm")
+    tpm_dict = eval(params.get('tpm_dict', '{}'))
+    auth_sec_dict = params.get("auth_sec_dict")
+
+    test.log.info("Setup vTPM device in guest xml.")
+    if vm.is_alive():
+        vm.destroy(gracefully=False)
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    # Remove all existing tpm devices
+    vmxml.remove_all_device_by_type('tpm')
+
+    tpm_dict['backend']['encryption_secret'] = auth_sec_dict['sec_uuid']
+    libvirt_vmxml.modify_vm_device(vmxml, 'tpm', tpm_dict)
+
+    vm.start()
+    vm.wait_for_login().close()
+
+
+def set_secret(params):
+    """
+    Set secret
+
+    :param params: dict, test parameters
+    """
+    auth_sec_dict = eval(params.get("auth_sec_dict"))
+    src_secret_value = params.get("src_secret_value")
+    src_secret_value_path = params.get("src_secret_value_path")
+    dst_secret_value = params.get("dst_secret_value")
+    dst_secret_value_path = params.get("dst_secret_value_path")
+    remote_pwd = params.get("migrate_dest_pwd")
+    remote_ip = params.get("migrate_dest_host")
+    remote_user = params.get("remote_user", "root")
+
+    def _create_secret(session=None, remote_args=None, secret_value_path=None):
+        """
+        create secret
+
+        :param session: a session object of remote host
+        :param remote_args: remote host parameters
+        :param secret_value_path: the path of secret value
+        """
+        src_sec_uuid = None
+        dst_sec_uuid = None
+        libvirt_secret.clean_up_secrets(session)
+        if remote_args:
+            dst_sec_uuid = libvirt.create_secret(auth_sec_dict, remote_args=remote_args)
+        else:
+            src_sec_uuid = libvirt.create_secret(auth_sec_dict)
+            auth_sec_dict.update({"sec_uuid": src_sec_uuid})
+        if os.path.exists(secret_value_path):
+            os.remove(secret_value_path)
+        if session:
+            cmd = "echo '%s' > %s" % (dst_secret_value, secret_value_path)
+            process.run(cmd, shell=True)
+            remote.scp_to_remote(remote_ip, '22', remote_user, remote_pwd,
+                                 secret_value_path, secret_value_path,
+                                 limit="", log_filename=None, timeout=60,
+                                 interface=None)
+            cmd = f"virsh secret-set-value {dst_sec_uuid} --file {secret_value_path} --plain"
+            remote.run_remote_cmd(cmd, params)
+        else:
+            cmd = "echo '%s' > %s" % (src_secret_value, secret_value_path)
+            process.run(cmd, shell=True)
+            cmd = f"virsh secret-set-value {src_sec_uuid} --file {secret_value_path} --plain"
+            process.run(cmd, shell=True)
+        return src_sec_uuid, dst_sec_uuid
+
+    src_sec_uuid, _ = _create_secret(secret_value_path=src_secret_value_path)
+    params.update({"auth_sec_dict": auth_sec_dict})
+    virsh_dargs = {'remote_ip': remote_ip, 'remote_user': remote_user,
+                   'remote_pwd': remote_pwd, 'unprivileged_user': None,
+                   'ssh_remote_auth': True}
+    remote_virsh_session = None
+    remote_virsh_session = virsh.VirshPersistent(**virsh_dargs)
+    _, dst_sec_uuid = _create_secret(session=remote_virsh_session, remote_args=virsh_dargs,
+                                     secret_value_path=dst_secret_value_path)
+    return src_sec_uuid, dst_sec_uuid
+
+
+def compare_swtpm_version(major, minor):
+    """
+    Get swtpm pkg version and check whether > major.minor
+
+    :param major: swtpm major version number
+    :param minor: swtpm minor version number
+    :return: boolean value compared to major.minor
+    """
+    cmd = 'rpm -q swtpm'
+    v_swtpm = process.run(cmd).stdout_text.strip().split('-')
+    v_major = int(v_swtpm[1].split('.')[0])
+    v_minor = int(v_swtpm[1].split('.')[1])
+    return False if (v_major == major and v_minor < minor) else True


### PR DESCRIPTION
XXX-303897 - Migrate vm with vtpm state on block device

Test result:
 (1/1) type_specific.io-github-autotest-libvirt.migration_with_vtpm.migration_with_vtpm_state_on_block_dev.auto_create_dir: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.migration_with_vtpm.migration_with_vtpm_state_on_block_dev.auto_create_dir: PASS (292.90 s)

 (1/1) type_specific.io-github-autotest-libvirt.migration_with_vtpm.migration_with_vtpm_state_on_block_dev.manual_create_dir: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.migration_with_vtpm.migration_with_vtpm_state_on_block_dev.manual_create_dir: PASS (286.99 s)

 (1/1) type_specific.io-github-autotest-libvirt.migration_with_vtpm.migration_with_vtpm_state_on_block_dev.auto_create_file: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.migration_with_vtpm.migration_with_vtpm_state_on_block_dev.auto_create_file: PASS (283.31 s)