### PR TITLE
Add new case for dimm memory lifecycle test

### DIFF
--- a/libvirt/tests/cfg/memory/memory_devices/dimm_memory_lifecycle.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/dimm_memory_lifecycle.cfg
@@ -1,0 +1,81 @@
+- memory.devices.dimm.lifecycle:
+    type = dimm_memory_lifecycle
+    no s390-virtio
+    start_vm = no
+    check_path_secure_cmd = "ls /dev/hugepages/libvirt/qemu/ -dlZ"
+    path_secure_context = " root root system_u:object_r:hugetlbfs_t:s0"
+    check_guest_secure_cmd = "ls /dev/hugepages/libvirt/qemu/%s-%s -dlZ"
+    guest_secure_context = " qemu qemu system_u:object_r:svirt_image_t:s0"
+    numa_mem_val = 1048576
+    memory_val = 2228224
+    current_mem_val = 2228224
+    init_size = 131072
+    plug_size = 262144
+    aarch64:
+        numa_mem_val = 4194304
+        memory_val = 8912896
+        current_mem_val = 8912896
+        init_size = 524288
+        plug_size = 1572864
+    vm_attrs = {'max_mem_rt': 15428800, 'max_mem_rt_slots': 16,'max_mem_rt_unit': 'KiB','memory_unit':"KiB", 'memory':${memory_val}, 'current_mem':${current_mem_val}, 'current_mem_unit':'KiB', 'vcpu': 4,'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '${numa_mem_val}', 'unit': 'KiB'},{'id':'1','cpus': '2-3','memory':'${numa_mem_val}','unit':'KiB'}]}}
+    init_target_dict = {'size':${init_size}, 'size_unit':'KiB', 'node':0}
+    init_target_xpath = [{'element_attrs':[".//target/size[@unit='KiB']"],'text':'${init_size}'}, {'element_attrs':[".//target/node"],'text':'0'}]
+    plug_target_dict = {'size':${plug_size}, 'size_unit':'KiB', 'node':1}
+    plug_target_xpath = [{'element_attrs':[".//target/size[@unit='KiB']"],'text':'${plug_size}'}, {'element_attrs':[".//target/node"],'text':'1'}]
+    x86_64:
+        bios_check = 'yes'
+        sysinfo_attrs = {'type': 'smbios', 'bios_entry': [{'entry': 'LENOVO', 'entry_name': 'vendor'}]}
+        idmap_attrs = {'uid': {'start': '0', 'target': '1000', 'count': '10'}, 'gid': {'start': '0', 'target': '1000', 'count': '10'}}
+        os_attrs = {'smbios_mode': 'sysinfo'}
+        bios_check_xpath = [{'element_attrs':[".//os/smbios[@mode='sysinfo']"]}, {'element_attrs':[".//sysinfo[@type='smbios']"]}, {'element_attrs':[".//sysinfo/bios/entry[@name='vendor']"],'text':'LENOVO'}, {'element_attrs':[".//idmap/uid[@start='0']", ".//idmap/uid[@target='1000']", ".//idmap/uid[@count='10']"]}, {'element_attrs':[".//idmap/gid[@start='0']", ".//idmap/gid[@target='1000']", ".//idmap/gid[@count='10']"]}]
+    variants kernel_pagesize:
+        - 4k:
+            only x86_64, aarch64
+            page_size = 4
+            default_hp_size = 2048
+        - 64k:
+            only aarch64
+            page_size = 64
+            default_hp_size = 524288
+    variants memory_source:
+        - no_source:
+            source_dict = {}
+            source_xpath = []
+        - nodemask:
+            nodeset_num = 1
+            source_dict = {'nodemask':'%s'}
+            source_xpath = [{'element_attrs':[".//source/nodemask"],'text':'%s'}]
+        - pagesize:
+            source_dict = {'pagesize':${page_size}, 'pagesize_unit':'KiB'}
+            source_xpath = [{'element_attrs':[".//source/pagesize[@unit='KiB']"],'text':'${page_size}'}]
+        - nodemask_pagesize:
+            nodeset_num = 2
+            use_huge_page = "yes"
+            source_dict = {'nodemask':'%s', 'pagesize':${default_hp_size}, 'pagesize_unit':'KiB'}
+            source_xpath = [{'element_attrs':[".//source/nodemask"],'text':'%s'}, {'element_attrs':[".//source/pagesize[@unit='KiB']"],'text':'${default_hp_size}'}]
+    variants address_config:
+        - no_address:
+            init_alias_name = "dimm0"
+            plug_alias_name = "dimm1"
+            init_address_dict = {}
+            plug_address_dict = {}
+            init_address_xpath= [{'element_attrs':[".//address[@slot='0']", ".//address[@base]"]}]
+            plug_address_xpath= [{'element_attrs':[".//address[@slot='1']", ".//address[@base]"]}]
+        - slot_base:
+            init_address = '0x200000000'
+            plug_address = '0x400000000'
+            aarch64:
+                init_address = '0x300000000'
+            init_slot = '1'
+            plug_slot = '2'
+            init_alias_name = "dimm${init_slot}"
+            plug_alias_name = "dimm${plug_slot}"
+            init_address_dict = {'attrs':{'base':'${init_address}', 'type':'dimm', 'slot':'${init_slot}'}}
+            init_address_xpath= [{'element_attrs':[".//address[@slot='${init_slot}']", ".//address[@base='${init_address}']"]}]
+            plug_address_dict = {'attrs':{'base':'${plug_address}', 'type':'dimm', 'slot':'${plug_slot}'}}
+            plug_address_xpath= [{'element_attrs':[".//address[@slot='${plug_slot}']", ".//address[@base='${plug_address}']"]}]
+    init_mem_device_dict = {'mem_model':'dimm', 'source':${source_dict}, 'target':${init_target_dict}, 'address':${init_address_dict}}
+    init_xpath_list = [${source_xpath}, ${init_target_xpath}, ${init_address_xpath}]
+    plug_mem_device_dict = {'mem_model':'dimm', 'source':${source_dict}, 'target':${plug_target_dict}, 'address':${plug_address_dict}}
+    plug_xpath_list = [${source_xpath}, ${plug_target_xpath}, ${plug_address_xpath}]
+

--- a/libvirt/tests/src/memory/memory_devices/dimm_memory_lifecycle.py
+++ b/libvirt/tests/src/memory/memory_devices/dimm_memory_lifecycle.py
@@ -1,0 +1,260 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright Red Hat
+#
+#   SPDX-License-Identifier: GPL-2.0
+#
+#   Author: Liang Cong <lcong@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import os
+import re
+
+from avocado.utils import process
+
+from virttest import data_dir
+from virttest import test_setup
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.libvirt_xml.devices import memory
+from virttest.utils_libvirt import libvirt_memory
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_libvirtd import Libvirtd
+from virttest.utils_test import libvirt
+
+from provider.memory import memory_base
+from provider.numa import numa_base
+
+
+def run(test, params, env):
+    """
+    Verify various config of dimm memory device settings take effect
+    during the life cycle of guest vm.
+    """
+
+    def clean_empty_memory_device_config(mem_device_dict):
+        """
+        Clean empty config of the memory device
+
+        :param mem_device_dict (dict): memory device config dictionary
+        """
+        for key in list(mem_device_dict.keys()):
+            if not mem_device_dict[key]:
+                del mem_device_dict[key]
+
+    def check_dimm_mem_device_xml(xpath_dict):
+        """
+        Check the dimm memory device config by xpath
+
+        :param xpath_dict (dict): xpath dict to check if the memory config is correct,
+                                  like {"alias_name":[xpath1, xpath2]},...}
+        """
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        test.log.debug(f"Current guest config xml is:\n{vmxml}")
+        memory_devices = vmxml.devices.by_device_tag('memory')
+        target_memory_num = 0
+        for alias_name, xpath_list in xpath_dict.items():
+            for memory_device in memory_devices:
+                if alias_name == memory_device.alias.get('name'):
+                    target_memory_num = target_memory_num + 1
+                    for xpath in xpath_list:
+                        libvirt_vmxml.check_guest_xml_by_xpaths(memory_device, xpath)
+        if target_memory_num != len(xpath_dict):
+            test.fail(
+                f"Expected {len(xpath_dict)} dimm mem devices with required alias name, but found {target_memory_num}")
+
+    def check_numa_node(mem_size, numa_list, page_size):
+        """
+        Check memory is allocated on target numa list with correct page size
+
+        :param mem_size (int): memory size
+        :param numa_list (list): target numa list
+        :param page_size (str): page size of the memory
+        """
+        cmd_output = numa_base.get_host_numa_memory_alloc_info(mem_size)
+        actual_numa_list = re.findall(r'N(\d+)=', cmd_output)
+        if not set(actual_numa_list).issubset(set(numa_list)):
+            test.fail(
+                f"Expected numa list {numa_list} doesn't contain actual numa in numa_maps output {cmd_output}")
+        if not re.search(fr'kernelpagesize_kB={page_size}', cmd_output):
+            test.fail(
+                f"Failed to find {page_size}kb memory page size in numa_maps output {cmd_output}")
+
+    def check_case_availability():
+        """
+        Check whether the case is available
+        """
+        memory_base.check_mem_page_sizes(test, page_size, default_hp_size)
+        memory_base.check_supported_version(params, test, vm)
+
+    def setup_test():
+        """
+        Setup for the case:
+        1. Get host available numa nodes
+        2. Change parameters according to available numa nodes
+        3. Allocate huge page memory for target host node if needs
+        """
+        if nodeset_num:
+            numatest_obj = numa_base.NumaTest(vm, params, test)
+            if 1 == nodeset_num:
+                min_memory_size = init_size + plug_size
+            elif 2 == nodeset_num:
+                min_memory_size = init_size if init_size >= plug_size else plug_size
+            numatest_obj.check_numa_nodes_availability(nodeset_num, min_memory_size)
+            numa_list = numatest_obj.get_available_numa_nodes(min_memory_size)[:nodeset_num]
+            nodeset_str = numa_base.convert_to_string_with_dash(
+                ','.join([str(node) for node in numa_list]))
+            params["numa_node_list"] = numa_list
+            source_dict = params.get("source_dict")
+            source_xpath = params.get("source_xpath")
+            source_dict = eval(source_dict % nodeset_str)
+            source_xpath = eval(source_xpath % nodeset_str)
+            init_mem_device_dict["source"] = source_dict
+            plug_mem_device_dict["source"] = source_dict
+            init_xpath_list[0] = source_xpath
+            plug_xpath_list[0] = source_xpath
+            test.log.debug(f"Selected numa nodeset is:{nodeset_str}")
+
+            if use_huge_page:
+                params["target_nodes"] = " ".join([str(node) for node in numa_list])
+                params["target_hugepages"] = (init_size + plug_size) / default_hp_size
+                hpc = test_setup.HugePageConfig(params)
+                hpc.setup()
+
+        if vm.is_alive():
+            vm.destroy()
+
+    def run_test():
+        """
+        Test steps
+        """
+        test.log.info("TEST_STEP1: Define the guest")
+        clean_empty_memory_device_config(init_mem_device_dict)
+        memory_base.define_guest_with_memory_device(params, init_mem_device_dict, vm_attrs)
+
+        if use_huge_page:
+            test.log.info("TEST_STEP2: Check secure context for default huge page mount path")
+            cmd_result = process.run(check_path_secure_cmd, ignore_status=True, shell=True)
+            libvirt.check_result(cmd_result, expected_match=path_secure_context)
+
+        test.log.info("TEST_STEP3: Start the guest")
+        vm.start()
+        vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        test.log.debug(f"Guest config xml after start is:\n{vmxml}")
+
+        if use_huge_page:
+            test.log.info("TEST_STEP4: Check secure context for default huge page mount path")
+            check_cmd = check_guest_secure_cmd % (vm.get_id(), vm_name)
+            cmd_result = process.run(check_cmd, ignore_status=True, shell=True)
+            libvirt.check_result(cmd_result, expected_match=guest_secure_context)
+
+        test.log.info("TEST_STEP5: Check dimm memory device config by virsh dumpxml")
+        check_dimm_mem_device_xml({init_alias_name: init_xpath_list})
+
+        if bios_check:
+            test.log.info("TEST_STEP6: Check smbios, sysinfo and idmap info by virsh dumpxml")
+            libvirt_vmxml.check_guest_xml_by_xpaths(vmxml, bios_check_xpath)
+
+        test.log.info("TEST_STEP7: Hotplug a dimm memory device")
+        clean_empty_memory_device_config(plug_mem_device_dict)
+        mem_device = memory.Memory()
+        mem_device.setup_attrs(**plug_mem_device_dict)
+        virsh.attach_device(vm_name, mem_device.xml, debug=True, ignore_status=False)
+
+        test.log.info(
+            "TEST_STEP8: Check dimm memory device config by virsh dumpxml")
+        check_dimm_mem_device_xml(
+            {init_alias_name: init_xpath_list, plug_alias_name: plug_xpath_list})
+
+        test.log.info("TEST_STEP9: Consume the guest memory")
+        with vm.wait_for_login() as session:
+            libvirt_memory.consume_vm_freememory(session)
+
+        if nodeset_num:
+            test.log.info("TEST_STEP10: Check dimm memory device source node")
+            numa_list = [str(node) for node in params['numa_node_list']]
+            expected_page_size = default_hp_size if use_huge_page else page_size
+            check_numa_node(init_size, numa_list, expected_page_size)
+            check_numa_node(plug_size, numa_list, expected_page_size)
+
+        test.log.info("TEST_STEP11: Life cycle test")
+        virsh.suspend(vm_name, ignore_status=False, debug=True)
+        virsh.resume(vm_name, ignore_status=False, debug=True)
+        check_dimm_mem_device_xml(
+            {init_alias_name: init_xpath_list, plug_alias_name: plug_xpath_list})
+
+        virsh.save(vm_name, state_file, ignore_status=False, debug=True)
+        virsh.restore(state_file, ignore_status=False, debug=True)
+        check_dimm_mem_device_xml(
+            {init_alias_name: init_xpath_list, plug_alias_name: plug_xpath_list})
+
+        virsh.managedsave(vm_name, ignore_status=False, debug=True)
+        vm.start()
+        check_dimm_mem_device_xml(
+            {init_alias_name: init_xpath_list, plug_alias_name: plug_xpath_list})
+
+        vm.reboot()
+        vm.wait_for_login().close()
+        check_dimm_mem_device_xml(
+            {init_alias_name: init_xpath_list, plug_alias_name: plug_xpath_list})
+
+        libvirt_daemon = Libvirtd()
+        if not libvirt_daemon.restart(reset_failed=False):
+            test.error("libvirt deamon restarts failed or is not working properly")
+        check_dimm_mem_device_xml(
+            {init_alias_name: init_xpath_list, plug_alias_name: plug_xpath_list})
+
+    def teardown_test():
+        """
+        1. Restore guest config xml
+        2. Clean huge page memory
+        3. Remove state file
+        """
+        bkxml.sync()
+        if use_huge_page:
+            hpc = test_setup.HugePageConfig(params)
+            hpc.cleanup()
+        if os.path.exists(state_file):
+            os.remove(state_file)
+
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+
+    vm_attrs = eval(params.get("vm_attrs", "{}"))
+    bios_check = params.get("bios_check", "no") == "yes"
+    if bios_check:
+        sysinfo_attrs = eval(params.get("sysinfo_attrs", "{}"))
+        idmap_attrs = eval(params.get("idmap_attrs", "{}"))
+        os_attrs = eval(params.get("os_attrs", "{}"))
+        vm_attrs.update({'sysinfo': sysinfo_attrs,
+                        'os': os_attrs, 'idmap': idmap_attrs})
+        bios_check_xpath = eval(params.get("bios_check_xpath"))
+    init_mem_device_dict = eval(
+        params.get("init_mem_device_dict", "{}"))
+    plug_mem_device_dict = eval(
+        params.get("plug_mem_device_dict", "{}"))
+    init_xpath_list = eval(params.get("init_xpath_list"))
+    plug_xpath_list = eval(params.get("plug_xpath_list"))
+    check_path_secure_cmd = params.get("check_path_secure_cmd")
+    path_secure_context = params.get("path_secure_context")
+    check_guest_secure_cmd = params.get("check_guest_secure_cmd")
+    guest_secure_context = params.get("guest_secure_context")
+    init_alias_name = params.get("init_alias_name")
+    plug_alias_name = params.get("plug_alias_name")
+    page_size = int(params.get("page_size"))
+    default_hp_size = int(params.get("default_hp_size"))
+    init_size = int(params.get("init_size"))
+    plug_size = int(params.get("plug_size"))
+    nodeset_num = int(params.get("nodeset_num", "0"))
+    use_huge_page = "yes" == params.get("use_huge_page")
+    state_file = f"{data_dir.get_tmp_dir()}/{vm_name}.save"
+
+    try:
+        check_case_availability()
+        setup_test()
+        run_test()
+
+    finally:
+        teardown_test()


### PR DESCRIPTION
Add new case VIRT-299042 Life cycle for various config of dimm memory device

Test run result:
x86_64:
(1/8) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.no_address.no_source.4k: STARTED
 (1/8) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.no_address.no_source.4k: PASS (102.76 s)
 (2/8) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.no_address.nodemask.4k: STARTED
 (2/8) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.no_address.nodemask.4k: PASS (104.58 s)
 (3/8) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.no_address.pagesize.4k: STARTED
 (3/8) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.no_address.pagesize.4k: PASS (139.10 s)
 (4/8) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.no_address.nodemask_pagesize.4k: STARTED
 (4/8) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.no_address.nodemask_pagesize.4k: PASS (113.81 s)
 (5/8) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.slot_base.no_source.4k: STARTED
 (5/8) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.slot_base.no_source.4k: PASS (104.87 s)
 (6/8) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.slot_base.nodemask.4k: STARTED
 (6/8) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.slot_base.nodemask.4k: PASS (106.58 s)
 (7/8) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.slot_base.pagesize.4k: STARTED
 (7/8) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.slot_base.pagesize.4k: PASS (104.62 s)
 (8/8) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.slot_base.nodemask_pagesize.4k: STARTED
 (8/8) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.slot_base.nodemask_pagesize.4k: PASS (109.62 s)

aarch64 64k kernel:
 (01/16) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.no_address.no_source.4k: STARTED
 (01/16) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.no_address.no_source.4k: CANCEL: Expected host default page size is 4 KiB, but get 64.0 KiB (6.28 s)
 (02/16) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.no_address.no_source.64k: STARTED
 (02/16) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.no_address.no_source.64k: PASS (100.36 s)
 (03/16) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.no_address.nodemask.4k: STARTED
 (03/16) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.no_address.nodemask.4k: CANCEL: Expected host default page size is 4 KiB, but get 64.0 KiB (6.90 s)
 (04/16) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.no_address.nodemask.64k: STARTED
 (04/16) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.no_address.nodemask.64k: PASS (107.75 s)
 (05/16) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.no_address.pagesize.4k: STARTED
 (05/16) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.no_address.pagesize.4k: CANCEL: Expected host default page size is 4 KiB, but get 64.0 KiB (6.88 s)
 (06/16) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.no_address.pagesize.64k: STARTED
 (06/16) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.no_address.pagesize.64k: PASS (101.20 s)
 (07/16) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.no_address.nodemask_pagesize.4k: STARTED
 (07/16) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.no_address.nodemask_pagesize.4k: CANCEL: Expected host default page size is 4 KiB, but get 64.0 KiB (7.13 s)
 (08/16) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.no_address.nodemask_pagesize.64k: STARTED
 (08/16) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.no_address.nodemask_pagesize.64k: PASS (105.42 s)
 (09/16) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.slot_base.no_source.4k: STARTED
 (09/16) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.slot_base.no_source.4k: CANCEL: Expected host default page size is 4 KiB, but get 64.0 KiB (7.03 s)
 (10/16) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.slot_base.no_source.64k: STARTED
 (10/16) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.slot_base.no_source.64k: PASS (102.04 s)
 (11/16) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.slot_base.nodemask.4k: STARTED
 (11/16) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.slot_base.nodemask.4k: CANCEL: Expected host default page size is 4 KiB, but get 64.0 KiB (6.50 s)
 (12/16) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.slot_base.nodemask.64k: STARTED
 (12/16) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.slot_base.nodemask.64k: PASS (109.46 s)
 (13/16) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.slot_base.pagesize.4k: STARTED
 (13/16) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.slot_base.pagesize.4k: CANCEL: Expected host default page size is 4 KiB, but get 64.0 KiB (6.66 s)
 (14/16) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.slot_base.pagesize.64k: STARTED
 (14/16) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.slot_base.pagesize.64k: PASS (96.48 s)
 (15/16) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.slot_base.nodemask_pagesize.4k: STARTED
 (15/16) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.slot_base.nodemask_pagesize.4k: CANCEL: Expected host default page size is 4 KiB, but get 64.0 KiB (6.65 s)
 (16/16) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.slot_base.nodemask_pagesize.64k: STARTED
 (16/16) type_specific.io-github-autotest-libvirt.memory.devices.dimm.lifecycle.slot_base.nodemask_pagesize.64k: PASS (103.55 s)