### PR TITLE
virsh_cpu_models: add filters

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/host/virsh_cpu_models.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/host/virsh_cpu_models.cfg
@@ -13,15 +13,13 @@
                     only local_host
                     check_qemu_cpu_supported_cmd = "/usr/libexec/qemu-kvm -cpu help | awk '/Available CPUs/,/Recognized CPUID flags/' | grep '^  ' | awk '{print $1}'"
                     skip_list = ['base', 'host', 'max']
-                    variants arch_option:
-                        - arch_x86:
-                            cpu_arch = "x86_64"
-                        - arch_s390:
-                            cpu_arch = "s390"
-                            msg = "all CPU models are accepted"
-                        - arch_aarch64:
-                            cpu_arch =  "aarch64"
-                            msg = "all CPU models are accepted"
+                    cpu_arch = "x86_64"
+                    s390-virtio:
+                        cpu_arch = "s390"
+                        msg = "all CPU models are accepted"
+                    aarch64:
+                        cpu_arch =  "aarch64"
+                        msg = "all CPU models are accepted"
             variants:
                 - local_host:
                 - remote_host:


### PR DESCRIPTION
969ec9b13d2be9d88381d686601288c695a1cb94 restructured the tests introducing a named variant for each of the main architectures.

However, this requires additional filtering in CI.

Instead, use existing avocado-vt configuration parameters to keep having a single variant that applies to all considered archs.