### PR TITLE
Update the directory path to save the vm

### DIFF
--- a/libvirt/tests/src/save_and_restore/restore_from_local_file.py
+++ b/libvirt/tests/src/save_and_restore/restore_from_local_file.py
@@ -102,7 +102,7 @@ def run(test, params, env):
     pre_path_options = params.get('pre_path_options', '')
     after_state = params.get('after_state', 'running')
     rand_id = utils_misc.generate_random_string(3)
-    save_path = f'/var/tmp/{vm_name}_{rand_id}.save'
+    save_path = f'/var/lib/libvirt/qemu/save/{vm_name}_{rand_id}.save'
     save_args = pre_path_options + ' ' + save_path
     check_cmd = params.get('check_cmd', '')
     check_cmd = check_cmd.format(


### PR DESCRIPTION
To keep the saved file under "/var/tmp" will cause some selinux deny issue. Update it to be "/var/lib/libvirt/qemu/save" to avoid the AVC denied issue.