### PR TITLE
Add lifecycle test for TDX guest with various configs

### DIFF
--- a/libvirt/tests/cfg/cpu/secure_tdx_with_various_config.cfg
+++ b/libvirt/tests/cfg/cpu/secure_tdx_with_various_config.cfg
@@ -1,0 +1,49 @@
+- cpu.secure_launch.tdx.with_various_config:
+    type = secure_tdx_with_various_config
+    start_vm = "no"
+    only x86_64
+    func_supported_since_libvirt_ver = (11, 10, 0)
+    kvm_probe_module_force_load = yes
+    kvm_probe_module_parameters = "tdx=1"
+    kvm_probe_module_ignored_parameters = vmentry_l1d_flush=not required
+    cpu_mode = "host-passthrough"
+    domcap_xpath = [{'element_attrs':[".//features/launchSecurity[@supported='yes']"]}, {'element_attrs':[".//features/launchSecurity/enum[@name='sectype']"]},  {'element_attrs':[".//features/launchSecurity/enum/value"],'text':'tdx'}]
+    mem_size = 2097152
+    mem_attr = ", 'memory_unit':'KiB','memory':${mem_size},'current_mem':${mem_size}"
+    cpu_attrs = ", 'cpu': {'mode': '${cpu_mode}'}"
+    os_firmware_dict = "{'os': {'os_firmware': 'efi', 'firmware': {'feature': [{'enabled': 'yes', 'name': 'enrolled-keys'}, {'enabled': 'yes', 'name': 'secure-boot'}]}}}"
+    launchsec_attrs = ", 'launchsecurity': {'launchsec_type': 'tdx', 'launchsec_policy': '0x10000000', 'launchsec_qgs_path': '/var/run/tdx-qgs/qgs.socket'}"
+    dmesg_pattern = "tdx: Guest detected"
+    tdx_device_path = "/dev/tdx_guest"
+    features_dict ="'features': {'smm': 'off'}"
+    qmp_cmd = '{"execute":"qom-get", "arguments":{"path":"/objects/lsec0", "property":"%s"}}'
+    variants:
+        - anonymous:
+            mem_back_attrs = ", 'mb':{'source_type':'anonymous','access_mode':'private'}"
+        - memfd:
+            only default_tdx
+            mem_back_attrs = ", 'mb':{'source_type':'memfd','access_mode':'private'}"
+        - hugepage:
+            only default_tdx
+            hugepage_memory = ${mem_size}
+            mem_back_attrs = ", 'mb':{'hugepages': {},'access_mode':'private'}"
+        - numa:
+            only default_tdx
+            mem_back_attrs = ""
+            cpu_attrs = ", 'vcpu':4, 'cpu': {'mode': '${cpu_mode}', 'numa_cell': [{'id': '0', 'cpus': '0-1', 'memory': '1048576', 'unit': 'KiB'},{'id':'1','cpus': '2-3','memory':'1048576','unit':'KiB'}]}"
+    variants:
+        - default_tdx:
+            launchsec_attrs = ", 'launchsecurity': {'launchsec_type': 'tdx'}"
+        - policy_qgs:
+            policy = "0x10000000"
+            qgs_path = "/var/run/tdx-qgs/qgs.socket"
+            qmp_expects_dict = {"sept-ve-disable": True, "quote-generation-socket": {"path":"${qgs_path}","type":"unix"}}
+            launchsec_attrs = ", 'launchsecurity': {'launchsec_type': 'tdx', 'launchsec_policy': '${policy}', 'launchsec_qgs_path': '${qgs_path}'}"
+        - custom_quote:
+            mrconfigid = "WQMUEz7x4Md1gPjhDTPH02dJgVt5llIKdAKMW7ybFG9me0RNbdEVkc16KEi/6Js4"
+            mrowner = "Zt2vA6jS/1EtLqfPTrkRZRn4fUDB+yvRTPUaPkJrTh2u+7Y9D2U0Kx4A9JzplStS"
+            mrownerconfig = "b1g5gT4d+y1kK/62A4aY3n23n8YJbXoZ74/gD5Z/l2v2F8H6g5f4N3a2B7n8H9iA"
+            qmp_expects_dict = {"mrconfigid": "${mrconfigid}", "mrownerconfig": "${mrownerconfig}", "mrowner": "${mrowner}"}
+            launchsec_attrs = ", 'launchsecurity': {'launchsec_type': 'tdx', 'launchsec_mrconfigid': '${mrconfigid}', 'launchsec_mrowner': '${mrowner}', 'launchsec_mrownerconfig':'${mrownerconfig}'}"
+    vm_attrs = "{${features_dict} ${launchsec_attrs} ${mem_attr} ${mem_back_attrs} ${cpu_attrs}}"
+

--- a/libvirt/tests/src/cpu/secure_tdx_with_various_config.py
+++ b/libvirt/tests/src/cpu/secure_tdx_with_various_config.py
@@ -1,0 +1,148 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright Red Hat
+#
+#   SPDX-License-Identifier: GPL-2.0
+#
+#   Author: Liang Cong <lcong@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import ast
+import json
+
+from avocado.utils import memory as avocado_mem
+
+from virttest import libvirt_version
+from virttest import virsh
+from virttest import utils_misc
+from virttest import utils_sys
+from virttest.libvirt_xml import domcapability_xml, vm_xml
+from virttest.staging import utils_memory
+from virttest.utils_libvirt import libvirt_bios, libvirt_memory, libvirt_vmxml
+
+
+def run(test, params, env):
+    """
+    Life cycle test of a TDX guest with various memory configs
+    """
+    def setup_test():
+        """
+        Test setup:
+        1. Set up hugepage
+        2. Prepare the guest xml
+        """
+        if hugepage_memory is not None:
+            test.log.info("TEST_SETUP: Set up hugepage")
+            default_pagesize = avocado_mem.get_huge_page_size()
+            hp_num = int(hugepage_memory) // default_pagesize
+            utils_memory.set_num_huge_pages(hp_num)
+
+        test.log.info("TEST_SETUP: Prepare the guest xml")
+        vmxml.os = libvirt_bios.remove_bootconfig_items_from_vmos(vmxml.os)
+        vm_attrs.update(os_firmware_dict)
+        vmxml.setup_attrs(**vm_attrs)
+
+    def _check_tdx_guest(guest_vm):
+        """
+        Verify the TDX environment inside the guest OS
+
+        :param guest_vm: The VM object
+        """
+        dmesg_pattern = params.get("dmesg_pattern")
+        tdx_device_path = params.get("tdx_device_path")
+        with guest_vm.wait_for_login() as session:
+            # Check dmesg for TDX initialization
+            if not utils_sys.check_dmesg_output(dmesg_pattern, True, session):
+                test.fail("Dmesg check for %s failed in guest" % dmesg_pattern)
+            # Check TDX device existence
+            if not utils_misc.check_exists(tdx_device_path, session):
+                test.fail("TDX device at %s doesn't exist in guest" % tdx_device_path)
+            # Memory consumption check
+            status, output = libvirt_memory.consume_vm_freememory(session)
+            if status:
+                test.fail("Fail to consume guest memory. Output:%s" % output)
+
+    def _check_tdx_via_qmp(guest_name):
+        """
+        Verifies TDX guest properties via QMP commands
+
+        :param guest_name: Name of VM
+        """
+        qmp_expects_dict = ast.literal_eval(params.get("qmp_expects_dict", "{}"))
+        qmp_cmd = params.get("qmp_cmd")
+        for prop, exp in qmp_expects_dict.items():
+            f_qmp_cmd = qmp_cmd % prop
+            res = virsh.qemu_monitor_command(guest_name, f_qmp_cmd, debug=True).stdout_text
+            actual = json.loads(res)['return']
+            if exp != actual:
+                test.fail(
+                    "QMP cmd '%s' result '%s' doesn't contain expected return value %s"
+                    % (f_qmp_cmd, res, exp)
+                )
+
+    def _check_tdx_support():
+        """
+        Validate host TDX support via libvirt domcapabilities
+        """
+        domcap_xpath = ast.literal_eval(params.get("domcap_xpath", "[]"))
+        if domcap_xpath:
+            domcap_xml = domcapability_xml.DomCapabilityXML()
+            if not libvirt_vmxml.check_guest_xml_by_xpaths(domcap_xml, domcap_xpath, True):
+                test.cancel("Host does not support required TDX features. "
+                            "Domcapabilities check failed for XPaths: %s. "
+                            "Domcapabilities xml is: %s" % (domcap_xpath, domcap_xml))
+
+    def run_test():
+        """
+        Test steps
+        1. Define the guest
+        2. Start the guest
+        3. Initial check TDX guest
+        4. Lifecycle operations of TDX guest
+        """
+        test.log.info("TEST_STEP1: Define the guest")
+        vmxml.sync()
+        cur_xml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        test.log.debug("Guest config xml before start:\n%s", cur_xml)
+
+        test.log.info("TEST_STEP2: Start the guest")
+        vm.start()
+        cur_xml = vm_xml.VMXML.new_from_dumpxml(vm_name)
+        test.log.debug("Guest config xml after start is:\n%s", cur_xml)
+
+        test.log.info("TEST_STEP3: Initial check TDX guest")
+        _check_tdx_guest(vm)
+        _check_tdx_via_qmp(vm_name)
+
+        test.log.info("TEST_STEP4: Lifecycle operations of TDX guest")
+        operations = [
+            ("Pause/Resume", lambda: [vm.pause(), vm.resume()]),
+            ("Reboot", lambda: vm.reboot()),
+            ("Shutdown/Start", lambda: [vm.shutdown(), vm.wait_for_shutdown(), vm.start()]),
+            ("Reset", lambda: virsh.reset(vm.name, ignore_status=False, debug=True))
+        ]
+        for op_name, op_func in operations:
+            test.log.info("Performing operation: %s", op_name)
+            op_func()
+            _check_tdx_guest(vm)
+            _check_tdx_via_qmp(vm_name)
+
+    libvirt_version.is_libvirt_feature_supported(params)
+    _check_tdx_support()
+    vm_name = params.get("main_vm")
+    vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+    bkxml = vmxml.copy()
+    vm = env.get_vm(vm_name)
+
+    os_firmware_dict = ast.literal_eval(params.get("os_firmware_dict", "{}"))
+    vm_attrs = ast.literal_eval(params.get("vm_attrs"))
+    hugepage_memory = params.get("hugepage_memory")
+
+    try:
+        setup_test()
+        run_test()
+    finally:
+        test.log.info("TEST_TEARDOWN: Clean up environment.")
+        if hugepage_memory is not None:
+            utils_memory.set_num_huge_pages(0)
+        bkxml.sync()


### PR DESCRIPTION
This commit introduces a new test case to verify the lifecycle operations of Intel TDX guests under different memory configurations, including:
1. anonymous memory
2. memfd memory
3. hugepage memory
4. numa

Depends on: 
https://github.com/avocado-framework/avocado-vt/pull/4347
https://github.com/avocado-framework/avocado-vt/pull/4328

Test results:
 (1/6) type_specific.io-github-autotest-libvirt.cpu.secure_launch.tdx.with_various_config.default_tdx.anonymous: STARTED
 (1/6) type_specific.io-github-autotest-libvirt.cpu.secure_launch.tdx.with_various_config.default_tdx.anonymous: PASS (132.41 s)
 (2/6) type_specific.io-github-autotest-libvirt.cpu.secure_launch.tdx.with_various_config.default_tdx.memfd: STARTED
 (2/6) type_specific.io-github-autotest-libvirt.cpu.secure_launch.tdx.with_various_config.default_tdx.memfd: PASS (128.64 s)
 (3/6) type_specific.io-github-autotest-libvirt.cpu.secure_launch.tdx.with_various_config.default_tdx.hugepage: STARTED
 (3/6) type_specific.io-github-autotest-libvirt.cpu.secure_launch.tdx.with_various_config.default_tdx.hugepage: PASS (126.86 s)
 (4/6) type_specific.io-github-autotest-libvirt.cpu.secure_launch.tdx.with_various_config.default_tdx.numa: STARTED
 (4/6) type_specific.io-github-autotest-libvirt.cpu.secure_launch.tdx.with_various_config.default_tdx.numa: PASS (121.36 s)
 (5/6) type_specific.io-github-autotest-libvirt.cpu.secure_launch.tdx.with_various_config.policy_qgs.anonymous: STARTED
 (5/6) type_specific.io-github-autotest-libvirt.cpu.secure_launch.tdx.with_various_config.policy_qgs.anonymous: PASS (127.89 s)
 (6/6) type_specific.io-github-autotest-libvirt.cpu.secure_launch.tdx.with_various_config.custom_quote.anonymous: STARTED
 (6/6) type_specific.io-github-autotest-libvirt.cpu.secure_launch.tdx.with_various_config.custom_quote.anonymous: PASS (128.62 s)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive TDX secure-launch test covering multiple memory backends (anonymous, memfd, hugepage, NUMA) and several launch-security variants
  * Validates guest-side TDX detection, expected launch-security properties via QMP, memory behavior, and full VM lifecycle (start, pause/resume, reboot, shutdown/start, reset)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->