### PR TITLE
migration: Skip sync_cpu_for_mig on aarch64

### DIFF
--- a/provider/migration/base_steps.py
+++ b/provider/migration/base_steps.py
@@ -561,6 +561,12 @@ def sync_cpu_for_mig(params):
 
     :param params: Dictionary with the test parameters
     """
+    # aarch64 only supports migration tests between hosts with the same CPU, so
+    # no need to sync the CPU. hypervisor-cpu-baseline --migratable is also
+    # not supported on aarch64.
+    if platform.machine() == "aarch64":
+        return
+
     dest_uri = params.get("virsh_migrate_desturi")
     vm_name = params.get("main_vm")
 


### PR DESCRIPTION
hypervisor-cpu-baseline --migratable is unsupported on aarch64 and returns empty output, causing ParseError in disk migration tests. Match the existing check_cpu_for_mig() aarch64 guard.

Assisted-by: Auto (Cursor Agent) (~90%)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved CPU synchronization behavior on ARM-based systems to prevent unnecessary processing steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->