### PR TITLE
virsh_nodeinfo: support core per cluster

### DIFF
--- a/libvirt/tests/src/virsh_cmd/host/virsh_nodeinfo.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_nodeinfo.py
@@ -140,7 +140,7 @@ def run(test, params, env):
         # Check Core(s) per socket
         cores_per_socket_nodeinfo = _check_nodeinfo(
             nodeinfo_output, 'Core(s) per socket', 4)
-        cmd = "lscpu | grep 'Core(s) per socket' | head -n1 | awk '{print $4}'"
+        cmd = "lscpu | grep 'Core(s) per [socket|cluster]' | head -n1 | awk '{print $4}'"
         cmd_result = process.run(cmd, ignore_status=True, shell=True)
         cores_per_socket_os = cmd_result.stdout_text.strip()
         spec_numa = False


### PR DESCRIPTION
In some hosts, the lscpu output does show "Core(s) per cluster" instead of 'Core(s) per socket'. Like below:

```
Architecture:                aarch64
  CPU op-mode(s):            64-bit
  Byte Order:                Little Endian
CPU(s):                      96
  On-line CPU(s) list:       0-95
Vendor ID:                   Cavium
  BIOS Vendor ID:            CN8890-1800BG2601-AAP-Y-G
  Model name:                ThunderX-88XX
    BIOS Model name:         2.1
    Model:                   1
    Thread(s) per core:      1
    Core(s) per cluster:     48
    Socket(s):               2
    Cluster(s):              2
```

Signed-off-by: Dan Zheng <dzheng@redhat.com>