### PR TITLE
Use recreate_serial_console in BIOS boot tests

### DIFF
--- a/libvirt/tests/src/bios/boot_order_ovmf.py
+++ b/libvirt/tests/src/bios/boot_order_ovmf.py
@@ -23,18 +23,14 @@ def check_boot(vm, test, params):
     time.sleep(3)
     if not status_error:
         try:
-            vm.cleanup_serial_console()
-            vm.create_serial_console()
-            vm.wait_for_serial_login()
+            vm.wait_for_serial_login(recreate_serial_console=True)
         except Exception as error:
             test.fail(f"Test fail: {error}")
         else:
             test.log.debug("Succeed to boot %s", vm.name)
     else:
         try:
-            vm.cleanup_serial_console()
-            vm.create_serial_console()
-            vm.wait_for_serial_login()
+            vm.wait_for_serial_login(recreate_serial_console=True)
         except LoginTimeoutError as expected_e:
             test.log.debug(f"Got expected error message: {expected_e}")
         except Exception as e:

--- a/libvirt/tests/src/bios/boot_order_seabios.py
+++ b/libvirt/tests/src/bios/boot_order_seabios.py
@@ -270,18 +270,14 @@ def run(test, params, env):
                             internal_timeout=0.5)
                 else:
                     time.sleep(3)
-                    vm.cleanup_serial_console()
-                    vm.create_serial_console()
-                    vm.wait_for_serial_login(timeout=15)
+                    vm.wait_for_serial_login(timeout=15, recreate_serial_console=True)
             except Exception as e:
                 test.fail(f"Test fail: {str(e)}")
             else:
                 test.log.debug("Succeed to boot %s", vm_name)
         else:
             try:
-                vm.cleanup_serial_console()
-                vm.create_serial_console()
-                vm.wait_for_serial_login(timeout=15)
+                vm.wait_for_serial_login(timeout=15, recreate_serial_console=True)
             except LoginTimeoutError as expected_e:
                 test.log.debug("Got expected error message: %s", str(expected_e))
             except Exception as exc:


### PR DESCRIPTION
Refactor BIOS boot order tests to use the recreate_serial_console parameter
instead of manually calling cleanup_serial_console() and
create_serial_console() before wait_for_serial_login().

This simplifies console management after VM boot operations, ensuring
proper console state for various boot scenarios including OVMF and SeaBIOS.

Modified test files:
- bios/boot_order_ovmf.py: Console after VM start for OVMF boot testing
- bios/boot_order_seabios.py: Console after VM start for SeaBIOS boot testing

Both tests handle console recreation after VM start operations where the
console needs to be reset to properly capture boot messages and login prompts.

Total: 2 files modified with 9 fewer lines of console management code.

Depends on: https://github.com/avocado-framework/avocado-vt/pull/4248 (Merged)
Depends on: https://github.com/autotest/tp-libvirt/pull/6890

Reopened from closed #6604 (rebased onto current master).