### PR TITLE
link_state_model_type:Restore vmxml for non root vm

### DIFF
--- a/libvirt/tests/src/virtual_network/link_state/link_state_model_type.py
+++ b/libvirt/tests/src/virtual_network/link_state/link_state_model_type.py
@@ -110,7 +110,7 @@ def run(test, params, env):
         session.close()
 
     finally:
-        bkxml.sync()
+        bkxml.sync(virsh_instance=virsh_ins)
         if interface_type == "ethernet":
             network_base.delete_tap(tap_name)
             utils_net.delete_linux_bridge_tmux(bridge_name, host_iface)


### PR DESCRIPTION
 (1/1) type_specific.local.virtual_network.link_state.model.user.passt.unprivileged_user.virtio.initial_up: STARTED
 (1/1) type_specific.local.virtual_network.link_state.model.user.passt.unprivileged_user.virtio.initial_up: PASS (52.53 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0