### PR TITLE
iface_unprivileged:update case to use existing vm

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_unprivileged.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_unprivileged.cfg
@@ -1,14 +1,12 @@
 - virtual_network.iface_unprivileged:
     type = iface_unprivileged
     start_vm = no
-    up_user = 'test_upu'
-    user_vm_name = 'non_root_vm'
-    bridge_name = "test_br0"
-    # Replace remote_ip by a actual IP address
-    remote_ip = "www.google.com"
-    ping_count = 3
-    ping_timeout = 10
-    iface_name =
+    outside_ip = "www.redhat.com"
+    vm_ping_outside = pass
+    host_iface =
+    test_user = test
+    test_passwd = test
+    unpr_vm_name = unpr-vm    
     variants:
         - precreated:
             case = 'precreated'

--- a/libvirt/tests/src/virtual_network/iface_unprivileged.py
+++ b/libvirt/tests/src/virtual_network/iface_unprivileged.py
@@ -1,22 +1,17 @@
-import logging as log
-import shutil
+import logging
+
 import aexpect
-
-from avocado.utils import process
-
 from virttest import libvirt_version
 from virttest import remote
 from virttest import utils_misc
 from virttest import utils_net
-from virttest import utils_package
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
-from virttest.utils_test import libvirt
+from virttest.utils_libvirt import libvirt_unprivileged
 
+from provider.virtual_network import network_base
 
-# Using as lower capital is not the best way to do, but this is just a
-# workaround to avoid changing the entire file.
-logging = log.getLogger('avocado.' + __name__)
+LOG = logging.getLogger('avocado.' + __name__)
 
 
 def run(test, params, env):
@@ -24,156 +19,64 @@ def run(test, params, env):
     Test interface with unprivileged user
     """
 
-    def create_bridge(br_name, iface_name):
-        """
-        Create bridge attached to physical interface
-        """
-        # Make sure the bridge not exist
-        if libvirt.check_iface(br_name, "exists", "--all"):
-            test.cancel("The bridge %s already exist" % br_name)
-
-        # Create bridge
-        utils_package.package_install('tmux')
-        cmd = 'tmux -c "ip link add name {0} type bridge; ip link set {1} up;' \
-              ' ip link set {1} master {0}; ip link set {0} up; pkill dhclient; ' \
-              'sleep 6; dhclient {0}; ifconfig {1} 0"'.format(br_name, iface_name)
-        process.run(cmd, shell=True, verbose=True)
-
-    def check_ping(dest_ip, ping_count, timeout, src_ip=None, session=None,
-                   expect_success=True):
-        """
-        Check if ping result meets expectation
-        """
-        status, output = utils_net.ping(dest=dest_ip, count=ping_count,
-                                        interface=src_ip, timeout=timeout,
-                                        session=session, force_ipv4=True)
-        success = True if status == 0 else False
-
-        if success != expect_success:
-            test.fail('Ping result not met expectation, '
-                      'actual result is {}'.format(success))
-
     if not libvirt_version.version_compare(5, 6, 0):
         test.cancel('Libvirt version is too low for this test.')
 
-    vm_name = params.get('main_vm')
-    rand_id = '_' + utils_misc.generate_random_string(3)
+    vm_name = params.get('unpr_vm_name')
+    test_user = params.get('test_user', '')
+    test_passwd = params.get('test_passwd', '')
+    unpr_vm_args = {
+        'username': params.get('username'),
+        'password': params.get('password'),
+    }
+    vm = libvirt_unprivileged.get_unprivileged_vm(vm_name, test_user,
+                                                  test_passwd,
+                                                  **unpr_vm_args)
+    uri = f'qemu+ssh://{test_user}@localhost/session'
+    virsh_ins = virsh.Virsh(uri=uri)
+    host_session = aexpect.ShellSession('su')
+    remote.VMManager.set_ssh_auth(host_session, 'localhost', test_user,
+                                  test_passwd)
+    host_session.close()
 
-    upu_vm_name = 'upu_vm' + rand_id
-    user_vm_name = params.get('user_vm_name', 'non_root_vm')
+    rand_id = '_' + utils_misc.generate_random_string(3)
     bridge_name = params.get('bridge_name', 'test_br0') + rand_id
     device_type = params.get('device_type', '')
-    iface_name = params.get("iface_name")
-    if not iface_name:
-        iface_name = utils_net.get_net_if(state="UP")[0]
+    host_iface = params.get('host_iface')
+    if not host_iface:
+        host_iface = utils_net.get_default_gateway(
+            iface_name=True, force_dhcp=True).split()[0]
     tap_name = params.get('tap_name', 'mytap0') + rand_id
     macvtap_name = params.get('macvtap_name', 'mymacvtap0') + rand_id
-    remote_ip = params.get('remote_ip')
-    up_user = params.get('up_user', 'test_upu') + rand_id
     case = params.get('case', '')
 
-    # Create unprivileged user
-    logging.info('Create unprivileged user %s', up_user)
-    process.run('useradd %s' % up_user, shell=True, verbose=True)
-    root_vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
-
-    upu_args = {
-        'unprivileged_user': up_user,
-        'ignore_status': False,
-        'debug': True,
-    }
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name,
+                                                   virsh_instance=virsh_ins)
+    bkxml = vmxml.copy()
 
     try:
-        # Create vm as unprivileged user
-        logging.info('Create vm as unprivileged user')
-        upu_vmxml = root_vmxml.copy()
-
-        # Prepare vm for unprivileged user
-        xml_devices = upu_vmxml.devices
-        disks = xml_devices.by_device_tag("disk")
-        for disk in disks:
-            ori_path = disk.source['attrs'].get('file')
-            if not ori_path:
-                continue
-
-            file_name = ori_path.split('/')[-1]
-            new_disk_path = '/home/{}/{}'.format(up_user, file_name)
-            logging.debug('New disk path:{}'.format(new_disk_path))
-
-            # Copy disk image file and chown to make sure that
-            # unprivileged user has access
-            shutil.copyfile(ori_path, new_disk_path)
-            shutil.chown(new_disk_path, up_user, up_user)
-
-            # Modify xml to set new path of disk
-            disk_index = xml_devices.index(disk)
-            source = xml_devices[disk_index].source
-            new_attrs = source.attrs
-            new_attrs['file'] = new_disk_path
-            source.attrs = new_attrs
-            xml_devices[disk_index].source = source
-            logging.debug(xml_devices[disk_index].source)
-
-        upu_vmxml.devices = xml_devices
-
-        new_xml_path = '/home/{}/upu.xml'.format(up_user)
-        shutil.copyfile(upu_vmxml.xml, new_xml_path)
-
-        # Define vm for unprivileged user
-        virsh.define(new_xml_path, **upu_args)
-        virsh.domrename(vm_name, upu_vm_name, **upu_args)
-        logging.debug(virsh.dumpxml(upu_vm_name, **upu_args))
-        upu_vmxml = vm_xml.VMXML()
-        upu_vmxml.xml = virsh.dumpxml(upu_vm_name, **upu_args).stdout_text
-
-        # Remove nvram tag of os to avoid permission issue
-        os_xml = upu_vmxml.os
-        os_xml.del_nvram()
-        upu_vmxml.os = os_xml
 
         if case == 'precreated':
             if device_type == 'tap':
                 # Create bridge
-                create_bridge(bridge_name, iface_name)
+                iface_attrs = network_base.get_iface_xml_inst(
+                    vm_name, 'on vm', virsh_ins=virsh_ins).fetch_attrs()
+                if iface_attrs.get('driver', {}).get('driver_attr', {}).get('queues'):
+                    tap_flag = 'multi_queue'
+                else:
+                    tap_flag = ''
+                utils_net.create_linux_bridge_tmux(bridge_name, host_iface)
 
-                # Create tap device
-                tap_cmd = 'ip tuntap add mode tap user {user} group {user} ' \
-                          'name {tap};ip link set {tap} up;ip link set {tap} ' \
-                          'master {br}'.format(tap=tap_name, user=up_user,
-                                               br=bridge_name)
-
-                # Execute command as root
-                process.run(tap_cmd, shell=True, verbose=True)
+                network_base.create_tap(
+                    tap_name, bridge_name, test_user, tap_flag)
 
             if device_type == 'macvtap':
                 # Create macvtap device
-                mac_addr = utils_net.generate_mac_address_simple()
-                macvtap_cmd = 'ip link add link {iface} name {macvtap} address' \
-                              ' {mac} type macvtap mode bridge;' \
-                              'ip link set {macvtap} up'.format(
-                               iface=iface_name,
-                               macvtap=macvtap_name,
-                               mac=mac_addr)
-                process.run(macvtap_cmd, shell=True, verbose=True)
-                cmd_get_tap = 'ip link show {} | head -1 | cut -d: -f1'.format(macvtap_name)
-                tap_index = process.run(cmd_get_tap, shell=True, verbose=True).stdout_text.strip()
-                device_path = '/dev/tap{}'.format(tap_index)
-                logging.debug('device_path: {}'.format(device_path))
-                # Change owner and group for device and ensure it is changed successfully
-
-                def ensure_permission_ready():
-                    """
-                    check if the permission set ready
-                    """
-                    process.run('chown {user} {path};chgrp {user} {path}'.format(
-                        user=up_user, path=device_path), shell=True, verbose=True)
-                    res = process.run('ls -l %s' % device_path, shell=True, verbose=True)
-                    return "%s %s" % (up_user, up_user) in str(res)
-
-                utils_misc.wait_for(ensure_permission_ready, timeout=10)
+                mac_addr = network_base.create_macvtap(
+                    macvtap_name, host_iface, test_user)
 
             # Modify interface
-            all_devices = upu_vmxml.devices
+            all_devices = vmxml.devices
             iface_list = all_devices.by_device_tag('interface')
             if not iface_list:
                 test.error('No iface to modify')
@@ -200,47 +103,25 @@ def run(test, params, env):
 
             if device_type == 'macvtap':
                 iface.mac_address = mac_addr
-            logging.debug(iface)
+            LOG.debug(iface)
 
-            upu_vmxml.devices = all_devices
-            logging.debug(upu_vmxml)
+            vmxml.devices = all_devices
+            LOG.debug(vmxml)
 
-            # Remove seclabel model="dac" since unprivileged user doesn't support this feature
-            upu_vmxml.del_seclabel([('model', 'dac'), ('relabel', 'yes')])
-            # Define updated xml
-            shutil.copyfile(upu_vmxml.xml, new_xml_path)
-            upu_vmxml.xml = new_xml_path
-            virsh.define(new_xml_path, **upu_args)
-            logging.debug(virsh.dumpxml(upu_vm_name, **upu_args).stdout_text)
-
-            # Switch to unprivileged user and modify vm's interface
-            # Start vm as unprivileged user and test network
-            virsh.start(upu_vm_name, debug=True, ignore_status=False,
-                        unprivileged_user=up_user)
-            cmd = ("su - %s -c 'virsh console %s'"
-                   % (up_user, upu_vm_name))
-            session = aexpect.ShellSession(cmd)
-            session.sendline()
-            remote.handle_prompts(session, params.get("username"),
-                                  params.get("password"), r"[\#\$]\s*$", 60)
-            logging.debug(session.cmd_output('ifconfig'))
-            check_ping(remote_ip, 5, 10, session=session)
+            vm.start()
+            session = vm.wait_for_serial_login(60)
+            LOG.debug(session.cmd_output('ifconfig'))
+            ips = {'outside_ip': params.get('outside_ip')}
+            network_base.ping_check(params, ips, session)
             session.close()
 
     finally:
-        if 'upu_virsh' in locals():
-            virsh.destroy(upu_vm_name, unprivileged_user=up_user)
-            virsh.undefine(upu_vm_name, options='--nvram', unprivileged_user=up_user)
+        bkxml.sync(virsh_instance=virsh_ins)
         if case == 'precreated':
             try:
-                if device_type == 'tap':
-                    process.run('ip tuntap del mode tap {}'.format(tap_name), shell=True, verbose=True)
-                elif device_type == 'macvtap':
-                    process.run('ip l del {}'.format(macvtap_name), shell=True, verbose=True)
+                if device_type in ('tap', 'macvtap'):
+                    network_base.delete_tap(tap_name)
             except Exception:
                 pass
             finally:
-                cmd = 'tmux -c "ip link set {1} nomaster;  ip link delete {0};' \
-                      'pkill dhclient; sleep 6; dhclient {1}"'.format(bridge_name, iface_name)
-                process.run(cmd, shell=True, verbose=True, ignore_status=True)
-        process.run('pkill -u {0};userdel -f -r {0}'.format(up_user), shell=True, verbose=True, ignore_status=True)
+                utils_net.delete_linux_bridge_tmux(bridge_name, host_iface)


### PR DESCRIPTION
Test result

```
 (1/2) type_specific.local.virtual_network.iface_unprivileged.precreated.host_tap: STARTED
 (1/2) type_specific.local.virtual_network.iface_unprivileged.precreated.host_tap: PASS (107.46 s)
 (2/2) type_specific.local.virtual_network.iface_unprivileged.precreated.host_macvtap: STARTED
 (2/2) type_specific.local.virtual_network.iface_unprivileged.precreated.host_macvtap: PASS (39.58 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```