### PR TITLE
nodedev_persistence: fix default configuration

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_persistence_mdev.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/nodedev/virsh_nodedev_persistence_mdev.cfg
@@ -2,6 +2,7 @@
     type = virsh_nodedev_persistence_mdev
     start_vm = "no"
     func_supported_since_libvirt_ver = (7, 6, 0)
+    devid = dasd
     variants:
         - ccw:
             only s390-virtio

--- a/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_persistence_mdev.py
+++ b/libvirt/tests/src/virsh_cmd/nodedev/virsh_nodedev_persistence_mdev.py
@@ -24,6 +24,7 @@ def get_device_xml(schid):
     mdev_xml['type_id'] = 'vfio_ccw-io'
     mdev_xml['uuid'] = '8d312cf6-f92a-485c-8db8-ba9299848f46'
     device_xml.set_cap(mdev_xml)
+    LOG.debug(f"NodedevXML {device_xml}")
     return device_xml.xml
 
 
@@ -71,9 +72,10 @@ def run(test, params, env):
     """
 
     schid = None
+    devid = params.get("devid")
 
     try:
-        schid, _ = ccw.get_device_info()
+        schid, _ = ccw.get_device_info(devid)
         ccw.set_override(schid)
         nodedev_file_path = get_device_xml(schid)
         virsh.nodedev_define(nodedev_file_path, ignore_status=False, debug=True)


### PR DESCRIPTION
11d5316 changed the standard device selection for ccw/dasd. This test was missed, fix it now.

Also, log the nodedev XML for easier debugging.