### PR TITLE
guest os booting: add block device support for NVRAM

### DIFF
--- a/libvirt/tests/cfg/guest_os_booting/ovmf_firmware/ovmf_backed_nvram.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/ovmf_firmware/ovmf_backed_nvram.cfg
@@ -5,7 +5,6 @@
     template_path = "/usr/share/edk2/ovmf/OVMF_VARS.secboot.fd"
     os_secure = "yes"
     firmware_type = "ovmf"
-    nvram_attrs = {'nvram_attrs': {'template': '${template_path}', 'type': '%s'}}
     func_supported_since_libvirt_ver = (8, 5, 0)
     only q35, aarch64
     aarch64:
@@ -18,3 +17,7 @@
     variants source_type:
         - file:
             nvram_source = {'nvram_source': {'attrs': {'file': '%s'}}}
+            nvram_attrs = {'nvram_attrs': {'template': '${template_path}', 'type': 'file'}}
+        - block:
+            nvram_source = {'nvram_source': {'attrs': {'dev': '%s'}}}
+            nvram_attrs = {'nvram_attrs': {'template': '${template_path}', 'type': 'block', 'format': 'qcow2'}}

--- a/libvirt/tests/src/guest_os_booting/ovmf_firmware/ovmf_backed_nvram.py
+++ b/libvirt/tests/src/guest_os_booting/ovmf_firmware/ovmf_backed_nvram.py
@@ -10,6 +10,9 @@ from virttest import virsh
 from virttest.data_dir import get_data_dir
 from virttest.libvirt_xml import vm_xml
 from provider.guest_os_booting import guest_os_booting_base as guest_os
+from provider.virtual_disk import disk_base
+import random
+import string
 
 
 def run(test, params, env):
@@ -41,16 +44,38 @@ def run(test, params, env):
                 test.fail("Configured os attributes {} don't existed in guest.".format(key))
         test.log.debug("Get expected os xml of guest.")
 
+    def generate_random_string(length=4):
+        letters = string.ascii_letters
+        return ''.join(random.choices(letters, k=length))
+
+    def create_block_device():
+        """
+        Setup one scsi_debug block device
+
+        :return: device name
+        """
+        name_term = generate_random_string(length=4)
+        disk_obj.lv_name = 'lv_' + name_term
+        disk_obj.vg_name = 'vg_' + name_term
+        _, new_image_path = disk_obj.prepare_disk_obj(disk_type='block', disk_dict={}, size='8M', convert_format='qcow2')
+        return new_image_path
+
     vm_name = guest_os.get_vm(params)
     firmware_type = params.get("firmware_type")
     source_type = params.get("source_type")
     nvram_file = os.path.join(get_data_dir(), "test.fd")
-    nvram_attrs = eval(params.get("nvram_attrs") % source_type)
+    nvram_attrs = eval(params.get("nvram_attrs"))
     os_dict = eval(params.get("os_dict"))
-    nvram_source = eval(params.get("nvram_source") % nvram_file)
-    libvirt_version.is_libvirt_feature_supported(params)
-
     vm = env.get_vm(vm_name)
+    if source_type == 'file':
+        nvram_source = eval(params.get("nvram_source") % nvram_file)
+    elif source_type == 'block':
+        disk_obj = disk_base.DiskBase(test, vm, params)
+        disk_obj.disk_size = '8M'
+        image_path = create_block_device()
+        nvram_source = eval(params.get("nvram_source") % image_path)
+        test.log.info('the path of nvram:' + image_path)
+    libvirt_version.is_libvirt_feature_supported(params)
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     bkxml = vmxml.copy()
 
@@ -67,4 +92,6 @@ def run(test, params, env):
             virsh.destroy(vm_name)
         if os.path.exists(nvram_file):
             os.remove(nvram_file)
+        if source_type == 'block':
+            disk_obj.cleanup_disk_preparation(disk_type='block')
         bkxml.sync()


### PR DESCRIPTION
add a new scenario for case VIRT-297065 - [OVMF] Boot ovmf vm with different types backed nvram