### PR TITLE
virsh_cmd: Fix pep8 E122 in virsh_reboot boot time helper

### DIFF
--- a/libvirt/tests/src/virsh_cmd/domain/virsh_reboot.py
+++ b/libvirt/tests/src/virsh_cmd/domain/virsh_reboot.py
@@ -45,8 +45,7 @@ def run(test, params, env):
             """
             boot_time = None
             try:
-                boot_time = \
-                session.cmd_output("grep btime /proc/stat | awk '{print $2}'")
+                boot_time = session.cmd_output("grep btime /proc/stat | awk '{print $2}'")
             except (aexpect.ShellStatusError, aexpect.ShellProcessTerminatedError) as e:
                 logging.error("Get boot_time error:%s" % e)
             return boot_time


### PR DESCRIPTION
## Summary
- Puts the `/proc/stat` boot-time command on one assignment line so inspekt no longer fails PEP8 E122.
- Unblocks master CI after #6905; the functional change is unchanged.

## Test plan
- [ ] Confirm GitHub Actions `CI` (Python 3.8/3.9/3.11/3.12) passes on this PR
- [ ] Confirm `inspekt checkall` no longer reports E122 on `virsh_reboot.py`