### PR TITLE
Auto five v2v cases

### DIFF
--- a/provider/v2v_vmcheck_helper.py
+++ b/provider/v2v_vmcheck_helper.py
@@ -1112,7 +1112,6 @@ def check_kubevirt_output(params):
 
     os_directory = params.get('os_directory')
     disk_count = int(params.get('vm_disk_count', 0))
-    vm_name = params.get('v2v_cmd_op_on')
 
     result = True
 
@@ -1121,11 +1120,7 @@ def check_kubevirt_output(params):
         fd.seek(0)
         data = load(fd, Loader=Loader)
 
-    if vm_name != data['metadata']['name']:
-        LOG.debug('expect vm name: %s' % vm_name)
-        result = False
-
-    if disk_count != len(data['spec']['domain']['devices']['disks']):
+    if disk_count != len(data['spec']['template']['spec']['domain']['devices']['disks']):
         LOG.debug('expect disk count: %s' % disk_count)
         result = False
 

--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -38,7 +38,6 @@
     variants:
         - kubevirt:
             only dest_kubevirt
-            only multiple_disks
         - json:
             only dest_json
             only uefi.win2019,device_map,without_ip_option,env_leak,block_dev
@@ -453,7 +452,9 @@
             esx_https_proxy = HTTPS_PROXY_V2V_EXAMPLE
         - usr_partition:
             only esx_70
+            version_required = "[virt-v2v-2.8.1-8,)"
             main_vm = VM_NAME_USR_PARTITION_V2V_EXAMPLE
+            checkpoint = "ogac"
         - dir_permission:
             only esx_70
             main_vm = VM_NAME_ESX70_RHEL9_V2V_EXAMPLE
@@ -535,23 +536,13 @@
                     checkpoint = "exist_uuid"
                     v2v_opts = ""
                     msg_content = "Disk with the UUID .*? already exists"
-        - no-copy:
-            only esx_70
-            only rhev.rhv_upload
-            # Means version >= libguestfs-1.40.2-15
-            version_required = "[libguestfs-1.40.2-15,)"
-            main_vm = VM_NAME_RHEL7_V2V_EXAMPLE
-            has_rhv_disk_uuid = 'yes'
-            v2v_opts = "--no-copy"
-            skip_vm_check = yes
-            skip_reason = '--no-copy is specified, no images will be copied'
-            variants:
-                - normal:
-                - without_rhv-disk-uuid:
-                  # Means version >= virt-v2v-1.45.3-1
-                  version_required = "[virt-v2v-1.45.3-1,)"
-                  checkpoint = "no_uuid"
-        # ovirt-guest-agent-common
+        - define_disk_path:
+            only esx_80
+            only dest_kubevirt
+            version_required = "[virt-v2v-2.8.1-2,)"
+            main_vm = VM_NAME_WIN2019_ONLINE_DISKS_V2V_EXAMPLE
+            checkpoint = define_disk_path
+            vm_disk_count = 4
         - OGAC:
             checkpoint = "ogac"
             variants:
@@ -769,13 +760,21 @@
                     luks_keys = LUKS_UUID_KEYS
                     v2v_opts += "--key all:clevis"
         - win_bitlocker:
-            only esx_70
-            version_required = "[virt-v2v-1.42.0-15,)"
-            checkpoint = 'luks_dev_keys'
-            main_vm = VM_NAME_WIN_BITLOCKER_V2V_EXAMPLE
-            luks_keys = LUKS_WIN_BIT_LOCKER_DEV_KEYS
             skip_vm_check = yes
             skip_reason = 'luks encryped, cannot boots up without password'
+            variants:
+                - without_tpm:
+                    only esx_70
+                    version_required = "[virt-v2v-1.42.0-15,)"
+                    checkpoint = 'luks_dev_keys'
+                    main_vm = VM_NAME_WIN_BITLOCKER_V2V_EXAMPLE
+                    luks_keys = LUKS_WIN_BIT_LOCKER_DEV_KEYS
+                - with_tpm:
+                    only esx_80
+                    checkpoint = 'luks_dev_keys'
+                    main_vm = VM_NAME_WIN11_WITH_TPM_BITLOCKER_V2V_EXAMPLE
+                    luks_keys = VM_WIN11_WITH_TPM_BITLOCKER_KEYS
+
         - cve_2022_2211:
             only esx_70
             only dest_local
@@ -974,11 +973,21 @@
                     skip_reason = 'bug RHEL-97179 is not fixed'
                     boottype = 3
                 - encrypted:
-                    main_vm = VM_NAME_SLES_BTRFS_ENCRYPTED_SLES12SP5_V2V_EXAMPLE
-                    skip_vm_check = yes
-                    skip_reason = 'bug RHEL-93583 is not fixed and cannot boot into OS without password automatically'
-                    checkpoint = 'luks_dev_keys'
-                    luks_keys = LUKS_ALL_KEYS
+                    variants:
+                        - sles12sp5:
+                            main_vm = VM_NAME_SLES_BTRFS_ENCRYPTED_SLES12SP5_V2V_EXAMPLE
+                            skip_vm_check = yes
+                            skip_reason = 'bug RHEL-93583 is not fixed and cannot boot into OS without password automatically'
+                            checkpoint = 'luks_dev_keys'
+                            luks_keys = LUKS_ALL_KEYS
+                        - sles15sp6:
+                            main_vm = VM_NAME_SLES_BTRFS_ENCRYPTED_SLES15SP6_V2V_EXAMPLE
+                            boottype = 3
+                            checkpoint = 'luks_dev_keys'
+                            luks_keys = LUKS_ALL_KEYS
+                            skip_vm_check = yes
+                            skip_reason = 'luks encryped, cannot boots up without password'
+                            version_required = "[libguestfs-1.56.1-3,)"
         - print_blkhash:
             only esx_70
             only libvirt

--- a/v2v/tests/cfg/v2v_options.cfg
+++ b/v2v/tests/cfg/v2v_options.cfg
@@ -353,6 +353,13 @@
                     only output_mode.none
                     input_disk_image = '/DISK_IMAGE_PATH_V2V_EXAMPLE/IMAGE_WITH_MEM_ALLOC_V2V_EXAMPLE'
                     v2v_options = '-i disk ${input_disk_image} -o null'
+                - in_place:
+                    only input_mode.none
+                    only output_mode.none
+                    checkpoint = 'in_place'
+                    disk_path = DEFAULT_TEST_IMAGE
+                    msg_content = 'virt-v2v-in-place: warning: virt-v2v-in-place is NOT SUPPORTED for command'
+                    expect_msg = yes
         - negative_test:
             status_error = "yes"
             variants:
@@ -408,13 +415,6 @@
                         - 2_mac:
                             v2v_options = '-i libvirt --mac 00:50:56:ac:6a:23:bridge:test --mac 00:50:56:ac:6a:23:bridge:ovirtmgmt'
                             msg_content = 'duplicate --mac parameter'
-                - in_place:
-                    only input_mode.libvirt.xen
-                    only output_mode.libvirt
-                    checkpoint = 'in_place'
-                    v2v_options = '--in-place'
-                    msg_content = 'virt-v2v: error: --in-place cannot be used in RHEL'
-                    expect_msg = yes
                 - xen_no_output_format:
                     only input_mode.libvirt.xen
                     only output_mode.libvirt


### PR DESCRIPTION
1. Check qemu-ga for rhel8 guest with usr partition
2. Convert sles15 guest with encrypted btrfs fs
3. Check output for virt-v2v-in-place
4. Convert win11 guest with vtpm and bitlocker
5. Check disks in specific path for kubevirt output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added in-place conversion mode that uses virt-v2v-in-place to accept a disk image and produce an output XML.
  - Added an optional disk-path workflow for ESX conversions to create and validate multiple disk images.

- Bug Fixes
  - Fixed KubeVirt disk-count validation to use the correct template path.
  - Relaxed VM name validation during KubeVirt checks and improved ESXi remote URI and password handling.

- Tests
  - Added positive coverage for in-place mode and removed the conflicting negative case.
  - Expanded test variants for BitLocker and encrypted SLES; updated version constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->