### PR TITLE
Add VM shutdown support and refactor lifecycle operations

### DIFF
--- a/libvirt/tests/cfg/sriov/vIOMMU/iommu_device_lifecycle.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/iommu_device_lifecycle.cfg
@@ -41,3 +41,6 @@
         - reboot_many_times:
             loop_time = 5
         - reset:
+        - shutdown:
+            start_after_shutdown = yes
+            shutdown_timeout = 60

--- a/libvirt/tests/src/sriov/vIOMMU/iommu_device_lifecycle.py
+++ b/libvirt/tests/src/sriov/vIOMMU/iommu_device_lifecycle.py
@@ -11,17 +11,139 @@ from provider.save import save_base
 from provider.sriov import sriov_base
 from provider.viommu import viommu_base
 from provider.sriov import check_points as sriov_check_points
+from provider.vm_lifecycle import lifecycle_base
 
 VIRSH_ARGS = {'debug': True, 'ignore_status': False}
 
 
+def check_network_access(test, session, need_sriov, ping_dest):
+    """
+    Verify network connectivity in the VM after lifecycle operations.
+
+    :param test: Test object for logging and assertions
+    :param session: Active session to the VM
+    :param need_sriov: Boolean indicating if SRIOV network testing is required
+    :param ping_dest: Destination IP address to ping for connectivity test
+    :raises: TestFail if network connectivity fails
+    """
+    if need_sriov:
+        sriov_check_points.check_vm_network_accessed(session, ping_dest=ping_dest)
+    else:
+        s, o = utils_net.ping(ping_dest, count=5, timeout=10, session=session)
+        if s:
+            test.fail(f"Failed to ping {ping_dest}! status: {s}, output: {o}")
+
+
+def test_save_suspend(test, vm, save_path, test_scenario):
+    """
+    Execute VM save/restore or suspend/resume lifecycle operations.
+
+    :param test: Test object for logging and assertions
+    :param vm: VM object to perform operations on
+    :param save_path: File path where VM state will be saved
+    :param test_scenario: Type of operation ('save_restore' or 'suspend_resume')
+    :raises: TestFail if save/restore or suspend/resume operations fail
+    """
+    pid_ping, upsince = save_base.pre_save_setup(vm, serial=True)
+
+    if test_scenario == "save_restore":
+        test.log.info("TEST_STEP: Save and restore the VM.")
+        virsh.save(vm.name, save_path, **VIRSH_ARGS)
+        virsh.restore(save_path, **VIRSH_ARGS)
+    elif test_scenario == "suspend_resume":
+        test.log.info("TEST_STEP: Suspend and resume the VM.")
+        virsh.suspend(vm.name, **VIRSH_ARGS)
+        virsh.resume(vm.name, **VIRSH_ARGS)
+
+    save_base.post_save_check(vm, pid_ping, upsince, serial=True)
+
+
+def test_reboot_reset_shutdown(test, vm, params, need_sriov, ping_dest, test_scenario):
+    """
+    Execute VM reboot, reset, or shutdown lifecycle operations with network verification.
+
+    :param test: Test object for logging and assertions
+    :param vm: VM object to perform operations on
+    :param params: Test parameters dictionary containing timeout and loop settings
+    :param need_sriov: Boolean indicating if SRIOV network testing is required
+    :param ping_dest: Destination IP address for network connectivity verification
+    :param test_scenario: Type of operation ('shutdown', 'reset', or 'reboot_many_times')
+    :raises: TestFail if lifecycle operations or network connectivity fail
+    """
+    login_timeout = int(params.get('login_timeout', 240))
+
+    vm.cleanup_serial_console()
+    vm.create_serial_console()
+
+    if test_scenario == "shutdown":
+        lifecycle_base.test_shutdown(test, vm, params)
+        if params.get("start_after_shutdown", "no") == "yes":
+            test.log.info("TEST_STEP: Starting VM after shutdown")
+            vm.start()
+        else:
+            return
+    elif test_scenario == "reset":
+        lifecycle_base.test_reset(test, vm, login_timeout)
+    else:  # reboot_many_times
+        for _ in range(int(params.get('loop_time', '5'))):
+            lifecycle_base.test_reboot(test, vm, params, login_timeout)
+
+    session = vm.wait_for_serial_login(timeout=login_timeout)
+    check_network_access(test, session, need_sriov, ping_dest)
+    session.close()
+
+
+def setup_vm_xml(test, vm, test_obj, need_sriov=False, cleanup_ifaces=True):
+    """
+    Configure VM XML with IOMMU, device, and network interface settings.
+
+    :param test: Test object for logging and assertions
+    :param vm: VM object to configure
+    :param test_obj: VIOMMU test object containing configuration parameters
+    :param need_sriov: Boolean indicating if SRIOV network interfaces are required
+    :param cleanup_ifaces: Boolean indicating if existing interfaces should be cleaned up
+    :raises: TestFail if VM XML configuration fails
+    """
+    test.log.info("TEST_SETUP: Update VM XML.")
+    test_obj.setup_iommu_test(iommu_dict=eval(test_obj.params.get('iommu_dict', '{}')),
+                              cleanup_ifaces=cleanup_ifaces)
+    test_obj.prepare_controller()
+
+    for dev in ["disk", "video"]:
+        dev_dict = eval(test_obj.params.get('%s_dict' % dev, '{}'))
+        if dev == "disk":
+            dev_dict = test_obj.update_disk_addr(dev_dict)
+        libvirt_vmxml.modify_vm_device(
+            vm_xml.VMXML.new_from_dumpxml(vm.name), dev, dev_dict)
+
+    if need_sriov:
+        sriov_test_obj = sriov_base.SRIOVTest(vm, test, test_obj.params)
+        iface_dicts = sriov_test_obj.parse_iface_dict()
+        test.log.debug(f"Provided SRIOV interface dictionaries: {iface_dicts}")
+        test_obj.params["iface_dict"] = str(iface_dicts)
+
+    iface_dict = test_obj.parse_iface_dict()
+    if cleanup_ifaces:
+        libvirt_vmxml.modify_vm_device(
+                vm_xml.VMXML.new_from_dumpxml(vm.name),
+                "interface", iface_dict)
+
+
 def run(test, params, env):
     """
-    Test lifecycle for vm with vIOMMU enabled with different devices.
+    Main test function for VM lifecycle operations with vIOMMU and various device configurations.
+
+    Tests VM lifecycle scenarios (shutdown, reset, reboot, save/restore, suspend/resume)
+    with vIOMMU enabled and different device types. Supports SRIOV network testing
+    and validates network connectivity after each lifecycle operation.
+
+    :param test: Test object for logging and assertions
+    :param params: Test parameters dictionary containing scenario and configuration settings
+    :param env: Test environment containing VM and host information
+    :raises: TestFail if any lifecycle operation or network verification fails
     """
     cleanup_ifaces = "yes" == params.get("cleanup_ifaces", "yes")
     ping_dest = params.get('ping_dest', "127.0.0.1")
-    iommu_dict = eval(params.get('iommu_dict', '{}'))
     test_scenario = params.get("test_scenario")
     need_sriov = "yes" == params.get("need_sriov", "no")
 
@@ -31,73 +153,21 @@ def run(test, params, env):
     rand_id = utils_misc.generate_random_string(3)
     save_path = f'/var/tmp/{vm_name}_{rand_id}.save'
     test_obj = viommu_base.VIOMMUTest(vm, test, params)
-    if need_sriov:
-        sroiv_test_obj = sriov_base.SRIOVTest(vm, test, params)
+
     try:
-        test.log.info("TEST_SETUP: Update VM XML.")
-        test_obj.setup_iommu_test(iommu_dict=iommu_dict,
-                                  cleanup_ifaces=cleanup_ifaces)
-        test_obj.prepare_controller()
-        for dev in ["disk", "video"]:
-            dev_dict = eval(params.get('%s_dict' % dev, '{}'))
-            if dev == "disk":
-                dev_dict = test_obj.update_disk_addr(dev_dict)
-            libvirt_vmxml.modify_vm_device(
-                vm_xml.VMXML.new_from_dumpxml(vm.name), dev, dev_dict)
-        if need_sriov:
-            iface_dicts = sroiv_test_obj.parse_iface_dict()
-            test.log.debug(iface_dicts)
-            test_obj.params["iface_dict"] = str(sroiv_test_obj.parse_iface_dict())
-        iface_dict = test_obj.parse_iface_dict()
-        if cleanup_ifaces:
-            libvirt_vmxml.modify_vm_device(
-                    vm_xml.VMXML.new_from_dumpxml(vm.name),
-                    "interface", iface_dict)
+        setup_vm_xml(test, vm, test_obj, need_sriov, cleanup_ifaces)
 
         test.log.info("TEST_STEP: Start the VM.")
         vm.start()
         test.log.debug(vm_xml.VMXML.new_from_dumpxml(vm.name))
-        if test_scenario in ["reboot_many_times", "reset"]:
-            vm.cleanup_serial_console()
-            vm.create_serial_console()
-            if test_scenario == "reset":
-                test.log.info("TEST_STEP: Reset the VM.")
-                session = vm.wait_for_serial_login(
-                    timeout=int(params.get('login_timeout')))
-                virsh.reset(vm.name, **VIRSH_ARGS)
-                _match, _text = session.read_until_last_line_matches(
-                    [r"[Ll]ogin:\s*"], timeout=240, internal_timeout=0.5)
-                session.close()
-            else:
-                for _ in range(int(params.get('loop_time', '5'))):
-                    test.log.info("TEST_STEP: Reboot the VM.")
-                    session = vm.wait_for_serial_login(
-                        timeout=int(params.get('login_timeout')))
-                    session.sendline(params.get("reboot_command"))
-                    _match, _text = session.read_until_last_line_matches(
-                        [r"[Ll]ogin:\s*"], timeout=240, internal_timeout=0.5)
-                    session.close()
 
-            session = vm.wait_for_serial_login(
-                timeout=int(params.get('login_timeout')))
-
-            if need_sriov:
-                sriov_check_points.check_vm_network_accessed(session, ping_dest=ping_dest)
-            else:
-                s, o = utils_net.ping(ping_dest, count=5, timeout=10, session=session)
-                if s:
-                    test.fail("Failed to ping %s! status: %s, output: %s." % (ping_dest, s, o))
+        if test_scenario in ["reboot_many_times", "reset", "shutdown"]:
+            test_reboot_reset_shutdown(test, vm, params, need_sriov, ping_dest, test_scenario)
+        elif test_scenario in ["save_restore", "suspend_resume"]:
+            test_save_suspend(test, vm, save_path, test_scenario)
         else:
-            pid_ping, upsince = save_base.pre_save_setup(vm, serial=True)
-            if test_scenario == "save_restore":
-                test.log.info("TEST_STEP: Save and restore the VM.")
-                virsh.save(vm.name, save_path, **VIRSH_ARGS)
-                virsh.restore(save_path, **VIRSH_ARGS)
-            elif test_scenario == "suspend_resume":
-                test.log.info("TEST_STEP: Suspend and resume the VM.")
-                virsh.suspend(vm.name, **VIRSH_ARGS)
-                virsh.resume(vm.name, **VIRSH_ARGS)
-            save_base.post_save_check(vm, pid_ping, upsince, serial=True)
+            test.log.warning(f"Unknown scenario: {test_scenario}")
+
     finally:
         test_obj.teardown_iommu_test()
         if os.path.exists(save_path):

--- a/libvirt/tests/src/sriov/vIOMMU/iommu_device_lifecycle.py
+++ b/libvirt/tests/src/sriov/vIOMMU/iommu_device_lifecycle.py
@@ -1,37 +1,19 @@
+import ast
 import os
 
 from virttest import utils_misc
-from virttest import utils_net
 from virttest import virsh
 
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_libvirt import libvirt_vmxml
 
 from provider.save import save_base
+from provider.sriov import check_points as sriov_check_points
 from provider.sriov import sriov_base
 from provider.viommu import viommu_base
-from provider.sriov import check_points as sriov_check_points
 from provider.vm_lifecycle import lifecycle_base
 
 VIRSH_ARGS = {'debug': True, 'ignore_status': False}
-
-
-def check_network_access(test, session, need_sriov, ping_dest):
-    """
-    Verify network connectivity in the VM after lifecycle operations.
-
-    :param test: Test object for logging and assertions
-    :param session: Active session to the VM
-    :param need_sriov: Boolean indicating if SRIOV network testing is required
-    :param ping_dest: Destination IP address to ping for connectivity test
-    :raises: TestFail if network connectivity fails
-    """
-    if need_sriov:
-        sriov_check_points.check_vm_network_accessed(session, ping_dest=ping_dest)
-    else:
-        s, o = utils_net.ping(ping_dest, count=5, timeout=10, session=session)
-        if s:
-            test.fail(f"Failed to ping {ping_dest}! status: {s}, output: {o}")
 
 
 def test_save_suspend(test, vm, save_path, test_scenario):
@@ -83,13 +65,15 @@ def test_reboot_reset_shutdown(test, vm, params, need_sriov, ping_dest, test_sce
         else:
             return
     elif test_scenario == "reset":
-        lifecycle_base.test_reset(test, vm, login_timeout)
+        test.log.info("TEST_STEP: Reset the VM.")
+        vm.reboot(method="libvirt_reset", serial=True, timeout=login_timeout)
     else:  # reboot_many_times
         for _ in range(int(params.get('loop_time', '5'))):
-            lifecycle_base.test_reboot(test, vm, params, login_timeout)
+            test.log.info("TEST_STEP: Reboot the VM.")
+            vm.reboot(serial=True, timeout=login_timeout)
 
     session = vm.wait_for_serial_login(timeout=login_timeout)
-    check_network_access(test, session, need_sriov, ping_dest)
+    sriov_check_points.check_network_access(test, session, need_sriov, ping_dest)
     session.close()
 
 
@@ -105,12 +89,12 @@ def setup_vm_xml(test, vm, test_obj, need_sriov=False, cleanup_ifaces=True):
     :raises: TestFail if VM XML configuration fails
     """
     test.log.info("TEST_SETUP: Update VM XML.")
-    test_obj.setup_iommu_test(iommu_dict=eval(test_obj.params.get('iommu_dict', '{}')),
+    test_obj.setup_iommu_test(iommu_dict=ast.literal_eval(test_obj.params.get('iommu_dict', '{}')),
                               cleanup_ifaces=cleanup_ifaces)
     test_obj.prepare_controller()
 
     for dev in ["disk", "video"]:
-        dev_dict = eval(test_obj.params.get('%s_dict' % dev, '{}'))
+        dev_dict = ast.literal_eval(test_obj.params.get('%s_dict' % dev, '{}'))
         if dev == "disk":
             dev_dict = test_obj.update_disk_addr(dev_dict)
         libvirt_vmxml.modify_vm_device(

--- a/libvirt/tests/src/sriov/vIOMMU/iommu_device_settings.py
+++ b/libvirt/tests/src/sriov/vIOMMU/iommu_device_settings.py
@@ -1,13 +1,11 @@
 from virttest import utils_disk
-from virttest import utils_net
 
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_libvirt import libvirt_vmxml
 
+from provider.sriov import check_points as sriov_check_points
 from provider.sriov import sriov_base
 from provider.viommu import viommu_base
-
-from provider.sriov import check_points as sriov_check_points
 
 
 def run(test, params, env):
@@ -80,11 +78,6 @@ def run(test, params, env):
 
         test.log.info("TEST_STEP: Check if the VM disk and network are woring well.")
         utils_disk.dd_data_to_vm_disk(vm_session, "/mnt/test")
-        if need_sriov:
-            sriov_check_points.check_vm_network_accessed(vm_session, ping_dest=ping_dest)
-        else:
-            s, o = utils_net.ping(ping_dest, count=5, timeout=10, session=vm_session)
-            if s:
-                test.fail("Failed to ping %s! status: %s, output: %s." % (ping_dest, s, o))
+        sriov_check_points.check_network_access(test, vm_session, need_sriov, ping_dest)
     finally:
         test_obj.teardown_iommu_test()

--- a/provider/sriov/check_points.py
+++ b/provider/sriov/check_points.py
@@ -124,6 +124,24 @@ def check_vlan(dev_name, iface_dict, status_error=False):
                                       "Actual: %s." % (exp_value, act_value))
 
 
+def check_network_access(test, session, need_sriov, ping_dest):
+    """
+    Verify network connectivity in the VM.
+
+    :param test: Test object for logging and assertions
+    :param session: Active session to the VM
+    :param need_sriov: Boolean indicating if SRIOV network testing is required
+    :param ping_dest: Destination IP address to ping for connectivity test
+    :raises: TestFail if network connectivity fails
+    """
+    if need_sriov:
+        check_vm_network_accessed(session, ping_dest=ping_dest)
+    else:
+        s, o = utils_net.ping(ping_dest, count=5, timeout=10, session=session)
+        if s:
+            test.fail(f"Failed to ping {ping_dest}! status: {s}, output: {o}")
+
+
 def check_vm_network_accessed(vm_session, ping_count=3, ping_timeout=5,
                               tcpdump_iface=None, tcpdump_status_error=False,
                               ping_dest=None):

--- a/provider/vm_lifecycle/lifecycle_base.py
+++ b/provider/vm_lifecycle/lifecycle_base.py
@@ -1,0 +1,66 @@
+"""
+Basic VM lifecycle operations.
+
+This module provides basic VM lifecycle operations:
+- Shutdown
+- Reset
+- Reboot
+
+These are the core operations that can be reused across different tests.
+"""
+
+from virttest import utils_misc
+from virttest import virsh
+
+# Common virsh arguments
+VIRSH_ARGS = {'debug': True, 'ignore_status': False}
+
+
+def test_shutdown(test, vm, params):
+    """
+    Test shutdown scenario
+
+    :param test: Test object
+    :param vm: VM object
+    :param params: Dictionary with the test parameters
+    :raises: TestFail if VM fails to shutdown
+    """
+    test.log.info("TEST_STEP: Shutdown the VM.")
+    virsh.shutdown(vm.name, **VIRSH_ARGS)
+    shutdown_timeout = int(params.get("shutdown_timeout", "60"))
+    if not utils_misc.wait_for(lambda: vm.is_dead(), shutdown_timeout):
+        test.fail("VM failed to shutdown")
+    test.log.info("VM successfully shutdown")
+
+
+def test_reset(test, vm, login_timeout):
+    """
+    Test reset scenario
+
+    :param test: Test object
+    :param vm: VM object
+    :param login_timeout: Login timeout
+    """
+    test.log.info("TEST_STEP: Reset the VM.")
+    session = vm.wait_for_serial_login(timeout=login_timeout)
+    virsh.reset(vm.name, **VIRSH_ARGS)
+    _match, _text = session.read_until_last_line_matches(
+            [r"[Ll]ogin:\s*"], timeout=login_timeout, internal_timeout=0.5)
+    session.close()
+
+
+def test_reboot(test, vm, params, login_timeout):
+    """
+    Test single reboot operation
+
+    :param test: Test object
+    :param vm: VM object
+    :param params: Dictionary with the test parameters
+    :param login_timeout: Login timeout
+    """
+    test.log.info("TEST_STEP: Reboot the VM.")
+    session = vm.wait_for_serial_login(timeout=login_timeout)
+    session.sendline(params.get("reboot_command"))
+    _match, _text = session.read_until_last_line_matches(
+        [r"[Ll]ogin:\s*"], timeout=login_timeout, internal_timeout=0.5)
+    session.close()

--- a/provider/vm_lifecycle/lifecycle_base.py
+++ b/provider/vm_lifecycle/lifecycle_base.py
@@ -1,18 +1,12 @@
 """
-Basic VM lifecycle operations.
+Reusable VM lifecycle operations.
 
-This module provides basic VM lifecycle operations:
-- Shutdown
-- Reset
-- Reboot
-
-These are the core operations that can be reused across different tests.
+This module provides:
+- Shutdown with wait and failure assertion
 """
 
-from virttest import utils_misc
 from virttest import virsh
 
-# Common virsh arguments
 VIRSH_ARGS = {'debug': True, 'ignore_status': False}
 
 
@@ -28,39 +22,6 @@ def test_shutdown(test, vm, params):
     test.log.info("TEST_STEP: Shutdown the VM.")
     virsh.shutdown(vm.name, **VIRSH_ARGS)
     shutdown_timeout = int(params.get("shutdown_timeout", "60"))
-    if not utils_misc.wait_for(lambda: vm.is_dead(), shutdown_timeout):
+    if not vm.wait_for_shutdown(count=shutdown_timeout):
         test.fail("VM failed to shutdown")
     test.log.info("VM successfully shutdown")
-
-
-def test_reset(test, vm, login_timeout):
-    """
-    Test reset scenario
-
-    :param test: Test object
-    :param vm: VM object
-    :param login_timeout: Login timeout
-    """
-    test.log.info("TEST_STEP: Reset the VM.")
-    session = vm.wait_for_serial_login(timeout=login_timeout)
-    virsh.reset(vm.name, **VIRSH_ARGS)
-    _match, _text = session.read_until_last_line_matches(
-            [r"[Ll]ogin:\s*"], timeout=login_timeout, internal_timeout=0.5)
-    session.close()
-
-
-def test_reboot(test, vm, params, login_timeout):
-    """
-    Test single reboot operation
-
-    :param test: Test object
-    :param vm: VM object
-    :param params: Dictionary with the test parameters
-    :param login_timeout: Login timeout
-    """
-    test.log.info("TEST_STEP: Reboot the VM.")
-    session = vm.wait_for_serial_login(timeout=login_timeout)
-    session.sendline(params.get("reboot_command"))
-    _match, _text = session.read_until_last_line_matches(
-        [r"[Ll]ogin:\s*"], timeout=login_timeout, internal_timeout=0.5)
-    session.close()


### PR DESCRIPTION
- Add shutdown test scenario to iommu_device_lifecycle.py
- Create reusable VM lifecycle provider module (provider/vm_lifecycle/)
- Refactor iommu_device_lifecycle.py for better code organization:
  * Extract inline logic into dedicated functions
  * Add check_network_access() for centralized network testing
  * Add test_save_suspend() for save/restore and suspend/resume
  * Add test_reboot_reset_shutdown() for lifecycle operations
  * Add setup_vm_xml() for VM configuration setup
- Fix typo: sroiv_test_obj -> sriov_test_obj
- Add support for optional VM restart after shutdown
- Improve code maintainability and reduce duplication

This enables testing VM shutdown scenarios with vIOMMU devices and provides reusable lifecycle operations for other tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared VM lifecycle module providing shutdown/reset/reboot helpers and improved scenario dispatch with explicit unknown-scenario handling.

* **Refactor**
  * Centralized VM/IOMMU/SR‑IOV setup and moved lifecycle flows into reusable helpers for clearer, modular execution and teardown.

* **Tests**
  * Expanded lifecycle scenarios (reboot/reset/shutdown, save/restore, suspend/resume), added an extra shutdown step, improved timeouts, connectivity verification, and save-file handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->