### PR TITLE
metadata:Changing the logic of metadata handling

### DIFF
--- a/libvirt/tests/src/virtual_network/network/virsh_cmds/virsh_net_metadata.py
+++ b/libvirt/tests/src/virtual_network/network/virsh_cmds/virsh_net_metadata.py
@@ -75,9 +75,12 @@ def check_net_metadata_result(test, params, expected_string, existed=True):
         if result.stdout.strip() != expected_string:
             test.fail('Expect "%s" was existed.' % expected_string)
     else:
-        if result.stderr.strip() != expected_string:
-            test.fail('Expect "%s" was existed.' % expected_string)
-    test.log.debug("Check %s PASS in virsh net-metadata", expected_string)
+        # libvirt >= 9.8 return empty stdout/stderr
+        if result.stderr.strip():
+            if result.stderr.strip() != expected_string:
+                test.fail('Expect "%s" was existed.' % expected_string)
+        else:
+            test.log.debug("No metadata present and no error — new libvirt behaviour.")
 
 
 def check_net_dumpxml(test, params, expected_xml, exist):


### PR DESCRIPTION
Judging from this link https://lists.libvirt.org/archives/list/devel%40lists.libvirt.org/thread/EQUTQGX22YVKCWIMMZOYU3SXGIT4YTWZ/  in the new patch, the wirsh tool no longer returns metadata. For what I changed verification leaving old logic for version without this patch and new logic for new versions with the patch