### PR TITLE
Add new cpu cases

### DIFF
--- a/libvirt/tests/cfg/cpu/setvcpus_check_node_id.cfg
+++ b/libvirt/tests/cfg/cpu/setvcpus_check_node_id.cfg
@@ -1,0 +1,6 @@
+- cpu.setvcpus.check_node_id:
+    type = setvcpus_check_node_id
+    start_vm = no
+    vm_attrs = {'vcpu': 10, 'current_vcpu': 5}
+    numa_cell = [{'id': '0', 'cpus': '0,2,4,6,8', 'memory': '524288'}, {'id': '1', 'cpus': '1,3,5,7,9', 'memory': '524288'}]
+    qmp_cmd = stap /usr/share/doc/libvirt-docs/examples/systemtap/qemu-monitor.stp

--- a/libvirt/tests/cfg/cpu/vm_with_cpu_mode_in_domcapabilities.cfg
+++ b/libvirt/tests/cfg/cpu/vm_with_cpu_mode_in_domcapabilities.cfg
@@ -1,0 +1,3 @@
+- cpu.vm_with_cpu_mode_in_domcapabilities:
+    type = vm_with_cpu_mode_in_domcapabilities
+    start_vm = no

--- a/libvirt/tests/src/cpu/setvcpus_check_node_id.py
+++ b/libvirt/tests/src/cpu/setvcpus_check_node_id.py
@@ -1,0 +1,79 @@
+import logging
+import re
+import time
+
+from aexpect import ShellSession
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+
+VIRSH_ARGS = {'ignore_status': False, 'debug': True}
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+
+def run(test, params, env):
+    """
+    Test libvirt will pass node-id to qemu when hot-plug vcpu
+    """
+    vm_name = params.get('main_vm')
+    vm_attrs = eval(params.get('vm_attrs', '{}'))
+    numa_cell = eval(params.get('numa_cell', '[]'))
+    qmp_cmd = params.get('qmp_cmd')
+
+    vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+
+    vm = env.get_vm(vm_name)
+
+    try:
+        vmxml.setup_attrs(**vm_attrs)
+        cpu = vmxml.cpu
+        cpu.xml = '<cpu/>'
+        cpu.numa_cell = cpu.dicts_to_cells(numa_cell)
+        vmxml.cpu = cpu
+        vmxml.sync()
+
+        virsh.dumpxml(vm_name, **VIRSH_ARGS)
+
+        qmp_sess = ShellSession(qmp_cmd)
+        time.sleep(5)
+
+        virsh.start(vm_name, **VIRSH_ARGS)
+        virsh.setvcpus(vm_name, vm_attrs['vcpu'], **VIRSH_ARGS)
+
+        virsh.dumpxml(vm_name, **VIRSH_ARGS)
+
+        qmp_out = qmp_sess.get_output()
+        LOG.debug(qmp_out)
+        qmp_sess.close()
+
+        node_vcpu_map = {int(c['id']): c['cpus'].split(',') for c in numa_cell}
+        vcpu_range = range(vm_attrs['current_vcpu'], vm_attrs['vcpu'])
+
+        for line in qmp_out.splitlines():
+            if 'device_add' in line:
+                LOG.debug(line)
+                d = re.search(r'(\{.*\})', line)
+                if d:
+                    d = eval(d.group(1))
+                    LOG.debug(f"Found device add with data {d}")
+                    arguments = d.get('arguments', {})
+                    vcpu_id = arguments.get('id')
+                    if vcpu_id is not None:
+                        LOG.info(f"VCPU is {vcpu_id}")
+                        vcpu_id_digit = vcpu_id.replace('vcpu', '')
+                        if int(vcpu_id_digit) not in vcpu_range:
+                            LOG.error(
+                                f"VCPU {vcpu_id} is supposed to be in range {list(vcpu_range)}")
+                    node_id = arguments.get('node-id')
+                    if node_id is not None:
+                        LOG.info(f"Node ID is {node_id}")
+                    if node_id in node_vcpu_map and vcpu_id.replace('vcpu', '') in node_vcpu_map[node_id]:
+                        LOG.info(
+                            f"VCPU {vcpu_id} on Node {node_id} found in the qmp output")
+                    else:
+                        LOG.error(
+                            f"VCPU {vcpu_id} on Node {node_id} not found in the qmp output"
+                        )
+    finally:
+        bkxml.sync()

--- a/libvirt/tests/src/cpu/vm_with_cpu_mode_in_domcapabilities.py
+++ b/libvirt/tests/src/cpu/vm_with_cpu_mode_in_domcapabilities.py
@@ -1,0 +1,69 @@
+import logging
+
+from virttest import virsh
+from virttest.libvirt_xml import domcapability_xml
+from virttest.libvirt_xml import vm_xml
+
+
+VIRSH_ARGS = {'ignore_status': False, 'debug': True}
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+
+def compare_xml(ele_a, ele_b):
+    if ele_a.tag != ele_b.tag:
+        return False
+    if (ele_a.text or '').strip() != (ele_b.text or '').strip():
+        return False
+    if (ele_a.tail or '').strip() != (ele_b.tail or '').strip():
+        return False
+    if ele_a.attrib != ele_b.attrib:
+        return False
+    if len(ele_a) != len(ele_b):
+        return False
+
+    children_a = sorted(ele_a, key=lambda x: (x.tag, sorted(x.attrib.items())))
+    children_b = sorted(ele_b, key=lambda x: (x.tag, sorted(x.attrib.items())))
+
+    return all(compare_xml(a, b) for a, b in zip(children_a, children_b))
+
+
+def run(test, params, env):
+    """
+    Test Start VM with cpu mode in "virsh domcapabilities"
+    """
+    vm_name = params.get('main_vm')
+
+    vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+
+    try:
+        domcap = domcapability_xml.DomCapabilityXML()
+        LOG.debug(domcap.xml)
+
+        # Update vm xml with cpu mode from domcapabilities
+        cpu = vmxml.cpu
+        cpuxml_cap = virsh.hypervisor_cpu_baseline(
+            domcap.xml, **VIRSH_ARGS).stdout_text
+        cpu.xml = cpuxml_cap
+        vmxml.cpu = cpu
+        vmxml.sync()
+
+        # cpu xml before vm start up
+        cpu_a = vmxml.cpu
+
+        virsh.dumpxml(vm_name, **VIRSH_ARGS)
+        virsh.start(vm_name, **VIRSH_ARGS)
+
+        cpu_b = vm_xml.VMXML.new_from_dumpxml(vm_name).cpu
+        LOG.debug(f'cpu xml after vm start up:\n{cpu_b}')
+        # attr 'check' is different after vm start up, but it's expected
+        cpu_a.check = cpu_b.check
+
+        # Compare cpu xml before and after vm start up, it should be the same
+        if not compare_xml(cpu_a.xmltreefile.getroot(),
+                           cpu_b.xmltreefile.getroot()):
+            test.fail('cpu xml changed after vm start')
+
+    finally:
+        bkxml.sync()


### PR DESCRIPTION
- VIRT-86511 - [cmd/domcapabilities] Start VM with cpu mode in "virsh domcapabilities"
- RHEL-114636 - [setvcpus] Check node-id in qemu monitor command when hot-plug vcpu

Test result

 (1/1) type_specific.local.setvcpus.check_node_id: STARTED
 (1/1) type_specific.local.setvcpus.check_node_id: PASS (22.85 s)
 (1/1) type_specific.local.vm_with_cpu_mode_in_domcapabilities: STARTED
 (1/1) type_specific.local.vm_with_cpu_mode_in_domcapabilities: PASS (16.59 s)