### PR TITLE
Use recreate_serial_console in migration tests

### DIFF
--- a/libvirt/tests/src/migration/migrate_mem.py
+++ b/libvirt/tests/src/migration/migrate_mem.py
@@ -279,11 +279,7 @@ def verify_test_back_mem_nvdimm(vm, params, test):
     :param test: test object
     """
     vm.connect_uri = params.get("virsh_migrate_connect_uri")
-    if vm.serial_console is not None:
-        test.log.debug("clean up old serial console")
-        vm.cleanup_serial_console()
-    vm.create_serial_console()
-    vm_session = vm.wait_for_serial_login(timeout=240)
+    vm_session = vm.wait_for_serial_login(timeout=240, recreate_serial_console=True)
     cmd = 'mount -o dax /dev/pmem0 /mnt'
     vm_session.cmd(cmd)
     expected_content = params.get('test_file_content') + '.back'

--- a/libvirt/tests/src/migration/migrate_network.py
+++ b/libvirt/tests/src/migration/migrate_network.py
@@ -313,10 +313,7 @@ def run(test, params, env):
                       vm_xml.VMXML.new_from_dumpxml(vm_name))
 
         # Check local guest network connection before migration
-        if vm.serial_console is not None:
-            vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm_session = vm.wait_for_serial_login(timeout=240)
+        vm_session = vm.wait_for_serial_login(timeout=240, recreate_serial_console=True)
         if not utils_package.package_install('dhcp-client', session=vm_session):
             test.error("Failed to install dhcp-client on guest.")
         utils_net.restart_guest_network(vm_session)
@@ -343,10 +340,7 @@ def run(test, params, env):
         # Check network accessibility after migration
         if int(mig_result.exit_status) == 0:
             vm.connect_uri = dest_uri
-            if vm.serial_console is not None:
-                vm.cleanup_serial_console()
-            vm.create_serial_console()
-            vm_session_after_mig = vm.wait_for_serial_login(timeout=240)
+            vm_session_after_mig = vm.wait_for_serial_login(timeout=240, recreate_serial_console=True)
             vm_session_after_mig.cmd(restart_dhclient)
             check_vm_network_accessed(ping_dest, session=vm_session_after_mig)
 
@@ -393,10 +387,7 @@ def run(test, params, env):
             logging.debug("VM is migrated back.")
 
             vm.connect_uri = bk_uri
-            if vm.serial_console is not None:
-                vm.cleanup_serial_console()
-            vm.create_serial_console()
-            vm_session_after_mig_bak = vm.wait_for_serial_login(timeout=240)
+            vm_session_after_mig_bak = vm.wait_for_serial_login(timeout=240, recreate_serial_console=True)
             vm_session_after_mig_bak.cmd(restart_dhclient)
             check_vm_network_accessed(ping_dest, vm_session_after_mig_bak)
     finally:

--- a/libvirt/tests/src/migration/migrate_with_panic_device.py
+++ b/libvirt/tests/src/migration/migrate_with_panic_device.py
@@ -57,9 +57,7 @@ def run(test, params, env):
         migration_obj.verify_default()
 
         backup_uri, vm.connect_uri = vm.connect_uri, dest_uri
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        remote_vm_session = vm.wait_for_serial_login(timeout=360)
+        remote_vm_session = vm.wait_for_serial_login(timeout=360, recreate_serial_console=True)
         try:
             remote_vm_session.cmd("systemctl stop kdump", ignore_all_errors=True)
             remote_vm_session.cmd("echo 1 > /proc/sys/kernel/sysrq")

--- a/libvirt/tests/src/migration/migration_with_virtiofs/migration_with_externally_launched_virtiofs_dev.py
+++ b/libvirt/tests/src/migration/migration_with_virtiofs/migration_with_externally_launched_virtiofs_dev.py
@@ -76,9 +76,7 @@ def run(test, params, env):
         expect_str = params.get("expect_str")
 
         backup_uri, vm.connect_uri = vm.connect_uri, desturi
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm_session = vm.wait_for_serial_login(timeout=120)
+        vm_session = vm.wait_for_serial_login(timeout=120, recreate_serial_console=True)
         output = vm_session.cmd_output("df -h")
         vm_session.close()
         test.log.debug("output: %s", output)

--- a/libvirt/tests/src/migration/migration_with_virtiofs/migration_with_internally_launched_virtiofs_dev.py
+++ b/libvirt/tests/src/migration/migration_with_virtiofs/migration_with_internally_launched_virtiofs_dev.py
@@ -64,9 +64,7 @@ def run(test, params, env):
         mnt_path_name = params.get("mnt_path_name")
 
         backup_uri, vm.connect_uri = vm.connect_uri, desturi
-        vm.cleanup_serial_console()
-        vm.create_serial_console()
-        vm_session = vm.wait_for_serial_login(timeout=120)
+        vm_session = vm.wait_for_serial_login(timeout=120, recreate_serial_console=True)
         output = vm_session.cmd_output("df -h")
         test.log.debug("output: %s", output)
         if not re.search(expect_str, output):

--- a/libvirt/tests/src/migration/migration_with_vtpm/migration_with_external_tpm.py
+++ b/libvirt/tests/src/migration/migration_with_vtpm/migration_with_external_tpm.py
@@ -54,12 +54,8 @@ def check_vtpm_func(params, vm, test, on_remote=False):
     src_uri = params.get("virsh_migrate_connect_uri")
     test.log.debug("Check vtpm func: (on_remote: %s).", on_remote)
     if on_remote:
-        if vm.serial_console is not None:
-            vm.cleanup_serial_console()
         vm.connect_uri = dest_uri
-    if vm.serial_console is None:
-        vm.create_serial_console()
-    vm_session = vm.wait_for_serial_login(timeout=240)
+    vm_session = vm.wait_for_serial_login(timeout=240, recreate_serial_console=True)
     if not utils_package.package_install("tpm2-tools", vm_session):
         test.error("Failed to install tpm2-tools in vm")
     cmd_result = vm_session.cmd_status(tpm_cmd)

--- a/libvirt/tests/src/migration/migration_with_vtpm/migration_with_shared_tpm.py
+++ b/libvirt/tests/src/migration/migration_with_vtpm/migration_with_shared_tpm.py
@@ -70,12 +70,8 @@ def check_vtpm_func(params, vm, test, remote=False):
     src_uri = params.get("virsh_migrate_connect_uri")
     test.log.debug("Check vtpm func: %s (remote).", remote)
     if remote:
-        if vm.serial_console is not None:
-            vm.cleanup_serial_console()
         vm.connect_uri = dest_uri
-    if vm.serial_console is None:
-        vm.create_serial_console()
-    vm_session = vm.wait_for_serial_login(timeout=240)
+    vm_session = vm.wait_for_serial_login(timeout=240, recreate_serial_console=True)
     if not utils_package.package_install("tpm2-tools", vm_session):
         test.error("Failed to install tpm2-tools in vm")
     cmd_result = vm_session.cmd_status(tpm_cmd)

--- a/libvirt/tests/src/migration/migration_with_vtpm/migration_with_vtpm_dev.py
+++ b/libvirt/tests/src/migration/migration_with_vtpm/migration_with_vtpm_dev.py
@@ -31,12 +31,8 @@ def check_vtpm_func(params, vm, test, remote=False):
     src_uri = params.get("virsh_migrate_connect_uri")
     test.log.debug("Check vtpm func: %s (remote).", remote)
     if remote:
-        if vm.serial_console is not None:
-            vm.cleanup_serial_console()
         vm.connect_uri = dest_uri
-    if vm.serial_console is None:
-        vm.create_serial_console()
-    vm_session = vm.wait_for_serial_login(timeout=240)
+    vm_session = vm.wait_for_serial_login(timeout=240, recreate_serial_console=True)
     if not utils_package.package_install("tpm2-tools", vm_session):
         test.error("Failed to install tpm2-tools in vm")
     cmd_result = vm_session.cmd_status(tpm_cmd)


### PR DESCRIPTION
Refactor migration tests to use the recreate_serial_console parameter
instead of manually calling cleanup_serial_console() and
create_serial_console() before wait_for_serial_login().

This simplifies console management when connecting to the migrated VM on the
destination host after switching the connection URI.

Modified test files across standard migration, vTPM, and virtiofs scenarios.
Depends on: https://github.com/avocado-framework/avocado-vt/pull/4248 (Merged)
Depends on: https://github.com/autotest/tp-libvirt/pull/6890

Part of recreate_serial_console series (avocado-vt#4248). Rebased onto current master.