### PR TITLE
Use recreate_serial_console in nwfilter test

### DIFF
--- a/libvirt/tests/src/nwfilter/nwfilter_binding_list.py
+++ b/libvirt/tests/src/nwfilter/nwfilter_binding_list.py
@@ -120,9 +120,7 @@ def run(test, params, env):
         utlv.check_result(ret, expected_match=[r"vnet\d+\s+clean-traffic"])
         utlv.check_result(ret, expected_match=[r"vnet\d+\s+allow-dhcp-server"])
         # detach a interface, before detach, make sure guest boot up
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm.wait_for_serial_login().close
+        vm.wait_for_serial_login(recreate_serial_console=True).close()
         option = "--type network" + " --mac " + new_iface_1.mac_address
         ret = virsh.detach_interface(vm_name, option, debug=True)
         time.sleep(time_wait)


### PR DESCRIPTION
Refactor nwfilter binding list test to use the recreate_serial_console
parameter instead of manually calling cleanup_serial_console() and
create_serial_console() before wait_for_serial_login().

This simplifies console management before interface detach operations.

Modified test file:
- nwfilter/nwfilter_binding_list.py: Console recreation before interface detach
  (also fixed bug: .close -> .close())

Total: 1 file modified with 2 fewer lines of console management code.

Depends on: https://github.com/avocado-framework/avocado-vt/pull/4248 (Merged)
Depends on: https://github.com/autotest/tp-libvirt/pull/6890

Reopened from closed #6605 (rebased onto current master).