### PR TITLE
in_place_upgrade_guest: add LEAPP_DEVEL_SKIP_CHECK_OS_RELEASE variable

### DIFF
--- a/libvirt/tests/cfg/in_place_upgrade_guest.cfg
+++ b/libvirt/tests/cfg/in_place_upgrade_guest.cfg
@@ -9,3 +9,4 @@
     upgrade_repos_path = "/etc/leapp/files/leapp_upgrade_repositories.repo"
     leapp_preupgrade_cmd = "leapp preupgrade --debug --no-rhsm"
     leapp_upgrade_cmd = "leapp upgrade --debug --no-rhsm"
+    leapp_skip_check_os = "LEAPP_UNSUPPORTED=1 LEAPP_DEVEL_SKIP_CHECK_OS_RELEASE=1"

--- a/libvirt/tests/src/in_place_upgrade_guest.py
+++ b/libvirt/tests/src/in_place_upgrade_guest.py
@@ -149,6 +149,11 @@ def run_leapp_cmd(test, params, session, step):
     if step == "upgrade":
         leapp_cmd = params.get("leapp_upgrade_cmd")
 
+    # May need to test versions that are not yet officially supported by leapp
+    # despite it being technically capable of the upgrade
+    leapp_skip_check_os = params.get("leapp_skip_check_os")
+    leapp_cmd = "%s %s" % (leapp_skip_check_os, leapp_cmd)
+
     status = session.cmd_status(leapp_cmd, timeout=900)
     if status == 0:
         test.log.info("Leapp %s executed successfully" % step)


### PR DESCRIPTION
From RHEL9.7, we need to keep the original upgrade-paths until devel-freeze, because it could happen the package could be released in advance when it's required, and such a released package must not officially support IPU form 9.7 to 10.1.