### PR TITLE
Improve case for lifecycle interface to create guest XML by the framework

### DIFF
--- a/libvirt/tests/cfg/virtual_network/lifecycle/lifecycle_full_xml_interface.cfg
+++ b/libvirt/tests/cfg/virtual_network/lifecycle/lifecycle_full_xml_interface.cfg
@@ -1,5 +1,11 @@
 - virtual_network.lifecycle.lifecycle_full_xml_interface:
     type = lifecycle_full_xml_interface
+    only Linux
+    create_vm_libvirt = yes
+    kill_vm_libvirt = yes
+    use_no_reboot = yes
+    ovmf:
+        kill_vm_libvirt_options = --nvram
     start_vm = no
     take_regular_screendumps = no
     vm_attrs = {"vcpu": 8}

--- a/libvirt/tests/src/virtual_network/lifecycle/lifecycle_full_xml_interface.py
+++ b/libvirt/tests/src/virtual_network/lifecycle/lifecycle_full_xml_interface.py
@@ -95,6 +95,8 @@ def run(test, params, env):
        e) Check the QoS setting (if there is)
     4-8 Check guest lifecycle
     """
+    # Skip the OVS bridge test
+    network_base.cancel_if_ovs_bridge(params, test)
     vm_name = params.get('main_vm')
     vm = env.get_vm(vm_name)
     vmxml_backup = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)


### PR DESCRIPTION
1.Add some parameters to allow the framework provide guest xml 
2.Add "only Linux" to limit guest type
3.Skip the OVS bridge test

ID: 22423

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced virtual network lifecycle test configuration: restricted to Linux, improved VM provisioning and teardown, switched to no-reboot mode, and added an OVMF-specific override affecting VM teardown behavior (uses NVRAM option).
  * Added an earlier validation to cancel/skip tests for OVS-bridge scenarios before VM setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->