### PR TITLE
passthrough/ccw: update disk selection

### DIFF
--- a/libvirt/tests/cfg/passthrough/ccw/libvirt_ccw_passthrough.cfg
+++ b/libvirt/tests/cfg/passthrough/ccw/libvirt_ccw_passthrough.cfg
@@ -1,7 +1,7 @@
 - libvirt_ccw_passthrough:
     type = libvirt_ccw_passthrough
     only s390-virtio
-    devid =
+    devid = dasd
     variants:
         - happy_path:
         - device_removal:

--- a/libvirt/tests/cfg/passthrough/ccw/libvirt_ccw_passthrough_read_write.cfg
+++ b/libvirt/tests/cfg/passthrough/ccw/libvirt_ccw_passthrough_read_write.cfg
@@ -1,7 +1,7 @@
 - libvirt_ccw_passthrough.read_write:
     type = libvirt_ccw_passthrough_read_write
     only s390-virtio
-    devid =
+    devid = dasd
     start_vm = yes
     variants:
         - happy_path:

--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_dasd.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_dasd.cfg
@@ -1,6 +1,6 @@
 - virtual_disks.dasd:
     type = virtual_disks_dasd
     only s390-virtio
-    devid =
+    devid = dasd
     variants:
         - read_native_partition_table:

--- a/libvirt/tests/src/passthrough/ccw/libvirt_ccw_passthrough.py
+++ b/libvirt/tests/src/passthrough/ccw/libvirt_ccw_passthrough.py
@@ -45,9 +45,6 @@ def guest_is_responsive(session):
 def run(test, params, env):
     """
     Test for CCW, esp. DASD disk passthrough on s390x.
-
-    The CCW disk/its subchannel for passthrough is expected to
-    be listed on the host but not enabled for use.
     """
 
     vm_name = params.get("main_vm")

--- a/libvirt/tests/src/passthrough/ccw/libvirt_ccw_passthrough_read_write.py
+++ b/libvirt/tests/src/passthrough/ccw/libvirt_ccw_passthrough_read_write.py
@@ -8,9 +8,6 @@ from provider.vfio import ccw
 def run(test, params, env):
     """
     Test for CCW, esp. DASD disk passthrough on s390x.
-
-    The CCW disk/its subchannel for passthrough is expected to
-    be listed on the host but not enabled for use.
     """
 
     vm_name = params.get("main_vm")

--- a/libvirt/tests/src/virtual_disks/virtual_disks_dasd.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_dasd.py
@@ -28,15 +28,7 @@ def get_partitioned_dasd_path(devid):
     :param devid: the ccw device id, e.g. 0.0.5200
     :return path: absolute path to block device, e.g. '/dev/dasda'
     """
-    paths = SubchannelPaths()
-    paths.get_info()
-    device = None
-    if devid:
-        device = paths.get_device(devid)
-    else:
-        device = paths.get_first_unused_and_safely_removable()
-    if not device:
-        raise TestError("Couldn't find dasd device for test")
+    device = ccw.get_device_info(devid, True)
     global TEST_DASD_ID
     TEST_DASD_ID = device[paths.HEADER["Device"]]
     enable_disk(TEST_DASD_ID)

--- a/libvirt/tests/src/virtual_disks/virtual_disks_dasd.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_dasd.py
@@ -6,7 +6,7 @@ import re
 from avocado.core.exceptions import TestError
 
 from virttest import virsh
-from virttest.utils_zchannels import SubchannelPaths
+from virttest.utils_zchannels import SubchannelPaths as paths
 from virttest.utils_misc import cmd_status_output, wait_for
 from virttest.libvirt_xml.vm_xml import VMXML
 
@@ -14,6 +14,7 @@ from provider.vfio import ccw
 
 TEST_DASD_ID = None
 TARGET = "vdb"  # suppose guest has only one disk 'vda'
+cleanup_actions = []
 
 
 # Using as lower capital is not the best way to do, but this is just a
@@ -31,14 +32,14 @@ def get_partitioned_dasd_path(devid):
     device = ccw.get_device_info(devid, True)
     global TEST_DASD_ID
     TEST_DASD_ID = device[paths.HEADER["Device"]]
-    enable_disk(TEST_DASD_ID)
+    try_enable_disk(TEST_DASD_ID)
     disk_path = get_device_path(TEST_DASD_ID)
     wait_for(lambda: ccw.format_dasd(disk_path, None), 10, first=1.0)
     wait_for(lambda: ccw.make_dasd_part(disk_path, None), 10, first=1.0)
     return disk_path
 
 
-def enable_disk(disk_id):
+def try_enable_disk(disk_id):
     """
     Enables the disk so it can be used
 
@@ -48,8 +49,10 @@ def enable_disk(disk_id):
 
     cmd = "chzdev -e %s" % disk_id
     err, out = cmd_status_output(cmd, shell=True)
-    if err:
-        raise TestError("Couldn't enable dasd '%s'. %s" % (disk_id, out))
+    if 'already configured' not in out:
+        cleanup_actions.append(lambda: disable_disk(disk_id))
+        if err:
+            raise TestError("Couldn't enable dasd '%s'. %s" % (disk_id, out))
 
 
 def disable_disk(disk_id):
@@ -147,17 +150,15 @@ def run(test, params, env):
     devid = params.get("devid")
 
     try:
+        cleanup_actions.append(lambda: vm.destroy())
         disk_path = get_partitioned_dasd_path(devid)
+
         attach_disk(vm_name, TARGET, disk_path)
 
         session = vm.wait_for_login()
         check_dasd_partition_table(session, TARGET)
         detach_disk(vm_name, TARGET)
     finally:
-        if vm.is_alive():
-            vm.destroy(gracefully=False)
-        # sync will release attached disk, precondition for disablement
-        backup_xml.sync()
-        global TEST_DASD_ID
-        if TEST_DASD_ID:
-            disable_disk(TEST_DASD_ID)
+        cleanup_actions.reverse()
+        for action in cleanup_actions:
+            action()

--- a/provider/vfio/ccw.py
+++ b/provider/vfio/ccw.py
@@ -336,13 +336,14 @@ def select_first_available_device(device_ids):
     raise TestError(f"None of the devices is available, {device_ids}")
 
 
-def get_device_info(devid=None, full=False):
+def get_device_info(devid="", full=False):
     """
     Gets the device info for passthrough.
     It selects a device that's safely removable if devid
     is not given.
 
     :param devid: The ccw device id, e.g. 0.0.5000
+                  Also supports value 'dasd' to return the first available DASD
     :param full: per default only return schid, chpids; return
                  full device info if True
     :return: The device info
@@ -350,10 +351,12 @@ def get_device_info(devid=None, full=False):
 
     paths = get_subchannel_info()
     device = None
-    if devid:
-        device = paths.get_device(devid)
-    else:
+    if not devid:
         device = paths.get_first_unused_and_safely_removable()
+    elif devid == "dasd":
+        device = paths.get_first_dasd_in_use()
+    else:
+        device = paths.get_device(devid)
     if full:
         return device
     schid = device[paths.HEADER["Subchan."]]

--- a/provider/vfio/ccw.py
+++ b/provider/vfio/ccw.py
@@ -336,14 +336,16 @@ def select_first_available_device(device_ids):
     raise TestError(f"None of the devices is available, {device_ids}")
 
 
-def get_device_info(devid=None):
+def get_device_info(devid=None, full=False):
     """
     Gets the device info for passthrough.
     It selects a device that's safely removable if devid
     is not given.
 
     :param devid: The ccw device id, e.g. 0.0.5000
-    :return: Subchannel and Channel path ids (schid, chpids)
+    :param full: per default only return schid, chpids; return
+                 full device info if True
+    :return: The device info
     """
 
     paths = get_subchannel_info()
@@ -352,6 +354,8 @@ def get_device_info(devid=None):
         device = paths.get_device(devid)
     else:
         device = paths.get_first_unused_and_safely_removable()
+    if full:
+        return device
     schid = device[paths.HEADER["Subchan."]]
     chpids = device[paths.HEADER["CHPIDs"]]
     return schid, chpids

--- a/provider/vfio/mdev_handlers.py
+++ b/provider/vfio/mdev_handlers.py
@@ -175,8 +175,6 @@ class CcwMdevHandler(MdevHandler):
             # need to sleep to avoid issue with setting device offline
             # adding a wait_for would likely be more complicated
             sleep(1)
-        if self.device_id:
-            ccw.set_device_offline(self.device_id)
 
 
 class ApMdevHandler(MdevHandler):

--- a/virttools/tests/cfg/virt_install/blk_installation.cfg
+++ b/virttools/tests/cfg/virt_install/blk_installation.cfg
@@ -4,4 +4,4 @@
     start_vm = False
     install_tree_url = INSTALL_TREE_URL
     kickstart_url = KICKSTART_URL
-    devid =
+    devid = dasd

--- a/virttools/tests/cfg/virt_install/hostdev_mdev.cfg
+++ b/virttools/tests/cfg/virt_install/hostdev_mdev.cfg
@@ -4,4 +4,4 @@
         - check_present_inside_guest:
             only s390-virtio
             mdev_type = vfio_ccw-io
-            devid =
+            devid = dasd

--- a/virttools/tests/cfg/virt_install/vfio_installation.cfg
+++ b/virttools/tests/cfg/virt_install/vfio_installation.cfg
@@ -4,4 +4,4 @@
     start_vm = False
     install_tree_url = INSTALL_TREE_URL
     kickstart_url = KICKSTART_URL
-    devid =
+    devid = dasd

--- a/virttools/tests/src/virt_install/blk_installation.py
+++ b/virttools/tests/src/virt_install/blk_installation.py
@@ -13,6 +13,9 @@ import logging as log
 from avocado.utils import process
 
 from virttest.utils_misc import cmd_status_output
+from virttest.utils_zchannels import SubchannelPaths as paths
+
+from provider.vfio import ccw
 
 
 logging = log.getLogger("avocado." + __name__)
@@ -34,9 +37,9 @@ def run(test, params, env):
         kickstart_url = params.get("kickstart_url")
 
         process.run("curl -k -o /tmp/ks.cfg %s" % kickstart_url)
-        process.run("chzdev -e %s" % devid)
+        device = ccw.get_device_info(devid, True)
+        devid = device[paths.HEADER["Device"]]
         disk_path = "/dev/disk/by-path/ccw-%s" % devid
-        cleanup_actions.insert(0, lambda: process.run("chzdev -d %s" % devid))
 
         cmd = ("virt-install --name %s"
                " --disk %s"

--- a/virttools/tests/src/virt_install/hostdev_mdev.py
+++ b/virttools/tests/src/virt_install/hostdev_mdev.py
@@ -2,9 +2,12 @@ import logging
 
 from avocado.core.exceptions import TestError
 from provider.vfio.mdev_handlers import MdevHandler
+from virttest import virsh
 from virttest.libvirt_xml.vm_xml import VMXML
 from virttest.utils_misc import cmd_status_output
-from virttest import virsh
+from virttest.utils_zchannels import SubchannelPaths as paths
+
+from provider.vfio import ccw
 
 LOG = logging.getLogger('avocado.' + __name__)
 
@@ -76,6 +79,8 @@ def run(test, params, env):
 
     try:
 
+        device = ccw.get_device_info(devid, True)
+        devid = device[paths.HEADER["Device"]]
         vm.undefine()
         handler = MdevHandler.from_type(mdev_type)
         disk = get_disk_for_import(vmxml)

--- a/virttools/tests/src/virt_install/vfio_installation.py
+++ b/virttools/tests/src/virt_install/vfio_installation.py
@@ -14,6 +14,9 @@ from avocado.utils import process
 
 from provider.vfio.mdev_handlers import MdevHandler
 from virttest.utils_misc import cmd_status_output
+from virttest.utils_zchannels import SubchannelPaths as paths
+
+from provider.vfio import ccw
 
 
 logging = log.getLogger("avocado." + __name__)
@@ -37,6 +40,8 @@ def run(test, params, env):
 
         process.run("curl -k -o /tmp/ks.cfg %s" % kickstart_url)
 
+        device = ccw.get_device_info(devid, True)
+        devid = device[paths.HEADER["Device"]]
         handler = MdevHandler.from_type("vfio_ccw-io")
         mdev_nodedev = handler.create_nodedev(devid=devid)
         target_address = handler.get_target_address()


### PR DESCRIPTION
Depends on https://github.com/avocado-framework/avocado-vt/pull/4119

Our test environments now use DASD only for passthrough tests. Therefore it's safe to select the first DASD in Use. Select assume per default environments are set up with at least 1 DASD disk in Use.