### PR TITLE
migration_with_memory_devices: set start_vm = no to fix 'Domain is ready active'

### DIFF
--- a/libvirt/tests/cfg/migration/migration_with_memory/migration_with_memory_devices.cfg
+++ b/libvirt/tests/cfg/migration/migration_with_memory/migration_with_memory_devices.cfg
@@ -1,5 +1,6 @@
 - migration.migration_with_memory.memory_devices:
     type = migration_with_memory_devices
+    start_vm = no
     no s390-virtio
     take_regular_screendumps = no
     migration_setup = "yes"


### PR DESCRIPTION

migration_obj.setup_connection() calls setup_default(), which already starts the VM when start_vm == "yes" (the default). The test then runs vm.start() in TEST_STEP2 and fails with:

  VMStartError: VM 'avocado-vt-vm1' failed to start:
    error: Domain is already active (exit status: 1)

Set start_vm = no at the test-class scope so setup_default() leaves the VM shut off, and the explicit vm.start() in TEST_STEP2 remains the single start point.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated migration test configuration for memory device scenarios to control VM startup behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/autotest/tp-libvirt/pull/6869)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->