### PR TITLE
add case for virtnetworkd not block host shutdown

### DIFF
--- a/libvirt/tests/cfg/virtual_network/network/block_test/virtnetworkd_unblock_systemd_inibit.cfg
+++ b/libvirt/tests/cfg/virtual_network/network/block_test/virtnetworkd_unblock_systemd_inibit.cfg
@@ -1,0 +1,20 @@
+- virtual_network.network.block_test:
+    type = virtnetworkd_unblock_systemd_inibit
+    start_vm = 'no'
+    take_regular_screendumps = no
+    cmd = "systemd-inhibit"
+    check_pattern = "virtnetworkd"
+    func_supported_since_libvirt_ver = (10, 10, 0)
+    variants service:
+        - virtnetworkd_unblock_systemd_inibit:
+    variants preset_net:
+        - default_net:
+            net_name = "default"
+        - define_net:
+            net_name = "network_conn"
+            forward = "'forward': {'mode': 'route'}"
+            ipv4_attrs = {'netmask': '255.255.255.0', 'address': '192.168.144.1', 'dhcp_ranges': {'attrs': {'end': '192.168.144.254', 'start': '192.168.144.2'}}}
+            network_attrs = {'name': '${net_name}', ${forward}, 'ips': [${ipv4_attrs}]}
+    variants network_states:
+        - active_net:
+        - inactive_net:

--- a/libvirt/tests/src/virtual_network/network/block_test/virtnetworkd_unblock_systemd_inibit.py
+++ b/libvirt/tests/src/virtual_network/network/block_test/virtnetworkd_unblock_systemd_inibit.py
@@ -1,0 +1,73 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright Redhat
+#
+#   SPDX-License-Identifier: GPL-2.0
+
+#   Author: Nannan Li<nanli@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import re
+
+from avocado.utils import process
+
+from virttest import libvirt_version
+from virttest import virsh
+from virttest.libvirt_xml.network_xml import NetworkXML
+from virttest.utils_libvirt import libvirt_network
+
+
+def run(test, params, env):
+    """
+    Test virtnetworkd should not block host OS shutdown.
+    """
+    def setup_test():
+        """
+        Prepare network and its status.
+        """
+        test.log.info("TEST_SETUP: Prepare network and its status.")
+        if preset_net == "define_net":
+            libvirt_network.create_or_del_network(network_attrs)
+            test.log.debug(f'{virsh.net_dumpxml(net_name).stdout_text}')
+
+        if network_states == "inactive_net":
+            virsh.net_destroy(net_name, debug=True)
+
+    def run_test():
+        """
+        Check systemd-inhibit for virtnetworkd not existing in the list.
+        """
+        test.log.info("TEST_STEP1：Check systemd-inhibit")
+        result = process.run(cmd, shell=True).stdout_text.strip()
+        if re.findall(check_pattern, result):
+            test.fail("Expected no '%s'", check_pattern)
+        test.log.debug("Check systemd-inhibit PASS")
+
+    def teardown_test():
+        """
+        Recover network.
+        """
+        test.log.info("TEST_TEARDOWN: Recover network.")
+        if preset_net == "default_net":
+            bk_net.sync()
+            libvirt_network.ensure_default_network()
+        else:
+            libvirt_network.create_or_del_network(network_attrs, is_del=True)
+
+    libvirt_version.is_libvirt_feature_supported(params)
+    net_name = params.get("net_name")
+    preset_net = params.get("preset_net")
+    if preset_net == "default_net":
+        default_net = NetworkXML.new_from_net_dumpxml(net_name)
+        bk_net = default_net.copy()
+    cmd = params.get("cmd")
+    network_states = params.get("network_states")
+    network_attrs = eval(params.get('network_attrs', '{}'))
+    check_pattern = params.get("check_pattern")
+
+    try:
+        setup_test()
+        run_test()
+
+    finally:
+        teardown_test()


### PR DESCRIPTION
    xxxx-304214:virtnetworkd should not block host OS shutdown when a virtual network is active
Signed-off-by: nanli <nanli@redhat.com>

```
avocado run --vt-type libvirt --vt-machine-type q35 virtual_network.network.block_test

 (1/4) type_specific.io-github-autotest-libvirt.virtual_network.network.block_test.active_net.default_net.virtnetworkd_unblock_systemd_inibit: PASS (6.71 s)
 (2/4) type_specific.io-github-autotest-libvirt.virtual_network.network.block_test.active_net.define_net.virtnetworkd_unblock_systemd_inibit: PASS (6.60 s)
 (3/4) type_specific.io-github-autotest-libvirt.virtual_network.network.block_test.inactive_net.default_net.virtnetworkd_unblock_systemd_inibit: PASS (6.68 s)
 (4/4) type_specific.io-github-autotest-libvirt.virtual_network.network.block_test.inactive_net.define_net.virtnetworkd_unblock_systemd_inibit: PASS (6.37 s)

```