### PR TITLE
migration: Add a libvirt version check

### DIFF
--- a/libvirt/tests/cfg/migration_with_copy_storage/migration_bandwidth_limit.cfg
+++ b/libvirt/tests/cfg/migration_with_copy_storage/migration_bandwidth_limit.cfg
@@ -49,6 +49,7 @@
             check_item_value = "9223372036853727232"
             action_during_mig = '[{"func": "set_bandwidth", "after_event": "block-job", "func_param": "params", "wait_for_after_event_timeout": "600"}, {"func": "libvirt_disk.check_item_by_blockjob", "func_param": "params", "need_sleep_time": "5"}, {"func": "check_domjobinfo_during_mig", "func_param": "params"}]'
         - set_bandwidth_by_blockjob:
+            func_supported_since_libvirt_ver = (11, 1, 0)
             check_item_value = "20971520"
             action_during_mig = '[{"func": "virsh.blockjob", "after_event": "block-job", "func_param": {"name": "${main_vm}", "path": "vda", "options": "--bandwidth ${bandwidth}"}, "wait_for_after_event_timeout": "600"}, {"func": "libvirt_disk.check_item_by_blockjob", "func_param": "params"}]'
     variants:

--- a/libvirt/tests/src/migration_with_copy_storage/migration_bandwidth_limit.py
+++ b/libvirt/tests/src/migration_with_copy_storage/migration_bandwidth_limit.py
@@ -8,6 +8,7 @@
 #
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+from virttest import libvirt_version
 from virttest import virsh
 
 from provider.migration import base_steps
@@ -41,6 +42,7 @@ def run(test, params, env):
         migration_obj.cleanup_connection()
         base_steps.cleanup_disks_remote(params, vm)
 
+    libvirt_version.is_libvirt_feature_supported(params)
     set_bandwidth = params.get('set_bandwidth', '')
     vm_name = params.get("migrate_main_vm")
 


### PR DESCRIPTION
Block job bandwidth setting during migration has been supported since libvirt 11.1.0. To ensure compatibility with older releases, add a libvirt version check.

Before:
 (1/1) type_specific.io-github-autotest-libvirt.migration_with_copy_storage.migration_bandwidth_limit.copy_storage_all.set_bandwidth_by_blockjob.p2p: FAIL: Check 'bandwidth' failed. (157.37 s)

After:
 (1/1) type_specific.io-github-autotest-libvirt.migration_with_copy_storage.migration_bandwidth_limit.copy_storage_all.set_bandwidth_by_blockjob.p2p: CANCEL: This libvirt version doesn't support this function. (48.57 s)