### PR TITLE
tpm_device: check vtpm support in domcapabilities

### DIFF
--- a/libvirt/tests/cfg/virtual_device/tpm_device.cfg
+++ b/libvirt/tests/cfg/virtual_device/tpm_device.cfg
@@ -7,6 +7,10 @@
     tpm_testsuite_url = "EXAMPLE_TPM_TESTSUITE_URL"
     no s390-virtio
     variants:
+        - domcaps:
+                only q35
+                func_supported_since_libvirt_ver = (8, 5, 0)
+                domcaps_check = 'yes'
         - normal_test:
             variants:
                 - passthrough:


### PR DESCRIPTION
virsh domcapabilities should be able to expose vtpm info, such as
version, model, backend type, should be same as qemu-kvm or swtpm
supported. There's a bug RHEL-102057 in which the return code of
'qemu-kvm -tpmdev help' is 1, so collect stderr instead of stdout.