### PR TITLE
hmat_info: correct the pattern

### DIFF
--- a/libvirt/tests/cfg/numa/guest_numa_hmat/hmat_info.cfg
+++ b/libvirt/tests/cfg/numa/guest_numa_hmat/hmat_info.cfg
@@ -46,5 +46,5 @@
     qemu_check_cache_1 = "-numa hmat-cache,node-id=0,size=128K,level=2,associativity=complex,policy=write-through,line=16"
     qemu_check_cache_2 = "-numa hmat-cache,node-id=1,size=10K,level=1,associativity=none,policy=none,line=8"    
     variants:
-        - default:
+        - @default:
             func_supported_since_libvirt_ver = (7, 5, 0)


### PR DESCRIPTION
This is to avoid the messed up case pattern


Signed-off-by: Dan Zheng <dzheng@redhat.com>