### PR TITLE
passt: support multiple default routes

### DIFF
--- a/libvirt/tests/cfg/virtual_network/passt/passt_attach_detach.cfg
+++ b/libvirt/tests/cfg/virtual_network/passt/passt_attach_detach.cfg
@@ -5,6 +5,7 @@
     outside_ip = 'www.redhat.com'
     start_vm = no
     mtu = 65520
+    multiple_nexthops = no
     variants user_type:
         - root_user:
             test_user = root

--- a/libvirt/tests/cfg/virtual_network/passt/passt_function.cfg
+++ b/libvirt/tests/cfg/virtual_network/passt/passt_function.cfg
@@ -5,6 +5,7 @@
     outside_ip = 'www.redhat.com'
     start_vm = no
     mtu = 65520
+    multiple_nexthops = no
     variants user_type:
         - root_user:
             test_user = root

--- a/libvirt/tests/cfg/virtual_network/passt/passt_lifecycle.cfg
+++ b/libvirt/tests/cfg/virtual_network/passt/passt_lifecycle.cfg
@@ -5,6 +5,7 @@
     outside_ip = 'www.redhat.com'
     start_vm = no
     mtu = 65520
+    multiple_nexthops = no
     variants operation:
         - save_restore:
             operation_a = save

--- a/libvirt/tests/cfg/virtual_network/passt/passt_reconnect.cfg
+++ b/libvirt/tests/cfg/virtual_network/passt/passt_reconnect.cfg
@@ -5,6 +5,7 @@
     outside_ip = 'www.redhat.com'
     start_vm = no
     mtu = 65520
+    multiple_nexthops = no
     variants user_type:
         - root_user:
             test_user = root

--- a/libvirt/tests/cfg/virtual_network/passt/passt_transfer_file.cfg
+++ b/libvirt/tests/cfg/virtual_network/passt/passt_transfer_file.cfg
@@ -4,6 +4,7 @@
     host_iface =
     outside_ip = 'www.redhat.com'
     start_vm = no
+    multiple_nexthops = no
     variants user_type:
         - root_user:
             test_user = root

--- a/libvirt/tests/src/virtual_network/passt/passt_attach_detach.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_attach_detach.py
@@ -81,6 +81,7 @@ def run(test, params, env):
     iface_attrs['backend']['logFile'] = log_file
     iface_attrs['source']['dev'] = host_iface
     vhostuser = 'yes' == params.get('vhostuser', 'no')
+    multiple_nexthops = 'yes' == params.get('multiple_nexthops', 'no')
 
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name,
                                                    virsh_instance=virsh_ins)
@@ -138,7 +139,7 @@ def run(test, params, env):
             vm_iface = utils_net.get_linux_ifname(session, mac)
             passt.check_vm_ip(iface_attrs, session, host_iface, vm_iface)
             passt.check_vm_mtu(session, vm_iface, mtu)
-            passt.check_default_gw(session, host_iface)
+            passt.check_default_gw(session, host_iface, multiple_nexthops)
             passt.check_nameserver(session)
 
             ips = {

--- a/libvirt/tests/src/virtual_network/passt/passt_function.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_function.py
@@ -67,6 +67,7 @@ def run(test, params, env):
     iface_attrs = eval(params.get('iface_attrs'))
     iface_attrs['backend']['logFile'] = log_file
     vhostuser = 'yes' == params.get('vhostuser', 'no')
+    multiple_nexthops = 'yes' == params.get('multiple_nexthops', 'no')
 
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name,
                                                    virsh_instance=virsh_ins)
@@ -109,7 +110,7 @@ def run(test, params, env):
         vm_iface = utils_net.get_linux_ifname(session, mac)
         passt.check_vm_ip(iface_attrs, session, host_iface, vm_iface)
         passt.check_vm_mtu(session, vm_iface, mtu)
-        passt.check_default_gw(session, host_iface)
+        passt.check_default_gw(session, host_iface, multiple_nexthops)
         passt.check_nameserver(session)
 
         ips = {

--- a/libvirt/tests/src/virtual_network/passt/passt_lifecycle.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_lifecycle.py
@@ -77,6 +77,7 @@ def run(test, params, env):
     options_b = eval(params.get('options_b', '{}'))
     passt_running = 'yes' == params.get('passt_running', 'no')
     vhostuser = 'yes' == params.get('vhostuser', 'no')
+    multiple_nexthops = 'yes' == params.get('multiple_nexthops', 'no')
 
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name,
                                                    virsh_instance=virsh_ins)
@@ -134,7 +135,7 @@ def run(test, params, env):
         vm_iface = utils_net.get_linux_ifname(session, mac)
         passt.check_vm_ip(iface_attrs, session, host_iface, vm_iface)
         passt.check_vm_mtu(session, vm_iface, mtu)
-        passt.check_default_gw(session, host_iface)
+        passt.check_default_gw(session, host_iface, multiple_nexthops)
         passt.check_nameserver(session)
 
         ips = {

--- a/libvirt/tests/src/virtual_network/passt/passt_reconnect.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_reconnect.py
@@ -69,6 +69,7 @@ def run(test, params, env):
     iface_attrs['backend']['logFile'] = log_file
     iface_attrs['source']['dev'] = host_iface
     vhostuser = 'yes' == params.get('vhostuser', 'no')
+    multiple_nexthops = 'yes' == params.get('multiple_nexthops', 'no')
 
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name,
                                                    virsh_instance=virsh_ins)
@@ -117,7 +118,7 @@ def run(test, params, env):
         vm_iface = utils_net.get_linux_ifname(session, mac)
         passt.check_vm_ip(iface_attrs, session, host_iface, vm_iface)
         passt.check_vm_mtu(session, vm_iface, mtu)
-        passt.check_default_gw(session, host_iface)
+        passt.check_default_gw(session, host_iface, multiple_nexthops)
         passt.check_nameserver(session)
 
         ips = {

--- a/libvirt/tests/src/virtual_network/passt/passt_transfer_file.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_transfer_file.py
@@ -159,6 +159,7 @@ def run(test, params, env):
     iface_attrs['backend']['logFile'] = log_file
     iface_attrs['source']['dev'] = host_iface
     direction = params.get('direction')
+    multiple_nexthops = 'yes' == params.get('multiple_nexthops', 'no')
 
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name,
                                                    virsh_instance=virsh_ins)
@@ -177,7 +178,7 @@ def run(test, params, env):
         LOG.debug(virsh_ins.dumpxml(vm_name).stdout_text)
 
         session = vm.wait_for_serial_login(timeout=60)
-        passt.check_default_gw(session, host_iface)
+        passt.check_default_gw(session, host_iface, multiple_nexthops)
 
         prot = 'TCP' if ip_ver == 'ipv4' else 'TCP6'
         if direction == 'host_to_vm':


### PR DESCRIPTION
In some environment, there are more than one default routes in ip route output, for example on ARM host.
This patch is to support this situation instead of only selecting the first default route which is not accurate.

For example:
"nexthops":[{"gateway":"fe80::4a5a:d00:6631:2920","dev":"eno1","weight":1,"flags":[]}, {"gateway":"fe80::4a5a:d00:6631:b20","dev":"eno1","weight":1,"flags":[]}