### PR TITLE
video_devices: add case for resolution

### DIFF
--- a/libvirt/tests/cfg/virtual_device/video_devices.cfg
+++ b/libvirt/tests/cfg/virtual_device/video_devices.cfg
@@ -5,6 +5,12 @@
         - positive_test:
             status_error = "no"
             variants:
+                - resolution_test:
+                    no qxl
+                    resolution_test = "yes"
+                    resolution_x = 507
+                    resolution_y = 510
+                    qemu_line = "xres.*:${resolution_x}.*yres.*:${resolution_y}"
                 - model_test:
                     model_test = "yes"
                     variants:
@@ -98,6 +104,7 @@
                     no mem_test
                     variants:
                         - qxl:
+                            no aarch64
                             secondary_video_model = qxl
                         - virtio:
                             secondary_video_model = virtio
@@ -105,20 +112,21 @@
                 - primary_video:
                     variants:
                         - qxl:
-                            no s390-virtio
+                            no s390-virtio, aarch64
                             primary_video_model = qxl
                         - vga:
-                            no s390-virtio
+                            no s390-virtio, aarch64
                             primary_video_model = vga
                         - cirrus:
-                            no s390-virtio
+                            no s390-virtio, aarch64
+                            no resolution_test
                             primary_video_model = cirrus
                             no mem_test
                         - virtio:
                             primary_video_model = virtio
                             no mem_test
                         - bochs:
-                            no s390-virtio
+                            no s390-virtio, aarch64
                             primary_video_model = bochs
                             only no_secondary_video..model_test.default no_secondary_video..vram..bochs_default_size
         - negative_test:


### PR DESCRIPTION
Case ID: VIRT-304063

Support resolution setting for video device.
```
<video>
<model type='virtio' heads='1' primary='yes'>
<resolution x='507' y='510'/>
</model>
</video>
```

Signed-off-by: Dan Zheng <dzheng@redhat.com>