### PR TITLE
Use recreate_serial_console in snapshot tests

### DIFF
--- a/libvirt/tests/src/snapshot/revert_disk_external_snap.py
+++ b/libvirt/tests/src/snapshot/revert_disk_external_snap.py
@@ -38,9 +38,7 @@ def revert_snap_and_check_files(params, vm, test, snap_name, expected_files):
 
     virsh.snapshot_revert(vm.name, snap_name, options=options, **virsh_dargs)
 
-    vm.cleanup_serial_console()
-    vm.create_serial_console()
-    session = vm.wait_for_serial_login()
+    session = vm.wait_for_serial_login(recreate_serial_console=True)
     for file in expected_files:
         output = session.cmd('ls %s' % file)
         if file not in output:

--- a/libvirt/tests/src/snapshot/revert_snapshot_after_xml_updated.py
+++ b/libvirt/tests/src/snapshot/revert_snapshot_after_xml_updated.py
@@ -68,9 +68,7 @@ def check_file_exist(test, vm, params, revert_snap):
 
     if not vm.is_alive():
         virsh.start(vm_name)
-    vm.cleanup_serial_console()
-    vm.create_serial_console()
-    session = vm.wait_for_serial_login()
+    session = vm.wait_for_serial_login(recreate_serial_console=True)
 
     if revert_snap == "1":
         file_list = eval(params.get("file_list"))[0:1]


### PR DESCRIPTION

Refactor snapshot tests to use the recreate_serial_console parameter
instead of manually calling cleanup_serial_console() and
create_serial_console() before wait_for_serial_login().

This simplifies console management after snapshot revert operations,
which require console recreation since the VM state may have changed.

Modified test files:
- snapshot/revert_snapshot_after_xml_updated.py: Console after VM start/revert
- snapshot/revert_disk_external_snap.py: Console after snapshot revert

Both tests handle console recreation after reverting to snapshots, where
the VM state is restored and the old console session is no longer valid.
Depends on: https://github.com/avocado-framework/avocado-vt/pull/4248 (Merged)
Depends on: https://github.com/autotest/tp-libvirt/pull/6890

Reopened from closed #6609 (rebased onto current master).