### PR TITLE
Fix failures of v2v cases on rhel10 round2

### DIFF
--- a/v2v/tests/cfg/function_test_esx.cfg
+++ b/v2v/tests/cfg/function_test_esx.cfg
@@ -921,9 +921,9 @@
             vcenter_fdqn = VCENTER_FDQN_V2V_EXAMPLE
         - verify_custom_path_cert:
             only esx_80
-            version_required = "[libvirt-10.10.0-7.6,)"
             boottype = 3
             main_vm = VM_NAME_NON_ADMIN_V2V_EXAMPLE
+            cert_file = VCENTER_LINUX_CERT_V2V_EXAMPLE
             checkpoint = 'verify_custom_path_cert'
             certs_src_dir = 'CERTS_DIR_V2V_EXAMPLE'
             vcenter_fdqn = VCENTER_FDQN_V2V_EXAMPLE
@@ -1004,7 +1004,7 @@
                             luks_keys = LUKS_ALL_KEYS
                             skip_vm_check = yes
                             skip_reason = 'luks encryped, cannot boots up without password'
-                            version_required = "[libguestfs-1.56.1-3,)"
+                            version_required = "[libguestfs-1.56.1-3,);[libguestfs-fssupport-10.1-2,)"
         - print_blkhash:
             only esx_70
             only libvirt

--- a/v2v/tests/src/function_test_esx.py
+++ b/v2v/tests/src/function_test_esx.py
@@ -1008,10 +1008,11 @@ def run(test, params, env):
             new_cmd = v2v_result.replace('/?no_verify=1', '').replace(vpx_hostname, vcenter_fdqn)
         if 'verify_custom_path_cert' in checkpoint:
             certs_src_dir = params.get('certs_src_dir')
+            cert_file = params.get('cert_file')
             certs_dest_dir = os.path.join(data_dir.get_tmp_dir(), 'vmwarecert')
             vcenter_fdqn = params.get('vcenter_fdqn')
             verify_certificate(certs_src_dir, certs_dest_dir, vcenter_fdqn, vpx_hostname)
-            new_cmd = v2v_result.replace('/?no_verify=1', '/?cacert=%s/faea32cd.0' % certs_dest_dir).replace(vpx_hostname, vcenter_fdqn)
+            new_cmd = v2v_result.replace('/?no_verify=1', '/?cacert=%s/%s' % (certs_dest_dir, cert_file)).replace(vpx_hostname, vcenter_fdqn)
         if checkpoint[0] in [
             'verify_certificate',
             'verify_custom_path_cert',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - ESX V2V test now supports custom certificate filenames instead of a hardcoded CA path, improving flexibility across environments.
  - Updated compatibility constraints for SLES encrypted (LUKS) scenarios to include required filesystem support, ensuring accurate coverage on newer stacks.
  - Removed an outdated version gate to reduce unnecessary test skips.
  - Added configuration to specify a certificate file path for verification, aligning tests with real-world setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->