### PR TITLE
Add new case VIRT-299198 for migration with memory allocation

### DIFF
--- a/libvirt/tests/cfg/migration/migration_with_memory/migration_with_various_memory_allocation.cfg
+++ b/libvirt/tests/cfg/migration/migration_with_memory/migration_with_various_memory_allocation.cfg
@@ -1,0 +1,49 @@
+- migration.migration_with_memory.memory_allocation:
+    type = migration_with_various_memory_allocation
+    take_regular_screendumps = no
+    migration_setup = "yes"
+    storage_type = 'nfs'
+    setup_local_nfs = 'yes'
+    disk_type = "file"
+    disk_source_protocol = "netfs"
+    mnt_path_name = ${nfs_mount_dir}
+    # Console output can only be monitored via virsh console output
+    only_pty = True
+    # Extra options to pass after <domain> <desturi>
+    virsh_migrate_extra = ""
+    # SSH connection time out
+    ssh_timeout = 60
+    # Local URI
+    virsh_migrate_connect_uri = 'qemu:///system'
+    virsh_migrate_dest_state = "running"
+    virsh_migrate_src_state = "shut off"
+    image_convert = "no"
+    server_ip = "${migrate_dest_host}"
+    server_user = "root"
+    server_pwd = "${migrate_dest_pwd}"
+    client_ip = "${migrate_source_host}"
+    migrate_desturi_port = "22"
+    migrate_desturi_type = "ssh"
+    virsh_migrate_desturi = "qemu+ssh://${migrate_dest_host}/system"
+    mem_attrs = "'memory_unit':'KiB','memory':8388608,'current_mem':8388608,'current_mem_unit':'KiB'"
+    max_mem_attrs = ", 'max_mem_rt': 10485760, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB'"
+    numa_attrs = ", 'vcpu': 4, 'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '4194304', 'unit': 'KiB'}, {'id': '1', 'cpus': '2-3', 'memory': '4194304', 'unit': 'KiB'}]}"
+    bandwidth = 100
+    virsh_migrate_options = "--p2p --live --persistent --bandwidth ${bandwidth} --migrateuri tcp://${migrate_dest_host}"
+    set_remote_libvirtd_log = "yes"
+    libvirtd_debug_level = "1"
+    libvirtd_debug_filters = "1:*"
+    check_no_str_remote_log = ["Unsupported migration cookie feature memory"]
+    variants:
+        - without_maxmemory:
+            max_mem_attrs = ""
+            numa_attrs = ""
+            expect_xpath = [{'element_attrs':[".//memory[@unit='KiB']"],'text':'8388608'},{'element_attrs':[".//currentMemory[@unit='KiB']"],'text':'8388608'}]
+        - without_slots:
+            func_supported_since_libvirt_ver = (9, 5, 0)
+            max_mem_attrs = ", 'max_mem_rt': 10485760, 'max_mem_rt_unit': 'KiB'"
+            expect_xpath = [{'element_attrs':[".//maxMemory[@unit='KiB']"],'text':'10485760'}, {'element_attrs':[".//memory[@unit='KiB']"],'text':'8388608'},{'element_attrs':[".//currentMemory[@unit='KiB']"],'text':'8388608'}, {'element_attrs':[".//cell[@memory='4194304']",".//cell[@id='0']", ".//cell[@cpus='0-1']"]}, {'element_attrs':[".//cell[@memory='4194304']",".//cell[@id='1']", ".//cell[@cpus='2-3']"]}]
+        - with_maxmemory:
+            expect_xpath = [{'element_attrs':[".//maxMemory[@unit='KiB']", ".//maxMemory[@slots='16']"],'text':'10485760'}, {'element_attrs':[".//memory[@unit='KiB']"],'text':'8388608'},{'element_attrs':[".//currentMemory[@unit='KiB']"],'text':'8388608'}, {'element_attrs':[".//cell[@memory='4194304']",".//cell[@id='0']", ".//cell[@cpus='0-1']"]}, {'element_attrs':[".//cell[@memory='4194304']",".//cell[@id='1']", ".//cell[@cpus='2-3']"]}]
+    vm_attrs = {${mem_attrs}${max_mem_attrs}${numa_attrs}}
+

--- a/libvirt/tests/src/migration/migration_with_memory/migration_with_various_memory_allocation.py
+++ b/libvirt/tests/src/migration/migration_with_memory/migration_with_various_memory_allocation.py
@@ -1,0 +1,58 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright Redhat
+#
+#   SPDX-License-Identifier: GPL-2.0
+
+#   Author: Liang Cong <lcong@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+from virttest import libvirt_version
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+
+from provider.migration import base_steps
+
+
+def run(test, params, env):
+    """
+    Verify guest migration behaviors with various memory allocations.
+
+    :param test: test object
+    :param params: Dictionary of test parameters
+    :param env: Dictionary of test environment
+    """
+    libvirt_version.is_libvirt_feature_supported(params)
+    vm_name = params.get("migrate_main_vm")
+    vm = env.get_vm(vm_name)
+    migration_obj = base_steps.MigrationBase(test, vm, params)
+    vmxml = migration_obj.orig_config_xml.copy()
+
+    vm_attrs = eval(params.get("vm_attrs"))
+    expect_xpath = eval(params.get("expect_xpath"))
+    desturi = params.get("virsh_migrate_desturi")
+
+    try:
+        # Test steps
+        # 1. Define and start the guest
+        # 2. Migrate the guest
+        # 3. Check the guest config xml on target server
+        test.log.info("TEST_STEP1: Define and start the guest")
+        vmxml.setup_attrs(**vm_attrs)
+        vmxml.sync()
+        migration_obj.setup_connection()
+        vm.start()
+        vm.wait_for_login().close()
+
+        test.log.info("TEST_STEP2: Migrate the guest")
+        migration_obj.run_migration()
+        migration_obj.verify_default()
+
+        test.log.info("TEST_STEP3: Check the guest config xml on target server")
+        virsh_obj = virsh.VirshPersistent(uri=desturi)
+        guest_xml = vm_xml.VMXML.new_from_dumpxml(vm_name, virsh_instance=virsh_obj)
+        libvirt_vmxml.check_guest_xml_by_xpaths(guest_xml, expect_xpath)
+
+    finally:
+        migration_obj.cleanup_connection()


### PR DESCRIPTION
test result:
 (1/3) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_allocation.without_maxmemory: STARTED
 (1/3) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_allocation.without_maxmemory: PASS (160.22 s)
 (2/3) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_allocation.without_slots: STARTED
 (2/3) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_allocation.without_slots: PASS (162.79 s)
 (3/3) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_allocation.with_maxmemory: STARTED
 (3/3) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_allocation.with_maxmemory: PASS (163.59 s)