### PR TITLE
migration: Delete redundant configuration

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_mem.cfg
+++ b/libvirt/tests/cfg/migration/migrate_mem.cfg
@@ -33,7 +33,6 @@
             aarch64:
                 cpuxml_cpu_mode = "host-passthrough"
             cpuxml_fallback = "allow"
-            cpuxml_model = "qemu64"
             cpuxml_numa_cell = [{'id': '0', 'cpus': '0-1', 'memory': '1024', 'unit': 'MiB', 'discard': 'yes'}, {'id': '1', 'cpus': '2-3', 'memory': '1024', 'unit': 'MiB'}]
             setvm_max_mem_rt_slots = "16"
             setvm_max_mem_rt = 8192


### PR DESCRIPTION
The qemu64 CPU model may cause incompatibility errors during
migration on some hosts. Removing this redundant setting ensures
broader compatibility.

Before:
VM 'avocado-vt-vm1' failed to start: error: Failed to start domain 'avocado-vt-vm1'&#10;error: the CPU is incompatible with host CPU: Host CPU does not provide required features: svm(exit status: 1)

After:
 (1/1) type_specific.io-github-autotest-libvirt.virsh.migrate_mem.mem_device: PASS (129.12 s)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Updated AArch64 migration memory test to remove an explicit CPU model override, aligning with platform defaults.
  - Improves reliability and accuracy of migration memory tests on ARM64 environments, reducing spurious failures.
  - Other CPU-related settings in this test scenario remain unchanged.
  - No impact on runtime features; end users should see more stable CI/test results without behavior changes in production.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->