### PR TITLE
virsh_save_image: enable different domain xml

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_save_image_define.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_save_image_define.cfg
@@ -2,6 +2,11 @@
     type = virsh_save_image_define
     vm_save = "vm.save"
     kill_vm_on_error = "no"
+    xml_before = "<boot dev='hd'/>"
+    xml_after = "<boot dev='cdrom'/>"
+    s390-virtio:
+        xml_before = "<boot order='1'/>"
+        xml_after = "<boot order='2'/>"
     variants:
        - running:
            restore_state = "running"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_save_image_edit.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_save_image_edit.cfg
@@ -3,6 +3,11 @@
     vm_save = "vm.save"
     kill_vm_on_error = "no"
     take_regular_screendumps = "no"
+    xml_before = "<boot dev='hd'/>"
+    xml_after = "<boot dev='cdrom'/>"
+    s390-virtio:
+        xml_before = "<boot order='1'/>"
+        xml_after = "<boot order='2'/>"
     variants:
         - no_option:
             restore_state = "running"


### PR DESCRIPTION
The test cases assume the guest uses `<boot dev='X'/>`. However, those are not supported on s390x.
Instead make the XML snippet that's updated configurable. On s390x, use `<boot order='n'/>` which is supported.