### PR TITLE
virtual_network: Move update_portgroup test to negative cases

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_update.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_update.cfg
@@ -75,23 +75,6 @@
                 - update_coalesce:
                     iface_coalesce = {'max': 64}
                     new_iface_coalesce = {'max': 32}
-                - update_portgroup:
-                    bo_0 = {'average': '128', 'burst': '256', 'peak': '256'}
-                    bi_0 = {'average': '1000', 'burst': '5120', 'peak': '5000'}
-                    portgroup_0 = {'bandwidth_outbound': ${bo_0}, 'name': 'sales', 'bandwidth_inbound': ${bi_0}, 'default': 'yes'}
-                    bo_1 = {'average': '256', 'burst': '512', 'peak': '128'}
-                    bi_1 = {'average': '500', 'burst': '1024', 'peak': '1000'}
-                    portgroup_1 = {'bandwidth_outbound': ${bi_1}, 'name': 'engineering', 'bandwidth_inbound': ${bo_1}}
-                    net_attr_portgroups = [${portgroup_0}, ${portgroup_1}]
-                    net_attr_nat_port = {'start': '1024', 'end': '65535'}
-                    net_attr_bridge = {'name': 'virbr1', 'stp': 'on', 'delay': '0'}
-                    net_attr_ips = [{'dhcp_ranges': {'attrs': {'end': '192.168.100.254', 'start': '192.168.100.100'}}, 'address': '192.168.100.1'}]
-                    net_attr_forward = {'mode': 'nat'}
-                    net_attr_mac = "'52:54:00:cf:11:a0'"
-                    net_attr_uuid = "'a2ab8047-591e-4f95-80f6-ad47b518b9e0'"
-                    iface_source = "{'network': 'default'}"
-                    del_bandwidth = "yes"
-                    new_iface_source = "{'network':'default', 'portgroup': 'engineering'}"
                 - update_boot_order:
                     cold_update = 'yes'
                     disk_boot = '1'
@@ -223,3 +206,21 @@
                         - vm_on:
                         - vm_off:
                             cold_update = 'yes'
+                - update_portgroup:
+                    bo_0 = {'average': '128', 'burst': '256', 'peak': '256'}
+                    bi_0 = {'average': '1000', 'burst': '5120', 'peak': '5000'}
+                    portgroup_0 = {'bandwidth_outbound': ${bo_0}, 'name': 'sales', 'bandwidth_inbound': ${bi_0}, 'default': 'yes'}
+                    bo_1 = {'average': '256', 'burst': '512', 'peak': '128'}
+                    bi_1 = {'average': '500', 'burst': '1024', 'peak': '1000'}
+                    portgroup_1 = {'bandwidth_outbound': ${bi_1}, 'name': 'engineering', 'bandwidth_inbound': ${bo_1}}
+                    net_attr_portgroups = [${portgroup_0}, ${portgroup_1}]
+                    net_attr_nat_port = {'start': '1024', 'end': '65535'}
+                    net_attr_bridge = {'name': 'virbr1', 'stp': 'on', 'delay': '0'}
+                    net_attr_ips = [{'dhcp_ranges': {'attrs': {'end': '192.168.100.254', 'start': '192.168.100.100'}}, 'address': '192.168.100.1'}]
+                    net_attr_forward = {'mode': 'nat'}
+                    net_attr_mac = "'52:54:00:cf:11:a0'"
+                    net_attr_uuid = "'a2ab8047-591e-4f95-80f6-ad47b518b9e0'"
+                    iface_source = "{'network': 'default'}"
+                    del_bandwidth = "yes"
+                    new_iface_source = "{'network':'default', 'portgroup': 'engineering'}"
+                    expect_err_msg = 'cannot modify network device portgroup attribute'


### PR DESCRIPTION
From libvirt v10.6.0[1], libvirt forbids changing the portgroup of interface device.

[1]: https://gitlab.com/libvirt/libvirt/-/commit/c3302ceb1d