### PR TITLE
numa_memory: Fix Python 3.13 compatibility and add numad availability…

### DIFF
--- a/libvirt/tests/src/numa/numa_memory.py
+++ b/libvirt/tests/src/numa/numa_memory.py
@@ -129,13 +129,38 @@ def verify_numa_for_auto_replacement(test, params, vmxml, node_list, qemu_cpu, v
     vcpu_placement = params.get("vcpu_placement")
     numa_memory = vmxml.numa_memory
     numad_cmd_opt = "-w %s:%s" % (vmxml.vcpu, vmxml.max_mem // 1024)
-    utils_test.libvirt.check_logfile('.*numad\s*%s' % numad_cmd_opt, log_file)
-    cmd = "grep -E 'Nodeset returned from numad:' %s" % log_file
-    cmdRes = process.run(cmd, shell=True, ignore_status=False)
-    # Sample: Nodeset returned from numad: 0-1
-    match_obj = re.search(r'Nodeset returned from numad:\s(.*)', cmdRes.stdout_text)
-    numad_ret = match_obj.group(1)
-    logging.debug("Nodeset returned from numad: %s", numad_ret)
+    
+    # Check if numad is installed 
+    try:
+        process.run("which numad", shell=True, ignore_status=False)
+        numad_installed = True
+    except process.CmdError:
+        numad_installed = False
+        logging.warning("numad is not installed, skipping numad verification")
+    
+    if numad_installed:
+        try:
+            utils_test.libvirt.check_logfile(r'.*numad\s*%s' % numad_cmd_opt, log_file)
+            cmd = "grep -E 'Nodeset returned from numad:' %s" % log_file
+            cmdRes = process.run(cmd, shell=True, ignore_status=False)
+            # Sample: Nodeset returned from numad: 0-1
+            match_obj = re.search(r'Nodeset returned from numad:\s(.*)', cmdRes.stdout_text)
+            if not match_obj:
+                test.fail("Failed to parse numad output from daemon.log")
+            numad_ret = match_obj.group(1)
+            logging.debug("Nodeset returned from numad: %s", numad_ret)
+        except (process.CmdError, test.TestFail) as e:
+            logging.error("numad is installed but failed to execute properly: %s", str(e))
+            logging.info("Falling back to using all available nodes")
+            if not node_list:
+                test.cancel("No NUMA nodes available on the system")
+            numad_ret = '-'.join(map(str, node_list))
+    else:
+        # Use all available nodes if numad is not installed
+        if not node_list:
+            test.cancel("No NUMA nodes available on the system")
+        numad_ret = '-'.join(map(str, node_list))
+        logging.info("Using all nodes as numad is not available: %s", numad_ret)
 
     numad_node = cpu.cpus_parser(numad_ret)
     left_node = [node_list.index(i) for i in node_list if i not in numad_node]
@@ -145,7 +170,7 @@ def verify_numa_for_auto_replacement(test, params, vmxml, node_list, qemu_cpu, v
         if numa_memory.get('mode') == 'strict':
             mem_compare(test, numad_node_seq, left_node, memory_status=memory_status)
         elif numa_memory.get('mode') == 'preferred':
-            mode_nodeset = 'prefer\s*.*:' + numad_ret
+            mode_nodeset = r'prefer\s*.*:' + numad_ret
             numa_mode_check(test, vm, mode_nodeset)
         else:
             mode_nodeset = numa_memory.get('mode') + ':' + numad_ret
@@ -316,7 +341,7 @@ def run(test, params, env):
                 used_node = [online_node_list.index(i) for i in used_node]
                 mem_compare(test, used_node, left_node, memory_status=memory_status)
             elif numa_memory.get('mode') == 'preferred':
-                mode_nodeset = 'prefer\s*.*:' + numa_memory.get('nodeset')
+                mode_nodeset = r'prefer\s*.*:' + numa_memory.get('nodeset')
                 numa_mode_check(test, vm, mode_nodeset)
             else:
                 mode_nodeset = numa_memory.get('mode') + ':' + numa_memory.get('nodeset')

--- a/libvirt/tests/src/numa/numa_memory.py
+++ b/libvirt/tests/src/numa/numa_memory.py
@@ -2,6 +2,7 @@ import logging as log
 import random
 import re
 
+from avocado.core import exceptions
 from avocado.utils import process
 
 from virttest import virt_vm
@@ -79,14 +80,13 @@ def numa_mode_check(test, vm, mode_nodeset):
     """
     vm_pid = vm.get_pid()
     numa_map = '/proc/%s/numa_maps' % vm_pid
-    # Open a file
     with open(numa_map) as file:
-        for line in file.readlines():
-            if not re.search(mode_nodeset, line):
-                test.fail("numa mode and nodeset is expected "
-                          "to be matched with '%s' "
-                          "in '%s', but not found" % (mode_nodeset,
-                                                      line))
+        content = file.read()
+    logging.debug("numa_maps content for pid %s:\n%s", vm_pid, content)
+    if not re.search(mode_nodeset, content):
+        test.fail("numa mode and nodeset is expected "
+                  "to be matched with '%s' "
+                  "in numa_maps, but not found" % mode_nodeset)
 
 
 def mem_compare(test, used_node, left_node, memory_status):
@@ -139,27 +139,20 @@ def verify_numa_for_auto_replacement(test, params, vmxml, node_list, qemu_cpu, v
         logging.warning("numad is not installed, skipping numad verification")
     
     if numad_installed:
-        try:
-            utils_test.libvirt.check_logfile(r'.*numad\s*%s' % numad_cmd_opt, log_file)
-            cmd = "grep -E 'Nodeset returned from numad:' %s" % log_file
-            cmdRes = process.run(cmd, shell=True, ignore_status=False)
-            # Sample: Nodeset returned from numad: 0-1
-            match_obj = re.search(r'Nodeset returned from numad:\s(.*)', cmdRes.stdout_text)
-            if not match_obj:
-                test.fail("Failed to parse numad output from daemon.log")
-            numad_ret = match_obj.group(1)
-            logging.debug("Nodeset returned from numad: %s", numad_ret)
-        except (process.CmdError, test.TestFail) as e:
-            logging.error("numad is installed but failed to execute properly: %s", str(e))
-            logging.info("Falling back to using all available nodes")
-            if not node_list:
-                test.cancel("No NUMA nodes available on the system")
-            numad_ret = '-'.join(map(str, node_list))
+        utils_test.libvirt.check_logfile(r'.*numad\s*%s' % numad_cmd_opt, log_file)
+        cmd = "grep -E 'Nodeset returned from numad:' %s" % log_file
+        cmdRes = process.run(cmd, shell=True, ignore_status=False)
+        # Sample: Nodeset returned from numad: 0-1
+        match_obj = re.search(r'Nodeset returned from numad:\s(.*)', cmdRes.stdout_text)
+        if not match_obj:
+            test.fail("Failed to parse numad output from daemon.log")
+        numad_ret = match_obj.group(1)
+        logging.debug("Nodeset returned from numad: %s", numad_ret)
     else:
         # Use all available nodes if numad is not installed
         if not node_list:
-            test.cancel("No NUMA nodes available on the system")
-        numad_ret = '-'.join(map(str, node_list))
+            raise exceptions.TestSkipError("No NUMA nodes available on the system")
+        numad_ret = libvirt_numa.convert_all_nodes_to_string(node_list)
         logging.info("Using all nodes as numad is not available: %s", numad_ret)
 
     numad_node = cpu.cpus_parser(numad_ret)


### PR DESCRIPTION
This patch addresses two critical issues in the NUMA memory test suite:

1. Python 3.13 SyntaxWarning for invalid escape sequences in regex patterns
2. Test failures when numad package is not installed on the system

v2:
numa_memory: fix numa_mode_check logic 
- Fix incorrect logic in numa_mode_check(): check entire numa_maps
  content instead of per-line matching to avoid false failures
- Import exceptions from avocado.core and use TestSkipError for
  missing NUMA nodes
- Remove silent try/except fallback to expose real failures
- Use libvirt_numa.convert_all_nodes_to_string() to avoid incorrect
  range parsing 

Signed-off-by: Sneh Shikha Yadav <syadav@linux.ibm.com>

