### PR TITLE
guest_os_booting: fix customize_loader custom path on AArch64

### DIFF
--- a/libvirt/tests/src/guest_os_booting/ovmf_firmware/ovmf_loader.py
+++ b/libvirt/tests/src/guest_os_booting/ovmf_firmware/ovmf_loader.py
@@ -10,7 +10,9 @@
 
 import os
 import shutil
+import tempfile
 
+from virttest import data_dir
 from virttest import libvirt_version
 from virttest import utils_sys
 from virttest import virsh
@@ -20,6 +22,54 @@ from virttest.utils_libvirt import libvirt_vmxml
 from provider.guest_os_booting import guest_os_booting_base as guest_os
 
 
+def _replace_path_in_obj(obj, old, new):
+    if old == new or not old:
+        return obj
+    if isinstance(obj, dict):
+        return {k: _replace_path_in_obj(v, old, new) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_replace_path_in_obj(i, old, new) for i in obj]
+    if isinstance(obj, str) and obj == old:
+        return new
+    return obj
+
+
+def _resolve_custom_loader_path(custom_loader_path, loader_dict, test):
+    """
+    Params often use /usr/share/edk2/ovmf/... (x86 layout). On aarch64 that
+    tree may be missing or unwritable — use Avocado data dir or /tmp.
+    """
+    if not custom_loader_path:
+        return custom_loader_path, loader_dict
+    dest_dir = os.path.dirname(custom_loader_path)
+    usable = (
+        dest_dir
+        and os.path.isdir(dest_dir)
+        and os.access(dest_dir, os.W_OK)
+    )
+    if usable:
+        return custom_loader_path, loader_dict
+    for alt in (
+        os.path.join(data_dir.get_data_dir(), "images", os.path.basename(custom_loader_path)),
+        os.path.join(tempfile.gettempdir(), os.path.basename(custom_loader_path)),
+    ):
+        parent = os.path.dirname(alt)
+        try:
+            os.makedirs(parent, exist_ok=True)
+        except OSError:
+            continue
+        if os.access(parent, os.W_OK):
+            test.log.info(
+                "custom_loader_path %r not usable (dir=%r); using %s instead",
+                custom_loader_path,
+                dest_dir,
+                alt,
+            )
+            loader_dict = _replace_path_in_obj(loader_dict, custom_loader_path, alt)
+            return alt, loader_dict
+    return custom_loader_path, loader_dict
+
+
 def create_custom_loader(test, loader_path, new_custom_path):
     """
     Create a customized OVMF loader by copying an existing one.
@@ -27,10 +77,13 @@ def create_custom_loader(test, loader_path, new_custom_path):
     :param new_custom_path: Absolute path where the copy will be placed.
     """
     try:
+        parent = os.path.dirname(new_custom_path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
         shutil.copy2(loader_path, new_custom_path)
         test.log.debug("ovmf lodader copied to the custom path %s", new_custom_path)
     except OSError as err:
-        test.fail("failed to create the custom ovmf loader path")
+        test.fail("failed to create the custom ovmf loader path: %s" % err)
 
 
 def run(test, params, env):
@@ -49,6 +102,8 @@ def run(test, params, env):
     use_file = "yes" == params.get("use_file", "no")
     stateless = "yes" == params.get("stateless", "no")
     custom_loader_path = params.get("custom_loader_path", "")
+    custom_loader_path, loader_dict = _resolve_custom_loader_path(
+        custom_loader_path, loader_dict, test)
     loader_path = params.get("loader_path")
     libvirt_version.is_libvirt_feature_supported(params)
 


### PR DESCRIPTION
Params often point custom_loader_path under /usr/share/edk2/ovmf/, which does not exist on AArch64 hosts. Resolve to a writable path under the Avocado data directory or /tmp, rewrite loader_dict paths to match, makedirs before copy2, and surface OSError text on failure.

Fixes positive_test.customize_loader on arm64-mmio.

Committer: Bolatbek Issakh <bissakh@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of custom OVMF loader paths: The system now automatically falls back to writable locations (Avocado data directory or `/tmp`) when the specified destination is inaccessible or missing.
  * Enhanced error messages to provide better diagnostics when custom loader creation fails.
  * Fixed path resolution to ensure parent directories are created before attempting file operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/autotest/tp-libvirt/pull/6871)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->