### PR TITLE
virsh_guestinfo: add case for cpu load

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_guestinfo.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_guestinfo.cfg
@@ -1,8 +1,10 @@
 - virsh.guestinfo:
     type = virsh_guestinfo
     start_vm = yes
+    func_supported_since_libvirt_ver = (6, 0, 0)
     variants:
         - positive:
+            start_vm = no
             start_ga = "yes"
             prepare_channel = "yes"
             variants:
@@ -26,6 +28,12 @@
                     serial_num = "12345678"
                 - interface_info:
                     option = "--interface"
+                - load_info:
+                    func_supported_since_libvirt_ver = (10, 10, 0)
+                    option = "--load"
+                    stress_in_vm = "yes"
+                    remove_exist_qa = "yes"
+                    load_info_field = ["load.1m", "load.5m", "load.15m"]
         - negative:
             status_error = "yes"
             variants:


### PR DESCRIPTION
This is to support the scenario like below

$ virsh guestinfo rhel1 --load
load.1m             : 0.917969
load.5m             : 1.265625
load.15m            : 0.906738

Signed-off-by: Dan Zheng <dzheng@redhat.com>