### PR TITLE
sriov_attach_detach_device_vfio_variant_driver: enhance test

### DIFF
--- a/libvirt/tests/cfg/sriov/plug_unplug/sriov_attach_detach_device_vfio_variant_driver.cfg
+++ b/libvirt/tests/cfg/sriov/plug_unplug/sriov_attach_detach_device_vfio_variant_driver.cfg
@@ -3,6 +3,7 @@
     start_vm = "no"
     expr_driver = "mlx5_vfio_pci"
     ping_dest = "www.redhat.com"
+    test_pf = "ens3f0np0"
 
     only x86_64, aarch64
     variants:

--- a/libvirt/tests/cfg/sriov/vfio/sriov_migration_vfio_variant_driver.cfg
+++ b/libvirt/tests/cfg/sriov/vfio/sriov_migration_vfio_variant_driver.cfg
@@ -25,6 +25,7 @@
     virsh_migrate_connect_uri = "qemu:///system"
     check_cont_ping = "no"
     migrate_vm_back = "yes"
+    test_pf = "ens3f0np0"
 
     only x86_64, aarch64
     variants:
@@ -52,6 +53,7 @@
         - with_postcopy:
             only single_iface..mlx5_vfio
             status_error = "yes"
+            migrate_vm_back = "no"
             postcopy_options = "--postcopy --timeout 10 --timeout-postcopy"
             err_msg = "VFIO migration is not supported with postcopy migration"
         - without_postcopy:
@@ -60,6 +62,7 @@
                 - with_iommu:
                     only single_iface..mlx5_vfio
                     status_error = "yes"
+                    migrate_vm_back = "no"
                     err_msg = "not supported with vIOMMU enabled"
                     variants:
                         - virtio:
@@ -71,7 +74,6 @@
                             enable_guest_iommu = "yes"
                             iommu_dict = {'model': 'intel', 'driver': {'intremap': 'on', 'caching_mode': 'on'}}
                 - without_iommu:
-                    migrate_vm_back = "yes"
     variants:
         - p2p_live:
             virsh_migrate_options = "--live --p2p --persistent --verbose"

--- a/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_device_vfio_variant_driver.py
+++ b/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_device_vfio_variant_driver.py
@@ -9,6 +9,8 @@ from virttest.libvirt_xml import vm_xml
 from virttest.utils_libvirt import libvirt_vfio
 from virttest.utils_libvirt import libvirt_vmxml
 
+from provider.sriov import sriov_vfio
+
 
 def run(test, params, env):
     """
@@ -40,10 +42,10 @@ def run(test, params, env):
     dev_type = params.get("dev_type", "hostdev_interface")
     device_type = "hostdev" if dev_type == "hostdev_device" else "interface"
     expr_driver = params.get("expr_driver", "mlx5_vfio_pci")
-    test_pf = params.get("test_pf", "ens3f0np0")
+    test_pf = params.get("test_pf")
     pf_pci = utils_sriov.get_pf_pci(test_pf=test_pf)
     iface_number = int(params.get("iface_number", "1"))
-    ping_dest = params.get("ping_dest", "www.redhat.com")
+    ping_dest = params.get("ping_dest")
 
     vm_name = params.get("main_vm", "avocado-vt-vm1")
     vm = env.get_vm(vm_name)
@@ -55,6 +57,7 @@ def run(test, params, env):
 
         test.log.info("TEST_STEP: Start the VM")
         vm.start()
+        test.log.debug(f'VMXML of {vm_name} after starting:\n{virsh.dumpxml(vm_name).stdout_text}')
         vm_session = vm.wait_for_serial_login(timeout=240)
         # FIXME: If the "IP" command is executed immediately after the interface
         # is attached, it will be hung.
@@ -74,8 +77,13 @@ def run(test, params, env):
             if act_hostdev_dict.get("driver")["driver_attr"].get("name") != "vfio":
                 test.fail("The hostdev driver is not set to VFIO.")
             libvirt_vfio.check_vfio_pci(vf_pci, exp_driver=expr_driver)
-        if utils_test.ping(ping_dest, count=3, timeout=5, session=vm_session):
-            test.fail("Failed to ping %s." % ping_dest)
+
+        test.log.info("TEST_STEP: ping test from VM to outside")
+        if sriov_vfio.is_linked(pf_name=test_pf) and ping_dest:
+            if utils_test.ping(ping_dest, count=3, timeout=5, session=vm_session):
+                test.fail("Failed to ping %s." % ping_dest)
+        else:
+            test.log.debug(f"Skip ping test from VM to outside due to no link to PF ")
 
         vm_hostdevs = vm_xml.VMXML.new_from_dumpxml(vm.name)\
             .devices.by_device_tag(device_type)
@@ -83,16 +91,20 @@ def run(test, params, env):
             test.log.info("TEST_STEP: Detach a hostdev interface/device from VM")
             virsh.detach_device(vm.name, vm_dev.xml, debug=True,
                                 wait_for_event=True, ignore_status=False)
+            test.log.debug("Verify: the hostdev interface/device in VM is detached successfully - PASS")
         vm_hostdevs = vm_xml.VMXML.new_from_dumpxml(vm.name)\
             .devices.by_device_tag(device_type)
         if vm_hostdevs:
             test.fail("Got hostdev interface/device(%s) after detaching the "
                       "device!" % vm_hostdevs)
+        else:
+            test.log.debug("Verify: The hostdev interface/device in VM xml is removed successfully - PASS")
         libvirt_vfio.check_vfio_pci(vf_pci, exp_driver="mlx5_core")
+        test.log.debug("Verify: Check VF driver successfully after detaching hostdev interface/device - PASS")
         virsh.reboot(vm.name, ignore_status=False, debug=True)
+        test.log.debug("Verify: VM reboot is successful after detaching hostdev interface/device - PASS")
         vm.cleanup_serial_console()
         vm.create_serial_console()
         vm.wait_for_serial_login().close()
-
     finally:
         orig_vm_xml.sync()

--- a/libvirt/tests/src/sriov/vfio/sriov_migration_vfio_variant_driver.py
+++ b/libvirt/tests/src/sriov/vfio/sriov_migration_vfio_variant_driver.py
@@ -40,7 +40,7 @@ def run(test, params, env):
 
         test.log.debug(f'VMXML of {vm_name}:\n{virsh.dumpxml(vm_name).stdout_text}')
 
-        migration_obj.setup_connection()
+        migration_obj.setup_connection(use_console=True)
         test.log.info("TEST_STEP: Migrate the VM to the target host.")
         migration_obj.run_migration()
         migration_obj.verify_default()
@@ -49,8 +49,12 @@ def run(test, params, env):
         if migrate_vm_back:
             test.log.info("TEST_STEP: Migrate back the VM to the source host.")
             migration_obj.run_migration_back()
-            migration_obj.migration_test.ping_vm(vm, params)
-            migration_obj.check_vm_cont_ping(False)
+            test_pf = params.get("test_pf")
+            if test_pf and sriov_vfio.is_linked(pf_name=test_pf):
+                migration_obj.migration_test.ping_vm(vm, params)
+                migration_obj.check_vm_cont_ping(False)
+            else:
+                test.log.debug(f"Skip ping vm due to no link to PF ")
 
     finally:
         orig_vm_xml.sync()

--- a/libvirt/tests/src/sriov/vfio/sriov_vm_lifecycle_vfio_variant_driver.py
+++ b/libvirt/tests/src/sriov/vfio/sriov_vm_lifecycle_vfio_variant_driver.py
@@ -73,7 +73,7 @@ def run(test, params, env):
             timeout=int(params.get('login_timeout')))
         session.sendline(params.get("shutdown_command"))
         if not vm.wait_for_shutdown():
-            test.fail("VM %s failed to shut down", vm.name)
+            test.fail("VM %s failed to shut down" % vm.name)
 
         vm.cleanup_serial_console()
         vm.start()

--- a/provider/sriov/sriov_vfio.py
+++ b/provider/sriov/sriov_vfio.py
@@ -1,5 +1,9 @@
 import logging
 
+from avocado.core import exceptions
+from avocado.utils import path as utils_path
+from avocado.utils import process
+
 from virttest import utils_net
 from virttest import utils_sriov
 from virttest import virsh
@@ -33,6 +37,22 @@ def parse_iface_dict(vf_pci, params):
     LOG.debug(f"Iface dict: {iface_dict}")
 
     return iface_dict
+
+
+def is_linked(pf_name):
+    """
+    Check if the specified pf has linked with a cable
+
+    :param pf_name: The name of the pf
+    :return: True if pf is linked with a cable, False otherwise.
+    """
+    try:
+        utils_path.find_command("ethtool")
+    except utils_path.CmdNotFoundError:
+        raise exceptions.TestFail("ethtool is not found")
+    cmd = "ethtool %s| grep \"Link detected:\" | grep \"yes\"" % pf_name
+    ret = process.run(cmd, ignore_status=True, shell=True)
+    return ret.exit_status == 0
 
 
 def attach_dev(vm, params):


### PR DESCRIPTION
The ping test is better to have. But we do not want to skip the test for detaching device when ping test fails. On some hosts, there is no NIC with cable for the vm to use, so ping test will fail as expected.

Signed-off-by: Dan Zheng <dzheng@redhat.com>