### PR TITLE
update msg for virsh hypervisor_cpu_compare with virsh capa

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_hypervisor_cpu_compare.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_hypervisor_cpu_compare.cfg
@@ -70,7 +70,8 @@
         - capa_xml:
             no s390-virtio, aarch64
             compare_file_type = "capa_xml"
-            status_error = "no"
+            status_error = "yes"
+            msg_pattern = "incorrect results"
         - cpu_xml:
             extract_mode = "yes"
             variants:
@@ -80,7 +81,8 @@
                 - f_capa_xml:
                     no s390-virtio, aarch64
                     compare_file_type = "capa_xml"
-                    status_error = "no"
+                    status_error = "yes"
+                    msg_pattern = "incorrect results"
                 - f_domcapa_xml:
                     compare_file_type = "domcapa_xml"
                     msg_pattern = "identical"


### PR DESCRIPTION
  hypervisor_cpu_compare with virsh capabilities result are not
recommanded in Bug xxxx-79460 


Signed-off-by: nanli <nanli@redhat.com>

virsh.hypervisor_cpu_compare.cpu_xml.f_capa_xml
virsh.hypervisor_cpu_compare.capa_xml


