### PR TITLE
SRIOV: fix an expected error message issue

### DIFF
--- a/libvirt/tests/cfg/sriov/vIOMMU/intel_iommu_aw_bits.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/intel_iommu_aw_bits.cfg
@@ -9,7 +9,7 @@
         - 39:
         - 36:
             status_error = yes
-            err_msg = "Supported values for aw-bits are"
+            err_msg = "Supported | supported values for aw-bits are"
         - 3423:
             status_error = yes
             err_msg = "Parameter 'aw-bits' expects uint8_t"


### PR DESCRIPTION
The previous error message is "Supported values for aw-bits are", but in current version it's "supported values for aw-bits are". So update the script to include all of them.