### PR TITLE
Virtual_disk: fix error message to match new change

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_iothreads_queue.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_iothreads_queue.cfg
@@ -82,7 +82,7 @@
             func_supported_since_libvirt_ver = (10, 10, 0)
             check_qemu_pattern =
             status_error = yes
-            err_msg = "error: Operation not supported: cannot modify field '<iothreads>' \(or it's parts\) of the disk*"
+            err_msg = "error: Operation not supported: cannot modify .*iothreads.* of the disk"
             variants:
                 - change_none_to_roundrobin:
                     only coldplug..round_robin


### PR DESCRIPTION
Update the error message to also cover "Operation not supported: cannot modify '<iothreads>' configuration of the disk".