### PR TITLE
Add graphics test for video devices test

### DIFF
--- a/libvirt/tests/cfg/virtual_device/video_devices.cfg
+++ b/libvirt/tests/cfg/virtual_device/video_devices.cfg
@@ -5,6 +5,17 @@
         - positive_test:
             status_error = "no"
             variants:
+                - graphics_test:
+                    graphics_test = "yes"
+                    only no_primary_video
+                    only no_secondary_video
+                    video_device = "no"
+                    qemu_line = "-device.*id.*video"
+                    variants:
+                        - with_graphics:
+                            with_graphics = "yes"
+                        - no_graphics:
+                            with_graphics = "no"
                 - resolution_test:
                     no qxl
                     resolution_test = "yes"
@@ -129,6 +140,8 @@
                             no s390-virtio, aarch64
                             primary_video_model = bochs
                             only no_secondary_video..model_test.default no_secondary_video..vram..bochs_default_size
+                - no_primary_video:
+                    only graphics_test
         - negative_test:
             status_error = "yes"
             variants:


### PR DESCRIPTION
Automate the following 2 cases:
VIRT-58691
VIRT-58691

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded test coverage for video/graphics scenarios with optional primary/secondary device combinations and configurable heads/memory/resolution, plus variants for graphics/no-graphics.

- **Bug Fixes**
  - Avoided undefined pattern usage during memory validation.

- **Tests**
  - Added controls for graphics presence and video-device addition, pre-start cleanup when graphics are disabled, VM-definition sync before start, and post-start validations of graphics presence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->