### PR TITLE
virtiofs.unpriviledged: fix hugepages tests for bootc

### DIFF
--- a/libvirt/tests/src/virtiofs/virtiofs_unprivileged.py
+++ b/libvirt/tests/src/virtiofs/virtiofs_unprivileged.py
@@ -40,7 +40,7 @@ test_passwd = ""
 _params = {}
 backup_huge_pages_num = 0
 user_config_path = ""
-hugepages_user_path = "/user_hugepages"
+hugepages_user_path = "/var/user_hugepages"
 with_hugepages = False
 qemu_config = None
 


### PR DESCRIPTION
bootc doesn't allow creating the hugepages user directory in the original path.

Add it to /var instead.