### PR TITLE
guest_os_booting: enable secure boot firmware feature on aarch64

### DIFF
--- a/libvirt/tests/cfg/guest_os_booting/ovmf_firmware/ovmf_firmware_feature.cfg
+++ b/libvirt/tests/cfg/guest_os_booting/ovmf_firmware/ovmf_firmware_feature.cfg
@@ -1,32 +1,52 @@
 - guest_os_booting.ovmf_firmware_feature:
     type =  ovmf_firmware_feature
+    only q35, aarch64
     start_vm = no
     loader_path = "/usr/share/edk2/ovmf/OVMF_CODE.secboot.fd"
-    nvram_template = "/usr/share/edk2/ovmf/OVMF_VARS.secboot.fd"
+    firmware_template = "/usr/share/edk2/ovmf/OVMF_VARS.secboot.fd"
+    firmware_store_element = nvram
+    loader_attr = type
+    loader_attr_value = pflash
     firmware_type = "ovmf"
-    only q35, aarch64
+    aarch64:
+        loader_path = "/usr/share/edk2/aarch64/QEMU_EFI.qemuvars.fd"
+        firmware_template = "/usr/share/edk2/aarch64/vars.secboot.json"
+        firmware_store_element = varstore
+        loader_attr_value = rom
     variants:
         - positive_test:
             status_error = "no"
             variants:
                 - enable_secure_boot:
-                    no aarch64
                     firmware_dict = {'os_firmware': 'efi', 'firmware': {'feature': [{'enabled': 'yes', 'name': 'enrolled-keys'}, {'enabled': 'yes', 'name': 'secure-boot'}]}}
-                    firmware_xpath = [{'element_attrs': ["./os/nvram[@template='${nvram_template}']"]}, {'element_attrs': ["./os/loader[@type='pflash']"], 'text': '${loader_path}'}]
+                    aarch64:
+                        func_supported_since_libvirt_ver = (12, 1, 0)
+                        func_supported_since_qemu_kvm_ver = (10, 1, 0)
+                    variants:
+                        - default:
+                        - custom_varstore_path:
+                            only aarch64
+                            firmware_varstore_path = "/tmp/vars.custom.json"
+                            firmware_dict = {'os_firmware': 'efi', 'firmware': {'feature': [{'enabled': 'yes', 'name': 'enrolled-keys'}, {'enabled': 'yes', 'name': 'secure-boot'}]}, 'loader': '${loader_path}', 'loader_type': 'rom', 'varstore_attrs': {'template': '${firmware_template}',  'path': '${firmware_varstore_path}'}}
                 - disable_secure_boot:
-                    no aarch64
-                    nvram_template = "/usr/share/edk2/ovmf/OVMF_VARS.fd"
+                    firmware_template = "/usr/share/edk2/ovmf/OVMF_VARS.fd"
                     firmware_dict = {'os_firmware': 'efi', 'firmware': {'feature': [{'enabled': 'no', 'name': 'enrolled-keys'}, {'enabled': 'yes', 'name': 'secure-boot'}]}}
-                    firmware_xpath = [{'element_attrs': ["./os/nvram[@template='${nvram_template}']"]}, {'element_attrs': ["./os/loader[@type='pflash']"], 'text': '${loader_path}'}]
+                    aarch64:
+                        func_supported_since_libvirt_ver = (12, 1, 0)
+                        func_supported_since_qemu_kvm_ver = (10, 1, 0)
+                        firmware_template = "/usr/share/edk2/aarch64/vars.blank.json"
                 - not_support_secure_boot:
                     func_supported_since_libvirt_ver = (9, 0, 0)
                     loader_path = "/usr/share/edk2/ovmf/OVMF_CODE.fd"
-                    nvram_template = "/usr/share/edk2/ovmf/OVMF_VARS.fd"
+                    firmware_template = "/usr/share/edk2/ovmf/OVMF_VARS.fd"
+                    loader_attr = readonly
+                    loader_attr_value = yes
                     aarch64:
                         loader_path = "/usr/share/edk2/aarch64/QEMU_EFI-silent-pflash.qcow2"
-                        nvram_template = "/usr/share/edk2/aarch64/vars-template-pflash.qcow2"
+                        firmware_template = "/usr/share/edk2/aarch64/vars-template-pflash.qcow2"
+                        firmware_store_element = nvram
                     firmware_dict = {'os_firmware': 'efi', 'firmware': {'feature': [{'enabled': 'no', 'name': 'enrolled-keys'}, {'enabled': 'no', 'name': 'secure-boot'}]}}
-                    firmware_xpath = [{'element_attrs': ["./os/nvram[@template='${nvram_template}']"]}, {'element_attrs': ["./os/loader[@readonly='yes']"], 'text': '${loader_path}'}]
+            firmware_xpath = [{'element_attrs': ["./os/${firmware_store_element}[@template='${firmware_template}']"]}, {'element_attrs': ["./os/loader[@${loader_attr}='${loader_attr_value}']"], 'text': '${loader_path}'}]
         - negative_test:
             status_error = "yes"
             variants:

--- a/libvirt/tests/src/guest_os_booting/ovmf_firmware/ovmf_firmware_feature.py
+++ b/libvirt/tests/src/guest_os_booting/ovmf_firmware/ovmf_firmware_feature.py
@@ -8,6 +8,7 @@
 #   Author: Meina Li <meili@redhat.com>
 #
 from virttest import libvirt_version
+from virttest import utils_misc
 from virttest.libvirt_xml import vm_xml
 from virttest.libvirt_xml import xcepts
 from virttest.utils_libvirt import libvirt_vmxml
@@ -27,6 +28,7 @@ def run(test, params, env):
     firmware_type = params.get("firmware_type")
     status_error = "yes" == params.get("status_error", "no")
     libvirt_version.is_libvirt_feature_supported(params)
+    utils_misc.is_qemu_function_supported(params)
 
     vm = env.get_vm(vm_name)
     vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)


### PR DESCRIPTION
## Summary

- Extend `guest_os_booting.ovmf_firmware_feature.positive_test.enable_secure_boot` to aarch64
- On ARM, libvirt selects the uefi-vars firmware (`QEMU_EFI.qemuvars.fd` + `vars.secboot.json` varstore) instead of pflash OVMF
- Gate the aarch64 variant on libvirt 12.1+ and QEMU 10.1+, where uefi-vars secure boot support is available
- Add QEMU version check in `ovmf_firmware_feature.py` via `is_qemu_function_supported()`

## Test plan

- [x] Run on x86 q35: `avocado run --vt-type libvirt guest_os_booting.ovmf_firmware_feature.positive_test.enable_secure_boot` — should pass unchanged
- [x] Run on aarch64 with libvirt >= 12.1 and QEMU >= 10.1: same test name — should define varstore/rom loader and boot successfully
- [x] Run on aarch64 with older libvirt/QEMU — test should cancel with unsupported version message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OVMF firmware feature coverage for AArch64 systems, updating secure boot expectations and firmware loader/variable-store handling.
  * Enhanced version-aware checks so unsupported secure boot scenarios are skipped more reliably across test variants.
  * Strengthened test preflight validation by adding an additional QEMU feature support check before preparing and evaluating OVMF firmware XML.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->