### PR TITLE
pause_by_domjobabort_and_recover: increase migrate_speed to ensure test does not timeout

### DIFF
--- a/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_by_domjobabort_and_recover.cfg
+++ b/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_by_domjobabort_and_recover.cfg
@@ -26,7 +26,7 @@
     migrate_desturi_type = "tcp"
     virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
     status_error = "yes"
-    migrate_speed = "5"
+    migrate_speed = "15"
     stress_package = "stress"
     stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20s"
     postcopy_options = "--timeout 4 --timeout-postcopy --postcopy"


### PR DESCRIPTION
Test would consistently timeout during migration. Since a migrate_speed of 5 is quite slow, increased to 15.

**Evidence of test passing:**
```
# avocado run --vt-type libvirt --vt-omit-data-loss --vt-machine-type arm64-pci migration.pause_postcopy_migration_and_recover.pause_by_domjobabort_and_recover.migrateuri.tcp.p2p --vt-connect-uri qemu:///system
JOB ID     : 91f8831afbbb7fd1a12628fb80a777b59ef8740f
JOB LOG    : /var/log/avocado/job-results/job-2025-03-28T16.13-91f8831/job.log
 (1/1) type_specific.io-github-autotest-libvirt.migration.pause_postcopy_migration_and_recover.pause_by_domjobabort_and_recover.migrateuri.tcp.p2p: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.migration.pause_postcopy_migration_and_recover.pause_by_domjobabort_and_recover.migrateuri.tcp.p2p: PASS (333.04 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2025-03-28T16.13-91f8831/results.html
JOB TIME   : 334.60 s
```