### PR TITLE
svirt: Update to check error message for relabel without label device

### DIFF
--- a/libvirt/tests/cfg/svirt/dac/dac_seclabel_per_device.cfg
+++ b/libvirt/tests/cfg/svirt/dac/dac_seclabel_per_device.cfg
@@ -32,6 +32,7 @@
             variants:
                 - without_label:
                    status_error = "yes"
+                   err_msg = "XML error: Cannot specify relabel if label is missing. model=dac"
                 - with_label:
                     variants:
                         - s_qemu:

--- a/libvirt/tests/src/svirt/dac/dac_seclabel_per_device.py
+++ b/libvirt/tests/src/svirt/dac/dac_seclabel_per_device.py
@@ -50,6 +50,7 @@ def run(test, params, env):
     test_device = params.get("test_device")
     test_scenario = params.get("test_scenario")
     # Get general variables.
+    err_msg = params.get("err_msg")
     added_user = None
     source_path = None
 
@@ -80,6 +81,13 @@ def run(test, params, env):
             except xcepts.LibvirtXMLError as details:
                 if not status_error:
                     test.fail(details)
+                else:
+                    if err_msg:
+                        if err_msg not in str(details):
+                            test.fail(details)
+                        else:
+                            return
+
             test.log.debug("VM XML: %s.", VMXML.new_from_inactive_dumpxml(vm_name))
             res = virsh.start(vm.name)
         else:


### PR DESCRIPTION
Device's <seclabel relabel='yes'/> with no <label/> will be rejected. So updating the case.


**Test results:**

```
 (1/4) type_specific.io-github-autotest-libvirt.svirt.dac.seclabel.per_device.relabel_yes.without_label.disk.cold_plug: STARTED
 (1/4) type_specific.io-github-autotest-libvirt.svirt.dac.seclabel.per_device.relabel_yes.without_label.disk.cold_plug: PASS (3.72 s)
 (2/4) type_specific.io-github-autotest-libvirt.svirt.dac.seclabel.per_device.relabel_yes.without_label.disk.hot_plug: STARTED
 (2/4) type_specific.io-github-autotest-libvirt.svirt.dac.seclabel.per_device.relabel_yes.without_label.disk.hot_plug: PASS (24.25 s)
 (3/4) type_specific.io-github-autotest-libvirt.svirt.dac.seclabel.per_device.relabel_yes.without_label.serial.cold_plug: STARTED
 (3/4) type_specific.io-github-autotest-libvirt.svirt.dac.seclabel.per_device.relabel_yes.without_label.serial.cold_plug: PASS (3.99 s)
 (4/4) type_specific.io-github-autotest-libvirt.svirt.dac.seclabel.per_device.relabel_yes.without_label.serial.hot_plug: STARTED
 (4/4) type_specific.io-github-autotest-libvirt.svirt.dac.seclabel.per_device.relabel_yes.without_label.serial.hot_plug: PASS (24.35 s)

```