### PR TITLE
virsh_domiflist: Update filters

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domiflist.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domiflist.cfg
@@ -29,8 +29,10 @@
                         - virtio_iface:
                             iface_model = "virtio"
                         - e1000_iface:
+                            only x86_64
                             iface_model = "e1000"
                         - rtl8139_iface:
+                            only x86_64
                             iface_model = "rtl8139"
                 - iface_options:
                     domiflist_domname_options = "name"


### PR DESCRIPTION
Only x86_64 machine supports e1000 and rtl8139 ifaces.