### PR TITLE
Snapshot: fix compress format issues

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_create_as.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_create_as.cfg
@@ -39,6 +39,7 @@
                     unix_channel = "no"
                     snap_createas_opts = "--quiesce --disk-only"
                 - invalid_compress_format:
+                    invalid_compress_format = "yes"
                     snap_createas_opts = "--live"
                     config_format = "yes"
                     memspec_opts = "live_memspec.img"
@@ -104,7 +105,8 @@
                 - live_memspec:
                     snap_createas_opts = "--live"
                     memspec_opts = "live_memspec.img"
-                    diskspec_opts = "vda,snapshot=external,file=external_disk0"
+                    snapshot_file = "external_disk0"
+                    diskspec_opts = "vda,snapshot=external,file=${snapshot_file}"
                     variants:
                         - compress_default:
                         - compress_format:


### PR DESCRIPTION
1. From libivrt-11.3.0, I think the virtqemud service with the invalid compress format can't restart as before. So I've updated the different test result.
2. For other raw/xz/gzip formats, the snapshot file didn't be removed in test, which will cause the error "external snapshot file for disk vda already exists" in next test.