### PR TITLE
migration: Add case about vm I/O error during migration

### DIFF
--- a/libvirt/tests/cfg/migration/migration_misc/vm_io_error.cfg
+++ b/libvirt/tests/cfg/migration/migration_misc/vm_io_error.cfg
@@ -1,0 +1,91 @@
+- migration.migration_misc.vm_io_error:
+    type = vm_io_error
+    migration_setup = 'yes'
+    storage_type = 'nfs'
+    setup_local_nfs = 'yes'
+    disk_type = "file"
+    disk_source_protocol = "netfs"
+    mnt_path_name = ${nfs_mount_dir}
+    # Console output can only be monitored via virsh console output
+    only_pty = True
+    take_regular_screendumps = no
+    # SSH connection time out
+    ssh_timeout = 60
+    # Local URI
+    virsh_migrate_connect_uri = 'qemu:///system'
+    virsh_migrate_dest_state = "running"
+    virsh_migrate_src_state = "shut off"
+    image_convert = 'no'
+    server_ip = "${migrate_dest_host}"
+    server_user = "root"
+    server_pwd = "${migrate_dest_pwd}"
+    client_ip = "${migrate_source_host}"
+    client_user = "root"
+    client_pwd = "${migrate_source_pwd}"
+    status_error = "no"
+    virsh_migrate_extra = "--undefinesource --persistent --bandwidth 20"
+    migrate_desturi_port = "16509"
+    migrate_desturi_type = "tcp"
+    virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
+    start_vm = "no"
+    loop_disk = "/var/tmp/vm_io_error_loop_disk.img"
+    loop_export_dir = "/var/tmp/vm_io_error_loop_export"
+    loop_mnt_dir = "/var/tmp/vm_io_error_loop_mnt"
+    second_disk = "${loop_mnt_dir}/vm_io_error_second_disk.qcow2"
+    action_during_mig = '[{"func": "dd_vm_disk", "after_event": "iteration: '1'", "func_param": "params"}]'
+    dev_name = "vdb"
+    check_network_accessibility_after_mig = "no"
+    simple_disk_check_after_mig = "no"
+    variants:
+        - p2p:
+            virsh_migrate_options = '--live --p2p --verbose'
+        - non_p2p:
+            virsh_migrate_options = '--live --verbose'
+    variants:
+        - with_percopy:
+    variants:
+        - no_space:
+    variants:
+        - error_policy_stop_and_cache_mode_none:
+            error_policy = "stop"
+            cache_mode = "none"
+            variants:
+                - with_abort_on_error:
+                    virsh_migrate_extra = "--undefinesource --persistent --bandwidth 20 --abort-on-error"
+                    status_error = "yes"
+                    err_msg = "job 'migration out' failed due to I/O error"
+                    virsh_migrate_dest_state = "nonexist"
+                    virsh_migrate_src_state = "paused"
+                    expected_event_src = ["io-error", "lifecycle.*Suspended I/O Error"]
+                    expected_event_target = ["lifecycle.*Started Migrated", "lifecycle.*Stopped Failed"]
+                - without_abort_on_error:
+                    virsh_migrate_src_state = "nonexist"
+                    virsh_migrate_dest_state = "paused"
+                    expected_event_src = ["migration-iteration", "io-error.*pause", "lifecycle.*Suspended I/O Error", "lifecycle.*Stopped Migrated", "job-completed"]
+                    expected_event_target = ["lifecycle.*Started Migrated", "lifecycle.*Resumed Migrated", "io-error", "lifecycle.*Suspended I/O Error"]
+        - error_policy_stop_and_cache_mode_writeback:
+            error_policy = "stop"
+            cache_mode = "writeback"
+            status_error = "yes"
+            virsh_migrate_dest_state = "nonexist"
+            virsh_migrate_src_state = "paused"
+            expected_event_src = ["io-error", "lifecycle.*Suspended I/O Error"]
+            expected_event_target = ["lifecycle.*Started Migrated", "lifecycle.*Stopped Failed"]
+            variants:
+                - with_abort_on_error:
+                    virsh_migrate_extra = "--undefinesource --persistent --bandwidth 20 --abort-on-error"
+                    err_msg = "job 'migration out' failed due to I/O error"
+                - without_abort_on_error:
+                    err_msg = "Error in migration completion: No space left on device"
+        - error_policy_report_and_cache_mode_none:
+            error_policy = "report"
+            cache_mode = "none"
+            virsh_migrate_src_state = "nonexist"
+            virsh_migrate_dest_state = "running"
+            expected_event_src = ["migration-iteration", "io-error.*report", "lifecycle.*Suspended Migrated", "lifecycle.*Stopped Migrated", "job-completed"]
+            expected_event_target = ["lifecycle.*Started Migrated", "lifecycle.*Resumed Migrated"]
+            variants:
+                - with_abort_on_error:
+                    virsh_migrate_extra = "--undefinesource --persistent --bandwidth 20 --abort-on-error"
+                - without_abort_on_error:
+    disk_dict = {"type_name": "file", "driver": {"name": "qemu", "type": "qcow2", "cache": "${cache_mode}", "error_policy": "${error_policy}"}, "device": "disk", "target": {"dev": "${dev_name}", "bus": "virtio"}, "source": {"attrs": {"file": "${second_disk}"}}}

--- a/libvirt/tests/src/migration/migration_misc/vm_io_error.py
+++ b/libvirt/tests/src/migration/migration_misc/vm_io_error.py
@@ -1,0 +1,134 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright Redhat
+#
+#   SPDX-License-Identifier: GPL-2.0
+#
+#   Author: Liping Cheng <lcheng@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+import os
+
+from avocado.utils import process
+
+from virttest import remote
+from virttest import utils_disk
+from virttest import utils_misc
+
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_disk
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+from provider.migration import base_steps
+from provider.migration import migration_base
+
+
+def prepare_second_disk(params, test):
+    """
+    Prepare second disk for the VM
+
+    :param params: Dictionary with the test parameters
+    :param test: test object
+    """
+    loop_disk = params.get("loop_disk")
+    loop_export_dir = params.get("loop_export_dir")
+    loop_mnt_dir = params.get("loop_mnt_dir")
+
+    if not os.path.exists(loop_export_dir):
+        os.mkdir(loop_export_dir)
+    if not os.path.exists(loop_mnt_dir):
+        os.mkdir(loop_mnt_dir)
+
+    process.run(f"truncate -s 30M {loop_disk}", shell=True, ignore_status=False)
+    process.run(f"losetup /dev/loop0 {loop_disk}", shell=True, ignore_status=False)
+    process.run(f"mkfs.ext4 /dev/loop0", shell=True, ignore_status=False)
+    process.run(f"mount /dev/loop0 {loop_export_dir}", shell=True, ignore_status=False)
+    libvirt.setup_or_cleanup_nfs(True, mount_dir=loop_mnt_dir, is_mount=True, export_dir=loop_export_dir)
+
+    libvirt_disk.create_disk("file", disk_format="qcow2", path=params.get("second_disk"), size="100M")
+
+    cmd = f"mkdir -p {loop_mnt_dir}"
+    server_ip = params.get("server_ip")
+    server_user = params.get("server_user")
+    server_pwd = params.get("server_pwd")
+    remote_session = remote.remote_login("ssh", params.get("server_ip"), "22",
+                                         params.get("server_user"),
+                                         params.get("server_pwd"),
+                                         r'[$#%]')
+    utils_misc.make_dirs(loop_mnt_dir, remote_session)
+    utils_disk.mount((params.get("client_ip") + ":" + loop_export_dir), loop_mnt_dir, session=remote_session)
+    remote_session.close()
+
+
+def run(test, params, env):
+    """
+    This case is to verify that if vm I/O error occurs during migration,
+    migration will succeed or fail depending on the vm disk configuration,
+    migration flag, etc
+
+    :param test: test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment.
+    """
+    def setup_test():
+        """
+        Setup steps
+
+        """
+        test.log.info("Setup steps for cases.")
+        prepare_second_disk(params, test)
+        migration_obj.setup_connection()
+
+        vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+        vmxml.add_device(libvirt_vmxml.create_vm_device_by_type("disk", eval(params.get("disk_dict"))))
+        vmxml.sync()
+        vm.start()
+        vm.wait_for_login().close()
+
+    def cleanup_test():
+        """
+        Cleanup steps for cases
+
+        """
+        test.log.info("Cleanup steps for cases.")
+        loop_disk = params.get("loop_disk")
+        loop_export_dir = params.get("loop_export_dir")
+        loop_mnt_dir = params.get("loop_mnt_dir")
+        client_ip = params.get("client_ip")
+
+        migration_obj.cleanup_connection()
+        remote_session = remote.remote_login("ssh", params.get("server_ip"), "22",
+                                             params.get("server_user"),
+                                             params.get("server_pwd"),
+                                             r'[$#%]')
+        utils_disk.umount(f"{client_ip}:{loop_export_dir}", loop_mnt_dir, session=remote_session)
+        remote_session.close()
+        remote.run_remote_cmd("rm -rf %s" % loop_mnt_dir, params)
+
+        process.run(f"umount {loop_mnt_dir}", shell=True, verbose=True)
+        process.run(f"exportfs -r", shell=True)
+        process.run(f"umount {loop_export_dir}", shell=True)
+        process.run(f"losetup -d /dev/loop0", shell=True)
+
+        utils_misc.safe_rmdir(loop_mnt_dir)
+        utils_misc.safe_rmdir(loop_export_dir)
+        process.run(f"rm -rf {loop_disk}", shell=True, ignore_status=True)
+
+    vm_name = params.get("migrate_main_vm")
+    virsh_session = None
+    remote_virsh_session = None
+
+    vm = env.get_vm(vm_name)
+    migration_obj = base_steps.MigrationBase(test, vm, params)
+    params.update({"migration_obj": migration_obj})
+
+    try:
+        setup_test()
+        virsh_session, remote_virsh_session = migration_base.monitor_event(params)
+        migration_obj.run_migration()
+        migration_obj.verify_default()
+        migration_base.check_event_output(params, test, virsh_session, remote_virsh_session)
+    finally:
+        cleanup_test()

--- a/provider/migration/migration_base.py
+++ b/provider/migration/migration_base.py
@@ -817,3 +817,21 @@ def update_port_for_firewall_rule(params):
     migration_port = ret.stdout_text.strip().split("\n")[0].split("    ")[4].split(':')[-1]
     params.update({"firewall_rule_on_dest": firewall_rule_on_dest % migration_port})
     params.update({"firewall_rule_on_src": firewall_rule_on_src % migration_port})
+
+
+def dd_vm_disk(params):
+    """
+    dd vm's disk
+
+    :param params: dictionary with the test parameter, get dest uri and migration object
+    """
+    migration_obj = params.get("migration_obj")
+    dev_name = params.get("dev_name")
+
+    migration_obj.vm.cleanup_serial_console()
+    migration_obj.vm.create_serial_console()
+    vm_session = migration_obj.vm.wait_for_serial_login(timeout=120)
+    vm_session.cmd(f"mkfs.ext4 /dev/{dev_name}")
+    vm_session.cmd(f"mount /dev/{dev_name} /mnt")
+    vm_session.cmd(f"nohup sh -c 'sleep 2 && dd if=/dev/urandom of=/mnt/test.data bs=1M count=100' > /dev/null 2>&1 &")
+    vm_session.close()


### PR DESCRIPTION
This case is to verify that if vm I/O error occurs during migration, migration will succeed or fail depending on the vm disk configuration, migration flag, etc.

VIRT-298402 - [VM migration] vm I/O error during migration

Test result:
 (01/12) type_specific.io-github-autotest-libvirt.migration.migration_misc.vm_io_error.error_policy_stop_and_cache_mode_none.with_abort_on_error.no_space.with_percopy.p2p: STARTED
 (01/12) type_specific.io-github-autotest-libvirt.migration.migration_misc.vm_io_error.error_policy_stop_and_cache_mode_none.with_abort_on_error.no_space.with_percopy.p2p: PASS (189.04 s)
 (02/12) type_specific.io-github-autotest-libvirt.migration.migration_misc.vm_io_error.error_policy_stop_and_cache_mode_none.with_abort_on_error.no_space.with_percopy.non_p2p: STARTED
 (02/12) type_specific.io-github-autotest-libvirt.migration.migration_misc.vm_io_error.error_policy_stop_and_cache_mode_none.with_abort_on_error.no_space.with_percopy.non_p2p: PASS (187.56 s)
 (03/12) type_specific.io-github-autotest-libvirt.migration.migration_misc.vm_io_error.error_policy_stop_and_cache_mode_none.without_abort_on_error.no_space.with_percopy.p2p: STARTED
 (03/12) type_specific.io-github-autotest-libvirt.migration.migration_misc.vm_io_error.error_policy_stop_and_cache_mode_none.without_abort_on_error.no_space.with_percopy.p2p: PASS (215.00 s)
 (04/12) type_specific.io-github-autotest-libvirt.migration.migration_misc.vm_io_error.error_policy_stop_and_cache_mode_none.without_abort_on_error.no_space.with_percopy.non_p2p: STARTED
 (04/12) type_specific.io-github-autotest-libvirt.migration.migration_misc.vm_io_error.error_policy_stop_and_cache_mode_none.without_abort_on_error.no_space.with_percopy.non_p2p: PASS (214.96 s)
 (05/12) type_specific.io-github-autotest-libvirt.migration.migration_misc.vm_io_error.error_policy_stop_and_cache_mode_writeback.with_abort_on_error.no_space.with_percopy.p2p: STARTED
 (05/12) type_specific.io-github-autotest-libvirt.migration.migration_misc.vm_io_error.error_policy_stop_and_cache_mode_writeback.with_abort_on_error.no_space.with_percopy.p2p: PASS (187.02 s)
 (06/12) type_specific.io-github-autotest-libvirt.migration.migration_misc.vm_io_error.error_policy_stop_and_cache_mode_writeback.with_abort_on_error.no_space.with_percopy.non_p2p: STARTED
 (06/12) type_specific.io-github-autotest-libvirt.migration.migration_misc.vm_io_error.error_policy_stop_and_cache_mode_writeback.with_abort_on_error.no_space.with_percopy.non_p2p: PASS (186.56 s)
 (07/12) type_specific.io-github-autotest-libvirt.migration.migration_misc.vm_io_error.error_policy_stop_and_cache_mode_writeback.without_abort_on_error.no_space.with_percopy.p2p: STARTED
 (07/12) type_specific.io-github-autotest-libvirt.migration.migration_misc.vm_io_error.error_policy_stop_and_cache_mode_writeback.without_abort_on_error.no_space.with_percopy.p2p: PASS (214.06 s)
 (08/12) type_specific.io-github-autotest-libvirt.migration.migration_misc.vm_io_error.error_policy_stop_and_cache_mode_writeback.without_abort_on_error.no_space.with_percopy.non_p2p: STARTED
 (08/12) type_specific.io-github-autotest-libvirt.migration.migration_misc.vm_io_error.error_policy_stop_and_cache_mode_writeback.without_abort_on_error.no_space.with_percopy.non_p2p: PASS (214.96 s)
 (1/4) type_specific.io-github-autotest-libvirt.migration.migration_misc.vm_io_error.error_policy_report_and_cache_mode_none.with_abort_on_error.no_space.with_percopy.p2p: STARTED
 (1/4) type_specific.io-github-autotest-libvirt.migration.migration_misc.vm_io_error.error_policy_report_and_cache_mode_none.with_abort_on_error.no_space.with_percopy.p2p: PASS (218.33 s)
 (2/4) type_specific.io-github-autotest-libvirt.migration.migration_misc.vm_io_error.error_policy_report_and_cache_mode_none.with_abort_on_error.no_space.with_percopy.non_p2p: STARTED
 (2/4) type_specific.io-github-autotest-libvirt.migration.migration_misc.vm_io_error.error_policy_report_and_cache_mode_none.with_abort_on_error.no_space.with_percopy.non_p2p: PASS (219.25 s)
 (3/4) type_specific.io-github-autotest-libvirt.migration.migration_misc.vm_io_error.error_policy_report_and_cache_mode_none.without_abort_on_error.no_space.with_percopy.p2p: STARTED
 (3/4) type_specific.io-github-autotest-libvirt.migration.migration_misc.vm_io_error.error_policy_report_and_cache_mode_none.without_abort_on_error.no_space.with_percopy.p2p: PASS (216.89 s)
 (4/4) type_specific.io-github-autotest-libvirt.migration.migration_misc.vm_io_error.error_policy_report_and_cache_mode_none.without_abort_on_error.no_space.with_percopy.non_p2p: STARTED
 (4/4) type_specific.io-github-autotest-libvirt.migration.migration_misc.vm_io_error.error_policy_report_and_cache_mode_none.without_abort_on_error.no_space.with_percopy.non_p2p: PASS (218.09 s)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a VM I/O error migration scenario with configurable error policies (stop/report), cache modes (none/writeback), p2p and non-p2p flows, and abort-on-error variants; includes support for NFS-backed secondary disks and migration parameters.
  - Added a background disk-write utility to generate sustained guest I/O during migration.

- **Tests**
  - Added an end-to-end migration test that prepares loopback/NFS-backed storage, attaches an extra disk, runs migration variants, and performs robust setup/cleanup of mounts and temporary resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->