### PR TITLE
virsh_find_storage_* : fix for Failed to connect socket to '/var/run/…

### DIFF
--- a/libvirt/tests/src/virsh_cmd/pool/virsh_find_storage_pool_sources.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_find_storage_pool_sources.py
@@ -8,6 +8,7 @@ from virttest import utils_split_daemons
 from virttest import utils_test
 from virttest import virsh
 from virttest.staging import lv_utils
+from virttest import test_setup
 
 from virttest import libvirt_version
 
@@ -60,6 +61,30 @@ def run(test, params, env):
     cleanup_nfs = False
     cleanup_iscsi = False
     cleanup_logical = False
+    polkit = None
+
+    # Setup polkit if ACL test
+    if params.get('setup_libvirt_polkit') == 'yes':
+        logging.info("Setting up polkit for ACL test")
+        polkit = test_setup.LibvirtPolkitConfig(params)
+        try:
+            polkit.setup()
+            logging.info("Polkit setup completed successfully")
+            
+            # Explicitly restart virtstoraged for storage driver ACL tests
+            # The libvirtd.restart() in polkit.setup() doesn't always restart virtstoraged
+            from virttest.staging import service
+            try:
+                virtstoraged = service.Factory.create_service("virtstoraged")
+                logging.info("Restarting virtstoraged to apply polkit rules")
+                virtstoraged.restart()
+                logging.info("virtstoraged restarted successfully")
+            except Exception as svc_err:
+                logging.warning("Failed to restart virtstoraged: %s", svc_err)
+                logging.warning("This may cause ACL test failures for storage operations")
+        except Exception as e:
+            logging.error("Failed to setup polkit: %s", e)
+            raise exceptions.TestError("Polkit setup failed: %s" % e)
 
     # Prepare source storage
     if source_host == "127.0.0.1":
@@ -128,3 +153,9 @@ def run(test, params, env):
         if cleanup_nfs:
             utils_test.libvirt.setup_or_cleanup_nfs(
                 False, restore_selinux=selinux_bak)
+        if polkit:
+            logging.info("Cleaning up polkit configuration")
+            try:
+                polkit.cleanup()
+            except Exception as e:
+                logging.warning("Failed to cleanup polkit: %s", e)

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_find_storage_pool_sources.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_find_storage_pool_sources.py
@@ -70,18 +70,22 @@ def run(test, params, env):
         try:
             polkit.setup()
             logging.info("Polkit setup completed successfully")
-            
+
             # Explicitly restart virtstoraged for storage driver ACL tests
             # The libvirtd.restart() in polkit.setup() doesn't always restart virtstoraged
-            from virttest.staging import service
-            try:
-                virtstoraged = service.Factory.create_service("virtstoraged")
-                logging.info("Restarting virtstoraged to apply polkit rules")
-                virtstoraged.restart()
-                logging.info("virtstoraged restarted successfully")
-            except Exception as svc_err:
-                logging.warning("Failed to restart virtstoraged: %s", svc_err)
-                logging.warning("This may cause ACL test failures for storage operations")
+            if utils_split_daemons.is_modular_daemon():
+                from virttest.staging import service
+                try:
+                    virtstoraged = service.Factory.create_service("virtstoraged")
+                    logging.info("Restarting virtstoraged to apply polkit rules")
+                    virtstoraged.restart()
+                    logging.info("virtstoraged restarted successfully")
+                except Exception as svc_err:
+                    raise exceptions.TestError(
+                        "Failed to restart virtstoraged after polkit setup: %s" % svc_err
+                    ) from svc_err
+        except exceptions.TestError:
+            raise
         except Exception as e:
             logging.error("Failed to setup polkit: %s", e)
             raise exceptions.TestError("Polkit setup failed: %s" % e)
@@ -157,5 +161,10 @@ def run(test, params, env):
             logging.info("Cleaning up polkit configuration")
             try:
                 polkit.cleanup()
+                if utils_split_daemons.is_modular_daemon():
+                    from virttest.staging import service
+                    virtstoraged = service.Factory.create_service("virtstoraged")
+                    logging.info("Restarting virtstoraged after polkit cleanup")
+                    virtstoraged.restart()
             except Exception as e:
                 logging.warning("Failed to cleanup polkit: %s", e)


### PR DESCRIPTION
…libvirt/virtstoraged-sock'

Added virtstoraged restart i.e. Deamon restarts after polkit configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved storage pool discovery tests by adding optional authorization/access-control setup and teardown.
  * When enabled, the tests apply ACL-related configuration and ensure required services are restarted to reflect changes.
  * Enhanced error handling so unexpected failures are reported consistently, with cleanup failures captured as warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->