### PR TITLE
Snapshot: add datastore test scenarios to snapshot

### DIFF
--- a/libvirt/tests/cfg/snapshot/revert_disk_external_snap.cfg
+++ b/libvirt/tests/cfg/snapshot/revert_disk_external_snap.cfg
@@ -4,6 +4,15 @@
     snap_names = ['s1', 's2', 's3']
     file_list = ["/mnt/s1", "/mnt/s2", "/mnt/s3"]
     func_supported_since_libvirt_ver = (9, 10, 0)
+    variants:
+        - with_datastore:
+            with_data_file = "yes"
+            disk_target = "vdb"
+            disk_type = "file"
+            disk_dict = {"type_name":"${disk_type}", "target":{"dev":"${disk_target}", "bus":"virtio"}, "driver": {"name":"qemu", "type":"qcow2"}}
+            func_supported_since_libvirt_ver = (10, 10, 0)
+            data_file_option = " -o data_file=%s"
+        - without_datastore:
     variants snap_type:
         - disk_only:
             snap_options = " %s --disk-only %s"


### PR DESCRIPTION
Automate case:
VIRT-303301 - [Disk snapshot][External] Create/revert/delete external snapshots for guest whose disk has data file