### PR TITLE
migrate_mem: restore configuration for s390x

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_mem.cfg
+++ b/libvirt/tests/cfg/migration/migrate_mem.cfg
@@ -54,6 +54,8 @@
             str_in_log = False
         - mem_balloon:
             ballooned_mem = "1572864"
+            s390-virtio:
+                ballooned_mem = "716800"
         - mem_nvdimm:
             no s390-virtio
             nvdimm_file_path = '${nfs_mount_dir}/nvdimm'


### PR DESCRIPTION
a31e2c2cd3d7a1ad41c3a7164566ab1db2e3b1f3 apparently fixed the configuration value for a specific VM setup.

This now leads to test failure for s390x with 1GB RAM.

For s390x, restore the previous value.