### PR TITLE
nbdkit: fix the failed case with the version issue

### DIFF
--- a/v2v/tests/cfg/nbdkit/nbdkit.cfg
+++ b/v2v/tests/cfg/nbdkit/nbdkit.cfg
@@ -228,4 +228,4 @@
       - cve_starttls:
         only source_none..dest_none
         checkpoint = 'cve_starttls'
-        version_required = "[nbdkit-server-1.26.5-1,)"
+        version_required = "[nbdkit-1.26.5-1,nbdkit-1.40)"


### PR DESCRIPTION
the package nbdkit on RHEL10 + has more than one rpm dependencies and it caused the rpmbuild failed.

Case on rhel9 can be passed successfully. 

Adding version control to skip this source pkg check on rhel10+.
