### PR TITLE
fix sriov vfio variant driver vf pci param

### DIFF
--- a/libvirt/tests/cfg/sriov/plug_unplug/sriov_attach_detach_device_vfio_variant_driver.cfg
+++ b/libvirt/tests/cfg/sriov/plug_unplug/sriov_attach_detach_device_vfio_variant_driver.cfg
@@ -3,9 +3,13 @@
     start_vm = "no"
     expr_driver = "mlx5_vfio_pci"
     ping_dest = "www.redhat.com"
-    test_pf = "ens3f0np0"
-
+    need_sriov = "yes"
+    vf_no = 4
     only x86_64, aarch64
+    
+    x86_64:
+        test_pf = "ens3f0np0"
+
     variants:
         - mlx5_vfio:
             driver_dict = {'driver': {'driver_attr': {'name': 'vfio', 'model': 'mlx5_vfio_pci'}}}

--- a/libvirt/tests/cfg/sriov/plug_unplug/sriov_attach_detach_device_vfio_variant_driver.cfg
+++ b/libvirt/tests/cfg/sriov/plug_unplug/sriov_attach_detach_device_vfio_variant_driver.cfg
@@ -3,7 +3,7 @@
     start_vm = "no"
     expr_driver = "mlx5_vfio_pci"
     ping_dest = "www.redhat.com"
-    need_sriov = "yes"
+    need_sriov = yes
     vf_no = 4
     only x86_64, aarch64
     
@@ -14,6 +14,7 @@
         - mlx5_vfio:
             driver_dict = {'driver': {'driver_attr': {'name': 'vfio', 'model': 'mlx5_vfio_pci'}}}
         - vfio_vfio:
+            expr_driver = "vfio-pci"
             driver_dict = {'driver': {'driver_attr': {'name': 'vfio', 'model': 'vfio_pci'}}}            
         - @default:
             driver_dict = {}

--- a/libvirt/tests/cfg/sriov/vfio/sriov_migration_vfio_variant_driver.cfg
+++ b/libvirt/tests/cfg/sriov/vfio/sriov_migration_vfio_variant_driver.cfg
@@ -25,9 +25,14 @@
     virsh_migrate_connect_uri = "qemu:///system"
     check_cont_ping = "no"
     migrate_vm_back = "yes"
-    test_pf = "ens3f0np0"
-
+    expr_driver = "mlx5_vfio_pci"
+    need_sriov = yes
+    vf_no = 4
     only x86_64, aarch64
+    
+    x86_64:
+        test_pf = "ens3f0np0"
+
     variants:
         - managed_yes:
             managed = "yes"
@@ -36,6 +41,10 @@
                     func_supported_since_libvirt_ver = (10, 0, 0)
                 - mlx5_vfio:
                     driver_dict = {'driver': {'driver_attr': {'name': 'vfio', 'model': 'mlx5_vfio_pci'}}}
+                    func_supported_since_libvirt_ver = (10, 0, 0)
+                - vfio_vfio:
+                    expr_driver = "vfio-pci"
+                    driver_dict = {'driver': {'driver_attr': {'name': 'vfio', 'model': 'vfio_pci'}}}
                     func_supported_since_libvirt_ver = (10, 0, 0)
         - managed_no:
             managed = "no"

--- a/libvirt/tests/cfg/sriov/vfio/sriov_migration_vfio_variant_driver.cfg
+++ b/libvirt/tests/cfg/sriov/vfio/sriov_migration_vfio_variant_driver.cfg
@@ -55,7 +55,7 @@
             status_error = "yes"
             migrate_vm_back = "no"
             postcopy_options = "--postcopy --timeout 10 --timeout-postcopy"
-            err_msg = "VFIO migration is not supported with postcopy migration"
+            err_msg = "VFIO migration is not supported|cannot migrate domain.*VFIO migration is not supported"
         - without_postcopy:
             postcopy_options = ""
             variants:

--- a/libvirt/tests/src/bios/boot_order_ovmf.py
+++ b/libvirt/tests/src/bios/boot_order_ovmf.py
@@ -23,18 +23,14 @@ def check_boot(vm, test, params):
     time.sleep(3)
     if not status_error:
         try:
-            vm.cleanup_serial_console()
-            vm.create_serial_console()
-            vm.wait_for_serial_login()
+            vm.wait_for_serial_login(recreate_serial_console=True)
         except Exception as error:
             test.fail(f"Test fail: {error}")
         else:
             test.log.debug("Succeed to boot %s", vm.name)
     else:
         try:
-            vm.cleanup_serial_console()
-            vm.create_serial_console()
-            vm.wait_for_serial_login()
+            vm.wait_for_serial_login(recreate_serial_console=True)
         except LoginTimeoutError as expected_e:
             test.log.debug(f"Got expected error message: {expected_e}")
         except Exception as e:

--- a/libvirt/tests/src/bios/boot_order_seabios.py
+++ b/libvirt/tests/src/bios/boot_order_seabios.py
@@ -270,18 +270,14 @@ def run(test, params, env):
                             internal_timeout=0.5)
                 else:
                     time.sleep(3)
-                    vm.cleanup_serial_console()
-                    vm.create_serial_console()
-                    vm.wait_for_serial_login(timeout=15)
+                    vm.wait_for_serial_login(timeout=15, recreate_serial_console=True)
             except Exception as e:
                 test.fail(f"Test fail: {str(e)}")
             else:
                 test.log.debug("Succeed to boot %s", vm_name)
         else:
             try:
-                vm.cleanup_serial_console()
-                vm.create_serial_console()
-                vm.wait_for_serial_login(timeout=15)
+                vm.wait_for_serial_login(timeout=15, recreate_serial_console=True)
             except LoginTimeoutError as expected_e:
                 test.log.debug("Got expected error message: %s", str(expected_e))
             except Exception as exc:

--- a/libvirt/tests/src/migration/migrate_mem.py
+++ b/libvirt/tests/src/migration/migrate_mem.py
@@ -279,11 +279,7 @@ def verify_test_back_mem_nvdimm(vm, params, test):
     :param test: test object
     """
     vm.connect_uri = params.get("virsh_migrate_connect_uri")
-    if vm.serial_console is not None:
-        test.log.debug("clean up old serial console")
-        vm.cleanup_serial_console()
-    vm.create_serial_console()
-    vm_session = vm.wait_for_serial_login(timeout=240)
+    vm_session = vm.wait_for_serial_login(timeout=240, recreate_serial_console=True)
     cmd = 'mount -o dax /dev/pmem0 /mnt'
     vm_session.cmd(cmd)
     expected_content = params.get('test_file_content') + '.back'

--- a/libvirt/tests/src/migration/migrate_network.py
+++ b/libvirt/tests/src/migration/migrate_network.py
@@ -313,10 +313,7 @@ def run(test, params, env):
                       vm_xml.VMXML.new_from_dumpxml(vm_name))
 
         # Check local guest network connection before migration
-        if vm.serial_console is not None:
-            vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm_session = vm.wait_for_serial_login(timeout=240)
+        vm_session = vm.wait_for_serial_login(timeout=240, recreate_serial_console=True)
         if not utils_package.package_install('dhcp-client', session=vm_session):
             test.error("Failed to install dhcp-client on guest.")
         utils_net.restart_guest_network(vm_session)
@@ -343,10 +340,7 @@ def run(test, params, env):
         # Check network accessibility after migration
         if int(mig_result.exit_status) == 0:
             vm.connect_uri = dest_uri
-            if vm.serial_console is not None:
-                vm.cleanup_serial_console()
-            vm.create_serial_console()
-            vm_session_after_mig = vm.wait_for_serial_login(timeout=240)
+            vm_session_after_mig = vm.wait_for_serial_login(timeout=240, recreate_serial_console=True)
             vm_session_after_mig.cmd(restart_dhclient)
             check_vm_network_accessed(ping_dest, session=vm_session_after_mig)
 
@@ -393,10 +387,7 @@ def run(test, params, env):
             logging.debug("VM is migrated back.")
 
             vm.connect_uri = bk_uri
-            if vm.serial_console is not None:
-                vm.cleanup_serial_console()
-            vm.create_serial_console()
-            vm_session_after_mig_bak = vm.wait_for_serial_login(timeout=240)
+            vm_session_after_mig_bak = vm.wait_for_serial_login(timeout=240, recreate_serial_console=True)
             vm_session_after_mig_bak.cmd(restart_dhclient)
             check_vm_network_accessed(ping_dest, vm_session_after_mig_bak)
     finally:

--- a/libvirt/tests/src/migration/migrate_with_panic_device.py
+++ b/libvirt/tests/src/migration/migrate_with_panic_device.py
@@ -57,9 +57,7 @@ def run(test, params, env):
         migration_obj.verify_default()
 
         backup_uri, vm.connect_uri = vm.connect_uri, dest_uri
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        remote_vm_session = vm.wait_for_serial_login(timeout=360)
+        remote_vm_session = vm.wait_for_serial_login(timeout=360, recreate_serial_console=True)
         try:
             remote_vm_session.cmd("systemctl stop kdump", ignore_all_errors=True)
             remote_vm_session.cmd("echo 1 > /proc/sys/kernel/sysrq")

--- a/libvirt/tests/src/migration/migration_with_virtiofs/migration_with_externally_launched_virtiofs_dev.py
+++ b/libvirt/tests/src/migration/migration_with_virtiofs/migration_with_externally_launched_virtiofs_dev.py
@@ -76,9 +76,7 @@ def run(test, params, env):
         expect_str = params.get("expect_str")
 
         backup_uri, vm.connect_uri = vm.connect_uri, desturi
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm_session = vm.wait_for_serial_login(timeout=120)
+        vm_session = vm.wait_for_serial_login(timeout=120, recreate_serial_console=True)
         output = vm_session.cmd_output("df -h")
         vm_session.close()
         test.log.debug("output: %s", output)

--- a/libvirt/tests/src/migration/migration_with_virtiofs/migration_with_internally_launched_virtiofs_dev.py
+++ b/libvirt/tests/src/migration/migration_with_virtiofs/migration_with_internally_launched_virtiofs_dev.py
@@ -64,9 +64,7 @@ def run(test, params, env):
         mnt_path_name = params.get("mnt_path_name")
 
         backup_uri, vm.connect_uri = vm.connect_uri, desturi
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm_session = vm.wait_for_serial_login(timeout=120)
+        vm_session = vm.wait_for_serial_login(timeout=120, recreate_serial_console=True)
         output = vm_session.cmd_output("df -h")
         test.log.debug("output: %s", output)
         if not re.search(expect_str, output):

--- a/libvirt/tests/src/migration/migration_with_vtpm/migration_with_external_tpm.py
+++ b/libvirt/tests/src/migration/migration_with_vtpm/migration_with_external_tpm.py
@@ -54,12 +54,8 @@ def check_vtpm_func(params, vm, test, on_remote=False):
     src_uri = params.get("virsh_migrate_connect_uri")
     test.log.debug("Check vtpm func: (on_remote: %s).", on_remote)
     if on_remote:
-        if vm.serial_console is not None:
-            vm.cleanup_serial_console()
         vm.connect_uri = dest_uri
-    if vm.serial_console is None:
-        vm.create_serial_console()
-    vm_session = vm.wait_for_serial_login(timeout=240)
+    vm_session = vm.wait_for_serial_login(timeout=240, recreate_serial_console=True)
     if not utils_package.package_install("tpm2-tools", vm_session):
         test.error("Failed to install tpm2-tools in vm")
     cmd_result = vm_session.cmd_status(tpm_cmd)

--- a/libvirt/tests/src/migration/migration_with_vtpm/migration_with_shared_tpm.py
+++ b/libvirt/tests/src/migration/migration_with_vtpm/migration_with_shared_tpm.py
@@ -70,12 +70,8 @@ def check_vtpm_func(params, vm, test, remote=False):
     src_uri = params.get("virsh_migrate_connect_uri")
     test.log.debug("Check vtpm func: %s (remote).", remote)
     if remote:
-        if vm.serial_console is not None:
-            vm.cleanup_serial_console()
         vm.connect_uri = dest_uri
-    if vm.serial_console is None:
-        vm.create_serial_console()
-    vm_session = vm.wait_for_serial_login(timeout=240)
+    vm_session = vm.wait_for_serial_login(timeout=240, recreate_serial_console=True)
     if not utils_package.package_install("tpm2-tools", vm_session):
         test.error("Failed to install tpm2-tools in vm")
     cmd_result = vm_session.cmd_status(tpm_cmd)

--- a/libvirt/tests/src/migration/migration_with_vtpm/migration_with_vtpm_dev.py
+++ b/libvirt/tests/src/migration/migration_with_vtpm/migration_with_vtpm_dev.py
@@ -31,12 +31,8 @@ def check_vtpm_func(params, vm, test, remote=False):
     src_uri = params.get("virsh_migrate_connect_uri")
     test.log.debug("Check vtpm func: %s (remote).", remote)
     if remote:
-        if vm.serial_console is not None:
-            vm.cleanup_serial_console()
         vm.connect_uri = dest_uri
-    if vm.serial_console is None:
-        vm.create_serial_console()
-    vm_session = vm.wait_for_serial_login(timeout=240)
+    vm_session = vm.wait_for_serial_login(timeout=240, recreate_serial_console=True)
     if not utils_package.package_install("tpm2-tools", vm_session):
         test.error("Failed to install tpm2-tools in vm")
     cmd_result = vm_session.cmd_status(tpm_cmd)

--- a/libvirt/tests/src/migration_with_copy_storage/disk_io_load_in_vm.py
+++ b/libvirt/tests/src/migration_with_copy_storage/disk_io_load_in_vm.py
@@ -55,9 +55,7 @@ def run(test, params, env):
 
         test.log.info("Verify steps.")
         backup_uri, vm.connect_uri = vm.connect_uri, dest_uri
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        remote_vm_session = vm.wait_for_serial_login(timeout=360)
+        remote_vm_session = vm.wait_for_serial_login(timeout=360, recreate_serial_console=True)
         remote_vm_dmesg = remote_vm_session.cmd_output("dmesg")
         if "I/O error" in remote_vm_dmesg:
             test.fail(f"Found I/O error in guest dmesg: {remote_vm_dmesg}")

--- a/libvirt/tests/src/migration_with_copy_storage/migration_with_backingchain.py
+++ b/libvirt/tests/src/migration_with_copy_storage/migration_with_backingchain.py
@@ -147,10 +147,8 @@ def check_disk(params, vm):
     disk_target1 = params.get("disk_target1")
     disk_target2 = params.get("disk_target2")
 
-    vm.cleanup_serial_console()
     backup_uri, vm.connect_uri = vm.connect_uri, dest_uri
-    vm.create_serial_console()
-    remote_vm_session = vm.wait_for_serial_login(timeout=120)
+    remote_vm_session = vm.wait_for_serial_login(timeout=120, recreate_serial_console=True)
     utils_disk.linux_disk_check(remote_vm_session, disk_target1)
     utils_disk.linux_disk_check(remote_vm_session, disk_target2)
 

--- a/libvirt/tests/src/nwfilter/nwfilter_binding_list.py
+++ b/libvirt/tests/src/nwfilter/nwfilter_binding_list.py
@@ -120,9 +120,7 @@ def run(test, params, env):
         utlv.check_result(ret, expected_match=[r"vnet\d+\s+clean-traffic"])
         utlv.check_result(ret, expected_match=[r"vnet\d+\s+allow-dhcp-server"])
         # detach a interface, before detach, make sure guest boot up
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm.wait_for_serial_login().close
+        vm.wait_for_serial_login(recreate_serial_console=True).close()
         option = "--type network" + " --mac " + new_iface_1.mac_address
         ret = virsh.detach_interface(vm_name, option, debug=True)
         time.sleep(time_wait)

--- a/libvirt/tests/src/snapshot/revert_disk_external_snap.py
+++ b/libvirt/tests/src/snapshot/revert_disk_external_snap.py
@@ -38,9 +38,7 @@ def revert_snap_and_check_files(params, vm, test, snap_name, expected_files):
 
     virsh.snapshot_revert(vm.name, snap_name, options=options, **virsh_dargs)
 
-    vm.cleanup_serial_console()
-    vm.create_serial_console()
-    session = vm.wait_for_serial_login()
+    session = vm.wait_for_serial_login(recreate_serial_console=True)
     for file in expected_files:
         output = session.cmd('ls %s' % file)
         if file not in output:

--- a/libvirt/tests/src/snapshot/revert_snapshot_after_xml_updated.py
+++ b/libvirt/tests/src/snapshot/revert_snapshot_after_xml_updated.py
@@ -68,9 +68,7 @@ def check_file_exist(test, vm, params, revert_snap):
 
     if not vm.is_alive():
         virsh.start(vm_name)
-    vm.cleanup_serial_console()
-    vm.create_serial_console()
-    session = vm.wait_for_serial_login()
+    session = vm.wait_for_serial_login(recreate_serial_console=True)
 
     if revert_snap == "1":
         file_list = eval(params.get("file_list"))[0:1]

--- a/libvirt/tests/src/sriov/failover/sriov_failover_at_dt_hostdev.py
+++ b/libvirt/tests/src/sriov/failover/sriov_failover_at_dt_hostdev.py
@@ -32,9 +32,7 @@ def run(test, params, env):
 
         test.log.info("TEST_STEP2: Start the VM")
         vm.start()
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm_session = vm.wait_for_serial_login(timeout=240)
+        vm_session = vm.wait_for_serial_login(timeout=240, recreate_serial_console=True)
 
         test.log.info("TEST_STEP3: Check interface quantity and network"
                       "accessibility.")

--- a/libvirt/tests/src/sriov/failover/sriov_failover_lifecycle.py
+++ b/libvirt/tests/src/sriov/failover/sriov_failover_lifecycle.py
@@ -29,9 +29,7 @@ def run(test, params, env):
 
         test.log.info("TEST_STEP2: Start the VM")
         vm.start()
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm_session = vm.wait_for_serial_login(timeout=240)
+        vm_session = vm.wait_for_serial_login(timeout=240, recreate_serial_console=True)
 
         test.log.info("TEST_STEP3: Check network accessibility")
         check_points.check_vm_network_accessed(vm_session,
@@ -67,9 +65,7 @@ def run(test, params, env):
         virsh.restore(save_file, debug=True, ignore_status=False)
         if not libvirt.check_vm_state(vm_name, "running"):
             test.fail("The guest should be running after executing 'virsh restore'.")
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm_session = vm.wait_for_serial_login()
+        vm_session = vm.wait_for_serial_login(recreate_serial_console=True)
 
         test.log.info("TEST_STEP7: Check network accessibility")
         check_points.check_vm_network_accessed(vm_session,
@@ -80,9 +76,7 @@ def run(test, params, env):
         test.log.info("TEST_STEP8: Managedsave the VM.")
         virsh.managedsave(vm_name, debug=True, ignore_status=False, timeout=10)
         vm.start()
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm_session = vm.wait_for_serial_login()
+        vm_session = vm.wait_for_serial_login(recreate_serial_console=True)
 
         test.log.info("TEST_STEP9: Check network accessibility")
         check_points.check_vm_network_accessed(vm_session,

--- a/libvirt/tests/src/sriov/failover/sriov_failover_migration.py
+++ b/libvirt/tests/src/sriov/failover/sriov_failover_migration.py
@@ -72,9 +72,7 @@ def run(test, params, env):
         """
         Verify network function
         """
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm_session = vm.wait_for_serial_login(timeout=240)
+        vm_session = vm.wait_for_serial_login(timeout=240, recreate_serial_console=True)
         check_points.check_vm_iface_num(vm_session, expr_iface_no,
                                         timeout=40, first=15)
 

--- a/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_device_vfio_variant_driver.py
+++ b/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_device_vfio_variant_driver.py
@@ -103,8 +103,6 @@ def run(test, params, env):
         test.log.debug("Verify: Check VF driver successfully after detaching hostdev interface/device - PASS")
         virsh.reboot(vm.name, ignore_status=False, debug=True)
         test.log.debug("Verify: VM reboot is successful after detaching hostdev interface/device - PASS")
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm.wait_for_serial_login().close()
+        vm.wait_for_serial_login(recreate_serial_console=True).close()
     finally:
         orig_vm_xml.sync()

--- a/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_device_vfio_variant_driver.py
+++ b/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_device_vfio_variant_driver.py
@@ -1,6 +1,5 @@
 import time
 
-from virttest import utils_net
 from virttest import utils_sriov
 from virttest import utils_test
 from virttest import virsh
@@ -16,29 +15,6 @@ def run(test, params, env):
     """
     Attach/detach device of hostdev type with vfio variant driver to/from guest
     """
-    def parse_iface_dict(pf_pci):
-        """
-        Parse interface dictionary from parameters
-        """
-        mac_addr = utils_net.generate_mac_address_simple()
-
-        vf_pci_addr = utils_sriov.pci_to_addr(vf_pci)
-        if params.get('iface_dict'):
-            iface_dict = eval(params.get('iface_dict', '{}'))
-        else:
-            if vf_pci_addr.get('type'):
-                del vf_pci_addr['type']
-            iface_dict = eval(params.get('hostdev_dict', '{}'))
-        driver_dict = eval(params.get("driver_dict", "{}"))
-        if driver_dict:
-            iface_dict.update(driver_dict)
-        managed = params.get("managed")
-        if managed:
-            iface_dict.update({"manged": managed})
-        test.log.debug(f"Iface dict: {iface_dict}")
-
-        return iface_dict
-
     dev_type = params.get("dev_type", "hostdev_interface")
     device_type = "hostdev" if dev_type == "hostdev_device" else "interface"
     expr_driver = params.get("expr_driver", "mlx5_vfio_pci")
@@ -66,7 +42,7 @@ def run(test, params, env):
         for idx in range(iface_number):
             test.log.info("TEST_STEP: Attach a hostdev interface/device to VM")
             vf_pci = utils_sriov.get_vf_pci_id(pf_pci, idx)
-            iface_dict = parse_iface_dict(vf_pci)
+            iface_dict = sriov_vfio.parse_iface_dict(vf_pci, params)
             iface_dev = libvirt_vmxml.create_vm_device_by_type(device_type, iface_dict)
             virsh.attach_device(vm.name, iface_dev.xml, ignore_status=False,
                                 debug=True)

--- a/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_device_with_flags.py
+++ b/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_device_with_flags.py
@@ -76,9 +76,7 @@ def run(test, params, env):
         if start_vm:
             if not vm.is_alive():
                 vm.start()
-            vm.cleanup_serial_console()
-            vm.create_serial_console()
-            vm_session = vm.wait_for_serial_login(timeout=240)
+            vm_session = vm.wait_for_serial_login(timeout=240, recreate_serial_console=True)
 
         libvirt_vfio.check_vfio_pci(sriov_test_obj.vf_pci, True)
 

--- a/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_interface_with_flags.py
+++ b/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_interface_with_flags.py
@@ -54,9 +54,7 @@ def run(test, params, env):
         if start_vm:
             if not vm.is_alive():
                 vm.start()
-            vm.cleanup_serial_console()
-            vm.create_serial_console()
-            vm_session = vm.wait_for_serial_login(timeout=240)
+            vm_session = vm.wait_for_serial_login(timeout=240, recreate_serial_console=True)
 
         mac_addr = utils_net.generate_mac_address_simple()
         alias_name = 'ua-' + str(uuid.uuid4())

--- a/libvirt/tests/src/sriov/plug_unplug/sriov_attach_released_hostdev.py
+++ b/libvirt/tests/src/sriov/plug_unplug/sriov_attach_released_hostdev.py
@@ -20,9 +20,7 @@ def run(test, params, env):
         :return: The session of VM
         """
         vm.start()
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        return vm.wait_for_serial_login(timeout=240)
+        return vm.wait_for_serial_login(timeout=240, recreate_serial_console=True)
 
     def run_test():
         """

--- a/libvirt/tests/src/sriov/vIOMMU/hotplug_device_with_iommu_enabled.py
+++ b/libvirt/tests/src/sriov/vIOMMU/hotplug_device_with_iommu_enabled.py
@@ -64,10 +64,9 @@ def run(test, params, env):
         test.log.info("TEST_STEP: Start the VM.")
         if not vm.is_alive():
             vm.start()
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
         vm_session = vm.wait_for_serial_login(
-            timeout=int(params.get('login_timeout')))
+            timeout=int(params.get('login_timeout')),
+            recreate_serial_console=True)
         pre_devices = viommu_base.get_devices_pci(vm_session, test_devices)
         if disk_dict:
             test.log.info("TEST_STEP: Attach a disk device to VM.")

--- a/libvirt/tests/src/sriov/vIOMMU/intel_iommu_aw_bits.py
+++ b/libvirt/tests/src/sriov/vIOMMU/intel_iommu_aw_bits.py
@@ -28,10 +28,9 @@ def run(test, params, env):
             if err_msg:
                 libvirt.check_result(result, err_msg)
             return
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
         vm_session = vm.wait_for_serial_login(
-            timeout=int(params.get('login_timeout')))
+            timeout=int(params.get('login_timeout')),
+            recreate_serial_console=True)
         test.log.debug(vm_xml.VMXML.new_from_dumpxml(vm.name))
 
         test.log.info("TEST_STEP: Check dmesg message.")

--- a/libvirt/tests/src/sriov/vIOMMU/intel_iommu_with_dma_translation.py
+++ b/libvirt/tests/src/sriov/vIOMMU/intel_iommu_with_dma_translation.py
@@ -32,9 +32,7 @@ def run(test, params, env):
         test.log.debug("The current guest xml ls: %s",
                        virsh.dumpxml(vm_name).stdout_text)
         test.log.info("TEST STEP3: Check the message for iommu group and DMA.")
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm_session = vm.wait_for_serial_login(timeout=1000)
+        vm_session = vm.wait_for_serial_login(timeout=1000, recreate_serial_console=True)
         dma_status, dma_o = vm_session.cmd_status_output("dmesg | grep -i 'Not attempting DMA translation'")
         iommu_status, iommu_o = vm_session.cmd_status_output("dmesg | grep -i 'Adding to iommu group'")
         if dma_translation == "on" and (not dma_status or iommu_status):

--- a/libvirt/tests/src/sriov/vIOMMU/iommu_device_settings.py
+++ b/libvirt/tests/src/sriov/vIOMMU/iommu_device_settings.py
@@ -34,10 +34,9 @@ def run(test, params, env):
         test_obj.setup_iommu_test(iommu_dict=iommu_dict, cleanup_ifaces=cleanup_ifaces)
         test_obj.prepare_controller()
         vm.start()
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
         vm_session = vm.wait_for_serial_login(
-            timeout=int(params.get('login_timeout')))
+            timeout=int(params.get('login_timeout')),
+            recreate_serial_console=True)
         pre_devices = viommu_base.get_devices_pci(vm_session, test_devices)
         vm.destroy()
 

--- a/libvirt/tests/src/sriov/vIOMMU/viommu_unload_driver.py
+++ b/libvirt/tests/src/sriov/vIOMMU/viommu_unload_driver.py
@@ -111,9 +111,7 @@ def run(test, params, env):
         time.sleep(5)
 
         test.log.info("TEST_STEP: Unload and load the driver.")
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm_serial = vm.wait_for_serial_login(timeout=120)
+        vm_serial = vm.wait_for_serial_login(timeout=120, recreate_serial_console=True)
         while not all_threads_done(threads):
             vm_serial.cmd("modprobe -r %s" % nic_driver, timeout=120)
             time.sleep(2)

--- a/libvirt/tests/src/sriov/vfio/sriov_migration_vfio_variant_driver.py
+++ b/libvirt/tests/src/sriov/vfio/sriov_migration_vfio_variant_driver.py
@@ -33,9 +33,7 @@ def run(test, params, env):
         dev_names = sriov_vfio.attach_dev(vm, params)
         if not vm.is_alive():
             vm.start()
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm.wait_for_serial_login().close()
+        vm.wait_for_serial_login(recreate_serial_console=True).close()
         time.sleep(30)
 
         test.log.debug(f'VMXML of {vm_name}:\n{virsh.dumpxml(vm_name).stdout_text}')

--- a/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_exclusive_check_running_domain.py
+++ b/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_exclusive_check_running_domain.py
@@ -30,9 +30,7 @@ def run(test, params, env):
         :return: The session of VM
         """
         vm.start()
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        return vm.wait_for_serial_login(timeout=240)
+        return vm.wait_for_serial_login(timeout=240, recreate_serial_console=True)
 
     def run_start_2nd_vm():
         """

--- a/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_iommu_at_dt_hostdev.py
+++ b/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_iommu_at_dt_hostdev.py
@@ -31,9 +31,7 @@ def run(test, params, env):
 
         test.log.info("TEST_STEP2: Start the VM with iommu enabled")
         vm.start()
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm_session = vm.wait_for_serial_login(timeout=240)
+        vm_session = vm.wait_for_serial_login(timeout=240, recreate_serial_console=True)
 
         test.log.info("TEST_STEP3: Check network accessibility")
         br_name = None

--- a/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_managedsave.py
+++ b/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_managedsave.py
@@ -25,9 +25,7 @@ def run(test, params, env):
 
         test.log.info("TEST_STEP2: Start the VM")
         vm.start()
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm.wait_for_serial_login(timeout=240).close()
+        vm.wait_for_serial_login(timeout=240, recreate_serial_console=True).close()
 
         test.log.info("TEST_STEP3: Managedsave the vm")
         result = virsh.managedsave(vm.name, debug=True)

--- a/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_reboot.py
+++ b/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_reboot.py
@@ -52,9 +52,7 @@ def run(test, params, env):
 
         test.log.info("TEST_STEP2: Start the VM")
         vm.start()
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm_session = vm.wait_for_serial_login(timeout=240)
+        vm_session = vm.wait_for_serial_login(timeout=240, recreate_serial_console=True)
         if params.get("check_ping_time") == "yes":
             avg_ping_time = get_avg_ping_time(vm_session, params)
 

--- a/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_suspend_resume.py
+++ b/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_suspend_resume.py
@@ -29,9 +29,7 @@ def run(test, params, env):
 
         test.log.info("TEST_STEP2: Start the VM")
         vm.start()
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm_session = vm.wait_for_serial_login(timeout=240)
+        vm_session = vm.wait_for_serial_login(timeout=240, recreate_serial_console=True)
 
         test.log.info("TEST_STEP3: Suspend VM and check vm's state.")
         virsh.suspend(vm.name, debug=True, ignore_status=False)

--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domif_setlink_getlink.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domif_setlink_getlink.py
@@ -255,12 +255,11 @@ def run(test, params, env):
         error_msg = None
         if status_error == "no" and not post_action:
             # Close then establish a connection with the serial console
-            vm.cleanup_serial_console()
-            vm.create_serial_console()
             # Serial login the vm to check link status
             # Start vm check the link statue
             session = vm.wait_for_serial_login(username=username,
-                                               password=password)
+                                               password=password,
+                                               recreate_serial_console=True)
             guest_if_name = utils_net.get_linux_ifname(session, mac_address)
 
             # Check link state in guest

--- a/libvirt/tests/src/virtio/virtio_page_per_vq.py
+++ b/libvirt/tests/src/virtio/virtio_page_per_vq.py
@@ -99,9 +99,7 @@ def run(test, params, env):
             test.log.info("TEST_STEP1: hotplug %s device", device_type)
             start_guest()
             virsh.attach_device(vm_name, device_xml.xml, ignore_status=False, debug=True)
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm_session = vm.wait_for_serial_login()
+        vm_session = vm.wait_for_serial_login(recreate_serial_console=True)
 
         test.log.info("TEST_STEP2: check the attribute in %s xml", device_type)
         check_attribute()

--- a/libvirt/tests/src/virtual_interface/interface_update_device_negative.py
+++ b/libvirt/tests/src/virtual_interface/interface_update_device_negative.py
@@ -24,9 +24,7 @@ def run(test, params, env):
             libvirt_vmxml.modify_vm_device(vmxml, 'interface', pre_iface_dict)
         if start_vm and not vm.is_alive():
             vm.start()
-            vm.cleanup_serial_console()
-            vm.create_serial_console()
-            session = vm.wait_for_serial_login(timeout=int(params.get("login_timeout", 600)))
+            session = vm.wait_for_serial_login(timeout=int(params.get("login_timeout", 600)), recreate_serial_console=True)
             session.close()
         test.log.info("TEST_STEP: Update interface device.")
         interface_base.update_iface_device(vm, params)

--- a/libvirt/tests/src/virtual_network/iface_bridge.py
+++ b/libvirt/tests/src/virtual_network/iface_bridge.py
@@ -281,9 +281,7 @@ def run(test, params, env):
             # restart libvirtd service then check the interface still works fine
             libvirtd = utils_libvirtd.Libvirtd()
             libvirtd.restart()
-            vm1.cleanup_serial_console()
-            vm1.create_serial_console()
-            session1 = vm1.wait_for_serial_login()
+            session1 = vm1.wait_for_serial_login(recreate_serial_console=True)
             ping(vm1_ip, remote_url, ping_count, ping_timeout, session=session1)
             logging.info("after reboot and restart libvirtd, the network works fine")
             if iface_driver:

--- a/libvirt/tests/src/virtual_network/passt/passt_lifecycle.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_lifecycle.py
@@ -126,9 +126,7 @@ def run(test, params, env):
             test.fail(f'Logfile of passt "{log_file}" not created')
 
         # Re-create console since vm has been restored/resumed
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        session = vm.wait_for_serial_login(timeout=60)
+        session = vm.wait_for_serial_login(timeout=60, recreate_serial_console=True)
 
         vm_iface = utils_net.get_linux_ifname(session, mac)
         passt.check_vm_ip(iface_attrs, session, host_iface, vm_iface)

--- a/provider/interface/check_points.py
+++ b/provider/interface/check_points.py
@@ -21,9 +21,7 @@ def check_network_accessibility(vm, **kwargs):
     """
     if kwargs.get("recreate_vm_session", "yes") == "yes":
         logging.debug("Recreating vm session...")
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm_session = vm.wait_for_serial_login()
+        vm_session = vm.wait_for_serial_login(recreate_serial_console=True)
     else:
         vm_session = vm.session
 

--- a/provider/migration/base_steps.py
+++ b/provider/migration/base_steps.py
@@ -94,9 +94,7 @@ class MigrationBase(object):
         if start_vm == "yes" and not self.vm.is_alive():
             self.vm.start()
             if use_console:
-                self.vm.cleanup_serial_console()
-                self.vm.create_serial_console()
-                self.vm.wait_for_serial_login().close()
+                self.vm.wait_for_serial_login(recreate_serial_console=True).close()
             else:
                 self.vm.wait_for_login().close()
         if self.check_cont_ping:
@@ -299,9 +297,7 @@ class MigrationBase(object):
             self.test.log.debug("Checking the output of %s", self.check_cont_ping_log)
             if check_on_dest:
                 backup_uri, self.vm.connect_uri = self.vm.connect_uri, dest_uri
-            self.vm.cleanup_serial_console()
-            self.vm.create_serial_console()
-            vm_session = self.vm.wait_for_serial_login(timeout=360)
+            vm_session = self.vm.wait_for_serial_login(timeout=360, recreate_serial_console=True)
             vm_session.cmd(
                 "> {0}; sleep 5; grep time= {0}".format(self.check_cont_ping_log))
             o = vm_session.cmd_output(f"cat {self.check_cont_ping_log}")

--- a/provider/migration/migration_base.py
+++ b/provider/migration/migration_base.py
@@ -261,10 +261,8 @@ def poweroff_vm(params):
 
     if poweroff_vm_dest:
         dest_uri = params.get("virsh_migrate_desturi")
-        migration_obj.vm.cleanup_serial_console()
         backup_uri, migration_obj.vm.connect_uri = migration_obj.vm.connect_uri, dest_uri
-        migration_obj.vm.create_serial_console()
-        remote_vm_session = migration_obj.vm.wait_for_serial_login(timeout=120)
+        remote_vm_session = migration_obj.vm.wait_for_serial_login(timeout=120, recreate_serial_console=True)
         remote_vm_session.cmd("poweroff", ignore_all_errors=True)
         remote_vm_session.close()
         migration_obj.vm.cleanup_serial_console()
@@ -780,9 +778,7 @@ def write_vm_disk_on_dest(params):
     migration_obj = params.get("migration_obj")
 
     backup_uri, migration_obj.vm.connect_uri = migration_obj.vm.connect_uri, desturi
-    migration_obj.vm.cleanup_serial_console()
-    migration_obj.vm.create_serial_console()
-    vm_session = migration_obj.vm.wait_for_serial_login(timeout=120)
+    vm_session = migration_obj.vm.wait_for_serial_login(timeout=120, recreate_serial_console=True)
     vm_session.cmd("while true; do echo 'do disk I/O error test' >> /tmp/disk_io_error_test; sleep 1; done &")
     vm_session.close()
     migration_obj.vm.connect_uri = backup_uri

--- a/provider/save/save_base.py
+++ b/provider/save/save_base.py
@@ -18,9 +18,7 @@ def pre_save_setup(vm, serial=False):
     :return: a tuple of pid of ping and uptime since when
     """
     if serial:
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        session = vm.wait_for_serial_login()
+        session = vm.wait_for_serial_login(recreate_serial_console=True)
     else:
         session = vm.wait_for_login()
     upsince = session.cmd_output('uptime --since').strip()
@@ -48,9 +46,7 @@ def post_save_check(vm, pid_ping, upsince, serial=False):
     :param serial: Whether to use a serial connection
     """
     if serial:
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        session = vm.wait_for_serial_login()
+        session = vm.wait_for_serial_login(recreate_serial_console=True)
     else:
         session = vm.wait_for_login()
     upsince_restore = session.cmd_output('uptime --since').strip()


### PR DESCRIPTION
The local parse_iface_dict() function had incorrect parameter name
(pf_pci instead of vf_pci), causing vf_pci to be undefined and
resulting in error: \"readlink /sys/bus/pci/devices/None/virtfn0\".

This change:
- Removes duplicate parse_iface_dict() function
- Uses existing sriov_vfio.parse_iface_dict() provider function
- Removes unused utils_net import

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Streamlined VM serial console handling across migration, snapshot, networking, and SR-IOV scenarios by consolidating setup into a single login step with automatic console recreation.
  - Reduced redundant console cleanup/creation steps to simplify flows and improve stability.
  - Ensured sessions are explicitly closed where appropriate.

- Bug Fixes
  - Improved reliability of post-action logins and detach/attach flows by recreating the console on demand, reducing intermittent failures.

- Tests
  - Harmonized test flows for boot, migration (incl. virtiofs/vTPM), snapshots, and virtual networking for more consistent outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->