### PR TITLE
add case for blockcopy with datafile property

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockcopy/blockcopy_with_different_qcow2_properties.cfg
+++ b/libvirt/tests/cfg/backingchain/blockcopy/blockcopy_with_different_qcow2_properties.cfg
@@ -7,6 +7,7 @@
     snap_extra = " --no-metadata --diskspec vda,snapshot=no"
     copy_image = "/tmp/copy.qcow2"
     image_path = "/var/lib/libvirt/images/test.qcow2"
+    snap_path = "/var/lib/libvirt/images/snap1"
     image_format = "qcow2"
     image_size = "500M"
     variants property:
@@ -16,6 +17,14 @@
             expected_extended_l2 = "true"
             property_command = "cluster_size=${cluster_size},extended_l2=${extended_l2_value}"
             image_extras = "-o ${property_command}"
+            expected_chain_after_snap = ['${snap_path}','${image_path}']
+        - with_datastore:
+            func_supported_since_libvirt_ver = (10, 10, 0)
+            datastore_path = "/var/lib/libvirt/images/datastore"
+            data_file_option = " -o data_file=%s"
+            property_command = "data_file=${datastore_path}"
+            image_extras = "-o ${property_command}"
+            expected_chain_after_snap = ['${snap_path}','${image_path}', '${datastore_path}']
    variants:
         - not_encrypt_disk:
             enable_encrypt_disk = "no"

--- a/libvirt/tests/src/backingchain/blockcopy/blockcopy_with_different_qcow2_properties.py
+++ b/libvirt/tests/src/backingchain/blockcopy/blockcopy_with_different_qcow2_properties.py
@@ -1,9 +1,10 @@
 import re
 
+from virttest import libvirt_version
 from virttest import virsh
-
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
+from virttest.utils_libvirt import libvirt_disk
 
 from provider.backingchain import blockcommand_base
 from provider.backingchain import check_functions
@@ -24,14 +25,20 @@ def run(test, params, env):
         Prepare image with properties and snap chain
         """
         test.log.info("SETUP:Prepare image with properties and snap chain")
+        if property_item == "with_datastore":
+            libvirt.create_local_disk("file", path=datastore_path, size=image_size,
+                                      disk_format=image_format)
         libvirt.create_local_disk("file", path=image_path, size=image_size,
                                   disk_format=image_format, extra=image_extras)
         check_property(image_path, property_item)
 
         prepare_disk()
-        test_obj.backingchain_common_setup(create_snap=True,
-                                           snap_num=1, extra=snap_extra)
-        check_property(test_obj.snap_path_list[0], property_item)
+        test_obj.backingchain_common_setup(
+            create_snap=True, snap_num=1, snap_path=snap_path, extra=snap_extra)
+
+        if property_item == "extended_l2_and_cluster_size":
+            check_property(test_obj.snap_path_list[0], property_item)
+        check_obj.check_backingchain_from_vmxml(disk_type, target_disk, expected_chain_after_snap)
 
     def run_test():
         """
@@ -43,8 +50,16 @@ def run(test, params, env):
                         ignore_status=False,
                         debug=True)
 
-        test.log.info("TEST_STEP2:Check properties after blockcopy.")
-        check_property(copy_image, property_item)
+        test.log.info("TEST_STEP2:Check guest xml and image properties "
+                      "after blockcopy.")
+        check_obj.check_backingchain_from_vmxml(disk_type, target_disk,
+                                                [copy_image])
+
+        if property_item == "extended_l2_and_cluster_size":
+            check_property(copy_image, property_item)
+
+        test.log.info("TEST_STEP3: Write file in guest")
+        libvirt_disk.check_virtual_disk_io(vm, target_disk)
 
     def teardown_test():
         """
@@ -54,6 +69,8 @@ def run(test, params, env):
         test_obj.backingchain_common_teardown()
         test_obj.clean_file(copy_image)
         test_obj.clean_file(image_path)
+        if datastore_path:
+            test_obj.clean_file(datastore_path)
 
         bkxml.sync()
 
@@ -71,6 +88,8 @@ def run(test, params, env):
             cluster_size_value = int(re.findall(r"\d+", cluster_size)[0])*1024*1024
             check_obj.check_image_info(path, 'csize',
                                        cluster_size_value)
+        elif property_item == "with_datastore":
+            check_obj.check_image_info(path, 'data file', datastore_path)
 
     def prepare_disk():
         """
@@ -82,6 +101,7 @@ def run(test, params, env):
             test_obj.new_image_path = disk_obj.add_vm_disk(
                 disk_type, disk_dict, new_image_path=image_path)
 
+    libvirt_version.is_libvirt_feature_supported(params)
     # Process cartesian parameters
     vm_name = params.get("main_vm")
     target_disk = params.get('target_disk')
@@ -98,6 +118,9 @@ def run(test, params, env):
     property_item = params.get('property')
     cluster_size = params.get('cluster_size')
     expected_extended_l2 = params.get('expected_extended_l2')
+    datastore_path = params.get("datastore_path")
+    snap_path = params.get("snap_path")
+    expected_chain_after_snap = eval(params.get("expected_chain_after_snap", '{}'))
     encryption_disk = params.get('enable_encrypt_disk', 'no') == "yes"
 
     vm = env.get_vm(vm_name)

--- a/provider/virtual_disk/disk_base.py
+++ b/provider/virtual_disk/disk_base.py
@@ -76,12 +76,17 @@ class DiskBase(object):
                 backing_list = disk.get_backingstore_list()
                 if disk_type != 'rbd_with_auth' and backing_list != []:
                     backing_list.pop()
-                source_list = [elem.find('source').get('file') or
-                               elem.find('source').get('name') or
-                               elem.find('source').get('dev') or
-                               elem.find('source').get('volume')
-                               for elem in backing_list
-                               if elem.find("source") is not None]
+                for elem in backing_list:
+                    source_ele = elem.find("source")
+                    if source_ele is not None:
+                        source_list = [source_ele.get('file') or
+                                       source_ele.get('name') or
+                                       source_ele.get('dev') or
+                                       source_ele.get('volume')]
+                        if source_ele.find("dataStore"):
+                            source_list.append(
+                                source_ele.find("dataStore").find('source').get('file'))
+
                 source_list.insert(0, active_level_path)
                 break
 


### PR DESCRIPTION
   xxxx-294532:Check qcow2 properties after blockcopy
Signed-off-by: nanli <nanli@redhat.com>

```
avocado run --vt-type libvirt --vt-machine-type q35  backingchain.blockcopy.image_properties..with_datastore

 (1/2) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.image_properties.not_encrypt_disk.with_datastore: PASS (27.70 s)
 (2/2) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.image_properties.encrypt_disk.with_datastore: PASS (34.90 s)

```

Depend on https://github.com/avocado-framework/avocado-vt/pull/4072 