### PR TITLE
Use recreate_serial_console in BIOS boot tests

### DIFF
--- a/libvirt/tests/src/bios/boot_order_ovmf.py
+++ b/libvirt/tests/src/bios/boot_order_ovmf.py
@@ -23,18 +23,14 @@ def check_boot(vm, test, params):
     time.sleep(3)
     if not status_error:
         try:
-            vm.cleanup_serial_console()
-            vm.create_serial_console()
-            vm.wait_for_serial_login()
+            vm.wait_for_serial_login(recreate_serial_console=True)
         except Exception as error:
             test.fail(f"Test fail: {error}")
         else:
             test.log.debug("Succeed to boot %s", vm.name)
     else:
         try:
-            vm.cleanup_serial_console()
-            vm.create_serial_console()
-            vm.wait_for_serial_login()
+            vm.wait_for_serial_login(recreate_serial_console=True)
         except LoginTimeoutError as expected_e:
             test.log.debug(f"Got expected error message: {expected_e}")
         except Exception as e:

--- a/libvirt/tests/src/bios/boot_order_seabios.py
+++ b/libvirt/tests/src/bios/boot_order_seabios.py
@@ -270,18 +270,14 @@ def run(test, params, env):
                             internal_timeout=0.5)
                 else:
                     time.sleep(3)
-                    vm.cleanup_serial_console()
-                    vm.create_serial_console()
-                    vm.wait_for_serial_login(timeout=15)
+                    vm.wait_for_serial_login(timeout=15, recreate_serial_console=True)
             except Exception as e:
                 test.fail(f"Test fail: {str(e)}")
             else:
                 test.log.debug("Succeed to boot %s", vm_name)
         else:
             try:
-                vm.cleanup_serial_console()
-                vm.create_serial_console()
-                vm.wait_for_serial_login(timeout=15)
+                vm.wait_for_serial_login(timeout=15, recreate_serial_console=True)
             except LoginTimeoutError as expected_e:
                 test.log.debug("Got expected error message: %s", str(expected_e))
             except Exception as exc:

--- a/provider/interface/check_points.py
+++ b/provider/interface/check_points.py
@@ -21,9 +21,7 @@ def check_network_accessibility(vm, **kwargs):
     """
     if kwargs.get("recreate_vm_session", "yes") == "yes":
         logging.debug("Recreating vm session...")
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm_session = vm.wait_for_serial_login()
+        vm_session = vm.wait_for_serial_login(recreate_serial_console=True)
     else:
         vm_session = vm.session
 

--- a/provider/migration/base_steps.py
+++ b/provider/migration/base_steps.py
@@ -93,9 +93,7 @@ class MigrationBase(object):
         if start_vm == "yes" and not self.vm.is_alive():
             self.vm.start()
             if use_console:
-                self.vm.cleanup_serial_console()
-                self.vm.create_serial_console()
-                self.vm.wait_for_serial_login().close()
+                self.vm.wait_for_serial_login(recreate_serial_console=True).close()
             else:
                 self.vm.wait_for_login().close()
         if self.check_cont_ping:
@@ -295,9 +293,7 @@ class MigrationBase(object):
             self.test.log.debug("Checking the output of %s", self.check_cont_ping_log)
             if check_on_dest:
                 backup_uri, self.vm.connect_uri = self.vm.connect_uri, dest_uri
-            self.vm.cleanup_serial_console()
-            self.vm.create_serial_console()
-            vm_session = self.vm.wait_for_serial_login(timeout=360)
+            vm_session = self.vm.wait_for_serial_login(timeout=360, recreate_serial_console=True)
             vm_session.cmd(
                 "> {0}; sleep 5; grep time= {0}".format(self.check_cont_ping_log))
             o = vm_session.cmd_output(f"cat {self.check_cont_ping_log}")

--- a/provider/migration/migration_base.py
+++ b/provider/migration/migration_base.py
@@ -257,10 +257,8 @@ def poweroff_vm(params):
 
     if poweroff_vm_dest:
         dest_uri = params.get("virsh_migrate_desturi")
-        migration_obj.vm.cleanup_serial_console()
         backup_uri, migration_obj.vm.connect_uri = migration_obj.vm.connect_uri, dest_uri
-        migration_obj.vm.create_serial_console()
-        remote_vm_session = migration_obj.vm.wait_for_serial_login(timeout=120)
+        remote_vm_session = migration_obj.vm.wait_for_serial_login(timeout=120, recreate_serial_console=True)
         remote_vm_session.cmd("poweroff", ignore_all_errors=True)
         remote_vm_session.close()
         migration_obj.vm.cleanup_serial_console()
@@ -776,9 +774,7 @@ def write_vm_disk_on_dest(params):
     migration_obj = params.get("migration_obj")
 
     backup_uri, migration_obj.vm.connect_uri = migration_obj.vm.connect_uri, desturi
-    migration_obj.vm.cleanup_serial_console()
-    migration_obj.vm.create_serial_console()
-    vm_session = migration_obj.vm.wait_for_serial_login(timeout=120)
+    vm_session = migration_obj.vm.wait_for_serial_login(timeout=120, recreate_serial_console=True)
     vm_session.cmd("while true; do echo 'do disk I/O error test' >> /tmp/disk_io_error_test; sleep 1; done &")
     vm_session.close()
     migration_obj.vm.connect_uri = backup_uri

--- a/provider/save/save_base.py
+++ b/provider/save/save_base.py
@@ -18,9 +18,7 @@ def pre_save_setup(vm, serial=False):
     :return: a tuple of pid of ping and uptime since when
     """
     if serial:
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        session = vm.wait_for_serial_login()
+        session = vm.wait_for_serial_login(recreate_serial_console=True)
     else:
         session = vm.wait_for_login()
     upsince = session.cmd_output('uptime --since').strip()
@@ -48,9 +46,7 @@ def post_save_check(vm, pid_ping, upsince, serial=False):
     :param serial: Whether to use a serial connection
     """
     if serial:
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        session = vm.wait_for_serial_login()
+        session = vm.wait_for_serial_login(recreate_serial_console=True)
     else:
         session = vm.wait_for_login()
     upsince_restore = session.cmd_output('uptime --since').strip()


### PR DESCRIPTION
Refactor BIOS boot order tests to use the recreate_serial_console parameter
instead of manually calling cleanup_serial_console() and
create_serial_console() before wait_for_serial_login().

This simplifies console management after VM boot operations, ensuring
proper console state for various boot scenarios including OVMF and SeaBIOS.

Modified test files:
- bios/boot_order_ovmf.py: Console after VM start for OVMF boot testing
- bios/boot_order_seabios.py: Console after VM start for SeaBIOS boot testing

Both tests handle console recreation after VM start operations where the
console needs to be reset to properly capture boot messages and login prompts.

Total: 2 files modified with 9 fewer lines of console management code.

Depends on: https://github.com/avocado-framework/avocado-vt/pull/4248
Depends on: https://github.com/autotest/tp-libvirt/pull/6596