### PR TITLE
migration: Skip vhostuser disk migration test on aarch64

### DIFF
--- a/libvirt/tests/cfg/migration/migration_with_disk/migration_with_vhostuser.cfg
+++ b/libvirt/tests/cfg/migration/migration_with_disk/migration_with_vhostuser.cfg
@@ -32,5 +32,6 @@
     disk_dict = {"type_name": "vhostuser", "device": "disk", "driver": {"name": "qemu", "type": "raw", "queues": ${queues}}, "source": {"attrs": {"type": "unix", "path": "${source_file}"}}, "target": {"dev": "vdb", "bus": "virtio"}}
     check_disk_after_mig = "yes"
     no ppc64le
+    no aarch64
     variants:
         - with_precopy:


### PR DESCRIPTION
## Summary
- Add `no aarch64` to `migration_with_vhostuser.cfg`, matching the existing `no ppc64le` exclusion
- RHEL `qemu-kvm-*el*.aarch64` does not advertise `vhost-user-blk`, so the test always fails at VM define with "vhostuser disk is not supported with this QEMU binary"

## Test plan
- [ ] Verify avocado-vt lists `migration.migration_with_disk.migration_with_vhostuser.with_precopy` on x86_64
- [ ] Verify the test is skipped on aarch64 (not listed / SKIP in CI)
- [ ] Re-run `cross_migration_cross_feature` on aarch64 after merge — vhostuser error should disappear

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated migration test configuration to exclude ARM-based architectures from disk migration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->