### PR TITLE
remove this filter because is already deleted in lastest nbdkit

### DIFF
--- a/v2v/tests/cfg/nbdkit/nbdkit.cfg
+++ b/v2v/tests/cfg/nbdkit/nbdkit.cfg
@@ -94,7 +94,7 @@
             variants:
                 - filters_thread_model:
                   version_required = "[nbdkit-server-1.32.5-4,)"
-                  filters = 'cow cacheextents rate readahead scan readahead blocksize'
+                  filters = 'cow rate readahead scan readahead blocksize'
                   checkpoint = 'check_vddk_filters_thread_model'
                 - create_options_7:
                   vddk_libdir_src = 'MOUNT_SRC_VDDK70_LIB_DIR_V2V_EXAMPLE'


### PR DESCRIPTION
error message: "thread mode of cacheextents is not parallel in vddk plugin"

