### PR TITLE
fix cpu max value increases

### DIFF
--- a/libvirt/tests/src/cpu/max_vcpus.py
+++ b/libvirt/tests/src/cpu/max_vcpus.py
@@ -112,7 +112,7 @@ def run(test, params, env):
                     exp_val = report_num_q35_7_8
                     if key == "pc-q35-rhel7.3.0":
                         exp_val = report_num_q35_73
-                    elif key == "pc-q35-rhel9.6.0" or key == 'q35':
+                    elif key == "pc-q35-rhel9.6.0" or key == "pc-q35-rhel10.0.0" or key == 'q35':
                         exp_val = report_num_q35_9_6
                     else:
                         if libvirt_version.version_compare(7, 0, 0):


### PR DESCRIPTION
   cpu max value increase in rhel10
Signed-off-by: nanli <nanli@redhat.com>

Before fix:
` (1/1) type_specific.io-github-autotest-libvirt.max_vcpus.virsh_capabilities: FAIL: Test failed as the q35_max_vcpus_num for machine type:pc-q35-rhel10.0.0 in virsh_capa is wrong. Expected: 710, Actual: 4096. (7.74 s)
`
After fix
 ```
avocado run --vt-type libvirt --vt-omit-data-loss --vt-machine-type q35 max_vcpus.virsh_capabilities --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.max_vcpus.virsh_capabilities: PASS (6.44 s)

```