### PR TITLE
guest_os_booting: Fix aarch64 test failures

### DIFF
--- a/libvirt/tests/cfg/guest_os_booting/boot_menu/bootmenu.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/boot_menu/bootmenu.cfg
@@ -20,6 +20,7 @@
                     directly_boot = "yes"
                     bootmenu_enable = "no"
                 - loadparm_override:
+                    only s390-virtio
                     bootmenu_timeout = 6000
                     disk_order = {'boot': '1', 'loadparm': '2'}
         - negative_test:

--- a/libvirt/tests/cfg/guest_os_booting/ovmf_firmware/ovmf_loader.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/ovmf_firmware/ovmf_loader.cfg
@@ -29,7 +29,9 @@
                     loader_xpath = [{'element_attrs': ["./os/loader[@stateless='yes']"], 'text': '${loader_path}'}]
                 - customize_loader:
                     custom_loader_path = "/usr/share/edk2/ovmf/OVMF_CODE.secboot.customize.fd"
-                    loader_dict = {'secure': '${os_secure}', 'loader_readonly': 'yes', 'loader_type': 'pflash', 'loader': '${loader_path}'}
+                    aarch64:
+                        custom_loader_path = "/usr/share/edk2/aarch64/QEMU_EFI-silent-pflash.customize.qcow2"
+                    loader_dict = {'secure': '${os_secure}', 'loader_readonly': 'yes', 'loader_type': 'pflash', 'loader': '${custom_loader_path}'}
         - negative_test:
             variants:
                 - readonly_no:

--- a/libvirt/tests/src/guest_os_booting/boot_order/boot_from_disk_device.py
+++ b/libvirt/tests/src/guest_os_booting/boot_order/boot_from_disk_device.py
@@ -1,5 +1,6 @@
 import copy
 import os
+import platform
 
 from virttest import data_dir
 from virttest import remote
@@ -33,7 +34,7 @@ def parse_disks_attrs(vmxml, test, params):
     if disk1_img:
         disk1_img_path = os.path.join(data_dir.get_data_dir(), "images", disk1_img)
         if download_disk1_img:
-            if firmware_type == "ovmf":
+            if firmware_type == "ovmf" and platform.machine() == "x86_64":
                 disk1_img_url = disk1_img_url.removesuffix('.qcow2') + '-ovmf.qcow2'
             if not disk1_img_url or not utils_misc.wait_for(
                 lambda: guest_os.test_file_download(disk1_img_url, disk1_img_path), 60

--- a/libvirt/tests/src/guest_os_booting/ovmf_firmware/ovmf_loader.py
+++ b/libvirt/tests/src/guest_os_booting/ovmf_firmware/ovmf_loader.py
@@ -65,9 +65,9 @@ def run(test, params, env):
             guest_os.prepare_smm_xml(vm_name, smm_state, "")
         if "nvram" in loader_dict:
             loader_dict["nvram"] = loader_dict["nvram"].replace("nvram_VARS", f"{vm_name}_VARS")
-        vmxml = guest_os.prepare_os_xml(vm_name, loader_dict, firmware_type)
         if custom_loader_path:
             create_custom_loader(test, loader_path, custom_loader_path)
+        vmxml = guest_os.prepare_os_xml(vm_name, loader_dict, firmware_type)
         # stateless='yes' only use for AMD test, so here we only check the dumpxml for it to avoid the machine issue
         if stateless:
             virsh.start(vm_name, debug=True)


### PR DESCRIPTION
## Summary

Fix three guest OS booting test failures on aarch64:

- **bootmenu/loadparm_override**: Restrict variant to `s390-virtio` only. The test uses s390-specific `loadparm` boot order, which conflicts with OVMF/SeaBIOS firmware boot elements on other architectures.
- **ovmf_loader/customize_loader**: Add aarch64 `custom_loader_path`, use it in `loader_dict`, and copy the custom loader before VM XML preparation so the file exists when the VM is defined.
- **boot_from_disk_device**: Skip `-ovmf` image URL suffix on aarch64; guest images are already OVMF-based and the suffixed URL does not exist.

Reference: RHEL-81731, VIRT-296930

## Test plan

- [x] Run `guest_os_booting.boot_menu` on aarch64 — `loadparm_override` variant should be skipped
- [x] Run `guest_os_booting.ovmf_firmware.ovmf_loader` on aarch64 — `customize_loader` variant should pass
- [x] Run `guest_os_booting.boot_order.boot_from_disk_device` on aarch64 — disk image download should succeed
- [ ] Verify x86_64 behavior unchanged for all three tests