### PR TITLE
migration: Update netperf

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_vm.cfg
+++ b/libvirt/tests/cfg/migration/migrate_vm.cfg
@@ -174,12 +174,9 @@
                                             migration_timeout = 600
                                             virsh_options = "--live --verbose"
                                         - netperf_network:
-                                            netperf_version = "netperf-2.6.0-1"
-                                            netperf_source = "shared/deps/netperf/${netperf_version}.tar.bz2"
-                                            client_path = "/var/tmp/"
-                                            server_path = "/var/tmp/"
-                                            netperf_test_duration = 300
-                                            netperf_para_sessions = 1
+                                            netperf_network = "yes"
+                                            netperf_cmd_dst = "netperf -H ${client_ip} -l 600 > /dev/null 2>&1 &"
+                                            netperf_cmd_src = "netperf -H ${server_ip} -l 600 &"
                                             migration_timeout = 600
                                             virsh_options = "--live --verbose"
                         - iothread:


### PR DESCRIPTION
Replaced compilation of netperf with the netperf rpm for testing.

Test result:
 (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_vm.positive_testing.live_migration.stress.host.netperf_network.without_postcopy: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_vm.positive_testing.live_migration.stress.host.netperf_network.without_postcopy: PASS (143.04 s)