### PR TITLE
Cancel RTC time recovery virsh_domtime tests on Power architecture!

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_domtime.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_domtime.py
@@ -2,6 +2,7 @@ import datetime
 import logging as log
 import re
 import time
+import platform
 
 from avocado.utils import process
 
@@ -426,11 +427,16 @@ def run(test, params, env):
             utils_time.sync_timezone_linux(vm)
             # Sync guest time with host
             if channel and agent and not shutdown:
-                res = virsh.domtime(vm_name, now=restore_time)
-                if res.exit_status:
-                    session.close()
-                    test.error("Failed to recover guest time:\n%s"
-                               % res)
+                # Skip time recovery on Power architecture - RTC reinjection not supported
+                if platform.machine() in ['ppc64', 'ppc64le']:
+                    logging.warning("Skipping time recovery on Power architecture - "
+                                    "RTC interrupt reinjection not available")
+                else:
+                    res = virsh.domtime(vm_name, now=restore_time)
+                    if res.exit_status:
+                        session.close()
+                        test.error("Failed to recover guest time:\n%s"
+                                   % res)
             session.close()
     finally:
         # Restore VM XML


### PR DESCRIPTION
RTC interrupt reinjection is not supported on Power pseries machines, causing virsh domtime --now to fail. Skip time recovery on ppc64/ppc64le while maintaining functionality on other archs (x86/s390x/...).

Signed-off-by: Anushree-Mathur <anushree.mathur@linux.ibm.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved domain time test stability on Power architectures (ppc64/ppc64le) by gracefully skipping unsupported time recovery operations with appropriate logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->