### PR TITLE
guest_os_booting: strip per-device boot before os/boots

### DIFF
--- a/provider/guest_os_booting/guest_os_booting_base.py
+++ b/provider/guest_os_booting/guest_os_booting_base.py
@@ -67,6 +67,9 @@ def prepare_os_xml(vm_name, os_dict, firmware_type=None):
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
     if firmware_type == "ovmf":
         vmxml.os = libvirt_bios.remove_bootconfig_items_from_vmos(vmxml.os)
+    # Libvirt rejects mixing <os>/boot with per-device <disk>/boot in domain XML.
+    if isinstance(os_dict, dict) and os_dict.get("boots"):
+        vmxml.remove_all_boots()
     LOG.debug("Set the os xml")
     vmxml.setup_attrs(os=os_dict)
     vmxml.sync()


### PR DESCRIPTION
Libvirt rejects domain XML that combines <os>/boot (boots) with per-device <disk>/boot. When prepare_os_xml() sets os_dict with boots=, remove all existing //boot nodes first via remove_all_boots().

Committer: Bolatbek Issakh <bissakh@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue that could prevent virtual machines from starting with certain boot configurations. The system now correctly cleans up conflicting boot entries in inactive domain settings so boot options are applied consistently and XML validation errors that blocked VM startup are avoided.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/autotest/tp-libvirt/pull/6866)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->