### PR TITLE
Release postcopy and additional parameter for aarch64

### DIFF
--- a/libvirt/tests/cfg/migration/migration_with_numa_topology.cfg
+++ b/libvirt/tests/cfg/migration/migration_with_numa_topology.cfg
@@ -24,14 +24,12 @@
         - base_options:
             add_options = ""
         - addtional_options:
-            no aarch64
             migration_connections = 3
             add_options = "--auto-converge  --parallel --parallel-connections ${migration_connections} --tls"
     variants:
         - without_postcopy:
             copy_type = ""
         - postcopy:
-            no aarch64
             only base_options
             copy_type = "--postcopy"
     variants:


### PR DESCRIPTION
test result:

 (1/1) type_specific.io-github-autotest-libvirt.migrate.migration_with_numa_topology.no_back_migration.without_postcopy.addtional_options.one_cluster_on_numa: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.migrate.migration_with_numa_topology.no_back_migration.without_postcopy.addtional_options.one_cluster_on_numa: PASS (602.44 s)

 (1/1) type_specific.io-github-autotest-libvirt.migrate.migration_with_numa_topology.with_back_migration.postcopy.base_options.multi_cluster_on_numa: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.migrate.migration_with_numa_topology.with_back_migration.postcopy.base_options.multi_cluster_on_numa: PASS (439.67 s)