### PR TITLE
serial: Add a hotplug/unplug case

### DIFF
--- a/libvirt/tests/cfg/serial/serial_functional.cfg
+++ b/libvirt/tests/cfg/serial/serial_functional.cfg
@@ -52,6 +52,15 @@
             only aarch64
             serial_dev_type = pty
             target_type = system-serial
+        - type_file_system_serial:
+            only aarch64
+            func_supported_since_libvirt_ver = (10, 10, 0)
+            serial_dev_type = file
+            target_model = pl011
+            serial_sources = path:/var/lib/libvirt/virt-test
+            hotplug_serial = "yes"
+            hotunplug_serial = "yes"
+            error_msg = "unsupported configuration: Cannot {} platform device"
         - type_spicevmc:
             serial_dev_type = spicevmc
         - type_spiceport:

--- a/libvirt/tests/src/serial/serial_functional.py
+++ b/libvirt/tests/src/serial/serial_functional.py
@@ -738,6 +738,7 @@ def run(test, params, env):
         elif serial_type in ['pipe']:
             return 'server'
 
+    libvirt_version.is_libvirt_feature_supported(params)
     serial_type = params.get('serial_dev_type', 'pty')
     sources_str = params.get('serial_sources', '')
     username = params.get('username')
@@ -850,6 +851,16 @@ def run(test, params, env):
             error_msg = params.get("error_msg")
             if error_msg not in result:
                 test.fail(f"Fail to get expected error message:{error_msg} from console")
+
+        if params.get("hotunplug_serial", "no") == "yes":
+            error_msg = params.get("error_msg", "").format("detach")
+            res = virsh.detach_device(vm_name, serial_dev.xml, debug=True)
+            libvirt.check_result(res, error_msg)
+
+        if params.get("hotplug_serial", "no") == "yes":
+            error_msg = params.get("error_msg", "").format("hotplug")
+            res = virsh.attach_device(vm_name, serial_dev.xml, debug=True)
+            libvirt.check_result(res, error_msg)
 
         vm.destroy()
 


### PR DESCRIPTION
This PR adds:

    VIRT-304021: [aarch64 only][hotplug]hotplug/hotunplug
    system-serial serial device


**Test results:**
`  (1/1) type_specific.io-github-autotest-libvirt.serial.functional.type_file_system_serial: PASS (88.38 s)
`