### PR TITLE
guest_os_booting: fix without_boot_dev xpath on AArch64/UEFI

### DIFF
--- a/libvirt/tests/src/guest_os_booting/os_configuration/without_default_os_attributes.py
+++ b/libvirt/tests/src/guest_os_booting/os_configuration/without_default_os_attributes.py
@@ -3,6 +3,7 @@
 #   Author: Meina Li <meili@redhat.com>
 
 import platform
+import re
 
 from virttest import virsh
 
@@ -10,6 +11,60 @@ from virttest.libvirt_xml import vm_xml
 from virttest.utils_libvirt import libvirt_vmxml
 
 from provider.guest_os_booting import guest_os_booting_base as guest_os
+
+
+def _guest_is_aarch64_arm64(params, host_arch):
+    """
+    Guest can be arm64 while Avocado runs on x86_64 (vt-machine-type arm64-mmio).
+    Do not rely only on platform.machine().
+    """
+    if host_arch == "aarch64":
+        return True
+    arch = (params.get("arch") or params.get("vm_arch_name") or "").lower()
+    if arch in ("aarch64", "arm64"):
+        return True
+    mt = (params.get("machine_type") or "").lower()
+    if "arm64" in mt or "aarch64" in mt:
+        return True
+    shortname = (params.get("shortname") or "").lower()
+    if "aarch64" in shortname or "arm64" in shortname:
+        return True
+    return False
+
+
+# Match ./os/boot[@dev='hd'] or ./os/boot[@dev="hd"] with optional whitespace.
+_LEGACY_OS_BOOT_HD = re.compile(
+    r"^\s*\./os/boot\[@dev=(['\"])hd\1\]\s*$",
+)
+
+
+def _adapt_os_xpath_uefi_disk_boot(os_xpath, params, host_arch):
+    """
+    UEFI AArch64 guests expose boot order on the disk (<boot order='1'/>),
+    not <os><boot dev='hd'/>.
+    """
+    if not _guest_is_aarch64_arm64(params, host_arch):
+        return os_xpath
+
+    disk_boot = ".//disk[@device='disk']/boot[@order='1']"
+
+    def _map_one(xp):
+        if not isinstance(xp, str):
+            return xp
+        if _LEGACY_OS_BOOT_HD.match(xp):
+            return disk_boot
+        return xp
+
+    def _walk(node):
+        if isinstance(node, str):
+            return _map_one(node)
+        if isinstance(node, (list, tuple)):
+            return type(node)(_walk(i) for i in node)
+        if isinstance(node, dict):
+            return {k: _walk(v) for k, v in node.items()}
+        return node
+
+    return _walk(os_xpath)
 
 
 def run(test, params, env):
@@ -20,10 +75,16 @@ def run(test, params, env):
     3) Check the guest dumpxml.
     """
     vm_name = guest_os.get_vm(params)
-    firmware_type = params.get("firmware_type")
     os_dict = eval(params.get("os_dict"))
     host_arch = platform.machine()
-    os_xpath = eval(params.get("os_xpath"))
+    os_xpath = _adapt_os_xpath_uefi_disk_boot(
+        eval(params.get("os_xpath")), params, host_arch)
+    test.log.info(
+        "without_boot_dev: host_arch=%s guest_aarch64_like=%s os_xpath=%r",
+        host_arch,
+        _guest_is_aarch64_arm64(params, host_arch),
+        os_xpath,
+    )
 
     vm = env.get_vm(vm_name)
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)


### PR DESCRIPTION
On UEFI virt guests, boot order appears on the disk device (<boot order='1'/>) instead of <os><boot dev='hd'/>. Map the legacy xpath when the host or params indicate AArch64/arm64, including arm64-mmio machine types and nested os_xpath structures.

Use a regex for xpath matching, walk dict values, and log the adapted os_xpath for debugging.

Committer: Bolatbek Issakh <bissakh@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced test coverage for ARM64/aarch64 guest systems with improved detection and boot configuration validation.
  * Strengthened guest OS configuration handling to better support UEFI disk boot scenarios on ARM64 platforms.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/autotest/tp-libvirt/pull/6870)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->