### PR TITLE
v2v: set boottype = 3 for vmx_default latest8 efi vm

### DIFF
--- a/v2v/tests/cfg/convert_from_file.cfg
+++ b/v2v/tests/cfg/convert_from_file.cfg
@@ -273,7 +273,7 @@
                                     main_vm = VM_NAME_GUEST_DISK_WITH_CHAR_SLASH_V2V_EXAMPLE
                         - vmx_default:
                             # Default
-                            vmx_nfs_src = NFS_ESX70_VMX_V2V_EXAMPLE
+                            vmx_nfs_src = NFS_VMX_V2V_EXAMPLE
                             # Do not skip vm checking by default
                             skip_vm_check = no
                             # By default, v2v will try to connect to source hypervisor
@@ -313,8 +313,9 @@
                                     # genid only supports libvirt, local, qemu
                                     only output_mode.libvirt
                                 - latest8:
-                                    only esx_70
-                                    main_vm = 'VM_NAME_ESX70_RHEL8_V2V_EXAMPLE'
+                                    only esx_80
+                                    boottype = 3
+                                    main_vm = 'VM_NAME_RHEL8_V2V_EXAMPLE'
                                 - latest7:
                                     only esx_70
                                     main_vm = 'VM_NAME_ESX70_RHEL7_V2V_EXAMPLE'


### PR DESCRIPTION
The vmx_default latest8 VM is efi-based and needs boottype = 3 to convert correctly. 
Without this, v2v defaults to bios boot and the converted VM fails to boot.
Also fixes the VM name placeholder mappings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration to support ESX 8.0 compatibility testing with RHEL8 VM support

* **Chores**
  * Modified NFS source configuration for VMX metadata retrieval

<!-- end of auto-generated comment: release notes by coderabbit.ai -->