### PR TITLE
migration: Add a step to enable unattended migration

### DIFF
--- a/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/unattended_migration_and_disruptive.cfg
+++ b/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/unattended_migration_and_disruptive.cfg
@@ -23,8 +23,6 @@
     server_pwd = "${migrate_dest_pwd}"
     check_network_accessibility_after_mig = "yes"
     migrate_speed = "5"
-    stress_package = "stress"
-    stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20s"
     postcopy_options = "--timeout 4 --timeout-postcopy --postcopy --postcopy-bandwidth 5"
     do_migration_during_mig = "yes"
     postcopy_options_during_mig = "--postcopy-resume"
@@ -80,7 +78,7 @@
             virsh_migrate_migrateuri = "unix://${migrateuri_socket_path}"
             virsh_migrate_disks_uri = "unix://${disks_uri_socket_path}"
             virsh_migrate_extra = "--migrateuri ${virsh_migrate_migrateuri}"
-            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "clear_pmsocat", "func_param": "params", "need_sleep_time": "60"}, {"func": "base_steps.recreate_conn_objs", "func_param": "params"}, {"func": "do_migration", "func_param": "params"}]'
+            action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: '1'", "func_param": 'params'}, {"func": "libvirt_service.kill_service", "func_param": "params"}, {"func": "clear_pmsocat", "func_param": "params", "need_sleep_time": "3"}, {"func": "base_steps.recreate_conn_objs", "func_param": "params", "need_sleep_time": "3"}, {"func": "do_migration", "func_param": "params", "need_sleep_time": "3"}]'
             check_port_or_network_conn_num = "no"
             status_error = "no"
             status_error_during_mig = "no"


### PR DESCRIPTION
Test result:
 (1/8) type_specific.io-github-autotest-libvirt.migration.pause_postcopy_migration_and_recover.unattended_migration_and_disruptive.poweroff_vm_dest.p2p: STARTED
 (1/8) type_specific.io-github-autotest-libvirt.migration.pause_postcopy_migration_and_recover.unattended_migration_and_disruptive.poweroff_vm_dest.p2p: PASS (299.20 s)
 (2/8) type_specific.io-github-autotest-libvirt.migration.pause_postcopy_migration_and_recover.unattended_migration_and_disruptive.poweroff_vm_dest.non_p2p: STARTED
 (2/8) type_specific.io-github-autotest-libvirt.migration.pause_postcopy_migration_and_recover.unattended_migration_and_disruptive.poweroff_vm_dest.non_p2p: PASS (330.12 s)
 (3/8) type_specific.io-github-autotest-libvirt.migration.pause_postcopy_migration_and_recover.unattended_migration_and_disruptive.pause_by_domjobabort.p2p: STARTED
 (3/8) type_specific.io-github-autotest-libvirt.migration.pause_postcopy_migration_and_recover.unattended_migration_and_disruptive.pause_by_domjobabort.p2p: PASS (284.15 s)
 (4/8) type_specific.io-github-autotest-libvirt.migration.pause_postcopy_migration_and_recover.unattended_migration_and_disruptive.pause_by_domjobabort.non_p2p: STARTED
 (4/8) type_specific.io-github-autotest-libvirt.migration.pause_postcopy_migration_and_recover.unattended_migration_and_disruptive.pause_by_domjobabort.non_p2p: PASS (282.81 s)
 (5/8) type_specific.io-github-autotest-libvirt.migration.pause_postcopy_migration_and_recover.unattended_migration_and_disruptive.pause_by_network.p2p: STARTED
 (5/8) type_specific.io-github-autotest-libvirt.migration.pause_postcopy_migration_and_recover.unattended_migration_and_disruptive.pause_by_network.p2p: PASS (312.92 s)
 (6/8) type_specific.io-github-autotest-libvirt.migration.pause_postcopy_migration_and_recover.unattended_migration_and_disruptive.pause_by_network.non_p2p: STARTED
 (6/8) type_specific.io-github-autotest-libvirt.migration.pause_postcopy_migration_and_recover.unattended_migration_and_disruptive.pause_by_network.non_p2p: PASS (314.93 s)
 (7/8) type_specific.io-github-autotest-libvirt.migration.pause_postcopy_migration_and_recover.unattended_migration_and_disruptive.pause_by_proxy.p2p: STARTED
 (7/8) type_specific.io-github-autotest-libvirt.migration.pause_postcopy_migration_and_recover.unattended_migration_and_disruptive.pause_by_proxy.p2p: PASS (254.83 s)
 (8/8) type_specific.io-github-autotest-libvirt.migration.pause_postcopy_migration_and_recover.unattended_migration_and_disruptive.pause_by_proxy.non_p2p: STARTED
 (8/8) type_specific.io-github-autotest-libvirt.migration.pause_postcopy_migration_and_recover.unattended_migration_and_disruptive.pause_by_proxy.non_p2p: PASS (255.27 s)