### PR TITLE
bootmenu: Restrict loadparm_override to s390-virtio

### DIFF
--- a/libvirt/tests/cfg/guest_os_booting/boot_menu/bootmenu.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/boot_menu/bootmenu.cfg
@@ -20,6 +20,7 @@
                     directly_boot = "yes"
                     bootmenu_enable = "no"
                 - loadparm_override:
+                    only s390-virtio
                     bootmenu_timeout = 6000
                     disk_order = {'boot': '1', 'loadparm': '2'}
         - negative_test:


### PR DESCRIPTION
The loadparm_override variant uses per-device boot order with the s390-specific loadparm attribute, but was not restricted to s390. This caused it to combine with by_ovmf (aarch64/q35) and by_seabios (x86_64), where it fails because per-device boot elements conflict with os/boot elements set by the firmware.

Add "only s390-virtio" to match the pattern used by all other loadparm tests in the codebase (boot_with_multiple_boot_order, virsh_boot).

Assisted-by: Cursor AI ~80%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refined boot menu test configuration to target specific platform requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->