### PR TITLE
Inc_backup: minor fix to correct function name

### DIFF
--- a/libvirt/tests/src/incremental_backup/incremental_backup_pull_mode_tls.py
+++ b/libvirt/tests/src/incremental_backup/incremental_backup_pull_mode_tls.py
@@ -170,7 +170,7 @@ def run(test, params, env):
         test.log.info("SETUP_TEST: prepare the guest.")
         prepare_guest()
         if with_secret_uuid:
-            write_datas()
+            write_data()
         test.log.info("TEST_STEP: start the backup.")
         backup_options = prepare_backup_xml()
         backup_begin(backup_options)


### PR DESCRIPTION
In script a wrong function name write_datas() has been used. The correct one is write_data().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Corrected data-writing logic in the incremental backup (pull mode over TLS) test path, ensuring the full-backup flow with secret-based authentication writes guest disk data correctly.
  - Improves test accuracy and stability without altering runtime behavior or public interfaces.
  - No user-facing changes; impacts only test reliability and coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->