### PR TITLE
Remove no more relevant case 

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_options_shared.cfg
+++ b/libvirt/tests/cfg/migration/migrate_options_shared.cfg
@@ -475,12 +475,6 @@
                                 stress_in_vm = "yes"
                                 stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 256M --timeout 70"
                                 actions_during_migration = "setmigratepostcopy"
-                        - cancel_concurrent_migration:
-                            only without_postcopy
-                            concurrent_migration = "yes"
-                            virsh_migrate_extra = "--bandwidth 5"
-                            asynch_migrate = "yes"
-                            actions_during_migration = "cancel_concurrent_migration"
                 - tunnelled_migration:
                     only without_postcopy
                     virsh_migrate_options = "--live --p2p --tunnelled --verbose"
@@ -523,20 +517,6 @@
                                     parallel_cn_nums = 0
                                 - set_cross_border:
                                     parallel_cn_nums = 256
-                - cache_unsafe:
-                    # Without '--unsafe', migration will fail and throw an error message
-                    err_msg = "Unsafe migration: Migration may lead to data corruption"
-                    variants:
-                        - writeback:
-                            cache = "writeback"
-                        - unsafe:
-                            cache = "unsafe"
-                        - writethrough:
-                            cache = "writethrough"
-                        - default:
-                            cache = "default"
-                        - nonexistence:
-                            remove_cache = "yes"
                 - native_tls:
                     variants:
                         - inconsistent_cn_server:


### PR DESCRIPTION
Removing test automation - that was inactivated long ago and it was not running from version 9.4. (now running and failing)
migrate_options_shared.positive_test.p2p_migration.cancel_concurrent_migration.without_postcopy
- checking behavior when user runs migration twice ... but now the second migration will return error ... and there are already tests for it.

 removing negative casese for unsafe cache
 migrate_options_shared.negative_test..cache_unsafe
 (that was canceled inside the code from versions libvirt 5.6 and qemu 4.0)