### PR TITLE
Update the method from system_reset to libvirt_reset for reboot

### DIFF
--- a/libvirt/tests/src/virtual_network/qemu/multi_nics_reboot.py
+++ b/libvirt/tests/src/virtual_network/qemu/multi_nics_reboot.py
@@ -9,7 +9,7 @@ def run(test, params, env):
     """
     Qemu reboot test:
     1) Log into a guest
-    3) Send a reboot command or a system_reset monitor command (optional)
+    3) Send a reboot command or a virsh-reset command (optional)
     4) Wait until the guest is up again
     5) Log into the guest to verify it's up again
 
@@ -41,7 +41,7 @@ def run(test, params, env):
     if params.get("reboot_method"):
         for vm in vms:
             test.log.debug("Reboot guest '%s'." % vm.name)
-            if params.get("reboot_method") == "system_reset":
+            if params.get("reboot_method") == "libvirt_reset":
                 time.sleep(params.get_numeric("sleep_before_reset", 10))
             # Reboot the VM
             if serial_login:

--- a/libvirt/tests/src/virtual_network/qemu/performance/netperf.py
+++ b/libvirt/tests/src/virtual_network/qemu/performance/netperf.py
@@ -219,7 +219,7 @@ def run(test, params, env):
                     test.fail(msg)
             session.close()
         if params.get("reboot_after_config", "yes") == "yes":
-            vm.reboot(method="system_reset", serial=True)
+            vm.reboot(method="libvirt_reset", serial=True)
 
     test.log.info(
         "TEST_STEP 4: Ensure guest networking is ready "


### PR DESCRIPTION
As it supported the method libvirt_reset for the reboot in the framework, this commit aims to update the related test cases with the libvirt_reset support.

Reference PR: https://github.com/avocado-framework/avocado-vt/pull/4312

ID: LIBVIRTAT-22302

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated VM reboot mechanism used in test suites.
  * Aligned test descriptions to reflect the new reboot option.
  * Adjusted restart behavior and timing in multi‑NIC and performance test scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->