### PR TITLE
AI policy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,3 +49,11 @@ Really quick start guide
 9. That's it.
 
 .. [1] You can always create your own test provider, if you have special purposes, or just want to develop your work independently.
+
+AI-Generated code policy
+========================
+The tp-libvirt project allows the use of AI-generated code, but it has to follow
+the guidelines and requirements outlined in the Policy for AI-Generated Code
+which can be found at:
+
+https://avocado-framework.readthedocs.io/en/latest/guides/contributor/chapters/ai_policy.html


### PR DESCRIPTION
This adds link of Avocado AI policy to the README file to be visible to tp-libvirt users and contributors.

Reference: avocado-framework/avocado#6168