### PR TITLE
virsh_domjobinfo: fix pipe file read stuck when background virsh cmd failed

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domjobinfo.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domjobinfo.py
@@ -150,6 +150,14 @@ def run(test, params, env):
         else:
             process = get_subprocess(action, vm_name, tmp_pipe, None)
 
+        try:
+            _, stderr = process.communicate(timeout=6)
+            if process.returncode:
+                os.unlink(tmp_pipe)
+                test.error('Background cmd met unexpected failure of %s, abort the test.' % stderr)
+        except subprocess.TimeoutExpired:
+            logging.debug("Background cmd is still running.")
+
         f = open(tmp_pipe, 'rb')
         dummy = f.read(1024 * 1024).decode(locale.getpreferredencoding(), 'ignore')
 


### PR DESCRIPTION
Since libvirt 11.5.0, the virsh dump --live option has been disabled and now returns an error message.
This causes the test to hang while attempting to read the virsh dump pipe file's input.

The fix implements subprocess.communicate() to handle the background command interaction:
Command failure: the test aborts immediately with the error message.
Command success: original logic remains unchanged.
Note: If the background command fails after the timeout period, this likely indicates a libvirt issue, so no changes are made for now.

Note: this PR comes from the discussion of closed PR: https://github.com/autotest/tp-libvirt/pull/6478

Test result with libvirt >= 11.5.0:
(01/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.normal_test.dump_action.live_dump.running_state.vm_id: STARTED
 (01/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.normal_test.dump_action.live_dump.running_state.vm_id: ERROR: Background cmd met unexpected failure of b"error: Failed to core dump domain 'avocado-vt-vm1' to /var/tmp/avocado_m85vaczv/domjobinfo.fifo\nerror: unsupported flags (0x2) in function qemuDomainCoreDumpWithFormat\n", abort the test. (21.61 s)
 (02/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.normal_test.dump_action.live_dump.paused_state.vm_name: STARTED
 (02/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.normal_test.dump_action.live_dump.paused_state.vm_name: ERROR: Background cmd met unexpected failure of b"error: Failed to core dump domain 'avocado-vt-vm1' to /var/tmp/avocado_4zt69ar6/domjobinfo.fifo\nerror: unsupported flags (0x2) in function qemuDomainCoreDumpWithFormat\n", abort the test. (18.84 s)
 (03/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.normal_test.dump_action.crash_dump.running_state.vm_id: STARTED
 (03/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.normal_test.dump_action.crash_dump.running_state.vm_id: PASS (30.01 s)
 (04/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.normal_test.dump_action.crash_dump.paused_state.vm_uuid: STARTED
 (04/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.normal_test.dump_action.crash_dump.paused_state.vm_uuid: PASS (29.90 s)
 (05/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.normal_test.dump_action.keep_complete_test.running_state.vm_name: STARTED
 (05/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.normal_test.dump_action.keep_complete_test.running_state.vm_name: ERROR: Background cmd met unexpected failure of b"error: Failed to core dump domain 'avocado-vt-vm1' to /var/tmp/avocado_62liqx51/domjobinfo.fifo\nerror: unsupported flags (0x2) in function qemuDomainCoreDumpWithFormat\n", abort the test. (22.09 s)
 (06/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.normal_test.save_action.running_state.vm_id: STARTED
 (06/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.normal_test.save_action.running_state.vm_id: PASS (37.78 s)
 (07/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.normal_test.save_action.paused_state.vm_name: STARTED
 (07/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.normal_test.save_action.paused_state.vm_name: PASS (37.94 s)
 (08/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.normal_test.managedsave_action.running_state.vm_id: STARTED
 (08/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.normal_test.managedsave_action.running_state.vm_id: PASS (37.37 s)
 (09/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.normal_test.managedsave_action.paused_state.vm_name: STARTED
 (09/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.normal_test.managedsave_action.paused_state.vm_name: PASS (37.46 s)
 (10/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.error_test.no_name: STARTED
 (10/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.error_test.no_name: PASS (26.84 s)
 (11/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.error_test.shutoff_state: STARTED
 (11/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.error_test.shutoff_state: PASS (5.50 s)
 (12/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.error_test.with_libvirtd_stop: STARTED
 (12/12) type_specific.io-github-autotest-libvirt.virsh.domjobinfo.error_test.with_libvirtd_stop: PASS (26.66 s)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Prevents indefinite waits by adding a bounded wait for background commands, ensures clearer error reporting on failures, and guarantees cleanup of temporary resources.

- Tests
  - Strengthens tests by enforcing a 6-second wait limit for background operations, capturing failure output, and adding debug logging when background commands remain running.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->