### PR TITLE
tpm_device: avoid chcon on bin files

### DIFF
--- a/libvirt/tests/cfg/virtual_device/tpm_device.cfg
+++ b/libvirt/tests/cfg/virtual_device/tpm_device.cfg
@@ -146,8 +146,6 @@
                     no default_model
                     source_attrs = {'type': 'unix', 'mode': 'connect', 'path': '/var/tmp/guest-swtpm.sock'}
                     statedir = "/var/tmp/mytpm"
-                    swtpm_setup_path = '/usr/bin/swtpm_setup'
-                    swtpm_path = '/usr/bin/swtpm'
                     variants:
                         - start_vm:
                             audit_cmd = "cat /var/log/audit/audit.log| grep 'tpm-external'"


### PR DESCRIPTION
Deleting chcon for /usr/bin/swtpm_setup or /usr/bin/swtpm, in case of running failure in Read-only filesystems.