### PR TITLE
Fix expected err_msg for virtio iommu additional attributes

### DIFF
--- a/libvirt/tests/cfg/sriov/vIOMMU/virtio_iommu_with_addtional_attributes.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/virtio_iommu_with_addtional_attributes.cfg
@@ -2,7 +2,7 @@
     type = virtio_iommu_with_addtional_attributes
     start_vm = "no"
     enable_guest_iommu = "yes"
-    err_msg = "iommu model 'virtio' doesn't support additional attributes"
+    err_msg = "iommu model 'virtio' doesn't support some additional attributes"
     func_supported_since_libvirt_ver = (8, 7, 0)
     only x86_64, aarch64
     variants:

--- a/libvirt/tests/cfg/sriov/vIOMMU/virtio_iommu_with_addtional_attributes.cfg
+++ b/libvirt/tests/cfg/sriov/vIOMMU/virtio_iommu_with_addtional_attributes.cfg
@@ -2,7 +2,8 @@
     type = virtio_iommu_with_addtional_attributes
     start_vm = "no"
     enable_guest_iommu = "yes"
-    err_msg = "iommu model 'virtio' doesn't support some additional attributes"
+    # Match old and new libvirt rejections for unsupported virtio-iommu attrs
+    err_msg = "iommu model 'virtio' doesn't support (some )?additional attributes"
     func_supported_since_libvirt_ver = (8, 7, 0)
     only x86_64, aarch64
     variants:
@@ -12,5 +13,8 @@
             iommu_dict = {'driver': {'eim': 'on'}, 'model': 'virtio'}
         - iotlb:
             iommu_dict = {'driver': {'iotlb': 'on'}, 'model': 'virtio'}
+        # aw_bits is supported for virtio-iommu since libvirt 12.2.0 (RHEL-76269,
+        # RHEL 10.3+). RHEL 10.3 viommu jobs skip this variant via ci-no in
+        # ci-shared-datas; positive coverage will be added separately.
         - aw_bits:
             iommu_dict = {'driver': {'aw_bits': '48'}, 'model': 'virtio'}

--- a/libvirt/tests/src/sriov/vIOMMU/virtio_iommu_with_addtional_attributes.py
+++ b/libvirt/tests/src/sriov/vIOMMU/virtio_iommu_with_addtional_attributes.py
@@ -1,3 +1,5 @@
+import re
+
 from provider.viommu import viommu_base
 
 from virttest.libvirt_xml import xcepts
@@ -19,10 +21,10 @@ def run(test, params, env):
         libvirt_virtio.add_iommu_dev(vm, iommu_dict)
     except xcepts.LibvirtXMLError as details:
         if err_msg:
-            test.log.debug("Check '%s' in %s.", err_msg, details)
-            if not str(details).count(err_msg):
-                test.fail("Incorrect error message, it should be '{}', but "
-                          "got '{}'.".format(err_msg, details))
+            test.log.debug(f"Check '{err_msg}' in {details}.")
+            if not re.search(err_msg, str(details)):
+                test.fail(f"Incorrect error message, expected pattern '{err_msg}', "
+                          f"but got '{details}'.")
     else:
         test.fail("Defining the VM should fail, but run successfully!")
     finally:


### PR DESCRIPTION
Libvirt now reports "doesn't support some additional attributes" instead of "doesn't support additional attributes". Update the expected error string so caching_mode, eim, and iotlb variants pass on RHEL 10.3.

Assisted-by: Claude AI (cursor) ~80%