### PR TITLE
migration: Fix the SSH connection issue

### DIFF
--- a/libvirt/tests/cfg/migration_with_copy_storage/async_job/query_domain_job_info.cfg
+++ b/libvirt/tests/cfg/migration_with_copy_storage/async_job/query_domain_job_info.cfg
@@ -20,6 +20,9 @@
     client_user = "root"
     client_pwd = "${migrate_source_pwd}"
     check_network_accessibility_after_mig = "yes"
+    storage_type = 'file'
+    start_vm = "yes"
+    setup_ssh = "yes"
     migrate_desturi_port = "16509"
     migrate_desturi_type = "tcp"
     virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"


### PR DESCRIPTION
Add the SSH connection steps.

Before:
Not found 'migration statistics are available only on the source host' in 'error: failed to connect to the hypervisor&#10;error: Cannot recv data: Warning: Permanently added '10.72.132.24' (ED25519) to the list of known hosts. &#10;Permission denied, please try again. &#10;Permission denied, please try again. &#10;root@10.72.132.24: Permission denied (publickey,gssapi-keyex,gssapi-with-mic,password).: Connection reset by peer

After:
 (1/1) type_specific.io-github-autotest-libvirt.migration_with_copy_storage.async_job.query_domain_job_info.copy_storage_all.p2p: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.migration_with_copy_storage.async_job.query_domain_job_info.copy_storage_all.p2p: PASS (202.06 s)