### PR TITLE
Inc_backup: fix "Backup job should be canceled but not" error

### DIFF
--- a/libvirt/tests/cfg/incremental_backup/incremental_backup_push_mode.cfg
+++ b/libvirt/tests/cfg/incremental_backup/incremental_backup_push_mode.cfg
@@ -24,6 +24,12 @@
                             variants:
                                 - target_file_not_exist:
                                     prepare_target_file = "no"
+                                - destroy_vm:
+                                    only original_disk_local.coldplug_disk.backup_to_raw.backup_to_file
+                                    error_operation = "destroy_vm"
+                                    expect_backup_canceled = "yes"
+                                    original_disk_size = "5000M"
+                                    dd_count = "2000"
                         - positive_test:
                 - not_reuse_target_file:
         - backup_to_block:
@@ -37,11 +43,6 @@
                             backup_error = "yes"
                             prepare_target_blkdev = "no"
                             target_blkdev_path = "/dev/not/exist"
-                        - destroy_vm:
-                            only original_disk_local.coldplug_disk.backup_to_raw.backup_to_block
-                            expect_backup_canceled = "yes"
-                            original_disk_size = "5000M"
-                            dd_count = "2000"
                         - kill_qemu:
                             only original_disk_local.hotplug_disk.backup_to_qcow2.backup_to_block
                             expect_backup_canceled = "yes"


### PR DESCRIPTION
Sometimes we can't destroy guest after backup because of "resource busy". This mainly happens with backup_to_block case. Because block type backup file may take more time than file type backup file on backup-begin process, which causes the resouce busy. So this PR is changed the destroy_vm test to backup_to_file.