### PR TITLE
Update case update_iface_qos_invalid

### DIFF
--- a/libvirt/tests/cfg/virtual_network/update_device/update_iface_qos_invalid.cfg
+++ b/libvirt/tests/cfg/virtual_network/update_device/update_iface_qos_invalid.cfg
@@ -10,11 +10,19 @@
             err_msg = could not convert bandwidth average value|Expected non-negative integer value
         - big_value:
             func_supported_since_libvirt_ver = (10,8,0)
-            update_attrs = {'bandwidth': {'inbound': {'average': '100000000000000000', 'peak': '5000', 'burst': '1024'}}}
-            err_msg = numerical overflow: value .* is too big for 'average' parameter, maximum is
+            variants:
+                - average:
+                    update_attrs = {'bandwidth': {'inbound': {'average': '100000000000000000', 'peak': '5000', 'burst': '1024'}}}
+                    err_msg = numerical overflow: value .* is too big for 'average' parameter, maximum is
+                - peak:
+                    update_attrs = {'bandwidth': {'inbound': {'average': '5000', 'peak': '100000000000000000', 'burst': '1024'}}}
+                    err_msg = numerical overflow: value .* is too big for 'peak' parameter, maximum is
+                - burst:
+                    update_attrs = {'bandwidth': {'inbound': {'average': '1024000', 'peak': '4096', 'burst': '4194304'}}}
+                    err_msg = numerical overflow: value .* is too big for 'burst' parameter, maximum is
         - max_value:
             func_supported_since_libvirt_ver = (10,8,0)
-            update_attrs = {'bandwidth': {'inbound': {'average': '18014398509481984', 'peak': '5000', 'burst': '1024'}}}
+            update_attrs = {'bandwidth': {'inbound': {'average': '18014398509481984', 'peak': '5000', 'burst': '4194303'}}}
             status_error = no
         - no_mandatory_average:
             update_attrs = {'bandwidth': {'outbound': {'peak': '5000', 'burst': '1024'}}}


### PR DESCRIPTION
Add more boundry test

Test result:
```
 (1/7) type_specific.local.virtual_network.update_device.iface_qos.invalid.neg_value: STARTED
 (1/7) type_specific.local.virtual_network.update_device.iface_qos.invalid.neg_value: PASS (29.96 s)
 (2/7) type_specific.local.virtual_network.update_device.iface_qos.invalid.big_value.average: STARTED
 (2/7) type_specific.local.virtual_network.update_device.iface_qos.invalid.big_value.average: PASS (32.23 s)
 (3/7) type_specific.local.virtual_network.update_device.iface_qos.invalid.big_value.peak: STARTED
 (3/7) type_specific.local.virtual_network.update_device.iface_qos.invalid.big_value.peak: PASS (39.19 s)
 (4/7) type_specific.local.virtual_network.update_device.iface_qos.invalid.big_value.burst: STARTED
 (4/7) type_specific.local.virtual_network.update_device.iface_qos.invalid.big_value.burst: PASS (38.85 s)
 (5/7) type_specific.local.virtual_network.update_device.iface_qos.invalid.max_value: STARTED
 (5/7) type_specific.local.virtual_network.update_device.iface_qos.invalid.max_value: PASS (40.01 s)
 (6/7) type_specific.local.virtual_network.update_device.iface_qos.invalid.no_mandatory_average: STARTED
 (6/7) type_specific.local.virtual_network.update_device.iface_qos.invalid.no_mandatory_average: PASS (38.61 s)
 (7/7) type_specific.local.virtual_network.update_device.iface_qos.invalid.floor_without_bandwidth: STARTED
 (7/7) type_specific.local.virtual_network.update_device.iface_qos.invalid.floor_without_bandwidth: PASS (36.95 s)
RESULTS    : PASS 7 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```