### PR TITLE
passt:Allow multiple nexthops

### DIFF
--- a/libvirt/tests/cfg/virtual_network/passt/passt_transfer_file.cfg
+++ b/libvirt/tests/cfg/virtual_network/passt/passt_transfer_file.cfg
@@ -4,7 +4,7 @@
     host_iface =
     outside_ip = 'www.redhat.com'
     start_vm = no
-    multiple_nexthops = no
+    multiple_nexthops = yes
     variants user_type:
         - root_user:
             test_user = root


### PR DESCRIPTION
The cases will failed with error "FAIL: Host default ipv6 gateway not consistent with vm" for the host with multiple nexthops in default route Allow multiple nexthops and disable ipv6 address gateway comparing if addresses is link-local