### PR TITLE
Fix the avc denials

### DIFF
--- a/libvirt/tests/src/save_and_restore/restore_from_unqualified_file.py
+++ b/libvirt/tests/src/save_and_restore/restore_from_unqualified_file.py
@@ -45,6 +45,7 @@ def run(test, params, env):
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     bkxml = vmxml.copy()
     try:
+        process.run('chcon -t qemu_var_run_t "/var/tmp"', ignore_status=True, shell=True)
         if scenario == 'invalid':
             process.run(f'echo > {save_path}', shell=True)
 


### PR DESCRIPTION
In the script, it creates a new directory /var/tmp, and put the saved file into this directory. It causes avc denials log in the audit log since this directory is not configured with proper selinux lables, fix it.