### PR TITLE
virtual_network: add case for pktgen with burst mode

### DIFF
--- a/libvirt/tests/cfg/virtual_network/qemu/pktgen_burst_mode_test.cfg
+++ b/libvirt/tests/cfg/virtual_network/qemu/pktgen_burst_mode_test.cfg
@@ -1,0 +1,24 @@
+- virtual_network.qemu_test.pktgen_burst_mode_test:
+    type = pktgen_burst_mode_test
+    no Windows
+    only virtio_net
+    no Host_RHEL.m5, Host_RHEL.m6
+    start_vm = no
+    vm_ping_host = "pass"
+    # tx: Guest transmission performance to external network.
+    pkg_dir = "tx"
+    pktgen_script = "pktgen_sample03_burst_single_flow"
+    pktgen_threads = 1
+    pkt_size = 64
+    burst = 3
+    pktgen_test_timeout = 30
+    record_list = pkt_size run_threads burst mpps
+    guest_ver_cmd = "uname -r"
+    kvm_ver_chk_cmd = "rpm -qa qemu-kvm-rhev qemu-kvm"
+    test_vm = no
+    flush_firewall_rules_cmd = "iptables -F ; nft flush ruleset"
+    queues_nic1 = "8"
+    create_vm_libvirt = "yes"
+    kill_vm_libvirt = "yes"
+    ovmf:
+        kill_vm_libvirt_options = " --nvram"

--- a/libvirt/tests/src/virtual_network/qemu/pktgen_burst_mode_test.py
+++ b/libvirt/tests/src/virtual_network/qemu/pktgen_burst_mode_test.py
@@ -1,0 +1,101 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright Redhat
+#
+#   SPDX-License-Identifier: GPL-2.0
+#   Author: Nannan Li<nanli@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+import os
+
+from avocado.utils import distro
+from avocado.utils import process
+
+from virttest import utils_misc
+from virttest import utils_net
+from virttest.libvirt_xml import vm_xml
+
+from provider.virtual_network import pktgen_utils
+from provider.virtual_network import network_base
+
+
+def write_to_result_file(test, params):
+    """
+    Write some qemu, kvm version info and write them into pktgen test result.
+
+    :params, params
+    :return result_file, pktgen test result file.
+    """
+    kvm_ver_chk_cmd = params.get("kvm_ver_chk_cmd")
+
+    result_path = utils_misc.get_path(test.resultsdir, "pktgen_perf.RHS")
+    result_file = open(result_path, "w")
+    kvm_ver = process.system_output(kvm_ver_chk_cmd, shell=True).decode()
+    host_ver = os.uname().release
+    result_file.write("### kvm-userspace-ver : %s\n" % kvm_ver)
+    result_file.write("### kvm_version : %s\n" % host_ver)
+
+    return result_file
+
+
+def run(test, params, env):
+    """
+    Pktgen tests with burst mode.
+    """
+    def run_test():
+        """
+        Run pktgen in burst mode for vm.
+        """
+        test.log.debug("TEST_STEP 1: Prepare qemu version into pktgen test result")
+        result_file = write_to_result_file(test, params)
+        if flush_firewall_rules_cmd:
+            process.system(flush_firewall_rules_cmd, shell=True)
+
+        _distro = distro.detect()
+        if _distro.name == 'rhel' and int(_distro.version) > 7:
+            is_64k_page_size = "64k" in host_ver
+            if is_64k_page_size:
+                pktgen_utils.install_package(host_ver, pagesize="64k")
+            else:
+                pktgen_utils.install_package(host_ver)
+
+        test.log.debug("TEST_STEP 2: Test with guest and host connectivity")
+        vm.start()
+        test.log.debug("Test with Guest xml:%s", vm_xml.VMXML.new_from_dumpxml(vm_name))
+        session = vm.wait_for_serial_login(restart_network=True)
+        network_base.ping_check(params, ips, session, force_ipv4=True)
+
+        test.log.debug("TEST_STEP 3: Install package and Run pktgen in burst mode.")
+        guest_ver = session.cmd_output(guest_ver_cmd)
+        result_file.write("### guest-kernel-ver :%s" % guest_ver)
+        if _distro.name == 'rhel' and int(_distro.version) > 7:
+            guest_is_64k_page_size = "64k" in guest_ver
+            if guest_is_64k_page_size:
+                pktgen_utils.install_package(
+                    guest_ver.strip(),
+                    pagesize="64k",
+                    vm=vm,
+                    session_serial=session)
+            else:
+                pktgen_utils.install_package(
+                    guest_ver.strip(), vm=vm, session_serial=session)
+
+        pktgen_utils.run_tests_for_category(
+            params, result_file, test_vm, vm, session)
+
+        test.log.debug("TEST_STEP: Check the guest dmesg without error messages.")
+        vm.verify_dmesg()
+        vm.verify_kernel_crash()
+
+        result_file.close()
+
+    vm_name = params.get("main_vm")
+    vm = env.get_vm(vm_name)
+    flush_firewall_rules_cmd = params.get("flush_firewall_rules_cmd")
+    guest_ver_cmd = params.get("guest_ver_cmd")
+    test_vm = params.get_boolean("test_vm")
+    host_ver = os.uname().release
+    ips = {'host_ip': utils_net.get_host_ip_address(params)}
+
+    run_test()

--- a/provider/virtual_network/pktgen_utils.py
+++ b/provider/virtual_network/pktgen_utils.py
@@ -1,0 +1,235 @@
+import aexpect
+import logging
+import os
+
+from avocado.utils import process
+
+from virttest import data_dir
+from virttest import utils_net
+from virttest import utils_misc
+from virttest import utils_package
+
+
+LOG_JOB = logging.getLogger("avocado.test")
+
+
+class PktgenConfig:
+    def __init__(self):
+        self.interface = None
+        self.dsc = None
+        self.runner = None
+        self.dest_path = "/tmp/"
+
+    def configure_pktgen(
+        self,
+        pkt_cate,
+        vm=None,
+        session_serial=None,
+    ):
+        """
+        Configure pktgen test environment for different packet categories.
+
+        :param pkt_cate: Packet category (tx, rx, loopback)
+        :param vm: VM instance
+        :param session_serial: Serial session for guest command execution
+        :return: Configured PktgenConfig instance
+        """
+        source_path = os.path.join(data_dir.get_shared_dir(), "scripts/pktgen_perf")
+
+        if pkt_cate == "tx":
+            LOG_JOB.info("test guest tx pps performance")
+            vm.copy_files_to(source_path, self.dest_path)
+            guest_mac = vm.get_mac_address(0)
+            self.interface = utils_net.get_linux_ifname(session_serial, guest_mac)
+            host_iface = utils_net.get_default_gateway(iface_name=True, force_dhcp=False, json=True)
+            dsc_dev = utils_net.Interface(host_iface)
+            self.dsc = dsc_dev.get_mac()
+            self.runner = session_serial.cmd
+        return self
+
+    def generate_pktgen_cmd(
+        self,
+        script,
+        pkt_cate,
+        interface,
+        dsc,
+        threads,
+        size,
+        burst,
+        session_serial=None,
+    ):
+        """
+        Generate pktgen command based on test parameters.
+
+        :param script: Script name to execute
+        :param pkt_cate: Packet category (tx, rx, loopback)
+        :param interface: Network interface
+        :param dsc: Destination MAC address or IP
+        :param threads: Number of threads
+        :param size: Packet size
+        :param burst: Burst size
+        :param session_serial: Serial session for guest command execution
+        :return: Generated command string
+        """
+        cmd = "%s -i %s -m %s -n 0 -t %s -s %s -b %s -c 0" % (
+            "%spktgen_perf/%s.sh" % (self.dest_path, script),
+            interface,
+            dsc,
+            threads,
+            size,
+            burst,
+        )
+
+        if (
+            session_serial
+            and self.runner.__name__ == session_serial.cmd.__name__
+        ):
+            cmd = f"{cmd} &"
+
+        return cmd
+
+
+def run_test(script, cmd, runner, interface, timeout):
+    """
+    Run pktgen  script on remote and gather packet numbers/time and
+    calculate mpps.
+    :param script: pktgen script name.
+    :param cmd: The command to execute the pktgen script
+    :param runner: The command runner function
+    :param interface: The network interface used by pktgen.
+    :param timeout: The maximum time allowed for the test to run
+    :return: The calculated MPPS (Million Packets Per Second)
+    """
+
+    packets = "cat /sys/class/net/%s/statistics/tx_packets" % interface
+    LOG_JOB.info("Start pktgen test by cmd '%s'", cmd)
+    try:
+        packet_b = runner(packets)
+        packet_a = None
+        runner(cmd, timeout)
+    except aexpect.ShellTimeoutError:
+        # when pktgen script is running on guest, the pktgen process
+        # need to be killed.
+        kill_cmd = (
+            "kill -9 `ps -ef | grep %s --color | grep -v grep | "
+            "awk '{print $2}'`" % script
+        )
+        runner(kill_cmd)
+        packet_a = runner(packets)
+    except process.CmdError:
+        # when pktgen script is running on host, the pktgen process
+        # will be quit when timeout triggers, so no need to kill it.
+        packet_a = runner(packets)
+
+    return "{:.2f}".format((int(packet_a) - int(packet_b)) / timeout / 10 ** 6)
+
+
+def install_package(ver, pagesize=None, vm=None, session_serial=None):
+    """
+    Check module pktgen, install kernel-modules-internal package.
+
+    :param ver: Kernel version string
+    :param pagesize: Page size specification for kernel package selection
+    :param vm: VM instance for guest installation
+    :param session_serial: Serial session for guest command execution
+    """
+    result = process.run("which brew", ignore_status=True, shell=True)
+    if result.exit_status != 0:
+        utils_package.package_install("brewkoji")
+
+    if pagesize:
+        kernel_ver = "kernel-%s-modules-internal-%s" % (pagesize, ver.split("+")[0])
+    else:
+        kernel_ver = "kernel-modules-internal-%s" % ver
+    cmd_download = "cd /tmp && brew download-build %s --rpm" % kernel_ver
+    cmd_install = "cd /tmp && rpm -ivh  %s.rpm --force --nodeps" % kernel_ver
+
+    utils_misc.cmd_status_output(cmd_download, shell=True)
+    cmd_clean = "rm -rf /tmp/%s.rpm" % kernel_ver
+    if session_serial:
+        local_path = "/tmp/%s.rpm" % kernel_ver
+        remote_path = "/tmp/"
+        vm.copy_files_to(local_path, remote_path)
+    utils_misc.cmd_status_output(cmd_install, session=session_serial)
+    utils_misc.cmd_status_output(cmd_clean, session=session_serial)
+
+
+def format_result(result):
+    """Format result with fixed width (12) and decimals (2)"""
+    if isinstance(result, str):
+        return "%12s" % result
+    elif isinstance(result, int):
+        return "%12d" % result
+    elif isinstance(result, float):
+        return "%12.2f" % result
+    else:
+        raise TypeError(f"unexpected result type: {type(result).__name__}")
+
+
+def run_tests_for_category(
+    params,
+    result_file,
+    test_vm=None,
+    vm=None,
+    session_serial=None,
+):
+    """
+    Run Pktgen tests for a specific category.
+
+    :param params: Dictionary with the test parameters
+    :param result_file: File to write the test results
+    :param test_vm: Flag indicating whether the test is running on a VM
+    :param vm: VM instance
+    :param session_serial: Session serial for VM
+    """
+
+    timeout = params.get_numeric("pktgen_test_timeout", "240")
+    category = params.get("pkg_dir")
+    record_list = params.get_list("record_list")
+    pktgen_script = params.get("pktgen_script")
+    # Get single values for threads and burst instead of looping
+    threads = params.get("pktgen_threads", "")
+    burst = params.get("burst", "")
+
+    record_line = ""
+    for record in record_list:
+        record_line += "%s|" % format_result(record)
+
+    pktgen_config = PktgenConfig()
+
+    for script in pktgen_script.split():
+        for pkt_cate in category.split():
+            result_file.write("Script:%s " % script)
+            result_file.write("Category:%s\n" % pkt_cate)
+            result_file.write("%s\n" % record_line.rstrip("|"))
+
+            # Use single values directly since they're not lists
+            size = params.get("pkt_size", "")
+            if pkt_cate != "loopback":
+                pktgen_config = pktgen_config.configure_pktgen(
+                    pkt_cate, vm, session_serial
+                )
+                exec_cmd = pktgen_config.generate_pktgen_cmd(
+                    script,
+                    pkt_cate,
+                    pktgen_config.interface,
+                    pktgen_config.dsc,
+                    threads,
+                    size,
+                    burst,
+                    session_serial,
+                )
+                if exec_cmd:
+                    pkt_cate_r = run_test(
+                        script,
+                        exec_cmd,
+                        pktgen_config.runner,
+                        pktgen_config.interface,
+                        timeout,
+                    )
+
+            line = "%s|" % format_result(size)
+            line += "%s|" % format_result(threads)
+            line += "%s|" % format_result(burst)
+            line += "%s" % format_result(pkt_cate_r)
+            result_file.write(("%s\n" % line))


### PR DESCRIPTION
This introduces test cases for pktgen burst mode functionality
in virtual network environments using virtio-net-pci devices. The tests
validate packet generation performance and reliability under different
burst configurations.

This change is to ensure comprehensive coverage of
network performance testing scenarios, particularly for high-throughput
use cases that require burst packet transmission capabilities.

Reference: XXXX-300599
Signed-off-by: nanli <nanli@redhat.com>


```
 (1/1) Host_RHEL.m10.u1.ovmf.qcow2.virtio_scsi.up.virtio_net.Guest.RHEL.10.1.x86_64.io-github-autotest-libvirt.virtual_network.qemu_test.pktgen_burst_mode_test.q35: PASS (425.71 s)


```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a pktgen burst-mode performance test for virtual networks with configurable threads, packet size, burst and timeout; excludes Windows and targets virtio_net. Supports VM lifecycle control, firewall handling, OVMF with 8-queue NIC, adaptive package steps by distro/version, connectivity checks, crash verification, and structured result recording.

* **New Features**
  * Added end-to-end pktgen benchmarking utilities: configuration, command generation, test execution with MPPS calculation, timeouts, installation helpers, formatted results, and category-based test runners.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->