### PR TITLE
add case for virsh net-desc cmd

### DIFF
--- a/libvirt/tests/cfg/virtual_network/network/virsh_cmds/virsh_net_desc.cfg
+++ b/libvirt/tests/cfg/virtual_network/network/virsh_cmds/virsh_net_desc.cfg
@@ -1,0 +1,47 @@
+- virtual_network.network.net_desc:
+    type = virsh_net_desc
+    net_name = "default"
+    func_supported_since_libvirt_ver = (9, 8, 0)
+    variants update_method:
+        - cmdline:
+        - edit_space:
+    variants update_item:
+        - title:
+            net_title = "network title"
+            execute_cmd =" --title '${net_title}'"
+            expected_xml = '<title>${net_title}</title>'
+            expected_str = ${net_title}
+            net_title_update = "network title update"
+            execute_update_cmd =" --title '${net_title_update}'"
+            expected_update_xml = '<title>${net_title_update}</title>'
+            expected_update_str = ${net_title_update}
+            remove_opt = " --title '' "
+            removed_msg = "No title for network: default"
+            get_cmd = ' --title'
+        - description:
+            net_desc = "network description"
+            execute_cmd = "${net_desc}"
+            expected_xml = '<description>${net_desc}</description>'
+            expected_str = ${net_desc}
+            net_desc_update = "network description update"
+            execute_update_cmd =" ${net_desc_update}"
+            expected_update_xml = '<description>${net_desc_update}</description>'
+            expected_update_str = ${net_desc_update}
+            remove_opt = "''"
+            removed_msg = "No description for network: default"
+            get_cmd = ' '
+    variants network_states:
+        - active_net:
+        - inactive_net:
+    variants:
+        - live:
+            opt = ' --live'
+            inactive_net:
+                error_msg = "error: Requested operation is not valid: network is not running"
+        - config:
+            opt = ' --config'
+        - current:
+            opt = ' --current'
+        - opt_none:
+            no inactive_net
+            opt = ' '

--- a/libvirt/tests/src/virtual_network/network/virsh_cmd/virsh_net_desc.py
+++ b/libvirt/tests/src/virtual_network/network/virsh_cmd/virsh_net_desc.py
@@ -1,0 +1,196 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright Redhat
+#
+#   SPDX-License-Identifier: GPL-2.0
+
+#   Author: Nannan Li<nanli@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import aexpect
+import re
+
+from virttest import libvirt_version
+from virttest import remote
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_test import libvirt
+from virttest.utils_libvirt import libvirt_network
+from virttest.libvirt_xml.network_xml import NetworkXML
+
+VIRSH_ARGS = {'ignore_status': False, 'debug': True}
+
+
+def virsh_net_desc(test, params, cmd):
+    """
+    Edit description or title with virsh net-desc by cmdline or
+    edit space according to scenario.
+
+    :params: test: test object.
+    :params: params: cfg parameter dict.
+    :params: cmd: virsh desc updating cmd, delete all content if cmd is empty.
+    """
+    update_method = params.get("update_method")
+    update_options = params.get("opt")
+    net_name = params.get("net_name")
+    error_msg = params.get("error_msg")
+
+    if update_method == "cmdline":
+        result = virsh.net_desc(net_name, extra=cmd+update_options, debug=True)
+        libvirt.check_exit_status(result, error_msg)
+
+    elif update_method == "edit_space":
+        send_cmd = r"virsh net-desc %s %s --edit %s" % (net_name, cmd, update_options)
+        test.log.debug("Send cmd: %s", send_cmd)
+        session = aexpect.ShellSession("sudo -s")
+        try:
+            session.sendline(send_cmd)
+            session.send('\x1b')
+            session.send('ZZ')
+            remote.handle_prompts(session, None, None, r"[\#\$]\s*$")
+        except Exception as e:
+            if not error_msg:
+                test.fail("Error occurred: %s when virsh net-desc --edit" % str(e))
+        session.close()
+
+
+def check_net_desc_result(test, params, get_cmd, expected_string, existed=True):
+    """
+    Get and check desc or title  by virsh net-desc cmd.
+
+    :params: test, test object.
+    :params: params, params object.
+    :params: get_cmd, the get cmd for virsh net-desc.
+    :params: expected_string, expected result string.
+    :params: existed, the flag of expected result string exist or not.
+    """
+    net_name = params.get("net_name")
+    update_options = params.get("opt")
+
+    result = virsh.net_desc(net_name, extra=get_cmd+update_options, debug=True)
+    if existed:
+        if result.stdout.strip() != expected_string:
+            test.fail('Expect "%s" was existed.' % expected_string)
+    else:
+        if result.stderr.strip() != expected_string:
+            test.fail('Expect "%s" was not existed.' % expected_string)
+    test.log.debug("Check '%s' PASS in virsh net-desc", expected_string)
+
+
+def _confirm_existed(params, dumpxml_opt, check_remove):
+    """
+    Get existed value according to the scenario.
+
+    :params: params, params object.
+    :params: dumpxml_opt, virsh net-dumpxml option, '--inactive' or ''
+    :params: check_remove, check net-dumpxml after removing.
+    :return: expected xml was existed flag.
+    """
+    opt = params.get('opt')
+    network_states = params.get('network_states')
+
+    existed = True
+    if ((dumpxml_opt == " " and opt == ' --config' and network_states == 'active_net')
+            or (dumpxml_opt == " --inactive" and opt == " --live")
+            or (dumpxml_opt == " --inactive" and network_states == 'active_net' and opt in [' --current', ' '])
+            or check_remove):
+        existed = False
+
+    return existed
+
+
+def check_net_dumpxml(test, params, expected_xml, check_remove=False):
+    """
+    Check if expected xml in virsh net-dumpxml.
+
+    :params: test, test object.
+    :params: params, params object.
+    :params: expected_xml, expected xml string.
+    :params: check_remove, check net-dumpxml after removing, default False
+    """
+    net_name = params.get("net_name")
+
+    dumpxml_opt = [" ",  " --inactive"]
+    for dump in dumpxml_opt:
+        existed = _confirm_existed(params, dump, check_remove)
+        result = virsh.net_dumpxml(net_name, dump, debug=True).stdout.strip()
+        if existed:
+            if not re.findall(expected_xml, result):
+                test.fail('Expect %s was existed' % expected_xml)
+        else:
+            if re.findall(expected_xml, result):
+                test.fail('Expect %s was not existed' % expected_xml)
+    test.log.debug("Checked '%s' PASS in active and inactive xml" % expected_xml)
+
+
+def run(test, params, env):
+    """
+    Test 'virsh net-desc' with different options to show or modify network description
+     or title.
+    """
+    def setup_test():
+        """
+        Prepare network status.
+        """
+        test.log.info("TEST_SETUP: Prepare network status.")
+        libvirt_network.ensure_default_network()
+        if network_states == "inactive_net":
+            virsh.net_destroy(net_name, **VIRSH_ARGS)
+
+    def run_test():
+        """
+        1. Update and remove network description or title.
+        2. Check description xml is existed or removed.
+        """
+        test.log.info("TEST_STEP1：Set a %s xml for network." % update_item)
+        virsh_net_desc(test, params, execute_cmd)
+        if error_msg:
+            return
+
+        test.log.info("TEST_STEP2: Check correct %s xml in network." % update_item)
+        check_net_desc_result(test, params, get_cmd, expected_str)
+        check_net_dumpxml(test, params, expected_xml)
+
+        test.log.info("TEST_STEP3-4: Modify and check %s xml in network." % update_item)
+        virsh_net_desc(test, params, execute_update_cmd)
+        check_net_desc_result(test, params, get_cmd, expected_update_str)
+        check_net_dumpxml(test, params, expected_update_xml)
+
+        test.log.info("TEST_STEP5-6: Remove and check %s xml in network." % update_item)
+        virsh_net_desc(test, params, remove_opt)
+        check_net_desc_result(test, params, get_cmd, removed_msg)
+        check_net_dumpxml(test, params, expected_update_xml, check_remove=True)
+
+    def teardown_test():
+        """
+        Clean data.
+        """
+        test.log.info("TEST_TEARDOWN: Clean up env.")
+        bk_net.sync()
+        bkxml.sync()
+        libvirt_network.ensure_default_network()
+
+    libvirt_version.is_libvirt_feature_supported(params)
+    vm_name = params.get('main_vm')
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+    default_net = NetworkXML.new_from_net_dumpxml('default')
+    bk_net = default_net.copy()
+
+    net_name = params.get("net_name")
+    network_states = params.get("network_states")
+    update_item = params.get("update_item")
+    error_msg = params.get("error_msg")
+    remove_opt = params.get("remove_opt")
+    removed_msg = params.get("removed_msg")
+    get_cmd = params.get("get_cmd")
+    execute_cmd, execute_update_cmd = params.get('execute_cmd'), params.get("execute_update_cmd")
+    expected_str, expected_update_str = params.get("expected_str"), params.get("expected_update_str")
+    expected_xml, expected_update_xml = params.get("expected_xml"), params.get("expected_update_xml")
+
+    try:
+        setup_test()
+        run_test()
+
+    finally:
+        teardown_test()


### PR DESCRIPTION
   xxxx-300439: Test virsh net-desc with different options to show or modify network description or title.
Signed-off-by: nanli <nanli@redhat.com>

https://github.com/avocado-framework/avocado-vt/pull/4144 
```
avocado run --vt-type libvirt --vt-machine-type q35 virtual_network.network.net_desc
(01/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.live.active_net.title.cmdline: STARTED
 (01/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.live.active_net.title.cmdline: PASS (9.34 s)
 (02/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.live.active_net.title.edit_space: STARTED
 (02/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.live.active_net.title.edit_space: PASS (11.44 s)
 (03/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.live.active_net.description.cmdline: STARTED
 (03/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.live.active_net.description.cmdline: PASS (9.70 s)
 (04/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.live.active_net.description.edit_space: STARTED
 (04/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.live.active_net.description.edit_space: PASS (11.38 s)
 (05/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.live.inactive_net.title.cmdline: STARTED
 (05/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.live.inactive_net.title.cmdline: PASS (8.56 s)
 (06/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.live.inactive_net.title.edit_space: STARTED
 (06/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.live.inactive_net.title.edit_space: PASS (11.75 s)
 (07/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.live.inactive_net.description.cmdline: STARTED
 (07/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.live.inactive_net.description.cmdline: PASS (8.61 s)
 (08/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.live.inactive_net.description.edit_space: STARTED
 (08/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.live.inactive_net.description.edit_space: PASS (9.45 s)
 (09/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.config.active_net.title.cmdline: STARTED
 (09/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.config.active_net.title.cmdline: PASS (12.96 s)
 (10/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.config.active_net.title.edit_space: STARTED
 (10/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.config.active_net.title.edit_space: PASS (11.49 s)
 (11/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.config.active_net.description.cmdline: STARTED
 (11/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.config.active_net.description.cmdline: PASS (9.61 s)
 (12/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.config.active_net.description.edit_space: STARTED
 (12/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.config.active_net.description.edit_space: PASS (11.48 s)
 (13/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.config.inactive_net.title.cmdline: STARTED
 (13/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.config.inactive_net.title.cmdline: PASS (9.52 s)
 (14/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.config.inactive_net.title.edit_space: STARTED
 (14/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.config.inactive_net.title.edit_space: PASS (11.29 s)
 (15/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.config.inactive_net.description.cmdline: STARTED
 (15/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.config.inactive_net.description.cmdline: PASS (8.97 s)
 (16/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.config.inactive_net.description.edit_space: STARTED
 (16/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.config.inactive_net.description.edit_space: PASS (11.29 s)
 (17/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.current.active_net.title.cmdline: STARTED
 (17/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.current.active_net.title.cmdline: PASS (9.44 s)
 (18/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.current.active_net.title.edit_space: STARTED
 (18/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.current.active_net.title.edit_space: PASS (11.43 s)
 (19/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.current.active_net.description.cmdline: STARTED
 (19/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.current.active_net.description.cmdline: PASS (9.13 s)
 (20/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.current.active_net.description.edit_space: STARTED
 (20/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.current.active_net.description.edit_space: PASS (11.37 s)
 (21/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.current.inactive_net.title.cmdline: STARTED
 (21/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.current.inactive_net.title.cmdline: PASS (8.79 s)
 (22/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.current.inactive_net.title.edit_space: STARTED
 (22/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.current.inactive_net.title.edit_space: PASS (11.26 s)
 (23/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.current.inactive_net.description.cmdline: STARTED
 (23/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.current.inactive_net.description.cmdline: PASS (9.20 s)
 (24/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.current.inactive_net.description.edit_space: STARTED
 (24/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.current.inactive_net.description.edit_space: PASS (11.38 s)
 (25/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.opt_none.active_net.title.cmdline: STARTED
 (25/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.opt_none.active_net.title.cmdline: PASS (8.95 s)
 (26/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.opt_none.active_net.title.edit_space: STARTED
 (26/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.opt_none.active_net.title.edit_space: PASS (11.29 s)
 (27/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.opt_none.active_net.description.cmdline: STARTED
 (27/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.opt_none.active_net.description.cmdline: PASS (9.04 s)
 (28/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.opt_none.active_net.description.edit_space: STARTED
 (28/28) type_specific.io-github-autotest-libvirt.virtual_network.network.net_desc.opt_none.active_net.description.edit_space: PASS (11.53 s)


```