### PR TITLE
guest_os_booting/boot_order: relax error message

### DIFF
--- a/libvirt/tests/cfg/guest_os_booting/boot_order/hotplug_device_with_boot_order.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/boot_order/hotplug_device_with_boot_order.cfg
@@ -14,7 +14,7 @@
             target_disk = "sda"
             device_dict = {"type_name":"file", "target":{"dev": "${target_disk}", "bus": "${bus_type}"}, 'boot': '2'}
             s390-virtio:
-                expected_error = unsupported configuration: This QEMU doesn't support
+                expected_error = This QEMU doesn't support.*usb
         - filesystem_device:
             target_dir = "mount_tag"
             source_dir = "/tmp"


### PR DESCRIPTION
Error message can slightly differ but still be correct. Relax the test condition accordingly.