### PR TITLE
migration: Update virtiofs case

### DIFF
--- a/libvirt/tests/cfg/migration/migration_with_virtiofs/migration_with_externally_launched_virtiofs_dev.cfg
+++ b/libvirt/tests/cfg/migration/migration_with_virtiofs/migration_with_externally_launched_virtiofs_dev.cfg
@@ -27,7 +27,7 @@
     virsh_migrate_desturi = "qemu+ssh://${migrate_dest_host}/system"
     func_supported_since_libvirt_ver = (10, 5, 0)
     vm_attrs = {'mb': {"source_type":"file", 'access_mode': 'shared'}}
-    socket_path = "/vm001-vhost-fs.sock"
+    socket_path = "/var/vm001-vhost-fs.sock"
     dev_type = "filesystem"
     mount_tag = "mount_tag1"
     mount_dir = "/mnt/${mount_tag}"

--- a/libvirt/tests/src/migration/migration_with_virtiofs/migration_with_externally_launched_virtiofs_dev.py
+++ b/libvirt/tests/src/migration/migration_with_virtiofs/migration_with_externally_launched_virtiofs_dev.py
@@ -35,17 +35,18 @@ def run(test, params, env):
         mount_dir = params.get("mount_dir")
         expect_str = params.get("expect_str")
 
-        cmd1 = f"chcon -t virtd_exec_t /usr/libexec/virtiofsd"
-        cmd2 = f"mkdir -p {mnt_path_name}"
-        cmd3 = f"systemd-run /usr/libexec/virtiofsd --socket-path={socket_path} -o source={mnt_path_name}"
-        multi_cmd1 = f"{cmd1}; {cmd2}; {cmd3}"
-        process.run(multi_cmd1, shell=True, ignore_status=False)
-        remote.run_remote_cmd(multi_cmd1, params, ignore_status=False)
+        cmd1 = f"mkdir -p {mnt_path_name}"
+        cmd2 = f"/usr/libexec/virtiofsd --socket-path={socket_path} -o source={mnt_path_name} &"
+        multi_cmd1 = f"{cmd1}; {cmd2}"
+        process.run(multi_cmd1, shell=True, ignore_status=False, ignore_bg_processes=True)
+        cmd3 = f"/usr/libexec/virtiofsd --socket-path={socket_path} -o source={mnt_path_name} > /dev/null 2>&1 &"
+        multi_cmd2 = f"{cmd1}; {cmd3}"
+        remote.run_remote_cmd(multi_cmd2, params, ignore_status=False)
         cmd4 = f"chcon -t svirt_image_t {socket_path}"
         cmd5 = f"chown qemu:qemu {socket_path}"
-        multi_cmd2 = f"{cmd4}; {cmd5}"
-        process.run(multi_cmd2, shell=True, ignore_status=False)
-        remote.run_remote_cmd(multi_cmd2, params, ignore_status=False)
+        multi_cmd3 = f"{cmd4}; {cmd5}"
+        process.run(multi_cmd3, shell=True, ignore_status=False)
+        remote.run_remote_cmd(multi_cmd3, params, ignore_status=False)
 
         migration_obj.setup_connection()
 


### PR DESCRIPTION
Don't need to use systemd-run to run virtiofsd process. So update
 case.

Test result(image mode):
Before:
Command 'chcon -t svirt_image_t /vm001-vhost-fs.sock; chown qemu:qemu /vm001-vhost-fs.sock' failed.&#10;stdout: b''&#10;stderr: b"chcon: cannot access '/vm001-vhost-fs.sock': No such file or directory\nchown: cannot access '/vm001-vhost-fs.sock': No such file or directory\n"&#10;additional_info: None

After:
(1/1) type_specific.io-github-autotest-libvirt.migration.migration_with_virtiofs.migration_with_externally_launched_virtiofs_dev.with_precopy: STARTED
(1/1) type_specific.io-github-autotest-libvirt.migration.migration_with_virtiofs.migration_with_externally_launched_virtiofs_dev.with_precopy: PASS (178.01 s)