### PR TITLE
migration: Add migrate_vm_back for case

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_vm_in_various_status/migrate_paused_vm.cfg
+++ b/libvirt/tests/cfg/migration/migrate_vm_in_various_status/migrate_paused_vm.cfg
@@ -33,6 +33,8 @@
         - migration_succeeds:
             status_error = "no"
             virsh_migrate_dest_state = "paused"
+            migrate_vm_back = "yes"
+            src_state = "paused"
         - cancel_migration:
             status_error = "yes"
             migrate_speed = "5"


### PR DESCRIPTION
Test result:
 (1/2) type_specific.io-github-autotest-libvirt.migration.migrate_vm_in_various_status.migrate_paused_vm.migration_succeeds.precopy.p2p: STARTED
 (1/2) type_specific.io-github-autotest-libvirt.migration.migrate_vm_in_various_status.migrate_paused_vm.migration_succeeds.precopy.p2p: PASS (206.03 s)
 (2/2) type_specific.io-github-autotest-libvirt.migration.migrate_vm_in_various_status.migrate_paused_vm.migration_succeeds.precopy.non_p2p: STARTED
 (2/2) type_specific.io-github-autotest-libvirt.migration.migrate_vm_in_various_status.migrate_paused_vm.migration_succeeds.precopy.non_p2p: PASS (205.74 s)

 (1/2) type_specific.io-github-autotest-libvirt.migration.migrate_vm_in_various_status.migrate_paused_vm.cancel_migration.precopy.p2p: STARTED
 (1/2) type_specific.io-github-autotest-libvirt.migration.migrate_vm_in_various_status.migrate_paused_vm.cancel_migration.precopy.p2p: PASS (170.84 s)
 (2/2) type_specific.io-github-autotest-libvirt.migration.migrate_vm_in_various_status.migrate_paused_vm.cancel_migration.precopy.non_p2p: STARTED
 (2/2) type_specific.io-github-autotest-libvirt.migration.migrate_vm_in_various_status.migrate_paused_vm.cancel_migration.precopy.non_p2p: PASS (169.34 s)
