### PR TITLE
migration: Add error checking in pause_and_recover_and_disruptive case

### DIFF
--- a/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_and_recover_and_disruptive.cfg
+++ b/libvirt/tests/cfg/migration/pause_postcopy_migration_and_recover/pause_and_recover_and_disruptive.cfg
@@ -61,6 +61,7 @@
             status_error_during_mig = "yes"
             poweroff_vm_dest = "yes"
             status_error = "yes"
+            err_msg = "domain is not running"
         - unattended_mig:
             service_name = "libvirtd"
             service_on_dst = "yes"
@@ -69,6 +70,7 @@
             expected_event_target_2 = ["event 'lifecycle' for domain.*: Resumed Migrated"]
             expected_event_src = ["event 'lifecycle' for domain .*: Stopped Migrated", "event 'job-completed' for domain"]
             status_error = "yes"
+            err_msg = "End of file while reading data: Input/output error"
         - pause_by_domjobabort:
             action_during_do_mig = '[{"func": "virsh.domjobabort", "before_pause": "yes", "func_param": "'%s --postcopy' % params.get('migrate_main_vm')", "need_sleep_time": "20"}, {"func": "resume_migration_again", "before_pause": "yes", "func_param": "params", "need_sleep_time": "10"}]'
             status_error_during_mig = "no"


### PR DESCRIPTION
Add error checking to ensure test only passes on expected errors.