### PR TITLE
migration: Fix connect sock issue

### DIFF
--- a/libvirt/tests/src/migration/migration_with_vtpm/migration_with_external_tpm.py
+++ b/libvirt/tests/src/migration/migration_with_vtpm/migration_with_external_tpm.py
@@ -101,13 +101,13 @@ def launch_external_swtpm(params, test, skip_setup=False, on_remote=False):
                 remote.run_remote_cmd(cmd1, params)
             else:
                 process.run(cmd1, ignore_status=False, shell=True)
+        cmd2 = ("nohup swtpm socket --ctrl type=unixio,path=%s,mode=0600 --tpmstate"
+                "dir=%s,mode=0600 --tpm2 --terminate > /dev/null 2>&1 & disown") % (source_socket, statedir)
         if on_remote:
-            cmd2 = "nohup swtpm socket --ctrl type=unixio,path=%s,mode=0600 --tpmstate dir=%s,mode=0600 --tpm2 --terminate > /dev/null 2>&1 &" % (source_socket, statedir)
             remote.run_remote_cmd(cmd2, params)
             remote.run_remote_cmd('chcon -t svirt_image_t %s' % source_socket, params)
             remote.run_remote_cmd('chown qemu:qemu %s' % source_socket, params)
         else:
-            cmd2 = "swtpm socket --ctrl type=unixio,path=%s,mode=0600 --tpmstate dir=%s,mode=0600 --tpm2 --terminate &" % (source_socket, statedir)
             process.run(cmd2, ignore_status=False, shell=True, ignore_bg_processes=True)
             process.run("ps aux|grep 'swtpm socket'|grep -v avocado-runner-avocado-vt|grep -v grep", ignore_status=True, shell=True)
             # Make sure the socket is created


### PR DESCRIPTION
Failed to run virtiofsd/swtpm command on target host which lead to 'Permission denied' error. So update case.

Before:
Command '/bin/virsh attach-device avocado-vt-vm1 /var/tmp/xml_utils_temp_0g89yjed.xml' failed.&#10;stdout: b'\n'&#10;stderr: b"error: Failed to attach device from /var/tmp/xml_utils_temp_0g89yjed.xml\nerror: internal error: unable to execute QEMU command 'chardev-add': Failed to add chardev 'chr-vu-fs0': Failed to connect to '/var/vm001-vhost-fs.sock': Permission denied\n"

VM 'avocado-vt-vm1' failed to start: error: Failed to start domain 'avocado-vt-vm1'&#10;error: internal error: process exited while connecting to monitor: 2025-06-09T16:59:09.005669Z qemu-kvm: -chardev socket,id=chrtpm,path=/var/tmp/guest-swtpm.sock: Failed to connect to '/var/tmp/guest-swtpm.sock': Permission denied(exit status: 1)

After:
 (1/1) type_specific.io-github-autotest-libvirt.migration.migration_with_virtiofs.migration_with_externally_launched_virtiofs_dev.with_precopy: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.migration.migration_with_virtiofs.migration_with_externally_launched_virtiofs_dev.with_precopy: PASS (205.86 s)

 (1/1) type_specific.io-github-autotest-libvirt.migration_with_vtpm.migration_with_external_tpm.persistent_and_p2p: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.migration_with_vtpm.migration_with_external_tpm.persistent_and_p2p: PASS (220.01 s)