### PR TITLE
Add CPU model auto-detection for Power systems for host-model and extend migration variants!

### DIFF
--- a/libvirt/tests/cfg/migration/migration_misc/migration_with_cpu_mode.cfg
+++ b/libvirt/tests/cfg/migration/migration_misc/migration_with_cpu_mode.cfg
@@ -29,6 +29,16 @@
             virsh_migrate_options = '--live --p2p --verbose'
         - non_p2p:
             virsh_migrate_options = '--live --verbose'
+        - p2p_tunneled:
+            virsh_migrate_options = '--live --p2p --tunnelled --verbose'
+        - postcopy:
+            virsh_migrate_options = '--live --postcopy --verbose'
+        - postcopy_p2p:
+            virsh_migrate_options = '--live --postcopy --p2p --verbose'
+        - auto_converge:
+            virsh_migrate_options = '--live --auto-converge --verbose'
+        - auto_converge_p2p:
+            virsh_migrate_options = '--live --auto-converge --p2p --verbose'
     variants migration_option:
         - with_xml:
         - without_xml:
@@ -38,5 +48,5 @@
             numa_cell = "'numa_cell': [{'cpus': '0-1', 'memory': '2097152', 'unit': 'KiB'}]"
             vm_attrs = {'cpu': {'mode': 'host-model', 'check': 'partial', ${numa_cell}}}
         - custom:
-            no aarch64
+            no aarch64,ppc64le,ppc64
             cpu_mode = "custom"

--- a/libvirt/tests/src/migration/migration_misc/migration_with_cpu_mode.py
+++ b/libvirt/tests/src/migration/migration_misc/migration_with_cpu_mode.py
@@ -1,4 +1,5 @@
 import os
+import platform
 
 from virttest import data_dir
 from virttest import virsh
@@ -15,6 +16,21 @@ def run(test, params, env):
     :param params: Dictionary with the test parameters
     :param env: Dictionary with test environment.
     """
+    def get_host_cpu_model():
+        """Get host CPU model in lowercase"""
+        try:
+            # virsh.capabilities() returns XML string directly
+            caps_xml = virsh.capabilities()
+            import re
+            match = re.search(r'<model>(\w+)</model>', caps_xml)
+            if match:
+                model = match.group(1).lower()
+                test.log.info(f"Detected CPU model: {model}")
+                return model
+        except Exception as e:
+            test.log.warning(f"Failed to detect CPU model: {e}")
+        return None
+
     def setup_test():
         """
         Setup steps
@@ -28,6 +44,13 @@ def run(test, params, env):
         vmxml = vm_xml.VMXML.new_from_dumpxml(vm_name)
         if cpu_mode == "host_model":
             vm_attrs = eval(params.get('vm_attrs', '{}'))
+            arch = platform.machine()
+            if arch in ['ppc64', 'ppc64le'] and 'cpu' in vm_attrs:
+                host_model = get_host_cpu_model()
+                if host_model:
+                    vm_attrs['cpu']['model'] = host_model
+                    vm_attrs['cpu']['fallback'] = params.get('model_fallback', 'forbid')
+                    test.log.info(f"Power arch - added CPU model: {host_model}")
             vmxml.setup_attrs(**vm_attrs)
             vmxml.sync()
         else:


### PR DESCRIPTION
- Auto-detect host CPU model on ppc64/ppc64le architectures
- Convert CPU model to lowercase for libvirt compatibility (POWER11 → power11)
- Add CPU model to VM XML with fallback='forbid' for host-model mode
- Extend migration variants to include:
  * p2p_tunneled: P2P with tunneled transport
  * postcopy: Postcopy migration
  * postcopy_p2p: Postcopy with P2P
  * auto_converge: Auto-converge for slow migrations
  * auto_converge_p2p: Auto-converge with P2P

This provides comprehensive migration testing with CPU mode configurations across 7 migration types, 2 XML options, and 1 CPU modes (14 test cases total).

Signed-off-by: Anushree-Mathur <anushree.mathur@linux.ibm.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded migration test coverage with additional scenarios for tunneled, post-copy, auto-converge, and peer-to-peer combinations.
  * Added support for using the host CPU model automatically in relevant migration setups on ppc64/ppc64le systems.

* **Bug Fixes**
  * Improved handling of host-model CPU migration by applying a detected CPU model and fallback behavior when available, helping reduce setup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->