### PR TITLE
vitual_network/../driver_packed: enable on s390x

### DIFF
--- a/libvirt/tests/cfg/virtual_network/elements_and_attributes/driver_packed.cfg
+++ b/libvirt/tests/cfg/virtual_network/elements_and_attributes/driver_packed.cfg
@@ -11,3 +11,5 @@
     expected_packed_bit = "1"
     check_multiqueue = yes
     expected_queue_count = 4
+    s390-virtio:
+        bustype = ccw


### PR DESCRIPTION
s390x uses virtio-ccw for all virtio downstream. Enable getting the feature attribute for those devices but don't change logic for existing tests which assume virtio-pci.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added support for validating packed virtqueue functionality across PCI and s390 (CCW) bus architectures.
  * Added a new test configuration for the s390-virtio bus type to broaden coverage.
  * Enhanced validation logic with bus-type-specific checks, improved error handling for unknown bus types, and a sensible default bus selection for existing tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->