### PR TITLE
migration: Add case about migration with heavy nework load on host

### DIFF
--- a/libvirt/tests/cfg/migration/migration_with_stress/network_load_on_host.cfg
+++ b/libvirt/tests/cfg/migration/migration_with_stress/network_load_on_host.cfg
@@ -1,0 +1,32 @@
+- migration.migration_with_stress.network_load_on_host:
+    type = network_load_on_host
+    migration_setup = 'yes'
+    storage_type = 'nfs'
+    setup_local_nfs = 'yes'
+    disk_type = "file"
+    disk_source_protocol = "netfs"
+    mnt_path_name = ${nfs_mount_dir}
+    # Console output can only be monitored via virsh console output
+    only_pty = True
+    take_regular_screendumps = no
+    # Extra options to pass after <domain> <desturi>
+    virsh_migrate_extra = ''
+    # SSH connection time out
+    ssh_timeout = 60
+    # Local URI
+    virsh_migrate_connect_uri = 'qemu:///system'
+    image_convert = 'no'
+    server_ip = "${migrate_dest_host}"
+    server_user = "root"
+    server_pwd = "${migrate_dest_pwd}"
+    client_ip = "${migrate_source_host}"
+    status_error = "no"
+    migrate_desturi_port = "16509"
+    migrate_desturi_type = "tcp"
+    virsh_migrate_desturi = "qemu+tcp://${migrate_dest_host}/system"
+    start_vm = "yes"
+    virsh_migrate_options = '--live --p2p --verbose --undefinesource --persistent --postcopy'
+    virsh_migrate_dest_state = "running"
+    virsh_migrate_src_state = "nonexist"
+    netperf_port = "12865"
+    netperf_data_port = "5000"

--- a/libvirt/tests/src/migration/migration_with_stress/network_load_on_host.py
+++ b/libvirt/tests/src/migration/migration_with_stress/network_load_on_host.py
@@ -1,0 +1,87 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright Redhat
+#
+#   SPDX-License-Identifier: GPL-2.0
+#
+#   Author: Liping Cheng <lcheng@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+from avocado.utils import process
+
+from virttest import remote
+from virttest import utils_package
+
+from provider.migration import base_steps
+
+
+def run(test, params, env):
+    """
+    This case is to verify that migration can succeed in high-speed network env
+    with heavy nework load
+
+    """
+    def setup_test():
+        """
+        Setup steps
+
+        """
+        client_ip = params.get("client_ip")
+
+        test.log.info("Setup steps.")
+        if not utils_package.package_install('netperf'):
+            test.error('Failed to install netperf on source host.')
+        if not utils_package.package_install('netperf', remote_session):
+            test.error('Failed to install netperf on target host.')
+
+        process.run("systemctl stop firewalld", shell=True, verbose=True)
+        remote.run_remote_cmd("systemctl stop firewalld", params)
+
+        src_netserver_cmd = f"nohup netserver >/dev/null 2>&1 &"
+        process.run(src_netserver_cmd, shell=True, verbose=True)
+        dst_netserver_cmd = f"nohup netserver >/dev/null 2>&1 &"
+        remote.run_remote_cmd(dst_netserver_cmd, params, ignore_status=False)
+
+        src_netperf_cmd = f"nohup netperf -H {server_ip} -l 600000000 >/dev/null 2>&1 &"
+        process.run(src_netperf_cmd, shell=True, verbose=True)
+
+        dst_netperf_cmd = f"nohup netperf -H {client_ip} -l 600000000 >/dev/null 2>&1 &"
+        remote.run_remote_cmd(dst_netperf_cmd, params, ignore_status=False)
+
+        migration_obj.setup_connection()
+
+    def cleanup_test():
+        """
+        Cleanup steps
+
+        """
+        test.log.info("Cleanup steps.")
+        migration_obj.cleanup_connection()
+        process.run("pkill netserver", shell=True, verbose=True, ignore_status=True)
+        remote.run_remote_cmd("pkill netserver", params, ignore_status=True)
+        process.run("pkill netperf", shell=True, verbose=True, ignore_status=True)
+        remote.run_remote_cmd("pkill netperf", params, ignore_status=True)
+        process.run("systemctl start firewalld", shell=True, verbose=True)
+        remote.run_remote_cmd("systemctl start firewalld", params)
+
+    vm_name = params.get("migrate_main_vm")
+    server_ip = params.get("server_ip")
+    server_user = params.get("server_user", "root")
+    server_pwd = params.get("server_pwd")
+    netperf_port = params.get("netperf_port")
+    netperf_data_port = params.get("netperf_data_port")
+
+    vm = env.get_vm(vm_name)
+    migration_obj = base_steps.MigrationBase(test, vm, params)
+    remote_runner = remote.RemoteRunner(host=server_ip,
+                                        username=server_user,
+                                        password=server_pwd)
+    remote_session = remote_runner.session
+
+    try:
+        setup_test()
+        migration_obj.run_migration()
+        migration_obj.verify_default()
+    finally:
+        cleanup_test()


### PR DESCRIPTION
This case is to verify that migration can succeed in high-speed network env with heavy nework load.

ID: VIRT-298248

Test result:
 (1/1) type_specific.io-github-autotest-libvirt.migration.migration_with_stress.network_load_on_host: STARTED
migration.migration_with_stress.network_load_on_host 
(1/1) type_specific.io-github-autotest-libvirt.migration.migration_with_stress.network_load_on_host: PASS (211.65 s)
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2025-12-15T02.10-31187f8/results.html
JOB TIME   : 214.61 s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test configuration and validation script for VM migration under heavy network load conditions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->