### PR TITLE
Storage: update the target path of netfs pool

### DIFF
--- a/libvirt/tests/cfg/storage/virsh_pool.cfg
+++ b/libvirt/tests/cfg/storage/virsh_pool.cfg
@@ -75,7 +75,7 @@
                             source_format = "auto"
                 - pool_type_netfs:
                     pool_type = "netfs"
-                    pool_target = "/nfs-mount"
+                    pool_target = "/tmp/nfs-mount"
                     variants:
                         - source_format_nfs:
                             source_format = "nfs"

--- a/libvirt/tests/cfg/storage/virsh_pool_autostart.cfg
+++ b/libvirt/tests/cfg/storage/virsh_pool_autostart.cfg
@@ -57,7 +57,7 @@
                             with_empty_vg = "yes"
                 - pool_type_netfs:
                     pool_type = "netfs"
-                    pool_target = "/nfs-mount"
+                    pool_target = "/tmp/nfs-mount"
                     variants:
                         - source_format_nfs:
                             source_format = "nfs"

--- a/libvirt/tests/cfg/virsh_cmd/pool/virsh_pool_acl.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/pool/virsh_pool_acl.cfg
@@ -78,7 +78,7 @@
                             pool_target = "/dev/logical"
                         - pool_type_netfs:
                             pool_type = "netfs"
-                            pool_target = "/nfs-mount"
+                            pool_target = "/tmp/nfs-mount"
                         - pool_type_iscsi:
                             pool_type = "iscsi"
                             pool_target = "/dev/disk/by-path"

--- a/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_download_upload.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/volume/virsh_vol_download_upload.cfg
@@ -92,7 +92,7 @@
                 - netfs_pool:
                     vol_download_upload_pool_type = "netfs"
                     vol_download_upload_pool_name = "netfs-pool"
-                    vol_download_upload_pool_target = "/nfs-mount"
+                    vol_download_upload_pool_target = "/tmp/nfs-mount"
                     vol_download_upload_vol_name = "netfs-vol"
                     vol_download_upload_format = "qcow2"
                     action_lookup = "connect_driver:QEMU|storage vol_name:netfs-vol"


### PR DESCRIPTION
In image mode, we can't create the target path /mnt for netfs pool, or it'll get error "Read-only file system". Updating it to /tmp/nfs-mount to fix this error.