### PR TITLE
Add focused VCPU migration test

### DIFF
--- a/libvirt/tests/cfg/migration/migration_options_vcpu.cfg
+++ b/libvirt/tests/cfg/migration/migration_options_vcpu.cfg
@@ -1,0 +1,48 @@
+- virsh.migration_options_vcpu:
+    type = migration_options_vcpu
+    # Migrating non-started VM causes undefined behavior
+    start_vm = yes
+    # Console output can only be monitored via virsh console output
+    only_pty = True
+    take_regular_screendumps = no
+    # Options to pass to virsh migrate command before <domain> <desturi>
+    virsh_migrate_options = "--live --verbose"
+    # Extra options to pass after <domain> <desturi>
+    virsh_migrate_extra = ""
+    # SSH connection time out
+    ssh_timeout = 60
+    # Remember to open ports 49152-49216 on destination and
+    # NAT-based host networking will cause external connectivity-loss
+    # to guest, consider a shared-bridge setup instead.
+    # FIXME: Implement libvirt URI connect user/password
+    # virsh_migrate_destuser = root
+    # virsh_migrate_destpwd = ""
+    migration_setup = "yes"
+    storage_type = 'nfs'
+    setup_local_nfs = 'yes'
+    virsh_migrate_dest_state = running
+    virsh_migrate_src_state = running
+    virsh_migrate_libvirtd_state = 'on'
+    # Local URI
+    virsh_migrate_connect_uri = "qemu:///system"
+    log_outputs = "/var/log/libvirt/libvirtd.log"
+    
+    # Migration mode - only precopy/without_postcopy for vcpu tests
+    postcopy_options = ""
+    
+    # Migrate VM back to verify bidirectional migration
+    migrate_vm_back = "yes"
+    
+    # Check guest XML after migration to verify vcpu count
+    guest_xml_check_after_mig = "<vcpu placement='static'>"
+    
+    variants:
+        - vcpu_1:
+            vcpu_num = 1
+        - vcpu_4:
+            vcpu_num = 4
+        - vcpu_8:
+            vcpu_num = 8
+        - vcpu_16:
+            vcpu_num = 16
+

--- a/libvirt/tests/src/migration/migration_options_vcpu.py
+++ b/libvirt/tests/src/migration/migration_options_vcpu.py
@@ -1,0 +1,171 @@
+import logging as log
+import re
+
+from virttest import virsh
+from virttest import remote
+from virttest.libvirt_xml import vm_xml
+from virttest.utils_test import libvirt
+
+# Using as lower capital is not the best way to do, but this is just a
+# workaround to avoid changing the entire file.
+logging = log.getLogger('avocado.' + __name__)
+
+
+def run(test, params, env):
+    """
+    Test virsh migrate command with different VCPU configurations.
+
+    This test verifies that migration works correctly with VMs configured
+    with different numbers of VCPUs (1, 4, 8, 16).
+
+    Steps:
+    1. Set up source and destination hosts for migration
+    2. Configure VM with specified number of VCPUs
+    3. Perform live migration from source to destination
+    4. Verify VCPU count in destination VM XML
+    5. Migrate back to source (if migrate_vm_back=yes)
+    6. Verify VCPU count after back-migration
+
+    :param test: test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment
+    """
+    # Get standard migration parameters
+    vm_name = params.get("migrate_main_vm", params.get("main_vm"))
+    server_ip = params.get("remote_ip")
+    server_user = params.get("remote_user", "root")
+    server_pwd = params.get("remote_pwd")
+    virsh_options = params.get("virsh_options", "")
+    options = params.get("virsh_migrate_options", "--live --verbose")
+    extra = params.get("virsh_migrate_extra", "")
+    dest_uri = params.get("virsh_migrate_desturi")
+
+    # VCPU-specific parameters
+    vcpu_num = params.get("vcpu_num")
+    migrate_vm_back = "yes" == params.get("migrate_vm_back", "no")
+    xml_check_after_mig = params.get("guest_xml_check_after_mig", "")
+
+    # Get VM object
+    vm = env.get_vm(vm_name)
+
+    # Remote virsh session parameters
+    remote_virsh_dargs = {
+        'remote_ip': server_ip,
+        'remote_user': server_user,
+        'remote_pwd': server_pwd,
+        'unprivileged_user': None,
+        'ssh_remote_auth': True
+    }
+
+    # Backup original VM XML
+    vmxml_backup = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+
+    try:
+        # Configure VM with specified number of VCPUs
+        if vcpu_num:
+            logging.info("Setting VM %s to use %s VCPUs", vm_name, vcpu_num)
+            vm_xml.VMXML.set_vm_vcpus(vm_name, int(vcpu_num))
+
+        # Make sure VM is running
+        if not vm.is_alive():
+            vm.start()
+
+        # Wait for VM to be ready
+        vm.wait_for_login()
+
+        logging.info("Migrating VM %s from source to destination", vm_name)
+        logging.debug("Migration command: virsh %s migrate %s %s %s %s",
+                      virsh_options, options, vm_name, dest_uri, extra)
+
+        # Perform migration
+        result = virsh.migrate(vm_name, dest_uri, options=options,
+                               extra=extra, virsh_opt=virsh_options,
+                               debug=True, ignore_status=True)
+
+        # Check migration result
+        libvirt.check_exit_status(result)
+
+        logging.info("Migration completed successfully")
+
+        # Verify VCPU count on destination
+        remote_virsh_session = None
+        try:
+            remote_virsh_session = virsh.VirshPersistent(**remote_virsh_dargs)
+            target_guest_dumpxml = remote_virsh_session.dumpxml(
+                vm_name, debug=True, ignore_status=True).stdout_text.strip()
+
+            if vcpu_num:
+                check_str = vcpu_num
+                xml_check = "%s%s</vcpu>" % (xml_check_after_mig, check_str)
+
+                logging.info("Checking for '%s' in target guest XML", xml_check)
+                if not re.search(xml_check, target_guest_dumpxml):
+                    test.fail("Fail to search '%s' in target guest XML:\n%s"
+                              % (xml_check, target_guest_dumpxml))
+
+                logging.info("VCPU count verified successfully on destination")
+        finally:
+            if remote_virsh_session:
+                remote_virsh_session.close_session()
+
+        # Migrate back to source if requested
+        if migrate_vm_back:
+            logging.info("Migrating VM %s back to source", vm_name)
+
+            # Get source URI
+            src_uri = params.get("virsh_migrate_connect_uri", "qemu:///system")
+
+            # Prepare remote command to migrate back
+            cmd = "virsh %s migrate %s %s %s %s" % (
+                virsh_options, options, vm_name, src_uri, extra)
+
+            logging.debug("Back-migration command: %s", cmd)
+
+            # Execute migration back from remote host
+            runner = remote.RemoteRunner(host=server_ip,
+                                         username=server_user,
+                                         password=server_pwd)
+            ret = runner.run(cmd, ignore_status=False)
+
+            if ret.exit_status != 0:
+                test.fail("Failed to migrate VM back to source: %s" % ret.stderr)
+
+            logging.info("Back-migration completed successfully")
+
+            # Verify VCPU count after back-migration
+            source_guest_dumpxml = virsh.dumpxml(vm_name, debug=True).stdout_text.strip()
+
+            if vcpu_num:
+                xml_check = "%s%s</vcpu>" % (xml_check_after_mig, vcpu_num)
+                logging.info("Checking for '%s' in source guest XML after back-migration",
+                             xml_check)
+                if not re.search(xml_check, source_guest_dumpxml):
+                    test.fail("Fail to search '%s' in source guest XML after back-migration:\n%s"
+                              % (xml_check, source_guest_dumpxml))
+
+                logging.info("VCPU count verified successfully after back-migration")
+
+        logging.info("Test completed successfully")
+
+    finally:
+        # Cleanup: restore original VM configuration
+        logging.info("Restoring original VM configuration")
+
+        # If VM is on remote, migrate it back first
+        if migrate_vm_back or libvirt.check_vm_state(vm_name, "running", uri=dest_uri):
+            try:
+                runner = remote.RemoteRunner(host=server_ip,
+                                             username=server_user,
+                                             password=server_pwd)
+                src_uri = params.get("virsh_migrate_connect_uri", "qemu:///system")
+                cmd = "virsh migrate %s %s --live" % (vm_name, src_uri)
+                runner.run(cmd, ignore_status=True)
+            except Exception as e:
+                logging.warning("Failed to migrate VM back during cleanup: %s", e)
+
+        # Restore original XML
+        if vm.is_alive():
+            vm.destroy(gracefully=False)
+
+        vmxml_backup.sync()
+        logging.info("Original VM configuration restored")

--- a/libvirt/tests/src/migration/migration_options_vcpu.py
+++ b/libvirt/tests/src/migration/migration_options_vcpu.py
@@ -2,9 +2,9 @@ import logging as log
 import re
 
 from virttest import virsh
-from virttest import remote
 from virttest.libvirt_xml import vm_xml
-from virttest.utils_test import libvirt
+
+from provider.migration import base_steps
 
 # Using as lower capital is not the best way to do, but this is just a
 # workaround to avoid changing the entire file.
@@ -30,25 +30,70 @@ def run(test, params, env):
     :param params: Dictionary with the test parameters
     :param env: Dictionary with test environment
     """
-    # Get standard migration parameters
-    vm_name = params.get("migrate_main_vm", params.get("main_vm"))
-    server_ip = params.get("remote_ip")
-    server_user = params.get("remote_user", "root")
-    server_pwd = params.get("remote_pwd")
-    virsh_options = params.get("virsh_options", "")
-    options = params.get("virsh_migrate_options", "--live --verbose")
-    extra = params.get("virsh_migrate_extra", "")
-    dest_uri = params.get("virsh_migrate_desturi")
-
     # VCPU-specific parameters
     vcpu_num = params.get("vcpu_num")
-    migrate_vm_back = "yes" == params.get("migrate_vm_back", "no")
     xml_check_after_mig = params.get("guest_xml_check_after_mig", "")
+    migrate_vm_back = "yes" == params.get("migrate_vm_back", "no")
+
+    # Check for required VCPU configuration
+    if not vcpu_num:
+        test.fail("Missing required configuration: vcpu_num must be specified")
 
     # Get VM object
+    vm_name = params.get("migrate_main_vm", params.get("main_vm"))
     vm = env.get_vm(vm_name)
 
-    # Remote virsh session parameters
+    # Initialize migration base helper
+    migration_base = base_steps.MigrationBase(test, vm, params)
+
+    try:
+        # Configure VM with specified number of VCPUs
+        logging.info("Setting VM %s to use %s VCPUs", vm_name, vcpu_num)
+        vm_xml.VMXML.set_vm_vcpus(vm_name, int(vcpu_num))
+
+        # Setup and start VM
+        migration_base.setup_default()
+
+        # Perform migration from source to destination
+        logging.info("Migrating VM %s from source to destination", vm_name)
+        migration_base.run_migration()
+
+        # Verify VCPU count on destination
+        verify_vcpu_count_on_destination(test, params, vm_name, vcpu_num, xml_check_after_mig)
+
+        # Verify migration success
+        migration_base.verify_default()
+
+        # Migrate back to source if requested
+        if migrate_vm_back:
+            logging.info("Migrating VM %s back to source", vm_name)
+            migration_base.run_migration_back()
+
+            # Verify VCPU count after back-migration
+            verify_vcpu_count_on_source(test, vm_name, vcpu_num, xml_check_after_mig)
+
+        logging.info("Test completed successfully")
+
+    finally:
+        # Cleanup: restore original VM configuration
+        logging.info("Restoring original VM configuration")
+        migration_base.cleanup_default()
+
+
+def verify_vcpu_count_on_destination(test, params, vm_name, vcpu_num, xml_check_after_mig):
+    """
+    Verify VCPU count on destination host after migration.
+
+    :param test: test object
+    :param params: Dictionary with the test parameters
+    :param vm_name: Name of the VM
+    :param vcpu_num: Expected number of VCPUs
+    :param xml_check_after_mig: XML prefix for verification
+    """
+    server_ip = params.get("remote_ip", params.get("server_ip"))
+    server_user = params.get("remote_user", params.get("server_user", "root"))
+    server_pwd = params.get("remote_pwd", params.get("server_pwd"))
+
     remote_virsh_dargs = {
         'remote_ip': server_ip,
         'remote_user': server_user,
@@ -57,115 +102,41 @@ def run(test, params, env):
         'ssh_remote_auth': True
     }
 
-    # Backup original VM XML
-    vmxml_backup = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
-
+    remote_virsh_session = None
     try:
-        # Configure VM with specified number of VCPUs
-        if vcpu_num:
-            logging.info("Setting VM %s to use %s VCPUs", vm_name, vcpu_num)
-            vm_xml.VMXML.set_vm_vcpus(vm_name, int(vcpu_num))
+        remote_virsh_session = virsh.VirshPersistent(**remote_virsh_dargs)
+        target_guest_dumpxml = remote_virsh_session.dumpxml(
+            vm_name, debug=True, ignore_status=True).stdout_text.strip()
 
-        # Make sure VM is running
-        if not vm.is_alive():
-            vm.start()
+        xml_check = "%s%s</vcpu>" % (xml_check_after_mig, vcpu_num)
 
-        # Wait for VM to be ready
-        vm.wait_for_login()
+        logging.info("Checking for '%s' in target guest XML", xml_check)
+        if not re.search(xml_check, target_guest_dumpxml):
+            test.fail("Fail to search '%s' in target guest XML:\n%s"
+                      % (xml_check, target_guest_dumpxml))
 
-        logging.info("Migrating VM %s from source to destination", vm_name)
-        logging.debug("Migration command: virsh %s migrate %s %s %s %s",
-                      virsh_options, options, vm_name, dest_uri, extra)
-
-        # Perform migration
-        result = virsh.migrate(vm_name, dest_uri, options=options,
-                               extra=extra, virsh_opt=virsh_options,
-                               debug=True, ignore_status=True)
-
-        # Check migration result
-        libvirt.check_exit_status(result)
-
-        logging.info("Migration completed successfully")
-
-        # Verify VCPU count on destination
-        remote_virsh_session = None
-        try:
-            remote_virsh_session = virsh.VirshPersistent(**remote_virsh_dargs)
-            target_guest_dumpxml = remote_virsh_session.dumpxml(
-                vm_name, debug=True, ignore_status=True).stdout_text.strip()
-
-            if vcpu_num:
-                check_str = vcpu_num
-                xml_check = "%s%s</vcpu>" % (xml_check_after_mig, check_str)
-
-                logging.info("Checking for '%s' in target guest XML", xml_check)
-                if not re.search(xml_check, target_guest_dumpxml):
-                    test.fail("Fail to search '%s' in target guest XML:\n%s"
-                              % (xml_check, target_guest_dumpxml))
-
-                logging.info("VCPU count verified successfully on destination")
-        finally:
-            if remote_virsh_session:
-                remote_virsh_session.close_session()
-
-        # Migrate back to source if requested
-        if migrate_vm_back:
-            logging.info("Migrating VM %s back to source", vm_name)
-
-            # Get source URI
-            src_uri = params.get("virsh_migrate_connect_uri", "qemu:///system")
-
-            # Prepare remote command to migrate back
-            cmd = "virsh %s migrate %s %s %s %s" % (
-                virsh_options, options, vm_name, src_uri, extra)
-
-            logging.debug("Back-migration command: %s", cmd)
-
-            # Execute migration back from remote host
-            runner = remote.RemoteRunner(host=server_ip,
-                                         username=server_user,
-                                         password=server_pwd)
-            ret = runner.run(cmd, ignore_status=False)
-
-            if ret.exit_status != 0:
-                test.fail("Failed to migrate VM back to source: %s" % ret.stderr)
-
-            logging.info("Back-migration completed successfully")
-
-            # Verify VCPU count after back-migration
-            source_guest_dumpxml = virsh.dumpxml(vm_name, debug=True).stdout_text.strip()
-
-            if vcpu_num:
-                xml_check = "%s%s</vcpu>" % (xml_check_after_mig, vcpu_num)
-                logging.info("Checking for '%s' in source guest XML after back-migration",
-                             xml_check)
-                if not re.search(xml_check, source_guest_dumpxml):
-                    test.fail("Fail to search '%s' in source guest XML after back-migration:\n%s"
-                              % (xml_check, source_guest_dumpxml))
-
-                logging.info("VCPU count verified successfully after back-migration")
-
-        logging.info("Test completed successfully")
-
+        logging.info("VCPU count verified successfully on destination")
     finally:
-        # Cleanup: restore original VM configuration
-        logging.info("Restoring original VM configuration")
+        if remote_virsh_session:
+            remote_virsh_session.close_session()
 
-        # If VM is on remote, migrate it back first
-        if migrate_vm_back or libvirt.check_vm_state(vm_name, "running", uri=dest_uri):
-            try:
-                runner = remote.RemoteRunner(host=server_ip,
-                                             username=server_user,
-                                             password=server_pwd)
-                src_uri = params.get("virsh_migrate_connect_uri", "qemu:///system")
-                cmd = "virsh migrate %s %s --live" % (vm_name, src_uri)
-                runner.run(cmd, ignore_status=True)
-            except Exception as e:
-                logging.warning("Failed to migrate VM back during cleanup: %s", e)
 
-        # Restore original XML
-        if vm.is_alive():
-            vm.destroy(gracefully=False)
+def verify_vcpu_count_on_source(test, vm_name, vcpu_num, xml_check_after_mig):
+    """
+    Verify VCPU count on source host after back-migration.
 
-        vmxml_backup.sync()
-        logging.info("Original VM configuration restored")
+    :param test: test object
+    :param vm_name: Name of the VM
+    :param vcpu_num: Expected number of VCPUs
+    :param xml_check_after_mig: XML prefix for verification
+    """
+    source_guest_dumpxml = virsh.dumpxml(vm_name, debug=True).stdout_text.strip()
+
+    xml_check = "%s%s</vcpu>" % (xml_check_after_mig, vcpu_num)
+    logging.info("Checking for '%s' in source guest XML after back-migration", xml_check)
+
+    if not re.search(xml_check, source_guest_dumpxml):
+        test.fail("Fail to search '%s' in source guest XML after back-migration:\n%s"
+                  % (xml_check, source_guest_dumpxml))
+
+    logging.info("VCPU count verified successfully after back-migration")

--- a/libvirt/tests/src/migration/migration_options_vcpu.py
+++ b/libvirt/tests/src/migration/migration_options_vcpu.py
@@ -40,7 +40,7 @@ def run(test, params, env):
         test.fail("Missing required configuration: vcpu_num must be specified")
 
     # Get VM object
-    vm_name = params.get("migrate_main_vm", params.get("main_vm"))
+    vm_name = params.get("migrate_main_vm")
     vm = env.get_vm(vm_name)
 
     # Initialize migration base helper


### PR DESCRIPTION
- Create migration_options_vcpu.cfg with 4 VCPU variants (1, 4, 8, 16)
- Implement migration_options_vcpu.py with focused test logic
- Support precopy migration with bidirectional testing
- Verify VCPU count preservation in XML after migration

This replaces the vcpu tests from migrate_options_shared with a clean, maintainable implementation focused solely on VCPU migration testing.

AI assisted code and commit. Human reviewed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable test settings for live VM migration with vCPU presets (1, 4, 8, 16).
  * Option to perform and verify bidirectional (back) migration.

* **Tests**
  * New automated test flow to perform migrations, verify vCPU counts on destination (and optionally on source), and ensure cleanup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->