### PR TITLE
Increase numa memory

### DIFF
--- a/libvirt/tests/cfg/memory/memory_devices/nvdimm_memory_turn_to_dram.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/nvdimm_memory_turn_to_dram.cfg
@@ -3,7 +3,7 @@
     type = nvdimm_memory_turn_to_dram
     start_vm = no
     mem_model = 'nvdimm'
-    numa_dict = "'vcpu': 2,'cpu':{'check': 'partial', 'fallback': 'allow','numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '524288'}],'topology':{'sockets': '2', 'cores': '1', 'threads': '1'}}"
+    numa_dict = "'vcpu': 2,'cpu':{'check': 'partial', 'fallback': 'allow','numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '4194304'}],'topology':{'sockets': '2', 'cores': '1', 'threads': '1'}}"
     vm_attrs = {${numa_dict},"max_mem_rt": 15242880, "max_mem_rt_slots": 16,'memory':4194304,'current_mem':4194304,}
     nvdimm_path = "/tmp/nvdimm"
     nvdimm_dict = {'mem_model':'${mem_model}',"mem_access":"shared",'target': {'size':1048576, 'size_unit':'KiB', 'node':0}, 'source':{'path': "${nvdimm_path}"},'address':{'attrs': {'type':'dimm','slot':'1'}}}


### PR DESCRIPTION
Since numa memory dominate the guest memory size, increase it to avoid memory shortage.

Test result:
 (1/1) type_specific.io-github-autotest-libvirt.memory.devices.nvdimm.turn_to_dram: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.memory.devices.nvdimm.turn_to_dram: PASS (188.81 s)