### PR TITLE
Optimize to accommodate multiple error msg

### DIFF
--- a/libvirt/tests/cfg/memory/memory_devices/invalid_nvdimm_memory_device_config.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/invalid_nvdimm_memory_device_config.cfg
@@ -17,43 +17,43 @@
     variants invalid_setting:
         - exceed_slot:
             slot = '4294967295'
-            define_error = "memory device slot '${slot}' exceeds slots count"
+            define_error = ["memory device slot '${slot}' exceeds slots count"]
         - max_addr:
             addr_base = '0xffffffffffffffff'
-            start_vm_error = "address must be aligned to"
-            attach_error = "nvdimm is not enabled: missing 'nvdimm' in '-M'"
+            start_vm_error = ["address must be aligned to"]
+            attach_error = ["nvdimm is not enabled: missing 'nvdimm' in '-M'"]
             aarch64:
-                attach_error = "nvdimm is not enabled: add 'nvdimm=on' to '-M'"
+                attach_error = ["nvdimm is not enabled: add 'nvdimm=on' to '-M'"]
         - unexisted_node:
             guest_node = '6'
-            start_vm_error = "can't add memory backend for guest node '${guest_node}' as the guest has only '2' NUMA nodes configured"
+            start_vm_error = ["can't add memory backend for guest node '${guest_node}' as the guest has only '2' NUMA nodes configured"]
         - unexisted_path:
             nvdimm_path = "/tmp/nonexist.file"
-            start_vm_error = "No such file or directory"
+            start_vm_error = ["No such file or directory"]
         - invalid_alignsize:
             alignsize = '2'
             align_attrs = "'alignsize':${alignsize},'alignsize_unit': 'KiB'"
-            start_vm_error = "must be multiples of page size 0x1000"
+            start_vm_error = ["must be multiples of page size 0x1000"]
         - invalid_addr_type:
             addr_type = 'fakedimm'
-            define_error = "Invalid value for attribute 'type' in element 'address': '${addr_type}'"
-            define_error_8 = "unknown address type '${addr_type}'"
-            attach_error_8 = "unknown address type '${addr_type}'"
+            define_error = ["Invalid value for attribute 'type' in element 'address': '${addr_type}'"]
+            define_error_8 = ["unknown address type '${addr_type}'"]
+            attach_error_8 = ["unknown address type '${addr_type}'"]
         - small_label:
             label_size = 100
             label_attrs = "'label':{'size_unit':'KiB','size':${label_size}}"
-            define_error ="nvdimm label must be at least 128KiB"
+            define_error = ["nvdimm label must be at least 128KiB"]
         - bigger_label:
             label_size = 524289
             label_attrs = "'label':{'size_unit':'KiB','size':${label_size}}"
-            define_error ="label size must be smaller than NVDIMM size"
+            define_error = ["label size must be smaller than NVDIMM size"]
         - bigger_target_memory:
             target_size = 1048576
-            start_vm_error = "backing store size 0x20000000 does not match 'size' option 0x40000000"
+            start_vm_error = ["backing store size 0x20000000 does not match 'size' option 0x40000000", "backing store size 0x20000000 is too small for 'size' option 0x40000000"]
         - with_discard:
             mem_discard = "yes"
             discard_attr = " 'mem_discard':'${mem_discard}',"
-            define_error = "discard is not supported for nvdimms"
+            define_error = ["discard is not supported for nvdimms"]
     addr_attrs = "'address':{'attrs': {'type': '${addr_type}', 'base': '${addr_base}', 'slot': '${slot}'}}"
     source_attrs = "'source': {${align_attrs},'path': '${nvdimm_path}'}"
     target_attrs = "'target': {'size': ${target_size},'size_unit': 'KiB','node':${guest_node}, ${label_attrs}}"
@@ -67,3 +67,4 @@
             max_dict = '"max_mem_rt": 10485760, "max_mem_rt_slots":16, "max_mem_rt_unit": "KiB"'
             numa_attrs = "'vcpu': 4,'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '${numa_mem}', 'unit': 'KiB'},{'id':'1','cpus': '2-3','memory':'${numa_mem}','unit':'KiB'}]}"
             vm_attrs = {${numa_attrs}, ${max_dict}, 'memory_unit':'KiB','memory':${mem_value},'current_mem':${current_mem},'current_mem_unit':"KiB"}
+


### PR DESCRIPTION
Test result:
(01/10) type_specific.io-github-autotest-libvirt.memory.devices.invalid_nvdimm.with_numa.exceed_slot: STARTED
 (01/10) type_specific.io-github-autotest-libvirt.memory.devices.invalid_nvdimm.with_numa.exceed_slot: PASS (31.94 s)
 (02/10) type_specific.io-github-autotest-libvirt.memory.devices.invalid_nvdimm.with_numa.max_addr: STARTED
 (02/10) type_specific.io-github-autotest-libvirt.memory.devices.invalid_nvdimm.with_numa.max_addr: PASS (39.96 s)
 (03/10) type_specific.io-github-autotest-libvirt.memory.devices.invalid_nvdimm.with_numa.unexisted_node: STARTED
 (03/10) type_specific.io-github-autotest-libvirt.memory.devices.invalid_nvdimm.with_numa.unexisted_node: PASS (40.11 s)
 (04/10) type_specific.io-github-autotest-libvirt.memory.devices.invalid_nvdimm.with_numa.unexisted_path: STARTED
 (04/10) type_specific.io-github-autotest-libvirt.memory.devices.invalid_nvdimm.with_numa.unexisted_path: PASS (39.74 s)
 (05/10) type_specific.io-github-autotest-libvirt.memory.devices.invalid_nvdimm.with_numa.invalid_alignsize: STARTED
 (05/10) type_specific.io-github-autotest-libvirt.memory.devices.invalid_nvdimm.with_numa.invalid_alignsize: PASS (40.24 s)
 (06/10) type_specific.io-github-autotest-libvirt.memory.devices.invalid_nvdimm.with_numa.invalid_addr_type: STARTED
 (06/10) type_specific.io-github-autotest-libvirt.memory.devices.invalid_nvdimm.with_numa.invalid_addr_type: PASS (39.99 s)
 (07/10) type_specific.io-github-autotest-libvirt.memory.devices.invalid_nvdimm.with_numa.small_label: STARTED
 (07/10) type_specific.io-github-autotest-libvirt.memory.devices.invalid_nvdimm.with_numa.small_label: PASS (40.00 s)
 (08/10) type_specific.io-github-autotest-libvirt.memory.devices.invalid_nvdimm.with_numa.bigger_label: STARTED
 (08/10) type_specific.io-github-autotest-libvirt.memory.devices.invalid_nvdimm.with_numa.bigger_label: PASS (39.29 s)
 (09/10) type_specific.io-github-autotest-libvirt.memory.devices.invalid_nvdimm.with_numa.bigger_target_memory: STARTED
 (09/10) type_specific.io-github-autotest-libvirt.memory.devices.invalid_nvdimm.with_numa.bigger_target_memory: PASS (39.56 s)
 (10/10) type_specific.io-github-autotest-libvirt.memory.devices.invalid_nvdimm.with_numa.with_discard: STARTED
 (10/10) type_specific.io-github-autotest-libvirt.memory.devices.invalid_nvdimm.with_numa.with_discard: PASS (39.08 s)