### PR TITLE
Add host validation case for secure launch features

### DIFF
--- a/libvirt/tests/cfg/cpu/secure_host_validate.cfg
+++ b/libvirt/tests/cfg/cpu/secure_host_validate.cfg
@@ -1,0 +1,55 @@
+- cpu.secure_launch.secure_host_validate:
+    type = secure_host_validate
+    start_vm = "no"
+    only x86_64
+    kernel_msg_cmd = "journalctl -b 0 -k"
+    variants:
+        - amd_secure:
+            cpu_vendor = "amd"
+            variants:
+                - sev_series:
+                    kvm_probe_module_force_load = yes
+                    req_kernel_opts = ["mem_encrypt=on", "amd_iommu=on"]
+                    validate_cmds = {"sevctl": {"package": "sevctl", "cmd_params": "ok"}, "virt-host-validate": {"package": "libvirt", "cmd_params": ""}}
+                    virt_host_validate_patterns = ['QEMU: Checking for secure guest support\s+:\s+PASS\n\s*\(SEV']
+                    sevctl_sev_pattern = '\[.*PASS.*\]\s+-\s+Secure\sEncrypted\sVirtualization\s+\(SEV\)'
+                    sevctl_sev_es_pattern = '\[.*PASS.*\]\s+-\s+Encrypted\sState\s+\(SEV-ES\)'
+                    sevctl_sev_snp_pattern = '\[.*PASS.*\]\s+-\s+Secure Nested Paging\s+\(SEV-SNP\)'
+                    variants:
+                        - sev:
+                            secure_feature = "sev"
+                            cpu_flags = ["sev"]
+                            kvm_probe_module_parameters = "sev=1"
+                            sevctl_patterns = ['${sevctl_sev_pattern}']
+                        - sev_es:
+                            secure_feature = "sev-es"
+                            cpu_flags = ["sev", "sev_es"]
+                            kvm_probe_module_parameters = "sev=1 sev-es=1"
+                            sevctl_patterns = ['${sevctl_sev_pattern}', '${sevctl_sev_es_pattern}']
+                        - sev_snp:
+                            secure_feature = "sev-snp"
+                            cpu_flags = ["sev", "sev_es", "sev_snp"]
+                            kvm_probe_module_parameters = "sev=1 sev-es=1 sev-snp=1"
+                            sevctl_patterns = ['${sevctl_sev_pattern}', '${sevctl_sev_es_pattern}', '${sevctl_sev_snp_pattern}']
+                            virt_host_validate_patterns = ['QEMU: Checking for secure guest support\s+:\s+PASS\n\s*\(SEV-SNP\)']
+        - inter_secure:
+            cpu_vendor = "intel"
+            variants:
+                - sgx:
+                    func_supported_since_libvirt_ver = (9, 0, 0)
+                    secure_feature = "sgx"
+                    cpu_flags = ["sgx", "sgx_lc"]
+                    kernel_msg_patterns = ["EPC section"]
+                    domcap_xpath = [{'element_attrs':[".//features/sgx[@supported='yes']"]}, {'element_attrs':[".//features/sgx/flc"],'text':'yes'}, {'element_attrs':[".//features/sgx/sgx1"],'text':'yes'}, {'element_attrs':[".//features/sgx/sgx2"],'text':'yes'}, {'element_attrs':[".//features/sgx/sections"]}]
+                - tdx:
+                    func_supported_since_libvirt_ver = (11, 10, 0)
+                    secure_feature = "tdx"
+                    cpu_flags = ["tdx_host_platform"]
+                    kvm_probe_module_force_load = yes
+                    kvm_probe_module_parameters = "tdx=1"
+                    kvm_probe_module_ignored_parameters = vmentry_l1d_flush=not required
+                    req_kernel_opts = ["nohibernate", "intel_iommu=on"]
+                    domcap_xpath = [{'element_attrs':[".//features/launchSecurity[@supported='yes']"]}, {'element_attrs':[".//features/launchSecurity/enum[@name='sectype']"]},  {'element_attrs':[".//features/launchSecurity/enum/value"],'text':'tdx'}]
+                    validate_cmds = {"virt-host-validate": {"package": "libvirt", "cmd_params": ""}}
+                    virt_host_validate_patterns = ['QEMU: Checking for secure guest support\s+:\s+PASS\n\s*\(TDX\)']
+

--- a/libvirt/tests/src/cpu/secure_host_validate.py
+++ b/libvirt/tests/src/cpu/secure_host_validate.py
@@ -1,0 +1,114 @@
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright Red Hat
+#
+#   SPDX-License-Identifier: GPL-2.0
+#
+#   Author: Liang Cong <lcong@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import ast
+
+from avocado.utils import cpu as cpu_utils
+from avocado.utils import process
+
+from virttest import cpu
+from virttest import libvirt_version
+from virttest import utils_misc
+from virttest import utils_package
+from virttest.libvirt_xml import domcapability_xml
+from virttest.utils_libvirt import libvirt_vmxml
+from virttest.utils_test import libvirt
+
+
+def run(test, params, env):
+    """
+    Verify below secure launch features are supported by the host:
+    1. AMD SEV, SEV-ES, SEV-SNP
+    2. INTEL SGX
+    3. INTEL TDX
+    """
+    def validate_prerequisites():
+        """
+        Verify secure launch prerequisites of the host.
+        """
+        def _validate_cpu_vendor():
+            """
+            Validate host CPU vendor matches the expected vendor specified
+            """
+            exp_vendor = params.get("cpu_vendor")
+            act_vendor = cpu_utils.get_vendor()
+            if exp_vendor and exp_vendor != act_vendor:
+                test.cancel("%s is not supported on %s CPU." % (secure_feature, act_vendor))
+
+        def _validate_cpu_flag():
+            """
+            Validate host CPU supports the required feature flags
+            """
+            host_cpu_flags = set(cpu.get_cpu_flags())
+            cpu_flags = ast.literal_eval(params.get("cpu_flags", "[]"))
+            if cpu_flags and not set(cpu_flags).issubset(host_cpu_flags):
+                test.cancel("%s requires cpu flags %s, but host cpu flags is %s." % (secure_feature, cpu_flags, host_cpu_flags))
+
+        def _validate_kernel_option():
+            """
+            Validate required kernel options are present in kernel cmdline
+            """
+            req_kernel_opts = ast.literal_eval(params.get("req_kernel_opts", "[]"))
+            ker_cml = utils_misc.get_ker_cmd()
+            if not all(opt in ker_cml for opt in req_kernel_opts):
+                test.cancel("%s requires kernel opt %s, but kernel cml is %s." % (secure_feature, req_kernel_opts, ker_cml))
+
+        secure_feature = params.get("secure_feature")
+        _validate_cpu_vendor()
+        _validate_cpu_flag()
+        _validate_kernel_option()
+
+    def setup_test():
+        """
+        Setup the environment:
+        1. install require packages
+        """
+        if validate_cmds:
+            req_pkgs = [cmd_info["package"] for cmd_info in validate_cmds.values()]
+            if not utils_package.package_install(req_pkgs):
+                test.error("Fail to install packages '%s'" % req_pkgs)
+
+    def run_test():
+        """
+        Test steps
+        1. Check expected kernel msg
+        2. Check specific tool output
+        3. Check virsh domcapabilities output
+        """
+        test.log.info("TEST_STEP1: Check expected kernel msg")
+        kernel_msg_cmd = params.get("kernel_msg_cmd")
+        kernel_msg_patterns = ast.literal_eval(
+            params.get("kernel_msg_patterns", "[]"))
+        result = process.run(kernel_msg_cmd, shell=True)
+        libvirt.check_result(result, expected_match=kernel_msg_patterns)
+
+        test.log.info("TEST_STEP2: Check specific tool output")
+        if validate_cmds:
+            for cmd, cmd_info in validate_cmds.items():
+                pkg_patterns = ast.literal_eval(
+                    params.get("%s_patterns" % cmd.replace("-", "_"), "[]"))
+                if pkg_patterns:
+                    pkg_cmd = "%s %s" % (cmd, cmd_info["cmd_params"])
+                    result = process.run(pkg_cmd, shell=True)
+                    for p_pattern in pkg_patterns:
+                        libvirt.check_result(result, expected_match=p_pattern)
+
+        test.log.info("TEST_STEP3: Check virsh domcapabilities output")
+        domcap_xpath = ast.literal_eval(params.get("domcap_xpath", "[]"))
+        if domcap_xpath:
+            domcap_xml = domcapability_xml.DomCapabilityXML()
+            libvirt_vmxml.check_guest_xml_by_xpaths(domcap_xml, domcap_xpath)
+
+    libvirt_version.is_libvirt_feature_supported(params)
+    validate_cmds = ast.literal_eval(params.get("validate_cmds", "{}"))
+
+    validate_prerequisites()
+    setup_test()
+    run_test()


### PR DESCRIPTION
Introduce a new test case to verify host environment supports required secure launch technologies.

The validation checks for the availability of the following features:
- AMD: SEV, SEV-ES, and SEV-SNP
- Intel: SGX and TDX

depends on: https://github.com/avocado-framework/avocado-vt/pull/4328



Test results:
(1/1) type_specific.io-github-autotest-libvirt.cpu.secure_launch.secure_host_validate.inter_secure.sgx: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.cpu.secure_launch.secure_host_validate.inter_secure.sgx: PASS (45.07 s)
 (1/1) type_specific.io-github-autotest-libvirt.cpu.secure_launch.secure_host_validate.inter_secure.tdx: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.cpu.secure_launch.secure_host_validate.inter_secure.tdx: PASS (46.02 s)
(1/3) type_specific.io-github-autotest-libvirt.cpu.secure_launch.secure_host_validate.amd_secure.sev_series.sev: STARTED
 (1/3) type_specific.io-github-autotest-libvirt.cpu.secure_launch.secure_host_validate.amd_secure.sev_series.sev: PASS (67.42 s)
 (2/3) type_specific.io-github-autotest-libvirt.cpu.secure_launch.secure_host_validate.amd_secure.sev_series.sev_es: STARTED
 (2/3) type_specific.io-github-autotest-libvirt.cpu.secure_launch.secure_host_validate.amd_secure.sev_series.sev_es: PASS (67.54 s)
 (3/3) type_specific.io-github-autotest-libvirt.cpu.secure_launch.secure_host_validate.amd_secure.sev_series.sev_snp: STARTED
 (3/3) type_specific.io-github-autotest-libvirt.cpu.secure_launch.secure_host_validate.amd_secure.sev_series.sev_snp: PASS (67.78 s)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new test suite and configuration profiles to validate secure host virtualization across AMD SEV/SEV-ES/SEV-SNP and Intel SGX/TDX. Tests verify host prerequisites (CPU vendor/flags, kernel options), collect and check kernel messages, run host-side validation commands, and inspect guest capability XML to confirm secure launch support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->