### PR TITLE
in_place_upgrade_guest: updated kernel check pattern

### DIFF
--- a/libvirt/tests/src/in_place_upgrade_guest.py
+++ b/libvirt/tests/src/in_place_upgrade_guest.py
@@ -202,7 +202,7 @@ def verify_upgrade_succeeded(test, params, vm, session, target_release, target_p
         test.log.info("Guest page size before upgrade (%s) does not match page size after upgrade (%s)" %
                       (target_page_size, post_page_size))
         test.log.info("Attempting temporary workaround to update the guest default kernel")
-        kernel_pattern = ".*el%s.*%sk" % (target_release.replace(".", "_"), int(target_page_size) // 1024)
+        kernel_pattern = ".*el%s*.*%sk" % (target_major_release, int(target_page_size) // 1024)
         kernel_version = utils_test.get_available_kernel_paths(session, kernel_pattern)[0]
         utils_test.update_vm_default_kernel(vm, kernel_version, reboot=True, guest_arch_name=vm_arch_name, timeout=900)
 


### PR DESCRIPTION
Updated kernel check pattern to allow for, for example, \*el10\*

Passing test:
```
((p3-ve) ) [root@ampere-mtcollins-altra-01 code]# avocado run --vt-type libvirt --vt-omit-data-loss --vt-machine-type arm64-mmio in_place_upgrade_guest --vt-connect-uri qemu:///system --vt-extra-params 'compose_url = http://download.eng.bos.redhat.com'
 (1/1) type_specific.io-github-autotest-libvirt.in_place_upgrade_guest: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.in_place_upgrade_guest: PASS (930.69 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 931.87 s
```