### PR TITLE
Improve virtual_network_address_tftp to support new test tool

### DIFF
--- a/libvirt/tests/cfg/virtual_network/address/virtual_network_address_tftp.cfg
+++ b/libvirt/tests/cfg/virtual_network/address/virtual_network_address_tftp.cfg
@@ -1,6 +1,8 @@
 - virtual_network.address.tftp:
     type = virtual_network_address_tftp
     start_vm = "no"
+    only Linux
+    vms = 
     func_supported_since_libvirt_ver = (8, 5, 0)
     network_dict = {'bridge': {'name': 'virbr1', 'stp': 'on', 'delay': '0'},  'forward': {'mode': 'nat'}, 'ips': [{'address': '192.168.120.1', 'netmask': '255.255.255.0', 'tftp_root': tftp_root}], 'nat_port': {'start': '1024', 'end': '65535'}, 'name': 'net_boot'}
     error_msg = "tftpboot inaccessible: No such file or directory"


### PR DESCRIPTION
1.Setup vms is empty to skip create guest command step
2.Add "only Linux" to limit guest type

ID: LIBVIRTAT-22420
Signed-off-by: Lei Yang leiyang@redhat.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a Linux-only execution constraint for the virtual network TFTP test configuration.
  * Introduced a new (currently empty) "vms" configuration field for virtual network address tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->