### PR TITLE
Add new case VIRT-299202 for migrate vm with various memory devices

### DIFF
--- a/libvirt/tests/cfg/migration/migration_with_memory/migration_with_memory_devices.cfg
+++ b/libvirt/tests/cfg/migration/migration_with_memory/migration_with_memory_devices.cfg
@@ -1,0 +1,98 @@
+- migration.migration_with_memory.memory_devices:
+    type = migration_with_memory_devices
+    no s390-virtio
+    take_regular_screendumps = no
+    migration_setup = "yes"
+    storage_type = 'nfs'
+    setup_local_nfs = 'yes'
+    disk_type = "file"
+    disk_source_protocol = "netfs"
+    mnt_path_name = ${nfs_mount_dir}
+    # Console output can only be monitored via virsh console output
+    only_pty = True
+    # Extra options to pass after <domain> <desturi>
+    virsh_migrate_extra = ""
+    # SSH connection time out
+    ssh_timeout = 60
+    # Local URI
+    virsh_migrate_connect_uri = 'qemu:///system'
+    virsh_migrate_dest_state = "running"
+    virsh_migrate_src_state = "shut off"
+    image_convert = "no"
+    server_ip = "${migrate_dest_host}"
+    server_user = "root"
+    server_pwd = "${migrate_dest_pwd}"
+    client_ip = "${migrate_source_host}"
+    migrate_desturi_port = "22"
+    migrate_desturi_type = "ssh"
+    virsh_migrate_desturi = "qemu+ssh://${migrate_dest_host}/system"
+    bandwidth = 100
+    virsh_migrate_options = "--p2p --live --persistent --bandwidth ${bandwidth} --migrateuri tcp://${migrate_dest_host}"
+    mem_val = 2097152
+    curr_mem_val = 2097152
+    start_mem_val = 3145728
+    mem_attrs = "'memory_unit':'KiB','memory':${mem_val},'current_mem':${curr_mem_val},'current_mem_unit':'KiB', 'max_mem_rt': 10485760, 'max_mem_rt_slots': 16, 'max_mem_rt_unit': 'KiB'"
+    numa_attrs = ", 'vcpu': 4, 'cpu': {'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '1048576', 'unit': 'KiB'}, {'id': '1', 'cpus': '2-3', 'memory': '1048576', 'unit': 'KiB'}]}"
+    variants hugepage_size:
+        - 2m:
+            only aarch64, x86_64
+            hp_size = 2048
+            hp_num = 2048
+        - 512m:
+            only aarch64
+            hp_size = 524288
+            hp_num = 8
+    variants mem_device_model:
+        - dimm:
+            mem_model = "dimm"
+            mem_define = {'mem_model': '${mem_model}', 'mem_access':'private', 'mem_discard':'no', 'source':{'nodemask':'0'}, 'target': {'size': 512, 'node': 1, 'size_unit': 'MiB'}}
+            mem_hotplug = {'mem_model': '${mem_model}', 'mem_access':'shared', 'mem_discard':'yes', 'source':{'pagesize':${hp_size}, 'pagesize_unit':'KiB'}, 'target': {'size': 512, 'node': 0, 'size_unit': 'MiB'}}
+            start_curr_mem_val = 2621440
+            mem_define_alias = dimm0
+            mem_hotplug_alias = dimm1
+            mem_define_xpath = [{'element_attrs':["./memory[@model='${mem_model}']", "./memory[@access='private']", "./memory[@discard='no']"]},{'element_attrs':["./memory/source/nodemask"],'text':'0'}, {'element_attrs':["./memory/target/node"], 'text':'1'}, {'element_attrs':["./memory/target/size[@unit='KiB']"],'text':'524288'}]
+            mem_hotplug_xpath = [{'element_attrs':["./memory[@model='${mem_model}']", "./memory[@access='shared']", "./memory[@discard='yes']"]},{'element_attrs':["./memory/source/pagesize[@unit='KiB']"],'text':'${hp_size}'}, {'element_attrs':["./memory/target/size[@unit='KiB']"],'text':'524288'}, {'element_attrs':["./memory/target/node"],'text':'0'}]
+        - virtio-mem:
+            func_supported_since_libvirt_ver = (8, 0, 0)
+            mem_model = "virtio-mem"
+            mem_define = {'mem_model': '${mem_model}', 'mem_access':'shared', 'mem_discard':'yes', 'source':{'pagesize':${hp_size}}, 'target': {'requested_size': 524288,'requested_unit':'KiB', 'block_size': ${hp_size}, 'block_unit':'KiB', 'size': 524288, 'node': 1, 'size_unit': 'KiB'}}
+            mem_hotplug = {'mem_model': '${mem_model}', 'mem_access':'private', 'mem_discard':'no', 'target': {'requested_size': 524288,'requested_unit':'KiB', 'block_size': ${hp_size}, 'block_unit':'KiB', 'size': 524288, 'node': 0, 'size_unit': 'KiB'}}
+            start_curr_mem_val = 3145728
+            mem_define_alias = virtiomem0
+            mem_hotplug_alias = virtiomem1
+            mem_define_xpath = [{'element_attrs':["./memory[@model='${mem_model}']", "./memory[@access='shared']", "./memory[@discard='yes']"]}, {'element_attrs':["./memory/source/pagesize[@unit='KiB']"],'text':'${hp_size}'}, {'element_attrs':["./memory/target/size[@unit='KiB']"],'text':'524288'}, {'element_attrs':["./memory/target/node"],'text':'1'}, {'element_attrs':["./memory/target/block[@unit='KiB']"],'text':'${hp_size}'}, {'element_attrs':["./memory/target/requested[@unit='KiB']"],'text':'524288'}, {'element_attrs':["./memory/target/current[@unit='KiB']"],'text':'524288'}]
+            mem_hotplug_xpath = [{'element_attrs':["./memory[@model='${mem_model}']", "./memory[@access='private']", "./memory[@discard='no']"]}, {'element_attrs':["./memory/target/size[@unit='KiB']"],'text':'524288'}, {'element_attrs':["./memory/target/node"],'text':'0'}, {'element_attrs':["./memory/target/block[@unit='KiB']"],'text':'${hp_size}'}, {'element_attrs':["./memory/target/requested[@unit='KiB']"],'text':'524288'}, {'element_attrs':["./memory/target/current[@unit='KiB']"],'text':'524288'}]
+        - nvdimm:
+            mem_model = "nvdimm"
+            nvdimm_define_path = "${nfs_mount_dir}/nvdimm1"
+            nvdimm_hotplug_path = "${nfs_mount_dir}/nvdimm2"
+            nvdimm_paths = ["${nvdimm_define_path}", "${nvdimm_hotplug_path}"]
+            nvdimm_paths_cmds = ["truncate -s 512M ${nvdimm_define_path}", "truncate -s 512M ${nvdimm_hotplug_path}"]
+            mem_define = {'mem_model': '${mem_model}', 'mem_access':'shared', 'source': {'path': '${nvdimm_define_path}'}, 'target': {'size': 524288, 'node': 0, 'size_unit': 'KiB'}}
+            mem_hotplug = {'mem_model': '${mem_model}', 'mem_access':'private', 'source': {'path': '${nvdimm_hotplug_path}'}, 'target': {'size': 524288, 'node': 1, 'size_unit': 'KiB'}}
+            start_curr_mem_val = 2097152
+            nvdimm_define_device = /dev/pmem0
+            nvdimm_hotplug_device = /dev/pmem1
+            nvdimm_define_mount_path = /mnt/define
+            nvdimm_hotplug_mount_path = /mnt/hotplug
+            nvdimm_define_file = ${nvdimm_define_mount_path}/define_file.txt
+            nvdimm_hotplug_file = ${nvdimm_hotplug_mount_path}/hotplug_file.txt
+            nvdimm_define_content = "nvdimm_define_content"
+            nvdimm_hotplug_content = "nvdimm_hotplug_content"
+            mem_define_alias = nvdimm0
+            mem_hotplug_alias = nvdimm1
+            mem_define_xpath = [{'element_attrs':["./memory[@model='${mem_model}']", "./memory[@access='shared']"]},{'element_attrs':["./memory/source/path"],'text':'${nvdimm_define_path}'}, {'element_attrs':["./memory/target/size[@unit='KiB']"],'text':'524288'}, {'element_attrs':["./memory/target/node"],'text':'0'}]
+            mem_hotplug_xpath =[{'element_attrs':["./memory[@model='${mem_model}']", "./memory[@access='private']"]},{'element_attrs':["./memory/source/path"],'text':'${nvdimm_hotplug_path}'}, {'element_attrs':["./memory/target/size[@unit='KiB']"],'text':'524288'}, {'element_attrs':["./memory/target/node"],'text':'1'}]
+    variants mem_backing:
+        - hugepage:
+            mb_attrs = ", 'mb': {'hugepages': {'pages': [{'size': '${hp_size}', 'unit': 'KiB'}]}}"
+        - file_backed:
+            mb_attrs = ", 'mb': {'source_type':'file'}"
+        - anonymous_backed:
+            mb_attrs = ", 'mb': {'source_type':'anonymous'}"
+        - memfd_backed:
+            mb_attrs = ", 'mb': {'source_type':'memfd'}"
+    kernel_hp_file = "/sys/kernel/mm/hugepages/hugepages-${hp_size}kB/nr_hugepages"
+    mem_xpath = [{'element_attrs':["./memory[@unit='KiB']"],'text':'${start_mem_val}'},{'element_attrs':["./currentMemory[@unit='KiB']"],'text':'${start_curr_mem_val}'}]
+    vm_attrs = {${mem_attrs}${numa_attrs}${mb_attrs}}
+

--- a/libvirt/tests/src/migration/migration_with_memory/migration_with_memory_devices.py
+++ b/libvirt/tests/src/migration/migration_with_memory/migration_with_memory_devices.py
@@ -1,0 +1,233 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright Redhat
+#
+#   SPDX-License-Identifier: GPL-2.0
+
+#   Author: Liang Cong <lcong@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import os
+
+from aexpect import remote
+from avocado.utils import process
+
+from virttest import libvirt_version
+from virttest import test_setup
+from virttest import utils_libvirtd
+from virttest import utils_misc
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.libvirt_xml.devices.memory import Memory
+from virttest.utils_libvirt import libvirt_vmxml
+
+from provider.memory import memory_base
+from provider.migration import base_steps
+
+
+def run(test, params, env):
+    """
+    Verify guest migration behaviors with various memory backing types.
+
+    :param test: test object
+    :param params: Dictionary of test parameters
+    :param env: Dictionary of test environment
+    """
+    def check_hugepage_support():
+        """
+        Verify hugepage size is supported by source and destination hosts
+        """
+        memory_base.check_mem_page_sizes(test, hp_size=hp_size)
+        memory_base.check_mem_page_sizes(test, hp_size=hp_size, session=remote_session)
+
+    def setup_hugepage():
+        """
+        Set hugepages on source and destination hosts
+        """
+        check_hugepage_support()
+        src_hpc = test_setup.HugePageConfig(params)
+        dst_hpc = test_setup.HugePageConfig(params, session=remote_session)
+        hpc_list = [src_hpc, dst_hpc]
+        for hpc_inst in hpc_list:
+            hpc_inst.set_kernel_hugepages(hp_size, hp_num, False)
+            hpc_inst.mount_hugepage_fs()
+            utils_libvirtd.Libvirtd(session=hpc_inst.session).restart()
+
+    def check_mem_device_xml(exp_xpath, alias_name, virsh_obj=virsh):
+        """
+        Check domain XML by xpaths
+
+        exp_xpath: list of memory device xpaths to check
+        alias_name: alias name of the memory device
+        virsh_obj: libvirt connection object
+        """
+        def _check_mem():
+            """
+            Check memory devices xml of domain XML
+
+            return True if all xpaths are found, False otherwise
+            """
+            guest_xml = vm_xml.VMXML.new_from_dumpxml(
+                vm_name, virsh_instance=virsh_obj)
+            memory_devices = guest_xml.devices.by_device_tag('memory')
+            target_memory_device = None
+            for memory_device in memory_devices:
+                if alias_name == memory_device.alias.get('name'):
+                    target_memory_device = memory_device
+            if not target_memory_device:
+                test.fail(f"Memory device with alias {alias_name} not found in domain xml {guest_xml}")
+            return libvirt_vmxml.check_guest_xml_by_xpaths(target_memory_device, exp_xpath, True, True)
+
+        if not utils_misc.wait_for(lambda: _check_mem(), timeout=30):
+            guest_xml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+            test.fail(f"Expected xml xpath:{exp_xpath} not found in domain xml:{guest_xml}")
+
+    def check_domain_xml(virsh_obj=virsh):
+        """
+        Check domain xml
+
+        :param virsh_obj: virsh instance
+        """
+        check_mem_device_xml(mem_define_xpath, mem_define_alias, virsh_obj=virsh_obj)
+        check_mem_device_xml(mem_hotplug_xpath, mem_hotplug_alias, virsh_obj=virsh_obj)
+        guest_xml = vm_xml.VMXML.new_from_dumpxml(vm_name, virsh_instance=virsh_obj)
+        libvirt_vmxml.check_guest_xml_by_xpaths(guest_xml, mem_xpath, False, False)
+
+    def check_nvdimm_file_content(session, device, mount_point, file_path, exp_content):
+        """
+        Check the content of a file on a NVDIMM device
+
+        session: vm session
+        device: NVDIMM device
+        mount_point: mount point of the NVDIMM device
+        file_path: path of the file on the NVDIMM device
+        exp_content: expected content of the file
+        """
+        session.cmd_output(f"mount -o dax {device} {mount_point}")
+        file_content = session.cmd_output(f"cat {file_path}").strip()
+        if file_content != exp_content:
+            test.file(f"Expected {file_path} content: {exp_content}, but found {file_content}")
+
+    def setup_nvdimm():
+        """
+        Create nvdimm file
+        """
+        nvdimm_paths_cmds = eval(params.get("nvdimm_paths_cmds"))
+        for cmd in nvdimm_paths_cmds:
+            process.run(cmd, ignore_status=False)
+
+    libvirt_version.is_libvirt_feature_supported(params)
+    mem_device_model = params.get("mem_device_model")
+    vm_name = params.get("migrate_main_vm")
+    vm = env.get_vm(vm_name)
+    server_ip = params.get("server_ip")
+    server_pwd = params.get("server_pwd")
+    migration_obj = base_steps.MigrationBase(test, vm, params)
+    remote_session = remote.remote_login(
+        client="ssh",
+        host=server_ip,
+        port=22,
+        username="root",
+        password=server_pwd,
+        prompt=r"[$#%]",
+    )
+
+    vm_attrs = eval(params.get("vm_attrs"))
+    desturi = params.get("virsh_migrate_desturi")
+    hp_size = int(params.get("hp_size"))
+    hp_num = params.get("hp_num")
+    mem_define = eval(params.get("mem_define"))
+    mem_hotplug = eval(params.get("mem_hotplug"))
+    nvdimm_define_device = params.get("nvdimm_define_device")
+    nvdimm_hotplug_device = params.get("nvdimm_hotplug_device")
+    nvdimm_define_mount_path = params.get("nvdimm_define_mount_path")
+    nvdimm_hotplug_mount_path = params.get("nvdimm_hotplug_mount_path")
+    nvdimm_define_file = params.get("nvdimm_define_file")
+    nvdimm_hotplug_file = params.get("nvdimm_hotplug_file")
+    nvdimm_define_content = params.get("nvdimm_define_content")
+    nvdimm_hotplug_content = params.get("nvdimm_hotplug_content")
+    mem_define_alias = params.get("mem_define_alias")
+    mem_hotplug_alias = params.get("mem_hotplug_alias")
+    mem_define_xpath = eval(params.get("mem_define_xpath"))
+    mem_hotplug_xpath = eval(params.get("mem_hotplug_xpath"))
+    mem_xpath = eval(params.get("mem_xpath"))
+    hpc_list = []
+
+    try:
+        setup_hugepage()
+        if "nvdimm" == mem_device_model:
+            setup_nvdimm()
+
+        # Test steps
+        # 1. Define the guest
+        # 2. Start the guest
+        # 3. Hotplug the memory device
+        # 4. Check the guest config xml by virsh dump
+        # 5. Create file on two nvdimm devices
+        # 6. Migrate the guest
+        # 7. Check the guest config xml on target server
+        # 8. Check files on two nvdimm devices
+        test.log.info("TEST_STEP1: Define the guest")
+        memory_base.define_guest_with_memory_device(params, [mem_define], vm_attrs)
+        migration_obj.setup_connection()
+
+        test.log.info("TEST_STEP2: Start the guest")
+        vm.start()
+        vm.wait_for_login().close()
+
+        test.log.info("TEST_STEP3: Hotplug the memory device")
+        mem_device = Memory()
+        mem_device.setup_attrs(**mem_hotplug)
+        virsh.attach_device(vm_name, mem_device.xml, ignore_status=False)
+
+        test.log.info("TEST_STEP4: Check the guest config xml by virsh dump")
+        check_domain_xml(virsh_obj=virsh)
+
+        if "nvdimm" == mem_device_model:
+            test.log.info("TEST_STEP5: Create file on two nvdimm devices")
+            with vm.wait_for_login() as vm_session:
+                memory_base.create_file_within_nvdimm_disk(
+                    test, vm_session, nvdimm_define_device,
+                    nvdimm_define_file, nvdimm_define_mount_path,
+                    test_str=nvdimm_define_content)
+                memory_base.create_file_within_nvdimm_disk(
+                    test, vm_session, nvdimm_hotplug_device,
+                    nvdimm_hotplug_file, nvdimm_hotplug_mount_path,
+                    test_str=nvdimm_hotplug_content)
+
+        test.log.info("TEST_STEP6: Migrate the guest")
+        migration_obj.run_migration()
+        migration_obj.verify_default()
+
+        test.log.info("TEST_STEP7: Check the guest config xml on target server")
+        virsh_obj = virsh.VirshPersistent(uri=desturi)
+        check_domain_xml(virsh_obj=virsh_obj)
+
+        if "nvdimm" == mem_device_model:
+            test.log.info("TEST_STEP8: Check files on two nvdimm devices")
+            backup_uri, vm.connect_uri = vm.connect_uri, desturi
+            vm.cleanup_serial_console()
+            vm.create_serial_console()
+            remote_vm_session = vm.wait_for_serial_login()
+            check_nvdimm_file_content(
+                remote_vm_session, nvdimm_define_device,
+                nvdimm_define_mount_path, nvdimm_define_file,
+                nvdimm_define_content)
+            check_nvdimm_file_content(
+                remote_vm_session, nvdimm_hotplug_device,
+                nvdimm_hotplug_mount_path, nvdimm_hotplug_file,
+                nvdimm_hotplug_content)
+            remote_vm_session.close()
+            vm.connect_uri = backup_uri
+
+    finally:
+        for hpc_inst in hpc_list:
+            hpc_inst.cleanup()
+            utils_libvirtd.Libvirtd(session=hpc_inst.session).restart()
+        if "nvdimm" == mem_device_model:
+            nvdimm_paths = eval(params.get("nvdimm_paths"))
+            for n_path in nvdimm_paths:
+                if os.path.exists(n_path):
+                    os.remove(n_path)
+        migration_obj.cleanup_connection()
+        remote_session.close()


### PR DESCRIPTION
Memory devices including dimm, nvdimm and virtio-mem devices with below memory backing:
1. hugepage;
2. file;
3. anonymous;
4. memfd;


Depends on: https://github.com/avocado-framework/avocado-vt/pull/4196

Test results:
(01/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.hugepage.dimm.2m: STARTED
 (01/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.hugepage.dimm.2m: CANCEL: Expected host default huge page size is 2048 KiB, but get 524288 KiB (58.63 s)
 (02/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.hugepage.dimm.512m: STARTED
 (02/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.hugepage.dimm.512m: PASS (161.56 s)
 (03/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.hugepage.virtio-mem.2m: STARTED
 (03/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.hugepage.virtio-mem.2m: CANCEL: Expected host default huge page size is 2048 KiB, but get 524288 KiB (59.19 s)
 (04/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.hugepage.virtio-mem.512m: STARTED
 (04/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.hugepage.virtio-mem.512m: PASS (162.63 s)
 (05/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.hugepage.nvdimm.2m: STARTED
 (05/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.hugepage.nvdimm.2m: CANCEL: Expected host default huge page size is 2048 KiB, but get 524288 KiB (58.76 s)
 (06/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.hugepage.nvdimm.512m: STARTED
 (06/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.hugepage.nvdimm.512m: PASS (202.90 s)
 (07/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.file_backed.dimm.2m: STARTED
 (07/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.file_backed.dimm.2m: CANCEL: Expected host default huge page size is 2048 KiB, but get 524288 KiB (59.64 s)
 (08/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.file_backed.dimm.512m: STARTED
 (08/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.file_backed.dimm.512m: PASS (161.88 s)
 (09/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.file_backed.virtio-mem.2m: STARTED
 (09/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.file_backed.virtio-mem.2m: CANCEL: Expected host default huge page size is 2048 KiB, but get 524288 KiB (59.34 s)
 (10/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.file_backed.virtio-mem.512m: STARTED
 (10/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.file_backed.virtio-mem.512m: PASS (161.93 s)
 (11/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.file_backed.nvdimm.2m: STARTED
 (11/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.file_backed.nvdimm.2m: CANCEL: Expected host default huge page size is 2048 KiB, but get 524288 KiB (58.81 s)
 (12/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.file_backed.nvdimm.512m: STARTED
 (12/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.file_backed.nvdimm.512m: PASS (203.55 s)
 (13/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.anonymous_backed.dimm.2m: STARTED
 (13/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.anonymous_backed.dimm.2m: CANCEL: Expected host default huge page size is 2048 KiB, but get 524288 KiB (59.52 s)
 (14/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.anonymous_backed.dimm.512m: STARTED
 (14/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.anonymous_backed.dimm.512m: PASS (162.59 s)
 (15/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.anonymous_backed.virtio-mem.2m: STARTED
 (15/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.anonymous_backed.virtio-mem.2m: CANCEL: Expected host default huge page size is 2048 KiB, but get 524288 KiB (58.93 s)
 (16/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.anonymous_backed.virtio-mem.512m: STARTED
 (16/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.anonymous_backed.virtio-mem.512m: PASS (161.57 s)
 (17/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.anonymous_backed.nvdimm.2m: STARTED
 (17/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.anonymous_backed.nvdimm.2m: CANCEL: Expected host default huge page size is 2048 KiB, but get 524288 KiB (59.15 s)
 (18/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.anonymous_backed.nvdimm.512m: STARTED
 (18/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.anonymous_backed.nvdimm.512m: PASS (203.23 s)
 (19/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.memfd_backed.dimm.2m: STARTED
 (19/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.memfd_backed.dimm.2m: CANCEL: Expected host default huge page size is 2048 KiB, but get 524288 KiB (58.84 s)
 (20/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.memfd_backed.dimm.512m: STARTED
 (20/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.memfd_backed.dimm.512m: PASS (161.66 s)
 (21/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.memfd_backed.virtio-mem.2m: STARTED
 (21/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.memfd_backed.virtio-mem.2m: CANCEL: Expected host default huge page size is 2048 KiB, but get 524288 KiB (59.94 s)
 (22/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.memfd_backed.virtio-mem.512m: STARTED
 (22/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.memfd_backed.virtio-mem.512m: PASS (162.18 s)
 (23/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.memfd_backed.nvdimm.2m: STARTED
 (23/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.memfd_backed.nvdimm.2m: CANCEL: Expected host default huge page size is 2048 KiB, but get 524288 KiB (59.10 s)
 (24/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.memfd_backed.nvdimm.512m: STARTED
 (24/24) type_specific.io-github-autotest-libvirt.migration.migration_with_memory.memory_devices.memfd_backed.nvdimm.512m: PASS (204.67 s)