### PR TITLE
LIBVIRTAT-22036: Add VM shutdown test to iommu_device_lifecycle

### DIFF
--- a/libvirt/tests/cfg/sriov/vIOMMU/iommu_device_lifecycle.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/iommu_device_lifecycle.cfg
@@ -41,3 +41,6 @@
         - reboot_many_times:
             loop_time = 5
         - reset:
+        - shutdown:
+            start_after_shutdown = yes
+            shutdown_timeout = 60

--- a/libvirt/tests/src/sriov/vIOMMU/iommu_device_lifecycle.py
+++ b/libvirt/tests/src/sriov/vIOMMU/iommu_device_lifecycle.py
@@ -87,6 +87,27 @@ def run(test, params, env):
                 s, o = utils_net.ping(ping_dest, count=5, timeout=10, session=session)
                 if s:
                     test.fail("Failed to ping %s! status: %s, output: %s." % (ping_dest, s, o))
+
+        elif test_scenario == "shutdown":
+            test.log.info("TEST_STEP: Shutdown the VM.")
+            virsh.shutdown(vm.name, **VIRSH_ARGS)
+            shutdown_timeout = int(params.get("shutdown_timeout", "60"))
+            if not utils_misc.wait_for(lambda: vm.is_dead(), shutdown_timeout):
+                test.fail("VM failed to shutdown")
+            test.log.info("VM successfully shutdown")
+
+            # Optional: Start VM again based on parameter
+            start_after_shutdown = "yes" == params.get("start_after_shutdown", "no")
+            if start_after_shutdown:
+                test.log.info("TEST_STEP: Starting VM after shutdown")
+                vm.start()
+                vm.cleanup_serial_console()
+                vm.create_serial_console()
+                session = vm.wait_for_serial_login(
+                    timeout=int(params.get('login_timeout', 240)))
+                test.log.info("VM successfully started after shutdown")
+                session.close()
+
         else:
             pid_ping, upsince = save_base.pre_save_setup(vm, serial=True)
             if test_scenario == "save_restore":


### PR DESCRIPTION
This change adds new test to verify virsh shutdown command is working as expected for VM with vIOMMU devices. Also added the optional possibility to start the VM again after the shutdown and parametrize the shutdown_timeout.

Improving test coverage for RHEL-109504.

Tests running and properly failing as the code not in distro yet.

 (1/3) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.shutdown.virtio_muti_devices.vhost_on.virtio: STARTED
 (1/3) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.shutdown.virtio_muti_devices.vhost_on.virtio: FAIL: VM failed to shutdown (71.56 s)
 (2/3) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.shutdown.virtio_muti_devices.vhost_on.smmuv3: STARTED
 (2/3) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.shutdown.virtio_muti_devices.vhost_on.smmuv3: FAIL: VM failed to shutdown (71.61 s)
 (3/3) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.shutdown.hostdev_iface.virtio: STARTED
 (3/3) type_specific.io-github-autotest-libvirt.vIOMMU.iommu_device_lifecycle.shutdown.hostdev_iface.virtio: FAIL: VM failed to shutdown (91.44 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 3 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2025-09-23T06.51-04fee85/results.html
JOB TIME   : 237.12 s