### PR TITLE
sriov: Enhance network accessibility check with static IP fallback

### DIFF
--- a/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_device.py
+++ b/libvirt/tests/src/sriov/plug_unplug/sriov_attach_detach_device.py
@@ -39,7 +39,7 @@ def run(test, params, env):
         if 'vlan' in iface_dict:
             check_points.check_vlan(sriov_test_obj.pf_name, iface_dict)
         else:
-            check_points.check_vm_network_accessed(vm_session)
+            check_points.check_vm_network_accessed(vm_session, ping_self=True)
 
         test.log.info("TEST_STEP5: Detach the hostdev interface/device.")
         vm_hostdev = vm_xml.VMXML.new_from_dumpxml(vm.name)\

--- a/provider/sriov/check_points.py
+++ b/provider/sriov/check_points.py
@@ -126,7 +126,7 @@ def check_vlan(dev_name, iface_dict, status_error=False):
 
 def check_vm_network_accessed(vm_session, ping_count=3, ping_timeout=5,
                               tcpdump_iface=None, tcpdump_status_error=False,
-                              ping_dest=None):
+                              ping_dest=None, ping_self=False, self_ip="192.168.1.251"):
     """
     Test VM's network accessibility
 
@@ -137,13 +137,15 @@ def check_vm_network_accessed(vm_session, ping_count=3, ping_timeout=5,
     :param tcpdump_status_error: Whether the tcpdump's output should include
         the string "ICMP echo request"
     :param ping_dest: Ping destination address
+    :param ping_self: Set the interface ip as 'self_ip' if failed to get dhcp ip
+    :param self_ip: Interface static ip addr to set
     :raise: test.fail when ping fails.
     :return: Output of ping command
     """
     if platform.machine() != "x86_64":
         return
     if not ping_dest:
-        ping_dest = sriov_base.get_ping_dest(vm_session)
+        ping_dest = sriov_base.get_ping_dest(vm_session, ping_self=ping_self, self_ip=self_ip)
     if tcpdump_iface:
         cmd = "tcpdump  -i %s icmp" % tcpdump_iface
         tcpdump_session = aexpect.ShellSession('bash')

--- a/provider/sriov/sriov_base.py
+++ b/provider/sriov/sriov_base.py
@@ -1,3 +1,5 @@
+import ipaddress
+import logging
 import os
 import re
 import time
@@ -22,6 +24,7 @@ from virttest.utils_libvirt import libvirt_network
 from provider.interface import interface_base
 
 SKIP_CHECKS = False
+LOG = logging.getLogger('avocado.' + __name__)
 
 
 def setup_vf(pf_pci, params, session=None):
@@ -66,13 +69,16 @@ def recover_vf(pf_pci, params, default_vf=0, timeout=60, session=None):
                            timeout=timeout)
 
 
-def get_ping_dest(vm_session, mac_addr="", restart_network=False):
+def get_ping_dest(vm_session, mac_addr="", restart_network=False,
+                  ping_self=False, self_ip="192.168.1.251"):
     """
     Get an ip address to ping
 
     :param vm_session: The session object to the guest
     :param mac_addr: mac address of given interface
     :param restart_network:  Whether to restart guest's network
+    :param ping_self: set the interface ip as 'self_ip' if failed to get dhcp ip
+    :param self_ip: interface static ip addr to set
     :return: ip address
     """
     if restart_network:
@@ -90,14 +96,39 @@ def get_ping_dest(vm_session, mac_addr="", restart_network=False):
         iface_name = vm_iface
     utils_misc.wait_for(
          lambda: utils_net.get_net_if_addrs(
-            iface_name, vm_session.cmd_output).get('ipv4'), 20)
+            iface_name, vm_session.cmd_output, "-c=never").get('ipv4'), 20)
     cmd = ("ip route |awk -F '/' '/^[0-9]/, /dev %s/ {print $1}'" % iface_name)
     status, output = utils_misc.cmd_status_output(cmd, shell=True,
                                                   session=vm_session)
-    if status or not output:
-        raise exceptions.TestError("Unable to get VM ip address! status - {}, "
-                                   "output - {}.".format(status, output))
-    return re.sub('\d+$', '1', output.strip().splitlines()[-1])
+    if status == 0 and output:
+        ip_addr = re.sub('\d+$', '1', output.strip().splitlines()[-1])
+        try:
+            ipaddress.ip_address(ip_addr)
+            return ip_addr
+        except ValueError:
+            LOG.debug("Unable to extract the ip address from:%s", output.strip())
+
+    if ping_self:
+        mac_list = utils_net.get_net_if_addrs(
+            iface_name, vm_session.cmd_output, "-c=never").get("mac")
+        if mac_list:
+            utils_net.set_guest_ip_addr(vm_session, mac_list[0], self_ip)
+            if utils_misc.wait_for(
+                lambda: self_ip in (utils_net.get_net_if_addrs(
+                    iface_name, vm_session.cmd_output, "-c=never"
+                ).get("ipv4")),
+                timeout=10
+            ):
+                return self_ip
+
+        raise exceptions.TestError(
+            "Unable to set VM static ip {} for interface:{}".format(self_ip, iface_name)
+        )
+
+    raise exceptions.TestError(
+        "Unable to get VM ip address! status - {}, "
+        "output - {}.".format(status, output)
+    )
 
 
 class SRIOVTest(object):


### PR DESCRIPTION
This commit updates the SR-IOV network verification logic to handle cases where the VM interface fails to acquire a DHCP address. If the gateway IP cannot be determined from the route table, it attempts to assign a static IP address as the ping destination.

Test results:
(01/13) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.hostdev_interface.vf_address.managed_yes: STARTED
 (01/13) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.hostdev_interface.vf_address.managed_yes: PASS (104.75 s)
 (02/13) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.hostdev_interface.vf_address.managed_no: STARTED
 (02/13) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.hostdev_interface.vf_address.managed_no: PASS (107.39 s)
 (03/13) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.hostdev_interface.vf_address.without_managed: STARTED
 (03/13) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.hostdev_interface.vf_address.without_managed: PASS (106.99 s)
 (04/13) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.hostdev_interface.vf_address.vlan: STARTED
 (04/13) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.hostdev_interface.vf_address.vlan: PASS (71.58 s)
 (05/13) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.hostdev_device.vf_address.managed_yes: STARTED
 (05/13) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.hostdev_device.vf_address.managed_yes: PASS (105.00 s)
 (06/13) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.hostdev_device.vf_address.managed_no: STARTED
 (06/13) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.hostdev_device.vf_address.managed_no: PASS (165.89 s)
 (07/13) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.hostdev_device.pf_address.managed_yes: STARTED
 (07/13) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.hostdev_device.pf_address.managed_yes: PASS (104.42 s)
 (08/13) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.hostdev_device.pf_address.managed_no: STARTED
 (08/13) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.hostdev_device.pf_address.managed_no: PASS (106.03 s)
 (09/13) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.network_interface.network.pf_name.managed_no: STARTED
 (09/13) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.network_interface.network.pf_name.managed_no: PASS (105.55 s)
 (10/13) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.network_interface.network.pf_name.managed_yes: STARTED
 (10/13) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.network_interface.network.pf_name.managed_yes: PASS (105.64 s)
 (11/13) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.network_interface.network.pf_name.without_managed: STARTED
 (11/13) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.network_interface.network.pf_name.without_managed: PASS (107.26 s)
 (12/13) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.network_interface.network.vf_address.managed_yes: STARTED
 (12/13) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.network_interface.network.vf_address.managed_yes: PASS (105.65 s)
 (13/13) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.network_interface.network.vf_address.without_managed: STARTED
 (13/13) type_specific.io-github-autotest-libvirt.sriov.plug_unplug.attach_detach_device.network_interface.network.vf_address.without_managed: PASS (105.92 s)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable network verification during SR-IOV attach/detach by adding an optional self-ping fallback for non‑VLAN flows when automatic IP discovery fails.
  * Stricter IP discovery and validation with a controlled fallback that can assign and verify a static guest IP or surface a clear error if setup fails.

* **Tests**
  * Coverage updated to exercise the self-ping fallback path, improving validation for non‑VLAN scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->