### PR TITLE
migration: Add case to test stopping virtqemud during migration

### DIFF
--- a/libvirt/tests/cfg/migration/destructive_operations_around_live_migration/stop_virtqemud_during_performphase.cfg
+++ b/libvirt/tests/cfg/migration/destructive_operations_around_live_migration/stop_virtqemud_during_performphase.cfg
@@ -1,0 +1,49 @@
+- migration.destructive_operations_around_live_migration.stop_virtqemud_during_performphase:
+    type = stop_virtqemud_during_performphase
+    migration_setup = 'yes'
+    storage_type = 'nfs'
+    setup_local_nfs = 'yes'
+    disk_type = "file"
+    disk_source_protocol = "netfs"
+    mnt_path_name = ${nfs_mount_dir}
+    # Console output can only be monitored via virsh console output
+    only_pty = True
+    take_regular_screendumps = no
+    # Extra options to pass after <domain> <desturi>
+    virsh_migrate_extra = ''
+    # SSH connection time out
+    ssh_timeout = 60
+    # Local URI
+    virsh_migrate_connect_uri = 'qemu:///system'
+    virsh_migrate_dest_state = "running"
+    virsh_migrate_src_state = "shut off"
+    image_convert = 'no'
+    server_ip = "${migrate_dest_host}"
+    server_user = "root"
+    server_pwd = "${migrate_dest_pwd}"
+    check_network_accessibility_after_mig = "yes"
+    migrate_desturi_port = "16509"
+    migrate_desturi_type = "tcp"
+    virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
+    status_error = "yes"
+    service_name = "virtqemud"
+    migrate_again_status_error = "no"
+    migrate_speed = "5"
+    simple_disk_check_after_mig = "yes"
+    service_operations = "stop"
+    action_during_mig = '[{"func": "libvirt_service.control_service", "func_param": "params", "after_event": "migration-iteration"}]'
+    expected_dest_state = "nonexist"
+    expected_src_state = "running"
+    variants:
+        - p2p:
+            virsh_migrate_options = '--live --p2p --verbose'
+        - non_p2p:
+            virsh_migrate_options = '--live --verbose'
+    variants:
+        - with_precopy:
+    variants test_case:
+        - stop_src_virtqemud:
+            err_msg = "Disconnected from qemu:///system due to end of file"
+        - stop_dst_virtqemud:
+            service_on_dst = "yes"
+            err_msg = "Unable to read from socket: Connection reset by peer"

--- a/libvirt/tests/src/migration/destructive_operations_around_live_migration/stop_virtqemud_during_performphase.py
+++ b/libvirt/tests/src/migration/destructive_operations_around_live_migration/stop_virtqemud_during_performphase.py
@@ -1,0 +1,72 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright Redhat
+#
+#   SPDX-License-Identifier: GPL-2.0
+#
+#   Author: Liping Cheng <lcheng@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+from virttest import remote
+from virttest import utils_libvirtd
+from virttest import virsh
+
+from virttest.utils_test import libvirt
+
+from provider.migration import base_steps
+
+
+def run(test, params, env):
+    """
+    This case is to test stopping virtqemud on the source/destination
+    during migration.
+
+    :param test: test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    def verify_test():
+        """
+        Verify migration result
+
+        """
+        server_ip = params.get("server_ip")
+        server_user = params.get("server_user", "root")
+        server_pwd = params.get("server_pwd")
+        dest_uri = params.get("virsh_migrate_desturi")
+        expected_src_state = params.get("expected_src_state")
+        expected_dest_state = params.get("expected_dest_state")
+        test_case = params.get("test_case")
+
+        func_returns = dict(migration_obj.migration_test.func_ret)
+        migration_obj.migration_test.func_ret.clear()
+        test.log.debug("Migration returns function results: %s", func_returns)
+        if test_case == "stop_dst_virtqemud":
+            dst_session = remote.wait_for_login('ssh', server_ip, '22',
+                                                server_user, server_pwd,
+                                                r"[\#\$]\s*$")
+            utils_libvirtd.Libvirtd("virtqemud", session=dst_session).start()
+            dst_session.close()
+        if expected_dest_state and expected_dest_state == "nonexist":
+            virsh.domstate(vm_name, uri=dest_uri, debug=True)
+            if virsh.domain_exists(vm_name, uri=dest_uri):
+                test.fail("The domain on target host is found, but expected not.")
+        if test_case == "stop_src_virtqemud":
+            utils_libvirtd.Libvirtd("virtqemud").start()
+        if expected_src_state:
+            if not libvirt.check_vm_state(vm.name, expected_src_state, uri=migration_obj.src_uri):
+                test.fail("Migrated VM failed to be in %s state at source." % expected_src_state)
+
+    vm_name = params.get("migrate_main_vm")
+    vm = env.get_vm(vm_name)
+    migration_obj = base_steps.MigrationBase(test, vm, params)
+
+    try:
+        migration_obj.setup_connection()
+        migration_obj.run_migration()
+        verify_test()
+        migration_obj.run_migration_again()
+        migration_obj.verify_default()
+    finally:
+        migration_obj.cleanup_connection()


### PR DESCRIPTION
To test stopping virtqemud on the source/destination during migration.

VIRT-17322 - [Migration] Stop SRC libvirtd during Perform Phase of live migration - p2p migration
RHEL-201764 - [Migration] Stop DST libvirtd during Perform Phase of live migration - p2p migration

Test result:
 (1/4) type_specific.io-github-autotest-libvirt.migration.destructive_operations_around_live_migration.stop_virtqemud_during_performphase.stop_src_virtqemud.with_precopy.p2p: STARTED
 (1/4) type_specific.io-github-autotest-libvirt.migration.destructive_operations_around_live_migration.stop_virtqemud_during_performphase.stop_src_virtqemud.with_precopy.p2p: PASS (246.77 s)
 (2/4) type_specific.io-github-autotest-libvirt.migration.destructive_operations_around_live_migration.stop_virtqemud_during_performphase.stop_src_virtqemud.with_precopy.non_p2p: STARTED
 (2/4) type_specific.io-github-autotest-libvirt.migration.destructive_operations_around_live_migration.stop_virtqemud_during_performphase.stop_src_virtqemud.with_precopy.non_p2p: PASS (215.56 s)
 (3/4) type_specific.io-github-autotest-libvirt.migration.destructive_operations_around_live_migration.stop_virtqemud_during_performphase.stop_dst_virtqemud.with_precopy.p2p: STARTED
 (3/4) type_specific.io-github-autotest-libvirt.migration.destructive_operations_around_live_migration.stop_virtqemud_during_performphase.stop_dst_virtqemud.with_precopy.p2p: PASS (373.10 s)
 (4/4) type_specific.io-github-autotest-libvirt.migration.destructive_operations_around_live_migration.stop_virtqemud_during_performphase.stop_dst_virtqemud.with_precopy.non_p2p: STARTED
 (4/4) type_specific.io-github-autotest-libvirt.migration.destructive_operations_around_live_migration.stop_virtqemud_during_performphase.stop_dst_virtqemud.with_precopy.non_p2p: PASS (376.89 s)