### PR TITLE
Handling kqemu testcase as libvirt dropped it 2.19.2 onwards!

### DIFF
--- a/libvirt/tests/src/virsh_cmd/host/virsh_maxvcpus.py
+++ b/libvirt/tests/src/virsh_cmd/host/virsh_maxvcpus.py
@@ -31,6 +31,11 @@ def run(test, params, env):
     status_error = params.get("status_error")
     connect_arg = params.get("connect_arg", "")
 
+    # Checking libvirt version before running maxvcpus with kqemu
+    if libvirt_version.version_compare(2, 19, 2):
+        if "kqemu" in option:
+            test.cancel("kqemu support was removed starting from libvirt 2.19.2 and QEMU 0.12")
+
     # params for transport connect.
     local_ip = params.get("local_ip", "ENTER.YOUR.LOCAL.IP")
     local_pwd = params.get("local_pwd", "ENTER.YOUR.LOCAL.ROOT.PASSWORD")


### PR DESCRIPTION
Support for kqemu was dropped in libvirt by commit 8e91a400c, so it is failing as expected. I have added the condition to cancel this testcase if libvirt version is greater than 2.19.2!
Reference link to confirm dropping kqemu support : https://lists.libvirt.org/archives/list/devel%40lists.libvirt.org/thread/PXHESERQAWL2NFDGZWDYY4I4M567YXDX/?utm_source=chatgpt.com
Signed-off-by: Anushree-Mathur <anushree.mathur@linux.ibm.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a pre-check to skip test scenarios that reference "kqemu" on libvirt 2.19.2 and newer, preventing incompatible test runs in updated environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->