### PR TITLE
Fix the AVC deny in audit log

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domjobabort.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domjobabort.py
@@ -120,6 +120,7 @@ def run(test, params, env):
         if os.path.exists(tmp_pipe):
             os.unlink(tmp_pipe)
         os.mkfifo(tmp_pipe)
+        process.run("chcon -t virtqemud_t %s" % tmp_pipe)
 
         process = get_subprocess(action, vm_name, tmp_pipe, remote_uri)
 


### PR DESCRIPTION
Take care of the *.fifo file since qemu needs to read from it.