### PR TITLE
Update SoftwareManager import path!

### DIFF
--- a/libvirt/tests/src/cpu/powerpc_hmi.py
+++ b/libvirt/tests/src/cpu/powerpc_hmi.py
@@ -3,7 +3,7 @@ import time
 import logging as log
 
 from avocado.utils import cpu
-from avocado.utils.software_manager import SoftwareManager
+from avocado.utils.software_manager.manager import SoftwareManager
 from avocado.utils import process
 
 from virttest import data_dir


### PR DESCRIPTION
Fixing an ImportError caused by Avocado updating its internal structure. The `SoftwareManager` class has moved to the `manager` submodule.

Updated the import statement to reflect this relocation.
Signed-off-by: Anushree-Mathur <anushree.mathur@linux.ibm.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal test infrastructure imports for compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->