### PR TITLE
migration: Update loop time

### DIFF
--- a/libvirt/tests/cfg/migration/async_ops/query_info_during_migration.cfg
+++ b/libvirt/tests/cfg/migration/async_ops/query_info_during_migration.cfg
@@ -31,7 +31,7 @@
     loop_disk_type = "block"
     block_device = "${nfs_mount_dir}/query_info_test.img"
     migrate_speed = "15"
-    loop_time = "20"
+    loop_time = "10"
     variants:
         - p2p:
             virsh_migrate_options = '--live --p2p --verbose'

--- a/provider/migration/migration_base.py
+++ b/provider/migration/migration_base.py
@@ -293,7 +293,7 @@ def execute_statistics_command(params):
     """
     vm_name = params.get("migrate_main_vm")
     disk_type = params.get("loop_disk_type")
-    loop_time = params.get("loop_time", "20")
+    loop_time = params.get("loop_time", "1")
 
     vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
     if disk_type:


### PR DESCRIPTION
Update loop time to ensure the VM is in running state when executing the command.

Test result:
 (1/1) type_specific.io-github-autotest-libvirt.migration.async_ops.query_info_during_migration.with_postcopy.non_p2p: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.migration.async_ops.query_info_during_migration.with_postcopy.non_p2p: PASS (266.12 s)