### PR TITLE
migration: Add case to test a short timeout

### DIFF
--- a/libvirt/tests/cfg/migration/memory_copy_mode/postcopy.cfg
+++ b/libvirt/tests/cfg/migration/memory_copy_mode/postcopy.cfg
@@ -53,3 +53,6 @@
             postcopy_options = '--postcopy --postcopy-after-precopy'
         - timeout_postcopy:
             postcopy_options = '--postcopy --timeout 10 --timeout-postcopy'
+        - timeout_with_short_value:
+            postcopy_options = '--postcopy --timeout 2 --timeout-postcopy --postcopy-after-precopy'
+            check_no_str_local_log = '["unable to execute QEMU command 'migrate-start-postcopy': Enable postcopy with migrate_set_capability before the start of migration"]'


### PR DESCRIPTION
Test result:
 (1/1) type_specific.io-github-autotest-libvirt.migration.memory_copy_mode.postcopy.timeout_with_short_value.p2p: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.migration.memory_copy_mode.postcopy.timeout_with_short_value.p2p: PASS (229.24 s)