### PR TITLE
update_device: Add the missing source network

### DIFF
--- a/libvirt/tests/cfg/virtual_network/update_device/update_iface_with_options_active.cfg
+++ b/libvirt/tests/cfg/virtual_network/update_device/update_iface_with_options_active.cfg
@@ -3,8 +3,8 @@
     start_vm = no
     timeout = 240
     vm_active = True
-    iface_attrs = {'link_state': 'up'}
-    update_attrs = {'link_state': 'down'}
+    iface_attrs = {'link_state': 'up', 'source': {'network': 'default'}}
+    update_attrs = {'link_state': 'down', 'source': {'network': 'default'}}
     variants options:
         - live:
             update_expect = {'active': True, 'inactive': False}


### PR DESCRIPTION
It will fix the error like following when defining a domain: XML error: interface type='network' requires a 'source' element