### PR TITLE
virsh_domjobinfo: don't fail on selinux labeling

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domjobinfo.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domjobinfo.py
@@ -142,7 +142,7 @@ def run(test, params, env):
         if os.path.exists(tmp_pipe):
             os.unlink(tmp_pipe)
         os.mkfifo(tmp_pipe)
-        host_process.run('chcon -t virtqemud_t %s' % tmp_pipe, ignore_status=False, shell=True)
+        host_process.run('chcon -t virtqemud_t %s' % tmp_pipe, ignore_status=True, shell=True)
 
         # Target file param is not needed for managedsave operation
         if action == "managedsave ":


### PR DESCRIPTION
e94a92687fbebb0eaaab3c37d8f0560eea41470c fixes AVC denials by applying SELinux labels on test data. However, this doesn't apply on older RHEL versions like RHEL 9.2 where the command will fail

"""
chcon: failed to change context of '/var/tmp/avocado_3jwe6qnb/domjobinfo.fifo' to 'unconfined_u:object_r:virtqemud_t:s0': Invalid argument """

As it's difficult to control which RHEL version and which selinux policy this command actually applies to, let's just ignore if it fails assuming it will only fail in cases where the label is invalid and either not necessary or the test case needs to be updated with a new label anyway.