### PR TITLE
cpu: add case for starting guest with new hyperv enlightments

### DIFF
--- a/libvirt/tests/cfg/cpu/vm_features.cfg
+++ b/libvirt/tests/cfg/cpu/vm_features.cfg
@@ -14,6 +14,24 @@
                         - tlbflush:
                             func_supported_since_libvirt_ver = (5, 0, 0)
                             hyperv_attr = {'relaxed': {'state': 'on'}, 'vapic': {'state': 'on'}, 'vpindex': {'state': 'on'}, 'tlbflush': {'state': 'on'}}
+                        - tlbflush_direct_extended:
+                            func_supported_since_libvirt_ver = (10, 10, 0)
+                            hyperv_attr = {'tlbflush': {'state': 'on', 'direct':{'state': 'on'}, 'extended':{'state': 'on'}}, 'vapic': {'state': 'on'}, 'vpindex': {'state': 'on'},'relaxed': {'state': 'on'}}
+                            qemu_include = 'hv-tlbflush=on,hv-tlbflush-direct=on,hv-tlbflush-ext=on'
+                            expected_xpaths = [{'element_attrs':['.//tlbflush[@state="on"]']},{'element_attrs':['.//tlbflush/direct[@state="on"]']},{'element_attrs':['.//tlbflush/extended[@state="on"]']}]
+                            check_xml = "yes"
+                        - emsr_bitmap:
+                            func_supported_since_libvirt_ver = (10, 10, 0)
+                            hyperv_attr = {'emsr_bitmap': {'state': 'on'}}
+                            qemu_include = 'hv-emsr-bitmap=on'
+                            check_xml = "yes"
+                            expected_xpaths = [{'element_attrs':['.//emsr_bitmap[@state="on"]']}]
+                        - xmm_input:
+                            func_supported_since_libvirt_ver = (10, 10, 0)
+                            hyperv_attr = {'xmm_input': {'state': 'on'}}
+                            qemu_include = 'hv-xmm-input=on'
+                            check_xml = "yes"
+                            expected_xpaths = [{'element_attrs':['.//xmm_input[@state="on"]']}]
                         - frequencies:
                             func_supported_since_libvirt_ver = (5, 0, 0)
                             hyperv_attr = {'relaxed': {'state': 'on'}, 'vapic': {'state': 'on'}, 'vpindex': {'state': 'on'}, 'frequencies': {'state': 'on'}}

--- a/libvirt/tests/src/cpu/vm_features.py
+++ b/libvirt/tests/src/cpu/vm_features.py
@@ -11,6 +11,7 @@ from virttest import virsh
 from virttest.libvirt_xml import domcapability_xml
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
+from virttest.utils_libvirt import libvirt_vmxml
 from virttest.libvirt_xml import xcepts
 
 # Using as lower capital is not the best way to do, but this is just a
@@ -180,6 +181,7 @@ def run(test, params, env):
     pkgs = params.get('pkgs')
     features_from_domcap = params.get('features_from_domcap')
     status_error = params.get('status_error') == 'yes'
+    check_xml = params.get('check_xml') == 'yes'
 
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     bkxml = vmxml.copy()
@@ -206,6 +208,9 @@ def run(test, params, env):
         try:
             ret = virsh.start(vm_name, debug=True)
             libvirt.check_exit_status(ret, status_error)
+            if check_xml:
+                vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+                libvirt_vmxml.check_guest_xml_by_xpaths(vmxml, eval(params.get("expected_xpaths")))
         except exceptions.TestFail as details:
             if re.search(r"host doesn\'t support paravirtual spinlocks",
                          str(details)):


### PR DESCRIPTION
    xxxx-304144:Start a guest with emsr_bitmap, xmm_input, tlbflush-direct and tlbflush-ext
Signed-off-by: nanli <nanli@redhat.com>

```
avocado run --vt-type libvirt --vt-machine-type q35 vm_features.positive_test.hyperv.tlbflush_direct_extended vm_features.positive_test.hyperv.emsr_bitmap vm_features.positive_test.hyperv.xmm_input 
 type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.tlbflush_direct_extended: PASS (22.20 s)
 type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.emsr_bitmap: PASS (22.18 s)
 type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.xmm_input: PASS (22.22 s)
```

Other related
```
avocado run --vt-type libvirt --vt-machine-type q35 vm_features.positive_test.hyperv
(1/9) type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.features_in_domcapabilities: STARTED
 (1/9) type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.features_in_domcapabilities: PASS (22.23 s)
 (2/9) type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.tlbflush: STARTED
 (2/9) type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.tlbflush: PASS (21.75 s)
 (3/9) type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.tlbflush_direct_extended: STARTED
 (3/9) type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.tlbflush_direct_extended: PASS (22.20 s)
 (4/9) type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.emsr_bitmap: STARTED
 (4/9) type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.emsr_bitmap: PASS (22.18 s)
 (5/9) type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.xmm_input: STARTED
 (5/9) type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.xmm_input: PASS (22.22 s)
 (6/9) type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.frequencies: STARTED
 (6/9) type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.frequencies: PASS (21.99 s)
 (7/9) type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.reenlightenment: STARTED
 (7/9) type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.reenlightenment: PASS (22.01 s)
 (8/9) type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.relaxed.enable: STARTED
 (8/9) type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.relaxed.enable: PASS (22.00 s)
 (9/9) type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.relaxed.disable: STARTED
 (9/9) type_specific.io-github-autotest-libvirt.vm_features.positive_test.hyperv.relaxed.disable: PASS (22.01 s)

```