### PR TITLE
passt:Update code of checking nameserver to fix error

### DIFF
--- a/provider/virtual_network/passt.py
+++ b/provider/virtual_network/passt.py
@@ -276,11 +276,18 @@ def check_nameserver(session):
     :param session: vm shell session instance
     """
     get_cmd = 'cat /etc/resolv.conf|grep -vE "#|;"'
-    on_host = process.run(get_cmd, shell=True).stdout_text.strip().split()
-    on_vm = session.cmd_output(get_cmd).strip().split()
+    on_host = process.run(get_cmd, shell=True).stdout_text.strip()
+    on_vm = session.cmd_output(get_cmd).strip()
+    LOG.debug(f'Output on host:\n{on_host}\nOutput on vm:\n{on_vm}')
     # remove zone index
-    on_host = [re.sub(r'%.*', '', x) for x in on_host]
-    on_vm = [re.sub(r'%.*', '', x) for x in on_vm]
+    on_host = [re.sub(r'%.*', '', x) for x in on_host.split()]
+    on_vm = [re.sub(r'%.*', '', x) for x in on_vm.split()]
+    # Remove irrelevant items such as "search"
+    on_host = set([(on_host[i], on_host[i + 1]) for i in range(len(on_host))
+                   if on_host[i].lower() == 'nameserver'])
+    on_vm = set([(on_vm[i], on_vm[i + 1]) for i in range(len(on_vm))
+                 if on_vm[i].lower() == 'nameserver'])
+    LOG.debug(f'On host:\n{on_host}\nOn vm:\n{on_vm}')
     if on_host == on_vm:
         LOG.debug(f'Nameserver on vm is consistent with host:\n{on_host}')
     else:


### PR DESCRIPTION
Remove irrelevant info such as "search" from output of resolv.conf to avoid inconsistency of nameserver between host and vm.

Test result:
 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.passt.interface_function.minimal.root_user: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.passt.interface_function.minimal.root_user: PASS (190.17 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0