### PR TITLE
backingchain/virsh_domblk: fix disk discovery

### DIFF
--- a/libvirt/tests/src/backingchain/virsh_domblk/domblkthreshold_with_backingchain_element.py
+++ b/libvirt/tests/src/backingchain/virsh_domblk/domblkthreshold_with_backingchain_element.py
@@ -5,6 +5,7 @@ from virttest import utils_disk
 from virttest import virsh
 from virttest import utils_misc
 from virttest.libvirt_xml import vm_xml
+from virttest.utils_libvirt import libvirt_disk
 
 from provider.backingchain import blockcommand_base
 from provider.virtual_disk import disk_base
@@ -37,6 +38,9 @@ def run(test, params, env):
         check_domstats_threshold(domstats_option, actual_threshold)
 
         test.log.info("TEST_STEP3-4:Write file and check event")
+        session = vm.wait_for_login()
+        target_disk = libvirt_disk.get_non_root_disk_name(session)
+        session.close()
         expected_event = event % (vm_name, target_disk, domblk_index,
                                   actual_threshold)
         event_session = virsh.EventTracker.start_get_event(vm_name)


### PR DESCRIPTION
The event is checking a specific disk name.

Like other occasions, such as 7b47a59, the way of recognizing added partitions assumed erroneously that disk names were persistent.

Apply the same solution by using get_non_root_disk_names to identify newly added disks in the VM more reliably.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test reliability for disk target detection by dynamically determining disk identifiers during test execution rather than relying on static pre-configured values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->