### PR TITLE
guest_os_booting: cover loadparm on interface

### DIFF
--- a/libvirt/tests/cfg/guest_os_booting/boot_order/boot_with_multiple_boot_order.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/boot_order/boot_with_multiple_boot_order.cfg
@@ -39,6 +39,15 @@
                                 install_tree_url = INSTALL_TREE_URL
                                 network_order = {'boot': '2', 'source': {'network': 'tftpnet'}}
                                 vm_memory = 1953125
+                            variants:
+                                - @default:
+                                - with_loadparm:
+                                    only s390-virtio
+                                    check_prompt = ["Received linux2/initrd.img"]
+                                    tftp_entries = linux1,linux2
+                                    network_order = {'boot': '2', 'loadparm': '2'}
+                                    test_cmd = "lsreipl"
+                                    expected_output = Loadparm:\s+"2"
         - cdrom:
             cdrom_order = {'boot': '1'}
             variants second_dev:

--- a/libvirt/tests/cfg/guest_os_booting/boot_order/boot_with_multiple_boot_order.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/boot_order/boot_with_multiple_boot_order.cfg
@@ -45,7 +45,7 @@
                                     only s390-virtio
                                     check_prompt = ["Received linux2/initrd.img"]
                                     tftp_entries = linux1,linux2
-                                    network_order = {'boot': '2', 'loadparm': '2'}
+                                    network_order = {'boot': '2', 'loadparm': '2', 'source': {'network': 'tftpnet'}}
                                     test_cmd = "lsreipl"
                                     expected_output = Loadparm:\s+"2"
         - cdrom:

--- a/provider/virtual_network/tftpboot.py
+++ b/provider/virtual_network/tftpboot.py
@@ -27,7 +27,32 @@ net_name = "tftpnet"
 cleanup_actions = []
 
 
-def create_tftp_content(install_tree_url, kickstart_url, arch):
+def _pxeconfig_content(entries, install_tree_url, kickstart_url):
+    """
+    Returns the configuration file contents for given entry names.
+    It will set the first entry as default and only use a single set
+    of installation data for simplicity because we want to test the
+    installation starts from the right folder, not the installation
+    itself.
+
+    :param entries: list of names for the configuration entries
+    """
+    kernel_cmdline = "append ip=dhcp inst.repo=%s inst.noverifyssl" % install_tree_url
+    if kickstart_url:
+        kernel_cmdline += " inst.ks=%s" % kickstart_url
+    else:
+        logging.debug("Create pxelinux.cfg without kickstart.")
+
+    contents = ["# pxelinux", f"default {entries[0]}"]
+    for entry in entries:
+        contents.append(f"label {entry}")
+        contents.append(f"kernel {entry}/kernel.img")
+        contents.append(f"initrd {entry}/initrd.img")
+        contents.append(kernel_cmdline)
+    return "\n".join(contents)
+
+
+def create_tftp_content(install_tree_url, kickstart_url, arch, entries):
     """
     Creates the folder for the tftp server,
     downloads images assuming they are below /images,
@@ -36,38 +61,37 @@ def create_tftp_content(install_tree_url, kickstart_url, arch):
     :param install_tree_url: url of the installation tree
     :param kickstart_url: url of the kickstart file
     :param arch: the architecture
+    :params entries: list of entry names for the pxe configuration
     """
 
     if arch != "s390x":
         raise NotImplementedError(f"No implementation available for '{arch}'.")
-
-    process.run("mkdir " + tftp_dir, ignore_status=False, shell=True, verbose=True)
-    cleanup_actions.insert(0, lambda: process.run("rm -rf " + tftp_dir, ignore_status=False, shell=True, verbose=True))
-
-    pxeconfig_content = """# pxelinux
-default linux
-label linux
-kernel kernel.img
-initrd initrd.img
-"""
-    kernel_cmdline = ("append ip=dhcp inst.repo=%s inst.noverifyssl"
-                      % install_tree_url)
-    if kickstart_url:
-        kernel_cmdline += " inst.ks=%s" % kickstart_url
-    else:
-        logging.debug("Create pxelinux.cfg without kickstart.")
-    pxeconfig_content += kernel_cmdline
-
-    with open(os.path.join(tftp_dir, boot_file), "w") as f:
-        f.write(pxeconfig_content)
+    if not entries or len([x for x in entries if len(x) == 0]) > 0:
+        raise ValueError(f"Expecting list of non-empty strings, got {entries}")
 
     cmds = []
 
     initrd_img_url = install_tree_url + "/images/initrd.img"
     kernel_img_url = install_tree_url + "/images/kernel.img"
 
-    cmds.append("curl %s -o %s/initrd.img" % (initrd_img_url, tftp_dir))
-    cmds.append("curl %s -o %s/kernel.img" % (kernel_img_url, tftp_dir))
+    process.run("mkdir " + tftp_dir, ignore_status=False, shell=True, verbose=True)
+    cleanup_actions.insert(
+        0,
+        lambda: process.run(
+            "rm -rf " + tftp_dir, ignore_status=False, shell=True, verbose=True
+        ),
+    )
+
+    for entry in entries:
+        entry_dir = os.path.join(tftp_dir, entry)
+        process.run("mkdir " + entry_dir, ignore_status=False, shell=True, verbose=True)
+        cmds.append("curl %s -o %s/initrd.img" % (initrd_img_url, entry_dir))
+        cmds.append("curl %s -o %s/kernel.img" % (kernel_img_url, entry_dir))
+
+    pxeconfig_content = _pxeconfig_content(entries, install_tree_url, kickstart_url)
+
+    with open(os.path.join(tftp_dir, boot_file), "w") as f:
+        f.write(pxeconfig_content)
 
     cmds.append("chmod -R a+r " + tftp_dir)
     cmds.append("chown -R nobody: " + tftp_dir)
@@ -85,13 +109,13 @@ def create_tftp_network():
     """
 
     net_params = {
-            "net_forward": "{'mode':'nat'}",
-            "net_ip_address": "192.168.150.1",
-            "dhcp_start_ipv4": "192.168.150.2",
-            "dhcp_end_ipv4": "192.168.150.254",
-            "tftp_root": tftp_dir,
-            "bootp_file": boot_file
-            }
+        "net_forward": "{'mode':'nat'}",
+        "net_ip_address": "192.168.150.1",
+        "dhcp_start_ipv4": "192.168.150.2",
+        "dhcp_end_ipv4": "192.168.150.254",
+        "tftp_root": tftp_dir,
+        "bootp_file": boot_file,
+    }
 
     net_xml = libvirt.create_net_xml(net_name, net_params)
     virsh.net_create(net_xml.xml, debug=True, ignore_status=False)

--- a/provider/virtual_network/tftpboot.py
+++ b/provider/virtual_network/tftpboot.py
@@ -52,7 +52,7 @@ def _pxeconfig_content(entries, install_tree_url, kickstart_url):
     return "\n".join(contents)
 
 
-def create_tftp_content(install_tree_url, kickstart_url, arch, entries):
+def create_tftp_content(install_tree_url, kickstart_url, arch, entries=["linux"]):
     """
     Creates the folder for the tftp server,
     downloads images assuming they are below /images,


### PR DESCRIPTION
Depends on https://github.com/avocado-framework/avocado-vt/pull/4239

s390x supports more than one network boot entry since QEMU 10.1.0. The loadparm value can be used to boot into entries directly.

Add test case that confirms that the second network entry is booted into.

The test only covers that the right entry is accessed, not the actual installation. As such, the test case creates a directory per entry but uses the same bootable data. The message confirms that the right folder is accessed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-entry TFTP/PXE boot menus with selectable default and per-entry kernel/initrd handling.
  * Configurable list of TFTP boot entries for flexible boot content generation.
  * s390x virtio loadparm boot path support with prompt/expected-output checks.

* **Tests**
  * Extended boot-order tests to cover multi-entry menus and the loadparm scenario.

* **Chores**
  * Minor formatting/style tweaks and improved network resource cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->