### PR TITLE
Use recreate_serial_console in copy storage migration tests

### DIFF
--- a/libvirt/tests/src/migration_with_copy_storage/disk_io_load_in_vm.py
+++ b/libvirt/tests/src/migration_with_copy_storage/disk_io_load_in_vm.py
@@ -55,9 +55,7 @@ def run(test, params, env):
 
         test.log.info("Verify steps.")
         backup_uri, vm.connect_uri = vm.connect_uri, dest_uri
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        remote_vm_session = vm.wait_for_serial_login(timeout=360)
+        remote_vm_session = vm.wait_for_serial_login(timeout=360, recreate_serial_console=True)
         remote_vm_dmesg = remote_vm_session.cmd_output("dmesg")
         if "I/O error" in remote_vm_dmesg:
             test.fail(f"Found I/O error in guest dmesg: {remote_vm_dmesg}")

--- a/libvirt/tests/src/migration_with_copy_storage/migration_with_backingchain.py
+++ b/libvirt/tests/src/migration_with_copy_storage/migration_with_backingchain.py
@@ -147,10 +147,8 @@ def check_disk(params, vm):
     disk_target1 = params.get("disk_target1")
     disk_target2 = params.get("disk_target2")
 
-    vm.cleanup_serial_console()
     backup_uri, vm.connect_uri = vm.connect_uri, dest_uri
-    vm.create_serial_console()
-    remote_vm_session = vm.wait_for_serial_login(timeout=120)
+    remote_vm_session = vm.wait_for_serial_login(timeout=120, recreate_serial_console=True)
     utils_disk.linux_disk_check(remote_vm_session, disk_target1)
     utils_disk.linux_disk_check(remote_vm_session, disk_target2)
 


### PR DESCRIPTION
Refactor migration with copy storage tests to use the recreate_serial_console
parameter instead of manually calling cleanup_serial_console() and
create_serial_console() before wait_for_serial_login().

This simplifies console management when connecting to the migrated VM on the
destination host after switching the connection URI.

Modified test files:
- migration_with_copy_storage/migration_with_backingchain.py: Console to remote host
- migration_with_copy_storage/disk_io_load_in_vm.py: Console to remote host after migration

Both tests handle console recreation when switching from source to destination
host connection, where the old console must be cleaned up and recreated with
the new URI.

Total: 2 files modified with 4 fewer lines of console management code.
Depends on: https://github.com/avocado-framework/avocado-vt/pull/4248 (Merged)
Depends on: https://github.com/autotest/tp-libvirt/pull/6890

Reopened from closed #6606 (rebased onto current master).