### PR TITLE
Add fallback logic for interface detection when ifconfig is unavailable!

### DIFF
--- a/libvirt/tests/src/passthrough/pci/libvirt_pci_passthrough.py
+++ b/libvirt/tests/src/passthrough/pci/libvirt_pci_passthrough.py
@@ -207,6 +207,36 @@ def run(test, params, env):
             # ping to server from each function
             for val in bus_info:
                 nic_name = str(utils_misc.get_interface_from_pci_id(val, session))
+
+                # If get_interface_from_pci_id returns None, use uevent file
+                if nic_name == "None" or not nic_name:
+                    logging.warning("get_interface_from_pci_id returned None for %s, trying uevent method", val)
+                    try:
+                        # Get all network interfaces using modern 'ip' command instead of deprecated 'ifconfig'
+                        ifaces_output = session.cmd_output("ip -o link show | awk -F': ' '{print $2}'")
+                        interfaces = [iface.strip() for iface in ifaces_output.strip().split("\n") if iface.strip()]
+
+                        # Find interface matching PCI address using uevent file
+                        for iface in interfaces:
+                            if iface in ["lo", "sit0"]:  # Skip loopback
+                                continue
+                            # Read PCI address from uevent file
+                            pci_cmd = "cat /sys/class/net/{}/device/uevent 2>/dev/null | grep PCI_SLOT_NAME | cut -d= -f2".format(iface)
+                            status, pci_addr = session.cmd_status_output(pci_cmd)
+                            if status == 0 and pci_addr.strip():
+                                # Normalize for comparison (case-insensitive)
+                                pci_normalized = pci_addr.strip().lower()
+                                val_normalized = val.lower()
+                                if pci_normalized == val_normalized:
+                                    nic_name = iface
+                                    logging.info("Found interface %s for PCI %s using uevent method", nic_name, val)
+                                    break
+                    except Exception as e:
+                        logging.error("Failed to find interface for PCI %s: %s", val, str(e))
+
+                if nic_name == "None" or not nic_name:
+                    test.error("Could not determine interface name for PCI device {}".format(val))
+                    continue
                 session.cmd("ip addr flush dev %s" % nic_name)
                 session.cmd("ip addr add %s/%s dev %s"
                             % (net_ip, netmask, nic_name))


### PR DESCRIPTION
The test fails with error "Device None does not exist" because the underlying utils_misc.get_interface_from_pci_id()
function relies on the deprecated ifconfig command, which is not installed by default.

When ifconfig is unavailable, the function returns None, causing the test to attempt configuring a network interface named "None", which fails.

This patch adds a fallback mechanism that:
1. Detects when get_interface_from_pci_id() returns None
2. Uses the modern 'ip' command to list network interfaces
3. Reads PCI addresses from /sys/class/net/{iface}/device/uevent
4. Matches PCI addresses to find the correct interface name

The fallback only activates when the primary method fails, ensuring no impact on systems where ifconfig is available.

Signed-off-by: Anushree-Mathur <anushree.mathur@linux.ibm.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved NIC interface detection for PCI passthrough device validation with enhanced fallback mechanism.
  * Strengthened error handling to gracefully skip devices when interface identification fails, with additional logging for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->