### PR TITLE
Virtual Interface: Drop SSH wait; just check VM is alive

### DIFF
--- a/libvirt/tests/src/virtual_interface/interface_update_device_negative.py
+++ b/libvirt/tests/src/virtual_interface/interface_update_device_negative.py
@@ -1,5 +1,4 @@
 from provider.interface import interface_base
-
 from virttest import libvirt_version
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_libvirt import libvirt_vmxml
@@ -25,7 +24,10 @@ def run(test, params, env):
             libvirt_vmxml.modify_vm_device(vmxml, 'interface', pre_iface_dict)
         if start_vm and not vm.is_alive():
             vm.start()
-            vm.wait_for_login(timeout=240).close()
+            vm.cleanup_serial_console()
+            vm.create_serial_console()
+            session = vm.wait_for_serial_login(timeout=int(params.get("login_timeout", 600)))
+            session.close()
         test.log.info("TEST_STEP: Update interface device.")
         interface_base.update_iface_device(vm, params)
     finally:


### PR DESCRIPTION
I removed the DHCP/SSH wait and only verify the VM is alive before running virsh update-device. This test’s goal is to confirm that hot-updating virtio NIC driver attributes (rss, rss_hash_report) is rejected, so guest networking isn’t needed. This change prevents flaky timeouts when DHCP is slow without reducing coverage.

 Committer: Bolatbek Issakh <bissakh@redhat.com>