### PR TITLE
Fix type mismatch error

### DIFF
--- a/provider/numa/numa_base.py
+++ b/provider/numa/numa_base.py
@@ -145,9 +145,9 @@ class NumaTest(object):
             self.params["numa_memory"] = numa_memory
         if numa_memnode:
             if numa_memnode.count('%s'):
-                numa_memnode = eval(numa_memnode % nodeset)
+                numa_memnode = numa_memnode % nodeset
                 self.params["numa_memnode"] = numa_memnode
-            numa_tune_dict.update({'numa_memnode': numa_memnode})
+            numa_tune_dict.update({'numa_memnode': eval(numa_memnode)})
         self.test.log.debug(numa_tune_dict)
         if numa_tune_dict:
             vmxml.setup_attrs(**numa_tune_dict)


### PR DESCRIPTION
Fix below error:
"value value is not any of [<class 'list'>], it is a <class 'str'>"

test result:
 (01/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_strict.single_node: STARTED
 (01/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_strict.single_node: PASS (34.45 s)
 (02/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_strict.multiple_nodes: STARTED
 (02/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_strict.multiple_nodes: PASS (37.47 s)
 (03/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_interleave.single_node: STARTED
 (03/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_interleave.single_node: PASS (82.00 s)
 (04/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_interleave.multiple_nodes: STARTED
 (04/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_interleave.multiple_nodes: PASS (36.52 s)
 (05/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_preferred.single_node: STARTED
 (05/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_preferred.single_node: PASS (44.15 s)
 (06/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_preferred.multiple_nodes: STARTED
 (06/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_preferred.multiple_nodes: PASS (42.77 s)
 (07/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_restrictive.single_node: STARTED
 (07/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_restrictive.single_node: PASS (8.33 s)
 (08/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_restrictive.multiple_nodes: STARTED
 (08/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.mem_mode_restrictive.multiple_nodes: PASS (8.38 s)
 (09/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.no_mem_mode.single_node: STARTED
 (09/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.no_mem_mode.single_node: PASS (43.13 s)
 (10/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.no_mem_mode.multiple_nodes: STARTED
 (10/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.no_mem_mode.multiple_nodes: PASS (42.82 s)
 (11/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.no_mem_mode.no_node: STARTED
 (11/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_strict.no_mem_mode.no_node: PASS (43.95 s)
 (12/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_interleave.mem_mode_strict.single_node: STARTED
 (12/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_interleave.mem_mode_strict.single_node: PASS (43.17 s)
 (13/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_interleave.mem_mode_strict.multiple_nodes: STARTED
 (13/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_interleave.mem_mode_strict.multiple_nodes: PASS (42.20 s)
 (14/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_interleave.mem_mode_interleave.single_node: STARTED
 (14/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_interleave.mem_mode_interleave.single_node: PASS (43.49 s)
 (15/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_interleave.mem_mode_interleave.multiple_nodes: STARTED
 (15/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_interleave.mem_mode_interleave.multiple_nodes: PASS (43.32 s)
 (16/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_interleave.mem_mode_preferred.single_node: STARTED
 (16/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_interleave.mem_mode_preferred.single_node: PASS (44.19 s)
 (17/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_interleave.mem_mode_preferred.multiple_nodes: STARTED
 (17/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_interleave.mem_mode_preferred.multiple_nodes: PASS (43.06 s)
 (18/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_interleave.mem_mode_restrictive.single_node: STARTED
 (18/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_interleave.mem_mode_restrictive.single_node: PASS (8.31 s)
 (19/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_interleave.mem_mode_restrictive.multiple_nodes: STARTED
 (19/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_interleave.mem_mode_restrictive.multiple_nodes: PASS (8.29 s)
 (20/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_interleave.no_mem_mode.single_node: STARTED
 (20/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_interleave.no_mem_mode.single_node: PASS (42.88 s)
 (21/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_interleave.no_mem_mode.multiple_nodes: STARTED
 (21/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_interleave.no_mem_mode.multiple_nodes: PASS (43.41 s)
 (22/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_interleave.no_mem_mode.no_node: STARTED
 (22/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_interleave.no_mem_mode.no_node: PASS (42.79 s)
 (23/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_preferred.mem_mode_strict.single_node: STARTED
 (23/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_preferred.mem_mode_strict.single_node: PASS (42.66 s)
 (24/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_preferred.mem_mode_strict.multiple_nodes: STARTED
 (24/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_preferred.mem_mode_strict.multiple_nodes: PASS (42.93 s)
 (25/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_preferred.mem_mode_interleave.single_node: STARTED
 (25/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_preferred.mem_mode_interleave.single_node: PASS (44.76 s)
 (26/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_preferred.mem_mode_interleave.multiple_nodes: STARTED
 (26/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_preferred.mem_mode_interleave.multiple_nodes: PASS (41.94 s)
 (27/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_preferred.mem_mode_preferred.single_node: STARTED
 (27/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_preferred.mem_mode_preferred.single_node: PASS (43.89 s)
 (28/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_preferred.mem_mode_preferred.multiple_nodes: STARTED
 (28/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_preferred.mem_mode_preferred.multiple_nodes: PASS (43.72 s)
 (29/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_preferred.mem_mode_restrictive.single_node: STARTED
 (29/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_preferred.mem_mode_restrictive.single_node: PASS (8.36 s)
 (30/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_preferred.mem_mode_restrictive.multiple_nodes: STARTED
 (30/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_preferred.mem_mode_restrictive.multiple_nodes: PASS (8.38 s)
 (31/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_preferred.no_mem_mode.single_node: STARTED
 (31/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_preferred.no_mem_mode.single_node: PASS (43.45 s)
 (32/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_preferred.no_mem_mode.multiple_nodes: STARTED
 (32/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_preferred.no_mem_mode.multiple_nodes: PASS (44.04 s)
 (33/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_preferred.no_mem_mode.no_node: STARTED
 (33/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_preferred.no_mem_mode.no_node: PASS (42.50 s)
 (34/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_restrictive.mem_mode_strict.single_node: STARTED
 (34/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_restrictive.mem_mode_strict.single_node: PASS (8.33 s)
 (35/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_restrictive.mem_mode_strict.multiple_nodes: STARTED
 (35/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_restrictive.mem_mode_strict.multiple_nodes: PASS (8.36 s)
 (36/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_restrictive.mem_mode_interleave.single_node: STARTED
 (36/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_restrictive.mem_mode_interleave.single_node: PASS (8.32 s)
 (37/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_restrictive.mem_mode_interleave.multiple_nodes: STARTED
 (37/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_restrictive.mem_mode_interleave.multiple_nodes: PASS (8.35 s)
 (38/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_restrictive.mem_mode_preferred.single_node: STARTED
 (38/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_restrictive.mem_mode_preferred.single_node: PASS (8.37 s)
 (39/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_restrictive.mem_mode_preferred.multiple_nodes: STARTED
 (39/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_restrictive.mem_mode_preferred.multiple_nodes: PASS (8.32 s)
 (40/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_restrictive.mem_mode_restrictive.single_node: STARTED
 (40/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_restrictive.mem_mode_restrictive.single_node: PASS (42.40 s)
 (41/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_restrictive.mem_mode_restrictive.multiple_nodes: STARTED
 (41/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_restrictive.mem_mode_restrictive.multiple_nodes: PASS (44.47 s)
 (42/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_restrictive.no_mem_mode.single_node: STARTED
 (42/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_restrictive.no_mem_mode.single_node: PASS (8.48 s)
 (43/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_restrictive.no_mem_mode.multiple_nodes: STARTED
 (43/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_restrictive.no_mem_mode.multiple_nodes: PASS (8.32 s)
 (44/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_restrictive.no_mem_mode.no_node: STARTED
 (44/44) type_specific.io-github-autotest-libvirt.guest_numa_node_tuning.host_guest_mixed_memory_binding.memnode_mode_restrictive.no_mem_mode.no_node: PASS (8.37 s)