### PR TITLE
Add migration test with CPU topology verification!

### DIFF
--- a/libvirt/tests/cfg/migration/migration_misc/migration_with_cpu_topology.cfg
+++ b/libvirt/tests/cfg/migration/migration_misc/migration_with_cpu_topology.cfg
@@ -1,0 +1,44 @@
+- io-github-autotest-libvirt.migration.migration_misc.migration_with_cpu_topology:
+    virt_test_type = libvirt
+    provider = io-github-autotest-libvirt
+    type = migration_with_cpu_topology
+    migration_setup = "yes"
+    storage_type = "nfs"
+    setup_local_nfs = "yes"
+    disk_type = "file"
+    disk_source_protocol = "netfs"
+    mnt_path_name = ${nfs_mount_dir}
+    only_pty = True
+    take_regular_screendumps = no
+    virsh_migrate_extra = ''
+    ssh_timeout = 60
+    virsh_migrate_connect_uri = 'qemu:///system'
+    image_convert = 'no'
+    server_ip = "${remote_ip}"
+    server_user = "root"
+    server_pwd = "${remote_pwd}"
+    status_error = "no"
+    migrate_desturi_port = "16509"
+    migrate_desturi_type = "ssh"
+    virsh_migrate_desturi = "qemu+ssh://${remote_ip}/system"
+    start_vm = "no"
+    topology_sockets = 1
+    variants:
+        - threads_2:
+            topology_threads = 2
+            topology_cores = 16
+        - threads_4:
+            topology_threads = 4
+            topology_cores = 8
+        - threads_8:
+            topology_threads = 8
+            topology_cores = 4
+    variants:
+        - p2p:
+            virsh_migrate_options = '--live --p2p --verbose'
+        - non_p2p:
+            virsh_migrate_options = '--live --verbose'
+        - postcopy:
+            virsh_migrate_options = '--live --postcopy --verbose'
+        - auto_converge:
+            virsh_migrate_options = '--live --auto-converge --verbose'

--- a/libvirt/tests/src/migration/migration_misc/migration_with_cpu_topology.py
+++ b/libvirt/tests/src/migration/migration_misc/migration_with_cpu_topology.py
@@ -1,0 +1,113 @@
+from virttest.libvirt_xml import vm_xml
+
+from provider.migration import base_steps
+
+
+def run(test, params, env):
+    """
+    Test migration with different CPU topology configurations
+
+    :param test: test object
+    :param params: Dictionary with the test parameters
+    :param env: Dictionary with test environment
+    """
+
+    def verify_guest_topology(vm_obj, expected_threads, test, use_serial=False):
+        """Verify CPU topology in guest OS"""
+        if use_serial:
+            vm_obj.cleanup_serial_console()
+            vm_obj.create_serial_console()
+            session = vm_obj.wait_for_serial_login(timeout=360)
+        else:
+            session = vm_obj.wait_for_login(timeout=360)
+
+        try:
+            cmd = "lscpu | grep 'Thread(s) per core' | awk '{print $NF}'"
+            output = session.cmd_output(cmd).strip()
+            actual_threads = int(output)
+
+            test.log.info("Expected threads per core: %s", expected_threads)
+            test.log.info("Actual threads per core in guest: %s", actual_threads)
+
+            if actual_threads != expected_threads:
+                test.fail("Thread count mismatch! Expected: %s, Got: %s" %
+                          (expected_threads, actual_threads))
+
+            cmd = "lscpu | grep '^CPU(s):' | head -1 | awk '{print $NF}'"
+            total_cpus = int(session.cmd_output(cmd).strip())
+            test.log.info("Total CPUs in guest: %s", total_cpus)
+
+            test.log.info("CPU topology verified: %s CPUs, %s threads per core",
+                          total_cpus, expected_threads)
+        finally:
+            session.close()
+            if use_serial:
+                vm_obj.cleanup_serial_console()
+
+    def setup_test():
+        """Setup CPU topology configuration"""
+        vcpu_sockets = int(params.get("topology_sockets", "1"))
+        vcpu_cores = int(params.get("topology_cores", "1"))
+        vcpu_threads = int(params.get("topology_threads", "1"))
+
+        test.log.info("Setup steps - configuring CPU topology")
+        migration_obj.setup_connection()
+
+        vmxml = vm_xml.VMXML.new_from_inactive_dumpxml(vm_name)
+
+        if vm.is_alive():
+            vm.destroy(gracefully=False)
+
+        test.log.info("Configuring CPU topology: sockets=%s, cores=%s, threads=%s",
+                      vcpu_sockets, vcpu_cores, vcpu_threads)
+
+        vmxml.vcpu = vcpu_sockets * vcpu_cores * vcpu_threads
+
+        cpu_xml = vmxml.cpu
+        cpu_xml.topology = {
+            "sockets": str(vcpu_sockets),
+            "cores": str(vcpu_cores),
+            "threads": str(vcpu_threads)
+        }
+        vmxml.cpu = cpu_xml
+        vmxml.sync()
+
+        test.log.debug("VM XML after topology configuration")
+
+        if not vm.is_alive():
+            vm.start()
+            vm.wait_for_login(timeout=360).close()
+
+        test.log.info("Verifying CPU topology before migration...")
+        verify_guest_topology(vm, vcpu_threads, test, use_serial=False)
+
+    def verify_test():
+        """Verify CPU topology after migration"""
+        vcpu_threads = int(params.get("topology_threads", "1"))
+        dest_uri = params.get("virsh_migrate_desturi")
+
+        test.log.info("Verifying CPU topology after migration...")
+
+        # Change connect_uri to destination and use serial console
+        backup_uri = migration_obj.vm.connect_uri
+        migration_obj.vm.connect_uri = dest_uri
+
+        try:
+            verify_guest_topology(migration_obj.vm, vcpu_threads, test, use_serial=True)
+        finally:
+            migration_obj.vm.connect_uri = backup_uri
+
+        migration_obj.verify_default()
+
+        test.log.info("All topology verifications passed!")
+
+    vm_name = params.get("migrate_main_vm")
+    vm = env.get_vm(vm_name)
+    migration_obj = base_steps.MigrationBase(test, vm, params)
+
+    try:
+        setup_test()
+        migration_obj.run_migration()
+        verify_test()
+    finally:
+        migration_obj.cleanup_connection()


### PR DESCRIPTION
This commit adds a new test case to verify VM migration with different CPU topology configurations (threads per core: 2, 4, 8).

Changes:
- Add migration_with_cpu_topology.py test implementation
  * Configures VM with specified CPU topology (sockets, cores, threads)
  * Verifies topology in guest before migration using lscpu
  * Verifies topology on destination using serial console

- Add migration_with_cpu_topology.cfg provider config
  * Defines 3 thread variants: threads_2, threads_4, threads_8
  * Defines 4 migration variants: p2p, non_p2p, postcopy, auto_converge
  * Maintains total vCPUs = 32 by adjusting cores accordingly
  * Total test combinations: 12 (3 threads × 4 migration types)

Test validates:
- CPU topology configuration persists through migration
- Thread count per core is correctly maintained
- VM remains functional on destination host
- Different migration methods (P2P, postcopy, auto-converge) work correctly

Tested on: IBM Power (ppc64le) with pseries machine type
Migration: Live migration between two Power hosts using NFS shared storage

Signed-off-by: Anushree-Mathur <anushree.mathur@linux.ibm.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new migration test scenario that preserves and verifies guest CPU topology during live migration.
  * Expanded migration coverage with multiple topology and migration-mode variants, including post-copy and auto-converge options.
  * Added support for both standard guest login and serial console verification after migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->