### PR TITLE
Storage: fix resize check fail issue

### DIFF
--- a/libvirt/tests/src/virsh_cmd/volume/virsh_vol_resize.py
+++ b/libvirt/tests/src/virsh_cmd/volume/virsh_vol_resize.py
@@ -217,9 +217,15 @@ def check_vol_info(pool_vol, vol_name, test, expect_info=None):
             if expect_info['Allocation'] != img_info['dsize']:
                 logging.debug("Allocation(Disk size) is %s bytes",
                               img_info['dsize'])
-                logging.error("Volume Allocation not equal to expect value %s",
-                              expect_info['Allocation'])
-                check_allocation_pass = False
+                image_mode = utils_sys.is_image_mode()
+                if image_mode:
+                    max_allow = expect_info['Allocation'] * 1.4
+                    if img_info['dsize'] <= max_allow:
+                        check_allocation_pass = True
+                else:
+                    logging.error("Volume Allocation not equal to expect value %s",
+                                  expect_info['Allocation'])
+                    check_allocation_pass = False
             return check_capacity_pass & check_allocation_pass
         except KeyError as detail:
             test.error("Fail to check volume info:\n%s" % detail)


### PR DESCRIPTION
In image mode, the volume size of netfs pool will be affected by the metadata size. So it has size change and this change is within a reasonable range. So cover this size change in code.