### PR TITLE
migration: Fix migrate-to-same-host issue in bi-directional tests

### DIFF
--- a/libvirt/tests/cfg/migration/migrate_vm.cfg
+++ b/libvirt/tests/cfg/migration/migrate_vm.cfg
@@ -10,6 +10,7 @@
     client_ip = "${migrate_source_host}"
     client_user = "root"
     client_pwd = "${migrate_source_pwd}"
+    migration_source_uri = "qemu+ssh://${client_ip}/system"
     start_vm = "no"
     storage_type =
     transport = "ssh"
@@ -114,7 +115,6 @@
                         - bi_directional:
                             virsh_options = "--live --verbose"
                             migrate_vm_back = "yes"
-                            migration_source_uri = "qemu+ssh://${client_ip}/system"
                         - iscsi:
                             setup_nfs = "no"
                             enable_virt_use_nfs = "no"
@@ -216,7 +216,6 @@
                         - bi_directional:
                             virsh_options = "--live --p2p --verbose"
                             migrate_vm_back = "yes"
-                            migration_source_uri = "qemu+ssh://${client_ip}/system"
                         - listen_address:
                             listen_address = "${server_ip}"
                             virsh_options = "--live --p2p --verbose --listen-address ${server_ip}"
@@ -288,7 +287,6 @@
                         - bi_directional:
                             virsh_options = "--live --p2p --tunnelled --verbose"
                             migrate_vm_back = "yes"
-                            migration_source_uri = "qemu+ssh://${client_ip}/system"
                 - migration_with_nbd:
                     setup_nfs = "no"
                     enable_virt_use_nfs = "no"
@@ -323,7 +321,6 @@
                             vol_name = "vol_migrate_vm"
                             pool_name = "glusterfs"
                             migrate_vm_back = "yes"
-                            migration_source_uri = "qemu+ssh://${client_ip}/system"
                         - rdma:
                             no s390-virtio
                             virsh_options = "--live --verbose"


### PR DESCRIPTION
Move migration_source_uri to top-level configuration to ensure it's always available when migrate_vm_back is enabled by CI overrides. This prevents the test from defaulting to qemu:///system (local host) during migration-back operations.

Changes:
- Add top-level migration_source_uri = "qemu+ssh://${client_ip}/system"
- Remove 4 redundant per-variant definitions in bi_directional cases

Resolves: LTF-823

AI assisted code and commit. Human reviewed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated VM migration configuration by defining the migration source URI at a single global location and removing redundant per-path/source overrides in nested migration sections to simplify settings and reduce duplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->