### PR TITLE
virsh_cmd: Change boot time fetching function

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_reboot.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_reboot.py
@@ -45,7 +45,8 @@ def run(test, params, env):
             """
             boot_time = None
             try:
-                boot_time = session.cmd_output("uptime --since")
+                boot_time = \
+                session.cmd_output("grep btime /proc/stat | awk '{print $2}'")
             except (aexpect.ShellStatusError, aexpect.ShellProcessTerminatedError) as e:
                 logging.error("Get boot_time error:%s" % e)
             return boot_time


### PR DESCRIPTION
The --since arg for uptime is not part of the basic package shipped with SLES releases. This caused the test to fail silently. This change uses /proc/stat to get boot time which will be present in every linux distro, thus making the test distro-independent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved boot time detection method in reboot tests for enhanced reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->