### PR TITLE
tests/iface_options: add pp64 compatibility for command line test

### DIFF
--- a/libvirt/tests/src/virtual_network/iface_options.py
+++ b/libvirt/tests/src/virtual_network/iface_options.py
@@ -284,7 +284,7 @@ def run(test, params, env):
         :raise avocado.core.exceptions.TestFail: if commandline doesn't match
         :return: None
         """
-        cmd = ("ps -ef | grep %s | grep qemu-kvm | grep -v grep " % vm_name)
+        cmd = ("ps -ef | grep %s | grep %s | grep -v grep " % (vm_name, "qemu-system-ppc64" if host_arch == 'ppc64le' else "qemu-kvm"))
         ret = process.run(cmd, shell=True)
         logging.debug("Command line %s", ret.stdout_text)
         if test_vhost_net:


### PR DESCRIPTION
The command line used for the test explicitly states "qemu-kvm", which is not used for ppc64le systems. Hence, this patch adds qemu-system-ppc64 to the command line after checking host architecture.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved QEMU process detection in tests to correctly identify running processes across different processor architectures, including ppc64le systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->