### PR TITLE
virsh_restore: fix script by adding default value

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_restore.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_restore.py
@@ -65,7 +65,7 @@ def run(test, params, env):
     check_log = params.get("check_log")
     check_str_not_in_log = params.get("check_str_not_in_log")
     qemu_conf_dict = eval(params.get("qemu_conf_dict", "{}"))
-    os_update_dict = eval(params.get("os_update_dict"))
+    os_update_dict = eval(params.get("os_update_dict", "{}"))
 
     vm_ref_uid = None
     vm_ref_gid = None


### PR DESCRIPTION
cca78d281bbe06462aace28cbe59b120007a5aa3 introduced a new test parameter but didn't provide a default value, leading to problems when reading the value.

Add default value empty dictionary like the local parameter it replaced at some places. This way the added code is just skipped if not necessary.