### PR TITLE
passt_function: Allow multiple nexthops

### DIFF
--- a/libvirt/tests/cfg/virtual_network/passt/passt_attach_detach.cfg
+++ b/libvirt/tests/cfg/virtual_network/passt/passt_attach_detach.cfg
@@ -5,7 +5,7 @@
     outside_ip = 'www.redhat.com'
     start_vm = no
     mtu = 65520
-    multiple_nexthops = no
+    multiple_nexthops = yes
     variants user_type:
         - root_user:
             test_user = root

--- a/libvirt/tests/cfg/virtual_network/passt/passt_function.cfg
+++ b/libvirt/tests/cfg/virtual_network/passt/passt_function.cfg
@@ -5,7 +5,7 @@
     outside_ip = 'www.redhat.com'
     start_vm = no
     mtu = 65520
-    multiple_nexthops = no
+    multiple_nexthops = yes
     variants user_type:
         - root_user:
             test_user = root


### PR DESCRIPTION
The cases will failed with error "FAIL: Host default ipv6 gateway not consistent with vm" for the host with multiple nexthops in default route like: default proto ra metric 100 pref medium
	nexthop via fe80::4a5a:d01:f631:3320 dev eno1 weight 1
	nexthop via fe80::4a5a:d01:f631:2420 dev eno1 weight 1

Allow multiple nexthops to fix the failures.