### PR TITLE
New case VIRT-299049 for dimm memory with various backing types

### DIFF
--- a/libvirt/tests/cfg/memory/memory_devices/dimm_memory_with_memory_backing_type.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/dimm_memory_with_memory_backing_type.cfg
@@ -1,0 +1,113 @@
+- memory.devices.dimm.memory_backing_type:
+    type = dimm_memory_with_memory_backing_type
+    no s390-virtio
+    start_vm = no
+    consume_value = 204800
+    source_dict = ""
+    cpu_mem_attrs = "'vcpu': 4, 'memory_unit':'KiB','memory':2097152,'current_mem':2097152,'current_mem_unit':'KiB'"
+    numa_attrs = "'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '1048576', 'unit': 'KiB'}, {'id': '1', 'cpus': '2-3', 'memory': '1048576', 'unit': 'KiB'}]}"
+    max_mem_attrs = "'max_mem_rt': 10485760, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB'"
+    hugepage_memory = 4194304
+    dimm_list = [{'mem_model':'dimm', 'target':{'size':524288, 'size_unit':'KiB', 'node':0}}, {'mem_model':'dimm', 'source':{'pagesize':%d, 'pagesize_unit':'KiB'}, 'target':{'size':524288, 'size_unit':'KiB', 'node':0}}, {'mem_model':'dimm', 'target':{'size':524288, 'size_unit':'KiB', 'node':1}}, {'mem_model':'dimm', 'source':{'pagesize':%d, 'pagesize_unit':'KiB'}, 'target':{'size':524288, 'size_unit':'KiB', 'node':1}}]
+    exp_prealloc_list = ['true', 'true', 'true', 'true']
+    dimm1_path = {"return": "/dev/hugepages/libvirt/qemu/"}
+    dimm3_path = {"return": "/dev/hugepages/libvirt/qemu/"}
+    dimm1_type = {"return": "memory-backend-file"}
+    dimm3_type = {"return": "memory-backend-file"}
+    variants:
+        - file:
+            source_type = "file"
+            source_dict = "'source_type':'${source_type}',"
+            dimm0_type = {"return": "memory-backend-file"}
+            dimm2_type = {"return": "memory-backend-file"}
+            ondemand, immediate_with_threads:
+                dimm0_path = {"return": "/var/lib/libvirt/qemu/ram/"}
+                dimm2_path = {"return": "/var/lib/libvirt/qemu/ram/"}
+            hugepage_nodeset:
+                dimm0_path = {"return": "/dev/hugepages/libvirt/qemu/"}
+                dimm2_path = {"return": "/var/lib/libvirt/qemu/ram/"}
+            hugepage:
+                dimm0_path = {"return": "/dev/hugepages/libvirt/qemu/"}
+                dimm2_path = {"return": "/dev/hugepages/libvirt/qemu/"}
+        - anonymous:
+            no hugepage,hugepage_nodeset
+            source_type = "anonymous"
+            source_dict = "'source_type':'${source_type}',"
+            ondemand, immediate_with_threads:
+                dimm0_type = {"return": "memory-backend-ram"}
+                dimm2_type = {"return": "memory-backend-ram"}
+                dimm0_path = {"error": {"desc": "memory-backend-ram.mem-path"}}
+                dimm2_path = {"error": {"desc": "memory-backend-ram.mem-path"}}
+        - memfd:
+            source_type = "memfd"
+            source_dict = "'source_type':'${source_type}',"
+            dimm0_path = {"error": {"desc": "memory-backend-memfd.mem-path"}}
+            dimm1_path = ${dimm0_path}
+            dimm2_path = ${dimm0_path}
+            dimm3_path = ${dimm0_path}
+            dimm0_type = {"return": "memory-backend-memfd"}
+            dimm1_type = ${dimm0_type}
+            dimm2_type = ${dimm0_type}
+            dimm3_type = ${dimm0_type}
+        - undefined:
+            source_dict = ""
+            ondemand, immediate_with_threads:
+                dimm0_type = {"return": "memory-backend-ram"}
+                dimm2_type = {"return": "memory-backend-ram"}
+                dimm0_path = {"error": {"desc": "memory-backend-ram.mem-path"}}
+                dimm2_path = {"error": {"desc": "memory-backend-ram.mem-path"}}
+            hugepage_nodeset:
+                dimm0_type = {"return": "memory-backend-file"}
+                dimm2_type = {"return": "memory-backend-ram"}
+                dimm0_path = {"return": "/dev/hugepages/libvirt/qemu/"}
+                dimm2_path = {"error": {"desc": "memory-backend-ram.mem-path"}}
+            hugepage:
+                dimm0_type = {"return": "memory-backend-file"}
+                dimm2_type = {"return": "memory-backend-file"}
+                dimm0_path = {"return": "/dev/hugepages/libvirt/qemu/"}
+                dimm2_path = {"return": "/dev/hugepages/libvirt/qemu/"}
+    variants alloc_mode:
+        - ondemand:
+            mode = "ondemand"
+            alloc_dict = "'allocation':{{'mode':'${mode}'}}"
+            exp_prealloc_list =['false', 'true', 'false', 'true']
+        - immediate_with_threads:
+            func_supported_since_libvirt_ver = (8, 2, 0)
+            mode = "immediate"
+            threads = 4
+            alloc_dict = "'allocation':{{'mode':'${mode}', 'threads':${threads}}}"
+            dimm0_threads = {"return": ${threads}}
+            dimm1_threads = ${dimm0_threads}
+            dimm2_threads = ${dimm0_threads}
+            dimm3_threads = ${dimm0_threads}
+            exp_threads_list = [${dimm0_threads}, ${dimm1_threads}, ${dimm2_threads}, ${dimm3_threads}]
+        - hugepage_nodeset:
+            mode = "immediate"
+            threads = 4
+            hugepage_memory = 4194304
+            alloc_dict = "'allocation':{{'mode':'${mode}', 'threads':${threads}}}, 'hugepages':{{'pages': [{{'unit': 'KiB', 'nodeset': '0', 'size': '{0}'}}]}}"
+            dimm0_threads = {"return": ${threads}}
+            dimm1_threads = ${dimm0_threads}
+            dimm2_threads = ${dimm0_threads}
+            dimm3_threads = ${dimm0_threads}
+            exp_threads_list = [${dimm0_threads}, ${dimm1_threads}, ${dimm2_threads}, ${dimm3_threads}]
+        - hugepage:
+            hugepage_memory = 4194304
+            alloc_dict = "'hugepages':{{'pages': [{{'unit': 'KiB', 'size': '{0}'}}]}}"
+    variants plug_type:
+        - cold_plug:
+            plug_option = "--config"
+        - hot_plug:
+            plug_option = ""
+    memory_backing_dict = {{'mb':{{${source_dict} ${alloc_dict}}}}}
+    vm_attrs = {${cpu_mem_attrs}, ${numa_attrs}, ${max_mem_attrs}}
+    preallocated_cmd = "info memdev"
+    preallocated_cmd_protocal = "--hmp"
+    preallocated_pattern = "memory backend: (\w*dimm\w*).*?prealloc: (true|false)"
+    property_type = "type"
+    exp_type_list = [${dimm0_type}, ${dimm1_type}, ${dimm2_type}, ${dimm3_type}]
+    property_mempath = "mem-path"
+    exp_mempath_list = [${dimm0_path}, ${dimm1_path}, ${dimm2_path}, ${dimm3_path}]
+    property_threads = "prealloc-threads"
+    qom_cmd_template = '{{"execute":"qom-get", "arguments":{{"path":"/objects/{0}", "property":"{1}"}}}}'
+

--- a/libvirt/tests/src/memory/memory_devices/dimm_memory_with_memory_backing_type.py
+++ b/libvirt/tests/src/memory/memory_devices/dimm_memory_with_memory_backing_type.py
@@ -1,0 +1,210 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright Red Hat
+#
+#   SPDX-License-Identifier: GPL-2.0
+#
+#   Author: Liang Cong <lcong@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import json
+import re
+
+from avocado.utils import memory as avocado_mem
+
+from virttest import libvirt_version
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.libvirt_xml.devices.memory import Memory
+from virttest.staging import utils_memory
+from virttest.utils_libvirt import libvirt_memory
+from virttest.utils_libvirtd import Libvirtd
+from virttest.utils_test import libvirt
+
+
+def run(test, params, env):
+    """
+    Verify dimm memory device works with various memory backing type
+    """
+    def setup_test():
+        """
+        Test setup:
+        1. Set up hugepage
+        2. Build dimm memory device list
+        3. Build memory backing config
+        """
+        nonlocal dimm_list, memory_backing_dict
+        test.log.info("TEST_SETUP: Set up hugepage")
+        default_pagesize = avocado_mem.get_huge_page_size()
+        hp_num = int(hugepage_memory) // default_pagesize
+        utils_memory.set_num_huge_pages(hp_num)
+
+        test.log.info("TEST_SETUP: Build dimm memory deivce list")
+        dimm_list = eval(dimm_list % (default_pagesize, default_pagesize))
+        for dimm in dimm_list:
+            dimm_device = Memory()
+            dimm_device.setup_attrs(**dimm)
+            dimm_device_list.append(dimm_device)
+
+        test.log.info("TEST_SETUP: Build memory backing config")
+        memory_backing_dict = memory_backing_dict.format(default_pagesize)
+        memory_backing_dict = eval(memory_backing_dict)
+
+    def attach_dimms(dimm_device_list, plug_option):
+        """
+        Attach dimm memory devices to vm
+
+        :param dimm_device_list: list of dimm memory device object
+        :param plug_option: flagstr for virsh attach-device command
+        """
+        for dimm_dev in dimm_device_list:
+            ret = virsh.attach_device(vm_name, dimm_dev.xml,
+                                      flagstr=plug_option, **virsh_args)
+            libvirt.check_result(ret)
+
+    def check_dimm_prealloc(exp_prealloc_list):
+        """
+        Verify dimm memory preallocation status against expected values
+
+        :param exp_prealloc_list: expected dimm memory preallocation list
+        """
+        preallocated_cmd = params.get("preallocated_cmd")
+        preallocated_cmd_protocal = params.get("preallocated_cmd_protocal")
+        pattern = params.get("preallocated_pattern")
+
+        ret = virsh.qemu_monitor_command(vm_name, preallocated_cmd,
+                                         preallocated_cmd_protocal, debug=True)
+        test.log.debug(f"qemu-monitor-command '{preallocated_cmd}' result: {ret.stdout_text}")
+        matches = sorted(re.findall(fr'{pattern}', ret.stdout_text, re.DOTALL))
+        actual_prealloc_list = [prealloc for _, prealloc in matches]
+        if actual_prealloc_list != exp_prealloc_list:
+            test.fail(
+                f"Expected preallocated list is {exp_prealloc_list}, but found {actual_prealloc_list}")
+        nonlocal dimm_name_list
+        dimm_name_list = [name for name, _ in matches]
+
+    def check_qemu_object_property(name_list, obj_property, exp_list, exact_match=False):
+        """
+        Verify qemu object properties against expected values
+
+        :param name_list: list of qemu object names
+        :param obj_property: qemu object property name
+        :param exp_list: expected values for the property
+        :param exact_match: whether to use exact match or substring match
+        """
+        def _compare_value(exp, act):
+            """
+            Compare expected value with actual value
+
+            :param exp: expected value
+            :param act: actual value
+            """
+            if exact_match:
+                return exp == act
+            return exp in act if act else False
+
+        nonlocal qom_cmd_template
+        for index, name in enumerate(name_list):
+            qom_cmd = qom_cmd_template.format(name, obj_property)
+            ret = virsh.qemu_monitor_command(vm_name, qom_cmd, debug=True)
+            data_dict = json.loads(ret.stdout_text)
+            exp_dict = exp_list[index]
+
+            if "return" in exp_dict:
+                if not _compare_value(exp_dict.get("return"), data_dict["return"]):
+                    test.fail(
+                        f"Expected dimm {name} {obj_property} is {exp_dict}, but found {data_dict}")
+            if "error" in exp_dict:
+                act_desc = data_dict.get("error", {}).get("desc", "")
+                exp_desc = exp_dict["error"]["desc"]
+                if not _compare_value(exp_desc, act_desc):
+                    test.fail(
+                        f"Expected dimm {name} error msg is {exp_dict}, but found {data_dict}")
+
+    libvirt_version.is_libvirt_feature_supported(params)
+    virsh_args = {'debug': True, 'ignore_status': False}
+    vm_name = params.get("main_vm")
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+    vm = env.get_vm(vm_name)
+
+    hugepage_memory = params.get("hugepage_memory")
+    vm_attrs = eval(params.get("vm_attrs"))
+    memory_backing_dict = params.get("memory_backing_dict")
+    plug_type = params.get("plug_type")
+    plug_option = params.get("plug_option")
+
+    dimm_list = params.get("dimm_list")
+    dimm_device_list = []
+    dimm_name_list = []
+    exp_prealloc_list = eval(params.get("exp_prealloc_list"))
+    exp_type_list = eval(params.get("exp_type_list"))
+    exp_mempath_list = eval(params.get("exp_mempath_list"))
+    exp_threads_list = eval(params.get("exp_threads_list", "[]"))
+    qom_cmd_template = params.get("qom_cmd_template")
+    property_type = params.get("property_type")
+    property_mempath = params.get("property_mempath")
+    property_threads = params.get("property_threads")
+    alloc_mode = params.get("alloc_mode")
+    consume_value = int(params.get("consume_value"))
+
+    try:
+        setup_test()
+
+        # Test steps:
+        # 1. Define the guest
+        # 2. Cold-plug dimm devices
+        # 3. Start the guest
+        # 4: Restart the libvirt deamon
+        # 5: Hot-plug dimm devices
+        # 6: Check dimm memory backend pre-allocated
+        # 7: Check dimm memory backing type
+        # 8: Check dimm memory backing path
+        # 9: Check dimm memory allocation threads
+        # 10: Consume guest memory successfully
+        test.log.info("TEST_STEP1: Define the guest")
+        vm_attrs.update(memory_backing_dict)
+        vmxml.setup_attrs(**vm_attrs)
+        vmxml.sync()
+
+        if plug_type == "cold_plug":
+            test.log.info("TEST_STEP2: Cold-plug dimm devices")
+            attach_dimms(dimm_device_list, plug_option)
+
+        test.log.info("TEST_STEP3: Start guest")
+        vm.start()
+        dom_xml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        test.log.debug(f"Domain xml after start is: {dom_xml}")
+        vm.wait_for_login().close()
+
+        test.log.info("TEST_STEP4: Restart the libvirt deamon")
+        Libvirtd().restart()
+
+        if plug_type == "hot_plug":
+            test.log.info("TEST_STEP5: Hot-plug dimm devices")
+            attach_dimms(dimm_device_list, plug_option)
+
+        test.log.info("TEST_STEP6: Check dimm memory backend pre-allocated")
+        check_dimm_prealloc(exp_prealloc_list)
+
+        test.log.info("TEST_STEP7: Check dimm memory backing type")
+        check_qemu_object_property(dimm_name_list, property_type, exp_type_list, True)
+
+        test.log.info("TEST_STEP8: Check dimm memory backing path")
+        check_qemu_object_property(dimm_name_list, property_mempath, exp_mempath_list)
+
+        if alloc_mode in ["immediate_with_threads", "hugepage_nodeset"]:
+            test.log.info("TEST_STEP9: Check dimm memory allocation threads")
+            check_qemu_object_property(dimm_name_list, property_threads, exp_threads_list, True)
+
+        test.log.info("TEST_STEP10: Consume guest memory successfully")
+        session = vm.wait_for_login()
+        status, output = libvirt_memory.consume_vm_freememory(session, consume_value)
+        if status:
+            test.fail(f"Fail to consume guest memory. Error:{output}")
+        session.close()
+
+    finally:
+        test.log.info("TEST_TEARDOWN: Clean up environment.")
+        utils_memory.set_num_huge_pages(0)
+        bkxml.sync()


### PR DESCRIPTION
Test results:
(01/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.cold_plug.ondemand.file: STARTED
 (01/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.cold_plug.ondemand.file: PASS (38.33 s)
 (02/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.cold_plug.ondemand.anonymous: STARTED
 (02/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.cold_plug.ondemand.anonymous: PASS (35.46 s)
 (03/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.cold_plug.ondemand.memfd: STARTED
 (03/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.cold_plug.ondemand.memfd: PASS (38.17 s)
 (04/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.cold_plug.ondemand.undefined: STARTED
 (04/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.cold_plug.ondemand.undefined: PASS (36.64 s)
 (05/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.cold_plug.immediate_with_threads.file: STARTED
 (05/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.cold_plug.immediate_with_threads.file: PASS (39.91 s)
 (06/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.cold_plug.immediate_with_threads.anonymous: STARTED
 (06/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.cold_plug.immediate_with_threads.anonymous: PASS (36.47 s)
 (07/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.cold_plug.immediate_with_threads.memfd: STARTED
 (07/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.cold_plug.immediate_with_threads.memfd: PASS (38.76 s)
 (08/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.cold_plug.immediate_with_threads.undefined: STARTED
 (08/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.cold_plug.immediate_with_threads.undefined: PASS (36.87 s)
 (09/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.cold_plug.hugepage_nodeset.file: STARTED
 (09/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.cold_plug.hugepage_nodeset.file: PASS (37.90 s)
 (10/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.cold_plug.hugepage_nodeset.memfd: STARTED
 (10/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.cold_plug.hugepage_nodeset.memfd: PASS (37.12 s)
 (11/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.cold_plug.hugepage_nodeset.undefined: STARTED
 (11/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.cold_plug.hugepage_nodeset.undefined: PASS (36.46 s)
 (12/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.cold_plug.hugepage.file: STARTED
 (12/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.cold_plug.hugepage.file: PASS (36.90 s)
 (13/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.cold_plug.hugepage.memfd: STARTED
 (13/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.cold_plug.hugepage.memfd: PASS (36.02 s)
 (14/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.cold_plug.hugepage.undefined: STARTED
 (14/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.cold_plug.hugepage.undefined: PASS (36.49 s)
  (01/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.hot_plug.ondemand.file: STARTED
 (01/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.hot_plug.ondemand.file: PASS (38.32 s)
 (02/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.hot_plug.ondemand.anonymous: STARTED
 (02/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.hot_plug.ondemand.anonymous: PASS (36.62 s)
 (03/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.hot_plug.ondemand.memfd: STARTED
 (03/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.hot_plug.ondemand.memfd: PASS (38.77 s)
 (04/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.hot_plug.ondemand.undefined: STARTED
 (04/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.hot_plug.ondemand.undefined: PASS (35.64 s)
 (05/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.hot_plug.immediate_with_threads.file: STARTED
 (05/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.hot_plug.immediate_with_threads.file: PASS (38.77 s)
 (06/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.hot_plug.immediate_with_threads.anonymous: STARTED
 (06/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.hot_plug.immediate_with_threads.anonymous: PASS (37.08 s)
 (07/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.hot_plug.immediate_with_threads.memfd: STARTED
 (07/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.hot_plug.immediate_with_threads.memfd: PASS (38.60 s)
 (08/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.hot_plug.immediate_with_threads.undefined: STARTED
 (08/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.hot_plug.immediate_with_threads.undefined: PASS (36.97 s)
 (09/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.hot_plug.hugepage_nodeset.file: STARTED
 (09/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.hot_plug.hugepage_nodeset.file: PASS (37.91 s)
 (10/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.hot_plug.hugepage_nodeset.memfd: STARTED
 (10/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.hot_plug.hugepage_nodeset.memfd: PASS (37.32 s)
 (11/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.hot_plug.hugepage_nodeset.undefined: STARTED
 (11/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.hot_plug.hugepage_nodeset.undefined: PASS (36.81 s)
 (12/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.hot_plug.hugepage.file: STARTED
 (12/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.hot_plug.hugepage.file: PASS (68.18 s)
 (13/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.hot_plug.hugepage.memfd: STARTED
 (13/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.hot_plug.hugepage.memfd: PASS (36.23 s)
 (14/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.hot_plug.hugepage.undefined: STARTED
 (14/14) type_specific.io-github-autotest-libvirt.memory.devices.dimm.memory_backing_type.hot_plug.hugepage.undefined: PASS (36.22 s)