### PR TITLE
migration: Fix incorrect path issue

### DIFF
--- a/libvirt/tests/cfg/migration/migration_with_vtpm/migration_with_vtpm_state_on_block_dev.cfg
+++ b/libvirt/tests/cfg/migration/migration_with_vtpm/migration_with_vtpm_state_on_block_dev.cfg
@@ -64,6 +64,6 @@
             file_name = "${dir_name}2-00.permall"
             block_dir = "${block_path}/${dir_name}"
             tpm_dict = {'tpm_model': '${tpm_model}', 'backend': {'backend_type': 'emulator', 'backend_version': '2.0', 'encryption_secret': '0051c505-1ad0-4d77-9b3e-360c8f5e3b86', 'source': {'type': 'file', 'path': '${block_dir}/${file_name}'}}}
-            check_lables_1 = '[r"tss  tss  system_u:object_r:virt_var_lib_t:s0.*.", r"root root unconfined_u:object_r:default_t:s0.*.."]'
+            check_lables_1 = '[r"tss  tss  system_u:object_r:virt_var_lib_t:s0.*.", r"root root unconfined_u:object_r:virt_var_lib_t:s0.*.."]'
             check_lables_2 = '[r"tss  tss  system_u:object_r:svirt_image_t:s0:c.*${file_name}"]'
             check_lables_3 = '[r"tss  tss  system_u:object_r:virt_var_lib_t:s0.*${file_name}"]'

--- a/libvirt/tests/src/migration/migration_with_vtpm/migration_with_vtpm_state_on_block_dev.py
+++ b/libvirt/tests/src/migration/migration_with_vtpm/migration_with_vtpm_state_on_block_dev.py
@@ -139,6 +139,10 @@ def prepare_iscsi_disk(params, test, block_dev):
     process.run(cmd, shell=True, verbose=True)
     remote.run_remote_cmd(cmd, params, ignore_status=False)
 
+    cmd = f'cat /etc/selinux/targeted/contexts/files/file_contexts.local|grep iscsiswtpm'
+    process.run(cmd, shell=True, verbose=True)
+    remote.run_remote_cmd(cmd, params, ignore_status=False)
+
     cmd = f"mkfs.xfs -f {dev_target}"
     remote.run_remote_cmd(cmd, params, ignore_status=False)
 
@@ -207,13 +211,13 @@ def run(test, params, env):
         test.log.info("Setup steps for auto_create_file.")
         process.run(f"mkdir {block_dir}", shell=True, verbose=True)
         utils_disk.mount(dev_src, block_dir)
-        process.run(f"restorecon -Rv {block_dir}", shell=True, verbose=True)
+        process.run(f"restorecon -Rv {block_path}", shell=True, verbose=True)
         process.run(f"chown tss:tss {block_dir}", shell=True, verbose=True)
 
         server_session = remote.wait_for_login("ssh", server_ip, "22", server_user, server_pwd, r"[\#\$]\s*$")
         remote.run_remote_cmd(f"mkdir {block_dir}", params, ignore_status=False)
         utils_disk.mount(dev_target, block_dir, session=server_session)
-        remote.run_remote_cmd(f"restorecon -Rv {block_dir}", params, ignore_status=False)
+        remote.run_remote_cmd(f"restorecon -Rv {block_path}", params, ignore_status=False)
         remote.run_remote_cmd(f"chown tss:tss {block_dir}", params, ignore_status=False)
         server_session.close()
 


### PR DESCRIPTION
Due to an incorrect restorecon path, the expected matching string could not be found. So update script.

Before:
Unable to find root root unconfined_u:object_r:default_t:s0.*.. in total 0&#10;drwxr-xr-x. 2 tss  tss  system_u:object_r:virt_var_lib_t:s0  6 Jun  5 07:11 .&#10;drwxr-xr-x. 3 root root system_u:object_r:var_t:s0          24 Jun  5 07:12 ..

After:
 (1/1) type_specific.io-github-autotest-libvirt.migration_with_vtpm.migration_with_vtpm_state_on_block_dev.auto_create_file: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.migration_with_vtpm.migration_with_vtpm_state_on_block_dev.auto_create_file: PASS (276.74 s)