### PR TITLE
cpu: Pin optimized-routines to v26.01 for SVE test

### DIFF
--- a/libvirt/tests/cfg/cpu/aarch64_cpu_sve.cfg
+++ b/libvirt/tests/cfg/cpu/aarch64_cpu_sve.cfg
@@ -51,7 +51,7 @@
             all_supports = "yes"
             install_pkgs = ["git", "gcc", "make", "glibc-static", "mpfr-devel", "libmpc-devel"]
             target_dir = "/home/optimized_routines"
-            optimized_repo_cmd = "git clone --depth=1 https://github.com/ARM-software/optimized-routines ${target_dir}"
+            optimized_repo_cmd = "git clone --depth=1 -b v26.01 https://github.com/ARM-software/optimized-routines ${target_dir}"
             optimized_echo_cmd = "echo 'CFLAGS += -march=armv8.2-a+sve' >> config.mk"
             optimized_compile_cmd = "cd ${target_dir}; cp config.mk.dist config.mk; ${optimized_echo_cmd}; make"
             optimized_execute_cmd = "cd ${target_dir}; make check 2>/dev/null"


### PR DESCRIPTION
Upstream master added SVE2 strchr assembly that fails to build with -march=armv8.2-a+sve on Apollo/Fujitsu-class hosts. Shallow clone the v26.01 release tag so optimized-routines stays SVE-only.

The test is passing with this change:
 (1/1) type_specific.io-github-autotest-libvirt.aarch64_cpu_sve.optimized-routines: STARTED
 (1/1) type_specific.io-github-autotest-libvirt.aarch64_cpu_sve.optimized-routines: PASS (802.06 s)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated CPU SVE test configuration to pin the test tooling to a specific release branch for more consistent test runs.
  * Improved VM startup reliability in CPU SVE tests by ensuring address caches are refreshed before guest login, reducing intermittent failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->