### PR TITLE
migration: Update mount path for image mode

### DIFF
--- a/libvirt/tests/cfg/migration/migration_with_vtpm/migration_with_shared_tpm.cfg
+++ b/libvirt/tests/cfg/migration/migration_with_vtpm/migration_with_shared_tpm.cfg
@@ -19,6 +19,7 @@
     client_pwd = "${migrate_source_pwd}"
     status_error = "no"
     transport_type = "ssh"
+    migrate_desturi_type = "ssh"
     virsh_migrate_desturi = "qemu+ssh://${migrate_dest_host}/system"
     tpm_cmd = "tpm2_getrandom --hex 16"
     auth_sec_dict = {"sec_ephemeral": "no", "sec_private": "yes", "sec_desc": "sample vTPM secret", "sec_usage": "vtpm", "sec_name": "VTPM_example"}
@@ -38,7 +39,6 @@
     storage_type = 'nfs'
     setup_local_nfs = 'yes'
     disk_type = "file"
-    disk_source_protocol = "netfs"
     mnt_path_name = ${nfs_mount_dir}
     variants:
         - persistent_and_p2p:
@@ -53,7 +53,7 @@
             transient_vm = "yes"
     variants shared_storage_type:
         - nfs:
-            nfs_export_dir = "/var/tmp"
+            nfs_export_dir = "${export_dir}/swtpm"
             src_mount_path = "${client_ip}:${nfs_export_dir}"
             tpm_security_contexts = "nfs_t"
             tpm_security_contexts_restore = "${tpm_security_contexts}"

--- a/libvirt/tests/src/migration/migration_with_vtpm/migration_with_shared_tpm.py
+++ b/libvirt/tests/src/migration/migration_with_vtpm/migration_with_shared_tpm.py
@@ -186,7 +186,7 @@ def run(test, params, env):
         src_mount_path = params.get("src_mount_path")
 
         test.log.info("Setup for nfs storage type.")
-        libvirt.set_vm_disk(vm, params)
+        migration_obj.setup_connection()
         if not os.path.exists(swtpm_path):
             os.mkdir(swtpm_path)
         libvirt.setup_or_cleanup_nfs(True, mount_dir=swtpm_path, is_mount=True, export_dir=nfs_export_dir)
@@ -227,7 +227,7 @@ def run(test, params, env):
         vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
         vmxml.set_seclabel([seclabel_dict])
         vmxml.sync()
-        libvirt.set_vm_disk(vm, params)
+        migration_obj.setup_connection()
         setup_vtpm(params, test, vm, migration_obj)
         check_tpm_security_context(params, vm, test, tpm_security_contexts)
         check_swtpm_process(params, test)


### PR DESCRIPTION
Before:
The string 'migration release-lock-outgoing,incoming' is not included in /var/log/libvirt/virtqemud.log

After:
 (1/1) type_specific.io-github-autotest-libvirt.migration_with_vtpm.migration_with_shared_tpm.nfs.persistent_and_non_p2p: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.migration_with_vtpm.migration_with_shared_tpm.nfs.persistent_and_non_p2p: PASS (248.63 s)