### PR TITLE
Add support for multiple VFIO interfaces in vIOMMU tests

### DIFF
--- a/libvirt/tests/cfg/sriov/vIOMMU/iommu_device_settings.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/iommu_device_settings.cfg
@@ -83,3 +83,33 @@
                     downstream_port = {'type': 'pci', 'model': 'pcie-switch-downstream-port', 'pre_controller': 'pcie-switch-upstream-port'}
                     root_port = {'type': 'pci', 'model': 'pcie-root-port', 'pre_controller': 'pcie-expander-bus'}
                     controller_dicts = [{'type': 'pci', 'model': 'pcie-expander-bus', 'target': {'busNr': '250'}, 'pre_controller': 'pcie-root'}, ${root_port}, ${upstream_port}, ${upstream_port}, ${downstream_port}, ${downstream_port}]
+        - multiple_vfio_pcie_root_port:
+            only virtio
+            need_sriov = yes
+            ping_dest = ''
+            test_devices = ["Eth"]
+            # Multiple VFIO interfaces under pcie-root-port
+            # pcie-root <-- pcie-root-port <--- disk with iommu=on
+            #              <-- pcie-root-port <- vfio interface
+            #              <-- pcie-root-port <- vfio interface
+            controller_dicts = [{'type': 'pci', 'model': 'pcie-root-port', 'pre_controller': 'pcie-root'}, {'type': 'pci', 'model': 'pcie-root-port', 'pre_controller': 'pcie-root'}, {'type': 'pci', 'model': 'pcie-root-port', 'pre_controller': 'pcie-root'}]
+            disk_dict = {'target': {'dev': 'vda', 'bus': 'virtio'}, 'device': 'disk', 'driver': ${disk_driver}}
+            iface_dict = [{'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}}, {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr2}}]
+        - multiple_vfio_pcie_expander_bus:
+            only virtio
+            need_sriov = yes
+            ping_dest = ''
+            test_devices = ["Eth"]
+            # Multiple VFIO interfaces with pcie-expander-bus
+            # pcie-root <--- pcie-expander-bus <-- pcie-root-port <--- virtio interface with iommu=on
+            #                I                 |<----------------- pcie-root-port <--- vfio interface
+            #                |                  |<------------------pcie-root-port <--- vfio interface
+            #                | <----------pcie-root-port < ---virtio disk with iommu=on
+            expander_bus = {'type': 'pci', 'model': 'pcie-expander-bus', 'target': {'busNr': '251'}, 'pre_controller': 'pcie-root'}
+            root_port1 = {'type': 'pci', 'model': 'pcie-root-port', 'pre_controller': 'pcie-expander-bus'}
+            root_port2 = {'type': 'pci', 'model': 'pcie-root-port', 'pre_controller': 'pcie-expander-bus'}
+            root_port3 = {'type': 'pci', 'model': 'pcie-root-port', 'pre_controller': 'pcie-expander-bus'}
+            controller_dicts = [${expander_bus}, ${root_port1}, ${root_port2}, ${root_port3}]
+            disk_dict = {'target': {'dev': 'vda', 'bus': 'virtio'}, 'device': 'disk', 'driver': ${disk_driver}}
+            # Mixed interfaces: one virtio network with iommu=on and two VFIO interfaces
+            iface_dict = [{'type_name': 'network', 'model': 'virtio', 'driver': {'driver_attr': {'name': 'vhost', 'iommu': 'on'}}, 'source': {'network': 'default'}}, {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}}, {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr2}}]

--- a/libvirt/tests/cfg/sriov/vIOMMU/iommu_device_settings.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/iommu_device_settings.cfg
@@ -26,7 +26,7 @@
             only q35
             iface_model = 'rtl8139'
             iface_dict = {'type_name': 'network', 'model': '${iface_model}', 'source': {'network': 'default'}}
-        - virtio_muti_devices:
+        - virtio_multi_devices:
             disk_dict = {'target': {'dev': 'vda', 'bus': 'virtio'}, 'device': 'disk', 'driver': ${disk_driver}}
             video_dict = {'primary': 'yes', 'model_heads': '1', 'model_type': 'virtio', 'driver': {'iommu': 'on'}}
             test_devices = ["Eth", "block", "gpu"]

--- a/libvirt/tests/src/sriov/vIOMMU/iommu_device_settings.py
+++ b/libvirt/tests/src/sriov/vIOMMU/iommu_device_settings.py
@@ -52,9 +52,10 @@ def run(test, params, env):
             libvirt_vmxml.modify_vm_device(
                 vm_xml.VMXML.new_from_dumpxml(vm.name), dev, dev_dict)
         if need_sriov:
-            iface_dicts = sroiv_test_obj.parse_iface_dict()
-            test.log.debug(iface_dicts)
-            test_obj.params["iface_dict"] = str(iface_dicts)
+            sriov_iface_dicts = sroiv_test_obj.parse_iface_dict()
+            test.log.debug(sriov_iface_dicts)
+            test_obj.params["iface_dict"] = str(sriov_iface_dicts)
+
         iface_dicts = test_obj.parse_iface_dict()
 
         if cleanup_ifaces:

--- a/libvirt/tests/src/sriov/vIOMMU/iommu_device_settings.py
+++ b/libvirt/tests/src/sriov/vIOMMU/iommu_device_settings.py
@@ -54,13 +54,20 @@ def run(test, params, env):
         if need_sriov:
             iface_dicts = sroiv_test_obj.parse_iface_dict()
             test.log.debug(iface_dicts)
-            test_obj.params["iface_dict"] = str(sroiv_test_obj.parse_iface_dict())
+            test_obj.params["iface_dict"] = str(iface_dicts)
         iface_dict = test_obj.parse_iface_dict()
 
         if cleanup_ifaces:
-            libvirt_vmxml.modify_vm_device(
-                    vm_xml.VMXML.new_from_dumpxml(vm.name),
-                    "interface", iface_dict)
+            # Handle both single dict and list of dicts
+            if isinstance(iface_dicts, list):
+                for iface_dict in iface_dicts:
+                    libvirt_vmxml.modify_vm_device(
+                            vm_xml.VMXML.new_from_dumpxml(vm.name),
+                            "interface", iface_dict)
+            else:
+                libvirt_vmxml.modify_vm_device(
+                        vm_xml.VMXML.new_from_dumpxml(vm.name),
+                        "interface", iface_dicts)
 
         test.log.info("TEST_STEP: Start the VM.")
         vm.start()

--- a/libvirt/tests/src/sriov/vIOMMU/iommu_device_settings.py
+++ b/libvirt/tests/src/sriov/vIOMMU/iommu_device_settings.py
@@ -55,7 +55,7 @@ def run(test, params, env):
             iface_dicts = sroiv_test_obj.parse_iface_dict()
             test.log.debug(iface_dicts)
             test_obj.params["iface_dict"] = str(iface_dicts)
-        iface_dict = test_obj.parse_iface_dict()
+        iface_dicts = test_obj.parse_iface_dict()
 
         if cleanup_ifaces:
             # Handle both single dict and list of dicts

--- a/provider/sriov/sriov_base.py
+++ b/provider/sriov/sriov_base.py
@@ -172,9 +172,31 @@ class SRIOVTest(object):
 
     def parse_iface_dict(self):
         """
-        Parse iface_dict from params
+        Parse iface_dict from params, supporting both single dict and list of dicts
 
-        :return: The updated iface_dict
+        :return: The updated iface_dict or list of iface_dicts
+        """
+        iface_dict = self.params.get("iface_dict", "{}")
+
+        # Check if it's a list of dictionaries
+        if isinstance(iface_dict, list):
+            # Handle multiple interface dictionaries
+            result = []
+            for single_iface_dict in iface_dict:
+                # Process each interface dictionary
+                processed_dict = self._process_single_iface_dict(single_iface_dict)
+                result.append(processed_dict)
+            return result
+        else:
+            # Handle single interface dictionary (existing behavior)
+            return self._process_single_iface_dict(iface_dict)
+
+    def _process_single_iface_dict(self, single_iface_dict):
+        """
+        Process a single interface dictionary
+
+        :param iface_dict: Single interface dictionary to process
+        :return: The processed interface dictionary
         """
         mac_addr = utils_net.generate_mac_address_simple()
         pf_pci_addr = self.pf_pci_addr
@@ -183,7 +205,7 @@ class SRIOVTest(object):
         pf_name = self.pf_name
         vf_name = self.vf_name
         if self.params.get('iface_dict'):
-            iface_dict = eval(self.params.get('iface_dict', '{}'))
+            iface_dict = eval(single_iface_dict)
         else:
             if pf_pci_addr.get('type'):
                 del pf_pci_addr['type']

--- a/provider/sriov/sriov_base.py
+++ b/provider/sriov/sriov_base.py
@@ -195,7 +195,7 @@ class SRIOVTest(object):
         """
         Process a single interface dictionary
 
-        :param iface_dict: Single interface dictionary to process
+        :param single_iface_dict: Single interface dictionary to process
         :return: The processed interface dictionary
         """
         mac_addr = utils_net.generate_mac_address_simple()

--- a/provider/sriov/sriov_base.py
+++ b/provider/sriov/sriov_base.py
@@ -176,26 +176,25 @@ class SRIOVTest(object):
 
         :return: The updated iface_dict or list of iface_dicts
         """
-        iface_dict = self.params.get("iface_dict", "{}")
+        iface_dict = eval(self.params.get("iface_dict", "{}"))
 
         # Check if it's a list of dictionaries
         if isinstance(iface_dict, list):
             # Handle multiple interface dictionaries
             result = []
             for single_iface_dict in iface_dict:
-                # Process each interface dictionary
-                processed_dict = self._process_single_iface_dict(single_iface_dict)
+                processed_dict = self._process_single_iface_dict(str(single_iface_dict))
                 result.append(processed_dict)
             return result
         else:
             # Handle single interface dictionary (existing behavior)
-            return self._process_single_iface_dict(iface_dict)
+            return self._process_single_iface_dict(str(iface_dict))
 
     def _process_single_iface_dict(self, single_iface_dict):
         """
         Process a single interface dictionary
 
-        :param single_iface_dict: Single interface dictionary to process
+        :param single_iface_dict: String representation of interface dictionary to process
         :return: The processed interface dictionary
         """
         mac_addr = utils_net.generate_mac_address_simple()

--- a/provider/viommu/viommu_base.py
+++ b/provider/viommu/viommu_base.py
@@ -115,22 +115,22 @@ class VIOMMUTest(object):
 
         :return: The updated iface_dict or list of iface_dicts based on type of input
         """
-        iface_dict = self.params.get("iface_dict", "{}")
+        iface_dict = eval(self.params.get("iface_dict", "{}"))
 
         if isinstance(iface_dict, list):
             result = []
             for single_iface_dict in iface_dict:
-                processed_dict = self._process_single_iface_dict(single_iface_dict)
+                processed_dict = self._process_single_iface_dict(str(single_iface_dict))
                 result.append(processed_dict)
             return result
         else:
-            return self._process_single_iface_dict(iface_dict)
+            return self._process_single_iface_dict(str(iface_dict))
 
     def _process_single_iface_dict(self, single_iface_dict):
         """
         Process a single interface dictionary
 
-        :param single_iface_dict: Single interface dictionary to process
+        :param single_iface_dict: String representation of interface dictionary to process
         :return: The processed interface dictionary
         """
         # generate mac address, if it is needed in iface_dict

--- a/provider/viommu/viommu_base.py
+++ b/provider/viommu/viommu_base.py
@@ -130,7 +130,7 @@ class VIOMMUTest(object):
         """
         Process a single interface dictionary
 
-        :param iface_dict: Single interface dictionary to process
+        :param single_iface_dict: Single interface dictionary to process
         :return: The processed interface dictionary
         """
         # generate mac address, if it is needed in iface_dict

--- a/provider/viommu/viommu_base.py
+++ b/provider/viommu/viommu_base.py
@@ -111,12 +111,31 @@ class VIOMMUTest(object):
 
     def parse_iface_dict(self):
         """
-        Parse iface_dict from params
+        Parse iface_dict from params, supporting both single dict and list of dicts
 
-        :return: The updated iface_dict
+        :return: The updated iface_dict or list of iface_dicts based on type of input
         """
+        iface_dict = self.params.get("iface_dict", "{}")
+
+        if isinstance(iface_dict, list):
+            result = []
+            for single_iface_dict in iface_dict:
+                processed_dict = self._process_single_iface_dict(single_iface_dict)
+                result.append(processed_dict)
+            return result
+        else:
+            return self._process_single_iface_dict(iface_dict)
+
+    def _process_single_iface_dict(self, single_iface_dict):
+        """
+        Process a single interface dictionary
+
+        :param iface_dict: Single interface dictionary to process
+        :return: The processed interface dictionary
+        """
+        # generate mac address, if it is needed in iface_dict
         mac_addr = utils_net.generate_mac_address_simple()
-        iface_dict = eval(self.params.get("iface_dict", "{}"))
+        iface_dict = eval(single_iface_dict)
 
         if self.controller_dicts and iface_dict:
             iface_bus = "%0#4x" % int(self.controller_dicts[-1].get("index"))


### PR DESCRIPTION
This commit enhances the vIOMMU test framework to support multiple VFIO interfaces in a single test configuration, addressing the need for testing complex PCIe topologies with multiple VFIO devices.

Changes:

1. Enhanced VIOMMUTest.parse_iface_dict():
   - Now supports both single interface dictionaries and lists of interface dictionaries
   - Maintains backward compatibility with existing single interface configurations
   - Added _process_single_iface_dict() helper method for cleaner code organization

2. Enhanced SRIOVTest.parse_iface_dict():
   - Added similar multiple interface support for SRIOV test cases
   - Maintains existing functionality while supporting new multiple interface scenarios
   - Added _process_single_iface_dict() helper method for consistency

3. Updated iommu_device_settings.py:
   - Modified to use the enhanced parse_iface_dict() methods
   - Added logic to handle both single and multiple interface configurations
   - Improved interface device modification logic for multiple interfaces

4. Added new test configurations:
   - multiple_vfio_pcie_root_port: Multiple VFIO interfaces under pcie-root-port
   - multiple_vfio_pcie_expander_bus: Multiple VFIO interfaces with pcie-expander-bus
   - Both configurations support complex PCIe topologies with mixed interface types

Technical Details:
- The parse_iface_dict() methods now detect if the input is a list or single dict
- For lists, each interface dictionary is processed individually
- Controller addressing is properly handled for each interface
- MAC address handling is preserved through the existing eval() process
- All changes maintain backward compatibility

This enhancement enables testing of complex vIOMMU scenarios with multiple VFIO devices in various PCIe topologies, improving test coverage for enterprise virtualization use cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Support multiple SR-IOV/VFIO interfaces per VM in vIOMMU scenarios.
  - Allow mixed virtio + VFIO interface configurations using PCIe expander-bus and multiple root ports.
  - Automatic address/slot assignment for multi-interface PCIe topologies.

- **Bug Fixes**
  - Corrected a configuration block name typo.

- **Tests**
  - Added config variants covering multiple VFIO interfaces with root-port and expander-bus layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->