### PR TITLE
cpu: add case for virsh cpu models compare with qemu

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_cpu_models.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_cpu_models.cfg
@@ -10,7 +10,18 @@
             variants:
                 - auto_get_arch:
                 - specific_arch:
-                    cpu_arch = "x86_64"
+                    only local_host
+                    check_qemu_cpu_supported_cmd = "/usr/libexec/qemu-kvm -cpu help | awk '/Available CPUs/,/Recognized CPUID flags/' | grep '^  ' | awk '{print $1}'"
+                    skip_list = ['base', 'host', 'max']
+                    variants arch_option:
+                        - arch_x86:
+                            cpu_arch = "x86_64"
+                        - arch_s390:
+                            cpu_arch = "s390"
+                            msg = "all CPU models are accepted"
+                        - arch_aarch64:
+                            cpu_arch =  "aarch64"
+                            msg = "all CPU models are accepted"
             variants:
                 - local_host:
                 - remote_host:

--- a/libvirt/tests/src/virsh_cmd/host/virsh_cpu_models.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_cpu_models.py
@@ -1,6 +1,8 @@
 import logging as log
 from six import itervalues
 
+from avocado.utils import process
+
 from virttest import ssh_key
 from virttest import virsh
 from virttest import libvirt_vm
@@ -13,6 +15,31 @@ from virttest.utils_test import libvirt as utlv
 logging = log.getLogger('avocado.' + __name__)
 
 
+def compare_cpu_model_with_qemu(test, params, virsh_cpu_model_result, qemu_cmd):
+    """
+    Compare the libvirt cpu model same with the model in qemu-kvm.
+
+    :params: test:  test object
+    :params: params, cfg parameter dict.
+    :params: virsh_cpu_model_result:virsh cpu-model result
+    :params: qemu_cmd: qemu cmd to get cpu model name.
+    """
+    arch_option = params.get("arch_option")
+    if arch_option == "arch_x86":
+        skip_list = eval(params.get("skip_list", []))
+        qemu_models = process.run(qemu_cmd, ignore_status=False, shell=True).stdout_text.strip().split("\n")
+        virsh_cpu_model_result = virsh_cpu_model_result.stdout_text.strip().split("\n")
+
+        for qemu_model in qemu_models:
+            if qemu_model not in {*virsh_cpu_model_result, *skip_list}:
+                test.fail("Expected the model of qemu-kvm:%s in virsh cpu-model result" % qemu_model)
+        test.log.debug("All the cpu models of qemu-kvm are contained in virsh cpu-models.")
+    else:
+        msg = params.get("msg", "")
+        if msg not in virsh_cpu_model_result.stdout_text:
+            test.fail("Expected '%s' in virsh cpu-models result" % msg)
+
+
 def run(test, params, env):
     """
     Test command virsh cpu-models
@@ -23,6 +50,7 @@ def run(test, params, env):
     remote_ref = params.get("remote_ref", "")
     connect_uri = libvirt_vm.normalize_connect_uri(params.get("connect_uri",
                                                               "default"))
+    qemu_cmd = params.get("check_qemu_cpu_supported_cmd", "")
 
     if remote_ref == "remote":
         remote_ip = params.get("remote_ip", "REMOTE.EXAMPLE.COM")
@@ -54,3 +82,4 @@ def run(test, params, env):
         result = virsh.cpu_models(arch, options=option, uri=connect_uri,
                                   ignore_status=True, debug=True)
         utlv.check_exit_status(result, expect_error=status_error)
+        compare_cpu_model_with_qemu(test, params, result, qemu_cmd)


### PR DESCRIPTION
  xxxx-303288 Compare x86 cpu models with qemu-kvm
Signed-off-by: nanli <nanli@redhat.com>

```
avocado run --vt-type libvirt --vt-machine-type q35 virsh.cpu_models.positive_test.local_host.specific_arch
 (1/3) type_specific.io-github-autotest-libvirt.virsh.cpu_models.positive_test.local_host.specific_arch.arch_x86: STARTED
 (1/3) type_specific.io-github-autotest-libvirt.virsh.cpu_models.positive_test.local_host.specific_arch.arch_x86: PASS (6.30 s)
 (2/3) type_specific.io-github-autotest-libvirt.virsh.cpu_models.positive_test.local_host.specific_arch.arch_s390: STARTED
 (2/3) type_specific.io-github-autotest-libvirt.virsh.cpu_models.positive_test.local_host.specific_arch.arch_s390: PASS (5.73 s)
 (3/3) type_specific.io-github-autotest-libvirt.virsh.cpu_models.positive_test.local_host.specific_arch.arch_aarch64: STARTED
 (3/3) type_specific.io-github-autotest-libvirt.virsh.cpu_models.positive_test.local_host.specific_arch.arch_aarch64: PASS (5.74 s)
```
Other related cases
```
avocado run --vt-type libvirt --vt-machine-type q35 virsh.cpu_models
 (1/7) type_specific.io-github-autotest-libvirt.virsh.cpu_models.positive_test.local_host.auto_get_arch: STARTED
 (1/7) type_specific.io-github-autotest-libvirt.virsh.cpu_models.positive_test.local_host.auto_get_arch: PASS (8.05 s)
 (2/7) type_specific.io-github-autotest-libvirt.virsh.cpu_models.positive_test.local_host.specific_arch.arch_x86: STARTED
 (2/7) type_specific.io-github-autotest-libvirt.virsh.cpu_models.positive_test.local_host.specific_arch.arch_x86: PASS (6.29 s)
 (3/7) type_specific.io-github-autotest-libvirt.virsh.cpu_models.positive_test.local_host.specific_arch.arch_s390: STARTED
 (3/7) type_specific.io-github-autotest-libvirt.virsh.cpu_models.positive_test.local_host.specific_arch.arch_s390: PASS (5.67 s)
 (4/7) type_specific.io-github-autotest-libvirt.virsh.cpu_models.positive_test.local_host.specific_arch.arch_aarch64: STARTED
 (4/7) type_specific.io-github-autotest-libvirt.virsh.cpu_models.positive_test.local_host.specific_arch.arch_aarch64: PASS (5.70 s)
 (5/7) type_specific.io-github-autotest-libvirt.virsh.cpu_models.positive_test.remote_host.auto_get_arch: STARTED
 (5/7) type_specific.io-github-autotest-libvirt.virsh.cpu_models.positive_test.remote_host.auto_get_arch: CANCEL: Please replace 'ENTER.YOUR.REMOTE.EXAMPLE.COM' with valid remote ip (5.61 s)
 (6/7) type_specific.io-github-autotest-libvirt.virsh.cpu_models.negative_test.invalid_arch: STARTED
 (6/7) type_specific.io-github-autotest-libvirt.virsh.cpu_models.negative_test.invalid_arch: PASS (5.62 s)
 (7/7) type_specific.io-github-autotest-libvirt.virsh.cpu_models.negative_test.invalid_option: STARTED
 (7/7) type_specific.io-github-autotest-libvirt.virsh.cpu_models.negative_test.invalid_option: PASS (5.56 s)

```