### PR TITLE
v2v:fix the failed no-shutdown case

### DIFF
--- a/v2v/tests/cfg/specific_kvm.cfg
+++ b/v2v/tests/cfg/specific_kvm.cfg
@@ -355,7 +355,7 @@
                 - not_shutdown:
                     only default.kvm
                     only output_mode.local
-                    msg_content = 'virt-v2v: error:.*is running or paused.*must be shut down'
+                    msg_content = 'virt-v2v.*is running or paused'
                     expect_msg = 'yes'
                     variants:
                         - running:


### PR DESCRIPTION
The error message is changed after 9.7/10.1. So modify the msg_content accordingly.