### PR TITLE
add case for disabling pxe boot for bridge type interface

### DIFF
--- a/libvirt/tests/cfg/virtual_network/rom/iface_rom_disable_pxe_boot.cfg
+++ b/libvirt/tests/cfg/virtual_network/rom/iface_rom_disable_pxe_boot.cfg
@@ -1,0 +1,36 @@
+- virtual_network.rom.disable_pxe_boot:
+    type = iface_rom_disable_pxe_boot
+    start_vm = "no"
+    iface_type = "bridge"
+    iface_order = 1
+    disk_order = 2
+    basic_os = {"bootmenu_enable": "yes", "bootmenu_timeout": 3000, "bios_useserial": "yes", "bios_reboot_timeout": 300}
+    variants firmware:
+        - seabios:
+            firmware_type = "seabios"
+            boot_msg = "SeaBIOS "
+            os_attrs = "${basic_os}"
+        - uefi:
+            only q35, aarch64
+            firmware_type = "ovmf"
+            boot_msg = "Start PXE"
+            os_attrs = {'os_firmware': 'efi', 'machine': 'q35', **${basic_os}}
+    variants model:
+        - virtio:
+            iface_model = "virtio"
+        - rtl8139:
+            iface_model = "rtl8139"
+        - e1000e:
+            iface_model = "e1000e"
+    variants rom:
+        - rom_enabled_no:
+            iface_rom = {'rom': {'enabled': 'no'}}
+            rom_xpath = "./devices/interface/rom[@enabled='no']"
+        - rom_bar_off:
+            iface_rom = {'rom': {'bar':'off'}}
+            rom_xpath = "./devices/interface/rom[@bar='off']"
+        - rom_bar_file_empty:
+            iface_rom = {'rom': {'bar':'on','file':''}}
+            rom_xpath = "./devices/interface/rom[@bar='on']"
+    iface_attrs = {'type_name': '${iface_type}', 'model': '${iface_model}','source':{'bridge':'%s'} ,'boot': ${iface_order}, **${iface_rom}}
+    expected_xpaths = [{'element_attrs': ["${rom_xpath}", "./devices/interface/model/[@type='${iface_model}']"]}, {'element_attrs': ["./devices/disk/boot[@order='${disk_order}']"]}]

--- a/libvirt/tests/src/virtual_network/rom/iface_rom_disable_pxe_boot.py
+++ b/libvirt/tests/src/virtual_network/rom/iface_rom_disable_pxe_boot.py
@@ -1,0 +1,98 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright Redhat
+#
+#   SPDX-License-Identifier: GPL-2.0
+#   Author: Nannan Li<nanli@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import re
+
+from virttest import utils_net
+from virttest import utils_misc
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_vmxml
+
+from provider.guest_os_booting import guest_os_booting_base as guest_os
+
+
+def run(test, params, env):
+    """
+    Test ROM disable PXE boot for bridge type interface.
+    """
+
+    def setup_test():
+        """
+        Setup test environment and VM configuration
+        """
+        test.log.info("TEST_SETUP: Configure firmware and boot order")
+        vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+        vmxml.remove_all_boots()
+        vmxml.set_boot_order_by_target_dev(
+            vmxml.get_devices('disk')[0].target.get('dev'), disk_order)
+        libvirt_vmxml.modify_vm_device(vmxml, 'interface', iface_attrs)
+
+        guest_os.prepare_os_xml(
+            vm_name, os_dict=os_attrs, firmware_type=firmware_type)
+        test.log.debug("Test guest xml:%s", vm_xml.VMXML.new_from_inactive_dumpxml(vm_name))
+
+    def run_test():
+        """
+        Check guest xml and pxe boot msg.
+        """
+        test.log.info("TEST_STEP 1: Checking VM XML configuration")
+        libvirt_vmxml.check_guest_xml_by_xpaths(
+            vm_xml.VMXML.new_from_inactive_dumpxml(vm_name), expected_xpaths)
+
+        test.log.debug("TEST_STEP 2: Verifying VM boots message")
+        virsh_session = virsh.VirshSession(virsh_exec=virsh.VIRSH_EXEC, auto_close=True)
+        virsh_session.sendline("start %s --console" % vm_name)
+        if not utils_misc.wait_for(
+                lambda: re.search(boot_msg, virsh_session.get_output()), 15
+        ):
+            if not (model in ["rtl8139", "e1000e"] and firmware == "uefi"):
+                test.fail("Boot msg:%s checking has failed:%s " % (boot_msg, virsh_session.get_output()))
+        test.log.info("Boot msg:%s checking has PASSED", boot_msg)
+
+    def teardown_test():
+        """
+        Clean up test environment
+        """
+        test.log.debug("TEST_TEARDOWN: Recover the env.")
+        utils_net.delete_linux_bridge_tmux(bridge_name, host_iface)
+        bkxml.sync()
+
+    vm_name = guest_os.get_vm(params)
+    os_attrs = eval(params.get("os_attrs", "{}"))
+    model = params.get("model")
+    firmware = params.get("firmware")
+    boot_msg = params.get("boot_msg")
+    expected_xpaths = eval(params.get("expected_xpaths"))
+    rand_id = utils_misc.generate_random_string(3)
+    bridge_type = params.get('bridge_type', '')
+    bridge_name = bridge_type + '_' + rand_id
+
+    if not utils_misc.wait_for(
+            lambda: utils_net.get_default_gateway(
+                iface_name=True, force_dhcp=True, json=True) is not None, timeout=15):
+        test.fail("Cannot get default gateway in 15s")
+    host_iface = params.get("host_iface")
+    iface_name = host_iface if host_iface else utils_net.get_default_gateway(
+        iface_name=True, force_dhcp=True).split()[0]
+    utils_net.create_linux_bridge_tmux(bridge_name, iface_name)
+    iface_attrs = eval(params.get("iface_attrs") % bridge_name)
+    disk_order = int(params.get("disk_order"))
+    firmware_type = params.get("firmware_type")
+
+    vm = env.get_vm(vm_name)
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+
+    try:
+
+        setup_test()
+        run_test()
+
+    finally:
+        teardown_test()


### PR DESCRIPTION
xxxx-296326: [rom] Disable pxe boot for bridge type interface
Signed-off-by: nanli <nanli@redhat.com>

```
# avocado run --vt-type libvirt --vt-omit-data-loss --vt-machine-type q35 virtual_network.rom.disable_pxe_boot
 (01/18) type_specific.io-github-autotest-libvirt.virtual_network.rom.disable_pxe_boot.rom_enabled_no.virtio.seabios: STARTED
 (01/18) type_specific.io-github-autotest-libvirt.virtual_network.rom.disable_pxe_boot.rom_enabled_no.virtio.seabios: PASS (9.23 s)
 (02/18) type_specific.io-github-autotest-libvirt.virtual_network.rom.disable_pxe_boot.rom_enabled_no.virtio.efi: STARTED
 (02/18) type_specific.io-github-autotest-libvirt.virtual_network.rom.disable_pxe_boot.rom_enabled_no.virtio.efi: PASS (14.33 s)
 (03/18) type_specific.io-github-autotest-libvirt.virtual_network.rom.disable_pxe_boot.rom_enabled_no.rtl8139.seabios: STARTED
 (03/18) type_specific.io-github-autotest-libvirt.virtual_network.rom.disable_pxe_boot.rom_enabled_no.rtl8139.seabios: PASS (9.19 s)
 (04/18) type_specific.io-github-autotest-libvirt.virtual_network.rom.disable_pxe_boot.rom_enabled_no.rtl8139.efi: STARTED
 (04/18) type_specific.io-github-autotest-libvirt.virtual_network.rom.disable_pxe_boot.rom_enabled_no.rtl8139.efi: PASS (23.33 s)
 (05/18) type_specific.io-github-autotest-libvirt.virtual_network.rom.disable_pxe_boot.rom_enabled_no.e1000e.seabios: STARTED
 (05/18) type_specific.io-github-autotest-libvirt.virtual_network.rom.disable_pxe_boot.rom_enabled_no.e1000e.seabios: PASS (9.22 s)
 (06/18) type_specific.io-github-autotest-libvirt.virtual_network.rom.disable_pxe_boot.rom_enabled_no.e1000e.efi: STARTED
 (06/18) type_specific.io-github-autotest-libvirt.virtual_network.rom.disable_pxe_boot.rom_enabled_no.e1000e.efi: PASS (23.37 s)
 (07/18) type_specific.io-github-autotest-libvirt.virtual_network.rom.disable_pxe_boot.rom_bar_off.virtio.seabios: STARTED
 (07/18) type_specific.io-github-autotest-libvirt.virtual_network.rom.disable_pxe_boot.rom_bar_off.virtio.seabios: PASS (9.24 s)
 (08/18) type_specific.io-github-autotest-libvirt.virtual_network.rom.disable_pxe_boot.rom_bar_off.virtio.efi: STARTED
 (08/18) type_specific.io-github-autotest-libvirt.virtual_network.rom.disable_pxe_boot.rom_bar_off.virtio.efi: PASS (13.33 s)
 (09/18) type_specific.io-github-autotest-libvirt.virtual_network.rom.disable_pxe_boot.rom_bar_off.rtl8139.seabios: STARTED
 (09/18) type_specific.io-github-autotest-libvirt.virtual_network.rom.disable_pxe_boot.rom_bar_off.rtl8139.seabios: PASS (9.20 s)
 (10/18) type_specific.io-github-autotest-libvirt.virtual_network.rom.disable_pxe_boot.rom_bar_off.rtl8139.efi: STARTED
 (10/18) type_specific.io-github-autotest-libvirt.virtual_network.rom.disable_pxe_boot.rom_bar_off.rtl8139.efi: PASS (23.35 s)
 (11/18) type_specific.io-github-autotest-libvirt.virtual_network.rom.disable_pxe_boot.rom_bar_off.e1000e.seabios: STARTED
 (11/18) type_specific.io-github-autotest-libvirt.virtual_network.rom.disable_pxe_boot.rom_bar_off.e1000e.seabios: PASS (9.20 s)
 (12/18) type_specific.io-github-autotest-libvirt.virtual_network.rom.disable_pxe_boot.rom_bar_off.e1000e.efi: STARTED
 (12/18) type_specific.io-github-autotest-libvirt.virtual_network.rom.disable_pxe_boot.rom_bar_off.e1000e.efi: PASS (23.31 s)
 (13/18) type_specific.io-github-autotest-libvirt.virtual_network.rom.disable_pxe_boot.rom_bar_file_empty.virtio.seabios: STARTED
 (13/18) type_specific.io-github-autotest-libvirt.virtual_network.rom.disable_pxe_boot.rom_bar_file_empty.virtio.seabios: PASS (9.21 s)
 (14/18) type_specific.io-github-autotest-libvirt.virtual_network.rom.disable_pxe_boot.rom_bar_file_empty.virtio.efi: STARTED
 (14/18) type_specific.io-github-autotest-libvirt.virtual_network.rom.disable_pxe_boot.rom_bar_file_empty.virtio.efi: PASS (14.33 s)
 (15/18) type_specific.io-github-autotest-libvirt.virtual_network.rom.disable_pxe_boot.rom_bar_file_empty.rtl8139.seabios: STARTED
 (15/18) type_specific.io-github-autotest-libvirt.virtual_network.rom.disable_pxe_boot.rom_bar_file_empty.rtl8139.seabios: PASS (9.22 s)
 (16/18) type_specific.io-github-autotest-libvirt.virtual_network.rom.disable_pxe_boot.rom_bar_file_empty.rtl8139.efi: STARTED
 (16/18) type_specific.io-github-autotest-libvirt.virtual_network.rom.disable_pxe_boot.rom_bar_file_empty.rtl8139.efi: PASS (23.35 s)
 (17/18) type_specific.io-github-autotest-libvirt.virtual_network.rom.disable_pxe_boot.rom_bar_file_empty.e1000e.seabios: STARTED
 (17/18) type_specific.io-github-autotest-libvirt.virtual_network.rom.disable_pxe_boot.rom_bar_file_empty.e1000e.seabios: PASS (9.17 s)
 (18/18) type_specific.io-github-autotest-libvirt.virtual_network.rom.disable_pxe_boot.rom_bar_file_empty.e1000e.efi: STARTED
 (18/18) type_specific.io-github-autotest-libvirt.virtual_network.rom.disable_pxe_boot.rom_bar_file_empty.e1000e.efi: PASS (23.33 s)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new test validating that PXE boot via NIC ROM is disabled on bridge-backed interfaces.
  * Covers Seabios and UEFI firmware variants (UEFI limited to q35/aarch64) and NIC models: virtio, rtl8139, e1000e.
  * Verifies ROM settings, NIC model, and disk boot order via XML checks and console boot message detection.
  * Automates temporary bridge setup/teardown and includes conditional allowances for specific NIC/firmware combos.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->