### PR TITLE
virtual_network/passt_function: ignore additional warning

### DIFF
--- a/libvirt/tests/src/virtual_network/passt/passt_function.py
+++ b/libvirt/tests/src/virtual_network/passt/passt_function.py
@@ -176,7 +176,10 @@ def run(test, params, env):
 
         if vhostuser and warning_check:
             # Exclude the warning like: 'warning : qemuDomainObjTaintMsg:5529 : Domain ... is tainted: custom-monitor'
-            check_warning = process.run('grep -v "qemuDomainObjTaintMsg.*custom-monitor" {0}|grep "warning :"'.format(libvirtd_debug_file),
+            # Also power management warnings can be ignored in capabilities
+            ignore_patterns = "qemuDomainObjTaintMsg.*custom-monitor|virQEMUCapsInit.*power management"
+            cmd = 'grep -Ev "{0}" {1} | grep "warning :"'.format(ignore_patterns, libvirtd_debug_file)
+            check_warning = process.run(cmd,
                                         shell=True,
                                         ignore_status=True,
                                         logger=LOG)


### PR DESCRIPTION
If power management is not available virtqemud log will contain a warning. This is not related to the test case and can be ignored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced warning detection filtering in test suite to improve accuracy of test failure identification and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->