### PR TITLE
Fix case - cow_on_read_path

### DIFF
--- a/v2v/tests/cfg/nbdkit/nbdkit.cfg
+++ b/v2v/tests/cfg/nbdkit/nbdkit.cfg
@@ -40,6 +40,7 @@
               - cow_on_read_path:
                 version_required = "[nbdkit-server-1.26.3-1,)"
                 checkpoint = 'cow_on_read_path'
+                unprivileged_user = "v2v_auto"
               - cow_block_size:
                 version_required = "[nbdkit-server-1.28.3-1,)"
                 checkpoint = 'cow_block_size'

--- a/v2v/tests/src/nbdkit/nbdkit.py
+++ b/v2v/tests/src/nbdkit/nbdkit.py
@@ -1,5 +1,6 @@
 import re
 import os
+import pwd
 import signal
 import logging
 import tempfile
@@ -22,6 +23,7 @@ def run(test, params, env):
     """
     checkpoint = params.get('checkpoint')
     version_required = params.get('version_required')
+    unprivileged_user = params.get('unprivileged_user')
 
     def test_filter_stats_fd_leak():
         """
@@ -763,7 +765,36 @@ nbdsh -u nbd+unix:///?socket=/tmp/sock -c 'h.zero (655360, 262144, 0)'
     elif checkpoint == 'cow_on_read_true':
         cow_on_read_true()
     elif checkpoint == 'cow_on_read_path':
-        cow_on_read_path()
+            regular_sudo_config = '/etc/sudoers.d/v2v_test'
+            try:
+                with open(regular_sudo_config, 'w') as fd:
+                    fd.write('%s ALL=(ALL)  NOPASSWD: ALL' % unprivileged_user)
+
+                # create user
+                try:
+                    pwd.getpwnam(unprivileged_user)
+                except KeyError:
+                    process.system("useradd %s" % unprivileged_user)
+
+                # generate ssh-key
+                rsa_private_key_path = '/home/%s/.ssh/id_rsa' % unprivileged_user
+                rsa_public_key_path = '/home/%s/.ssh/id_rsa.pub' % unprivileged_user
+                process.system(
+                    'su - %s -c \'ssh-keygen -t rsa -q -N "" -f %s\'' %
+                    (unprivileged_user, rsa_private_key_path))
+
+                with open(rsa_public_key_path) as fd:
+                    pub_key = fd.read()
+                
+                # Run the cow_on_read_path test as the non-root user
+                LOG.info("Running cow_on_read_path test as non-root user: %s" % unprivileged_user)
+                cow_on_read_path()
+            finally:
+                # Cleanup: remove sudoers config and user
+                if os.path.exists(regular_sudo_config):
+                    os.remove(regular_sudo_config)
+                if unprivileged_user:
+                    process.run("userdel -fr %s" % unprivileged_user, shell=True, ignore_status=True)
     elif checkpoint == 'cow_block_size':
         cow_block_size()
     elif checkpoint == 'reduce_verbosity_debugging':


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test variant that exercises nbdkit behavior as an unprivileged user: test harness now creates the unprivileged account, provisions temporary sudo/SSH access to run the scenario non-root, and performs cleanup afterward to improve coverage of privilege-separated paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->