### PR TITLE
libvirt_vcpu_plug_unplug: Mask qemu-guest-agent instead of remove it 

### DIFF
--- a/libvirt/tests/src/libvirt_vcpu_plug_unplug.py
+++ b/libvirt/tests/src/libvirt_vcpu_plug_unplug.py
@@ -321,8 +321,8 @@ def run(test, params, env):
             vm.prepare_guest_agent(prepare_xml=False, start=start_qemuga)
             vm.setenforce(0)
         else:
-            # Remove qemu-guest-agent for negative test
-            vm.remove_package('qemu-guest-agent')
+            # Stop qemu-guest-agent service for negative test
+            vm.set_state_guest_agent(False)
 
         # Run test
         for _ in range(iterations):


### PR DESCRIPTION
If the qemu-guest-agent installed in the base commit for bootc system of
guest, it cannot be removed. Stop its service for such a condition.

Signed-off-by: Han Han <hhan@redhat.com>