### PR TITLE
virtual_disks: fix sgio issue with multipath disk

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_multipath.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multipath.py
@@ -179,6 +179,7 @@ def run(test, params, env):
         attach_option = ""
         if not hotplug_disk:
             attach_option = "--config"
+        time.sleep(15)
         result = virsh.attach_device(vm_name, disk_xml, flagstr=attach_option,
                                      ignore_status=True, debug=True)
         libvirt.check_exit_status(result, status_error)


### PR DESCRIPTION
The auto case virtual_disks.multipath.rawio_yes.sgio_filtered.hotplug has 20% failure rate. It maybe caused by using udev to scan the multipath device for too long, causing the device to be occupied. So add timeout before test.
Also because for multipath SAN, the scaning time between 10s to 30s. So use 15s here.