### PR TITLE
network/block_test: fix test config

### DIFF
--- a/libvirt/tests/cfg/virtual_network/network/block_test/virtnetworkd_unblock_systemd_inibit.cfg
+++ b/libvirt/tests/cfg/virtual_network/network/block_test/virtnetworkd_unblock_systemd_inibit.cfg
@@ -18,3 +18,4 @@
     variants network_states:
         - active_net:
         - inactive_net:
+


### PR DESCRIPTION
Test config was missing newline. As such, the cartesian config wouldn't find any test cases anymore.

With the additional newline the test run works well again.