### PR TITLE
Delete a negative test with invalid setting

### DIFF
--- a/libvirt/tests/cfg/save_and_restore/save_with_formats.cfg
+++ b/libvirt/tests/cfg/save_and_restore/save_with_formats.cfg
@@ -12,8 +12,3 @@
                 - gzip:
                 - bzip2:
                 - xz:
-        - negative_test:
-            status_error = yes
-            variants save_format:
-                - abc:
-                    error_msg = Invalid save image format specified in configuration file


### PR DESCRIPTION
There was a negative test to save with formats as "abc". The behavior changes to handel such kind of settings in qemu.conf. Before, the setting can be saved and the daemon can start, but virsh save failed; Now, the daemon can not start with such invalid setting. Delete this negative test as it can not cause any problem if daemon can not start with it.