### PR TITLE
ovmf_backed_nvram: ensure qcow2 format specified on arm

### DIFF
--- a/libvirt/tests/cfg/guest_os_booting/ovmf_firmware/ovmf_backed_nvram.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/ovmf_firmware/ovmf_backed_nvram.cfg
@@ -11,13 +11,14 @@
         loader_path = "/usr/share/edk2/aarch64/QEMU_EFI-silent-pflash.qcow2"
         template_path = "/usr/share/edk2/aarch64/vars-template-pflash.qcow2"
         os_secure = "no"
-        nvram_attrs = {'nvram_attrs': {'template': '${template_path}', 'type': '%s', 'format': 'qcow2'}}
     os_dict = {'secure': '${os_secure}', 'loader_readonly': 'yes', 'loader_type': 'pflash', 'loader': '${loader_path}'}
 
     variants source_type:
         - file:
             nvram_source = {'nvram_source': {'attrs': {'file': '%s'}}}
             nvram_attrs = {'nvram_attrs': {'template': '${template_path}', 'type': 'file'}}
+            aarch64:
+                nvram_attrs = {'nvram_attrs': {'template': '${template_path}', 'type': 'file', 'format': 'qcow2'}}
         - block:
             nvram_source = {'nvram_source': {'attrs': {'dev': '%s'}}}
             nvram_attrs = {'nvram_attrs': {'template': '${template_path}', 'type': 'block', 'format': 'qcow2'}}


### PR DESCRIPTION
Updated cfg so that in all cases, on aarch64, the format is set to qcow2.

**Test results:**
Before:
```
(.libvirt-ci-venv-ci-runtest-Eqr9Ec) bash-5.1# avocado run --vt-type libvirt --vt-omit-data-loss --vt-machine-type arm64-mmio guest_os_booting.ovmf_backed_nvram.file --job-timeout 1200 --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.guest_os_booting.ovmf_backed_nvram.file: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.guest_os_booting.ovmf_backed_nvram.file: FAIL: Configured os xml value {'template': '/usr/share/edk2/aarch64/vars-template-pflash.qcow2', 'type': 'file', 'format': 'raw'} doesn't match the entry {'template': '/usr/share/edk2/aarch64/vars-template-pflash.qcow2', 'type': 'file', 'format': 'qcow2'} in gu... (37.67 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 1 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2025-07-30T19.19-b527ff4/results.html
JOB TIME   : 39.33 s
```

After:
```
(.libvirt-ci-venv-ci-runtest-Eqr9Ec) bash-5.1# avocado run --vt-type libvirt --vt-omit-data-loss --vt-machine-type arm64-mmio guest_os_booting.ovmf_backed_nvram.file --job-timeout 1200 --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.guest_os_booting.ovmf_backed_nvram.file: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.guest_os_booting.ovmf_backed_nvram.file: PASS (37.03 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2025-07-30T19.41-4224b28/results.html
JOB TIME   : 38.87 s
```