### PR TITLE
migration: Add migrate_vm_back for some cases

### DIFF
--- a/libvirt/tests/cfg/migration/memory_copy_mode/postcopy.cfg
+++ b/libvirt/tests/cfg/migration/memory_copy_mode/postcopy.cfg
@@ -36,6 +36,7 @@
     check_str_local_log = '['{"capability":"postcopy-preempt","state":true}']'
     expected_event_src = ["lifecycle.*Suspended Migrated", "lifecycle.*Suspended Post-copy", "lifecycle.*Stopped Migrated", "job-completed"]
     expected_event_target = ["event 'lifecycle'.*: Started Migrated", "event 'lifecycle'.*: Resumed Post-copy", "event 'lifecycle'.*: Resumed Migrated"]
+    migrate_vm_back = "yes"
     variants:
         - p2p:
             virsh_migrate_options = '--live --p2p --verbose'

--- a/libvirt/tests/cfg/migration/memory_copy_mode/precopy.cfg
+++ b/libvirt/tests/cfg/migration/memory_copy_mode/precopy.cfg
@@ -35,6 +35,7 @@
     action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: \'1\'", "func_param": "params"}, {"func": "set_migrate_speed_to_high", "func_param": "params"}]'
     expected_event_src = ["migration-iteration.*iteration: '1'", "lifecycle.*Suspended Migrated", "lifecycle.*Stopped Migrated", "job-completed"]
     expected_event_target = ["event 'lifecycle'.*: Started Migrated", "event 'lifecycle'.*: Resumed Migrated"]
+    migrate_vm_back = "yes"
     variants:
         - p2p:
             service_to_check = "virtqemud|libvirtd"

--- a/libvirt/tests/cfg/migration/migration_uri/migration_desturi.cfg
+++ b/libvirt/tests/cfg/migration/migration_uri/migration_desturi.cfg
@@ -60,13 +60,16 @@
     variants:
         - ipv4:
             dest_host = "${migrate_dest_host}"
+            migrate_vm_back = "yes"
         - ipv6:
             ipv6_config = "yes"
             ipv6_addr_des = "ENTER.YOUR.IPv6.DESTINATION"
             dest_host = "[${ipv6_addr_des}]"
             server_info_ip = "${ipv6_addr_des}"
+            migrate_vm_back = "yes"
         - hostname:
             dest_host = "ENTER.YOUR.EXAMPLE.SERVER_CN"
+            migrate_vm_back = "yes"
         - wrong_hostname:
             dest_host = "for_test_hostname"
             status_error = "yes"

--- a/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_tls.cfg
+++ b/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_tls.cfg
@@ -54,6 +54,7 @@
             check_str_local_log = '['"dir":"/etc/pki/qemu","endpoint":"client","verify-peer":true']'
             check_str_remote_log = '['"dir":"/etc/pki/qemu","endpoint":"server","verify-peer":true']'
             action_during_mig = '[{"func": "libvirt_network.check_established", "after_event": "iteration: \'1\'", "func_param": "params"}, {"func": "set_migrate_speed_to_high", "func_param": "params"}]'
+            migrate_vm_back = "yes"
         - tls_destination:
             no with_postcopy
             custom_pki_path = "/etc/pki/qemu"

--- a/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_tunnelled.cfg
+++ b/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_tunnelled.cfg
@@ -28,6 +28,7 @@
     expected_network_conn_num = "0"
     stress_package = "stress"
     stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20s"
+    migrate_vm_back = "yes"
     variants desturi_protocol:
         - desturi_tls:
             migrate_desturi_port = "16514"

--- a/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_unix_proxy.cfg
+++ b/libvirt/tests/cfg/migration/migration_uri/migration_network_data_transport_unix_proxy.cfg
@@ -24,6 +24,7 @@
     migrate_speed = "10"
     stress_package = "stress"
     stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20s"
+    migrate_vm_back = "yes"
     variants:
         - p2p:
             virsh_migrate_options = '--live --p2p --verbose'

--- a/libvirt/tests/cfg/migration/migration_uri/tcp_common.cfg
+++ b/libvirt/tests/cfg/migration/migration_uri/tcp_common.cfg
@@ -32,6 +32,7 @@
     libvirtd_debug_level = "1"
     libvirtd_debug_filters = "1:*"
     check_no_str_local_log = ["Cannot open log file"]
+    migrate_vm_back = "yes"
     variants:
         - p2p:
             virsh_migrate_options = '--live --p2p --verbose'

--- a/libvirt/tests/cfg/migration/migration_uri/tcp_listen_address.cfg
+++ b/libvirt/tests/cfg/migration/migration_uri/tcp_listen_address.cfg
@@ -30,6 +30,7 @@
     ipv6_addr_des = "ENTER.YOUR.IPv6.DESTINATION"
     stress_package = "stress"
     stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20s"
+    migrate_vm_back = "yes"
     variants:
         - p2p:
             virsh_migrate_options = '--live --p2p --verbose'

--- a/libvirt/tests/cfg/migration/migration_uri/tcp_migrateuri.cfg
+++ b/libvirt/tests/cfg/migration/migration_uri/tcp_migrateuri.cfg
@@ -29,6 +29,7 @@
     migrate_speed = "5"
     stress_package = "stress"
     stress_args = "--cpu 8 --io 4 --vm 2 --vm-bytes 128M --timeout 20s"
+    migrate_vm_back = "yes"
     variants:
         - p2p:
             virsh_migrate_options = '--live --p2p --verbose'

--- a/libvirt/tests/src/migration/memory_copy_mode/memory_copy_mode.py
+++ b/libvirt/tests/src/migration/memory_copy_mode/memory_copy_mode.py
@@ -30,6 +30,7 @@ def run(test, params, env):
 
     vm_name = params.get("migrate_main_vm")
     test_case = params.get('test_case', '')
+    migrate_vm_back = params.get_boolean("migrate_vm_back", True)
 
     virsh_session = None
     remote_virsh_session = None
@@ -47,5 +48,7 @@ def run(test, params, env):
         migration_obj.run_migration()
         verify_test()
         migration_base.check_event_output(params, test, virsh_session, remote_virsh_session)
+        if migrate_vm_back:
+            migration_obj.run_migration_back()
     finally:
         migration_obj.cleanup_connection()

--- a/libvirt/tests/src/migration/migration_uri/migration_desturi.py
+++ b/libvirt/tests/src/migration/migration_uri/migration_desturi.py
@@ -23,6 +23,7 @@ def run(test, params, env):
         migration_obj.verify_default()
 
     test_case = params.get('test_case', '')
+    migrate_vm_back = params.get_boolean("migrate_vm_back", True)
     vm_name = params.get("migrate_main_vm")
     vm = env.get_vm(vm_name)
     migration_obj = base_steps.MigrationBase(test, vm, params)
@@ -34,5 +35,7 @@ def run(test, params, env):
         migration_obj.setup_connection()
         migration_obj.run_migration()
         verify_test()
+        if migrate_vm_back:
+            migration_obj.run_migration_back()
     finally:
         migration_obj.cleanup_connection()

--- a/libvirt/tests/src/migration/migration_uri/migration_network_data_transport.py
+++ b/libvirt/tests/src/migration/migration_uri/migration_network_data_transport.py
@@ -14,6 +14,7 @@ def run(test, params, env):
 
     libvirt_version.is_libvirt_feature_supported(params)
 
+    migrate_vm_back = params.get_boolean("migrate_vm_back", True)
     vm_name = params.get("migrate_main_vm")
     vm = env.get_vm(vm_name)
     migration_obj = base_steps.MigrationBase(test, vm, params)
@@ -22,5 +23,7 @@ def run(test, params, env):
         migration_obj.setup_connection()
         migration_obj.run_migration()
         migration_obj.verify_default()
+        if migrate_vm_back:
+            migration_obj.run_migration_back()
     finally:
         migration_obj.cleanup_connection()

--- a/libvirt/tests/src/migration/migration_uri/migration_network_data_transport_tls.py
+++ b/libvirt/tests/src/migration/migration_uri/migration_network_data_transport_tls.py
@@ -127,6 +127,7 @@ def run(test, params, env):
 
     test_case = params.get('test_case', '')
     migrate_again = "yes" == params.get("migrate_again", "no")
+    migrate_vm_back = params.get_boolean("migrate_vm_back", True)
     vm_name = params.get("migrate_main_vm")
 
     vm = env.get_vm(vm_name)
@@ -145,5 +146,7 @@ def run(test, params, env):
         if migrate_again:
             migration_obj.run_migration_again()
         migration_obj.verify_default()
+        if migrate_vm_back:
+            migration_obj.run_migration_back()
     finally:
         cleanup_test()

--- a/libvirt/tests/src/migration/migration_uri/tcp_common.py
+++ b/libvirt/tests/src/migration/migration_uri/tcp_common.py
@@ -35,6 +35,7 @@ def run(test, params, env):
     libvirt_version.is_libvirt_feature_supported(params)
 
     test_case = params.get('test_case', '')
+    migrate_vm_back = params.get_boolean("migrate_vm_back", True)
     vm_name = params.get("migrate_main_vm")
     vm = env.get_vm(vm_name)
     qemu_log = "/var/log/libvirt/qemu/%s.log" % vm_name
@@ -44,5 +45,7 @@ def run(test, params, env):
         setup_test()
         migration_obj.run_migration()
         verify_test()
+        if migrate_vm_back:
+            migration_obj.run_migration_back()
     finally:
         migration_obj.cleanup_connection()


### PR DESCRIPTION
To test vm migration back, migrate_vm_back was added for some cases.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for back-migration testing in VM migration scenarios. When enabled via configuration flag, migration tests can now optionally migrate virtual machines back to their original location after successful migration, enabling more comprehensive bidirectional migration validation across multiple test configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->