### PR TITLE
sriov: Extend event wait time

### DIFF
--- a/libvirt/tests/src/sriov/locked_memory_check/sriov_with_hotplug_memory.py
+++ b/libvirt/tests/src/sriov/locked_memory_check/sriov_with_hotplug_memory.py
@@ -131,7 +131,7 @@ def run(test, params, env):
         if without_hostdev:
             test.log.info("TEST_STEP: Hot-unplug iface device and check locked memory limit.")
             virsh.detach_device(vm_name, iface_dev.xml, debug=True, ignore_status=False,
-                                wait_for_event=True)
+                                wait_for_event=True, event_timeout=30)
             vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
             check_memory_limit(vmxml, first_mem, with_hostdev_device=False)
     finally:


### PR DESCRIPTION
Before the fix:
```
 (3/4) type_specific.io-github-autotest-libvirt.sriov.locked_memory_check.hotplug_memory.without_hardlimit.start_vm_without_hostdev.hostdev_device.pf_address: ERROR: Not found event device-removed after 7 seconds (199.32 s)
 (4/4) type_specific.io-github-autotest-libvirt.sriov.locked_memory_check.hotplug_memory.with_hardlimit.start_vm_without_hostdev.hostdev_device.pf_address: STARTED
 (4/4) type_specific.io-github-autotest-libvirt.sriov.locked_memory_check.hotplug_memory.with_hardlimit.start_vm_without_hostdev.hostdev_device.pf_address: ERROR: Not found event device-removed after 7 seconds (200.04 s)
```

**After the fix:**
```
 (1/2) type_specific.io-github-autotest-libvirt.sriov.locked_memory_check.hotplug_memory.without_hardlimit.start_vm_without_hostdev.hostdev_device.pf_address: STARTED
 (1/2) type_specific.io-github-autotest-libvirt.sriov.locked_memory_check.hotplug_memory.without_hardlimit.start_vm_without_hostdev.hostdev_device.pf_address: PASS (198.83 s)
 (2/2) type_specific.io-github-autotest-libvirt.sriov.locked_memory_check.hotplug_memory.with_hardlimit.start_vm_without_hostdev.hostdev_device.pf_address: STARTED
 (2/2) type_specific.io-github-autotest-libvirt.sriov.locked_memory_check.hotplug_memory.with_hardlimit.start_vm_without_hostdev.hostdev_device.pf_address: PASS (199.57 s)
```
