### PR TITLE
domstats: fix failure by adding sched_schedstats

### DIFF
--- a/libvirt/tests/src/virsh_cmd/monitor/virsh_domstats.py
+++ b/libvirt/tests/src/virsh_cmd/monitor/virsh_domstats.py
@@ -13,7 +13,7 @@ from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.devices.panic import Panic
 
 from virttest import libvirt_version
-
+from avocado.utils import process
 
 # Using as lower capital is not the best way to do, but this is just a
 # workaround to avoid changing the entire file.
@@ -355,6 +355,8 @@ def run(test, params, env):
         if "--iothread" in domstats_option:
             add_iothread(vm_list, iothread_add_ids)
         # Run virsh command
+        process.run("echo 1 > /proc/sys/kernel/sched_schedstats", shell=True)
+        logging.debug("enable sched_schedstats success")
         result = virsh.domstats(vm_list, domstats_option, ignore_status=True,
                                 debug=True)
         status = result.exit_status


### PR DESCRIPTION
fix domstats failures by adding "echo 1 > /proc/sys/kernel/sched_schedstats" before domststs command