### PR TITLE
virtual_disks_encryption: fix disk discovery

### DIFF
--- a/libvirt/tests/src/virtual_disks/virtual_disks_encryption.py
+++ b/libvirt/tests/src/virtual_disks/virtual_disks_encryption.py
@@ -13,6 +13,7 @@ from virttest import remote
 from virttest import virt_vm
 from virttest import virsh
 from virttest import utils_disk
+from virttest.utils_libvirt import libvirt_disk
 from virttest.utils_test import libvirt
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import secret_xml
@@ -113,8 +114,8 @@ def run(test, params, env):
                 test.fail("Failed to query/install parted, make sure"
                           " that you have usable repo in guest")
 
-            new_parts = utils_disk.get_parts_list(session)
-            added_parts = list(set(new_parts).difference(set(old_parts)))
+            added_disks = libvirt_disk.get_non_root_disk_names(session)
+            added_parts = [x[0] for x in added_disks]
             logging.info("Added parts:%s", added_parts)
             if len(added_parts) != 1:
                 logging.error("The number of new partitions is invalid in VM")


### PR DESCRIPTION
Previously, the test failed sometimes with

"Check encryption disk in VM failed"

because the wrong disk was selected for checking.

Like other occasions, such as 7b47a59, the way of recognizing added partitions assumed erroneously that disk names were persistent.

Apply the same solution by using `get_non_root_disk_names` to identify newly added disks in the VM more reliably.