### PR TITLE
migration: Update error message

### DIFF
--- a/libvirt/tests/cfg/migration/destructive_operations_around_live_migration/kill_qemu_during_performphase.cfg
+++ b/libvirt/tests/cfg/migration/destructive_operations_around_live_migration/kill_qemu_during_performphase.cfg
@@ -47,7 +47,7 @@
             expected_dest_state = "nonexist"
             expected_src_state = "running"
             migrate_speed = "1"
-            err_msg = "QEMU unexpectedly closed the monitor"
+            err_msg = "QEMU unexpectedly closed the monitor|Unable to read from socket: Connection reset by peer"
             check_disk_on_dest = "no"
             virsh_migrate_extra = "--bandwidth 1000"
         - kill_dest_qemu_after_vm_paused:
@@ -58,7 +58,7 @@
             expected_dest_state = "nonexist"
             expected_src_state = "running"
             virsh_migrate_extra = "--timeout 2 --timeout-suspend --bandwidth 1000"
-            err_msg = "QEMU unexpectedly closed the monitor"
+            err_msg = "QEMU unexpectedly closed the monitor|Unable to read from socket: Connection reset by peer"
         - kill_src_qemu:
             expected_dest_state = "nonexist"
             expected_src_state = "shut off"


### PR DESCRIPTION
Before:
Can not find the expected patterns 'QEMU unexpectedly closed the monitor' in output 'Migration: [ 1.27 %] Migration: [ 4.48 %] Migration: [ 7.64 %] Migration: [10.39 %] Migration: [13.14 %] Migration: [16.00 %] Migration: [18.91 %] Migration: [21.63 %] Migration: [27.08 %] Migration: [37.57 %] Migration: [82.07 %]error: operation failed: job 'migration out' failed: Unable to read from socket: Connection reset by peer'

After:
 (1/1) type_specific.io-github-autotest-libvirt.migration.destructive_operations_around_live_migration.kill_qemu_during_performphase.kill_dest_qemu_after_vm_paused.with_precopy.non_p2p: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.migration.destructive_operations_around_live_migration.kill_qemu_during_performphase.kill_dest_qemu_after_vm_paused.with_precopy.non_p2p: PASS (201.39 s)