### PR TITLE
Add cpu case of cpuset limited by cgroup

### DIFF
--- a/libvirt/tests/cfg/cpu/vcpupin.cfg
+++ b/libvirt/tests/cfg/cpu/vcpupin.cfg
@@ -3,6 +3,7 @@
     vcpu_placement = 'static'
     vcpu_max = 4
     vcpu_current = 2
+    update_xml = yes
     variants:
         - positive:
             variants test_case:
@@ -16,3 +17,8 @@
                 - vcpupin_current_inactive_vm:
                     vcpupin_conf = "{'0': 'x,y', '1': 'x-y,^z', '2': 'x-y,^z,m', '3': 'r'}"
                     affinity_pattern = 'CPU Affinity:\s*(.*) .*out of'
+                - cpuset_limilted_in_cgroup:
+                    update_xml = no
+                    vcpu_max = 2
+                    vcpupin_conf = {'0': '2', '1': '4'}
+                    vm_attrs = {'cputune': {'vcpupins': [{'vcpu': '0', 'cpuset': '2'}, {'vcpu': '1', 'cpuset': '4'}]}}


### PR DESCRIPTION
- RHEL-179878 - [vcpupin] Start VM with vcpupin config when machine cpuset is limited in cgroup

Test result:
```
 (1/5) type_specific.local.vcpupin.positive.vcpupin_live_active_vm: STARTED
 (1/5) type_specific.local.vcpupin.positive.vcpupin_live_active_vm: PASS (52.31 s)
 (2/5) type_specific.local.vcpupin.positive.vcpupin_live_config_active_vm: STARTED
 (2/5) type_specific.local.vcpupin.positive.vcpupin_live_config_active_vm: PASS (110.40 s)
 (3/5) type_specific.local.vcpupin.positive.vcpupin_current_active_vm: STARTED
 (3/5) type_specific.local.vcpupin.positive.vcpupin_current_active_vm: PASS (113.93 s)
 (4/5) type_specific.local.vcpupin.positive.vcpupin_current_inactive_vm: STARTED
 (4/5) type_specific.local.vcpupin.positive.vcpupin_current_inactive_vm: PASS (112.18 s)
 (5/5) type_specific.local.vcpupin.positive.cpuset_limilted_in_cgroup: STARTED
 (5/5) type_specific.local.vcpupin.positive.cpuset_limilted_in_cgroup: PASS (87.76 s)
RESULTS    : PASS 5 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```