### PR TITLE
Skip CPU driver check for win2016 (known issue RHEL-17685)

### DIFF
--- a/provider/v2v_vmcheck_helper.py
+++ b/provider/v2v_vmcheck_helper.py
@@ -843,6 +843,8 @@ class VMChecker(object):
         if re.search(r"(Intel|AMD) Processor", win_dirvers):
             if re.search(r"(Intel|AMD) Processor", win_dirvers).group(0) in cpu_drivers:
                 LOG.info("CPU driver '%s' is found" % re.search(r"(Intel|AMD) Processor", win_dirvers).group(0))
+        elif self.os_version == 'win2016':
+            LOG.info("CPU driver not found for win2016, known issue (RHEL-17685), skipping check")
         else:
             err_msg = "CPU driver is not found"
             self.log_err(err_msg)


### PR DESCRIPTION
After v2v conversion, win2016 guests show a Device Manager error (code 45) for the CPU — the Intel/AMD Processor driver does not appear in the driver list. This is a win2016-specific issue (confirmed not reproducible on win10, win11, win2019, win2022) and is cosmetic — the guest boots and runs normally.

The current code treats a missing CPU driver as a test failure, but for win2016 this is a known, unfixable VMware/Windows interaction (RHEL-17685, closed as minor). Skipping the check for win2016 avoids a false test failure.

The fix is self-healing: if the underlying issue is ever resolved and the CPU driver appears in win2016's driver list, the normal regex check will match first and this elif branch will not be reached.

Ref: RHEL-17685, LNXVAST-2542

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CPU driver validation now accommodates a known issue on Windows 2016 without reporting false failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->