### PR TITLE
Add new cpu case of hyper-v

### DIFF
--- a/libvirt/tests/cfg/cpu/vm_with_hyperv.cfg
+++ b/libvirt/tests/cfg/cpu/vm_with_hyperv.cfg
@@ -1,0 +1,19 @@
+- vm_with_hyperv:
+    type = vm_with_hyperv
+    start_vm = "no"
+    variants:
+        - relaxed:
+            hv_attrs = {'spinlocks': {'state': 'on', 'retries': '4096'}, 'vendor_id': {'state': 'on', 'value': 'KVM Hv'}, 'vapic': {'state': 'on'}, 'relaxed': {'state': 'on'}}
+            expect_qemu_cmd = yes
+            qemu_cmd = ['hv\-relaxed=on', 'hv\-vapic=on', 'hv\-spinlocks=0x1000', 'hv\-vendor\-id=KVM Hv']
+        - runtime:
+            variants:
+                - set_on:
+                    hv_attrs = {'frequencies': {'state': 'on'}, 'stimer': {'state': 'on'}, 'synic': {'state': 'on'}, 'vpindex': {'state': 'on'}, 'runtime': {'state': 'on'}}
+                    expect_qemu_cmd = yes
+                    qemu_cmd = ['hv\-time=on', 'hv\-runtime=on', 'hv\-synic=on', 'hv\-stimer=on', 'hv\-frequencies=on']
+                    clock_attrs = {'offset': 'utc', 'timers': [{'present': 'yes', 'name': 'hypervclock'}]}
+                - set_off:
+                    hv_attrs = {'frequencies': {'state': 'off'}, 'stimer': {'state': 'off'}, 'synic': {'state': 'off'}, 'runtime': {'state': 'off'}}
+                    expect_qemu_cmd = no
+                    qemu_cmd = hv-

--- a/libvirt/tests/src/cpu/vm_with_hyperv.py
+++ b/libvirt/tests/src/cpu/vm_with_hyperv.py
@@ -1,0 +1,41 @@
+import logging
+
+from virttest import virsh
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_test import libvirt
+
+VIRSH_ARGS = {'ignore_status': False, 'debug': True}
+
+LOG = logging.getLogger('avocado.' + __name__)
+
+
+def run(test, params, env):
+    """
+    Test start VM with hyper-v related features
+    """
+    vm_name = params.get('main_vm')
+
+    vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+    hv_attrs = eval(params.get('hv_attrs', '{}'))
+    clock_attrs = eval(params.get('clock_attrs', '{}'))
+    expect_qemu_cmd = 'yes' == params.get('expect_qemu_cmd', 'no')
+    qemu_cmd = params.get('qemu_cmd')
+
+    try:
+        # Configure Hyper-V features
+        features = vmxml.features
+        features.setup_attrs(hyperv=hv_attrs)
+        vmxml.features = features
+
+        # Configure clock settings if specified
+        if clock_attrs:
+            vmxml.setup_attrs(clock=clock_attrs)
+
+        vmxml.sync()
+
+        virsh.start(vm_name, **VIRSH_ARGS)
+        libvirt.check_qemu_cmd_line(qemu_cmd, expect_exist=expect_qemu_cmd)
+
+    finally:
+        bkxml.sync()


### PR DESCRIPTION
- RHEL-185271 - [features][hyper] Start windows VM with hyper-v related features (runtime/synic/stimer/frequencies)
- VIRT-17925 - [features][hyper] Start windows VM with hyper-v related features (relaxed/vapic/spinlocks/vendor_id)

Depends on:
- https://github.com/avocado-framework/avocado-vt/pull/4237

Test result:
```
 (1/3) type_specific.local.vm_with_hyperv.relaxed: STARTED
 (1/3) type_specific.local.vm_with_hyperv.relaxed: PASS (7.91 s)
 (2/3) type_specific.local.vm_with_hyperv.runtime.set_on: STARTED
 (2/3) type_specific.local.vm_with_hyperv.runtime.set_on: PASS (10.04 s)
 (3/3) type_specific.local.vm_with_hyperv.runtime.set_off: STARTED
 (3/3) type_specific.local.vm_with_hyperv.runtime.set_off: PASS (18.23 s)
RESULTS    : PASS 3 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```