### PR TITLE
virtiofs: fix negative scenarios

### DIFF
--- a/libvirt/tests/src/virtiofs/virtiofs.py
+++ b/libvirt/tests/src/virtiofs/virtiofs.py
@@ -565,9 +565,9 @@ def run(test, params, env):
 
         for index in range(guest_num):
             end_test = set_up_and_start_vm(index)
-            check_qemu_cmdline()
             if end_test:
                 return
+            check_qemu_cmdline()
 
         shared_data(vm_names, fs_devs)
 


### PR DESCRIPTION
QEMU cmdline check was always executed, also in negative scenario. Return test immediately when done.