### PR TITLE
v2v: fix the failure case of matrix on win2025_bios not exist

### DIFF
--- a/v2v/tests/cfg/convert_vm_to_libvirt.cfg
+++ b/v2v/tests/cfg/convert_vm_to_libvirt.cfg
@@ -122,7 +122,7 @@
                     only esx
                     os_version = "win11"
                 - win2025:
-                    only esx
+                    only source_esx.esx_80
                     os_version = "win2025"
     variants:
         - xen:


### PR DESCRIPTION
Fix "no bios VM exists" issue.