### PR TITLE
Increase memory balloon size to avoid guest crash for short of memory

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_mem.cfg
+++ b/libvirt/tests/cfg/migration/migrate_mem.cfg
@@ -53,7 +53,7 @@
             check_str_local_log = 'Unsupported migration cookie feature memory-hotplug'
             str_in_log = False
         - mem_balloon:
-            ballooned_mem = "716800"
+            ballooned_mem = "1572864"
         - mem_nvdimm:
             no s390-virtio
             nvdimm_file_path = '${nfs_mount_dir}/nvdimm'


### PR DESCRIPTION
Test result:
 (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_mem.mem_balloon: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_mem.mem_balloon: PASS (145.92 s)