### PR TITLE
Enable virtio-mem on s390x

### DIFF
--- a/libvirt/tests/cfg/memory/memory_devices/change_virtio_mem_request_size.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/change_virtio_mem_request_size.cfg
@@ -1,6 +1,5 @@
 - memory.devices.virtio_mem.change_memory:
     type = change_virtio_mem_request_size
-    no s390-virtio
     start_vm = yes
     mem_model = "virtio-mem"
     allocate_huge_pages = "4194304KiB"
@@ -26,19 +25,28 @@
     numa_attrs = "'vcpu': 4, 'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '${numa_mem}', 'unit': 'KiB'},{'id':'1','cpus': '2-3','memory':'${numa_mem}','unit':'KiB'}]}"
     max_attrs = "'max_mem_rt': ${max_mem}, 'max_mem_rt_slots': ${max_mem_slots}, 'max_mem_rt_unit': 'KiB'"
     vm_attrs = {${base_attrs}, ${numa_attrs}, ${max_attrs}}
+    with_numa = yes
+    s390-virtio:
+        with_numa = no
+        vm_attrs = {${base_attrs}, ${max_attrs}}
     expect_xpath = [{'element_attrs':[".//memory[@unit='${memory_unit}']"],'text':'%d'},{'element_attrs':[".//currentMemory[@unit='KiB']"],'text':'%d'}]
     variants guest_state:
         - shutoff_guest:
+            no s390-virtio
             no file hugepages memfd
             mem_basic = {'mem_model': '${mem_model}', 'target': {'requested_unit': '${requested_unit}', 'size': %s, 'node': ${basic_node}, 'size_unit': 'KiB', 'requested_size': %s, 'block_unit': 'KiB', 'block_size': %s}}
         - running_guest:
-            kernel_extra_params_add = "memhp_default_state=online_movable"
-            kernel_extra_params_remove = "memhp_default_state"
+            kernel_params_add = "memhp_default_state=online_movable"
+            kernel_params_remove = "memhp_default_state"
             attach_node = 1
             attached_device =  "--node ${attach_node}"
             basic_device_alias = "--alias virtiomem0"
             mem_basic = {'mem_model': '${mem_model}', 'target': {'requested_unit': '${requested_unit}', 'size': %s, 'node': ${basic_node}, 'size_unit': 'KiB', 'requested_size': %s, 'block_unit': 'KiB', 'block_size': %s}}
             mem_attach = {'mem_model': '${mem_model}', 'target': {'requested_unit': '${requested_unit}', 'size': %s, 'node': ${attach_node}, 'size_unit': 'KiB', 'requested_size': %s, 'block_unit': 'KiB', 'block_size': %s}}
+            s390-virtio:
+                attached_device = "--alias virtiomem1"
+                mem_basic = {'mem_model': '${mem_model}', 'target': {'requested_unit': '${requested_unit}', 'size': %s, 'size_unit': 'KiB', 'requested_size': %s, 'block_unit': 'KiB', 'block_size': %s}}
+                mem_attach = {'mem_model': '${mem_model}', 'target': {'requested_unit': '${requested_unit}', 'size': %s, 'size_unit': 'KiB', 'requested_size': %s, 'block_unit': 'KiB', 'block_size': %s}}
     variants requested_setting:
         - normal_requested:
             update_request_size = '1024MiB'
@@ -49,14 +57,19 @@
             error_msg = "requested size must be smaller than or equal to"
         - not_mutiple_of_block_requested:
             update_request_size = '513MiB'
+            s390-virtio:
+                update_request_size = '524800KiB'
             error_msg = "requested size must be an integer multiple of block size"
     variants memory_backing:
         - file:
             source_type = 'file'
             source_attr = "'source_type':'${source_type}'"
         - hugepages:
+            s390-virtio:
+                kvm_module_parameters = "hpage=1"
             hugepages_attr = "'hugepages': {}"
         - memfd:
             source_type = 'memfd'
             source_attr = "'source_type':'${source_type}'"
         - undefined:
+

--- a/libvirt/tests/cfg/memory/memory_devices/invalid_virtio_mem_config.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/invalid_virtio_mem_config.cfg
@@ -6,13 +6,31 @@
     target_size = 524288
     request_size = 262144
     block_size = 2048
+    with_numa = yes
     aarch64:
         request_size = 524288
         block_size = 524288
+    s390-virtio:
+        with_numa = no
+        request_size = 262144
+        block_size = 1024
     guest_node = 0
     addr_base = '0x100000000'
     pagesize_cmd = "getconf PAGE_SIZE"
     pagesize_unit = 'b'
+    mem_value = 2097152
+    mem_unit = 'KiB'
+    current_mem = 2097152
+    current_mem_unit = 'KiB'
+    numa_mem = 1048576
+    max_mem_slots = 16
+    max_mem = 10485760
+    max_mem_unit = 'KiB'
+    max_dict = '"max_mem_rt": ${max_mem}, "max_mem_rt_slots": ${max_mem_slots}, "max_mem_rt_unit": "${max_mem_unit}"'
+    numa_attrs = "'vcpu': 4,'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '${numa_mem}', 'unit': 'KiB'},{'id':'1','cpus': '2-3','memory':'${numa_mem}','unit':'KiB'}]}"
+    vm_attrs = {${numa_attrs}, ${max_dict}, 'memory_unit':'KiB','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':"KiB"}
+    s390-virtio:
+        vm_attrs = {${max_dict}, 'memory_unit':'KiB','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':"KiB"}
     required_kernel = [5.14.0,)
     guest_required_kernel = [5.8.0,)
     func_supported_since_libvirt_ver = (8, 0, 0)
@@ -25,9 +43,11 @@
             addr_base = '0xffffffffffffffff'
             define_error = "memory device address must be aligned to blocksize"
         - unexisted_node:
+            no s390-virtio
             guest_node = '6'
             define_error = "can't add memory backend for guest node '${guest_node}' as the guest has only '2' NUMA nodes configured"
         - unexisted_nodemask:
+            no s390-virtio
             node_mask = '7'
             start_vm_error = "NUMA node ${node_mask} is unavailable"
         - invalid_pagesize:
@@ -36,6 +56,8 @@
             start_vm_error = "Unable to find any usable hugetlbfs mount for 9 KiB"
         - small_block:
             block_size = '1024'
+            s390-virtio:
+                block_size = '512'
             define_error = "block size too small, must be at least"
         - invalid_block:
             block_size = "3072"
@@ -43,18 +65,7 @@
     addr_dict = "'address':{'attrs': {'base': '${addr_base}','slot': '0'}}"
     source_dict = "'source': {'nodemask': '${node_mask}','pagesize': %d, 'pagesize_unit':'${pagesize_unit}'}"
     mem_dict = {'mem_model':'${mem_model}', ${source_dict}, 'target': {'size':${target_size}, 'size_unit':'KiB', ${addr_dict}, 'node':${guest_node},'requested_size': ${request_size}, 'block_size': ${block_size}}}
-    variants basic_memory:
-        - with_numa:
-            no s390-virtio
-                mem_value = 2097152
-                mem_unit = 'KiB'
-                current_mem = 2097152
-                current_mem_unit = 'KiB'
-                numa_mem = 1048576
-                max_mem_slots = 16
-                max_mem = 10485760
-                max_mem_unit = 'KiB'
-                max_dict = '"max_mem_rt": ${max_mem}, "max_mem_rt_slots": ${max_mem_slots}, "max_mem_rt_unit": "${max_mem_unit}"'
-                numa_attrs = "'vcpu': 4,'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '${numa_mem}', 'unit': 'KiB'},{'id':'1','cpus': '2-3','memory':'${numa_mem}','unit':'KiB'}]}"
-                vm_attrs = {${numa_attrs}, ${max_dict}, 'memory_unit':'KiB','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':"KiB"}
+    s390-virtio:
+        source_dict = "'source': {'pagesize': %d, 'pagesize_unit':'${pagesize_unit}'}"
+        mem_dict = {'mem_model':'${mem_model}', ${source_dict}, 'target': {'size':${target_size}, 'size_unit':'KiB', ${addr_dict}, 'requested_size': ${request_size}, 'block_size': ${block_size}}}
 

--- a/libvirt/tests/cfg/memory/memory_devices/virtio_mem_access_and_discard.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/virtio_mem_access_and_discard.cfg
@@ -2,23 +2,42 @@
     type = virtio_mem_access_and_discard
     start_vm = no
     mem_model = "virtio-mem"
-    virtio_mem_num = 6
     share_0 = 'false'
     discard_0 = 'False'
     check_path = "ls -l /var/lib/libvirt/qemu/ram/%s"
     target_size = 131072
     requested_size = 131072
     block_size = 2048
-    no s390-virtio
+    mem_value = 3145728
+    current_mem = 3145728
+    max_mem = 10485760
     aarch64:
+        max_mem = 20971520
         target_size = 1048576
         requested_size = 524288
         block_size = 524288
     mem_basic = {'mem_model': '${mem_model}', 'target': {'requested_unit': 'KiB', 'size': ${target_size}, 'size_unit': 'KiB', 'requested_size': ${requested_size}, 'block_unit': 'KiB', 'block_size': ${block_size}}}
+    base_attrs = "'vcpu': 6, 'placement': 'static', 'memory_unit':'KiB','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'KiB'"
+    max_attrs = "'max_mem_rt': ${max_mem}, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB'"
     required_kernel = [5.14.0,)
     guest_required_kernel = [5.8.0,)
     func_supported_since_libvirt_ver = (8, 0, 0)
     func_supported_since_qemu_kvm_ver = (6, 2, 0)
+    variants:
+        - with_numa:
+            no s390-virtio
+            numa_mem = 1048576
+            mem_access_1 = "shared"
+            discard_1 = "yes"
+            mem_access_2 = "private"
+            discard_2 = "no"
+            numa_attrs = "'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '${numa_mem}', 'unit': 'KiB'}, {'id': '1', 'cpus': '2-3', 'memory': '${numa_mem}', 'unit': 'KiB', 'memAccess':'${mem_access_1}','discard':'${discard_1}'},{'id':'2','cpus': '4-5','memory':'${numa_mem}','unit':'KiB', 'memAccess':'${mem_access_2}','discard':'${discard_2}'}]}"
+            vm_attrs = {${base_attrs}, ${numa_attrs}, ${max_attrs}}
+            mem_conf_list = [(None, None, 0), ('shared', 'yes', 0), (None, None, 1), ('private', 'no', 1), (None, None, 2), ('shared', 'yes', 2)]
+        - without_numa:
+            only s390-virtio
+            vm_attrs = {${base_attrs}, ${max_attrs}}
+            mem_conf_list = [(None, None, None), ('shared', 'yes', None)]
     variants memory_backing:
         - file:
             source_type = 'file'
@@ -57,19 +76,4 @@
     expected_share = ['${share_0}', 'true', 'true', 'false', 'false', 'true']
     check_discard = '{"execute":"qom-get", "arguments":{"path":"/objects/%s", "property":"discard-data"}}'
     expected_discard = ['${discard_0}', 'True', 'True', 'False', 'False', 'True']
-    variants:
-        - with_numa:
-            mem_value = 3145728
-            current_mem = 3145728
-            max_mem = 10485760
-            numa_mem = 1048576
-            aarch64:
-                max_mem = 20971520
-            mem_access_1 = "shared"
-            discard_1 = "yes"
-            mem_access_2 = "private"
-            discard_2 = "no"
-            base_attrs = "'vcpu': 6, 'placement': 'static', 'memory_unit':'KiB','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'KiB'"
-            numa_attrs = "'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '${numa_mem}', 'unit': 'KiB'}, {'id': '1', 'cpus': '2-3', 'memory': '${numa_mem}', 'unit': 'KiB', 'memAccess':'${mem_access_1}','discard':'${discard_1}'},{'id':'2','cpus': '4-5','memory':'${numa_mem}','unit':'KiB', 'memAccess':'${mem_access_2}','discard':'${discard_2}'}]}"
-            max_attrs = "'max_mem_rt': ${max_mem}, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB'"
-            vm_attrs = {${base_attrs}, ${numa_attrs}, ${max_attrs}}
+

--- a/libvirt/tests/cfg/memory/memory_devices/virtio_mem_coldplug_and_unplug.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/virtio_mem_coldplug_and_unplug.cfg
@@ -1,6 +1,5 @@
 - memory.devices.virtio_mem.coldplug_and_unplug:
     type = virtio_mem_coldplug_and_unplug
-    no s390-virtio
     start_vm = "no"
     mem_model = "virtio-mem"
     target_size = 524288
@@ -20,6 +19,9 @@
     numa_dict = "'vcpu': 4,'cpu':{'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '${numa_mem}'}, {'id': '1', 'cpus': '2-3', 'memory': '${numa_mem}'}]}"
     vm_attrs = {${numa_dict},${max_dict},'memory_unit':'KiB','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'KiB'}
     numa_xpath = [{'element_attrs':[".//cell[@unit='KiB']",".//cell[@id='0']",".//cell[@memory='${numa_mem}']"]}]
+    s390-virtio:
+        vm_attrs = {${max_dict},'memory_unit':'KiB','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'KiB'}
+        numa_xpath = []
     base = '0x100000000'
     plug_option = " --config"
     required_kernel = [5.14.0,)
@@ -37,6 +39,10 @@
             virtio_xpath = [{'element_attrs':["./devices/memory/target/size[@unit='${size_unit}']"],'text':'${target_size}'},{'element_attrs':[".//memory/target/block[@unit='${block_unit}']"],'text':'%s'}, {'element_attrs':[".//memory/target/requested[@unit='${request_unit}']"],'text':'${request_size}'},{'element_attrs':[".//memory/target/address[@base='${base}']"]}]
             unplug_xpath = ${virtio_xpath}
             plug_xpath = [{'element_attrs':[".//memory/target/size[@unit='${plug_size_unit}']"],'text':'${plug_target_size}'},{'element_attrs':[".//memory/target/block[@unit='${block_unit}']"],'text':'%s'}, {'element_attrs':[".//memory/target/requested[@unit='${plug_request_unit}']"],'text':'${plug_request_size}'},{'element_attrs':[".//memory/target/address[@base='${base}']"]}]
+            s390-virtio:
+                virtio_dict = {'mem_model':'${mem_model}','target': {${addr_dict},'size':${target_size}, 'size_unit':'${size_unit}', 'requested_size': ${request_size},'requested_unit':'${request_unit}', 'block_size': %s, 'block_unit':'${block_unit}'}}
+                unplug_dict = ${virtio_dict}
+                plug_dict = {'mem_model':'${mem_model}','target': {${addr_dict},'size':${plug_target_size},'requested_size': ${plug_request_size}, 'block_size': %s, 'size_unit':'${plug_size_unit}','requested_unit':'${plug_request_unit}','block_unit':'${plug_block_unit}'}}
         - source_and_mib:
             target_size = 512
             request_size = 512
@@ -54,12 +60,22 @@
             plug_dict = {'mem_model':'${mem_model}',${source_dict},'target': {'size':${plug_target_size},'requested_size': ${plug_request_size}, 'block_size': %s, 'size_unit':'${plug_size_unit}','requested_unit':'${plug_request_unit}','block_unit':'${plug_block_unit}','node':1}}
             virtio_xpath = [{'element_attrs':[".//memory/target/size[@unit='KiB']"],'text':'%s'},{'element_attrs':[".//memory/target/block[@unit='KiB']"],'text':'%s'}, {'element_attrs':[".//memory/target/requested[@unit='KiB']"],'text':'%s'}, {'element_attrs':[".//memory/source/pagesize"]}, {'element_attrs':[".//memory/source/nodemask"],'text':'${nodemask}'}]
             unplug_xpath = ${virtio_xpath}
+            s390-virtio:
+                source_dict = "'source': {'pagesize': 4, 'pagesize_unit':'KiB'}"
+                virtio_dict = {'mem_model':'${mem_model}',${source_dict}, 'target': {'size':${target_size}, 'size_unit':'${size_unit}','requested_unit':'${request_unit}','block_unit':'${block_unit}','requested_size': ${request_size}, 'block_size': %s}}
+                unplug_dict = ${virtio_dict}
+                plug_dict = {'mem_model':'${mem_model}',${source_dict},'target': {'size':${plug_target_size},'requested_size': ${plug_request_size}, 'block_size': %s, 'size_unit':'${plug_size_unit}','requested_unit':'${plug_request_unit}','block_unit':'${plug_block_unit}'}}
+                virtio_xpath = [{'element_attrs':[".//memory/target/size[@unit='KiB']"],'text':'%s'},{'element_attrs':[".//memory/target/block[@unit='KiB']"],'text':'%s'}, {'element_attrs':[".//memory/target/requested[@unit='KiB']"],'text':'%s'}, {'element_attrs':[".//memory/source/pagesize"]}]
+                unplug_xpath = ${virtio_xpath}
             plug_xpath = [{'element_attrs':[".//memory/target/size[@unit='KiB']"],'text':'%s'},{'element_attrs':[".//memory/target/block[@unit='KiB']"],'text':'%s'}, {'element_attrs':[".//memory/target/requested[@unit='KiB']"],'text':'%s'}]
         - unplug_none_dev:
             addr_dict = "'address':{'attrs': {'base': '${base}'}}"
             virtio_dict = {'mem_model':'${mem_model}', 'target': {'size':${target_size}, 'size_unit':'KiB', ${addr_dict}, 'node':0,'requested_size': ${request_size}, 'block_size': %s}}
             unplug_request_size = 0
             unplug_dict = {'mem_model':'${mem_model}', 'target': {'requested_size': ${unplug_request_size}, 'size':${target_size}, 'size_unit':'KiB', ${addr_dict}, 'node':0,'block_size': %s}}
+            s390-virtio:
+                virtio_dict = {'mem_model':'${mem_model}', 'target': {'size':${target_size}, 'size_unit':'KiB', ${addr_dict}, 'requested_size': ${request_size}, 'block_size': %s}}
+                unplug_dict = {'mem_model':'${mem_model}', 'target': {'requested_size': ${unplug_request_size}, 'size':${target_size}, 'size_unit':'KiB', ${addr_dict}, 'block_size': %s}}
             unplug_error = "matching memory device was not found"
             virtio_xpath = [{'element_attrs':[".//memory/target/size[@unit='${size_unit}']"],'text':'${target_size}'},{'element_attrs':[".//memory/target/block[@unit='${block_unit}']"],'text':'%s'}, {'element_attrs':[".//memory/target/requested[@unit='${request_unit}']"],'text':'${request_size}'},{'element_attrs':[".//memory/target/address[@base='${base}']"]}]
             unplug_xpath = [{'element_attrs':[".//memory/target/size[@unit='${size_unit}']"],'text':'${target_size}'},{'element_attrs':[".//memory/target/block[@unit='${plug_block_unit}']"],'text':'%s'}, {'element_attrs':[".//memory/target/requested[@unit='${plug_request_unit}']"],'text':'${unplug_request_size}'},{'element_attrs':[".//memory/target/address[@base='${base}']"]}]
@@ -75,6 +91,9 @@
             virtio_xpath = [{'element_attrs':[".//memory/target/size[@unit='${size_unit}']"],'text':'${target_size}'},{'element_attrs':[".//memory/target/block[@unit='${block_unit}']"],'text':'%s'}, {'element_attrs':[".//memory/target/requested[@unit='${request_unit}']"],'text':'${request_size}'}]
             plug_xpath = [{'element_attrs':[".//memory/target/size[@unit='${size_unit}']"],'text':'%s'},{'element_attrs':[".//memory/target/block[@unit='${block_unit}']"],'text':'%s'}, {'element_attrs':[".//memory/target/requested[@unit='${request_unit}']"],'text':'%s'}]
             plug_error = "Attaching memory device with size '\S+' would exceed domain's maxMemory config size '${max_mem}'"
+            s390-virtio:
+                virtio_dict = {'mem_model':'${mem_model}', 'target': {'size':${target_size}, 'size_unit':'KiB','requested_size': ${request_size}, 'block_size': %s}}
+                plug_dict = {'mem_model':'${mem_model}','target': {'size':${plug_target_size},'requested_size': ${plug_request_size}, 'block_size': %s, 'size_unit':'${plug_size_unit}','requested_unit':'${plug_request_unit}','block_unit':'${plug_block_unit}'}}
         - duplicate_addr:
             addr_dict = "'address':{'attrs': {'base': '0x100000000'}}"
             virtio_dict = {'mem_model':'${mem_model}', 'target': {${addr_dict},'size':${target_size}, 'size_unit':'KiB', ${addr_dict}, 'node':0,'requested_size': ${request_size}, 'block_size': %s}}
@@ -82,3 +101,7 @@
             plug_error = "unsupported configuration: memory device address [0x100000000:0x108000000] overlaps with other memory device (0x100000000)"
             virtio_xpath = [{'element_attrs':[".//memory/target/size[@unit='${size_unit}']"],'text':'${target_size}'},{'element_attrs':[".//memory/target/block[@unit='${block_unit}']"],'text':'%s'}, {'element_attrs':[".//memory/target/requested[@unit='${request_unit}']"],'text':'${request_size}'},{'element_attrs':[".//memory/target/address[@base='${base}']"]}]
             plug_xpath = ${virtio_xpath}
+            s390-virtio:
+                virtio_dict = {'mem_model':'${mem_model}', 'target': {${addr_dict},'size':${target_size}, 'size_unit':'KiB', ${addr_dict}, 'requested_size': ${request_size}, 'block_size': %s}}
+                plug_dict = ${virtio_dict}
+

--- a/libvirt/tests/cfg/memory/memory_devices/virtio_mem_device_lifecycle.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/virtio_mem_device_lifecycle.cfg
@@ -1,6 +1,5 @@
 - memory.devices.virtio_mem.lifecycle:
     type = virtio_mem_device_lifecycle
-    no s390-virtio
     start_vm = no
     state_file = "/tmp/%s.save"
     numa_mem_val = 1048576
@@ -17,11 +16,14 @@
     guest_required_kernel = [5.8.0,)
     func_supported_since_libvirt_ver = (8, 0, 0)
     func_supported_since_qemu_kvm_ver = (6, 2, 0)
+    s390-virtio:
+        vm_attrs = {'max_mem_rt': 15428800, 'max_mem_rt_unit': 'KiB','memory_unit':"KiB", 'memory':${memory_val}, 'current_mem':${current_mem_val}, 'current_mem_unit':'KiB', 'vcpu': 4}
     variants kernel_pagesize:
         - 4k:
-            only x86_64, aarch64
             page_size = 4
             default_hp_size = 2048
+            s390-virtio:
+                default_hp_size = 1024
         - 64k:
             only aarch64
             page_size = 64
@@ -31,6 +33,7 @@
             source_dict = {}
             source_xpath = []
         - nodemask:
+            no s390-virtio
             nodeset_num = 1
             source_dict = {'nodemask':'%s'}
             source_xpath = [{'element_attrs':[".//source/nodemask"],'text':'%s'}]
@@ -38,6 +41,7 @@
             source_dict = {'pagesize':${page_size}, 'pagesize_unit':'KiB'}
             source_xpath = [{'element_attrs':[".//source/pagesize[@unit='KiB']"],'text':'${page_size}'}]
         - nodemask_pagesize:
+            no s390-virtio
             nodeset_num = 2
             use_huge_page = "yes"
             source_dict = {'nodemask':'%s', 'pagesize':${default_hp_size}, 'pagesize_unit':'KiB'}
@@ -54,6 +58,11 @@
             init_target_xpath = [{'element_attrs':[".//target/size[@unit='KiB']"],'text':'${init_size}'}, {'element_attrs':[".//target/requested[@unit='KiB']"],'text':'${init_requested}'}, {'element_attrs':[".//target/block[@unit='KiB']"],'text':'${default_hp_size}'}, {'element_attrs':[".//target/current[@unit='KiB']"],'text':'${init_requested}'}, {'element_attrs':[".//target/node"],'text':'0'}, {'element_attrs':[".//target/address[@base='${init_address}']"]}]
             plug_target_dict = {'size':${plug_size}, 'size_unit':'KiB', 'node':1, 'requested_size':${plug_requested}, 'requested_unit':'KiB', 'block_size':${default_hp_size}, 'address':{'attrs':{'base':'${plug_address}'}}}
             plug_target_xpath = [{'element_attrs':[".//target/size[@unit='KiB']"],'text':'${plug_size}'}, {'element_attrs':[".//target/requested[@unit='KiB']"],'text':'${plug_requested}'}, {'element_attrs':[".//target/block[@unit='KiB']"],'text':'${default_hp_size}'}, {'element_attrs':[".//target/current[@unit='KiB']"],'text':'${plug_requested}'}, {'element_attrs':[".//target/node"],'text':'1'}, {'element_attrs':[".//target/address[@base='${plug_address}']"]}]
+            s390-virtio:
+                init_target_dict = {'size':${init_size}, 'size_unit':'KiB', 'requested_size':${init_requested}, 'requested_unit':'KiB', 'block_size':${default_hp_size}, 'address':{'attrs':{'base':'${init_address}'}}}
+                init_target_xpath = [{'element_attrs':[".//target/size[@unit='KiB']"],'text':'${init_size}'}, {'element_attrs':[".//target/requested[@unit='KiB']"],'text':'${init_requested}'}, {'element_attrs':[".//target/block[@unit='KiB']"],'text':'${default_hp_size}'}, {'element_attrs':[".//target/current[@unit='KiB']"],'text':'${init_requested}'}, {'element_attrs':[".//target/address[@base='${init_address}']"]}]
+                plug_target_dict = {'size':${plug_size}, 'size_unit':'KiB', 'requested_size':${plug_requested}, 'requested_unit':'KiB', 'block_size':${default_hp_size}, 'address':{'attrs':{'base':'${plug_address}'}}}
+                plug_target_xpath = [{'element_attrs':[".//target/size[@unit='KiB']"],'text':'${plug_size}'}, {'element_attrs':[".//target/requested[@unit='KiB']"],'text':'${plug_requested}'}, {'element_attrs':[".//target/block[@unit='KiB']"],'text':'${default_hp_size}'}, {'element_attrs':[".//target/current[@unit='KiB']"],'text':'${plug_requested}'}, {'element_attrs':[".//target/address[@base='${plug_address}']"]}]
         - part_requested_and_no_address:
             init_size = 1048576
             init_requested = 524288
@@ -63,6 +72,11 @@
             init_target_xpath = [{'element_attrs':[".//target/size[@unit='KiB']"],'text':'${init_size}'}, {'element_attrs':[".//target/requested[@unit='KiB']"],'text':'${init_requested}'}, {'element_attrs':[".//target/block[@unit='KiB']"],'text':'${default_hp_size}'}, {'element_attrs':[".//target/current[@unit='KiB']"],'text':'${init_requested}'}, {'element_attrs':[".//target/node"],'text':'0'}, {'element_attrs':[".//target/address"]}]
             plug_target_dict = {'size':${plug_size}, 'size_unit':'KiB', 'node':1, 'requested_size':${plug_requested}, 'requested_unit':'KiB', 'block_size':${default_hp_size}}
             plug_target_xpath = [{'element_attrs':[".//target/size[@unit='KiB']"],'text':'${plug_size}'}, {'element_attrs':[".//target/requested[@unit='KiB']"],'text':'${plug_requested}'}, {'element_attrs':[".//target/block[@unit='KiB']"],'text':'${default_hp_size}'}, {'element_attrs':[".//target/current[@unit='KiB']"],'text':'${plug_requested}'}, {'element_attrs':[".//target/node"],'text':'1'}, {'element_attrs':[".//target/address"]}]
+            s390-virtio:
+                init_target_dict = {'size':${init_size}, 'size_unit':'KiB', 'requested_size':${init_requested}, 'requested_unit':'KiB', 'block_size':${default_hp_size}}
+                init_target_xpath = [{'element_attrs':[".//target/size[@unit='KiB']"],'text':'${init_size}'}, {'element_attrs':[".//target/requested[@unit='KiB']"],'text':'${init_requested}'}, {'element_attrs':[".//target/block[@unit='KiB']"],'text':'${default_hp_size}'}, {'element_attrs':[".//target/current[@unit='KiB']"],'text':'${init_requested}'}, {'element_attrs':[".//target/address"]}]
+                plug_target_dict = {'size':${plug_size}, 'size_unit':'KiB', 'requested_size':${plug_requested}, 'requested_unit':'KiB', 'block_size':${default_hp_size}}
+                plug_target_xpath = [{'element_attrs':[".//target/size[@unit='KiB']"],'text':'${plug_size}'}, {'element_attrs':[".//target/requested[@unit='KiB']"],'text':'${plug_requested}'}, {'element_attrs':[".//target/block[@unit='KiB']"],'text':'${default_hp_size}'}, {'element_attrs':[".//target/current[@unit='KiB']"],'text':'${plug_requested}'}, {'element_attrs':[".//target/address"]}]
     init_mem_device_dict = {'mem_model':'virtio-mem', 'source':${source_dict}, 'target':${init_target_dict}}
     init_xpath_list = [${source_xpath}, ${init_target_xpath}]
     plug_mem_device_dict = {'mem_model':'virtio-mem', 'source':${source_dict}, 'target':${plug_target_dict}}

--- a/libvirt/tests/cfg/memory/memory_devices/virtio_mem_dynamic_slots.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/virtio_mem_dynamic_slots.cfg
@@ -1,6 +1,5 @@
 - memory.devices.virtio_mem.dynamic_slots:
     type = virtio_mem_dynamic_slots
-    no s390-virtio
     start_vm = "no"
     mem_model = "virtio-mem"
     allocate_size = "3145728"
@@ -13,6 +12,8 @@
     numa_attrs = "'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '${numa_mem}', 'unit': 'KiB'},{'id':'1','cpus': '2-3','memory':'${numa_mem}','unit':'KiB'}]}"
     max_attrs = "'max_mem_rt': ${max_mem}, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB'"
     vm_attrs = {${base_attrs}, ${numa_attrs}, ${max_attrs}}
+    s390-virtio:
+        vm_attrs = {${base_attrs}, ${max_attrs}}
     required_kernel = [5.14.0,)
     guest_required_kernel = [5.8.0,)
     func_supported_since_libvirt_ver = (10, 0, 0)
@@ -25,6 +26,8 @@
             target_size = 524288
             request_size = 524288
             virtio_mem_dict = {'mem_model':'${mem_model}','target': {'size':${target_size}, 'requested_size': ${request_size},'block_size': %s, 'node':0}}
+            s390-virtio:
+                virtio_mem_dict = {'mem_model':'${mem_model}','target': {'size':${target_size}, 'requested_size': ${request_size},'block_size': %s}}
     variants dynamic_memory_slots:
         - undefined_dynamic_memory_slots:
             slots_pattern = ["alias memslot-0 @memvirtiomem0", "alias memslot-0 @memvirtiomem1"]
@@ -40,7 +43,10 @@
             source_type = 'file'
             source_attr = "'source_type':'${source_type}'"
         - hugepages_mb:
+            s390-virtio:
+                kvm_module_parameters = "hpage=1"
             hugepages_attr = "'hugepages': {}"
         - memfd_mb:
             source_type = 'memfd'
             source_attr = "'source_type':'${source_type}'"
+

--- a/libvirt/tests/cfg/memory/memory_devices/virtio_mem_hot_unplug.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/virtio_mem_hot_unplug.cfg
@@ -1,5 +1,4 @@
 - memory.devices.virtio_mem.hot_unplug:
-    no s390-virtio
     type = virtio_mem_hot_unplug
     start_vm = yes
     mem_model = "virtio-mem"
@@ -24,8 +23,13 @@
     max_mem = 4194304
     max_mem_slots = 16
     base = "0x100000000"
+    with_numa = yes
+    s390-virtio:
+        with_numa = no
+        base = "0x40000000"
     addr_dict = "'address':{'attrs': {'base': '${base}'}}"
-    kernel_extra_params_add = "memhp_default_state=online_movable"
+    kernel_params_add = "memhp_default_state=online_movable"
+    kernel_params_remove = "memhp_default_state"
     unplug_event = "device-removed"
     audit_cmd = "grep VIRT_RESOURCE /var/log/audit/audit.log | grep 'mem' | tail -n 20"
     ausearch_check = 'old-mem=%d new-mem=%d'
@@ -34,6 +38,8 @@
     max_dict = '"max_mem_rt": ${max_mem}, "max_mem_rt_slots": ${max_mem_slots}, "max_mem_rt_unit": "KiB"'
     numa_dict = "'vcpu': 4,'cpu':{'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '${numa_mem}'}, {'id': '1', 'cpus': '2-3', 'memory': '${numa_mem}'}]}"
     vm_attrs = {${numa_dict},${max_dict},'memory_unit':'KiB','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'KiB'}
+    s390-virtio:
+        vm_attrs = {${max_dict},'memory_unit':'KiB','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'KiB'}
     required_kernel = [5.14.0,)
     guest_required_kernel = [5.8.0,)
     func_supported_since_libvirt_ver = (10, 0, 0)
@@ -47,6 +53,7 @@
             unplug_request_size = '0'
             updated_request_option = "--requested-size 0"
         - source_mib_and_hugepages:
+            no s390-virtio
             target_size = "1024"
             request_size = "512"
             size_unit = 'MiB'
@@ -66,11 +73,18 @@
             request_size = "524288"
             unplug_target_size = "1048576"
             unplug_request_size = "524288"
+            s390-virtio:
+                base = "0x80000000"
+                addr_dict = "'address':{'attrs': {'base': '${base}'}}"
         - none_zero_current:
         - none_zero_request:
+            no s390-virtio
             source_dict = {'nodemask': '0','pagesize': %d, 'pagesize_unit':'KiB'}
     virtio_dict = {'mem_model':'${mem_model}','alias': {'name': '%s'},'target': {${addr_dict},'size':${target_size}, 'size_unit':'${size_unit}', 'node':${node},'requested_size': ${request_size},'requested_unit':'${request_unit}', 'block_size': %s, 'block_unit':'${block_unit}'}}
     unplug_dict = {'mem_model':'${mem_model}','alias': {'name': '%s'},'target': {${addr_dict},'size':${unplug_target_size},'requested_size': ${unplug_request_size}, 'block_size': %s, 'size_unit':'${unplug_size_unit}','requested_unit':'${unplug_request_unit}','block_unit':'${unplug_block_unit}','node':${unplug_node}}}
+    s390-virtio:
+        virtio_dict = {'mem_model':'${mem_model}','alias': {'name': '%s'},'target': {${addr_dict},'size':${target_size}, 'size_unit':'${size_unit}', 'requested_size': ${request_size},'requested_unit':'${request_unit}', 'block_size': %s, 'block_unit':'${block_unit}'}}
+        unplug_dict = {'mem_model':'${mem_model}','alias': {'name': '%s'},'target': {${addr_dict},'size':${unplug_target_size},'requested_size': ${unplug_request_size}, 'block_size': %s, 'size_unit':'${unplug_size_unit}','requested_unit':'${unplug_request_unit}','block_unit':'${unplug_block_unit}'}}
     variants plug_way:
         - detach:
             detach_method = "detach"
@@ -87,3 +101,4 @@
                 unplug_error = "${zero_size_error_msg}|${basic_error_msg}"
             none_zero_request:
                 unplug_error = "${zero_request_error_msg}|${basic_error_msg}"
+

--- a/libvirt/tests/cfg/memory/memory_devices/virtio_mem_hotplug.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/virtio_mem_hotplug.cfg
@@ -1,5 +1,4 @@
 - memory.devices.virtio_mem.hotplug:
-    no s390-virtio
     type = virtio_mem_hotplug
     start_vm = no
     mem_model = "virtio-mem"
@@ -30,6 +29,12 @@
     max_dict = '"max_mem_rt": ${max_mem}, "max_mem_rt_slots": ${max_mem_slots}, "max_mem_rt_unit": "KiB"'
     numa_dict = "'vcpu': 4,'cpu':{'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '${numa_mem}'}, {'id': '1', 'cpus': '2-3', 'memory': '${numa_mem}'}]}"
     vm_attrs = {${numa_dict},${max_dict},'memory_unit':'KiB','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'KiB'}
+    s390-virtio:
+        base = "0x80000000"
+        mem_value = 3145728
+        current_mem = 3145728
+        numa_dict = 
+        vm_attrs = {${max_dict},'memory_unit':'KiB','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'KiB'}
     required_kernel = [5.14.0,)
     guest_required_kernel = [5.8.0,)
     func_supported_since_libvirt_ver = (8, 0, 0)
@@ -40,8 +45,11 @@
             plug_request_size = '524288'
             addr_dict = {'attrs': {'base':'${base}'}}
             plug_base = "0x140000000"
+            s390-virtio:
+                plug_base = "0xc0000000"
             plug_addr_dict = {'attrs': {'base':'${plug_base}'}}
         - source_mib_and_hugepages:
+            no s390-virtio
             target_size = "512"
             request_size = "512"
             size_unit = 'MiB'
@@ -62,6 +70,8 @@
         - duplicate_addr:
             target_size = '524288'
             request_size = '524288'
+            s390-virtio:
+                base = "0xc0000000"
             addr_dict = {'attrs': {'base':'${base}'}}
             plug_error = "address range conflicts|overlaps"
             plug_target_size = ${target_size}
@@ -69,3 +79,7 @@
             plug_addr_dict = ${addr_dict}
     virtio_dict = {'mem_model':'${mem_model}','target': {'size':${target_size}, 'size_unit':'${size_unit}', 'node':${node},'requested_size': ${request_size},'requested_unit':'${request_unit}', 'block_size': %s, 'block_unit':'${block_unit}'}}
     plug_dict = {'mem_model':'${mem_model}','target': {'size':${plug_target_size},'requested_size': ${plug_request_size}, 'block_size': %s, 'size_unit':'${plug_size_unit}','requested_unit':'${plug_request_unit}','block_unit':'${plug_block_unit}','node':${plug_node}}}
+    s390-virtio:
+        virtio_dict = {'mem_model':'${mem_model}','target': {'size':${target_size}, 'size_unit':'${size_unit}','requested_size': ${request_size},'requested_unit':'${request_unit}', 'block_size': %s, 'block_unit':'${block_unit}'}}
+        plug_dict = {'mem_model':'${mem_model}','target': {'size':${plug_target_size},'requested_size': ${plug_request_size}, 'block_size': %s, 'size_unit':'${plug_size_unit}','requested_unit':'${plug_request_unit}','block_unit':'${plug_block_unit}'}}
+

--- a/libvirt/tests/cfg/memory/memory_devices/virtio_mem_with_memory_allocation_and_numa.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/virtio_mem_with_memory_allocation_and_numa.cfg
@@ -1,6 +1,5 @@
 - memory.devices.virtio_mem.memory_allocation_and_numa:
     type = virtio_mem_with_memory_allocation_and_numa
-    no s390-virtio
     start_vm = no
     mem_model = "virtio-mem"
     mem_value = 8388608
@@ -29,11 +28,13 @@
         - without_numa:
             numa_attrs = ""
         - with_numa:
+            no s390-virtio
             numa_mem = 8388608
             numa_attrs = "'vcpu': 4, 'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-3', 'memory': '${numa_mem}', 'unit': 'KiB'}]},"
     vm_attrs = {${base_attrs} ${max_attrs} ${numa_attrs}}
     variants:
         - virtio_mem_with_node:
+            no s390-virtio
             node = 0
             virtio_mem_dict = {'mem_model': '${mem_model}', 'target': {'requested_unit': '${request_size_unit}', 'size': ${target_size}, 'node': ${node}, 'size_unit': '${target_size_unit}', 'requested_size': ${request_size}, 'block_unit': 'KiB', 'block_size': %s}}
             no_maxmemory:
@@ -52,22 +53,32 @@
                     define_error = "${err_msg2}"
                     hot_plug_error = "${err_msg1}"
             with_maxmemory:
-                hot_plug_error = "${err_msg2}"
-                cold_plug_error = "${err_msg2}"
+                x86_64, aarch64:
+                    hot_plug_error = "${err_msg2}"
+                    cold_plug_error = "${err_msg2}"
+                s390-virtio:
+                    coldplug_start_error =
             no_maxmemory:
                 cold_plug_error = "${err_msg1}"
                 without_numa,with_numa:
                     hot_plug_error = "${err_msg1}"
         - virtio_mem_with_exceed_size:
             only without_numa.with_maxmemory
-            target_size = "10485760"
+            target_size = "524288"
+            s390-virtio:
+                target_size = "15728640"
             request_size = "512"
             target_size_unit = "KiB"
             virtio_mem_dict = {'mem_model': '${mem_model}', 'target': {'requested_unit': '${request_size_unit}', 'size': ${target_size}, 'size_unit': '${target_size_unit}', 'requested_size': ${request_size}, 'block_unit': 'KiB', 'block_size': %s}}
             coldplug_start_error = "${err_msg2}"
             with_maxmemory:
-                hot_plug_error = "${err_msg2}"
-                cold_plug_error = "${err_msg2}"
+                x86_64, aarch64:
+                    hot_plug_error = "${err_msg2}"
+                    cold_plug_error = "${err_msg2}"
+                s390-virtio:
+                    coldplug_start_error =
+                    cold_plug_error = "would exceed domain's maxMemory config size"
+                    hot_plug_error = "${cold_plug_error}"
             without_numa:
                 with_maxmemory:
                     define_error = "Total size of memory devices exceeds the total memory size"
@@ -79,3 +90,4 @@
         - hot_plug:
             operation = "attach"
             plug_option = " "
+

--- a/libvirt/tests/cfg/memory/memory_devices/virtio_mem_with_memory_backing_type.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/virtio_mem_with_memory_backing_type.cfg
@@ -1,6 +1,5 @@
 - memory.devices.virtio_mem.memory_backing_type:
     type = virtio_mem_with_memory_backing_type
-    no s390-virtio
     start_vm = no
     mem_model = "virtio-mem"
     virtio_mem_num = 2
@@ -11,16 +10,22 @@
     max_mem = 4194304
     numa_mem = 1048576
     aarch_max_mem = 20971520
+    virtio_config = [(None, 0),  ("huge_page", 1)]
     base_attrs = "'vcpu': 4, 'memory_unit':'KiB','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':'KiB'"
     numa_attrs = "'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '${numa_mem}', 'unit': 'KiB'}, {'id': '1', 'cpus': '2-3', 'memory': '${numa_mem}', 'unit': 'KiB'}]}"
     max_attrs = "'max_mem_rt': %s, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB'"
     vm_attrs = {${base_attrs}, ${numa_attrs}, ${max_attrs}}
+    s390-virtio:
+        virtio_config = [(None,),  (None,)]
+        vm_attrs = {${base_attrs}, ${max_attrs}}
     target_size = 524288
     request_size = 524288
     type0 = "memory-backend-ram"
     type1 = "memory-backend-file"
     path0 = ""
     path1 = "/dev/hugepages/libvirt/qemu/"
+    prealloc0 = "True"
+    prealloc1 = "True"
     required_kernel = [5.14.0,)
     guest_required_kernel = [5.8.0,)
     func_supported_since_libvirt_ver = (8, 0, 0)
@@ -43,10 +48,18 @@
         - undefined:
     variants allocation_mode:
         - alloc_ondemand:
+            prealloc0 = "False"
+            s390-virtio:
+                prealloc1 = "False"
             mode = "ondemand"
             alloc_attr = "'allocation':{'mode':'${mode}'}"
             file:
                 path0 = "/var/lib/libvirt/qemu/ram/"
+                s390-virtio:
+                    path1 = "/var/lib/libvirt/qemu/ram/"
+            anonymous, undefined:
+                s390-virtio:
+                    type1 = "memory-backend-ram"
         - alloc_immediate_with_threads:
             func_supported_since_libvirt_ver = (8, 2, 0)
             mode = "immediate"
@@ -54,7 +67,14 @@
             alloc_attr = "'allocation':{'mode':'${mode}', 'threads':${threads}}"
             file:
                 path0 = "/var/lib/libvirt/qemu/ram/"
+                s390-virtio:
+                    path1 = "/var/lib/libvirt/qemu/ram/"
+            anonymous, undefined:
+                s390-virtio:
+                    type1 = "memory-backend-ram"
         - set_hugepage:
+            s390-virtio:
+                kvm_module_parameters = "hpage=1"
             hugepages_attr = "'hugepages': {}"
             undefined:
                 type0 = "memory-backend-file"
@@ -65,9 +85,12 @@
                 path0 = "/dev/hugepages/libvirt/qemu/"
     check_backing_type = '{"execute":"qom-get", "arguments":{"path":"/objects/%s", "property":"type"}}'
     check_mem_path = '{"execute":"qom-get", "arguments":{"path":"/objects/%s", "property":"mem-path"}}'
+    check_prealloc_config = '{"execute":"qom-get", "arguments":{"path":"/machine/peripheral/%s", "property":"prealloc"}}'
+    expected_prealloc_config = ['${prealloc0}', '${prealloc1}']
     expected_allocated = ['false', 'false']
     expected_backing_type = ['${type0}', '${type1}']
     expected_mem_path = ['${path0}', '${path1}']
     variants attach_type:
         - hot_plug:
         - cold_plug:
+

--- a/libvirt/tests/src/memory/memory_devices/invalid_virtio_mem_config.py
+++ b/libvirt/tests/src/memory/memory_devices/invalid_virtio_mem_config.py
@@ -92,9 +92,10 @@ def run(test, params, env):
         """
         Check host has at least 2 numa nodes.
         """
-        test.log.info("TEST_SETUP: Check the numa nodes")
-        numa_obj = numa_base.NumaTest(vm, params, test)
-        numa_obj.check_numa_nodes_availability()
+        if with_numa:
+            test.log.info("TEST_SETUP: Check the numa nodes")
+            numa_obj = numa_base.NumaTest(vm, params, test)
+            numa_obj.check_numa_nodes_availability()
 
     def run_test():
         """
@@ -129,6 +130,7 @@ def run(test, params, env):
         bkxml.sync()
 
     vm_name = params.get("main_vm")
+    with_numa = params.get("with_numa", "yes") == "yes"
     vm = env.get_vm(vm_name)
     original_vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     bkxml = original_vmxml.copy()

--- a/libvirt/tests/src/memory/memory_devices/virtio_mem_with_memory_allocation_and_numa.py
+++ b/libvirt/tests/src/memory/memory_devices/virtio_mem_with_memory_allocation_and_numa.py
@@ -59,7 +59,8 @@ def check_guest_xml(vm, params, test):
     virtio_mem = vmxml.get_devices("memory")[0]
     target = virtio_mem.target
     target_size = int(target.get_size())
-    target_node = target.get_node()
+    if params.get("node"):
+        target_node = target.get_node()
     target_block = target.get_block_size()
     target_request = target.get_requested_size()
     target_current = int(target.get_current_size())


### PR DESCRIPTION
Test results:


(1/9) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.access_and_discard.undefined.file.without_numa: STARTED
 (1/9) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.access_and_discard.undefined.file.without_numa: PASS (27.41 s)
 (2/9) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.access_and_discard.undefined.anonymous.without_numa: STARTED
 (2/9) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.access_and_discard.undefined.anonymous.without_numa: PASS (26.99 s)
 (3/9) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.access_and_discard.undefined.memfd.without_numa: STARTED
 (3/9) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.access_and_discard.undefined.memfd.without_numa: PASS (28.18 s)
 (4/9) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.access_and_discard.shared_and_discard.file.without_numa: STARTED
 (4/9) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.access_and_discard.shared_and_discard.file.without_numa: PASS (29.06 s)
 (5/9) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.access_and_discard.shared_and_discard.anonymous.without_numa: STARTED
 (5/9) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.access_and_discard.shared_and_discard.anonymous.without_numa: PASS (28.85 s)
 (6/9) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.access_and_discard.shared_and_discard.memfd.without_numa: STARTED
 (6/9) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.access_and_discard.shared_and_discard.memfd.without_numa: PASS (28.04 s)
 (7/9) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.access_and_discard.private_and_no_discard.file.without_numa: STARTED
 (7/9) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.access_and_discard.private_and_no_discard.file.without_numa: PASS (27.89 s)
 (8/9) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.access_and_discard.private_and_no_discard.anonymous.without_numa: STARTED
 (8/9) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.access_and_discard.private_and_no_discard.anonymous.without_numa: PASS (28.03 s)
 (9/9) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.access_and_discard.private_and_no_discard.memfd.without_numa: STARTED
 (9/9) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.access_and_discard.private_and_no_discard.memfd.without_numa: PASS (27.96 s)
(1/5) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.coldplug_and_unplug.with_addr: STARTED
 (1/5) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.coldplug_and_unplug.with_addr: PASS (14.71 s)
 (2/5) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.coldplug_and_unplug.source_and_mib: STARTED
 (2/5) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.coldplug_and_unplug.source_and_mib: PASS (15.00 s)
 (3/5) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.coldplug_and_unplug.unplug_none_dev: STARTED
 (3/5) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.coldplug_and_unplug.unplug_none_dev: PASS (15.30 s)
 (4/5) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.coldplug_and_unplug.plug_exceeded_max_mem: STARTED
 (4/5) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.coldplug_and_unplug.plug_exceeded_max_mem: PASS (14.78 s)
 (5/5) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.coldplug_and_unplug.duplicate_addr: STARTED
 (5/5) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.coldplug_and_unplug.duplicate_addr: PASS (15.04 s)
 (1/4) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.lifecycle.all_requested_and_address.no_source.4k: STARTED
 (1/4) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.lifecycle.all_requested_and_address.no_source.4k: PASS (79.39 s)
 (2/4) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.lifecycle.all_requested_and_address.pagesize.4k: STARTED
 (2/4) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.lifecycle.all_requested_and_address.pagesize.4k: PASS (79.50 s)
 (3/4) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.lifecycle.part_requested_and_no_address.no_source.4k: STARTED
 (3/4) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.lifecycle.part_requested_and_no_address.no_source.4k: PASS (78.17 s)
 (4/4) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.lifecycle.part_requested_and_no_address.pagesize.4k: STARTED
 (4/4) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.lifecycle.part_requested_and_no_address.pagesize.4k: PASS (78.10 s)
 (1/5) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.hot_unplug.detach.target_and_address: STARTED
 (1/5) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.hot_unplug.detach.target_and_address: PASS (92.51 s)
 (2/5) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.hot_unplug.detach.nonexistent_mem: STARTED
 (2/5) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.hot_unplug.detach.nonexistent_mem: PASS (81.96 s)
 (3/5) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.hot_unplug.detach.none_zero_current: STARTED
 (3/5) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.hot_unplug.detach.none_zero_current: PASS (82.66 s)
 (4/5) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.hot_unplug.detach_alias.target_and_address: STARTED
 (4/5) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.hot_unplug.detach_alias.target_and_address: PASS (88.04 s)
 (5/5) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.hot_unplug.detach_alias.none_zero_current: STARTED
 (5/5) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.hot_unplug.detach_alias.none_zero_current: PASS (81.88 s)
(1/3) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.hotplug.target_and_address: STARTED
 (1/3) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.hotplug.target_and_address: PASS (31.41 s)
 (2/3) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.hotplug.plug_exceeded_max_mem: STARTED
 (2/3) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.hotplug.plug_exceeded_max_mem: PASS (25.05 s)
 (3/3) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.hotplug.duplicate_addr: STARTED
 (3/3) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.hotplug.duplicate_addr: PASS (25.03 s)
(1/9) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.define_guest.virtio_mem_without_node.without_numa.no_maxmemory: STARTED
 (1/9) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.define_guest.virtio_mem_without_node.without_numa.no_maxmemory: PASS (14.02 s)
 (2/9) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.define_guest.virtio_mem_without_node.without_numa.with_maxmemory: STARTED
 (2/9) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.define_guest.virtio_mem_without_node.without_numa.with_maxmemory: PASS (23.34 s)
 (3/9) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.define_guest.virtio_mem_with_exceed_size.without_numa.with_maxmemory: STARTED
 (3/9) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.define_guest.virtio_mem_with_exceed_size.without_numa.with_maxmemory: PASS (14.46 s)
 (4/9) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.cold_plug.virtio_mem_without_node.without_numa.no_maxmemory: STARTED
 (4/9) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.cold_plug.virtio_mem_without_node.without_numa.no_maxmemory: PASS (14.67 s)
 (5/9) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.cold_plug.virtio_mem_without_node.without_numa.with_maxmemory: STARTED
 (5/9) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.cold_plug.virtio_mem_without_node.without_numa.with_maxmemory: PASS (15.23 s)
 (6/9) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.cold_plug.virtio_mem_with_exceed_size.without_numa.with_maxmemory: STARTED
 (6/9) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.cold_plug.virtio_mem_with_exceed_size.without_numa.with_maxmemory: PASS (14.99 s)
 (7/9) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.hot_plug.virtio_mem_without_node.without_numa.no_maxmemory: STARTED
 (7/9) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.hot_plug.virtio_mem_without_node.without_numa.no_maxmemory: PASS (23.07 s)
 (8/9) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.hot_plug.virtio_mem_without_node.without_numa.with_maxmemory: STARTED
 (8/9) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.hot_plug.virtio_mem_without_node.without_numa.with_maxmemory: PASS (23.05 s)
 (9/9) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.hot_plug.virtio_mem_with_exceed_size.without_numa.with_maxmemory: STARTED
 (9/9) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_allocation_and_numa.hot_plug.virtio_mem_with_exceed_size.without_numa.with_maxmemory: PASS (22.92 s)

(01/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.hot_plug.alloc_ondemand.file: STARTED
 (01/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.hot_plug.alloc_ondemand.file: PASS (29.41 s)
 (02/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.hot_plug.alloc_ondemand.anonymous: STARTED
 (02/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.hot_plug.alloc_ondemand.anonymous: PASS (30.18 s)
 (03/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.hot_plug.alloc_ondemand.memfd: STARTED
 (03/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.hot_plug.alloc_ondemand.memfd: PASS (30.13 s)
 (04/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.hot_plug.alloc_ondemand.undefined: STARTED
 (04/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.hot_plug.alloc_ondemand.undefined: PASS (29.96 s)
 (05/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.hot_plug.alloc_immediate_with_threads.file: STARTED
 (05/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.hot_plug.alloc_immediate_with_threads.file: PASS (29.13 s)
 (06/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.hot_plug.alloc_immediate_with_threads.anonymous: STARTED
 (06/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.hot_plug.alloc_immediate_with_threads.anonymous: PASS (28.51 s)
 (07/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.hot_plug.alloc_immediate_with_threads.memfd: STARTED
 (07/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.hot_plug.alloc_immediate_with_threads.memfd: PASS (28.48 s)
 (08/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.hot_plug.alloc_immediate_with_threads.undefined: STARTED
 (08/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.hot_plug.alloc_immediate_with_threads.undefined: PASS (28.88 s)
 (09/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.hot_plug.set_hugepage.file: STARTED
 (09/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.hot_plug.set_hugepage.file: PASS (29.14 s)
 (10/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.hot_plug.set_hugepage.memfd: STARTED
 (10/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.hot_plug.set_hugepage.memfd: PASS (29.03 s)
 (11/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.hot_plug.set_hugepage.undefined: STARTED
 (11/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.hot_plug.set_hugepage.undefined: PASS (29.88 s)
 (12/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.cold_plug.alloc_ondemand.file: STARTED
 (12/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.cold_plug.alloc_ondemand.file: PASS (28.07 s)
 (13/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.cold_plug.alloc_ondemand.anonymous: STARTED
 (13/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.cold_plug.alloc_ondemand.anonymous: PASS (26.66 s)
 (14/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.cold_plug.alloc_ondemand.memfd: STARTED
 (14/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.cold_plug.alloc_ondemand.memfd: PASS (27.10 s)
 (15/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.cold_plug.alloc_ondemand.undefined: STARTED
 (15/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.cold_plug.alloc_ondemand.undefined: PASS (28.04 s)
 (16/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.cold_plug.alloc_immediate_with_threads.file: STARTED
 (16/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.cold_plug.alloc_immediate_with_threads.file: PASS (27.83 s)
 (17/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.cold_plug.alloc_immediate_with_threads.anonymous: STARTED
 (17/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.cold_plug.alloc_immediate_with_threads.anonymous: PASS (27.06 s)
 (18/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.cold_plug.alloc_immediate_with_threads.memfd: STARTED
 (18/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.cold_plug.alloc_immediate_with_threads.memfd: PASS (26.89 s)
 (19/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.cold_plug.alloc_immediate_with_threads.undefined: STARTED
 (19/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.cold_plug.alloc_immediate_with_threads.undefined: PASS (27.75 s)
 (20/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.cold_plug.set_hugepage.file: STARTED
 (20/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.cold_plug.set_hugepage.file: PASS (25.80 s)
 (21/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.cold_plug.set_hugepage.memfd: STARTED
 (21/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.cold_plug.set_hugepage.memfd: PASS (27.18 s)
 (22/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.cold_plug.set_hugepage.undefined: STARTED
 (22/22) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.memory_backing_type.cold_plug.set_hugepage.undefined: PASS (27.31 s)
  (1/5) type_specific.io-github-autotest-libvirt.memory.devices.invalid_virtio_mem.over_request_mem: STARTED
 (1/5) type_specific.io-github-autotest-libvirt.memory.devices.invalid_virtio_mem.over_request_mem: PASS (15.59 s)
 (2/5) type_specific.io-github-autotest-libvirt.memory.devices.invalid_virtio_mem.max_addr: STARTED
 (2/5) type_specific.io-github-autotest-libvirt.memory.devices.invalid_virtio_mem.max_addr: PASS (16.60 s)
 (3/5) type_specific.io-github-autotest-libvirt.memory.devices.invalid_virtio_mem.invalid_pagesize: STARTED
 (3/5) type_specific.io-github-autotest-libvirt.memory.devices.invalid_virtio_mem.invalid_pagesize: PASS (15.71 s)
 (4/5) type_specific.io-github-autotest-libvirt.memory.devices.invalid_virtio_mem.small_block: STARTED
 (4/5) type_specific.io-github-autotest-libvirt.memory.devices.invalid_virtio_mem.small_block: PASS (16.36 s)
 (5/5) type_specific.io-github-autotest-libvirt.memory.devices.invalid_virtio_mem.invalid_block: STARTED
 (5/5) type_specific.io-github-autotest-libvirt.memory.devices.invalid_virtio_mem.invalid_block: PASS (16.81 s)

  (01/12) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.dynamic_slots.default_mb.undefined_dynamic_memory_slots.basic_virtio: STARTED
 (01/12) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.dynamic_slots.default_mb.undefined_dynamic_memory_slots.basic_virtio: PASS (25.21 s)
 (02/12) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.dynamic_slots.default_mb.enable_dynamic_memory_slots.basic_virtio: STARTED
 (02/12) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.dynamic_slots.default_mb.enable_dynamic_memory_slots.basic_virtio: PASS (26.98 s)
 (03/12) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.dynamic_slots.default_mb.disable_dynamic_memory_slots.basic_virtio: STARTED
 (03/12) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.dynamic_slots.default_mb.disable_dynamic_memory_slots.basic_virtio: PASS (25.89 s)
 (04/12) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.dynamic_slots.file_mb.undefined_dynamic_memory_slots.basic_virtio: STARTED
 (04/12) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.dynamic_slots.file_mb.undefined_dynamic_memory_slots.basic_virtio: PASS (25.86 s)
 (05/12) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.dynamic_slots.file_mb.enable_dynamic_memory_slots.basic_virtio: STARTED
 (05/12) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.dynamic_slots.file_mb.enable_dynamic_memory_slots.basic_virtio: PASS (25.31 s)
 (06/12) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.dynamic_slots.file_mb.disable_dynamic_memory_slots.basic_virtio: STARTED
 (06/12) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.dynamic_slots.file_mb.disable_dynamic_memory_slots.basic_virtio: PASS (25.24 s)
 (07/12) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.dynamic_slots.hugepages_mb.undefined_dynamic_memory_slots.basic_virtio: STARTED
 (07/12) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.dynamic_slots.hugepages_mb.undefined_dynamic_memory_slots.basic_virtio: PASS (29.42 s)
 (08/12) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.dynamic_slots.hugepages_mb.enable_dynamic_memory_slots.basic_virtio: STARTED
 (08/12) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.dynamic_slots.hugepages_mb.enable_dynamic_memory_slots.basic_virtio: PASS (28.99 s)
 (09/12) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.dynamic_slots.hugepages_mb.disable_dynamic_memory_slots.basic_virtio: STARTED
 (09/12) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.dynamic_slots.hugepages_mb.disable_dynamic_memory_slots.basic_virtio: PASS (29.09 s)
 (10/12) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.dynamic_slots.memfd_mb.undefined_dynamic_memory_slots.basic_virtio: STARTED
 (10/12) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.dynamic_slots.memfd_mb.undefined_dynamic_memory_slots.basic_virtio: PASS (25.58 s)
 (11/12) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.dynamic_slots.memfd_mb.enable_dynamic_memory_slots.basic_virtio: STARTED
 (11/12) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.dynamic_slots.memfd_mb.enable_dynamic_memory_slots.basic_virtio: PASS (25.92 s)
 (12/12) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.dynamic_slots.memfd_mb.disable_dynamic_memory_slots.basic_virtio: STARTED
 (12/12) type_specific.io-github-autotest-libvirt.memory.devices.virtio_mem.dynamic_slots.memfd_mb.disable_dynamic_memory_slots.basic_virtio: PASS (27.27 s)