### PR TITLE
Improve cases for iface_hotplug to create guest XML by the framework

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_hotplug.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_hotplug.cfg
@@ -1,5 +1,10 @@
 - virtual_network.iface_hotplug:
     type = iface_hotplug
+    only Linux
+    create_vm_libvirt = yes
+    kill_vm_libvirt = yes
+    ovmf:
+        kill_vm_libvirt_options = --nvram
     take_regular_screendumps = "no"
     start_vm = "yes"
     poll_timeout = 10


### PR DESCRIPTION
1.Add some parameters to allow the framework provide guest xml 
2.Add "only Linux" to limit guest type

ID: LIBVIRTAT-22386

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced virtual network interface hotplug test with Linux-only gating and explicit VM lifecycle management.
  * Added specific cleanup handling for OVMF configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->