### PR TITLE
Update the option for test cmd

### DIFF
--- a/libvirt/tests/src/virtual_network/passt/passt_transfer_file.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_transfer_file.py
@@ -48,7 +48,7 @@ def transfer_host_to_vm(session, prot, ip_ver, params, test):
     cmd_transfer = eval(params.get('cmd_transfer'))
     process.run(cmd_transfer, shell=True)
 
-    if session.cmd_status(f'test -a {rec_file}') != 0:
+    if session.cmd_status(f'test -e {rec_file}') != 0:
         test.fail(f'VM did not recieve {rec_file}')
     vm_file_md5 = session.cmd_output(f'md5sum {rec_file}')
     vm_file_md5 = vm_file_md5.split()[0]


### PR DESCRIPTION
Replace the test command option '-a' with '-e', since '-e' is to check if the file exists.