### PR TITLE
Exclude ROM disable PXE boot tests on aarch64

### DIFF
--- a/libvirt/tests/cfg/virtual_network/rom/iface_rom_disable_pxe_boot.cfg
+++ b/libvirt/tests/cfg/virtual_network/rom/iface_rom_disable_pxe_boot.cfg
@@ -6,6 +6,7 @@
     disk_order = 2
     basic_os = {"bootmenu_enable": "yes", "bootmenu_timeout": 3000, "bios_useserial": "yes", "bios_reboot_timeout": 300}
     no s390-virtio
+    no aarch64
     variants firmware:
         - seabios:
             firmware_type = "seabios"


### PR DESCRIPTION
All 18 virtual_network.rom.disable_pxe_boot test variants fail on aarch64 due to architecture incompatibilities in the test configuration:

- seabios variants (6): SeaBIOS firmware does not exist on aarch64, causing "Unable to get vm!" errors.
- uefi variants (6): The os_attrs hardcode machine type 'q35', but aarch64 requires 'virt', causing "Unable to find 'efi' firmware that is compatible with the current configuration" errors.

The remaining 6 variants (rom_bar_off) are already in the CI skiplist for aarch64 with the reason "Feature 'ROM tuning' is not supported on aarch64 machine".

Since none of the 18 tests have ever passed on aarch64 and all pass on x86_64, exclude the entire test from aarch64 at the cfg level, consistent with the existing s390-virtio exclusion.

Polarion: VIRT-296326

Made-with: Cursor
Signed-off-by: hholoubk <hholoubk@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration to exclude aarch64 architecture from certain virtual network interface tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->