### PR TITLE
Fix pipe open stuck when job process return error

### DIFF
--- a/libvirt/tests/src/virsh_cmd/host/virsh_nodeinfo.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_nodeinfo.py
@@ -140,7 +140,7 @@ def run(test, params, env):
         # Check Core(s) per socket
         cores_per_socket_nodeinfo = _check_nodeinfo(
             nodeinfo_output, 'Core(s) per socket', 4)
-        cmd = "lscpu | grep 'Core(s) per socket' | head -n1 | awk '{print $4}'"
+        cmd = "lscpu | grep 'Core(s) per [socket|cluster]' | head -n1 | awk '{print $4}'"
         cmd_result = process.run(cmd, ignore_status=True, shell=True)
         cores_per_socket_os = cmd_result.stdout_text.strip()
         spec_numa = False


### PR DESCRIPTION
Since test script use block type to read from job process generated fifo file (dump file etc). But when the job process cmd get error, nothing will be written to fifo file, so main process stuck to wait for reading data.

So this time open fifo with non-block type and wait for data is written by job process, if there is data can be read, then switch back to block type to read all data (not-block type read and write performance too low to finish).


 (01/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.normal_test.dump_action.live_dump.running_state.vm_id: STARTED
 (01/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.normal_test.dump_action.live_dump.running_state.vm_id: FAIL: Job subprocess did not write fifo file in 60 seconds,job subprocess result is: {'timeout': False, 'returncode': 0, 'output': b'\n', 'error': b"error: Failed to core dump domain 'avocado-vt-vm1' to /var/tmp/avocado_0zpn0piw/domjobinfo.fifo\nerror: unsuppor... (115.28 s)
 (02/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.normal_test.dump_action.live_dump.paused_state.vm_name: STARTED
 (02/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.normal_test.dump_action.live_dump.paused_state.vm_name: FAIL: Job subprocess did not write fifo file in 60 seconds,job subprocess result is: {'timeout': False, 'returncode': 0, 'output': b'\n', 'error': b"error: Failed to core dump domain 'avocado-vt-vm1' to /var/tmp/avocado_whing4y2/domjobinfo.fifo\nerror: unsuppor... (84.17 s)
 (03/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.normal_test.dump_action.crash_dump.running_state.vm_id: STARTED
 (03/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.normal_test.dump_action.crash_dump.running_state.vm_id: PASS (26.42 s)
 (04/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.normal_test.dump_action.crash_dump.paused_state.vm_uuid: STARTED
 (04/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.normal_test.dump_action.crash_dump.paused_state.vm_uuid: PASS (25.39 s)
 (05/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.normal_test.dump_action.keep_complete_test.running_state.vm_name: STARTED
 (05/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.normal_test.dump_action.keep_complete_test.running_state.vm_name: FAIL: Job subprocess did not write fifo file in 60 seconds,job subprocess result is: {'timeout': False, 'returncode': 0, 'output': b'\n', 'error': b"error: Failed to core dump domain 'avocado-vt-vm1' to /var/tmp/avocado_jayq0ok7/domjobinfo.fifo\nerror: unsuppor... (86.95 s)
 (06/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.normal_test.save_action.running_state.vm_id: STARTED
 (06/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.normal_test.save_action.running_state.vm_id: PASS (26.00 s)
 (07/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.normal_test.save_action.paused_state.vm_name: STARTED
 (07/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.normal_test.save_action.paused_state.vm_name: PASS (56.02 s)
 (08/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.normal_test.managedsave_action.running_state.vm_id: STARTED
 (08/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.normal_test.managedsave_action.running_state.vm_id: PASS (25.06 s)
 (09/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.normal_test.managedsave_action.paused_state.vm_name: STARTED
 (09/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.normal_test.managedsave_action.paused_state.vm_name: PASS (25.46 s)
 (10/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.error_test.no_name: STARTED
 (10/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.error_test.no_name: PASS (34.08 s)
 (11/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.error_test.shutoff_state: STARTED
 (11/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.error_test.shutoff_state: PASS (6.23 s)
 (12/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.error_test.with_libvirtd_stop: STARTED
 (12/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.error_test.with_libvirtd_stop: PASS (31.84 s)