### PR TITLE
Add test for iommufd

### DIFF
--- a/libvirt/tests/cfg/sriov/vm_lifecycle/sriov_vm_lifecycle_reboot.cfg
+++ b/libvirt/tests/cfg/sriov/vm_lifecycle/sriov_vm_lifecycle_reboot.cfg
@@ -4,6 +4,11 @@
 
     only x86_64, aarch64
     variants:
+        - with_iommufd:
+            func_supported_since_libvirt_ver = (11, 10, 0)
+            driver_dict = {'driver': {'driver_attr': {'iommufd': 'yes'}}}
+        - without_iommufd:
+    variants:
         - with_iommu:
             only vf_address..managed_yes, failover
             no network_interface

--- a/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_reboot.py
+++ b/libvirt/tests/src/sriov/vm_lifecycle/sriov_vm_lifecycle_reboot.py
@@ -50,8 +50,10 @@ def run(test, params, env):
             libvirt.add_vm_device(
                 vm_xml.VMXML.new_from_dumpxml(vm_name), iface_dev2)
 
+        test.log.debug("VM XML before vm starts:\n%s", vm_xml.VMXML.new_from_dumpxml(vm_name))
         test.log.info("TEST_STEP2: Start the VM")
         vm.start()
+        test.log.debug("VM XML after vm starts:\n%s", vm_xml.VMXML.new_from_dumpxml(vm_name))
         vm.cleanup_serial_console()
         vm.create_serial_console()
         vm_session = vm.wait_for_serial_login(timeout=240)

--- a/provider/sriov/sriov_base.py
+++ b/provider/sriov/sriov_base.py
@@ -192,6 +192,22 @@ class SRIOVTest(object):
             if vf_pci_addr2.get('type'):
                 del vf_pci_addr2['type']
             iface_dict = eval(self.params.get('hostdev_dict', '{}'))
+
+        driver_dict = eval(self.params.get("driver_dict", "{}"))
+        if driver_dict:
+            if iface_dict.get("driver"):
+                # We need to merge the key/values for driver_attr.
+                # For example:
+                #  iface_dict = {'driver': {'driver_attr': {'name': 'vfio'}}}
+                #  driver_dict = {'driver': {'driver_attr': {'iommufd': 'yes'}}}
+                # The expected result:
+                #  iface_dict = {'driver': {'driver_attr': {'name': 'vfio', 'iommufd': 'yes'}}}
+                existing_driver_dict = iface_dict.get("driver")
+                existing_attrs_dict = existing_driver_dict.get("driver_attr")
+                for attr_key, attr_value in driver_dict.get("driver").get("driver_attr").items():
+                    existing_attrs_dict.update({attr_key: attr_value})
+            else:
+                iface_dict.update(driver_dict)
         return iface_dict
 
     def parse_network_dict(self):


### PR DESCRIPTION
The IOMMUFD is a new machinism and implementation for VFIO passthrough/hotplug. We enable some existing test cases with iommufd setting.

We need to make sure both traditional and IOMMUFD can work.

Signed-off-by: Dan Zheng <dzheng@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for testing IOMMU-FD enabled and disabled scenarios
  * Safer merging of driver-specific interface settings to preserve existing attributes

* **Tests**
  * Expanded lifecycle test variants to cover the new IOMMU-FD configurations
  * Added debug logging to capture VM state before and after startup during lifecycle tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->