### PR TITLE
Avoid to install the stress package

### DIFF
--- a/libvirt/tests/cfg/save_and_restore/abort_managedsave.cfg
+++ b/libvirt/tests/cfg/save_and_restore/abort_managedsave.cfg
@@ -6,4 +6,5 @@
     event_cmd = "event --loop --all"
     expected_event = ["Suspended Paused", "Resumed Unpaused"]
     stress_type = "stress"
+    stress_package = "stress"
     stress_cmds = "stress --cpu 8 --io 4 --vm 2 --vm-bytes 128M --vm-keep"

--- a/libvirt/tests/cfg/save_and_restore/abort_save.cfg
+++ b/libvirt/tests/cfg/save_and_restore/abort_save.cfg
@@ -2,5 +2,6 @@
     type = abort_save
     start_vm = no
     stress_type = "stress"
+    stress_package = "stress"
     stress_cmds = "stress --cpu 8 --io 4 --vm 2 --vm-bytes 128M --vm-keep"
 


### PR DESCRIPTION
In the original code, there was no stress_package parameter, so the job always compiled and installed it from the repository. With this parameter set, the job first checks whether the package exists on the guest, and installs it only if it is not already present.