### PR TITLE
virsh_pool_autostart: refresh pool after starting

### DIFF
--- a/libvirt/tests/src/storage/virsh_pool_autostart.py
+++ b/libvirt/tests/src/storage/virsh_pool_autostart.py
@@ -162,6 +162,7 @@ def run(test, params, env):
                 virsh.pool_start(pool_name, debug=True, ignore_status=False)
                 # Avoid running vol_list too quickly
                 time.sleep(3)
+                virsh.pool_refresh(pool_name, debug=True, ignore_status=False)
                 res = virsh.vol_list(pool_name, debug=True,
                                      ignore_status=False).stdout_text
                 vol = re.findall(r"(\S+)\ +(\S+)", str(res.strip()))[1]


### PR DESCRIPTION
Refreshing the pool after starting to avoid the occasional error with `vol = re.findall(r"(\S+)\ +(\S+)", str(res.strip()))[1]` of "IndexError: list index out of range, where res is defined as `res = virsh.vol_list(pool_name, debug=True, ignore_status=False).stdout_text`.

```
(.libvirt-ci-venv-ci-runtest-VwELSs) [root@ampere-mtsnow-altramax-08 ~]# avocado run --vt-type libvirt --vt-omit-data-loss --vt-machine-type arm64-mmio virsh.pool_autostart.positive_test.name_option.pool_type_iscsi.destroy_pool_used_by_guest --job-timeout 1200 --vt-connect-uri qemu:///system
JOB ID     : efc079d3f4e1ab267e7d5f0c05ff38574bf68e8f
JOB LOG    : /var/log/avocado/job-results/job-2025-09-12T04.44-efc079d/job.log
 (1/1) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_iscsi.destroy_pool_used_by_guest: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.virsh.pool_autostart.positive_test.name_option.pool_type_iscsi.destroy_pool_used_by_guest: PASS (110.78 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2025-09-12T04.44-efc079d/results.html
JOB TIME   : 111.99 s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of storage pool autostart test by refreshing the pool state before listing volumes, reducing flakiness and ensuring up-to-date volume detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->