### PR TITLE
domhostname: Add no_start_qemu_guest_agent tests

### DIFF
--- a/libvirt/tests/cfg/guest_agent/domhostname.cfg
+++ b/libvirt/tests/cfg/guest_agent/domhostname.cfg
@@ -8,3 +8,9 @@
             domain_ref = "id"
         - domain_UUID:
             domain_ref = "uuid"
+        - negative:
+            status_error = "yes"
+            variants:
+                - no_start_qemu_guest_agent:
+                    no_start_qemu_ga = "yes"
+                    domain_ref = "uuid"

--- a/libvirt/tests/src/guest_agent/domhostname.py
+++ b/libvirt/tests/src/guest_agent/domhostname.py
@@ -11,12 +11,22 @@ def run(test, params, env):
     vm_name = params.get("main_vm")
     vm = env.get_vm(vm_name)
     expr_hostname = params.get("expr_hostname", "myhostname")
+    start_qemu_ga = ("no" == params.get("no_start_qemu_ga", "no"))
+    status_error = ("yes" == params.get("status_error", "no"))
 
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     backup_xml = vmxml.copy()
 
     try:
-        vm.prepare_guest_agent()
+        fail_patterns = []
+        match_patterns = []
+        if status_error:
+            if not start_qemu_ga:
+                fail_patterns.append(r"QEMU guest agent is not connected")
+        else:
+            match_patterns.append(rf"{expr_hostname}")
+
+        vm.prepare_guest_agent(start=start_qemu_ga)
 
         test.log.info(f"TEST_STEP: Set VM's hostname to {expr_hostname}.")
         vm_session = vm.wait_for_login()
@@ -26,6 +36,6 @@ def run(test, params, env):
 
         test.log.info(f"TEST_STEP: Get VM's hostname via guest agent.")
         res = virsh.domhostname(domain_ref, debug=True)
-        libvirt.check_result(res, expected_match=expr_hostname)
+        libvirt.check_result(res, expected_fails=fail_patterns, expected_match=match_patterns)
     finally:
         backup_xml.sync()


### PR DESCRIPTION
Automate RHEL-246544
This is a negative test, no_start_qemu_guest_agent means "don't start qemu-guest-agent service in vm". In this scenario, an error will be printed.

Test result:
 (1/1) type_specific.io-github-autotest-libvirt.guest_agent.domhostname.negative.no_start_qemu_guest_agent: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.guest_agent.domhostname.negative.no_start_qemu_guest_agent: PASS (84.54 s)
