### PR TITLE
Improve cases for misc and nss to create guest XML by the framework

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_nss.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_nss.cfg
@@ -1,5 +1,10 @@
 - virtual_network.iface_nss:
     type = iface_nss
+    only Linux
+    create_vm_libvirt = yes
+    kill_vm_libvirt = yes
+    ovmf:
+        kill_vm_libvirt_options = --nvram
     start_vm = "yes"
     net_name = "default"
     variants:

--- a/libvirt/tests/cfg/virtual_network/network_misc.cfg
+++ b/libvirt/tests/cfg/virtual_network/network_misc.cfg
@@ -1,5 +1,11 @@
 - virtual_network.network_misc:
     type = network_misc
+    only Linux
+    create_vm_libvirt = yes
+    use_no_reboot = yes
+    kill_vm_libvirt = yes
+    ovmf:
+        kill_vm_libvirt_options = --nvram
     start_vm = no
     variants test_group:
         - zone:

--- a/libvirt/tests/src/virtual_network/iface_nss.py
+++ b/libvirt/tests/src/virtual_network/iface_nss.py
@@ -6,6 +6,7 @@ from virttest.utils_test.__init__ import ping
 from virttest import virsh
 from virttest import libvirt_xml
 from virttest.libvirt_xml.devices import interface
+from provider.virtual_network import network_base
 
 
 # Using as lower capital is not the best way to do, but this is just a
@@ -55,6 +56,8 @@ def run(test, params, env):
     3. Start the vm and check if the libvirt-nss module works properly by checking if the guest's hostname or
     domain name can be resolved successfully
     """
+    # Skip the OVS bridge test
+    network_base.cancel_if_ovs_bridge(params, test)
     nss_option = params.get("nss_option", None)
     guest_name = params.get("guest_name", "nssguest")
     net_name = params.get("net_name", "default")
@@ -82,6 +85,7 @@ def run(test, params, env):
         new_iface = interface.Interface('network')
         new_iface.xml = iface_xml.xml
         new_iface.type_name = "network"
+        new_iface.del_source()
         new_iface.source = {'network': net_name}
         vmxml.add_device(new_iface)
         vmxml.sync()


### PR DESCRIPTION
1.Add some parameters to allow the framework provide guest xml
2.Add "only Linux" to limit guest type
3.Skip the OVS bridge test

ID: 22413

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added Linux-only gating and enabled libvirt VM lifecycle management with NVRAM-aware teardown options in virtual network tests.
  * Adjusted test flow to skip unsupported bridge scenarios and refined network interface attach/detach sequencing for more reliable validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->