### PR TITLE
ovmf_loader: skip readonly_no test case when in image mode

### DIFF
--- a/libvirt/tests/src/guest_os_booting/ovmf_firmware/ovmf_loader.py
+++ b/libvirt/tests/src/guest_os_booting/ovmf_firmware/ovmf_loader.py
@@ -40,6 +40,10 @@ def run(test, params, env):
     bkxml = vmxml.copy()
 
     try:
+        # Check if image mode
+        if loader_dict.get("loader_readonly") == "no" and os.path.isdir("/ostree"):
+            test.cancel("The image mode filesystem is read only so {'loader_readonly': 'no'} is not supported")
+
         if smm_state:
             guest_os.prepare_smm_xml(vm_name, smm_state, "")
         vmxml = guest_os.prepare_os_xml(vm_name, loader_dict, firmware_type)


### PR DESCRIPTION
Skipped test case:
```
(.libvirt-ci-venv-ci-runtest-r4oXkX) bash-5.1# avocado run --vt-type libvirt --vt-omit-data-loss --vt-machine-type arm64-mmio guest_os_booting.ovmf_loader.negative_test.readonly_no --job-timeout 1200 --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.guest_os_booting.ovmf_loader.negative_test.readonly_no: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.guest_os_booting.ovmf_loader.negative_test.readonly_no: CANCEL: The image mode filesystem is read only so {'loader_readonly': 'no'} is not supported (4.95 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 1
JOB HTML   : /var/log/avocado/job-results/job-2025-08-05T17.04-b723d84/results.html
JOB TIME   : 8.04 s
```