### PR TITLE
Virtual_disk: fix ssh network authentication methods failed issue

### DIFF
--- a/provider/virtual_disk/disk_base.py
+++ b/provider/virtual_disk/disk_base.py
@@ -482,6 +482,8 @@ class DiskBase(object):
         process.run("ssh-keygen -t rsa -q -N '' -f %s" % keyfile, shell=True)
         process.run("ssh-keyscan -p 22 127.0.0.1 >> %s" % known_hosts_path, shell=True)
         process.run("cat %s >> %s" % (f"{keyfile}.pub", authorized_path), shell=True)
+        process.run("sshd -t", shell=True)
+        process.run("systemctl reload sshd", shell=True)
 
         if with_secret_passwd:
             libvirt_secret.clean_up_secrets()


### PR DESCRIPTION
The ssh network disk related case will fail at the first time because the sshd/authorized_keys is not ready. Add some ssh steps to test and reload it.