### PR TITLE
libvirt_rng: hotplug arbitrary file as rng backend

### DIFF
--- a/libvirt/tests/cfg/security/rng/libvirt_rng.cfg
+++ b/libvirt/tests/cfg/security/rng/libvirt_rng.cfg
@@ -12,7 +12,7 @@
     snap_options = " %s"
     variants:
         - hotplug_unplug:
-            only backend_rdm.default, backend_tcp, backend_udp, backend_builtin
+            only backend_rdm.default, backend_tcp, backend_udp, backend_builtin, backend_rdm.arbitrary_source
             rng_attach_device = "yes"
             variants:
                 - positive:
@@ -62,6 +62,10 @@
                     only device_assign
                     with_packed = "yes"
                     driver_packed = "on"
+                - arbitrary_source:
+                    only hotplug_unplug.positive.no_options
+                    backend_dev = '/var/lib/libvirt/images/fd.img'
+                    source_file_size = '10M'
                 - invalid_address:
                     address = "{ 'domain': '0x9999', 'bus': '0x00', 'slot': '0x00', 'function': '0x0'}"
                     expected_create_error = ".*Invalid PCI address.*"


### PR DESCRIPTION
Test hotplugging an arbitrary file as virtio-rng backend file, which is not a valid random source but supported to be set.