### PR TITLE
add case: audit log checking for interface with different models

### DIFF
--- a/libvirt/tests/cfg/virtual_network/hotplug/attach_detach_interface/attach_interface_with_model.cfg
+++ b/libvirt/tests/cfg/virtual_network/hotplug/attach_detach_interface/attach_interface_with_model.cfg
@@ -9,6 +9,7 @@
         - virtio:
             iface_driver = virtio_net
             pci_model = pcie-root-port
+            check_audit_log = yes
             s390-virtio:
                 check_pci_model = no
                 bridge_controller_needed = no
@@ -16,6 +17,7 @@
             only x86_64
             iface_driver = e1000e
             pci_model = pcie-root-port
+            check_audit_log = yes
         - igb:
             only x86_64
             func_supported_since_libvirt_ver = (9, 3, 0)
@@ -25,3 +27,4 @@
             only x86_64
             iface_driver = 8139cp
             pci_model = pcie-to-pci-bridge
+            check_audit_log = yes


### PR DESCRIPTION
   xxxx-89003: [audit log] Audit log related to guest network interface of different models
Signed-off-by: nanli <nanli@redhat.com>

```
avocado run --vt-type libvirt  --vt-machine-type q35 virtual_network.hotplug.attach_interface.model.virtio virtual_network.hotplug.attach_interface.model.rtl8139 virtual_network.hotplug.attach_interface.model.e1000

 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.hotplug.attach_interface.model.virtio: PASS (101.07 s)
 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.hotplug.attach_interface.model.rtl8139: PASS (101.12 s)
 (1/1) type_specific.io-github-autotest-libvirt.virtual_network.hotplug.attach_interface.model.e1000: PASS (100.69 s)


```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Added host audit log verification for network interface hotplug (attach/detach), including pre-test log rotation/clearing and post-action checks for expected host audit entries referencing the VM and MAC address.
  - Enabled audit checks via configuration for virtio, e1000e, and 8139cp interface models.
  - Improved failure messages when expected audit records are not found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->