### PR TITLE
[virsh metadata] change the checking logic for missing metadata

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_metadata.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_metadata.cfg
@@ -31,9 +31,11 @@
             variants:
                 - config_current_option:
                     metadata_set = "yes"
+                    metadata_empty = "yes"
                     metadata_option = "--config --current"
                 - live_current_option:
                     metadata_set = "yes"
+                    metadata_empty = "yes"
                     metadata_option = "--live --current"
                 - invalid_option:
                     metadata_option = "--xyz"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_metadata.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_metadata.py
@@ -38,6 +38,7 @@ def run(test, params, env):
     virsh_dargs = {'debug': True, 'ignore_status': True}
     metadata_set = "yes" == params.get("metadata_set", "no")
     metadata_get = "yes" == params.get("metadata_get", "yes")
+    metadata_empty = "yes" == params.get("metadata_empty", "no")
     metadata_remove = "yes" == params.get("metadata_remove", "no")
     restart_libvirtd = "yes" == params.get("restart_libvirtd", "no")
     status_error = "yes" == params.get("status_error", "no")
@@ -112,6 +113,9 @@ def run(test, params, env):
                                         **virsh_dargs)
                 check_result(result, status_error)
         # Get metadata
+        if metadata_empty and libvirt_version.version_compare(11, 3, 0):
+            status_error = False
+            metadata_value = ""
         for option in metadata_option.split():
             if option == "--config":
                 vm.destroy()


### PR DESCRIPTION
from libvirt 11.3.0, instead of return status error, libvirt will return an empty string if there is no metadata to be returned Added a new parameter 'metadata_empty' for the negative test cases. This parameter is used to verify that the metadata were not altered by the preceding command.

refer to
https://gitlab.com/libvirt/libvirt/-/commit/312088d9b62334c950310f369b2e0fe2302a74a3 --- tools: virsh: metadata: do not report error on missing metadata