### PR TITLE
[virsh detach device]remove unnecessary package

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_detach_device_alias.py
@@ -146,7 +146,7 @@ def run(test, params, env):
 
         :return: usb vendor and product id
         """
-        install_cmd = process.run("yum install usbutils* -y", shell=True)
+        install_cmd = process.run("yum install usbutils -y", shell=True)
         result = process.run("lsusb|awk '{print $6\":\"$2\":\"$4}'", shell=True)
         if not result.exit_status:
             return result.stdout_text.rstrip(':')


### PR DESCRIPTION
Remove the wildcard from the yum command to avoid installing extraneous packages.