### PR TITLE
Sriov: fix "unplug of device was rejected by the guest" failure

### DIFF
--- a/libvirt/tests/cfg/sriov/locked_memory_check/sriov_with_hotplug_memory.cfg
+++ b/libvirt/tests/cfg/sriov/locked_memory_check/sriov_with_hotplug_memory.cfg
@@ -1,9 +1,10 @@
 - sriov.locked_memory_check.hotplug_memory:
     type = sriov_with_hotplug_memory
-    start_vm = "no"
+    start_vm = "yes"
     mem_dict1 = {'mem_model': 'dimm', 'target': {'size': 1, 'size_unit': 'G', 'node': 0}, 'alias': {'name': 'ua-d9cbe3cc-40fe-4aed-b245-874c534e8362'}}
     mem_dict2 = {'mem_model': 'dimm', 'target': {'size': 1, 'size_unit': 'G', 'node': 0}}
     vm_attrs = {'max_mem_rt': 6291456, 'max_mem_rt_slots': 32, 'max_mem_rt_unit': 'K', 'vcpu': 8, 'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-3', 'memory': '%s', 'unit': 'K'}, {'id': '1', 'cpus': '4-7', 'memory': '%s', 'unit': 'K'}]}}
+    kernel_extra_params_add = "memhp_default_state=online_movable"
     only x86_64, aarch64
     variants dev_type:
         - hostdev_interface:

--- a/libvirt/tests/src/sriov/locked_memory_check/sriov_with_hotplug_memory.py
+++ b/libvirt/tests/src/sriov/locked_memory_check/sriov_with_hotplug_memory.py
@@ -105,7 +105,7 @@ def run(test, params, env):
         test.log.info("TEST_STEP: Start the vm and check locked memory limit.")
         vm.start()
         test.log.debug("The current guest xml is:%s", virsh.dumpxml(vm_name).stdout_text)
-        vm_session = vm.wait_for_serial_login(timeout=240).close
+        vm.wait_for_login(timeout=240).close()
         default_mem = libvirt_memory.normalize_mem_size(
                        vmxml.get_current_mem(),
                        vmxml.get_current_mem_unit())


### PR DESCRIPTION
Fix the unplug failure of dimm memory device by adding memhp_default_state=online_movable to guest kernel which is a common workaround.