### PR TITLE
boot_from_disk_device: Skip -ovmf image suffix on aarch64

### DIFF
--- a/libvirt/tests/src/guest_os_booting/boot_order/boot_from_disk_device.py
+++ b/libvirt/tests/src/guest_os_booting/boot_order/boot_from_disk_device.py
@@ -1,5 +1,6 @@
 import copy
 import os
+import platform
 
 from virttest import data_dir
 from virttest import remote
@@ -33,7 +34,7 @@ def parse_disks_attrs(vmxml, test, params):
     if disk1_img:
         disk1_img_path = os.path.join(data_dir.get_data_dir(), "images", disk1_img)
         if download_disk1_img:
-            if firmware_type == "ovmf":
+            if firmware_type == "ovmf" and platform.machine() == "x86_64":
                 disk1_img_url = disk1_img_url.removesuffix('.qcow2') + '-ovmf.qcow2'
             if not disk1_img_url or not utils_misc.wait_for(
                 lambda: guest_os.test_file_download(disk1_img_url, disk1_img_path), 60


### PR DESCRIPTION
The multi_disks_bootable test appends '-ovmf' to the disk image URL when firmware_type is "ovmf". This is needed on x86_64 where separate seabios and OVMF guest images exist, but on aarch64 all guest images are already OVMF-based. The suffixed image URL does not exist on aarch64, causing download failure.

Restrict the -ovmf suffix to x86_64 only.

Assisted-by: Cursor AI ~80%