### PR TITLE
Fix the avc inproper AVC check

### DIFF
--- a/libvirt/tests/src/save_and_restore/save_to_block.py
+++ b/libvirt/tests/src/save_and_restore/save_to_block.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 import re
 
@@ -34,6 +35,10 @@ def run(test, params, env):
 
     try:
         selinux_status = passt.ensure_selinux_enforcing()
+        # Record time for comparison avc log when finished
+        start_time = datetime.datetime.now()
+        unix_ts_start = start_time.timestamp()
+        LOG.debug('Start time is: %s', start_time)
         if namespaces:
             qemu_conf.namespaces = eval(namespaces)
             libvirtd.restart()
@@ -57,12 +62,22 @@ def run(test, params, env):
         LOG.debug(f'VM state after restore: {vm.state()}')
         if vm.state() != 'running':
             test.fail(f'VM should be running after restore, not {vm.state()}')
-
-        avc_denied = process.run("grep -E 'avc:.*denied' /var/log/audit/audit.log",
-                                 ignore_status=True).stdout_text.strip()
-        if avc_denied:
-            test.fail(f'Got avc denied:\n{avc_denied}')
-
+        # Record time for comparison avc log
+        end_time = datetime.datetime.now()
+        unix_ts_end = end_time.timestamp()
+        LOG.debug('End time is: %s', end_time)
+        avc_denied_log = process.run("grep -E 'avc:.*denied' /var/log/audit/audit.log",
+                                     ignore_status=True).stdout_text.strip()
+        # Filter matching lines
+        filtered_lines = []
+        for line in avc_denied_log.splitlines():
+            match = re.search(r"audit\((\d+\.\d+):\d+\)", line)
+            if match:
+                log_ts = float(match.group(1))
+                if unix_ts_start <= log_ts <= unix_ts_end:
+                    filtered_lines.append(line.strip())
+        if filtered_lines:
+            test.fail(f'Got avc denied:\n{filtered_lines}')
         save_base.post_save_check(vm, pid_ping, upsince)
         virsh.shutdown(vm_name, **VIRSH_ARGS)
     finally:


### PR DESCRIPTION
This test script checks for any AVC denials during test execution. However, it doesn't clear the audit log history before running, which causes the test to always fail. The script has been updated to check timestamps and only report a failure if AVC denials occur within the test start and end time window.