### PR TITLE
migration: Add new case for copy storage migration

### DIFF
--- a/libvirt/tests/cfg/migration_with_copy_storage/no_sufficient_disk_space_on_target.cfg
+++ b/libvirt/tests/cfg/migration_with_copy_storage/no_sufficient_disk_space_on_target.cfg
@@ -1,0 +1,36 @@
+- migration_with_copy_storage.no_sufficient_disk_space_on_target:
+    type = no_sufficient_disk_space_on_target
+    migration_setup = 'yes'
+    # Console output can only be monitored via virsh console output
+    only_pty = True
+    take_regular_screendumps = no
+    # Extra options to pass after <domain> <desturi>
+    virsh_migrate_extra = ""
+    # SSH connection time out
+    ssh_timeout = 60
+    # Local URI
+    virsh_migrate_connect_uri = "qemu:///system"
+    image_convert = "no"
+    migrate_desturi_port = "16509"
+    migrate_desturi_type = "tcp"
+    virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
+    setup_nfs = "no"
+    nfs_mount_dir =
+    server_ip = "${migrate_dest_host}"
+    server_user = "root"
+    server_pwd = "${migrate_dest_pwd}"
+    client_ip = "${migrate_source_host}"
+    client_user = "root"
+    client_pwd = "${migrate_source_pwd}"
+    status_error = "yes"
+    disk_size = "200M"
+    block_path = "/var/tmp/no_sufficient_disk_space.qcow2"
+    err_msg = "No space left on device"
+    variants:
+        - p2p:
+            virsh_migrate_options = "--live --p2p --verbose"
+        - non_p2p:
+            virsh_migrate_options = "--live --verbose"
+    variants:
+        - copy_storage_all:
+            copy_storage_option = "--copy-storage-all"

--- a/libvirt/tests/src/migration_with_copy_storage/no_sufficient_disk_space_on_target.py
+++ b/libvirt/tests/src/migration_with_copy_storage/no_sufficient_disk_space_on_target.py
@@ -1,0 +1,89 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright Redhat
+#
+#   SPDX-License-Identifier: GPL-2.0
+#
+#   Author: Liping Cheng <lcheng@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+import os
+
+from virttest import remote
+from virttest import utils_misc
+
+from virttest.utils_libvirt import libvirt_disk
+
+from provider.migration import base_steps
+
+
+def run(test, params, env):
+    """
+    To verify that live migration with copying storage will fail when there
+    is no sufficient disk space on target host.
+
+    :param test: test object
+    :param params: dictionary with the test parameters
+    :param env: dictionary with test environment.
+    """
+    def setup_test():
+        """
+        Setup steps
+
+        """
+        disk_size = params.get("disk_size")
+        block_path = params.get("block_path")
+
+        migration_obj.setup_connection()
+        remote_session = remote.remote_login("ssh", server_ip, "22",
+                                             server_user, server_pwd,
+                                             r'[$#%]')
+        utils_misc.make_dirs(disk_path, remote_session)
+        remote_session.cmd(f"rm -rf {block_path}")
+        libvirt_disk.create_disk(first_disk["type"], path=block_path,
+                                 size=disk_size, disk_format="qcow2",
+                                 extra="-o preallocation=falloc",
+                                 session=remote_session)
+        remote_session.cmd(f"losetup /dev/loop0 {block_path}")
+        remote_session.cmd("mkfs.ext3 /dev/loop0")
+        remote_session.cmd(f"mount /dev/loop0 {disk_path}")
+
+        _, file_size = vm.get_device_size(first_disk["target"])
+        libvirt_disk.create_disk(first_disk["type"], path=disk_name,
+                                 size=file_size, disk_format="qcow2",
+                                 session=remote_session)
+        remote_session.close()
+
+    def cleanup_test():
+        """
+        Cleanup steps
+
+        """
+        block_path = params.get("block_path")
+
+        migration_obj.cleanup_connection()
+        remote_session = remote.remote_login("ssh", server_ip, "22",
+                                             server_user, server_pwd,
+                                             r'[$#%]')
+        remote_session.cmd(f"umount {disk_path}")
+        remote_session.cmd("losetup -d /dev/loop0")
+        remote_session.cmd(f"rm -rf {block_path}")
+        remote_session.close()
+
+    server_ip = params.get("server_ip")
+    server_user = params.get("server_user")
+    server_pwd = params.get("server_pwd")
+    vm_name = params.get("migrate_main_vm")
+    vm = env.get_vm(vm_name)
+    first_disk = vm.get_first_disk_devices()
+    disk_name = first_disk["source"]
+    disk_path = os.path.dirname(disk_name)
+    migration_obj = base_steps.MigrationBase(test, vm, params)
+
+    try:
+        setup_test()
+        migration_obj.run_migration()
+        migration_obj.verify_default()
+    finally:
+        cleanup_test()


### PR DESCRIPTION
Add case to verify that live migration with copying storage will fail when there is no sufficient disk space on target host.

VIRT-297909 - VM live migration with copy storage - no sufficient disk space on target host