### PR TITLE
vIOMMU: Add a ping check before and after migration

### DIFF
--- a/libvirt/tests/cfg/sriov/vIOMMU/migration_iommu_device.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/migration_iommu_device.cfg
@@ -24,6 +24,7 @@
     virsh_migrate_desturi = "qemu+ssh://${migrate_dest_host}/system"
     virsh_migrate_connect_uri = "qemu:///system"
     check_network_accessibility_after_mig = "yes"
+    check_cont_ping = "yes"
     disk_driver = {'name': 'qemu', 'type': 'qcow2', 'iommu': 'on'}
     variants:
         - virtio:

--- a/libvirt/tests/src/sriov/vIOMMU/migration_iommu_device.py
+++ b/libvirt/tests/src/sriov/vIOMMU/migration_iommu_device.py
@@ -85,5 +85,6 @@ def run(test, params, env):
             test.log.info("TEST_STEP: Migrate back the VM to the source host.")
             migration_obj.run_migration_back()
             migration_obj.migration_test.ping_vm(vm, params)
+            migration_obj.check_vm_cont_ping(False)
     finally:
         test_obj.teardown_iommu_test()


### PR DESCRIPTION
Check that the ping command can be executed continuously before and after the migration.

**x86_64:**
` (1/1) type_specific.io-github-autotest-libvirt.vIOMMU.migration.iommu_device.virtio_muti_devices.vhost_on.virtio: PASS (192.20 s)
`
**aarch64:**

` (1/1) type_specific.io-github-autotest-libvirt.vIOMMU.migration.iommu_device.virtio_muti_devices.vhost_on.virtio:PASS (260.41 s)
`