### PR TITLE
Improve virtual_network.qos cases to support new test tool

### DIFF
--- a/libvirt/tests/cfg/virtual_network/qos/check_actual_network_throughput.cfg
+++ b/libvirt/tests/cfg/virtual_network/qos/check_actual_network_throughput.cfg
@@ -1,11 +1,26 @@
 - virtual_network.qos.check_actual_network_throughput:
     type = check_actual_network_throughput
-    start_vm = no
+    start_vm = "no"
+    only Linux
+    create_vm_libvirt = yes
+    use_no_reboot = yes
+    kill_vm_libvirt = yes
+    ovmf:
+        kill_vm_libvirt_options = --nvram
     timeout = 240
     host_iface =
+    bridge_name =
     inbound = {'average': '512', 'peak': '1024', 'burst': '32'}
     outbound = {'average': '128', 'peak': '1024', 'burst': '32'}
     iface_bw_attrs = {'bandwidth': {'inbound': ${inbound}, 'outbound': ${outbound}}}
+
+    # Netperf configs
+    netperf_link = netperf-2.7.1.tar.bz2
+    server_path = /var/tmp/
+    client_path = /var/tmp/
+    netperf_test_duration = 60
+    disable_firewall = "systemctl stop firewalld.service"
+
     variants iface_type:
         - network:
             net_bw_attrs = {'bandwidth_inbound': ${inbound}, 'bandwidth_outbound': ${outbound}}
@@ -20,19 +35,7 @@
                 - br:
                     net_fwm = bridge
                     iface_attrs = {'type_name': 'network', 'model': 'virtio', 'source': {'network': net_name}}
-                    variants br_type:
-                        - linux_br:
-                            net_attrs = {'name': net_name, 'forward': {'mode': 'bridge'}, 'bridge': {'name': br_name}, **${net_bw_attrs}}
-                        - ovs_br:
-                            net_attrs = {'name': net_name, 'forward': {'mode': 'bridge'}, 'bridge': {'name': br_name}, **${net_bw_attrs}, 'virtualport_type': 'openvswitch'}
+                    net_attrs = {'name': net_name, 'forward': {'mode': 'bridge'}, 'bridge': {'name': '${bridge_name}'}, **${net_bw_attrs}}
         - br:
             iface_type = bridge
-            variants br_type:
-                - linux_br:
-                    iface_attrs = {'type_name': 'bridge', 'source': {'bridge': br_name}, 'model': 'virtio', **${iface_bw_attrs}}
-                - ovs_br:
-                    iface_attrs = {'type_name': 'bridge', 'source': {'bridge': br_name}, 'model': 'virtio', **${iface_bw_attrs}, 'virtualport': {'type': 'openvswitch'}}
-                    libvirtd_debug_file = /var/log/libvirt/libvird.log
-                    libvirtd_debug_level = 1
-                    expect_msg = warning.*Setting different .peak. value than .average. for QoS for OVS interface.*might have unexpected results
-                    throuput_bw = 1024
+            iface_attrs = {'type_name': 'bridge', 'source': {'bridge': '${bridge_name}'}, 'model': 'virtio', **${iface_bw_attrs}}

--- a/libvirt/tests/cfg/virtual_network/qos/check_bandwidth_by_domiftune.cfg
+++ b/libvirt/tests/cfg/virtual_network/qos/check_bandwidth_by_domiftune.cfg
@@ -1,6 +1,12 @@
 - virtual_network.qos.check_bandwidth_by_domiftune:
     type = check_bandwidth_by_domiftune
     start_vm = no
+    only Linux
+    create_vm_libvirt = yes
+    use_no_reboot = yes
+    kill_vm_libvirt = yes
+    ovmf:
+        kill_vm_libvirt_options = --nvram
     timeout = 240
     host_iface =
     net_attrs = {'bandwidth_outbound': {'average': '500', 'peak': '1000', 'burst': '1024'}, 'bandwidth_inbound': {'average': '1000', 'peak': '5000', 'burst': '5120'}}
@@ -11,6 +17,7 @@
             bw_with_floor = 
             update_bw = {'inbound': {'average': '100', 'peak': '200', 'burst': '300', 'floor': '150'}, 'outbound': {'average': '200', 'peak': '300', 'burst': '200'}}
         - direct:
+            create_vm_libvirt = no
             iface_attrs = {'source': {'dev': host_iface, 'mode': 'bridge'}, 'model': 'virtio', 'type_name': 'direct'}
         - br:
             br_type = linux_br

--- a/libvirt/tests/cfg/virtual_network/qos/check_qos_floor.cfg
+++ b/libvirt/tests/cfg/virtual_network/qos/check_qos_floor.cfg
@@ -1,6 +1,12 @@
 - virtual_network.qos.check_qos_floor:
     type = check_qos_floor
     start_vm = no
+    only Linux
+    create_vm_libvirt = yes
+    use_no_reboot = yes
+    kill_vm_libvirt = yes
+    ovmf:
+        kill_vm_libvirt_options = --nvram
     timeout = 240
     net_attrs = {'name': net_name, 'forward': {'mode': 'nat'}, 'ips': [{'dhcp_ranges': {'attrs': {'start': '192.168.100.2', 'end': '192.168.100.254'}}, 'netmask': '255.255.255.0', 'address': '192.168.100.1'}]}
     iface_attrs = {'source': {'network': net_name}, 'type_name': 'network', 'model': 'virtio'}

--- a/libvirt/tests/cfg/virtual_network/qos/test_bandwidth_boundry.cfg
+++ b/libvirt/tests/cfg/virtual_network/qos/test_bandwidth_boundry.cfg
@@ -1,6 +1,12 @@
 - virtual_network.qos.test_bandwidth_boundry:
     type = test_bandwidth_boundry
     start_vm = yes
+    only Linux
+    create_vm_libvirt = yes
+    use_no_reboot = yes
+    kill_vm_libvirt = yes
+    ovmf:
+        kill_vm_libvirt_options = --nvram
     variants bw_type:
         - inbound:
         - outbound:

--- a/libvirt/tests/src/virtual_network/qos/check_actual_network_throughput.py
+++ b/libvirt/tests/src/virtual_network/qos/check_actual_network_throughput.py
@@ -3,7 +3,6 @@ import logging
 from avocado.utils import process
 from virttest import utils_misc
 from virttest import utils_net
-from virttest import utils_package
 from virttest import virsh
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml.network_xml import NetworkXML
@@ -12,7 +11,7 @@ from virttest.utils_libvirt import libvirt_network
 from virttest.utils_libvirt import libvirt_vmxml
 from virttest.utils_test import libvirt
 
-from provider.virtual_network import network_base
+from provider.virtual_network import network_base, netperf_base
 
 VIRSH_ARGS = {'ignore_status': False, 'debug': True}
 
@@ -23,38 +22,57 @@ def run(test, params, env):
     """
     Check the actual network throughput
     per bandwidth settings in network/interface
-
     """
     vm_name = params.get('main_vm')
     vm = env.get_vm(vm_name)
-    br_type = params.get('br_type', '')
     rand_id = utils_misc.generate_random_string(3)
-    br_name = br_type + '_' + rand_id
     net_name = 'net_' + rand_id
-    host_iface = params.get('host_iface')
-    host_iface = host_iface if host_iface else utils_net.get_net_if(
-        state='UP')[0]
     iface_attrs = eval(params.get('iface_attrs', '{}'))
     net_attrs = eval(params.get('net_attrs', '{}'))
     inbound = eval(params.get('inbound'))
     outbound = eval(params.get('outbound'))
     throuput_bw = params.get('throuput_bw')
     expect_msg = params.get('expect_msg')
+    iface_type = params.get("iface_type", "bridge")
+    bridge_name = params.get('netdst', '')
+
+    # Original case design: 'virbr0' (NAT) and 'bridge' variants are mutually exclusive.
+    # Prevent pollution of the core libvirt bridge with incompatible bridge variants.
+    if bridge_name == 'virbr0':
+        net_fwm = params.get('net_fwm', '')
+        if iface_type == 'bridge' or (iface_type == 'network' and net_fwm == 'bridge'):
+            test.cancel("Original logic: 'virbr0' only supports 'nat' variant. Skipping bridge variant.")
+
+    is_ovs_bridge = False
+    if bridge_name:
+        try:
+            is_ovs_bridge = not isinstance(utils_net.find_bridge_manager(bridge_name), utils_net.Bridge)
+        except process.CmdError:
+            pass
+
+    # Dynamic attribute configuration for OVS
+    if iface_type == 'bridge':
+        iface_attrs['source'] = {'bridge': bridge_name}
+        network_base.setup_ovs_bridge_attrs(params, iface_attrs)
+        if is_ovs_bridge:
+            expect_msg = r"warning.*Setting different .peak. value than .average. for QoS for OVS interface.*might have unexpected results"
+            throuput_bw = 1024
+            libvirtd_debug_file = params.get("libvirtd_debug_file", "/var/log/libvirt/libvirtd.log")
+            params["libvirtd_debug_file"] = libvirtd_debug_file
+    elif iface_type == 'network' and params.get('net_fwm') == 'bridge':
+        net_attrs['bridge'] = {'name': bridge_name}
+        if is_ovs_bridge:
+            net_attrs['virtualport_type'] = 'openvswitch'
 
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     bkxml = vmxml.copy()
     net_xml = NetworkXML.new_from_net_dumpxml('default')
     bk_net_xml = net_xml.copy()
     firewalld = service.Factory.create_service("firewalld")
-    iface_type = params.get("iface_type")
+    fw_was_running = firewalld.status()
 
     try:
-        if br_type == 'linux_br':
-            utils_net.create_linux_bridge_tmux(br_name, host_iface)
-            process.run(f'ip l show type bridge {br_name}', shell=True)
-        elif br_type == 'ovs_br':
-            utils_net.create_ovs_bridge(br_name)
-
+        # 1. Setup Network or modify Interface QoS
         if 'name' in net_attrs:
             libvirt_network.create_or_del_network(net_attrs)
         else:
@@ -62,22 +80,28 @@ def run(test, params, env):
             net_xml.sync()
             LOG.debug(f'Network xml of default: {net_xml}')
 
+        orig_iface = vmxml.get_devices('interface')[0]
+        iface_attrs['mac_address'] = orig_iface.mac_address
+
         vmxml.del_device('interface', by_tag=True)
         libvirt_vmxml.modify_vm_device(vmxml, 'interface', iface_attrs)
         LOG.debug(f'VMXML of {vm_name}:\n{virsh.dumpxml(vm_name).stdout_text}')
 
         vm.start()
-        vm_sess = vm.wait_for_serial_login()
-        if expect_msg:
-            libvirt.check_logfile(expect_msg,
-                                  params.get("libvirtd_debug_file"))
 
+        login_timeout = params.get_numeric("login_timeout", 360)
+        vm_sess = vm.wait_for_login(timeout=login_timeout)
+        if expect_msg:
+            libvirt.check_logfile(expect_msg, params.get("libvirtd_debug_file", "/var/log/libvirt/libvirtd.log"))
+
+        # 3. Verify TC rules (Class and Filter)
         iface = network_base.get_iface_xml_inst(vm_name, 'on vm')
         mac = iface.mac_address
         tap_device = libvirt.get_ifname_host(vm_name, mac)
         LOG.debug(f'tap device on host with mac {mac} is: {tap_device}.')
-        source_br = iface.source['bridge']
-        LOG.debug(f'source bridge of interface is: {source_br}.')
+        source_br = iface.source.get('bridge')
+        if source_br:
+            LOG.debug(f'source bridge of interface is: {source_br}.')
 
         if 'bandwidth' in iface_attrs:
             tc_args = [tap_device, '1:1', iface_attrs['bandwidth']['inbound']]
@@ -87,40 +111,44 @@ def run(test, params, env):
             filter_bw = net_attrs['bandwidth_outbound']
 
         if not utils_net.check_class_rules(*tc_args):
-            test.fail('Class rule check failed. Please check log.')
+            test.fail('Class rule check (Inbound) failed. Please check log.')
         LOG.debug('Class rule check: PASS')
 
         if not utils_net.check_filter_rules(tc_args[0], filter_bw):
-            test.fail('Filter rule check failed. Please check log.')
+            test.fail('Filter rule check (Outbound) failed. Please check log.')
         LOG.debug('Filter rule check: PASS')
 
-        if not utils_package.package_install('netperf', session=vm_sess):
-            test.error('Failed to install netperf on VM.')
+        # 4. Prepare Netperf Environment
+        firewalld.stop()
+        disable_firewall = params.get("disable_firewall", "systemctl stop firewalld.service")
+        vm_sess.cmd(disable_firewall)
 
-        vm_sess.close()
-        vm_sess = vm.wait_for_serial_login()
-
-        host_ip = utils_net.get_linux_iface_info(
-            iface=source_br)['addr_info'][0]['local']
+        host_ip = utils_net.get_linux_iface_info(iface=source_br)['addr_info'][0]['local']
         vm_ip = network_base.get_vm_ip(vm_sess, mac)
         LOG.debug(f'Host ip address with br {source_br}: {host_ip}\n'
                   f'Vm ip address: {vm_ip}')
 
-        firewalld.stop()
-        vm_sess.cmd('systemctl stop firewalld')
+        # Compile netperf for both host and VM
+        host_nserver, host_nperf = netperf_base.compile_netperf_pkg(params, env, "localhost")
+        vm_nserver, vm_nperf = netperf_base.compile_netperf_pkg(params, env, vm_name)
 
+        # 5. Throughput Validation
+        test.log.info("TEST_STEP: Checking Inbound throughput (Host -> VM)")
         network_base.check_throughput(
-            vm_sess.cmd, lambda x: process.run(x).stdout_text,
-            vm_ip, throuput_bw if throuput_bw else inbound["average"], 'inbound'
+            vm_sess.cmd, lambda x: process.run(x, shell=True).stdout_text,
+            vm_ip, throuput_bw if throuput_bw else inbound["average"], 'inbound',
+            netserver_cmd=vm_nserver, netperf_cmd=host_nperf
         )
 
+        test.log.info("TEST_STEP: Checking Outbound throughput (VM -> Host)")
         network_base.check_throughput(
-            lambda x: process.run(x).stdout_text,
-            vm_sess.cmd,  host_ip, outbound["average"], 'outbound'
+            lambda x: process.run(x, shell=True).stdout_text, vm_sess.cmd,
+            host_ip, outbound["average"], 'outbound',
+            netserver_cmd=host_nserver, netperf_cmd=vm_nperf
         )
-        vm_sess.close()
-        vm.destroy()
-        if iface_type == "bridge" and br_type == "ovs_br":
+        vm_sess.cmd(f"rm -rf {vm_nserver.split('/src/')[0]}")
+        vm.destroy(gracefully=False)
+        if iface_type == "bridge" and is_ovs_bridge:
             ovs_list_cmd = 'ovs-vsctl list qos'
             ovs_list_output = process.run(ovs_list_cmd).stdout_text
             if ovs_list_output:
@@ -128,12 +156,14 @@ def run(test, params, env):
                           f'But we got {ovs_list_output}')
 
     finally:
+        # Unified and safe cleanup logic
+        if host_nserver:
+            process.run(f"rm -rf {host_nserver.split('/src/')[0]}", shell=True)
+        if vm_sess:
+            vm_sess.close()
+
         bkxml.sync()
         bk_net_xml.sync()
         if 'name' in net_attrs:
             libvirt_network.create_or_del_network(net_attrs, is_del=True)
-        if br_type == 'linux_br':
-            utils_net.delete_linux_bridge_tmux(br_name, host_iface)
-        if br_type == 'ovs_br':
-            utils_net.delete_ovs_bridge(br_name)
         firewalld.start()

--- a/libvirt/tests/src/virtual_network/qos/check_bandwidth_by_domiftune.py
+++ b/libvirt/tests/src/virtual_network/qos/check_bandwidth_by_domiftune.py
@@ -26,11 +26,15 @@ def run(test, params, env):
     vm = env.get_vm(vm_name)
     br_type = params.get('br_type', '')
     rand_id = utils_misc.generate_random_string(3)
-    br_name = br_type + '_' + rand_id
+    netdst = params.get('netdst')
+    br_name = netdst if netdst else br_type + '_' + rand_id
     host_iface = params.get('host_iface')
-    host_iface = host_iface if host_iface else utils_net.get_default_gateway(
-        iface_name=True, force_dhcp=True, json=True)
+    if not host_iface and not netdst:
+        host_iface = utils_net.get_default_gateway(
+            iface_name=True, force_dhcp=True, json=True)
     iface_attrs = eval(params.get('iface_attrs', '{}'))
+    if netdst and iface_attrs.get('type_name') == 'bridge':
+        network_base.setup_ovs_bridge_attrs(params, iface_attrs)
     net_attrs = eval(params.get('net_attrs', '{}'))
     update_bw = eval(params.get('update_bw', '{}'))
 
@@ -40,7 +44,7 @@ def run(test, params, env):
     bk_net_xml = net_xml.copy()
 
     try:
-        if br_type == 'linux_br':
+        if br_type == 'linux_br' and not netdst:
             utils_net.create_linux_bridge_tmux(br_name, host_iface)
             process.run(f'ip l show type bridge {br_name}', shell=True)
 
@@ -140,5 +144,5 @@ def run(test, params, env):
             session.close()
         bkxml.sync()
         bk_net_xml.sync()
-        if br_type == 'linux_br':
+        if br_type == 'linux_br' and not netdst:
             utils_net.delete_linux_bridge_tmux(br_name, host_iface)


### PR DESCRIPTION
1.Add some parameters to allow the framework provide guest xml 
2.Add "only Linux" to limit guest type
3.Add a check about host bridge type for check_actual_network_throughput and check_bandwidth_by_domiftune
4.Change the method for specifying different bridge types via the test command intead of case cfg varaint for check_actual_network_throughput

ID: LIBVIRTAT-22417
Assisted-by: Gemini AI
Signed-off-by: Lei Yang leiyang@redhat.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Standardized VM lifecycle management across network QoS tests with Linux-only execution constraints.
  * Enhanced network throughput validation with local netperf compilation on both host and VM.
  * Improved VM session initialization and dynamic interface configuration for bridge and OVS scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->