### PR TITLE
Remove dhclient from tests

### DIFF
--- a/libvirt/tests/src/virtual_network/update_device/update_iface_source.py
+++ b/libvirt/tests/src/virtual_network/update_device/update_iface_source.py
@@ -76,7 +76,7 @@ def run(test, params, env):
         vm_iface = utils_net.get_linux_ifname(session, mac)
         LOG.debug(f'Interface inside vm: {vm_iface}')
 
-        LOG.info('Run dhclient to refresh network.')
+        LOG.info('Run command to refresh network.')
         utils_net.restart_guest_network(session, mac)
 
         vm_iface_info = utils_net.get_linux_iface_info(

--- a/libvirt/tests/src/virtual_network/virtual_network_multivms.py
+++ b/libvirt/tests/src/virtual_network/virtual_network_multivms.py
@@ -23,26 +23,6 @@ from provider.virtual_network import network_base
 logging = log.getLogger('avocado.' + __name__)
 
 
-def create_bridge(br_name, iface_name):
-    """
-    Create bridge attached to physical interface
-
-    :param br_name: bridge to be created
-    :param iface_name: physical interface name
-    :return:
-    """
-    # Make sure the bridge not exist
-    if libvirt.check_iface(br_name, "exists", "--all"):
-        return
-
-    # Create bridge using commands
-    utils_package.package_install('tmux')
-    cmd = 'tmux -c "ip link add name {0} type bridge; ip link set {1} up;' \
-          ' ip link set {1} master {0}; ip link set {0} up; pkill dhclient; ' \
-          'sleep 6; dhclient {0}; ifconfig {1} 0"'.format(br_name, iface_name)
-    process.run(cmd, shell=True, verbose=True)
-
-
 def ping_func(session, **expect):
     """
     Check whether ping result meet expectation
@@ -424,7 +404,4 @@ def run(test, params, env):
 
         # Remove test bridge
         if bridge_created:
-            cmd = 'tmux -c "ip link set {1} nomaster;  ip link delete {0};' \
-                  'pkill dhclient; sleep 6; dhclient {1}"'.format(
-                   bridge_name, iface_name)
-            process.run(cmd, shell=True, verbose=True, ignore_status=True)
+            utils_net.delete_linux_bridge_tmux(bridge_name, iface_name)


### PR DESCRIPTION
dhclient is deprecated on RHEL 10 and will have to be removed from our
code base. Use avocado-vt functions instead of invoking it directly so
this can be handled from avocado-vt when needed.