### PR TITLE
migration: Update canonical_paths_in_shared_filesystems case

### DIFF
--- a/libvirt/tests/cfg/migration/migration_misc/canonical_paths_in_shared_filesystems.cfg
+++ b/libvirt/tests/cfg/migration/migration_misc/canonical_paths_in_shared_filesystems.cfg
@@ -18,7 +18,7 @@
     virsh_migrate_dest_state = "running"
     virsh_migrate_src_state = "shut off"
     image_convert = 'no'
-    vms = avocado-vt-vm1
+    vms = avocado-vt-vm1 vm2
     server_ip = "${migrate_dest_host}"
     server_user = "root"
     server_pwd = "${migrate_dest_pwd}"
@@ -31,7 +31,7 @@
     virsh_migrate_desturi = "qemu+ssh://${migrate_dest_host}/system"
     start_vm = "no"
     nfs_mount_options = "bind"
-    export_dir = "/nfs"
+    export_dir = "/var/shared_filesystems"
     nfs_server_ip = "${migrate_source_host}"
     images_path = "/var/lib/libvirt/images"
     nvram_path = "/var/lib/libvirt/qemu/nvram"
@@ -60,11 +60,6 @@
             no aarch64
             firmware_type = "seabios"
             os_dict = {'type': 'hvm', 'boots': ['hd'], 'machine': 'q35'}
-        - statless_uefi:
-            no aarch64
-            firmware_type = "ovmf"
-            loader_path = "/usr/share/edk2/ovmf/OVMF.amdsev.fd"
-            loader_dict = {'os_firmware': 'efi', 'loader_stateless': 'yes', 'loader': '${loader_path}', 'loader_type': 'rom'}
         - uefi_with_nvram:
             firmware_type = "ovmf"
             loader_path = "/usr/share/edk2/ovmf/OVMF_CODE.secboot.fd"

--- a/libvirt/tests/src/migration/migration_misc/canonical_paths_in_shared_filesystems.py
+++ b/libvirt/tests/src/migration/migration_misc/canonical_paths_in_shared_filesystems.py
@@ -10,8 +10,6 @@ from virttest import utils_misc
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_test import libvirt
-from virttest.utils_libvirt import libvirt_bios
-from virttest.utils_test import libvirt
 
 from provider.guest_os_booting import guest_os_booting_base as guest_os
 from provider.migration import base_steps
@@ -144,9 +142,6 @@ def run(test, params, env):
             os_dict = eval(params.get("os_dict"))
             vmxml.del_os()
             vmxml.setup_attrs(os=os_dict)
-        elif boot_type == "statless_uefi":
-            vmxml.os = libvirt_bios.remove_bootconfig_items_from_vmos(vmxml.os)
-            vmxml.setup_attrs(os=loader_dict)
         else:
             vmxml.setup_attrs(os=loader_dict)
         vmxml.sync()
@@ -161,8 +156,8 @@ def run(test, params, env):
 
         """
         test.log.info("Verify test again.")
-        dargs = {"check_disk_on_dest": "no"}
-        migration_obj.migration_test.post_migration_check([vm], dargs)
+        params.update({"check_disk_on_dest": "no"})
+        migration_obj.migration_test.post_migration_check([vm], params)
 
     def cleanup_test():
         """


### PR DESCRIPTION
1. When set 'stateless=yes', NVRAM will never be created. As a
result, the “Boot Option Restored” prompt appears every time the
VM starts. Since manual intervention is required for the VM to
fully boot, we decided to remove the stateless test scenario.
2. Add 'vm2' for seabios test.
3. Update 'export_dir' to avoid path access issue in image mode.


Package mode:
 (1/4) type_specific.io-github-autotest-libvirt.migration.migration_misc.canonical_paths_in_shared_filesystems.bios.with_tpm: STARTED
 (1/4) type_specific.io-github-autotest-libvirt.migration.migration_misc.canonical_paths_in_shared_filesystems.bios.with_tpm: PASS (175.34 s)
 (2/4) type_specific.io-github-autotest-libvirt.migration.migration_misc.canonical_paths_in_shared_filesystems.bios.without_tpm: STARTED
 (2/4) type_specific.io-github-autotest-libvirt.migration.migration_misc.canonical_paths_in_shared_filesystems.bios.without_tpm: PASS (174.65 s)
 (3/4) type_specific.io-github-autotest-libvirt.migration.migration_misc.canonical_paths_in_shared_filesystems.uefi_with_nvram.with_tpm: STARTED
 (3/4) type_specific.io-github-autotest-libvirt.migration.migration_misc.canonical_paths_in_shared_filesystems.uefi_with_nvram.with_tpm: PASS (181.72 s)
 (4/4) type_specific.io-github-autotest-libvirt.migration.migration_misc.canonical_paths_in_shared_filesystems.uefi_with_nvram.without_tpm: STARTED
 (4/4) type_specific.io-github-autotest-libvirt.migration.migration_misc.canonical_paths_in_shared_filesystems.uefi_with_nvram.without_tpm: PASS (172.10 s)
RESULTS    : PASS 4 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2025-12-29T21.58-aafb155/results.html
JOB TIME   : 708.45 s


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Removed the statless UEFI test variant from migration scenarios.
  * Added an additional VM to migration test runs and changed the shared-filesystem path used in tests.
  * Simplified post-migration verification by consolidating verification parameters.
  * Cleaned up test setup logic and removed obsolete test-specific handling to streamline UEFI handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->