### PR TITLE
LIBVIRTAT-20967: Add  multiple VFIO interfaces in vIOMMU test

### DIFF
--- a/libvirt/tests/cfg/sriov/vIOMMU/iommu_device_settings.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/iommu_device_settings.cfg
@@ -26,7 +26,7 @@
             only q35
             iface_model = 'rtl8139'
             iface_dict = {'type_name': 'network', 'model': '${iface_model}', 'source': {'network': 'default'}}
-        - virtio_muti_devices:
+        - virtio_multi_devices:
             disk_dict = {'target': {'dev': 'vda', 'bus': 'virtio'}, 'device': 'disk', 'driver': ${disk_driver}}
             video_dict = {'primary': 'yes', 'model_heads': '1', 'model_type': 'virtio', 'driver': {'iommu': 'on'}}
             test_devices = ["Eth", "block", "gpu"]
@@ -83,3 +83,33 @@
                     downstream_port = {'type': 'pci', 'model': 'pcie-switch-downstream-port', 'pre_controller': 'pcie-switch-upstream-port'}
                     root_port = {'type': 'pci', 'model': 'pcie-root-port', 'pre_controller': 'pcie-expander-bus'}
                     controller_dicts = [{'type': 'pci', 'model': 'pcie-expander-bus', 'target': {'busNr': '250'}, 'pre_controller': 'pcie-root'}, ${root_port}, ${upstream_port}, ${upstream_port}, ${downstream_port}, ${downstream_port}]
+        - multiple_vfio_pcie_root_port:
+            only virtio
+            need_sriov = yes
+            ping_dest = ''
+            test_devices = ["Eth"]
+            # Multiple VFIO interfaces under pcie-root-port
+            # pcie-root <-- pcie-root-port <--- disk with iommu=on
+            #              <-- pcie-root-port <- vfio interface
+            #              <-- pcie-root-port <- vfio interface
+            controller_dicts = [{'type': 'pci', 'model': 'pcie-root-port', 'pre_controller': 'pcie-root'}, {'type': 'pci', 'model': 'pcie-root-port', 'pre_controller': 'pcie-root'}, {'type': 'pci', 'model': 'pcie-root-port', 'pre_controller': 'pcie-root'}]
+            disk_dict = {'target': {'dev': 'vda', 'bus': 'virtio'}, 'device': 'disk', 'driver': ${disk_driver}}
+            iface_dict = [{'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}}, {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr2}}]
+        - multiple_vfio_pcie_expander_bus:
+            only virtio
+            need_sriov = yes
+            ping_dest = ''
+            test_devices = ["Eth"]
+            # Multiple VFIO interfaces with pcie-expander-bus
+            # pcie-root <--- pcie-expander-bus <-- pcie-root-port <--- virtio interface with iommu=on
+            #                I                 |<----------------- pcie-root-port <--- vfio interface
+            #                |                  |<------------------pcie-root-port <--- vfio interface
+            #                | <----------pcie-root-port < ---virtio disk with iommu=on
+            expander_bus = {'type': 'pci', 'model': 'pcie-expander-bus', 'target': {'busNr': '251'}, 'pre_controller': 'pcie-root'}
+            root_port1 = {'type': 'pci', 'model': 'pcie-root-port', 'pre_controller': 'pcie-expander-bus'}
+            root_port2 = {'type': 'pci', 'model': 'pcie-root-port', 'pre_controller': 'pcie-expander-bus'}
+            root_port3 = {'type': 'pci', 'model': 'pcie-root-port', 'pre_controller': 'pcie-expander-bus'}
+            controller_dicts = [${expander_bus}, ${root_port1}, ${root_port2}, ${root_port3}]
+            disk_dict = {'target': {'dev': 'vda', 'bus': 'virtio'}, 'device': 'disk', 'driver': ${disk_driver}}
+            # Mixed interfaces: one virtio network with iommu=on and two VFIO interfaces
+            iface_dict = [{'type_name': 'network', 'model': 'virtio', 'driver': {'driver_attr': {'name': 'vhost', 'iommu': 'on'}}, 'source': {'network': 'default'}}, {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}}, {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr2}}]

--- a/libvirt/tests/cfg/sriov/vIOMMU/iommu_device_settings.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/iommu_device_settings.cfg
@@ -112,4 +112,4 @@
             controller_dicts = [${expander_bus}, ${root_port1}, ${root_port2}, ${root_port3}]
             disk_dict = {'target': {'dev': 'vda', 'bus': 'virtio'}, 'device': 'disk', 'driver': ${disk_driver}}
             # Mixed interfaces: one virtio network with iommu=on and two VFIO interfaces
-            iface_dict = [{'type_name': 'network', 'model': 'virtio', 'driver': {'driver_attr': {'name': 'vhost', 'iommu': 'on'}}, 'source': {'network': 'default'}}, {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}}, {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr2}}]
+            iface_dict = [{'type_name': 'network', 'model': 'virtio', 'driver': {'driver_attr': {'iommu': 'on'}}, 'source': {'network': 'default'}}, {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}}, {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr2}}]

--- a/libvirt/tests/cfg/sriov/vIOMMU/iommu_device_settings.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/iommu_device_settings.cfg
@@ -105,13 +105,13 @@
             #                I                 |<----------------- pcie-root-port <--- vfio interface
             #                |                  |<------------------pcie-root-port <--- vfio interface
             #                | <----------pcie-root-port < ---virtio disk with iommu=on
-            expander_bus = {'type': 'pci', 'model': 'pcie-expander-bus', 'target': {'busNr': '251'}, 'pre_controller': 'pcie-root', 'contr_alias': 'pci-expander'}
+            expander_bus = {'type': 'pci', 'model': 'pcie-expander-bus', 'target': {'busNr': '251'}, 'pre_controller': 'pcie-root', 'alias': {'name': 'pci-expander'}}
             root_port1 = {'type': 'pci', 'model': 'pcie-root-port', 'pre_controller': 'pcie-expander-bus', 'alias': {'name': 'pcr.1'}}
             root_port2 = {'type': 'pci', 'model': 'pcie-root-port', 'pre_controller': 'pcie-expander-bus', 'alias': {'name': 'pcr.2'}}
             root_port3 = {'type': 'pci', 'model': 'pcie-root-port', 'pre_controller': 'pcie-expander-bus', 'alias': {'name': 'pcr.3'}}
             root_port4 = {'type': 'pci', 'model': 'pcie-root-port', 'pre_controller': 'pcie-root', 'alias': {'name': 'pcr.4'}}
             controller_dicts = [${expander_bus}, ${root_port1}, ${root_port2}, ${root_port3}, ${root_port4}]
+            disk_dict = {'target': {'dev': 'vda', 'bus': 'virtio'}, 'device': 'disk', 'driver': ${disk_driver}, 'address': {'alias': {'name': 'pcr.1'}}}
             #disk_dict = {'target': {'dev': 'vda', 'bus': 'virtio'}, 'device': 'disk', 'driver': ${disk_driver}, 'address': {'type_name': 'pci', 'attrs': {'bus': '0x14', 'slot': '0x00', 'function': '0x0'}}}
-            disk_dict = {'target': {'dev': 'vda', 'bus': 'virtio'}, 'device': 'disk', 'driver': ${disk_driver}, 'address': {'type_name': 'pci', 'attrs': {'alias':{'name': 'pcr.4'}}}}
             # Mixed interfaces: one virtio network with iommu=on and two VFIO interfaces
-            iface_dict = [{'type_name': 'network', 'model': 'virtio', 'driver': {'driver_attr': {'iommu': 'on'}}, 'source': {'network': 'default'}}, {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}}, {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr2}, 'address': {'type_name': 'pci', 'attrs': {'alias':{'name': 'pcr.2'}}}}]
+            iface_dict = [{'type_name': 'network', 'model': 'virtio', 'driver': {'driver_attr': {'iommu': 'on'}}, 'source': {'network': 'default'},'address':{'alias':{'name':'pcr.4'}}}, {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr},'address':{'alias':{'name':'pcr.2'}}}, {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr2},'address':{'alias':{'name':'pcr.3'}}}]

--- a/libvirt/tests/cfg/sriov/vIOMMU/iommu_device_settings.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/iommu_device_settings.cfg
@@ -106,12 +106,12 @@
             #                |                  |<------------------pcie-root-port <--- vfio interface
             #                | <----------pcie-root-port < ---virtio disk with iommu=on
             expander_bus = {'type': 'pci', 'model': 'pcie-expander-bus', 'target': {'busNr': '251'}, 'pre_controller': 'pcie-root', 'contr_alias': 'pci-expander'}
-            root_port1 = {'type': 'pci', 'model': 'pcie-root-port', 'pre_controller': 'pcie-expander-bus'}
-            root_port2 = {'type': 'pci', 'model': 'pcie-root-port', 'pre_controller': 'pcie-expander-bus'}
-            root_port3 = {'type': 'pci', 'model': 'pcie-root-port', 'pre_controller': 'pcie-expander-bus'}
-            root_port4 = {'type': 'pci', 'model': 'pcie-root-port', 'pre_controller': 'pcie-root'}
+            root_port1 = {'type': 'pci', 'model': 'pcie-root-port', 'pre_controller': 'pcie-expander-bus', 'alias': {'name': 'pcr.1'}}
+            root_port2 = {'type': 'pci', 'model': 'pcie-root-port', 'pre_controller': 'pcie-expander-bus', 'alias': {'name': 'pcr.2'}}
+            root_port3 = {'type': 'pci', 'model': 'pcie-root-port', 'pre_controller': 'pcie-expander-bus', 'alias': {'name': 'pcr.3'}}
+            root_port4 = {'type': 'pci', 'model': 'pcie-root-port', 'pre_controller': 'pcie-root', 'alias': {'name': 'pcr.4'}}
             controller_dicts = [${expander_bus}, ${root_port1}, ${root_port2}, ${root_port3}, ${root_port4}]
             #disk_dict = {'target': {'dev': 'vda', 'bus': 'virtio'}, 'device': 'disk', 'driver': ${disk_driver}, 'address': {'type_name': 'pci', 'attrs': {'bus': '0x14', 'slot': '0x00', 'function': '0x0'}}}
             disk_dict = {'target': {'dev': 'vda', 'bus': 'virtio'}, 'device': 'disk', 'driver': ${disk_driver}, 'address': {'type_name': 'pci', 'attrs': {'alias':{'name': 'pcr.4'}}}}
             # Mixed interfaces: one virtio network with iommu=on and two VFIO interfaces
-            iface_dict = [{'type_name': 'network', 'model': 'virtio', 'driver': {'driver_attr': {'iommu': 'on'}}, 'source': {'network': 'default'}}, {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}}, {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr2}}]
+            iface_dict = [{'type_name': 'network', 'model': 'virtio', 'driver': {'driver_attr': {'iommu': 'on'}}, 'source': {'network': 'default'}}, {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}}, {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr2}, 'address': {'type_name': 'pci', 'attrs': {'alias':{'name': 'pcr.2'}}}}]

--- a/libvirt/tests/cfg/sriov/vIOMMU/iommu_device_settings.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/iommu_device_settings.cfg
@@ -105,11 +105,13 @@
             #                I                 |<----------------- pcie-root-port <--- vfio interface
             #                |                  |<------------------pcie-root-port <--- vfio interface
             #                | <----------pcie-root-port < ---virtio disk with iommu=on
-            expander_bus = {'type': 'pci', 'model': 'pcie-expander-bus', 'target': {'busNr': '251'}, 'pre_controller': 'pcie-root'}
+            expander_bus = {'type': 'pci', 'model': 'pcie-expander-bus', 'target': {'busNr': '251'}, 'pre_controller': 'pcie-root', 'contr_alias': 'pci-expander'}
             root_port1 = {'type': 'pci', 'model': 'pcie-root-port', 'pre_controller': 'pcie-expander-bus'}
             root_port2 = {'type': 'pci', 'model': 'pcie-root-port', 'pre_controller': 'pcie-expander-bus'}
             root_port3 = {'type': 'pci', 'model': 'pcie-root-port', 'pre_controller': 'pcie-expander-bus'}
-            controller_dicts = [${expander_bus}, ${root_port1}, ${root_port2}, ${root_port3}]
-            disk_dict = {'target': {'dev': 'vda', 'bus': 'virtio'}, 'device': 'disk', 'driver': ${disk_driver}}
+            root_port4 = {'type': 'pci', 'model': 'pcie-root-port', 'pre_controller': 'pcie-root'}
+            controller_dicts = [${expander_bus}, ${root_port1}, ${root_port2}, ${root_port3}, ${root_port4}]
+            #disk_dict = {'target': {'dev': 'vda', 'bus': 'virtio'}, 'device': 'disk', 'driver': ${disk_driver}, 'address': {'type_name': 'pci', 'attrs': {'bus': '0x14', 'slot': '0x00', 'function': '0x0'}}}
+            disk_dict = {'target': {'dev': 'vda', 'bus': 'virtio'}, 'device': 'disk', 'driver': ${disk_driver}, 'address': {'type_name': 'pci', 'attrs': {'alias':{'name': 'pcr.4'}}}}
             # Mixed interfaces: one virtio network with iommu=on and two VFIO interfaces
             iface_dict = [{'type_name': 'network', 'model': 'virtio', 'driver': {'driver_attr': {'iommu': 'on'}}, 'source': {'network': 'default'}}, {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr}}, {'managed': 'yes', 'type_name': 'hostdev', 'hostdev_address': {'type_name': 'pci', 'attrs': vf_pci_addr2}}]

--- a/libvirt/tests/src/sriov/vIOMMU/iommu_device_settings.py
+++ b/libvirt/tests/src/sriov/vIOMMU/iommu_device_settings.py
@@ -61,8 +61,9 @@ def run(test, params, env):
         if cleanup_ifaces:
             # Handle both single dict and list of dicts
             if isinstance(iface_dict, list):
+                libvirt_vmxml.remove_vm_devices_by_type(vm, 'interface')
                 for single_iface_dict in iface_dict:
-                    libvirt_vmxml.modify_vm_device(
+                    libvirt_vmxml.add_vm_device(
                             vm_xml.VMXML.new_from_dumpxml(vm.name),
                             "interface", single_iface_dict)
             else:
@@ -72,6 +73,8 @@ def run(test, params, env):
 
         test.log.info("TEST_STEP: Start the VM.")
         vm.start()
+        vm.cleanup_serial_console()
+        vm.create_serial_console()
         vm_session = vm.wait_for_serial_login(
             timeout=int(params.get('login_timeout')))
         test.log.debug(vm_xml.VMXML.new_from_dumpxml(vm.name))
@@ -98,4 +101,5 @@ def run(test, params, env):
         if 'vm_session' in locals():
             test.log.debug("Closing vm_session")
             vm_session.close()
+        vm.cleanup_serial_console()
         test_obj.teardown_iommu_test()

--- a/libvirt/tests/src/sriov/vIOMMU/iommu_device_settings.py
+++ b/libvirt/tests/src/sriov/vIOMMU/iommu_device_settings.py
@@ -3,6 +3,7 @@ from virttest import utils_net
 
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
 
 from provider.sriov import sriov_base
 from provider.viommu import viommu_base
@@ -63,9 +64,11 @@ def run(test, params, env):
             if isinstance(iface_dict, list):
                 libvirt_vmxml.remove_vm_devices_by_type(vm, 'interface')
                 for single_iface_dict in iface_dict:
-                    libvirt_vmxml.add_vm_device(
+                    dev_obj = libvirt_vmxml.create_vm_device_by_type("interface", single_iface_dict)
+                    test.log.debug(f"XML of interface device is:\n{dev_obj}")
+                    libvirt.add_vm_device(
                             vm_xml.VMXML.new_from_dumpxml(vm.name),
-                            "interface", single_iface_dict)
+                            dev_obj)
             else:
                 libvirt_vmxml.modify_vm_device(
                         vm_xml.VMXML.new_from_dumpxml(vm.name),

--- a/libvirt/tests/src/sriov/vIOMMU/iommu_device_settings.py
+++ b/libvirt/tests/src/sriov/vIOMMU/iommu_device_settings.py
@@ -35,9 +35,6 @@ def run(test, params, env):
     try:
         test_obj.setup_iommu_test(iommu_dict=iommu_dict, cleanup_ifaces=cleanup_ifaces)
         test_obj.prepare_controller()
-        test_obj.log_controller_dicts()
-        #jtest.log.debug("------------------------------------------------------------")
-        #jtime.sleep(60)
         vm.start()
         vm.cleanup_serial_console()
         vm.create_serial_console()

--- a/libvirt/tests/src/sriov/vIOMMU/iommu_device_settings.py
+++ b/libvirt/tests/src/sriov/vIOMMU/iommu_device_settings.py
@@ -58,9 +58,16 @@ def run(test, params, env):
         iface_dict = test_obj.parse_iface_dict()
 
         if cleanup_ifaces:
-            libvirt_vmxml.modify_vm_device(
-                    vm_xml.VMXML.new_from_dumpxml(vm.name),
-                    "interface", iface_dict)
+            # Handle both single dict and list of dicts
+            if isinstance(iface_dict, list):
+                for single_iface_dict in iface_dict:
+                    libvirt_vmxml.modify_vm_device(
+                            vm_xml.VMXML.new_from_dumpxml(vm.name),
+                            "interface", single_iface_dict)
+            else:
+                libvirt_vmxml.modify_vm_device(
+                        vm_xml.VMXML.new_from_dumpxml(vm.name),
+                        "interface", iface_dict)
 
         test.log.info("TEST_STEP: Start the VM.")
         vm.start()

--- a/libvirt/tests/src/sriov/vIOMMU/iommu_device_settings.py
+++ b/libvirt/tests/src/sriov/vIOMMU/iommu_device_settings.py
@@ -1,3 +1,4 @@
+import time
 from virttest import utils_disk
 from virttest import utils_net
 
@@ -34,6 +35,9 @@ def run(test, params, env):
     try:
         test_obj.setup_iommu_test(iommu_dict=iommu_dict, cleanup_ifaces=cleanup_ifaces)
         test_obj.prepare_controller()
+        test_obj.log_controller_dicts()
+        #jtest.log.debug("------------------------------------------------------------")
+        #jtime.sleep(60)
         vm.start()
         vm.cleanup_serial_console()
         vm.create_serial_console()
@@ -47,17 +51,21 @@ def run(test, params, env):
             dev_dict = eval(params.get('%s_dict' % dev, '{}'))
             if dev == "disk" and dev_dict:
                 dev_dict = test_obj.update_disk_addr(dev_dict)
+                test.log.debug(f"disk_addr_updated:{dev_dict}")
                 if dev_dict["target"].get("bus") != "virtio":
                     libvirt_vmxml.modify_vm_device(
                             vm_xml.VMXML.new_from_dumpxml(vm.name), dev, {'driver': None})
 
             libvirt_vmxml.modify_vm_device(
                 vm_xml.VMXML.new_from_dumpxml(vm.name), dev, dev_dict)
+        test_obj.log_controller_dicts()
         if need_sriov:
             iface_dicts = sroiv_test_obj.parse_iface_dict()
             test.log.debug(iface_dicts)
             test_obj.params["iface_dict"] = str(sroiv_test_obj.parse_iface_dict())
+        test_obj.log_controller_dicts()
         iface_dict = test_obj.parse_iface_dict()
+        test_obj.log_controller_dicts()
 
         if cleanup_ifaces:
             # Handle both single dict and list of dicts
@@ -105,4 +113,6 @@ def run(test, params, env):
             test.log.debug("Closing vm_session")
             vm_session.close()
         vm.cleanup_serial_console()
+        test.log.debug("------------------------------------------------------------")
+        time.sleep(60)
         test_obj.teardown_iommu_test()

--- a/libvirt/tests/src/sriov/vIOMMU/iommu_device_settings.py
+++ b/libvirt/tests/src/sriov/vIOMMU/iommu_device_settings.py
@@ -39,6 +39,7 @@ def run(test, params, env):
         vm_session = vm.wait_for_serial_login(
             timeout=int(params.get('login_timeout')))
         pre_devices = viommu_base.get_devices_pci(vm_session, test_devices)
+        vm_session.close()
         vm.destroy()
 
         for dev in ["disk", "video"]:
@@ -94,4 +95,7 @@ def run(test, params, env):
             if s:
                 test.fail("Failed to ping %s! status: %s, output: %s." % (ping_dest, s, o))
     finally:
+        if 'vm_session' in locals():
+            test.log.debug("Closing vm_session")
+            vm_session.close()
         test_obj.teardown_iommu_test()

--- a/provider/viommu/viommu_base.py
+++ b/provider/viommu/viommu_base.py
@@ -135,7 +135,7 @@ class VIOMMUTest(object):
 
         :param iface_dict: Interface dictionary to update with controller info
         """
-        if self.controller_dicts and iface_dict:
+        if self.controller_dicts and iface_dict and iface_dict.get('type_name') != 'hostdev':
             iface_bus = "%0#4x" % int(self.controller_dicts[-1].get("index"))
             iface_attrs = {"bus": iface_bus}
             if self.controller_dicts[-1].get("model") == "pcie-to-pci-bridge":

--- a/provider/viommu/viommu_base.py
+++ b/provider/viommu/viommu_base.py
@@ -212,9 +212,20 @@ class VIOMMUTest(object):
             libvirt_vmxml.modify_vm_device(
                 vm_xml.VMXML.new_from_dumpxml(self.vm.name), "controller",
                 contr_dict, 100)
-            contr_dict["index"] = libvirt_pcicontr.get_max_contr_indexes(
-                vm_xml.VMXML.new_from_dumpxml(self.vm.name),
-                contr_dict["type"], contr_dict["model"])[-1]
+            # Only assign index if it wasn't already assigned
+            if "index" not in contr_dict:
+                # Check if target busNr is specified and use it as index
+                if contr_dict.get("target", {}).get("busNr"):
+                    target_bus = int(contr_dict["target"]["busNr"])
+                    contr_dict["index"] = target_bus
+                    self.test.log.debug(f"Using target busNr {target_bus} as index for controller {i}: {contr_dict['model']}")
+                else:
+                    contr_dict["index"] = libvirt_pcicontr.get_max_contr_indexes(
+                        vm_xml.VMXML.new_from_dumpxml(self.vm.name),
+                        contr_dict["type"], contr_dict["model"])[-1]
+                    self.test.log.debug(f"Assigned index {contr_dict['index']} to controller {i}: {contr_dict['model']}")
+            else:
+                self.test.log.debug(f"Index already assigned {contr_dict['index']} for controller {i}: {contr_dict['model']}")
             self.controller_dicts[i] = contr_dict
 
         self.test.log.debug(f"Prepared controllers according to {self.controller_dicts}")

--- a/provider/viommu/viommu_base.py
+++ b/provider/viommu/viommu_base.py
@@ -111,13 +111,30 @@ class VIOMMUTest(object):
 
     def parse_iface_dict(self):
         """
-        Parse iface_dict from params
+        Parse iface_dict from params, supporting both single dict and list of dicts
 
-        :return: The updated iface_dict
+        :return: The updated iface_dict or list of iface_dicts based on type of input
         """
+        # generate mac address, if it is needed in iface_dict
         mac_addr = utils_net.generate_mac_address_simple()
         iface_dict = eval(self.params.get("iface_dict", "{}"))
 
+        if isinstance(iface_dict, list):
+            result = []
+            for single_iface_dict in iface_dict:
+                self._update_iface_dict_with_controller_info(single_iface_dict)
+                result.append(single_iface_dict)
+            return result
+        else:
+            self._update_iface_dict_with_controller_info(iface_dict)
+            return iface_dict
+
+    def _update_iface_dict_with_controller_info(self, iface_dict):
+        """
+        Update interface dictionary with controller addressing information
+
+        :param iface_dict: Interface dictionary to update with controller info
+        """
         if self.controller_dicts and iface_dict:
             iface_bus = "%0#4x" % int(self.controller_dicts[-1].get("index"))
             iface_attrs = {"bus": iface_bus}
@@ -129,7 +146,6 @@ class VIOMMUTest(object):
 
             iface_dict.update({"address": {"attrs": iface_attrs}})
         self.test.log.debug("iface_dict: %s.", iface_dict)
-        return iface_dict
 
     def prepare_controller(self):
         """

--- a/provider/viommu/viommu_base.py
+++ b/provider/viommu/viommu_base.py
@@ -192,19 +192,13 @@ class VIOMMUTest(object):
             self.test.log.debug(f"Final controller config: {contr_dict}")
             libvirt_vmxml.modify_vm_device(
                 vm_xml.VMXML.new_from_dumpxml(self.vm.name), "controller",
-                contr_dict, 100)
+                contr_dict)
             # Only assign index if it wasn't already assigned
             if "index" not in contr_dict:
-                # Check if target busNr is specified and use it as index
-                if contr_dict.get("target", {}).get("busNr"):
-                    target_bus = int(contr_dict["target"]["busNr"])
-                    contr_dict["index"] = target_bus
-                    self.test.log.debug(f"Using target busNr {target_bus} as index for controller {i}: {contr_dict['model']}")
-                else:
-                    contr_dict["index"] = libvirt_pcicontr.get_max_contr_indexes(
-                        vm_xml.VMXML.new_from_dumpxml(self.vm.name),
-                        contr_dict["type"], contr_dict["model"])[-1]
-                    self.test.log.debug(f"Assigned index {contr_dict['index']} to controller {i}: {contr_dict['model']}")
+                contr_dict["index"] = libvirt_pcicontr.get_max_contr_indexes(
+                    vm_xml.VMXML.new_from_dumpxml(self.vm.name),
+                    contr_dict["type"], contr_dict["model"])[-1]
+                self.test.log.debug(f"Assigned index {contr_dict['index']} to controller {i}: {contr_dict['model']}")
             else:
                 self.test.log.debug(f"Index already assigned {contr_dict['index']} for controller {i}: {contr_dict['model']}")
             self.controller_dicts[i] = contr_dict

--- a/provider/viommu/viommu_base.py
+++ b/provider/viommu/viommu_base.py
@@ -160,10 +160,13 @@ class VIOMMUTest(object):
             contr_dict = self.controller_dicts[i]
             pre_controller = contr_dict.get("pre_controller")
             if pre_controller:
+                self.test.log.debug(f"Processing controller {i}: {contr_dict}")
+                self.test.log.debug(f"Looking for pre_controller: {pre_controller}")
                 pre_contrs = list(
                     filter(None, [c.get("index") for c in self.controller_dicts
                                   if c["type"] == contr_dict["type"] and
                                   c["model"] == pre_controller]))
+                self.test.log.debug(f"Found pre_contrs: {pre_contrs}")
                 if pre_contrs:
                     pre_idx = pre_contrs[0]
                 else:

--- a/provider/viommu/viommu_base.py
+++ b/provider/viommu/viommu_base.py
@@ -108,6 +108,7 @@ class VIOMMUTest(object):
         libvirt_version.is_libvirt_feature_supported(self.params)
         new_xml = vm_xml.VMXML.new_from_inactive_dumpxml(self.vm.name)
         self.orig_config_xml = new_xml.copy()
+        self.test.log.debug("Original VM configuration backed up for restore")
 
     def parse_iface_dict(self):
         """
@@ -259,3 +260,4 @@ class VIOMMUTest(object):
         if self.vm.is_alive():
             self.vm.destroy(gracefully=False)
         self.orig_config_xml.sync()
+        self.test.log.debug("VM configuration restored to original state")


### PR DESCRIPTION

- Enhanced VIOMMUTest.parse_iface_dict() to handle both single dict and list of dicts
- Added _update_iface_dict_with_controller_info() helper method for maintainability
- Updated iommu_device_settings.py to handle multiple interfaces in modify_vm_device()
- Added two new test configurations for multiple VFIO interfaces:
  * Case 10: Multiple VFIO interfaces under pcie-root-port
  * Case 11: Multiple VFIO interfaces with pcie-expander-bus
- Maintained backward compatibility with existing single interface configurations
- All changes pass inspekt code quality checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added two VFIO scenarios for multi-device testing: PCIe root-port and expander-bus variants.
  - Support for multiple interface entries with automatic controller/address assignment and PCIe-bridge slot handling.

- Bug Fixes
  - Fixed config key typo (virtio_multi_devices).
  - Improved VM session and serial console setup/cleanup for reliable multi-interface management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->