### PR TITLE
Add case to disable pauth cpu feature

### DIFF
--- a/libvirt/tests/cfg/cpu/vcpu_feature.cfg
+++ b/libvirt/tests/cfg/cpu/vcpu_feature.cfg
@@ -3,7 +3,7 @@
     start_vm = "no"
     cpu_check = "full"
     variants:
-        - policy_diable:
+        - policy_disable:
             feature_policy = "disable"
         - policy_require:
             feature_policy = "require"
@@ -13,8 +13,19 @@
     variants:
         - positive_test:
             variants:
+                - host_with_pauth:
+                    only aarch64
+                    only policy_disable 
+                    func_supported_since_libvirt_ver = (10, 7, 0)
+                    host_supported_feature = "yes"
+                    feature_name = "pauth"
+                    feature_check_name = "paca"
+                    check_vm_feature = "yes" 
+                    check_qemu_pattern = "-cpu host,pauth=off" 
+                    cpu_check = "none"
+                    start_vm = "yes"
                 - host_with_vmx:
-                    only policy_diable
+                    only policy_disable
                     host_supported_feature = "yes"
                     feature_name = "vmx"
                     check_vm_feature = "yes"
@@ -27,3 +38,4 @@
                     host_supported_feature = "no"
                     feature_name = "cr8legacy"
                     err_msg = "guest CPU doesn't match specification: missing features: .*${feature_name}"
+


### PR DESCRIPTION
Case ID:  VIRT-304022
new TC implementation: 
1. Configure vm xml cpu section to disable the pauth feature.
2. Start the vm
3. Check the vm can be logged on
4.  Check the parameter 'pauth=off' could be passed to qemu command line

Reusing existing vcpu_feature.py with new configuration and new check option.

! be aware, that for RHEL-8 and RHEL-9 is the PAUTH feature by default disabled. 