### PR TITLE
Add kernel version checking for hmat dmesg verification

### DIFF
--- a/libvirt/tests/cfg/numa/guest_numa_hmat/hmat_info.cfg
+++ b/libvirt/tests/cfg/numa/guest_numa_hmat/hmat_info.cfg
@@ -48,4 +48,6 @@
     variants:
         - @default:
             func_supported_since_libvirt_ver = (7, 5, 0)
+            guest_required_kernel_1 = [5.0.0, 5.14.0)
+            guest_required_kernel_2 = [6.0.0, 6.12.0)
 


### PR DESCRIPTION
Since RHEL-70321 and RHEL-70322, the hmat msg moved to pr_debug(), so it could not be printed directly in dmesg. Adding kernel version checking for it.

on guest kernel version like kernel-6.12.0-116.el10.x86_64:
before fix :
(1/1) type_specific.io-github-autotest-libvirt.guest_numa_hmat.hmat_info.default:
FAIL: Expect 'Flags:00 Type:Access Latency Initiator' in guest dmesg, but not found (41.88 s)

after fix:
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_hmat.hmat_info.default: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.guest_numa_hmat.hmat_info.default: PASS (211.04 s)