### PR TITLE
LIBVIRTAT-22036: Add VM shutdown test to iommu_device_lifecycle for better vIOMMU device coverage

### DIFF
--- a/libvirt/tests/cfg/sriov/vIOMMU/iommu_device_lifecycle.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/iommu_device_lifecycle.cfg
@@ -43,3 +43,4 @@
         - reset:
         - shutdown:
             start_after_shutdown = yes
+            shutdown_timeout = 60

--- a/libvirt/tests/cfg/sriov/vIOMMU/iommu_device_lifecycle.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/iommu_device_lifecycle.cfg
@@ -41,3 +41,5 @@
         - reboot_many_times:
             loop_time = 5
         - reset:
+        - shutdown:
+            start_after_shutdown = yes

--- a/libvirt/tests/src/sriov/vIOMMU/iommu_device_lifecycle.py
+++ b/libvirt/tests/src/sriov/vIOMMU/iommu_device_lifecycle.py
@@ -87,6 +87,22 @@ def run(test, params, env):
                 s, o = utils_net.ping(ping_dest, count=5, timeout=10, session=session)
                 if s:
                     test.fail("Failed to ping %s! status: %s, output: %s." % (ping_dest, s, o))
+
+        elif test_scenario == "shutdown":
+            test.log.info("TEST_STEP: Shutdown the VM.")
+            virsh.shutdown(vm.name, **VIRSH_ARGS)
+            if not utils_misc.wait_for(lambda: vm.is_dead(), 60):
+                test.fail("VM failed to shutdown")
+            test.log.info("VM successfully shutdown")
+
+            # Optional: Start VM again based on parameter
+            start_after_shutdown = "yes" == params.get("start_after_shutdown", "no")
+            if start_after_shutdown:
+                test.log.info("TEST_STEP: Starting VM after shutdown")
+                vm.start()
+                vm.wait_for_login(timeout=int(params.get('login_timeout', 240)))
+                test.log.info("VM successfully started after shutdown")
+
         else:
             pid_ping, upsince = save_base.pre_save_setup(vm, serial=True)
             if test_scenario == "save_restore":


### PR DESCRIPTION
This change adds new test to verify virsh shutdown command is working as expected for VM with vIOMMU devices.
Also added the optional possibility to start the VM again after the shutdown.

Improving test coverage for RHEL-109504.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new "shutdown" lifecycle scenario to vIOMMU SR-IOV device lifecycle tests.
  * Verifies VM clean shutdown with a configurable timeout and reports failure if shutdown does not complete in time.
  * Optional parameter to automatically restart the VM after shutdown and verify successful boot/login.
  * Existing scenarios (reboot, reset, save/restore, suspend/resume) remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->