### PR TITLE
Change audit log search cmd

### DIFF
--- a/libvirt/tests/cfg/memory/memory_devices/dimm_memory_hot_unplug.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/dimm_memory_hot_unplug.cfg
@@ -14,7 +14,7 @@
     max_mem = 4194304
     max_mem_slots = 16
     slot = '0'
-    audit_cmd = "ausearch -m VIRT_RESOURCE | grep 'mem' | tail -n 30"
+    audit_cmd = "grep VIRT_RESOURCE /var/log/audit/audit.log | grep 'mem' | tail -n 20"
     ausearch_check = 'old-mem=%d new-mem=%d'
     expected_log = "ACPI_DEVICE_OST|device_del"
     kernel_hp_file = '/sys/devices/system/node/node0/hugepages/hugepages-%skB/nr_hugepages'

--- a/libvirt/tests/cfg/memory/memory_devices/dimm_memory_hotplug.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/dimm_memory_hotplug.cfg
@@ -17,7 +17,7 @@
     max_mem = 4194304
     max_mem_slots = 16
     plug_event = "device-added"
-    audit_cmd = "ausearch --start today -m VIRT_RESOURCE | grep 'mem'"
+    audit_cmd = "grep VIRT_RESOURCE /var/log/audit/audit.log | grep 'mem' | tail -n 20"
     ausearch_check = 'old-mem=%d new-mem=%d'
     expected_log = "ACPI_DEVICE_OST|device_add"
     kernel_hp_file = '/sys/devices/system/node/node0/hugepages/hugepages-%skB/nr_hugepages'

--- a/libvirt/tests/cfg/memory/memory_devices/virtio_mem_hot_unplug.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/virtio_mem_hot_unplug.cfg
@@ -27,7 +27,7 @@
     addr_dict = "'address':{'attrs': {'base': '${base}'}}"
     kernel_extra_params_add = "memhp_default_state=online_movable"
     unplug_event = "device-removed"
-    audit_cmd = "ausearch --start today -m VIRT_RESOURCE | grep 'mem'"
+    audit_cmd = "grep VIRT_RESOURCE /var/log/audit/audit.log | grep 'mem' | tail -n 20"
     ausearch_check = 'old-mem=%d new-mem=%d'
     expected_log = "device_del"
     kernel_hp_file = '/sys/devices/system/node/node0/hugepages/hugepages-%skB/nr_hugepages'

--- a/libvirt/tests/cfg/memory/memory_devices/virtio_mem_hotplug.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/virtio_mem_hotplug.cfg
@@ -23,7 +23,7 @@
     max_mem = 4194304
     max_mem_slots = 16
     plug_event = "device-added"
-    audit_cmd = "ausearch --start today -m VIRT_RESOURCE | grep 'mem'"
+    audit_cmd = "grep VIRT_RESOURCE /var/log/audit/audit.log | grep 'mem' | tail -n 20"
     ausearch_check = 'old-mem=%d new-mem=%d'
     expected_log = "device_add"
     kernel_hp_file = '/sys/devices/system/node/node0/hugepages/hugepages-%skB/nr_hugepages'

--- a/libvirt/tests/cfg/memory/memory_misc.cfg
+++ b/libvirt/tests/cfg/memory/memory_misc.cfg
@@ -203,7 +203,7 @@
                         cpu_attrs = {'mode': 'host-passthrough', 'numa_cell': [{'id': '0', 'cpus': '0,2', 'memory': '${numa_node_size}', 'unit': 'KiB'}, {'id': '1', 'cpus': '1,3', 'memory': '${numa_node_size}', 'unit': 'KiB'}]}
                     dimm_device_1_attrs = {'mem_model': 'dimm', 'target': {'size': ${at_size}, 'size_unit': 'KiB', 'node': 1}}
                     dimm_device_0_attrs = {'mem_model': 'dimm', 'target': {'size': 0, 'size_unit': 'KiB', 'node': 0}}
-                    audit_cmd = ausearch -ts recent -m VIRT_RESOURCE| grep 'mem'
+                    audit_cmd = grep VIRT_RESOURCE /var/log/audit/audit.log | grep 'mem' | tail -n 20
                     error_msg = "unable to execute QEMU command 'object-add':.*memory-backend-ram.* doesn't take value '0'"
                     dominfo_check_0 = 'Max memory:\s+%d KiB\nUsed memory:\s+%d KiB'
                     dominfo_check_1 = 'Max memory:\s+%d KiB\nUsed memory:\s+%d KiB'


### PR DESCRIPTION
ausearch cmd may not get result during automation, so change cmd to search audit log directly.

Test result:
 (1/5) type_specific.io-github-autotest-libvirt.memory.devices.dimm.hotplug.target_and_address: STARTED
 (1/5) type_specific.io-github-autotest-libvirt.memory.devices.dimm.hotplug.target_and_address: PASS (36.31 s)
 (2/5) type_specific.io-github-autotest-libvirt.memory.devices.dimm.hot_unplug.online_movable_mem.source_and_mib: STARTED
 (2/5) type_specific.io-github-autotest-libvirt.memory.devices.dimm.hot_unplug.online_movable_mem.source_and_mib: PASS (160.80 s)
 (3/5) type_specific.io-github-autotest-libvirt.memory_misc.audit_size.at_dt_mem: STARTED
 (3/5) type_specific.io-github-autotest-libvirt.memory_misc.audit_size.at_dt_mem: PASS (30.78 s)
 (4/5) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.hot_unplug.detach_alias.source_mib_and_hugepages: STARTED
 (4/5) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.hot_unplug.detach_alias.source_mib_and_hugepages: PASS (181.88 s)
 (5/5) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.hotplug.source_mib_and_hugepages: STARTED
 (5/5) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.hotplug.source_mib_and_hugepages: PASS (57.53 s)