### PR TITLE
Refactor serial console sriov

### DIFF
--- a/libvirt/tests/src/sriov/failover/sriov_failover_at_dt_hostdev.py
+++ b/libvirt/tests/src/sriov/failover/sriov_failover_at_dt_hostdev.py
@@ -32,9 +32,7 @@ def run(test, params, env):
 
         test.log.info("TEST_STEP2: Start the VM")
         vm.start()
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm_session = vm.wait_for_serial_login(timeout=240)
+        vm_session = vm.wait_for_serial_login(timeout=240, recreate_serial_console=True)
 
         test.log.info("TEST_STEP3: Check interface quantity and network"
                       "accessibility.")

--- a/libvirt/tests/src/sriov/failover/sriov_failover_lifecycle.py
+++ b/libvirt/tests/src/sriov/failover/sriov_failover_lifecycle.py
@@ -29,9 +29,7 @@ def run(test, params, env):
 
         test.log.info("TEST_STEP2: Start the VM")
         vm.start()
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm_session = vm.wait_for_serial_login(timeout=240)
+        vm_session = vm.wait_for_serial_login(timeout=240, recreate_serial_console=True)
 
         test.log.info("TEST_STEP3: Check network accessibility")
         check_points.check_vm_network_accessed(vm_session,
@@ -67,9 +65,7 @@ def run(test, params, env):
         virsh.restore(save_file, debug=True, ignore_status=False)
         if not libvirt.check_vm_state(vm_name, "running"):
             test.fail("The guest should be running after executing 'virsh restore'.")
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm_session = vm.wait_for_serial_login()
+        vm_session = vm.wait_for_serial_login(recreate_serial_console=True)
 
         test.log.info("TEST_STEP7: Check network accessibility")
         check_points.check_vm_network_accessed(vm_session,
@@ -80,9 +76,7 @@ def run(test, params, env):
         test.log.info("TEST_STEP8: Managedsave the VM.")
         virsh.managedsave(vm_name, debug=True, ignore_status=False, timeout=10)
         vm.start()
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm_session = vm.wait_for_serial_login()
+        vm_session = vm.wait_for_serial_login(recreate_serial_console=True)
 
         test.log.info("TEST_STEP9: Check network accessibility")
         check_points.check_vm_network_accessed(vm_session,

--- a/libvirt/tests/src/sriov/failover/sriov_failover_migration.py
+++ b/libvirt/tests/src/sriov/failover/sriov_failover_migration.py
@@ -72,9 +72,7 @@ def run(test, params, env):
         """
         Verify network function
         """
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm_session = vm.wait_for_serial_login(timeout=240)
+        vm_session = vm.wait_for_serial_login(timeout=240, recreate_serial_console=True)
         check_points.check_vm_iface_num(vm_session, expr_iface_no,
                                         timeout=40, first=15)
 

--- a/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_device_vfio_variant_driver.py
+++ b/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_device_vfio_variant_driver.py
@@ -103,8 +103,6 @@ def run(test, params, env):
         test.log.debug("Verify: Check VF driver successfully after detaching hostdev interface/device - PASS")
         virsh.reboot(vm.name, ignore_status=False, debug=True)
         test.log.debug("Verify: VM reboot is successful after detaching hostdev interface/device - PASS")
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm.wait_for_serial_login().close()
+        vm.wait_for_serial_login(recreate_serial_console=True).close()
     finally:
         orig_vm_xml.sync()

--- a/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_device_with_flags.py
+++ b/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_device_with_flags.py
@@ -76,9 +76,7 @@ def run(test, params, env):
         if start_vm:
             if not vm.is_alive():
                 vm.start()
-            vm.cleanup_serial_console()
-            vm.create_serial_console()
-            vm_session = vm.wait_for_serial_login(timeout=240)
+            vm_session = vm.wait_for_serial_login(timeout=240, recreate_serial_console=True)
 
         libvirt_vfio.check_vfio_pci(sriov_test_obj.vf_pci, True)
 

--- a/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_interface_with_flags.py
+++ b/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_interface_with_flags.py
@@ -54,9 +54,7 @@ def run(test, params, env):
         if start_vm:
             if not vm.is_alive():
                 vm.start()
-            vm.cleanup_serial_console()
-            vm.create_serial_console()
-            vm_session = vm.wait_for_serial_login(timeout=240)
+            vm_session = vm.wait_for_serial_login(timeout=240, recreate_serial_console=True)
 
         mac_addr = utils_net.generate_mac_address_simple()
         alias_name = 'ua-' + str(uuid.uuid4())

--- a/libvirt/tests/src/sriov/plug_unplug/sriov_attach_released_hostdev.py
+++ b/libvirt/tests/src/sriov/plug_unplug/sriov_attach_released_hostdev.py
@@ -20,9 +20,7 @@ def run(test, params, env):
         :return: The session of VM
         """
         vm.start()
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        return vm.wait_for_serial_login(timeout=240)
+        return vm.wait_for_serial_login(timeout=240, recreate_serial_console=True)
 
     def run_test():
         """

--- a/libvirt/tests/src/sriov/vIOMMU/hotplug_device_with_iommu_enabled.py
+++ b/libvirt/tests/src/sriov/vIOMMU/hotplug_device_with_iommu_enabled.py
@@ -64,10 +64,9 @@ def run(test, params, env):
         test.log.info("TEST_STEP: Start the VM.")
         if not vm.is_alive():
             vm.start()
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
         vm_session = vm.wait_for_serial_login(
-            timeout=int(params.get('login_timeout')))
+            timeout=int(params.get('login_timeout')),
+            recreate_serial_console=True)
         pre_devices = viommu_base.get_devices_pci(vm_session, test_devices)
         if disk_dict:
             test.log.info("TEST_STEP: Attach a disk device to VM.")

--- a/libvirt/tests/src/sriov/vIOMMU/intel_iommu_aw_bits.py
+++ b/libvirt/tests/src/sriov/vIOMMU/intel_iommu_aw_bits.py
@@ -28,10 +28,9 @@ def run(test, params, env):
             if err_msg:
                 libvirt.check_result(result, err_msg)
             return
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
         vm_session = vm.wait_for_serial_login(
-            timeout=int(params.get('login_timeout')))
+            timeout=int(params.get('login_timeout')),
+            recreate_serial_console=True)
         test.log.debug(vm_xml.VMXML.new_from_dumpxml(vm.name))
 
         test.log.info("TEST_STEP: Check dmesg message.")

--- a/libvirt/tests/src/sriov/vIOMMU/intel_iommu_with_dma_translation.py
+++ b/libvirt/tests/src/sriov/vIOMMU/intel_iommu_with_dma_translation.py
@@ -32,9 +32,7 @@ def run(test, params, env):
         test.log.debug("The current guest xml ls: %s",
                        virsh.dumpxml(vm_name).stdout_text)
         test.log.info("TEST STEP3: Check the message for iommu group and DMA.")
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm_session = vm.wait_for_serial_login(timeout=1000)
+        vm_session = vm.wait_for_serial_login(timeout=1000, recreate_serial_console=True)
         dma_status, dma_o = vm_session.cmd_status_output("dmesg | grep -i 'Not attempting DMA translation'")
         iommu_status, iommu_o = vm_session.cmd_status_output("dmesg | grep -i 'Adding to iommu group'")
         if dma_translation == "on" and (not dma_status or iommu_status):

--- a/libvirt/tests/src/sriov/vIOMMU/iommu_device_settings.py
+++ b/libvirt/tests/src/sriov/vIOMMU/iommu_device_settings.py
@@ -34,10 +34,9 @@ def run(test, params, env):
         test_obj.setup_iommu_test(iommu_dict=iommu_dict, cleanup_ifaces=cleanup_ifaces)
         test_obj.prepare_controller()
         vm.start()
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
         vm_session = vm.wait_for_serial_login(
-            timeout=int(params.get('login_timeout')))
+            timeout=int(params.get('login_timeout')),
+            recreate_serial_console=True)
         pre_devices = viommu_base.get_devices_pci(vm_session, test_devices)
         vm.destroy()
 

--- a/libvirt/tests/src/sriov/vIOMMU/viommu_unload_driver.py
+++ b/libvirt/tests/src/sriov/vIOMMU/viommu_unload_driver.py
@@ -111,9 +111,7 @@ def run(test, params, env):
         time.sleep(5)
 
         test.log.info("TEST_STEP: Unload and load the driver.")
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm_serial = vm.wait_for_serial_login(timeout=120)
+        vm_serial = vm.wait_for_serial_login(timeout=120, recreate_serial_console=True)
         while not all_threads_done(threads):
             vm_serial.cmd("modprobe -r %s" % nic_driver, timeout=120)
             time.sleep(2)

--- a/libvirt/tests/src/sriov/vfio/sriov_migration_vfio_variant_driver.py
+++ b/libvirt/tests/src/sriov/vfio/sriov_migration_vfio_variant_driver.py
@@ -33,9 +33,7 @@ def run(test, params, env):
         dev_names = sriov_vfio.attach_dev(vm, params)
         if not vm.is_alive():
             vm.start()
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm.wait_for_serial_login().close()
+        vm.wait_for_serial_login(recreate_serial_console=True).close()
         time.sleep(30)
 
         test.log.debug(f'VMXML of {vm_name}:\n{virsh.dumpxml(vm_name).stdout_text}')

--- a/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_exclusive_check_running_domain.py
+++ b/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_exclusive_check_running_domain.py
@@ -30,9 +30,7 @@ def run(test, params, env):
         :return: The session of VM
         """
         vm.start()
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        return vm.wait_for_serial_login(timeout=240)
+        return vm.wait_for_serial_login(timeout=240, recreate_serial_console=True)
 
     def run_start_2nd_vm():
         """

--- a/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_iommu_at_dt_hostdev.py
+++ b/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_iommu_at_dt_hostdev.py
@@ -31,9 +31,7 @@ def run(test, params, env):
 
         test.log.info("TEST_STEP2: Start the VM with iommu enabled")
         vm.start()
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm_session = vm.wait_for_serial_login(timeout=240)
+        vm_session = vm.wait_for_serial_login(timeout=240, recreate_serial_console=True)
 
         test.log.info("TEST_STEP3: Check network accessibility")
         br_name = None

--- a/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_managedsave.py
+++ b/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_managedsave.py
@@ -25,9 +25,7 @@ def run(test, params, env):
 
         test.log.info("TEST_STEP2: Start the VM")
         vm.start()
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm.wait_for_serial_login(timeout=240).close()
+        vm.wait_for_serial_login(timeout=240, recreate_serial_console=True).close()
 
         test.log.info("TEST_STEP3: Managedsave the vm")
         result = virsh.managedsave(vm.name, debug=True)

--- a/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_reboot.py
+++ b/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_reboot.py
@@ -52,9 +52,7 @@ def run(test, params, env):
 
         test.log.info("TEST_STEP2: Start the VM")
         vm.start()
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm_session = vm.wait_for_serial_login(timeout=240)
+        vm_session = vm.wait_for_serial_login(timeout=240, recreate_serial_console=True)
         if params.get("check_ping_time") == "yes":
             avg_ping_time = get_avg_ping_time(vm_session, params)
 

--- a/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_suspend_resume.py
+++ b/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_suspend_resume.py
@@ -29,9 +29,7 @@ def run(test, params, env):
 
         test.log.info("TEST_STEP2: Start the VM")
         vm.start()
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm_session = vm.wait_for_serial_login(timeout=240)
+        vm_session = vm.wait_for_serial_login(timeout=240, recreate_serial_console=True)
 
         test.log.info("TEST_STEP3: Suspend VM and check vm's state.")
         virsh.suspend(vm.name, debug=True, ignore_status=False)

--- a/provider/interface/check_points.py
+++ b/provider/interface/check_points.py
@@ -21,9 +21,7 @@ def check_network_accessibility(vm, **kwargs):
     """
     if kwargs.get("recreate_vm_session", "yes") == "yes":
         logging.debug("Recreating vm session...")
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm_session = vm.wait_for_serial_login()
+        vm_session = vm.wait_for_serial_login(recreate_serial_console=True)
     else:
         vm_session = vm.session
 

--- a/provider/migration/base_steps.py
+++ b/provider/migration/base_steps.py
@@ -94,9 +94,7 @@ class MigrationBase(object):
         if start_vm == "yes" and not self.vm.is_alive():
             self.vm.start()
             if use_console:
-                self.vm.cleanup_serial_console()
-                self.vm.create_serial_console()
-                self.vm.wait_for_serial_login().close()
+                self.vm.wait_for_serial_login(recreate_serial_console=True).close()
             else:
                 self.vm.wait_for_login().close()
         if self.check_cont_ping:
@@ -299,9 +297,7 @@ class MigrationBase(object):
             self.test.log.debug("Checking the output of %s", self.check_cont_ping_log)
             if check_on_dest:
                 backup_uri, self.vm.connect_uri = self.vm.connect_uri, dest_uri
-            self.vm.cleanup_serial_console()
-            self.vm.create_serial_console()
-            vm_session = self.vm.wait_for_serial_login(timeout=360)
+            vm_session = self.vm.wait_for_serial_login(timeout=360, recreate_serial_console=True)
             vm_session.cmd(
                 "> {0}; sleep 5; grep time= {0}".format(self.check_cont_ping_log))
             o = vm_session.cmd_output(f"cat {self.check_cont_ping_log}")

--- a/provider/migration/migration_base.py
+++ b/provider/migration/migration_base.py
@@ -261,10 +261,8 @@ def poweroff_vm(params):
 
     if poweroff_vm_dest:
         dest_uri = params.get("virsh_migrate_desturi")
-        migration_obj.vm.cleanup_serial_console()
         backup_uri, migration_obj.vm.connect_uri = migration_obj.vm.connect_uri, dest_uri
-        migration_obj.vm.create_serial_console()
-        remote_vm_session = migration_obj.vm.wait_for_serial_login(timeout=120)
+        remote_vm_session = migration_obj.vm.wait_for_serial_login(timeout=120, recreate_serial_console=True)
         remote_vm_session.cmd("poweroff", ignore_all_errors=True)
         remote_vm_session.close()
         migration_obj.vm.cleanup_serial_console()
@@ -780,9 +778,7 @@ def write_vm_disk_on_dest(params):
     migration_obj = params.get("migration_obj")
 
     backup_uri, migration_obj.vm.connect_uri = migration_obj.vm.connect_uri, desturi
-    migration_obj.vm.cleanup_serial_console()
-    migration_obj.vm.create_serial_console()
-    vm_session = migration_obj.vm.wait_for_serial_login(timeout=120)
+    vm_session = migration_obj.vm.wait_for_serial_login(timeout=120, recreate_serial_console=True)
     vm_session.cmd("while true; do echo 'do disk I/O error test' >> /tmp/disk_io_error_test; sleep 1; done &")
     vm_session.close()
     migration_obj.vm.connect_uri = backup_uri

--- a/provider/save/save_base.py
+++ b/provider/save/save_base.py
@@ -18,9 +18,7 @@ def pre_save_setup(vm, serial=False):
     :return: a tuple of pid of ping and uptime since when
     """
     if serial:
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        session = vm.wait_for_serial_login()
+        session = vm.wait_for_serial_login(recreate_serial_console=True)
     else:
         session = vm.wait_for_login()
     upsince = session.cmd_output('uptime --since').strip()
@@ -48,9 +46,7 @@ def post_save_check(vm, pid_ping, upsince, serial=False):
     :param serial: Whether to use a serial connection
     """
     if serial:
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        session = vm.wait_for_serial_login()
+        session = vm.wait_for_serial_login(recreate_serial_console=True)
     else:
         session = vm.wait_for_login()
     upsince_restore = session.cmd_output('uptime --since').strip()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated serial console session management across test and provider modules by replacing explicit cleanup and recreation sequences with a single `wait_for_serial_login()` call using a new parameter flag. Applied consistently across 20+ files in the libvirt test suite and migration/save provider modules, simplifying the codebase while maintaining existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->