### PR TITLE
boot_from_cdrom_device: avoid os/boot plus cdrom boot conflict

### DIFF
--- a/libvirt/tests/src/guest_os_booting/boot_order/boot_from_cdrom_device.py
+++ b/libvirt/tests/src/guest_os_booting/boot_order/boot_from_cdrom_device.py
@@ -54,7 +54,11 @@ def update_vm_xml(vm, params, cdrom_attrs_list):
     os_attrs = {}
     if os_attrs_boots:
         os_attrs = {'boots': os_attrs_boots}
+        vmxml.remove_all_boots()
         vmxml.setup_attrs(os=os_attrs)
+        for _attrs in cdrom_attrs_list:
+            _attrs.pop('boot', None)
+            _attrs.pop('loadparm', None)
     else:
         vmxml.remove_all_boots()
     if "yes" == params.get("check_bootable_iso", "no"):


### PR DESCRIPTION
When os_attrs_boots is set, call remove_all_boots() before setup_attrs, and drop boot/loadparm from cdrom attr dicts so libvirt does not see per-device boot together with <os>/boot.

Committer: Bolatbek Issakh <bissakh@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved boot order handling for CDROM devices to ensure operating system-level boot settings take precedence over device-level boot attributes, preventing configuration conflicts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/autotest/tp-libvirt/pull/6865)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->