### PR TITLE
multi_vms_with_stress: add stress_package param to check if stress already installed

### DIFF
--- a/libvirt/tests/cfg/cpu/multi_vms_with_stress.cfg
+++ b/libvirt/tests/cfg/cpu/multi_vms_with_stress.cfg
@@ -2,4 +2,5 @@
     type = multi_vms_with_stress
     memory = 4194304
     vm_names = vm2 vm3
-    stress_args = '--cpu 4 --io 4 --vm 2 --vm-bytes 128M &'
+    stress_args = "--cpu 4 --io 4 --vm 2 --vm-bytes 128M &"
+    stress_package = "stress"


### PR DESCRIPTION
Depends on: https://github.com/avocado-framework/avocado-vt/pull/4208

With dependency:
```
(.libvirt-ci-venv-ci-runtest-tZ4ye3) bash-5.2# avocado run --vt-type libvirt --vt-omit-data-loss --vt-machine-type arm64-mmio multi_vms_with_stress --job-timeout 1200 --vt-connect-uri qemu:///system
 (1/1) type_specific.io-github-autotest-libvirt.multi_vms_with_stress: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.multi_vms_with_stress: PASS (137.97 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced stress test configuration with new package specification option for multi-VM testing.

* **Style**
  * Standardized quote formatting in stress test configuration for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->