### PR TITLE
Fix some failures of v2v specific_kvm job

### DIFF
--- a/v2v/tests/cfg/specific_kvm.cfg
+++ b/v2v/tests/cfg/specific_kvm.cfg
@@ -233,9 +233,9 @@
                     checkpoint = 'ntpd_on'
                 - sync_ntp:
                     checkpoint = 'sync_ntp'
-        - no_space:
+        - set_cache_dir:
             only esx.esx_70
-            checkpoint = 'host_no_space_setcache'
+            checkpoint = 'set_cache_dir'
             main_vm = 'VM_ESX_DEFAULT_NAME_V2V_EXAMPLE'
         - no_libguestfs_backend:
             only esx.esx_70
@@ -355,7 +355,7 @@
                 - not_shutdown:
                     only default.kvm
                     only output_mode.local
-                    msg_content = 'virt-v2v.*is running or paused'
+                    msg_content = 'virt-v2v: warning:.*Converting a live guest will result in corrupted output.'
                     expect_msg = 'yes'
                     variants:
                         - running:
@@ -377,5 +377,9 @@
                             main_vm = "VM_GUEST_NO_SPACE_V2V_EXAMPLE"
                             checkpoint = 'host_no_space'
                             msg_content = 'virt-v2v: error: insufficient free space in the conversion server'
+                        - guest:
+                            only default.esx.esx_70
+                            main_vm = "VM_GUEST_NO_SPACE_V2V_EXAMPLE"
+                            msg_content = 'virt-v2v: error: not enough free space for conversion on filesystem'
                 - fstab_invalid:
                     only fstab.invalid


### PR DESCRIPTION
1. Adjust cases about no space scenarios
2. Change the error info for cases about running guest
3. Improve the checkpoint of cases about time sync