### PR TITLE
Disable interface multiqueue when starting guest with virtqemud in foreground mode

### DIFF
--- a/libvirt/tests/src/daemon/crash_regression.py
+++ b/libvirt/tests/src/daemon/crash_regression.py
@@ -8,6 +8,7 @@ from avocado.utils import process
 
 from virttest import virsh
 from virttest import data_dir
+from virttest import libvirt_vmxml
 from virttest.utils_libvirtd import LibvirtdSession
 from virttest.utils_libvirtd import Libvirtd
 from virttest.libvirt_xml import xcepts
@@ -40,8 +41,12 @@ def run_shutdown_console(params, libvirtd, vm):
     """
     Start a vm with console connected and then shut it down.
     """
+    vm_xml = VMXML.new_from_inactive_dumpxml(vm.name)
+    vm_xml_backup = vm_xml.copy()
+    libvirt_vmxml.modify_vm_device(vm_xml, 'interface', {'driver': None})
     vm.start(autoconsole=True)
     vm.shutdown()
+    vm_xml_backup.sync()
 
 
 def run_restart_console(params, libvirtd, vm):


### PR DESCRIPTION
Guest will crash if booting guest with interface multiqueue enabled and virtqemud in foregound mode since running daemons from cli is considered unsupported by selinux-policy.

It reports avc dened error without the fix:
time->Thu Sep 11 01:39:57 2025
type=PROCTITLE msg=audit(1757569197.527:38921): proctitle=2F7573722F6C6962657865632F71656D752D6B766D002D6E616D650067756573743D61766F6361646F2D76742D766D312C64656275672D746872656164733D6F6E002D53002D6F626A656374007B22716F6D2D74797065223A22736563726574222C226964223A226D61737465724B657930222C22666F726D6174223A227261
type=SYSCALL msg=audit(1757569197.527:38921): arch=c000003e syscall=16 success=no exit=-13 a0=1a a1=400454d9 a2=7fa6f1836d70 a3=0 items=0 ppid=1 pid=550563 auid=0 uid=107 gid=107 euid=107 suid=107 fsuid=107 egid=107 sgid=107 fsgid=107 tty=(none) ses=8 comm=43505520302F4B564D exe="/usr/libexec/qemu-kvm" subj=unconfined_u:unconfined_r:svirt_t:s0:c790,c975 key=(null)
type=AVC msg=audit(1757569197.527:38921): avc:  denied  { attach_queue } for  pid=550563 comm=43505520302F4B564D scontext=unconfined_u:unconfined_r:svirt_t:s0:c790,c975 tcontext=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 tclass=tun_socket permissive=0

After the fix, the case pass and no avc dened error:
$ avocado run daemon.crash_regression.shutdown_console --vt-type libvirt
JOB LOG    : /var/log/avocado/job-results/job-2025-09-11T03.42-0320716/job.log
 (1/1) type_specific.io-github-autotest-libvirt.daemon.crash_regression.shutdown_console: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.daemon.crash_regression.shutdown_console: PASS (134.41 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2025-09-11T03.42-0320716/results.html
JOB TIME   : 136.40 s

$ ausearch -m avc --start recent
<no matches>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated VM lifecycle test to apply configuration changes before shutdown and persist them after shutdown.
  * Replaced the prior immediate console-start flow with a backup-and-sync sequence that synchronizes VM configuration post-shutdown.
  * Ensured backups are created and restored to keep tests isolated and reliable across outcomes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->