### PR TITLE
v2v:add new case on non-int-disk guest

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -946,6 +946,10 @@
             main_vm = VM_NAME_DVS_NET_NO_PORTID_CONNECTIONID_V2V_EXAMPLE
             skip_vm_check = yes
             skip_reason = 'Bug RHEL-732 is not fixed'
+        - non_int_disk:
+            only esx_80
+            main_vm = VM_NAME_NON_INT_DISK_V2V_EXAMPLE
+            version_required = "[nbdkit-1.36.2-2,)"
     variants:
         - positive_test:
             status_error = 'no'


### PR DESCRIPTION
 (1/1) type_specific.io-github-autotest-libvirt.function_test_esx.positive_test.non_int_disk.esx_80.libvirt.it_vddk.vpx_uri: PASS (505.09 s)