### PR TITLE
Use recreate_serial_console in virtio test

### DIFF
--- a/libvirt/tests/src/virtio/virtio_page_per_vq.py
+++ b/libvirt/tests/src/virtio/virtio_page_per_vq.py
@@ -99,9 +99,7 @@ def run(test, params, env):
             test.log.info("TEST_STEP1: hotplug %s device", device_type)
             start_guest()
             virsh.attach_device(vm_name, device_xml.xml, ignore_status=False, debug=True)
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm_session = vm.wait_for_serial_login()
+        vm_session = vm.wait_for_serial_login(recreate_serial_console=True)
 
         test.log.info("TEST_STEP2: check the attribute in %s xml", device_type)
         check_attribute()


### PR DESCRIPTION

Refactor virtio test to use the recreate_serial_console parameter
instead of manually calling cleanup_serial_console() and
create_serial_console() before wait_for_serial_login().

This simplifies console management after VM start and device hotplug
operations in virtio page_per_vq testing.

Modified test file:
- virtio/virtio_page_per_vq.py: Console after VM start/device hotplug

The test handles console recreation after VM initialization where the
console needs to be properly set up for testing virtio device attributes.
Depends on: https://github.com/avocado-framework/avocado-vt/pull/4248 (Merged)
Depends on: https://github.com/autotest/tp-libvirt/pull/6890

Reopened from closed #6607 (rebased onto current master).