### PR TITLE
migration: Update check items in query_domain_job_info case

### DIFF
--- a/libvirt/tests/cfg/migration_with_copy_storage/async_job/query_domain_job_info.cfg
+++ b/libvirt/tests/cfg/migration_with_copy_storage/async_job/query_domain_job_info.cfg
@@ -31,7 +31,7 @@
     status_error = "no"
     str_items = {"Job type": "Unbounded", "Operation": "Outgoing migration"}
     s_all_items = ["Time elapsed", "Data processed", "Data remaining", "Data total", "File processed", "File remaining", "File total"]
-    m_all_items = ["Time elapsed", "Data remaining", "Memory processed", "Memory remaining", "Memory total", "Memory bandwidth", "Page size", "Iteration", "File processed", "File total", "Constant pages", "Normal pages", "Normal data", "Expected downtime", "Setup time"]
+    m_all_items = ["Time elapsed", "Data remaining", "Memory processed", "Memory remaining", "Memory total", "Page size", "Iteration", "File processed", "File total", "Constant pages", "Normal pages", "Normal data", "Expected downtime", "Setup time"]
     m_int_items = {"Dirty rate": "0", "Postcopy requests": "0", "File remaining": "0"}
     m_sum_items = {"Data processed": "Memory processed+File processed", "Data total": "Memory total+File total"}
     dest_items = {"error_msg": "migration statistics are available only on the source host"}


### PR DESCRIPTION
Remove unnecessary check items.

Before:
Missing item: ['Memory bandwidth', 'Page size', 'Iteration', 'File processed', 'File total', 'Constant pages', 'Normal pages', 'Normal data', 'Expected downtime', 'Setup time'] from all_items


After:
 (1/1) type_specific.io-github-autotest-libvirt.migration_with_copy_storage.async_job.query_domain_job_info.copy_storage_all.p2p: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.migration_with_copy_storage.async_job.query_domain_job_info.copy_storage_all.p2p: PASS (202.56 s)