### PR TITLE
migration: Update error message

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_vm.cfg
+++ b/libvirt/tests/cfg/migration/migrate_vm.cfg
@@ -716,7 +716,7 @@
                             config_libvirtd = "yes"
                             variants:
                                 - no_migrate_disks:
-                                    err_msg = "error: internal error: unable to execute QEMU command '(nbd-server-add|block-export-add)': Block node is read-only"
+                                    err_msg = "error: internal error: unable to execute QEMU command '(nbd-server-add|block-export-add)'"
                                     virsh_options = "--live --verbose --copy-storage-all"
                         - create_neither_target_pool_nor_image:
                             create_target_image = "no"


### PR DESCRIPTION
Before:
The expected error 'error: internal error: unable to execute QEMU command '(nbd-server-add|block-export-add)': Block node is read-only' was not found in output 'error: internal error: unable to execute QEMU command 'block-export-add': Failed to get "write" lock

After:
 (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_vm.negative_testing.live_storage_migration.with_migrate_disks.no_migrate_disks.without_postcopy: PASS (136.87 s)