### PR TITLE
 add  daemon restart mechanism after polkit rules are created

### DIFF
--- a/libvirt/tests/src/virsh_cmd/pool/virsh_find_storage_pool_sources.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_find_storage_pool_sources.py
@@ -8,6 +8,7 @@ from virttest import utils_split_daemons
 from virttest import utils_test
 from virttest import virsh
 from virttest.staging import lv_utils
+from virttest import test_setup
 
 from virttest import libvirt_version
 
@@ -60,6 +61,30 @@ def run(test, params, env):
     cleanup_nfs = False
     cleanup_iscsi = False
     cleanup_logical = False
+    polkit = None
+
+    # Setup polkit if ACL test
+    if params.get('setup_libvirt_polkit') == 'yes':
+        logging.info("Setting up polkit for ACL test")
+        polkit = test_setup.LibvirtPolkitConfig(params)
+        try:
+            polkit.setup()
+            logging.info("Polkit setup completed successfully")
+            
+            # Explicitly restart virtstoraged for storage driver ACL tests
+            # The libvirtd.restart() in polkit.setup() doesn't always restart virtstoraged
+            from virttest.staging import service
+            try:
+                virtstoraged = service.Factory.create_service("virtstoraged")
+                logging.info("Restarting virtstoraged to apply polkit rules")
+                virtstoraged.restart()
+                logging.info("virtstoraged restarted successfully")
+            except Exception as svc_err:
+                logging.warning("Failed to restart virtstoraged: %s", svc_err)
+                logging.warning("This may cause ACL test failures for storage operations")
+        except Exception as e:
+            logging.error("Failed to setup polkit: %s", e)
+            raise exceptions.TestError("Polkit setup failed: %s" % e)
 
     # Prepare source storage
     if source_host == "127.0.0.1":
@@ -128,3 +153,9 @@ def run(test, params, env):
         if cleanup_nfs:
             utils_test.libvirt.setup_or_cleanup_nfs(
                 False, restore_selinux=selinux_bak)
+        if polkit:
+            logging.info("Cleaning up polkit configuration")
+            try:
+                polkit.cleanup()
+            except Exception as e:
+                logging.warning("Failed to cleanup polkit: %s", e)

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool_acl.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool_acl.py
@@ -8,7 +8,6 @@ from virttest import libvirt_storage
 from virttest import data_dir
 from virttest import utils_split_daemons
 from virttest import virsh
-from virttest import test_setup
 from virttest.staging import lv_utils
 from virttest.utils_test import libvirt as utlv
 

--- a/libvirt/tests/src/virsh_cmd/pool/virsh_pool_acl.py
+++ b/libvirt/tests/src/virsh_cmd/pool/virsh_pool_acl.py
@@ -8,6 +8,7 @@ from virttest import libvirt_storage
 from virttest import data_dir
 from virttest import utils_split_daemons
 from virttest import virsh
+from virttest import test_setup
 from virttest.staging import lv_utils
 from virttest.utils_test import libvirt as utlv
 
@@ -84,6 +85,23 @@ def run(test, params, env):
         if params.get('setup_libvirt_polkit') == 'yes':
             test.cancel("API acl test not supported in current"
                         " libvirt version.")
+
+    # Polkit is already set up by the test framework when setup_libvirt_polkit=yes
+    # We just need to ensure virtstoraged is restarted after polkit rules are created
+    if params.get('setup_libvirt_polkit') == 'yes':
+        logging.info("ACL test detected - ensuring virtstoraged is restarted")
+        from virttest.staging import service
+        try:
+            virtstoraged = service.Factory.create_service("virtstoraged")
+            logging.info("Restarting virtstoraged to apply polkit rules")
+            virtstoraged.restart()
+            logging.info("virtstoraged restarted successfully")
+            import time
+            time.sleep(2)
+            logging.info("virtstoraged should now have loaded polkit rules")
+        except Exception as svc_err:
+            logging.warning("Failed to restart virtstoraged: %s", svc_err)
+
 
     acl_dargs = {'uri': uri, 'unprivileged_user': unprivileged_user,
                  'debug': True}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved storage pool and ACL tests with enhanced Polkit-based access control handling.
  * Added proper initialization and cleanup procedures for Polkit configurations in test scenarios.
  * Enhanced reliability of ACL tests through proper service restart and rule application procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->