### PR TITLE
Improve virtual_network.iface_network.net_pxe to support new test tool

### DIFF
--- a/libvirt/tests/cfg/virtual_network/iface_network.cfg
+++ b/libvirt/tests/cfg/virtual_network/iface_network.cfg
@@ -209,6 +209,18 @@
                     nat_port = "{'start':'1024','end':'65535'}"
                     routes = "{'address':'192.168.132.0','prefix':'24','gateway':'192.168.130.2'} {'family':'ipv6','address':'2001:db8:ca2:6::','prefix':'64','gateway':'2001:db8:ca2:6::2'} {'family':'ipv6','address':'2001:db9:4:1::','prefix':'64','gateway':'2001:db8:ca2:6::3','metric':'2'}"
         - net_pxe:
+            only Linux
+            create_vm_libvirt = yes
+            use_no_reboot = yes
+            kill_vm_libvirt = yes
+            ovmf:
+                kill_vm_libvirt_options = --nvram
+            clone_master = yes
+            master_images_clone = image1
+            remove_image_image1 = yes
+            kernel = vmlinuz
+            initrd = initrd.img
+            netdst_nic1 = virbr0
             pxe_boot = "yes"
             tftp_root = "/var/lib/tftpboot"
             bootp_file = "pxelinux.0"

--- a/libvirt/tests/src/virtual_network/iface_network.py
+++ b/libvirt/tests/src/virtual_network/iface_network.py
@@ -18,6 +18,7 @@ from virttest import utils_misc
 from virttest import utils_package
 from virttest import utils_libguestfs
 from virttest import utils_libvirtd
+from virttest import data_dir
 from virttest.utils_test import libvirt
 from virttest.utils_test.__init__ import ping
 from virttest.utils_libvirt import libvirt_network
@@ -57,15 +58,31 @@ def run(test, params, env):
         # Try to install required packages
         if not utils_package.package_install(pkg_list):
             test.error("Failed to install required packages")
-        boot_initrd = params.get("boot_initrd", "EXAMPLE_INITRD")
-        boot_vmlinuz = params.get("boot_vmlinuz", "EXAMPLE_VMLINUZ")
-        if boot_initrd.count("EXAMPLE") or boot_vmlinuz.count("EXAMPLE"):
-            test.cancel("Please provide initrd/vmlinuz URL")
-        # Download pxe boot images
-        process.system("wget %s -O %s/initrd.img" % (boot_initrd, tftp_root))
-        process.system("wget %s -O %s/vmlinuz" % (boot_vmlinuz, tftp_root))
-        process.system("cp -f /usr/share/syslinux/pxelinux.0 {0};"
-                       " mkdir -m 777 -p {0}/pxelinux.cfg".format(tftp_root), shell=True)
+
+        if not os.path.isdir(tftp_root):
+            process.system("mkdir -p %s" % tftp_root)
+
+        pxe_file_name = params.get("bootp_file", "pxelinux.0")
+        if params.get("netdst"):
+            root_dir = data_dir.get_data_dir()
+            # Directly use root_dir/images/guest_name, removing export_dir support
+            img_dir = os.path.join(root_dir, "images", params.get("guest_name", ""))
+
+            kernel = os.path.join(img_dir, params.get("kernel", ""))
+            initrd = os.path.join(img_dir, params.get("initrd", ""))
+            process.run("cp -f %s %s/vmlinuz" % (kernel, tftp_root), shell=True, verbose=True)
+            process.run("cp -f %s %s/initrd.img" % (initrd, tftp_root), shell=True, verbose=True)
+        else:
+            boot_initrd = params.get("boot_initrd", "EXAMPLE_INITRD")
+            boot_vmlinuz = params.get("boot_vmlinuz", "EXAMPLE_VMLINUZ")
+            if boot_initrd.count("EXAMPLE") or boot_vmlinuz.count("EXAMPLE"):
+                test.cancel("Please provide initrd/vmlinuz URL")
+            # Download pxe boot images
+            process.system("wget %s -O %s/initrd.img" % (boot_initrd, tftp_root))
+            process.system("wget %s -O %s/vmlinuz" % (boot_vmlinuz, tftp_root))
+
+        process.system("cp -f /usr/share/syslinux/{0} {1}".format(pxe_file_name, tftp_root), shell=True)
+        process.system("mkdir -m 777 -p {0}/pxelinux.cfg".format(tftp_root), shell=True)
         ldlinux_file = "/usr/share/syslinux/ldlinux.c32"
         if os.path.exists(ldlinux_file):
             process.system("cp -f {0} {1}".format(ldlinux_file, tftp_root), shell=True)
@@ -80,6 +97,18 @@ PROMPT 1
 TIMEOUT 3"""
         with open(pxe_file, 'w') as p_file:
             p_file.write(boot_txt)
+        # Ensure everything in tftp_root is accessible by dnsmasq
+        process.run("chmod -R a+rX %s" % tftp_root, shell=True)
+        if params.get("netdst"):
+            process.run("chown -R nobody: %s" % tftp_root, shell=True, ignore_status=True)
+            for ref in ["/usr/sbin/dnsmasq", "/usr/libexec/libvirt_leaseshelper"]:
+                if os.path.exists(ref):
+                    process.run("chcon -R --reference %s %s" % (ref, tftp_root),
+                                shell=True, ignore_status=True)
+                    break
+        else:
+            # For non-netdst, ensure simple permissions are at least set
+            process.run("chmod -R 777 %s" % tftp_root, shell=True, ignore_status=True)
 
     def modify_iface_xml(sync=True):
         """


### PR DESCRIPTION
1.Setup vms is empty to skip create guest command step
2.Add "only Linux" to limit guest type
3.Add selinux context control for tftp folder when setup netdst 
4.Setup netdst to virbr0 becuase this scenario depends on libvirt default network

ID: LIBVIRTAT-22430
Signed-off-by: Lei Yang leiyang@redhat.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended PXE/VM provisioning options and lifecycle controls.
  * Enabled cloning and explicit selection/removal of boot images and destination NICs.
* **Improvements**
  * Conditional handling for local vs. URL-sourced kernel/initrd assets.
  * More robust TFTP setup with improved file permissions, ownership handling, and SELinux relabel attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->