### PR TITLE
migration: Fix some issues in pause_and_recover_twice

### DIFF
--- a/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_and_recover_twice.cfg
+++ b/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_and_recover_twice.cfg
@@ -22,19 +22,13 @@
     server_user = "root"
     server_pwd = "${migrate_dest_pwd}"
     check_network_accessibility_after_mig = "yes"
-    status_error = "no"
+    status_error = "yes"
     migrate_speed = "5"
-    stress_package = "stress"
-    stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20s"
-    postcopy_options = "--timeout 4 --timeout-postcopy --postcopy"
-    do_migration_during_mig = "yes"
-    postcopy_options_during_mig = "--postcopy-resume"
+    postcopy_options = "--postcopy"
+    postcopy_resume = "--postcopy-resume"
     err_msg = "job 'migration in' failed in post-copy phase"
     test_case = "pause_and_recover_twice"
-    status_error_during_mig = "yes"
-    status_error_during_mig_twice = "no"
     func_supported_since_libvirt_ver = (8, 5, 0)
-
     variants:
         - p2p:
             virsh_migrate_options = '--live --p2p --verbose'
@@ -42,15 +36,16 @@
             virsh_migrate_options = '--live --verbose'
     variants recover_failed_reason:
         - network_issue:
-            port_to_check = "49154"
-            virsh_migrate_extra = "--migrateuri tcp://${migrate_dest_host}:${port_to_check} --listen-address ${migrate_dest_host}"
-            firewall_rule_on_dest = "ipv4 filter INPUT 0 -p tcp --dport ${port_to_check} -j DROP"
-            firewall_rule_on_src = "ipv4 filter INPUT 0 -p tcp --sport ${port_to_check} -j DROP"
-            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "virsh.domjobabort", "func_param": "'%s --postcopy' % params.get('migrate_main_vm')", "need_sleep_time": "5"}, {"func": "libvirt_network.setup_firewall_rule", "func_param": "params"}, {"func": "do_migration", "func_param": "params", "need_sleep_time": "15"}, {"func": "libvirt_network.cleanup_firewall_rule", "func_param": "params", "need_sleep_time": "5"}, {"func": "resume_migration_again", "func_param": "params", "need_sleep_time": "5"}]'
             migrate_desturi_port = "16509"
             migrate_desturi_type = "tcp"
             virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
-            err_msg_during_mig = "unable to connect to server at.*: Connection timed out"
+            firewall_rule_on_dest = "ipv4 filter INPUT 0 -p tcp --dport %s -j DROP"
+            firewall_rule_on_src = "ipv4 filter INPUT 0 -p tcp --sport %s -j DROP"
+            action_during_mig = '[{"func": "virsh.migrate_postcopy", "func_param": "'%s' % params.get('migrate_main_vm')", "need_sleep_time": "5"}, {"func": "virsh.domjobabort", "func_param": "'%s --postcopy' % params.get('migrate_main_vm')", "need_sleep_time": "3"}]'
+            action_during_mig_resume = '[{"func": "update_port_for_firewall_rule", "before_pause": "yes", "func_param": "params", "need_sleep_time": "3"}, {"func": "libvirt_network.setup_firewall_rule", "before_pause": "yes", "func_param": "params", "need_sleep_time": "3"}]'
+            status_error_resume = "yes"
+            err_msg_resume = "job 'migration in' failed in post-copy phase"
+            status_error_resume_again = "no"
             tcp_config_list = '{"tcp_keepalive_probes": "3", "tcp_keepalive_intvl": "3", "tcp_retries1": "1", "tcp_retries2": "1", "tcp_fin_timeout": "2"}'
             recover_tcp_config_list = '{"tcp_keepalive_probes": "9", "tcp_keepalive_intvl": "75", "tcp_retries1": "3", "tcp_retries2": "15", "tcp_fin_timeout": "60"}'
         - proxy_issue:
@@ -63,6 +58,8 @@
             virsh_migrate_migrateuri = "unix://${migrateuri_socket_path}"
             virsh_migrate_disks_uri = "unix://${disks_uri_socket_path}"
             virsh_migrate_extra = "--migrateuri ${virsh_migrate_migrateuri}"
-            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "virsh.domjobabort", "func_param": "'%s --postcopy' % params.get('migrate_main_vm')", "need_sleep_time": "5"}, {"func": "clear_pmsocat", "func_param": "params"}, {"func": "do_migration", "func_param": "params", "need_sleep_time": "60"}, {"func": "base_steps.recreate_conn_objs", "func_param": "params"}, {"func": "resume_migration_again", "func_param": "params"}]'
-            check_port_or_network_conn_num = "no"
-            err_msg_during_mig = "Failed to connect socket to .*: Connection refused"
+            action_during_mig = '[{"func": "virsh.migrate_postcopy", "func_param": "'%s' % params.get('migrate_main_vm')", "need_sleep_time": "5"}, {"func": "virsh.domjobabort", "func_param": "'%s --postcopy' % params.get('migrate_main_vm')", "need_sleep_time": "2"}, {"func": "clear_pmsocat", "func_param": "params", "need_sleep_time": "2"}]'
+            err_msg = "internal error: client socket is closed|End of file while reading data: Input/output error|job 'migration in' failed in post-copy phase"
+            status_error_resume = "yes"
+            err_msg_resume = "Failed to connect socket to .*: Connection refused"
+            status_error_resume_again = "no"


### PR DESCRIPTION
1. Update error message.
2. Update to use migration port instead of fixed port when breaking the network.
3. Adjusted the code structure to improve maintainability.