### PR TITLE
migration: Update tcp connections 

### DIFF
--- a/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_and_recover_and_disruptive.cfg
+++ b/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_and_recover_and_disruptive.cfg
@@ -77,9 +77,9 @@
             virsh_migrate_extra = "--migrateuri tcp://${migrate_dest_host}:${port_to_check} --listen-address ${migrate_dest_host}"
             firewall_rule_on_dest = "ipv4 filter INPUT 0 -p tcp --dport ${port_to_check} -j DROP"
             firewall_rule_on_src = "ipv4 filter INPUT 0 -p tcp --sport ${port_to_check} -j DROP"
-            action_during_do_mig = '[{"func": "libvirt_network.setup_firewall_rule", "func_param": "params", "need_sleep_time": "10"}, {"func": "libvirt_network.cleanup_firewall_rule", "func_param": "params", "need_sleep_time": "90"}]'
+            action_during_do_mig = '[{"func": "libvirt_network.setup_firewall_rule", "func_param": "params", "need_sleep_time": "10"}, {"func": "libvirt_network.cleanup_firewall_rule", "func_param": "params", "need_sleep_time": "10"}]'
             status_error_during_mig = "no"
-            tcp_config_list = '{"tcp_keepalive_probes": "9", "tcp_keepalive_intvl": "60", "tcp_retries1": "4", "tcp_retries2": "8", "tcp_fin_timeout": "2"}'
+            tcp_config_list = '{"tcp_keepalive_probes": "3", "tcp_keepalive_intvl": "3", "tcp_retries1": "1", "tcp_retries2": "1", "tcp_fin_timeout": "2"}'
             recover_tcp_config_list = '{"tcp_keepalive_probes": "9", "tcp_keepalive_intvl": "75", "tcp_retries1": "3", "tcp_retries2": "15", "tcp_fin_timeout": "60"}'
         - pause_by_proxy_issue:
             action_during_do_mig = '[{"func": "clear_pmsocat", "func_param": "params", "need_sleep_time": "5"}, {"func": "base_steps.recreate_conn_objs", "func_param": "params", "need_sleep_time": "10"}]'

--- a/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_and_recover_twice.cfg
+++ b/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_and_recover_twice.cfg
@@ -46,12 +46,12 @@
             virsh_migrate_extra = "--migrateuri tcp://${migrate_dest_host}:${port_to_check} --listen-address ${migrate_dest_host}"
             firewall_rule_on_dest = "ipv4 filter INPUT 0 -p tcp --dport ${port_to_check} -j DROP"
             firewall_rule_on_src = "ipv4 filter INPUT 0 -p tcp --sport ${port_to_check} -j DROP"
-            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "virsh.domjobabort", "func_param": "'%s --postcopy' % params.get('migrate_main_vm')", "need_sleep_time": "5"}, {"func": "libvirt_network.setup_firewall_rule", "func_param": "params"}, {"func": "do_migration", "func_param": "params", "need_sleep_time": "90"}, {"func": "libvirt_network.cleanup_firewall_rule", "func_param": "params", "need_sleep_time": "5"}, {"func": "resume_migration_again", "func_param": "params", "need_sleep_time": "5"}]'
+            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "virsh.domjobabort", "func_param": "'%s --postcopy' % params.get('migrate_main_vm')", "need_sleep_time": "5"}, {"func": "libvirt_network.setup_firewall_rule", "func_param": "params"}, {"func": "do_migration", "func_param": "params", "need_sleep_time": "15"}, {"func": "libvirt_network.cleanup_firewall_rule", "func_param": "params", "need_sleep_time": "5"}, {"func": "resume_migration_again", "func_param": "params", "need_sleep_time": "5"}]'
             migrate_desturi_port = "16509"
             migrate_desturi_type = "tcp"
             virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
             err_msg_during_mig = "unable to connect to server at.*: Connection timed out"
-            tcp_config_list = '{"tcp_keepalive_probes": "9", "tcp_keepalive_intvl": "60", "tcp_retries1": "4", "tcp_retries2": "8", "tcp_fin_timeout": "2"}'
+            tcp_config_list = '{"tcp_keepalive_probes": "3", "tcp_keepalive_intvl": "3", "tcp_retries1": "1", "tcp_retries2": "1", "tcp_fin_timeout": "2"}'
             recover_tcp_config_list = '{"tcp_keepalive_probes": "9", "tcp_keepalive_intvl": "75", "tcp_retries1": "3", "tcp_retries2": "15", "tcp_fin_timeout": "60"}'
         - proxy_issue:
             transport_type = "unix_proxy"

--- a/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/unattended_migration.cfg
+++ b/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/unattended_migration.cfg
@@ -67,9 +67,10 @@
             expected_event_src = ["event 'lifecycle' for domain .*: Suspended Post-copy"]
             expected_event_src_2 = ["event 'lifecycle' for domain .*: Stopped Migrated", "event 'job-completed' for domain"]
             expected_event_target = ["event 'lifecycle' for domain.*: Resumed Post-copy", "event 'lifecycle' for domain.*: Resumed Migrated"]
-            tcp_config_list = '{"tcp_keepalive_probes": "9", "tcp_keepalive_intvl": "60", "tcp_retries1": "4", "tcp_retries2": "8", "tcp_fin_timeout": "2"}'
+            tcp_config_list = '{"tcp_keepalive_probes": "3", "tcp_keepalive_intvl": "3", "tcp_retries1": "1", "tcp_retries2": "1", "tcp_fin_timeout": "2"}'
             recover_tcp_config_list = '{"tcp_keepalive_probes": "9", "tcp_keepalive_intvl": "75", "tcp_retries1": "3", "tcp_retries2": "15", "tcp_fin_timeout": "60"}'
             action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "check_event_before_unattended", "func_param": "params"}, {"func": "libvirt_network.setup_firewall_rule", "func_param": "params"}, {"func": "do_common_check", "func_param": "params", "need_sleep_time": "90"}, {"func": "wait_for_unattended_mig", "func_param": "params"}, {"func": "libvirt_network.cleanup_firewall_rule", "func_param": "params"}]'
+            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "check_event_before_unattended", "func_param": "params"}, {"func": "libvirt_network.setup_firewall_rule", "func_param": "params"}, {"func": "do_common_check", "func_param": "params", "need_sleep_time": "15"}, {"func": "wait_for_unattended_mig", "func_param": "params"}]'
     variants migration_options:
         - with_undefinesource_persistent:
             virsh_migrate_extra = "--undefinesource --persistent"

--- a/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/unattended_migration_and_disruptive.cfg
+++ b/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/unattended_migration_and_disruptive.cfg
@@ -64,10 +64,10 @@
             virsh_migrate_extra = "--migrateuri tcp://${migrate_dest_host}:${port_to_check} --listen-address ${migrate_dest_host}"
             firewall_rule_on_dest = "ipv4 filter INPUT 0 -p tcp --dport ${port_to_check} -j DROP"
             firewall_rule_on_src = "ipv4 filter INPUT 0 -p tcp --sport ${port_to_check} -j DROP"
-            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "libvirt_service.kill_service", "func_param": "params"}, {"func": "libvirt_network.setup_firewall_rule", "func_param": "params", "need_sleep_time": "5"}, {"func": "libvirt_network.cleanup_firewall_rule", "func_param": "params", "need_sleep_time": "90"}, {"func": "do_migration", "func_param": "params", "need_sleep_time": "10"}]'
+            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "libvirt_service.kill_service", "func_param": "params"}, {"func": "libvirt_network.setup_firewall_rule", "func_param": "params", "need_sleep_time": "5"}, {"func": "libvirt_network.cleanup_firewall_rule", "func_param": "params", "need_sleep_time": "10"}, {"func": "do_migration", "func_param": "params", "need_sleep_time": "10"}]'
             status_error = "no"
             status_error_during_mig = "no"
-            tcp_config_list = '{"tcp_keepalive_probes": "9", "tcp_keepalive_intvl": "60", "tcp_retries1": "4", "tcp_retries2": "8", "tcp_fin_timeout": "2"}'
+            tcp_config_list = '{"tcp_keepalive_probes": "3", "tcp_keepalive_intvl": "3", "tcp_retries1": "1", "tcp_retries2": "1", "tcp_fin_timeout": "2"}'
             recover_tcp_config_list = '{"tcp_keepalive_probes": "9", "tcp_keepalive_intvl": "75", "tcp_retries1": "3", "tcp_retries2": "15", "tcp_fin_timeout": "60"}'
             action_during_do_mig = '[{"func": "set_migrate_speed_to_high", "before_pause": "yes", "func_param": "params"}]'
         - pause_by_proxy:

--- a/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/pause_and_recover_and_disruptive.py
+++ b/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/pause_and_recover_and_disruptive.py
@@ -21,7 +21,7 @@ def run(test, params, env):
         """
         test.log.info("Setup for pause_by_network")
         tcp_config_list = eval(params.get("tcp_config_list"))
-        libvirt_network.change_tcp_config(tcp_config_list)
+        libvirt_network.change_tcp_config(tcp_config_list, params)
         migration_obj.setup_connection()
 
     def cleanup_pause_by_network():
@@ -31,7 +31,7 @@ def run(test, params, env):
         """
         test.log.info("Cleanup for pause_by_network")
         recover_tcp_config_list = eval(params.get("recover_tcp_config_list"))
-        libvirt_network.change_tcp_config(recover_tcp_config_list)
+        libvirt_network.change_tcp_config(recover_tcp_config_list, params)
         migration_obj.cleanup_connection()
 
     libvirt_version.is_libvirt_feature_supported(params)

--- a/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/pause_and_recover_twice.py
+++ b/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/pause_and_recover_twice.py
@@ -21,7 +21,7 @@ def run(test, params, env):
         """
         test.log.info("Setup for network issue")
         tcp_config_list = eval(params.get("tcp_config_list"))
-        libvirt_network.change_tcp_config(tcp_config_list)
+        libvirt_network.change_tcp_config(tcp_config_list, params)
         migration_obj.setup_connection()
 
     def cleanup_network_issue():
@@ -31,7 +31,7 @@ def run(test, params, env):
         """
         test.log.info("Cleanup for network issue")
         recover_tcp_config_list = eval(params.get("recover_tcp_config_list"))
-        libvirt_network.change_tcp_config(recover_tcp_config_list)
+        libvirt_network.change_tcp_config(recover_tcp_config_list, params)
         migration_obj.cleanup_connection()
 
     libvirt_version.is_libvirt_feature_supported(params)

--- a/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/unattended_migration_and_disruptive.py
+++ b/libvirt/tests/src/migration/pause_postcopy_migration_and_recover/unattended_migration_and_disruptive.py
@@ -22,7 +22,7 @@ def run(test, params, env):
         """
         test.log.info("Setup for pause_by_network.")
         tcp_config_list = eval(params.get("tcp_config_list"))
-        libvirt_network.change_tcp_config(tcp_config_list)
+        libvirt_network.change_tcp_config(tcp_config_list, params)
         migration_obj.setup_connection()
 
     def cleanup_pause_by_network():
@@ -32,7 +32,7 @@ def run(test, params, env):
         """
         test.log.info("Cleanup for pause_by_network")
         recover_tcp_config_list = eval(params.get("recover_tcp_config_list"))
-        libvirt_network.change_tcp_config(recover_tcp_config_list)
+        libvirt_network.change_tcp_config(recover_tcp_config_list, params)
         migration_obj.cleanup_connection()
 
     libvirt_version.is_libvirt_feature_supported(params)


### PR DESCRIPTION
Update tcp configurations parameters to make tcp connections timeout more quickly.

Test result: 2 cases failed due to one bug.
 (1/4) type_specific.io-github-autotest-libvirt.migration.pause_postcopy_migration_and_recover.unattended_migration.with_undefinesource_persistent.network_issue_libvirt_layer.p2p: STARTED
 (1/4) type_specific.io-github-autotest-libvirt.migration.pause_postcopy_migration_and_recover.unattended_migration.with_undefinesource_persistent.network_issue_libvirt_layer.p2p: FAIL: Migrated VMs failed to be in failed to get domain state at source (367.11 s)
 (2/4) type_specific.io-github-autotest-libvirt.migration.pause_postcopy_migration_and_recover.unattended_migration.with_undefinesource_persistent.network_issue_libvirt_layer.non_p2p: STARTED
 (2/4) type_specific.io-github-autotest-libvirt.migration.pause_postcopy_migration_and_recover.unattended_migration.with_undefinesource_persistent.network_issue_libvirt_layer.non_p2p: FAIL: Migrated VMs failed to be in failed to get domain state at source (356.66 s)
 (3/4) type_specific.io-github-autotest-libvirt.migration.pause_postcopy_migration_and_recover.unattended_migration.without_undefinesource_persistent.network_issue_libvirt_layer.p2p: STARTED
 (3/4) type_specific.io-github-autotest-libvirt.migration.pause_postcopy_migration_and_recover.unattended_migration.without_undefinesource_persistent.network_issue_libvirt_layer.p2p: PASS (373.13 s)
 (4/4) type_specific.io-github-autotest-libvirt.migration.pause_postcopy_migration_and_recover.unattended_migration.without_undefinesource_persistent.network_issue_libvirt_layer.non_p2p: STARTED
 (4/4) type_specific.io-github-autotest-libvirt.migration.pause_postcopy_migration_and_recover.unattended_migration.without_undefinesource_persistent.network_issue_libvirt_layer.non_p2p: PASS (356.10 s)