### PR TITLE
vcpucount: Add no_start_qemu_guest_agent test

### DIFF
--- a/libvirt/tests/cfg/virsh_cmd/domain/virsh_vcpucount.cfg
+++ b/libvirt/tests/cfg/virsh_cmd/domain/virsh_vcpucount.cfg
@@ -34,10 +34,15 @@
                             vcpucount_options = "--xyz"
                         - config_guest_option:
                             vcpucount_options = "--guest --config"
+                        - no_start_qemu_guest_agent:
+                            vcpucount_options = "--guest"
+                            no_start_qemu_ga = "yes"
+                            vcpucount_err_msg = "QEMU guest agent is not connected"
                         - active_maximum_option:
                             vcpucount_options = "--active --maximum"
         - positive_tests:
             status_error = "no"
+            set_option = ["--config", "--config --maximum", "--live", "--guest"]
             variants:
                 - shutoff_test:
                     vcpucount_pre_vm_state = "shut off"


### PR DESCRIPTION
Automate RHEL-246544

Test results:
 (1/1) type_specific.io-github-autotest-libvirt.virsh.vcpucount.negative_tests.running_test.no_start_qemu_guest_agent: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.virsh.vcpucount.negative_tests.running_test.no_start_qemu_guest_agent: PASS (91.56 s)

Test results for existing test cases:
 (1/1) type_specific.io-github-autotest-libvirt.virsh.vcpucount.negative_tests.shutoff_test.guest_option: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.virsh.vcpucount.negative_tests.shutoff_test.guest_option: PASS (6.31 s)
 (1/1) type_specific.io-github-autotest-libvirt.virsh.vcpucount.positive_tests.running_test.no_option: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.virsh.vcpucount.positive_tests.running_test.no_option: PASS (250.81 s)
