### PR TITLE
scalability: Add a case about iommu and ioapic setting

### DIFF
--- a/libvirt/tests/cfg/scalability/define_create_vm_with_more_vcpus.cfg
+++ b/libvirt/tests/cfg/scalability/define_create_vm_with_more_vcpus.cfg
@@ -1,0 +1,28 @@
+- scalability.intel_iommu.define_create_vm_with_more_vcpus:
+    type = define_create_vm_with_more_vcpus
+    start_vm = "yes"
+    enable_guest_iommu = "yes"
+    feature_name = "ioapic"
+    func_supported_since_libvirt_ver = (10, 10, 0)
+    vm_attrs = {"vcpu": 384}
+    exp_iommu_dict = {"model": "intel", "driver": {"intremap": "on", "eim": "on"}}
+
+    only q35
+    variants:    
+        - with_ioapic:
+            with_ioapic = "yes"
+            feature_attr = ["driver", "qemu"]
+        - without_ioapic:
+    variants:
+        - with_iommu:
+            variants:
+                - default:
+                    only without_ioapic
+                    iommu_dict = {"model": "intel"}
+                - with_intremap_on:
+                    iommu_dict = {"model": "intel", "driver": {"intremap": "on"}}
+        - without_iommu:
+    variants:
+        - define_vm:
+            define_vm = "yes"
+        - create_vm:

--- a/libvirt/tests/src/scalability/define_create_vm_with_more_vcpus.py
+++ b/libvirt/tests/src/scalability/define_create_vm_with_more_vcpus.py
@@ -1,0 +1,78 @@
+from virttest import libvirt_version
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+
+
+def run(test, params, env):
+    """
+    libvirt should automatically add iommu and ioapic setting
+    when define/create guest with more than 255 vcpus
+    """
+    libvirt_version.is_libvirt_feature_supported(params)
+    iommu_dict = eval(params.get("iommu_dict", "{}"))
+    exp_iommu_dict = eval(params.get("exp_iommu_dict", "{}"))
+    define_vm = params.get("define_vm", "no") == "yes"
+    with_ioapic = params.get("with_ioapic", "no") == "yes"
+    feature_name = params.get("feature_name", "ioapic")
+    feature_attr = eval(params.get("feature_attr", "[]"))
+
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    vm = env.get_vm(vm_name)
+    vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+    backup_vmxml = vmxml.copy()
+    try:
+        libvirt_vmxml.remove_vm_devices_by_type(vm, "iommu")
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        vm_attrs = eval(params.get("vm_attrs", "{}"))
+        vmxml.setup_attrs(**vm_attrs)
+
+        test.log.info(f"TEST_STEP: Update {feature_name} feature.")
+        features = vmxml.features
+        test.log.debug(f"orignal features: {features}")
+        if features.has_feature(feature_name):
+            if not with_ioapic:
+                test.log.debug(f"removing {feature_name}...")
+                features.remove_feature(feature_name)
+        else:
+            if with_ioapic:
+                test.log.debug(f"Adding {feature_name}...")
+                features.add_feature(feature_name, *feature_attr)
+        vmxml.features = features
+
+        if iommu_dict:
+            test.log.info("TEST_STEP: Define VM with intel iommu device.")
+            iommu_dev = libvirt_vmxml.create_vm_device_by_type(
+                "iommu", iommu_dict)
+            vmxml.add_device(iommu_dev)
+        vmxml.xmltreefile.write()
+        test.log.debug(f"vm xml will be updated as below: \n{vmxml}")
+        if define_vm:
+            vmxml.sync()
+        else:
+            virsh.destroy(vm_name, debug=True)
+            virsh.undefine(vm_name, options='--nvram', debug=True, ignore_status=False)
+            virsh.create(vmxml.xml, debug=True, ignore_status=False)
+
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        features = vmxml.features
+        test.log.debug(f"features after updating: {features}")
+        if not features.has_feature(feature_name):
+            test.fail("Failed to get feature - %s." % feature_name)
+
+        if exp_iommu_dict:
+            actual_iommu = vm_xml.VMXML.new_from_dumpxml(vm.name)\
+                .devices.by_device_tag("iommu")[0].fetch_attrs()
+
+            test.log.debug(f"actual iommu device: {actual_iommu}\n"
+                           f"expected iommu device: {exp_iommu_dict}")
+            if exp_iommu_dict != actual_iommu:
+                test.log.warning("iommu device xml comparison failed. "
+                                 "Adding alias and try again...")
+                exp_iommu_dict.update({"alias": {"name": "iommu0"}})
+                if exp_iommu_dict != actual_iommu:
+                    test.fail("Incorrect iommu device!")
+    finally:
+        if not define_vm:
+            vm.define(vmxml.xml)
+        backup_vmxml.sync()


### PR DESCRIPTION
This PR adds:
    VIRT-303993: Define/Create guest with more than 255 vcpus

**Test results:**
```
 (01/10) type_specific.io-github-autotest-libvirt.scalability.intel_iommu.define_create_vm_with_more_vcpus.define_vm.with_iommu.default.without_ioapic: STARTED
 (01/10) type_specific.io-github-autotest-libvirt.scalability.intel_iommu.define_create_vm_with_more_vcpus.define_vm.with_iommu.default.without_ioapic: PASS (130.53 s)
 (02/10) type_specific.io-github-autotest-libvirt.scalability.intel_iommu.define_create_vm_with_more_vcpus.define_vm.with_iommu.with_intremap_on.with_ioapic: STARTED
 (02/10) type_specific.io-github-autotest-libvirt.scalability.intel_iommu.define_create_vm_with_more_vcpus.define_vm.with_iommu.with_intremap_on.with_ioapic: PASS (131.70 s)
 (03/10) type_specific.io-github-autotest-libvirt.scalability.intel_iommu.define_create_vm_with_more_vcpus.define_vm.with_iommu.with_intremap_on.without_ioapic: STARTED
 (03/10) type_specific.io-github-autotest-libvirt.scalability.intel_iommu.define_create_vm_with_more_vcpus.define_vm.with_iommu.with_intremap_on.without_ioapic: PASS (131.37 s)
 (04/10) type_specific.io-github-autotest-libvirt.scalability.intel_iommu.define_create_vm_with_more_vcpus.define_vm.without_iommu.with_ioapic: STARTED
 (04/10) type_specific.io-github-autotest-libvirt.scalability.intel_iommu.define_create_vm_with_more_vcpus.define_vm.without_iommu.with_ioapic: PASS (129.51 s)
 (05/10) type_specific.io-github-autotest-libvirt.scalability.intel_iommu.define_create_vm_with_more_vcpus.define_vm.without_iommu.without_ioapic: STARTED
 (05/10) type_specific.io-github-autotest-libvirt.scalability.intel_iommu.define_create_vm_with_more_vcpus.define_vm.without_iommu.without_ioapic: PASS (130.92 s)
 (06/10) type_specific.io-github-autotest-libvirt.scalability.intel_iommu.define_create_vm_with_more_vcpus.create_vm.with_iommu.default.without_ioapic: STARTED
 (06/10) type_specific.io-github-autotest-libvirt.scalability.intel_iommu.define_create_vm_with_more_vcpus.create_vm.with_iommu.default.without_ioapic: PASS (147.35 s)
 (07/10) type_specific.io-github-autotest-libvirt.scalability.intel_iommu.define_create_vm_with_more_vcpus.create_vm.with_iommu.with_intremap_on.with_ioapic: STARTED
 (07/10) type_specific.io-github-autotest-libvirt.scalability.intel_iommu.define_create_vm_with_more_vcpus.create_vm.with_iommu.with_intremap_on.with_ioapic: PASS (141.90 s)
 (08/10) type_specific.io-github-autotest-libvirt.scalability.intel_iommu.define_create_vm_with_more_vcpus.create_vm.with_iommu.with_intremap_on.without_ioapic: STARTED
 (08/10) type_specific.io-github-autotest-libvirt.scalability.intel_iommu.define_create_vm_with_more_vcpus.create_vm.with_iommu.with_intremap_on.without_ioapic: PASS (141.25 s)
 (09/10) type_specific.io-github-autotest-libvirt.scalability.intel_iommu.define_create_vm_with_more_vcpus.create_vm.without_iommu.with_ioapic: STARTED
 (09/10) type_specific.io-github-autotest-libvirt.scalability.intel_iommu.define_create_vm_with_more_vcpus.create_vm.without_iommu.with_ioapic: PASS (140.95 s)
 (10/10) type_specific.io-github-autotest-libvirt.scalability.intel_iommu.define_create_vm_with_more_vcpus.create_vm.without_iommu.without_ioapic: STARTED
 (10/10) type_specific.io-github-autotest-libvirt.scalability.intel_iommu.define_create_vm_with_more_vcpus.create_vm.without_iommu.without_ioapic: PASS (143.43 s)
RESULTS    : PASS 10 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2025-03-05T04.06-9dadfad/results.html

```