### PR TITLE
GPU: Add cases for aarch64

### DIFF
--- a/libvirt/tests/cfg/gpu/hotplug_gpu.cfg
+++ b/libvirt/tests/cfg/gpu/hotplug_gpu.cfg
@@ -1,0 +1,8 @@
+- gpu.lifecycle_vm_with_gpu:
+    type = lifecycle_vm_with_gpu
+    start_vm = "no"
+
+    only aarch64
+    variants:
+        - gpu_address:
+            hostdev_dict = {'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': gpu_pci_addr}, 'managed': 'yes'}

--- a/libvirt/tests/cfg/gpu/lifecycle_vm_with_gpu.cfg
+++ b/libvirt/tests/cfg/gpu/lifecycle_vm_with_gpu.cfg
@@ -1,0 +1,9 @@
+- gpu.lifecycle_vm_with_gpu:
+    type = lifecycle_vm_with_gpu
+    start_vm = "no"
+    unsupported_error = "VFIO migration is not supported in kernel"
+
+    only aarch64
+    variants:
+        - gpu_address:
+            hostdev_dict = {'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': gpu_pci_addr}, 'managed': 'yes'}

--- a/libvirt/tests/cfg/gpu/start_vm_with_gpu.cfg
+++ b/libvirt/tests/cfg/gpu/start_vm_with_gpu.cfg
@@ -1,0 +1,14 @@
+- gpu.start_vm_with_gpu:
+    type = start_vm_with_gpu
+    start_vm = "no"
+
+    only aarch64
+    variants:
+        - gpu_address:
+            variants:
+                - managed_yes:
+                    hostdev_dict = {'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': gpu_pci_addr}, 'managed': 'yes'}
+                - managed_no:
+                    hostdev_dict = {'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': gpu_pci_addr}, 'managed': 'no'}
+                - managed_ignore:
+                    hostdev_dict = {'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': gpu_pci_addr}}

--- a/libvirt/tests/cfg/gpu/start_vm_with_gpu_managed_disabled.cfg
+++ b/libvirt/tests/cfg/gpu/start_vm_with_gpu_managed_disabled.cfg
@@ -1,0 +1,16 @@
+- gpu.managed_disabled_gpu:
+    type = start_vm_with_gpu_managed_disabled
+    start_vm = "no"
+    error_msg = "Unmanaged PCI device"
+
+    only aarch64
+    variants:
+        - gpu_address:
+            variants:
+                - managed_no:
+                    hostdev_dict = {'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': gpu_pci_addr}, 'managed': 'no'}
+                - managed_ignore:
+                    hostdev_dict = {'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': gpu_pci_addr}}
+    variants test_scenario:
+        - define_start:
+        - hotplug:

--- a/libvirt/tests/cfg/gpu/vm_cuda_sanity.cfg
+++ b/libvirt/tests/cfg/gpu/vm_cuda_sanity.cfg
@@ -1,0 +1,10 @@
+- gpu.vm_cuda_sanity:
+    type = vm_cuda_sanity
+    start_vm = "no"
+    cuda_samples_path = "../../deps/gpu/cuda-samples.tar.gz"
+    cuda_tests = ["./cuda-samples/build/Samples/1_Utilities/deviceQuery/deviceQuery", "./cuda-samples/build/Samples/1_Utilities/bandwidthTest/bandwidthTest", "./cuda-samples/build/Samples//0_Introduction/simpleMultiCopy/simpleMultiCopy"]
+
+    only aarch64
+    variants:
+        - gpu_address:
+            hostdev_dict = {'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': gpu_pci_addr}, 'managed': 'yes'}

--- a/libvirt/tests/cfg/gpu/vm_mig_sanity.cfg
+++ b/libvirt/tests/cfg/gpu/vm_mig_sanity.cfg
@@ -1,0 +1,10 @@
+- gpu.mig_sanity:
+    type = vm_mig_sanity
+    start_vm = "no"
+    cuda_samples_path = "../../deps/gpu/cuda-samples.tar.gz"
+    cuda_test = "./cuda-samples/build/Samples/5_Domain_Specific/BlackScholes/BlackScholes"
+
+    only aarch64
+    variants:
+        - gpu_address:
+            hostdev_dict = {'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': gpu_pci_addr}, 'managed': 'yes'}

--- a/libvirt/tests/cfg/gpu/vm_nvidia_gpu_driver.cfg
+++ b/libvirt/tests/cfg/gpu/vm_nvidia_gpu_driver.cfg
@@ -1,0 +1,8 @@
+- gpu.nvidia_driver:
+    type = vm_nvidia_gpu_driver
+    start_vm = "no"
+
+    only aarch64
+    variants:
+        - gpu_address:
+            hostdev_dict = {'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': gpu_pci_addr}, 'managed': 'yes'}

--- a/libvirt/tests/src/gpu/hotplug_gpu.py
+++ b/libvirt/tests/src/gpu/hotplug_gpu.py
@@ -1,0 +1,56 @@
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+from provider.gpu import gpu_base
+
+
+def run(test, params, env):
+    """
+    Hotplug/unplug GPU device
+    """
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    vm = env.get_vm(vm_name)
+    virsh_args = {'ignore_status': False, 'debug': True}
+
+    gpu_test = gpu_base.GPUTest(vm, test, params)
+    hostdev_dict = gpu_test.parse_hostdev_dict()
+
+    try:
+        gpu_test.setup_default()
+        test.log.info("TEST_STEP: Start the VM")
+        vm.start()
+        vm_session = vm.wait_for_login()
+
+        test.log.info("TEST_STEP: Hotplug a gpu device to vm")
+        gpu_dev = libvirt_vmxml.create_vm_device_by_type("hostdev", hostdev_dict)
+        virsh.attach_device(vm.name, gpu_dev.xml, **virsh_args)
+        gpu_test.check_gpu_dev(vm)
+        test.log.debug(f'VMXML of {vm_name}:\n{virsh.dumpxml(vm_name).stdout_text}')
+
+        gpu_test.install_latest_driver(vm_session)
+        gpu_test.nvidia_smi_check(vm_session)
+
+        test.log.info("TEST_STEP: Unplug a gpu device from vm")
+        vm_hostdev = vm_xml.VMXML.new_from_dumpxml(vm.name)\
+            .devices.by_device_tag("hostdev")[0]
+        virsh.detach_device(vm.name, vm_hostdev.xml,
+                            wait_for_event=True, event_timeout=30,
+                            **virsh_args)
+        gpu_test.check_gpu_dev(vm, True)
+
+        test.log.info("TEST_STEP: Hotplug back the gpu device")
+        virsh.attach_device(vm.name, gpu_dev.xml, **virsh_args)
+        gpu_test.check_gpu_dev(vm)
+        gpu_test.nvidia_smi_check(vm_session)
+
+        test.log.info("TEST_STEP: Check gpu device exclusivity")
+        res = virsh.attach_device(vm.name, gpu_dev.xml, debug=True)
+        libvirt.check_result(res, "in use")
+        gpu_test.check_gpu_dev(vm)
+        gpu_test.nvidia_smi_check(vm_session)
+        vm_session.close()
+    finally:
+        gpu_test.teardown_default()

--- a/libvirt/tests/src/gpu/lifecycle_vm_with_gpu.py
+++ b/libvirt/tests/src/gpu/lifecycle_vm_with_gpu.py
@@ -1,0 +1,76 @@
+import os
+
+from virttest import data_dir
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+from provider.gpu import gpu_base
+
+
+def run(test, params, env):
+    """
+    Lifecycle test on vm with GPU device
+    """
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    vm = env.get_vm(vm_name)
+    virsh_args = {'ignore_status': False, 'debug': True}
+    unsupported_error = params.get("unsupported_error")
+    gpu_test = gpu_base.GPUTest(vm, test, params)
+    hostdev_dict = gpu_test.parse_hostdev_dict()
+
+    try:
+        gpu_test.setup_default()
+        libvirt_vmxml.modify_vm_device(
+                vm_xml.VMXML.new_from_dumpxml(vm.name), "hostdev",
+                hostdev_dict)
+        test.log.info("TEST_STEP: Start the VM")
+        vm.start()
+        test.log.debug(f'VMXML of {vm_name}:\n{virsh.dumpxml(vm_name).stdout_text}')
+        gpu_test.check_gpu_dev(vm)
+        vm_session = vm.wait_for_login()
+        gpu_test.install_latest_driver(vm_session)
+        gpu_test.nvidia_smi_check(vm_session)
+        vm_session.close()
+
+        test.log.info("TEST_STEP: Shudown and start VM")
+        virsh.shutdown(vm.name, **virsh_args, wait_for_event=True)
+        if not vm.wait_for_shutdown():
+            test.error('VM failed to shutdown in 60s')
+        virsh.start(vm.name, **virsh_args)
+        gpu_test.check_gpu_dev(vm)
+
+        test.log.info("TEST_STEP: Reboot VM")
+        virsh.reboot(vm.name, **virsh_args)
+        gpu_test.check_gpu_dev(vm)
+
+        test.log.info("TEST_STEP: Reset VM")
+        virsh.reset(vm.name, **virsh_args)
+        gpu_test.check_gpu_dev(vm)
+        vm_session = vm.wait_for_login()
+        gpu_test.nvidia_smi_check(vm_session)
+        vm_session.close()
+
+        test.log.info("TEST_STEP: Save the VM.")
+        save_path = os.path.join(data_dir.get_tmp_dir(), vm.name + '.save')
+        res = virsh.save(vm.name, save_path, debug=True)
+        libvirt.check_result(res, unsupported_error)
+        res = virsh.managedsave(vm.name, debug=True)
+        libvirt.check_result(res, unsupported_error)
+        res = virsh.snapshot_create(vm.name, debug=True)
+        libvirt.check_result(res, unsupported_error)
+        gpu_test.check_gpu_dev(vm)
+
+        test.log.info("TEST_STEP: Suspend and resume the vm.")
+        virsh.suspend(vm.name, **virsh_args)
+        if not libvirt.check_vm_state(vm_name, "paused"):
+            test.fail("VM should be paused!")
+        virsh.resume(vm.name, **virsh_args)
+        if not libvirt.check_vm_state(vm_name, "running"):
+            test.fail("VM should be running!")
+        gpu_test.check_gpu_dev(vm)
+
+    finally:
+        gpu_test.teardown_default()

--- a/libvirt/tests/src/gpu/start_vm_with_gpu.py
+++ b/libvirt/tests/src/gpu/start_vm_with_gpu.py
@@ -1,0 +1,49 @@
+from virttest import utils_misc
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_libvirt import libvirt_vfio
+
+from provider.gpu import gpu_base
+
+
+def run(test, params, env):
+    """
+    Start vm with GPU device
+    """
+
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    vm = env.get_vm(vm_name)
+    gpu_test = gpu_base.GPUTest(vm, test, params)
+    dev_name = gpu_test.gpu_dev_name
+    dev_pci = gpu_test.gpu_pci
+    hostdev_dict = gpu_test.parse_hostdev_dict()
+    managed_disabled = hostdev_dict.get('managed') != "yes"
+
+    try:
+        gpu_test.setup_default(dev_name=dev_name,
+                               managed_disabled=managed_disabled)
+        libvirt_vmxml.modify_vm_device(
+                vm_xml.VMXML.new_from_dumpxml(vm.name), "hostdev",
+                hostdev_dict)
+        test.log.info("TEST_STEP: Start the VM")
+        vm.start()
+        test.log.debug(f'VMXML of {vm_name}:\n{virsh.dumpxml(vm_name).stdout_text}')
+        gpu_test.check_gpu_dev(vm)
+        libvirt_vfio.check_vfio_pci(dev_pci)
+
+        test.log.info("TEST_STEP: Destroy VM")
+        vm.destroy(gracefully=False)
+
+        if not utils_misc.wait_for(
+            lambda: libvirt_vfio.check_vfio_pci(
+                dev_pci, not managed_disabled, True), 10, 5):
+            test.fail("Got incorrect driver!")
+        if managed_disabled:
+            virsh.nodedev_reattach(dev_name, debug=True, ignore_status=False)
+            libvirt_vfio.check_vfio_pci(dev_pci, True)
+    finally:
+        gpu_test.teardown_default(
+            managed_disabled=managed_disabled,
+            dev_name=dev_name)

--- a/libvirt/tests/src/gpu/start_vm_with_gpu_managed_disabled.py
+++ b/libvirt/tests/src/gpu/start_vm_with_gpu_managed_disabled.py
@@ -1,0 +1,38 @@
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+from provider.gpu import gpu_base
+
+
+def run(test, params, env):
+    """
+    Start vm with GPU device with managed=no or ignored
+    """
+    error_msg = params.get("error_msg", "Unmanaged")
+    test_scenario = params.get("test_scenario")
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    vm = env.get_vm(vm_name)
+    gpu_test = gpu_base.GPUTest(vm, test, params)
+    hostdev_dict = gpu_test.parse_hostdev_dict()
+
+    try:
+        gpu_test.setup_default()
+        if test_scenario == "define_start":
+            test.log.info("TEST_STEP: Start the VM")
+            libvirt_vmxml.modify_vm_device(
+                    vm_xml.VMXML.new_from_dumpxml(vm.name), "hostdev",
+                    hostdev_dict)
+            res = virsh.start(vm.name, debug=True)
+        else:
+            test.log.info("TEST_STEP: Hotplug a gpu device")
+            vm.start()
+            vm.wait_for_login().close()
+            gpu_dev = libvirt_vmxml.create_vm_device_by_type("hostdev", hostdev_dict)
+            res = virsh.attach_device(vm.name, gpu_dev.xml, debug=True)
+        libvirt.check_result(res, error_msg)
+
+    finally:
+        gpu_test.teardown_default()

--- a/libvirt/tests/src/gpu/vm_cuda_sanity.py
+++ b/libvirt/tests/src/gpu/vm_cuda_sanity.py
@@ -1,0 +1,52 @@
+import os
+
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+
+from provider.gpu import gpu_base
+
+
+def run(test, params, env):
+    """
+    cuda sanity tests in guest
+    """
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    vm = env.get_vm(vm_name)
+    cuda_tests = eval(params.get("cuda_tests", "[]"))
+    gpu_test = gpu_base.GPUTest(vm, test, params)
+    hostdev_dict = gpu_test.parse_hostdev_dict()
+
+    try:
+        gpu_test.setup_default()
+        libvirt_vmxml.modify_vm_device(
+                vm_xml.VMXML.new_from_dumpxml(vm.name), "hostdev",
+                hostdev_dict)
+        test.log.info("TEST_STEP: Start the VM")
+        vm.start()
+        vm_session = vm.wait_for_login()
+        test.log.debug(f'VMXML of {vm_name}:\n{virsh.dumpxml(vm_name).stdout_text}')
+        cuda_samples_path = os.path.join(os.path.dirname(__file__), params.get("cuda_samples_path"))
+        cuda_sample_guest_path = os.path.join("/tmp", os.path.basename(cuda_samples_path))
+        vm.copy_files_to(
+            cuda_samples_path, os.path.dirname(cuda_sample_guest_path),
+            timeout=240)
+        vm_session.cmd(f"tar -xf {cuda_sample_guest_path} -C /root")
+        vm_session.cmd(f"rm -rf {cuda_sample_guest_path}")
+
+        test.log.info("TEST_STEP: Install the driver")
+        gpu_test.install_latest_driver(vm_session)
+        gpu_test.install_cuda_toolkit(vm_session)
+        gpu_test.nvidia_smi_check(vm_session)
+
+        test.log.info("TEST_STEP: Run cuda sanity tests")
+        for s_test in cuda_tests:
+            test.log.debug(f"TEST_STEP: Run {s_test}")
+            s, o = vm_session.cmd_status_output(s_test, timeout=600)
+            test.log.debug(f"output: {o}")
+            if s:
+                test.fail("Failed to run cuda sanity - %s" % s_test)
+
+    finally:
+        gpu_test.teardown_default()

--- a/libvirt/tests/src/gpu/vm_mig_sanity.py
+++ b/libvirt/tests/src/gpu/vm_mig_sanity.py
@@ -1,0 +1,79 @@
+import os
+import re
+
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+
+from provider.gpu import gpu_base
+
+
+def run(test, params, env):
+    """
+    MIG sanity test in vm with GPU device
+    """
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    vm = env.get_vm(vm_name)
+    cuda_test = params.get("cuda_test")
+
+    gpu_test = gpu_base.GPUTest(vm, test, params)
+    hostdev_dict = gpu_test.parse_hostdev_dict()
+
+    try:
+        gpu_test.setup_default()
+        libvirt_vmxml.modify_vm_device(
+                vm_xml.VMXML.new_from_dumpxml(vm.name), "hostdev",
+                hostdev_dict)
+        test.log.info("TEST_STEP: Start the VM")
+        vm.start()
+        vm_session = vm.wait_for_login()
+        test.log.debug(f'VMXML of {vm_name}:\n{virsh.dumpxml(vm_name).stdout_text}')
+
+        test.log.info("TEST_STEP: Copy the sample")
+        guest_gpu_pci = gpu_base.get_gpu_pci(vm_session)
+        cuda_samples_path = os.path.join(os.path.dirname(__file__), params.get("cuda_samples_path"))
+        cuda_sample_guest_path = os.path.join("/tmp", os.path.basename(cuda_samples_path))
+        vm.copy_files_to(
+            cuda_samples_path, os.path.dirname(cuda_sample_guest_path),
+            timeout=240)
+        vm_session.cmd(f"tar -xf {cuda_sample_guest_path} -C /root")
+        vm_session.cmd(f"rm -rf {cuda_sample_guest_path}")
+
+        test.log.info("TEST_STEP: Install the driver")
+        gpu_test.install_latest_driver(vm_session, True)
+        gpu_test.install_cuda_toolkit(vm_session, True)
+
+        test.log.info("TEST_STEP: Enable MIG mode")
+        vm_session.cmd(f"nvidia-smi -i {guest_gpu_pci} -mig 1")
+        output = vm_session.cmd_output(f"nvidia-smi -i {guest_gpu_pci} --query-gpu=pci.bus_id,mig.mode.current --format=csv,noheader")
+        if "Enabled" not in output:
+            test.fail("Failed to enable MIG mode!")
+
+        test.log.info("TEST_STEP: Create GPU instances ")
+        vm_session.cmd(f"nvidia-smi mig -cgi 4g.20gb,2g.10gb,1g.5gb -C")
+        res = vm_session.cmd_output_safe("nvidia-smi -L")
+        compute_instances = re.findall(r"Device .(\d).*UUID: (.*)\)", res)
+        if not compute_instances:
+            test.fail("Failed to get compute instances!")
+        for dev in compute_instances:
+            s, o = vm_session.cmd_status_output(f"CUDA_VISIBLE_DEVICES={dev[1]} {cuda_test}")
+            test.log.debug(f"dev: {dev[1]}, output of BlackScholes: {o}")
+            if s:
+                test.fail("Failed to run BlackScholes test!")
+
+        test.log.info("TEST_STEP: Destroy the GPU instances")
+        res = vm_session.cmd_output_safe("nvidia-smi mig -lci | awk '/MIG/ {print $2, $3}'")
+        for line in res.splitlines():
+            if line:
+                ids = line.split()
+                test.log.debug(f"Destroy instance - {ids}")
+                vm_session.cmd(f"nvidia-smi mig -dci -ci {ids[0]} -gi {ids[1]}")
+
+        test.log.info("TEST_STEP: Disable MIG mode")
+        vm_session.cmd(f"nvidia-smi -i {guest_gpu_pci} -mig 0")
+        output = vm_session.cmd_output(f"nvidia-smi -i {guest_gpu_pci} --query-gpu=pci.bus_id,mig.mode.current --format=csv,noheader")
+        if "Disabled" not in output:
+            test.fail("Failed to disable MIG mode!")
+    finally:
+        gpu_test.teardown_default()

--- a/libvirt/tests/src/gpu/vm_nvidia_gpu_driver.py
+++ b/libvirt/tests/src/gpu/vm_nvidia_gpu_driver.py
@@ -1,0 +1,40 @@
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+
+from provider.gpu import gpu_base
+
+
+def run(test, params, env):
+    """
+    GPU driver installation/uninstallation/re-installation on vm with GPU device
+    """
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    vm = env.get_vm(vm_name)
+    gpu_test = gpu_base.GPUTest(vm, test, params)
+
+    hostdev_dict = gpu_test.parse_hostdev_dict()
+
+    try:
+        gpu_test.setup_default()
+        libvirt_vmxml.modify_vm_device(
+                vm_xml.VMXML.new_from_dumpxml(vm.name), "hostdev",
+                hostdev_dict)
+        test.log.info("TEST_STEP: Start the VM")
+        vm.start()
+        vm_session = vm.wait_for_login()
+        test.log.debug(f'VMXML of {vm_name}:\n{virsh.dumpxml(vm_name).stdout_text}')
+
+        test.log.info("TEST_STEP: Install the driver")
+        gpu_test.install_latest_driver(vm_session)
+        gpu_test.nvidia_smi_check(vm_session)
+
+        test.log.info("TEST_STEP: Uninstall the driver")
+        vm_session.cmd("dnf module -y remove --all nvidia-driver", timeout=600)
+
+        test.log.info("TEST_STEP: Re-install the driver")
+        gpu_test.install_latest_driver(vm_session)
+        gpu_test.nvidia_smi_check(vm_session)
+    finally:
+        gpu_test.teardown_default()

--- a/provider/gpu/gpu_base.py
+++ b/provider/gpu/gpu_base.py
@@ -1,0 +1,235 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright Red Hat
+#
+#   SPDX-License-Identifier: GPL-2.0
+#
+#   Author: yicui@redhat.com
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import logging
+import re
+import os
+import platform
+import requests
+
+from avocado.core import exceptions
+from avocado.utils import process
+
+from virttest import libvirt_version
+from virttest import utils_misc
+from virttest import utils_package
+from virttest import utils_sriov
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+LOG = logging.getLogger("avocado." + __name__)
+
+
+def get_gpus_info(session=None):
+    """
+    Get GPUs information
+
+    :param session: The session object to the host
+    :raise: exceptions.TestError when command fails
+    :return: dict, GPUs' info.
+        eg. {'3b:00.0': {'driver': 'ixgbe', 'pci_id': '0000:3b:00.0',
+                         'iface': 'ens1f0', 'status': 'up'},
+             '3b:00.1': {'driver': 'ixgbe', 'pci_id': '0000:3b:00.1',
+                         'iface': 'ens1f1', 'status': 'down'}}
+
+    """
+    dev_info = {}
+    status, output = utils_misc.cmd_status_output(
+        "lspci -D -nn|awk '/3D controller/'",
+        shell=True, session=session
+    )
+    if status or not output:
+        raise exceptions.TestError(
+            "Unable to get 3D controllers. status: %s,"
+            "stdout: %s." % (status, output)
+        )
+    pattern = r'(\S+:\S+:\S+.\d+)\s.*\s\[(\w+:\w+)\]'
+    matches = re.findall(pattern, output)
+    for match in matches:
+        dev_info[match[0]] = {"pci_id": match[0], "ID": re.sub(":", " ", match[1])}
+
+    for pci in dev_info.keys():
+        _, output = utils_misc.cmd_status_output(
+            "lspci -v -s %s" % pci, shell=True, session=session
+        )
+        driver_in_use = re.search("driver in use: (.*)", output)
+        if driver_in_use:
+            dev_info[pci].update({"driver": driver_in_use[1]})
+
+    LOG.debug(f"GPU info: {dev_info}.")
+    return dev_info
+
+
+def get_gpu_pci(session=None):
+    """
+    Get the pci id of the first available GPU.
+
+    :param session: The session object to the host
+    :return: pci id of GPU, eg. 0000:01:00.0
+    """
+    return list(get_gpus_info(session=session).values())[0].get("pci_id")
+
+
+def pci_to_addr(pci_id):
+    """
+    Get address dict according to pci_id
+
+    :param pci_id: PCI ID of a device(eg. 0000:05:10.1)
+    :return: address dict
+    """
+    pci_list = ["0x%s" % x for x in re.split("[.:]", pci_id)]
+    return dict(zip(["domain", "bus", "slot", "function"], pci_list + ["pci"]))
+
+
+class GPUTest(object):
+    """
+    Wrapper class for GPU testing
+    """
+    def __init__(self, vm, test, params, session=None):
+        self.vm = vm
+        self.test = test
+        self.params = params
+        self.session = session
+        self.remote_virsh_dargs = None
+
+        libvirt_version.is_libvirt_feature_supported(self.params)
+        self.gpu_pci = get_gpu_pci(session=self.session)
+        if not self.gpu_pci:
+            test.cancel("NO available gpu found.")
+        self.gpu_pci_addr = pci_to_addr(self.gpu_pci)
+        self.gpu_dev_name = utils_sriov.get_device_name(self.gpu_pci)
+
+        new_xml = vm_xml.VMXML.new_from_inactive_dumpxml(self.vm.name)
+        self.orig_config_xml = new_xml.copy()
+
+    def parse_hostdev_dict(self):
+        """
+        Parse hostdev_dict from params
+
+        :return: The updated iface_dict
+        """
+        gpu_pci_addr = self.gpu_pci_addr
+        hostdev_dict = eval(self.params.get('hostdev_dict', '{}'))
+        return hostdev_dict
+
+    def check_gpu_dev(self, vm, status_error=False):
+        """
+        Check GPU device in guest
+
+        :param vm: vm object
+        :param status_error: True if expect not existing, otherwise False
+        """
+        vm_session = vm.wait_for_login(timeout=240)
+        s, o = vm_session.cmd_status_output("lspci |grep 3D")
+        vm_session.close()
+        result = process.CmdResult(stdout=o, exit_status=s)
+        libvirt.check_exit_status(result, status_error)
+
+    def nvidia_smi_check(self, vm_session):
+        """
+        Run nvidia-smi command and check GPU device's info
+
+        :param vm_session: vm's session
+        """
+        gpu_pci = get_gpu_pci(session=vm_session)
+        s, o = vm_session.cmd_status_output("nvidia-smi -q")
+        if s or not re.search(gpu_pci, o):
+            self.test.fail("Failed to run nvidia-smi command. Status: %s, output: %s."
+                           % (s, o))
+
+    def install_latest_driver(self, vm_session, local_rpm=False):
+        """
+        Install the latest data centre driver
+
+        :param vm_session: vm session object
+        :local_rpm: Install the driver using local rpm
+        """
+        pkgs = ["gcc", "kernel*headers*", "kernel*devel*"]
+        if not utils_package.package_install(pkgs, vm_session):
+            self.test.error(f"Unable to install {pkgs} in guest!")
+        arch = platform.machine()
+        if local_rpm:
+            url = "https://developer.nvidia.com/datacenter-driver-downloads"
+            page = requests.Session().get(url)
+            pkg_download_cmd = re.findall(rf"(wget https://developer.download.nvidia.com/compute/nvidia-driver/\S+/local_installers/nvidia-driver-local-repo-rhel9-\S+{arch}.rpm)", page.text)
+            if not pkg_download_cmd:
+                self.test.error("Unable to get download command!")
+            pkg_name = os.path.basename(pkg_download_cmd[0])
+            vm_session.cmd(pkg_download_cmd[0], timeout=240)
+            vm_session.cmd(f"rpm -i {pkg_name}", timeout=120)
+        else:
+            # TODO: Get distro from guest. epel repo should be covered in ci
+            distro = "rhel9"
+            pkg_mgr = utils_package.package_manager(vm_session, "epel-release")
+            if not pkg_mgr.is_installed("epel-release"):
+                vm_session.cmd_output_safe(f"subscription-manager repos --enable=rhel-9-for-{arch}-appstream-rpms")
+                vm_session.cmd_output_safe(f"subscription-manager repos --enable=rhel-9-for-{arch}-baseos-rpms")
+                vm_session.cmd_output_safe(f"subscription-manager repos --enable=codeready-builder-for-rhel-9-{arch}-rpms")
+                vm_session.cmd_output_safe("dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm", timeout=600)
+
+            if vm_session.cmd_status(f"ls /etc/yum.repos.d/cuda-{distro}.repo"):
+                repo_url = f"https://developer.download.nvidia.com/compute/cuda/repos/{distro}/sbsa/cuda-{distro}.repo"
+                vm_session.cmd(f"dnf config-manager --add-repo {repo_url}")
+                vm_session.cmd(f"sed -i 's/^gpgcheck=1/gpgcheck=0/' /etc/yum.repos.d/cuda-{distro}.repo")
+                vm_session.cmd("dnf clean all")
+            vm_session.cmd("dnf -y module install nvidia-driver:open-dkms --skip-broken", timeout=600)
+
+    def install_cuda_toolkit(self, vm_session, runfile=False):
+        """
+        Install cuda toolkit
+        :param vm_session: vm session object
+        :runfile: Install the cuda toolkit using runfile
+        """
+        if runfile:
+            url = "https://developer.nvidia.com/cuda-downloads"
+            page = requests.Session().get(url)
+            pkg_download_cmd = re.findall(r"(wget https://developer.download.nvidia.com/compute/cuda/\S+/local_installers/cuda_\S+_linux_sbsa.run)", page.text)
+            if not pkg_download_cmd:
+                self.test.error("Unable to get download command!")
+            pkg_name = os.path.basename(pkg_download_cmd[0])
+            vm_session.cmd(pkg_download_cmd[0], timeout=240)
+            vm_session.cmd(f"sh {pkg_name} --silent", timeout=600)
+        else:
+            pkgs = "cuda-toolkit"
+            if not utils_package.package_install(pkgs, vm_session):
+                self.test.fail(f"Unable to install {pkgs} in guest!")
+
+    def setup_default(self, **dargs):
+        """
+        Default setup
+
+        :param dargs: test keywords
+        """
+        dev_name = dargs.get('dev_name')
+        managed_disabled = dargs.get('managed_disabled', False)
+
+        self.test.log.debug("Removing the existing hostdev device...")
+        libvirt_vmxml.remove_vm_devices_by_type(self.vm, 'hostdev')
+
+        if managed_disabled:
+            virsh.nodedev_detach(dev_name, debug=True, ignore_status=False)
+
+    def teardown_default(self, **dargs):
+        """
+        Default cleanup
+
+        :param dargs: test keywords
+        """
+        dev_name = dargs.get('dev_name')
+        managed_disabled = dargs.get('managed_disabled', False)
+        self.test.log.info("TEST_TEARDOWN: Recover test environment.")
+        if self.vm.is_alive():
+            self.vm.destroy(gracefully=False)
+        self.orig_config_xml.sync()
+
+        if managed_disabled:
+            virsh.nodedev_reattach(dev_name, debug=True, ignore_status=False)


### PR DESCRIPTION
```
1..10
ok 1 type_specific.io-github-autotest-libvirt.gpu.lifecycle_vm_with_gpu.gpu_address
not ok 2 type_specific.io-github-autotest-libvirt.gpu.hotplug_gpu.gpu_address  <------------- reported a bug
ok 3 type_specific.io-github-autotest-libvirt.gpu.managed_disabled_gpu.define_start.gpu_address.managed_no
ok 4 type_specific.io-github-autotest-libvirt.gpu.managed_disabled_gpu.define_start.gpu_address.managed_ignore
ok 5 type_specific.io-github-autotest-libvirt.gpu.managed_disabled_gpu.hotplug.gpu_address.managed_no
ok 6 type_specific.io-github-autotest-libvirt.gpu.managed_disabled_gpu.hotplug.gpu_address.managed_ignore
ok 7 type_specific.io-github-autotest-libvirt.gpu.start_vm_with_gpu.gpu_address.managed_yes
ok 8 type_specific.io-github-autotest-libvirt.gpu.start_vm_with_gpu.gpu_address.managed_no
ok 9 type_specific.io-github-autotest-libvirt.gpu.start_vm_with_gpu.gpu_address.managed_ignore
ok 10 type_specific.io-github-autotest-libvirt.gpu.nvidia_driver.gpu_address
 (1/1) type_specific.io-github-autotest-libvirt.gpu.vm_cuda_sanity.gpu_address: PASS (502.26 s)
 (1/1) type_specific.io-github-autotest-libvirt.gpu.mig_sanity.gpu_address: PASS 

```
