### PR TITLE
Virtual_disk: fix avc denials caused by denied file access

### DIFF
--- a/libvirt/tests/cfg/virtual_disks/virtual_disks_nbd.cfg
+++ b/libvirt/tests/cfg/virtual_disks/virtual_disks_nbd.cfg
@@ -26,10 +26,11 @@
                     deleteExisted = "no"
                     virt_disk_check_partitions = "no"
                     snapshot_name1 = "snap1"
-                    snapshot_name1_file = "/tmp/${snapshot_name1}-testvm.qcow2"
+                    snapshot_path = "/var/lib/libvirt/images"
+                    snapshot_name1_file = "${snapshot_path}/${snapshot_name1}-testvm.qcow2"
                     snapshot_name2 = "snap2"
-                    snapshot_name2_mem_file = "/tmp/${snapshot_name2}-testvm-mem"
-                    snapshot_name2_disk_file = "/tmp/${snapshot_name2}-testvm.qcow2"
+                    snapshot_name2_mem_file = "${snapshot_path}/${snapshot_name2}-testvm-mem"
+                    snapshot_name2_disk_file = "${snapshot_path}/${snapshot_name2}-testvm.qcow2"
         - lifecycle_operate:
     variants:
         - enable_export:


### PR DESCRIPTION
Some avc denails will occur but not affect the feature function in several virtual_disk.nbd cases. This file path is random, So update them to a selinux allowed one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Snapshot files are now stored under the standard images directory (/var/lib/libvirt/images) instead of temporary locations.
  * All snapshot-related paths use a unified snapshot directory for consistent path resolution.

* **Chores**
  * Updated configuration to remove hard-coded temporary paths and align snapshot file locations across memory and disk snapshots.

Impact: Snapshot locations are predictable and persist in the designated images directory; no other behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->