### PR TITLE
passt: Replace the test file dir '/' with '/var/tmp'

### DIFF
--- a/libvirt/tests/cfg/virtual_network/passt/passt_transfer_file.cfg
+++ b/libvirt/tests/cfg/virtual_network/passt/passt_transfer_file.cfg
@@ -40,7 +40,7 @@
             bs = 1M
         - 1G:
             bs = 100M
-    test_file = /${file_size}_file
+    test_file = /var/tmp/${file_size}_file
     rec_file = out_${file_size}
     cmd_create_file = dd if=/dev/urandom bs=${bs} count=10 > ${test_file}
     cmd_listen = f'socat -u {prot}-LISTEN:{port},reuseaddr OPEN:${rec_file},create'


### PR DESCRIPTION
For RHEL image mode, the directory '/' is read-only. It will cause the case failures when trying to write a file on it. Fix it with the writable directory '/var/tmp'.