### PR TITLE
virsh_dump: drop --live option support

### DIFF
--- a/libvirt/tests/cfg/guest_kernel_debugging/virsh_dump.cfg
+++ b/libvirt/tests/cfg/guest_kernel_debugging/virsh_dump.cfg
@@ -20,14 +20,10 @@
                 - pause_dump:
                     paused_after_start_vm = "yes"
                     variants:
-                        - live:
-                            dump_options = "--live"
                         - crash:
                             dump_options = "--crash"
                         - reset:
                             dump_options = "--reset"
-                - live_dump:
-                    dump_options = "--live"
                 - crash_dump:
                     dump_options = "--crash"
                 - reset_dump:
@@ -89,6 +85,8 @@
                     dump_options = "--live --reset"
                 - invalid_option4:
                     dump_options = "--crash --reset"
+                - invalid_option_live:
+                    dump_options = "--live"    
                 - shutoff_dump:
                     start_vm = "no"
                 - acl_test:

--- a/libvirt/tests/src/guest_kernel_debugging/virsh_dump.py
+++ b/libvirt/tests/src/guest_kernel_debugging/virsh_dump.py
@@ -334,7 +334,7 @@ def run(test, params, env):
         if not log_file:
             log_file = utils_misc.get_path(test.debugdir, "libvirtd.log")
         error = "Invalid dump_image_format.*" + image_format
-        return libvirt.check_logfile(error, log_file, ignore_status=True)
+        return utils_misc.wait_for(lambda: libvirt.check_logfile(error, log_file, ignore_status=True), timeout=30)
 
     # Configure dump_image_format in /etc/libvirt/qemu.conf.
     qemu_config = utils_config.LibvirtQemuConfig()


### PR DESCRIPTION
The --live flag was removed from virsh dump upstream, so any positive test that still use it now fails immediately. ref: https://gitlab.com/libvirt/libvirt/-/issues/646

Delete all test cases that relied on --live, and add a negative test to make sure the command rejects the obsolete option.

Additionally, fix an unstable race by using utils_misc.wait_for(). Preventing the race condition where the log file had not yet been fully generated when the first check occurred.