### PR TITLE
boot_from_disk_device: avoid os/boot plus disk boot conflict

### DIFF
--- a/libvirt/tests/src/guest_os_booting/boot_order/boot_from_disk_device.py
+++ b/libvirt/tests/src/guest_os_booting/boot_order/boot_from_disk_device.py
@@ -65,7 +65,11 @@ def update_vm_xml(vm, params, disk_attrs_list):
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm.name)
     if os_attrs_boots:
         os_attrs = {"boots": os_attrs_boots}
+        vmxml.remove_all_boots()
         vmxml.setup_attrs(os=os_attrs)
+        for _attrs in disk_attrs_list:
+            _attrs.pop("boot", None)
+            _attrs.pop("loadparm", None)
     else:
         vm_os = vmxml.os
         vm_os.del_boots()


### PR DESCRIPTION
When os_attrs_boots is set, remove all //boot nodes then apply os boots. Strip boot/loadparm from cloned disk attrs so inherited per-disk boot does not remain alongside <os><boot> (libvirt unsupported configuration).

Committer: Bolatbek Issakh <bissakh@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed boot configuration handling to prevent disk-specific boot settings from conflicting with OS-level boot settings.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/autotest/tp-libvirt/pull/6867)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->