### PR TITLE
Fixing maxvcpu mismatch with topology issue, making it dynamic!

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_emulatorpin.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_emulatorpin.py
@@ -273,6 +273,11 @@ def run(test, params, env):
         if 'cpuset' in vcpu_attrs:
             if vcpu_attrs['cpuset'] == "x,y":
                 vcpu_attrs['cpuset'] = "0,%s" % (cpu_max - 1)
+                # Updating max cpus according to smp value if topology is present
+                if vmxml.get_cpu_topology():
+                    topology = vmxml.get_cpu_topology()
+                    max_vcpu = (int(topology['sockets']) * int(topology['cores']) * int(topology['threads']))
+                    vcpu_attrs['vcpu'] = max_vcpu
         vmxml.setup_attrs(**vcpu_attrs)
         vmxml.sync()
         try:


### PR DESCRIPTION
Maxvcpu is hardcoded for the specific testcase in virsh_emulatorpin.py. When smp value, vcpu_cores, vcpu_threads, vcpu_sockets is specified at the time of running the testcase then the hardcoded value will fail. Adding the code to get this value dynamically based on the smp value provided in the test suite config file.
1 example is that hardcoded value is 7 in virsh_emulatorpin.cfg but in the testsuite config smp value given is 32 not topology will be affected in this case my check will help.

Signed-off-by: Anushree-Mathur <anushree.mathur@linux.ibm.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced vCPU configuration handling to properly compute maximum vCPUs from available CPU topology information when processing emulator pin attributes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->