### PR TITLE
domfsfreeze/thaw: Add new test cases and update existing test cases

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domfsfreeze.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domfsfreeze.cfg
@@ -44,3 +44,7 @@
                     setup_libvirt_polkit = "yes"
                     unprivileged_user = 'testacl'
                     virsh_uri = "qemu:///system"
+                - specify_nonexistent_mnt:
+                    status_error = "no"
+                    domfsfreeze_options = "--mountpoint /not-exist"
+                    check_zero_freeze = "yes"

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domfsfreeze_domfsthaw.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domfsfreeze_domfsthaw.cfg
@@ -4,10 +4,11 @@
     take_regular_screendumps = "no"
     variants:
         - positive:
+            require_second_disk = "yes"
             variants:
                 - normal:
                 - with_mountpoint:
-                    mountpoint = "/"
+                    specified_mountpoint = "/"
         - negative:
             variants:
                 - no_agent_channel:

--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_domfsthaw.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_domfsthaw.cfg
@@ -24,5 +24,6 @@
                     no_qemu_ga = "yes"
                 - invalid_mountpoint:
                     domfsthaw_options = "xyz"
+                    fail_patts = [r'error: argument unsupported: specifying mountpoints is not supported']
                 - invalid_option:
                     domfsthaw_options = "--invalid"

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domfsfreeze.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domfsfreeze.py
@@ -51,6 +51,7 @@ def run(test, params, env):
     has_channel = ("no" == params.get("no_qemu_ga", "no"))
     start_qemu_ga = ("no" == params.get("no_start_qemu_ga", "no"))
     status_error = ("yes" == params.get("status_error", "no"))
+    check_zero_freeze = ("yes" == params.get("check_zero_freeze", "no"))
 
     # Do backup for origin xml
     xml_backup = vm_xml.VMXML.new_from_dumpxml(vm_name)
@@ -92,7 +93,12 @@ def run(test, params, env):
                                    uri=uri, debug=True)
         libvirt.check_exit_status(result, status_error)
         if not result.exit_status:
-            check_freeze(session)
+            if check_zero_freeze:
+                # If 0 filesystem is frozen, then executing another guest agent
+                # command should succeed
+                virsh.domtime(vm_ref, ignore_status=False)
+            else:
+                check_freeze(session)
 
     finally:
         # Do domain recovery

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domfsfreeze_domfsthaw.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domfsfreeze_domfsthaw.py
@@ -1,8 +1,11 @@
 import aexpect
 
-from virttest import virsh
+from virttest import virsh, utils_disk
 from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_disk
 from virttest.utils_test import libvirt
+
+from provider.virtual_disk import disk_base
 
 
 def run(test, params, env):
@@ -17,50 +20,160 @@ def run(test, params, env):
     6) Retouch the file the ensure guest file system are not frozen;
     7) Cleanup test environment.
     """
-    def check_freeze(session):
+    def check_freeze(session, mountpoints, file_name):
         """
         Check whether file system has been frozen by touch a test file
         and see if command will hang.
+        TODO: A strange part is that when only one mountpoint is frozen, "touch file" in
+        other mountpoints will also fail. We should figure out the reason and fix the
+        auto script later.
 
         :param session: Guest session to be tested.
+        :param mountpoints: The list of guest mountpoints.
+        :param file_name: The name of file to be created on guest.
         """
-        try:
-            output = session.cmd_output('touch freeze_test',
-                                        timeout=10)
-            test.fail("Failed to freeze file system. "
-                      "Create file succeeded:\n%s" % output)
-        except aexpect.ShellTimeoutError:
-            pass
+        test.log.info("TEST_STEP: Check file system freeze.")
+        for mntpoint in mountpoints:
+            try:
+                output = session.cmd_output("touch %s/%s" % (mntpoint, file_name), timeout=10)
+                test.fail(
+                    "Failed to freeze file system %s. Create file succeeded:\n%s"
+                    % (mntpoint, output)
+                )
+            except aexpect.ShellTimeoutError:
+                pass
 
-    def check_thaw(session):
+    def check_thaw(session, mountpoints, file_name):
         """
         Check whether file system has been thawed by check a test file
         prohibited from creation when frozen created and successfully touch
         the file again.
 
         :param session: Guest session to be tested.
+        :param mountpoints: The list of guest mountpoints.
+        :param file_name: The name of file to be checked on guest.
         """
-        status, output = session.cmd_status_output('ls freeze_test')
-        if status:
-            test.fail("Failed to thaw file system. "
-                      "Find created file failed:\n%s" % output)
+        test.log.info("TEST_STEP: Check file system thaw.")
+        for mntpoint in mountpoints:
+            status, output = session.cmd_status_output("ls %s/%s" % (mntpoint, file_name))
+            if status:
+                test.fail(
+                    "Failed to thaw file system %s. Can't find created file:\n%s"
+                    % (mntpoint, output)
+                )
 
-        try:
-            output = session.cmd_output('touch freeze_test', timeout=10)
-        except aexpect.ShellTimeoutError:
-            test.fail("Failed to freeze file system. "
-                      "Touch file timeout:\n%s" % output)
+            try:
+                output = session.cmd_output("touch %s/%s" % (mntpoint, file_name), timeout=10)
+            except aexpect.ShellTimeoutError:
+                test.fail(
+                    "Failed to thaw file system %s. Touch file timeout:\n%s"
+                    % (mntpoint, output)
+                )
 
-    def cleanup(session):
+    def attach_second_disk(disk_obj, disk_type):
+        """
+        Attach second disk to a domain, including:
+        1. Create a block type disk
+        2. Attach the disk to the domain
+
+        :param disk_obj: The DiskBase object.
+        :param disk_type: The type of disk source.
+        """
+        test.log.info("TEST_STEP: Attach second disk to vm.")
+        disk_dict = {
+            "type_name": disk_type,
+            "target": {"dev": "vdb", "bus": "virtio"},
+            "driver": {"name": "qemu", "type": "raw"},
+        }
+
+        disk_obj.add_vm_disk(disk_type=disk_type, disk_dict=disk_dict, new_image_path="")
+
+    def mount_second_disk_in_vm(session):
+        """
+        Mount the second disk in a domain, including:
+        1. Make filesystem on the second disk
+        2. Mount the second disk in vm
+
+        :param session: The guest console session
+        :return: The mountpoint of the second disk
+        """
+        test.log.info("TEST_STEP: Mount second disk in vm.")
+        second_disk = libvirt_disk.get_non_root_disk_name(session)
+        return utils_disk.configure_empty_disk(session, second_disk[0], "100M", "linux")[0]
+
+    def generate_random_string(length=10):
+        """
+        Generate a random string with specified length.
+        """
+        import random
+        import string
+
+        return "".join(
+            random.choice(string.ascii_letters + string.digits) for _ in range(length)
+        )
+
+    def set_selinux_label(session):
+        """
+        Per default selinux will block the guest agent from freezing
+        the file system when the second disk is attached to the domain.
+        This function will set selinux label to allow this.
+
+        :param session: Guest console session
+        """
+        session.cmd_output(
+            "setsebool -P virt_qemu_ga_read_nonsecurity_files on", timeout=120
+        )
+
+    def run_agent_command_when_frozen(vm_name, command_name="domtime"):
+        """
+        Run qemu guest agent command when guest filesystem is fronzen.
+        It should fail with reasonable error.
+
+        :param vm_name (string): Vm name
+        :param command_name (string): Qemu agent command name, e.g. domtime
+        Returns:
+            None
+        """
+        test.log.info("TEST_STEP: Run qemu guest agent command when frozen.")
+        fail_patts = [
+            r"error: guest agent command failed: unable to execute QEMU agent command '\S+': Command guest-get-time has been disabled: the command is not allowed",
+            r"error: internal error: unable to execute QEMU agent command '\S+': Command guest-get-time has been disabled: the command is not allowed",
+        ]
+
+        virsh_command = eval("virsh.%s" % command_name)
+        res = virsh_command(vm_name)
+        libvirt.check_result(res, fail_patts)
+
+    def run_agent_command_when_thawed(vm_name, command_name="domtime"):
+        """
+        Run qemu guest agent command when guest filesystem is thawed.
+        It should succeed.
+
+        :param vm_name (string): Vm name
+        :param command_name (string): Qemu agent command name, e.g. domtime
+        Returns:
+            None
+        """
+        test.log.info("TEST_STEP: Run qemu guest agent command when thawed.")
+        virsh_command = eval("virsh.%s" % command_name)
+        res = virsh_command(vm_name)
+        libvirt.check_exit_status(res, expect_error=False)
+
+    def cleanup(session, mountpoints, test_file):
         """
         Clean up the test file used for freeze/thaw test.
 
         :param session: Guest session to be cleaned up.
+        :param mountpoints (list): List of mountpoints in guest.
+        :param test_file (string): Test file name to be cleaned up.
         """
-        status, output = session.cmd_status_output('rm -f freeze_test')
-        if status:
-            test.error("Failed to cleanup test file"
-                       "Find created file failed:\n%s" % output)
+        for mntpoint in mountpoints:
+            status, output = session.cmd_status_output("rm -f %s/%s" % (mntpoint, test_file))
+            if status:
+                test.error(
+                    "Failed to cleanup test file. Can't find created file:\n%s/%s"
+                    % (mntpoint, output)
+                )
 
     if not virsh.has_help_command('domfsfreeze'):
         test.cancel("This version of libvirt does not support "
@@ -68,15 +181,35 @@ def run(test, params, env):
 
     channel = ("yes" == params.get("prepare_channel", "yes"))
     agent = ("yes" == params.get("start_agent", "yes"))
-    mountpoint = params.get("mountpoint", None)
+    specified_mountpoint = params.get("specified_mountpoint", None)
+    require_second_disk = "yes" == params.get("require_second_disk", "no")
     vm_name = params.get("main_vm")
     vm = env.get_vm(vm_name)
 
     xml_backup = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    test_file = generate_random_string() + "_freeze_test"
     try:
+        disk_obj = disk_base.DiskBase(test, vm, params)
+        if require_second_disk:
+            attach_second_disk(disk_obj, disk_type="block")
+
         # Add or remove qemu-agent from guest before test
         vm.prepare_guest_agent(channel=channel, start=agent)
         session = vm.wait_for_login()
+
+        second_disk_mntpoint = None
+        if require_second_disk:
+            second_disk_mntpoint = mount_second_disk_in_vm(session)
+            set_selinux_label(session)
+
+        freezed_mountpoints = []
+        if specified_mountpoint is not None:
+            freezed_mountpoints.append(specified_mountpoint)
+        else:
+            freezed_mountpoints.append("/")
+            if second_disk_mntpoint is not None:
+                freezed_mountpoints.append(second_disk_mntpoint)
+
         try:
             # Expected fail message patterns
             fail_patts = []
@@ -93,18 +226,25 @@ def run(test, params, env):
                 r'specifying mountpoints is not supported',
             ]
 
-            res = virsh.domfsfreeze(vm_name, mountpoint=mountpoint)
+            test.log.info("TEST_STEP: Do domfsfreeze.")
+            res = virsh.domfsfreeze(vm_name, mountpoint=specified_mountpoint)
             libvirt.check_result(res, fail_patts, skip_patts)
             if not res.exit_status:
-                check_freeze(session)
+                check_freeze(session, freezed_mountpoints, test_file)
+                run_agent_command_when_frozen(vm_name)
 
-            res = virsh.domfsthaw(vm_name, mountpoint=mountpoint)
+            test.log.info("TEST_STEP: Do domfsthaw.")
+            res = virsh.domfsthaw(vm_name)
             libvirt.check_result(res, fail_patts, skip_patts)
             if not res.exit_status:
-                check_thaw(session)
-
-            cleanup(session)
+                check_thaw(session, freezed_mountpoints, test_file)
+                run_agent_command_when_thawed(vm_name)
         finally:
+            cleanup(session, freezed_mountpoints, test_file)
             session.close()
     finally:
+        if vm.is_alive():
+            vm.destroy()
+        if require_second_disk:
+            disk_obj.cleanup_disk_preparation(disk_type="block")
         xml_backup.sync()

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domfsthaw.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domfsthaw.py
@@ -1,5 +1,6 @@
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
+from virttest.utils_test import libvirt
 
 
 def run(test, params, env):
@@ -25,6 +26,7 @@ def run(test, params, env):
     status_error = ("yes" == params.get("status_error", "no"))
     options = params.get("domfsthaw_options", "")
     vm_ref = params.get("vm_ref", "")
+    fail_patts = params.get("fail_patts", [])
 
     # Do backup for origin xml
     xml_backup = vm_xml.VMXML.new_from_dumpxml(vm_name)
@@ -66,6 +68,8 @@ def run(test, params, env):
                 test.fail("Fail to do virsh domfsthaw, error %s" %
                           cmd_result.stderr)
         else:
+            if fail_patts:
+                libvirt.check_result(cmd_result, fail_patts)
             if cmd_result.exit_status == 0:
                 test.fail("Command 'virsh domfsthaw' failed ")
 


### PR DESCRIPTION
Automate test case VIRT-12668

New test cases:
- virsh.domfsfreeze.negative_tests.specify_nonexistent_mnt

Updated test cases:
- virsh.domfsfreeze_domfsthaw.positive.normal
- virsh.domfsfreeze_domfsthaw.positive.with_mountpoint 
- virsh.domfsthaw.positive_tests.no_freezed_fs
- virsh.domfsthaw.negative_tests.invalid_mountpoint

Test results:
 (1/5) type_specific.io-github-autotest-libvirt.virsh.domfsfreeze.negative_tests.specify_nonexistent_mnt: STARTED
 (1/5) type_specific.io-github-autotest-libvirt.virsh.domfsfreeze.negative_tests.specify_nonexistent_mnt: PASS (82.53 s)
 (2/5) type_specific.io-github-autotest-libvirt.virsh.domfsfreeze_domfsthaw.positive.normal: STARTED
 (2/5) type_specific.io-github-autotest-libvirt.virsh.domfsfreeze_domfsthaw.positive.normal: PASS (85.67 s)
 (3/5) type_specific.io-github-autotest-libvirt.virsh.domfsfreeze_domfsthaw.positive.with_mountpoint: STARTED
 (3/5) type_specific.io-github-autotest-libvirt.virsh.domfsfreeze_domfsthaw.positive.with_mountpoint: PASS (76.13 s)
 (4/5) type_specific.io-github-autotest-libvirt.virsh.domfsthaw.positive_tests.no_freezed_fs: STARTED
 (4/5) type_specific.io-github-autotest-libvirt.virsh.domfsthaw.positive_tests.no_freezed_fs: PASS (144.81 s)
 (5/5) type_specific.io-github-autotest-libvirt.virsh.domfsthaw.negative_tests.invalid_mountpoint: STARTED
 (5/5) type_specific.io-github-autotest-libvirt.virsh.domfsthaw.negative_tests.invalid_mountpoint: PASS (114.08 s)
