### PR TITLE
virtual_network/ethernet: select interface more reliably

### DIFF
--- a/libvirt/tests/src/virtual_network/connectivity/connectivity_check_ethernet_interface.py
+++ b/libvirt/tests/src/virtual_network/connectivity/connectivity_check_ethernet_interface.py
@@ -12,7 +12,6 @@ from virttest.utils_libvirt import libvirt_unprivileged
 from virttest.utils_libvirt import libvirt_vmxml
 from virttest.utils_test import libvirt
 
-from provider.interface import interface_base
 from provider.virtual_network import network_base
 
 LOG = logging.getLogger('avocado.' + __name__)
@@ -175,9 +174,10 @@ def run(test, params, env):
                 LOG.info('MTU check of vmxml PASS')
 
             # Check mtu inside vm
-            vm_iface = interface_base.get_vm_iface(session)
-            vm_iface_info = utils_net.get_linux_iface_info(iface=vm_iface,
+            iface_mac = iface['mac_address']
+            vm_iface_info = utils_net.get_linux_iface_info(mac=iface_mac,
                                                            session=session)
+            vm_iface = vm_iface_info['ifname']
             vm_mtu = vm_iface_info['mtu']
             if int(vm_mtu) != int(iface_mtu):
                 test.fail(f'MTU of interface inside vm should be '


### PR DESCRIPTION
Previously, the code used `interface_base.get_vm_iface` to select what ever that function determined to be the first guest interface inside the guest. However, this selection could fail leading to a mismatch in MTU values in test cases that have two interfaces on the VM.

Instead, use `utils_net_get_linux_iface_info` to select the interface more reliably via the mac that's given by the previously obtained interface information from the VM XML. This assures that the vm interface corresponds to the selected domain xml element.

Assisted-by: Cursor/Claude-4-Sonnet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * In-VM MTU checks now select the network interface by MAC address, ensuring the correct interface is validated; host-side checks unchanged.

* **Tests**
  * Connectivity tests updated to use MAC-based interface lookup for in-VM MTU validation while preserving MTU comparison logic, outcomes, and overall test flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->