### PR TITLE
nbdkit: fix the value which is supported after 1.40

### DIFF
--- a/v2v/tests/src/nbdkit/nbdkit.py
+++ b/v2v/tests/src/nbdkit/nbdkit.py
@@ -459,7 +459,7 @@ nbdsh -u nbd+unix:///?socket=/tmp/sock -c 'h.zero (655360, 262144, 0)'
         if not re.search('0m0', cmd_pass.stderr_text):
             test.fail('fail to test delay-close option when nbdkit clients are not shutdown')
         #Set invalid number for delay option
-        values = ['10secs', '40SECS', '10s', '10MS', '1:']
+        values = ['10secs', '40SECS', '10MS', '1:']
         for value in values:
             cmd_num = process.run("nbdkit null --filter=delay delay-open=%s --run 'nbdinfo $uri'" % value,
                                   shell=True, ignore_status=True)


### PR DESCRIPTION
the value:10s is supported after 1.40. So remove this value for 10.1.

DELAY FORMAT
In nbdkit ≥ 1.40, [nbdkit_parse_delay(3)](https://libguestfs.org/nbdkit_parse_delay.3.html) is used to parse the delay parameters, so a wide variety of formats are accepted, such as:

delay-read=1.5
delay-write=100ms
delay-zero=1.2μs
delay-trim=1000ns
In nbdkit ≤ 1.38, only a whole number of seconds, or a whole number of milliseconds (if suffixed by ms) were allowed.