### PR TITLE
Forbid doing blockcopy to the same source

### DIFF
--- a/libvirt/tests/cfg/backingchain/blockjob/blockjob_pivot_after_irregular_operations.cfg
+++ b/libvirt/tests/cfg/backingchain/blockjob/blockjob_pivot_after_irregular_operations.cfg
@@ -4,6 +4,7 @@
     target_disk = 'vda'
     pivot_option = " --pivot"
     abort_option = " --abort"
+    disk_size = 3G
     variants test_scenario:
         - before_finish:
             blockcopy_options = "blockcopy %s %s %s --transient-job --bytes 200"
@@ -11,3 +12,7 @@
         - delete_copy_file:
             blockcopy_options = " --transient-job --wait --verbose "
             err_msg = "No such file or directory"
+        - same_target:
+            blockcopy_options = "--blockdev --verbose --raw --transient-job --pivot"
+            target_disk = 'vdc'
+            err_msg = Failed to get "write" lock

--- a/libvirt/tests/src/backingchain/blockjob/blockjob_pivot_after_irregular_operations.py
+++ b/libvirt/tests/src/backingchain/blockjob/blockjob_pivot_after_irregular_operations.py
@@ -1,5 +1,7 @@
 import os
 
+from avocado.utils import process
+from avocado.utils import linux_modules
 from virttest import utils_misc
 from virttest import virsh
 
@@ -23,8 +25,29 @@ def run(test, params, env):
         """
         Prepare active guest
         """
-        test.log.info("TEST_SETUP:Setup env")
+        test.log.info("TEST_SETUP: Setup env")
         test_obj.backingchain_common_setup()
+
+    def setup_blk_dev(size):
+        """
+        Setup 2 block devices, one emulated and another via iSCSI server,
+        both with the same size.
+
+        :size: the disk size in gigabytes, like "3G"
+        :return: A list containing the names of the two prepared disks.
+        """
+        test.log.debug("TEST_SETUP: Setting up 2 additional block devices...")
+        cmd_lsblk = 'lsblk -d -o NAME -n'
+        current_disk_names = process.run(cmd_lsblk, shell=True).stdout_text.strip().splitlines()
+        # create 1st scsi disk
+        libvirt.setup_or_cleanup_iscsi(True, image_size=size)
+        # create 2nd scsi disk with same size
+        size_in_mib = str(int(size.rstrip("G")) * 1024)
+        libvirt.create_scsi_disk(scsi_option="", scsi_size=size_in_mib)
+        updated_disk_names = process.run(cmd_lsblk, shell=True).stdout_text.strip().splitlines()
+        new_disks = [disk for disk in updated_disk_names if disk not in current_disk_names]
+        test.log.debug(f"Prepared 2 disks: {new_disks}")
+        return new_disks
 
     def run_before_finish():
         """
@@ -69,6 +92,37 @@ def run(test, params, env):
         virsh.blockjob(vm_name, target_disk, options=pivot_option,
                        debug=True, ignore_status=False)
 
+    def run_same_target():
+        """
+        Execute blockcopy operations with target block device being the same as or different from source.
+
+        Steps:
+            1. Prepare two distinct block devices on the host.
+            2. Hotplug one disk to the VM with its source device set as one of the prepared block devices.
+            3. Attempt negative test: perform blockcopy with target device identical to source.
+            4. Perform positive test: execute blockcopy with target device being another prepared block device.
+
+        :return: None
+        """
+        size = params.get("disk_size", "3G")
+        blk_dev1, blk_dev2 = setup_blk_dev(size)
+
+        if not vm.is_alive():
+            vm.start()
+        vm.wait_for_login().close()
+        test.log.info("TEST_STEP1: Hotplug a disk with source device as one of the block devices on host")
+        virsh.attach_disk(vm_name, f'/dev/{blk_dev1}', target_disk, debug=True)
+        output1 = virsh.domblklist(vm_name).stdout_text
+        test.log.info(f"After hotplugging, current VM disk list is: {output1}")
+
+        test.log.info("TEST_STEP2: Perform blockcopy with identical source and target devices...")
+        ret1 = virsh.blockcopy(vm_name, target_disk, f'/dev/{blk_dev1}', blockcopy_options)
+        libvirt.check_result(ret1, expected_fails=err_msg)
+
+        test.log.info("TEST_STEP3: Execute blockcopy with different source and target devices...")
+        ret2 = virsh.blockcopy(vm_name, target_disk, f'/dev/{blk_dev2}', blockcopy_options)
+        libvirt.check_result(ret2, expected_match='[100.00 %]')
+
     def teardown_test():
         """
         Clean data.
@@ -77,8 +131,10 @@ def run(test, params, env):
                        debug=True, ignore_status=True)
         test_obj.clean_file(tmp_copy_path)
         bkxml.sync()
+        if test_scenario == 'same_target':
+            libvirt.setup_or_cleanup_iscsi(is_setup=False)
+            linux_modules.unload_module("scsi_debug")
 
-    # Process cartesian parameters
     vm_name = params.get("main_vm")
     target_disk = params.get("target_disk")
     blockcopy_options = params.get("blockcopy_options")
@@ -91,7 +147,6 @@ def run(test, params, env):
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     bkxml = vmxml.copy()
 
-    # Create object
     test_obj = blockcommand_base.BlockCommand(test, vm, params)
     check_obj = check_functions.Checkfunction(test, vm, params)
 


### PR DESCRIPTION
Do blockjob --pivot after forbid doing blockcopy to the same source device. Automate case VIRT-294594 S3 scenario.