### PR TITLE
Cancel the testcase as maximum mode is not supported for ppc!

### DIFF
--- a/libvirt/tests/src/cpu/vcpu_misc.py
+++ b/libvirt/tests/src/cpu/vcpu_misc.py
@@ -1,5 +1,6 @@
 import logging as log
 import os
+import platform
 import re
 
 from avocado.utils import process
@@ -91,6 +92,10 @@ def update_cpu_xml(vmxml, params, test):
     vm_name = params.get('main_vm')
     with_topology = "yes" == params.get("with_topology", "no")
     customize_cpu_features = "yes" == params.get("customize_cpu_features", "no")
+
+    # Check for machine type for mode as maximum
+    if (platform.machine() in ['ppc64', 'ppc64le']) and (cpu_mode == "maximum"):
+        test.cancel("\"maximum\" mode is not supported in power arch")
 
     # Create cpu xml for test
     if vmxml.xmltreefile.find('cpu'):


### PR DESCRIPTION
Added a condition to cancel a testcase if machine is ppc64 or ppc64le and cpu_mode is maximum as this mode is not supported for power architecture.

Signed-off-by: Anushree-Mathur <anushree.mathur@linux.ibm.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Tests now automatically cancel on Power (PPC) systems when CPU mode is set to "maximum", stopping execution early (before CPU XML creation) to avoid running unsupported configurations on that hardware.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->