### PR TITLE
Use recreate_serial_console in copy storage migration tests

### DIFF
--- a/libvirt/tests/src/migration_with_copy_storage/disk_io_load_in_vm.py
+++ b/libvirt/tests/src/migration_with_copy_storage/disk_io_load_in_vm.py
@@ -55,9 +55,7 @@ def run(test, params, env):
 
         test.log.info("Verify steps.")
         backup_uri, vm.connect_uri = vm.connect_uri, dest_uri
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        remote_vm_session = vm.wait_for_serial_login(timeout=360)
+        remote_vm_session = vm.wait_for_serial_login(timeout=360, recreate_serial_console=True)
         remote_vm_dmesg = remote_vm_session.cmd_output("dmesg")
         if "I/O error" in remote_vm_dmesg:
             test.fail(f"Found I/O error in guest dmesg: {remote_vm_dmesg}")

--- a/libvirt/tests/src/migration_with_copy_storage/migration_with_backingchain.py
+++ b/libvirt/tests/src/migration_with_copy_storage/migration_with_backingchain.py
@@ -147,10 +147,8 @@ def check_disk(params, vm):
     disk_target1 = params.get("disk_target1")
     disk_target2 = params.get("disk_target2")
 
-    vm.cleanup_serial_console()
     backup_uri, vm.connect_uri = vm.connect_uri, dest_uri
-    vm.create_serial_console()
-    remote_vm_session = vm.wait_for_serial_login(timeout=120)
+    remote_vm_session = vm.wait_for_serial_login(timeout=120, recreate_serial_console=True)
     utils_disk.linux_disk_check(remote_vm_session, disk_target1)
     utils_disk.linux_disk_check(remote_vm_session, disk_target2)
 

--- a/provider/interface/check_points.py
+++ b/provider/interface/check_points.py
@@ -21,9 +21,7 @@ def check_network_accessibility(vm, **kwargs):
     """
     if kwargs.get("recreate_vm_session", "yes") == "yes":
         logging.debug("Recreating vm session...")
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm_session = vm.wait_for_serial_login()
+        vm_session = vm.wait_for_serial_login(recreate_serial_console=True)
     else:
         vm_session = vm.session
 

--- a/provider/migration/base_steps.py
+++ b/provider/migration/base_steps.py
@@ -93,9 +93,7 @@ class MigrationBase(object):
         if start_vm == "yes" and not self.vm.is_alive():
             self.vm.start()
             if use_console:
-                self.vm.cleanup_serial_console()
-                self.vm.create_serial_console()
-                self.vm.wait_for_serial_login().close()
+                self.vm.wait_for_serial_login(recreate_serial_console=True).close()
             else:
                 self.vm.wait_for_login().close()
         if self.check_cont_ping:
@@ -295,9 +293,7 @@ class MigrationBase(object):
             self.test.log.debug("Checking the output of %s", self.check_cont_ping_log)
             if check_on_dest:
                 backup_uri, self.vm.connect_uri = self.vm.connect_uri, dest_uri
-            self.vm.cleanup_serial_console()
-            self.vm.create_serial_console()
-            vm_session = self.vm.wait_for_serial_login(timeout=360)
+            vm_session = self.vm.wait_for_serial_login(timeout=360, recreate_serial_console=True)
             vm_session.cmd(
                 "> {0}; sleep 5; grep time= {0}".format(self.check_cont_ping_log))
             o = vm_session.cmd_output(f"cat {self.check_cont_ping_log}")

--- a/provider/migration/migration_base.py
+++ b/provider/migration/migration_base.py
@@ -257,10 +257,8 @@ def poweroff_vm(params):
 
     if poweroff_vm_dest:
         dest_uri = params.get("virsh_migrate_desturi")
-        migration_obj.vm.cleanup_serial_console()
         backup_uri, migration_obj.vm.connect_uri = migration_obj.vm.connect_uri, dest_uri
-        migration_obj.vm.create_serial_console()
-        remote_vm_session = migration_obj.vm.wait_for_serial_login(timeout=120)
+        remote_vm_session = migration_obj.vm.wait_for_serial_login(timeout=120, recreate_serial_console=True)
         remote_vm_session.cmd("poweroff", ignore_all_errors=True)
         remote_vm_session.close()
         migration_obj.vm.cleanup_serial_console()
@@ -776,9 +774,7 @@ def write_vm_disk_on_dest(params):
     migration_obj = params.get("migration_obj")
 
     backup_uri, migration_obj.vm.connect_uri = migration_obj.vm.connect_uri, desturi
-    migration_obj.vm.cleanup_serial_console()
-    migration_obj.vm.create_serial_console()
-    vm_session = migration_obj.vm.wait_for_serial_login(timeout=120)
+    vm_session = migration_obj.vm.wait_for_serial_login(timeout=120, recreate_serial_console=True)
     vm_session.cmd("while true; do echo 'do disk I/O error test' >> /tmp/disk_io_error_test; sleep 1; done &")
     vm_session.close()
     migration_obj.vm.connect_uri = backup_uri

--- a/provider/save/save_base.py
+++ b/provider/save/save_base.py
@@ -18,9 +18,7 @@ def pre_save_setup(vm, serial=False):
     :return: a tuple of pid of ping and uptime since when
     """
     if serial:
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        session = vm.wait_for_serial_login()
+        session = vm.wait_for_serial_login(recreate_serial_console=True)
     else:
         session = vm.wait_for_login()
     upsince = session.cmd_output('uptime --since').strip()
@@ -48,9 +46,7 @@ def post_save_check(vm, pid_ping, upsince, serial=False):
     :param serial: Whether to use a serial connection
     """
     if serial:
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        session = vm.wait_for_serial_login()
+        session = vm.wait_for_serial_login(recreate_serial_console=True)
     else:
         session = vm.wait_for_login()
     upsince_restore = session.cmd_output('uptime --since').strip()


### PR DESCRIPTION
Refactor migration with copy storage tests to use the recreate_serial_console
parameter instead of manually calling cleanup_serial_console() and
create_serial_console() before wait_for_serial_login().

This simplifies console management when connecting to the migrated VM on the
destination host after switching the connection URI.

Modified test files:
- migration_with_copy_storage/migration_with_backingchain.py: Console to remote host
- migration_with_copy_storage/disk_io_load_in_vm.py: Console to remote host after migration

Both tests handle console recreation when switching from source to destination
host connection, where the old console must be cleaned up and recreated with
the new URI.

Total: 2 files modified with 4 fewer lines of console management code.