### PR TITLE
Inc_backup: add new test scenario for latency-histogram feature

### DIFF
--- a/libvirt/tests/cfg/backingchain/with_disk_attributes_test/commit_pull_with_disk_driver_attributes.cfg
+++ b/libvirt/tests/cfg/backingchain/with_disk_attributes_test/commit_pull_with_disk_driver_attributes.cfg
@@ -17,6 +17,11 @@
             driver_element = "driver_metadatacache"
             driver_include = {"driver": {"name": "qemu", "type":"qcow2"}}
             driver_dict = {"${driver_element}": {"max_size": 1024, "max_size_unit": "bytes"}, **${driver_include}}
+        - with_latency_histogram:
+            func_supported_since_libvirt_ver = (11, 10, 0)
+            driver_element = "driver_statistics"
+            driver_include = {"driver": {"name": "qemu", "type":"qcow2"}}
+            driver_dict = {"${driver_element}": {"latency_histogram": [{"type": "read", "bin": [{"start": "0"}, {"start": "1000"}, {"start": "100000"}]}]}, **${driver_include}}
     variants block_cmd:
         - blockcommit:
             blockcommit_options = " --active --pivot"

--- a/libvirt/tests/src/backingchain/with_disk_attributes_test/commit_pull_with_disk_driver_attributes.py
+++ b/libvirt/tests/src/backingchain/with_disk_attributes_test/commit_pull_with_disk_driver_attributes.py
@@ -1,4 +1,5 @@
 from virttest import virsh
+from virttest import libvirt_version
 from virttest.libvirt_xml import snapshot_xml
 from virttest.libvirt_xml import vm_xml
 from virttest.utils_libvirt import libvirt_vmxml
@@ -15,6 +16,7 @@ def run(test, params, env):
     - cache and discard
     - detect_zeroes
     - metadata_cache ->max_size
+    - latency_histogram with statistics
     2) Do blockcommit/blockpull and check dumpxml.
     """
 
@@ -82,6 +84,7 @@ def run(test, params, env):
             test.log.debug("Can get the expected attributes '%s'" % cur_dict)
 
     # Process cartesian parameters
+    libvirt_version.is_libvirt_feature_supported(params)
     vm_name = params.get("main_vm")
     target_disk = params.get('target_disk')
     disk_type = params.get("disk_type")


### PR DESCRIPTION
Automate case:
VIRT-294609 - Do blockcommit/blockpull with different attributes of driver elements

Automate a new test scenario of driver element: statistics/latency-histogram

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added new test variant for latency histogram monitoring in disk driver attributes with histogram bin configuration for read operations.
  * Introduced feature-gated test coverage requiring libvirt version 11.10.0 or later.
  * Updated test documentation to reflect latency histogram and statistics capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->