### PR TITLE
Fix two issues for snapshot-create-as cmd

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_create_as.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/snapshot/virsh_snapshot_create_as.cfg
@@ -109,6 +109,7 @@
                     diskspec_opts = "vda,snapshot=external,file=${snapshot_file}"
                     variants:
                         - compress_default:
+                            default_format = "yes"
                         - compress_format:
                             config_format = "yes"
                             variants:
@@ -214,3 +215,4 @@
                     action_lookup = "connect_driver:QEMU domain_name:${main_vm}"
                     unprivileged_user = "EXAMPLE"
                     virsh_uri = "qemu:///system"
+

--- a/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_create_as.py
+++ b/libvirt/tests/src/virsh_cmd/snapshot/virsh_snapshot_create_as.py
@@ -267,7 +267,8 @@ def check_snapslist(test, vm_name, options, option_dict, output,
             if option_disk.find('driver=') >= 0:
                 dtypes = []
                 for each in range(len(disks)):
-                    dtypes.append(disks[each].find('driver').get('type'))
+                    if disks[each].find('driver') is not None:
+                        dtypes.append(disks[each].find('driver').get('type'))
                 logging.debug("All drivers are %s", dtypes)
                 if disk_dict['driver'] in dtypes:
                     logging.info("Found driver %s in diskspec",
@@ -279,7 +280,8 @@ def check_snapslist(test, vm_name, options, option_dict, output,
             if option_disk.find('file=') >= 0:
                 sfiles = []
                 for each in range(len(disks)):
-                    sfiles.append(disks[each].find('source').get('file'))
+                    if disks[each].find('source') is not None:
+                        sfiles.append(disks[each].find('source').get('file'))
                 logging.debug("All sources are %s", sfiles)
                 if disk_dict['file'] in sfiles:
                     logging.info("Found source %s in diskspec",
@@ -367,6 +369,7 @@ def run(test, params, env):
     domain_state = params.get("domain_state")
     memspec_opts = params.get("memspec_opts")
     config_format = "yes" == params.get("config_format", "no")
+    default_format = "yes" == params.get("default_format", "no")
     snapshot_image_format = params.get("snapshot_image_format")
     diskspec_opts = params.get("diskspec_opts")
     create_autodestroy = 'yes' == params.get("create_autodestroy", "no")
@@ -690,7 +693,7 @@ def run(test, params, env):
                     if os.path.exists(disk_path):
                         os.unlink(disk_path)
         snap_path = os.path.join(tmp_dir, snapshot_file)
-        if config_format and not invalid_compress_format:
+        if (config_format and not invalid_compress_format) or default_format:
             if os.path.exists(snap_path):
                 os.remove(snap_path)
 


### PR DESCRIPTION
1.compress_default case will generate snapshot disk which is not cleaned up, so add cleanup. 2.multi_diskspec_no_snapshot contains no snapshot disk, so skip it.

Before fix:
 (1/3) type_specific.io-github-autotest-libvirt.virsh.snapshot_create_as.positive_tests.acl_test.file_disk.no_snapshot_attr.live_memspec.compress_default: STARTED
 (1/3) type_specific.io-github-autotest-libvirt.virsh.snapshot_create_as.positive_tests.acl_test.file_disk.no_snapshot_attr.live_memspec.compress_default: PASS (25.91 s)
 (2/3) type_specific.io-github-autotest-libvirt.virsh.snapshot_create_as.positive_tests.acl_test.file_disk.no_snapshot_attr.live_memspec.compress_format.xz: STARTED
 (2/3) type_specific.io-github-autotest-libvirt.virsh.snapshot_create_as.positive_tests.acl_test.file_disk.no_snapshot_attr.live_memspec.compress_format.xz: FAIL: Run failed with right command:  (26.78 s)
 (3/3) type_specific.io-github-autotest-libvirt.virsh.snapshot_create_as.positive_tests.acl_test.file_disk.no_snapshot_attr.multi_diskspec_no_snapshot: STARTED
 (3/3) type_specific.io-github-autotest-libvirt.virsh.snapshot_create_as.positive_tests.acl_test.file_disk.no_snapshot_attr.multi_diskspec_no_snapshot: ERROR: 'NoneType' object has no attribute 'get' (26.16 s)



After fix:
 (1/3) type_specific.io-github-autotest-libvirt.virsh.snapshot_create_as.positive_tests.acl_test.file_disk.no_snapshot_attr.live_memspec.compress_default: STARTED
 (1/3) type_specific.io-github-autotest-libvirt.virsh.snapshot_create_as.positive_tests.acl_test.file_disk.no_snapshot_attr.live_memspec.compress_default: PASS (25.54 s)
 (2/3) type_specific.io-github-autotest-libvirt.virsh.snapshot_create_as.positive_tests.acl_test.file_disk.no_snapshot_attr.live_memspec.compress_format.xz: STARTED
 (2/3) type_specific.io-github-autotest-libvirt.virsh.snapshot_create_as.positive_tests.acl_test.file_disk.no_snapshot_attr.live_memspec.compress_format.xz: PASS (28.99 s)
 (3/3) type_specific.io-github-autotest-libvirt.virsh.snapshot_create_as.positive_tests.acl_test.file_disk.no_snapshot_attr.multi_diskspec_no_snapshot: STARTED
 (3/3) type_specific.io-github-autotest-libvirt.virsh.snapshot_create_as.positive_tests.acl_test.file_disk.no_snapshot_attr.multi_diskspec_no_snapshot: PASS (25.06 s)