### PR TITLE
automate VIRT-303225 - [vIOMMU] virsh reset when booting guest for 10+ times

### DIFF
--- a/libvirt/tests/cfg/sriov/vIOMMU/iommu_repeated_reset.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/iommu_repeated_reset.cfg
@@ -1,0 +1,28 @@
+- vIOMMU.iommu_repeated_reset:
+    type = iommu_repeated_reset
+    ping_dest = '8.8.8.8'
+    max_wait_ms = 3000
+    max_repeat = 10
+    str_in_log = False
+    log_messages = "virtio: zero sized buffers are not allowed"
+    variants:
+        - virtio:
+            only q35, aarch64
+            func_supported_since_libvirt_ver = (8, 3, 0)
+            iommu_dict = {'model': 'virtio'}
+        - intel:
+            only q35
+            start_vm = "yes"
+            enable_guest_iommu = "yes"
+            iommu_dict = {'model': 'intel', 'driver': {'intremap': 'on', 'caching_mode': 'on', 'eim': 'on', 'iotlb': 'on', 'aw_bits': '48'}}
+        - smmuv3:
+            only aarch64
+            func_supported_since_libvirt_ver = (5, 5, 0)
+            iommu_dict = {'model': 'smmuv3'}
+    variants:
+        - scsi_controller:
+            controller_dicts = [{'type': 'scsi', 'model': 'virtio-scsi','driver': {'iommu': 'on'}}]
+            disk_driver = {'name': 'qemu', 'type': 'qcow2'}
+            disk_dict = {'target': {'dev': 'sda', 'bus': 'scsi'}, 'driver': ${disk_driver}}
+            cleanup_ifaces = no
+            start_vm = "yes"

--- a/libvirt/tests/src/sriov/vIOMMU/iommu_repeated_reset.py
+++ b/libvirt/tests/src/sriov/vIOMMU/iommu_repeated_reset.py
@@ -1,0 +1,76 @@
+import os
+from time import sleep
+from random import uniform
+
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+from virttest import utils_logfile
+
+from provider.viommu import viommu_base
+
+
+def run(test, params, env):
+    """
+    Start vm with iommu device and kinds of virtio devices with iommu=on, and
+    check network and disk function.
+    """
+
+    def setup_test():
+        utils_logfile.clear_log_file(log_file_name, '/var/log/libvirt/qemu')
+        test_obj.setup_iommu_test(iommu_dict=iommu_dict, cleanup_ifaces=False)
+        test_obj.prepare_controller()
+        test.log.debug("---------------------------------------------------------------------------")
+        dev_dict = eval(params.get('disk_dict', '{}'))
+        test.log.debug(f"disk_dict: {dev_dict}")
+        if dev_dict:
+            dev_dict = test_obj.update_disk_addr(dev_dict)
+            if dev_dict["target"].get("bus") != "virtio":
+                libvirt_vmxml.modify_vm_device(
+                   vm_xml.VMXML.new_from_dumpxml(vm.name), 'disk', {'driver': None})
+
+            libvirt_vmxml.modify_vm_device(
+                vm_xml.VMXML.new_from_dumpxml(vm.name), 'disk', dev_dict)
+
+    iommu_dict = eval(params.get('iommu_dict', '{}'))
+
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    log_file_name = f"{vm_name}.log"
+    log_file = os.path.join("/var/log/libvirt/qemu", log_file_name)
+    vm = env.get_vm(vm_name)
+
+    test_obj = viommu_base.VIOMMUTest(vm, test, params)
+
+    try:
+        setup_test()
+
+        test.log.info("TEST_STEP: Start the VM and wait for login.")
+        vm.start()
+        vm.wait_for_login().close()
+        test.log.info("TEST_STEP: Reboot the VM and wait for event 'reboot'")
+        virsh.reboot(vm_name, wait_for_event=True, debug=True, ignore_status=False)
+        test.log.debug("TEST_STEP: verify user is able to login also after restarts")
+        vm.wait_for_login().close()
+
+        max_wait_ms = int(params.get('max_wait_ms', 0))
+        max_repeat = int(params.get('max_repeat', 10))
+
+        for _ in range(max_repeat):
+            if max_wait_ms > 0:
+                wait_time = uniform(0, max_wait_ms) / 1000
+                test.log.debug(f"waiting before reset {wait_time}s")
+                sleep(wait_time)
+            virsh.reset(vm_name)
+
+        test.log.debug(vm_xml.VMXML.new_from_dumpxml(vm.name))
+
+        test.log.debug("TEST_STEP: verify user is able to login also after restarts")
+        vm.wait_for_login().close()
+        log_messages = params.get('log_messages', "")
+        str_in_log = (params.get('str_in_log', "False") == "True")
+        test.log.debug("TEST_STEP: check log for error messages")
+        libvirt.check_logfile(log_messages, log_file, str_in_log)
+
+    finally:
+        test_obj.teardown_iommu_test()


### PR DESCRIPTION
**!!! the test is using new functions added to the avocado-vt framework in 
https://github.com/avocado-framework/avocado-vt/pull/4095** 

the test is about running starting VM according matrix setting, 
1. start VM and wait till booted, then reboot the guest ad
2. do guest reset during guest rebooting required times (with some randomized sleep time to reset in different part of reboot) 
3. log into the VM
4. check the /var/log/libvirt/qemu/vm.log for virtio: zero sized buffers are not allowed

the test can be parametrized:
- max_wait_ms = 3000 # max number of miliseconds to wait between resets to provide some randomness in execution, the number should be less then expected time needed for reboot
- max_repeat = 10 # number of repetition 
- log_messages # single string or list of strings to be checked in the log
- fail_if_found = True # parameter to switch if the message should be there or not

Note: 
The test is based (copied - yes I know this sucks) from VIRT-294579 (with some parts removed due smaller matrix) and to be honest I don't know if the rows 26-40 are written the best way as I am not the author of it.  


