### PR TITLE
Memory_balloon: Increase RSS sampling timeout

### DIFF
--- a/libvirt/tests/src/memory/memory_balloon/memory_balloon_freepagereporting.py
+++ b/libvirt/tests/src/memory/memory_balloon/memory_balloon_freepagereporting.py
@@ -72,7 +72,7 @@ def run(test, params, env):
 
         test.log.info(
             "TEST_STEP4: Login the guest and consume the guest memory")
-        rss_mem_thread = utils_misc.InterruptedThread(get_rss_mem_list)
+        rss_mem_thread = utils_misc.InterruptedThread(get_rss_mem_list, kwargs={"timeout": 120})
         rss_mem_thread.start()
         free_mem = utils_memory.freememtotal(session)
         session.cmd_status("swapoff -a")


### PR DESCRIPTION
The test was failing because the host RSS drop did not reach the configured min_memory_difference within the default 30s window. Free Page Reporting can take longer to reclaim memory, especially on ARM hosts or under low memory pressure.

Committer: Bolatbek Issakh <bissakh@redhat.com>