### PR TITLE
Inc_backup: fix checkpoint already existes when no readonly disk

### DIFF
--- a/libvirt/tests/src/incremental_backup/incremental_backup_pull_mode.py
+++ b/libvirt/tests/src/incremental_backup/incremental_backup_pull_mode.py
@@ -337,7 +337,7 @@ def run(test, params, env):
             logging.debug("ROUND_%s Checkpoint Xml: %s",
                           backup_index, checkpoint_xml)
 
-            if backup_index == 0:
+            if backup_index == 0 and with_readonly:
                 virsh.checkpoint_create(vm_name, checkpoint_xml.xml, debug=True)
 
             # Create some data in vdb


### PR DESCRIPTION
For some test with readonly disk, we need to create chekcpoint first. But now the condition affects other test cases, so we need to add another condition with_readonly to judge.