### PR TITLE
add case for ethernet connectivity with various model and backend

### DIFF
--- a/libvirt/tests/cfg/virtual_network/connectivity/connectivity_check_ethernet_interface.cfg
+++ b/libvirt/tests/cfg/virtual_network/connectivity/connectivity_check_ethernet_interface.cfg
@@ -14,6 +14,41 @@
         - positive_test:
             status_error = no
             variants:
+                - virtio:
+                    model = 'virtio'
+                - virtio_transitional:
+                    only default_rom.vhost..tap.one_iface
+                    no larger_mtu
+                    model = 'virtio-transitional'
+                - virtio_non_transitional:
+                    only tap.one_iface
+                    no larger_mtu
+                    model = 'virtio-non-transitional'
+                - e1000:
+                    only tap.one_iface
+                    no larger_mtu,smaller_mtu
+                    model = 'e1000'
+                - e1000e:
+                    only default_rom.vhost..tap.one_iface
+                    no larger_mtu,smaller_mtu
+                    model = 'e1000e'
+                - rtl8139:
+                    only rom_not_enabled.vhost..tap.one_iface.smaller_mtu
+                    no larger_mtu,smaller_mtu
+                    model = 'rtl8139'
+            variants:
+                - vhost:
+                    driver_attrs = {'driver': {'driver_attr': {'name': 'vhost'}}}
+                - vhost_multi_queue:
+                    driver_attrs = {'driver': {'driver_attr': {'queues': '4', 'name': 'vhost'}}}
+                - no_vhost:
+                    driver_attrs = {}
+            variants:
+                - rom_not_enabled:
+                    extra_attrs = {'rom': {'enabled': 'no'}}
+                - default_rom:
+                    extra_attrs = {}
+            variants:
                 - no_mtu:
                     mtu_attrs = {}
                 - larger_mtu:
@@ -39,16 +74,16 @@
                         - two_ifaces:
                             only smaller_mtu_multi_ifaces
                             extra_attrs = {'rom': {'enabled': 'no'}}
-                            iface_attrs_2 = {'type_name': 'ethernet', 'target': {'dev': tap_name_2, 'managed': 'no'}, 'model': 'virtio', 'mtu': {'size': '${iface_mtu_2}'}, 'driver': {'driver_attr': {'name': 'vhost'}}, 'rom': {'enabled': 'no'}} 
+                            iface_attrs_2 = {'type_name': 'ethernet', 'target': {'dev': tap_name_2, 'managed': 'no'}, 'model': '${model}', 'mtu': {'size': '${iface_mtu_2}'}, **${extra_attrs}, **${driver_attrs}}
                             s390-virtio, aarch64:
                                 extra_attrs =
-                                iface_attrs_2 = {'type_name': 'ethernet', 'target': {'dev': tap_name_2, 'managed': 'no'}, 'model': 'virtio', 'mtu': {'size': '${iface_mtu_2}'}, 'driver': {'driver_attr': {'name': 'vhost'}}}
+                                iface_attrs_2 = {'type_name': 'ethernet', 'target': {'dev': tap_name_2, 'managed': 'no'}, 'model': '${model}', 'mtu': {'size': '${iface_mtu_2}'}, **{driver_attrs}}
                 - macvtap:
                     vm_ping_outside = pass
                     vm_ping_host_public = fail
-            iface_attrs = {'target': {'dev': tap_name, 'managed': 'no'}, 'model': 'virtio', 'type_name': 'ethernet', **${mtu_attrs}, **${extra_attrs}}
+            iface_attrs = {'target': {'dev': tap_name, 'managed': 'no'}, 'model': '${model}', 'type_name': 'ethernet', **${mtu_attrs}, **${extra_attrs}, **${driver_attrs}}
             s390-virtio, aarch64:
-                iface_attrs = {'target': {'dev': tap_name, 'managed': 'no'}, 'model': 'virtio', 'type_name': 'ethernet', **${mtu_attrs}}
+                iface_attrs = {'target': {'dev': tap_name, 'managed': 'no'}, 'model': '${model}', 'type_name': 'ethernet', **${mtu_attrs}}
         - negative_test:
             status_error = yes
             variants:


### PR DESCRIPTION
   xxxx-304653 - [Ethernet] Check the connectivity of Ethernet with various model and backend
Signed-off-by: nanli <nanli@redhat.com>

Test cases and related cases 


```
avocado run --vt-type libvirt --vt-omit-data-loss --vt-machine-type q35  virtual_network.connectivity_check.ethernet_interface

libvirt.virtual_network.connectivity_check.ethernet_interface.managed_no.positive_test.tap.one_iface.no_mtu.rom_not_enabled.vhost.virtio.non_root_user: STARTED
 (01/47) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.ethernet_interface.managed_no.positive_test.tap.one_iface.no_mtu.rom_not_enabled.vhost.virtio.non_root_user: PASS (59.96 s)
 (02/47) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.ethernet_interface.managed_no.positive_test.tap.one_iface.no_mtu.rom_not_enabled.vhost.virtio_non_transitional.non_root_user: PASS (70.67 s)
 (03/47) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.ethernet_interface.managed_no.positive_test.tap.one_iface.no_mtu.rom_not_enabled.vhost.e1000.non_root_user: PASS (66.69 s)
...

 (47/47) type_specific.io-github-autotest-libvirt.virtual_network.connectivity_check.ethernet_interface.managed_no.negative_test.no_multi_queue_flag.non_root_user: PASS (48.18 s)
RESULTS    : PASS 47 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0

```
 virtual_network.connectivity_check.ethernet_interface..vhost_multi_queue scenarios are skipped due to bug : 'RHEL-101163' in libvirt ci mr:  libvirt-ci/-/merge_requests/2736 
