### PR TITLE
gpu: Fix errors

### DIFF
--- a/libvirt/tests/cfg/gpu/hotplug_gpu.cfg
+++ b/libvirt/tests/cfg/gpu/hotplug_gpu.cfg
@@ -1,5 +1,5 @@
-- gpu.lifecycle_vm_with_gpu:
-    type = lifecycle_vm_with_gpu
+- gpu.hotplug_gpu:
+    type = hotplug_gpu
     start_vm = "no"
 
     only aarch64

--- a/libvirt/tests/cfg/gpu/vm_cuda_sanity.cfg
+++ b/libvirt/tests/cfg/gpu/vm_cuda_sanity.cfg
@@ -1,7 +1,7 @@
 - gpu.vm_cuda_sanity:
     type = vm_cuda_sanity
     start_vm = "no"
-    cuda_samples_path = "../../deps/gpu/cuda-samples.tar.gz"
+    cuda_samples_path = "http://download.libvirt.redhat.com/libvirt-CI-resources/gpu/cuda-samples.tar.gz"
     cuda_tests = ["./cuda-samples/build/Samples/1_Utilities/deviceQuery/deviceQuery", "./cuda-samples/build/Samples/1_Utilities/bandwidthTest/bandwidthTest", "./cuda-samples/build/Samples//0_Introduction/simpleMultiCopy/simpleMultiCopy"]
 
     only aarch64

--- a/libvirt/tests/cfg/gpu/vm_mig_sanity.cfg
+++ b/libvirt/tests/cfg/gpu/vm_mig_sanity.cfg
@@ -1,7 +1,7 @@
 - gpu.mig_sanity:
     type = vm_mig_sanity
     start_vm = "no"
-    cuda_samples_path = "../../deps/gpu/cuda-samples.tar.gz"
+    cuda_samples_path = "http://download.libvirt.redhat.com/libvirt-CI-resources/gpu/cuda-samples.tar.gz"
     cuda_test = "./cuda-samples/build/Samples/5_Domain_Specific/BlackScholes/BlackScholes"
 
     only aarch64

--- a/libvirt/tests/src/gpu/vm_cuda_sanity.py
+++ b/libvirt/tests/src/gpu/vm_cuda_sanity.py
@@ -27,11 +27,9 @@ def run(test, params, env):
         vm.start()
         vm_session = vm.wait_for_login()
         test.log.debug(f'VMXML of {vm_name}:\n{virsh.dumpxml(vm_name).stdout_text}')
-        cuda_samples_path = os.path.join(os.path.dirname(__file__), params.get("cuda_samples_path"))
+        cuda_samples_path = params.get("cuda_samples_path")
         cuda_sample_guest_path = os.path.join("/tmp", os.path.basename(cuda_samples_path))
-        vm.copy_files_to(
-            cuda_samples_path, os.path.dirname(cuda_sample_guest_path),
-            timeout=240)
+        vm_session.cmd(f"wget {cuda_samples_path} -O {cuda_sample_guest_path}")
         vm_session.cmd(f"tar -xf {cuda_sample_guest_path} -C /root")
         vm_session.cmd(f"rm -rf {cuda_sample_guest_path}")
 

--- a/libvirt/tests/src/gpu/vm_mig_sanity.py
+++ b/libvirt/tests/src/gpu/vm_mig_sanity.py
@@ -32,11 +32,9 @@ def run(test, params, env):
 
         test.log.info("TEST_STEP: Copy the sample")
         guest_gpu_pci = gpu_base.get_gpu_pci(vm_session)
-        cuda_samples_path = os.path.join(os.path.dirname(__file__), params.get("cuda_samples_path"))
+        cuda_samples_path = params.get("cuda_samples_path")
         cuda_sample_guest_path = os.path.join("/tmp", os.path.basename(cuda_samples_path))
-        vm.copy_files_to(
-            cuda_samples_path, os.path.dirname(cuda_sample_guest_path),
-            timeout=240)
+        vm_session.cmd(f"wget {cuda_samples_path} -O {cuda_sample_guest_path}")
         vm_session.cmd(f"tar -xf {cuda_sample_guest_path} -C /root")
         vm_session.cmd(f"rm -rf {cuda_sample_guest_path}")
 


### PR DESCRIPTION
1. Fix hotplug case's pattern and type
2. Update to download cuda sample file from storage server

**Test results:**
` (1/1) type_specific.io-github-autotest-libvirt.gpu.vm_cuda_sanity.gpu_address: PASS (819.33 s)
`