### PR TITLE
hotplug_gpu: updated since hotunplug is not supported for NVIDIA GPUs

### DIFF
--- a/libvirt/tests/src/gpu/hotplug_gpu.py
+++ b/libvirt/tests/src/gpu/hotplug_gpu.py
@@ -1,6 +1,5 @@
 from virttest import virsh
 
-from virttest.libvirt_xml import vm_xml
 from virttest.utils_libvirt import libvirt_vmxml
 from virttest.utils_test import libvirt
 
@@ -9,7 +8,8 @@ from provider.gpu import gpu_base
 
 def run(test, params, env):
     """
-    Hotplug/unplug GPU device
+    Hotplug GPU device
+    Note: Hotunplug is not supported for nvidia GPUs
     """
     vm_name = params.get("main_vm", "avocado-vt-vm1")
     vm = env.get_vm(vm_name)
@@ -33,24 +33,10 @@ def run(test, params, env):
         gpu_test.install_latest_driver(vm_session)
         gpu_test.nvidia_smi_check(vm_session)
 
-        test.log.info("TEST_STEP: Unplug a gpu device from vm")
-        vm_hostdev = vm_xml.VMXML.new_from_dumpxml(vm.name)\
-            .devices.by_device_tag("hostdev")[0]
-        virsh.detach_device(vm.name, vm_hostdev.xml,
-                            wait_for_event=True, event_timeout=30,
-                            **virsh_args)
-        gpu_test.check_gpu_dev(vm, True)
-
-        test.log.info("TEST_STEP: Hotplug back the gpu device")
-        virsh.attach_device(vm.name, gpu_dev.xml, **virsh_args)
-        gpu_test.check_gpu_dev(vm)
-        gpu_test.nvidia_smi_check(vm_session)
-
         test.log.info("TEST_STEP: Check gpu device exclusivity")
         res = virsh.attach_device(vm.name, gpu_dev.xml, debug=True)
         libvirt.check_result(res, "in use")
         gpu_test.check_gpu_dev(vm)
-        gpu_test.nvidia_smi_check(vm_session)
         vm_session.close()
     finally:
         gpu_test.teardown_default()


### PR DESCRIPTION
Marked as a draft while waiting for patches that will allow these changes to be tested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Simplified GPU hotplug test flow by removing unsupported hot‑unplug steps, focusing on hotplug validation only.
  * Reduces flaky results and false failures with NVIDIA GPUs.

* **Documentation**
  * Clarified that hot‑unplug is not supported for NVIDIA GPUs.
  * Updated test logs/messages to reflect hotplug‑only behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->