### PR TITLE
sriov: Add migration and lifecycle test for vfio variant driver

### DIFF
--- a/libvirt/tests/cfg/sriov/vfio/sriov_migration_vfio_variant_driver.cfg
+++ b/libvirt/tests/cfg/sriov/vfio/sriov_migration_vfio_variant_driver.cfg
@@ -1,0 +1,79 @@
+- sriov.migration.vfio_variant_driver:
+    type = sriov_migration_vfio_variant_driver
+    # Migrating non-started VM causes undefined behavior
+    start_vm = yes
+    # Console output can only be monitored via virsh console output
+    only_pty = True
+    take_regular_screendumps = no
+    # Options to pass to virsh migrate command before <domain> <desturi>
+    virsh_migrate_options = ""
+    # Extra options to pass after <domain> <desturi>
+    virsh_migrate_extra = ""
+    # SSH connection time out
+    ssh_timeout = 60
+    migration_setup = "yes"
+    storage_type = 'nfs'
+    setup_local_nfs = 'yes'
+    disk_type = "file"
+    disk_source_protocol = "netfs"
+    mnt_path_name = ${nfs_mount_dir}
+    image_convert = 'no'
+    virsh_migrate_dest_state = "running"
+    virsh_migrate_src_state = "shut off"
+    virsh_migrate_options = "--p2p --live --verbose  --persistent"
+    virsh_migrate_desturi = "qemu+ssh://${migrate_dest_host}/system"
+    virsh_migrate_connect_uri = "qemu:///system"
+    check_cont_ping = "no"
+    migrate_vm_back = "yes"
+
+    only x86_64, aarch64
+    variants:
+        - managed_yes:
+            managed = "yes"
+            variants:
+                - @default:
+                    func_supported_since_libvirt_ver = (10, 0, 0)
+                - mlx5_vfio:
+                    driver_dict = {'driver': {'driver_attr': {'name': 'vfio', 'model': 'mlx5_vfio_pci'}}}
+                    func_supported_since_libvirt_ver = (10, 0, 0)
+        - managed_no:
+            managed = "no"
+    variants dev_type:
+        - hostdev_interface:
+            iface_dict = {'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}, 'mac_address': mac_addr, 'managed': '${managed}'}
+        - hostdev_device:
+            hostdev_dict = {'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': vf_pci_addr}, 'managed': '${managed}'}
+    variants:
+        - single_iface:
+            iface_number = 1
+        - multiple_ifaces:
+            iface_number = 4
+    variants:
+        - with_postcopy:
+            only single_iface..mlx5_vfio
+            status_error = "yes"
+            postcopy_options = "--postcopy --timeout 10 --timeout-postcopy"
+            err_msg = "VFIO migration is not supported with postcopy migration"
+        - without_postcopy:
+            postcopy_options = ""
+            variants:
+                - with_iommu:
+                    only single_iface..mlx5_vfio
+                    status_error = "yes"
+                    err_msg = "not supported with vIOMMU enabled"
+                    variants:
+                        - virtio:
+                            only q35, aarch64
+                            iommu_dict = {'model': 'virtio'}
+                        - intel:
+                            only q35
+                            start_vm = "yes"
+                            enable_guest_iommu = "yes"
+                            iommu_dict = {'model': 'intel', 'driver': {'intremap': 'on', 'caching_mode': 'on'}}
+                - without_iommu:
+                    migrate_vm_back = "yes"
+    variants:
+        - p2p_live:
+            virsh_migrate_options = "--live --p2p --persistent --verbose"
+        - non_p2p_live:
+            virsh_migrate_options = "--live --verbose"

--- a/libvirt/tests/cfg/sriov/vfio/sriov_vm_lifecycle_vfio_variant_driver.cfg
+++ b/libvirt/tests/cfg/sriov/vfio/sriov_vm_lifecycle_vfio_variant_driver.cfg
@@ -1,0 +1,43 @@
+- sriov.vm_lifecyle.vfio_variant_driver:
+    type = sriov_vm_lifecycle_vfio_variant_driver
+    start_vm = "no"
+
+    only x86_64, aarch64
+    variants:
+        - managed_yes:
+            managed = "yes"
+            variants:
+                - @default:
+                    func_supported_since_libvirt_ver = (10, 0, 0)
+                - mlx5_vfio:
+                    driver_dict = {'driver': {'driver_attr': {'name': 'vfio', 'model': 'mlx5_vfio_pci'}}}
+                    func_supported_since_libvirt_ver = (10, 0, 0)
+        - managed_no:
+            managed = "no"
+    variants dev_type:
+        - hostdev_interface:
+            iface_dict = {'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}, 'mac_address': mac_addr, 'managed': '${managed}'}
+        - hostdev_device:
+            hostdev_dict = {'mode': 'subsystem', 'type': 'pci', 'source': {'untyped_address': vf_pci_addr}, 'managed': '${managed}'}
+    variants:
+        - single_iface:
+            iface_number = 1
+        - multiple_ifaces:
+            iface_number = 4
+    variants:
+        - start_vm:
+            variants:
+                - with_iommu:
+                    err_msg = "not supported with vIOMMU enabled"
+                    variants:
+                        - virtio:
+                            only q35, aarch64
+                            iommu_dict = {'model': 'virtio'}
+                        - intel:
+                            only q35
+                            start_vm = "yes"
+                            enable_guest_iommu = "yes"
+                            iommu_dict = {'model': 'intel', 'driver': {'intremap': 'on', 'caching_mode': 'on'}}
+                - without_iommu:
+        - hotplug:
+            hotplug = "yes"

--- a/libvirt/tests/src/sriov/vfio/sriov_migration_vfio_variant_driver.py
+++ b/libvirt/tests/src/sriov/vfio/sriov_migration_vfio_variant_driver.py
@@ -1,0 +1,59 @@
+import time
+from provider.migration import base_steps
+from provider.sriov import sriov_vfio
+
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_virtio
+from virttest.utils_libvirt import libvirt_vmxml
+
+
+def run(test, params, env):
+    """
+    Migration testing of VM with vfio variant driver
+    """
+    managed = params.get("managed")
+    iommu_dict = eval(params.get("iommu_dict", "{}"))
+
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    vm = env.get_vm(vm_name)
+    dev_names = []
+
+    migration_obj = base_steps.MigrationBase(test, vm, params)
+
+    new_xml = vm_xml.VMXML.new_from_inactive_dumpxml(vm.name)
+    orig_vm_xml = new_xml.copy()
+    try:
+        libvirt_vmxml.remove_vm_devices_by_type(vm, 'interface')
+        libvirt_vmxml.remove_vm_devices_by_type(vm, 'hostdev')
+        if iommu_dict:
+            libvirt_virtio.add_iommu_dev(vm, iommu_dict)
+
+        dev_names = sriov_vfio.attach_dev(vm, params)
+        if not vm.is_alive():
+            vm.start()
+        vm.cleanup_serial_console()
+        vm.create_serial_console()
+        vm.wait_for_serial_login().close()
+        time.sleep(30)
+
+        test.log.debug(f'VMXML of {vm_name}:\n{virsh.dumpxml(vm_name).stdout_text}')
+
+        migration_obj.setup_connection()
+        test.log.info("TEST_STEP: Migrate the VM to the target host.")
+        migration_obj.run_migration()
+        migration_obj.verify_default()
+
+        migrate_vm_back = "yes" == params.get("migrate_vm_back", "yes")
+        if migrate_vm_back:
+            test.log.info("TEST_STEP: Migrate back the VM to the source host.")
+            migration_obj.run_migration_back()
+            migration_obj.migration_test.ping_vm(vm, params)
+            migration_obj.check_vm_cont_ping(False)
+
+    finally:
+        orig_vm_xml.sync()
+        if managed == "no":
+            for dev in dev_names:
+                virsh.nodedev_reattach(dev, debug=True)

--- a/libvirt/tests/src/sriov/vfio/sriov_vm_lifecycle_vfio_variant_driver.py
+++ b/libvirt/tests/src/sriov/vfio/sriov_vm_lifecycle_vfio_variant_driver.py
@@ -1,0 +1,100 @@
+from provider.sriov import sriov_vfio
+
+from virttest import utils_misc
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_virtio
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+
+def run(test, params, env):
+    """
+    Lifecycle testing of VM with vfio variant driver
+    """
+    hotplug = params.get("hotplug", "no") == "yes"
+    err_msg = params.get("err_msg")
+    managed = params.get("managed")
+    iommu_dict = eval(params.get("iommu_dict", "{}"))
+    virsh_args = {'ignore_status': False, 'debug': True}
+
+    vm_name = params.get("main_vm", "avocado-vt-vm1")
+    vm = env.get_vm(vm_name)
+    rand_id = utils_misc.generate_random_string(3)
+    save_path = f'/var/tmp/{vm_name}_{rand_id}.save'
+    dev_names = []
+
+    new_xml = vm_xml.VMXML.new_from_inactive_dumpxml(vm.name)
+    orig_vm_xml = new_xml.copy()
+    try:
+        libvirt_vmxml.remove_vm_devices_by_type(vm, 'interface')
+        libvirt_vmxml.remove_vm_devices_by_type(vm, 'hostdev')
+        if iommu_dict:
+            libvirt_virtio.add_iommu_dev(vm, iommu_dict)
+
+        if hotplug:
+            vm.start()
+            vm.wait_for_serial_login().close()
+            dev_names = sriov_vfio.attach_dev(vm, params)
+        else:
+            dev_names = sriov_vfio.attach_dev(vm, params)
+            vm.start()
+            vm.wait_for_serial_login().close()
+
+        test.log.debug(f'VMXML of {vm_name}:\n{virsh.dumpxml(vm_name).stdout_text}')
+
+        test.log.info("TEST_STEP: Save and restore the VM.")
+        result = virsh.save(vm.name, save_path, debug=True)
+        libvirt.check_result(result, err_msg)
+        if err_msg:
+            return
+        virsh.restore(save_path, **virsh_args)
+
+        test.log.info("TEST_STEP: Suspend VM and check vm's state.")
+        virsh.suspend(vm.name, debug=True, ignore_status=False)
+        if not libvirt.check_vm_state(vm_name, "paused"):
+            test.fail("The guest should be down after executing 'virsh suspend'.")
+
+        test.log.info("TEST_STEP: Resume the VM and check vm's state.")
+        virsh.resume(vm.name, debug=True, ignore_status=False)
+        if not libvirt.check_vm_state(vm_name, "running"):
+            test.fail("The guest should be down after executing 'virsh resume'.")
+
+        test.log.info("TEST_STEP: Managedsave and Start the VM.")
+        virsh.managedsave(vm.name, **virsh_args)
+        virsh.start(vm.name, debug=True, ignore_status=False)
+        if not libvirt.check_vm_state(vm_name, "running"):
+            test.fail("The guest should be down after executing 'virsh managedsave'.")
+
+        vm.shutdown()
+        vm.start()
+        session = vm.wait_for_serial_login(
+            timeout=int(params.get('login_timeout')))
+        session.sendline(params.get("shutdown_command"))
+        if not vm.wait_for_shutdown():
+            test.fail("VM %s failed to shut down", vm.name)
+
+        vm.cleanup_serial_console()
+        vm.start()
+
+        session = vm.wait_for_serial_login(
+            timeout=int(params.get('login_timeout')))
+        virsh.reset(vm.name, **virsh_args)
+        _match, _text = session.read_until_last_line_matches(
+                [r"[Ll]ogin:\s*"], timeout=240, internal_timeout=0.5)
+        session.close()
+
+        test.log.info("TEST_STEP: Reboot the VM using command inside the VM.")
+        session = vm.wait_for_serial_login(
+            timeout=int(params.get('login_timeout')))
+        session.sendline(params.get("reboot_command"))
+        _match, _text = session.read_until_last_line_matches(
+            [r"[Ll]ogin:\s*"], timeout=240, internal_timeout=0.5)
+        session.close()
+
+    finally:
+        orig_vm_xml.sync()
+        if managed == "no":
+            for dev in dev_names:
+                virsh.nodedev_reattach(dev, debug=True)

--- a/provider/sriov/sriov_vfio.py
+++ b/provider/sriov/sriov_vfio.py
@@ -1,0 +1,71 @@
+import logging
+
+from virttest import utils_net
+from virttest import utils_sriov
+from virttest import virsh
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+
+LOG = logging.getLogger("avocado." + __name__)
+
+
+def parse_iface_dict(vf_pci, params):
+    """
+    Parse interface dictionary from parameters
+
+    :param vf_pci: The pci address of VF
+    :param params: The parameters of the test
+    :return: The dictionary of interface
+    """
+    mac_addr = utils_net.generate_mac_address_simple()
+
+    vf_pci_addr = utils_sriov.pci_to_addr(vf_pci)
+    if params.get("iface_dict"):
+        iface_dict = eval(params.get("iface_dict", "{}"))
+    else:
+        if vf_pci_addr.get("type"):
+            del vf_pci_addr["type"]
+        iface_dict = eval(params.get("hostdev_dict", "{}"))
+    driver_dict = eval(params.get("driver_dict", "{}"))
+    if driver_dict:
+        iface_dict.update(driver_dict)
+    LOG.debug(f"Iface dict: {iface_dict}")
+
+    return iface_dict
+
+
+def attach_dev(vm, params):
+    """
+    Attach device(s) to VM
+
+    :param vm: The vm object
+    :param params: The parameters of the test
+    :return: The Attached devices' name
+    """
+    hotplug = params.get("hotplug", "no") == "yes"
+    test_pf = params.get("test_pf", "ens3f0np0")
+    pf_pci = utils_sriov.get_pf_pci(test_pf=test_pf)
+    dev_type = params.get("dev_type", "hostdev_interface")
+    device_type = "hostdev" if dev_type == "hostdev_device" else "interface"
+    iface_number = int(params.get("iface_number", "1"))
+    managed = params.get("managed")
+    virsh_args = {"ignore_status": False, "debug": True}
+    dev_names = []
+
+    for idx in range(iface_number):
+        LOG.info("Attach a hostdev interface/device to VM")
+        vf_pci = utils_sriov.get_vf_pci_id(pf_pci, idx)
+        dev_name = utils_sriov.get_device_name(vf_pci)
+        dev_names.append(dev_name)
+        if managed == "no":
+            virsh.nodedev_detach(dev_name, debug=True, ignore_status=False)
+        iface_dict = parse_iface_dict(vf_pci, params)
+
+        if hotplug:
+            iface_dev = libvirt_vmxml.create_vm_device_by_type(device_type, iface_dict)
+            virsh.attach_device(vm.name, iface_dev.xml, **virsh_args)
+        else:
+            libvirt_vmxml.modify_vm_device(
+                vm_xml.VMXML.new_from_dumpxml(vm.name), device_type, iface_dict, index=idx)
+    return dev_names


### PR DESCRIPTION
This PR adds:
    VIRT-299307 VM lifecycle with vfio variant driver
    VIRT-299308 Migrate VM with vfio variant driver


**Test results:**
```
 (01/36) type_specific.io-github-autotest-libvirt.sriov.vm_lifecyle.vfio_variant_driver.start_vm.with_iommu.virtio.single_iface.hostdev_interface.managed_yes.default: STARTED
 (01/36) type_specific.io-github-autotest-libvirt.sriov.vm_lifecyle.vfio_variant_driver.start_vm.with_iommu.virtio.single_iface.hostdev_interface.managed_yes.default: PASS (89.69 s)
 (02/36) type_specific.io-github-autotest-libvirt.sriov.vm_lifecyle.vfio_variant_driver.start_vm.with_iommu.virtio.single_iface.hostdev_interface.managed_yes.mlx5_vfio: STARTED
 (02/36) type_specific.io-github-autotest-libvirt.sriov.vm_lifecyle.vfio_variant_driver.start_vm.with_iommu.virtio.single_iface.hostdev_interface.managed_yes.mlx5_vfio: PASS (90.14 s)
 (03/36) type_specific.io-github-autotest-libvirt.sriov.vm_lifecyle.vfio_variant_driver.start_vm.with_iommu.virtio.single_iface.hostdev_interface.managed_no: STARTED
 (03/36) type_specific.io-github-autotest-libvirt.sriov.vm_lifecyle.vfio_variant_driver.start_vm.with_iommu.virtio.single_iface.hostdev_interface.managed_no: PASS (91.09 s)
 (04/36) type_specific.io-github-autotest-libvirt.sriov.vm_lifecyle.vfio_variant_driver.start_vm.with_iommu.virtio.single_iface.hostdev_device.managed_yes.default: STARTED
 (04/36) type_specific.io-github-autotest-libvirt.sriov.vm_lifecyle.vfio_variant_driver.start_vm.with_iommu.virtio.single_iface.hostdev_device.managed_yes.default: PASS (93.85 s)
...
 (36/36) type_specific.io-github-autotest-libvirt.sriov.vm_lifecyle.vfio_variant_driver.hotplug.multiple_ifaces.hostdev_device.managed_no: PASS (170.48 s)
RESULTS    : PASS 36 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0

```

migration results: Migration fails on this env, dzheng will file an issue for it.
` (1/1) type_specific.io-github-autotest-libvirt.sriov.migration.vfio_variant_driver.non_p2p_live.without_postcopy.without_iommu.single_iface.hostdev_device.managed_yes.mlx5_vfio: FAIL: Migration: [ 0.00 %]error: internal error: QEMU unexpectedly closed the monitor (vm='avocado-vt-vm1'): 2025-07-15T10:55:33.233009Z qemu-kvm: error while loading state section id 53(0000:00:01.0:00.0/vfio)\n2025-07-15T10:55:33.233320Z qemu-kvm: load of migr... (229.42 s)`
