### PR TITLE
fix get_source_list function missing some disk source paths

### DIFF
--- a/provider/virtual_disk/disk_base.py
+++ b/provider/virtual_disk/disk_base.py
@@ -79,10 +79,10 @@ class DiskBase(object):
                 for elem in backing_list:
                     source_ele = elem.find("source")
                     if source_ele is not None:
-                        source_list = [source_ele.get('file') or
-                                       source_ele.get('name') or
-                                       source_ele.get('dev') or
-                                       source_ele.get('volume')]
+                        source_list.append(source_ele.get('file') or
+                                           source_ele.get('name') or
+                                           source_ele.get('dev') or
+                                           source_ele.get('volume'))
                         if source_ele.find("dataStore"):
                             source_list.append(
                                 source_ele.find("dataStore").find('source').get('file'))


### PR DESCRIPTION
    replace "=" with "append"
Signed-off-by: nanli <nanli@redhat.com>

Before fix
```
~# avocado run --vt-type libvirt --vt-omit-data-loss --vt-machine-type arm64-mmio backingchain.blockpull.relative_path.file_disk.keep_relative --vt-connect-uri qemu:///system
 (1/1) backingchain.blockpull.relative_path.file_disk.keep_relative: ERROR: list index out of range (22.62 s)
```


After fix
```
~# avocado run --vt-type libvirt --vt-omit-data-loss --vt-machine-type arm64-mmio backingchain.blockpull.relative_path.file_disk.keep_relative --vt-connect-uri qemu:///system
 (1/1) backingchain.blockpull.relative_path.file_disk.keep_relative: PASS (23.55 s)


```

Some influenced cases
```
]# avocado run --vt-type libvirt --vt-omit-data-loss --vt-machine-type arm64-mmio  backingchain.blockcommit.relative_path backingchain.blockcopy.image_properties  --vt-connect-uri qemu:///system
 (01/14) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.file_disk.keep_relative.active.vm_started: STARTED
 (01/14) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.file_disk.keep_relative.active.vm_started: PASS (23.06 s)
 (02/14) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.file_disk.keep_relative.active.vm_paused: STARTED
 (02/14) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.file_disk.keep_relative.active.vm_paused: PASS (23.84 s)
 (03/14) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.file_disk.keep_relative.inactive.keep_relative.vm_started: STARTED
 (03/14) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.file_disk.keep_relative.inactive.keep_relative.vm_started: PASS (23.99 s)
 (04/14) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.file_disk.keep_relative.inactive.keep_relative.vm_paused: STARTED
 (04/14) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.file_disk.keep_relative.inactive.keep_relative.vm_paused: PASS (24.27 s)
 (05/14) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.file_disk.keep_relative.inactive.keep_relative_bandwidth.vm_started: STARTED
 (05/14) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.file_disk.keep_relative.inactive.keep_relative_bandwidth.vm_started: PASS (24.23 s)
 (06/14) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.file_disk.keep_relative.inactive.keep_relative_bandwidth.vm_paused: STARTED
 (06/14) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.file_disk.keep_relative.inactive.keep_relative_bandwidth.vm_paused:PASS (23.89 s)
 (07/14) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.block_disk.keep_relative.active.vm_started: STARTED
 (07/14) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.block_disk.keep_relative.active.vm_started: PASS (46.19 s)
 (08/14) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.block_disk.keep_relative.active.vm_paused: STARTED
 (08/14) type_specific.io-github-autotest-libvirt.backingchain.blockcommit.relative_path.block_disk.keep_relative.active.vm_paused: PASS (45.52 s)
 (11/14) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.image_properties.not_encrypt_disk.extended_l2_and_cluster_size: STARTED
 (11/14) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.image_properties.not_encrypt_disk.extended_l2_and_cluster_size: PASS (27.79 s)
 (12/14) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.image_properties.not_encrypt_disk.with_datastore: STARTED
 (12/14) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.image_properties.not_encrypt_disk.with_datastore: PASS (27.26 s)
 (13/14) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.image_properties.encrypt_disk.extended_l2_and_cluster_size: STARTED
 (13/14) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.image_properties.encrypt_disk.extended_l2_and_cluster_size: PASS (33.96 s)
 (14/14) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.image_properties.encrypt_disk.with_datastore: STARTED
 (14/14) type_specific.io-github-autotest-libvirt.backingchain.blockcopy.image_properties.encrypt_disk.with_datastore: PASS (34.02 s)

```