### PR TITLE
guest_kernel_debugging: update crashkernel value

### DIFF
--- a/libvirt/tests/cfg/guest_kernel_debugging/nmi_test.cfg
+++ b/libvirt/tests/cfg/guest_kernel_debugging/nmi_test.cfg
@@ -10,7 +10,7 @@
             status_error = "no"
             variants:
                 - send_nmi:
-                    kernel_params = "crashkernel=128M@64M"
+                    kernel_params = "crashkernel=1G-2G:192M,2G-64G:256M"
                     # please change this for your linux distribution,
                     # the "/boot/grub2/grub.cfg" is default
                     grub_file = "/boot/grub2/grub.cfg"


### PR DESCRIPTION
RHEL 10 doesn't work with the current crashkernel configuration anymore. Generally, minimal system requirements have changed and increased.

Update the crashkernel configuration to reflect this and fix the test step.