### PR TITLE
nvdimm: disable test on s390x

### DIFF
--- a/libvirt/tests/cfg/memory/memory_devices/nvdimm_memory_turn_to_dram.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/nvdimm_memory_turn_to_dram.cfg
@@ -1,4 +1,5 @@
 - memory.devices.nvdimm.turn_to_dram:
+    no s390-virtio
     type = nvdimm_memory_turn_to_dram
     start_vm = no
     mem_model = 'nvdimm'


### PR DESCRIPTION
No NVDIMM nor DIMM on s390x, disable.