### PR TITLE
Skip vm check for aws ova case

### DIFF
--- a/v2v/tests/cfg/convert_from_file.cfg
+++ b/v2v/tests/cfg/convert_from_file.cfg
@@ -180,6 +180,7 @@
                                 - ec2:
                                     enable_legacy_policy = yes
                                     ova_file = OVA_FILE_EC2_V2V_EXAMPLE
+                                    skip_vm_check = yes
                                 - Eaton:
                                     ova_file = OVA_FILE_EATON_V2V_EXAMPLE
                                     skip_vm_check = yes

--- a/v2v/tests/cfg/convert_from_file.cfg
+++ b/v2v/tests/cfg/convert_from_file.cfg
@@ -180,6 +180,7 @@
                                 - ec2:
                                     enable_legacy_policy = yes
                                     ova_file = OVA_FILE_EC2_V2V_EXAMPLE
+                                    # Skip VM check for AWS EC2 OVA; not applicable for vm checks and avoids false failures.
                                     skip_vm_check = yes
                                 - Eaton:
                                     ova_file = OVA_FILE_EATON_V2V_EXAMPLE


### PR DESCRIPTION
Fixed case failure due to vm check added without need

Case: convert_from_file.positive_test.linux.input_mode.ova.aws.ec2.output_mode.libvirt 

Test Result:
```
# avocado run --vt-type v2v convert_from_file.positive_test.linux.input_mode.ova.aws.ec2.output_mode.libvirt 

 (1/1) type_specific.io-github-autotest-libvirt.convert_from_file.positive_test.linux.input_mode.ova.aws.ec2.output_mode.libvirt: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.convert_from_file.positive_test.linux.input_mode.ova.aws.ec2.output_mode.libvirt: PASS (85.51 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Test configuration updated to skip VM checks for the AWS EC2 variant to match other entries.
  * This prevents irrelevant VM validation failures, improves consistency across test cases, and reduces false negatives during test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->