### PR TITLE
Fix chcon cmd error when rhel < 10

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domjobinfo.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domjobinfo.py
@@ -4,6 +4,7 @@ import logging as log
 import time
 import locale
 
+from avocado.utils import distro
 from avocado.utils import process as host_process
 
 from virttest import virsh
@@ -142,7 +143,8 @@ def run(test, params, env):
         if os.path.exists(tmp_pipe):
             os.unlink(tmp_pipe)
         os.mkfifo(tmp_pipe)
-        host_process.run('chcon -t virtqemud_t %s' % tmp_pipe, ignore_status=False, shell=True)
+        if distro.detect().name == 'rhel' and int(distro.detect().version) >= 10:
+            host_process.run('chcon -t virtqemud_t %s' % tmp_pipe, ignore_status=False, shell=True)
 
         # Target file param is not needed for managedsave operation
         if action == "managedsave ":


### PR DESCRIPTION
Since selinux domain virtqemud_t only exists in rhel10, so we should not use chcon cmd when rhel < 10
This fill fix error in rhel9.7 below:
chcon: failed to change context of '/var/tmp/avocado_rqj2h4qd/domjobinfo.fifo' to 'system_u:object_r:virtqemud_t:s0': Invalid argument

Test result after fix in rhel9.7:
 (1/1) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.normal_test.dump_action.live_dump.running_state.vm_id: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.normal_test.dump_action.live_dump.running_state.vm_id: PASS (34.38 s)