### PR TITLE
vIOMMU: Fix up login timeout issue

### DIFF
--- a/libvirt/tests/cfg/sriov/vIOMMU/intel_iommu_virtio_device_with_ats.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/intel_iommu_virtio_device_with_ats.cfg
@@ -28,5 +28,5 @@
         - pcie_root_port_from_expander_bus:
             test_devices = ["Eth", "block"]
             root_port = {'type': 'pci', 'model': 'pcie-root-port', 'pre_controller': 'pcie-expander-bus'}
-            controller_dicts = [{'type': 'pci', 'model': 'pcie-expander-bus', 'pre_controller': 'pcie-root'}, ${root_port}, ${root_port}]
+            controller_dicts = [{'type': 'pci', 'model': 'pcie-expander-bus', 'target': {'busNr': '252'}, 'pre_controller': 'pcie-root'}, ${root_port}, ${root_port}]
             disk_dict = {'target': {'dev': 'vda', 'bus': 'virtio'}, 'device': 'disk', 'driver': ${disk_driver}}


### PR DESCRIPTION
To avoid vm login timeout issue, the busNr of the pcie-expander-bus controller should be set to less than 254.

**Test results:**
` (1/1) type_specific.io-github-autotest-libvirt.vIOMMU.intel_iommu.virtio_device_with_ats.pcie_root_port_from_expander_bus: PASS (206.10 s)`
