### PR TITLE
boot_from_virtiofs_device: find vmlinuz file in image mode

### DIFF
--- a/libvirt/tests/src/guest_os_booting/boot_order/boot_from_virtiofs_device.py
+++ b/libvirt/tests/src/guest_os_booting/boot_order/boot_from_virtiofs_device.py
@@ -43,7 +43,7 @@ def run(test, params, env):
         process.run(multi_cmd, shell=True, ignore_status=False)
         change_virtiofs_root_passwd()
         # Copy vmlinuz from host to use in guest.
-        cmd5 = f"cp $(ls /boot/vmlinuz* | tail -n 1) {vmlinuz_file}"
+        cmd5 = f"cp $(find /boot -name 'vmlinuz*' | tail -n 1) {vmlinuz_file}"
         process.run(cmd5, shell=True)
 
     def change_virtiofs_root_passwd():


### PR DESCRIPTION
In image mode, the path is not /boot/vmlinuz* but instead /boot/ostree/default*/vmlinuz*.

Passing test:
```
(.libvirt-ci-venv-ci-runtest-r4oXkX) bash-5.1# avocado run --vt-type libvirt --vt-omit-data-loss --vt-machine-type arm64-mmio guest_os_booting.boot_order.virtiofs_device.start_guest --job-timeout 1200 --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.virtiofs_device.start_guest: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.guest_os_booting.boot_order.virtiofs_device.start_guest: PASS (124.61 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2025-08-05T15.49-b1ab141/results.html
JOB TIME   : 126.48 s
```