### PR TITLE
Virtual_disk: fix virtio_scsi driver issue in image mode

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_multidisks.py
@@ -21,6 +21,7 @@ from virttest import utils_disk
 from virttest import data_dir
 from virttest import utils_selinux
 from virttest import utils_package
+from virttest import utils_sys
 
 from virttest.utils_test import libvirt
 from virttest.utils_config import LibvirtQemuConfig
@@ -1095,8 +1096,10 @@ def run(test, params, env):
                                   guest_arch_name=arch)
         if add_disk_driver:
             # Ignore errors here
-            session.cmd("dracut --force --add-drivers '%s'"
-                        % add_disk_driver, timeout=360)
+            image_mode = utils_sys.is_image_mode(session=session)
+            if not image_mode:
+                session.cmd("dracut --force --add-drivers '%s'"
+                            % add_disk_driver, timeout=360)
             # In terms of s390x, additional step is needed for normal guest
             # boot, see https://bugzilla.redhat.com/show_bug.cgi?id=2214147
             if arch == 's390x':


### PR DESCRIPTION
Dracut command is used in guest to add the scsi driver. But in image mode it can't write to /boot/efi. Because actually this is not a necessary checkpoint in test scenario, so I think we can directly skip this step in case.