### PR TITLE
change the version of nbdkit to latest

### DIFF
--- a/v2v/tests/cfg/nbdkit/nbdkit.cfg
+++ b/v2v/tests/cfg/nbdkit/nbdkit.cfg
@@ -228,4 +228,4 @@
       - cve_starttls:
         only source_none..dest_none
         checkpoint = 'cve_starttls'
-        version_required = "[nbdkit-1.26.5-1,nbdkit-1.40)"
+        version_required = "[nbdkit-1.26.5-1,nbdkit-1.45)"


### PR DESCRIPTION
There's one file I missed in my last pr https://github.com/autotest/tp-libvirt/pull/6481 
we need make sure the nbdkit version is in the range nbdkit-1.26.5-1,nbdkit-1.45

