### PR TITLE
vcpu_affinity: override helper functions on s390x

### DIFF
--- a/libvirt/tests/src/cpu/vcpu_affinity.py
+++ b/libvirt/tests/src/cpu/vcpu_affinity.py
@@ -10,10 +10,13 @@ from virttest.utils_test import libvirt
 from virttest import utils_libvirtd
 from virttest import libvirt_cgroup
 
+from provider.cpu import patch_total_cpu_count_s390x
+
 
 # Using as lower capital is not the best way to do, but this is just a
 # workaround to avoid changing the entire file.
 logging = log.getLogger('avocado.' + __name__)
+patch_total_cpu_count_s390x(cpuutil)
 
 
 def check_vcpu_placement(test, params):

--- a/libvirt/tests/src/libvirt_vcpu_plug_unplug.py
+++ b/libvirt/tests/src/libvirt_vcpu_plug_unplug.py
@@ -14,12 +14,16 @@ from virttest import utils_test
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml.vm_xml import VMXML
 
+from provider.cpu import patch_total_cpu_count_s390x
+
+
 vm_uptime_init = 0
 
 
 # Using as lower capital is not the best way to do, but this is just a
 # workaround to avoid changing the entire file.
 logging = log.getLogger('avocado.' + __name__)
+patch_total_cpu_count_s390x(cpu_util)
 
 
 def run(test, params, env):

--- a/provider/cpu.py
+++ b/provider/cpu.py
@@ -1,0 +1,28 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright Red Hat
+#
+#   SPDX-License-Identifier: GPL-2.0
+#
+#   Author: smitterl@redhat.com
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import platform
+
+
+def patch_total_cpu_count_s390x(cpu_module):
+    """
+    On s390x, override the avocado utility functions because on an
+    LPAR they would return the number of CPUs available on the CEC
+    but not on the LPAR.
+
+    :param cpu_module: the module after import in calling script
+    """
+
+    if platform.machine() == "s390x":
+        online_before_test = cpu_module.online_count()
+
+        def _online_before_test():
+            return online_before_test
+        cpu_module.total_cpus_count = _online_before_test
+        cpu_module.total_count = _online_before_test

--- a/spell.ignore
+++ b/spell.ignore
@@ -95,6 +95,7 @@ capabilities
 cartesian
 ccw
 CCW
+CEC
 cd
 cdrom
 cellno


### PR DESCRIPTION
On s390x, override the avocado utility functions because on an LPAR they would return the number of CPUs available on the CEC but not on the LPAR.

Instead, use only the CPUs that are currently online on the LPAR before starting the test which will manipulate their state in some cases.