### PR TITLE
aarch64_cpu_sve: extend timeout

### DIFF
--- a/libvirt/tests/src/cpu/aarch64_cpu_sve.py
+++ b/libvirt/tests/src/cpu/aarch64_cpu_sve.py
@@ -249,7 +249,7 @@ def update_cpu_xml(cpu_xml, params, test, supported_list, unsupported_list):
     logging.debug("cpu_xml is %s" % cpu_xml)
 
 
-def execute_cmds(cmd, session, test, timeout=360, ignore_status=False):
+def execute_cmds(cmd, session, test, timeout=720, ignore_status=False):
     """
     Execute a command with vm session
 


### PR DESCRIPTION
The make check tests need more time, so this case needs bigger timeout

Signed-off-by: Dan Zheng <dzheng@redhat.com>