### PR TITLE
guestinfo: Check guest_bus in the output

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_guestinfo.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_guestinfo.cfg
@@ -22,6 +22,7 @@
                     option = "--disk"
                     disk_target_name = "vdb"
                     disk_name = "vdb.img"
+                    disk_target_bus = "virtio"
                     serial_num = "12345678"
                 - interface_info:
                     option = "--interface"


### PR DESCRIPTION
This is an update to RHEL-201783
"guest_bus" is added to the output of "virsh guestinfo --disk". Supported since libvirt-11.2.0