### PR TITLE
tests failing due missing default value 

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_restore.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_restore.py
@@ -65,7 +65,7 @@ def run(test, params, env):
     check_log = params.get("check_log")
     check_str_not_in_log = params.get("check_str_not_in_log")
     qemu_conf_dict = eval(params.get("qemu_conf_dict", "{}"))
-    os_update_dict = eval(params.get("os_update_dict"))
+    os_update_dict = eval(params.get("os_update_dict", "{}"))
 
     vm_ref_uid = None
     vm_ref_gid = None


### PR DESCRIPTION
Due latest changes in case configuration, there are now some variants, that doesn't have proper value set. 
and the test is failing. 

I cannot say if the solution is perfect .. but at least it is not failing. 
I'm running all variants on ARM now. (I will not run it on x86_64 or s390)