### PR TITLE
migration: Update pause by network test case

### DIFF
--- a/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_by_network_and_recover.cfg
+++ b/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_by_network_and_recover.cfg
@@ -27,10 +27,8 @@
     stress_package = "stress"
     stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20s"
     postcopy_options = "--timeout 4 --timeout-postcopy --postcopy --postcopy-bandwidth 5"
-    action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "libvirt_network.setup_firewall_rule", "func_param": "params", "need_sleep_time": "5"}, {"func": "do_common_check", "func_param": "params", "need_sleep_time": "90"}, {"func": "libvirt_network.cleanup_firewall_rule", "func_param": "params"}]'
+    action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "libvirt_network.setup_firewall_rule", "func_param": "params", "need_sleep_time": "5"}]'
     migrate_again = 'yes'
-    migrate_again_status_error = 'no'
-    action_during_mig_again = '[{"func": "do_common_check", "before_pause": "yes", "func_param": "params"}, {"func": "set_migrate_speed_to_high", "before_pause": "yes", "func_param": "params"}]'
     virsh_migrate_extra_mig_again = "--timeout 4 --timeout-postcopy --postcopy --postcopy-resume"
     postcopy_resume_migration = "yes"
     migrate_speed_high = "1048576"
@@ -38,12 +36,10 @@
     expected_dest_state = "running"
     expected_src_state = "paused"
     dominfo_check = "Persistent:     no"
-    expected_event_src = ["event 'lifecycle' for domain.*: Suspended Post-copy Error", "event 'lifecycle' for domain .*: Suspended Post-copy", "event 'lifecycle' for domain .*: Stopped Migrated", "event 'job-completed' for domain"]
-    expected_event_target = ["event 'lifecycle' for domain.*: Resumed Post-copy Error", "event 'lifecycle' for domain.*: Resumed Post-copy", "event 'lifecycle' for domain.*: Resumed Migrated"]
     migrate_desturi_port = "16509"
     migrate_desturi_type = "tcp"
     virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
-    tcp_config_list = '{"tcp_keepalive_probes": "9", "tcp_keepalive_intvl": "60", "tcp_retries1": "4", "tcp_retries2": "8", "tcp_fin_timeout": "2"}'
+    tcp_config_list = '{"tcp_keepalive_probes": "3", "tcp_keepalive_intvl": "3", "tcp_retries1": "1", "tcp_retries2": "1", "tcp_fin_timeout": "2"}'
     recover_tcp_config_list = '{"tcp_keepalive_probes": "9", "tcp_keepalive_intvl": "75", "tcp_retries1": "3", "tcp_retries2": "15", "tcp_fin_timeout": "60"}'
     func_supported_since_libvirt_ver = (8, 5, 0)
 
@@ -68,7 +64,15 @@
             firewall_rule_on_dest = "ipv4 filter INPUT 0 -p tcp --dport ${port_to_check} -j DROP"
             firewall_rule_on_src = "ipv4 filter INPUT 0 -p tcp --sport ${port_to_check} -j DROP"
             err_msg = "job 'migration in' failed in post-copy phase"
+            migrate_again_status_error = 'no'
+            action_during_mig_again = '[{"func": "do_common_check", "before_pause": "yes", "func_param": "params"}, {"func": "set_migrate_speed_to_high", "before_pause": "yes", "func_param": "params"}]'
+            expected_event_src = ["event 'lifecycle' for domain.*: Suspended Post-copy Error", "event 'lifecycle' for domain .*: Suspended Post-copy", "event 'lifecycle' for domain .*: Stopped Migrated", "event 'job-completed' for domain"]
+            expected_event_target = ["event 'lifecycle' for domain.*: Resumed Post-copy Error", "event 'lifecycle' for domain.*: Resumed Post-copy", "event 'lifecycle' for domain.*: Resumed Migrated"]
         - libvirt_layer:
             firewall_rule_on_dest = "ipv4 filter INPUT 0 -p tcp --dport ${migrate_desturi_port} -j DROP"
             firewall_rule_on_src = "ipv4 filter INPUT 0 -p tcp --sport ${migrate_desturi_port} -j DROP"
-            err_msg = "internal error: client socket is closed|connection closed due to keepalive timeout"
+            err_msg = "internal error: client socket is closed|connection closed due to keepalive timeout|Cannot recv data: Connection timed out"
+            migrate_again_status_error = 'yes'
+            err_msg_again = "QEMU reports migration is still running"
+            expected_event_src = ["event 'lifecycle' for domain.*: Suspended Post-copy Error", "event 'lifecycle' for domain .*: Suspended Post-copy"]
+            expected_event_target = ["event 'lifecycle' for domain.*: Resumed Post-copy"]


### PR DESCRIPTION
For libvirt layer network broken, recover postcopy migration step will fail because qemu migration still running. So updated auto script.


