### PR TITLE
Use recreate_serial_console in network/interface tests

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domif_setlink_getlink.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domif_setlink_getlink.py
@@ -255,12 +255,11 @@ def run(test, params, env):
         error_msg = None
         if status_error == "no" and not post_action:
             # Close then establish a connection with the serial console
-            vm.cleanup_serial_console()
-            vm.create_serial_console()
             # Serial login the vm to check link status
             # Start vm check the link statue
             session = vm.wait_for_serial_login(username=username,
-                                               password=password)
+                                               password=password,
+                                               recreate_serial_console=True)
             guest_if_name = utils_net.get_linux_ifname(session, mac_address)
 
             # Check link state in guest

--- a/libvirt/tests/src/virtio/virtio_page_per_vq.py
+++ b/libvirt/tests/src/virtio/virtio_page_per_vq.py
@@ -99,9 +99,7 @@ def run(test, params, env):
             test.log.info("TEST_STEP1: hotplug %s device", device_type)
             start_guest()
             virsh.attach_device(vm_name, device_xml.xml, ignore_status=False, debug=True)
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm_session = vm.wait_for_serial_login()
+        vm_session = vm.wait_for_serial_login(recreate_serial_console=True)
 
         test.log.info("TEST_STEP2: check the attribute in %s xml", device_type)
         check_attribute()

--- a/libvirt/tests/src/virtual_interface/interface_update_device_negative.py
+++ b/libvirt/tests/src/virtual_interface/interface_update_device_negative.py
@@ -24,9 +24,7 @@ def run(test, params, env):
             libvirt_vmxml.modify_vm_device(vmxml, 'interface', pre_iface_dict)
         if start_vm and not vm.is_alive():
             vm.start()
-            vm.cleanup_serial_console()
-            vm.create_serial_console()
-            session = vm.wait_for_serial_login(timeout=int(params.get("login_timeout", 600)))
+            session = vm.wait_for_serial_login(timeout=int(params.get("login_timeout", 600)), recreate_serial_console=True)
             session.close()
         test.log.info("TEST_STEP: Update interface device.")
         interface_base.update_iface_device(vm, params)

--- a/libvirt/tests/src/virtual_network/iface_bridge.py
+++ b/libvirt/tests/src/virtual_network/iface_bridge.py
@@ -281,9 +281,7 @@ def run(test, params, env):
             # restart libvirtd service then check the interface still works fine
             libvirtd = utils_libvirtd.Libvirtd()
             libvirtd.restart()
-            vm1.cleanup_serial_console()
-            vm1.create_serial_console()
-            session1 = vm1.wait_for_serial_login()
+            session1 = vm1.wait_for_serial_login(recreate_serial_console=True)
             ping(vm1_ip, remote_url, ping_count, ping_timeout, session=session1)
             logging.info("after reboot and restart libvirtd, the network works fine")
             if iface_driver:

--- a/libvirt/tests/src/virtual_network/passt/passt_lifecycle.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_lifecycle.py
@@ -126,9 +126,7 @@ def run(test, params, env):
             test.fail(f'Logfile of passt "{log_file}" not created')
 
         # Re-create console since vm has been restored/resumed
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        session = vm.wait_for_serial_login(timeout=60)
+        session = vm.wait_for_serial_login(timeout=60, recreate_serial_console=True)
 
         vm_iface = utils_net.get_linux_ifname(session, mac)
         passt.check_vm_ip(iface_attrs, session, host_iface, vm_iface)

--- a/provider/interface/check_points.py
+++ b/provider/interface/check_points.py
@@ -21,9 +21,7 @@ def check_network_accessibility(vm, **kwargs):
     """
     if kwargs.get("recreate_vm_session", "yes") == "yes":
         logging.debug("Recreating vm session...")
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm_session = vm.wait_for_serial_login()
+        vm_session = vm.wait_for_serial_login(recreate_serial_console=True)
     else:
         vm_session = vm.session
 

--- a/provider/migration/base_steps.py
+++ b/provider/migration/base_steps.py
@@ -93,9 +93,7 @@ class MigrationBase(object):
         if start_vm == "yes" and not self.vm.is_alive():
             self.vm.start()
             if use_console:
-                self.vm.cleanup_serial_console()
-                self.vm.create_serial_console()
-                self.vm.wait_for_serial_login().close()
+                self.vm.wait_for_serial_login(recreate_serial_console=True).close()
             else:
                 self.vm.wait_for_login().close()
         if self.check_cont_ping:
@@ -295,9 +293,7 @@ class MigrationBase(object):
             self.test.log.debug("Checking the output of %s", self.check_cont_ping_log)
             if check_on_dest:
                 backup_uri, self.vm.connect_uri = self.vm.connect_uri, dest_uri
-            self.vm.cleanup_serial_console()
-            self.vm.create_serial_console()
-            vm_session = self.vm.wait_for_serial_login(timeout=360)
+            vm_session = self.vm.wait_for_serial_login(timeout=360, recreate_serial_console=True)
             vm_session.cmd(
                 "> {0}; sleep 5; grep time= {0}".format(self.check_cont_ping_log))
             o = vm_session.cmd_output(f"cat {self.check_cont_ping_log}")

--- a/provider/migration/migration_base.py
+++ b/provider/migration/migration_base.py
@@ -257,10 +257,8 @@ def poweroff_vm(params):
 
     if poweroff_vm_dest:
         dest_uri = params.get("virsh_migrate_desturi")
-        migration_obj.vm.cleanup_serial_console()
         backup_uri, migration_obj.vm.connect_uri = migration_obj.vm.connect_uri, dest_uri
-        migration_obj.vm.create_serial_console()
-        remote_vm_session = migration_obj.vm.wait_for_serial_login(timeout=120)
+        remote_vm_session = migration_obj.vm.wait_for_serial_login(timeout=120, recreate_serial_console=True)
         remote_vm_session.cmd("poweroff", ignore_all_errors=True)
         remote_vm_session.close()
         migration_obj.vm.cleanup_serial_console()
@@ -776,9 +774,7 @@ def write_vm_disk_on_dest(params):
     migration_obj = params.get("migration_obj")
 
     backup_uri, migration_obj.vm.connect_uri = migration_obj.vm.connect_uri, desturi
-    migration_obj.vm.cleanup_serial_console()
-    migration_obj.vm.create_serial_console()
-    vm_session = migration_obj.vm.wait_for_serial_login(timeout=120)
+    vm_session = migration_obj.vm.wait_for_serial_login(timeout=120, recreate_serial_console=True)
     vm_session.cmd("while true; do echo 'do disk I/O error test' >> /tmp/disk_io_error_test; sleep 1; done &")
     vm_session.close()
     migration_obj.vm.connect_uri = backup_uri

--- a/provider/save/save_base.py
+++ b/provider/save/save_base.py
@@ -18,9 +18,7 @@ def pre_save_setup(vm, serial=False):
     :return: a tuple of pid of ping and uptime since when
     """
     if serial:
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        session = vm.wait_for_serial_login()
+        session = vm.wait_for_serial_login(recreate_serial_console=True)
     else:
         session = vm.wait_for_login()
     upsince = session.cmd_output('uptime --since').strip()
@@ -48,9 +46,7 @@ def post_save_check(vm, pid_ping, upsince, serial=False):
     :param serial: Whether to use a serial connection
     """
     if serial:
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        session = vm.wait_for_serial_login()
+        session = vm.wait_for_serial_login(recreate_serial_console=True)
     else:
         session = vm.wait_for_login()
     upsince_restore = session.cmd_output('uptime --since').strip()


### PR DESCRIPTION
Refactor network and interface tests to use the recreate_serial_console
parameter instead of manually calling cleanup_serial_console() and
create_serial_console() before wait_for_serial_login().

This simplifies console management in scenarios where the console needs
to be recreated after state changes such as:
- After libvirtd restart
- After VM save/restore or suspend/resume operations
- After VM start or device hotplug

Modified test files:
- virtual_network/iface_bridge.py: Console recreation after libvirtd restart
- virtual_network/passt/passt_lifecycle.py: Console after restore/resume
- virtual_interface/interface_update_device_negative.py: Console after VM start
- virsh_cmd/domain/virsh_domif_setlink_getlink.py: Console for link state check
- virtio/virtio_page_per_vq.py: Console after device attach

All tests now use a cleaner single-line pattern for console recreation.

Note: iface_hotplug.py was not modified as it creates console without
immediately calling wait_for_serial_login(), which doesn't match the
refactoring pattern.