### PR TITLE
migration: Update error message

### DIFF
--- a/libvirt/tests/cfg/migration/destructive_operations_around_live_migration/kill_qemu_during_performphase.cfg
+++ b/libvirt/tests/cfg/migration/destructive_operations_around_live_migration/kill_qemu_during_performphase.cfg
@@ -47,7 +47,7 @@
             expected_dest_state = "nonexist"
             expected_src_state = "running"
             migrate_speed = "1"
-            err_msg = "QEMU unexpectedly closed the monitor|Unable to read from socket: Connection reset by peer"
+            err_msg = "QEMU unexpectedly closed the monitor|Unable to read from socket: Connection reset by peer|Channel error: Input/output error"
             check_disk_on_dest = "no"
             virsh_migrate_extra = "--bandwidth 1000"
         - kill_dest_qemu_after_vm_paused:
@@ -58,7 +58,7 @@
             expected_dest_state = "nonexist"
             expected_src_state = "running"
             virsh_migrate_extra = "--timeout 2 --timeout-suspend --bandwidth 1000"
-            err_msg = "QEMU unexpectedly closed the monitor|Unable to read from socket: Connection reset by peer"
+            err_msg = "QEMU unexpectedly closed the monitor|Unable to read from socket: Connection reset by peer|Channel error: Input/output error"
         - kill_src_qemu:
             expected_dest_state = "nonexist"
             expected_src_state = "shut off"


### PR DESCRIPTION
Before:
Can not find the expected patterns 'QEMU unexpectedly closed the monitor|Unable to read from socket: Connection reset by peer' in output 'Migration: [ 1.37 %] Migration: [ 4.58 %] Migration: [ 7.78 %] Migration: [10.55 %] Migration: [13.32 %] Migration: [16.12 %] Migration: [18.84 %] Migration: [21.61 %] Migration: [27.25 %] Migration: [81.68 %] Migration: [86.86 %] Migration: [89.58 %] Migration: [94.85 %]error: operation failed: job 'migration out' failed: Channel error: Input/output error'

After:
 (1/1) type_specific.io-github-autotest-libvirt.migration.destructive_operations_around_live_migration.kill_qemu_during_performphase.kill_dest_qemu_before_vm_paused.with_precopy.non_p2p: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.migration.destructive_operations_around_live_migration.kill_qemu_during_performphase.kill_dest_qemu_before_vm_paused.with_precopy.non_p2p: PASS (226.08 s)