### PR TITLE
Add Power10 compat mode tests with vcpu plug_unplug!

### DIFF
--- a/libvirt/tests/cfg/libvirt_vcpu_plug_unplug.cfg
+++ b/libvirt/tests/cfg/libvirt_vcpu_plug_unplug.cfg
@@ -94,7 +94,17 @@
                             vcpu_plug_num = 240
                             vcpu_unplug_num = 1
                             vcpu_max_num = 240
-
+                        - with_compat_mode:
+                            only live
+                            only ppc64le,ppc64
+                            only POWER11
+                            compat_mode = "yes"
+                            cpu_model = "power10"
+                            test_itr = 5
+                            vcpu_max_num = "8"
+                            vcpu_current_num = "2"
+                            vcpu_plug_num = "6"
+                            vcpu_unplug_num = "3"
                     variants:
                         - live:
                             setvcpu_option = "--live"

--- a/libvirt/tests/src/libvirt_vcpu_plug_unplug.py
+++ b/libvirt/tests/src/libvirt_vcpu_plug_unplug.py
@@ -240,6 +240,8 @@ def run(test, params, env):
     with_stress = "yes" == params.get("run_stress", "no")
     iterations = int(params.get("test_itr", 1))
     topology_correction = "yes" == params.get("topology_correction", "no")
+    compat_mode = params.get("compat_mode")
+    cpu_model =  params.get("cpu_model")
     # Init expect vcpu count values
     expect_vcpu_num = {'max_config': vcpu_max_num, 'max_live': vcpu_max_num,
                        'cur_config': vcpu_current_num,
@@ -298,6 +300,21 @@ def run(test, params, env):
             vmxml.set_agent_channel()
         else:
             vmxml.remove_agent_channels()
+        if compat_mode:
+            logging.info("Setting compatibility mode with CPU model: %s", cpu_model)
+
+            try:
+                cpu_xml = vmxml.cpu
+            except xcepts.LibvirtXMLNotFoundError:
+                logging.debug("No CPU element found, creating new one")
+                cpu_xml = VMCPUXML()
+
+            # Force mode to host-model when explicit compat model is provided
+            cpu_xml.mode = "host-model"
+            cpu_xml.model = cpu_model
+            vmxml.cpu = cpu_xml
+            logging.info("CPU mode set to 'host-model' with model '%s'", cpu_model)
+
         vmxml.sync()
 
         vmxml.set_vm_vcpus(vm_name, vcpu_max_num, vcpu_current_num,


### PR DESCRIPTION
Add Power10 compatibility mode testing for CPU hotplug/unplug on Power11 systems. Enables testing backward compatibility scenarios where guests run with older Power CPU models.

- Add compat_mode and cpu_model parameters
- Add with_power10_compat config variant
- Restrict to POWER11 hosts via config filter
- Test hotplug/unplug with power10 CPU model

7 testcases have been added, in which it brings up the compat mode guest then run vcpu plug_unplug on the guest having different numa or hugepages configuration.

Signed-off-by: Anushree-Mathur <anushree.mathur@linux.ibm.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new test variant for virtual CPU plug/unplug operations with CPU compatibility mode support
  * Extended test framework to handle CPU model configuration and validate vCPU operations under different compatibility settings on supported architectures
  * Improved test coverage for CPU-related vCPU operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->