### PR TITLE
virsh_shutdown: Extend timeout of vm shutdown

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_shutdown.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_shutdown.py
@@ -111,7 +111,7 @@ def run(test, params, env):
                 session.cmd_output('LANG=C')
                 command = ("virsh -c %s shutdown %s %s"
                            % (remote_uri, vm_name, mode))
-                status = session.cmd_status(command, internal_timeout=5)
+                status = session.cmd_status(command, internal_timeout=10)
                 session.close()
             except process.CmdError:
                 status = 1


### PR DESCRIPTION
Update timeout to make the case stable.

Before:
 (1/1) type_specific.io-github-autotest-libvirt.virsh.shutdown.normal_test.remote_option.agent_mode.agent_test: FAIL: Run failed with right command (49.11 s)

After:
 (1/1) type_specific.io-github-autotest-libvirt.virsh.shutdown.normal_test.remote_option.agent_mode.agent_test: PASS (48.37 s)