### PR TITLE
Update case:update interface type live

### DIFF
--- a/libvirt/tests/cfg/virtual_network/update_device/update_iface_type_live.cfg
+++ b/libvirt/tests/cfg/virtual_network/update_device/update_iface_type_live.cfg
@@ -3,12 +3,35 @@
     host_iface =
     start_vm = no
     timeout = 240
+    extra_attrs = {}
+    check_link = yes
     variants:
         - bridge_type:
             iface_type = bridge
             create_linux_br = yes
             net_attrs = {'name': net_name, 'bridge': {'name': linux_br}, 'forward': {'mode': 'bridge'}}
+        - ovsbr_type:
+            iface_type = bridge
+            create_ovs_br = yes
+            net_attrs = {'name': net_name, 'bridge': {'name': linux_br}, 'forward': {'mode': 'bridge'}}
+            extra_attrs = {'virtualport': {'type': 'openvswitch'}}
+            variants:
+                - default:
+                - no_change:
+                    check_link = no
+                    with_iface_xml = yes
+                    variants operation:
+                        - default:
+                        - attach_device:
+                        - attach_interface:
+                            net_attrs = {'name': net_name, 'bridge': {'name': linux_br}, 'forward': {'mode': 'bridge'}, 'virtualport_type': 'openvswitch'}
+                    variants xml_opt:
+                        - active:
+                            xml_opt =
+                        - inactive:
+                            xml_opt = --inactive
+
         - direct_type:
             iface_type = direct
             net_attrs = {'name': net_name, 'forward': {'mode': 'bridge'}, 'forward_interface': [{'dev': host_iface}]}
-    iface_attrs = {'model': 'virtio', 'type_name': 'network', 'source': {'network': net_name}, 'mac_address': mac}
+    iface_attrs = {'model': 'virtio', 'type_name': 'network', 'source': {'network': net_name}, 'mac_address': mac, **${extra_attrs}}

--- a/libvirt/tests/src/virtual_network/update_device/update_iface_type_live.py
+++ b/libvirt/tests/src/virtual_network/update_device/update_iface_type_live.py
@@ -8,6 +8,8 @@ from virttest.libvirt_xml import vm_xml
 from virttest.utils_libvirt import libvirt_network
 from virttest.utils_libvirt import libvirt_vmxml
 
+from provider.virtual_network import network_base
+
 VIRSH_ARGS = {'ignore_status': False, 'debug': True}
 
 LOG = logging.getLogger('avocado.' + __name__)
@@ -21,7 +23,10 @@ def run(test, params, env):
     vm = env.get_vm(vm_name)
     rand_id = utils_misc.generate_random_string(3)
     create_linux_br = 'yes' == params.get('create_linux_br', 'no')
-    linux_br = 'linux_br_' + rand_id
+    create_ovs_br = 'yes' == params.get('create_ovs_br', 'no')
+    check_link = 'yes' == params.get('check_link', 'yes')
+    linux_br = 'br_' + rand_id
+    operation = params.get('operation', 'attach_device')
     net_name = 'net_' + rand_id
     mac = utils_net.generate_mac_address_simple()
     iface_attrs = eval(params.get('iface_attrs', '{}'))
@@ -42,35 +47,52 @@ def run(test, params, env):
         if create_linux_br:
             LOG.debug(f'Create linux bridge: {linux_br}')
             utils_net.create_linux_bridge_tmux(linux_br, host_iface)
+        if create_ovs_br:
+            LOG.debug(f'Create ovs bridge: {linux_br}')
+            utils_net.create_ovs_bridge(linux_br)
         libvirt_network.create_or_del_network(net_attrs)
         LOG.debug(f'Network xml:\n'
                   f'{virsh.net_dumpxml(net_attrs["name"]).stdout_text}')
 
+        iface = libvirt_vmxml.create_vm_device_by_type(
+            'interface', iface_attrs)
+        LOG.debug(f'Interface to attach/add:\n{iface.xmltreefile.str_out()}')
+
+        if operation == 'default':
+            vmxml.add_device(iface)
+            vmxml.sync()
+
         vm.start()
         session = vm.wait_for_serial_login()
 
-        iface = libvirt_vmxml.create_vm_device_by_type(
-            'interface', iface_attrs)
-        LOG.debug(f'Interface to attach:\n{iface}')
-
-        virsh.attach_device(vm_name, iface.xml, **VIRSH_ARGS)
+        if operation == 'attach_device':
+            virsh.attach_device(vm_name, iface.xml,
+                                flagstr='--persistent', **VIRSH_ARGS)
+        elif operation == 'attach_interface':
+            virsh.attach_interface(
+                vm_name, f'--source {net_name} --model virtio --type network --persistent', **VIRSH_ARGS)
 
         vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
-        iface_at = vmxml.get_devices('interface')[0]
-        LOG.debug(f'Interface xml after attached to vm:\n{iface_at}')
-        LOG.debug(f'Interface type after attached to vm:\n'
-                  f'{iface_at.type_name}')
+        iface_at = network_base.get_iface_xml_inst(vm_name, 'after attach')
+        LOG.debug(f'Interface type after attached to vm: {iface_at.type_name}')
         if iface_at.type_name != iface_type:
             test.fail(f'Interface type should change to {iface_type}')
 
         LOG.debug('Update interface link state')
         link_state = 'down'
         iface.setup_attrs(**{'link_state': link_state})
-        LOG.debug(iface)
+        if params.get('with_iface_xml') == 'yes':
+            xml_opt = params.get('xml_opt', '')
+            iface = network_base.get_iface_xml_inst(
+                vm_name, f'on vm ({xml_opt})', options=f'{xml_opt}')
+        LOG.debug(f'Update iface with xml:\n{iface}')
 
         virsh.update_device(vm_name, iface.xml, **VIRSH_ARGS)
         vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
-        iface_update = vmxml.get_devices('interface')[0]
+        iface_update = network_base.get_iface_xml_inst(vm_name, 'after update')
+        if not check_link:
+            return
+
         LOG.debug(f'Link state of interface after update: '
                   f'{iface_update.link_state}')
         if iface_update.link_state != link_state:
@@ -95,3 +117,5 @@ def run(test, params, env):
         if create_linux_br:
             LOG.debug(f'Delete linux bridge: {linux_br}')
             utils_net.delete_linux_bridge_tmux(linux_br, host_iface)
+        if create_ovs_br:
+            utils_net.delete_ovs_bridge(linux_br)


### PR DESCRIPTION
- VIRT-298342 - [update-device] live update interface with different interface type - bridge/direct type

Furthermore, use get_iface_xml_inst instead because it contains the
get_devices function and logging, making code cleaner