### PR TITLE
Fix vmware_tools uninstall check: exit code 0 treated as failure

### DIFF
--- a/v2v/tests/src/function_test_esx.py
+++ b/v2v/tests/src/function_test_esx.py
@@ -300,8 +300,7 @@ def run(test, params, env):
             _, res = vmcheck.run_cmd(cmd)
             vmtools_info = re.search(r'uninstalling VMware Tools\s+.*exit code\s+(\d+)', res)
             if vmtools_info:
-                exit_code = vmtools_info.group(1)
-                return int(exit_code)
+                return vmtools_info.group(1)
 
         cmd = r'type "C:\Program Files\Guestfs\Firstboot\log.txt"'
 
@@ -318,12 +317,15 @@ def run(test, params, env):
             vmcheck.create_session(timeout=1200)
             res = utils_misc.wait_for(lambda: _get_vmtools_info(cmd), 900, step=30)
 
-        if res:
-            if os_version in ['win2025', 'win2019'] and str(res) == '1603':
-                #Some windows guests fail to uninstall vmware tools due to bug RHEL-51169
-                LOG.info('%s guest fail to unintall VMware tools with exit code 1603 which is known issue' % os_version)
-            else:
-                test.fail("Fail to uninstall VMware-tools with exit code %s" % res)
+        if not res:
+            test.fail("Expected pattern 'uninstalling VMware Tools\\s+.*exit code\\s+(\\d+)' "
+                      "not found in firstboot log")
+        elif res == '0':
+            LOG.info('VMware Tools was uninstalled successfully')
+        elif os_version in ['win2025', 'win2019'] and res == '1603':
+            LOG.info('%s guest fail to uninstall VMware tools with exit code 1603 which is known issue' % os_version)
+        else:
+            test.fail("Fail to uninstall VMware-tools with exit code %s" % res)
 
     def check_windows_service(vmcheck, service_name):
         """

--- a/v2v/tests/src/function_test_esx.py
+++ b/v2v/tests/src/function_test_esx.py
@@ -323,7 +323,7 @@ def run(test, params, env):
         elif res == '0':
             LOG.info('VMware Tools was uninstalled successfully')
         elif os_version in ['win2025', 'win2019'] and res == '1603':
-            LOG.info('%s guest fail to uninstall VMware tools with exit code 1603 which is known issue' % os_version)
+            LOG.info('%s guest failed to uninstall VMware Tools with exit code 1603, which is a known issue' % os_version)
         else:
             test.fail("Fail to uninstall VMware-tools with exit code %s" % res)
 


### PR DESCRIPTION
_get_vmtools_info returned int(exit_code), making exit code 0 falsy. wait_for() treated it as "not ready" and kept polling until the 900s timeout, then returned None. The subsequent `if res:` check (None is falsy) silently passed the test without verifying anything.

Fix: return exit code as string so "0" is truthy, and handle all cases explicitly:
- Pattern not found in log -> test.fail with regex details
- Exit code 0 -> log success
- Exit code 1603 on win2019/win2025 -> log known issue
- Any other exit code -> test.fail

Ref: RHEL-51169

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows VMware Tools verification with explicit failure detection when verification patterns aren't found
  * Enhanced exit code reporting for better diagnostics
  * Added special handling for known compatibility issues on Windows Server 2019 and 2025

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/autotest/tp-libvirt/pull/6874?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->