### PR TITLE
check_negative_parameter: test invalid log_outputs

### DIFF
--- a/libvirt/tests/cfg/daemon/conf_file/libvirtd_conf/check_negative_parameter.cfg
+++ b/libvirt/tests/cfg/daemon/conf_file/libvirtd_conf/check_negative_parameter.cfg
@@ -33,6 +33,21 @@
             parameter_value = "-1"
         - log_level:
             parameter_value = "-1"
+        - log_outputs:
+            only virtqemud
+            variants:
+                - abc:
+                    parameter_value = "'abc'"
+                    errmsg = "libvirt:  error.*Malformed format for log output"
+                - 5_syslog:
+                    parameter_value = "'5:syslog'"
+                    errmsg = "libvirt:  error.*Invalid log priority"
+                - 1_abc:
+                    parameter_value = "'1:abc'"
+                    errmsg = "libvirt:  error.*Invalid log destination"
+                - 1_file:
+                    parameter_value = "'1:file'"
+                    errmsg = "libvirt:  error.*Log output.*does not meet the format requirements"
         - keepalive_count:
             parameter_value = "-5"
     variants daemon_name:

--- a/libvirt/tests/src/daemon/conf_file/libvirtd_conf/check_negative_parameter.py
+++ b/libvirt/tests/src/daemon/conf_file/libvirtd_conf/check_negative_parameter.py
@@ -18,7 +18,8 @@ def run(test, params, env):
     integer etc in libvirtd.conf.
 
     """
-    check_string_in_log = params.get("check_string_in_log")
+    errmsg = params.get("errmsg", "")
+    check_string_in_log = errmsg if errmsg else params.get("check_string_in_log")
     daemon_name = params.get("daemon_name")
     parameter_name = params.get("parameter_name")
     parameter_value = params.get("parameter_value")


### PR DESCRIPTION
Set invalid values for log_outputs in virtqemud.conf, check error
messages when virtqemud.service restarting fails.