### PR TITLE
Auto case: Deprecated options removed from v2v man page

### DIFF
--- a/v2v/tests/cfg/v2v_options.cfg
+++ b/v2v/tests/cfg/v2v_options.cfg
@@ -143,6 +143,29 @@
                     v2v_options = --help
                     in_man = 'ovirtmgmt'
                     not_in_man = rhvm
+                - deprecated_options:
+                    only input_mode.none
+                    only output_mode.none
+                    version_required = "[virt-v2v-2.8.1-8,)"
+                    v2v_options = --help
+                    variants:
+                        - compressed:
+                            in_man = '-oo compressed'
+                            not_in_man = "--compressed"
+                        - vddk:
+                            in_man = '-io vddk-'
+                            not_in_man = "--vddk-"
+                        - vdsm:
+                            not_in_man = "-o vdsm"
+                        - no-trim:
+                            not_in_man = "--no-trim"
+                        - vmtype:
+                            not_in_man = "--vmtype"
+                        - password-file:
+                            in_man = "-ip filename"
+                            not_in_man = "--password-file"
+                        - qemu-boot:
+                            not_in_man = "--qemu-boot"
                 - option_oa:
                     # Set output allocation mode
                     only input_mode.libvirt.xen


### PR DESCRIPTION
Test Results:
```
# avocado run --vt-type v2v v2v_options.positive_test.deprecated_options..input_mode.none.output_mode.none

 (1/7) type_specific.io-github-autotest-libvirt.v2v_options.positive_test.deprecated_options.compressed.input_mode.none.output_mode.none: STARTED
 (1/7) type_specific.io-github-autotest-libvirt.v2v_options.positive_test.deprecated_options.compressed.input_mode.none.output_mode.none: PASS (6.55 s)
 (2/7) type_specific.io-github-autotest-libvirt.v2v_options.positive_test.deprecated_options.vddk.input_mode.none.output_mode.none: STARTED
 (2/7) type_specific.io-github-autotest-libvirt.v2v_options.positive_test.deprecated_options.vddk.input_mode.none.output_mode.none: PASS (6.65 s)
 (3/7) type_specific.io-github-autotest-libvirt.v2v_options.positive_test.deprecated_options.vdsm.input_mode.none.output_mode.none: STARTED
 (3/7) type_specific.io-github-autotest-libvirt.v2v_options.positive_test.deprecated_options.vdsm.input_mode.none.output_mode.none: PASS (6.75 s)
 (4/7) type_specific.io-github-autotest-libvirt.v2v_options.positive_test.deprecated_options.no-trim.input_mode.none.output_mode.none: STARTED
 (4/7) type_specific.io-github-autotest-libvirt.v2v_options.positive_test.deprecated_options.no-trim.input_mode.none.output_mode.none: PASS (6.73 s)
 (5/7) type_specific.io-github-autotest-libvirt.v2v_options.positive_test.deprecated_options.vmtype.input_mode.none.output_mode.none: STARTED
 (5/7) type_specific.io-github-autotest-libvirt.v2v_options.positive_test.deprecated_options.vmtype.input_mode.none.output_mode.none: PASS (6.67 s)
 (6/7) type_specific.io-github-autotest-libvirt.v2v_options.positive_test.deprecated_options.password-file.input_mode.none.output_mode.none: STARTED
 (6/7) type_specific.io-github-autotest-libvirt.v2v_options.positive_test.deprecated_options.password-file.input_mode.none.output_mode.none: PASS (6.78 s)
 (7/7) type_specific.io-github-autotest-libvirt.v2v_options.positive_test.deprecated_options.qemu-boot.input_mode.none.output_mode.none: STARTED
 (7/7) type_specific.io-github-autotest-libvirt.v2v_options.positive_test.deprecated_options.qemu-boot.input_mode.none.output_mode.none: PASS (6.75 s)
RESULTS    : PASS 7 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0


```