### PR TITLE
Refactor SR-IOV VFIO test to use dynamic driver verification

### DIFF
--- a/libvirt/tests/cfg/sriov/plug_unplug/sriov_attach_detach_device_vfio_variant_driver.cfg
+++ b/libvirt/tests/cfg/sriov/plug_unplug/sriov_attach_detach_device_vfio_variant_driver.cfg
@@ -1,13 +1,15 @@
 - sriov.plug_unplug.vfio_variant_driver:
     type = sriov_attach_detach_device_vfio_variant_driver
     start_vm = "no"
-    expr_driver = "mlx5_vfio_pci"
     ping_dest = "www.redhat.com"
     test_pf = "ens3f0np0"
 
     only x86_64, aarch64
+    x86_64:
+        test_pf = "ens3f0np0"
     variants:
         - mlx5_vfio:
+            expr_driver = "mlx5_vfio_pci"
             driver_dict = {'driver': {'driver_attr': {'name': 'vfio', 'model': 'mlx5_vfio_pci'}}}
         - vfio_vfio:
             driver_dict = {'driver': {'driver_attr': {'name': 'vfio', 'model': 'vfio_pci'}}}            


### PR DESCRIPTION
- Remove hardcoded driver values and improve config organization
- Refactor SRIOV VFIO test to use dynamic driver verification
- Simplify SR-IOV VFIO driver check logic by removing unnecessary conditionals
- The check_vfio_pci function can handle None values for exp_driver parameter
- Reduces code complexity and improves maintainability

Depends on  
https://github.com/avocado-framework/avocado-vt/pull/4255

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Removed a global default driver setting; driver can now be variant-specific.
  * Added an x86_64-specific test override and introduced a new default variant.
  * Tests now record each device's original driver before operations and log restorations.
  * Verification strengthened to ensure devices are restored to their original driver after detach.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->