### PR TITLE
contributor guidelines: fix link

### DIFF
--- a/contributor_reviewer_maintainer_guidelines.rst
+++ b/contributor_reviewer_maintainer_guidelines.rst
@@ -1,2 +1,2 @@
 Please follow up the same best practices as avocado-vt:
-https://github.com/avocado-framework/avocado-vt/blob/master/PR_Review_And_Contribute_Practices.txt
+https://github.com/avocado-framework/avocado-vt/blob/master/docs/source/contributing/Guidelines.rst


### PR DESCRIPTION
Links to avocado-vt contributor guidelines. That file was moved. Fix url.