### PR TITLE
migration: Fix decode failure

### DIFF
--- a/libvirt/tests/cfg/migration/migration_with_vtpm/migration_with_vtpm_state_on_block_dev.cfg
+++ b/libvirt/tests/cfg/migration/migration_with_vtpm/migration_with_vtpm_state_on_block_dev.cfg
@@ -33,7 +33,7 @@
     dst_secret_value_path = "/var/tmp/dst_secretinfile"
     status_error = "no"
     func_supported_since_libvirt_ver = (10, 10, 0)
-    block_path = "/iscsiswtpm"
+    block_path = "/var/iscsiswtpm"
     libvirtd_debug_file = '/var/log/libvirt/virtqemud.log'
     libvirtd_debug_filters = "1:*"
     libvirtd_debug_level = "1"
@@ -62,7 +62,7 @@
         - auto_create_file:
             dir_name = "mig_vtpm_auto_file_test"
             file_name = "${dir_name}2-00.permall"
-            block_dir = "${block_path}/{dir_name}"
+            block_dir = "${block_path}/${dir_name}"
             tpm_dict = {'tpm_model': '${tpm_model}', 'backend': {'backend_type': 'emulator', 'backend_version': '2.0', 'encryption_secret': '0051c505-1ad0-4d77-9b3e-360c8f5e3b86', 'source': {'type': 'file', 'path': '${block_dir}/${file_name}'}}}
             check_lables_1 = '[r"tss  tss  system_u:object_r:virt_var_lib_t:s0.*.", r"root root unconfined_u:object_r:default_t:s0.*.."]'
             check_lables_2 = '[r"tss  tss  system_u:object_r:svirt_image_t:s0:c.*${file_name}"]'

--- a/libvirt/tests/src/migration/migration_with_vtpm/migration_with_vtpm_state_on_block_dev.py
+++ b/libvirt/tests/src/migration/migration_with_vtpm/migration_with_vtpm_state_on_block_dev.py
@@ -80,7 +80,7 @@ def check_capability(params, test):
     :param params: Dictionary with the test parameters
     :param test: test object
     """
-    with open(params.get("libvirtd_debug_file"), 'r') as f:
+    with open(params.get("libvirtd_debug_file"), 'r', errors='ignore') as f:
         log_file = f.read()
         if migration_vtpm.compare_swtpm_version(0, 10):
             cmd = "swtpm socket --print-capabilities"
@@ -89,7 +89,7 @@ def check_capability(params, test):
                 test.fail(f"Not found 'tpmstate-opt-lock' in {ret}")
 
             check_items(eval(params.get("unexpected_list_1", "[]")), log_file, test, str_in_log=False)
-            check_items(eval(params.get("expected_list_1"), "[]"), log_file, test)
+            check_items(eval(params.get("expected_list_1", "[]")), log_file, test)
         else:
             if libvirt_version.version_compare(11, 0, 0):
                 check_items(eval(params.get("expected_list_2", "[]")), log_file, test)


### PR DESCRIPTION
Fix following issue:
    'utf-8' codec can't decode byte 0xff in position 1465040: invalid start byte

The ignoring will not impact some key strings matched in the log.