### PR TITLE
Handle unsupported architectures in virsh CPU models check!

### DIFF
--- a/libvirt/tests/src/virsh_cmd/host/virsh_cpu_models.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_cpu_models.py
@@ -81,5 +81,9 @@ def run(test, params, env):
         logging.debug("Get the CPU models for arch: %s" % arch)
         result = virsh.cpu_models(arch, options=option, uri=connect_uri,
                                   ignore_status=True, debug=True)
+        # Check if the architecture is not supported; log it and skip to the next architecture.
+        if "architecture is not supported by CPU driver" in result.stderr:
+            logging.info("%s architecture is not supported by CPU driver as expected" % arch)
+            continue
         utlv.check_exit_status(result, expect_error=status_error)
         compare_cpu_model_with_qemu(test, params, result, qemu_cmd)


### PR DESCRIPTION
Add a check to skip unsupported architectures when running virsh cpu-models. Logs the message and continues with the next architecture to avoid unnecessary failures as it is expected..

Signed-off-by: Anushree-Mathur <anushree.mathur@linux.ibm.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced virsh cpu-models tests to gracefully skip unsupported CPU architectures instead of failing, improving test reliability across different environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->