### PR TITLE
Add required parameters for shared disk and tls setup

### DIFF
--- a/libvirt/tests/cfg/migration/migration_with_numa_topology.cfg
+++ b/libvirt/tests/cfg/migration/migration_with_numa_topology.cfg
@@ -1,6 +1,10 @@
 - migrate.migration_with_numa_topology:
     type = migration_with_numa_topology
     only aarch64
+    migration_setup = "yes"
+    storage_type = "nfs"
+    setup_local_nfs = "yes"
+    take_regular_screendumps = no
     start_vm = 'no'
     dest_persist_xml = "yes"
     dest_xml = "yes"
@@ -26,6 +30,8 @@
         - addtional_options:
             migration_connections = 3
             add_options = "--auto-converge  --parallel --parallel-connections ${migration_connections} --tls"
+            migrate_dest_host_cn = "ENTER.YOUR.EXAMPLE.SERVER_CN"
+            migrate_source_host_cn = "ENTER.YOUR.EXAMPLE.CLIENT_CN"
     variants:
         - without_postcopy:
             copy_type = ""


### PR DESCRIPTION
depends on: https://github.com/avocado-framework/avocado-vt/pull/4111

test results:
 (1/6) type_specific.io-github-autotest-libvirt.migrate.migration_with_numa_topology.no_back_migration.without_postcopy.base_options.one_cluster_on_numa: STARTED
 (1/6) type_specific.io-github-autotest-libvirt.migrate.migration_with_numa_topology.no_back_migration.without_postcopy.base_options.one_cluster_on_numa: PASS (414.32 s)
 (2/6) type_specific.io-github-autotest-libvirt.migrate.migration_with_numa_topology.no_back_migration.without_postcopy.base_options.multi_cluster_on_numa: STARTED
 (2/6) type_specific.io-github-autotest-libvirt.migrate.migration_with_numa_topology.no_back_migration.without_postcopy.base_options.multi_cluster_on_numa: PASS (414.07 s)
 (3/6) type_specific.io-github-autotest-libvirt.migrate.migration_with_numa_topology.no_back_migration.without_postcopy.addtional_options.one_cluster_on_numa: STARTED
 (3/6) type_specific.io-github-autotest-libvirt.migrate.migration_with_numa_topology.no_back_migration.without_postcopy.addtional_options.one_cluster_on_numa: PASS (505.06 s)
 (4/6) type_specific.io-github-autotest-libvirt.migrate.migration_with_numa_topology.no_back_migration.without_postcopy.addtional_options.multi_cluster_on_numa: STARTED
 (4/6) type_specific.io-github-autotest-libvirt.migrate.migration_with_numa_topology.no_back_migration.without_postcopy.addtional_options.multi_cluster_on_numa: PASS (493.82 s)
 (5/6) type_specific.io-github-autotest-libvirt.migrate.migration_with_numa_topology.no_back_migration.postcopy.base_options.one_cluster_on_numa: STARTED
 (5/6) type_specific.io-github-autotest-libvirt.migrate.migration_with_numa_topology.no_back_migration.postcopy.base_options.one_cluster_on_numa: PASS (413.16 s)
 (6/6) type_specific.io-github-autotest-libvirt.migrate.migration_with_numa_topology.no_back_migration.postcopy.base_options.multi_cluster_on_numa: STARTED
 (6/6) type_specific.io-github-autotest-libvirt.migrate.migration_with_numa_topology.no_back_migration.postcopy.base_options.multi_cluster_on_numa: PASS (413.75 s)