### PR TITLE
Enable kvm-no-adjvtime on aarch64 to avoid time adjustment after migration

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -494,6 +494,8 @@
                             cmd_in_vm_after_migration = "tpm2_getrandom 10"                                                   
                 - timer:
                     no s390-virtio
+                    aarch64:
+                        armvtimer = {"clock": {"offset": "utc", "timers": [{"name": "armvtimer", "tickpolicy": "discard"}]}}
                     timer_migration = "yes"
                     asynch_migrate = "yes"
                     actions_during_migration = "setmaxdowntime"

--- a/libvirt/tests/src/migration/migrate_options_shared.py
+++ b/libvirt/tests/src/migration/migrate_options_shared.py
@@ -1057,6 +1057,7 @@ def run(test, params, env):
     low_speed = params.get("low_speed", None)
     migrate_vm_back = "yes" == params.get("migrate_vm_back", "no")
     timer_migration = "yes" == params.get("timer_migration", "no")
+    armvtimer = eval(params.get("armvtimer", "{}"))
     concurrent_migration = "yes" == params.get("concurrent_migration", "no")
 
     remote_virsh_dargs = {'remote_ip': server_ip, 'remote_user': server_user,
@@ -1276,6 +1277,10 @@ def run(test, params, env):
                     test.error("Failed to install swtpm packages on {} host."
                                .format(loc))
             remote_session.close()
+
+        if timer_migration and armvtimer:
+            new_xml.setup_attrs(**armvtimer)
+            new_xml.sync()
 
         # Change the disk of the vm to shared disk and then start VM
         libvirt.set_vm_disk(vm, params)


### PR DESCRIPTION
Test result:
 (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_options_shared.positive_test.timer.without_postcopy: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_options_shared.positive_test.timer.without_postcopy: PASS (123.76 s)