### PR TITLE
connectivity_check_ethernet_interface: extend the login timeout

### DIFF
--- a/libvirt/tests/cfg/virtual_network/connectivity/connectivity_check_ethernet_interface.cfg
+++ b/libvirt/tests/cfg/virtual_network/connectivity/connectivity_check_ethernet_interface.cfg
@@ -7,7 +7,7 @@
     ovmf:
         kill_vm_libvirt_options = --nvram
     start_vm = no
-    timeout = 240
+    timeout = 360
     outside_ip = 'www.redhat.com'
     host_iface =
     extra_attrs = {}

--- a/libvirt/tests/src/virtual_network/connectivity/connectivity_check_ethernet_interface.py
+++ b/libvirt/tests/src/virtual_network/connectivity/connectivity_check_ethernet_interface.py
@@ -59,6 +59,7 @@ def run(test, params, env):
     iface_attrs = eval(params.get('iface_attrs'))
     iface_attrs_2 = eval(params.get('iface_attrs_2', '{}'))
     iface_amount = params.get('iface_amount')
+    login_timeout = params.get_numeric("timeout", 360)
     outside_ip = params.get('outside_ip')
     host_iface = params.get('host_iface')
     host_iface = host_iface if host_iface else utils_net.get_default_gateway(
@@ -123,7 +124,7 @@ def run(test, params, env):
             return
 
         vm.create_serial_console()
-        session = vm.wait_for_serial_login(60)
+        session = vm.wait_for_serial_login(timeout=login_timeout)
 
         ips = {
             'outside_ip': outside_ip,


### PR DESCRIPTION
Extend the login timeout due to sometime poorly server source need more time to boot up guest

ID: LIBVIRTAT-22431
Signed-off-by: Lei Yang leiyang@redhat.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased connectivity check timeout duration from 240 to 360 seconds.
  * Updated serial login timeout to be configurable with improved default timing for virtual network connectivity tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->