### PR TITLE
migration: Fix eval arg error

### DIFF
--- a/libvirt/tests/cfg/migration/migration_numa/migration_numatune.cfg
+++ b/libvirt/tests/cfg/migration/migration_numa/migration_numatune.cfg
@@ -40,6 +40,7 @@
     no s390-virtio
     aarch64:        
         cpu_mode = 'host-passthrough'
+    start_vm = "yes"
     variants mem_pagesize:
         - default:
         - hugepage:

--- a/libvirt/tests/src/migration/migration_numa/migration_numatune.py
+++ b/libvirt/tests/src/migration/migration_numa/migration_numatune.py
@@ -32,7 +32,7 @@ def update_numa_memnode(numatest, node0, node1):
     elif mem_mode == "restrictive":
         numa_memnode = numa_memnode % (node0, node1)
 
-    numatest.params["numa_memnode"] = eval(numa_memnode)
+    numatest.params["numa_memnode"] = numa_memnode
 
 
 def setup_test(numatest_src, numatest_dst, migration_obj):
@@ -101,7 +101,7 @@ def verify_test(numatest, migration_obj):
     actual_numa_memnodes = vmxml_remote.numa_memnode
     actual_numa_memory = vmxml_remote.numa_memory
     conf_numa_memory = numatest.params.get("numa_memory")
-    conf_numa_memnode = numatest.params.get("numa_memnode")
+    conf_numa_memnode = eval(numatest.params.get("numa_memnode"))
     if actual_numa_memnodes != conf_numa_memnode:
         numatest.test.fail("Expect numa memnode to be '%s' on remote vm, "
                            "but found '%s'" % (conf_numa_memnode, actual_numa_memnodes))


### PR DESCRIPTION
Before:
eval() arg 1 must be a string, bytes or code object

After:
 (1/8) type_specific.io-github-autotest-libvirt.migration.numa.numatune.mem_mode_strict.default: STARTED
 (1/8) type_specific.io-github-autotest-libvirt.migration.numa.numatune.mem_mode_strict.default: PASS (165.93 s)
 (2/8) type_specific.io-github-autotest-libvirt.migration.numa.numatune.mem_mode_strict.hugepage: STARTED
 (2/8) type_specific.io-github-autotest-libvirt.migration.numa.numatune.mem_mode_strict.hugepage: PASS (229.78 s)
 (3/8) type_specific.io-github-autotest-libvirt.migration.numa.numatune.mem_mode_interleave.default: STARTED
 (3/8) type_specific.io-github-autotest-libvirt.migration.numa.numatune.mem_mode_interleave.default: PASS (168.31 s)
 (4/8) type_specific.io-github-autotest-libvirt.migration.numa.numatune.mem_mode_interleave.hugepage: STARTED
 (4/8) type_specific.io-github-autotest-libvirt.migration.numa.numatune.mem_mode_interleave.hugepage: PASS (197.59 s)
 (5/8) type_specific.io-github-autotest-libvirt.migration.numa.numatune.mem_mode_preferred.default: STARTED
 (5/8) type_specific.io-github-autotest-libvirt.migration.numa.numatune.mem_mode_preferred.default: PASS (167.47 s)
 (6/8) type_specific.io-github-autotest-libvirt.migration.numa.numatune.mem_mode_preferred.hugepage: STARTED
 (6/8) type_specific.io-github-autotest-libvirt.migration.numa.numatune.mem_mode_preferred.hugepage: PASS (199.61 s)
 (7/8) type_specific.io-github-autotest-libvirt.migration.numa.numatune.mem_mode_restrictive.default: STARTED
 (7/8) type_specific.io-github-autotest-libvirt.migration.numa.numatune.mem_mode_restrictive.default: PASS (168.07 s)
 (8/8) type_specific.io-github-autotest-libvirt.migration.numa.numatune.mem_mode_restrictive.hugepage: STARTED
 (8/8) type_specific.io-github-autotest-libvirt.migration.numa.numatune.mem_mode_restrictive.hugepage: PASS (200.95 s)