### PR TITLE
Add a case to test nbdcopy with blkhash in virt-v2v debugging output

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -972,6 +972,13 @@
                     skip_reason = 'bug RHEL-93583 is not fixed and cannot boot into OS without password automatically'
                     checkpoint = 'luks_dev_keys'
                     luks_keys = LUKS_ALL_KEYS
+        - print_blkhash:
+                    only esx_70
+                    only libvirt
+                    v2v_debug = force_on
+                    version_required = "[virt-v2v-2.8.1-1,)"
+                    checkpoint = "print_blkhash"
+                    msg_content_yes = "nbdcopy.*--blkhash"
 
     variants:
         - positive_test:

--- a/v2v/tests/src/function_test_esx.py
+++ b/v2v/tests/src/function_test_esx.py
@@ -701,6 +701,12 @@ def run(test, params, env):
                       (len(error_list), error_list))
 
     try:
+        # Added version_required condition due to different versions of v2v for RHEL9 and RHEL10
+        # RHEL9 V2V version - "[virt-v2v-2.7.1-12,)"
+        # RHEL10 V2V version - "[virt-v2v-2.8.1-1,)"
+        if "print_blkhash" in checkpoint and "el9" in process.run("uname -r", shell=True).stdout_text:
+            version_required = "[virt-v2v-2.7.1-12,)"
+
         if version_required and not utils_v2v.multiple_versions_compare(
                 version_required):
             test.cancel("Testing requires version: %s" % version_required)


### PR DESCRIPTION
Automate case for print blkhash of converted image in virt-v2v debugging output

Test results:
```
# avocado run  --vt-type v2v function_test_esx.positive_test.print_blkhash.esx_70.libvirt.it_vddk.vpx_uri
JOB ID     : 93c4b080d59b27c761ca3e917f3f9fba27b9f46e
JOB LOG    : /var/log/avocado/job-results/job-2025-07-11T06.27-93c4b08/job.log
 (1/1) type_specific.io-github-autotest-libvirt.function_test_esx.positive_test.print_blkhash.esx_70.libvirt.it_vddk.vpx_uri: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.function_test_esx.positive_test.print_blkhash.esx_70.libvirt.it_vddk.vpx_uri: PASS (274.71 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2025-07-11T06.27-93c4b08/results.html
JOB TIME   : 276.53 s
```