### PR TITLE
Improve test cases for update_device to create guest XML by the framework

### DIFF
--- a/libvirt/tests/cfg/virtual_network/update_device/update_device_coalesce.cfg
+++ b/libvirt/tests/cfg/virtual_network/update_device/update_device_coalesce.cfg
@@ -1,10 +1,15 @@
 - virtual_network.update_device.coalesce:
     type = update_device_coalesce
+    only Linux
+    create_vm_libvirt = yes
+    use_no_reboot = yes
+    kill_vm_libvirt = yes
+    ovmf:
+        kill_vm_libvirt_options = --nvram
     host_iface =
     start_vm = no
     timeout = 240
     outside_ip = 'www.redhat.com'
-    extra_attrs = {}
     vm_ping_outside = pass
     variants:
         - delete_iface_coalesce:
@@ -31,5 +36,4 @@
             iface_type = bridge
             br_type = ovs_br
             iface_source = {'source': {'bridge': br_name}}
-            extra_attrs = {'virtualport': {'type': 'openvswitch'}}
-    iface_attrs = {'type_name': '${iface_type}', **${coalesce}, **${iface_source}, 'model': 'virtio', 'mac_address': mac, **${extra_attrs}}
+    iface_attrs = {'type_name': '${iface_type}', **${coalesce}, **${iface_source}, 'model': 'virtio', 'mac_address': mac}

--- a/libvirt/tests/cfg/virtual_network/update_device/update_iface_link_state.cfg
+++ b/libvirt/tests/cfg/virtual_network/update_device/update_iface_link_state.cfg
@@ -1,5 +1,11 @@
 - virtual_network.update_device.iface_link_state:
     type = update_iface_link_state
+    only Linux
+    create_vm_libvirt = yes
+    use_no_reboot = yes
+    kill_vm_libvirt = yes
+    ovmf:
+        kill_vm_libvirt_options = --nvram
     start_vm = no
     timeout = 240
     outside_ip = "www.redhat.com"

--- a/libvirt/tests/cfg/virtual_network/update_device/update_iface_source.cfg
+++ b/libvirt/tests/cfg/virtual_network/update_device/update_iface_source.cfg
@@ -1,5 +1,11 @@
 - virtual_network.update_device.iface_source:
     type = update_iface_source
+    only Linux
+    create_vm_libvirt = yes
+    use_no_reboot = yes
+    kill_vm_libvirt = yes
+    ovmf:
+        kill_vm_libvirt_options = --nvram
     host_iface =
     start_vm = no
     outside_ip = 'www.redhat.com'

--- a/libvirt/tests/cfg/virtual_network/update_device/update_iface_with_identifier.cfg
+++ b/libvirt/tests/cfg/virtual_network/update_device/update_iface_with_identifier.cfg
@@ -1,5 +1,11 @@
 - virtual_network.update_device.iface_with_identifier:
     type = update_iface_with_identifier
+    only Linux
+    create_vm_libvirt = yes
+    use_no_reboot = yes
+    kill_vm_libvirt = yes
+    ovmf:
+        kill_vm_libvirt_options = --nvram
     start_vm = no
     timeout = 240
     iface_a_attrs = {'source': {'network': 'default'}, 'model': 'virtio', 'type_name': 'network', 'alias': {'name': alias_a}}

--- a/libvirt/tests/cfg/virtual_network/update_device/update_iface_with_options_active.cfg
+++ b/libvirt/tests/cfg/virtual_network/update_device/update_iface_with_options_active.cfg
@@ -1,5 +1,11 @@
 - virtual_network.update_device.with_options.active_vm:
     type = update_iface_with_options
+    only Linux
+    create_vm_libvirt = yes
+    use_no_reboot = yes
+    kill_vm_libvirt = yes
+    ovmf:
+        kill_vm_libvirt_options = --nvram
     start_vm = no
     timeout = 240
     vm_active = True

--- a/libvirt/tests/cfg/virtual_network/update_device/update_iface_with_options_inactive.cfg
+++ b/libvirt/tests/cfg/virtual_network/update_device/update_iface_with_options_inactive.cfg
@@ -1,5 +1,11 @@
 - virtual_network.update_device.with_options.inactive_vm:
     type = update_iface_with_options
+    only Linux
+    create_vm_libvirt = yes
+    use_no_reboot = yes
+    kill_vm_libvirt = yes
+    ovmf:
+        kill_vm_libvirt_options = --nvram
     start_vm = no
     timeout = 240
     vm_active = False

--- a/libvirt/tests/cfg/virtual_network/update_device/update_iface_with_unchangable.cfg
+++ b/libvirt/tests/cfg/virtual_network/update_device/update_iface_with_unchangable.cfg
@@ -1,5 +1,11 @@
 - virtual_network.update_device.with_unchangable:
     type = update_iface_with_unchangable
+    only Linux
+    create_vm_libvirt = yes
+    use_no_reboot = yes
+    kill_vm_libvirt = yes
+    ovmf:
+        kill_vm_libvirt_options = --nvram
     start_vm = no
     host_iface =
     iface_attrs_boot = 2

--- a/libvirt/tests/src/virtual_network/update_device/update_device_coalesce.py
+++ b/libvirt/tests/src/virtual_network/update_device/update_device_coalesce.py
@@ -1,7 +1,5 @@
 import logging
 
-from avocado.utils import process
-from virttest import utils_misc
 from virttest import utils_net
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
@@ -41,9 +39,9 @@ def run(test, params, env):
     """
     vm_name = params.get('main_vm')
     vm = env.get_vm(vm_name)
-    rand_id = utils_misc.generate_random_string(3)
     br_type = params.get('br_type', '')
-    br_name = br_type + '_' + rand_id
+    netdst = params.get('netdst', 'virbr0')
+    br_name = netdst.split(',')[0]
     mac = utils_net.generate_mac_address_simple()
     iface_attrs = eval(params.get('iface_attrs', '{}'))
     host_iface = params.get('host_iface')
@@ -53,17 +51,19 @@ def run(test, params, env):
     updated_rx_frames = params.get('updated_rx_frames', '0')
     updated_coalesce = eval(params.get('updated_coalesce', '{}'))
 
+    if br_type == 'linux_br':
+        network_base.cancel_if_ovs_bridge(params, test)
+    elif br_type == 'ovs_br':
+        br_backend = utils_net.find_bridge_manager(br_name)
+        if isinstance(br_backend, utils_net.Bridge):
+            test.cancel("Skip OVS bridge test as the host uses Linux bridge")
+        # Setup OVS bridge configuration only for the OVS bridge variant
+        network_base.setup_ovs_bridge_attrs(params, iface_attrs)
+
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     bkxml = vmxml.copy()
 
     try:
-        LOG.info('Create bridge for test.')
-        if br_type == 'linux_br':
-            utils_net.create_linux_bridge_tmux(br_name, host_iface)
-            process.run(f'ip l show type bridge {br_name}', shell=True)
-        elif br_type == 'ovs_br':
-            utils_net.create_ovs_bridge(br_name)
-
         LOG.info('Setup interface on vm.')
         mac = vm_xml.VMXML.get_first_mac_by_name(vm_name)
         vmxml.del_device('interface', by_tag=True)
@@ -106,9 +106,3 @@ def run(test, params, env):
         if 'session' in locals():
             session.close()
         bkxml.sync()
-        if br_type == 'linux_br':
-            LOG.debug(f'Delete linux bridge: {br_name}')
-            utils_net.delete_linux_bridge_tmux(br_name, host_iface)
-        if br_type == 'ovs_br':
-            LOG.debug(f'Delete ovs bridge: {br_name}')
-            utils_net.delete_ovs_bridge(br_name)

--- a/libvirt/tests/src/virtual_network/update_device/update_iface_link_state.py
+++ b/libvirt/tests/src/virtual_network/update_device/update_iface_link_state.py
@@ -24,8 +24,9 @@ def run(test, params, env):
     host_iface = host_iface if host_iface else utils_net.get_default_gateway(
         iface_name=True, force_dhcp=True, json=True)
     rand_id = utils_misc.generate_random_string(3)
-    bridge_name = "br_" + rand_id
     tap_name = "tap_" + rand_id
+    netdst = (params.get('netdst') or '').split(',', 1)[0].strip()
+    bridge_name = netdst if netdst else "br_" + rand_id
     interface_type = params.get("interface_type")
     iface_attrs = eval(params.get("iface_attrs", "{}"))
     initial_link_state = params.get("initial_link_state", "")
@@ -44,7 +45,9 @@ def run(test, params, env):
 
     try:
         if interface_type == "ethernet":
-            utils_net.create_linux_bridge_tmux(bridge_name, host_iface)
+            network_base.cancel_if_ovs_bridge(params, test)
+            if not netdst:
+                utils_net.create_linux_bridge_tmux(bridge_name, host_iface)
             network_base.create_tap(tap_name, bridge_name, "root")
 
         mac = vm_xml.VMXML.get_first_mac_by_name(vm_name)
@@ -109,4 +112,5 @@ def run(test, params, env):
         bkxml.sync()
         if interface_type == "ethernet":
             network_base.delete_tap(tap_name)
-            utils_net.delete_linux_bridge_tmux(bridge_name, host_iface)
+            if not netdst:
+                utils_net.delete_linux_bridge_tmux(bridge_name, host_iface)


### PR DESCRIPTION
1.Add some parameters to allow the framework provide guest xml 
2.Add "only Linux" to limit guest type
3.Remove create ovs and linux_br , let them created by the test loop's environment setup par

ID: LIBVIRTAT-22356

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added Linux-only constraints and VM lifecycle controls (create VM, no-reboot flow, forced VM termination) across virtual-network update-device tests.
  * Updated OVMF options to handle NVRAM during VM termination.
  * Simplified interface attribute declarations by removing default extra_attrs.

* **Refactor**
  * Simplified bridge handling: derive bridge target from provided network destination, skip/cancel OVS bridge cases, and avoid creating/deleting platform bridges during tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->