### PR TITLE
numa_config_with_auto_placement:fix incorrect iothreadid

### DIFF
--- a/libvirt/tests/src/numa/numa_config_with_auto_placement.py
+++ b/libvirt/tests/src/numa/numa_config_with_auto_placement.py
@@ -163,18 +163,17 @@ def check_iothreadinfo(vm_name, cpu_range, config=''):
                                 ignore_status=False)
     range_found = False
     live_vmxml = libvirt_xml.VMXML.new_from_dumpxml(vm_name)
-    iothreadid_list = live_vmxml.iothreadids.iothread
-    for one_iothread in iothreadid_list:
-        iothread_attrs = one_iothread.fetch_attrs()
-        iothread_id = iothread_attrs['id']
-        if re.search('{}\s*{}'.format(iothread_id, cpu_range),
+    iothread_num = live_vmxml.iothreads
+    for iothread_id in range(1, iothread_num + 1):
+        if re.search("{}\s*{}".format(iothread_id, cpu_range),
                      result.stdout_text):
             logging.debug(
-                'Expected cpu affinity: {} found in stdout for '
-                'iothread: {}.'.format(cpu_range, iothread_id))
+                "Expected cpu affinity: {} found in stdout for "
+                "iothread: {}.".format(cpu_range, iothread_id))
             range_found = True
         else:
-            logging.debug('Iothread {} has no cpu affinity'.format(iothread_id))
+            logging.debug("Expect Iothread {} has cpu affinity {}, "
+                          "but not found".format(iothread_id, cpu_range))
 
     if not range_found:
         raise TestFail('Expected cpu affinity: {} not found in stdout of '


### PR DESCRIPTION
This case has no iothreadid setting, so previous fix is incorrect. The iothread id is ordered from 1. So this patch is to use new way to count the iothread id.

Signed-off-by: Dan Zheng <dzheng@redhat.com>
