### PR TITLE
[guest os booting] fix image download url issue

### DIFF
--- a/libvirt/tests/src/guest_os_booting/boot_order/boot_from_disk_device.py
+++ b/libvirt/tests/src/guest_os_booting/boot_order/boot_from_disk_device.py
@@ -29,9 +29,12 @@ def parse_disks_attrs(vmxml, test, params):
     del disk_org_attrs["address"]
     disk1_img_url = params.get("disk1_img_url", "")
     download_disk1_img = "yes" == params.get("download_disk1_img", "no")
+    firmware_type = params.get("firmware_type")
     if disk1_img:
         disk1_img_path = os.path.join(data_dir.get_data_dir(), "images", disk1_img)
         if download_disk1_img:
+            if firmware_type == "ovmf":
+                disk1_img_url = disk1_img_url.removesuffix('.qcow2') + '-ovmf.qcow2'
             if not disk1_img_url or not utils_misc.wait_for(
                 lambda: guest_os.test_file_download(disk1_img_url, disk1_img_path), 60
             ):


### PR DESCRIPTION
add disk image url for fix "Unable to download boot image" cases

guest_os_booting.boot_order.disk_device.seabios.disk_boot_order.multi_disks_bootable

guest_os_booting.boot_order.disk_device.ovmf.disk_boot_order.multi_disks_bootable