### PR TITLE
Automated nbdcopy obeys allocated and destination_is_zero options when running in synchronous mode

### DIFF
--- a/v2v/tests/cfg/libnbd/libnbd.cfg
+++ b/v2v/tests/cfg/libnbd/libnbd.cfg
@@ -10,6 +10,13 @@
             checkpoint = 'get_size'
         - is_zero:
             checkpoint = 'is_zero'
+        - nbdcopy:
+          version_required = "[nbdkit-server-1.46.1-3,);[libnbd-1.24.1-1,)"
+          variants:
+            - destination_is_zero:
+              checkpoint = 'check_option_destination_is_zero'
+            - allocated:
+              checkpoint = 'check_option_allocated'
         - unsanitized_hostname:
             version_required = "[nbdkit-server-1.45.12-2,);[libnbd-1.23.12-1,)"
             checkpoint = 'check_unsanitized_hostname'

--- a/v2v/tests/src/libnbd/libnbd.py
+++ b/v2v/tests/src/libnbd/libnbd.py
@@ -1,7 +1,12 @@
 import nbd
+import os
+import logging
 
 from avocado.utils import process
+from virttest import data_dir
 from virttest.utils_v2v import multiple_versions_compare
+
+LOG = logging.getLogger('avocado.v2v.' + __name__)
 
 
 def run(test, params, env):
@@ -95,6 +100,104 @@ def run(test, params, env):
             if expected_err_msg not in cmd_output:
                 test.fail(f"Unsanitized hostname validation failed. Expected error message - {expected_err_msg!r}, got {cmd_output!r}")
 
+    def get_disk_usage(path):
+        """Returns the actual disk usage (blocks) in human readable format."""
+        # du -h equivalent
+        stat = os.stat(path)
+        # st_blocks is usually in 512-byte units
+        usage_bytes = stat.st_blocks * 512
+        return usage_bytes / (1024 * 1024)
+
+    def test_nbdcopy_option_destination_is_zero():
+        """
+        Test Case: Verify --destination-is-zero optimizes copying to pre-zeroed targets.
+
+        Steps:
+        1. Create a 100M sparse source image containing a small string at a 1M offset.
+        2. Verify source disk usage is minimal (typically 4K).
+        3. Create a 100M destination image fully allocated with zeros (non-sparse).
+        4. Verify destination initial disk usage is 100M.
+        5. Run 'nbdcopy' with --destination-is-zero from source to destination.
+        6. Verify destination disk usage has decreased to match source sparseness (~4K).
+        7. Perform a binary comparison (cmp) to ensure data integrity.
+        """
+        # Configuration
+        SRC_IMG = os.path.join(data_dir.get_tmp_dir(), "src.img")
+        DEST_ZERO = os.path.join(data_dir.get_tmp_dir(), "dest_zero.img")
+
+        # 1. Create source with small data (sparse)
+        process.run(f"truncate -s 100M {SRC_IMG}", shell=True)
+        process.run(f"echo 'HELLO' | dd of={SRC_IMG} bs=1 seek=1M conv=notrunc", shell=True)
+
+        # 2. Create destination that is FULLY ALLOCATED (non-sparse) zeroes
+        process.run(f"dd if=/dev/zero of={DEST_ZERO} bs=1M count=100", shell=True)
+        LOG.info(f"Initial Dest Usage: {get_disk_usage(DEST_ZERO)}MB (Should be 100MB)")
+
+        # 3. Run nbdcopy with --destination-is-zero
+        # This tells nbdcopy it can skip writing zeroes, effectively punching holes
+        process.run(f"nbdcopy --destination-is-zero --synchronous {SRC_IMG} {DEST_ZERO} -v", shell=True)
+
+        # 4. Verify
+        dest_usage = get_disk_usage(DEST_ZERO)
+        LOG.info(f"Final Dest Usage: {dest_usage}MB (Should be very small, e.g., <1MB)")
+
+        if dest_usage > 1:
+            test.fail(f"FAILURE: Destination not sparsified (usage: {dest_usage}MB).")
+
+        # Compare content
+        result = process.run(f"cmp {SRC_IMG} {DEST_ZERO}", shell=True, ignore_status=True)
+        if result.exit_status != 0:
+            test.fail("FAILURE: Content mismatch between source and destination.")
+
+    def test_nbdcopy_option_allocated():
+        """
+        Test Case: Verify --allocated forces a non-sparse output.
+
+        Steps:
+        1. Create a 100M sparse source image using 'truncate'.
+        2. Write 1M of random data at two different offsets (10M and 50M)
+        to ensure the file remains sparse.
+        3. Verify source disk usage is minimal (~2M) using 'du'.
+        4. Run 'nbdcopy' with --allocated and --synchronous flags from
+        source to destination.
+        5. Verify destination disk usage is exactly 100M.
+        6. Verify destination and source logical sizes are identical.
+        """
+        # Configuration
+        SRC_IMG = os.path.join(data_dir.get_tmp_dir(), "src.img")
+        DEST_ALLOC = os.path.join(data_dir.get_tmp_dir(), "dest_alloc.img")
+
+        # 1. Create sparse source image (100M)
+        process.run(f"truncate -s 100M {SRC_IMG}", shell=True)
+
+        # 2. Write random data at specific offsets to keep it sparse
+        process.run(f"dd if=/dev/urandom of={SRC_IMG} bs=1M count=1 seek=10 conv=notrunc", shell=True)
+        process.run(f"dd if=/dev/urandom of={SRC_IMG} bs=1M count=1 seek=50 conv=notrunc", shell=True)
+
+        src_usage = get_disk_usage(SRC_IMG)
+        LOG.info(f"Source Disk Usage: {src_usage}MB (Should be ~2MB)")
+
+        # 3. Run nbdcopy with --allocated
+        cmd_nbdcopy = f"nbdcopy --allocated --synchronous {SRC_IMG} {DEST_ALLOC} -v"
+        process.run(cmd_nbdcopy, shell=True)
+
+        # 4. Verify destination file usage
+        dest_usage = get_disk_usage(DEST_ALLOC)
+        LOG.info(f"Destination Disk Usage: {dest_usage}MB (Should be 100MB)")
+        if dest_usage < 100:
+            test.fail("FAILURE: Destination is still sparse.")
+
+        # 5. Verify logical sizes match
+        src_size = os.path.getsize(SRC_IMG)
+        dest_size = os.path.getsize(DEST_ALLOC)
+        if src_size != dest_size:
+            test.fail(f"FAILURE: Logical size mismatch. Source: {src_size}, Dest: {dest_size}")
+
+        # 6. Verify content
+        result = process.run(f"cmp {SRC_IMG} {DEST_ALLOC}", shell=True, ignore_status=True)
+        if result.exit_status != 0:
+            test.fail("FAILURE: Content mismatch between source and destination.")
+
     if version_required and not multiple_versions_compare(
             version_required):
         test.cancel("Testing requires version: %s" % version_required)
@@ -105,5 +208,9 @@ def run(test, params, env):
         test_is_zero()
     elif checkpoint == 'check_unsanitized_hostname':
         test_unsanitized_hostname()
+    elif checkpoint == 'check_option_destination_is_zero':
+        test_nbdcopy_option_destination_is_zero()
+    elif checkpoint == 'check_option_allocated':
+        test_nbdcopy_option_allocated()
     else:
         test.error('Not found testcase: %s' % checkpoint)


### PR DESCRIPTION
Test result:
```
# avocado run --vt-type v2v libnbd.nbdcopy
JOB ID     : 8b62a567e8e052ddd9cb211181be2f9bead6f05d
JOB LOG    : /var/log/avocado/job-results/job-2026-04-08T06.07-8b62a56/job.log
 (1/2) type_specific.io-github-autotest-libvirt.libnbd.nbdcopy.destination_is_zero: STARTED
 (1/2) type_specific.io-github-autotest-libvirt.libnbd.nbdcopy.destination_is_zero: PASS (1.60 s)
 (2/2) type_specific.io-github-autotest-libvirt.libnbd.nbdcopy.allocated: STARTED
 (2/2) type_specific.io-github-autotest-libvirt.libnbd.nbdcopy.allocated: PASS (1.53 s)
RESULTS    : PASS 2 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB HTML   : /var/log/avocado/job-results/job-2026-04-08T06.07-8b62a56/results.html
JOB TIME   : 8.36 s

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added version-gated test variants exercising nbdcopy behavior.
  * Added validation for the --destination-is-zero option: verifies reduced on-disk usage and byte-level equality after copy.
  * Added validation for the --allocated option: verifies allocation-aware copy behavior and synchronous-mode effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->