### PR TITLE
connectivity: Disable Reverse Path Filtering for ping

### DIFF
--- a/libvirt/tests/src/virtual_network/connectivity/connectivity_check_ethernet_interface.py
+++ b/libvirt/tests/src/virtual_network/connectivity/connectivity_check_ethernet_interface.py
@@ -144,10 +144,14 @@ def run(test, params, env):
                 mac_addr: ips,
                 mac_addr_2: {'outside_ip': vm_default_gw}
             }
+            LOG.debug('Disabling Reverse Path Filtering by default')
+            session.cmd('sysctl -w net.ipv4.conf.all.rp_filter=0')
             for mac in (mac_addr, mac_addr_2):
                 iface_vm_info = utils_net.get_linux_iface_info(
                     mac=mac, session=session)
                 iface_vm = iface_vm_info['ifname']
+                LOG.debug(f'Disabling Reverse Path Filtering for {iface_vm}')
+                session.cmd(f'sysctl -w net.ipv4.conf.{iface_vm}.rp_filter=0')
                 LOG.debug(f'Check connetivity of iface {iface_vm}({mac})')
                 ping_args = {
                     'vm_ping_outside': {'interface': iface_vm},


### PR DESCRIPTION
For the guest with multiple interfaces, the asymmetric routing may send the ICMP packets from one interface and receive them by another interface. For example:
\# ping 1.1.1.1 -I enp7s0
PING 1.1.1.1 (1.1.1.1) from 192.168.122.252 enp7s0: 56(84) bytes of data

Capturing on 'enp1s0'
    1 0.000000000      1.1.1.1 → 192.168.122.252 ICMP 98 Echo (ping) reply    id=0x0007, seq=1295/3845, ttl=52
    2 0.511943887      1.1.1.1 → 192.168.122.252 ICMP 98 Echo (ping) reply    id=0x000c, seq=29/7424, ttl=52

If the rp_filter[1] is enabled, Linux will refuse the replied ICMP packets and cause packets loss.

[1]: https://sysctl-explorer.net/net/ipv4/rp_filter/