### PR TITLE
resolving skipped cases: 56145

### DIFF
--- a/libvirt/tests/cfg/daemon/conf_file/sysconfig_libvirt_guests/libvirt_guests.cfg
+++ b/libvirt/tests/cfg/daemon/conf_file/sysconfig_libvirt_guests/libvirt_guests.cfg
@@ -18,23 +18,16 @@
                     parallel_shutdown = ""
                     variants:
                         - persistent_only_none:
+                            only suspend_on_shutdown
                             persistent_only = ""
-                            shutdown_on_shutdown:
-                                transient_vm_operation = "shutdown"
-                            suspend_on_shutdown:
-                                transient_vm_operation = "nothing"
+                            transient_vm_operation = "nothing"
                         - persistent_only_true:
                             persistent_only = "true"
                             transient_vm_operation = "nothing"
-                        - persistent_only_false:
-                            persistent_only = "false"
-                            transient_vm_operation = ${on_shutdown}
                         - persistent_only_default:
+                            only suspend_on_shutdown
                             persistent_only = "default"
-                            shutdown_on_shutdown:
-                                transient_vm_operation = "shutdown"
-                            suspend_on_shutdown:
-                                transient_vm_operation = "nothing"
+                            transient_vm_operation = "nothing"
             variants:
                 - start_on_boot:
                     on_boot = "start"


### PR DESCRIPTION
There are 4 skipped cases in the job related to managed-save feature and bug 56145
According developer resolution such cases doesn't make sense for transient VMs, so I've removed it from configuration. 

skipped cases:
libvirt_guests.positive_test.no_parallel_shutdown.shutdown_on_shutdown.none_on_boot.with_transient_vm.persistent_only_default
libvirt_guests.positive_test.no_parallel_shutdown.shutdown_on_shutdown.none_on_boot.with_transient_vm.persistent_only_false
libvirt_guests.positive_test.no_parallel_shutdown.shutdown_on_shutdown.none_on_boot.with_transient_vm.persistent_only_none
libvirt_guests.positive_test.no_parallel_shutdown.suspend_on_shutdown.default_vol.none_on_boot.with_transient_vm.persistent_only_false