### PR TITLE
Add one negative:no_start_qemu_guest_agent case into domhostname

### DIFF
--- a/libvirt/tests/cfg/guest_agent/domhostname.cfg
+++ b/libvirt/tests/cfg/guest_agent/domhostname.cfg
@@ -8,3 +8,8 @@
             domain_ref = "id"
         - domain_UUID:
             domain_ref = "uuid"
+        - negative:
+            status_error = "yes"
+            variants:
+                - no_start_qemu_guest_agent:
+                    no_start_qemu_ga = "yes"

--- a/libvirt/tests/src/guest_agent/domhostname.py
+++ b/libvirt/tests/src/guest_agent/domhostname.py
@@ -11,21 +11,32 @@ def run(test, params, env):
     vm_name = params.get("main_vm")
     vm = env.get_vm(vm_name)
     expr_hostname = params.get("expr_hostname", "myhostname")
+    status_error = params.get("status_error", "no") == "yes"
+    start_qemu_ga = params.get("no_start_qemu_ga", "no") == "no"
 
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     backup_xml = vmxml.copy()
 
     try:
-        vm.prepare_guest_agent()
+        vm.prepare_guest_agent(start=start_qemu_ga)
 
-        test.log.info(f"TEST_STEP: Set VM's hostname to {expr_hostname}.")
-        vm_session = vm.wait_for_login()
-        vm_session.cmd("hostname %s" % expr_hostname)
+        if not status_error:
+            test.log.info(f"TEST_STEP: Set VM's hostname to {expr_hostname}.")
+            vm_session = vm.wait_for_login()
+            vm_session.cmd("hostname %s" % expr_hostname)
+
         domain_ref = vm.get_id() if params.get("domain_ref") == 'id' \
-            else eval('vm.%s' % params.get("domain_ref"))
+            else eval('vm.%s' % params.get("domain_ref", "name"))
 
         test.log.info(f"TEST_STEP: Get VM's hostname via guest agent.")
-        res = virsh.domhostname(domain_ref, debug=True)
-        libvirt.check_result(res, expected_match=expr_hostname)
+        res = virsh.domhostname(domain_ref, ignore_status=True, debug=True)
+
+        fail_patterns = []
+        if status_error:
+            if not start_qemu_ga:
+                fail_patterns.append(r"QEMU guest agent is not connected")
+            libvirt.check_result(res, expected_fails=fail_patterns)
+        else:
+            libvirt.check_result(res, expected_match=expr_hostname)
     finally:
         backup_xml.sync()


### PR DESCRIPTION
This change adds a negative test case to the `domhostname` test. The new case, `no_start_qemu_guest_agent`, verifies that the `domhostname` command fails as expected when the QEMU guest agent is not running in the guest.

The test logic in `domhostname.py` is updated to handle this case by optionally preventing the guest agent from starting and then checking for the appropriate error message. The test configuration in `domhostname.cfg` is updated to include this new negative test variant.