### PR TITLE
virsh_metadata: fix no option

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_metadata.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_metadata.py
@@ -3,8 +3,10 @@ import xml.dom.minidom
 
 import aexpect
 
+from virttest import libvirt_version
 from virttest import remote
 from virttest import virsh
+
 from virttest.utils_test import libvirt as utlv
 from virttest.utils_libvirtd import Libvirtd
 from virttest.libvirt_xml import vm_xml
@@ -137,6 +139,7 @@ def run(test, params, env):
             check_result(result, status_error)
             # Get metadata again
             for option in metadata_option.split():
-                check_result(get_metadata(metadata_option=option), True)
+                expect_error = False if libvirt_version.version_compare(11, 3, 0) else True
+                check_result(get_metadata(metadata_option=option), expect_error)
     finally:
         vmxml.sync()


### PR DESCRIPTION
According to https://gitlab.com/libvirt/libvirt/-/commit/312088d9b62334c950310f369b2e0fe2302a74a3 the command will return an empty string instead of error message after libvirt-11.3.0


Signed-off-by: Dan Zheng <dzheng@redhat.com>