### PR TITLE
Add new cpu case of hv-passthrough

### DIFF
--- a/libvirt/tests/cfg/cpu/vm_features.cfg
+++ b/libvirt/tests/cfg/cpu/vm_features.cfg
@@ -44,6 +44,9 @@
                                     hyperv_attr={'relaxed': {'state': 'on'}}
                                 - disable:
                                     hyperv_attr={'relaxed': {'state': 'on'}}
+                        - passthrough:
+                            hyperv_attr = {'mode': 'passthrough'}
+                            qemu_include = 'hv-passthrough=on'
                 - pmu:
                     no pseries, s390-virtio
                     variants:


### PR DESCRIPTION
- RHEL-288471 - Start VM with hyperv passthrough mode

Test result:
 (1/1) type_specific.local.vm_features.positive_test.hyperv.passthrough: STARTED
 (1/1) type_specific.local.vm_features.positive_test.hyperv.passthrough: PASS (34.33 s)