### PR TITLE
nvdimm: update expected hot_plug_error to match new QEMU message

### DIFF
--- a/libvirt/tests/cfg/memory/memory_devices/nvdimm_memory_with_memory_allocation_and_numa.cfg
+++ b/libvirt/tests/cfg/memory/memory_devices/nvdimm_memory_with_memory_allocation_and_numa.cfg
@@ -41,7 +41,7 @@
             hot_plug_nvdimm..no_node:
                 hot_plug_error = "target NUMA node needs to be specified for memory device"
             hot_plug_nvdimm..with_node:
-                hot_plug_error = "nvdimm is not enabled: missing 'nvdimm' in '-M'"
+                hot_plug_error = "nvdimm is not enabled:"
     variants numa_setting:
         - no_numa:
             numa_dict = ""


### PR DESCRIPTION
QEMU now reports "nvdimm is not enabled: add 'nvdimm=on' to '-M'" instead of the old "missing 'nvdimm' in '-M'". Updated the expected hot_plug_error in cfg (with_slot → hot_plug_nvdimm.with_node) so the test properly recognizes the failure again.
Committer: Bolatbek Issakh <bissakh@redhat.com>