### PR TITLE
Fix specific kvm functional cases

### DIFF
--- a/provider/v2v_vmcheck_helper.py
+++ b/provider/v2v_vmcheck_helper.py
@@ -518,10 +518,14 @@ class VMChecker(object):
         # All pci device which provided by Red Hat, Inc.
         # https://devicehunt.com/view/type/pci/vendor/1AF4/
         # https://devicehunt.com/view/type/pci/vendor/1B36
+        virt_memory_balloon = 'Virtio memory balloon'
+        if "el10" in process.run("uname -r", shell=True).stdout_text:
+            virt_memory_balloon = 'Virtio 1.0 balloon'
+
         virtio_name_id_mapping = {
             'Virtio network device': ['1000', '1041'],
             'Virtio block device': ['1001', '1042'],
-            'Virtio memory balloon': ['1002', '1045'],
+            virt_memory_balloon: ['1002', '1045'],
             'Virtio console': ['1003', '1043'],
             'Virtio SCSI': ['1004', '1048'],
             'Virtio RNG': ['1005', '1044'],
@@ -685,9 +689,12 @@ class VMChecker(object):
         # Check virtio PCI devices
         LOG.info("Checking virtio PCI devices")
         pci_devs = self.checker.get_vm_pci_list()
+        virt_memory_balloon = "Virtio memory balloon"
+        if "el10" in process.run("uname -r", shell=True).stdout_text:
+            virt_memory_balloon = "Virtio 1.0 balloon"
         virtio_devs = ["Virtio network device",
                        "Virtio block device",
-                       "Virtio memory balloon"]
+                       virt_memory_balloon]
         # Virtio RNG supports from kernel-2.6.26
         # https://wiki.qemu.org/Features/VirtIORNG
         if compare_version(FEATURE_SUPPORT['virtio_rng'], kernel_version):


### PR DESCRIPTION
Fixed error:
`1 checkpoints failed: ['Not find Virtio memory balloon']`